### PR TITLE
sidebar sort: fix issue with recency

### DIFF
--- a/apps/tlon-web/src/logic/useSidebarSort.ts
+++ b/apps/tlon-web/src/logic/useSidebarSort.ts
@@ -57,13 +57,15 @@ export function useRecentSort() {
         whomIsDm(aNest) || whomIsMultiDm(aNest)
           ? processedUnreads.dmUnreads
           : processedUnreads.channelUnreads;
-      const aLast = aUnreads[aNest];
+      // if the nest is not in the unreads, default to negative infinity
+      const aLast = aUnreads[aNest] ?? Number.NEGATIVE_INFINITY;
 
       const bUnreads =
         whomIsDm(bNest) || whomIsMultiDm(bNest)
           ? processedUnreads.dmUnreads
           : processedUnreads.channelUnreads;
-      const bLast = bUnreads[bNest];
+      // if the nest is not in the unreads, default to negative infinity
+      const bLast = bUnreads[bNest] ?? Number.NEGATIVE_INFINITY;
 
       return Math.sign(aLast - bLast);
     },


### PR DESCRIPTION
My recent change to useRecentSort() didn't account for the fact that some channels/dms don't have any unreads.

This led to a bizarre looking recent sort order for groups.

This fixes that by defaulting to Number.NEGATIVE_INFINITY if we can't find an unread (rather than only if we can't find recency).

Tested locally on a live ship.

Fixes LAND-1747

PR Checklist
- [ ] Includes changes to desk files
- [x] Describes how you tested the PR locally (test ship vs livenet)
- [ ] If a new feature, includes automated tests
- [x] Comments added anywhere logic may be confusing without context