### PR TITLE
native: pending arrows

### DIFF
--- a/packages/ui/src/components/ChatMessage/ChatContent.tsx
+++ b/packages/ui/src/components/ChatMessage/ChatContent.tsx
@@ -417,12 +417,7 @@ export default function ChatContent({
             })}
         </YStack>
       ) : null}
-      <XStack
-        justifyContent="space-between"
-        alignItems="flex-start"
-        // borderWidth={1}
-        // borderColor="orange"
-      >
+      <XStack justifyContent="space-between" alignItems="flex-start">
         {inlineLength > 0 ? (
           <View flexGrow={1} flexShrink={1}>
             <LineRenderer storyInlines={storyInlines} isNotice={isNotice} />
@@ -436,5 +431,4 @@ export default function ChatContent({
       </XStack>
     </YStack>
   );
-  1;
 }

--- a/packages/ui/src/components/ChatMessage/ChatContent.tsx
+++ b/packages/ui/src/components/ChatMessage/ChatContent.tsx
@@ -417,19 +417,23 @@ export default function ChatContent({
             })}
         </YStack>
       ) : null}
-      {inlineLength > 0 ? (
-        <LineRenderer storyInlines={storyInlines} isNotice={isNotice} />
-      ) : null}
-      {deliveryStatus && (
-        <XStack
-          justifyContent="flex-end"
-          position="absolute"
-          right={0}
-          bottom={0}
-        >
-          <ChatMessageDeliveryStatus status={deliveryStatus} />
-        </XStack>
-      )}
+      <XStack
+        justifyContent="space-between"
+        alignItems="flex-start"
+        // borderWidth={1}
+        // borderColor="orange"
+      >
+        {inlineLength > 0 ? (
+          <View flexGrow={1} flexShrink={1}>
+            <LineRenderer storyInlines={storyInlines} isNotice={isNotice} />
+          </View>
+        ) : null}
+        {deliveryStatus ? (
+          <View flexShrink={1}>
+            <ChatMessageDeliveryStatus status={deliveryStatus} />
+          </View>
+        ) : null}
+      </XStack>
     </YStack>
   );
   1;

--- a/packages/ui/src/components/ChatMessage/ChatMessageDeliveryStatus.tsx
+++ b/packages/ui/src/components/ChatMessage/ChatMessageDeliveryStatus.tsx
@@ -1,23 +1,41 @@
 import * as db from '@tloncorp/shared/dist/db';
-
-import { SizableText } from '../../core';
+import { useMemo } from 'react';
+import { Path, Svg } from 'react-native-svg';
+import { useTheme } from 'tamagui';
 
 export function ChatMessageDeliveryStatus({
   status,
 }: {
   status: db.PostDeliveryStatus;
 }) {
-  const statusDisplay =
-    status === 'failed'
-      ? 'Failed'
-      : status === 'pending'
-        ? 'Pending...'
-        : 'Sent...';
+  const theme = useTheme();
+
+  const firstArrowColor = useMemo(
+    () =>
+      status === 'pending' ? theme.tertiaryText.val : theme.primaryText.val,
+    [status, theme.primaryText.val, theme.tertiaryText.val]
+  );
+  const secondArrowColor = useMemo(
+    () => theme.tertiaryText.val,
+    [theme.tertiaryText.val]
+  );
+
   return (
-    <SizableText
-      color={status === 'failed' ? '$negativeActionText' : '$secondaryText'}
-    >
-      {statusDisplay}
-    </SizableText>
+    <Svg fill="none" viewBox="0 0 24 24" height="24" width="24">
+      <Path
+        d="M7 8L11 12L7 16"
+        stroke={firstArrowColor}
+        strokeWidth="2"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+      />
+      <Path
+        d="M15 8L19 12L15 16"
+        stroke={secondArrowColor}
+        strokeWidth="2"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+      />
+    </Svg>
   );
 }

--- a/packages/ui/src/components/ChatMessage/ChatMessageDeliveryStatus.tsx
+++ b/packages/ui/src/components/ChatMessage/ChatMessageDeliveryStatus.tsx
@@ -24,14 +24,14 @@ export function ChatMessageDeliveryStatus({
     <Svg fill="none" viewBox="0 0 24 24" height="24" width="24">
       <Path
         d="M7 8L11 12L7 16"
-        stroke={firstArrowColor}
+        stroke={status === 'pending' ? theme.tertiaryText.val : theme.primaryText.val}
         strokeWidth="2"
         strokeLinecap="round"
         strokeLinejoin="round"
       />
       <Path
         d="M15 8L19 12L15 16"
-        stroke={secondArrowColor}
+        stroke={theme.tertiaryText.val}
         strokeWidth="2"
         strokeLinecap="round"
         strokeLinejoin="round"

--- a/packages/ui/src/components/ChatMessage/ChatMessageDeliveryStatus.tsx
+++ b/packages/ui/src/components/ChatMessage/ChatMessageDeliveryStatus.tsx
@@ -10,21 +10,13 @@ export function ChatMessageDeliveryStatus({
 }) {
   const theme = useTheme();
 
-  const firstArrowColor = useMemo(
-    () =>
-      status === 'pending' ? theme.tertiaryText.val : theme.primaryText.val,
-    [status, theme.primaryText.val, theme.tertiaryText.val]
-  );
-  const secondArrowColor = useMemo(
-    () => theme.tertiaryText.val,
-    [theme.tertiaryText.val]
-  );
-
   return (
     <Svg fill="none" viewBox="0 0 24 24" height="24" width="24">
       <Path
         d="M7 8L11 12L7 16"
-        stroke={status === 'pending' ? theme.tertiaryText.val : theme.primaryText.val}
+        stroke={
+          status === 'pending' ? theme.tertiaryText.val : theme.primaryText.val
+        }
         strokeWidth="2"
         strokeLinecap="round"
         strokeLinejoin="round"


### PR DESCRIPTION
https://github.com/tloncorp/tlon-apps/assets/90741358/7b659b3e-a550-4e64-a4fb-8e42b7d22b18

Adds back in the arrows instead of plain text and adjusts flex spacing to prevent text colliding with the indicator.

Depending on word breaks, long messages do sometimes adjust their layout when the indicator clears. Ochre seemed to have a pretty narrow right gutter, but if we want to reserve space there to comfortably fit the indicators instead, I can do that. (also fine for now if the indicator may change down the line)

Fixes LAND-1853