### PR TITLE
native: small sync fixes

### DIFF
--- a/apps/tlon-mobile/src/screens/ChannelScreen.tsx
+++ b/apps/tlon-mobile/src/screens/ChannelScreen.tsx
@@ -68,6 +68,8 @@ export default function ChannelScreen(props: ChannelScreenProps) {
       (unread.countWithoutThreads ?? 0) > 0 &&
       unread?.firstUnreadPostId;
     return selectedPostId || firstUnreadId;
+    // We only want this to rerun when the channel is loaded for the first time.
+    // eslint-disable-next-line
   }, [!!channel]);
   const {
     posts,

--- a/apps/tlon-mobile/src/screens/ChannelScreen.tsx
+++ b/apps/tlon-mobile/src/screens/ChannelScreen.tsx
@@ -9,7 +9,7 @@ import {
 } from '@tloncorp/shared/dist/store';
 import { Story } from '@tloncorp/shared/dist/urbit';
 import { Channel, ChannelSwitcherSheet } from '@tloncorp/ui';
-import React, { useCallback } from 'react';
+import React, { useCallback, useMemo } from 'react';
 
 import type { HomeStackParamList } from '../types';
 import { useChannelContext } from './useChannelContext';
@@ -58,12 +58,17 @@ export default function ChannelScreen(props: ChannelScreenProps) {
   });
 
   const selectedPostId = props.route.params.selectedPostId;
-  const unread = channel?.unread;
-  const firstUnreadId =
-    unread &&
-    (unread.countWithoutThreads ?? 0) > 0 &&
-    unread?.firstUnreadPostId;
-  const cursor = selectedPostId || firstUnreadId;
+  const cursor = useMemo(() => {
+    if (!channel) {
+      return undefined;
+    }
+    const unread = channel?.unread;
+    const firstUnreadId =
+      unread &&
+      (unread.countWithoutThreads ?? 0) > 0 &&
+      unread?.firstUnreadPostId;
+    return selectedPostId || firstUnreadId;
+  }, [!!channel]);
   const {
     posts,
     query: postsQuery,

--- a/packages/shared/src/db/queries.ts
+++ b/packages/shared/src/db/queries.ts
@@ -1309,6 +1309,7 @@ export const getChannelPosts = createReadQuery(
         .where(
           and(
             eq($posts.channelId, channelId),
+            not(eq($posts.type, 'reply')),
             gte($posts.id, window.oldestPostId),
             lte($posts.id, window.newestPostId)
           )

--- a/packages/shared/src/db/query.ts
+++ b/packages/shared/src/db/query.ts
@@ -167,6 +167,7 @@ export async function withCtxOrDefault<T>(
     }
     logger.log(`${meta.label}:trigger:${listDebugLabel(pendingEffects)}`);
     queryClient.invalidateQueries({
+      fetchStatus: 'idle',
       predicate: (query) => {
         const tableKey = query.queryKey[1];
         const shouldInvalidate =

--- a/packages/shared/src/store/postActions.ts
+++ b/packages/shared/src/store/postActions.ts
@@ -34,7 +34,7 @@ export async function sendPost({
     posts: [cachePost],
     older: sync.channelCursors.get(channel.id),
   });
-  sync.channelCursors.set(channel.id, cachePost.id);
+  sync.updateChannelCursor(channel.id, cachePost.id);
   try {
     await api.sendPost({
       channelId: channel.id,

--- a/packages/shared/src/store/sync.ts
+++ b/packages/shared/src/store/sync.ts
@@ -46,14 +46,7 @@ export const syncLatestPosts = async () => {
     ])
   );
   const allPosts = result.flatMap((set) => set.map((p) => p.latestPost));
-  for (const post of allPosts) {
-    if (
-      !channelCursors.has(post.channelId) ||
-      post.id > channelCursors.get(post.channelId)!
-    ) {
-      channelCursors.set(post.channelId, post.id);
-    }
-  }
+  allPosts.forEach((p) => updateChannelCursor(p.channelId, p.id));
   await db.insertLatestPosts(allPosts);
 };
 


### PR DESCRIPTION
- Prevents replies from showing up in main scroll
- Fixes situation where conversations could become stuck when loading older posts
- Fixes issue where replies confused our channel cursor tracking, which could cause new posts to fail to appear
- Prevents channel cursor from changing after initially set, preventing some extraneous refreshes

Fixes TLON-2050