### PR TITLE
Perf: set cache time to 5m

### DIFF
--- a/apps/tlon-web/src/queryClient.ts
+++ b/apps/tlon-web/src/queryClient.ts
@@ -3,7 +3,7 @@ import { QueryClient } from '@tanstack/react-query';
 const queryClient = new QueryClient({
   defaultOptions: {
     queries: {
-      cacheTime: Infinity,
+      cacheTime: 5 * 60 * 1000,
       refetchOnWindowFocus: false,
       refetchOnReconnect: false,
     },


### PR DESCRIPTION
I think it's worth trying this on wannec to see if it helps with the issue we're seeing of the app getting progressively slower overtime (and also getting much faster when the user clears the cache).

Five minutes is the suggested "sane" cache time by tanstack. We could bump it out to maybe a day or something if five minutes is too noticeable.