### PR TITLE
native: fix pinned group channel rendering

### DIFF
--- a/packages/shared/src/api/groupsApi.ts
+++ b/packages/shared/src/api/groupsApi.ts
@@ -33,6 +33,9 @@ export const getPinnedItemType = (rawItem: string) => {
     }
     return 'dm';
   } else {
+    if (rawItem.split('/').length === 3) {
+      return 'channel';
+    }
     return 'groupDm';
   }
 };

--- a/packages/shared/src/db/schema.ts
+++ b/packages/shared/src/db/schema.ts
@@ -113,7 +113,9 @@ export const threadUnreadsRelations = relations(threadUnreads, ({ one }) => ({
 export const pins = sqliteTable(
   'pins',
   {
-    type: text('type').$type<'group' | 'dm' | 'groupDm'>().notNull(),
+    type: text('type')
+      .$type<'group' | 'channel' | 'dm' | 'groupDm'>()
+      .notNull(),
     index: integer('index').notNull(),
     itemId: text('item_id').notNull(),
   },

--- a/packages/ui/src/components/ChannelListItem/index.tsx
+++ b/packages/ui/src/components/ChannelListItem/index.tsx
@@ -15,6 +15,7 @@ export default function ChannelListItem({
   useTypeIcon?: boolean;
 } & ListItemProps<db.ChannelWithLastPostAndMembers>) {
   const title = utils.getChannelTitle(model);
+
   return (
     <ListItem
       {...props}
@@ -77,6 +78,13 @@ function ChannelListItemIcon({
           backgroundColor={backgroundColor}
         />
       );
+    } else if (hasGroup(model) && model.group.iconImage) {
+      return (
+        <ListItem.ImageIcon
+          imageUrl={model.group.iconImage}
+          backgroundColor={backgroundColor}
+        />
+      );
     } else {
       return (
         <ListItem.TextIcon
@@ -86,4 +94,8 @@ function ChannelListItemIcon({
       );
     }
   }
+}
+
+function hasGroup(channel: db.Channel): channel is db.ChannelWithGroup {
+  return 'group' in channel && !!channel.group;
 }

--- a/packages/ui/src/components/ChatList.tsx
+++ b/packages/ui/src/components/ChatList.tsx
@@ -90,7 +90,7 @@ export function ChatList({
 }
 
 function getChannelKey(channel: db.ChannelSummary) {
-  return channel.id;
+  return channel.id + channel.pin?.itemId ?? '';
 }
 
 const ChatListItem = React.memo(
@@ -108,7 +108,11 @@ const ChatListItem = React.memo(
       onLongPress?.(model);
     }, [onLongPress]);
 
-    if (model.type === 'dm' || model.type === 'groupDm') {
+    if (
+      model.type === 'dm' ||
+      model.type === 'groupDm' ||
+      model.pin?.type === 'channel'
+    ) {
       return (
         <ChannelListItem
           model={model}


### PR DESCRIPTION
Fix duplicate issues in chat list by differentiating between channel items and group items.