### PR TITLE
unreads: make all sources fully reactive to children

### DIFF
--- a/apps/tlon-web/src/components/Leap/useLeap.tsx
+++ b/apps/tlon-web/src/components/Leap/useLeap.tsx
@@ -305,7 +305,7 @@ export default function useLeap() {
 
       // so are unread groups, but just a little
       const groupUnread = getGroupUnread(groupFlag);
-      if (groupUnread.status === 'unread') {
+      if (groupUnread.combined.status === 'unread') {
         newScore += 2;
       }
 
@@ -405,7 +405,7 @@ export default function useLeap() {
 
       // prefer unreads as well
       const groupUnread = getGroupUnread(groupFlag);
-      if (groupUnread.status === 'unread') {
+      if (groupUnread.combined.status === 'unread') {
         newScore += 5;
       }
 

--- a/apps/tlon-web/src/dms/DMOptions.tsx
+++ b/apps/tlon-web/src/dms/DMOptions.tsx
@@ -72,11 +72,9 @@ export default function DmOptions({
   const isDMorMultiDm = useIsDmOrMultiDm(whom);
   const unread = !chatUnread
     ? { status: 'read', count: 0, notify: false }
-    : whomIsFlag(whom)
-      ? chatUnread
-      : chatUnread.combined;
-  const hasNotify = !!chatUnread?.combined.notify;
-  const hasActivity = pending || unread.status === 'unread' || hasNotify;
+    : chatUnread.combined;
+  const hasNotify = unread.notify;
+  const hasActivity = pending || unread.status === 'unread';
   const key = whomIsFlag(whom) ? `chat/${whom}` : whom;
   const { mutate: leaveChat } = useLeaveMutation();
   const { mutateAsync: addPin } = useAddPinMutation();
@@ -261,7 +259,7 @@ export default function DmOptions({
               <button
                 className={cn(
                   'default-focus absolute left-1/2 top-1/2 -translate-x-1/2 -translate-y-1/2 rounded-lg p-0.5 transition-opacity focus-within:opacity-100 hover:opacity-100 group-focus-within:opacity-100 group-hover:opacity-100',
-                  hasNotify && 'text-blue',
+                  hasActivity && hasNotify && 'text-blue',
                   isOpen || alwaysShowEllipsis ? 'opacity:100' : 'opacity-0'
                 )}
                 aria-label="Open Message Options"

--- a/apps/tlon-web/src/logic/channel.ts
+++ b/apps/tlon-web/src/logic/channel.ts
@@ -111,7 +111,7 @@ function channelUnread(nest: string, unreads: Record<string, Unread>) {
     return false;
   }
 
-  return unread.status === 'unread' || unread.combined.notify;
+  return unread.combined.status === 'unread';
 }
 
 export function useCheckChannelUnread() {


### PR DESCRIPTION
Previously only DMs and groups were fully reactive to their children, meaning that we took into account the client-side unread status of each child as a sum, so if a child was seen and it was the last source of unreads, the dot would go away. However, we weren't accounting for notify in the channel case which we always want to badge with a blue dot, but when I fixed that in tloncorp/tlon-apps#3589 this made blue dots stickier because channels weren't fully reactive to children.

This PR fixes TLON-2072 by making all sources fully reactive to their children's statuses.

PR Checklist
- [ ] Includes changes to desk files
- [ ] Describes how you tested the PR locally (test ship vs livenet)
- [ ] If a new feature, includes automated tests
- [X] Comments added anywhere logic may be confusing without context