### PR TITLE
native: fix chat list order and more

### DIFF
--- a/packages/shared/src/api/initApi.ts
+++ b/packages/shared/src/api/initApi.ts
@@ -19,7 +19,12 @@ export interface InitData {
 }
 
 export const getInitData = async () => {
-  const response = await scry<ub.GroupsInit>({
+  const response = await scry<
+    ub.GroupsInit & {
+      unreads: ub.Unreads;
+      chat: ub.DMInit & { unreads: ub.Unreads };
+    }
+  >({
     app: 'groups-ui',
     path: '/v1/init',
   });
@@ -28,18 +33,17 @@ export const getInitData = async () => {
   const channelsInit = toClientChannelsInit(response.channels);
   const groups = toClientGroups(response.groups, true);
   const unjoinedGroups = toClientGroupsFromGangs(response.gangs);
-  // const channelUnreads = toClientUnreads(response.unreads, 'channel');
+  const channelUnreads = toClientUnreads(response.unreads, 'channel');
   const dmChannels = toClientDms(response.chat.dms);
   const groupDmChannels = toClientGroupDms(response.chat.clubs);
   const invitedDms = toClientDms(response.chat.invited, true);
-  // const talkUnreads = toClientUnreads(response.chat.unreads, 'dm');
+  const talkUnreads = toClientUnreads(response.chat.unreads, 'dm');
 
   return {
     pins,
     groups,
     unjoinedGroups,
-    // unreads: [...channelUnreads, ...talkUnreads],
-    unreads: [],
+    unreads: [...channelUnreads, ...talkUnreads],
     channels: [...dmChannels, ...groupDmChannels, ...invitedDms],
     channelPerms: channelsInit,
   };

--- a/packages/shared/src/store/sync.ts
+++ b/packages/shared/src/store/sync.ts
@@ -16,83 +16,80 @@ export const channelCursors = new Map<string, string>();
 const logger = createDevLogger('sync', false);
 
 export const syncInitData = async () => {
-  return syncQueue.add('init', async () => {
-    const initData = await api.getInitData();
-    return batchEffects('init sync', async (ctx) => {
-      return await Promise.all([
-        db.insertPinnedItems(initData.pins, ctx),
-        db.insertGroups({ groups: initData.groups }, ctx),
-        db.insertUnjoinedGroups(initData.unjoinedGroups, ctx),
-        db.insertChannels(initData.channels, ctx),
-        resetUnreads(initData.unreads, ctx),
-        db.insertChannelPerms(initData.channelPerms, ctx),
-      ]);
-    });
+  const initData = await syncQueue.add('init', () => api.getInitData());
+  return batchEffects('init sync', async (ctx) => {
+    return await Promise.all([
+      db.insertPinnedItems(initData.pins, ctx),
+      db.insertGroups({ groups: initData.groups }, ctx),
+      db.insertUnjoinedGroups(initData.unjoinedGroups, ctx),
+      db.insertChannels(initData.channels, ctx),
+      resetUnreads(initData.unreads, ctx),
+      db.insertChannelPerms(initData.channelPerms, ctx),
+    ]);
   });
 };
 
 export const syncLatestPosts = async () => {
-  return syncQueue.add('latest-posts', async () => {
-    const result = await Promise.all([
+  const result = await syncQueue.add('latest-posts', async () =>
+    Promise.all([
       api.getLatestPosts({ type: 'channels' }),
       api.getLatestPosts({ type: 'chats' }),
-    ]);
-    const allPosts = result.flatMap((set) => set.map((p) => p.latestPost));
-    for (const post of allPosts) {
-      if (
-        !channelCursors.has(post.channelId) ||
-        post.id > channelCursors.get(post.channelId)!
-      ) {
-        channelCursors.set(post.channelId, post.id);
-      }
+    ])
+  );
+  const allPosts = result.flatMap((set) => set.map((p) => p.latestPost));
+  for (const post of allPosts) {
+    if (
+      !channelCursors.has(post.channelId) ||
+      post.id > channelCursors.get(post.channelId)!
+    ) {
+      channelCursors.set(post.channelId, post.id);
     }
-    await db.insertLatestPosts(allPosts);
-  });
+  }
+  await db.insertLatestPosts(allPosts);
 };
 
 export const syncChanges = async (options: api.GetChangedPostsOptions) => {
-  return syncQueue.add('changes', async () => {
-    const result = await api.getChangedPosts(options);
-    await persistPagedPostData(options.channelId, result);
-  });
+  const result = await syncQueue.add('changes', () =>
+    api.getChangedPosts(options)
+  );
+  await persistPagedPostData(options.channelId, result);
 };
 
 export const syncSettings = async () => {
-  return syncQueue.add('settings', async () => {
-    const settings = await api.getSettings();
-    await db.insertSettings(settings);
-  });
+  const settings = await syncQueue.add('settings', () => api.getSettings());
+  return db.insertSettings(settings);
 };
 
 export const syncContacts = async () => {
-  return syncQueue.add('contacts', async () => {
-    const contacts = await api.getContacts();
-    await db.insertContacts(contacts);
-  });
+  const contacts = await syncQueue.add('contacts', () => api.getContacts());
+  await db.insertContacts(contacts);
 };
 
 export const syncPinnedItems = async () => {
-  const pinnedItems = await api.getPinnedItems();
+  const pinnedItems = await syncQueue.add('pinnedItems', () =>
+    api.getPinnedItems()
+  );
   await db.insertPinnedItems(pinnedItems);
 };
 
 export const syncGroups = async () => {
-  return syncQueue.add('groups', async () => {
-    const groups = await api.getGroups({ includeMembers: false });
-    await db.insertGroups({ groups: groups });
-  });
+  const groups = await syncQueue.add('groups', () =>
+    api.getGroups({ includeMembers: false })
+  );
+  await db.insertGroups({ groups: groups });
 };
 
 export const syncDms = async () => {
-  const [dms, groupDms] = await Promise.all([api.getDms(), api.getGroupDms()]);
+  const [dms, groupDms] = await syncQueue.add('dms', () =>
+    Promise.all([api.getDms(), api.getGroupDms()])
+  );
   await db.insertChannels([...dms, ...groupDms]);
 };
 
 export const syncUnreads = async () => {
-  const [channelUnreads, dmUnreads] = await Promise.all([
-    api.getChannelUnreads(),
-    api.getDMUnreads(),
-  ]);
+  const [channelUnreads, dmUnreads] = await syncQueue.add('unreads', () =>
+    Promise.all([api.getChannelUnreads(), api.getDMUnreads()])
+  );
   const unreads = [...channelUnreads, ...dmUnreads];
   await resetUnreads(unreads);
 };

--- a/packages/ui/src/components/ChannelListItem/index.tsx
+++ b/packages/ui/src/components/ChannelListItem/index.tsx
@@ -103,7 +103,7 @@ function ChannelListItemIcon({
       return (
         <ListItem.TextIcon
           fallbackText={utils.getChannelTitle(model)}
-          backgroundColor={backgroundColor}
+          backgroundColor={backgroundColor ?? '$secondaryBackground'}
         />
       );
     }


### PR DESCRIPTION
This pr contains a few small fixes/improvements.
- Re-enables the old unreads api for now, which fixes chat list order, unread counts, and a number of other things.
- Refactors sync methods so that we're attempting to load the next request while the last one is persisting to the database.
- Adds a background tint to text icons that don't have a background color set (minor visual thing that's been bugging me).

    
Before:
<img src="https://github.com/tloncorp/tlon-apps/assets/357216/2fd67540-7551-4442-8b62-a9517ac975fa" width="300">

After:
<img src="https://github.com/tloncorp/tlon-apps/assets/357216/345be387-20f3-444b-aa24-58095f7f8e21" width="300">