### PR TITLE
native: android fixes, logout, & view build number

### DIFF
--- a/apps/tlon-mobile/src/lib/nativeDb.ts
+++ b/apps/tlon-mobile/src/lib/nativeDb.ts
@@ -53,6 +53,7 @@ export async function purgeDb() {
   client = null;
   logger.log('purged sqlite database, recreating');
   setupDb();
+  runMigrations();
 }
 
 export function getDbPath() {

--- a/apps/tlon-mobile/src/screens/ProfileScreen.tsx
+++ b/apps/tlon-mobile/src/screens/ProfileScreen.tsx
@@ -4,7 +4,7 @@ import * as store from '@tloncorp/shared/dist/store';
 import { ProfileScreenView, View } from '@tloncorp/ui';
 import { useCallback } from 'react';
 
-import { useShip } from '../contexts/ship';
+import { clearShipInfo, useShip } from '../contexts/ship';
 import { useCurrentUserId } from '../hooks/useCurrentUser';
 import { purgeDb } from '../lib/nativeDb';
 import NavBar from '../navigation/NavBarView';
@@ -23,6 +23,7 @@ export default function ProfileScreen(props: Props) {
     api.queryClient.clear();
     api.removeUrbitClient();
     clearShip();
+    clearShipInfo();
     removeHostingToken();
     removeHostingUserId();
   }, [clearShip]);

--- a/apps/tlon-mobile/src/screens/ProfileScreen.tsx
+++ b/apps/tlon-mobile/src/screens/ProfileScreen.tsx
@@ -1,16 +1,31 @@
 import { NativeStackScreenProps } from '@react-navigation/native-stack';
+import * as api from '@tloncorp/shared/dist/api';
 import * as store from '@tloncorp/shared/dist/store';
 import { ProfileScreenView, View } from '@tloncorp/ui';
+import { useCallback } from 'react';
 
+import { useShip } from '../contexts/ship';
 import { useCurrentUserId } from '../hooks/useCurrentUser';
+import { purgeDb } from '../lib/nativeDb';
 import NavBar from '../navigation/NavBarView';
 import { SettingsStackParamList } from '../types';
