### PR TITLE
native: color fixes

### DIFF
--- a/packages/editor/src/MessageInputEditor.tsx
+++ b/packages/editor/src/MessageInputEditor.tsx
@@ -15,6 +15,7 @@ import CodeBlock from '@tiptap/extension-code-block';
 import { EditorContent } from '@tiptap/react';
 
 import { ShortcutsBridge } from './bridges/shortcut';
+import { useIsDark } from './useMedia';
 
 export const MessageInputEditor = () => {
   const editor = useTenTap({
@@ -45,6 +46,7 @@ export const MessageInputEditor = () => {
   return (
     <EditorContent
       style={{
+        color: useIsDark() ? 'white' : 'black',
         flex: 1,
         fontFamily:
           "System, -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Ubuntu, 'Helvetica Neue', sans-serif",

--- a/packages/editor/src/useMedia.ts
+++ b/packages/editor/src/useMedia.ts
@@ -1,0 +1,70 @@
+import { useCallback, useEffect } from 'react';
+import create from 'zustand';
+
+interface MediaMatchStore {
+  media: {
+    [query: string]: boolean;
+  };
+  setQuery: (query: string, data: boolean) => void;
+}
+
+const useMediaMatchStore = create<MediaMatchStore>((set, get) => ({
+  media: {},
+  setQuery: (query, data) => {
+    set((draft) => {
+      draft.media[query] = data;
+    });
+  },
+}));
+
+function useQuery(query: string) {
+  return useMediaMatchStore(
+    useCallback(
+      (s) => {
+        if (s.media[query]) {
+          return s.media[query];
+        }
+
+        const mQuery = window.matchMedia(query);
+        return mQuery.matches;
+      },
+      [query]
+    )
+  );
+}
+
+const queries: string[] = [];
+
+export default function useMedia(mediaQuery: string) {
+  const value = useQuery(mediaQuery);
+
+  const update = useCallback(
+    (e: MediaQueryListEvent) => {
+      useMediaMatchStore.getState().setQuery(mediaQuery, e.matches);
+    },
+    [mediaQuery]
+  );
+
+  useEffect(() => {
+    if (queries.includes(mediaQuery)) {
+      return;
+    }
+
+    const query = window.matchMedia(mediaQuery);
+    queries.push(mediaQuery);
+    useMediaMatchStore.getState().setQuery(mediaQuery, query.matches);
+
+    query.addEventListener('change', update);
+    update({ matches: query.matches } as MediaQueryListEvent);
+  }, [update, mediaQuery]);
+
+  return value;
+}
+
+export function useIsMobile() {
+  return useMedia('(max-width: 767px)');
+}
+
+export function useIsDark() {
+  return useMedia('(prefers-color-scheme: dark)');
+}

--- a/packages/ui/src/components/ActionSheet.tsx
+++ b/packages/ui/src/components/ActionSheet.tsx
@@ -52,7 +52,7 @@ const ActionSheetActionFrame = styled(Stack, {
     default: {
       true: {
         backgroundColor: '$background',
-        borderColor: 'rgb(229, 229, 229)',
+        borderColor: '$tertiaryText',
       },
     },
     success: {

--- a/packages/ui/src/components/ChannelListItem/index.tsx
+++ b/packages/ui/src/components/ChannelListItem/index.tsx
@@ -61,7 +61,12 @@ function ChannelListItemIcon({
   const backgroundColor = model.iconImageColor as ColorProp;
   if (useTypeIcon) {
     const icon = utils.getChannelTypeIcon(model.type);
-    return <ListItem.SystemIcon icon={icon} backgroundColor={'$gray50'} />;
+    return (
+      <ListItem.SystemIcon
+        icon={icon}
+        backgroundColor={'$secondaryBackground'}
+      />
+    );
   } else if (model.type === 'dm' && model.members?.[0]?.contactId) {
     return (
       <ListItem.AvatarIcon


### PR DESCRIPTION
- Uses $tertiaryText on ActionSheet item borders and on channel icons in ChannelListItem.
- Adds the useMedia hook to the editor package and utilizes it to show white text on a dark background in dark mode.

![Screenshot 2024-04-26 at 12 15 43 PM](https://github.com/tloncorp/tlon-apps/assets/748181/193b9e24-add3-40a1-a699-ca2802ca4ea2)

![Screenshot 2024-04-26 at 12 16 58 PM](https://github.com/tloncorp/tlon-apps/assets/748181/9cf528b5-9ad1-4b88-9f01-21ba6378ed64)

![Screenshot 2024-04-26 at 12 17 09 PM](https://github.com/tloncorp/tlon-apps/assets/748181/559d5929-670d-462d-a4bf-39cde0656564)

Fixes LAND-1802
Fixes LAND-1803
Fixes LAND-1084