### PR TITLE
native: fix issues with reactions in DMs

### DIFF
--- a/packages/shared/src/store/postActions.ts
+++ b/packages/shared/src/store/postActions.ts
@@ -183,12 +183,13 @@ export async function addPostReaction(
   });
 
   try {
-    await api.addReaction(
-      post.channelId,
-      post.id,
-      formattedShortcode,
-      currentUserId
-    );
+    await api.addReaction({
+      channelId: post.channelId,
+      postId: post.id,
+      shortCode: formattedShortcode,
+      our: currentUserId,
+      postAuthor: post.authorId,
+    });
     sync.syncChannel(post.channelId, Date.now());
   } catch (e) {
     console.error('Failed to add post reaction', e);
@@ -208,7 +209,12 @@ export async function removePostReaction(post: db.Post, currentUserId: string) {
   await db.deletePostReaction({ postId: post.id, contactId: currentUserId });
 
   try {
-    await api.removeReaction(post.channelId, post.id, currentUserId);
+    await api.removeReaction({
+      channelId: post.channelId,
+      postId: post.id,
+      our: currentUserId,
+      postAuthor: post.authorId,
+    });
     sync.syncChannel(post.channelId, Date.now());
   } catch (e) {
     console.error('Failed to remove post reaction', e);


### PR DESCRIPTION
Fixes LAND-1997. We were using %channels pokes where we should have been using %chat.