### PR TITLE
native: remove cursor from useChannelPosts query key

### DIFF
--- a/packages/shared/src/store/useChannelPosts.ts
+++ b/packages/shared/src/store/useChannelPosts.ts
@@ -65,7 +65,7 @@ export const useChannelPosts = (options: UseChanelPostsParams) => {
       return secondResult ?? [];
     },
     queryKey: [
-      ['channelPosts', options.channelId, options.cursor, mountTime],
+      ['channelPosts', options.channelId, mountTime],
       useKeyFromQueryDeps(db.getChannelPosts, options),
     ],
     getNextPageParam: (


### PR DESCRIPTION
Fixes TLON-2046 by removing the cursor param from the query key in useChannelPosts. Having the cursor in there forced the query to refetch every time we got a new message, so the user would briefly see the channel reload (since the data would be reset each time). 