### PR TITLE
notebooks: add %task to inline for dejs, fix issue with posting task lists

### DIFF
--- a/desk/lib/channel-json.hoon
+++ b/desk/lib/channel-json.hoon
@@ -776,6 +776,12 @@
       :~  href/so
           content/so
       ==
+    ::
+      :-  %task
+      %-  ot
+      :~  checked/bo
+          content/(ar inline)
+      ==
     ==
   ::
   ++  memo


### PR DESCRIPTION
We were seeing a cast fail on attempting to send a (notebook) post with task items because we weren't actually decoding the %tasks in channel-json.