### PR TITLE
web: fix leap crashing issue

### DIFF
--- a/apps/tlon-web/src/components/Leap/useLeap.tsx
+++ b/apps/tlon-web/src/components/Leap/useLeap.tsx
@@ -138,17 +138,9 @@ export default function useLeap() {
       filter: string,
       entry: fuzzy.FilterResult<[string, Contact]>
     ): number => {
-      const parts = entry.string.split('~');
+      const ship = entry.original[0];
+      const nickname = entry.original[1].nickname;
       let newScore = entry.score;
-
-      // shouldn't happen
-      if (parts.length === 1) {
-        return newScore;
-      }
-
-      const [nickname, ship] = parts;
-
-      // console.log('ship', ship, 'score', newScore);
 
       // boost mutuals significantly
       if (preSiggedMutuals.includes(preSig(ship))) {

--- a/apps/tlon-web/src/state/chat/chat.ts
+++ b/apps/tlon-web/src/state/chat/chat.ts
@@ -1318,7 +1318,7 @@ export function useCheckDmUnread() {
   const unreads = useUnreads();
   return useCallback(
     (whom: string) => {
-      return unreads[whom].combined.status === 'unread';
+      return unreads[whom]?.combined.status === 'unread';
     },
     [unreads]
   );


### PR DESCRIPTION
We were using entry.string, which couldn't split out to [ship, nickname] appropriately anymore. `whom` passed to useCheckDmUnread was always `${ship}{nickname}`, which we'll never find an unread for. We can just pull the ship and the nickname out of the entry.original property instead. I also updated useCheckDmUnread() so that unreads[whom] is optional.

Fixes TLON-2029