### PR TITLE
native: message sending fixes

### DIFF
--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -28,6 +28,7 @@
   "dependencies": {
     "@urbit/api": "^2.2.0",
     "big-integer": "^1.6.52",
+    "exponential-backoff": "^3.1.1",
     "sorted-btree": "^1.8.1"
   },
   "devDependencies": {
@@ -39,13 +40,13 @@
     "vitest": "^1.4.0"
   },
   "peerDependencies": {
-    "react": "^18.2.0",
+    "@tanstack/react-query": "^5.32.1",
     "@tiptap/core": "^2.0.3",
     "@tiptap/pm": "^2.0.3",
     "@tiptap/react": "^2.0.3",
     "@tiptap/suggestion": "^2.0.3",
     "drizzle-orm": "0.30.9",
-    "@tanstack/react-query": "^5.32.1"
+    "react": "^18.2.0"
   },
   "optionalDependencies": {
     "@rollup/rollup-linux-x64-gnu": "4.9.5"

--- a/packages/shared/src/api/postsApi.ts
+++ b/packages/shared/src/api/postsApi.ts
@@ -537,7 +537,7 @@ export function buildCachePost({
     authorId,
     channelId: channel.id,
     groupId: channel.groupId,
-    type: channel.id.split('/')[0] as db.PostType,
+    type: parentId ? 'reply' : (channel.id.split('/')[0] as db.PostType),
     sentAt,
     receivedAt: sentAt,
     title: '',

--- a/packages/shared/src/db/queries.ts
+++ b/packages/shared/src/db/queries.ts
@@ -826,6 +826,19 @@ export const getPosts = createReadQuery(
   ['posts']
 );
 
+export const getPendingPosts = createReadQuery(
+  'getPendingPosts',
+  (channelId: string) => {
+    return client.query.posts.findMany({
+      where: and(
+        eq($posts.channelId, channelId),
+        isNotNull($posts.deliveryStatus)
+      ),
+    });
+  },
+  []
+);
+
 export const getPostWithRelations = createReadQuery(
   'getPostWithRelations',
   async ({ id }: { id: string }) => {

--- a/packages/shared/src/store/postActions.ts
+++ b/packages/shared/src/store/postActions.ts
@@ -23,7 +23,7 @@ export async function sendPost({
       content,
       sentAt: cachePost.sentAt,
     });
-    sync.syncPendingMessageDelivery({ channelId: channel.id });
+    sync.syncChannelMessageDelivery({ channelId: channel.id });
   } catch (e) {
     console.error('Failed to send post', e);
     await db.updatePost({ id: cachePost.id, deliveryStatus: 'failed' });
@@ -61,7 +61,7 @@ export async function sendReply({
       content,
       sentAt: cachePost.sentAt,
     });
-    sync.syncPendingMessageDelivery({ channelId: channel.id });
+    sync.syncChannelMessageDelivery({ channelId: channel.id });
   } catch (e) {
     console.error('Failed to send reply', e);
     await db.updatePost({ id: cachePost.id, deliveryStatus: 'failed' });

--- a/packages/shared/src/store/postActions.ts
+++ b/packages/shared/src/store/postActions.ts
@@ -23,6 +23,7 @@ export async function sendPost({
       content,
       sentAt: cachePost.sentAt,
     });
+    sync.syncPendingMessageDelivery({ channelId: channel.id });
   } catch (e) {
     console.error('Failed to send post', e);
     await db.updatePost({ id: cachePost.id, deliveryStatus: 'failed' });
@@ -60,6 +61,7 @@ export async function sendReply({
       content,
       sentAt: cachePost.sentAt,
     });
+    sync.syncPendingMessageDelivery({ channelId: channel.id });
   } catch (e) {
     console.error('Failed to send reply', e);
     await db.updatePost({ id: cachePost.id, deliveryStatus: 'failed' });

--- a/packages/shared/src/store/sync.ts
+++ b/packages/shared/src/store/sync.ts
@@ -1,7 +1,8 @@
+import { backOff } from 'exponential-backoff';
+
 import * as api from '../api';
 import * as db from '../db';
 import { createDevLogger } from '../debug';
-import * as urbit from '../urbit';
 import { syncQueue } from './syncQueue';
 
 const logger = createDevLogger('sync', false);
@@ -156,6 +157,40 @@ export async function syncChannel(id: string, remoteUpdatedAt: number) {
       id,
       remoteUpdatedAt,
       syncedAt: Date.now(),
+    });
+  }
+}
+
+export async function syncPendingMessageDelivery({
+  channelId,
+}: {
+  channelId: string;
+}) {
+  const checkDelivered = async () => {
+    const hasPendingBefore = (await db.getPendingPosts(channelId)).length > 0;
+    if (!hasPendingBefore) {
+      return true;
+    }
+
+    await syncChannel(channelId, Date.now());
+    const hasPendingAfter = (await db.getPendingPosts(channelId)).length > 0;
+    if (hasPendingAfter) {
+      throw new Error('Still have pending messages');
+    }
+
+    return true;
+  };
+
+  try {
+    // try checking delivery status immediately
+    checkDelivered();
+  } catch (e) {
+    // thereafter, try checking with exponential backoff. Config values
+    // are arbitrary reasonable sounding defaults
+    backOff(checkDelivered, {
+      startingDelay: 2000, // 2 seconds
+      maxDelay: 3 * 60 * 1000, // 3 minutes
+      numOfAttempts: 20,
     });
   }
 }

--- a/packages/shared/src/store/sync.ts
+++ b/packages/shared/src/store/sync.ts
@@ -161,21 +161,48 @@ export async function syncChannel(id: string, remoteUpdatedAt: number) {
   }
 }
 
-export async function syncPendingMessageDelivery({
+const currentPendingMessageSyncs = new Map<string, Promise<boolean>>();
+export async function syncChannelMessageDelivery({
   channelId,
 }: {
   channelId: string;
 }) {
+  if (currentPendingMessageSyncs.has(channelId)) {
+    logger.log(`message delivery sync already in progress for ${channelId}`);
+  }
+
+  try {
+    logger.log(`syncing messsage delivery for ${channelId}`);
+    const syncPromise = syncChannelWithBackoff({ channelId });
+    currentPendingMessageSyncs.set(channelId, syncPromise);
+    await syncPromise;
+    logger.log(`all messages in ${channelId} are delivered`);
+  } catch (e) {
+    logger.error(
+      `some messages in ${channelId} still undelivered, is the channel offline?`
+    );
+  } finally {
+    currentPendingMessageSyncs.delete(channelId);
+  }
+}
+
+export async function syncChannelWithBackoff({
+  channelId,
+}: {
+  channelId: string;
+}): Promise<boolean> {
   const checkDelivered = async () => {
     const hasPendingBefore = (await db.getPendingPosts(channelId)).length > 0;
     if (!hasPendingBefore) {
       return true;
     }
 
+    logger.log(`still have undelivered messages, syncing...`);
     await syncChannel(channelId, Date.now());
+
     const hasPendingAfter = (await db.getPendingPosts(channelId)).length > 0;
     if (hasPendingAfter) {
-      throw new Error('Still have pending messages');
+      throw new Error('Keep going');
     }
 
     return true;
@@ -183,11 +210,12 @@ export async function syncPendingMessageDelivery({
 
   try {
     // try checking delivery status immediately
-    checkDelivered();
+    await checkDelivered();
+    return true;
   } catch (e) {
     // thereafter, try checking with exponential backoff. Config values
     // are arbitrary reasonable sounding defaults
-    backOff(checkDelivered, {
+    return backOff(checkDelivered, {
       startingDelay: 2000, // 2 seconds
       maxDelay: 3 * 60 * 1000, // 3 minutes
       numOfAttempts: 20,

--- a/packages/shared/src/store/useChannelPosts.ts
+++ b/packages/shared/src/store/useChannelPosts.ts
@@ -6,7 +6,7 @@ import { createDevLogger } from '../debug';
 import * as sync from './sync';
 import { useKeyFromQueryDeps } from './useKeyFromQueryDeps';
 
-const postsLogger = createDevLogger('useChannelPosts', true);
+const postsLogger = createDevLogger('useChannelPosts', false);
 
 type UseChanelPostsParams = db.GetChannelPostsOptions & {
   anchorToNewest?: boolean;

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -962,6 +962,9 @@ importers:
       drizzle-orm:
         specifier: 0.30.9
         version: 0.30.9(patch_hash=cegrec33e6f7d6ltk7vff5r7w4)(@op-engineering/op-sqlite@5.0.5(react-native@0.73.4(@babel/core@7.23.7)(@babel/preset-env@7.23.7(@babel/core@7.23.7))(encoding@0.1.13)(react@18.2.0))(react@18.2.0))(@opentelemetry/api@1.8.0)(@types/better-sqlite3@7.6.9)(@types/react@18.2.55)(better-sqlite3@9.5.0)(react@18.2.0)
+      exponential-backoff:
+        specifier: ^3.1.1
+        version: 3.1.1
       react:
         specifier: ^18.2.0
         version: 18.2.0
@@ -7339,6 +7342,9 @@ packages:
   expo@50.0.6:
     resolution: {integrity: sha512-CVg0h9bmYeTWtw4EOL0HKNL+zu84YZl5nLWRPKrcpt8jox1VQQAYmvJGMdM5gSRxq5CFNLlWGxq9O8Zvfi1SOQ==}
     hasBin: true
+
+  exponential-backoff@3.1.1:
+    resolution: {integrity: sha512-dX7e/LHVJ6W3DE1MHWi9S1EYzDESENfLrYohG2G++ovZrYOkm4Knwa0mc1cn84xJOR4KEU0WSchhLbd0UklbHw==}
 
   express@4.18.2:
     resolution: {integrity: sha512-5/PsL6iGPdfQ/lKM1UuielYgv3BUoJfz1aUwU9vHZ+J7gyvwdQXFEBIEIaxeGf0GIcreATNyBExtalisDbuMqQ==}
@@ -20696,6 +20702,8 @@ snapshots:
       - encoding
       - supports-color
       - utf-8-validate
+
+  exponential-backoff@3.1.1: {}
 
   express@4.18.2:
     dependencies:


### PR DESCRIPTION
This trivially fixes the issue where replies were showing up in the main channel if they're undelivered. Also attempts to fix the issue where messages are getting stuck in pending/sent states.

Repro'ing the stuck states was tricky, so I mostly tested by sending messages to a group on a local ship that I could start/stop at will.

### Notes on Delivery Tracking
Theoretically we should always be hearing a fact when a message is delivered. If for some reason we miss it, we're more susceptible to getting stuck in the wrong state (compared to Web) since we're using an additional client side cache layer behind `react-query`. We can probably alleviate this with smarter refetching logic + `useChannelPosts` configuration, but refining that will be an ongoing process. 

This PR takes an approach that's more blunt. It adds a `syncChannelMessageDelivery` function which attempts to continuously re-sync a channel with exponential backoff if we have any undelivered messages. It's triggered after sending a message/reply. This seemed to reliably avoid messages getting stuck undelivered, but does feel a bit heavy handed. Curious what you guys think.

Fixes LAND-1847