### PR TITLE
native: hide send arrow if editor is empty

### DIFF
--- a/packages/ui/src/components/MessageInput/MessageInputBase.tsx
+++ b/packages/ui/src/components/MessageInput/MessageInputBase.tsx
@@ -39,6 +39,7 @@ export const MessageInputContainer = ({
   mentionText,
   groupMembers,
   onSelectMention,
+  editorIsEmpty,
 }: PropsWithChildren<{
   onPressSend?: () => void;
   setImageAttachment: (image: string | null) => void;
@@ -49,6 +50,7 @@ export const MessageInputContainer = ({
   mentionText?: string;
   groupMembers: db.ChatMember[];
   onSelectMention: (contact: db.Contact) => void;
+  editorIsEmpty: boolean;
 }>) => {
   const { references, setReferences } = useReferences();
   const hasUploadedImage = useMemo(
@@ -132,14 +134,16 @@ export const MessageInputContainer = ({
         ) : null}
         {children}
         <View paddingBottom="$m">
-          <IconButton
-            color={sendIconColor}
-            disabled={uploadIsLoading}
-            onPress={onPressSend}
-          >
-            {/* TODO: figure out what send button should look like */}
-            <ArrowUp />
-          </IconButton>
+          {editorIsEmpty ? null : (
+            <IconButton
+              color={sendIconColor}
+              disabled={uploadIsLoading}
+              onPress={onPressSend}
+            >
+              {/* TODO: figure out what send button should look like */}
+              <ArrowUp />
+            </IconButton>
+          )}
         </View>
       </XStack>
     </YStack>

--- a/packages/ui/src/components/MessageInput/index.tsx
+++ b/packages/ui/src/components/MessageInput/index.tsx
@@ -23,6 +23,7 @@ export function MessageInput({
       containerHeight={0}
       groupMembers={groupMembers}
       onSelectMention={() => {}}
+      editorIsEmpty={true}
     >
       <TextArea
         flexGrow={1}


### PR DESCRIPTION
fixes LAND-1875 by hiding the send arrow when we have nothing to send.