### PR TITLE
Add react-native-fast-image

### DIFF
--- a/apps/tlon-mobile/ios/Podfile.lock
+++ b/apps/tlon-mobile/ios/Podfile.lock
@@ -183,6 +183,18 @@ PODS:
     - hermes-engine/Pre-built (= 0.73.4)
   - hermes-engine/Pre-built (0.73.4)
   - libevent (2.1.12)
+  - libwebp (1.3.2):
+    - libwebp/demux (= 1.3.2)
+    - libwebp/mux (= 1.3.2)
+    - libwebp/sharpyuv (= 1.3.2)
+    - libwebp/webp (= 1.3.2)
+  - libwebp/demux (1.3.2):
+    - libwebp/webp
+  - libwebp/mux (1.3.2):
+    - libwebp/demux
+  - libwebp/sharpyuv (1.3.2)
+  - libwebp/webp (1.3.2):
+    - libwebp/sharpyuv
   - nanopb (2.30909.1):
     - nanopb/decode (= 2.30909.1)
     - nanopb/encode (= 2.30909.1)
@@ -1257,6 +1269,10 @@ PODS:
     - React-Core
   - RNDeviceInfo (10.12.0):
     - React-Core
+  - RNFastImage (8.6.3):
+    - React-Core
+    - SDWebImage (~> 5.11.1)
+    - SDWebImageWebPCoder (~> 0.8.4)
   - RNFBApp (18.8.0):
     - Firebase/CoreOnly (= 10.20.0)
     - React-Core
@@ -1280,6 +1296,12 @@ PODS:
     - React-Core
   - RNSVG (14.1.0):
     - React-Core
+  - SDWebImage (5.11.1):
+    - SDWebImage/Core (= 5.11.1)
+  - SDWebImage/Core (5.11.1)
+  - SDWebImageWebPCoder (0.8.5):
+    - libwebp (~> 1.0)
+    - SDWebImage/Core (~> 5.10)
   - SocketRocket (0.6.1)
   - sqlite3 (3.42.0):
     - sqlite3/common (= 3.42.0)
@@ -1371,6 +1393,7 @@ DEPENDENCIES:
   - "recaptcha-enterprise-react-native (from `../../../node_modules/@google-cloud/recaptcha-enterprise-react-native`)"
   - "RNCAsyncStorage (from `../../../node_modules/@react-native-async-storage/async-storage`)"
   - RNDeviceInfo (from `../../../node_modules/react-native-device-info`)
+  - RNFastImage (from `../../../node_modules/react-native-fast-image`)
   - "RNFBApp (from `../../../node_modules/@react-native-firebase/app`)"
   - "RNFBCrashlytics (from `../../../node_modules/@react-native-firebase/crashlytics`)"
   - RNGestureHandler (from `../../../node_modules/react-native-gesture-handler`)
@@ -1394,12 +1417,15 @@ SPEC REPOS:
     - GoogleDataTransport
     - GoogleUtilities
     - libevent
+    - libwebp
     - nanopb
     - PromisesObjC
     - PromisesSwift
     - ReachabilitySwift
     - RecaptchaEnterprise
     - RecaptchaInterop
+    - SDWebImage
+    - SDWebImageWebPCoder
     - SocketRocket
     - sqlite3
 
@@ -1565,6 +1591,8 @@ EXTERNAL SOURCES:
     :path: "../../../node_modules/@react-native-async-storage/async-storage"
   RNDeviceInfo:
     :path: "../../../node_modules/react-native-device-info"
+  RNFastImage:
+    :path: "../../../node_modules/react-native-fast-image"
   RNFBApp:
     :path: "../../../node_modules/@react-native-firebase/app"
   RNFBCrashlytics:
@@ -1625,6 +1653,7 @@ SPEC CHECKSUMS:
   GoogleUtilities: 0759d1a57ebb953965c2dfe0ba4c82e95ccc2e34
   hermes-engine: b2669ce35fc4ac14f523b307aff8896799829fe2
   libevent: 4049cae6c81cdb3654a443be001fb9bdceff7913
+  libwebp: 1786c9f4ff8a279e4dac1e8f385004d5fc253009
   nanopb: d4d75c12cd1316f4a64e3c6963f879ecd4b5e0d5
   op-sqlite: af2411e57364db634729dbd4d4b24d0a9d973ab7
   PromisesObjC: c50d2056b5253dadbd6c2bea79b0674bd5a52fa4
@@ -1681,16 +1710,19 @@ SPEC CHECKSUMS:
   RecaptchaInterop: 7d1a4a01a6b2cb1610a47ef3f85f0c411434cb21
   RNCAsyncStorage: 618d03a5f52fbccb3d7010076bc54712844c18ef
   RNDeviceInfo: db5c64a060e66e5db3102d041ebe3ef307a85120
