### PR TITLE
native: support CalmEngine in ChatList

### DIFF
--- a/apps/tlon-mobile/src/hooks/useCalmSettings.ts
+++ b/apps/tlon-mobile/src/hooks/useCalmSettings.ts
@@ -7,8 +7,5 @@ export const useCalmSettings = () => {
   const calmSettingsQuery = store.useCalmSettings({
     userId: currentUserId,
   });
-
-  console.log(calmSettingsQuery.data);
-
   return { calmSettings: calmSettingsQuery.data ?? null } as const;
 };

--- a/apps/tlon-mobile/src/hooks/useCalmSettings.ts
+++ b/apps/tlon-mobile/src/hooks/useCalmSettings.ts
@@ -1,0 +1,14 @@
+import * as store from '@tloncorp/shared/dist/store';
+
+import { useCurrentUserId } from '../hooks/useCurrentUser';
+
+export const useCalmSettings = () => {
+  const currentUserId = useCurrentUserId();
+  const calmSettingsQuery = store.useCalmSettings({
+    userId: currentUserId,
+  });
+
+  console.log(calmSettingsQuery.data);
+
+  return { calmSettings: calmSettingsQuery.data ?? null } as const;
+};

--- a/apps/tlon-mobile/src/screens/ChatListScreen.tsx
+++ b/apps/tlon-mobile/src/screens/ChatListScreen.tsx
@@ -4,6 +4,7 @@ import * as db from '@tloncorp/shared/dist/db';
 import * as logic from '@tloncorp/shared/dist/logic';
 import * as store from '@tloncorp/shared/dist/store';
 import {
+  CalmProvider,
   ChatList,
   ChatOptionsSheet,
   ContactsProvider,
@@ -19,6 +20,7 @@ import ContextMenu from 'react-native-context-menu-view';
 
 import AddGroupSheet from '../components/AddGroupSheet';
 import { TLON_EMPLOYEE_GROUP } from '../constants';
+import { useCalmSettings } from '../hooks/useCalmSettings';
 import * as featureFlags from '../lib/featureFlags';
 import NavBar from '../navigation/NavBarView';
 import type { HomeStackParamList } from '../types';
@@ -146,72 +148,76 @@ export default function ChatListScreen(
     identifyTlonEmployee();
   }
 
+  const { calmSettings } = useCalmSettings();
+
   return (
-    <ContactsProvider contacts={contacts ?? []}>
-      <View backgroundColor="$background" flex={1}>
-        <ScreenHeader title={isFetchingInitData ? 'Loading…' : 'Channels'} />
-        {chats && (chats.unpinned.length || !isFetchingInitData) ? (
-          <ChatList
-            pinned={resolvedChats.pinned}
-            unpinned={resolvedChats.unpinned}
-            pendingChats={resolvedChats.pendingChats}
-            onLongPressItem={onLongPressItem}
-            onPressItem={onPressChat}
-          />
-        ) : null}
-        <View
-          zIndex={50}
-          position="absolute"
-          bottom="$s"
-          alignItems="center"
-          width={'100%'}
-          pointerEvents="box-none"
-        >
-          <ContextMenu
-            dropdownMenuMode={true}
-            actions={[
-              { title: 'Create or join a group' },
-              { title: 'Start a direct message' },
-            ]}
-            onPress={(event) => {
-              const { index } = event.nativeEvent;
-              if (index === 0) {
-                setAddGroupOpen(true);
-              }
-              if (index === 1) {
-                setStartDmOpen(true);
-              }
-            }}
-          >
-            <FloatingActionButton
-              icon={<Icon type="Add" size="$s" marginRight="$s" />}
-              label={'Add'}
-              onPress={() => {}}
+    <CalmProvider calmSettings={calmSettings}>
+      <ContactsProvider contacts={contacts ?? []}>
+        <View backgroundColor="$background" flex={1}>
+          <ScreenHeader title={isFetchingInitData ? 'Loading…' : 'Channels'} />
+          {chats && (chats.unpinned.length || !isFetchingInitData) ? (
+            <ChatList
+              pinned={resolvedChats.pinned}
+              unpinned={resolvedChats.unpinned}
+              pendingChats={resolvedChats.pendingChats}
+              onLongPressItem={onLongPressItem}
+              onPressItem={onPressChat}
             />
-          </ContextMenu>
+          ) : null}
+          <View
+            zIndex={50}
+            position="absolute"
+            bottom="$s"
+            alignItems="center"
+            width={'100%'}
+            pointerEvents="box-none"
+          >
+            <ContextMenu
+              dropdownMenuMode={true}
+              actions={[
+                { title: 'Create or join a group' },
+                { title: 'Start a direct message' },
+              ]}
+              onPress={(event) => {
+                const { index } = event.nativeEvent;
+                if (index === 0) {
+                  setAddGroupOpen(true);
+                }
+                if (index === 1) {
+                  setStartDmOpen(true);
+                }
+              }}
+            >
+              <FloatingActionButton
+                icon={<Icon type="Add" size="$s" marginRight="$s" />}
+                label={'Add'}
+                onPress={() => {}}
+              />
+            </ContextMenu>
+          </View>
+          <ChatOptionsSheet
+            open={longPressedItem !== null}
+            onOpenChange={handleChatOptionsOpenChange}
+            channel={longPressedItem ?? undefined}
+          />
+          <StartDmSheet
+            goToDm={goToDm}
+            open={startDmOpen}
+            onOpenChange={handleDmOpenChange}
+          />
+          <AddGroupSheet
+            open={addGroupOpen}
+            onOpenChange={handleAddGroupOpenChange}
+            onCreatedGroup={handleGroupCreated}
+          />
+          <GroupPreviewSheet
+            open={selectedGroup !== null}
+            onOpenChange={handleGroupPreviewSheetOpenChange}
+            group={selectedGroup ?? undefined}
+          />
         </View>
-        <ChatOptionsSheet
-          open={longPressedItem !== null}
-          onOpenChange={handleChatOptionsOpenChange}
-          channel={longPressedItem ?? undefined}
-        />
-        <StartDmSheet
-          goToDm={goToDm}
-          open={startDmOpen}
-          onOpenChange={handleDmOpenChange}
-        />
-        <AddGroupSheet
-          open={addGroupOpen}
-          onOpenChange={handleAddGroupOpenChange}
-          onCreatedGroup={handleGroupCreated}
-        />
-        <GroupPreviewSheet
-          open={selectedGroup !== null}
-          onOpenChange={handleGroupPreviewSheetOpenChange}
-          group={selectedGroup ?? undefined}
-        />
-      </View>
-      <NavBar navigation={props.navigation} />
-    </ContactsProvider>
+        <NavBar navigation={props.navigation} />
+      </ContactsProvider>
+    </CalmProvider>
   );
 }

