### PR TITLE
native: render interleaved content for notes

### DIFF
--- a/packages/shared/src/logic/utils.ts
+++ b/packages/shared/src/logic/utils.ts
@@ -268,13 +268,14 @@ export const extractContentTypes = (
   inlines: ub.Inline[];
   references: api.ContentReference[];
   blocks: ub.Block[];
+  story: api.PostContent;
 } => {
   const story = JSON.parse(content as string) as api.PostContent;
   const inlines = extractInlinesFromContent(story);
   const references = extractReferencesFromContent(story);
   const blocks = extractBlocksFromContent(story);
 
-  return { inlines, references, blocks };
+  return { inlines, references, blocks, story };
 };
 
 export const extractContentTypesFromPost = (
@@ -283,12 +284,13 @@ export const extractContentTypesFromPost = (
   inlines: ub.Inline[];
   references: api.ContentReference[];
   blocks: ub.Block[];
+  story: api.PostContent;
 } => {
-  const { inlines, references, blocks } = extractContentTypes(
+  const { inlines, references, blocks, story } = extractContentTypes(
     post.content as string
   );
 
-  return { inlines, references, blocks };
+  return { inlines, references, blocks, story };
 };
 
 export const isTextPost = (post: db.Post) => {

--- a/packages/ui/src/components/BigInput.tsx
+++ b/packages/ui/src/components/BigInput.tsx
@@ -150,7 +150,6 @@ export function BigInput({
           ref={editorRef}
         />
       </ScrollView>
-      {console.log('editorRef', editorRef.current)}
       {channelType === 'notebook' &&
         editorRef.current &&
         editorRef.current.editor && (

--- a/packages/ui/src/components/ContentRenderer.tsx
+++ b/packages/ui/src/components/ContentRenderer.tsx
@@ -717,7 +717,7 @@ LineRenderer.displayName = 'LineRenderer';
 
 export type PostViewMode = 'chat' | 'block' | 'note';
 
-export default function ChatContent({
+export default function ContentRenderer({
   post,
   shortened = false,
   isNotice = false,
@@ -736,7 +736,7 @@ export default function ChatContent({
   isEdited?: boolean;
   viewMode?: PostViewMode;
 }) {
-  const { inlines, blocks, references } = useMemo(
+  const { inlines, blocks, references, story } = useMemo(
     () => extractContentTypesFromPost(post),
     [post]
   );
@@ -788,6 +788,37 @@ export default function ChatContent({
 
   if (blocks.length === 0 && inlines.length === 0 && references.length === 0) {
     return null;
+  }
+
+  if (post.type === 'note' && story) {
+    // Notes are always rendered with interleaved content
+
+    return (
+      <YStack width="100%">
+        {story.map((s, k) => {
+          if ('block' in s) {
+            return <BlockContent key={k} block={s.block} />;
+          }
+
+          if ('type' in s && s.type === 'reference') {
+            return <ContentReference key={k} reference={s} />;
+          }
+
+          if ('inline' in s) {
+            return (
+              <LineRenderer
+                key={k}
+                inlines={s.inline}
+                isNotice={isNotice}
+                onPressImage={onPressImage}
+                onLongPress={onLongPress}
+                viewMode={viewMode}
+              />
+            );
+          }
+        })}
+      </YStack>
+    );
   }
 
   return (


### PR DESCRIPTION
Fixes TLON-1958 by making sure we always interleave rendered content for notes (as opposed to chat where blocks should always appear before the text/inline content, or galleries where the content is either text or an image).

![Simulator Screenshot - iPhone 15 Pro - 2024-06-03 at 14 08 51](https://github.com/tloncorp/tlon-apps/assets/1221094/6c2e6481-14f6-44ca-8da9-71c8fb6d08db)
