### PR TITLE
GroupActions: don't prevent non-hosting admins from leaving group

### DIFF
--- a/apps/tlon-web/src/groups/GroupActions.tsx
+++ b/apps/tlon-web/src/groups/GroupActions.tsx
@@ -13,7 +13,12 @@ import VolumeSetting from '@/components/VolumeSetting';
 import EllipsisIcon from '@/components/icons/EllipsisIcon';
 import useIsGroupUnread from '@/logic/useIsGroupUnread';
 import { useIsMobile } from '@/logic/useMedia';
-import { citeToPath, getPrivacyFromGroup, useCopy } from '@/logic/utils';
+import {
+  citeToPath,
+  getPrivacyFromGroup,
+  preSig,
+  useCopy,
+} from '@/logic/utils';
 import {
   useAmAdmin,
   useGang,
@@ -112,6 +117,7 @@ const GroupActions = React.memo(
     const { claim } = useGang(flag);
     const location = useLocation();
     const navigate = useNavigate();
+    const [host, name] = flag.split('/');
     const hasActivity = isGroupUnread(flag);
     const group = useGroup(flag);
     const privacy = group ? getPrivacyFromGroup(group) : undefined;
@@ -303,7 +309,7 @@ const GroupActions = React.memo(
       keepOpenOnClick: true,
     });
 
-    if (!flag.includes(ship) && !isAdmin) {
+    if (preSig(ship) !== host) {
       actions.push({
         key: 'leave',
         type: 'destructive',


### PR DESCRIPTION
Removes a erroneous check for non-admin status in the "Leave group" GroupAction. Instead, we just look at the flag (is the current ship the host?).

We probably also need to bolster this to prevent channel hosts from leaving the group and orphaning their hosted channels.

PR Checklist
- [ ] Includes changes to desk files
- [x] Tested locally with the Vite dev server proxied against a livenet planet
- [ ] If a new feature, includes automated tests
- [ ] Comments added anywhere logic may be confusing without context