### PR TITLE
native: fix input lag

### DIFF
--- a/apps/tlon-mobile/src/screens/ChannelScreen.tsx
+++ b/apps/tlon-mobile/src/screens/ChannelScreen.tsx
@@ -155,7 +155,6 @@ export default function ChannelScreen(props: ChannelScreenProps) {
 
       return draft;
     } catch (e) {
-      console.log('Error loading draft', e);
       return null;
     }
   }, [currentChannelId]);
@@ -165,7 +164,7 @@ export default function ChannelScreen(props: ChannelScreenProps) {
       try {
         await storage.save({ key: `draft-${currentChannelId}`, data: draft });
       } catch (e) {
-        console.log('Error saving draft', e);
+        return;
       }
     },
     [currentChannelId]
@@ -175,7 +174,7 @@ export default function ChannelScreen(props: ChannelScreenProps) {
     try {
       await storage.remove({ key: `draft-${currentChannelId}` });
     } catch (e) {
-      console.log('Error clearing draft', e);
+      return;
     }
   }, [currentChannelId]);
 

--- a/packages/editor/src/MessageInputEditor.tsx
+++ b/packages/editor/src/MessageInputEditor.tsx
@@ -12,12 +12,26 @@ import {
   useTenTap,
 } from '@10play/tentap-editor';
 import CodeBlock from '@tiptap/extension-code-block';
+import { Slice } from '@tiptap/pm/model';
+import { EditorView } from '@tiptap/pm/view';
 import { EditorContent } from '@tiptap/react';
+import { useCallback } from 'react';
 
 import { MentionsBridge, ShortcutsBridge } from './bridges';
 import { useIsDark } from './useMedia';
 
 export const MessageInputEditor = () => {
+  const handlePaste = useCallback(
+    (_view: EditorView, event: ClipboardEvent, _slice: Slice) => {
+      const text = event.clipboardData?.getData('text/plain');
+
+      window.ReactNativeWebView.postMessage(
+        JSON.stringify({ type: 'paste', payload: text })
+      );
+    },
+    []
+  );
+
   const editor = useTenTap({
     bridges: [
       CoreBridge,
@@ -41,6 +55,9 @@ export const MessageInputEditor = () => {
     ],
     tiptapOptions: {
       extensions: [CodeBlock],
+      editorProps: {
+        handlePaste,
+      },
     },
   });
 


### PR DESCRIPTION
fixes LAND-1871 by removing most of the content parsing (and all of the content replacement) from onContentUpdate.

Instead, we listen for a paste event within the editor in the webview and send a message up to the react native app, then handle the content parsing/updating in a handler.

onContentUpdate is still used for triggering a mention or storing a draft, but we don't manipulate the content there anymore.