### PR TITLE
channels: fix missing reply meta in old scries

### DIFF
--- a/desk/lib/channel-utils.hoon
+++ b/desk/lib/channel-utils.hoon
@@ -117,7 +117,6 @@
 ++  suv-post-without-replies
   |=  post=v-post:c
   ^-  simple-post:c
-  =.  replies.post  ~
   (s-post (uv-post-without-replies post))
 ::
 ++  uv-replies


### PR DESCRIPTION
We mistakenly were clearing the replies before we could compute the meta, fixes LAND-1767

PR Checklist
- [X] Includes changes to desk files
- [ ] Describes how you tested the PR locally (test ship vs livenet)
- [ ] If a new feature, includes automated tests
- [ ] Comments added anywhere logic may be confusing without context