### PR TITLE
web: Fix issue with rendering mentions in gallery content

### DIFF
--- a/apps/tlon-web/src/chat/ChatContent/ChatContent.tsx
+++ b/apps/tlon-web/src/chat/ChatContent/ChatContent.tsx
@@ -55,7 +55,7 @@ interface ShipMentionProps {
   ship: string;
 }
 
-function ShipMention({ ship }: ShipMentionProps) {
+export function ShipMention({ ship }: ShipMentionProps) {
   const location = useLocation();
 
   return (

--- a/apps/tlon-web/src/heap/HeapContent.tsx
+++ b/apps/tlon-web/src/heap/HeapContent.tsx
@@ -12,9 +12,11 @@ import {
   isInlineCode,
   isItalics,
   isLink,
+  isShip,
   isStrikethrough,
 } from '@tloncorp/shared/dist/urbit/content';
 
+import { ShipMention } from '@/chat/ChatContent/ChatContent';
 import ContentReference from '@/components/References/ContentReference';
 
 interface HeapContentProps {
@@ -108,11 +110,21 @@ export function InlineContent({ inline }: InlineContentProps) {
     );
   }
 
+  if (isShip(inline)) {
+    return <ShipMention ship={inline.ship} />;
+  }
+
   if (isBreak(inline)) {
     return <br />;
   }
 
-  throw new Error(`Unhandled message type: ${JSON.stringify(inline)}`);
+  console.log(`Unhandled message type: ${JSON.stringify(inline)}`);
+
+  return (
+    <span className="font-bold">
+      This content cannot be rendered, unhandled message type.
+    </span>
+  );
 }
 
 export default function HeapContent({


### PR DESCRIPTION
Realized that we don't render mentions in text gallery posts in the old web app after making a mention in a gallery post in the new mobile app. This fixes that. Also removes the throw on hitting unhandled message content.