### PR TITLE
native: scroller fixes

### DIFF
--- a/packages/ui/src/components/Channel/Scroller.tsx
+++ b/packages/ui/src/components/Channel/Scroller.tsx
@@ -145,7 +145,7 @@ export default function Scroller({
       // (they are objects, not functions)
       const RenderItem = renderItem;
       return (
-        <>
+        <View>
           {isFirstUnread ? (
             <ChannelDivider
               timestamp={item.receivedAt}
@@ -168,7 +168,7 @@ export default function Scroller({
               onLongPress={() => handlePostLongPressed(item)}
             />
           </PressableMessage>
-        </>
+        </View>
       );
     },
     [

--- a/packages/ui/src/components/Channel/Scroller.tsx
+++ b/packages/ui/src/components/Channel/Scroller.tsx
@@ -83,23 +83,6 @@ export default function Scroller({
   };
 
   useEffect(() => {
-    if (firstUnread && flatListRef.current) {
-      console.log(
-        'scrolling to',
-        firstUnread,
-        posts.findIndex((post) => post.id === firstUnread)
-      );
-      const unreadIndex = posts.findIndex((post) => post.id === firstUnread);
-      if (unreadIndex !== -1) {
-        flatListRef.current.scrollToIndex({
-          index: unreadIndex,
-          animated: true,
-        });
-      }
-    }
-  }, [firstUnread, posts]);
-
-  useEffect(() => {
     if (selectedPost && flatListRef.current) {
       const scrollToIndex = posts.findIndex((post) => post.id === selectedPost);
       if (scrollToIndex > -1) {

--- a/packages/ui/src/components/Channel/Scroller.tsx
+++ b/packages/ui/src/components/Channel/Scroller.tsx
@@ -192,9 +192,9 @@ export default function Scroller({
 
   return (
     <View flex={1}>
-      {unreadCount && !hasPressedGoToBottom ? (
+      {/* {unreadCount && !hasPressedGoToBottom ? (
         <UnreadsButton onPress={pressedGoToBottom} />
-      ) : null}
+      ) : null} */}
       <FlatList<db.Post>
         ref={flatListRef}
         data={posts}


### PR DESCRIPTION
- Disables scroll-to-unread for now, since it was causing problems
- Fixes date + unread divider positions -- because the divider + message were wrapped in a dummy element, inverted FlatList transform was being applied to them individually rather than both together, which meant that the divider rendered under the message rather than on top. Resolved by just wrapping both in a view.