### PR TITLE
native: better handle linked images in gallery posts

### DIFF
--- a/packages/shared/src/logic/utils.ts
+++ b/packages/shared/src/logic/utils.ts
@@ -321,7 +321,7 @@ export const textPostIsLinkedImage = (post: db.Post): boolean => {
 
   const { inlines } = extractContentTypesFromPost(post);
 
-  if (inlines.length === 2) {
+  if (inlines.length <= 2) {
     const [first] = inlines;
     if (typeof first === 'object' && 'link' in first) {
       const link = first as ub.Link;


### PR DESCRIPTION
It looks like we could have posts with inline links where the total inlines could be one rather than two, we need to account for both.

Fixes TLON-2048