### PR TITLE
mar: add dummy json grow

### DIFF
--- a/desk/mar/dummy.hoon
+++ b/desk/mar/dummy.hoon
@@ -3,9 +3,11 @@
 ++  grow
   |%
   ++  noun  dum
+  ++  json  dum
   --
 ++  grab
   |%
   +$  noun  *
+  +$  json  *
   --
 --


### PR DESCRIPTION
Until recently arvo had a bug where sometimes clay would return a false conversion gate when requesting a mark that is named the same as something in the subject. https://github.com/urbit/urbit/pull/6898 is going out in the next release and will fix this. 

Consider the following code;

https://github.com/tloncorp/tlon-apps/blob/e3f642ee5d5056c59ead51f015ed3e26fb5db0cb/apps/tlon-web/src/state/bootstrap.ts#L84-L88

This causes ships on pre-release arvo to experience this from time to time:

```
clay: read-at-tako fail [desk=%groups care=%c case=[%da p=~2024.4.11..11.30.21..584b] path=/json/ui-vita]
[%no-cast-from %json %ui-vita]
[%error-building-cast %json %ui-vita]
[%error-building-tube %json %ui-vita]
```

This error message is harmless but annoying.

`/mar/ui/vita` calls out to `/mar/dummy` so I added the json conversion here to fix this issue.