+  RNFastImage: 5c9c9fed9c076e521b3f509fe79e790418a544e8
   RNFBApp: 5810d39f89d38272f29d9908cb19ef641922c081
   RNFBCrashlytics: 56e4773cf2d3710dd1e42d2f38d3667589d743f5
   RNGestureHandler: 28bdf9a766c081e603120f79e925b72817c751c6
   RNReanimated: 1873432b0b86d0224bbe19aacea7ad8eef4e7518
   RNScreens: 2b73f5eb2ac5d94fbd61fa4be0bfebd345716825
   RNSVG: ba3e7232f45e34b7b47e74472386cf4e1a676d0a
+  SDWebImage: a7f831e1a65eb5e285e3fb046a23fcfbf08e696d
+  SDWebImageWebPCoder: 908b83b6adda48effe7667cd2b7f78c897e5111d
   SocketRocket: f32cd54efbe0f095c4d7594881e52619cfe80b17
   sqlite3: f163dbbb7aa3339ad8fc622782c2d9d7b72f7e9c
   UMAppLoader: 5df85360d65cabaef544be5424ac64672e648482
-  Yoga: 1b901a6d6eeba4e8a2e8f308f708691cdb5db312
+  Yoga: 64cd2a583ead952b0315d5135bf39e053ae9be70
 
 PODFILE CHECKSUM: d59ebf4f7bf380484b7a43b4d76c4eb1ece5846c
 

--- a/apps/tlon-mobile/package.json
+++ b/apps/tlon-mobile/package.json
@@ -72,6 +72,7 @@
     "react-native-branch": "^5.9.0",
     "react-native-country-codes-picker": "^2.3.3",
     "react-native-device-info": "^10.8.0",
+    "react-native-fast-image": "^8.6.3",
     "react-native-fetch-api": "^3.0.0",
     "react-native-gesture-handler": "~2.14.0",
     "react-native-get-random-values": "^1.11.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -66,6 +66,7 @@
         "react-native-branch": "^5.9.0",
         "react-native-country-codes-picker": "^2.3.3",
         "react-native-device-info": "^10.8.0",
+        "react-native-fast-image": "^8.6.3",
         "react-native-fetch-api": "^3.0.0",
         "react-native-gesture-handler": "~2.14.0",
         "react-native-get-random-values": "^1.11.0",
