### PR TITLE
channels: dont crash on read

### DIFF
--- a/desk/app/channels.hoon
+++ b/desk/app/channels.hoon
@@ -782,7 +782,7 @@
       =/  thread=(pole knot)  ted.rope
       =/  top-id=(unit id-post:c)
         ?+  thread  ~
-          [* * * * id=@ rest=*]  `(slav %ui (cat 3 '0i' id.thread))
+          [* * * * id=@ rest=*]  (slaw %ui (cat 3 '0i' id.thread))
         ==
       ::  look at what post id the notification is coming from, and
       ::  if it's newer than the last read, mark the notification

--- a/desk/mar/ui/heads.hoon
+++ b/desk/mar/ui/heads.hoon
@@ -1,0 +1,20 @@
+/-  u=ui
+/+  cj=chat-json, dj=channel-json
+|_  =mixed-heads:u
+++  grad  %noun
+++  grow
+  |%
+  ++  noun  mixed-heads
+  ++  json
+    =,  enjs:format
+    ^-  ^json
+    %-  pairs
+    :~  channels/(channel-heads:enjs:dj chan.mixed-heads)
+        dms/(chat-heads:enjs:cj chat.mixed-heads)
+    ==
+  --
+++  grab
+  |%
+  ++  noun  mixed-heads:u
+  --
+--


### PR DESCRIPTION
Reported by @patosullivan we potentially can crash when doing a read action because we might have a malformed notification thread. Also adds mark that @Fang- forgot.

PR Checklist
- [ ] Includes changes to desk files
- [ ] Describes how you tested the PR locally (test ship vs livenet)
- [ ] If a new feature, includes automated tests
- [ ] Comments added anywhere logic may be confusing without context