### PR TITLE
native: version negotiation for channels

### DIFF
--- a/apps/tlon-mobile/src/fixtures/Channel.fixture.tsx
+++ b/apps/tlon-mobile/src/fixtures/Channel.fixture.tsx
@@ -56,7 +56,10 @@ const ChannelFixtureWrapper = ({
   );
 };
 
-export const ChannelFixture = (props: { theme?: 'light' | 'dark' }) => {
+export const ChannelFixture = (props: {
+  theme?: 'light' | 'dark';
+  negotiationMatch?: boolean;
+}) => {
   const [open, setOpen] = useState(false);
   const [currentChannel, setCurrentChannel] = useState<db.Channel | null>(null);
   const { bottom } = useSafeAreaInsets();
@@ -83,6 +86,7 @@ export const ChannelFixture = (props: { theme?: 'light' | 'dark' }) => {
         currentUserId="~zod"
         channel={currentChannel || tlonLocalChannelWithUnreads}
         contacts={initialContacts}
+        negotiationMatch={props.negotiationMatch ?? true}
         group={group}
         goBack={() => {}}
         goToSearch={() => {}}
@@ -144,6 +148,7 @@ export const NotebookChannelFixture = (props: { theme?: 'light' | 'dark' }) => {
     <ChannelFixtureWrapper theme={props.theme}>
       <Channel
         posts={notebookPosts}
+        negotiationMatch={true}
         currentUserId="~zod"
         channel={tlonLocalChannelWithUnreads}
         contacts={initialContacts}
@@ -240,6 +245,7 @@ const ChannelFixtureWithImage = () => {
         goToImageViewer={() => {}}
         messageSender={() => {}}
         editPost={() => {}}
+        negotiationMatch={true}
         uploadInfo={{
           imageAttachment: imageAttachment,
           resetImageAttachment: resetImageAttachment,
@@ -273,4 +279,5 @@ export default {
   chat: <ChannelFixture />,
   notebook: <NotebookChannelFixture />,
   chatWithImage: <ChannelFixtureWithImage />,
+  negotiationMismatch: <ChannelFixture negotiationMatch={false} />,
 };

--- a/apps/tlon-mobile/src/fixtures/FixtureWrapper.tsx
+++ b/apps/tlon-mobile/src/fixtures/FixtureWrapper.tsx
@@ -1,3 +1,4 @@
+import { QueryClientProvider, queryClient } from '@tloncorp/shared/dist';
 import type { ColorProp } from '@tloncorp/ui';
 import { Theme, View } from '@tloncorp/ui';
 import type { PropsWithChildren } from 'react';
@@ -22,38 +23,40 @@ export const FixtureWrapper = ({
   theme?: 'light' | 'dark';
 }>) => {
   return (
-    <GestureHandlerRootView style={{ flex: 1 }}>
-      <Theme name={theme}>
-        <View
-          backgroundColor={backgroundColor ?? '$secondaryBackground'}
-          flex={1}
-          flexDirection="column"
-          width={fillWidth ? '100%' : 'unset'}
-          height={fillHeight ? '100%' : 'unset'}
-          justifyContent={
-            verticalAlign === 'top'
-              ? 'flex-start'
-              : verticalAlign === 'bottom'
-                ? 'flex-end'
-                : 'center'
-          }
-          alignItems={
-            horizontalAlign === 'left'
-              ? 'flex-start'
-              : horizontalAlign === 'right'
-                ? 'flex-end'
-                : 'center'
-          }
-        >
+    <QueryClientProvider client={queryClient}>
+      <GestureHandlerRootView style={{ flex: 1 }}>
+        <Theme name={theme}>
           <View
-            backgroundColor={innerBackgroundColor ?? '$background'}
+            backgroundColor={backgroundColor ?? '$secondaryBackground'}
+            flex={1}
+            flexDirection="column"
             width={fillWidth ? '100%' : 'unset'}
             height={fillHeight ? '100%' : 'unset'}
+            justifyContent={
+              verticalAlign === 'top'
+                ? 'flex-start'
+                : verticalAlign === 'bottom'
+                  ? 'flex-end'
+                  : 'center'
+            }
+            alignItems={
+              horizontalAlign === 'left'
+                ? 'flex-start'
+                : horizontalAlign === 'right'
+                  ? 'flex-end'
+                  : 'center'
+            }
           >
-            {children}
+            <View
+              backgroundColor={innerBackgroundColor ?? '$background'}
+              width={fillWidth ? '100%' : 'unset'}
+              height={fillHeight ? '100%' : 'unset'}
+            >
+              {children}
+            </View>
           </View>
-        </View>
-      </Theme>
-    </GestureHandlerRootView>
+        </Theme>
+      </GestureHandlerRootView>
+    </QueryClientProvider>
   );
 };

--- a/apps/tlon-mobile/src/fixtures/PostScreen.fixture.tsx
+++ b/apps/tlon-mobile/src/fixtures/PostScreen.fixture.tsx
@@ -14,6 +14,7 @@ export default (
     <PostScreenView
       editPost={() => {}}
       editingPost={undefined}
+      negotiationMatch={true}
       setEditingPost={() => {}}
       currentUserId="~solfer-magfed"
       contacts={initialContacts}

--- a/apps/tlon-mobile/src/screens/ChannelScreen.tsx
+++ b/apps/tlon-mobile/src/screens/ChannelScreen.tsx
@@ -4,7 +4,7 @@ import { sync } from '@tloncorp/shared';
 import type * as db from '@tloncorp/shared/dist/db';
 import * as store from '@tloncorp/shared/dist/store';
 import { useChannel, usePostWithRelations } from '@tloncorp/shared/dist/store';
-import type { JSONContent, Story } from '@tloncorp/shared/dist/urbit';
+import { JSONContent, Story } from '@tloncorp/shared/dist/urbit';
 import { Channel, ChannelSwitcherSheet, View } from '@tloncorp/ui';
 import React, { useCallback, useEffect, useLayoutEffect, useMemo } from 'react';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
@@ -49,6 +49,18 @@ export default function ChannelScreen(props: ChannelScreenProps) {
   const calmSettingsQuery = store.useCalmSettings({
     userId: useCurrentUserId(),
   });
+
+  const channelHost = useMemo(
+    () => currentChannelId.split('/')[1],
+    [currentChannelId]
+  );
+
+  const { matchedOrPending } = store.useNegotiate(
+    channelHost,
+    'channels',
+    'channels-server'
+  );
+
   const channelQuery = store.useChannelWithLastPostAndMembers({
     id: currentChannelId,
   });
@@ -251,6 +263,7 @@ export default function ChannelScreen(props: ChannelScreenProps) {
         editingPost={editingPost}
         setEditingPost={setEditingPost}
         editPost={editPost}
+        negotiationMatch={matchedOrPending}
       />
       {groupQuery.data && (
         <ChannelSwitcherSheet

--- a/apps/tlon-mobile/src/screens/PostScreen.tsx
+++ b/apps/tlon-mobile/src/screens/PostScreen.tsx
@@ -69,6 +69,17 @@ export default function PostScreen(props: PostScreenProps) {
     uploaderKey: `${postParam.channelId}/${postParam.id}`,
   });
 
+  const channelHost = useMemo(
+    () => postParam.channelId.split('/')[1],
+    [postParam.channelId]
+  );
+
+  const { matchedOrPending } = store.useNegotiate(
+    channelHost,
+    'channels',
+    'channels-server'
+  );
+
   const posts = useMemo(() => {
     return post ? [...(threadPosts ?? []), post] : null;
   }, [post, threadPosts]);
@@ -160,6 +171,7 @@ export default function PostScreen(props: PostScreenProps) {
       editingPost={editingPost}
       setEditingPost={setEditingPost}
       editPost={editPost}
+      negotiationMatch={matchedOrPending}
     />
   ) : null;
 }

--- a/packages/shared/src/store/index.ts
+++ b/packages/shared/src/store/index.ts
@@ -8,3 +8,4 @@ export * from './channelActions';
 export * from './useThreadPosts';
 export * from './useInitialSync';
 export * from './storage';
+export * from './useNegotiation';

--- a/packages/shared/src/store/storage/utils.ts
+++ b/packages/shared/src/store/storage/utils.ts
@@ -42,7 +42,7 @@ export const handleImagePicked = async (uri: string, uploader: Uploader) => {
   }
 };
 
-export const getShipInfo = async () => {
+export const getShipInfo = () => {
   const { ship, url } = client;
 
   if (!ship) {
@@ -53,7 +53,7 @@ export const getShipInfo = async () => {
 };
 
 export const getIsHosted = async () => {
-  const shipInfo = await getShipInfo();
+  const shipInfo = getShipInfo();
   const isHosted = shipInfo?.shipUrl?.endsWith('tlon.network');
   return isHosted;
 };

--- a/packages/shared/src/store/useNegotiation.ts
+++ b/packages/shared/src/store/useNegotiation.ts
@@ -1,0 +1,159 @@
+import { useQuery } from '@tanstack/react-query';
+import { debounce } from 'lodash';
+import { useCallback, useEffect, useMemo, useRef } from 'react';
+
+import * as api from '../api';
+import { queryClient } from '../api';
+import { MatchingEvent, MatchingResponse } from '../urbit/negotiation';
+import { getShipInfo } from './storage';
+
+function negotiationUpdater(
+  event: MatchingEvent | null,
+  queryKey: string[],
+  invalidate: React.MutableRefObject<() => void>
+) {
+  if (event && event.match === true) {
+    queryClient.setQueryData(queryKey, (prev: MatchingResponse | undefined) => {
+      if (prev === undefined) {
+        return prev;
+      }
+
+      const newPrev = { ...prev };
+
+      newPrev[event.gill] = 'match';
+
+      return newPrev;
+    });
+  } else if (event && event.match === false) {
+    queryClient.setQueryData(queryKey, (prev: MatchingResponse | undefined) => {
+      if (prev === undefined) {
+        return prev;
+      }
+
+      const newPrev = { ...prev };
+
+      newPrev[event.gill] = 'clash';
+
+      return newPrev;
+    });
+  }
+
+  invalidate.current();
+}
+
+export function useNegotiation(app: string, agent: string) {
+  const queryKey = useMemo(() => ['negotiation', app], [app]);
+
+  const invalidate = useRef(
+    debounce(
+      () => {
+        queryClient.invalidateQueries({ queryKey, refetchType: 'none' });
+      },
+      300,
+      {
+        leading: true,
+        trailing: true,
+      }
+    )
+  );
+
+  useEffect(() => {
+    api.subscribe(
+      {
+        app,
+        path: `/~/negotiate/notify/json`,
+      },
+      (event: MatchingEvent) => negotiationUpdater(event, queryKey, invalidate)
+    );
+  }, [agent, app, queryKey]);
+
+  return useQuery<MatchingResponse>({
+    queryKey,
+    staleTime: 5000,
+    queryFn: () =>
+      api.scry({
+        app,
+        path: '/~/negotiate/status/json',
+      }),
+  });
+}
+
+export function useNegotiate(ship: string, app: string, agent: string) {
+  const { data, ...rest } = useNegotiation(app, agent);
+
+  if (rest.isLoading || rest.isError || data === undefined) {
+    return { ...rest, status: 'await', matchedOrPending: true };
+  }
+
+  const isInData = `${ship}/${agent}` in data;
+
+  if (isInData) {
+    return {
+      ...rest,
+      status: data[`${ship}/${agent}`],
+      matchedOrPending:
+        data[`${ship}/${agent}`] === 'match' ||
+        data[`${ship}/${agent}`] === 'await',
+    };
+  }
+
+  return { ...rest, status: 'await', matchedOrPending: true };
+}
+
+export function useNegotiateMulti(ships: string[], app: string, agent: string) {
+  const { data, ...rest } = useNegotiation(app, agent);
+
+  if (rest.isLoading || rest.isError || data === undefined) {
+    return { ...rest, match: false, haveAllNegotiations: false };
+  }
+
+  const shipInfo = getShipInfo();
+
+  const shipKeys = ships
+    .filter((ship) => ship !== shipInfo.ship)
+    .map((ship) => `${ship}/${agent}`);
+
+  const allShipsMatch = shipKeys.every(
+    (ship) => ship in data && data[ship] === 'match'
+  );
+
+  const haveAllNegotiations = shipKeys.every((ship) => ship in data);
+
+  return { ...rest, match: allShipsMatch, haveAllNegotiations };
+}
+
+export function useForceNegotiationUpdate(ships: string[], app: string) {
+  const { data } = useNegotiation(app, app);
+  const unknownShips = useMemo(
+    () =>
+      ships.filter(
+        (ship) =>
+          !data ||
+          !(`${ship}/${app}` in data) ||
+          data[`${ship}/${app}`] !== 'match'
+      ),
+    [ships, app, data]
+  );
+  const negotiateUnknownShips = useCallback(
+    async (shipsToCheck: string[]) => {
+      const responses: Promise<number | undefined>[] = [];
+      shipsToCheck.forEach((ship) => {
+        responses.push(
+          api.poke({
+            app,
+            mark: 'chat-negotiate',
+            json: ship,
+          })
+        );
+      });
+      await Promise.all(responses);
+    },
+    [app]
+  );
+
+  useEffect(() => {
+    if (unknownShips.length > 0) {
+      negotiateUnknownShips(unknownShips);
+    }
+  }, [unknownShips, negotiateUnknownShips]);
+}

--- a/packages/ui/src/components/Channel/index.tsx
+++ b/packages/ui/src/components/Channel/index.tsx
@@ -18,7 +18,7 @@ import {
 } from '../../contexts';
 import { ReferencesProvider } from '../../contexts/references';
 import { RequestsProvider } from '../../contexts/requests';
-import { Spinner, View, YStack } from '../../core';
+import { Spinner, Text, View, YStack } from '../../core';
 import * as utils from '../../utils';
 import { ChatMessage } from '../ChatMessage';
 import { MessageInput } from '../MessageInput';
@@ -59,6 +59,7 @@ export function Channel({
   editingPost,
   setEditingPost,
   editPost,
+  negotiationMatch,
 }: {
   channel: db.Channel;
   currentUserId: string;
@@ -86,6 +87,7 @@ export function Channel({
   editingPost?: db.Post;
   setEditingPost?: (post: db.Post | undefined) => void;
   editPost: (post: db.Post, content: Story) => void;
+  negotiationMatch: boolean;
 }) {
   const [inputShouldBlur, setInputShouldBlur] = useState(false);
   const title = utils.getChannelTitle(channel);
@@ -125,7 +127,7 @@ export function Channel({
                     style={{ flex: 1 }}
                     contentContainerStyle={{ flex: 1 }}
                   >
-                    <YStack flex={1}>
+                    <YStack alignItems="center" flex={1}>
                       {uploadInfo.imageAttachment ? (
                         <UploadedImagePreview
                           imageAttachment={uploadInfo.imageAttachment}
@@ -167,20 +169,38 @@ export function Channel({
                           onStartReached={onScrollStartReached}
                         />
                       )}
-                      {!editingPost && chatChannel && canWrite && (
-                        <MessageInput
-                          shouldBlur={inputShouldBlur}
-                          setShouldBlur={setInputShouldBlur}
-                          send={messageSender}
-                          channelId={channel.id}
-                          setImageAttachment={uploadInfo.setImageAttachment}
-                          uploadedImage={uploadInfo.uploadedImage}
-                          canUpload={uploadInfo.canUpload}
-                          groupMembers={group?.members ?? []}
-                          storeDraft={storeDraft}
-                          clearDraft={clearDraft}
-                          getDraft={getDraft}
-                        />
+                      {negotiationMatch &&
+                        !editingPost &&
+                        chatChannel &&
+                        canWrite && (
+                          <MessageInput
+                            shouldBlur={inputShouldBlur}
+                            setShouldBlur={setInputShouldBlur}
+                            send={messageSender}
+                            channelId={channel.id}
+                            setImageAttachment={uploadInfo.setImageAttachment}
+                            uploadedImage={uploadInfo.uploadedImage}
+                            canUpload={uploadInfo.canUpload}
+                            groupMembers={group?.members ?? []}
+                            storeDraft={storeDraft}
+                            clearDraft={clearDraft}
+                            getDraft={getDraft}
+                          />
+                        )}
+                      {!negotiationMatch && chatChannel && canWrite && (
+                        <View
+                          width="90%"
+                          alignItems="center"
+                          justifyContent="center"
+                          backgroundColor="$secondaryBackground"
+                          borderRadius="$xl"
+                          padding="$l"
+                        >
+                          <Text>
+                            Your ship&apos;s version of the Tlon app
+                            doesn&apos;t match the channel host.
+                          </Text>
+                        </View>
                       )}
                     </YStack>
                   </KeyboardAvoidingView>

--- a/packages/ui/src/components/PostScreenView.tsx
+++ b/packages/ui/src/components/PostScreenView.tsx
@@ -7,7 +7,7 @@ import { KeyboardAvoidingView, Platform } from 'react-native';
 
 import { CalmProvider, CalmState, ContactsProvider } from '../contexts';
 import { ReferencesProvider } from '../contexts/references';
-import { YStack } from '../core';
+import { Text, View, YStack } from '../core';
 import * as utils from '../utils';
 import { ChannelHeader } from './Channel/ChannelHeader';
 import Scroller from './Channel/Scroller';
@@ -32,6 +32,7 @@ export function PostScreenView({
   editingPost,
   setEditingPost,
   editPost,
+  negotiationMatch,
 }: {
   currentUserId: string;
   calmSettings?: CalmState;
@@ -49,6 +50,7 @@ export function PostScreenView({
   editingPost?: db.Post;
   setEditingPost?: (post: db.Post | undefined) => void;
   editPost: (post: db.Post, content: Story) => void;
+  negotiationMatch: boolean;
 }) {
   const [inputShouldBlur, setInputShouldBlur] = useState(false);
   const canWrite = utils.useCanWrite(channel, currentUserId);
@@ -94,7 +96,7 @@ export function PostScreenView({
                   />
                 )
               )}
-              {!editingPost && channel && canWrite && (
+              {negotiationMatch && !editingPost && channel && canWrite && (
                 <MessageInput
                   shouldBlur={inputShouldBlur}
                   setShouldBlur={setInputShouldBlur}
@@ -108,6 +110,21 @@ export function PostScreenView({
                   clearDraft={clearDraft}
                   getDraft={getDraft}
                 />
+              )}
+              {!negotiationMatch && channel && canWrite && (
+                <View
+                  width="90%"
+                  alignItems="center"
+                  justifyContent="center"
+                  backgroundColor="$secondaryBackground"
+                  borderRadius="$xl"
+                  padding="$l"
+                >
+                  <Text>
+                    Your ship&apos;s version of the Tlon app doesn&apos;t match
+                    the channel host.
+                  </Text>
+                </View>
               )}
             </KeyboardAvoidingView>
           </YStack>


### PR DESCRIPTION
Fixes LAND-1828. We skip the db and just query the api directly. We'd have to sync regularly and write to/read from the db anyway, this saves a step and squeaks out a little performance.

We assume there is a match until we hear otherwise. Users shouldn't see the message about a mismatch unless we know that one exists.

Reuses/adapts logic from tlon-web.

Looks like this:
![Simulator Screenshot - iPhone 15 Pro - 2024-05-14 at 13 37 42](https://github.com/tloncorp/tlon-apps/assets/1221094/03c55e11-1a2c-486c-a0d1-0dd1293f760c)
