### PR TITLE
native: don't error on custom channel types

### DIFF
--- a/packages/shared/src/urbit/utils.ts
+++ b/packages/shared/src/urbit/utils.ts
@@ -12,10 +12,19 @@ const APP_PREFIXES = ['chat', 'heap', 'diary'];
 
 export function checkNest(nest: string): boolean {
   const parts = nest.split('/');
-  if (parts.length !== 3 || !APP_PREFIXES.includes(parts[0])) {
+  if (parts.length !== 3) {
     console.error('Invalid nest:', nest);
     return false;
   }
+
+  if (!APP_PREFIXES.includes(parts[0])) {
+    console.log(
+      `Custom channel type detected (${parts[0]}), pretending its chat.`,
+      nest
+    );
+    return false;
+  }
+
   return true;
 }
 


### PR DESCRIPTION
OTT

If a legacy custom channel type is found (`quorum` for example), we treat it as a chat channel and move on. When we do type checking for nests, it doesn't influence app logic beyond logging an error if they're invalid.

To be less disruptive, if we detect a custom channel this simply describes the behavior vs logging an error which pops up in the simulator.