### PR TITLE
android: fix issue with channel view 'wiping away' on keyboard dismiss

### DIFF
--- a/packages/ui/src/components/Channel/index.tsx
+++ b/packages/ui/src/components/Channel/index.tsx
@@ -70,9 +70,9 @@ export function Channel({
               showSpinner={isLoadingPosts}
             />
             <KeyboardAvoidingView
-              behavior={Platform.OS === 'ios' ? 'padding' : 'height'}
-              keyboardVerticalOffset={70}
+              behavior={Platform.OS === 'ios' ? 'padding' : 'position'}
               style={{ flex: 1 }}
+              contentContainerStyle={{ flex: 1 }}
             >
               <YStack flex={1}>
                 {!posts || !contacts ? (


### PR DESCRIPTION
It turns out this was caused by the KeyboardAvoidingView's `keyboardVerticalOffset` prop, which a) positioned the input box too high on iOS b) causes this weird issue on android when used in combination with the `height` behavior. Removing the offset and setting the behavior to `position` when on android fixes the issue, and iOS still looks/works the same.

Note that we also need to set a `contentContainerStyle` when using the `position` behavior on Android (this does not effect the way the component renders when we're using the `padding` behavior on iOS).