### PR TITLE
native: fix weird unread banner in gallery channels

### DIFF
--- a/apps/tlon-mobile/src/fixtures/ChannelDivider.fixture.tsx
+++ b/apps/tlon-mobile/src/fixtures/ChannelDivider.fixture.tsx
@@ -7,14 +7,14 @@ const posts = createFakePosts(100);
 
 export default (
   <FixtureWrapper fillWidth={true} verticalAlign="center">
-    <ChannelDivider timestamp={Date.now()} unreadCount={0} />
+    <ChannelDivider index={0} timestamp={Date.now()} unreadCount={0} />
     <ChatMessage
       showAuthor={true}
       showReplies={true}
       currentUserId="~solfer-magfed"
       post={posts[0]}
     ></ChatMessage>
-    <ChannelDivider timestamp={Date.now()} unreadCount={3} />
+    <ChannelDivider index={0} timestamp={Date.now()} unreadCount={3} />
     <ChatMessage
       currentUserId="~solfer-magfed"
       post={posts[1]}

--- a/packages/ui/src/components/Channel/ChannelDivider.tsx
+++ b/packages/ui/src/components/Channel/ChannelDivider.tsx
@@ -2,6 +2,7 @@ import * as db from '@tloncorp/shared/dist/db';
 import { isToday, makePrettyDay } from '@tloncorp/shared/dist/logic';
 import * as store from '@tloncorp/shared/dist/store';
 import { useCallback, useMemo } from 'react';
+import { useWindowDimensions } from 'tamagui';
 
 import { SizableText, View, XStack } from '../../core';
 
@@ -10,6 +11,7 @@ export function ChannelDivider({
   unreadCount,
   isFirstPostOfDay,
   channelInfo,
+  index,
 }: {
   timestamp: number;
   unreadCount: number;
@@ -18,12 +20,14 @@ export function ChannelDivider({
     id: string;
     type: db.ChannelType;
   };
+  index: number;
 }) {
   const color = unreadCount ? '$positiveActionText' : '$border';
   const hideTime = unreadCount && isToday(timestamp) && !isFirstPostOfDay;
   const time = useMemo(() => {
     return makePrettyDay(new Date(timestamp));
   }, [timestamp]);
+  const { width } = useWindowDimensions();
 
   // for now, trigger a simple delayed read when the unread divider is displayed
   const handleLayout = useCallback(() => {
@@ -32,8 +36,28 @@ export function ChannelDivider({
     }
   }, [channelInfo, unreadCount]);
 
+  const isEven = index % 2 === 0;
+
   return (
-    <XStack alignItems="center" padding="$l" onLayout={handleLayout}>
+    <XStack
+      marginRight={
+        channelInfo?.type === 'gallery'
+          ? !isEven
+            ? 0
+            : -(width / 2)
+          : undefined
+      }
+      marginLeft={
+        channelInfo?.type === 'gallery'
+          ? isEven
+            ? 0
+            : -(width / 2)
+          : undefined
+      }
+      alignItems="center"
+      padding="$l"
+      onLayout={handleLayout}
+    >
       <View width={'$2xl'} flex={1} height={1} backgroundColor={color} />
       <View
         paddingHorizontal="$m"
@@ -50,7 +74,7 @@ export function ChannelDivider({
           {!hideTime ? `${time}` : null}
           {!hideTime && unreadCount ? ' • ' : null}
           {unreadCount
-            ? `${unreadCount} new message${unreadCount === 1 ? '' : 's'} below`
+            ? `${unreadCount} new message${unreadCount === 1 ? '' : 's'} ${channelInfo?.type === 'gallery' ? 'above' : 'below'}`
             : null}
         </SizableText>
       </View>

--- a/packages/ui/src/components/Channel/Scroller.tsx
+++ b/packages/ui/src/components/Channel/Scroller.tsx
@@ -1,5 +1,6 @@
 import { createDevLogger } from '@tloncorp/shared/dist';
 import * as db from '@tloncorp/shared/dist/db';
+import { Post } from '@tloncorp/shared/dist/db';
 import {
   extractContentTypesFromPost,
   isSameDay,
@@ -112,26 +113,55 @@ export default function Scroller({
   hasNewerPosts?: boolean;
   hasOlderPosts?: boolean;
 }) {
-  const filteredPosts = useMemo(
-    () =>
-      posts?.filter((post) => {
-        const { blocks, inlines, references } =
-          extractContentTypesFromPost(post);
+  const filteredPosts = useMemo(() => {
+    const postsWithContent = posts?.filter((post) => {
+      const { blocks, inlines, references } = extractContentTypesFromPost(post);
 
-        if (
-          blocks.length === 0 &&
-          inlines.length === 0 &&
-          references.length === 0 &&
-          post.title === '' &&
-          post.image === ''
-        ) {
-          return false;
-        }
+      if (
+        blocks.length === 0 &&
+        inlines.length === 0 &&
+        references.length === 0 &&
+        post.title === '' &&
+        post.image === ''
+      ) {
+        return false;
+      }
 
-        return true;
-      }),
-    [posts]
-  );
+      return true;
+    });
+
+    if (!firstUnreadId || !postsWithContent || channelType !== 'gallery') {
+      return postsWithContent;
+    }
+
+    const firstUnreadIndex = postsWithContent.findIndex(
+      (post) => post.id === firstUnreadId
+    );
+
+    if (firstUnreadIndex === -1) {
+      return postsWithContent;
+    }
+
+    // if first unread is at an odd index, we don't need to add an empty post
+    if (firstUnreadIndex % 2 !== 0) {
+      return postsWithContent;
+    }
+
+    const before = postsWithContent.slice(0, firstUnreadIndex + 1);
+    const after = postsWithContent.slice(firstUnreadIndex + 1);
+    const emptyPost: Post = {
+      id: '',
+      authorId: '~zod',
+      channelId: '',
+      content: JSON.stringify([{ inline: '' }]),
+      receivedAt: 0,
+      sentAt: 0,
+      type: 'block',
+      replyCount: 0,
+    };
+
+    return [...before, emptyPost, ...after];
+  }, [firstUnreadId, posts, channelType]);
 
   const [hasPressedGoToBottom, setHasPressedGoToBottom] = useState(false);
   const flatListRef = useRef<FlatList<db.Post>>(null);
@@ -216,17 +246,27 @@ export default function Scroller({
       // this is necessary because we can't call memoized components as functions
       // (they are objects, not functions)
       const RenderItem = renderItem;
+
+      if (item.id === '' && item.type === 'block') {
+        return <View height={1} width="50%" backgroundColor="$background" />;
+      }
+
       return (
         <View onLayout={() => handleItemLayout(item, index)}>
-          {isFirstUnread ? (
+          {isFirstUnread && channelType !== 'gallery' ? (
             <ChannelDivider
               timestamp={item.receivedAt}
               unreadCount={unreadCount ?? 0}
               isFirstPostOfDay={isFirstPostOfDay}
               channelInfo={{ id: channelId, type: channelType }}
+              index={index}
             />
           ) : isFirstPostOfDay && item.type === 'chat' ? (
-            <ChannelDivider unreadCount={0} timestamp={item.receivedAt} />
+            <ChannelDivider
+              unreadCount={0}
+              timestamp={item.receivedAt}
+              index={index}
+            />
           ) : null}
           <PressableMessage
             ref={activeMessageRefs.current[item.id]}
@@ -246,6 +286,15 @@ export default function Scroller({
               onPress={onPressPost}
             />
           </PressableMessage>
+          {isFirstUnread && channelType === 'gallery' ? (
+            <ChannelDivider
+              timestamp={item.receivedAt}
+              unreadCount={unreadCount ?? 0}
+              isFirstPostOfDay={isFirstPostOfDay}
+              channelInfo={{ id: channelId, type: channelType }}
+              index={index}
+            />
+          ) : null}
         </View>
       );
     },

--- a/packages/ui/src/components/Channel/UploadedImagePreview.tsx
+++ b/packages/ui/src/components/Channel/UploadedImagePreview.tsx
@@ -14,7 +14,6 @@ export default function UploadedImagePreview({
   resetImageAttachment: () => void;
   uploading?: boolean;
 }) {
-
   return (
     <XStack
       padding="$l"


### PR DESCRIPTION
Fixes TLON-1956 by positioning the unread banner in a sane way within the gallery channel (requires creating a fake post that renders as blank next to firstUnread posts with an even index).

![Simulator Screenshot - iPhone 15 Pro - 2024-06-11 at 13 05 04](https://github.com/tloncorp/tlon-apps/assets/1221094/3ad0f29d-4a84-4e2a-8215-29796df0b042)
![Simulator Screenshot - iPhone 15 Pro - 2024-06-11 at 13 05 26](https://github.com/tloncorp/tlon-apps/assets/1221094/c2a956d9-a1f9-445f-ba28-d01ff049d9bb)