+import { removeHostingToken, removeHostingUserId } from '../utils/hosting';
 
 type Props = NativeStackScreenProps<SettingsStackParamList, 'Profile'>;
 
 export default function ProfileScreen(props: Props) {
+  const { clearShip } = useShip();
   const currentUserId = useCurrentUserId();
   const { data: contacts } = store.useContacts();
+
+  const handleLogout = useCallback(async () => {
+    await purgeDb();
+    api.queryClient.clear();
+    api.removeUrbitClient();
+    clearShip();
+    removeHostingToken();
+    removeHostingUserId();
+  }, [clearShip]);
 
   return (
     <View backgroundColor="$background" flex={1}>
@@ -18,6 +33,7 @@ export default function ProfileScreen(props: Props) {
         contacts={contacts ?? []}
         currentUserId={currentUserId}
         onAppSettingsPressed={() => props.navigation.navigate('FeatureFlags')}
+        handleLogout={handleLogout}
       />
       <NavBar navigation={props.navigation} />
     </View>

--- a/packages/ui/src/components/AddChats/AddDmSheet.tsx
+++ b/packages/ui/src/components/AddChats/AddDmSheet.tsx
@@ -1,7 +1,9 @@
+import { QueryClientProvider, queryClient } from '@tloncorp/shared/dist/api';
 import * as store from '@tloncorp/shared/dist/store';
 import { useCallback, useEffect, useState } from 'react';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
 
+import { ContactsProvider, useContacts } from '../../contexts';
 import { XStack, YStack, ZStack } from '../../core';
 import { triggerHaptic } from '../../utils';
 import { Button } from '../Button';
@@ -18,6 +20,7 @@ export function StartDmSheet({
   onOpenChange: (open: boolean) => void;
   goToDm: (participants: string[]) => void;
 }) {
+  const contacts = useContacts();
   const insets = useSafeAreaInsets();
   const [contentScrolling, setContentScrolling] = useState(false);
   const [dmParticipants, setDmParticipants] = useState<string[]>([]);
@@ -60,31 +63,35 @@ export function StartDmSheet({
     >
       <Sheet.Overlay />
       <Sheet.LazyFrame paddingTop="$s" paddingHorizontal="$2xl">
-        <Sheet.Handle marginBottom="$l" />
-        <ZStack flex={1}>
-          <YStack flex={1} gap="$2xl">
-            <ContactBook
-              key={contactBookKey}
-              multiSelect
-              onSelectedChange={setDmParticipants}
-              searchable
-              searchPlaceholder="Start a DM with..."
-              onScrollChange={setContentScrolling}
-            />
-            {dmParticipants.length > 0 && (
-              <XStack
-                position="absolute"
-                bottom={insets.bottom + 12}
-                justifyContent="center"
-              >
-                <StartDMButton
-                  participants={dmParticipants}
-                  onPress={handleGoToDm}
+        <QueryClientProvider client={queryClient}>
+          <ContactsProvider contacts={contacts ?? null}>
+            <Sheet.Handle marginBottom="$l" />
+            <ZStack flex={1}>
+              <YStack flex={1} gap="$2xl">
+                <ContactBook
+                  key={contactBookKey}
+                  multiSelect
+                  onSelectedChange={setDmParticipants}
+                  searchable
+                  searchPlaceholder="Start a DM with..."
+                  onScrollChange={setContentScrolling}
                 />
-              </XStack>
-            )}
-          </YStack>
-        </ZStack>
+                {dmParticipants.length > 0 && (
+                  <XStack
+                    position="absolute"
+                    bottom={insets.bottom + 12}
+                    justifyContent="center"
+                  >
+                    <StartDMButton
+                      participants={dmParticipants}
+                      onPress={handleGoToDm}
+                    />
+                  </XStack>
+                )}
+              </YStack>
+            </ZStack>
+          </ContactsProvider>
+        </QueryClientProvider>
       </Sheet.LazyFrame>
     </Sheet>
   );

--- a/packages/ui/src/components/Channel/index.tsx
+++ b/packages/ui/src/components/Channel/index.tsx
@@ -125,7 +125,18 @@ export function Channel({
       ? NotebookPost
       : GalleryPost;
   const renderEmptyComponent = useCallback(() => {
-    return <EmptyChannelNotice channel={channel} userId={currentUserId} />;
+    return (
+      <View
+        // hack to fix inverted Flatlist empty component being erroneously rotated on Android
+        style={
+          Platform.OS === 'android'
+            ? { transform: [{ rotateY: '180deg' }] }
+            : {}
+        }
+      >
+        <EmptyChannelNotice channel={channel} userId={currentUserId} />
+      </View>
+    );
   }, [currentUserId, channel]);
 
   const onPressGroupRef = useCallback((group: db.Group) => {

--- a/packages/ui/src/components/Channel/index.tsx
+++ b/packages/ui/src/components/Channel/index.tsx
@@ -8,6 +8,7 @@ import { UploadInfo } from '@tloncorp/shared/dist/api';
 import * as db from '@tloncorp/shared/dist/db';
 import { JSONContent, Story } from '@tloncorp/shared/dist/urbit';
 import { useCallback, useMemo, useState } from 'react';
+import { Platform } from 'react-native';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
 import { AnimatePresence } from 'tamagui';
 

--- a/packages/ui/src/components/ProfileScreenView.tsx
+++ b/packages/ui/src/components/ProfileScreenView.tsx
@@ -1,6 +1,6 @@
 import * as db from '@tloncorp/shared/dist/db';
 import { PropsWithChildren } from 'react';
-import { Dimensions, ImageBackground } from 'react-native';
+import { Alert, Dimensions, ImageBackground } from 'react-native';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
 import { ScrollView, XStack, getTokens } from 'tamagui';
 
@@ -14,6 +14,7 @@ import { ListItem } from './ListItem';
 interface Props {
   currentUserId: string;
   onAppSettingsPressed?: () => void;
+  handleLogout: () => void;
 }
 
 export function ProfileScreenView({
@@ -30,6 +31,19 @@ export function ProfileScreenView({
 export function Wrapped(props: Props) {
   const { top } = useSafeAreaInsets();
   const contact = useContact(props.currentUserId);
+
+  const onLogoutPress = () => {
+    Alert.alert('Log out', 'Are you sure you want to log out?', [
+      {
+        text: 'Cancel',
+        style: 'cancel',
+      },
+      {
+        text: 'Log out',
+        onPress: props.handleLogout,
+      },
+    ]);
+  };
 
   return (
     <ScrollView>
@@ -51,6 +65,12 @@ export function Wrapped(props: Props) {
             title="App Settings"
             icon="Settings"
             onPress={props.onAppSettingsPressed}
+          />
+          <ProfileAction
+            title="Log Out"
+            icon="LogOut"
+            hideCaret
+            onPress={onLogoutPress}
           />
         </View>
       </YStack>
@@ -138,10 +158,12 @@ function ProfileRow({
 function ProfileAction({
   icon,
   title,
+  hideCaret,
   onPress,
 }: {
   icon: IconType;
   title: string;
+  hideCaret?: boolean;
   onPress?: () => void;
 }) {
   return (
@@ -154,7 +176,7 @@ function ProfileAction({
       <ListItem.MainContent>
         <ListItem.Title>{title}</ListItem.Title>
       </ListItem.MainContent>
-      <ListItem.Icon icon="ChevronRight" />
+      {!hideCaret && <ListItem.Icon icon="ChevronRight" />}
     </ListItem>
   );
 }


### PR DESCRIPTION
Bit of a hodgepodge. 

Biggest piece is fixing a few Android bugs. Namely the new create/join sheets crashing due to an issue with Tamagui Sheet's ["modal" property](https://github.com/gorhom/react-native-portal/issues/34) and one where the empty channel message was showing up rotated.

Also adds the ability to log out and display hidden dev info by clicking the _Profile_  page avatar 5 times rapidly

Fixes TLON-1935
Fixes TLON-2042