### PR TITLE
native: properly track channel membership

### DIFF
--- a/packages/shared/src/api/channelsApi.ts
+++ b/packages/shared/src/api/channelsApi.ts
@@ -100,22 +100,27 @@ export const subscribeToChannelsUpdates = async (
   );
 };
 
-export function toClientChannelsInit(channels: ub.Channels) {
+export function toClientChannelsInit(
+  channels: ub.Channels,
+  readersMap: Record<string, string[]>
+) {
   return Object.entries(channels).map(([id, channel]) => {
-    return toClientChannelInit(id, channel);
+    return toClientChannelInit(id, channel, readersMap[id] ?? []);
   });
 }
 
 export type ChannelInit = {
   channelId: string;
   writers: string[];
+  readers: string[];
 };
 
 export function toClientChannelInit(
   id: string,
-  channel: ub.Channel
+  channel: ub.Channel,
+  readers: string[]
 ): ChannelInit {
-  return { channelId: id, writers: channel.perms.writers ?? [] };
+  return { channelId: id, writers: channel.perms.writers ?? [], readers };
 }
 
 export const toChannelsUpdate = (

--- a/packages/shared/src/api/groupsApi.ts
+++ b/packages/shared/src/api/groupsApi.ts
@@ -731,6 +731,18 @@ export const toGroupUpdate = (
   return { type: 'unknown' };
 };
 
+export const extractChannelReaders = (groups: ub.Groups) => {
+  const channelReaders: Record<string, string[]> = {};
+
+  Object.entries(groups).forEach(([groupId, group]) => {
+    Object.entries(group.channels).forEach(([channelId, channel]) => {
+      channelReaders[channelId] = channel.readers ?? [];
+    });
+  });
+
+  return channelReaders;
+};
+
 const extractFlaggedPosts = (
   groupId: string,
   flaggedContent?: FlaggedContent

--- a/packages/shared/src/api/initApi.ts
+++ b/packages/shared/src/api/initApi.ts
@@ -3,6 +3,7 @@ import type * as ub from '../urbit';
 import { toClientChannelsInit } from './channelsApi';
 import { toClientDms, toClientGroupDms } from './chatApi';
 import {
+  extractChannelReaders,
   toClientGroups,
   toClientGroupsFromGangs,
   toClientPinnedItems,
@@ -30,7 +31,8 @@ export const getInitData = async () => {
   });
 
   const pins = toClientPinnedItems(response.pins);
-  const channelsInit = toClientChannelsInit(response.channels);
+  const channelReaders = extractChannelReaders(response.groups);
+  const channelsInit = toClientChannelsInit(response.channels, channelReaders);
   const groups = toClientGroups(response.groups, true);
   const unjoinedGroups = toClientGroupsFromGangs(response.gangs);
   const channelUnreads = toClientUnreads(response.unreads, 'channel');

--- a/packages/shared/src/db/migrations/0000_lean_ultragirl.sql
+++ b/packages/shared/src/db/migrations/0000_lean_ultragirl.sql
@@ -1,3 +1,9 @@
+CREATE TABLE `channel_readers` (
+	`channel_id` text NOT NULL,
+	`role_id` text NOT NULL,
+	PRIMARY KEY(`channel_id`, `role_id`)
+);
+--> statement-breakpoint
 CREATE TABLE `channel_writers` (
 	`channel_id` text NOT NULL,
 	`role_id` text NOT NULL,

--- a/packages/shared/src/db/migrations/meta/0000_snapshot.json
+++ b/packages/shared/src/db/migrations/meta/0000_snapshot.json
@@ -1,9 +1,40 @@
 {
   "version": "5",
   "dialect": "sqlite",
-  "id": "6437e540-2bea-411a-ae8d-9a03afab8a6c",
+  "id": "ee04f14e-565a-47d2-9a47-e45266f326f8",
   "prevId": "00000000-0000-0000-0000-000000000000",
   "tables": {
+    "channel_readers": {
+      "name": "channel_readers",
+      "columns": {
+        "channel_id": {
+          "name": "channel_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "role_id": {
+          "name": "role_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "channel_readers_channel_id_role_id_pk": {
+          "columns": [
+            "channel_id",
+            "role_id"
+          ],
+          "name": "channel_readers_channel_id_role_id_pk"
+        }
+      },
+      "uniqueConstraints": {}
+    },
     "channel_writers": {
       "name": "channel_writers",
       "columns": {

--- a/packages/shared/src/db/migrations/meta/_journal.json
+++ b/packages/shared/src/db/migrations/meta/_journal.json
@@ -5,8 +5,8 @@
     {
       "idx": 0,
       "version": "5",
-      "when": 1716405616603,
-      "tag": "0000_redundant_lilith",
+      "when": 1718254390066,
+      "tag": "0000_lean_ultragirl",
       "breakpoints": true
     }
   ]

--- a/packages/shared/src/db/migrations/migrations.js
+++ b/packages/shared/src/db/migrations/migrations.js
@@ -1,7 +1,7 @@
 // This file is required for Expo/React Native SQLite migrations - https://orm.drizzle.team/quick-sqlite/expo
 
 import journal from './meta/_journal.json';
-import m0000 from './0000_redundant_lilith.sql';
+import m0000 from './0000_lean_ultragirl.sql';
 
   export default {
     journal,

--- a/packages/shared/src/db/queries.ts
+++ b/packages/shared/src/db/queries.ts
@@ -24,7 +24,7 @@ import {
   sql,
 } from 'drizzle-orm';
 
-import { ChannelInit } from '../api';
+import { ChannelInit, getCurrentUserId } from '../api';
 import { createDevLogger } from '../debug';
 import { appendContactIdToReplies, getCompositeGroups } from '../logic';
 import { Rank, desig } from '../urbit';
@@ -35,6 +35,7 @@ import {
   withTransactionCtx,
 } from './query';
 import {
+  channelReaders as $channelReaders,
   channelWriters as $channelWriters,
   channels as $channels,
   chatMemberGroupRoles as $chatMemberGroupRoles,
@@ -538,6 +539,23 @@ export const insertChannelPerms = createWriteQuery(
         roleId: writer,
       }))
     );
+
+    const readers = channelsInit.flatMap((chanInit) =>
+      chanInit.readers.map((reader) => ({
+        channelId: chanInit.channelId,
+        roleId: reader,
+      }))
+    );
+
+    if (readers.length > 0) {
+      return ctx.db
+        .insert($channelReaders)
+        .values(readers)
+        .onConflictDoUpdate({
+          target: [$channelReaders.channelId, $channelReaders.roleId],
+          set: conflictUpdateSetAll($channelReaders),
+        });
+    }
 
     if (writers.length === 0) {
       return;
@@ -1202,11 +1220,50 @@ export const getChannelNavSection = createReadQuery(
 export const setJoinedGroupChannels = createWriteQuery(
   'setJoinedGroupChannels',
   async ({ channelIds }: { channelIds: string[] }, ctx: QueryCtx) => {
+    const currentUserId = getCurrentUserId();
+    if (channelIds.length === 0) return;
+
+    const channels = await ctx.db.query.channels.findMany({
+      with: {
+        readerRoles: true,
+        group: {
+          with: {
+            roles: {
+              with: {
+                members: true,
+              },
+            },
+          },
+        },
+      },
+    });
+    const channelsIndex = new Map<string, Channel>();
+    for (const channel of channels) {
+      channelsIndex.set(channel.id, channel);
+    }
+
+    const channelsWhereMember = channelIds.filter((id) => {
+      const channel = channelsIndex.get(id);
+      const isOpenChannel = channel?.readerRoles?.length === 0;
+
+      const userRolesForGroup =
+        channel?.group?.roles
+          ?.filter((role) =>
+            role.members?.map((m) => m.contactId).includes(currentUserId)
+          )
+          .map((role) => role.id) ?? [];
+
+      const isClosedButCanRead = channel?.readerRoles
+        ?.map((r) => r.roleId)
+        .some((r) => userRolesForGroup.includes(r));
+      return isOpenChannel || isClosedButCanRead;
+    });
+
     logger.log('setJoinedGroupChannels', channelIds);
     return await ctx.db
       .update($channels)
       .set({
-        currentUserIsMember: inArray($channels.id, channelIds),
+        currentUserIsMember: inArray($channels.id, channelsWhereMember),
       })
       .where(isNotNull($channels.groupId));
   },

--- a/packages/shared/src/db/queries.ts
+++ b/packages/shared/src/db/queries.ts
@@ -1217,6 +1217,15 @@ export const getChannelNavSection = createReadQuery(
   ['groupNavSectionChannels']
 );
 
+/* This sets which channels the current user is a member of, which is what we key off of
+when determining channels to show in the UI. There's no direct setting for this on
+the backend. Instead we look at two things:
+   1) do you have an unreads entry for the channel?
+   2) if you do, do you have read permissions for it?
+    Read permissions are stored as an array of roles. If the array is empty, anyone
+    can read the channel. If it's not empty, we check to make sure the user has one of the
+    reader roles.
+*/
 export const setJoinedGroupChannels = createWriteQuery(
   'setJoinedGroupChannels',
   async ({ channelIds }: { channelIds: string[] }, ctx: QueryCtx) => {

--- a/packages/shared/src/db/schema.ts
+++ b/packages/shared/src/db/schema.ts
@@ -218,6 +218,7 @@ export const groupRolesRelations = relations(groupRoles, ({ one, many }) => ({
     references: [groups.id],
   }),
   writeChannels: many(channelWriters),
+  readChannels: many(channelReaders),
 }));
 
 export const chatMembers = sqliteTable(
@@ -370,6 +371,34 @@ export const groupRankBanRelations = relations(groupRankBans, ({ one }) => ({
     references: [groups.id],
   }),
 }));
+
+export const channelReaders = sqliteTable(
+  'channel_readers',
+  {
+    channelId: text('channel_id').notNull(),
+    roleId: text('role_id').notNull(),
+  },
+  (table) => {
+    return {
+      pk: primaryKey({
+        columns: [table.channelId, table.roleId],
+      }),
+    };
+  }
+);
+
+export const channelReaderRelations = relations(channelReaders, ({ one }) => {
+  return {
+    channel: one(channels, {
+      fields: [channelReaders.channelId],
+      references: [channels.id],
+    }),
+    role: one(groupRoles, {
+      fields: [channelReaders.roleId],
+      references: [groupRoles.id],
+    }),
+  };
+});
 
 export const channelWriters = sqliteTable(
   'channel_writers',
@@ -542,6 +571,7 @@ export const channelRelations = relations(channels, ({ one, many }) => ({
   threadUnreads: many(threadUnreads),
   members: many(chatMembers),
   writerRoles: many(channelWriters),
+  readerRoles: many(channelReaders),
 }));
 
 export type PostDeliveryStatus = 'pending' | 'sent' | 'failed';


### PR DESCRIPTION
Right now the way we determine if you're a member of a channel is by seeing if you have an unread for it. This is similar to what we do on web, except that web also looks to see at least one of your roles is in the _readers_ array for that channel if the _readers_ array isn't empty.

We were only tracking channel writers on mobile, not readers. This adds support for storing readers and uses a check against read entries when setting `currentUserIsMember`.

Tested by checking that channels I didn't have access to were absent after the change.

Fixes TLON-2081