### PR TITLE
ci: disable e2e tests (for now)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,21 +28,22 @@ jobs:
       - name: Run Tests
         run: pnpm -r test run
 
-      - name: Install Playwright Browsers
-        run: pnpm exec playwright install --with-deps
-        working-directory: ./apps/tlon-web
+      #NOTE  e2e tests disabled temporarily, please investigate why they fail
 
-      #NOTE  disabled temporarily, please investigate why they fail
+      # - name: Install Playwright Browsers
+      #   run: pnpm exec playwright install --with-deps
+      #   working-directory: ./apps/tlon-web
+
       # - name: Run E2E Tests for Groups
       #   run: pnpm e2e
       #   working-directory: ./apps/tlon-web
 
-      - uses: actions/upload-artifact@v3
-        if: always()
-        with:
-          name: playwright-report
-          path: ./apps/tlon-web/playwright-report/
-          retention-days: 30
+      # - uses: actions/upload-artifact@v3
+      #   if: always()
+      #   with:
+      #     name: playwright-report
+      #     path: ./apps/tlon-web/playwright-report/
+      #     retention-days: 30
 
       - name: Build
         run: pnpm build

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,9 +32,10 @@ jobs:
         run: pnpm exec playwright install --with-deps
         working-directory: ./apps/tlon-web
 
-      - name: Run E2E Tests for Groups
-        run: pnpm e2e
-        working-directory: ./apps/tlon-web
+      #NOTE  disabled temporarily, please investigate why they fail
+      # - name: Run E2E Tests for Groups
+      #   run: pnpm e2e
+      #   working-directory: ./apps/tlon-web
 
       - uses: actions/upload-artifact@v3
         if: always()


### PR DESCRIPTION
As discussed out of band, these "seemingly just started failing due to timeouts at some point". We ignored this and got used to the red X's.

It seems preferable to disable the tests until we have time to re-enable them and investigate their failures properly, rather than get used to CI failures.
