### PR TITLE
app: add routes for msgs tab notification settings

### DIFF
--- a/apps/tlon-web/src/app.tsx
+++ b/apps/tlon-web/src/app.tsx
@@ -501,11 +501,11 @@ const GroupsRoutes = React.memo(({ isMobile, isSmall }: RoutesProps) => {
             element={<GroupInfo title={`• ${groupsTitle}`} />}
           />
           <Route
-            path="/groups/:ship/:name/volume"
+            path="/dm?/groups/:ship/:name/volume"
             element={<GroupVolumeDialog title={`• ${groupsTitle}`} />}
           />
           <Route
-            path="/groups/:ship/:name/channels/:chType/:chShip/:chName/volume"
+            path="/dm?/groups/:ship/:name/channels/:chType/:chShip/:chName/volume"
             element={<ChannelVolumeDialog title={`• ${groupsTitle}`} />}
           />
           <Route


### PR DESCRIPTION
Fixes issue seen in demo where notification settings modal didn't work in messages tab. 

PR Checklist
- [ ] Includes changes to desk files
- [ ] Describes how you tested the PR locally (test ship vs livenet)
- [ ] If a new feature, includes automated tests
- [ ] Comments added anywhere logic may be confusing without context