### PR TITLE
negotiate: produce vase for /dbug/state scry

### DIFF
--- a/desk/lib/negotiate.hoon
+++ b/desk/lib/negotiate.hoon
@@ -680,7 +680,7 @@
         ?:  ?=(?(~ [~ ~]) dat)  ~
         (fall ((soft (list mass)) q.q.u.u.dat) ~)
       ?:  =(/x/dbug/state path)
-        ``noun+(slop on-save:og !>(negotiate=state))
+        ``noun+!>((slop on-save:og !>(negotiate=state)))
       ?.  ?=([@ %~.~ %negotiate *] path)
         (on-peek:og path)
       !:


### PR DESCRIPTION
Instead of producing the implicitly-unpacked vase, !> the vase, so the result of the scry itself remains a vase.

`/lib/dbug` expects this, and violating it causes agents using this library to not work right it `/app/dbug` or the debug dashboard.
