### PR TITLE
ops: manual build order

### DIFF
--- a/apps/tlon-mobile/package.json
+++ b/apps/tlon-mobile/package.json
@@ -21,7 +21,7 @@
     "lint:staged": "lint-staged",
     "test": "vitest --watch false",
     "tsc": "tsc --noEmit",
-    "postinstall": "npm run generate",
+    "build": "npm run generate",
     "eas-build-post-install": "./post-install",
     "cosmos": "cosmos-native"
   },

--- a/package-lock.json
+++ b/package-lock.json
@@ -25,7 +25,6 @@
     },
     "apps/tlon-mobile": {
       "version": "4.0.0",
-      "hasInstallScript": true,
       "dependencies": {
         "@10play/tentap-editor": "^0.4.55",
         "@google-cloud/recaptcha-enterprise-react-native": "^18.3.0",
@@ -38008,7 +38007,6 @@
     },
     "packages/editor": {
       "name": "@tloncorp/editor",
-      "hasInstallScript": true,
       "dependencies": {
         "@tiptap/core": "^2.0.3",
         "@tiptap/extension-code-block": "^2.0.3",
@@ -38586,7 +38584,6 @@
     },
     "packages/ui": {
       "name": "@tloncorp/ui",
-      "hasInstallScript": true,
       "dependencies": {
         "@tamagui/animations-moti": "1.93.2",
         "@tamagui/get-token": "1.93.2",

--- a/package.json
+++ b/package.json
@@ -8,15 +8,20 @@
   ],
   "scripts": {
     "build:shared": "npm run build --prefix ./packages/shared",
-    "build:web": "npm run build:shared && npm run build --prefix ./apps/tlon-web",
-    "build:editor": "npm run build:shared && npm run build --prefix ./packages/editor",
+    "build:ui": "npm run build --prefix ./packages/ui",
+    "build:editor": "npm run build --prefix ./packages/editor",
+    "build:web": "npm run build --prefix ./apps/tlon-web",
+    "build:mobile": "npm run build --prefix ./apps/tlon-mobile",
+    "build:apps": "npm run build:mobile",
+    "build:packages": "npm run build:shared && npm run build:ui && npm run build:editor",
+    "build:all": "npm run build:packages && npm run build:apps",
     "dev:shared": "npm run dev --prefix ./packages/shared",
     "dev:android": "concurrently \"npm run dev:shared\" \"npm run dev --prefix ./apps/tlon-mobile\" \"npm run android --prefix ./apps/tlon-mobile\"",
     "dev:ios": "concurrently \"npm run dev:shared\" \"npm run dev --prefix ./apps/tlon-mobile\" \"npm run ios --prefix ./apps/tlon-mobile\"",
     "dev:web": "concurrently \"npm run dev:shared\" \"npm run dev-no-ssl --prefix ./apps/tlon-web\"",
     "test": "npm run test --workspaces --if-present -- run -u",
     "prepare": "husky",
-    "postinstall": "npx patch-package"
+    "postinstall": "npx patch-package && npm run build:all"
   },
   "devDependencies": {
     "@trivago/prettier-plugin-sort-imports": "^4.3.0",

--- a/packages/editor/package.json
+++ b/packages/editor/package.json
@@ -3,8 +3,7 @@
   "scripts": {
     "dev": "vite",
     "build": "vite build && npm run post-build",
-    "post-build": "node ../../node_modules/@10play/tentap-editor/scripts/buildEditor.js ./dist/index.html",
-    "postinstall": "npm run build"
+    "post-build": "node ../../node_modules/@10play/tentap-editor/scripts/buildEditor.js ./dist/index.html"
   },
   "dependencies": {
     "@tiptap/core": "^2.0.3",

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -6,9 +6,9 @@
   "types": "./dist/index.d.ts",
   "scripts": {
     "build": "tsup",
+    "preinstall": "rm -f ./tsconfig.tsbuildinfo",
     "dev": "npm run build -- --watch",
     "dev:migrations": "concurrently \"npm run watch-migrations\" \"npm run dev\"",
-    "postinstall": "npm run build",
     "test": "vitest",
     "types": "tsc",
     "lint:format": "prettier src/ --write",

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -13,8 +13,7 @@
     "build": "npx tamagui-build --skip-types && cp -R src/assets/icons/*.svg dist/cjs/assets/icons/ && cp -R src/assets/icons/*.svg dist/esm/assets/icons/",
     "watch": "mkdir -p dist/cjs/assets/icons && mkdir -p dist/esm/assets/icons && cp -R src/assets/icons/*.svg dist/cjs/assets/icons/ && cp -R src/assets/icons/*.svg dist/esm/assets/icons/ && tamagui-build --watch --skip-types",
     "lint:format": "prettier src/ --write",
-    "lint:all": "npm run lint:format",
-    "postinstall": "npm run build"
+    "lint:all": "npm run lint:format"
   },
   "dependencies": {
     "@tamagui/animations-moti": "1.93.2",


### PR DESCRIPTION
- move post-install logic at app & package level to build scripts (avoiding post-install lifecycle hook)
- add scripts to top level `package.json` for building sub-packages in acceptable order
- call those build scripts in top level post-install hook

Want to make sure this fixes the issues we're observing before we try to build things concurrently. Anecdotally, it spends most of the time waiting for the initial package install anyhow.

Also adds preinstall hook to remove that troublesome `tsconfig.tsbuildinfo` file in `packages/shared`