### PR TITLE
native: eliminate left-side icons in MessageInputBase

### DIFF
--- a/packages/ui/src/components/MessageInput/MessageInputBase.tsx
+++ b/packages/ui/src/components/MessageInput/MessageInputBase.tsx
@@ -1,7 +1,7 @@
 import { JSONContent } from '@tiptap/core';
 import { PropsWithChildren } from 'react';
 
-import { Attachment, Camera, ChannelGalleries, Send } from '../../assets/icons';
+import { ArrowUp } from '../../assets/icons';
 import { XStack } from '../../core';
 import { IconButton } from '../IconButton';
 
@@ -23,22 +23,11 @@ export const MessageInputContainer = ({
       gap="$l"
       alignItems="center"
     >
-      <XStack gap="$l">
-        <IconButton onPress={() => {}}>
-          <Camera />
-        </IconButton>
-        <IconButton onPress={() => {}}>
-          <Attachment />
-        </IconButton>
-        <IconButton onPress={() => {}}>
-          <ChannelGalleries />
-        </IconButton>
-      </XStack>
       <XStack flex={1} gap="$l" alignItems="center">
         {children}
         <IconButton onPress={onPressSend}>
           {/* TODO: figure out what send button should look like */}
-          <Send />
+          <ArrowUp />
         </IconButton>
       </XStack>
     </XStack>


### PR DESCRIPTION
Removes the non-functional attachment icons in MessageInputBase. Also switches the send button to ArrowUp.

![Screenshot 2024-04-18 at 3 52 19 PM](https://github.com/tloncorp/tlon-apps/assets/748181/e1f523f2-965c-488d-beb6-346ecbc8f376)
