### PR TITLE
native: fix keyboard focus issues by relying on the OS

### DIFF
--- a/packages/ui/src/components/Channel/Scroller.tsx
+++ b/packages/ui/src/components/Channel/Scroller.tsx
@@ -78,7 +78,6 @@ export default function Scroller({
   channelId,
   firstUnreadId,
   unreadCount,
-  setInputShouldBlur,
   onStartReached,
   onEndReached,
   onPressPost,
@@ -101,7 +100,6 @@ export default function Scroller({
   channelId: string;
   firstUnreadId?: string | null;
   unreadCount?: number | null;
-  setInputShouldBlur?: (shouldBlur: boolean) => void;
   onStartReached?: () => void;
   onEndReached?: () => void;
   onPressPost?: (post: db.Post) => void;
@@ -283,8 +281,7 @@ export default function Scroller({
 
   const handleScrollBeginDrag = useCallback(() => {
     userHasScrolledRef.current = true;
-    setInputShouldBlur?.(true);
-  }, [setInputShouldBlur]);
+  }, []);
 
   const pendingEvents = useRef({
     onEndReached: false,

--- a/packages/ui/src/components/Channel/index.tsx
+++ b/packages/ui/src/components/Channel/index.tsx
@@ -291,7 +291,6 @@ export function Channel({
                                     onPressPost={goToPost}
                                     onPressReplies={goToPost}
                                     onPressImage={goToImageViewer}
-                                    setInputShouldBlur={setInputShouldBlur}
                                     onEndReached={onScrollEndReached}
                                     onStartReached={onScrollStartReached}
                                   />

--- a/packages/ui/src/components/DetailView/DetailView.tsx
+++ b/packages/ui/src/components/DetailView/DetailView.tsx
@@ -129,7 +129,6 @@ const DetailViewFrameComponent = ({
         renderItem={() => (
           <View paddingTop="$m" paddingHorizontal="$xs">
             <Scroller
-              setInputShouldBlur={setInputShouldBlur}
               inverted
               renderItem={ChatMessage}
               channelType="chat"

--- a/packages/ui/src/components/PostScreenView.tsx
+++ b/packages/ui/src/components/PostScreenView.tsx
@@ -148,7 +148,6 @@ export function PostScreenView({
                   isChatChannel && (
                     <View paddingBottom={bottom} flex={1}>
                       <Scroller
-                        setInputShouldBlur={setInputShouldBlur}
                         inverted
                         renderItem={ChatMessage}
                         channelType="chat"


### PR DESCRIPTION
Fixes TLON-1995
Fixes TLON-1996

This fixes the keyboard focus jankiness we've been seeing by relying on the native OS rather than react state to dismiss the keyboard. On iOS, if the user interacts with the scroller the keyboard will automatically be dismissed. On Android, it won't, but Android has the hide keyboard button built-into the keyboard itself, and this is a normal interaction on Android.