### PR TITLE
native, ui: move from TabStack to new custom NavBar component

### DIFF
--- a/apps/tlon-mobile/src/navigation/NavBarView.tsx
+++ b/apps/tlon-mobile/src/navigation/NavBarView.tsx
@@ -1,0 +1,45 @@
+import { useNavigationState } from '@react-navigation/native';
+import * as store from '@tloncorp/shared/dist/store';
+import { AvatarNavIcon, NavBar, NavIcon } from '@tloncorp/ui';
+
+import { useCurrentUserId } from '../hooks/useCurrentUser';
+
+const NavBarView = (props: { navigation: any }) => {
+  const state = useNavigationState((state) => state);
+  const isRouteActive = (routeName: string) => {
+    return state.routes[state.index].name === routeName;
+  };
+  const { data: unreadCount } = store.useAllUnreadsCounts();
+  const currentUserId = useCurrentUserId();
+  const { data: contact, isLoading } = store.useContact({ id: currentUserId });
+
+  return (
+    <NavBar>
+      <NavIcon
+        type="Home"
+        activeType="HomeFilled"
+        isActive={isRouteActive('ChatList')}
+        hasUnreads={(unreadCount?.channels ?? 0) > 0}
+        onPress={() => props.navigation.navigate('ChatList')}
+      />
+      <NavIcon
+        type="Notifications"
+        activeType="NotificationsFilled"
+        hasUnreads={false}
+        isActive={isRouteActive('Activity')}
+        onPress={() => props.navigation.navigate('Activity')}
+      />
+      {contact && (
+        <AvatarNavIcon
+          id={currentUserId}
+          contact={contact}
+          isLoading={isLoading}
+          focused={isRouteActive('Profile')}
+          onPress={() => props.navigation.navigate('Profile')}
+        />
+      )}
+    </NavBar>
+  );
+};
+
+export default NavBarView;

--- a/apps/tlon-mobile/src/navigation/TabStack.tsx
+++ b/apps/tlon-mobile/src/navigation/TabStack.tsx
@@ -1,54 +1,29 @@
-import { createBottomTabNavigator } from '@react-navigation/bottom-tabs';
-import * as store from '@tloncorp/shared/dist/store';
-import type { IconType } from '@tloncorp/ui';
-import { Circle, Icon, SizableText, View, useStyle } from '@tloncorp/ui';
-import { Avatar } from '@tloncorp/ui';
-import type { ViewStyle } from 'react-native';
+import { createNativeStackNavigator } from '@react-navigation/native-stack';
+import { View } from '@tloncorp/ui';
 
-import { useCurrentUserId } from '../hooks/useCurrentUser';
+import NavBar from '../navigation/NavBarView';
 import ProfileScreen from '../screens/ProfileScreen';
 import type { TabParamList } from '../types';
 import { HomeStack } from './HomeStack';
 
