### PR TITLE
native: refine ref preview on input

### DIFF
--- a/packages/ui/src/components/ChatMessage/ChatContent.tsx
+++ b/packages/ui/src/components/ChatMessage/ChatContent.tsx
@@ -22,6 +22,7 @@ import {
   isStrikethrough,
 } from '@tloncorp/shared/dist/urbit/content';
 import { ImageLoadEventData } from 'expo-image';
+import { truncate } from 'lodash';
 import { PostDeliveryStatus } from 'packages/shared/dist/db';
 import { ReactElement, memo, useCallback, useMemo, useState } from 'react';
 import { TouchableOpacity } from 'react-native';
@@ -333,12 +334,14 @@ LineRenderer.displayName = 'LineRenderer';
 
 export default function ChatContent({
   story,
+  shortened = false,
   isNotice = false,
   deliveryStatus,
   onPressImage,
   onLongPress,
 }: {
   story: PostContent;
+  shortened?: boolean;
   isNotice?: boolean;
   deliveryStatus?: PostDeliveryStatus | null;
   onPressImage?: (src: string) => void;
@@ -353,6 +356,37 @@ export default function ChatContent({
         : [],
     [story]
   );
+  const firstInlineIsMention = useMemo(
+    () =>
+      storyInlines.length > 0 &&
+      typeof storyInlines[0] === 'object' &&
+      'ship' in storyInlines[0],
+    [storyInlines]
+  );
+  const shortenedStoryInlines = useMemo(
+    () =>
+      story !== null
+        ? firstInlineIsMention
+          ? storyInlines
+              .map((i) =>
+                typeof i === 'string'
+                  ? truncate(i, { length: 100, omission: '' })
+                  : i
+              )
+              .slice(0, 2)
+              .concat('...')
+          : storyInlines
+              .map((i) =>
+                typeof i === 'string'
+                  ? truncate(i, { length: 100, omission: '' })
+                  : i
+              )
+              .slice(0, 1)
+              .concat('...')
+        : [],
+    [firstInlineIsMention, storyInlines, story]
+  );
+
   const storyBlocks = useMemo(
     () =>
       story !== null ? (story.filter((s) => 'block' in s) as VerseBlock[]) : [],
@@ -394,14 +428,14 @@ export default function ChatContent({
 
   return (
     <YStack width="100%">
-      {referenceLength > 0 ? (
+      {!shortened && referenceLength > 0 ? (
         <YStack gap="$s" paddingBottom="$l">
           {storyReferences.map((ref, key) => {
             return <ContentReference key={key} reference={ref} />;
           })}
         </YStack>
       ) : null}
-      {blockLength > 0 ? (
+      {!shortened && blockLength > 0 ? (
         <YStack>
           {blockContent
             .filter((a) => !!a)
@@ -418,7 +452,10 @@ export default function ChatContent({
         </YStack>
       ) : null}
       {inlineLength > 0 ? (
-        <LineRenderer storyInlines={storyInlines} isNotice={isNotice} />
+        <LineRenderer
+          storyInlines={shortened ? shortenedStoryInlines : storyInlines}
+          isNotice={isNotice}
+        />
       ) : null}
       {deliveryStatus && (
         <XStack
@@ -432,5 +469,4 @@ export default function ChatContent({
       )}
     </YStack>
   );
-  1;
 }

--- a/packages/ui/src/components/ContentReference/ChatReference.tsx
+++ b/packages/ui/src/components/ContentReference/ChatReference.tsx
@@ -43,7 +43,7 @@ export default function ChatReference({
         <Reference.Icon type="ArrowRef" />
       </Reference.Header>
       <Reference.Body>
-        <ChatContent story={content} />
+        <ChatContent shortened story={content} />
       </Reference.Body>
     </Reference>
   );

--- a/packages/ui/src/components/ContentReference/ChatReference.tsx
+++ b/packages/ui/src/components/ContentReference/ChatReference.tsx
@@ -43,7 +43,7 @@ export default function ChatReference({
         <Reference.Icon type="ArrowRef" />
       </Reference.Header>
       <Reference.Body>
-        <ChatContent shortened story={content} />
+        <ChatContent shortened={asAttachment} story={content} />
       </Reference.Body>
     </Reference>
   );

--- a/packages/ui/src/components/ContentReference/Reference.tsx
+++ b/packages/ui/src/components/ContentReference/Reference.tsx
@@ -1,4 +1,5 @@
 import { ComponentProps, PropsWithChildren } from 'react';
+import { Dimensions } from 'react-native';
 import { createStyledContext, styled, withStaticProperties } from 'tamagui';
 
 import { View, XStack, YStack } from '../../core';
@@ -28,7 +29,7 @@ const ReferenceFrame = styled(YStack, {
     asAttachment: {
       true: {
         borderRadius: 0,
-        width: '100%',
+        width: Dimensions.get('window').width - 40,
       },
     },
   } as const,
@@ -44,7 +45,7 @@ const ReferenceHeader = styled(XStack, {
   variants: {
     asAttachment: {
       true: {
-        width: '100%',
+        width: Dimensions.get('window').width - 40,
       },
     },
   } as const,

--- a/packages/ui/src/components/MessageInput/MessageInputBase.tsx
+++ b/packages/ui/src/components/MessageInput/MessageInputBase.tsx
@@ -63,13 +63,19 @@ export const MessageInputContainer = ({
         >
           {Object.keys(references).map((ref) =>
             references[ref] !== null ? (
-              <XStack position="relative" key={ref} width="100%" height="auto">
+              <XStack
+                left={20}
+                position="relative"
+                key={ref}
+                width="100%"
+                height="auto"
+              >
                 <ContentReference
                   asAttachment
                   reference={references[ref]!}
                   key={ref}
                 />
-                <View position="absolute" top={8} right={8}>
+                <View position="absolute" top={8} right={48}>
                   <IconButton
                     onPress={() => {
                       setReferences({ ...references, [ref]: null });


### PR DESCRIPTION
Fixes LAND-1854 by truncating the text in the chat message when it's within a ref that's attached to the input, also adjusts the position/width of the ref preview.

![Simulator Screenshot - iPhone 15 Pro - 2024-05-06 at 16 02 56](https://github.com/tloncorp/tlon-apps/assets/1221094/7ff29bbe-bee1-4ea6-afd8-dcd9b8d3e922)
