### PR TITLE
web/nav: channel navigator on group row long-press, channel header tap

### DIFF
--- a/apps/tlon-web/src/app.tsx
+++ b/apps/tlon-web/src/app.tsx
@@ -93,6 +93,7 @@ import {
   useTheme,
 } from '@/state/settings';
 
+import ChannelInfo from './channels/ChannelInfo';
 import ChannelVolumeDialog from './channels/ChannelVolumeDialog';
 import MobileChatSearch from './chat/ChatSearch/MobileChatSearch';
 import ReportContent from './components/ReportContent';
@@ -479,13 +480,14 @@ function GroupsRoutes({ state, location, isMobile, isSmall }: RoutesProps) {
           <Route path="/groups/:ship/:name">
             <Route path="invite" element={<GroupInviteDialog />} />
           </Route>
-          <Route
-            path="/groups/:ship/:name/info"
-            element={<GroupInfo title={`• ${groupsTitle}`} />}
-          />
+          <Route path="/groups/:ship/:name/info" element={<GroupInfo />} />
           <Route
             path="/groups/:ship/:name/volume"
             element={<GroupVolumeDialog title={`• ${groupsTitle}`} />}
+          />
+          <Route
+            path="/groups/:ship/:name/channels/:chType/:chShip/:chName/info"
+            element={<ChannelInfo />}
           />
           <Route
             path="/groups/:ship/:name/channels/:chType/:chShip/:chName/volume"

--- a/apps/tlon-web/src/channels/ChannelHeader.tsx
+++ b/apps/tlon-web/src/channels/ChannelHeader.tsx
@@ -1,5 +1,6 @@
 import cn from 'classnames';
 import { PropsWithChildren } from 'react';
+import { useLocation, useNavigate } from 'react-router-dom';
 
 import MobileHeader from '@/components/MobileHeader';
 import ReconnectingSpinner from '@/components/ReconnectingSpinner';
@@ -28,6 +29,8 @@ export default function ChannelHeader({
   const isMobile = useIsMobile();
   const channel = useGroupChannel(groupFlag, nest);
   const isAdmin = useAmAdmin(groupFlag);
+  const navigate = useNavigate();
+  const location = useLocation();
 
   const actionProps: ChannelActionsProps = {
     nest,
@@ -41,9 +44,13 @@ export default function ChannelHeader({
     return (
       <MobileHeader
         title={
-          <ChannelActions
-            {...actionProps}
+          <button
             className="flex max-w-full items-center justify-center"
+            onClick={() => {
+              navigate(`/groups/${groupFlag}/info`, {
+                state: { backgroundLocation: location },
+              });
+            }}
           >
             <ChannelIcon
               nest={nest}
@@ -56,7 +63,7 @@ export default function ChannelHeader({
               className="ml-1 inline-flex flex-none"
               nest={nest}
             />
-          </ChannelActions>
+          </button>
         }
         action={
           <div className="flex h-12 flex-row items-center justify-end space-x-2">

--- a/apps/tlon-web/src/channels/ChannelInfo.tsx
+++ b/apps/tlon-web/src/channels/ChannelInfo.tsx
@@ -1,0 +1,194 @@
+import { GroupChannel } from '@tloncorp/shared/dist/urbit/groups';
+import cn from 'classnames';
+import React, { PropsWithChildren, useCallback, useState } from 'react';
+import { useLocation, useNavigate, useParams } from 'react-router';
+
+import ActionMenu, { Action } from '@/components/ActionMenu';
+import VolumeSetting from '@/components/VolumeSetting';
+import WidgetDrawer from '@/components/WidgetDrawer';
+import CaretLeftIcon from '@/components/icons/CaretLeftIcon';
+import DeleteChannelModal from '@/groups/ChannelsList/DeleteChannelModal';
+import EditChannelModal from '@/groups/ChannelsList/EditChannelModal';
+import GroupAvatar from '@/groups/GroupAvatar';
+import { useIsChannelHost } from '@/logic/channel';
+import { useDismissNavigate, useModalNavigate } from '@/logic/routing';
+import { Status } from '@/logic/status';
+import { useIsMobile } from '@/logic/useMedia';
+import { useLeaveMutation } from '@/state/channel/channel';
+import {
+  useAmAdmin,
+  useDeleteChannelMutation,
+  useGroup,
+  useGroupChannel,
+  useRouteGroup,
+} from '@/state/groups';
+
+import ChannelHostConnection from './ChannelHostConnection';
+import EditChannelForm from './EditChannelForm';
+
+export default function ChannelInfo(props: {
+  open?: boolean;
+  onOpenChange?: (open: boolean) => void;
+}) {
+  const dismiss = useDismissNavigate();
+
+  const [view, setView] = useState<'root' | 'volume' | 'edit' | 'delete'>(
+    'root'
+  );
+  const onOpenChange = (open: boolean) => {
+    if (!open) {
+      dismiss();
+      setView('root');
+    }
+    if (props.onOpenChange) {
+      props.onOpenChange(open);
+    }
+  };
+
+  const delayedViewNav = (newView: 'root' | 'volume' | 'edit' | 'delete') => {
+    setTimeout(() => {
+      setView(newView);
+    }, 100);
+  };
+
+  const location = useLocation();
+  const groupFlag = useRouteGroup();
+
+  const { chType, chShip, chName } = useParams<{
+    chType: string;
+    chShip: string;
+    chName: string;
+  }>();
+
+  const nest = `${chType}/${chShip}/${chName}`;
+  const chFlag = `${chShip}/${chName}`;
+  const group = useGroup(groupFlag);
+  const channel = useGroupChannel(groupFlag, nest);
+
+  const isMobile = useIsMobile();
+  const isAdmin = useAmAdmin(groupFlag);
+  const isChannelHost = useIsChannelHost(chFlag);
+
+  // const { mutateAsync: leave } = useLeaveMutation();
+  // const { mutate: deleteChannelMutate } = useDeleteChannelMutation();
+
+  // const [editIsOpen, setEditIsOpen] = useState(false);
+  // const [deleteChannelIsOpen, setDeleteChannelIsOpen] = useState(false);
+  // const [deleteStatus, setDeleteStatus] = useState<Status>('initial');
+  // const [showNotifications, setShowNotifications] = useState(false);
+
+  // const navigate = useNavigate();
+
+  // const [navigationStarted, setNavigationStarted] = useState(false);
+
+  // const buttonClasses =
+  //   'w-full flex justify-center items-center flex-col text-center p-3 text-sm bg-gray-50 rounded-lg space-y-2';
+
+  return (
+    <WidgetDrawer
+      open={props.open || true}
+      onOpenChange={onOpenChange}
+      className="h-[80vh]"
+      withGrabber={true}
+    >
+      <div className="mt-6 flex h-full flex-col space-y-3 overflow-y-auto">
+        {view === 'root' && (
+          <>
+            <div className="flex w-full items-center space-x-2 px-6 py-2">
+              <GroupAvatar size="h-10 w-10" {...group?.meta} />
+              <div className="flex flex-col">
+                <h1 className="text-lg font-semibold">{channel?.meta.title}</h1>
+                <p className="text-gray-400">{group?.meta.title}</p>
+              </div>
+            </div>
+            <div className="flex flex-col items-stretch justify-center space-y-3 px-6">
+              <button
+                className="button"
+                onClick={() => delayedViewNav('volume')}
+              >
+                Set Notifications for {channel?.meta.title}
+              </button>
+              {isAdmin && (
+                <button
+                  className="button"
+                  onClick={() => delayedViewNav('edit')}
+                >
+                  Edit {channel?.meta.title}
+                </button>
+              )}
+              {isAdmin && (
+                <button
+                  className="button"
+                  onClick={() => delayedViewNav('delete')}
+                >
+                  Delete {channel?.meta.title}
+                </button>
+              )}
+              {!isChannelHost && (
+                <button className="button">Leave {channel?.meta.title}</button>
+              )}
+            </div>
+          </>
+        )}
+
+        {view === 'volume' && <VolumeSheet back={() => setView('root')} />}
+        {view === 'edit' && <EditSheet back={() => setView('root')} />}
+        {view === 'delete' && <DeleteSheet back={() => setView('root')} />}
+      </div>
+    </WidgetDrawer>
+  );
+}
+
+export function VolumeSheet(props: { back: () => void }) {
+  return (
+    <div className="flex w-full flex-col items-center px-6 py-2">
+      <div className="mb-4 flex w-full items-center justify-between">
+        <div
+          className="flex h-6 w-6 items-center justify-center"
+          onClick={() => props.back()}
+        >
+          <CaretLeftIcon className="relative right-1 h-6 w-6" />
+        </div>
+        <h3 className="text-[17px]">Set Volume</h3>
+        <div className="invisible h-6 w-6" />
+      </div>
+      <div>set volume</div>
+    </div>
+  );
+}
+
+export function EditSheet(props: { back: () => void }) {
+  return (
+    <div className="flex w-full flex-col items-center px-6 py-2">
+      <div className="mb-4 flex w-full items-center justify-between">
+        <div
+          className="flex h-6 w-6 items-center justify-center"
+          onClick={() => props.back()}
+        >
+          <CaretLeftIcon className="relative right-1 h-6 w-6" />
+        </div>
+        <h3 className="text-[17px]">Edit Channel</h3>
+        <div className="invisible h-6 w-6" />
+      </div>
+      <div>channel info form</div>
+    </div>
+  );
+}
+
+export function DeleteSheet(props: { back: () => void }) {
+  return (
+    <div className="flex w-full flex-col items-center px-6 py-2">
+      <div className="mb-4 flex w-full items-center justify-between">
+        <div
+          className="flex h-6 w-6 items-center justify-center"
+          onClick={() => props.back()}
+        >
+          <CaretLeftIcon className="relative right-1 h-6 w-6" />
+        </div>
+        <h3 className="text-[17px]">Delete Channel</h3>
+        <div className="invisible h-6 w-6" />
+      </div>
+      <div>Confirm you want to delete channel</div>
+    </div>
+  );
+}

--- a/apps/tlon-web/src/channels/ChannelInfo.tsx
+++ b/apps/tlon-web/src/channels/ChannelInfo.tsx
@@ -3,10 +3,15 @@ import React, { useCallback, useState } from 'react';
 import { useNavigate, useParams } from 'react-router';
 
 import LoadingSpinner from '@/components/LoadingSpinner/LoadingSpinner';
+import SidebarItem from '@/components/Sidebar/SidebarItem';
 import useActiveTab from '@/components/Sidebar/util';
 import VolumeSetting from '@/components/VolumeSetting';
 import WidgetDrawer from '@/components/WidgetDrawer';
+import BellIcon from '@/components/icons/BellIcon';
 import CaretLeftIcon from '@/components/icons/CaretLeftIcon';
+import LeaveIcon from '@/components/icons/LeaveIcon';
+import PencilSettingsIcon from '@/components/icons/PencilSettingsIcon';
+import XIcon from '@/components/icons/XIcon';
 import GroupAvatar from '@/groups/GroupAvatar';
 import { useIsChannelHost } from '@/logic/channel';
 import { useDismissNavigate } from '@/logic/routing';
@@ -126,32 +131,38 @@ export default function ChannelInfo(props: {
               </div>
             </div>
             <div className="flex flex-col items-stretch justify-center space-y-3 px-6">
-              <button
-                className="button"
+              <SidebarItem
+                icon={<BellIcon className="h-6 w-6" />}
                 onClick={() => delayedViewNav('volume')}
+                showCaret
               >
                 Set Notifications for {channel?.meta.title}
-              </button>
-              {!isChannelHost && (
-                <button className="button" onClick={leaveChannel}>
-                  Leave {channel?.meta.title}
-                </button>
-              )}
+              </SidebarItem>
               {isAdmin && (
-                <button
-                  className="button"
+                <SidebarItem
+                  icon={<PencilSettingsIcon className="h-6 w-6" />}
                   onClick={() => delayedViewNav('edit')}
+                  showCaret
                 >
                   Edit {channel?.meta.title}
-                </button>
+                </SidebarItem>
               )}
               {isAdmin && (
-                <button
-                  className="button"
+                <SidebarItem
+                  icon={<XIcon className="h-6 w-6" />}
                   onClick={() => delayedViewNav('delete')}
+                  showCaret
                 >
                   Delete {channel?.meta.title}
-                </button>
+                </SidebarItem>
+              )}
+              {!isChannelHost && (
+                <SidebarItem
+                  onClick={leaveChannel}
+                  icon={<LeaveIcon className="h-6 w-6" />}
+                >
+                  Leave {channel?.meta.title}
+                </SidebarItem>
               )}
             </div>
           </>

--- a/apps/tlon-web/src/channels/EditChannelForm.tsx
+++ b/apps/tlon-web/src/channels/EditChannelForm.tsx
@@ -179,17 +179,10 @@ export default function EditChannelForm({
 
   return (
     <FormProvider {...form}>
-      <div className="sm:w-96">
-        <header className="mb-3 flex flex-col">
-          <h2 className="text-lg font-bold leading-6">
-            {prettyChannelTypeName(app)} Channel Details
-          </h2>
-          <p className="text-sm leading-5 text-gray-600">
-            Edit the channel&apos;s details
-          </p>
-        </header>
-      </div>
-      <form className="flex flex-col" onSubmit={form.handleSubmit(onSubmit)}>
+      <form
+        className="flex w-full flex-col"
+        onSubmit={form.handleSubmit(onSubmit)}
+      >
         <label className="mb-3 font-semibold">
           Channel Name*
           <input

--- a/apps/tlon-web/src/components/Sidebar/GroupsSidebarItem.tsx
+++ b/apps/tlon-web/src/components/Sidebar/GroupsSidebarItem.tsx
@@ -35,10 +35,8 @@ const GroupsSidebarItem = React.memo(
     }, [navigate, flag, location]);
 
     useEffect(() => {
-      console.log(location);
-    }, [location]);
+      console.log('BL: EFFECT RUN', action);
 
-    useEffect(() => {
       if (!isMobile) {
         return;
       }

--- a/apps/tlon-web/src/components/Sidebar/GroupsSidebarItem.tsx
+++ b/apps/tlon-web/src/components/Sidebar/GroupsSidebarItem.tsx
@@ -3,7 +3,6 @@ import { useLocation, useNavigate } from 'react-router';
 
 import GroupActions from '@/groups/GroupActions';
 import GroupAvatar from '@/groups/GroupAvatar';
-import { useModalNavigate } from '@/logic/routing';
 import useLongPress from '@/logic/useLongPress';
 import { useIsMobile } from '@/logic/useMedia';
 import { useGroups } from '@/state/groups';

--- a/apps/tlon-web/src/components/Sidebar/GroupsSidebarItem.tsx
+++ b/apps/tlon-web/src/components/Sidebar/GroupsSidebarItem.tsx
@@ -35,16 +35,16 @@ const GroupsSidebarItem = React.memo(
     }, [navigate, flag, location]);
 
     useEffect(() => {
-      console.log('BL: EFFECT RUN', action);
-
-      if (!isMobile) {
+      if (!isMobile || isNew) {
         return;
       }
 
       if (action === 'longpress') {
         handleNavigate();
       }
-    }, [action, handleNavigate, isMobile]);
+
+      // eslint-disable-next-line react-hooks/exhaustive-deps
+    }, [action]);
 
     return (
       <SidebarItem
@@ -56,26 +56,25 @@ const GroupsSidebarItem = React.memo(
           />
         }
         actions={
-          <div />
-          // isNew ? (
-          //   <GroupActions
-          //     open={optionsOpen}
-          //     onOpenChange={setOptionsOpen}
-          //     flag={flag}
-          //     triggerDisabled={disableActions}
-          //   >
-          //     <p className="flex items-center rounded-full bg-blue-soft px-2 py-1 text-sm text-blue">
-          //       NEW
-          //     </p>
-          //   </GroupActions>
-          // ) : (
-          //   <GroupActions
-          //     open={optionsOpen}
-          //     onOpenChange={setOptionsOpen}
-          //     flag={flag}
-          //     triggerDisabled={disableActions}
-          //   />
-          // )
+          isNew ? (
+            <GroupActions
+              open={optionsOpen}
+              onOpenChange={setOptionsOpen}
+              flag={flag}
+              triggerDisabled={disableActions}
+            >
+              <p className="flex items-center rounded-full bg-blue-soft px-2 py-1 text-sm text-blue">
+                NEW
+              </p>
+            </GroupActions>
+          ) : (
+            <GroupActions
+              open={optionsOpen}
+              onOpenChange={setOptionsOpen}
+              flag={flag}
+              triggerDisabled={disableActions}
+            />
+          )
         }
         className={isNew ? 'pr-10' : undefined}
         to={`/groups/${flag}`}

--- a/apps/tlon-web/src/components/Sidebar/GroupsSidebarItem.tsx
+++ b/apps/tlon-web/src/components/Sidebar/GroupsSidebarItem.tsx
@@ -43,6 +43,10 @@ const GroupsSidebarItem = React.memo(
         handleNavigate();
       }
 
+      // FIXME: the exhaustive deps rule is disabled because we don't want to
+      // trigger the navigation when something deep in isMobile or any of the
+      // dependencies of handleNavigate change.
+
       // eslint-disable-next-line react-hooks/exhaustive-deps
     }, [action]);
 

--- a/apps/tlon-web/src/components/Sidebar/GroupsSidebarItem.tsx
+++ b/apps/tlon-web/src/components/Sidebar/GroupsSidebarItem.tsx
@@ -1,7 +1,9 @@
-import React, { useEffect, useMemo, useState } from 'react';
+import React, { useCallback, useEffect, useMemo, useState } from 'react';
+import { useLocation, useNavigate } from 'react-router';
 
 import GroupActions from '@/groups/GroupActions';
 import GroupAvatar from '@/groups/GroupAvatar';
+import { useModalNavigate } from '@/logic/routing';
 import useLongPress from '@/logic/useLongPress';
 import { useIsMobile } from '@/logic/useMedia';
 import { useGroups } from '@/state/groups';
@@ -23,15 +25,28 @@ const GroupsSidebarItem = React.memo(
     );
     const enableImages = useMemo(() => !isScrolling, [isScrolling]);
 
+    const location = useLocation();
+    const navigate = useNavigate();
+
+    const handleNavigate = useCallback(() => {
+      navigate(`/groups/${flag}/info`, {
+        state: { backgroundLocation: location },
+      });
+    }, [navigate, flag, location]);
+
+    useEffect(() => {
+      console.log(location);
+    }, [location]);
+
     useEffect(() => {
       if (!isMobile) {
         return;
       }
 
       if (action === 'longpress') {
-        setOptionsOpen(true);
+        handleNavigate();
       }
-    }, [action, isMobile]);
+    }, [action, handleNavigate, isMobile]);
 
     return (
       <SidebarItem
@@ -43,25 +58,26 @@ const GroupsSidebarItem = React.memo(
           />
         }
         actions={
-          isNew ? (
-            <GroupActions
-              open={optionsOpen}
-              onOpenChange={setOptionsOpen}
-              flag={flag}
-              triggerDisabled={disableActions}
-            >
-              <p className="flex items-center rounded-full bg-blue-soft px-2 py-1 text-sm text-blue">
-                NEW
-              </p>
-            </GroupActions>
-          ) : (
-            <GroupActions
-              open={optionsOpen}
-              onOpenChange={setOptionsOpen}
-              flag={flag}
-              triggerDisabled={disableActions}
-            />
-          )
+          <div />
+          // isNew ? (
+          //   <GroupActions
+          //     open={optionsOpen}
+          //     onOpenChange={setOptionsOpen}
+          //     flag={flag}
+          //     triggerDisabled={disableActions}
+          //   >
+          //     <p className="flex items-center rounded-full bg-blue-soft px-2 py-1 text-sm text-blue">
+          //       NEW
+          //     </p>
+          //   </GroupActions>
+          // ) : (
+          //   <GroupActions
+          //     open={optionsOpen}
+          //     onOpenChange={setOptionsOpen}
+          //     flag={flag}
+          //     triggerDisabled={disableActions}
+          //   />
+          // )
         }
         className={isNew ? 'pr-10' : undefined}
         to={`/groups/${flag}`}

--- a/apps/tlon-web/src/groups/GroupAdmin/GroupInfo.tsx
+++ b/apps/tlon-web/src/groups/GroupAdmin/GroupInfo.tsx
@@ -1,5 +1,6 @@
 import { ViewProps } from '@tloncorp/shared/dist/urbit/groups';
-import React from 'react';
+import React, { useEffect } from 'react';
+import { useLocation } from 'react-router';
 
 import WidgetDrawer from '@/components/WidgetDrawer';
 import { useDismissNavigate } from '@/logic/routing';
@@ -10,6 +11,12 @@ import ChannelList from '../GroupSidebar/ChannelList';
 export default function GroupInfo({ title }: ViewProps) {
   const flag = useRouteGroup();
   const dismiss = useDismissNavigate();
+  const location = useLocation();
+
+  useEffect(() => {
+    console.log(location);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
 
   const onOpenChange = (open: boolean) => {
     if (!open) {

--- a/apps/tlon-web/src/groups/GroupAdmin/GroupInfo.tsx
+++ b/apps/tlon-web/src/groups/GroupAdmin/GroupInfo.tsx
@@ -1,22 +1,39 @@
 import { ViewProps } from '@tloncorp/shared/dist/urbit/groups';
 import React, { useEffect } from 'react';
 import { useLocation } from 'react-router';
+import { Link } from 'react-router-dom';
 
 import WidgetDrawer from '@/components/WidgetDrawer';
+import InviteIcon from '@/components/icons/InviteIcon';
+import LeaveIcon from '@/components/icons/LeaveIcon';
+import PinIcon from '@/components/icons/PinIcon';
+import PinIcon16 from '@/components/icons/PinIcon16';
+import SmileIcon from '@/components/icons/SmileIcon';
 import { useDismissNavigate } from '@/logic/routing';
 
-import { useRouteGroup } from '../../state/groups/groups';
+import {
+  useGroup,
+  usePinnedGroups,
+  useRouteGroup,
+} from '../../state/groups/groups';
+import { useGroupActions } from '../GroupActions';
+import GroupAvatar from '../GroupAvatar';
 import ChannelList from '../GroupSidebar/ChannelList';
 
 export default function GroupInfo({ title }: ViewProps) {
   const flag = useRouteGroup();
+  const group = useGroup(flag);
   const dismiss = useDismissNavigate();
   const location = useLocation();
 
-  useEffect(() => {
-    console.log(location);
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, []);
+  const { isPinned, copyItemText, onCopy, onPinClick } = useGroupActions({
+    flag,
+  });
+
+  // useEffect(() => {
+  //   console.log(location);
+  //   // eslint-disable-next-line react-hooks/exhaustive-deps
+  // }, []);
 
   const onOpenChange = (open: boolean) => {
     if (!open) {
@@ -24,9 +41,56 @@ export default function GroupInfo({ title }: ViewProps) {
     }
   };
 
+  const buttonClasses =
+    'w-full flex justify-center items-center flex-col text-center p-3 text-sm bg-gray-50 rounded-lg space-y-2';
+
   return (
-    <WidgetDrawer open={true} onOpenChange={onOpenChange} className="h-[70vh]">
-      <ChannelList noScroller={true} flag={flag} />
+    <WidgetDrawer open={true} onOpenChange={onOpenChange} className="h-[80vh]">
+      <div className="mt-6 flex h-full flex-col space-y-3 overflow-y-auto">
+        <div className="flex items-center space-x-2 px-6 py-2">
+          <GroupAvatar size="h-10 w-10" {...group?.meta} />
+          <div className="flex flex-col">
+            <h1 className="text-lg font-semibold">{group?.meta.title}</h1>
+            <p className="text-gray-400">Group quick actions</p>
+          </div>
+        </div>
+        <div className="flex items-center justify-between space-x-1 px-6">
+          <Link
+            className={buttonClasses}
+            to={`/groups/${flag}/invite`}
+            state={{ backgroundLocation: location }}
+          >
+            <InviteIcon className="h-6 w-6" />
+            <span>Invite</span>
+          </Link>
+
+          <button className={buttonClasses} onClick={onPinClick}>
+            <PinIcon16 className="h-6 w-6" />
+            <span>{isPinned ? 'Unpin' : 'Pin'}</span>
+          </button>
+          <Link className={buttonClasses} to={`/groups/${flag}/members`}>
+            <SmileIcon className="h-6 w-6" />
+            <span>Members</span>
+          </Link>
+          <Link
+            className={buttonClasses}
+            to={`/groups/${flag}/leave`}
+            state={{ backgroundLocation: location }}
+          >
+            <LeaveIcon className="h-6 w-6" />
+            <span>Leave</span>
+          </Link>
+        </div>
+        <div className="flex flex-col items-stretch justify-center space-y-3 px-6">
+          <button className={buttonClasses} onClick={onCopy}>
+            {copyItemText}
+          </button>
+          <button className={buttonClasses}>Group Notification Settings</button>
+        </div>
+        <div className="w-full">
+          <ChannelList noScroller={true} flag={flag} />
+        </div>
+      </div>
     </WidgetDrawer>
   );
 }

--- a/apps/tlon-web/src/groups/GroupAdmin/GroupInfo.tsx
+++ b/apps/tlon-web/src/groups/GroupAdmin/GroupInfo.tsx
@@ -6,13 +6,13 @@ import WidgetDrawer from '@/components/WidgetDrawer';
 import InviteIcon from '@/components/icons/InviteIcon';
 import LeaveIcon from '@/components/icons/LeaveIcon';
 import PinIcon16 from '@/components/icons/PinIcon16';
+import SlidersIcon from '@/components/icons/SlidersIcon';
 import SmileIcon from '@/components/icons/SmileIcon';
+import { useGroupActions } from '@/groups/GroupActions';
+import GroupAvatar from '@/groups/GroupAvatar';
+import ChannelList from '@/groups/GroupSidebar/ChannelList';
 import { useDismissNavigate, useModalNavigate } from '@/logic/routing';
-
-import { useGroup, useRouteGroup } from '../../state/groups/groups';
-import { useGroupActions } from '../GroupActions';
-import GroupAvatar from '../GroupAvatar';
-import ChannelList from '../GroupSidebar/ChannelList';
+import { useAmAdmin, useGroup, useRouteGroup } from '@/state/groups/groups';
 
 export default function GroupInfo() {
   const flag = useRouteGroup();
@@ -20,6 +20,7 @@ export default function GroupInfo() {
   const dismiss = useDismissNavigate();
   const location = useLocation();
   const navigate = useModalNavigate();
+  const isAdmin = useAmAdmin(flag);
 
   const { isPinned, copyItemText, onCopy, onPinClick } = useGroupActions({
     flag,
@@ -68,18 +69,25 @@ export default function GroupInfo() {
             <SmileIcon className="h-6 w-6" />
             <span>Members</span>
           </Link>
-          <button
-            className={buttonClasses}
-            onClick={() => {
-              setNavigationStarted(true);
-              navigate(`/groups/${flag}/leave`, {
-                state: { backgroundLocation: location },
-              });
-            }}
-          >
-            <LeaveIcon className="h-6 w-6" />
-            <span>Leave</span>
-          </button>
+          {isAdmin ? (
+            <Link to={`/groups/${flag}/edit`} className={buttonClasses}>
+              <SlidersIcon className="h-6 w-6" />
+              <span>Settings</span>
+            </Link>
+          ) : (
+            <button
+              className={buttonClasses}
+              onClick={() => {
+                setNavigationStarted(true);
+                navigate(`/groups/${flag}/leave`, {
+                  state: { backgroundLocation: location },
+                });
+              }}
+            >
+              <LeaveIcon className="h-6 w-6" />
+              <span>Leave</span>
+            </button>
+          )}
         </div>
         <div className="flex flex-col items-stretch justify-center space-y-3 px-6">
           <button className={buttonClasses} onClick={onCopy}>

--- a/apps/tlon-web/src/groups/GroupAdmin/GroupInfo.tsx
+++ b/apps/tlon-web/src/groups/GroupAdmin/GroupInfo.tsx
@@ -1,23 +1,15 @@
 import { ViewProps } from '@tloncorp/shared/dist/urbit/groups';
 import React from 'react';
-import { Helmet } from 'react-helmet';
 
-import Dialog from '@/components/Dialog';
+import WidgetDrawer from '@/components/WidgetDrawer';
 import { useDismissNavigate } from '@/logic/routing';
 
-import { useGroup, useRouteGroup } from '../../state/groups/groups';
-import GroupSummary from '../GroupSummary';
-import GroupMemberManager from './GroupMemberManager';
+import { useRouteGroup } from '../../state/groups/groups';
+import ChannelList from '../GroupSidebar/ChannelList';
 
 export default function GroupInfo({ title }: ViewProps) {
   const flag = useRouteGroup();
-  const group = useGroup(flag);
-  const meta = group?.meta;
   const dismiss = useDismissNavigate();
-
-  if (!meta) {
-    return null;
-  }
 
   const onOpenChange = (open: boolean) => {
     if (!open) {
@@ -26,26 +18,8 @@ export default function GroupInfo({ title }: ViewProps) {
   };
 
   return (
-    <Dialog
-      defaultOpen
-      modal
-      onOpenChange={onOpenChange}
-      className="m-0 flex h-[90vh] w-[90vw]  flex-col justify-center bg-transparent p-0 sm:h-[75vh] sm:max-h-[800px] sm:w-[75vw] sm:max-w-[800px]"
-    >
-      <Helmet>
-        <title>
-          {group?.meta ? `Info for ${group.meta.title} ${title}` : title}
-        </title>
-      </Helmet>
-      <div className="card mb-6">
-        <GroupSummary flag={flag} preview={{ ...group, flag }} />
-        {meta.description && (
-          <p className="mt-4 w-full leading-5">{meta.description}</p>
-        )}
-      </div>
-      <div className="grow">
-        <GroupMemberManager />
-      </div>
-    </Dialog>
+    <WidgetDrawer open={true} onOpenChange={onOpenChange} className="h-[70vh]">
+      <ChannelList noScroller={true} flag={flag} />
+    </WidgetDrawer>
   );
 }

--- a/apps/tlon-web/src/groups/GroupAdmin/GroupInfo.tsx
+++ b/apps/tlon-web/src/groups/GroupAdmin/GroupInfo.tsx
@@ -1,44 +1,37 @@
-import { ViewProps } from '@tloncorp/shared/dist/urbit/groups';
-import React, { useEffect } from 'react';
+import React, { useState } from 'react';
 import { useLocation } from 'react-router';
 import { Link } from 'react-router-dom';
 
 import WidgetDrawer from '@/components/WidgetDrawer';
 import InviteIcon from '@/components/icons/InviteIcon';
 import LeaveIcon from '@/components/icons/LeaveIcon';
-import PinIcon from '@/components/icons/PinIcon';
 import PinIcon16 from '@/components/icons/PinIcon16';
 import SmileIcon from '@/components/icons/SmileIcon';
-import { useDismissNavigate } from '@/logic/routing';
+import { useDismissNavigate, useModalNavigate } from '@/logic/routing';
 
-import {
-  useGroup,
-  usePinnedGroups,
-  useRouteGroup,
-} from '../../state/groups/groups';
+import { useGroup, useRouteGroup } from '../../state/groups/groups';
 import { useGroupActions } from '../GroupActions';
 import GroupAvatar from '../GroupAvatar';
 import ChannelList from '../GroupSidebar/ChannelList';
 
-export default function GroupInfo({ title }: ViewProps) {
+export default function GroupInfo() {
   const flag = useRouteGroup();
   const group = useGroup(flag);
   const dismiss = useDismissNavigate();
   const location = useLocation();
+  const navigate = useModalNavigate();
 
   const { isPinned, copyItemText, onCopy, onPinClick } = useGroupActions({
     flag,
   });
 
-  // useEffect(() => {
-  //   console.log(location);
-  //   // eslint-disable-next-line react-hooks/exhaustive-deps
-  // }, []);
+  const [navigationStarted, setNavigationStarted] = useState(false);
 
   const onOpenChange = (open: boolean) => {
-    if (!open) {
+    if (!open && !navigationStarted) {
       dismiss();
     }
+    setNavigationStarted(false);
   };
 
   const buttonClasses =
@@ -55,37 +48,54 @@ export default function GroupInfo({ title }: ViewProps) {
           </div>
         </div>
         <div className="flex items-center justify-between space-x-1 px-6">
-          <Link
+          <button
             className={buttonClasses}
-            to={`/groups/${flag}/invite`}
-            state={{ backgroundLocation: location }}
+            onClick={() => {
+              setNavigationStarted(true);
+              navigate(`/groups/${flag}/invite`, {
+                state: { backgroundLocation: location },
+              });
+            }}
           >
             <InviteIcon className="h-6 w-6" />
             <span>Invite</span>
-          </Link>
-
+          </button>
           <button className={buttonClasses} onClick={onPinClick}>
             <PinIcon16 className="h-6 w-6" />
             <span>{isPinned ? 'Unpin' : 'Pin'}</span>
           </button>
-          <Link className={buttonClasses} to={`/groups/${flag}/members`}>
+          <Link to={`/groups/${flag}/members`} className={buttonClasses}>
             <SmileIcon className="h-6 w-6" />
             <span>Members</span>
           </Link>
-          <Link
+          <button
             className={buttonClasses}
-            to={`/groups/${flag}/leave`}
-            state={{ backgroundLocation: location }}
+            onClick={() => {
+              setNavigationStarted(true);
+              navigate(`/groups/${flag}/leave`, {
+                state: { backgroundLocation: location },
+              });
+            }}
           >
             <LeaveIcon className="h-6 w-6" />
             <span>Leave</span>
-          </Link>
+          </button>
         </div>
         <div className="flex flex-col items-stretch justify-center space-y-3 px-6">
           <button className={buttonClasses} onClick={onCopy}>
             {copyItemText}
           </button>
-          <button className={buttonClasses}>Group Notification Settings</button>
+          <button
+            className={buttonClasses}
+            onClick={() => {
+              setNavigationStarted(true);
+              navigate(`/groups/${flag}/volume`, {
+                state: { backgroundLocation: location },
+              });
+            }}
+          >
+            Group notifications settings
+          </button>
         </div>
         <div className="w-full">
           <ChannelList noScroller={true} flag={flag} />

--- a/apps/tlon-web/src/groups/GroupAdmin/GroupInfo.tsx
+++ b/apps/tlon-web/src/groups/GroupAdmin/GroupInfo.tsx
@@ -26,12 +26,17 @@ export default function GroupInfo() {
     flag,
   });
 
+  // We need to track if the user has started a navigation so that we can
+  // dismiss the drawer if they close it without starting a navigation
   const [navigationStarted, setNavigationStarted] = useState(false);
 
   const onOpenChange = (open: boolean) => {
+    // If the drawer is being closed and we haven't started a navigation,
+    // dismiss the drawer
     if (!open && !navigationStarted) {
       dismiss();
     }
+    // Reset the navigation started state
     setNavigationStarted(false);
   };
 

--- a/apps/tlon-web/src/groups/GroupSidebar/ChannelList.tsx
+++ b/apps/tlon-web/src/groups/GroupSidebar/ChannelList.tsx
@@ -127,6 +127,9 @@ const ChannelList = React.memo(
     flag: string;
     noScroller?: boolean;
   }) => {
+    // Using the useGroup hook to get the group data with a mandatory flag,
+    // rather than relying on whatever "group" is in scope. This is used to
+    // ensure we get a complete channel list on the MobileRoot view.
     const group = useGroup(flag);
     const connected = useGroupConnection(flag);
     const { sortFn, sortChannels } = useChannelSort();
@@ -298,6 +301,9 @@ const ChannelList = React.memo(
       );
     }
 
+    // If noScroller is true, we're rendering this list in a context where
+    // scrolling is handled by a parent component. In this case, we don't want
+    // to use Virtuoso, so we just render the items directly.
     if (noScroller) {
       return <>{items.map((item, index) => renderItem(index, item))}</>;
     }

--- a/apps/tlon-web/src/groups/GroupSidebar/ChannelList.tsx
+++ b/apps/tlon-web/src/groups/GroupSidebar/ChannelList.tsx
@@ -17,6 +17,7 @@ import LoadingSpinner from '@/components/LoadingSpinner/LoadingSpinner';
 import GroupListPlaceholder from '@/components/Sidebar/GroupListPlaceholder';
 import SidebarItem from '@/components/Sidebar/SidebarItem';
 import UnreadIndicator from '@/components/Sidebar/UnreadIndicator';
+import EllipsisIcon from '@/components/icons/EllipsisIcon';
 import FilterIconMobileNav from '@/components/icons/FilterIconMobileNav';
 import SortIcon from '@/components/icons/SortIcon';
 import { DEFAULT_SORT } from '@/constants';
@@ -267,7 +268,7 @@ const ChannelList = React.memo(
                   <div
                     onClick={() => navigate(`${channelHref(flag, nest)}/info`)}
                   >
-                    <UnreadIndicator className="m-0.5 h-5 w-5 text-gray-400" />
+                    <EllipsisIcon className="h-8 w-8 p-1 text-gray-400" />
                   </div>
                 )}
               </>

--- a/apps/tlon-web/src/groups/GroupSidebar/ChannelList.tsx
+++ b/apps/tlon-web/src/groups/GroupSidebar/ChannelList.tsx
@@ -248,13 +248,15 @@ const ChannelList = React.memo(
             return renderStaticTop();
           case 'section-header':
             return (
-              <div className="mx-4 text-gray-100 sm:mx-2">
+              <div key={_index} className="mx-4 text-gray-100 sm:mx-2">
                 {renderSectionHeader(item.section)}
               </div>
             );
           case 'channel':
             return (
-              <div className="mx-4 sm:mx-2">{renderChannel(item.channel)}</div>
+              <div key={_index} className="mx-4 sm:mx-2">
+                {renderChannel(item.channel)}
+              </div>
             );
           default:
             return null;

--- a/apps/tlon-web/src/groups/GroupSidebar/GroupSidebar.tsx
+++ b/apps/tlon-web/src/groups/GroupSidebar/GroupSidebar.tsx
@@ -179,7 +179,7 @@ export default function GroupSidebar() {
         </div>
       </div>
       <div className="flex-1 overflow-y-auto">
-        <ChannelList />
+        <ChannelList flag={flag} />
       </div>
     </nav>
   );

--- a/apps/tlon-web/src/groups/MobileGroupChannelList.tsx
+++ b/apps/tlon-web/src/groups/MobileGroupChannelList.tsx
@@ -93,7 +93,7 @@ export default function MobileGroupChannelList() {
           paddingBottom,
         }}
       >
-        <ChannelList paddingTop={6} />
+        <ChannelList flag={flag} paddingTop={6} />
       </div>
       <div
         className="absolute left-[-5%] top-[-5%] -z-10 h-64 w-[110%] bg-cover bg-center mix-blend-multiply blur-md dark:mix-blend-screen"

--- a/apps/tlon-web/src/logic/routing.ts
+++ b/apps/tlon-web/src/logic/routing.ts
@@ -30,11 +30,9 @@ export function useDismissNavigate() {
   const state = location.state as ModalLocationState | null;
 
   return useCallback(() => {
-    console.log('BL: DISMISS CALLED', state?.backgroundLocation.pathname);
     if (state?.backgroundLocation) {
       // we want to replace the current location with the background location
       // so that the user won't navigate back to the modal if they hit the back button
-      console.log('BL: FOUND', state.backgroundLocation.pathname);
       navigate(state.backgroundLocation, { replace: true });
     }
   }, [navigate, state]);

--- a/apps/tlon-web/src/logic/routing.ts
+++ b/apps/tlon-web/src/logic/routing.ts
@@ -30,9 +30,11 @@ export function useDismissNavigate() {
   const state = location.state as ModalLocationState | null;
 
   return useCallback(() => {
+    console.log('BL: DISMISS CALLED', state?.backgroundLocation.pathname);
     if (state?.backgroundLocation) {
       // we want to replace the current location with the background location
       // so that the user won't navigate back to the modal if they hit the back button
+      console.log('BL: FOUND', state.backgroundLocation.pathname);
       navigate(state.backgroundLocation, { replace: true });
     }
   }, [navigate, state]);


### PR DESCRIPTION
Adding a draft PR that fixes LAND-1664 (feature-complete) and fixes LAND-1666 (in progress). See the linked Linear issues for the full interaction spec.

- Reappropriates GroupInfo (a route-based modal we abandoned) to contain all current group options, plus a ChannelList.
- Adjusts ChannelList to accept a mandatory flag prop, which avoids "group" collision when opening the menu from MobileRoot. (Simply accepting the group in scope resulted in an incomplete list of channels outside the group context.)
- Adjusts ChannelList to return a flat array of channel navigation row elements, unbounded by the Virtuoso scroller. (This was causing lots of layout problems and deemed unnecessary.)

Contains some sketchy useEffect usage to play nice with long-pressing the GroupsSidebarItem row. @latter-bolden and I dug into it and keeping an exhaustive list of dependencies caused re-rendering issues when dismissing the GroupInfo sheet.

Also uses state to properly navigate the user to other overlay routes from GroupInfo without prematurely closing the sheet and preserving background location.

Tested locally with the Vite dev server proxied to a livenet planet. Will test using the native client connected to the dev server.

---

PR Checklist
- [ ] Includes changes to desk files
- [x] Describes how you tested the PR locally (test ship vs livenet)
- [ ] If a new feature, includes automated tests
- [x] Comments added anywhere logic may be confusing without context