### PR TITLE
native: add action sheet component

### DIFF
--- a/apps/tlon-mobile/cosmos.imports.ts
+++ b/apps/tlon-mobile/cosmos.imports.ts
@@ -3,6 +3,7 @@
 import { RendererConfig, UserModuleWrappers } from 'react-cosmos-core';
 
 import * as fixture0 from './src/App.fixture';
+import * as fixture15 from './src/fixtures/ActionSheet.fixture';
 import * as fixture14 from './src/fixtures/Button.fixture';
 import * as fixture13 from './src/fixtures/Channel.fixture';
 import * as fixture12 from './src/fixtures/ChannelHeader.fixture';
@@ -40,6 +41,7 @@ const fixtures = {
   'src/fixtures/ChannelHeader.fixture.tsx': { module: fixture12 },
   'src/fixtures/Channel.fixture.tsx': { module: fixture13 },
   'src/fixtures/Button.fixture.tsx': { module: fixture14 },
+  'src/fixtures/ActionSheet.fixture.tsx': { module: fixture15 },
 };
 
 const decorators = {

--- a/apps/tlon-mobile/src/fixtures/ActionSheet.fixture.tsx
+++ b/apps/tlon-mobile/src/fixtures/ActionSheet.fixture.tsx
@@ -1,39 +1,63 @@
-import ActionSheet from '@tloncorp/ui/src/components/ActionSheet';
+import { ActionSheet } from '@tloncorp/ui/src/components/ActionSheet';
 
 import { FixtureWrapper } from './FixtureWrapper';
 
 const ActionSheetFixture = () => {
+  const actions = [
+    {
+      title: 'Action 1',
+      action: () => console.log('Action 1'),
+      description: 'Action 1 Description',
+    },
+    {
+      title: 'Action 2',
+      action: () => console.log('Action 2'),
+      description: 'Action 2 Description',
+      variant: 'success',
+    },
+    {
+      title: 'Action 3',
+      action: () => console.log('Action 3'),
+      description: 'Action 3 Description',
+      variant: 'destructive',
+    },
+    {
+      title: 'Action 4',
+      action: () => console.log('Action 4'),
+      description: 'Action 4 Description',
+      variant: 'primary',
+    },
+  ];
+
   return (
     <FixtureWrapper fillWidth>
       <ActionSheet
-        sheetTitle="Action Sheet Title"
-        sheetDescription="Action Sheet Description"
         open={true}
-        onOpenChange={(open) => console.log('Open Change', open)}
-        actions={[
-          {
-            title: 'Action 1',
-            action: () => console.log('Action 1'),
-            description: 'Action 1 Description',
-          },
-          {
-            title: 'Action 2',
-            action: () => console.log('Action 2'),
-            description: 'Action 2 Description',
-            backgroundColor: '$greenSoft',
-            titleColor: '$green',
-            borderColor: '$green',
-          },
-          {
-            title: 'Action 3',
-            action: () => console.log('Action 3'),
-            description: 'Action 3 Description',
-            backgroundColor: '$redSoft',
-            titleColor: '$red',
-            borderColor: '$red',
-          },
-        ]}
-      />
+        onOpenChange={(open: boolean) => console.log('Open Change', open)}
+      >
+        <ActionSheet.Header>
+          <ActionSheet.Title>Action Sheet Title</ActionSheet.Title>
+          <ActionSheet.Description>
+            Action Sheet Description
+          </ActionSheet.Description>
+        </ActionSheet.Header>
+        {actions.map((action, index) => (
+          <ActionSheet.Action
+            key={index}
+            success={action.variant === 'success'}
+            destructive={action.variant === 'destructive'}
+            primary={action.variant === 'primary'}
+            action={action.action}
+          >
+            <ActionSheet.ActionTitle>{action.title}</ActionSheet.ActionTitle>
+            {action.description && (
+              <ActionSheet.ActionDescription>
+                {action.description}
+              </ActionSheet.ActionDescription>
+            )}
+          </ActionSheet.Action>
+        ))}
+      </ActionSheet>
     </FixtureWrapper>
   );
 };

--- a/apps/tlon-mobile/src/fixtures/ActionSheet.fixture.tsx
+++ b/apps/tlon-mobile/src/fixtures/ActionSheet.fixture.tsx
@@ -1,0 +1,43 @@
+import ActionSheet from '@tloncorp/ui/src/components/ActionSheet';
+
+import { FixtureWrapper } from './FixtureWrapper';
+
+const ActionSheetFixture = () => {
+  return (
+    <FixtureWrapper fillWidth>
+      <ActionSheet
+        sheetTitle="Action Sheet Title"
+        sheetDescription="Action Sheet Description"
+        open={true}
+        onOpenChange={(open) => console.log('Open Change', open)}
+        actions={[
+          {
+            title: 'Action 1',
+            action: () => console.log('Action 1'),
+            description: 'Action 1 Description',
+          },
+          {
+            title: 'Action 2',
+            action: () => console.log('Action 2'),
+            description: 'Action 2 Description',
+            backgroundColor: '$greenSoft',
+            titleColor: '$green',
+            borderColor: '$green',
+          },
+          {
+            title: 'Action 3',
+            action: () => console.log('Action 3'),
+            description: 'Action 3 Description',
+            backgroundColor: '$redSoft',
+            titleColor: '$red',
+            borderColor: '$red',
+          },
+        ]}
+      />
+    </FixtureWrapper>
+  );
+};
+
+export default {
+  default: <ActionSheetFixture />,
+};

--- a/apps/tlon-mobile/src/fixtures/Channel.fixture.tsx
+++ b/apps/tlon-mobile/src/fixtures/Channel.fixture.tsx
@@ -94,7 +94,6 @@ const ChannelFixture = () => {
         messageSender={() => {}}
         setImageAttachment={() => {}}
         resetImageAttachment={() => {}}
-        paddingBottom={bottom}
         canUpload={true}
       />
       <ChannelSwitcherSheet
@@ -179,7 +178,6 @@ const ChannelFixtureWithImage = () => {
         uploadedImage={uploadedImage}
         setImageAttachment={fakeSetImageAttachment}
         resetImageAttachment={resetImageAttachment}
-        paddingBottom={bottom}
         canUpload={true}
       />
       <ChannelSwitcherSheet

--- a/apps/tlon-mobile/src/screens/ChannelScreen.tsx
+++ b/apps/tlon-mobile/src/screens/ChannelScreen.tsx
@@ -207,7 +207,6 @@ export default function ChannelScreen(props: ChannelScreenProps) {
         resetImageAttachment={resetImageAttachment}
         onScrollEndReached={handleScrollEndReached}
         onScrollStartReached={handleScrollStartReached}
-        paddingBottom={bottom}
         canUpload={!!uploader}
       />
       {group && (

--- a/packages/ui/src/components/ActionSheet.tsx
+++ b/packages/ui/src/components/ActionSheet.tsx
@@ -1,30 +1,150 @@
-import { ColorTokens, Stack, Text, View } from '../core';
+import { ComponentProps, PropsWithChildren } from 'react';
+import { TouchableOpacity, Vibration } from 'react-native';
+import {
+  SheetProps,
+  createStyledContext,
+  styled,
+  withStaticProperties,
+} from 'tamagui';
+
+import { Stack, Text, View } from '../core';
 import { Sheet } from './Sheet';
 
-export type Action = {
-  title: string;
-  description?: string;
-  backgroundColor?: ColorTokens;
-  borderColor?: ColorTokens;
-  titleColor?: ColorTokens;
-  action?: () => void;
-};
+const ActionSheetActionContext = createStyledContext<{
+  success?: boolean;
+  primary?: boolean;
+  destructive?: boolean;
+  default?: boolean;
+}>({
+  default: true,
+  success: false,
+  primary: false,
+  destructive: false,
+});
 
-type Props = {
+type ActionSheetProps = {
   open: boolean;
   onOpenChange: (open: boolean) => void;
-  actions: Action[];
-  sheetTitle?: string;
-  sheetDescription?: string;
 };
 
-export default function ActionSheet({
+const ActionSheetFrame = styled(View, {
+  gap: '$xl',
+  paddingHorizontal: '$2xl',
+  paddingTop: '$xl',
+  paddingBottom: '$4xl',
+});
+
+const ActionSheetHeader = styled(Stack, {
+  paddingBottom: '$m',
+  flexDirection: 'column',
+});
+
+const ActionSheetActionFrame = styled(Stack, {
+  context: ActionSheetActionContext,
+  padding: '$l',
+  borderWidth: 1,
+  borderRadius: '$l',
+  pressStyle: {
+    backgroundColor: '$positiveBackground',
+  },
+  variants: {
+    default: {
+      true: {
+        backgroundColor: '$background',
+        borderColor: 'rgb(229, 229, 229)',
+      },
+    },
+    success: {
+      true: {
+        backgroundColor: '$greenSoft',
+        borderColor: '$green',
+      },
+    },
+    primary: {
+      true: {
+        backgroundColor: '$blueSoft',
+        borderColor: '$blue',
+      },
+    },
+    destructive: {
+      true: {
+        backgroundColor: '$redSoft',
+        borderColor: '$red',
+      },
+    },
+  } as const,
+});
+
+const ActionSheetTitle = styled(Text, {
+  fontSize: '$l',
+  fontWeight: '500',
+});
+
+const ActionSheetDescription = styled(Text, {
+  fontSize: '$l',
+  color: '$secondaryText',
+});
+
+const ActionSheetActionTitle = styled(Text, {
+  context: ActionSheetActionContext,
+  fontSize: '$l',
+  fontWeight: '500',
+  variants: {
+    default: {
+      true: {
+        color: '$primaryText',
+      },
+    },
+    success: {
+      true: {
+        color: '$green',
+      },
+    },
+    primary: {
+      true: {
+        color: '$blue',
+      },
+    },
+    destructive: {
+      true: {
+        color: '$red',
+      },
+    },
+  } as const,
+});
+
+const ActionSheetActionDescription = styled(Text, {
+  color: '$secondaryText',
+  fontSize: '$s',
+});
+
+function ActionSheetAction({
+  children,
+  action,
+  ...props
+}: PropsWithChildren<ComponentProps<typeof ActionSheetActionFrame>> & {
+  action: () => void;
+}) {
+  return (
+    <TouchableOpacity
+      onPress={() => {
+        action();
+        Vibration.vibrate(400);
+      }}
+    >
+      <ActionSheetActionFrame onPress={action} {...props}>
+        {children}
+      </ActionSheetActionFrame>
+    </TouchableOpacity>
+  );
+}
+
+const ActionSheetFrameComponent = ({
   open,
   onOpenChange,
-  sheetTitle,
-  sheetDescription,
-  actions,
-}: Props) {
+  children,
+  ...props
+}: PropsWithChildren<ActionSheetProps & SheetProps>) => {
   return (
     <Sheet
       open={open}
@@ -33,53 +153,22 @@ export default function ActionSheet({
       dismissOnSnapToBottom
       snapPointsMode="fit"
       animation="quick"
+      {...props}
     >
       <Sheet.Overlay animation="quick" />
       <Sheet.Frame>
         <Sheet.Handle paddingTop="$xl" />
-        <View
-          gap="$xl"
-          paddingHorizontal="$2xl"
-          paddingTop="$xl"
-          paddingBottom="$4xl"
-        >
-          {sheetTitle || sheetDescription ? (
-            <Stack paddingBottom="$m" flexDirection="column">
-              {sheetTitle ? (
-                <Text fontSize="$l" fontWeight="500">
-                  {sheetTitle}
-                </Text>
-              ) : null}
-              {sheetDescription ? (
-                <Text fontSize="$l" color="$secondaryText">
-                  {sheetDescription}
-                </Text>
-              ) : null}
-            </Stack>
-          ) : null}
-
-          {actions.map((action, index) => (
-            <Stack
-              key={index}
-              padding="$l"
-              backgroundColor={action.backgroundColor}
-              borderWidth={1}
-              borderColor={action.borderColor ?? 'rgb(229, 229, 229)'}
-              borderRadius="$l"
-              onPress={action.action}
-            >
-              <Text fontSize="$l" color={action.titleColor} fontWeight="500">
-                {action.title}
-              </Text>
-              {action.description ? (
-                <Text color="$secondaryText" fontSize="$s">
-                  {action.description}
-                </Text>
-              ) : null}
-            </Stack>
-          ))}
-        </View>
+        <ActionSheetFrame>{children}</ActionSheetFrame>
       </Sheet.Frame>
     </Sheet>
   );
-}
+};
+
+export const ActionSheet = withStaticProperties(ActionSheetFrameComponent, {
+  Action: ActionSheetAction,
+  Header: ActionSheetHeader,
+  Title: ActionSheetTitle,
+  Description: ActionSheetDescription,
+  ActionTitle: ActionSheetActionTitle,
+  ActionDescription: ActionSheetActionDescription,
+});

--- a/packages/ui/src/components/ActionSheet.tsx
+++ b/packages/ui/src/components/ActionSheet.tsx
@@ -1,0 +1,85 @@
+import { ColorTokens, Stack, Text, View } from '../core';
+import { Sheet } from './Sheet';
+
+export type Action = {
+  title: string;
+  description?: string;
+  backgroundColor?: ColorTokens;
+  borderColor?: ColorTokens;
+  titleColor?: ColorTokens;
+  action?: () => void;
+};
+
+type Props = {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  actions: Action[];
+  sheetTitle?: string;
+  sheetDescription?: string;
+};
+
+export default function ActionSheet({
+  open,
+  onOpenChange,
+  sheetTitle,
+  sheetDescription,
+  actions,
+}: Props) {
+  return (
+    <Sheet
+      open={open}
+      onOpenChange={onOpenChange}
+      modal
+      dismissOnSnapToBottom
+      snapPointsMode="fit"
+      animation="quick"
+    >
+      <Sheet.Overlay animation="quick" />
+      <Sheet.Frame>
+        <Sheet.Handle paddingTop="$xl" />
+        <View
+          gap="$xl"
+          paddingHorizontal="$2xl"
+          paddingTop="$xl"
+          paddingBottom="$4xl"
+        >
+          {sheetTitle || sheetDescription ? (
+            <Stack paddingBottom="$m" flexDirection="column">
+              {sheetTitle ? (
+                <Text fontSize="$l" fontWeight="500">
+                  {sheetTitle}
+                </Text>
+              ) : null}
+              {sheetDescription ? (
+                <Text fontSize="$l" color="$secondaryText">
+                  {sheetDescription}
+                </Text>
+              ) : null}
+            </Stack>
+          ) : null}
+
+          {actions.map((action, index) => (
+            <Stack
+              key={index}
+              padding="$l"
+              backgroundColor={action.backgroundColor}
+              borderWidth={1}
+              borderColor={action.borderColor ?? 'rgb(229, 229, 229)'}
+              borderRadius="$l"
+              onPress={action.action}
+            >
+              <Text fontSize="$l" color={action.titleColor} fontWeight="500">
+                {action.title}
+              </Text>
+              {action.description ? (
+                <Text color="$secondaryText" fontSize="$s">
+                  {action.description}
+                </Text>
+              ) : null}
+            </Stack>
+          ))}
+        </View>
+      </Sheet.Frame>
+    </Sheet>
+  );
+}

--- a/packages/ui/src/components/ActionSheet.tsx
+++ b/packages/ui/src/components/ActionSheet.tsx
@@ -1,5 +1,6 @@
+import * as Haptics from 'expo-haptics';
 import { ComponentProps, PropsWithChildren } from 'react';
-import { TouchableOpacity, Vibration } from 'react-native';
+import { TouchableOpacity } from 'react-native';
 import {
   SheetProps,
   createStyledContext,
@@ -127,9 +128,9 @@ function ActionSheetAction({
 }) {
   return (
     <TouchableOpacity
-      onPress={() => {
+      onPress={async () => {
+        await Haptics.selectionAsync();
         action();
-        Vibration.vibrate(400);
       }}
     >
       <ActionSheetActionFrame onPress={action} {...props}>

--- a/packages/ui/src/components/Channel/index.tsx
+++ b/packages/ui/src/components/Channel/index.tsx
@@ -40,7 +40,6 @@ export function Channel({
   // TODO: implement gallery and notebook
   type,
   isLoadingPosts,
-  paddingBottom,
   canUpload,
 }: {
   channel: db.ChannelWithLastPostAndMembers;
@@ -64,7 +63,6 @@ export function Channel({
   onScrollEndReached?: () => void;
   onScrollStartReached?: () => void;
   isLoadingPosts?: boolean;
-  paddingBottom: number;
   canUpload: boolean;
 }) {
   const [inputShouldBlur, setInputShouldBlur] = useState(false);
@@ -120,7 +118,6 @@ export function Channel({
                   channelId={channel.id}
                   setImageAttachment={setImageAttachment}
                   uploadedImage={uploadedImage}
-                  paddingBottom={paddingBottom}
                   canUpload={canUpload}
                 />
               </YStack>

--- a/packages/ui/src/components/GroupOptionsSheet.tsx
+++ b/packages/ui/src/components/GroupOptionsSheet.tsx
@@ -1,7 +1,6 @@
 import type * as db from '@tloncorp/shared/dist/db';
 
-import { Stack, Text, View } from '../core';
-import { Sheet } from './Sheet';
+import ActionSheet, { Action } from './ActionSheet';
 
 interface Props {
   open: boolean;
@@ -9,145 +8,57 @@ interface Props {
   channel?: db.Channel;
 }
 
+const actions: Action[] = [
+  {
+    title: 'Connected',
+    backgroundColor: '$greenSoft',
+    borderColor: '$green',
+    titleColor: '$green',
+    action: () => {},
+  },
+  {
+    title: 'Invite People',
+    backgroundColor: '$blueSoft',
+    borderColor: '$blue',
+    titleColor: '$blue',
+    action: () => {},
+  },
+  {
+    title: 'Group settings',
+    description: 'Configure group details and privacy',
+    action: () => {},
+  },
+  {
+    title: 'Copy group reference',
+    description: 'Copy an in-Urbit link to this group',
+    action: () => {},
+  },
+  {
+    title: 'Group members',
+    description: 'View all members and roles',
+    action: () => {},
+  },
+  {
+    title: 'Channels',
+    description: 'View all channels you have access to',
+    action: () => {},
+  },
+  {
+    title: 'Group notification settings',
+    description: 'Configure your notifications for this group',
+    action: () => {},
+  },
+  // TODO: channel pin state
+];
+
 export function ChatOptionsSheet({ open, onOpenChange, channel }: Props) {
   return (
-    <Sheet
+    <ActionSheet
       open={open}
       onOpenChange={onOpenChange}
-      modal
-      dismissOnSnapToBottom
-      snapPointsMode="fit"
-      animation="quick"
-    >
-      <Sheet.Overlay animation="quick" />
-      <Sheet.Frame>
-        <Sheet.Handle paddingTop="$xl" />
-        <View
-          gap="$xl"
-          paddingHorizontal="$2xl"
-          paddingTop="$xl"
-          paddingBottom="$4xl"
-        >
-          <Stack paddingBottom="$m" flexDirection="column">
-            <Text fontSize="$l" fontWeight="500">
-              {/* TODO: Handle titles of group dms + dms */}
-              {channel?.title}
-            </Text>
-            <Text fontSize="$l" color="$secondaryText">
-              Quick actions
-            </Text>
-          </Stack>
-
-          <Stack
-            padding="$l"
-            backgroundColor="$greenSoft"
-            borderWidth={1}
-            borderColor="$green"
-            borderRadius="$l"
-          >
-            <Text fontSize="$l" color="$green" fontWeight="500">
-              Connected
-            </Text>
-          </Stack>
-
-          <Stack
-            padding="$l"
-            borderWidth={1}
-            borderColor="$blueSoft"
-            borderRadius="$l"
-          >
-            <Text fontSize="$l" color="$blue" fontWeight="500">
-              Invite People
-            </Text>
-          </Stack>
-
-          <Stack
-            padding="$l"
-            borderWidth={1}
-            borderColor="rgb(229, 229, 229)"
-            borderRadius="$l"
-          >
-            <Text fontSize="$l" fontWeight="500">
-              Group settings
-            </Text>
-            <Text color="$secondaryText" fontSize="$s">
-              Configure group details and privacy
-            </Text>
-          </Stack>
-
-          <Stack
-            borderWidth={1}
-            borderColor="rgb(229, 229, 229)"
-            borderRadius="$l"
-          >
-            {
-              // TODO: channel pin state
-              /* <Stack
-              padding="$l"
-              borderBottomWidth={1}
-              borderBottomColor="rgb(229, 229, 229)"
-            >
-              <Text fontSize="$l" fontWeight="500">
-                {group?.pin ? 'Unpin' : 'Pin'}
-              </Text>
-              <Text color="$secondaryText" fontSize="$s">
-                {group?.pin ? 'Unpin' : 'Pin'} this group{' '}
-                {group?.pin ? 'from' : 'to'} the top of your
-                Groups list
-              </Text>
-            </Stack> */
-            }
-
-            <Stack
-              padding="$l"
-              borderBottomWidth={1}
-              borderBottomColor="rgb(229, 229, 229)"
-            >
-              <Text fontSize="$l" fontWeight="500">
-                Copy group reference
-              </Text>
-              <Text color="$secondaryText" fontSize="$s">
-                Copy an in-Urbit link to this group
-              </Text>
-            </Stack>
-
-            <Stack
-              padding="$l"
-              borderBottomWidth={1}
-              borderBottomColor="rgb(229, 229, 229)"
-            >
-              <Text fontSize="$l" fontWeight="500">
-                Group members
-              </Text>
-              <Text color="$secondaryText" fontSize="$s">
-                View all members and roles
-              </Text>
-            </Stack>
-
-            <Stack
-              padding="$l"
-              borderBottomWidth={1}
-              borderBottomColor="rgb(229, 229, 229)"
-            >
-              <Text fontSize="$l" fontWeight="500">
-                Channels
-              </Text>
-              <Text color="$secondaryText" fontSize="$s">
-                View all channels you have access to
-              </Text>
-            </Stack>
-
-            <Stack padding="$l">
-              <Text fontSize="$l" fontWeight="500">
-                Group notification settings
-              </Text>
-              <Text color="$secondaryText" fontSize="$s">
-                Configure your notifications for this group
-              </Text>
-            </Stack>
-          </Stack>
-        </View>
-      </Sheet.Frame>
-    </Sheet>
+      actions={actions}
+      sheetTitle={channel?.title ?? undefined}
+      sheetDescription="Quick actions"
+    />
   );
 }

--- a/packages/ui/src/components/GroupOptionsSheet.tsx
+++ b/packages/ui/src/components/GroupOptionsSheet.tsx
@@ -1,6 +1,6 @@
 import type * as db from '@tloncorp/shared/dist/db';
 
-import ActionSheet, { Action } from './ActionSheet';
+import { ActionSheet } from './ActionSheet';
 
 interface Props {
   open: boolean;
@@ -8,19 +8,15 @@ interface Props {
   channel?: db.Channel;
 }
 
-const actions: Action[] = [
+const actions = [
   {
     title: 'Connected',
-    backgroundColor: '$greenSoft',
-    borderColor: '$green',
-    titleColor: '$green',
+    variant: 'success',
     action: () => {},
   },
   {
     title: 'Invite People',
-    backgroundColor: '$blueSoft',
-    borderColor: '$blue',
-    titleColor: '$blue',
+    variant: 'primary',
     action: () => {},
   },
   {
@@ -53,12 +49,29 @@ const actions: Action[] = [
 
 export function ChatOptionsSheet({ open, onOpenChange, channel }: Props) {
   return (
-    <ActionSheet
-      open={open}
-      onOpenChange={onOpenChange}
-      actions={actions}
-      sheetTitle={channel?.title ?? undefined}
-      sheetDescription="Quick actions"
-    />
+    <ActionSheet open={open} onOpenChange={onOpenChange}>
+      <ActionSheet.Header>
+        <ActionSheet.Title>
+          {channel?.title ?? 'Group Options'}
+        </ActionSheet.Title>
+        <ActionSheet.Description>Quick actions</ActionSheet.Description>
+      </ActionSheet.Header>
+      {actions.map((action, index) => (
+        <ActionSheet.Action
+          key={index}
+          action={action.action}
+          primary={action.variant === 'primary'}
+          success={action.variant === 'success'}
+          destructive={action.variant === 'destructive'}
+        >
+          <ActionSheet.ActionTitle>{action.title}</ActionSheet.ActionTitle>
+          {action.description && (
+            <ActionSheet.ActionDescription>
+              {action.description}
+            </ActionSheet.ActionDescription>
+          )}
+        </ActionSheet.Action>
+      ))}
+    </ActionSheet>
   );
 }

--- a/packages/ui/src/components/MessageInput/AttachmentButton.native.tsx
+++ b/packages/ui/src/components/MessageInput/AttachmentButton.native.tsx
@@ -4,7 +4,7 @@ import { useEffect, useState } from 'react';
 
 import { Add } from '../../assets/icons';
 import { Spinner, View } from '../../core';
-import ActionSheet, { Action } from '../ActionSheet';
+import { ActionSheet } from '../ActionSheet';
 import { IconButton } from '../IconButton';
 
 export default function AttachmentButton({
@@ -64,6 +64,19 @@ export default function AttachmentButton({
     requestCameraPermission,
   ]);
 
+  const actions = [
+    {
+      title: 'Photo Library',
+      description: 'Choose a photo from your library',
+      action: pickImage,
+    },
+    {
+      title: 'Take a Photo',
+      description: 'Use your camera to take a photo',
+      action: takePicture,
+    },
+  ];
+
   return (
     <>
       {uploadedImage && uploadedImage.url === '' ? (
@@ -78,22 +91,22 @@ export default function AttachmentButton({
       <ActionSheet
         open={showInputSelector}
         onOpenChange={(open: boolean) => setShowInputSelector(open)}
-        sheetTitle="Add an attachment"
-        actions={
-          [
-            {
-              title: 'Photo Library',
-              description: 'Choose a photo from your library',
-              action: pickImage,
-            },
-            {
-              title: 'Take a Photo',
-              description: 'Use your camera to take a photo',
-              action: takePicture,
-            },
-          ] as Action[]
-        }
-      />
+      >
+        <ActionSheet.Header>
+          <ActionSheet.Title>Attach a file</ActionSheet.Title>
+          <ActionSheet.Description>
+            Choose a file to attach
+          </ActionSheet.Description>
+        </ActionSheet.Header>
+        {actions.map((action, index) => (
+          <ActionSheet.Action key={index} action={action.action}>
+            <ActionSheet.ActionTitle>{action.title}</ActionSheet.ActionTitle>
+            <ActionSheet.ActionDescription>
+              {action.description}
+            </ActionSheet.ActionDescription>
+          </ActionSheet.Action>
+        ))}
+      </ActionSheet>
     </>
   );
 }

--- a/packages/ui/src/components/MessageInput/AttachmentButton.native.tsx
+++ b/packages/ui/src/components/MessageInput/AttachmentButton.native.tsx
@@ -2,20 +2,17 @@ import { Upload } from '@tloncorp/shared/dist/api';
 import * as ImagePicker from 'expo-image-picker';
 import { useEffect, useState } from 'react';
 
-import { Add, Camera, ChannelGalleries } from '../../assets/icons';
-import { Spinner, View, YStack } from '../../core';
-import { Button } from '../Button';
+import { Add } from '../../assets/icons';
+import { Spinner, View } from '../../core';
+import ActionSheet, { Action } from '../ActionSheet';
 import { IconButton } from '../IconButton';
-import { Sheet } from '../Sheet';
 
 export default function AttachmentButton({
   setImage,
   uploadedImage,
-  paddingBottom,
 }: {
   setImage: (uri: string | null) => void;
   uploadedImage?: Upload | null;
-  paddingBottom: number;
 }) {
   const [showInputSelector, setShowInputSelector] = useState(false);
   const [mediaLibraryPermissionStatus, requestMediaLibraryPermission] =
@@ -78,50 +75,25 @@ export default function AttachmentButton({
           <Add />
         </IconButton>
       )}
-      <Sheet
+      <ActionSheet
         open={showInputSelector}
         onOpenChange={(open: boolean) => setShowInputSelector(open)}
-        modal
-        animation="quick"
-        dismissOnSnapToBottom
-        snapPointsMode="fit"
-      >
-        <Sheet.Overlay animation="quick" />
-        <Sheet.Frame>
-          <Sheet.Handle paddingTop="$xl" />
-          <YStack
-            paddingBottom={paddingBottom}
-            gap="$xl"
-            paddingHorizontal="$xl"
-            paddingTop="$xl"
-          >
-            <Button
-              borderWidth={0}
-              alignItems="center"
-              gap="$s"
-              onPress={pickImage}
-              padding="$xs"
-            >
-              <Button.Icon>
-                <ChannelGalleries />
-              </Button.Icon>
-              <Button.Text size="$s">Photo Library</Button.Text>
-            </Button>
-            <Button
-              borderWidth={0}
-              alignItems="center"
-              gap="$s"
-              onPress={takePicture}
-              padding="$xs"
-            >
-              <Button.Icon>
-                <Camera />
-              </Button.Icon>
-              <Button.Text size="$s">Take a Photo</Button.Text>
-            </Button>
-          </YStack>
-        </Sheet.Frame>
-      </Sheet>
+        sheetTitle="Add an attachment"
+        actions={
+          [
+            {
+              title: 'Photo Library',
+              description: 'Choose a photo from your library',
+              action: pickImage,
+            },
+            {
+              title: 'Take a Photo',
+              description: 'Use your camera to take a photo',
+              action: takePicture,
+            },
+          ] as Action[]
+        }
+      />
     </>
   );
 }

--- a/packages/ui/src/components/MessageInput/AttachmentButton.tsx
+++ b/packages/ui/src/components/MessageInput/AttachmentButton.tsx
@@ -5,11 +5,9 @@ import { IconButton } from '../IconButton';
 
 export default function AttachmentButton({
   setImage,
-  paddingBottom,
 }: {
   setImage: (uri: string) => void;
   uploadedImage?: Upload | null;
-  paddingBottom: number;
 }) {
   return (
     <IconButton onPress={() => {}}>

--- a/packages/ui/src/components/MessageInput/MessageInputBase.tsx
+++ b/packages/ui/src/components/MessageInput/MessageInputBase.tsx
@@ -14,7 +14,6 @@ export interface MessageInputProps {
   channelId: string;
   setImageAttachment: (image: string | null) => void;
   uploadedImage?: Upload | null;
-  paddingBottom?: number;
   canUpload?: boolean;
 }
 
@@ -23,13 +22,11 @@ export const MessageInputContainer = ({
   onPressSend,
   setImageAttachment,
   uploadedImage,
-  paddingBottom,
   canUpload,
 }: PropsWithChildren<{
   onPressSend?: () => void;
   setImageAttachment: (image: string | null) => void;
   uploadedImage?: Upload | null;
-  paddingBottom?: number;
   canUpload?: boolean;
 }>) => {
   const hasUploadedImage = useMemo(
@@ -58,7 +55,6 @@ export const MessageInputContainer = ({
             <AttachmentButton
               uploadedImage={uploadedImage}
               setImage={setImageAttachment}
-              paddingBottom={paddingBottom ?? 0}
             />
           </XStack>
         ) : null}

--- a/packages/ui/src/components/MessageInput/index.native.tsx
+++ b/packages/ui/src/components/MessageInput/index.native.tsx
@@ -60,7 +60,6 @@ export function MessageInput({
   channelId,
   setImageAttachment,
   uploadedImage,
-  paddingBottom,
   canUpload,
 }: MessageInputProps) {
   const [containerHeight, setContainerHeight] = useState(0);
@@ -167,7 +166,6 @@ export function MessageInput({
       setImageAttachment={setImageAttachment}
       onPressSend={handleSend}
       uploadedImage={uploadedImage}
-      paddingBottom={paddingBottom}
       canUpload={canUpload}
     >
       <XStack

--- a/packages/ui/src/components/MessageInput/index.tsx
+++ b/packages/ui/src/components/MessageInput/index.tsx
@@ -11,14 +11,12 @@ export function MessageInput({
   channelId,
   setImageAttachment,
   uploadedImage,
-  paddingBottom,
   canUpload,
 }: MessageInputProps) {
   const [isFocused, setIsFocused] = useState(false);
 
   return (
     <MessageInputContainer
-      paddingBottom={paddingBottom}
       setImageAttachment={setImageAttachment}
       canUpload={canUpload}
     >


### PR DESCRIPTION
![Simulator Screenshot - iPhone 15 - 2024-04-25 at 10 53 58](https://github.com/tloncorp/tlon-apps/assets/1221094/b2d8bb10-a425-4381-9eb5-66ff17612aa8)

![Simulator Screenshot - iPhone 15 - 2024-04-25 at 11 07 43](https://github.com/tloncorp/tlon-apps/assets/1221094/d245dc67-9239-47e9-950b-a5f5b3e0f243)

![Simulator Screenshot - iPhone 15 - 2024-04-25 at 11 08 07](https://github.com/tloncorp/tlon-apps/assets/1221094/ebb8cc05-a142-40e0-82cd-256332d83351)



I added a generic ActionSheet component and implemented it in the two places (that I'm aware of) that we need it. Also added a fixture for it.

Fixes LAND-1811