### PR TITLE
native: fix isNotice variant of ChatMessage, ChannelDivider

### DIFF
--- a/apps/tlon-mobile/src/fixtures/ChannelDivider.fixture.tsx
+++ b/apps/tlon-mobile/src/fixtures/ChannelDivider.fixture.tsx
@@ -7,6 +7,7 @@ const posts = createFakePosts(100);
 
 export default (
   <FixtureWrapper fillWidth={true} verticalAlign="center">
+    <ChannelDivider timestamp={Date.now()} unreadCount={0} />
     <ChatMessage
       showAuthor={true}
       showReplies={true}

--- a/apps/tlon-mobile/src/fixtures/ChatMessage.fixture.tsx
+++ b/apps/tlon-mobile/src/fixtures/ChatMessage.fixture.tsx
@@ -9,6 +9,11 @@ import {
 
 const fakeMentionContent = createContentWithMention('yo', '~bus');
 const fakeMentionPost = createFakePost('chat', fakeMentionContent);
+const fakeNoticeContent = createContentWithMention(
+  'joined the chat',
+  '~sampel-palnet'
+);
+const fakeNoticePost = createFakePost('notice', fakeNoticeContent);
 const fakeBlockQuoteContent = createBlockquoteContent(
   'Velit mollit veniam ad duis id deserunt aute. Irure duis consectetur proident voluptate. Deserunt adipisicing ullamco ex nisi cupidatat cillum enim. Reprehenderit velit non esse ad. Ut id ex incididunt laboris sunt eiusmod ullamco deserunt cillum enim in velit commodo. Culpa magna reprehenderit proident. Reprehenderit consequat sunt dolore aute sunt. Culpa officia nisi adipisicing eu ullamco eu velit dolore.',
   'wtf are you talking about'
@@ -27,7 +32,18 @@ const ChatMessageFixtureWithBlockQuote = () => (
   </FixtureWrapper>
 );
 
+const ChatMessageFixtureIsNotice = () => (
+  <FixtureWrapper fillWidth>
+    <ChatMessage
+      post={fakeNoticePost}
+      showReplies={false}
+      currentUserId="~zod"
+    />
+  </FixtureWrapper>
+);
+
 export default {
   withMention: ChatMessageFixtureWithMention,
   withBlockQuote: ChatMessageFixtureWithBlockQuote,
+  isNotice: ChatMessageFixtureIsNotice,
 };

--- a/packages/ui/src/components/Channel/ChannelDivider.tsx
+++ b/packages/ui/src/components/Channel/ChannelDivider.tsx
@@ -19,7 +19,7 @@ export function ChannelDivider({
     type: db.ChannelType;
   };
 }) {
-  const color = unreadCount ? '$positiveActionText' : '$tertiaryText';
+  const color = unreadCount ? '$positiveActionText' : '$border';
   const hideTime = unreadCount && isToday(timestamp) && !isFirstPostOfDay;
   const time = useMemo(() => {
     return makePrettyDay(new Date(timestamp));
@@ -33,15 +33,27 @@ export function ChannelDivider({
   }, [channelInfo, unreadCount]);
 
   return (
-    <XStack alignItems="center" padding="$l" gap="$l" onLayout={handleLayout}>
-      <View width={'$2xl'} height={1} backgroundColor={color} />
-      <SizableText size="$s" fontWeight="$l" color={color}>
-        {!hideTime ? `${time}` : null}
-        {!hideTime && unreadCount ? ' • ' : null}
-        {unreadCount
-          ? `${unreadCount} new message${unreadCount === 1 ? '' : 's'} below`
-          : null}
-      </SizableText>
+    <XStack alignItems="center" padding="$l" onLayout={handleLayout}>
+      <View width={'$2xl'} flex={1} height={1} backgroundColor={color} />
+      <View
+        paddingHorizontal="$m"
+        backgroundColor={color}
+        borderRadius={'$2xl'}
+      >
+        <SizableText
+          ellipsizeMode="middle"
+          numberOfLines={1}
+          size="$s"
+          fontWeight="$l"
+          color={unreadCount ? '$background' : '$secondaryText'}
+        >
+          {!hideTime ? `${time}` : null}
+          {!hideTime && unreadCount ? ' • ' : null}
+          {unreadCount
+            ? `${unreadCount} new message${unreadCount === 1 ? '' : 's'} below`
+            : null}
+        </SizableText>
+      </View>
       <View flex={1} height={1} backgroundColor={color} />
     </XStack>
   );

--- a/packages/ui/src/components/ChatMessage/ChatContent.tsx
+++ b/packages/ui/src/components/ChatMessage/ChatContent.tsx
@@ -15,7 +15,14 @@ import {
 import { ImageLoadEventData } from 'expo-image';
 import { truncate } from 'lodash';
 import { Post, PostDeliveryStatus } from 'packages/shared/dist/db';
-import { ReactElement, memo, useCallback, useMemo, useState } from 'react';
+import {
+  ComponentProps,
+  ReactElement,
+  memo,
+  useCallback,
+  useMemo,
+  useState,
+} from 'react';
 import { TouchableOpacity } from 'react-native';
 
 import { ColorTokens, Image, Text, View, XStack, YStack } from '../../core';
@@ -24,20 +31,14 @@ import ContentReference from '../ContentReference';
 import ChatEmbedContent from './ChatEmbedContent';
 import { ChatMessageDeliveryStatus } from './ChatMessageDeliveryStatus';
 
-interface ShipMentionProps {
-  ship: string;
-  [key: string]: any;
-}
-
-function ShipMention({ ship, ...rest }: ShipMentionProps) {
+function ShipMention(props: ComponentProps<typeof ContactName>) {
   return (
     <ContactName
       onPress={() => {}}
       fontWeight={'500'}
       color="$positiveActionText"
-      userId={ship}
       showNickname
-      {...rest}
+      {...props}
     />
   );
 }
@@ -171,7 +172,7 @@ export function InlineContent({
     return <Text height="$s" />;
   }
   if (isShip(inline)) {
-    return <ShipMention ship={inline.ship} />;
+    return <ShipMention userId={inline.ship} />;
   }
   console.error(`Unhandled message type: ${JSON.stringify(inline)}`);
   return (
@@ -313,7 +314,7 @@ const LineRenderer = memo(
         currentLine.push(
           <ShipMention
             key={`ship-${index}`}
-            ship={inline.ship}
+            userId={inline.ship}
             fontSize={isNotice ? '$s' : 'unset'}
           />
         );

--- a/packages/ui/src/components/ChatMessage/ChatContent.tsx
+++ b/packages/ui/src/components/ChatMessage/ChatContent.tsx
@@ -24,7 +24,12 @@ import ContentReference from '../ContentReference';
 import ChatEmbedContent from './ChatEmbedContent';
 import { ChatMessageDeliveryStatus } from './ChatMessageDeliveryStatus';
 
-function ShipMention({ ship }: { ship: string }) {
+interface ShipMentionProps {
+  ship: string;
+  [key: string]: any;
+}
+
+function ShipMention({ ship, ...rest }: ShipMentionProps) {
   return (
     <ContactName
       onPress={() => {}}
@@ -32,6 +37,7 @@ function ShipMention({ ship }: { ship: string }) {
       color="$positiveActionText"
       userId={ship}
       showNickname
+      {...rest}
     />
   );
 }
@@ -271,9 +277,8 @@ const LineRenderer = memo(
           currentLine.push(
             <Text
               key={`string-${inline}-${index}`}
-              color={isNotice ? '$tertiaryText' : color}
-              fontSize={viewMode === 'block' ? '$s' : '$m'}
-              fontWeight={isNotice ? '500' : 'normal'}
+              color={isNotice ? '$secondaryText' : color}
+              fontSize={viewMode === 'block' || isNotice ? '$s' : '$m'}
               lineHeight="$m"
             >
               {inline}
@@ -306,7 +311,11 @@ const LineRenderer = memo(
         currentLine = [];
       } else if (isShip(inline)) {
         currentLine.push(
-          <ShipMention key={`ship-${index}`} ship={inline.ship} />
+          <ShipMention
+            key={`ship-${index}`}
+            ship={inline.ship}
+            fontSize={isNotice ? '$s' : 'unset'}
+          />
         );
       } else {
         currentLine.push(

--- a/packages/ui/src/components/ChatMessage/ChatMessage.tsx
+++ b/packages/ui/src/components/ChatMessage/ChatMessage.tsx
@@ -19,14 +19,16 @@ const NoticeWrapper = ({
 }) => {
   if (isNotice) {
     return (
-      <XStack gap="$m">
-        <Icon
-          type="AddPerson"
-          color="$secondaryText"
-          size="$m"
-          backgroundColor={'$secondaryBackground'}
-        />
-        {children}
+      <XStack alignItems="center" padding="$l">
+        <View width={'$2xl'} flex={1} height={1} backgroundColor="$border" />
+        <View
+          paddingHorizontal="$m"
+          backgroundColor="$border"
+          borderRadius={'$2xl'}
+        >
+          {children}
+        </View>
+        <View flex={1} height={1} backgroundColor="$border" />
       </XStack>
     );
   }
@@ -113,7 +115,7 @@ const ChatMessage = ({
           />
         </View>
       ) : null}
-      <View paddingLeft="$4xl">
+      <View paddingLeft={!isNotice && '$4xl'}>
         {editing ? (
           <MessageInput
             groupMembers={[]}


### PR DESCRIPTION
Adjusts the ChannelDivider and the isNotice variant of ChatMessage to be full-width with a pill in the center. Also adds fixtures for both.

![image](https://github.com/tloncorp/tlon-apps/assets/748181/6716c533-18b0-4a30-97bb-773f7b05bc58)
![image](https://github.com/tloncorp/tlon-apps/assets/748181/c7ed701b-0894-4d6f-96e6-cd58854f8db6)
![Screenshot 2024-05-29 at 11 41 55 AM](https://github.com/tloncorp/tlon-apps/assets/748181/d94a624f-11e8-4457-8cf5-d0823785326e)


