### PR TITLE
native: get height from webview to set editor container height in native

### DIFF
--- a/apps/tlon-mobile/src/fixtures/MessageInput.fixture.tsx
+++ b/apps/tlon-mobile/src/fixtures/MessageInput.fixture.tsx
@@ -15,6 +15,7 @@ const MessageInputFixture = () => {
           send={() => {}}
           channelId="channel-id"
           setImageAttachment={() => {}}
+          canUpload={true}
         />
       </View>
     </FixtureWrapper>

--- a/packages/editor/src/MessageInputEditor.tsx
+++ b/packages/editor/src/MessageInputEditor.tsx
@@ -45,7 +45,8 @@ export const MessageInputEditor = () => {
   return (
     <EditorContent
       style={{
-        flex: 1,
+        overflow: 'auto',
+        height: 'auto',
         fontFamily:
           "System, -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Ubuntu, 'Helvetica Neue', sans-serif",
       }}

--- a/packages/editor/src/MessageInputEditor.tsx
+++ b/packages/editor/src/MessageInputEditor.tsx
@@ -47,6 +47,8 @@ export const MessageInputEditor = () => {
       style={{
         overflow: 'auto',
         height: 'auto',
+        // making this explicit
+        fontSize: 16,
         fontFamily:
           "System, -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Ubuntu, 'Helvetica Neue', sans-serif",
       }}

--- a/packages/ui/src/components/MessageInput/MessageInputBase.tsx
+++ b/packages/ui/src/components/MessageInput/MessageInputBase.tsx
@@ -3,7 +3,7 @@ import { Upload } from 'packages/shared/dist/api';
 import { PropsWithChildren, useCallback, useMemo } from 'react';
 
 import { ArrowUp } from '../../assets/icons';
-import { XStack, YStack } from '../../core';
+import { View, XStack, YStack } from '../../core';
 import { IconButton } from '../IconButton';
 import AttachmentButton from './AttachmentButton';
 
@@ -48,18 +48,19 @@ export const MessageInputContainer = ({
         paddingHorizontal="$m"
         paddingVertical="$s"
         gap="$l"
-        alignItems="center"
+        alignItems="flex-end"
+        justifyContent="space-between"
       >
         {hasUploadedImage ? null : canUpload ? (
-          <XStack gap="$l" animation="quick">
+          <View paddingBottom="$m">
             <AttachmentButton
               uploadedImage={uploadedImage}
               setImage={setImageAttachment}
             />
-          </XStack>
+          </View>
         ) : null}
-        <XStack flex={1} gap="$l" alignItems="center">
-          {children}
+        {children}
+        <View paddingBottom="$m">
           <IconButton
             color={sendIconColor}
             disabled={uploadIsLoading}
@@ -68,7 +69,7 @@ export const MessageInputContainer = ({
             {/* TODO: figure out what send button should look like */}
             <ArrowUp />
           </IconButton>
-        </XStack>
+        </View>
       </XStack>
     </YStack>
   );

--- a/packages/ui/src/components/MessageInput/index.native.tsx
+++ b/packages/ui/src/components/MessageInput/index.native.tsx
@@ -186,7 +186,7 @@ export function MessageInput({
         e.onEditorMessage && e.onEditorMessage({ type, payload }, editor);
       });
     },
-    [editor, handleAddNewLine, webviewRef]
+    [editor, handleAddNewLine]
   );
 
   const tentapInjectedJs = useMemo(

--- a/packages/ui/src/components/MessageInput/index.native.tsx
+++ b/packages/ui/src/components/MessageInput/index.native.tsx
@@ -58,6 +58,10 @@ const getInjectedJS = (bridgeExtensions: BridgeExtension[]) => {
   return injectJS;
 };
 
+// 52 accounts for the 16px padding around the text within the input
+// and the 20px line height of the text. 16 + 20 + 16 = 52
+const DEFAULT_CONTAINER_HEIGHT = 52;
+
 export function MessageInput({
   shouldBlur,
   setShouldBlur,
@@ -67,7 +71,9 @@ export function MessageInput({
   uploadedImage,
   canUpload,
 }: MessageInputProps) {
-  const [containerHeight, setContainerHeight] = useState(52);
+  const [containerHeight, setContainerHeight] = useState(
+    DEFAULT_CONTAINER_HEIGHT
+  );
   const editor = useEditorBridge({
     customSource: editorHtml,
     autofocus: false,


### PR DESCRIPTION
and fix the flex issues with buttons (i.e., they stay at the bottom as the message input container grows)

fixes LAND-1813