### PR TITLE
groups: previewing issues and fact crash fix

### DIFF
--- a/apps/tlon-web/src/groups/useGroupJoin.ts
+++ b/apps/tlon-web/src/groups/useGroupJoin.ts
@@ -48,7 +48,7 @@ export default function useGroupJoin(
     location.pathname.includes('gangs/');
   const modalNavigate = useModalNavigate();
   const dismiss = useDismissNavigate();
-  const group = useGroup(flag, inModal);
+  const group = useGroup(flag, false);
   const { privacy } = useGroupPrivacy(flag);
   const requested = gang?.claim?.progress === 'knocking';
   const invited = gang?.invite;

--- a/apps/tlon-web/src/logic/useGroupPrivacy.ts
+++ b/apps/tlon-web/src/logic/useGroupPrivacy.ts
@@ -3,7 +3,7 @@ import { useGang, useGroup } from '@/state/groups';
 import { getPrivacyFromGroup, getPrivacyFromPreview } from './utils';
 
 export default function useGroupPrivacy(flag: string) {
-  const group = useGroup(flag);
+  const group = useGroup(flag, false);
   const gang = useGang(flag);
 
   const privacy = group

--- a/apps/tlon-web/src/state/groups/groups.ts
+++ b/apps/tlon-web/src/state/groups/groups.ts
@@ -348,16 +348,15 @@ export const useGangPreview = (
     app: 'groups',
     path: `/gangs/${flag}/preview`,
     options: {
-      enabled: !disabled,
-      initialData: gangs[flag]?.preview || undefined,
+      enabled: !disabled && !!flag,
     },
   });
 
   if (rest.isLoading || rest.isError) {
-    return null;
+    return gangs[flag]?.preview || null;
   }
 
-  return data as GroupPreview;
+  return (data as GroupPreview) || gangs[flag]?.preview || null;
 };
 
 export function useGangList() {

--- a/desk/app/groups.hoon
+++ b/desk/app/groups.hoon
@@ -1451,7 +1451,9 @@
       go-core
     ::
         %edit
-      ::  TODO: REFACTOR GROUPS PLZ
+      ::  TODO: we don't know why we could be desynced on cabals, but we
+      ::        need to be safe so we don't enter a loop.
+      ::        REFACTOR GROUPS PLZ
       =?  cabals.group  (~(has by cabals.group) sect)
         %+  ~(jab by cabals.group)  sect
         |=  cabal:g

--- a/desk/app/groups.hoon
+++ b/desk/app/groups.hoon
@@ -1734,7 +1734,10 @@
   ^+  cor
   =/  =wire  /gangs/index/(scot %p ship)
   =/  =dock  [ship dap.bowl]
-  (emit %pass wire %agent dock %watch `path`wire)
+  %-  emil
+  :~  [%pass wire %agent dock %leave ~]
+      [%pass wire %agent dock %watch `path`wire]
+  ==
 ::
 ++  hi-and-req-gang-index
   |=  =ship
@@ -1827,9 +1830,16 @@
       =/  =action:g  [flag now.bowl %cordon %shut %del-ships %ask ships]
       (poke-host /rescind act:mar:g !>(action))
     ++  get-preview
-      %^  subscribe  (welp ga-area /preview)
-        [p.flag dap.bowl]
-      /groups/(scot %p p.flag)/[q.flag]/preview
+      |=  delay=?
+      =/  =wire  (welp ga-area /preview)
+      =/  =dock  [p.flag dap.bowl]
+      =/  =path  /groups/(scot %p p.flag)/[q.flag]/preview
+      ^+  cor
+      =^  caz=(list card)  subs
+        (~(unsubscribe s [subs bowl]) wire dock)
+      =^  crds=(list card)  subs
+        (~(subscribe s [subs bowl]) wire dock path delay)
+      (emil (welp caz crds))
     --
   ++  ga-start-join
     ^+  ga-core

--- a/desk/app/groups.hoon
+++ b/desk/app/groups.hoon
@@ -1451,7 +1451,7 @@
       go-core
     ::
         %edit
-      =.  cabals.group
+      =?  cabals.group  (~(has by cabals.group) sect)
         %+  ~(jab by cabals.group)  sect
         |=  cabal:g
         +<(meta meta.diff)

--- a/desk/app/groups.hoon
+++ b/desk/app/groups.hoon
@@ -1451,6 +1451,7 @@
       go-core
     ::
         %edit
+      ::  TODO: REFACTOR GROUPS PLZ
       =?  cabals.group  (~(has by cabals.group) sect)
         %+  ~(jab by cabals.group)  sect
         |=  cabal:g
@@ -1830,16 +1831,14 @@
       =/  =action:g  [flag now.bowl %cordon %shut %del-ships %ask ships]
       (poke-host /rescind act:mar:g !>(action))
     ++  get-preview
-      |=  delay=?
       =/  =wire  (welp ga-area /preview)
       =/  =dock  [p.flag dap.bowl]
       =/  =path  /groups/(scot %p p.flag)/[q.flag]/preview
       ^+  cor
-      =^  caz=(list card)  subs
-        (~(unsubscribe s [subs bowl]) wire dock)
-      =^  crds=(list card)  subs
-        (~(subscribe s [subs bowl]) wire dock path delay)
-      (emil (welp caz crds))
+      %-  emil
+      :~  [%pass wire %agent dock %leave ~]
+          [%pass wire %agent dock %watch wire]
+      ==
     --
   ++  ga-start-join
     ^+  ga-core
@@ -1863,7 +1862,7 @@
   ++  ga-watch
     |=  =(pole knot)
     ^+  ga-core
-    =.  cor  (get-preview:ga-pass |)
+    =.  cor  get-preview:ga-pass
     ga-core
   ::
   ++  ga-give-update
@@ -1880,6 +1879,7 @@
       ::
           [%preview ~]
         ?+  -.sign  ~|(weird-take/[wire -.sign] !!)
+          %kick  ga-core  ::  kick for single response sub, just take it
           %watch-ack
           ?~  p.sign  ga-core :: TODO: report retreival failure
           %-  (slog u.p.sign)
@@ -1913,10 +1913,6 @@
             (emit (pass-hark new-yarn))
           ga-core
           ::
-            %kick
-          ?.  (~(has by xeno) flag)  ga-core
-          ?^  pev.gang  ga-core
-          ga-core(cor (get-preview:ga-pass &))
         ==
       ::
           [%join %add ~]
@@ -1967,7 +1963,7 @@
   ++  ga-invite
     |=  =invite:g
     =.  vit.gang  `invite
-    =.  cor  (get-preview:ga-pass |)
+    =.  cor  get-preview:ga-pass
     =.  cor  ga-give-update
     ga-core
   ::


### PR DESCRIPTION
This fixes two issues I found. One being that we don't actually fetch group previews because we were setting initial data, so they were potentially always using stale data (unless you don't have that group yet). The other issue is that editing a cabal that someone doesn't know about will crash because we use jab by without checking for existence of key.

PR Checklist
- [X] Includes changes to desk files
- [ ] Describes how you tested the PR locally (test ship vs livenet)
- [ ] If a new feature, includes automated tests
- [ ] Comments added anywhere logic may be confusing without context