### PR TITLE
web: add missing find route back (fixes desktop lure links)

### DIFF
--- a/apps/tlon-web/src/app.tsx
+++ b/apps/tlon-web/src/app.tsx
@@ -187,6 +187,7 @@ const GroupsRoutes = React.memo(({ isMobile, isSmall }: RoutesProps) => {
       <Routes location={state?.backgroundLocation || location}>
         <Route element={<AppNav />}>
           <Route element={<GroupsNav />}>
+            <Route path="/find/:ship/:name" element={<GroupPreviewModal />} />
             <Route path="/groups" element={<GroupsNav />} />
             <Route index element={isMobile ? <MobileGroupsNavHome /> : null} />
             <Route


### PR DESCRIPTION
Looks like this (user sees the home screen to the app, with the group preview modal):

![image](https://github.com/tloncorp/tlon-apps/assets/1221094/2dc04dc6-7a54-426a-9ecb-0299c8e4aab6)

(also note that I cut off half of the screen in the screenshot, the modal shows in the middle like it normally does)