### PR TITLE
ChatMessage: consistent line-heights, XStack for notices

### DIFF
--- a/packages/ui/src/components/ChatMessage/ChatContent.tsx
+++ b/packages/ui/src/components/ChatMessage/ChatContent.tsx
@@ -38,10 +38,7 @@ function ShipMention({ ship }: { ship: string }) {
   return (
     <ContactName
       onPress={() => {}}
-      backgroundColor="$positiveBackground"
-      borderRadius="$s"
-      borderWidth={1}
-      borderColor="$border"
+      fontWeight={'500'}
       color="$positiveActionText"
       userId={ship}
       showNickname
@@ -62,13 +59,13 @@ export function InlineContent({
   if (typeof story === 'string') {
     if (utils.isSingleEmoji(story)) {
       return (
-        <Text paddingTop="$xl" fontSize="$xl">
+        <Text paddingTop="$xl" lineHeight="$m" fontSize="$xl">
           {story}
         </Text>
       );
     }
     return (
-      <Text color={color} fontSize="$m">
+      <Text color={color} lineHeight="$m" fontSize="$m">
         {story}
       </Text>
     );
@@ -78,7 +75,7 @@ export function InlineContent({
     return (
       <>
         {story.bold.map((s, k) => (
-          <Text fontSize="$m" fontWeight="bold" key={k}>
+          <Text fontSize="$m" lineHeight="$m" fontWeight="bold" key={k}>
             <InlineContent story={s} color={color} />
           </Text>
         ))}
@@ -90,7 +87,7 @@ export function InlineContent({
     return (
       <>
         {story.italics.map((s, k) => (
-          <Text fontSize="$m" fontStyle="italic" key={k}>
+          <Text fontSize="$m" lineHeight="$m" fontStyle="italic" key={k}>
             <InlineContent story={s} color={color} />
           </Text>
         ))}
@@ -102,7 +99,12 @@ export function InlineContent({
     return (
       <>
         {story.strike.map((s, k) => (
-          <Text fontSize="$m" textDecorationLine="line-through" key={k}>
+          <Text
+            fontSize="$m"
+            lineHeight="$m"
+            textDecorationLine="line-through"
+            key={k}
+          >
             <InlineContent story={s} color={color} />
           </Text>
         ))}
@@ -118,6 +120,7 @@ export function InlineContent({
         backgroundColor="$secondaryBackground"
         padding="$xs"
         borderRadius="$s"
+        lineHeight="$m"
       >
         {story['inline-code']}
       </Text>
@@ -138,6 +141,7 @@ export function InlineContent({
           borderRadius="$s"
           color={color}
           backgroundColor="$secondaryBackground"
+          lineHeight="$m"
         >
           {story.code}
         </Text>
@@ -236,18 +240,6 @@ const LineRenderer = memo(
     const inlineElements: ReactElement[][] = [];
     let currentLine: ReactElement[] = [];
 
-    if (isNotice) {
-      currentLine.push(
-        <Icon
-          type="AddPerson"
-          color="$secondaryText"
-          backgroundColor="$secondaryBackground"
-          borderRadius="$s"
-          marginRight="$s"
-        />
-      );
-    }
-
     storyInlines.forEach((inline, index) => {
       if (isBreak(inline)) {
         inlineElements.push(currentLine);
@@ -269,7 +261,7 @@ const LineRenderer = memo(
               key={`string-${inline}-${index}`}
               color={isNotice ? '$tertiaryText' : color}
               fontSize="$m"
-              fontWeight={isNotice ? '600' : 'normal'}
+              fontWeight={isNotice ? '500' : 'normal'}
               lineHeight="$m"
             >
               {inline}
@@ -324,7 +316,7 @@ const LineRenderer = memo(
           }
 
           return (
-            <Text key={`line-${index}`} flexWrap="wrap">
+            <Text key={`line-${index}`} flexWrap="wrap" lineHeight="$m">
               {line}
             </Text>
           );

--- a/packages/ui/src/components/ChatMessage/ChatEmbedContent.tsx
+++ b/packages/ui/src/components/ChatMessage/ChatEmbedContent.tsx
@@ -59,7 +59,7 @@ export default function ChatEmbedContent({
   }
 
   return (
-    <Text textDecorationLine="underline" onPress={openLink}>
+    <Text textDecorationLine="underline" lineHeight="$m" onPress={openLink}>
       <InlineContent story={content} />
     </Text>
   );

--- a/packages/ui/src/components/ChatMessage/ChatMessage.tsx
+++ b/packages/ui/src/components/ChatMessage/ChatMessage.tsx
@@ -2,11 +2,35 @@ import { PostContent } from '@tloncorp/shared/dist/api';
 import * as db from '@tloncorp/shared/dist/db';
 import { memo, useCallback, useMemo } from 'react';
 
-import { SizableText, View, YStack } from '../../core';
+import { SizableText, View, XStack, YStack } from '../../core';
+import { Icon } from '../Icon';
 import AuthorRow from './AuthorRow';
 import ChatContent from './ChatContent';
 import { ChatMessageReplySummary } from './ChatMessageReplySummary';
 import { ReactionsDisplay } from './ReactionsDisplay';
+
+const NoticeWrapper = ({
+  isNotice,
+  children,
+}: {
+  isNotice?: boolean;
+  children: JSX.Element;
+}) => {
+  if (isNotice) {
+    return (
+      <XStack gap="$m">
+        <Icon
+          type="AddPerson"
+          color="$secondaryText"
+          size="$m"
+          backgroundColor={'$secondaryBackground'}
+        />
+        {children}
+      </XStack>
+    );
+  }
+  return children;
+};
 
 const ChatMessage = ({
   post,
@@ -26,6 +50,10 @@ const ChatMessage = ({
   onLongPress?: (post: db.Post) => void;
 }) => {
   const isNotice = post.type === 'notice';
+
+  if (isNotice) {
+    showAuthor = false;
+  }
 
   const content = useMemo(
     () => JSON.parse(post.content as string) as PostContent,
@@ -88,13 +116,15 @@ const ChatMessage = ({
             You have hidden or flagged this message.
           </SizableText>
         ) : (
-          <ChatContent
-            story={content}
-            isNotice={isNotice}
-            onPressImage={handleImagePressed}
-            onLongPress={handleLongPress}
-            deliveryStatus={post.deliveryStatus}
-          />
+          <NoticeWrapper isNotice={isNotice}>
+            <ChatContent
+              story={content}
+              isNotice={isNotice}
+              onPressImage={handleImagePressed}
+              onLongPress={handleLongPress}
+              deliveryStatus={post.deliveryStatus}
+            />
+          </NoticeWrapper>
         )}
       </View>
       <ReactionsDisplay post={post} currentUserId={currentUserId} />


### PR DESCRIPTION
I noticed that in chat messages with multiple inline elements, we ended up with inconsistent line-heights. I also decided to take a crack at the DM join notice.

- Makes all ContactNames in ChatMessages font-weight: 500.
- Removes the blue background from ContactNames in ChatMessages as discussed.
- Removes the AddPerson Icon from the LineRenderer in ChatContent and conditionally wraps ChatContent in ChatMessage with an XStack to align everything vertically.
- Hides the author for the Notice message type.
- Enforces a $m line-height in every inline text element.

![image](https://github.com/tloncorp/tlon-apps/assets/748181/ea440d66-58d3-4a2d-9b10-28cee2aa044c)
