### PR TITLE
groups: dont leave subscriptions locally

### DIFF
--- a/desk/app/groups.hoon
+++ b/desk/app/groups.hoon
@@ -1737,9 +1737,11 @@
   ^+  cor
   =/  =wire  /gangs/index/(scot %p ship)
   =/  =dock  [ship dap.bowl]
+  =/  watch  [%pass wire %agent dock %watch `path`wire]
   %-  emil
+  ?:  =(ship our.bowl)  ~[watch]
   :~  [%pass wire %agent dock %leave ~]
-      [%pass wire %agent dock %watch `path`wire]
+      watch
   ==
 ::
 ++  hi-and-req-gang-index
@@ -1836,10 +1838,12 @@
       =/  =wire  (welp ga-area /preview)
       =/  =dock  [p.flag dap.bowl]
       =/  =path  /groups/(scot %p p.flag)/[q.flag]/preview
+      =/  watch  [%pass wire %agent dock %watch wire]
       ^+  cor
       %-  emil
+      ?:  =(p.flag our.bowl)  ~[watch]
       :~  [%pass wire %agent dock %leave ~]
-          [%pass wire %agent dock %watch wire]
+          watch
       ==
     --
   ++  ga-start-join


### PR DESCRIPTION
Likely to have caused a loop for some reason with group previews?

PR Checklist
- [X] Includes changes to desk files
- [ ] Describes how you tested the PR locally (test ship vs livenet)
- [ ] If a new feature, includes automated tests
- [ ] Comments added anywhere logic may be confusing without context