### PR TITLE
Add declaration maps to shared package

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -37972,7 +37972,6 @@
     "packages/shared": {
       "name": "@tloncorp/shared",
       "version": "1.0.0",
-      "hasInstallScript": true,
       "dependencies": {
         "@urbit/api": "^2.2.0",
         "big-integer": "^1.6.52",
@@ -37984,10 +37983,24 @@
         "better-sqlite3": "^9.4.3",
         "drizzle-kit": "^0.20.14",
         "tsup": "^8.0.1",
+        "typescript": "^5.1.3",
         "vitest": "^1.4.0"
       },
       "peerDependencies": {
         "react": "^18.2.0"
+      }
+    },
+    "packages/shared/node_modules/typescript": {
+      "version": "5.1.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.1.3.tgz",
+      "integrity": "sha512-XH627E9vkeqhlZFQuL+UsyAXEnibT0kWR2FWONlr4sTjvxyJYnyefgrkyECLzM5NenmKzRAy2rR/OlYLA1HkZw==",
+      "dev": true,
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
       }
     },
     "packages/ui": {

--- a/packages/shared/.gitignore
+++ b/packages/shared/.gitignore
@@ -1,1 +1,2 @@
 dist/
+tsconfig.tsbuildinfo

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -10,6 +10,7 @@
     "dev:migrations": "concurrently \"npm run watch-migrations\" \"npm run dev\"",
     "postinstall": "npm run build",
     "test": "vitest",
+    "types": "tsc",
     "lint:format": "prettier src/ --write",
     "lint:all": "npm run lint:format",
     "generate": "npm run generate:migration",
@@ -27,6 +28,7 @@
     "better-sqlite3": "^9.4.3",
     "drizzle-kit": "^0.20.14",
     "tsup": "^8.0.1",
+    "typescript": "^5.1.3",
     "vitest": "^1.4.0"
   },
   "peerDependencies": {

--- a/packages/shared/tsconfig.json
+++ b/packages/shared/tsconfig.json
@@ -6,7 +6,26 @@
     "esModuleInterop": true,
     "allowSyntheticDefaultImports": true,
     "module": "NodeNext",
-    "jsx": "react-jsx"
+    "jsx": "react-jsx",
+    "declaration": true,
+    "declarationMap": true,
+    "emitDeclarationOnly": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true,
+    "rootDir": "./src",
+    "outDir": "dist",
+    "composite": true,
+    "allowJs": true,
   },
-  "exclude": ["../../node_modules", "public"]
+  "files": [
+    "./src/index.ts",
+  ],
+  "include": [
+    "src/**/*",
+    "src/**/*.json",
+    "src/**/*.sql"
+  ],
+  "exclude": [
+    "src/**/*.test.ts",
+  ]
 }

--- a/packages/shared/tsup.config.ts
+++ b/packages/shared/tsup.config.ts
@@ -1,3 +1,4 @@
+import { exec } from 'child_process';
 import { defineConfig } from 'tsup';
 
 export default defineConfig({
@@ -10,11 +11,17 @@ export default defineConfig({
     'src/api/index.ts',
   ],
   format: ['esm'],
-  dts: true,
   minify: false,
   external: ['react'],
   ignoreWatch: ['**/node_modules/**', '**/.git/**'],
   loader: {
     '.sql': 'text',
+  },
+  onSuccess() {
+    return new Promise((resolve, reject) => {
+      exec('npm run types', (err) => {
+        err ? reject(err) : resolve();
+      });
+    });
   },
 });


### PR DESCRIPTION
This should enable us to use "go to definition" to go directly to the source file, rather than .d.ts file.