### PR TITLE
native: blur message input when adding an attachment

### DIFF
--- a/packages/ui/src/components/MessageInput/AttachmentButton.native.tsx
+++ b/packages/ui/src/components/MessageInput/AttachmentButton.native.tsx
@@ -1,5 +1,5 @@
 import { UploadInfo } from '@tloncorp/shared/dist/api';
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 
 import { Add } from '../../assets/icons';
 import { Spinner, View } from '../../core';
@@ -8,10 +8,18 @@ import { IconButton } from '../IconButton';
 
 export default function AttachmentButton({
   uploadInfo,
+  setShouldBlur,
 }: {
   uploadInfo: UploadInfo;
+  setShouldBlur: (shouldBlur: boolean) => void;
 }) {
   const [showInputSelector, setShowInputSelector] = useState(false);
+
+  useEffect(() => {
+    if (showInputSelector) {
+      setShouldBlur(true);
+    }
+  }, [showInputSelector, setShouldBlur]);
 
   return (
     <>

--- a/packages/ui/src/components/MessageInput/AttachmentButton.tsx
+++ b/packages/ui/src/components/MessageInput/AttachmentButton.tsx
@@ -9,8 +9,10 @@ import { IconButton } from '../IconButton';
 
 export default function AttachmentButton({
   uploadInfo,
+  setShouldBlur,
 }: {
   uploadInfo: UploadInfo;
+  setShouldBlur: (shouldBlur: boolean) => void;
 }) {
   return (
     <IconButton onPress={() => {}}>

--- a/packages/ui/src/components/MessageInput/MessageInputBase.tsx
+++ b/packages/ui/src/components/MessageInput/MessageInputBase.tsx
@@ -51,6 +51,7 @@ export interface MessageInputProps {
 export const MessageInputContainer = ({
   children,
   onPressSend,
+  setShouldBlur,
   uploadInfo,
   containerHeight,
   showMentionPopup = false,
@@ -65,6 +66,7 @@ export const MessageInputContainer = ({
   onPressEdit,
   goBack,
 }: PropsWithChildren<{
+  setShouldBlur: (shouldBlur: boolean) => void;
   onPressSend: () => void;
   uploadInfo?: UploadInfo;
   containerHeight: number;
@@ -124,7 +126,10 @@ export const MessageInputContainer = ({
         {hasUploadedImage ? null : uploadInfo?.canUpload &&
           showAttachmentButton ? (
           <View paddingBottom="$xs">
-            <AttachmentButton uploadInfo={uploadInfo} />
+            <AttachmentButton
+              uploadInfo={uploadInfo}
+              setShouldBlur={setShouldBlur}
+            />
           </View>
         ) : null}
         {children}

--- a/packages/ui/src/components/MessageInput/index.native.tsx
+++ b/packages/ui/src/components/MessageInput/index.native.tsx
@@ -611,6 +611,7 @@ export const MessageInput = forwardRef<MessageInputHandle, MessageInputProps>(
 
     return (
       <MessageInputContainer
+        setShouldBlur={setShouldBlur}
         onPressSend={handleSend}
         onPressEdit={handleEdit}
         uploadInfo={uploadInfo}

--- a/packages/ui/src/components/MessageInput/index.tsx
+++ b/packages/ui/src/components/MessageInput/index.tsx
@@ -20,6 +20,7 @@ export function MessageInput({
       groupMembers={groupMembers}
       onSelectMention={() => {}}
       onPressSend={() => {}}
+      setShouldBlur={setShouldBlur}
     >
       <TextArea
         flexGrow={1}


### PR DESCRIPTION
Fixes TLON-2032 by blurring the message input when we pop the attachment sheet open.