### PR TITLE
mobile: misc fixes for init related data.

### DIFF
--- a/packages/shared/src/api/initApi.ts
+++ b/packages/shared/src/api/initApi.ts
@@ -15,7 +15,7 @@ export interface InitData {
 export const getInitData = async () => {
   const response = await scry<ub.GroupsInit>({
     app: 'groups-ui',
-    path: '/init',
+    path: '/v1/init',
   });
   // TODO: handle gangs,possibly handle response.channels, but not sure if
   // necessary.

--- a/packages/shared/src/api/unreadsApi.ts
+++ b/packages/shared/src/api/unreadsApi.ts
@@ -1,3 +1,5 @@
+import { daToDate, decToUd, udToDec } from '@urbit/api';
+
 import * as db from '../db';
 import { threadUnreads } from '../db/schema';
 import type * as ub from '../urbit';
@@ -80,7 +82,9 @@ export const toClientUnread = (
     countWithoutThreads: unread.unread?.count ?? 0,
     firstUnreadPostId: unread.unread?.id ?? null,
     firstUnreadPostReceivedAt: unread.unread?.id
-      ? udToDate(unread.unread?.id)
+      ? type === 'dm'
+        ? udToDate(decToUd(unread.unread.id.split('/')[1]))
+        : udToDate(unread.unread.id)
       : null,
     threadUnreads: Object.entries(unread.threads ?? {}).map(
       ([threadId, thread]) =>

--- a/packages/shared/src/db/queries.ts
+++ b/packages/shared/src/db/queries.ts
@@ -819,6 +819,8 @@ export const insertPinnedItems = createWriteQuery(
   async (pinnedItems: Pin[]) => {
     return client.transaction(async (tx) => {
       await tx.delete($pins);
+      // users may not have pinned items
+      if (!pinnedItems.length) return;
       await tx.insert($pins).values(pinnedItems);
     });
   },

--- a/packages/ui/src/components/ChatList.tsx
+++ b/packages/ui/src/components/ChatList.tsx
@@ -24,6 +24,10 @@ export function ChatList({
   onLongPressItem?: (chat: db.ChannelSummary) => void;
 }) {
   const data = useMemo(() => {
+    if (pinned.length === 0) {
+      return [{ title: 'All', data: unpinned }];
+    }
+
     return [
       { title: 'Pinned', data: pinned },
       { title: 'All', data: unpinned },


### PR DESCRIPTION
1) we should use the new /v1/init endpoint.
2) DMs have a different message id type (patp with a ud that has decimals in it), our unreadsApi didn't account for that. 
3) users may not always have pins, we were failing to insert because we tried to pass an empty array into insertPinnedItems 
4) since we don't always have pins, hide that section in the ui.
