### PR TITLE
activity: feed endpoints

### DIFF
--- a/desk/app/activity.hoon
+++ b/desk/app/activity.hoon
@@ -400,8 +400,23 @@
   ^-  [(unit event:a) ? out]
   ?:  =(limit.acc 0)  [~ & acc]
   :-  ~   :-  |
-  ?.  ?=(?(%post %reply %dm-post %dm-reply) -<.event)  acc
   =/  =source:a  (determine-source -.event)
+  ?.  ?=(?(%post %reply %dm-post %dm-reply) -<.event)  acc
+  ::  if it's a channel we don't host, we don't care
+  ?:  ?&  ?=(%channel -.source)
+          !=(ship.nest.source our.bowl)
+      ==
+    acc
+  ::  if it's a thread make sure it's one we care about
+  ?:  ?&  ?=(?(%reply %dm-reply) -<.event)
+          !notified.event
+      ==
+    acc
+  ::  if it's a DM make sure we haven't muted it
+  ?:  ?&  ?=(%dm-post -<.event)
+          !notified.event
+      ==
+    acc
   =-  acc(limit (sub limit.acc 1), happenings (snoc happenings.acc -))
   =/  is-mention
     ?-  -<.event
@@ -457,7 +472,7 @@
   ^-  [(unit event:a) ? out]
   ?:  =(limit.acc 0)  [~ & acc]
   :-  ~   :-  |
-  ?.  ?=(?(%reply %dm-reply) -<.event)  acc
+  ?.  &(?=(?(%reply %dm-reply) -<.event) notified.event)  acc
   =/  is-mention
     ?-  -<.event
       %reply  mention.event

--- a/desk/app/activity.hoon
+++ b/desk/app/activity.hoon
@@ -309,9 +309,14 @@
       [%x %all ~]
     ``activity-stream+!>(stream:base)
   ::
-      [%x %all start=@ count=@ ~]
+      [%x %all count=@ start=?(~ [u=@ ~])]
+    =/  start
+      ?~  start.pole  now.bowl
+      ?^  tim=(slaw %ud u.start.pole)  u.tim
+      (slav %da u.start.pole)
+    =/  count  (slav %ud count.pole)
     =-  ``activity-stream+!>((gas:on-event:a *stream:a -))
-    (tab:on-event:a stream:base `(slav %da start.pole) (slav %ud count.pole))
+    (bat:ex-event:a stream:base `start count)
   ::
       [%x %feed %init count=@ ~]
     =-  ``activity-feed-init+!>(-)

--- a/desk/app/activity.hoon
+++ b/desk/app/activity.hoon
@@ -430,7 +430,6 @@
       ==
     acc(times new-times)
   :-  new-times
-  :-  (sub limit.acc 1)
   =/  mention=(unit activity-bundle:a)
     ?.  |(?=(%all type) ?=(%mentions type))  ~
     =/  is-mention
