### PR TITLE
native: stray polish items

### DIFF
--- a/apps/tlon-mobile/src/fixtures/ChannelHeader.fixture.tsx
+++ b/apps/tlon-mobile/src/fixtures/ChannelHeader.fixture.tsx
@@ -4,4 +4,11 @@ import { tlonLocalBulletinBoard } from './fakeData';
 
 const channel = tlonLocalBulletinBoard;
 
-export default <ChannelHeader title={channel.title ?? ''} />;
+export default (
+  <ChannelHeader
+    title={channel.title ?? ''}
+    showSearchButton={true}
+    showPickerButton={true}
+    showSpinner={true}
+  />
+);

--- a/packages/ui/src/components/Channel/ChannelHeader.tsx
+++ b/packages/ui/src/components/Channel/ChannelHeader.tsx
@@ -38,11 +38,16 @@ export function ChannelHeader({
         borderBottomColor="$border"
         height="$4xl"
       >
-        <XStack alignItems="center" gap="$m">
+        <XStack alignItems="center" gap="$m" flex={1}>
           <IconButton onPress={goBack}>
             <ChevronLeft />
           </IconButton>
-          <SizableText color="$primaryText" size="$m">
+          <SizableText
+            flexShrink={1}
+            numberOfLines={1}
+            color="$primaryText"
+            size="$m"
+          >
             {title}
           </SizableText>
         </XStack>

--- a/packages/ui/src/components/ChatMessage/ChatContent.tsx
+++ b/packages/ui/src/components/ChatMessage/ChatContent.tsx
@@ -173,7 +173,11 @@ export function BlockContent({
   onPressImage?: (src: string) => void;
   onLongPress?: () => void;
 }) {
-  const [aspect, setAspect] = useState<number | null>(null);
+  const [aspect, setAspect] = useState<number | null>(() => {
+    return isImage(story) && story.image.height && story.image.width
+      ? story.image.width / story.image.height
+      : null;
+  });
 
   const handleImageLoaded = useCallback((e: ImageLoadEventData) => {
     setAspect(e.source.width / e.source.height);
@@ -204,8 +208,8 @@ export function BlockContent({
           borderRadius="$m"
           onLoad={handleImageLoaded}
           width={200}
+          backgroundColor={'$secondaryBackground'}
           height={aspect ? 200 / aspect : 100}
-          resizeMode="contain"
         />
       </TouchableOpacity>
     );


### PR DESCRIPTION
Two small improvements from last week that didn't make it up:
- Truncate long names in channel titles
- Use cached image aspect for initial render (can prevent a layout shift)

Fixes LAND-1849.