@@ -32596,6 +32597,15 @@
       "integrity": "sha512-gnBkjyZNEqRd+5BNrdzuvmlraHTCH/to2x0Gp9rtDt0O9xWWW1MTYohUVWX9A0Ad2HVYcGanDCIvjWp4ngMZFg==",
       "peerDependencies": {
         "react-native": "*"
+      }
+    },
+    "node_modules/react-native-fast-image": {
+      "version": "8.6.3",
+      "resolved": "https://registry.npmjs.org/react-native-fast-image/-/react-native-fast-image-8.6.3.tgz",
+      "integrity": "sha512-Sdw4ESidXCXOmQ9EcYguNY2swyoWmx53kym2zRsvi+VeFCHEdkO+WG1DK+6W81juot40bbfLNhkc63QnWtesNg==",
+      "peerDependencies": {
+        "react": "^17 || ^18",
+        "react-native": ">=0.60.0"
       }
     },
     "node_modules/react-native-fetch-api": {

--- a/packages/ui/src/components/ChatMessage/ChatContent.tsx
+++ b/packages/ui/src/components/ChatMessage/ChatContent.tsx
@@ -18,7 +18,6 @@ import {
   isShip,
   isStrikethrough,
 } from '@tloncorp/shared/dist/urbit/content';
-import { findLastIndex } from 'lodash';
 
 import { Image, SizableText, View, YStack } from '../../core';
 import { Button } from '../Button';

--- a/packages/ui/src/components/ListItem.tsx
+++ b/packages/ui/src/components/ListItem.tsx
@@ -57,31 +57,17 @@ function ListItemIcon({
   const resolvedBackgroundColor = backgroundColor ?? '$secondaryBackground';
   const size = '$4xl';
   return imageUrl ? (
-    imageUrl.includes('.svg') ? (
-      <View
-        width={size}
-        height={size}
-        borderRadius="$s"
-        //@ts-ignore This is an arbitrary, user-set color
-        backgroundColor={resolvedBackgroundColor}
-        overflow="hidden"
-        {...props}
-      >
-        <RemoteSvg width="100%" height="100%" uri={imageUrl} />
-      </View>
-    ) : (
-      <Image
-        width={size}
-        height={size}
-        borderRadius="$s"
-        //@ts-ignore This is an arbitrary, user-set color
-        backgroundColor={resolvedBackgroundColor}
-        {...props}
-        source={{
-          uri: imageUrl,
-        }}
-      />
-    )
+    <Image
+      width={size}
+      height={size}
+      borderRadius="$s"
+      //@ts-ignore This is an arbitrary, user-set color
+      backgroundColor={resolvedBackgroundColor}
+      {...props}
+      source={{
+        uri: imageUrl,
+      }}
+    />
   ) : (
     <Stack
       //@ts-ignore This is an arbitrary, user-set color

--- a/packages/ui/src/components/ListItem.tsx
+++ b/packages/ui/src/components/ListItem.tsx
@@ -1,18 +1,7 @@
-import React, { ComponentProps, PropsWithChildren, ReactElement } from 'react';
-import { Pressable } from 'react-native';
-import {
-  Image,
-  NativePlatform,
-  Stack,
-  Text,
-  View,
-  XStack,
-  YStack,
-  styled,
-  withStaticProperties,
-} from 'tamagui';
+import { ComponentProps, PropsWithChildren, ReactElement } from 'react';
+import { styled, withStaticProperties } from 'tamagui';
 
-import { SizableText } from '../core';
+import { Image, SizableText, Stack, Text, View, XStack, YStack } from '../core';
 import { Icon } from './Icon';
 import RemoteSvg from './RemoteSvg';
 

--- a/packages/ui/src/components/RemoteSvg.tsx
+++ b/packages/ui/src/components/RemoteSvg.tsx
@@ -1,5 +1,6 @@
 import { UriProps } from 'react-native-svg';
-import { Image } from 'tamagui';
+
+import { Image } from '../core';
 
 export default function RemoteSvg(props: UriProps) {
   return (

--- a/packages/ui/src/core/Image.native.tsx
+++ b/packages/ui/src/core/Image.native.tsx
@@ -18,7 +18,12 @@ export const Image = React.forwardRef(function (
         ? props.source?.uri
         : undefined;
   }, [props.source]);
-  if (url && url.endsWith('svg')) {
+
+  const isSvg = useMemo(() => {
+    return url && new URL(url).pathname.endsWith('svg');
+  }, [url]);
+
+  if (url && isSvg) {
     return <StyledSvgUri {...props} uri={url} ref={ref} />;
   }
   return <StyledFastImage {...props} ref={ref} />;

--- a/packages/ui/src/core/Image.native.tsx
+++ b/packages/ui/src/core/Image.native.tsx
@@ -1,0 +1,25 @@
+import React, { ComponentProps, useMemo } from 'react';
+import FastImage from 'react-native-fast-image';
+import { SvgUri } from 'react-native-svg';
+import { styled } from 'tamagui';
+
+const StyledFastImage = styled(FastImage, { name: 'FastImage' });
+const StyledSvgUri = styled(SvgUri, { name: 'Svg' });
+
+export const Image = React.forwardRef(function (
+  // TODO: Add support for fallback and onLoad, props are only slightly different
+  props: Omit<ComponentProps<typeof StyledFastImage>, 'fallback' | 'onLoad'>,
+  ref
+) {
+  const url = useMemo(() => {
+    return typeof props.source === 'string'
+      ? props.source
+      : typeof props.source === 'object'
+        ? props.source?.uri
+        : undefined;
+  }, [props.source]);
+  if (url && url.endsWith('svg')) {
+    return <StyledSvgUri {...props} uri={url} ref={ref} />;
+  }
+  return <StyledFastImage {...props} ref={ref} />;
+});

--- a/packages/ui/src/core/Image.tsx
+++ b/packages/ui/src/core/Image.tsx
@@ -1,0 +1,1 @@
+export { Image } from 'tamagui';

--- a/packages/ui/src/core/index.ts
+++ b/packages/ui/src/core/index.ts
@@ -1,3 +1,4 @@
 export * from './tamagui';
 export * from './Text';
 export * from './Button';
+export * from './Image';

--- a/packages/ui/src/core/tamagui.ts
+++ b/packages/ui/src/core/tamagui.ts
@@ -1,6 +1,5 @@
 export {
   Circle,
-  Image,
   useTheme,
   useStyle,
   View,

--- a/packages/ui/src/index.ts
+++ b/packages/ui/src/index.ts
@@ -1,7 +1,7 @@
 export * from './core';
 
 export * from './components/Avatar';
-export * from './components/Channel'
+export * from './components/Channel';
 export * from './components/Icon';
 export * from './components/ListItem';
 export * from './components/TamaguiProvider';
@@ -13,4 +13,4 @@ export * from './components/GroupListItem';
 export * from './components/GroupList';
 export * from './components/ChannelSwitcherSheet';
 export * from './tamagui.config';
-export * from './contexts'
+export * from './contexts';


### PR DESCRIPTION
Replacement for native `Image` with more aggressive caching + performance config: https://github.com/DylanVann/react-native-fast-image.

At some point we should also consider caching svg source for svg images.