### PR TITLE
native: add unread count to ChannelListItem

### DIFF
--- a/packages/shared/src/db/queries.ts
+++ b/packages/shared/src/db/queries.ts
@@ -463,6 +463,7 @@ export const getChannelWithLastPostAndMembers = createReadQuery(
             contact: true,
           },
         },
+        unread: true,
       },
     });
   },

--- a/packages/shared/src/db/schema.ts
+++ b/packages/shared/src/db/schema.ts
@@ -371,8 +371,9 @@ export const postsRelations = relations(posts, ({ one, many }) => ({
   parent: one(posts, {
     fields: [posts.parentId],
     references: [posts.id],
+    relationName: 'parent',
   }),
-  replies: many(posts),
+  replies: many(posts, { relationName: 'parent' }),
   images: many(postImages),
 }));
 

--- a/packages/shared/src/db/types.ts
+++ b/packages/shared/src/db/types.ts
@@ -91,6 +91,7 @@ export type ChannelWithGroup = Channel & { group: GroupWithMembersAndRoles };
 export type ChannelWithLastPostAndMembers = Channel & {
   lastPost: Post | null;
   members?: (ChatMember & { contact: Contact | null })[] | null;
+  unread: Unread | null;
 };
 
 export type ChannelSummary = Channel & {

--- a/packages/ui/src/components/ChannelListItem/index.tsx
+++ b/packages/ui/src/components/ChannelListItem/index.tsx
@@ -42,8 +42,8 @@ export default function ChannelListItem({
       </ListItem.MainContent>
       <ListItem.EndContent position="relative" top={3}>
         {model.lastPost && <ListItem.Time time={model.lastPost.receivedAt} />}
-        {model.unreadCount && model.unreadCount > 0 ? (
-          <ListItem.Count>{model.unreadCount}</ListItem.Count>
+        {model.unread?.count && model.unread.count > 0 ? (
+          <ListItem.Count>{model.unread.count}</ListItem.Count>
         ) : null}
       </ListItem.EndContent>
     </ListItem>
@@ -60,9 +60,7 @@ function ChannelListItemIcon({
   const backgroundColor = model.iconImageColor as ColorProp;
   if (useTypeIcon) {
     const icon = utils.getChannelTypeIcon(model.type);
-    return (
-      <ListItem.SystemIcon icon={icon} backgroundColor={backgroundColor} />
-    );
+    return <ListItem.SystemIcon icon={icon} backgroundColor={'$gray50'} />;
   } else if (model.type === 'dm') {
     return (
       <ListItem.AvatarIcon


### PR DESCRIPTION
Changes the schema to account for postsRelations that contribute to the unread count; adds `unread` to the ChannelWithLastPostAndMembers query and type; reflects the count in the ChannelListItem UI.

![Screenshot 2024-04-18 at 4 36 11 PM](https://github.com/tloncorp/tlon-apps/assets/748181/b23be1c2-3218-4921-971e-d0258b1901dc)
