### PR TITLE
nav: make sure we always navigate to right tab

### DIFF
--- a/apps/tlon-web/src/channels/ChannelActions.tsx
+++ b/apps/tlon-web/src/channels/ChannelActions.tsx
@@ -4,7 +4,7 @@ import React, { PropsWithChildren, useCallback, useState } from 'react';
 import { useLocation, useNavigate } from 'react-router';
 
 import ActionMenu, { Action } from '@/components/ActionMenu';
-import useActiveTab from '@/components/Sidebar/util';
+import useActiveTab, { useNavWithinTab } from '@/components/Sidebar/util';
 import VolumeSetting from '@/components/VolumeSetting';
 import EllipsisIcon from '@/components/icons/EllipsisIcon';
 import DeleteChannelModal from '@/groups/ChannelsList/DeleteChannelModal';
@@ -36,8 +36,7 @@ const ChannelActions = React.memo(
     className,
     children,
   }: ChannelActionsProps) => {
-    const navigate = useNavigate();
-    const location = useLocation();
+    const { navigate } = useNavWithinTab();
     const isMobile = useIsMobile();
     const [_app, flag] = nestToFlag(nest);
     const groupFlag = useRouteGroup();
@@ -136,9 +135,7 @@ const ChannelActions = React.memo(
         if (isMobile) {
           setShowNotifications(true);
         } else {
-          navigate(`/groups/${groupFlag}/channels/${nest}/volume`, {
-            state: { backgroundLocation: location },
-          });
+          navigate(`/groups/${groupFlag}/channels/${nest}/volume`, true);
         }
       },
       content: 'Notifications',

--- a/apps/tlon-web/src/components/References/CurioReference.tsx
+++ b/apps/tlon-web/src/components/References/CurioReference.tsx
@@ -15,6 +15,7 @@ import getHeapContentType from '@/logic/useHeapContentType';
 import { useRemotePost } from '@/state/channel/channel';
 import { useChannelPreview, useGang } from '@/state/groups';
 
+import { useNavWithinTab } from '../Sidebar/util';
 import ReferenceBar from './ReferenceBar';
 import ReferenceInHeap from './ReferenceInHeap';
 import UnavailableReference from './UnavailableReference';
@@ -41,8 +42,7 @@ function CurioReference({
     idReply
   );
   const preview = useChannelPreview(nest, isScrolling);
-  const location = useLocation();
-  const navigate = useNavigate();
+  const { navigate } = useNavWithinTab();
   const groupFlag = preview?.group?.flag || '~zod/test';
   const gang = useGang(groupFlag);
   const { group } = useGroupJoin(groupFlag, gang);
@@ -83,9 +83,10 @@ function CurioReference({
 
   const handleOpenReferenceClick = () => {
     if (!group) {
-      navigate(`/gangs/${groupFlag}?type=curio&nest=${nest}&id=${idCurio}`, {
-        state: { backgroundLocation: location },
-      });
+      navigate(
+        `/gangs/${groupFlag}?type=curio&nest=${nest}&id=${idCurio}`,
+        true
+      );
       return;
     }
     navigate(`/groups/${groupFlag}/channels/${nest}/curio/${idCurio}`);

--- a/apps/tlon-web/src/components/References/NoteReference.tsx
+++ b/apps/tlon-web/src/components/References/NoteReference.tsx
@@ -18,6 +18,7 @@ import { useRemotePost } from '@/state/channel/channel';
 import { useChannelPreview, useGang } from '@/state/groups';
 
 import ShipName from '../ShipName';
+import { useNavWithinTab } from '../Sidebar/util';
 import NotebookIcon from '../icons/NotebookIcon';
 import ReferenceBar from './ReferenceBar';
 import ReferenceInHeap from './ReferenceInHeap';
@@ -41,8 +42,7 @@ function NoteReference({
   const gang = useGang(groupFlag);
   const { group } = useGroupJoin(groupFlag, gang);
   const { reference, isError } = useRemotePost(nest, id, isScrolling);
-  const navigate = useNavigate();
-  const location = useLocation();
+  const { navigate } = useNavWithinTab();
   const note = useMemo(() => {
     if (reference && 'post' in reference) {
       return reference.post;
@@ -74,9 +74,7 @@ function NoteReference({
   const { title, image } = getKindDataFromEssay(note.essay);
   const handleOpenReferenceClick = () => {
     if (!group) {
-      navigate(`/gangs/${groupFlag}?type=note&nest=${nest}&id=${id}`, {
-        state: { backgroundLocation: location },
-      });
+      navigate(`/gangs/${groupFlag}?type=note&nest=${nest}&id=${id}`, true);
       return;
     }
 

--- a/apps/tlon-web/src/components/References/ReferenceBar.tsx
+++ b/apps/tlon-web/src/components/References/ReferenceBar.tsx
@@ -8,6 +8,8 @@ import ChannelIcon from '@/channels/ChannelIcon';
 import Author from '@/chat/ChatMessage/Author';
 import GroupAvatar from '@/groups/GroupAvatar';
 
+import { useNavWithinTab } from '../Sidebar/util';
+
 interface ReferenceBarProps {
   nest: string;
   time: BigInteger;
@@ -35,7 +37,7 @@ export default function ReferenceBar({
   heapComment = false,
   reply = false,
 }: ReferenceBarProps) {
-  const navigate = useNavigate();
+  const { navigate } = useNavWithinTab();
   const unix = new Date(daToUnix(time));
 
   const navigateToChannel = useCallback(() => {

--- a/apps/tlon-web/src/components/References/WritBaseReference.tsx
+++ b/apps/tlon-web/src/components/References/WritBaseReference.tsx
@@ -12,6 +12,7 @@ import { isImageUrl, nestToFlag } from '@/logic/utils';
 import { useChannelPreview, useGang } from '@/state/groups';
 
 import ShipName from '../ShipName';
+import { useNavWithinTab } from '../Sidebar/util';
 import ReferenceBar from './ReferenceBar';
 import ReferenceInHeap from './ReferenceInHeap';
 
@@ -31,8 +32,7 @@ function WritBaseReference({
   children,
 }: WritBaseReferenceProps) {
   const preview = useChannelPreview(nest, isScrolling);
-  const location = useLocation();
-  const navigate = useNavigate();
+  const { navigate } = useNavWithinTab();
   const [app, chFlag] = nestToFlag(nest);
   const refMessageType = useMemo(() => {
     if (app === 'chat') {
@@ -93,16 +93,12 @@ function WritBaseReference({
       if ('post' in reference) {
         navigate(
           `/gangs/${groupFlag}?type=chat&nest=${nest}&id=${reference.post.seal.id}`,
-          {
-            state: { backgroundLocation: location },
-          }
+          true
         );
       } else {
         navigate(
           `/gangs/${groupFlag}?type=chat&nest=${nest}&id=${reference.reply['id-post']}`,
-          {
-            state: { backgroundLocation: location },
-          }
+          true
         );
       }
       return;

--- a/apps/tlon-web/src/components/Sidebar/util.tsx
+++ b/apps/tlon-web/src/components/Sidebar/util.tsx
@@ -1,5 +1,5 @@
 import { useCallback } from 'react';
-import { useLocation, useNavigate } from 'react-router';
+import { NavigateOptions, To, useLocation, useNavigate } from 'react-router';
 
 import { useNavState, usePutEntryMutation } from '@/state/settings';
 
@@ -48,6 +48,57 @@ export function useNavToTab() {
     },
     [navState, navigate]
   );
+}
+
+export function useNavWithinTab() {
+  const location = useLocation();
+  const navigate = useNavigate();
+  const isActive = (path: string) => location.pathname.startsWith(path);
+
+  const navTo = useCallback(
+    (to: number | To, modal = false, options?: NavigateOptions) => {
+      const opts = modal
+        ? {
+            ...options,
+            state: location.state || {
+              ...options?.state,
+              backgroundLocation: location,
+            },
+          }
+        : options;
+
+      if (typeof to === 'number') {
+        navigate(to);
+        return;
+      }
+
+      const isStringPath = typeof to === 'string';
+      let path = isStringPath ? to : to.pathname || '';
+
+      if (isActive('/groups') || location.pathname === '/') {
+        path = path.replace(/^\/dm/, '');
+      }
+
+      if (isActive('/messages') || isActive('/dm')) {
+        path = path.replace(/^\/groups/, '/dm/groups');
+      }
+
+      navigate(
+        !isStringPath
+          ? {
+              ...to,
+              pathname: path,
+            }
+          : path,
+        opts
+      );
+    },
+    [location, navigate]
+  );
+
+  return {
+    navigate: navTo,
+  };
 }
 
 export function useSaveNavState() {

--- a/apps/tlon-web/src/diary/diary-add-note.tsx
+++ b/apps/tlon-web/src/diary/diary-add-note.tsx
@@ -1,7 +1,6 @@
 import { constructStory } from '@tloncorp/shared/dist/urbit/channel';
 import { JSONContent } from '@tloncorp/shared/dist/urbit/content';
 import cn from 'classnames';
-import { isFirstDayOfMonth } from 'date-fns';
 import { useCallback, useEffect, useRef, useState } from 'react';
 import { Helmet } from 'react-helmet';
 import { FormProvider, useForm } from 'react-hook-form';
@@ -18,7 +17,6 @@ import Tooltip from '@/components/Tooltip';
 import CaretLeft16Icon from '@/components/icons/CaretLeft16Icon';
 import PencilIcon from '@/components/icons/PencilIcon';
 import { captureGroupsAnalyticsEvent } from '@/logic/analytics';
-import asyncCallWithTimeout from '@/logic/asyncWithTimeout';
 import { useChannelCompatibility } from '@/logic/channel';
 import getKindDataFromEssay from '@/logic/getKindData';
 import { JSONToInlines, diaryMixedToJSON } from '@/logic/tiptap';

--- a/apps/tlon-web/src/groups/GroupActions.tsx
+++ b/apps/tlon-web/src/groups/GroupActions.tsx
@@ -9,6 +9,7 @@ import { Link, useLocation, useNavigate } from 'react-router-dom';
 
 import ActionMenu, { Action } from '@/components/ActionMenu';
 import UnreadIndicator from '@/components/Sidebar/UnreadIndicator';
+import { useNavWithinTab } from '@/components/Sidebar/util';
 import VolumeSetting from '@/components/VolumeSetting';
 import EllipsisIcon from '@/components/icons/EllipsisIcon';
 import useIsGroupUnread from '@/logic/useIsGroupUnread';
@@ -116,7 +117,7 @@ const GroupActions = React.memo(
     const { isGroupUnread } = useIsGroupUnread();
     const { claim } = useGang(flag);
     const location = useLocation();
-    const navigate = useNavigate();
+    const { navigate } = useNavWithinTab();
     const [host, name] = flag.split('/');
     const hasActivity = isGroupUnread(flag);
     const group = useGroup(flag);
@@ -273,9 +274,7 @@ const GroupActions = React.memo(
           if (isMobile) {
             setShowNotifications(true);
           } else {
-            navigate(`/groups/${flag}/volume`, {
-              state: { backgroundLocation: location },
-            });
+            navigate(`/groups/${flag}/volume`, true);
           }
         },
         containerClassName:

--- a/apps/tlon-web/src/groups/Join/GroupPreview.tsx
+++ b/apps/tlon-web/src/groups/Join/GroupPreview.tsx
@@ -6,6 +6,7 @@ import Dialog from '@/components/Dialog';
 import LoadingSpinner from '@/components/LoadingSpinner/LoadingSpinner';
 import ShipConnection from '@/components/ShipConnection';
 import ShipName from '@/components/ShipName';
+import { useNavWithinTab } from '@/components/Sidebar/util';
 import WidgetDrawer from '@/components/WidgetDrawer';
 import Globe16Icon from '@/components/icons/Globe16Icon';
 import Lock16Icon from '@/components/icons/Lock16Icon';
@@ -186,7 +187,7 @@ export function MobileGroupPreview({
 }
 
 export function DesktopGroupPreview({ flag }: { flag: string }) {
-  const navigate = useNavigate();
+  const { navigate } = useNavWithinTab();
   const gang = useGang(flag);
   const preview = useGangPreview(flag);
   const { group, reject, button, status } = useGroupJoin(

--- a/apps/tlon-web/src/groups/LureAutojoiner.tsx
+++ b/apps/tlon-web/src/groups/LureAutojoiner.tsx
@@ -3,6 +3,7 @@ import cookies from 'browser-cookies';
 import { useCallback, useEffect } from 'react';
 import { useNavigate } from 'react-router';
 
+import { useNavWithinTab } from '@/components/Sidebar/util';
 import { getPrivacyFromGang } from '@/logic/utils';
 import {
   useGroupJoinMutation,
@@ -11,7 +12,7 @@ import {
 
 export default function LureAutojoiner(): React.ReactElement {
   const { mutateAsync: joinMutation } = useGroupJoinMutation();
-  const navigate = useNavigate();
+  const { navigate } = useNavWithinTab();
 
   const pendingGangsWithoutClaim = usePendingGangsWithoutClaim();
 

--- a/apps/tlon-web/src/groups/NewGroup/NewGroup.tsx
+++ b/apps/tlon-web/src/groups/NewGroup/NewGroup.tsx
@@ -4,6 +4,7 @@ import { FormProvider, useForm } from 'react-hook-form';
 import { useNavigate } from 'react-router';
 
 import NavigationDots from '@/components/NavigationDots';
+import { useNavWithinTab } from '@/components/Sidebar/util';
 import NewGroupForm from '@/groups/NewGroup/NewGroupForm';
 import NewGroupInvite from '@/groups/NewGroup/NewGroupInvite';
 import NewGroupPrivacy from '@/groups/NewGroup/NewGroupPrivacy';
@@ -31,7 +32,7 @@ interface NewGroupProps {
 }
 
 export default function NewGroup({ stepMeta }: NewGroupProps) {
-  const navigate = useNavigate();
+  const { navigate } = useNavWithinTab();
   const [shipsToInvite, setShipsToInvite] = useState<ShipWithRoles[]>([]);
   // const [templateType, setTemplateType] = useState<TemplateTypes>('none');
   const { mutate: createGroupMutation, status } = useCreateGroupMutation();

--- a/apps/tlon-web/src/groups/useGroupJoin.ts
+++ b/apps/tlon-web/src/groups/useGroupJoin.ts
@@ -2,6 +2,7 @@ import { Gang, Group, PrivacyType } from '@tloncorp/shared/dist/urbit/groups';
 import { useCallback, useEffect, useState } from 'react';
 import { useLocation, useNavigate } from 'react-router';
 
+import { useNavWithinTab } from '@/components/Sidebar/util';
 import { useDismissNavigate, useModalNavigate } from '@/logic/routing';
 import useGroupPrivacy from '@/logic/useGroupPrivacy';
 import {
@@ -42,7 +43,7 @@ export default function useGroupJoin(
     | undefined = undefined
 ) {
   const location = useLocation();
-  const navigate = useNavigate();
+  const { navigate } = useNavWithinTab();
   const modalIsOpen =
     !!location.state?.backgroundLocation &&
     location.pathname.includes('gangs/');
@@ -72,9 +73,7 @@ export default function useGroupJoin(
       return navigate(`/groups/${flag}`);
     }
 
-    return navigate(`/gangs/${flag}`, {
-      state: { backgroundLocation: location },
-    });
+    return navigate(`/gangs/${flag}`, true);
   }, [flag, group, location, navigate]);
 
   const join = useCallback(async () => {
@@ -143,9 +142,7 @@ export default function useGroupJoin(
       return;
     }
     if (inModal) {
-      modalNavigate(`/gangs/${flag}/reject`, {
-        state: { backgroundLocation: location },
-      });
+      navigate(`/gangs/${flag}/reject`, true);
     } else {
       navigate(`/gangs/${flag}/reject`);
     }

--- a/apps/tlon-web/src/heap/useCurioActions.ts
+++ b/apps/tlon-web/src/heap/useCurioActions.ts
@@ -2,6 +2,7 @@ import { decToUd } from '@urbit/api';
 import { useCallback, useState } from 'react';
 import { useLocation, useNavigate } from 'react-router';
 
+import { useNavWithinTab } from '@/components/Sidebar/util';
 import { citeToPath, nestToFlag, useCopy } from '@/logic/utils';
 import { useDeletePostMutation, usePostToggler } from '@/state/channel/channel';
 import { useGroupFlag } from '@/state/groups';
@@ -17,8 +18,7 @@ export default function useCurioActions({
   time,
   refToken,
 }: useCurioActionsProps) {
-  const navigate = useNavigate();
-  const location = useLocation();
+  const { navigate } = useNavWithinTab();
   const flag = useGroupFlag();
   const [, chFlag] = nestToFlag(nest);
   const chanPath = citeToPath({
@@ -46,9 +46,10 @@ export default function useCurioActions({
 
   const onEdit = useCallback(() => {
     setMenuOpen(false);
-    navigate(`/groups/${flag}/channels/heap/${chFlag}/curio/${time}/edit`, {
-      state: { backgroundLocation: location },
-    });
+    navigate(
+      `/groups/${flag}/channels/heap/${chFlag}/curio/${time}/edit`,
+      true
+    );
   }, [location, navigate, time, flag, chFlag]);
 
   const navigateToCurio = useCallback(() => {
@@ -71,9 +72,8 @@ export default function useCurioActions({
   }, [isHidden, show, hide]);
 
   const reportContent = useCallback(() => {
-    navigate('/report-content', {
+    navigate('/report-content', true, {
       state: {
-        backgroundLocation: location,
         post: time,
         reply: null,
         nest,
@@ -81,7 +81,7 @@ export default function useCurioActions({
       },
     });
     hide();
-  }, [navigate, hide, location, nest, time, flag]);
+  }, [navigate, hide, nest, time, flag]);
 
   return {
     didCopy,

--- a/apps/tlon-web/src/logic/channel.ts
+++ b/apps/tlon-web/src/logic/channel.ts
@@ -12,6 +12,7 @@ import { useCallback, useEffect, useMemo, useState } from 'react';
 import { useNavigate, useParams } from 'react-router';
 
 import { ChatStore, useChatStore } from '@/chat/useChatStore';
+import { useNavWithinTab } from '@/components/Sidebar/util';
 import {
   ALPHABETICAL_SORT,
   DEFAULT_SORT,
@@ -289,7 +290,7 @@ export function useFullChannel({
   nest,
   initialize,
 }: FullChannelParams) {
-  const navigate = useNavigate();
+  const { navigate } = useNavWithinTab();
   const group = useGroup(groupFlag);
   const [, chan] = nestToFlag(nest);
   const { ship } = getFlagParts(chan);

--- a/apps/tlon-web/src/logic/useCreateDefaultGroup.ts
+++ b/apps/tlon-web/src/logic/useCreateDefaultGroup.ts
@@ -1,5 +1,6 @@
 import { useNavigate } from 'react-router';
 
+import { useNavWithinTab } from '@/components/Sidebar/util';
 import { useCreateMutation } from '@/state/channel/channel';
 import { useCreateGroupMutation } from '@/state/groups';
 
@@ -8,7 +9,7 @@ export default function useCreateDefaultGroup() {
     useCreateGroupMutation();
   const { mutateAsync: createChannelMutation, isLoading: channelIsLoading } =
     useCreateMutation();
-  const navigate = useNavigate();
+  const { navigate } = useNavWithinTab();
 
   async function createGroup({
     title,

--- a/apps/tlon-web/src/profiles/FavoriteGroup.tsx
+++ b/apps/tlon-web/src/profiles/FavoriteGroup.tsx
@@ -2,6 +2,7 @@ import * as Tooltip from '@radix-ui/react-tooltip';
 import React from 'react';
 import { useLocation, useNavigate } from 'react-router';
 
+import { useNavWithinTab } from '@/components/Sidebar/util';
 import GroupAvatar from '@/groups/GroupAvatar';
 import { useModalNavigate } from '@/logic/routing';
 import { useGang, useGangPreview, useGroup } from '@/state/groups';
@@ -17,7 +18,7 @@ export default function FavoriteGroup({ groupFlag }: FavoriteGroupProps) {
   const location = useLocation();
   const gang = useGang(noShipGroupFlag);
   const preview = useGangPreview(noShipGroupFlag, !!group);
-  const navigate = useNavigate();
+  const { navigate } = useNavWithinTab();
   const modalNavigate = useModalNavigate();
 
   const data = {
@@ -37,9 +38,7 @@ export default function FavoriteGroup({ groupFlag }: FavoriteGroupProps) {
     if (group) {
       navigate(`/groups/${noShipGroupFlag}`);
     } else {
-      modalNavigate(`/gangs/${noShipGroupFlag}`, {
-        state: { backgroundLocation: location },
-      });
+      navigate(`/gangs/${noShipGroupFlag}`, true);
     }
   };
 

--- a/apps/tlon-web/src/replies/ReplyMessageOptions.tsx
+++ b/apps/tlon-web/src/replies/ReplyMessageOptions.tsx
@@ -10,6 +10,7 @@ import ActionMenu, { Action } from '@/components/ActionMenu';
 import ConfirmationModal from '@/components/ConfirmationModal';
 import EmojiPicker from '@/components/EmojiPicker';
 import IconButton from '@/components/IconButton';
+import { useNavWithinTab } from '@/components/Sidebar/util';
 import AddReactIcon from '@/components/icons/AddReactIcon';
 import BubbleIcon from '@/components/icons/BubbleIcon';
 import CautionIcon from '@/components/icons/CautionIcon';
@@ -95,8 +96,7 @@ export default function ReplyMessageOptions(props: {
   const group = useGroup(groupFlag);
   const { privacy } = useGroupPrivacy(groupFlag);
   const canWrite = canWriteChannel(perms, vessel, group?.bloc);
-  const navigate = useNavigate();
-  const location = useLocation();
+  const { navigate } = useNavWithinTab();
   const { mutate: deleteReply, isLoading: isDeleteReplyLoading } =
     useDeleteReplyMutation();
   const { mutate: deleteChatMessage, isLoading: isDeleteChatMessageLoading } =
@@ -247,9 +247,8 @@ export default function ReplyMessageOptions(props: {
   );
 
   const reportContent = useCallback(() => {
-    navigate('/report-content', {
+    navigate('/report-content', true, {
       state: {
-        backgroundLocation: location,
         post: threadParentId,
         reply: seal.id,
         nest,
@@ -277,9 +276,7 @@ export default function ReplyMessageOptions(props: {
         </div>
       ),
       onClick: () => {
-        navigate(`picker/${seal.id}`, {
-          state: { backgroundLocation: location },
-        });
+        navigate(`picker/${seal.id}`, true);
       },
     });
   }


### PR DESCRIPTION
This attempts to make a hook that will respect navigations within tabs fixing LAND-1579

PR Checklist
- [ ] Includes changes to desk files
- [ ] Describes how you tested the PR locally (test ship vs livenet)
- [ ] If a new feature, includes automated tests
- [ ] Comments added anywhere logic may be confusing without context