### PR TITLE
native: show user sigil in bottom nav while contacts is still loading in

### DIFF
--- a/apps/tlon-mobile/src/navigation/NavBarView.tsx
+++ b/apps/tlon-mobile/src/navigation/NavBarView.tsx
@@ -11,7 +11,7 @@ const NavBarView = (props: { navigation: any }) => {
   };
   const { data: unreadCount } = store.useUnreadsCount();
   const currentUserId = useCurrentUserId();
-  const { data: contact, isLoading } = store.useContact({ id: currentUserId });
+  const { data: contact } = store.useContact({ id: currentUserId });
 
   return (
     <NavBar>
@@ -29,15 +29,12 @@ const NavBarView = (props: { navigation: any }) => {
         isActive={isRouteActive('Activity')}
         onPress={() => props.navigation.navigate('Activity')}
       />
-      {contact && (
-        <AvatarNavIcon
-          id={currentUserId}
-          contact={contact}
-          isLoading={isLoading}
-          focused={isRouteActive('Settings')}
-          onPress={() => props.navigation.navigate('Settings')}
-        />
-      )}
+      <AvatarNavIcon
+        id={currentUserId}
+        contact={contact}
+        focused={isRouteActive('Settings')}
+        onPress={() => props.navigation.navigate('Settings')}
+      />
     </NavBar>
   );
 };

--- a/packages/ui/src/components/NavBar/NavIcon.tsx
+++ b/packages/ui/src/components/NavBar/NavIcon.tsx
@@ -9,16 +9,14 @@ export function AvatarNavIcon({
   id,
   focused,
   contact,
-  isLoading,
   onPress,
 }: {
   id: string;
   focused: boolean;
-  contact: Contact;
-  isLoading: boolean;
+  contact?: Contact | null;
   onPress?: () => void;
 }) {
-  return isLoading && !contact ? null : (
+  return (
     <View flex={1} onPress={onPress} alignItems="center" paddingTop={'$s'}>
       <Avatar
         width={20}


### PR DESCRIPTION
Fixes TLON-1967 by showing the default, unstyled sigil in the bottom nav until we get the contact details for the logged-in user (rather than just not showing the button at all).