### PR TITLE
native: remove chat tab from navigation

### DIFF
--- a/apps/tlon-mobile/src/navigation/TabStack.tsx
+++ b/apps/tlon-mobile/src/navigation/TabStack.tsx
@@ -58,21 +58,7 @@ export const TabStack = () => {
           tabBarShowLabel: false,
         }}
       />
-      <Tab.Screen
-        name="Messages"
-        component={View}
-        options={{
-          tabBarIcon: ({ focused }) => (
-            <TabIcon
-              type={'Messages'}
-              activeType={'MessagesFilled'}
-              isActive={focused}
-              hasUnreads={(unreadCount?.dms ?? 0) > 0}
-            />
-          ),
-          tabBarShowLabel: false,
-        }}
-      />
+
       <Tab.Screen
         name="Activity"
         component={View}
@@ -106,9 +92,9 @@ function AvatarTabIcon({ id, focused }: { id: string; focused: boolean }) {
   return isLoading && !contact ? null : (
     // Uniquely sized avatar for tab bar
     <Avatar
-      width={20}
-      height={20}
-      borderRadius={3}
+      width={26}
+      height={26}
+      borderRadius={6}
       contact={contact}
       contactId={id}
       opacity={focused ? 1 : 0.6}

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "build:all": "npm run build:packages && npm run build:apps",
     "dev:shared": "npm run dev --prefix ./packages/shared",
     "dev:android": "concurrently \"npm run dev:shared\" \"npm run dev --prefix ./apps/tlon-mobile\" \"npm run android --prefix ./apps/tlon-mobile\"",
-    "dev:ios": "concurrently \"npm run dev:shared\" \"npm run dev --prefix ./apps/tlon-mobile\" \"npm run ios --prefix ./apps/tlon-mobile\"",
+    "dev:ios": "concurrently \"npm run dev:shared\" \"npm run dev --prefix ./apps/tlon-mobile\" \"npm run ios --prefix ./apps/tlon-mobile\" \"npm run watch --prefix ./packages/ui\"",
     "dev:web": "concurrently \"npm run dev:shared\" \"npm run dev-no-ssl --prefix ./apps/tlon-web\"",
     "test": "npm run test --workspaces --if-present -- run -u",
     "prepare": "husky",


### PR DESCRIPTION
Very straightforward; removes the message bubble from the bottom tab navigation bar.

Also fixes the `npm run dev:ios` mega-script.