### PR TITLE
native: don't pass empty posts to scroller, fixes gallery grid issue

### DIFF
--- a/packages/ui/src/components/Channel/Scroller.tsx
+++ b/packages/ui/src/components/Channel/Scroller.tsx
@@ -2,10 +2,7 @@ import { createDevLogger } from '@tloncorp/shared/dist';
 import * as db from '@tloncorp/shared/dist/db';
 import {
   extractContentTypesFromPost,
-  isImagePost,
-  isReferencePost,
   isSameDay,
-  isTextPost,
 } from '@tloncorp/shared/dist/logic';
 import { Story } from '@tloncorp/shared/dist/urbit';
 import { MotiView } from 'moti';

--- a/packages/ui/src/components/Channel/Scroller.tsx
+++ b/packages/ui/src/components/Channel/Scroller.tsx
@@ -1,6 +1,12 @@
 import { createDevLogger } from '@tloncorp/shared/dist';
 import * as db from '@tloncorp/shared/dist/db';
-import { isSameDay } from '@tloncorp/shared/dist/logic';
+import {
+  extractContentTypesFromPost,
+  isImagePost,
+  isReferencePost,
+  isSameDay,
+  isTextPost,
+} from '@tloncorp/shared/dist/logic';
 import { Story } from '@tloncorp/shared/dist/urbit';
 import { MotiView } from 'moti';
 import React, {
@@ -109,6 +115,27 @@ export default function Scroller({
   hasNewerPosts?: boolean;
   hasOlderPosts?: boolean;
 }) {
+  const filteredPosts = useMemo(
+    () =>
+      posts?.filter((post) => {
+        const { blocks, inlines, references } =
+          extractContentTypesFromPost(post);
+
+        if (
+          blocks.length === 0 &&
+          inlines.length === 0 &&
+          references.length === 0 &&
+          post.title === '' &&
+          post.image === ''
+        ) {
+          return false;
+        }
+
+        return true;
+      }),
+    [posts]
+  );
+
   const [hasPressedGoToBottom, setHasPressedGoToBottom] = useState(false);
   const flatListRef = useRef<FlatList<db.Post>>(null);
 
@@ -176,7 +203,7 @@ export default function Scroller({
   }, [hasFoundAnchor, theme.background.val]);
   const listRenderItem: ListRenderItem<db.Post> = useCallback(
     ({ item, index }) => {
-      const previousItem = posts?.[index + 1];
+      const previousItem = filteredPosts?.[index + 1];
       const isFirstPostOfDay = !isSameDay(
         item.receivedAt ?? 0,
         previousItem?.receivedAt ?? 0
@@ -224,7 +251,7 @@ export default function Scroller({
       );
     },
     [
-      posts,
+      filteredPosts,
       unreadCount,
       firstUnreadId,
       handleItemLayout,
@@ -331,13 +358,13 @@ export default function Scroller({
       {/* {unreadCount && !hasPressedGoToBottom ? (
         <UnreadsButton onPress={pressedGoToBottom} />
       ) : null} */}
-      {posts && (
+      {filteredPosts && (
         <FlatList<db.Post>
           ref={flatListRef}
           // This is needed so that we can force a refresh of the list when
           // we need to switch from 1 to 2 columns or vice versa.
           key={channelType}
-          data={posts}
+          data={filteredPosts}
           renderItem={listRenderItem}
           ListEmptyComponent={renderEmptyComponent}
           keyExtractor={getPostId}

--- a/packages/ui/src/components/GalleryPost/GalleryPost.tsx
+++ b/packages/ui/src/components/GalleryPost/GalleryPost.tsx
@@ -82,7 +82,18 @@ export default function GalleryPost({
   );
 
   if (!postIsJustImage && !postIsJustText && !postIsJustReference) {
-    return null;
+    // This should never happen, but if it does, we should log it
+    const content = JSON.parse(post.content as string);
+    console.log('Unsupported post type', {
+      post,
+      content,
+    });
+
+    return (
+      <View padding="$m" key={post.id} position="relative" alignItems="center">
+        <Text>Unsupported post type</Text>
+      </View>
+    );
   }
 
   return (


### PR DESCRIPTION
Fixes TLON-1945. We were seeing some posts appear as if they were in a "single column" per row in ed's product group because the posts actually had no content, so the GalleryPost component just returned null. We need to filter out posts like this before we pass them into FlatList.

I also added a "Unsupported content type" component we can return if we run into this again, so we'll know what's going on (it shouldn't happen again, but just in case).