--- a/packages/ui/src/components/Avatar.tsx
+++ b/packages/ui/src/components/Avatar.tsx
@@ -2,7 +2,7 @@ import * as db from '@tloncorp/shared/dist/db';
 import { ComponentProps, useMemo } from 'react';
 import { getTokenValue, styled } from 'tamagui';
 
-import { useCalm } from '../contexts';
+import { useCalm } from '../contexts/calm';
 import { Image, View } from '../core';
 import { useSigilColors } from '../utils/colorUtils';
 import UrbitSigil from './UrbitSigil';
@@ -27,10 +27,12 @@ export function Avatar({
       {...props}
       // @ts-expect-error custom color
       backgroundColor={
-        contact?.avatarImage ? 'transparent' : colors.backgroundColor
+        contact?.avatarImage && !disableAvatars
+          ? 'transparent'
+          : colors.backgroundColor
       }
     >
-      {contact?.avatarImage && !disableAvatars ? (
+      {!disableAvatars && contact?.avatarImage ? (
         <Image
           source={{
             uri: contact.avatarImage,

--- a/packages/ui/src/components/GroupListItem/GroupListItemContent.tsx
+++ b/packages/ui/src/components/GroupListItem/GroupListItemContent.tsx
@@ -1,7 +1,8 @@
 import type * as db from '@tloncorp/shared/dist/db';
 import { useMemo } from 'react';
 
-import { View, XStack } from '../../core';
+import { useCalm } from '../../contexts/calm';
+import { XStack } from '../../core';
 import { Badge } from '../Badge';
 import ContactName from '../ContactName';
 import { Icon } from '../Icon';
@@ -13,6 +14,8 @@ export default function GroupListItemContent({
   onLongPress,
   ...props
 }: ListItemProps<db.Group>) {
+  const { disableAvatars } = useCalm();
+
   const { isPending, statusDisplay, isErrored } = useMemo(
     () => getDisplayInfo(model),
     [model]
@@ -28,13 +31,17 @@ export default function GroupListItemContent({
       <ListItem.Icon
         fallbackText={model.title?.[0]}
         backgroundColor={
-          model.iconImageColor
-            ? model.iconImageColor
-            : model.iconImage
-              ? 'transparent'
-              : 'unset'
+          disableAvatars
+            ? '$secondaryBackground'
+            : model.iconImageColor
+              ? model.iconImageColor
+              : model.iconImage
+                ? 'transparent'
+                : '$secondaryBackground'
         }
-        imageUrl={model.iconImage ?? undefined}
+        imageUrl={
+          !disableAvatars && model.iconImage ? model.iconImage : undefined
+        }
       />
       <ListItem.MainContent>
         <ListItem.Title>{model.title}</ListItem.Title>

--- a/packages/ui/src/utils/channelUtils.tsx
+++ b/packages/ui/src/utils/channelUtils.tsx
@@ -3,8 +3,19 @@ import { useMemberRoles } from '@tloncorp/shared/dist/store';
 import { useMemo } from 'react';
 
 import type { IconType } from '../components/Icon';
+import { useCalm } from '../contexts/calm';
+
+export function useChannelMemberName(member: db.ChatMember) {
+  const { disableNicknames } = useCalm();
+  if (disableNicknames) {
+    return member.contactId;
+  }
+  return member.contact?.nickname ? member.contact.nickname : member.contactId;
+}
 
 export function getChannelTitle(channel: db.Channel) {
+  const getChannelMemberName = useChannelMemberName;
+
   if (channel.type === 'dm') {
     const member = channel.members?.[0];
     if (!member) {
@@ -18,10 +29,6 @@ export function getChannelTitle(channel: db.Channel) {
   } else {
     return channel.title ?? 'Untitled channel';
   }
-}
-
-export function getChannelMemberName(member: db.ChatMember) {
-  return member.contact?.nickname ? member.contact.nickname : member.contactId;
 }
 
 export function isDmChannel(channel: db.Channel): boolean {


### PR DESCRIPTION
- Adds a useCalmSettings hook we can use outside of the channel context
- Wraps ChatListScreen in a CalmProvider (and gets the Calm settings using said hook)
- Disables group icons in GroupListItemContent if disableAvatars is set
- Changes the getChannelTitle util to use a useChannelMemberName hook, which respects disableNicknames (and gives us bare @ps for DMs in ChatList)

Calm disabled:
![Screenshot 2024-06-11 at 3 44 49 PM](https://github.com/tloncorp/tlon-apps/assets/748181/5c661e0d-d883-4791-92d2-9faefd742a3b)

Calm enabled:
![Screenshot 2024-06-11 at 3 45 39 PM](https://github.com/tloncorp/tlon-apps/assets/748181/267fe525-6d26-4557-86bb-9c823663b711)

Fixes TLON-2070
