### PR TITLE
native: fix weird height issue on input on android

### DIFF
--- a/package.json
+++ b/package.json
@@ -46,7 +46,8 @@
       "usehooks-ts@2.6.0": "patches/usehooks-ts@2.6.0.patch",
       "react-native-storage@1.0.1": "patches/react-native-storage@1.0.1.patch",
       "react-native-reanimated@3.8.1": "patches/react-native-reanimated@3.8.1.patch",
-      "drizzle-orm@0.30.9": "patches/drizzle-orm@0.30.9.patch"
+      "drizzle-orm@0.30.9": "patches/drizzle-orm@0.30.9.patch",
+      "@10play/tentap-editor@0.4.55": "patches/@10play__tentap-editor@0.4.55.patch"
     },
     "allowNonAppliedPatches": true,
     "overrides": {

--- a/patches/@10play__tentap-editor@0.4.55.patch
+++ b/patches/@10play__tentap-editor@0.4.55.patch
@@ -1,0 +1,13 @@
+diff --git a/src/RichText/RichText.tsx b/src/RichText/RichText.tsx
+index b878f5382cd64a62a6c4a66b52b6a32a9e2cf96a..c95d3513806d85560115d35d12ecf08480ed2e1a 100644
+--- a/src/RichText/RichText.tsx
++++ b/src/RichText/RichText.tsx
+@@ -33,7 +33,7 @@ const styles = StyleSheet.create({
+ const DEV_SERVER_URL = 'http://localhost:3000';
+ 
+ // TODO: make it a prop
+-const TOOLBAR_HEIGHT = 44;
++const TOOLBAR_HEIGHT = 0;
+ 
+ export const RichText = ({ editor, ...props }: RichTextProps) => {
+   const [loaded, setLoaded] = useState(isFabric());

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -9,6 +9,9 @@ overrides:
   '@urbit/http-api': 3.1.0-dev-2
 
 patchedDependencies:
+  '@10play/tentap-editor@0.4.55':
+    hash: s2uo542ywkfolgcnjwqbuh6ps4
+    path: patches/@10play__tentap-editor@0.4.55.patch
   '@tiptap/react@2.0.3':
     hash: tt2duu22fpwhmhaws3iaoig4mu
     path: patches/@tiptap__react@2.0.3.patch
@@ -76,7 +79,7 @@ importers:
     dependencies:
       '@10play/tentap-editor':
         specifier: ^0.4.55
-        version: 0.4.55(@tiptap/core@2.3.0(@tiptap/pm@2.3.0))(react-native-webview@13.6.4(react-native@0.73.4(@babel/core@7.23.7)(@babel/preset-env@7.23.7(@babel/core@7.23.7))(encoding@0.1.13)(react@18.2.0))(react@18.2.0))(react-native@0.73.4(@babel/core@7.23.7)(@babel/preset-env@7.23.7(@babel/core@7.23.7))(encoding@0.1.13)(react@18.2.0))(react@18.2.0)
+        version: 0.4.55(patch_hash=s2uo542ywkfolgcnjwqbuh6ps4)(@tiptap/core@2.3.0(@tiptap/pm@2.3.0))(react-native-webview@13.6.4(react-native@0.73.4(@babel/core@7.23.7)(@babel/preset-env@7.23.7(@babel/core@7.23.7))(encoding@0.1.13)(react@18.2.0))(react@18.2.0))(react-native@0.73.4(@babel/core@7.23.7)(@babel/preset-env@7.23.7(@babel/core@7.23.7))(encoding@0.1.13)(react@18.2.0))(react@18.2.0)
       '@aws-sdk/client-s3':
         specifier: ^3.190.0
         version: 3.190.0
@@ -885,7 +888,7 @@ importers:
     dependencies:
       '@10play/tentap-editor':
         specifier: ^0.4.55
-        version: 0.4.55(@tiptap/core@2.0.3(@tiptap/pm@2.0.3))(react-native-webview@13.6.4(react-native@0.73.4(@babel/core@7.23.7)(@babel/preset-env@7.23.7(@babel/core@7.23.7))(encoding@0.1.13)(react@18.2.0))(react@18.2.0))(react-native@0.73.4(@babel/core@7.23.7)(@babel/preset-env@7.23.7(@babel/core@7.23.7))(encoding@0.1.13)(react@18.2.0))(react@18.2.0)
+        version: 0.4.55(patch_hash=s2uo542ywkfolgcnjwqbuh6ps4)(@tiptap/core@2.0.3(@tiptap/pm@2.0.3))(react-native-webview@13.6.4(react-native@0.73.4(@babel/core@7.23.7)(@babel/preset-env@7.23.7(@babel/core@7.23.7))(encoding@0.1.13)(react@18.2.0))(react@18.2.0))(react-native@0.73.4(@babel/core@7.23.7)(@babel/preset-env@7.23.7(@babel/core@7.23.7))(encoding@0.1.13)(react@18.2.0))(react@18.2.0)
       '@tiptap/core':
         specifier: ^2.0.3
         version: 2.0.3(@tiptap/pm@2.0.3)
@@ -990,7 +993,7 @@ importers:
     dependencies:
       '@10play/tentap-editor':
         specifier: ^0.4.55
-        version: 0.4.55(@tiptap/core@2.3.0(@tiptap/pm@2.3.0))(react-native-webview@13.6.4(react-native@0.73.4(@babel/core@7.23.7)(@babel/preset-env@7.23.7(@babel/core@7.23.7))(encoding@0.1.13)(react@18.2.0))(react@18.2.0))(react-native@0.73.4(@babel/core@7.23.7)(@babel/preset-env@7.23.7(@babel/core@7.23.7))(encoding@0.1.13)(react@18.2.0))(react@18.2.0)
+        version: 0.4.55(patch_hash=s2uo542ywkfolgcnjwqbuh6ps4)(@tiptap/core@2.3.0(@tiptap/pm@2.3.0))(react-native-webview@13.6.4(react-native@0.73.4(@babel/core@7.23.7)(@babel/preset-env@7.23.7(@babel/core@7.23.7))(encoding@0.1.13)(react@18.2.0))(react@18.2.0))(react-native@0.73.4(@babel/core@7.23.7)(@babel/preset-env@7.23.7(@babel/core@7.23.7))(encoding@0.1.13)(react@18.2.0))(react@18.2.0)
       '@emoji-mart/data':
         specifier: ^1.1.2
         version: 1.1.2
@@ -12154,7 +12157,7 @@ packages:
 
 snapshots:
 
-  '@10play/tentap-editor@0.4.55(@tiptap/core@2.0.3(@tiptap/pm@2.0.3))(react-native-webview@13.6.4(react-native@0.73.4(@babel/core@7.23.7)(@babel/preset-env@7.23.7(@babel/core@7.23.7))(encoding@0.1.13)(react@18.2.0))(react@18.2.0))(react-native@0.73.4(@babel/core@7.23.7)(@babel/preset-env@7.23.7(@babel/core@7.23.7))(encoding@0.1.13)(react@18.2.0))(react@18.2.0)':
+  '@10play/tentap-editor@0.4.55(patch_hash=s2uo542ywkfolgcnjwqbuh6ps4)(@tiptap/core@2.0.3(@tiptap/pm@2.0.3))(react-native-webview@13.6.4(react-native@0.73.4(@babel/core@7.23.7)(@babel/preset-env@7.23.7(@babel/core@7.23.7))(encoding@0.1.13)(react@18.2.0))(react@18.2.0))(react-native@0.73.4(@babel/core@7.23.7)(@babel/preset-env@7.23.7(@babel/core@7.23.7))(encoding@0.1.13)(react@18.2.0))(react@18.2.0)':
     dependencies:
       '@tiptap/extension-blockquote': 2.3.0(@tiptap/core@2.0.3(@tiptap/pm@2.0.3))
       '@tiptap/extension-bold': 2.3.0(@tiptap/core@2.0.3(@tiptap/pm@2.0.3))
@@ -12190,7 +12193,7 @@ snapshots:
     transitivePeerDependencies:
       - '@tiptap/core'
 
-  '@10play/tentap-editor@0.4.55(@tiptap/core@2.3.0(@tiptap/pm@2.3.0))(react-native-webview@13.6.4(react-native@0.73.4(@babel/core@7.23.7)(@babel/preset-env@7.23.7(@babel/core@7.23.7))(encoding@0.1.13)(react@18.2.0))(react@18.2.0))(react-native@0.73.4(@babel/core@7.23.7)(@babel/preset-env@7.23.7(@babel/core@7.23.7))(encoding@0.1.13)(react@18.2.0))(react@18.2.0)':
+  '@10play/tentap-editor@0.4.55(patch_hash=s2uo542ywkfolgcnjwqbuh6ps4)(@tiptap/core@2.3.0(@tiptap/pm@2.3.0))(react-native-webview@13.6.4(react-native@0.73.4(@babel/core@7.23.7)(@babel/preset-env@7.23.7(@babel/core@7.23.7))(encoding@0.1.13)(react@18.2.0))(react@18.2.0))(react-native@0.73.4(@babel/core@7.23.7)(@babel/preset-env@7.23.7(@babel/core@7.23.7))(encoding@0.1.13)(react@18.2.0))(react@18.2.0)':
     dependencies:
       '@tiptap/extension-blockquote': 2.3.0(@tiptap/core@2.3.0(@tiptap/pm@2.3.0))
       '@tiptap/extension-bold': 2.3.0(@tiptap/core@2.3.0(@tiptap/pm@2.3.0))


### PR DESCRIPTION
Apparently 44px of padding was hardcoded into tentap's RichText component when rendered on android (apparently to account for the OS's bottom nav bar?). I set it to zero, seems fine with both gesture based nav and older button based nav, so I patched tentap with that value set to zero.

Fixes LAND-1795