### PR TITLE
mobile: use platform/theme neutral overlay for image viewer

### DIFF
--- a/packages/ui/src/components/Channel/ChatScroll.tsx
+++ b/packages/ui/src/components/Channel/ChatScroll.tsx
@@ -117,6 +117,7 @@ export default function ChatScroll({
             showReplies={showReplies}
             onPressReplies={onPressReplies}
             onPressImage={onPressImage}
+            onLongPress={() => handleSetActive(item)}
           />
         </PressableMessage>
       );
@@ -191,7 +192,7 @@ function getPostId(post: db.Post) {
 const PressableMessage = forwardRef<
   RNView,
   PropsWithChildren<{ isActive: boolean; onLongPress: () => void }>
->(({ isActive, onLongPress, children }, ref) => {
+>(function PressableMessageComponent({ isActive, onLongPress, children }, ref) {
   return isActive ? (
     // need the extra React Native View for ref measurement
     <MotiView

--- a/packages/ui/src/components/ChatMessage/ChatContent.tsx
+++ b/packages/ui/src/components/ChatMessage/ChatContent.tsx
@@ -174,9 +174,11 @@ export function InlineContent({ story }: { story: Inline | null }) {
 export function BlockContent({
   story,
   onPressImage,
+  onLongPress,
 }: {
   story: Block;
   onPressImage?: (src: string) => void;
+  onLongPress?: () => void;
 }) {
   // TODO add support for other embeds and refs
 
@@ -200,6 +202,7 @@ export function BlockContent({
     return (
       <TouchableOpacity
         onPress={onPressImage ? () => onPressImage(story.image.src) : undefined}
+        onLongPress={onLongPress}
         activeOpacity={0.9}
       >
         <Image
@@ -303,9 +306,11 @@ const LineRenderer = memo(({ storyInlines }: { storyInlines: Inline[] }) => {
 export default function ChatContent({
   story,
   onPressImage,
+  onLongPress,
 }: {
   story: Story;
   onPressImage?: (src: string) => void;
+  onLongPress?: () => void;
 }) {
   const storyInlines = useMemo(
     () =>
@@ -351,6 +356,7 @@ export default function ChatContent({
                   key={key}
                   story={storyItem.block}
                   onPressImage={onPressImage}
+                  onLongPress={onLongPress}
                 />
               );
             })}

--- a/packages/ui/src/components/ChatMessage/index.tsx
+++ b/packages/ui/src/components/ChatMessage/index.tsx
@@ -14,6 +14,7 @@ const ChatMessage = ({
   unreadCount,
   onPressReplies,
   onPressImage,
+  onLongPress,
   showReplies,
   currentUserId,
 }: {
@@ -24,6 +25,7 @@ const ChatMessage = ({
   currentUserId: string;
   onPressReplies?: (post: db.PostInsert) => void;
   onPressImage?: (post: db.PostInsert, imageUri?: string) => void;
+  onLongPress?: () => void;
 }) => {
   const isUnread = useMemo(
     () => firstUnread && post.id === firstUnread,
@@ -86,6 +88,7 @@ const ChatMessage = ({
                 ? (uri?: string) => onPressImage(post, uri)
                 : undefined
             }
+            onLongPress={onLongPress}
           />
         )}
       </View>

--- a/packages/ui/src/components/IconButton.tsx
+++ b/packages/ui/src/components/IconButton.tsx
@@ -1,5 +1,5 @@
 import { Button } from '../components/Button';
-import { SizeTokens, ThemeTokens, useTheme } from '../core';
+import { ColorTokens, SizeTokens, ThemeTokens, useTheme } from '../core';
 
 export function IconButton({
   children,
@@ -11,7 +11,7 @@ export function IconButton({
   children: React.ReactNode;
   onPress?: () => void;
   size?: SizeTokens;
-  color?: ThemeTokens;
+  color?: ThemeTokens | ColorTokens;
   disabled?: boolean;
 }) {
   const theme = useTheme();

--- a/packages/ui/src/components/ImageViewerScreenView.tsx
+++ b/packages/ui/src/components/ImageViewerScreenView.tsx
@@ -3,11 +3,14 @@ import * as db from '@tloncorp/shared/dist/db';
 import { BlurView } from 'expo-blur';
 import * as Haptics from 'expo-haptics';
 import { useRef, useState } from 'react';
-import { Dimensions } from 'react-native';
+import { Dimensions, TouchableOpacity } from 'react-native';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
 
-import { View, XStack, YStack, ZStack } from '../core';
+import { Close } from '../assets/icons';
+import { Stack, View, XStack, YStack, ZStack } from '../core';
 import { Button } from './Button';
+import { Icon } from './Icon';
+import { IconButton } from './IconButton';
 
 interface ImageZoomRef {
   reset: () => void;
@@ -67,27 +70,20 @@ export function ImageViewerScreenView(props: {
         </View>
 
         {/* overlay */}
-        <YStack>
-          <XStack opacity={showOverlay ? 1 : 0}>
-            <BlurView style={{ flex: 1 }} tint="extraLight" intensity={70}>
-              <ZStack height={100}>
-                <View flex={1} backgroundColor="$white" opacity={0.6} />
-                <XStack
-                  zIndex="$m"
-                  paddingTop={top}
-                  paddingBottom="$s"
-                  paddingRight="$m"
-                >
-                  <XStack flex={1} justifyContent="flex-end">
-                    <Button minimal onPress={() => props.goBack()}>
-                      <Button.Text color="$positiveActionText" fontWeight="500">
-                        Done
-                      </Button.Text>
-                    </Button>
-                  </XStack>
-                </XStack>
-              </ZStack>
-            </BlurView>
+        <YStack padding="$xl" paddingTop={top}>
+          <XStack opacity={showOverlay ? 1 : 0} justifyContent="flex-end">
+            <TouchableOpacity
+              onPress={() => props.goBack()}
+              activeOpacity={0.8}
+            >
+              <Stack
+                padding="$m"
+                backgroundColor="$darkOverlay"
+                borderRadius="$l"
+              >
+                <Icon type="Close" size="$l" color="$white" />
+              </Stack>
+            </TouchableOpacity>
           </XStack>
         </YStack>
       </ZStack>


### PR DESCRIPTION
Removes the existing overlay in the ImageViewer in favor of a simpler close icon. Right now it may be a bit too subtle, but I think it'll be more clear when the overlay is open once it's more featureful (save to camera roll action for example)

Also fixes longpress on message images to open the actions. Still has that brief yet annoying resize stutter when we swap in the animated message (I'm coming for you!)

Fixes LAND-1797