### PR TITLE
native: fix scrolling in chat channels

### DIFF
--- a/packages/ui/src/components/Channel/ChatScroll.tsx
+++ b/packages/ui/src/components/Channel/ChatScroll.tsx
@@ -111,7 +111,7 @@ export default function ChatScroll({
   }, []);
 
   return (
-    <View flex={1} onPress={handleContainerPressed}>
+    <View flex={1}>
       {unreadCount && !hasPressedGoToBottom && (
         <UnreadsButton onPress={pressedGoToBottom} />
       )}
@@ -126,6 +126,7 @@ export default function ChatScroll({
         onStartReached={onStartReached}
         contentContainerStyle={contentContainerStyle}
         inverted
+        onScrollBeginDrag={handleContainerPressed}
         onScrollToIndexFailed={handleScrollToIndexFailed}
       />
     </View>


### PR DESCRIPTION
fixes land-1769 by removing the onPress from View, passing the same handler to onScrollBeginDrag, which achieves the same effect afaict.
