### PR TITLE
Simplify database types

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,4 @@ bin
 gha-creds-*
 .turbo
 tsconfig.tsbuildinfo
+launch.json

--- a/apps/tlon-mobile/src/fixtures/Channel.fixture.tsx
+++ b/apps/tlon-mobile/src/fixtures/Channel.fixture.tsx
@@ -52,8 +52,7 @@ const ChannelFixtureWrapper = ({ children }: PropsWithChildren) => {
 
 const ChannelFixture = () => {
   const [open, setOpen] = useState(false);
-  const [currentChannel, setCurrentChannel] =
-    useState<db.ChannelWithLastPostAndMembers | null>(null);
+  const [currentChannel, setCurrentChannel] = useState<db.Channel | null>(null);
   const { bottom } = useSafeAreaInsets();
 
   const tlonLocalChannelWithUnreads = {
@@ -64,7 +63,7 @@ const ChannelFixture = () => {
 
   useEffect(() => {
     if (group) {
-      const firstChatChannel = group.channels.find((c) => c.type === 'chat');
+      const firstChatChannel = group.channels?.find((c) => c.type === 'chat');
       if (firstChatChannel) {
         setCurrentChannel(firstChatChannel);
       }
@@ -102,7 +101,7 @@ const ChannelFixture = () => {
         group={group}
         channels={group.channels || []}
         paddingBottom={bottom}
-        onSelect={(channel: db.ChannelWithLastPostAndMembers) => {
+        onSelect={(channel: db.Channel) => {
           setCurrentChannel(channel);
           setOpen(false);
         }}
@@ -116,8 +115,7 @@ const ChannelFixtureWithImage = () => {
   const [open, setOpen] = useState(false);
   const [imageAttachment, setImageAttachment] = useState<string | null>(null);
   const [uploadedImage, setUploadedImage] = useState<Upload | null>(null);
-  const [currentChannel, setCurrentChannel] =
-    useState<db.ChannelWithLastPostAndMembers | null>(null);
+  const [currentChannel, setCurrentChannel] = useState<db.Channel | null>(null);
   const { bottom } = useSafeAreaInsets();
   const mostRecentFile = fakeMostRecentFile;
 
@@ -147,7 +145,7 @@ const ChannelFixtureWithImage = () => {
 
   useEffect(() => {
     if (group) {
-      const firstChatChannel = group.channels.find((c) => c.type === 'chat');
+      const firstChatChannel = group.channels?.find((c) => c.type === 'chat');
       if (firstChatChannel) {
         setCurrentChannel(firstChatChannel);
       }
@@ -186,7 +184,7 @@ const ChannelFixtureWithImage = () => {
         group={group}
         channels={group.channels || []}
         paddingBottom={bottom}
-        onSelect={(channel: db.ChannelWithLastPostAndMembers) => {
+        onSelect={(channel: db.Channel) => {
           setCurrentChannel(channel);
           setOpen(false);
         }}

--- a/apps/tlon-mobile/src/fixtures/ChannelSwitcherSheet.fixture.tsx
+++ b/apps/tlon-mobile/src/fixtures/ChannelSwitcherSheet.fixture.tsx
@@ -8,7 +8,7 @@ export default {
       open
       onOpenChange={() => {}}
       group={group}
-      channels={group.channels}
+      channels={group.channels!}
       contacts={initialContacts}
       onSelect={(channel) => console.debug(`Selected ${channel.title}`)}
     />

--- a/apps/tlon-mobile/src/fixtures/GroupList.fixture.tsx
+++ b/apps/tlon-mobile/src/fixtures/GroupList.fixture.tsx
@@ -20,10 +20,10 @@ function makeChannelSummary({
   members,
 }: {
   channel?: Partial<db.Channel>;
-  group?: db.GroupSummary;
+  group?: db.Group;
   lastPost?: db.Post;
   members?: (db.ChatMember & { contact: db.Contact | null })[];
-}): db.ChannelSummary {
+}): db.Channel {
   return {
     id: 'channel-' + id++,
     type: 'chat',

--- a/apps/tlon-mobile/src/fixtures/fakeData.ts
+++ b/apps/tlon-mobile/src/fixtures/fakeData.ts
@@ -204,7 +204,7 @@ const emptyChannel: db.Channel = {
   remoteUpdatedAt: null,
 };
 
-export const tlonLocalIntros: db.ChannelWithLastPostAndMembers = {
+export const tlonLocalIntros: db.Channel = {
   ...emptyChannel,
   id: '~nibset-napwyn/intros',
   type: 'chat',
@@ -240,7 +240,7 @@ export const tlonLocalIntros: db.ChannelWithLastPostAndMembers = {
   },
 };
 
-export const tlonLocalWaterCooler: db.ChannelWithLastPostAndMembers = {
+export const tlonLocalWaterCooler: db.Channel = {
   ...emptyChannel,
   id: '~nibset-napwyn/water-cooler',
   type: 'chat',
@@ -275,7 +275,7 @@ export const tlonLocalWaterCooler: db.ChannelWithLastPostAndMembers = {
   },
 };
 
-export const tlonLocalSupport: db.ChannelWithLastPostAndMembers = {
+export const tlonLocalSupport: db.Channel = {
   ...emptyChannel,
   id: '~nibset-napwyn/support',
   type: 'chat',
@@ -310,7 +310,7 @@ export const tlonLocalSupport: db.ChannelWithLastPostAndMembers = {
   },
 };
 
-export const tlonLocalBulletinBoard: db.ChannelWithLastPostAndMembers = {
+export const tlonLocalBulletinBoard: db.Channel = {
   ...emptyChannel,
   id: '~nibset-napwyn/bulletin-board',
   type: 'gallery',
@@ -345,7 +345,7 @@ export const tlonLocalBulletinBoard: db.ChannelWithLastPostAndMembers = {
   },
 };
 
-export const tlonLocalCommunityCatalog: db.ChannelWithLastPostAndMembers = {
+export const tlonLocalCommunityCatalog: db.Channel = {
   ...emptyChannel,
   id: '~nibset-napwyn/community-catalog',
   type: 'gallery',
@@ -379,7 +379,7 @@ export const tlonLocalCommunityCatalog: db.ChannelWithLastPostAndMembers = {
   },
 };
 
-export const tlonLocalGettingStarted: db.ChannelWithLastPostAndMembers = {
+export const tlonLocalGettingStarted: db.Channel = {
   ...emptyChannel,
   id: '~nibset-napwyn/getting-started',
   type: 'notebook',
@@ -413,7 +413,7 @@ export const tlonLocalGettingStarted: db.ChannelWithLastPostAndMembers = {
   },
 };
 
-const tlonLocalChannels: db.ChannelWithLastPostAndMembers[] = [
+const tlonLocalChannels: db.Channel[] = [
   tlonLocalIntros,
   tlonLocalWaterCooler,
   tlonLocalSupport,
@@ -422,7 +422,7 @@ const tlonLocalChannels: db.ChannelWithLastPostAndMembers[] = [
   tlonLocalCommunityCatalog,
 ];
 
-const tlonLocalNavSections: db.GroupNavSectionWithRelations[] = [
+const tlonLocalNavSections: db.GroupNavSection[] = [
   {
     index: 0,
     id: 'welcome-zone-id',
@@ -494,7 +494,7 @@ const tlonLocalNavSections: db.GroupNavSectionWithRelations[] = [
   },
 ];
 
-export const group: db.GroupWithRelations = {
+export const group: db.Group = {
   id: '~nibset-napwyn/tlon',
   title: 'Tlon Local',
   channels: tlonLocalChannels,
@@ -589,7 +589,7 @@ const getRandomFakeContact = () => {
   return initialContacts[Math.floor(Math.random() * keys.length)];
 };
 
-export const createFakePost = (): db.PostWithRelations => {
+export const createFakePost = (): db.Post => {
   const fakeContact = getRandomFakeContact();
   const ship = fakeContact.id;
   const id = Math.random().toString(36).substring(7);
@@ -665,7 +665,7 @@ function getRandomTimeOnSameDay() {
   ).getTime();
 }
 
-export const createFakePosts = (count: number): db.PostWithRelations[] => {
+export const createFakePosts = (count: number): db.Post[] => {
   const posts = [];
   for (let i = 0; i < count; i++) {
     posts.push(createFakePost());
@@ -687,7 +687,7 @@ const dates = {
   lastMonth: Date.now() - 1000 * 60 * 60 * 24 * 30,
 };
 
-export const groupWithColorAndNoImage: db.GroupSummary = {
+export const groupWithColorAndNoImage: db.Group = {
   id: '1',
   title: 'Test Group',
   isSecret: false,
@@ -703,10 +703,9 @@ export const groupWithColorAndNoImage: db.GroupSummary = {
   lastPost: { ...createFakePost() },
 };
 
-export const groupWithLongTitle = {
+export const groupWithLongTitle: db.Group = {
   ...groupWithColorAndNoImage,
   title: 'And here, a reallly long title, wazzup, ok',
-  textContent: 'HIIIIIIIIIII',
   lastPostAt: dates.earlierToday,
   lastPost: {
     ...createFakePost(),
@@ -715,7 +714,7 @@ export const groupWithLongTitle = {
   },
 };
 
-export const groupWithNoColorOrImage = {
+export const groupWithNoColorOrImage: db.Group = {
   ...groupWithColorAndNoImage,
   iconImageColor: null,
   lastPost: createFakePost(),
@@ -723,7 +722,7 @@ export const groupWithNoColorOrImage = {
   unreadCount: Math.floor(Math.random() * 20),
 };
 
-export const groupWithImage = {
+export const groupWithImage: db.Group = {
   ...groupWithColorAndNoImage,
   iconImage:
     'https://dans-gifts.s3.amazonaws.com/dans-gifts/solfer-magfed/2024.4.6..15.49.54..4a7e.f9db.22d0.e560-IMG_4770.jpg',
@@ -732,7 +731,7 @@ export const groupWithImage = {
   unreadCount: Math.floor(Math.random() * 20),
 };
 
-export const groupWithSvgImage = {
+export const groupWithSvgImage: db.Group = {
   ...groupWithColorAndNoImage,
   iconImage: 'https://tlon.io/local-icon.svg',
   lastPost: createFakePost(),

--- a/apps/tlon-mobile/src/screens/ChannelScreen.tsx
+++ b/apps/tlon-mobile/src/screens/ChannelScreen.tsx
@@ -67,7 +67,7 @@ export default function ChannelScreen(props: ChannelScreenProps) {
         }),
     count: 50,
   });
-  const posts = useMemo<db.PostWithRelations[]>(
+  const posts = useMemo<db.Post[]>(
     () => postsData?.pages.flatMap((p) => p) ?? [],
     [postsData]
   );
@@ -158,14 +158,14 @@ export default function ChannelScreen(props: ChannelScreenProps) {
   }, [fetchPreviousPage, hasPreviousPage, isFetchingPreviousPage]);
 
   const handleGoToPost = useCallback(
-    (post: db.PostInsert) => {
+    (post: db.Post) => {
       props.navigation.push('Post', { post });
     },
     [props.navigation]
   );
 
   const handleGoToImage = useCallback(
-    (post: db.PostInsert, uri?: string) => {
+    (post: db.Post, uri?: string) => {
       // @ts-expect-error TODO: fix typing for nested stack navigation
       props.navigation.navigate('ImageViewer', { post, uri });
     },

--- a/apps/tlon-mobile/src/screens/ChannelSearchScreen.tsx
+++ b/apps/tlon-mobile/src/screens/ChannelSearchScreen.tsx
@@ -39,7 +39,7 @@ export default function ChannelSearch({
   }, [navigation]);
 
   const navigateToPost = useCallback(
-    (post: db.PostWithRelations) => {
+    (post: db.Post) => {
       navigation.navigate('Channel', {
         channel,
         selectedPost: post,

--- a/apps/tlon-mobile/src/types.ts
+++ b/apps/tlon-mobile/src/types.ts
@@ -28,14 +28,14 @@ export type HomeStackParamList = {
     channel: db.Channel;
   };
   Post: {
-    post: db.PostInsert;
+    post: db.Post;
   };
 };
 
 export type RootStackParamList = {
   Tabs: NavigatorScreenParams<TabParamList>;
   ImageViewer: {
-    post: db.PostInsert;
+    post: db.Post;
     uri?: string;
   };
 };

--- a/packages/shared/src/api/channelsApi.ts
+++ b/packages/shared/src/api/channelsApi.ts
@@ -43,7 +43,7 @@ type ChannelUnreadData = {
   postCount?: number;
   unreadCount?: number;
   firstUnreadPostId?: string;
-  unreadThreads?: db.ThreadUnreadStateInsert[];
+  unreadThreads?: db.ThreadUnreadState[];
   lastPostAt?: number;
 };
 
@@ -63,9 +63,7 @@ function toUnreadData(channelId: string, unread: ub.Unread): ChannelUnreadData {
   };
 }
 
-function toThreadUnreadStateData(
-  unread: ub.Unread
-): db.ThreadUnreadStateInsert[] {
+function toThreadUnreadStateData(unread: ub.Unread): db.ThreadUnreadState[] {
   return Object.entries(unread.threads).map(([threadId, unreadState]) => {
     return {
       threadId,

--- a/packages/shared/src/api/chatApi.ts
+++ b/packages/shared/src/api/chatApi.ts
@@ -13,7 +13,7 @@ export const markChatRead = (whom: string) =>
     },
   });
 
-export type GetDmsResponse = db.ChannelInsert[];
+export type GetDmsResponse = db.Channel[];
 
 export const getDms = async (): Promise<GetDmsResponse> => {
   const result = (await scry({ app: 'chat', path: '/dm' })) as string[];
@@ -21,7 +21,7 @@ export const getDms = async (): Promise<GetDmsResponse> => {
 };
 
 export const toClientDms = (dmContacts: string[]) => {
-  return dmContacts.map((id): db.ChannelInsert => {
+  return dmContacts.map((id): db.Channel => {
     return {
       id,
       type: 'dm' as const,
@@ -39,12 +39,12 @@ export const getGroupDms = async (): Promise<GetDmsResponse> => {
 
 export const toClientGroupDms = (groupDms: ub.Clubs): GetDmsResponse => {
   return Object.entries(groupDms).map(
-    ([id, club]): db.ChannelInsert => ({
+    ([id, club]): db.Channel => ({
       id,
       type: 'groupDm',
       ...toClientMeta(club.meta),
       members: club.team.map(
-        (member): db.ChatMemberInsert => ({
+        (member): db.ChatMember => ({
           contactId: member,
           chatId: id,
           membershipType: 'channel',

--- a/packages/shared/src/api/contactsApi.ts
+++ b/packages/shared/src/api/contactsApi.ts
@@ -11,9 +11,7 @@ export const getContacts = async () => {
   return toClientContacts(results);
 };
 
-export const toClientContacts = (
-  contacts: ub.ContactRolodex
-): db.ContactInsert[] => {
+export const toClientContacts = (contacts: ub.ContactRolodex): db.Contact[] => {
   return Object.entries(contacts).flatMap(([ship, contact]) =>
     contact === null ? [] : [toClientContact(ship, contact)]
   );
@@ -22,7 +20,7 @@ export const toClientContacts = (
 export const toClientContact = (
   id: string,
   contact: ub.Contact | null
-): db.ContactInsert => {
+): db.Contact => {
   return {
     id,
     nickname: contact?.nickname ?? null,

--- a/packages/shared/src/api/groupsApi.ts
+++ b/packages/shared/src/api/groupsApi.ts
@@ -94,8 +94,8 @@ export function toClientGroup(
   id: string,
   group: ub.Group,
   isJoined: boolean
-): db.GroupInsert {
-  const rolesById: Record<string, db.GroupRoleInsert> = {};
+): db.Group {
+  const rolesById: Record<string, db.GroupRole> = {};
   const roles = Object.entries(group.cabals ?? {}).map(([roleId, role]) => {
     const data: db.GroupRole = {
       id: roleId,
@@ -117,7 +117,7 @@ export function toClientGroup(
         if (!zone) {
           return;
         }
-        const data: db.GroupNavSectionWithRelations = {
+        const data: db.GroupNavSection = {
           id: zoneId,
           groupId: id,
           ...toClientMeta(zone.meta),
@@ -133,7 +133,7 @@ export function toClientGroup(
         };
         return data;
       })
-      .filter((s): s is db.GroupNavSectionWithRelations => !!s),
+      .filter((s): s is db.GroupNavSection => !!s),
     members: Object.entries(group.fleet).map(([userId, vessel]) => {
       return toClientGroupMember({
         groupId: id,
@@ -153,7 +153,7 @@ function toClientChannels({
 }: {
   channels: Record<string, ub.GroupChannel>;
   groupId: string;
-}): db.ChannelInsert[] {
+}): db.Channel[] {
   return Object.entries(channels).map(([id, channel]) =>
     toClientChannel({ id, channel, groupId })
   );
@@ -167,7 +167,7 @@ function toClientChannel({
   id: string;
   channel: ub.GroupChannel;
   groupId: string;
-}): db.ChannelInsert {
+}): db.Channel {
   return {
     id,
     groupId,
@@ -187,7 +187,7 @@ function toClientGroupMember({
   groupId: string;
   contactId: string;
   vessel: { sects: string[]; joined: number };
-}): db.ChatMemberInsert {
+}): db.ChatMember {
   return {
     membershipType: 'group',
     contactId,

--- a/packages/shared/src/api/initApi.ts
+++ b/packages/shared/src/api/initApi.ts
@@ -9,7 +9,7 @@ export interface InitData {
   pins: db.Pin[];
   groups: db.Group[];
   unreads: db.Unread[];
-  channels: db.ChannelInsert[];
+  channels: db.Channel[];
 }
 
 export const getInitData = async () => {

--- a/packages/shared/src/api/postsApi.test.ts
+++ b/packages/shared/src/api/postsApi.test.ts
@@ -1,6 +1,6 @@
 import { beforeAll, beforeEach, expect, test } from 'vitest';
 
-import { PostInsert } from '../db';
+import { Post } from '../db';
 import rawChannelPostWithRepliesData from '../test/channelPostWithReplies.json';
 import rawChannelPostsData from '../test/channelPosts.json';
 import rawDmPostWithRepliesData from '../test/dmPostWithReplies.json';
@@ -20,7 +20,7 @@ beforeEach(async () => {
 test('toPostData', async () => {
   const postsData = rawChannelPostsData as unknown as PagedPosts;
   const { posts } = toPostsData('testChannielId', postsData.posts);
-  const oldestPost = posts.reduce<PostInsert>((acc, post) => {
+  const oldestPost = posts.reduce<Post>((acc, post) => {
     const time = post.receivedAt ?? 0;
     return time < (acc.receivedAt ?? 0) ? post : acc;
   }, posts[0]);

--- a/packages/shared/src/api/postsApi.ts
+++ b/packages/shared/src/api/postsApi.ts
@@ -320,7 +320,7 @@ async function with404Handler<T>(scryRequest: Promise<any>, defaultValue: T) {
 export interface GetChannelPostsResponse {
   older?: string | null;
   newer?: string | null;
-  posts: db.PostInsert[];
+  posts: db.Post[];
   deletedPosts?: string[];
   totalPosts?: number;
 }
@@ -371,7 +371,7 @@ export function toPostsData(
   posts: ub.Posts | Record<string, ub.Reply>
 ) {
   const [deletedPosts, otherPosts] = Object.entries(posts).reduce<
-    [string[], db.PostInsert[]]
+    [string[], db.Post[]]
   >(
     (memo, [id, post]) => {
       if (post === null) {
@@ -394,7 +394,7 @@ export function toPostsData(
 export function toPostData(
   channelId: string,
   post: ub.Post | ub.PostDataResponse
-): db.PostInsert {
+): db.Post {
   const type = isNotice(post)
     ? 'notice'
     : (channelId.split('/')[0] as db.PostType);
@@ -453,7 +453,7 @@ function getReplyData(
   postId: string,
   channelId: string,
   post: ub.PostDataResponse
-): db.PostInsert[] {
+): db.Post[] {
   return Object.entries(post.seal.replies ?? {}).map(([, reply]) => {
     const [content, flags] = toPostContent(reply.memo.content);
     const id = reply.seal.id;

--- a/packages/shared/src/api/unreadsApi.ts
+++ b/packages/shared/src/api/unreadsApi.ts
@@ -61,7 +61,7 @@ export const subscribeUnreads = async (
 export const toClientUnreads = (
   unreads: ub.Unreads,
   type: db.Unread['type']
-): (db.Unread & { threadUnreads: db.ThreadUnreadState[] })[] => {
+): db.Unread[] => {
   return Object.entries(unreads).map(([id, contact]) =>
     toClientUnread(id, contact, type)
   );

--- a/packages/shared/src/db/schema.ts
+++ b/packages/shared/src/db/schema.ts
@@ -33,7 +33,7 @@ export const contacts = sqliteTable('contacts', {
   coverImage: text('coverImage'),
 });
 
-export const contactsRelations = relations(contacts, ({ one, many }) => ({
+export const contactsRelations = relations(contacts, ({ many }) => ({
   pinnedGroups: many(contactGroups),
 }));
 
@@ -125,6 +125,17 @@ export const pins = sqliteTable(
   }
 );
 
+export const pinRelations = relations(pins, ({ one }) => ({
+  group: one(groups, {
+    fields: [pins.itemId],
+    references: [groups.id],
+  }),
+  channel: one(channels, {
+    fields: [pins.itemId],
+    references: [channels.id],
+  }),
+}));
+
 export const groups = sqliteTable('groups', {
   id: text('id').primaryKey(),
   ...metaFields,
@@ -135,6 +146,7 @@ export const groups = sqliteTable('groups', {
 });
 
 export const groupsRelations = relations(groups, ({ one, many }) => ({
+  pin: one(pins),
   roles: many(groupRoles),
   members: many(chatMembers),
   navSections: many(groupNavSections),
@@ -309,6 +321,7 @@ export const channels = sqliteTable('channels', {
 });
 
 export const channelRelations = relations(channels, ({ one, many }) => ({
+  pin: one(pins),
   group: one(groups, {
     fields: [channels.groupId],
     references: [groups.id],

--- a/packages/shared/src/db/types.ts
+++ b/packages/shared/src/db/types.ts
@@ -8,118 +8,46 @@ import type {
 import * as schema from './schema';
 
 export type Schema = typeof schema;
-type SchemaWithRelations = ExtractTablesWithRelations<Schema>;
-type DbTableNames = SchemaWithRelations[keyof SchemaWithRelations]['dbName'];
+export type SchemaWithRelations = ExtractTablesWithRelations<Schema>;
 export type TableName = keyof SchemaWithRelations;
-type TableRelations<T extends TableName> = SchemaWithRelations[T]['relations'];
+type TableSchema = SchemaWithRelations[keyof SchemaWithRelations];
 
-type SchemaFromDbTableName<T extends DbTableNames> = Extract<
+type SchemaFromDbTableName<T> = Extract<
   SchemaWithRelations[keyof SchemaWithRelations],
   { dbName: T }
 >;
 
-type InsertRelations<T extends TableName> = {
-  [K in keyof TableRelations<T>]?: TableRelations<T>[K] extends Many<
-    infer TTableName
-  >
-    ? TTableName extends DbTableNames
-      ? Insertable<SchemaFromDbTableName<TTableName>['tsName']>[] | null
-      : never
-    : TableRelations<T>[K] extends One<infer TTableName>
-      ? TTableName extends DbTableNames
-        ? Insertable<SchemaFromDbTableName<TTableName>['tsName']> | null
-        : never
-      : never;
+type RelationTableName<T> = T extends Many<infer V> | One<infer V>
+  ? SchemaFromDbTableName<V>['tsName']
+  : never;
+
+type BaseModelRelations<T extends TableSchema> = {
+  [K in keyof T['relations']]?: T['relations'][K] extends Many<string>
+    ? BaseModel<RelationTableName<T['relations'][K]>>[] | null
+    : BaseModel<RelationTableName<T['relations'][K]>> | null;
 };
 
-export type Insertable<T extends TableName> = InferModelFromColumns<
+type BaseModel<T extends TableName> = InferModelFromColumns<
   SchemaWithRelations[T]['columns'],
   'insert'
 > &
-  InsertRelations<T>;
+  BaseModelRelations<SchemaWithRelations[T]>;
 
-export type Contact = typeof schema.contacts.$inferSelect;
-export type ContactInsert = Insertable<'contacts'>;
-export type Unread = typeof schema.unreads.$inferSelect;
-export type UnreadInsert = Insertable<'unreads'>;
-export type GroupsTable = typeof schema.groups;
-export type Group = typeof schema.groups.$inferSelect;
-
-export type GroupSummary = Group & {
-  unreadCount?: number | null;
-  lastPost?: Post | null;
-};
-
-export type GroupWithRelations = Group & {
-  members: ChatMember[];
-  roles: GroupRole[];
-  channels: ChannelWithLastPostAndMembers[];
-  navSections: GroupNavSectionWithRelations[];
-};
-
-export type GroupWithMembersAndRoles = Group & {
-  members: ChatMember[];
-  roles: GroupRole[];
-};
-
-export type GroupInsert = Insertable<'groups'>;
-export type GroupRole = typeof schema.groupRoles.$inferSelect;
-export type GroupRoleInsert = typeof schema.groupRoles.$inferInsert;
-export type ChatMember = typeof schema.chatMembers.$inferSelect;
-export type ChatMemberInsert = Insertable<'chatMembers'>;
-export type ChatMemberGroupRole =
-  typeof schema.chatMemberGroupRoles.$inferSelect;
-export type ChatMemberGroupRoleInsert =
-  typeof schema.chatMemberGroupRoles.$inferInsert;
-export type GroupNavSection = typeof schema.groupNavSections.$inferSelect;
-export type GroupNavSectionInsert = typeof schema.groupNavSections.$inferInsert;
-export type GroupNavSectionWithRelations = GroupNavSection & {
-  channels: GroupNavSectionChannel[];
-};
-export type GroupNavSectionChannel =
-  typeof schema.groupNavSectionChannels.$inferSelect;
-export type GroupNavSectionChannelInsert =
-  typeof schema.groupNavSectionChannels.$inferInsert;
-export type Channel = typeof schema.channels.$inferSelect;
-export type ChannelWithRelations = Channel & {
-  group: GroupWithRelations;
-  posts: Post[];
-  lastPost: Post | null;
-  threadUnreadStates: ThreadUnreadState[];
-};
-export type ChannelWithGroup = Channel & { group: GroupWithMembersAndRoles };
-export type ChannelWithLastPostAndMembers = Channel & {
-  lastPost: Post | null;
-  members?: (ChatMember & { contact: Contact | null })[] | null;
-  unread: Unread | null;
-};
-
-export type ChannelSummary = Channel & {
-  unread: Unread | null;
-  lastPost: Post | null;
-  group: Group | null;
-  members: (ChatMember & { contact: Contact | null })[] | null;
-  pin?: Pin | null;
-};
-
-export type ChannelInsert = Insertable<'channels'>;
+export type Contact = BaseModel<'contacts'>;
+export type ContactPinnedGroups = Contact['pinnedGroups'];
+export type Unread = BaseModel<'unreads'>;
+// TODO: We need to include unread count here because it's  returned by the chat
+// list query, but doesn't feel great.
+export type Group = BaseModel<'groups'> & { unreadCount?: number | null };
+export type ChatMember = BaseModel<'chatMembers'>;
+export type GroupRole = BaseModel<'groupRoles'>;
+export type ChatMemberGroupRole = BaseModel<'chatMemberGroupRoles'>;
+export type GroupNavSection = BaseModel<'groupNavSections'>;
+export type GroupNavSectionChannel = BaseModel<'groupNavSectionChannels'>;
+export type Channel = BaseModel<'channels'>;
 export type ChannelType = schema.ChannelType;
-export type ThreadUnreadState = typeof schema.threadUnreads.$inferSelect;
-export type ThreadUnreadStateInsert = typeof schema.threadUnreads.$inferInsert;
-export type Post = typeof schema.posts.$inferSelect;
-export type PostWithRelations = Post & {
-  reactions: Reaction[] | null;
-  author: Contact | null;
-};
-
-export type PostInsertWithAuthor = PostInsert & {
-  author: Contact | null;
-};
-
-export type PostInsertWithReactions = PostInsert & {
-  reactions: ReactionInsert[];
-};
-
+export type ThreadUnreadState = BaseModel<'threadUnreads'>;
+export type Post = BaseModel<'posts'>;
 export type PostType = Post['type'];
 export type PostFlags = Pick<
   Post,
@@ -129,12 +57,8 @@ export type PostFlags = Pick<
   | 'hasImage'
   | 'hasLink'
 >;
-export type PostMetadata = Partial<Pick<Post, 'title' | 'image'>>;
-export type PostInsert = Insertable<'posts'>;
-export type PostImage = typeof schema.postImages.$inferSelect;
-export type PostReaction = typeof schema.postReactions.$inferSelect;
-export type Reaction = typeof schema.postReactions.$inferSelect;
-export type ReactionInsert = typeof schema.postReactions.$inferInsert;
-export type Pin = typeof schema.pins.$inferSelect;
+export type PostMetadata = Pick<Post, 'title' | 'image'>;
+export type PostImage = BaseModel<'postImages'>;
+export type Reaction = BaseModel<'postReactions'>;
+export type Pin = BaseModel<'pins'>;
 export type PinType = schema.PinType;
-export type PinInsert = typeof schema.pins.$inferInsert;

--- a/packages/shared/src/logic/references.ts
+++ b/packages/shared/src/logic/references.ts
@@ -2,6 +2,6 @@ import { udToDec } from '@urbit/api';
 
 import * as db from '../db';
 
-export function getPostReferencePath(post: db.PostInsert) {
+export function getPostReferencePath(post: db.Post) {
   return `/1/chan/${post.channelId}/msg/${udToDec(post.id)}`;
 }

--- a/packages/shared/src/logic/utils.ts
+++ b/packages/shared/src/logic/utils.ts
@@ -127,7 +127,7 @@ export function normalizeUrbitColor(color: string): string {
   return `#${lengthAdjustedColor}`;
 }
 
-export function getPinPartial(channel: db.ChannelSummary): {
+export function getPinPartial(channel: db.Channel): {
   type: db.PinType;
   itemId: string;
 } {

--- a/packages/shared/src/store/channelActions.ts
+++ b/packages/shared/src/store/channelActions.ts
@@ -2,7 +2,7 @@ import * as api from '../api';
 import * as db from '../db';
 import * as logic from '../logic';
 
-export async function pinItem(channel: db.ChannelSummary) {
+export async function pinItem(channel: db.Channel) {
   // optimistic update
   const partialPin = logic.getPinPartial(channel);
   db.insertPinnedItem(partialPin);

--- a/packages/shared/src/store/dbHooks.ts
+++ b/packages/shared/src/store/dbHooks.ts
@@ -9,15 +9,15 @@ export * from './useChannelSearch';
 // Can break em out as they get bigger.
 
 export interface CurrentChats {
-  pinned: db.ChannelSummary[];
-  unpinned: db.ChannelSummary[];
+  pinned: db.Channel[];
+  unpinned: db.Channel[];
 }
 
 export const useCurrentChats = (): UseQueryResult<CurrentChats | null> => {
   return useQuery({
     queryFn: db.getChats,
     queryKey: ['currentChats', useKeyFromQueryDeps(db.getGroup)],
-    select(channels: db.ChannelSummary[]) {
+    select(channels: db.Channel[]) {
       for (let i = 0; i < channels.length; ++i) {
         if (!channels[i].pin) {
           return {

--- a/packages/shared/src/store/postActions.ts
+++ b/packages/shared/src/store/postActions.ts
@@ -2,7 +2,7 @@ import * as api from '../api';
 import * as db from '../db';
 import * as sync from './sync';
 
-export async function hidePost({ post }: { post: db.PostInsert }) {
+export async function hidePost({ post }: { post: db.Post }) {
   // optimistic update
   await db.updatePost({ id: post.id, hidden: true });
 
@@ -16,7 +16,7 @@ export async function hidePost({ post }: { post: db.PostInsert }) {
   }
 }
 
-export async function showPost({ post }: { post: db.PostInsert }) {
+export async function showPost({ post }: { post: db.Post }) {
   // optimistic update
   await db.updatePost({ id: post.id, hidden: false });
 
@@ -30,7 +30,7 @@ export async function showPost({ post }: { post: db.PostInsert }) {
   }
 }
 
-export async function deletePost({ post }: { post: db.PostInsert }) {
+export async function deletePost({ post }: { post: db.Post }) {
   // optimistic update
   await db.deletePost(post.id);
 
@@ -45,7 +45,7 @@ export async function deletePost({ post }: { post: db.PostInsert }) {
 }
 
 export async function addPostReaction(
-  post: db.PostInsert,
+  post: db.Post,
   shortCode: string,
   currentUserId: string
 ) {
@@ -74,10 +74,7 @@ export async function addPostReaction(
   }
 }
 
-export async function removePostReaction(
-  post: db.PostInsert,
-  currentUserId: string
-) {
+export async function removePostReaction(post: db.Post, currentUserId: string) {
   const existingReaction = await db.getPostReaction({
     postId: post.id,
     contactId: currentUserId,

--- a/packages/shared/src/store/sync.test.ts
+++ b/packages/shared/src/store/sync.test.ts
@@ -64,10 +64,9 @@ const outputData = [
 test('syncs pins', async () => {
   setScryOutput(inputData);
   await syncPinnedItems();
-  const savedItems = await db.getPinnedItems({
-    orderBy: 'index',
-    direction: 'asc',
-  });
+  const savedItems = (await db.getPinnedItems()).sort(
+    (a, b) => a.index - b.index
+  );
   expect(savedItems).toEqual(outputData);
 });
 
@@ -231,7 +230,7 @@ const groupId = '~solfer-magfed/test-group';
 const channelId = 'chat/~solfer-magfed/test-channel';
 const unreadTime = 1712091148002;
 
-const testGroupData: db.GroupInsert = {
+const testGroupData: db.Group = {
   ...toClientGroup(
     groupId,
     Object.values(rawGroupsData)[0] as unknown as UrbitGroup,

--- a/packages/shared/src/store/sync.ts
+++ b/packages/shared/src/store/sync.ts
@@ -46,7 +46,7 @@ export const syncUnreads = async () => {
   await resetUnreads(unreads);
 };
 
-const resetUnreads = async (unreads: db.UnreadInsert[]) => {
+const resetUnreads = async (unreads: db.Unread[]) => {
   await db.insertUnreads(unreads);
   await db.setJoinedGroupChannels({
     channelIds: unreads
@@ -63,9 +63,7 @@ async function handleUnreadUpdate(unread: db.Unread) {
 
 type StaleChannel = db.Channel & { unread: db.Unread };
 
-export const syncStaleChannels = async ({
-  type,
-}: { type?: 'channel' | 'dm' } = {}) => {
+export const syncStaleChannels = async () => {
   const channels: StaleChannel[] = optimizeChannelLoadOrder(
     await db.getStaleChannels()
   );
@@ -178,7 +176,7 @@ async function persistPagedPostData(
     const reactions = data.posts
       .map((p) => p.reactions)
       .flat()
-      .filter(Boolean) as db.ReactionInsert[];
+      .filter(Boolean) as db.Reaction[];
     if (reactions.length) {
       await db.insertPostReactions({ reactions });
     }

--- a/packages/shared/src/store/useAttachAuthorToPosts.ts
+++ b/packages/shared/src/store/useAttachAuthorToPosts.ts
@@ -2,12 +2,9 @@ import _ from 'lodash';
 import { useEffect, useMemo, useState } from 'react';
 
 import * as db from '../db';
-import { getFallbackContact } from '../db/fallback';
 
-export function useAttachAuthorToPostInserts(posts: db.PostInsert[]) {
-  const [postsWithAuthor, setPostsWithAuthor] = useState<
-    db.PostInsertWithAuthor[]
-  >([]);
+export function useAttachAuthorToPosts(posts: db.Post[]) {
+  const [postsWithAuthor, setPostsWithAuthor] = useState<db.Post[]>([]);
   const [authorsCache, setAuthorsCache] = useState<
     Record<string, db.Contact | null>
   >({});

--- a/packages/shared/src/store/useChannelPosts.ts
+++ b/packages/shared/src/store/useChannelPosts.ts
@@ -17,7 +17,7 @@ export const useChannelPosts = (options: db.GetChannelPostsOptions) => {
   }, []);
   return useInfiniteQuery({
     initialPageParam: options,
-    queryFn: async (ctx): Promise<db.PostWithRelations[]> => {
+    queryFn: async (ctx): Promise<db.Post[]> => {
       const queryOptions = ctx.pageParam || options;
       postsLogger.log(
         'start',

--- a/packages/shared/src/store/useChannelSearch.ts
+++ b/packages/shared/src/store/useChannelSearch.ts
@@ -4,7 +4,7 @@ import bigInt from 'big-integer';
 import { useEffect, useMemo } from 'react';
 
 import { searchChatChannel } from '../api/channelsApi';
-import { useAttachAuthorToPostInserts } from './useAttachAuthorToPostInserts';
+import { useAttachAuthorToPosts } from './useAttachAuthorToPosts';
 
 const MIN_RESULT_LOAD_THRESHOLD = 20;
 
@@ -18,7 +18,7 @@ export function useChannelSearch(channelId: string, query: string) {
     fetchNextPage,
   } = useInfiniteChannelSearch(channelId, query);
 
-  const posts = useAttachAuthorToPostInserts(results);
+  const posts = useAttachAuthorToPosts(results);
 
   // Makes sure we load enough results to fill the screen before relying on infinite scroll
   useEffect(() => {

--- a/packages/ui/src/components/Channel/ChatScroll.tsx
+++ b/packages/ui/src/components/Channel/ChatScroll.tsx
@@ -43,7 +43,7 @@ export default function ChatScroll({
   onPressReplies,
   showReplies = true,
 }: {
-  posts: db.PostWithRelations[];
+  posts: db.Post[];
   currentUserId: string;
   channelType: db.ChannelType;
   unreadCount?: number;
@@ -52,12 +52,12 @@ export default function ChatScroll({
   selectedPost?: string;
   onStartReached?: () => void;
   onEndReached?: () => void;
-  onPressImage?: (post: db.PostInsert, imageUri?: string) => void;
-  onPressReplies?: (post: db.PostInsert) => void;
+  onPressImage?: (post: db.Post, imageUri?: string) => void;
+  onPressReplies?: (post: db.Post) => void;
   showReplies?: boolean;
 }) {
   const [hasPressedGoToBottom, setHasPressedGoToBottom] = useState(false);
-  const flatListRef = useRef<FlatList<db.PostWithRelations>>(null);
+  const flatListRef = useRef<FlatList<db.Post>>(null);
 
   const pressedGoToBottom = () => {
     setHasPressedGoToBottom(true);
@@ -92,16 +92,15 @@ export default function ChatScroll({
     }
   }, [selectedPost]);
 
-  const [activeMessage, setActiveMessage] =
-    useState<db.PostWithRelations | null>(null);
+  const [activeMessage, setActiveMessage] = useState<db.Post | null>(null);
   const activeMessageRefs = useRef<Record<string, RefObject<RNView>>>({});
 
-  const handleSetActive = useCallback((active: db.PostWithRelations) => {
+  const handleSetActive = useCallback((active: db.Post) => {
     activeMessageRefs.current[active.id] = createRef();
     setActiveMessage(active);
   }, []);
 
-  const renderItem: ListRenderItem<db.PostWithRelations> = useCallback(
+  const renderItem: ListRenderItem<db.Post> = useCallback(
     ({ item }) => {
       return (
         <PressableMessage
@@ -153,7 +152,7 @@ export default function ChatScroll({
       {unreadCount && !hasPressedGoToBottom && (
         <UnreadsButton onPress={pressedGoToBottom} />
       )}
-      <FlatList<db.PostWithRelations>
+      <FlatList<db.Post>
         ref={flatListRef}
         data={posts}
         renderItem={renderItem}

--- a/packages/ui/src/components/Channel/index.tsx
+++ b/packages/ui/src/components/Channel/index.tsx
@@ -42,17 +42,17 @@ export function Channel({
   isLoadingPosts,
   canUpload,
 }: {
-  channel: db.ChannelWithLastPostAndMembers;
+  channel: db.Channel;
   currentUserId: string;
   selectedPost?: string;
-  posts: db.PostWithRelations[] | null;
+  posts: db.Post[] | null;
   contacts: db.Contact[] | null;
-  group: db.GroupWithRelations | null;
+  group: db.Group | null;
   calmSettings: CalmState;
   goBack: () => void;
   goToChannels: () => void;
-  goToPost: (post: db.PostInsert) => void;
-  goToImageViewer: (post: db.PostInsert, imageUri?: string) => void;
+  goToPost: (post: db.Post) => void;
+  goToImageViewer: (post: db.Post, imageUri?: string) => void;
   goToSearch: () => void;
   messageSender: (content: Story, channelId: string) => void;
   imageAttachment?: string | null;

--- a/packages/ui/src/components/ChannelListItem/index.tsx
+++ b/packages/ui/src/components/ChannelListItem/index.tsx
@@ -13,7 +13,7 @@ export default function ChannelListItem({
   ...props
 }: {
   useTypeIcon?: boolean;
-} & ListItemProps<db.ChannelWithLastPostAndMembers>) {
+} & ListItemProps<db.Channel>) {
   const title = utils.getChannelTitle(model);
 
   return (
@@ -55,7 +55,7 @@ function ChannelListItemIcon({
   model,
   useTypeIcon,
 }: {
-  model: db.ChannelWithLastPostAndMembers;
+  model: db.Channel;
   useTypeIcon?: boolean;
 }) {
   const backgroundColor = model.iconImageColor as ColorProp;
@@ -101,6 +101,8 @@ function ChannelListItemIcon({
   }
 }
 
-function hasGroup(channel: db.Channel): channel is db.ChannelWithGroup {
+function hasGroup(
+  channel: db.Channel
+): channel is db.Channel & { group: db.Group } {
   return 'group' in channel && !!channel.group;
 }

--- a/packages/ui/src/components/ChannelNavSection.tsx
+++ b/packages/ui/src/components/ChannelNavSection.tsx
@@ -9,8 +9,8 @@ export default function ChannelNavSection({
   channels,
   onSelect,
 }: {
-  section: db.GroupNavSectionWithRelations;
-  channels: db.ChannelWithLastPostAndMembers[];
+  section: db.GroupNavSection;
+  channels: db.Channel[];
   onSelect: (channel: any) => void;
 }) {
   const sectionChannels = useMemo(
@@ -24,7 +24,7 @@ export default function ChannelNavSection({
   );
 
   const getChannel = useCallback(
-    (channelId: string | null) => {
+    (channelId?: string | null) => {
       return channels.find((c) => c.id === channelId);
     },
     [channels]

--- a/packages/ui/src/components/ChannelNavSections.tsx
+++ b/packages/ui/src/components/ChannelNavSections.tsx
@@ -11,8 +11,8 @@ export default function ChannelNavSections({
   onSelect,
   paddingBottom,
 }: {
-  group: db.GroupWithRelations;
-  channels: db.ChannelWithLastPostAndMembers[];
+  group: db.Group;
+  channels: db.Channel[];
   onSelect: (channel: any) => void;
   paddingBottom?: number;
 }) {
@@ -20,8 +20,8 @@ export default function ChannelNavSections({
     () =>
       channels.filter(
         (c) =>
-          !group.navSections.some((s) =>
-            s.channels.some((sc) => sc.channelId === c.id)
+          !group.navSections?.some((s) =>
+            s.channels?.some((sc) => sc.channelId === c.id)
           )
       ),
     [channels, group.navSections]
@@ -34,7 +34,7 @@ export default function ChannelNavSections({
 
   return (
     <YStack paddingBottom={paddingBottom} alignSelf="stretch" gap="$s">
-      {group.navSections.map((section) => (
+      {group.navSections?.map((section) => (
         <ChannelNavSection
           key={section.id}
           section={section}

--- a/packages/ui/src/components/ChannelSearch/SearchResults.tsx
+++ b/packages/ui/src/components/ChannelSearch/SearchResults.tsx
@@ -14,9 +14,9 @@ export function SearchResults({
   navigateToPost,
   search,
 }: {
-  posts: db.PostInsertWithAuthor[];
+  posts: db.Post[];
   currentUserId: string;
-  navigateToPost: (post: db.PostWithRelations) => void;
+  navigateToPost: (post: db.Post) => void;
   search: SearchState;
 }) {
   const insets = useSafeAreaInsets();
@@ -72,9 +72,7 @@ export function SearchResults({
                 renderItem={({ item: post }) => (
                   <View
                     marginBottom="$m"
-                    onPress={() =>
-                      navigateToPost(post as unknown as db.PostWithRelations)
-                    }
+                    onPress={() => navigateToPost(post as unknown as db.Post)}
                   >
                     <ChatMessage post={post} currentUserId={currentUserId} />
                   </View>

--- a/packages/ui/src/components/ChannelSwitcherSheet.tsx
+++ b/packages/ui/src/components/ChannelSwitcherSheet.tsx
@@ -9,10 +9,10 @@ import { Sheet } from './Sheet';
 interface Props {
   open: boolean;
   onOpenChange: (open: boolean) => void;
-  group: db.GroupWithRelations;
-  channels: db.ChannelWithLastPostAndMembers[];
+  group: db.Group;
+  channels: db.Channel[];
   contacts: db.Contact[];
-  onSelect: (channel: db.ChannelWithLastPostAndMembers) => void;
+  onSelect: (channel: db.Channel) => void;
   paddingBottom?: number;
 }
 

--- a/packages/ui/src/components/ChatList.tsx
+++ b/packages/ui/src/components/ChatList.tsx
@@ -22,8 +22,8 @@ export function ChatList({
   onLongPressItem,
   onPressItem,
 }: store.CurrentChats & {
-  onPressItem?: (chat: db.ChannelSummary) => void;
-  onLongPressItem?: (chat: db.ChannelSummary) => void;
+  onPressItem?: (chat: db.Channel) => void;
+  onLongPressItem?: (chat: db.Channel) => void;
 }) {
   const data = useMemo(() => {
     if (pinned.length === 0) {
@@ -46,9 +46,7 @@ export function ChatList({
   ) as StyleProp<ViewStyle>;
 
   const renderItem = useCallback(
-    ({
-      item,
-    }: SectionListRenderItemInfo<db.ChannelSummary, { title: string }>) => {
+    ({ item }: SectionListRenderItemInfo<db.Channel, { title: string }>) => {
       return (
         <SwipableChatRow model={item}>
           <ChatListItem
@@ -66,7 +64,7 @@ export function ChatList({
     ({
       section,
     }: {
-      section: SectionListData<db.ChannelSummary, { title: string }>;
+      section: SectionListData<db.Channel, { title: string }>;
     }) => {
       return <ListSectionHeader>{section.title}</ListSectionHeader>;
     },
@@ -92,17 +90,12 @@ export function ChatList({
   );
 }
 
-function getChannelKey(channel: db.ChannelSummary) {
+function getChannelKey(channel: db.Channel) {
   return channel.id + channel.pin?.itemId ?? '';
 }
 
 const ChatListItem = React.memo(
-  ({
-    model,
-    onPress,
-    onLongPress,
-    ...props
-  }: ListItemProps<db.ChannelSummary>) => {
+  ({ model, onPress, onLongPress, ...props }: ListItemProps<db.Channel>) => {
     const handlePress = useCallback(() => {
       onPress?.(model);
     }, [onPress]);

--- a/packages/ui/src/components/ChatMessage/ChatMessageActions.tsx
+++ b/packages/ui/src/components/ChatMessage/ChatMessageActions.tsx
@@ -34,7 +34,7 @@ export function ChatMessageActions({
   channelType,
   onDismiss,
 }: {
-  post: db.PostWithRelations;
+  post: db.Post;
   currentUserId: string;
   postRef: RefObject<RNView>;
   channelType: db.ChannelType;
@@ -155,7 +155,7 @@ export function EmojiToolbar({
   currentUserId,
   onDismiss,
 }: {
-  post: db.PostWithRelations;
+  post: db.Post;
   currentUserId: string;
   onDismiss: () => void;
 }) {
@@ -256,7 +256,7 @@ function MessageContainer({
   post,
   currentUserId,
 }: {
-  post: db.PostWithRelations;
+  post: db.Post;
   currentUserId: string;
 }) {
   const screenHeight = Dimensions.get('window').height;

--- a/packages/ui/src/components/ChatMessage/ChatMessageActionsList.tsx
+++ b/packages/ui/src/components/ChatMessage/ChatMessageActionsList.tsx
@@ -12,7 +12,7 @@ export default function ChatMessageActionsList({
   post,
 }: {
   dismiss: () => void;
-  post: db.PostInsert;
+  post: db.Post;
   channelType: db.ChannelType;
 }) {
   const postActions = getPostActions(post, channelType);
@@ -40,7 +40,7 @@ interface ChannelAction {
   actionType?: 'destructive';
 }
 function getPostActions(
-  post: db.PostInsert,
+  post: db.Post,
   channelType: db.ChannelType
 ): ChannelAction[] {
   switch (channelType) {
@@ -91,7 +91,7 @@ async function handleAction({
   dismiss,
 }: {
   id: string;
-  post: db.PostInsert;
+  post: db.Post;
   dismiss: () => void;
 }) {
   switch (id) {

--- a/packages/ui/src/components/ChatMessage/ReactionsDisplay.tsx
+++ b/packages/ui/src/components/ChatMessage/ReactionsDisplay.tsx
@@ -9,7 +9,7 @@ export function ReactionsDisplay({
   post,
   currentUserId,
 }: {
-  post: db.PostWithRelations | db.PostInsertWithAuthor;
+  post: db.Post;
   currentUserId: string;
 }) {
   const reactionDetails = useReactionDetails(

--- a/packages/ui/src/components/ChatMessage/index.tsx
+++ b/packages/ui/src/components/ChatMessage/index.tsx
@@ -18,13 +18,13 @@ const ChatMessage = ({
   showReplies,
   currentUserId,
 }: {
-  post: db.PostWithRelations | db.PostInsertWithAuthor;
+  post: db.Post;
   firstUnread?: string;
   unreadCount?: number;
   showReplies?: boolean;
   currentUserId: string;
-  onPressReplies?: (post: db.PostInsert) => void;
-  onPressImage?: (post: db.PostInsert, imageUri?: string) => void;
+  onPressReplies?: (post: db.Post) => void;
+  onPressImage?: (post: db.Post, imageUri?: string) => void;
   onLongPress?: () => void;
 }) => {
   const isUnread = useMemo(

--- a/packages/ui/src/components/GroupListItem/GroupListItem.tsx
+++ b/packages/ui/src/components/GroupListItem/GroupListItem.tsx
@@ -9,7 +9,7 @@ export const GroupListItem = ({
   onPress,
   onLongPress,
   ...props
-}: ListItemProps<db.GroupSummary>) => {
+}: ListItemProps<db.Group>) => {
   const handlePress = useCallback(() => {
     onPress?.(model);
   }, [onPress, model]);

--- a/packages/ui/src/components/GroupListItem/GroupListItemContent.tsx
+++ b/packages/ui/src/components/GroupListItem/GroupListItemContent.tsx
@@ -7,7 +7,7 @@ export default function GroupListItemContent({
   onPress,
   onLongPress,
   ...props
-}: ListItemProps<db.GroupSummary>) {
+}: ListItemProps<db.Group>) {
   return (
     <ListItem
       {...props}

--- a/packages/ui/src/components/ImageViewerScreenView.tsx
+++ b/packages/ui/src/components/ImageViewerScreenView.tsx
@@ -17,7 +17,7 @@ interface ImageZoomRef {
 }
 
 export function ImageViewerScreenView(props: {
-  post?: db.PostWithRelations;
+  post?: db.Post;
   uri?: string;
   goBack: () => void;
 }) {

--- a/packages/ui/src/components/PostScreenView.tsx
+++ b/packages/ui/src/components/PostScreenView.tsx
@@ -14,7 +14,7 @@ export function PostScreenView({
 }: {
   currentUserId: string;
   channel: db.Channel | null;
-  posts: db.PostWithRelations[] | null;
+  posts: db.Post[] | null;
   goBack?: () => void;
 }) {
   return (

--- a/packages/ui/src/components/SwipableChatListItem.tsx
+++ b/packages/ui/src/components/SwipableChatListItem.tsx
@@ -10,7 +10,7 @@ import { XStack } from '../core';
 import { Icon, IconType } from './Icon';
 
 export function SwipableChatRow(
-  props: PropsWithChildren<{ model: db.ChannelSummary; jailBroken?: boolean }>
+  props: PropsWithChildren<{ model: db.Channel; jailBroken?: boolean }>
 ) {
   async function handleAction(actionId: 'pin' | 'placeholder') {
     await Haptics.impactAsync(Haptics.ImpactFeedbackStyle.Light);
@@ -57,7 +57,7 @@ function LeftActions({
   progress,
   drag,
 }: {
-  model: db.ChannelSummary;
+  model: db.Channel;
   progress: Animated.AnimatedInterpolation<string | number>;
   drag: Animated.AnimatedInterpolation<string | number>;
 }) {
@@ -110,7 +110,7 @@ function RightActions({
   jailBroken,
 }: {
   jailBroken?: boolean;
-  model: db.ChannelSummary;
+  model: db.Channel;
   progress: Animated.AnimatedInterpolation<string | number>;
   drag: Animated.AnimatedInterpolation<string | number>;
   handleAction: (actionId: 'pin') => void;

--- a/packages/ui/src/contexts/groups.tsx
+++ b/packages/ui/src/contexts/groups.tsx
@@ -2,7 +2,7 @@ import * as db from '@tloncorp/shared/dist/db';
 import { createContext, useContext, useMemo } from 'react';
 
 type State = {
-  groups: db.GroupWithRelations[] | null;
+  groups: db.Group[] | null;
 };
 
 type ContextValue = State;
@@ -31,7 +31,7 @@ export const GroupsProvider = ({
   groups,
 }: {
   children: React.ReactNode;
-  groups: db.GroupWithRelations[] | null;
+  groups: db.Group[] | null;
 }) => {
   const value = useMemo(() => ({ groups }), [groups]);
   return <Context.Provider value={value}>{children}</Context.Provider>;

--- a/packages/ui/src/utils/channelUtils.tsx
+++ b/packages/ui/src/utils/channelUtils.tsx
@@ -2,7 +2,7 @@ import type * as db from '@tloncorp/shared/dist/db';
 
 import type { IconType } from '../components/Icon';
 
-export function getChannelTitle(channel: db.ChannelWithLastPostAndMembers) {
+export function getChannelTitle(channel: db.Channel) {
   if (channel.type === 'dm') {
     const member = channel.members?.[0];
     if (!member) {
@@ -19,9 +19,7 @@ export function getChannelTitle(channel: db.ChannelWithLastPostAndMembers) {
   }
 }
 
-export function getChannelMemberName(
-  member: db.ChatMember & { contact: db.Contact | null }
-) {
+export function getChannelMemberName(member: db.ChatMember) {
   return member.contact?.nickname ? member.contact.nickname : member.contactId;
 }
 

--- a/packages/ui/src/utils/postUtils.tsx
+++ b/packages/ui/src/utils/postUtils.tsx
@@ -10,7 +10,7 @@ export interface ReactionDetails {
   list: { value: string; count: number; users: string[] }[];
 }
 export function useReactionDetails(
-  reactions: db.PostReaction[],
+  reactions: db.Reaction[],
   ourId: string
 ): ReactionDetails {
   return useMemo(() => {


### PR DESCRIPTION
Proposal for replacing our various compound models with universal versions, where every relation is an optional property. So, the type for `db.Group` will be something like 

```typescript
type Group = {
  id: string;
  title: string;
  // ...other direct props
  navSections?: GroupNavSection[] | null;
  channels?: GroupChannel[] | null;
  // ...other relations
}
```

We don't even really lose much type safety because we're always checking these things exist anyway. And I gotta say it felt really good to delete all those long names. Curious what everyone thinks though! Or if this has downsides I'm missing.