### PR TITLE
edit: allow editing a message with a quoted reply

### DIFF
--- a/apps/tlon-web/src/chat/ChatInput/ChatInput.tsx
+++ b/apps/tlon-web/src/chat/ChatInput/ChatInput.tsx
@@ -316,6 +316,22 @@ export default function ChatInput({
 
   const onUpdate = useRef(
     debounce(({ editor }: HandlerParams) => {
+      const editorJson = editor.getJSON();
+      // if the only content is an empty mention, clear the draft
+      // this is a workaround for a bug where the editor doesn't clear
+      // the mention after sending a reply
+      const isEmtpyMention =
+        editorJson?.content?.length === 1 &&
+        editorJson?.content[0].content?.length === 2 &&
+        editorJson?.content[0].content[0].type === 'mention' &&
+        editorJson?.content[0].content[1].type === 'text' &&
+        editorJson?.content[0].content[1].text === ': ';
+
+      if (isEmtpyMention) {
+        setDraft(inlinesToJSON(['']));
+        return;
+      }
+
       setDraft(editor.getJSON());
     }, 300)
   );

--- a/apps/tlon-web/src/chat/ChatMessage/ChatMessage.tsx
+++ b/apps/tlon-web/src/chat/ChatMessage/ChatMessage.tsx
@@ -4,6 +4,7 @@ import {
   Post,
   Story,
   Unread,
+  VerseBlock,
   constructStory,
 } from '@tloncorp/shared/dist/urbit/channel';
 import { DMUnread } from '@tloncorp/shared/dist/urbit/dms';
@@ -320,10 +321,22 @@ const ChatMessage = React.memo<
 
       const onSubmit = useCallback(
         async (editor: Editor) => {
-          // const now = Date.now();
           const editorJson = editor.getJSON();
+          // users can't edit blocks, so we need to preserve them
+          // and only update the inline content
+          const existingBlocks = (
+            essay.content.filter((verse) => 'block' in verse) as VerseBlock[]
+          ).map((b) => b.block);
           const inlineContent = JSONToInlines(editorJson);
           const content = constructStory(inlineContent);
+
+          if (existingBlocks.length > 0) {
+            content.push(
+              ...existingBlocks.map((b) => ({
+                block: b,
+              }))
+            );
+          }
 
           if (content.length === 0) {
             return;
@@ -344,9 +357,13 @@ const ChatMessage = React.memo<
         [editPost, whom, seal.id, essay, setSearchParams]
       );
 
+      // we only want to pass in the inline content to the editor
+      const contentInlines = essay.content.filter((verse) => 'inline' in verse);
+      const jsonContent = diaryMixedToJSON(contentInlines);
+
       const messageEditor = useMessageEditor({
         whom: writ.seal.id,
-        content: diaryMixedToJSON(essay.content),
+        content: jsonContent,
         uploadKey: 'chat-editor-should-not-be-used-for-uploads',
         allowMentions: true,
         onEnter: useCallback(


### PR DESCRIPTION
fixes LAND-1750 by only attempting to edit inlines

Also fixes (in a hacky way, didn't root cause it) an issue with our drafts sometimes containing empty mentions. You would usually see this after sending a quote reply, leaving the channel, and coming back.