@@ -443,7 +442,7 @@
     ?.  is-mention  ~
     `[source time ~[[time event]]]
   ?^  mention
-    [(snoc happenings.acc u.mention) collapsed.acc]
+    [(sub limit.acc 1) (snoc happenings.acc u.mention) collapsed.acc]
   =/  care
     ?|  ?=(%all type)
         &(?=(%replies type) ?=(?(%reply %dm-reply) -<.event))
@@ -452,11 +451,11 @@
   ?.  ?&  care
           !(~(has in collapsed.acc) time)
       ==
-    [happenings collapsed]:acc
+    [limit happenings collapsed]:acc
   =/  top  (top-messages source stream:(get-index source))
   =/  collapsed
     (~(gas in collapsed.acc) (turn top |=([=time-id:a *] time-id)))
-  [(snoc happenings.acc [source time top]) collapsed]
+  [(sub limit.acc 1) (snoc happenings.acc [source time top]) collapsed]
   +$  out
     $:  times=(map source:a time-id:a)
         limit=@ud

--- a/desk/lib/activity-json.hoon
+++ b/desk/lib/activity-json.hoon
@@ -144,6 +144,13 @@
         children+?~(children.sum ~ (activity u.children.sum))
     ==
   ::
+  ++  activity-bundle
+    |=  ab=activity-bundle:a
+    %-  pairs
+    :~  source+(source source.ab)
+        latest+s+(scot %ud latest.ab)
+        events+a+(turn events.ab time-event)
+    ==
   ++  event
     |=  e=event:a
     %-  pairs
@@ -226,7 +233,7 @@
   ++  time-event
     |=  te=time-event:a
     %-  pairs
-    :~  time+(time time.te)
+    :~  time+s+(scot %ud time.te)
         event+(event event.te)
     ==
   +|  %collections
@@ -276,6 +283,10 @@
     %+  turn  ~(tap by vm)
     |=  [e=event-type:a v=volume:a]
     [e (volume v)]
+  ++  feed
+    |=  f=feed:a
+    a+(turn f activity-bundle)
+  ::
   +|  %updates
   ++  update
     |=  u=update:a

--- a/desk/lib/activity-json.hoon
+++ b/desk/lib/activity-json.hoon
@@ -148,6 +148,7 @@
     |=  ab=activity-bundle:a
     %-  pairs
     :~  source+(source source.ab)
+        source-key+s+(string-source source.ab)
         latest+s+(scot %ud latest.ab)
         events+a+(turn events.ab time-event)
     ==
@@ -299,10 +300,12 @@
     ==
   ::
   ++  added
-    |=  ad=time-event:a
+    |=  [src=source:a te=time-event:a]
     %-  pairs
-    :~  time+(time time.ad)
-        event+(event event.ad)
+    :~  source+(source src)
+        source-key+s+(string-source src)
+        time+(time time.te)
+        event+(event event.te)
     ==
   ::
   ++  read

--- a/desk/lib/mark-warmer.hoon
+++ b/desk/lib/mark-warmer.hoon
@@ -35,4 +35,7 @@
 /$  act-sum     %activity-summary     %json
 /$  act-vol     %activity-settings    %json
 /$  act-evt     %activity-event       %json
+/$  act-stream  %activity-stream      %json
+/$  act-feed    %activity-feed        %json
+/$  act-fe-it   %activity-feed-init   %json
 ~

--- a/desk/mar/activity/feed-init.hoon
+++ b/desk/mar/activity/feed-init.hoon
@@ -1,0 +1,20 @@
+/-  a=activity
+/+  aj=activity-json
+|_  [all=feed:a mentions=feed:a replies=feed:a]
+++  grad  %noun
+++  grow
+  |%
+  ++  noun  [all mentions replies]
+  ++  json
+    =,  enjs:format
+    %-  pairs
+    :~  all+(feed:enjs:aj all)
+        mentions+(feed:enjs:aj mentions)
+        replies+(feed:enjs:aj replies)
+    ==
+  --
+++  grab
+  |%
+  ++  noun  [all=feed:a mentions=feed:a replies=feed:a]
+  --
+--

--- a/desk/mar/activity/feed.hoon
+++ b/desk/mar/activity/feed.hoon
@@ -1,0 +1,14 @@
+/-  a=activity
+/+  aj=activity-json
+|_  =feed:a
+++  grad  %noun
+++  grow
+  |%
+  ++  noun  feed
+  ++  json  (feed:enjs:aj feed)
+  --
+++  grab
+  |%
+  ++  noun  feed:a
+  --
+--

--- a/desk/sur/activity.hoon
+++ b/desk/sur/activity.hoon
@@ -57,7 +57,7 @@
 ::    $adjust: the volume of a source was adjusted
 ::
 +$  update
-  $%  [%add time-event]
+  $%  [%add =source time-event]
       [%del =source]
       [%read =source =activity-summary]
       [%adjust =source volume-map=(unit volume-map)]

--- a/desk/sur/activity.hoon
+++ b/desk/sur/activity.hoon
@@ -16,6 +16,8 @@
 +$  volume-map
   $~  default-volumes
   (map event-type volume)
+::  $feed: a set of grouped events
++$  feed  (list activity-bundle)
 +|  %actions
 ::  $action: how to interact with our activity stream
 ::
@@ -163,6 +165,12 @@
   ==
 +$  unread-point  [message-key count=@ud notify=_|]
 +$  volume  [unreads=? notify=?]
++$  activity-bundle
+  $:  =source
+      latest=time
+      events=(list time-event)
+  ==
+::
 +|  %primitives
 +$  whom
   $%  [%ship p=ship]

--- a/packages/shared/src/urbit/activity.ts
+++ b/packages/shared/src/urbit/activity.ts
@@ -173,6 +173,13 @@ export interface ActivitySummary {
   children: Activity | null;
 }
 
+export interface ActivityBundle {
+  source: Source;
+  latest: string;
+  events: ActivityEvent[];
+  'source-key': string;
+}
+
 export type Activity = Record<string, ActivitySummary>;
 
 export type Indices = Record<string, IndexData>;
@@ -180,6 +187,8 @@ export type Indices = Record<string, IndexData>;
 export type Stream = Record<string, ActivityEvent>;
 
 export type VolumeMap = Partial<Record<ExtendedEventType, Volume>>;
+
+export type ActivityFeed = ActivityBundle[];
 
 export type ReadAction =
   | { event: ActivityIncomingEvent }
@@ -218,8 +227,10 @@ export interface ActivityVolumeUpdate {
 
 export interface ActivityAddUpdate {
   add: {
+    source: Source;
     time: string;
     event: ActivityEvent;
+    'source-key': string;
   };
 }
 


### PR DESCRIPTION
This adds two endpoints specifically for the activity tab with pagination.

`/activity/feed/init/{count}.json` gives latest items limited by count for each tab

`/activity/feed/{type}/{count}/{start}?.json`
- count: `@ud` representing number of items you wish to receive
- start: `@ud` or `@da` optional parameter, will only get events before this time
- type: `all | mentions | replies`
  - `all`: any post, reply, dm, or dm reply that I was notified for
  - `mentions`: any message that mentions me
  - `threads`: any replies for which I was notified for

Also updates the `add` update to include source and the stringified form of source.

Fixes TLON-2036

PR Checklist
- [X] Includes changes to desk files
- [X] Describes how you tested the PR locally (test ship vs livenet)
- [ ] If a new feature, includes automated tests
- [X] Comments added anywhere logic may be confusing without context