-const Tab = createBottomTabNavigator<TabParamList>();
+const ActivityScreen = (props: any) => {
+  return (
+    <View backgroundColor="$background" flex={1}>
+      <NavBar navigation={props.navigation} />
+    </View>
+  );
+};
+
+const Tab = createNativeStackNavigator<TabParamList>();
 
 export const TabStack = () => {
-  const currentUserId = useCurrentUserId();
-  const { data: unreadCount } = store.useAllUnreadsCounts();
-  const headerStyle = useStyle({
-    paddingHorizontal: '$xl',
-  }) as ViewStyle;
-
-  const tabBarStyle = useStyle({
-    backgroundColor: '$background',
-    borderTopWidth: 1,
-    borderTopColor: '$border',
-    paddingTop: '$m',
-  }) as ViewStyle;
-
   return (
     <Tab.Navigator
       id="TabBar"
       initialRouteName="Groups"
       screenOptions={{
         headerShown: false,
-        tabBarStyle: tabBarStyle,
-        // eslint-disable-next-line @typescript-eslint/no-unused-vars
-        headerTitle({ style, ...props }) {
-          return (
-            <SizableText
-              size="$s"
-              fontSize="$m"
-              fontWeight="$s"
-              lineHeight="$s"
-              color="$primaryText"
-              {...props}
-            />
-          );
-        },
-        headerLeftContainerStyle: headerStyle,
-        headerRightContainerStyle: headerStyle,
-        tabBarShowLabel: false,
+        animation: 'none',
       }}
     >
       <Tab.Screen
@@ -56,83 +31,22 @@ export const TabStack = () => {
         component={HomeStack}
         options={{
           headerShown: false,
-          tabBarIcon: ({ focused }) => (
-            <TabIcon
-              type={'Home'}
-              activeType={'HomeFilled'}
-              isActive={focused}
-              hasUnreads={(unreadCount?.channels ?? 0) > 0}
-            />
-          ),
-          tabBarShowLabel: false,
         }}
       />
-
       <Tab.Screen
         name="Activity"
-        component={View}
+        component={ActivityScreen}
         options={{
-          tabBarIcon: ({ focused }) => (
-            <TabIcon
-              type={'Notifications'}
-              activeType={'NotificationsFilled'}
-              isActive={focused}
-            />
-          ),
-          tabBarShowLabel: false,
+          headerShown: false,
         }}
       />
       <Tab.Screen
         name="Profile"
         component={ProfileScreen}
         options={{
-          tabBarIcon: ({ focused }) => (
-            <AvatarTabIcon id={currentUserId!} focused={focused} />
-          ),
-          tabBarShowLabel: false,
+          headerShown: false,
         }}
       />
     </Tab.Navigator>
   );
 };
-
-function AvatarTabIcon({ id, focused }: { id: string; focused: boolean }) {
-  const { data: contact, isLoading } = store.useContact({ id });
-  return isLoading && !contact ? null : (
-    // Uniquely sized avatar for tab bar
-    <Avatar
-      width={26}
-      height={26}
-      borderRadius={6}
-      contact={contact}
-      contactId={id}
-      opacity={focused ? 1 : 0.6}
-    />
-  );
-}
-
-function TabIcon({
-  type,
-  activeType,
-  isActive,
-  hasUnreads = false,
-}: {
-  type: IconType;
-  activeType?: IconType;
-  isActive: boolean;
-  hasUnreads?: boolean;
-}) {
-  const resolvedType = isActive && activeType ? activeType : type;
-  return (
-    <View flex={1}>
-      <View flex={1} />
-      <Icon
-        type={resolvedType}
-        color={isActive ? '$primaryText' : '$activeBorder'}
-      />
-      <View flex={1} justifyContent="center" alignItems="center">
-        <Circle size="$s" backgroundColor={hasUnreads ? '$blue' : undefined} />
-      </View>
-    </View>
-  );
-}

--- a/apps/tlon-mobile/src/screens/ChatListScreen.tsx
+++ b/apps/tlon-mobile/src/screens/ChatListScreen.tsx
@@ -13,6 +13,7 @@ import { Icon } from '@tloncorp/ui';
 import React from 'react';
 
 import { useRefetchQueryOnFocus } from '../hooks/useRefetchQueryOnFocus';
+import NavBar from '../navigation/NavBarView';
 import type { HomeStackParamList } from '../types';
 
 type ChatListScreenProps = NativeStackScreenProps<
@@ -59,6 +60,7 @@ export default function ChatListScreen(
           channel={longPressedItem ?? undefined}
         />
       </View>
+      <NavBar navigation={props.navigation} />
     </ContactsProvider>
   );
 }

--- a/apps/tlon-mobile/src/screens/ProfileScreen.tsx
+++ b/apps/tlon-mobile/src/screens/ProfileScreen.tsx
@@ -3,6 +3,7 @@ import * as store from '@tloncorp/shared/dist/store';
 import { ProfileScreenView, View } from '@tloncorp/ui';
 
 import { useCurrentUserId } from '../hooks/useCurrentUser';
+import NavBar from '../navigation/NavBarView';
 import { TabParamList } from '../types';
 
 type Props = BottomTabScreenProps<TabParamList, 'Profile'>;
@@ -17,6 +18,7 @@ export default function ProfileScreen(props: Props) {
         contacts={contacts ?? []}
         currentUserId={currentUserId}
       />
+      <NavBar navigation={props.navigation} />
     </View>
   );
 }

--- a/packages/ui/src/components/ChatList.tsx
+++ b/packages/ui/src/components/ChatList.tsx
@@ -41,6 +41,7 @@ export function ChatList({
       gap: '$s',
       paddingTop: '$l',
       paddingHorizontal: '$l',
+      paddingBottom: '$6xl',
     },
     { resolveValues: 'value' }
   ) as StyleProp<ViewStyle>;

--- a/packages/ui/src/components/ChatList.tsx
+++ b/packages/ui/src/components/ChatList.tsx
@@ -8,12 +8,14 @@ import {
   StyleProp,
   ViewStyle,
 } from 'react-native';
+import { useSafeAreaInsets } from 'react-native-safe-area-context';
 
 import { useStyle } from '../core';
 import ChannelListItem from './ChannelListItem';
 import { GroupListItem } from './GroupListItem';
 import { ListItemProps } from './ListItem';
 import { ListSectionHeader } from './ListSectionHeader';
