### PR TITLE
native: fix ref navigation

### DIFF
--- a/apps/tlon-mobile/src/screens/ChannelScreen.tsx
+++ b/apps/tlon-mobile/src/screens/ChannelScreen.tsx
@@ -174,7 +174,7 @@ export default function ChannelScreen(props: ChannelScreenProps) {
 
   const handleGoToRef = useCallback(
     (channel: db.Channel, post: db.Post) => {
-      props.navigation.push('Channel', { channel, selectedPost: post });
+      props.navigation.navigate('Channel', { channel, selectedPost: post });
     },
     [props.navigation]
   );

--- a/apps/tlon-mobile/src/screens/ChannelScreen.tsx
+++ b/apps/tlon-mobile/src/screens/ChannelScreen.tsx
@@ -177,8 +177,7 @@ export default function ChannelScreen(props: ChannelScreenProps) {
       if (channel.id === currentChannelId) {
         props.navigation.navigate('Channel', { channel, selectedPost: post });
       } else {
-        props.navigation.pop();
-        props.navigation.push('Channel', { channel, selectedPost: post });
+        props.navigation.replace('Channel', { channel, selectedPost: post });
       }
     },
     [props.navigation, currentChannelId]

--- a/apps/tlon-mobile/src/screens/ChannelScreen.tsx
+++ b/apps/tlon-mobile/src/screens/ChannelScreen.tsx
@@ -174,9 +174,14 @@ export default function ChannelScreen(props: ChannelScreenProps) {
 
   const handleGoToRef = useCallback(
     (channel: db.Channel, post: db.Post) => {
-      props.navigation.navigate('Channel', { channel, selectedPost: post });
+      if (channel.id === currentChannelId) {
+        props.navigation.navigate('Channel', { channel, selectedPost: post });
+      } else {
+        props.navigation.pop();
+        props.navigation.push('Channel', { channel, selectedPost: post });
+      }
     },
-    [props.navigation]
+    [props.navigation, currentChannelId]
   );
 
   const handleGoToImage = useCallback(


### PR DESCRIPTION
I should have used `navigation.navigate`, not `navigation.push`. Fixed here.

fixes LAND-1845

Makes it so that we don't transition to a new screen when pressing a ref.