### PR TITLE
channels: remove duplicate replies

### DIFF
--- a/apps/tlon-web/src/heap/HeapDetail/HeapDetailSidebar/HeapDetailSidebarInfo.tsx
+++ b/apps/tlon-web/src/heap/HeapDetail/HeapDetailSidebar/HeapDetailSidebarInfo.tsx
@@ -4,6 +4,7 @@ import Author from '@/chat/ChatMessage/Author';
 import getKindDataFromEssay from '@/logic/getKindData';
 import { firstInlineSummary } from '@/logic/tiptap';
 import { URL_REGEX, getFirstInline, makePrettyDay } from '@/logic/utils';
+import { useIsPostPending } from '@/state/channel/channel';
 
 interface HeapDetailSidebarProps {
   essay: PostEssay;
@@ -13,6 +14,10 @@ export default function HeapDetailSidebarInfo({
   essay,
 }: HeapDetailSidebarProps) {
   const { content, author, sent } = essay;
+  const isPending = useIsPostPending({
+    author,
+    sent,
+  });
   if (!content || content.length === 0) return null;
 
   const { title } = getKindDataFromEssay(essay);
@@ -33,9 +38,11 @@ export default function HeapDetailSidebarInfo({
         <time className="text-base font-semibold text-gray-400">
           {makePrettyDay(unixDate)}
         </time>
-        <span className="ml-auto text-sm font-semibold text-gray-400">
-          Saved, awaiting host confirmation
-        </span>
+        {isPending && (
+          <span className="ml-auto text-sm font-semibold text-gray-400">
+            Saved, awaiting host confirmation
+          </span>
+        )}
       </div>
 
       <Author ship={author} />

--- a/apps/tlon-web/src/state/channel/channel.ts
+++ b/apps/tlon-web/src/state/channel/channel.ts
@@ -64,10 +64,8 @@ import {
   cacheIdFromString,
   cacheIdToString,
   checkNest,
-  log,
   nestToFlag,
   stringToTa,
-  useIsDmOrMultiDm,
   whomIsFlag,
 } from '@/logic/utils';
 import queryClient from '@/queryClient';
@@ -1303,7 +1301,18 @@ export function usePost(nest: Nest, postId: string, disabled = false) {
     ...post,
     seal: {
       ...post?.seal,
-      replies: [...diff, ...pendingReplies],
+      replies: [
+        ...diff,
+        ...pendingReplies.filter(([, reply]) => {
+          const clientIds = diff.map(([, r]) =>
+            r ? `${r.memo.author}:${r.memo.sent}` : ''
+          );
+          return !clientIds.some(
+            (id) =>
+              id === (reply ? `${reply.memo.author}:${reply.memo.sent}` : '')
+          );
+        }),
+      ],
     },
   };
 


### PR DESCRIPTION
Fixes LAND-1754 and LAND-1764, heap detail wasn't even checking pending and we needed to do the same de-duping with replies as we did with posts. 

PR Checklist
- [ ] Includes changes to desk files
- [ ] Describes how you tested the PR locally (test ship vs livenet)
- [ ] If a new feature, includes automated tests
- [ ] Comments added anywhere logic may be confusing without context