### PR TITLE
native: fix issue with scroller not moving to newly sent posts

### DIFF
--- a/packages/ui/src/components/Channel/Scroller.tsx
+++ b/packages/ui/src/components/Channel/Scroller.tsx
@@ -422,7 +422,7 @@ export default function Scroller({
       // we're starting at an older post and scrolling down towards newer ones,
       // as it will trigger on every new page load, causing jumping. Instead, we
       // only enable it when there's nothing newer left to load (so, for new incoming messages only).
-      autoscrollToTopThreshold: hasNewerPosts ? undefined : 0,
+      autoscrollToTopThreshold: hasNewerPosts ? 0 : undefined,
     };
   }, [hasNewerPosts]);
 


### PR DESCRIPTION
Fixes TLON-2049. Looks like this ternary was just flipped?