### PR TITLE
chat: include $whom in %writ-response mark

### DIFF
--- a/desk/app/chat.hoon
+++ b/desk/app/chat.hoon
@@ -1204,10 +1204,10 @@
     =/  response=(unit response:writs:c)  (diff-to-response diff pact.club)
     ?~  response  cu-core
     =.  cor
-      =/  =cage  writ-response+!>(u.response)
+      =/  =cage  writ-response+!>([[%club id] u.response])
       (emit %give %fact ~[/ cu-area] cage)
     =.  cor
-      =/  =cage  writ-response+!>(u.response)
+      =/  =cage  writ-response+!>([[%club id] u.response])
       (emit %give %fact ~[/ cu-area-writs] cage)
     cu-core
   ::
@@ -1568,10 +1568,10 @@
     =/  response=(unit response:writs:c)  (diff-to-response diff pact.dm)
     ?~  response  di-core
     =.  cor
-      =/  =cage  writ-response+!>(u.response)
+      =/  =cage  writ-response+!>([[%ship ship] u.response])
       (emit %give %fact ~[/ di-area] cage)
     =.  cor
-      =/  =cage  writ-response+!>(u.response)
+      =/  =cage  writ-response+!>([[%ship ship] u.response])
       (emit %give %fact ~[/ di-area-writs] cage)
     di-core
   ::

--- a/desk/lib/chat-json.hoon
+++ b/desk/lib/chat-json.hoon
@@ -211,9 +211,10 @@
       ==
     ==
   ++  writs-response
-    |=  =response:writs:c
+    |=  [=whom:c =response:writs:c]
     %-  pairs
-    :~  id/(id id.response)
+    :~  whom/s/(^whom whom)
+        id/(id id.response)
         response/(response-delta response.response)
     ==
   ::

--- a/desk/mar/writ-response.hoon
+++ b/desk/mar/writ-response.hoon
@@ -1,14 +1,14 @@
 /-  c=chat
 /+  j=chat-json
-|_  =response:writs:c
+|_  [=whom:c =response:writs:c]
 ++  grad  %noun
 ++  grow
   |%
-  ++  noun  response
-  ++  json  (writs-response:enjs:j response)
+  ++  noun  [whom response]
+  ++  json  (writs-response:enjs:j whom response)
   --
 ++  grab
   |%
-  ++  noun  response:writs:c
+  ++  noun  ,[whom:c response:writs:c]
   --
 --

--- a/desk/tests/app/chat.hoon
+++ b/desk/tests/app/chat.hoon
@@ -42,8 +42,8 @@
     :~  (ex-poke /contacts/~zod [~dev %contacts] act:mar:contacts !>([%heed ~[~zod]]))
         (ex-fact ~[/unreads] %chat-unread-update !>([whom unread]))
         (ex-poke /hark [~dev %hark] %hark-action-1 !>([%new-yarn new-yarn]))
-        (ex-fact ~[/dm/~zod] %writ-response !>(response))
-        (ex-fact ~[/dm/~zod/writs] %writ-response !>(response))
+        (ex-fact ~[/dm/~zod] %writ-response !>([[%ship ~zod] response]))
+        (ex-fact ~[/dm/~zod/writs] %writ-response !>([[%ship ~zod] response]))
     ==
   ;<  *  bind:m  (wait ~s1)
   ;<  bw=bowl  bind:m  get-bowl


### PR DESCRIPTION
This lets us specify the chat that the writ response happened in/for, which cannot otherwise be known if you're subscribing to the / "firehose" endpoint as opposed to an individual, specific chat.

We expect to get away with just tacking it on, because nothing on our backend listens for this mark, it's not used in scry endpoints, and the json is "backwards compatible" in the sense that it just has an additional field on the top-level object now.

Closes TLON-1880 again.
