### PR TITLE
mobile: empty channel placeholder & hide input when no write permissions

### DIFF
--- a/packages/shared/src/api/channelsApi.ts
+++ b/packages/shared/src/api/channelsApi.ts
@@ -33,6 +33,24 @@ export const subscribeToChannelsUpdates = async (
   );
 };
 
+export function toClientChannelsInit(channels: ub.Channels) {
+  return Object.entries(channels).map(([id, channel]) => {
+    return toClientChannelInit(id, channel);
+  });
+}
+
+export type ChannelInit = {
+  channelId: string;
+  writers: string[];
+};
+
+export function toClientChannelInit(
+  id: string,
+  channel: ub.Channel
+): ChannelInit {
+  return { channelId: id, writers: channel.perms.writers ?? [] };
+}
+
 export const toChannelsUpdate = (
   channelEvent: ub.ChannelsSubscribeResponse
 ): ChannelsUpdate => {

--- a/packages/shared/src/api/groupsApi.ts
+++ b/packages/shared/src/api/groupsApi.ts
@@ -1,7 +1,6 @@
 import * as db from '../db';
 import type * as ub from '../urbit';
 import { getChannelType } from '../urbit';
-import { ChannelInit } from './channelsApi';
 import { toClientMeta } from './converters';
 import { poke, scry } from './urbit';
 

--- a/packages/shared/src/api/groupsApi.ts
+++ b/packages/shared/src/api/groupsApi.ts
@@ -1,6 +1,7 @@
 import * as db from '../db';
 import type * as ub from '../urbit';
 import { getChannelType } from '../urbit';
+import { ChannelInit } from './channelsApi';
 import { toClientMeta } from './converters';
 import { poke, scry } from './urbit';
 

--- a/packages/shared/src/api/initApi.ts
+++ b/packages/shared/src/api/initApi.ts
@@ -1,5 +1,6 @@
 import * as db from '../db';
 import type * as ub from '../urbit';
+import { toClientChannelsInit } from './channelsApi';
 import { toClientDms, toClientGroupDms } from './chatApi';
 import { toClientGroups, toClientPinnedItems } from './groupsApi';
 import { toClientUnreads } from './unreadsApi';
@@ -20,6 +21,7 @@ export const getInitData = async () => {
   // TODO: handle gangs,possibly handle response.channels, but not sure if
   // necessary.
   const pins = toClientPinnedItems(response.pins);
+  const channelsInit = toClientChannelsInit(response.channels);
   const groups = toClientGroups(response.groups, true);
   const channelUnreads = toClientUnreads(response.unreads, 'channel');
   const dmChannels = toClientDms(response.chat.dms);
@@ -31,5 +33,6 @@ export const getInitData = async () => {
     groups,
     unreads: [...channelUnreads, ...talkUnreads],
     channels: [...dmChannels, ...groupDmChannels],
+    channelPerms: channelsInit,
   };
 };

--- a/packages/shared/src/db/migrations/0000_chemical_korg.sql
+++ b/packages/shared/src/db/migrations/0000_chemical_korg.sql
@@ -1,3 +1,9 @@
+CREATE TABLE `channel_writers` (
+	`channel_id` text NOT NULL,
+	`role_id` text NOT NULL,
+	PRIMARY KEY(`channel_id`, `role_id`)
+);
+--> statement-breakpoint
 CREATE TABLE `channels` (
 	`id` text PRIMARY KEY NOT NULL,
 	`type` text NOT NULL,

--- a/packages/shared/src/db/migrations/meta/0000_snapshot.json
+++ b/packages/shared/src/db/migrations/meta/0000_snapshot.json
@@ -1,9 +1,40 @@
 {
   "version": "5",
   "dialect": "sqlite",
-  "id": "f1010117-2191-4949-bce8-a3276aa816a6",
+  "id": "0026bec3-f096-4df7-ac76-bf47bba6492b",
   "prevId": "00000000-0000-0000-0000-000000000000",
   "tables": {
+    "channel_writers": {
+      "name": "channel_writers",
+      "columns": {
+        "channel_id": {
+          "name": "channel_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "role_id": {
+          "name": "role_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "channel_writers_channel_id_role_id_pk": {
+          "columns": [
+            "channel_id",
+            "role_id"
+          ],
+          "name": "channel_writers_channel_id_role_id_pk"
+        }
+      },
+      "uniqueConstraints": {}
+    },
     "channels": {
       "name": "channels",
       "columns": {

--- a/packages/shared/src/db/migrations/meta/_journal.json
+++ b/packages/shared/src/db/migrations/meta/_journal.json
@@ -5,8 +5,8 @@
     {
       "idx": 0,
       "version": "5",
-      "when": 1714757917890,
-      "tag": "0000_colossal_chronomancer",
+      "when": 1714968172411,
+      "tag": "0000_chemical_korg",
       "breakpoints": true
     }
   ]

--- a/packages/shared/src/db/migrations/migrations.js
+++ b/packages/shared/src/db/migrations/migrations.js
@@ -1,7 +1,7 @@
 // This file is required for Expo/React Native SQLite migrations - https://orm.drizzle.team/quick-sqlite/expo
 
 import journal from './meta/_journal.json';
-import m0000 from './0000_colossal_chronomancer.sql';
+import m0000 from './0000_chemical_korg.sql';
 
   export default {
     journal,

--- a/packages/shared/src/db/queries.ts
+++ b/packages/shared/src/db/queries.ts
@@ -385,20 +385,6 @@ export const getChatMember = createReadQuery(
   ['chatMembers', 'chatMemberGroupRoles']
 );
 
-export const getGroupMembers = createReadQuery(
-  'getGroupMembers',
-  async ({ groupId }: { groupId: string }) => {
-    return client.query.chatMembers.findMany({
-      where: eq($chatMembers.chatId, groupId),
-      with: {
-        contact: true,
-        roles: true,
-      },
-    });
-  },
-  ['chatMembers', 'contacts']
-);
-
 export const getUnreadsCount = createReadQuery(
   'getUnreadsCount',
   async ({ type }: { type?: Unread['type'] }) => {

--- a/packages/shared/src/db/schema.ts
+++ b/packages/shared/src/db/schema.ts
@@ -179,6 +179,7 @@ export const groupRolesRelations = relations(groupRoles, ({ one, many }) => ({
     fields: [groupRoles.groupId],
     references: [groups.id],
   }),
+  writeChannels: many(channelWriters),
 }));
 
 export const chatMembers = sqliteTable(
@@ -199,6 +200,34 @@ export const chatMembers = sqliteTable(
     };
   }
 );
+
+export const channelWriters = sqliteTable(
+  'channel_writers',
+  {
+    channelId: text('channel_id').notNull(),
+    roleId: text('role_id').notNull(),
+  },
+  (table) => {
+    return {
+      pk: primaryKey({
+        columns: [table.channelId, table.roleId],
+      }),
+    };
+  }
+);
+
+export const channelWriterRelations = relations(channelWriters, ({ one }) => {
+  return {
+    channel: one(channels, {
+      fields: [channelWriters.channelId],
+      references: [channels.id],
+    }),
+    role: one(groupRoles, {
+      fields: [channelWriters.roleId],
+      references: [groupRoles.id],
+    }),
+  };
+});
 
 export const chatMembersRelations = relations(chatMembers, ({ one, many }) => ({
   roles: many(chatMemberGroupRoles),
@@ -336,6 +365,7 @@ export const channelRelations = relations(channels, ({ one, many }) => ({
   }),
   threadUnreads: many(threadUnreads),
   members: many(chatMembers),
+  writerRoles: many(channelWriters),
 }));
 
 export type PostDeliveryStatus = 'pending' | 'sent' | 'failed';

--- a/packages/shared/src/store/dbHooks.ts
+++ b/packages/shared/src/store/dbHooks.ts
@@ -93,7 +93,12 @@ export const useMemberRoles = (chatId: string, userId: string) => {
     queryFn: () => db.getChatMember({ chatId, contactId: userId }),
   });
 
-  return chatMember?.roles.map((role) => role.roleId) ?? [];
+  const memberRoles = useMemo(
+    () => chatMember?.roles.map((role) => role.roleId) ?? [],
+    [chatMember]
+  );
+
+  return memberRoles;
 };
 
 export const useChannelPostsAround = (

--- a/packages/shared/src/store/dbHooks.ts
+++ b/packages/shared/src/store/dbHooks.ts
@@ -1,4 +1,5 @@
 import { UseQueryResult, useQuery } from '@tanstack/react-query';
+import { useMemo } from 'react';
 
 import * as db from '../db';
 import { useKeyFromQueryDeps } from './useKeyFromQueryDeps';
@@ -84,6 +85,15 @@ export const useGroupByChannel = (channelId: string) => {
     queryKey: [['group', channelId]],
     queryFn: () => db.getGroupByChannel(channelId).then((r) => r ?? null),
   });
+};
+
+export const useMemberRoles = (chatId: string, userId: string) => {
+  const { data: chatMember } = useQuery({
+    queryKey: ['memberRoles', chatId, userId],
+    queryFn: () => db.getChatMember({ chatId, contactId: userId }),
+  });
+
+  return chatMember?.roles.map((role) => role.roleId) ?? [];
 };
 
 export const useChannelPostsAround = (

--- a/packages/shared/src/store/sync.ts
+++ b/packages/shared/src/store/sync.ts
@@ -13,6 +13,7 @@ export const syncInitData = async () => {
     await db.insertGroups(initData.groups);
     await resetUnreads(initData.unreads);
     await db.insertChannels(initData.channels);
+    await db.insertChannelPerms(initData.channelPerms);
   });
 };
 

--- a/packages/ui/src/components/Channel/EmptyChannelNotice.tsx
+++ b/packages/ui/src/components/Channel/EmptyChannelNotice.tsx
@@ -1,0 +1,34 @@
+import * as db from 'packages/shared/dist/db';
+import React, { useMemo } from 'react';
+
+import { ScrollView, SizableText, View } from '../../core';
+import { useIsAdmin } from '../../utils';
+
+export function EmptyChannelNotice({
+  channel,
+  userId,
+}: {
+  channel: db.Channel;
+  userId: string;
+}) {
+  const isGroupAdmin = useIsAdmin(channel.groupId ?? '', userId);
+
+  return (
+    <ScrollView
+      padding="$xl"
+      contentContainerStyle={{ flex: 1, justifyContent: 'flex-end' }}
+    >
+      <View backgroundColor="$blueSoft" borderRadius="$xl" padding="$xl">
+        <SizableText>{getNoticeText(isGroupAdmin)}</SizableText>
+      </View>
+    </ScrollView>
+  );
+}
+
+function getNoticeText(isAdmin: boolean) {
+  if (isAdmin) {
+    return 'This is a general discussion channel for your group. People you invite can post, react, and comment.';
+  }
+
+  return 'There are no messages...yet.';
+}

--- a/packages/ui/src/components/Channel/EmptyChannelNotice.tsx
+++ b/packages/ui/src/components/Channel/EmptyChannelNotice.tsx
@@ -1,5 +1,4 @@
 import * as db from 'packages/shared/dist/db';
-import React, { useMemo } from 'react';
 
 import { ScrollView, SizableText, View } from '../../core';
 import { useIsAdmin } from '../../utils';

--- a/packages/ui/src/components/Channel/EmptyChannelNotice.tsx
+++ b/packages/ui/src/components/Channel/EmptyChannelNotice.tsx
@@ -1,4 +1,5 @@
 import * as db from 'packages/shared/dist/db';
+import { useMemo } from 'react';
 
 import { ScrollView, SizableText, View } from '../../core';
 import { useIsAdmin } from '../../utils';
@@ -11,6 +12,7 @@ export function EmptyChannelNotice({
   userId: string;
 }) {
   const isGroupAdmin = useIsAdmin(channel.groupId ?? '', userId);
+  const noticeText = useMemo(() => getNoticeText(isGroupAdmin), [isGroupAdmin]);
 
   return (
     <ScrollView
@@ -18,7 +20,7 @@ export function EmptyChannelNotice({
       contentContainerStyle={{ flex: 1, justifyContent: 'flex-end' }}
     >
       <View backgroundColor="$blueSoft" borderRadius="$xl" padding="$xl">
-        <SizableText>{getNoticeText(isGroupAdmin)}</SizableText>
+        <SizableText>{noticeText}</SizableText>
       </View>
     </ScrollView>
   );

--- a/packages/ui/src/components/Channel/index.tsx
+++ b/packages/ui/src/components/Channel/index.tsx
@@ -22,6 +22,7 @@ import * as utils from '../../utils';
 import { MessageInput } from '../MessageInput';
 import { ChannelHeader } from './ChannelHeader';
 import ChatScroll from './ChatScroll';
+import { EmptyChannelNotice } from './EmptyChannelNotice';
 import UploadedImagePreview from './UploadedImagePreview';
 
 //TODO implement usePost and useChannel
@@ -85,6 +86,7 @@ export function Channel({
   const [inputShouldBlur, setInputShouldBlur] = useState(false);
   const title = utils.getChannelTitle(channel);
   const groups = useMemo(() => (group ? [group] : null), [group]);
+  const canWrite = utils.useCanWrite(channel, currentUserId);
 
   return (
     <CalmProvider initialCalm={calmSettings}>
@@ -130,6 +132,11 @@ export function Channel({
                         >
                           <Spinner />
                         </View>
+                      ) : posts.length === 0 && group !== null ? (
+                        <EmptyChannelNotice
+                          channel={channel}
+                          userId={currentUserId}
+                        />
                       ) : (
                         <ChatScroll
                           currentUserId={currentUserId}
@@ -147,15 +154,17 @@ export function Channel({
                           onStartReached={onScrollStartReached}
                         />
                       )}
-                      <MessageInput
-                        shouldBlur={inputShouldBlur}
-                        setShouldBlur={setInputShouldBlur}
-                        send={messageSender}
-                        channelId={channel.id}
-                        setImageAttachment={setImageAttachment}
-                        uploadedImage={uploadedImage}
-                        canUpload={canUpload}
-                      />
+                      {canWrite && (
+                        <MessageInput
+                          shouldBlur={inputShouldBlur}
+                          setShouldBlur={setInputShouldBlur}
+                          send={messageSender}
+                          channelId={channel.id}
+                          setImageAttachment={setImageAttachment}
+                          uploadedImage={uploadedImage}
+                          canUpload={canUpload}
+                        />
+                      )}
                     </YStack>
                   </KeyboardAvoidingView>
                 </YStack>

--- a/packages/ui/src/utils/channelUtils.tsx
+++ b/packages/ui/src/utils/channelUtils.tsx
@@ -1,4 +1,6 @@
 import type * as db from '@tloncorp/shared/dist/db';
+import { useMemberRoles } from '@tloncorp/shared/dist/store';
+import { useMemo } from 'react';
 
 import type { IconType } from '../components/Icon';
 
@@ -21,6 +23,35 @@ export function getChannelTitle(channel: db.Channel) {
 
 export function getChannelMemberName(member: db.ChatMember) {
   return member.contact?.nickname ? member.contact.nickname : member.contactId;
+}
+
+export function isDmChannel(channel: db.Channel): boolean {
+  return channel.type !== 'dm' && channel.type !== 'groupDm';
+}
+
+export function isGroupChannel(channel: db.Channel): boolean {
+  return !isDmChannel(channel);
+}
+
+export function useIsAdmin(chatId: string, userId: string): boolean {
+  const memberRoles = useMemberRoles(chatId, userId);
+  const isAdmin = useMemo(() => memberRoles.includes('admin'), [memberRoles]);
+  return isAdmin;
+}
+
+export function useCanWrite(channel: db.Channel, userId: string): boolean {
+  const writers = useMemo(
+    () => channel.writerRoles?.map((role) => role.roleId) ?? [],
+    [channel.writerRoles]
+  );
+  const memberRoles = useMemberRoles(channel.groupId ?? '', userId);
+  const canWrite = useMemo(
+    () =>
+      writers.length === 0 ||
+      memberRoles.some((role) => writers.includes(role)),
+    [writers, memberRoles]
+  );
+  return canWrite;
 }
 
 export function getChannelTypeIcon(type: db.Channel['type']): IconType {


### PR DESCRIPTION
- adds a placeholder for empty groups channels (leaving out DMs since we'll want that sigil block there instead)
- stores channel write permissions on init and checks them before displaying the message input

Fixes LAND-1827
Fixes LAND-1829