### PR TITLE
channels, chat: /heads endpoint for latest messages

### DIFF
--- a/desk/app/chat.hoon
+++ b/desk/app/chat.hoon
@@ -647,6 +647,38 @@
         pins
     ==
   ::
+      [%x %heads ?(~ [@ ~])]
+    =/  since=(unit time)
+      ?~  t.t.path  ~
+      ?^  tim=(slaw %da i.t.t.path)  `u.tim
+      `(slav %ud i.t.t.path)
+    :^  ~  ~  %chat-heads
+    !>  ^-  chat-heads:c
+    %+  murn
+      %+  welp
+        (turn ~(tap by dms) |=([=@p dm:c] [ship+p pact remark]))
+      (turn ~(tap by clubs) |=([=id:club:c club:c] [club+id pact remark]))
+    |=  [=whom:c =pact:c =remark:c]
+    ^-  (unit [_whom time (unit writ:c)])
+    ::  if there is no latest post, give nothing
+    ::
+    ?~  vp=(ram:on:writs:c wit.pact)  ~
+    =*  result
+      `[whom recency.remark `val.u.vp]
+    ::  if the request is bounded, check that latest message is "in bounds"
+    ::  (and not presumably already known by the requester)
+    ::
+    ?:  ?|  ?=(~ since)
+            |((gth key.u.vp u.since) (gth recency.remark u.since))
+        ==
+      ::  latest is in range (or recency was changed), give it directly
+      ::
+      result
+    ::  unlike in channels, there is no edit or deletion, so we don't need
+    ::  to account for related edge-cases
+    ::
+    ~
+  ::
       [%x %dm ~]
     ``ships+!>(~(key by accepted-dms))
   ::

--- a/desk/app/groups-ui.hoon
+++ b/desk/app/groups-ui.hoon
@@ -135,6 +135,11 @@
       ==
     ``ui-init-1+!>(init)
   ::
+      [%x %v1 %heads since=?(~ [u=@ ~])]
+    =+  .^(chan=channel-heads:d (scry %gx %channels %v2 %heads (snoc since.pole %channel-heads)))
+    =+  .^(chat=chat-heads:c (scry %gx %chat %heads (snoc since.pole %chat-heads)))
+    ``ui-heads+!>(`mixed-heads:u`[chan chat])
+  ::
       [%x %pins ~]
     ``ui-pins+!>(pins)
   ==

--- a/desk/lib/channel-json.hoon
+++ b/desk/lib/channel-json.hoon
@@ -134,6 +134,17 @@
       %reacts  (reacts reacts.r-reply)
     ==
   ::
+  ++  channel-heads
+    |=  heads=channel-heads:c
+    :-  %a
+    %+  turn  heads
+    |=  [=nest:c recency=^time latest=(unit post:c)]
+    %-  pairs
+    :~  nest+(^nest nest)
+        recency+(time recency)
+        latest+?~(latest ~ (post u.latest))
+    ==
+  ::
   ++  paged-posts
     |=  pn=paged-posts:c
     %-  pairs

--- a/desk/lib/chat-json.hoon
+++ b/desk/lib/chat-json.hoon
@@ -322,6 +322,17 @@
         essay+(essay:enjs:dj +.writ)
     ==
   ::
+  ++  chat-heads
+    |=  heads=chat-heads:c
+    :-  %a
+    %+  turn  heads
+    |=  [=whom:c recency=^time latest=(unit writ:c)]
+    %-  pairs
+    :~  whom+s+(^whom whom)
+        recency+(time recency)
+        latest+?~(latest ~ (writ u.latest))
+    ==
+  ::
   ++  paged-writs
     |=  pw=paged-writs:c
     %-  pairs

--- a/desk/lib/mark-warmer.hoon
+++ b/desk/lib/mark-warmer.hoon
@@ -12,6 +12,7 @@
 /$  perm        %channel-perm         %json
 /$  scan        %channel-scan         %json
 /$  unreads     %channel-unreads      %json
+/$  heads       %channel-heads        %json
 /$  posts       %channel-posts        %json
 /$  simple-posts  %channel-simple-posts  %json
 /$  post        %channel-post         %json

--- a/desk/lib/mark-warmer.hoon
+++ b/desk/lib/mark-warmer.hoon
@@ -1,5 +1,6 @@
 /$  init        %ui-init              %json
 /$  init-1      %ui-init-1            %json
+/$  heads       %ui-heads             %json
 /$  pins        %ui-pins              %json
 /$  groups      %groups               %json
 /$  group       %group                %json

--- a/desk/mar/channel/heads.hoon
+++ b/desk/mar/channel/heads.hoon
@@ -1,0 +1,14 @@
+/-  c=channels
+/+  j=channel-json
+|_  =channel-heads:c
+++  grad  %noun
+++  grow
+  |%
+  ++  noun  channel-heads
+  ++  json  (channel-heads:enjs:j channel-heads)
+  --
+++  grab
+  |%
+  ++  noun  channel-heads:c
+  --
+--

--- a/desk/mar/chat/heads.hoon
+++ b/desk/mar/chat/heads.hoon
@@ -1,0 +1,14 @@
+/-  c=chat
+/+  j=chat-json
+|_  =chat-heads:c
+++  grad  %noun
+++  grow
+  |%
+  ++  noun  chat-heads
+  ++  json  (chat-heads:enjs:j chat-heads)
+  --
+++  grab
+  |%
+  ++  noun  chat-heads:c
+  --
+--

--- a/desk/sur/channels.hoon
+++ b/desk/sur/channels.hoon
@@ -485,6 +485,7 @@
         =remark
     ==
   --
++$  channel-heads  (list [=nest recency=time latest=(unit post)])
 +$  paged-posts
   $:  =posts
       newer=(unit time)

--- a/desk/sur/chat.hoon
+++ b/desk/sur/chat.hoon
@@ -81,6 +81,7 @@
       total=@ud
   ==
 ::
++$  chat-heads  (list [=whom recency=time latest=(unit writ)])
 ::  $writs: a set of time ordered chat messages
 ::
 ++  writs

--- a/desk/sur/ui.hoon
+++ b/desk/sur/ui.hoon
@@ -19,6 +19,9 @@
       =chat
       profile=?
   ==
+::
++$  mixed-heads  [chan=channel-heads:d chat=chat-heads:c]
+::
 +$  chat
   $:  clubs=(map id:club:c crew:club:c)
       dms=(set ship)


### PR DESCRIPTION
We add a `/heads` scry endpoint, which returns the latest message for every channel/chat. If the optional date path element is specified, we only include results whose latest message is after that date.

Groups-ui gets a `/heads` endpoint also, which simply merges the channels and chat `/heads` scries. Maybe, arguably, this should go into the init endpoint instead.

For channels, we also implement `/changes`, which gives you all changes made to a channel since the given timestamp. We currently cannot reasonably do this for chats, because those don't track changelogs, so including new replies would require checking all threads in the entire backlog.  
We could track new things in state to make that more performant, but we don't do that right now. Adding that should probably be considered out of scope here.

Fixes LAND-1840