### PR TITLE
desktop: fix missing groups sidebar metadata

### DIFF
--- a/apps/tlon-web/src/app.tsx
+++ b/apps/tlon-web/src/app.tsx
@@ -1,6 +1,7 @@
 // Copyright 2022, Tlon Corporation
 import { TooltipProvider } from '@radix-ui/react-tooltip';
 import { TamaguiProvider, config } from '@tloncorp/ui';
+import '@tloncorp/ui/src/tamagui.d.ts';
 import cookies from 'browser-cookies';
 import { usePostHog } from 'posthog-js/react';
 import React, { Suspense, useEffect, useMemo, useState } from 'react';

--- a/apps/tlon-web/src/groups/GroupSidebar/GroupSidebar.tsx
+++ b/apps/tlon-web/src/groups/GroupSidebar/GroupSidebar.tsx
@@ -46,6 +46,12 @@ function GroupHeader() {
   const calm = useCalm();
   const isDark = useIsDark();
 
+  useEffect(() => {
+    if (realGroup) {
+      lastGroupRef.current = realGroup;
+    }
+  }, [realGroup]);
+
   const bgStyle = useCallback(() => {
     if (
       group &&

--- a/apps/tlon-web/tsconfig.json
+++ b/apps/tlon-web/tsconfig.json
@@ -19,8 +19,7 @@
       "vite/client",
       "vitest/globals",
       "@testing-library/jest-dom",
-      "vite-plugin-pwa/react",
-      "../../packages/ui/src/tamagui.d.ts"
+      "vite-plugin-pwa/react"
     ],
     "paths": {
       "@/*": ["./src/*"]


### PR DESCRIPTION
There was a recent performance optimization targeting sidebar transition lag that updated the sidebar to avoid re-rendering. The caching there seems too aggressive causing missing group metadata when refreshed or navigated to directly (no title or icon). This small fix makes sure we use the correct data there.

Performance wise, I didn't notice an impact. Though the issue was subtle iirc.

Also smuggling in a small change to avoid `tsc` failing to find the tamagui type declarations.

FIxes LAND-1765