### PR TITLE
native: darkmode-safe EmptyChannelNotice

### DIFF
--- a/packages/ui/src/components/Channel/EmptyChannelNotice.tsx
+++ b/packages/ui/src/components/Channel/EmptyChannelNotice.tsx
@@ -15,16 +15,18 @@ export function EmptyChannelNotice({
   const noticeText = useMemo(() => getNoticeText(isGroupAdmin), [isGroupAdmin]);
 
   return (
-    <View backgroundColor="$blueSoft" borderRadius="$xl" padding="$xl">
-      <SizableText>{noticeText}</SizableText>
+    <View alignItems="center" paddingHorizontal="$2xl">
+      <SizableText textAlign="center" color="$secondaryText">
+        {noticeText}
+      </SizableText>
     </View>
   );
 }
 
 function getNoticeText(isAdmin: boolean) {
   if (isAdmin) {
-    return 'This is a general discussion channel for your group. People you invite can post, react, and comment.';
+    return 'This is your group’s default welcome channel. Feel free to rename it or create additional channels.';
   }
 
-  return 'There are no messages...yet.';
+  return 'There are no messages... yet.';
 }


### PR DESCRIPTION
Changes the EmptyChannelNotice (A) in textual content and (B) to sit directly on the channel, rather than in a card. (New design calls for this.) This resolves an issue where the notice text was unreadable in dark mode.

Fixes TLON-1954

Before:

![image](https://github.com/tloncorp/tlon-apps/assets/748181/ca1ae6ec-5168-4d28-b5c4-3ed2c7aa4143)

After:

![image](https://github.com/tloncorp/tlon-apps/assets/748181/9268dbdb-3289-4f08-9e55-c52071e8e34d)
