### PR TITLE
groups: fix issue where admins can't delete if they're not the host

### DIFF
--- a/desk/lib/channel-utils.hoon
+++ b/desk/lib/channel-utils.hoon
@@ -306,7 +306,6 @@
     ;:  weld
         /gx
         groups-scry
-        /channel/[kind.nest]/(scot %p ship.nest)/[name.nest]
         /fleet/(scot %p her)/is-bloc/loob
     ==  ==
   ::


### PR DESCRIPTION
Apparently the `is-admin` util has been broken. It was scrying into the wrong place to check if a user is an admin. It only appeared to work because of an early return where we check if the ship is also the host of the channel.

If an admin was *not* also the host of the channel, then they were not able to delete messages in that channel.