### PR TITLE
native: limits unread counts in ChatList to 99

### DIFF
--- a/packages/ui/src/components/ChannelListItem/index.tsx
+++ b/packages/ui/src/components/ChannelListItem/index.tsx
@@ -51,7 +51,7 @@ export default function ChannelListItem({
         <ListItem.EndContent>
           {model.lastPost && <ListItem.Time time={model.lastPost.receivedAt} />}
           <ListItem.Count opacity={model.unread?.count ? 1 : 0}>
-            {model.unread?.count ?? 0}
+            {(model.unreadCount ?? 0) > 99 ? '99+' : model.unreadCount ?? 0}
           </ListItem.Count>
         </ListItem.EndContent>
       )}

--- a/packages/ui/src/components/GroupListItem/GroupListItemContent.tsx
+++ b/packages/ui/src/components/GroupListItem/GroupListItemContent.tsx
@@ -75,7 +75,7 @@ export default function GroupListItemContent({
         <ListItem.EndContent>
           <ListItem.Time time={model.lastPostAt} />
           <ListItem.Count opacity={model.unreadCount ? 1 : 0}>
-            {model.unreadCount ?? 0}
+            {(model.unreadCount ?? 0) > 99 ? '99+' : model.unreadCount ?? 0}
           </ListItem.Count>
         </ListItem.EndContent>
       )}


### PR DESCRIPTION
Shows "99+" in the badge for DMs/groups with more than 99 unread messages in the ChatList.