+import { navHeight } from './NavBar/NavBar';
 import { SwipableChatRow } from './SwipableChatListItem';
 
 export function ChatList({
@@ -25,6 +27,8 @@ export function ChatList({
   onPressItem?: (chat: db.Channel) => void;
   onLongPressItem?: (chat: db.Channel) => void;
 }) {
+  const { bottom } = useSafeAreaInsets();
+
   const data = useMemo(() => {
     if (pinned.length === 0) {
       return [{ title: 'All', data: unpinned }];
@@ -41,7 +45,7 @@ export function ChatList({
       gap: '$s',
       paddingTop: '$l',
       paddingHorizontal: '$l',
-      paddingBottom: '$6xl',
+      paddingBottom: navHeight + bottom,
     },
     { resolveValues: 'value' }
   ) as StyleProp<ViewStyle>;

--- a/packages/ui/src/components/NavBar/NavBar.tsx
+++ b/packages/ui/src/components/NavBar/NavBar.tsx
@@ -1,0 +1,30 @@
+import React from 'react';
+import { useSafeAreaInsets } from 'react-native-safe-area-context';
+
+import { XStack } from '../../core';
+import { View } from '../View';
+
+const NavBar = React.memo(function NavBar(props: {
+  children: React.ReactNode | React.ReactNode[] | null | undefined;
+}) {
+  const { bottom } = useSafeAreaInsets();
+
+  return (
+    <View
+      position="absolute"
+      width={'100%'}
+      bottom={0}
+      paddingBottom={bottom}
+      backgroundColor={'$background'}
+      borderTopWidth={1}
+      paddingTop={'$m'}
+      borderTopColor={'$border'}
+    >
+      <XStack justifyContent="space-around" alignItems="flex-start">
+        {props.children}
+      </XStack>
+    </View>
+  );
+});
+
+export default NavBar;

--- a/packages/ui/src/components/NavBar/NavBar.tsx
+++ b/packages/ui/src/components/NavBar/NavBar.tsx
@@ -4,6 +4,8 @@ import { useSafeAreaInsets } from 'react-native-safe-area-context';
 import { XStack } from '../../core';
 import { View } from '../View';
 
+export const navHeight = 50;
+
 const NavBar = React.memo(function NavBar(props: {
   children: React.ReactNode | React.ReactNode[] | null | undefined;
 }) {
@@ -14,11 +16,11 @@ const NavBar = React.memo(function NavBar(props: {
       position="absolute"
       width={'100%'}
       bottom={0}
-      paddingBottom={bottom}
       backgroundColor={'$background'}
       borderTopWidth={1}
       paddingTop={'$m'}
       borderTopColor={'$border'}
+      height={navHeight + bottom}
     >
       <XStack justifyContent="space-around" alignItems="flex-start">
         {props.children}

--- a/packages/ui/src/components/NavBar/NavIcon.tsx
+++ b/packages/ui/src/components/NavBar/NavIcon.tsx
@@ -1,0 +1,63 @@
+import { Contact } from '@tloncorp/shared/dist/db';
+
+import { Circle } from '../../core/tamagui';
+import { Avatar } from '../Avatar';
+import { Icon, IconType } from '../Icon';
+import { View } from '../View';
+
+export function AvatarNavIcon({
+  id,
+  focused,
+  contact,
+  isLoading,
+  onPress,
+}: {
+  id: string;
+  focused: boolean;
+  contact: Contact;
+  isLoading: boolean;
+  onPress?: () => void;
+}) {
+  return isLoading && !contact ? null : (
+    <View flex={1} onPress={onPress} alignItems="center" paddingTop={'$s'}>
+      <Avatar
+        width={22}
+        height={22}
+        borderRadius={4}
+        contact={contact}
+        contactId={id}
+        opacity={focused ? 1 : 0.6}
+      />
+    </View>
+  );
+}
+
+export default function NavIcon({
+  type,
+  activeType,
+  isActive,
+  hasUnreads = false,
+  onPress,
+}: {
+  type: IconType;
+  activeType?: IconType;
+  isActive: boolean;
+  hasUnreads?: boolean;
+  onPress?: () => void;
+}) {
+  const resolvedType = isActive && activeType ? activeType : type;
+  return (
+    <View alignItems="center" flex={1} onPress={onPress}>
+      <Icon
+        type={resolvedType}
+        color={isActive ? '$primaryText' : '$activeBorder'}
+      />
+      <View justifyContent="center" alignItems="center">
+        <Circle
+          size="$s"
+          backgroundColor={hasUnreads ? '$blue' : 'transparent'}
+        />
+      </View>
+    </View>
+  );
+}

--- a/packages/ui/src/components/NavBar/NavIcon.tsx
+++ b/packages/ui/src/components/NavBar/NavIcon.tsx
@@ -21,9 +21,9 @@ export function AvatarNavIcon({
   return isLoading && !contact ? null : (
     <View flex={1} onPress={onPress} alignItems="center" paddingTop={'$s'}>
       <Avatar
-        width={22}
-        height={22}
-        borderRadius={4}
+        width={20}
+        height={20}
+        borderRadius={3}
         contact={contact}
         contactId={id}
         opacity={focused ? 1 : 0.6}

--- a/packages/ui/src/components/NavBar/index.ts
+++ b/packages/ui/src/components/NavBar/index.ts
@@ -1,0 +1,4 @@
+import NavBar from './NavBar';
+import NavIcon, { AvatarNavIcon } from './NavIcon';
+
+export { NavBar, NavIcon, AvatarNavIcon };

--- a/packages/ui/src/components/ProfileScreenView.tsx
+++ b/packages/ui/src/components/ProfileScreenView.tsx
@@ -10,6 +10,7 @@ import { Avatar } from './Avatar';
 import ContactName from './ContactName';
 import { IconType } from './Icon';
 import { ListItem } from './ListItem';
+import { navHeight } from './NavBar/NavBar';
 
 interface Props {
   currentUserId: string;
@@ -27,7 +28,7 @@ export function ProfileScreenView({
 }
 
 export function Wrapped(props: Props) {
-  const { top } = useSafeAreaInsets();
+  const { top, bottom } = useSafeAreaInsets();
   const contact = useContact(props.currentUserId);
 
   return (
@@ -36,7 +37,7 @@ export function Wrapped(props: Props) {
         flex={1}
         paddingHorizontal="$xl"
         paddingTop={top}
-        paddingBottom={'$6xl'}
+        paddingBottom={navHeight + bottom}
       >
         <View marginTop="$l">
           {contact ? (

--- a/packages/ui/src/components/ProfileScreenView.tsx
+++ b/packages/ui/src/components/ProfileScreenView.tsx
@@ -32,7 +32,12 @@ export function Wrapped(props: Props) {
 
   return (
     <ScrollView>
-      <YStack flex={1} paddingHorizontal="$xl" paddingTop={top}>
+      <YStack
+        flex={1}
+        paddingHorizontal="$xl"
+        paddingTop={top}
+        paddingBottom={'$6xl'}
+      >
         <View marginTop="$l">
           {contact ? (
             <ProfileDisplayWidget

--- a/packages/ui/src/index.ts
+++ b/packages/ui/src/index.ts
@@ -13,6 +13,7 @@ export * from './components/ChatMessage/ChatMessageActions/Component';
 export * from './components/UrbitSigil';
 export * from './components/View';
 export * from './components/Sheet';
+export * from './components/NavBar';
 export * from './components/GroupOptionsSheet';
 export * from './components/GroupListItem';
 export * from './components/ChatList';

--- a/packages/ui/src/tamagui.config.ts
+++ b/packages/ui/src/tamagui.config.ts
@@ -54,8 +54,6 @@ export const tokens = createTokens({
     '2xl': 24,
     '3xl': 32,
     '4xl': 48,
-    '5xl': 64,
-    '6xl': 96,
   },
   size: {
     '2xs': 2,
@@ -69,7 +67,6 @@ export const tokens = createTokens({
     '3xl': 32,
     '4xl': 48,
     '5xl': 64,
-    '6xl': 96,
   },
   radius: {
     '2xs': 2,
@@ -82,8 +79,6 @@ export const tokens = createTokens({
     '2xl': 24,
     '3xl': 32,
     '4xl': 48,
-    '5xl': 64,
-    '6xl': 96,
   },
   zIndex: {
     s: 0,

--- a/packages/ui/src/tamagui.config.ts
+++ b/packages/ui/src/tamagui.config.ts
@@ -54,6 +54,8 @@ export const tokens = createTokens({
     '2xl': 24,
     '3xl': 32,
     '4xl': 48,
+    '5xl': 64,
+    '6xl': 96,
   },
   size: {
     '2xs': 2,
@@ -67,6 +69,7 @@ export const tokens = createTokens({
     '3xl': 32,
     '4xl': 48,
     '5xl': 64,
+    '6xl': 96,
   },
   radius: {
     '2xs': 2,
@@ -79,6 +82,8 @@ export const tokens = createTokens({
     '2xl': 24,
     '3xl': 32,
     '4xl': 48,
+    '5xl': 64,
+    '6xl': 96,
   },
   zIndex: {
     s: 0,


### PR DESCRIPTION
Renovates the app navigation to use nested Native Stacks and a custom NavBar component.

- Rather than using createBottomTabNavigator, uses createNativeStackNavigator for all nested "home" screens (ChatList, Channel, Post, ChannelSearch).
- Adds a custom navigation component (NavBar) in packages/ui which seeks to be as generic as possible
- Adds a NavBarView to the app screens themselves, which in turn takes the navigation prop from the parent screen and handles all the navigate() calls itself

Functionality is exactly the same as before but eliminates the gray box on view transition (fixes LAND-1873). Thanks to @patosullivan for the talk-through assist.

Note that this is an absolutely-positioned element, so any screen that uses a scroller that extends below the bottom edge of the screen will need to be padded up at the bottom.