### PR TITLE
native: center-aligned FloatingActionButton for galleries/notebooks

### DIFF
--- a/packages/ui/src/components/Channel/index.tsx
+++ b/packages/ui/src/components/Channel/index.tsx
@@ -11,7 +11,6 @@ import { useCallback, useMemo, useState } from 'react';
 import { KeyboardAvoidingView, Platform } from 'react-native';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
 
-import { Add, ArrowUp } from '../../assets/icons';
 import {
   CalmProvider,
   CalmState,
@@ -28,6 +27,7 @@ import { ChatMessage } from '../ChatMessage';
 import FloatingActionButton from '../FloatingActionButton';
 import { GalleryPost } from '../GalleryPost';
 import { GroupPreviewSheet } from '../GroupPreviewSheet';
+import { Icon } from '../Icon';
 import { LoadingSpinner } from '../LoadingSpinner';
 import { MessageInput } from '../MessageInput';
 import { NotebookPost } from '../NotebookPost';
@@ -285,28 +285,27 @@ export function Channel({
                           <NegotionMismatchNotice />
                         )}
                         {!isChatChannel && canWrite && !showGalleryInput && (
-                          <View position="absolute" bottom="$l" right="$l">
-                            {uploadInfo.uploadedImage &&
-                            uploadInfo.uploading ? (
-                              <View alignItems="center" padding="$m">
-                                <Spinner />
-                              </View>
-                            ) : (
-                              <FloatingActionButton
-                                onPress={() =>
-                                  uploadInfo.uploadedImage
-                                    ? messageSender([], channel.id)
-                                    : setShowAddGalleryPost(true)
-                                }
-                                icon={
-                                  uploadInfo.uploadedImage ? (
-                                    <ArrowUp />
-                                  ) : (
-                                    <Add />
-                                  )
-                                }
-                              />
-                            )}
+                          <View
+                            position="absolute"
+                            bottom={bottom}
+                            flex={1}
+                            width="100%"
+                            alignItems="center"
+                          >
+                            {!uploadInfo.uploading &&
+                              !uploadInfo.uploadedImage && (
+                                <FloatingActionButton
+                                  onPress={() => setShowAddGalleryPost(true)}
+                                  label="New Post"
+                                  icon={
+                                    <Icon
+                                      type="Add"
+                                      size={'$s'}
+                                      marginRight={'$s'}
+                                    />
+                                  }
+                                />
+                              )}
                           </View>
                         )}
                         {channel.type === 'gallery' && canWrite && (

--- a/packages/ui/src/components/FloatingActionButton.tsx
+++ b/packages/ui/src/components/FloatingActionButton.tsx
@@ -1,21 +1,34 @@
-import { IconButton } from './IconButton';
+import { Button } from '../core/Button';
+import { SizableText } from '../core/Text';
 
 export default function FloatingActionButton({
   onPress,
   icon,
+  label,
 }: {
   onPress: () => void;
-  icon: React.ReactNode;
+  icon?: React.ReactNode;
+  label?: string;
 }) {
   return (
-    <IconButton
-      backgroundColor="$primaryText"
-      backgroundColorOnPress="$tertiaryText"
-      color="$background"
-      radius="$xl"
+    <Button
+      paddingHorizontal="$m"
+      paddingVertical="$s"
+      alignItems="center"
       onPress={onPress}
     >
       {icon}
-    </IconButton>
+      {label && (
+        <SizableText
+          ellipsizeMode="tail"
+          numberOfLines={1}
+          fontSize={'$s'}
+          maxWidth={200}
+          height={'$2xl'}
+        >
+          {label}
+        </SizableText>
+      )}
+    </Button>
   );
 }

--- a/packages/ui/src/components/GalleryPost/GalleryPost.tsx
+++ b/packages/ui/src/components/GalleryPost/GalleryPost.tsx
@@ -140,7 +140,9 @@ export default function GalleryPost({
           ))}
         {postIsJustText && !textPostIsJustLinkedImage && (
           <View
-            backgroundColor="$background"
+            backgroundColor={
+              !detailView ? '$secondaryBackground' : '$background'
+            }
             borderRadius="$l"
             padding="$l"
             width={detailView ? WIDTH_DETAIL_VIEW_CONTENT : HEIGHT_AND_WIDTH}
@@ -161,7 +163,7 @@ export default function GalleryPost({
               />
               {!detailView && (
                 <LinearGradient
-                  colors={['$transparentBackground', '$background']}
+                  colors={['$transparentBackground', '$secondaryBackground']}
                   start={{ x: 0, y: 0.4 }}
                   end={{ x: 0, y: 1 }}
                   style={{


### PR DESCRIPTION
Modifies the FloatingActionButton slightly:
- Uses a Button component in the FAB
- Uses the Icon component when passing in an icon to actually render the icon the way Button wants it
- Absolutely positions the button in the channel at the bottom/center to conform with latest designs
- Adds a secondaryBackground to pure-text Gallery posts in the channel to help with visual structure (@urcades, feel free to weigh in)

@patosullivan The FAB was also showing up post-upload in the gallery image upload view, maybe the logic there was placeholder? Double-check that for me please. This doesn't show the FAB in the confirm step.

![Screenshot 2024-05-29 at 3 55 00 PM](https://github.com/tloncorp/tlon-apps/assets/748181/d37e20ab-bfc5-46a8-9083-8430bb8e6ec5)
