### PR TITLE
native: correctly handle channel join updates

### DIFF
--- a/packages/shared/src/api/channelsApi.ts
+++ b/packages/shared/src/api/channelsApi.ts
@@ -3,6 +3,7 @@ import { decToUd, unixToDa } from '@urbit/api';
 import * as db from '../db';
 import { createDevLogger } from '../debug';
 import * as ub from '../urbit';
+import { Posts } from '../urbit';
 import { stringToTa } from '../urbit/utils';
 import { getCanonicalPostId } from './apiUtils';
 import {
@@ -57,6 +58,12 @@ export type JoinChannelSuccessUpdate = {
   channelId: string;
 };
 
+export type InitialPostsOnChannelJoin = {
+  type: 'initialPostsOnChannelJoin';
+  channelId: string;
+  posts: db.Post[];
+};
+
 export type LeaveChannelSuccessUpdate = {
   type: 'leaveChannelSuccess';
   channelId: string;
@@ -76,8 +83,9 @@ export type ChannelsUpdate =
   | HidePostUpdate
   | ShowPostUpdate
   // | CreateChannelUpdate
-  // | JoinChannelSuccessUpdate
+  | JoinChannelSuccessUpdate
   | LeaveChannelSuccessUpdate
+  | InitialPostsOnChannelJoin
   // | MarkChannelReadUpdate
   | WritersUpdate;
 
@@ -153,13 +161,12 @@ export const toChannelsUpdate = (
     // };
     // }
 
-    // not clear that this is necessary
-    // if ('join' in channelEvent.response) {
-    // return {
-    // type: 'joinChannelSuccess',
-    // channelId,
-    // };
-    // }
+    if ('join' in channelEvent.response) {
+      return {
+        type: 'joinChannelSuccess',
+        channelId,
+      };
+    }
 
     // not clear that this is necessary
     // if ('read' in channelEvent.response) {
@@ -169,13 +176,25 @@ export const toChannelsUpdate = (
     // };
     // }
 
-    // not used yet
-    // if ('leave' in channelEvent.response) {
-    // return {
-    // type: 'leaveChannelSuccess',
-    // channelId,
-    // };
-    // }
+    if ('leave' in channelEvent.response) {
+      return {
+        type: 'leaveChannelSuccess',
+        channelId,
+      };
+    }
+
+    if ('posts' in channelEvent.response) {
+      const { posts: postsFromBackend }: { posts: Posts } =
+        channelEvent.response;
+
+      const posts = Object.entries(postsFromBackend)
+        .filter(([_, post]) => post !== null)
+        .map(([_, post]) => {
+          return toPostData(channelId, post!);
+        });
+
+      return { type: 'initialPostsOnChannelJoin', channelId, posts };
+    }
 
     if ('post' in channelEvent.response) {
       // post events
@@ -241,7 +260,7 @@ export const toChannelsUpdate = (
     }
   }
 
-  logger.log(`unknown event`);
+  logger.log(`unknown event`, channelEvent);
   return { type: 'unknown' };
 };
 

--- a/packages/shared/src/db/queries.ts
+++ b/packages/shared/src/db/queries.ts
@@ -458,6 +458,8 @@ export const deleteGroup = createWriteQuery(
 export const insertUnjoinedGroups = createWriteQuery(
   'insertUnjoinedGroups',
   async (groups: Group[], ctx: QueryCtx) => {
+    logger.log('insertUnjoinedGroups', groups.length);
+
     return withTransactionCtx(ctx, async (txCtx) => {
       // ensure we never delete metadata if we get a partial for some reason
       // during the join process
@@ -1195,12 +1197,46 @@ export const getChannelNavSection = createReadQuery(
 export const setJoinedGroupChannels = createWriteQuery(
   'setJoinedGroupChannels',
   async ({ channelIds }: { channelIds: string[] }, ctx: QueryCtx) => {
+    logger.log('setJoinedGroupChannels', channelIds);
     return await ctx.db
       .update($channels)
       .set({
         currentUserIsMember: inArray($channels.id, channelIds),
       })
       .where(isNotNull($channels.groupId));
+  },
+  ['channels']
+);
+
+export const addJoinedGroupChannel = createWriteQuery(
+  'addJoinedGroupChannel',
+  async ({ channelId }: { channelId: string }, ctx: QueryCtx) => {
+    logger.log('addJoinedGroupChannel', channelId);
+
+    await ctx.db.insert($groupNavSectionChannels).values({
+      channelId,
+      groupNavSectionId: 'default',
+    });
+
+    return await ctx.db
+      .update($channels)
+      .set({
+        currentUserIsMember: true,
+      })
+      .where(eq($channels.id, channelId));
+  },
+  ['channels']
+);
+
+export const removeJoinedGroupChannel = createWriteQuery(
+  'removeJoinedGroupChannel',
+  async ({ channelId }: { channelId: string }, ctx: QueryCtx) => {
+    return await ctx.db
+      .update($channels)
+      .set({
+        currentUserIsMember: false,
+      })
+      .where(eq($channels.id, channelId));
   },
   ['channels']
 );
@@ -2023,6 +2059,7 @@ export const deleteContact = createWriteQuery(
 export const insertUnreads = createWriteQuery(
   'insertUnreads',
   async (unreads: Unread[], ctx: QueryCtx) => {
+    logger.log('insertUnreads', unreads.length, unreads);
     return withTransactionCtx(ctx, async (txCtx) => {
       await txCtx.db
         .insert($unreads)

--- a/packages/shared/src/db/queries.ts
+++ b/packages/shared/src/db/queries.ts
@@ -531,13 +531,18 @@ export const getFlaggedPosts = createReadQuery(
 
 export const insertChannelPerms = createWriteQuery(
   'insertChannelPerms',
-  (channelsInit: ChannelInit[], ctx: QueryCtx) => {
+  async (channelsInit: ChannelInit[], ctx: QueryCtx) => {
     const writers = channelsInit.flatMap((chanInit) =>
       chanInit.writers.map((writer) => ({
         channelId: chanInit.channelId,
         roleId: writer,
       }))
     );
+
+    if (writers.length === 0) {
+      return;
+    }
+
     return ctx.db
       .insert($channelWriters)
       .values(writers)

--- a/packages/shared/src/store/sync.ts
+++ b/packages/shared/src/store/sync.ts
@@ -17,13 +17,6 @@ const logger = createDevLogger('sync', false);
 
 export const syncInitData = async () => {
   const initData = await syncQueue.add('init', () => api.getInitData());
-  const writers = initData.channelPerms.flatMap((chanInit) =>
-    chanInit.writers.map((writer) => ({
-      channelId: chanInit.channelId,
-      roleId: writer,
-    }))
-  );
-
   return batchEffects('init sync', async (ctx) => {
     return await Promise.all([
       db.insertPinnedItems(initData.pins, ctx),
@@ -31,9 +24,7 @@ export const syncInitData = async () => {
       db.insertUnjoinedGroups(initData.unjoinedGroups, ctx),
       db.insertChannels(initData.channels, ctx),
       resetUnreads(initData.unreads, ctx),
-      writers.length > 0
-        ? db.insertChannelPerms(initData.channelPerms, ctx)
-        : null,
+      db.insertChannelPerms(initData.channelPerms, ctx),
     ]);
   });
 };


### PR DESCRIPTION
Fixes TLON-2064 by updating the logic around channel join updates on the channel subscription.

Also fixes an issue with initial sync if the ship doesn't know about any channels with writer roles (don't attempt to update unless we actually have something to insert, otherwise we'll fail because we're trying to insert nothing).

Attempted to handle channel leaves, but it looks like there might be a backend issue with leaving channels right now. Chatting with hunter about it.