### PR TITLE
native: "sticky" section headers on ChatListScreen

### DIFF
--- a/apps/tlon-mobile/src/screens/ChatListScreen.tsx
+++ b/apps/tlon-mobile/src/screens/ChatListScreen.tsx
@@ -33,6 +33,7 @@ type ChatListScreenProps = NativeStackScreenProps<
 export default function ChatListScreen(
   props: ChatListScreenProps & { contacts: db.Contact[] }
 ) {
+  const [screenTitle, setScreenTitle] = useState('Home');
   {
     /* FIXME: Disabling long-press on ChatListScreen items for now */
   }
@@ -158,11 +159,15 @@ export default function ChatListScreen(
 
   const { calmSettings } = useCalmSettings();
 
+  const handleSectionChange = useCallback((title: string) => {
+    setScreenTitle(title);
+  }, []);
+
   return (
     <CalmProvider calmSettings={calmSettings}>
       <ContactsProvider contacts={contacts ?? []}>
         <View backgroundColor="$background" flex={1}>
-          <ScreenHeader title={isFetchingInitData ? 'Loading…' : 'Channels'} />
+          <ScreenHeader title={isFetchingInitData ? 'Loading…' : screenTitle} />
           {chats && (chats.unpinned.length || !isFetchingInitData) ? (
             <ChatList
               pinned={resolvedChats.pinned}
@@ -171,6 +176,7 @@ export default function ChatListScreen(
               // FIXME: Disabling long-press on ChatListScreen items for now
               // onLongPressItem={onLongPressItem}
               onPressItem={onPressChat}
+              onSectionChange={handleSectionChange}
             />
           ) : null}
           <View

--- a/packages/ui/src/components/ChatList.tsx
+++ b/packages/ui/src/components/ChatList.tsx
@@ -22,10 +22,6 @@ import { SwipableChatRow } from './SwipableChatListItem';
 
 type ListItem = db.Channel | db.Group;
 
-function isValidListItem(item: any): item is ListItem {
-  return item && typeof item === 'object' && 'id' in item;
-}
-
 export function ChatList({
   pinned,
   unpinned,
@@ -127,13 +123,22 @@ export function ChatList({
     }
   ).current;
 
+  const getChannelKey = useCallback((item: ListItem) => {
+    if (!item || typeof item !== 'object' || !item.id) {
+      return 'invalid-item';
+    }
+
+    if (logic.isGroup(item)) {
+      return item.id;
+    }
+    return `${item.id}-${item.pin?.itemId ?? ''}`;
+  }, []);
+
   return (
     <SectionList
       sections={data}
       contentContainerStyle={contentContainerStyle}
-      keyExtractor={(item) =>
-        isValidListItem(item) ? getChannelKey(item) : 'invalid-item'
-      }
+      keyExtractor={getChannelKey}
       stickySectionHeadersEnabled={false}
       renderItem={renderItem}
       maxToRenderPerBatch={11}
@@ -146,12 +151,6 @@ export function ChatList({
     />
   );
 }
-
-function getChannelKey(item: ListItem) {
-  if (logic.isGroup(item)) return item.id;
-  return item.id + item.pin?.itemId ?? '';
-}
-
 const ChatListItem = React.memo(function ChatListItemComponent({
   model,
   onPress,


### PR DESCRIPTION
From the department of "things nobody asked for."

- Updates the ChatListScreen's header to say "Home" by default.
- Changes the ChatListScreen's header text based on the user's scroll position in ChatList. Updates based on the title of the section, which could be out of view.
- Adds an isValidListItem check to filter out section headers (which aren't *technically* valid list items—the isGroup check will always fail without an ID when extracting the key).
- Resets the title to "Home" when the user has reached the top of the SectionList scroll.

Video attached.

https://github.com/tloncorp/tlon-apps/assets/748181/4aed4f12-93bd-4a5f-a102-aab3d4375648

