### PR TITLE
native: handle delete post subscription events

### DIFF
--- a/packages/shared/src/store/sync.ts
+++ b/packages/shared/src/store/sync.ts
@@ -107,6 +107,9 @@ export const handleChannelsUpdate = async (update: api.ChannelsUpdate) => {
       // finally, always insert the post itself
       await db.insertChannelPosts(update.post.channelId, [update.post]);
       break;
+    case 'deletePost':
+      await db.deletePosts({ ids: [update.postId] });
+      break;
     case 'updateReactions':
       await db.replacePostReactions({
         postId: update.postId,


### PR DESCRIPTION
Fixes LAND-1887.

Also, we don't need to specifically handle edit, that's handled via the `addPost` case (it comes in via postResponse.set).