### PR TITLE
native: manually update channel posts

### DIFF
--- a/apps/tlon-mobile/src/lib/nativeDb.ts
+++ b/apps/tlon-mobile/src/lib/nativeDb.ts
@@ -2,7 +2,7 @@ import type { OPSQLiteConnection } from '@op-engineering/op-sqlite';
 import { open } from '@op-engineering/op-sqlite';
 import { createDevLogger, escapeLog } from '@tloncorp/shared';
 import type { Schema } from '@tloncorp/shared/dist/db';
-import { schema, setClient } from '@tloncorp/shared/dist/db';
+import { handleChange, schema, setClient } from '@tloncorp/shared/dist/db';
 import { migrations } from '@tloncorp/shared/dist/db/migrations';
 import type { OPSQLiteDatabase } from 'drizzle-orm/op-sqlite';
 import { drizzle } from 'drizzle-orm/op-sqlite';
@@ -26,6 +26,8 @@ export function setupDb() {
   connection.execute('PRAGMA mmap_size=268435456');
   connection.execute('PRAGMA journal_mode=MEMORY');
   connection.execute('PRAGMA synchronous=OFF');
+
+  connection.updateHook(handleChange);
 
   client = drizzle(connection, {
     schema,

--- a/packages/shared/src/db/changeListener.ts
+++ b/packages/shared/src/db/changeListener.ts
@@ -1,0 +1,59 @@
+import { useEffect } from 'react';
+
+import { queryClient } from '../api';
+
+type PostChangeListener = (changes: Record<string, string[]>) => void;
+const listeners: PostChangeListener[] = [];
+let postEvents: Record<string, string[]> = {};
+
+export function useDatabasePostChangeListener(cb: PostChangeListener) {
+  useEffect(() => {
+    listeners.push(cb);
+    return () => {
+      const index = listeners.indexOf(cb);
+      if (index !== -1) {
+        listeners.splice(index, 1);
+      }
+    };
+  }, [cb]);
+}
+
+/**
+ * Flush current pending change batch
+ */
+export function flush() {
+  if (Object.keys(postEvents).length) {
+    Object.keys(postEvents).forEach((k) => {
+      postEvents[k].forEach((id) => {
+        queryClient.invalidateQueries({
+          queryKey: ['post', id],
+        });
+      });
+    });
+    postEvents = {};
+  }
+}
+
+export function handleChange({
+  table,
+  operation,
+  row,
+}: {
+  table: string;
+  operation: 'INSERT' | 'UPDATE' | 'DELETE';
+  /** Set on insert and update, contains raw data for updated row w/ snake case
+   * keys (`id`, `channel_id`, 'group_id`, etc.) */
+  row?: any;
+}) {
+  if (table === 'posts' && row && !row.parent_id) {
+    postEvents[row.channel_id] ||= [];
+    postEvents[row.channel_id].push(row.id);
+  }
+  // We count updates to a post's reaction as post updates so that they trigger
+  // channel refresh.
+  if (table === 'post_reactions' && row) {
+    queryClient.refetchQueries({
+      queryKey: ['post', row.post_id],
+    });
+  }
+}

--- a/packages/shared/src/db/changeListener.ts
+++ b/packages/shared/src/db/changeListener.ts
@@ -1,22 +1,6 @@
-import { useEffect } from 'react';
-
 import { queryClient } from '../api';
 
-type PostChangeListener = (changes: Record<string, string[]>) => void;
-const listeners: PostChangeListener[] = [];
 let postEvents: Record<string, string[]> = {};
-
-export function useDatabasePostChangeListener(cb: PostChangeListener) {
-  useEffect(() => {
-    listeners.push(cb);
-    return () => {
-      const index = listeners.indexOf(cb);
-      if (index !== -1) {
-        listeners.splice(index, 1);
-      }
-    };
-  }, [cb]);
-}
 
 /**
  * Flush current pending change batch

--- a/packages/shared/src/db/index.ts
+++ b/packages/shared/src/db/index.ts
@@ -4,3 +4,4 @@ export * from './types';
 export * from './fallback';
 export * from './modelBuilders';
 export { setClient } from './client';
+export * from './changeListener';

--- a/packages/shared/src/db/queries.ts
+++ b/packages/shared/src/db/queries.ts
@@ -1873,7 +1873,7 @@ export const getPendingPosts = createReadQuery(
 
 export const getPostWithRelations = createReadQuery(
   'getPostWithRelations',
-  async ({ id }: { id: string }, ctx: QueryCtx) => {
+  async ({ id }: { id: string }, ctx: QueryCtx): Promise<Post | null> => {
     return ctx.db.query.posts
       .findFirst({
         where: eq($posts.id, id),

--- a/packages/shared/src/db/queries.ts
+++ b/packages/shared/src/db/queries.ts
@@ -9,6 +9,7 @@ import {
   count,
   desc,
   eq,
+  exists,
   getTableColumns,
   gt,
   gte,
@@ -1554,15 +1555,33 @@ function setPostGroups(ctx: QueryCtx) {
       groupId: sql`${ctx.db
         .select({ groupId: $channels.groupId })
         .from($channels)
-        .where(eq($channels.id, $posts.channelId))}`,
+        .where(
+          and(eq($channels.id, $posts.channelId), isNotNull($channels.groupId))
+        )}`,
     })
-    .where(isNull($posts.groupId));
+    .where(
+      and(
+        isNull($posts.groupId),
+        exists(
+          ctx.db
+            .select()
+            .from($channels)
+            .where(
+              and(eq($channels.id, $posts.id), isNotNull($channels.groupId))
+            )
+        )
+      )
+    );
 }
 
 async function setLastPosts(ctx: QueryCtx) {
   const $lastPost = ctx.db.$with('lastPost').as(
     ctx.db
-      .select({ id: $posts.id, receivedAt: $posts.receivedAt })
+      .select({
+        id: $posts.id,
+        channelId: $posts.channelId,
+        receivedAt: $posts.receivedAt,
+      })
       .from($posts)
       .where(
         and(eq($posts.channelId, $channels.id), not(eq($posts.type, 'reply')))
@@ -1577,7 +1596,19 @@ async function setLastPosts(ctx: QueryCtx) {
     .set({
       lastPostId: sql`(select ${$lastPost.id} from ${$lastPost})`,
       lastPostAt: sql`(select ${$lastPost.receivedAt} from ${$lastPost})`,
-    });
+    })
+    .where(
+      or(
+        isNull($channels.lastPostId),
+        lt(
+          $channels.lastPostId,
+          sql`${ctx.db
+            .select({ id: max($posts.id) })
+            .from($posts)
+            .where(eq($posts.channelId, $channels.id))}`
+        )
+      )
+    );
 
   const $groupLastPost = ctx.db.$with('groupLastPost').as(
     ctx.db
@@ -1599,7 +1630,19 @@ async function setLastPosts(ctx: QueryCtx) {
     .set({
       lastPostId: sql`(select ${$groupLastPost.lastPostId} from ${$groupLastPost})`,
       lastPostAt: sql`(select ${$groupLastPost.lastPostAt} from ${$groupLastPost})`,
-    });
+    })
+    .where(
+      or(
+        isNull($groups.lastPostId),
+        lt(
+          $groups.lastPostId,
+          sql`${ctx.db
+            .select({ id: max($posts.id) })
+            .from($posts)
+            .where(eq($posts.groupId, $groups.id))}`
+        )
+      )
+    );
 }
 
 // Delete any pending posts whose sentAt matches the incoming sentAt.

--- a/packages/shared/src/db/query.ts
+++ b/packages/shared/src/db/query.ts
@@ -6,7 +6,7 @@ import * as changeListener from './changeListener';
 import { AnySqliteDatabase, AnySqliteTransaction, client } from './client';
 import { TableName } from './types';
 
-const logger = createDevLogger('query', true);
+const logger = createDevLogger('query', false);
 
 export interface QueryMeta<TOptions> {
   /**

--- a/packages/shared/src/db/query.ts
+++ b/packages/shared/src/db/query.ts
@@ -2,10 +2,11 @@ import { sql } from 'drizzle-orm';
 
 import { queryClient } from '../api';
 import { createDevLogger, escapeLog, listDebugLabel } from '../debug';
+import * as changeListener from './changeListener';
 import { AnySqliteDatabase, AnySqliteTransaction, client } from './client';
 import { TableName } from './types';
 
-const logger = createDevLogger('query', false);
+const logger = createDevLogger('query', true);
 
 export interface QueryMeta<TOptions> {
   /**
@@ -162,6 +163,7 @@ export async function withCtxOrDefault<T>(
   // Invalidate queries based on affected tables. We run in the next tick to
   // prevent possible loops.
   setTimeout(() => {
+    changeListener.flush();
     if (!pendingEffects.size) {
       return;
     }

--- a/packages/shared/src/db/query.ts
+++ b/packages/shared/src/db/query.ts
@@ -87,7 +87,6 @@ export const createQuery = <TOptions, TReturn>(
     ctx?: QueryCtx
   ): Promise<TReturn> {
     const startTime = Date.now();
-    logger.log(meta.label + ':start');
     // Resolve arguments based on parameter count of query function
     const [ctxArg, runQuery] = hasNoOptions(queryFn)
       ? [
@@ -110,7 +109,6 @@ export const createQuery = <TOptions, TReturn>(
             ? meta.tableEffects(options!)
             : meta.tableEffects;
         if (effects.length) {
-          logger.log(`${meta.label}:pending:[${effects.join(' ')}]`);
           effects.forEach((e) => resolvedCtx.pendingEffects.add(e));
         }
       }
@@ -167,7 +165,7 @@ export async function withCtxOrDefault<T>(
     if (!pendingEffects.size) {
       return;
     }
-    logger.log(`${meta.label}:trigger:${listDebugLabel(pendingEffects)}`);
+    const invalidated: string[] = [];
     queryClient.invalidateQueries({
       fetchStatus: 'idle',
       predicate: (query) => {
@@ -175,11 +173,16 @@ export async function withCtxOrDefault<T>(
         const shouldInvalidate =
           tableKey instanceof Set && setsOverlap(tableKey, pendingEffects);
         if (shouldInvalidate) {
-          logger.log(`${meta.label}:invalidate:${escapeLog(query.queryHash)}`);
+          invalidated.push(query.queryHash);
         }
         return shouldInvalidate;
       },
     });
+    logger.log(
+      `${meta.label}:triggered:${listDebugLabel(pendingEffects)}`,
+      'invalidating',
+      invalidated.map(escapeLog)
+    );
   }, 0);
   return result;
 }
@@ -200,6 +203,8 @@ const enqueueTransaction = async (fn: () => Promise<any>) => {
   }
 };
 
+const txLogger = createDevLogger('tx', false);
+
 /**
  * Creates a new context that will run operations against a transaction.
  * Executes the handler directly if already in a transaction.
@@ -210,20 +215,20 @@ export async function withTransactionCtx<T>(
 ): Promise<T> {
   return new Promise((resolve, reject) =>
     enqueueTransaction(async () => {
-      logger.log(ctx.meta.label, 'tx:handler');
+      txLogger.log(ctx.meta.label, 'tx:handler');
       try {
         await ctx.db.run(sql`BEGIN`);
-        logger.log(ctx.meta.label, 'tx:begin');
+        txLogger.log(ctx.meta.label, 'tx:begin');
 
         const result = await handler(ctx);
-        logger.log(ctx.meta.label, 'tx:run');
+        txLogger.log(ctx.meta.label, 'tx:run');
 
         await ctx.db.run(sql`COMMIT`);
         resolve(result);
-        logger.log(ctx.meta.label, 'tx:commit');
+        txLogger.log(ctx.meta.label, 'tx:commit');
         return result;
       } catch (e) {
-        logger.log('tx:error', e);
+        txLogger.log('tx:error', e);
         reject(e);
         await ctx.db.run(sql`ROLLBACK`);
       }

--- a/packages/shared/src/store/dbHooks.ts
+++ b/packages/shared/src/store/dbHooks.ts
@@ -218,9 +218,14 @@ export const useChannel = (options: { id: string }) => {
   });
 };
 
-export const usePostWithRelations = (options: { id: string }) => {
+export const usePostWithRelations = (
+  options: { id: string },
+  initialData?: db.Post
+) => {
   return useQuery({
-    queryKey: [['post', options]],
+    queryKey: ['post', options.id],
+    staleTime: Infinity,
+    initialData,
     queryFn: () => db.getPostWithRelations(options),
   });
 };

--- a/packages/shared/src/store/postActions.ts
+++ b/packages/shared/src/store/postActions.ts
@@ -29,12 +29,7 @@ export async function sendPost({
 
   // optimistic update
   const cachePost = db.buildPendingPost({ authorId, channel, content });
-  await db.insertChannelPosts({
-    channelId: channel.id,
-    posts: [cachePost],
-    older: sync.channelCursors.get(channel.id),
-  });
-  sync.updateChannelCursor(channel.id, cachePost.id);
+  sync.handleAddPost(cachePost);
   try {
     await api.sendPost({
       channelId: channel.id,

--- a/packages/shared/src/store/sync.ts
+++ b/packages/shared/src/store/sync.ts
@@ -6,6 +6,7 @@ import { QueryCtx, batchEffects } from '../db/query';
 import { createDevLogger } from '../debug';
 import { useStorage } from './storage';
 import { syncQueue } from './syncQueue';
+import { addToChannelPosts } from './useChannelPosts';
 
 // Used to track latest post we've seen for each channel.
 // Updated when:
@@ -406,7 +407,7 @@ export const handleChatUpdate = async (update: api.ChatEvent) => {
   }
 };
 
-async function handleAddPost(post: db.Post) {
+export async function handleAddPost(post: db.Post) {
   // first check if it's a reply. If it is and we haven't already cached
   // it, we need to add it to the parent post
   if (post.parentId) {
@@ -426,12 +427,14 @@ async function handleAddPost(post: db.Post) {
       posts: [post],
     });
   } else {
+    const older = channelCursors.get(post.channelId);
+    addToChannelPosts(post, older);
+    updateChannelCursor(post.channelId, post.id);
     await db.insertChannelPosts({
       channelId: post.channelId,
       posts: [post],
-      older: channelCursors.get(post.channelId),
+      older,
     });
-    updateChannelCursor(post.channelId, post.id);
   }
 }
 

--- a/packages/ui/src/components/Channel/Scroller.tsx
+++ b/packages/ui/src/components/Channel/Scroller.tsx
@@ -29,7 +29,7 @@ import {
 import Animated from 'react-native-reanimated';
 import { useStyle, useTheme } from 'tamagui';
 
-import { useRequests } from '../../contexts/requests';
+import { useLivePost } from '../../contexts/requests';
 import { useScrollDirectionTracker } from '../../contexts/scroll';
 import { Modal, View, XStack } from '../../core';
 import { Button } from '../Button';
@@ -523,9 +523,7 @@ const ScrollerItem = ({
   activeMessage?: db.Post | null;
   messageRef: RefObject<RNView>;
 }) => {
-  const { usePost } = useRequests();
-  const { data: updatedPost } = usePost({ id: item.id }, item);
-  const post = updatedPost ?? item;
+  const post = useLivePost(item);
 
   const handleLayout = useCallback(() => {
     onLayout?.(post, index);

--- a/packages/ui/src/components/Channel/Scroller.tsx
+++ b/packages/ui/src/components/Channel/Scroller.tsx
@@ -29,6 +29,7 @@ import {
 import Animated from 'react-native-reanimated';
 import { useStyle, useTheme } from 'tamagui';
 
+import { useRequests } from '../../contexts/requests';
 import { useScrollDirectionTracker } from '../../contexts/scroll';
 import { Modal, View, XStack } from '../../core';
 import { Button } from '../Button';
@@ -256,6 +257,7 @@ export default function Scroller({
       backgroundColor: theme.background.val,
     };
   }, [hasFoundAnchor, theme.background.val]);
+
   const listRenderItem: ListRenderItem<db.Post> = useCallback(
     ({ item, index }) => {
       const previousItem = filteredPosts?.[index + 1];
@@ -268,82 +270,58 @@ export default function Scroller({
         item.type === 'block' ||
         previousItem?.authorId !== item.authorId ||
         previousItem?.type === 'notice' ||
-        (item.replyCount ?? 0) > 0 ||
         isFirstPostOfDay;
+
       const isFirstUnread = item.id === firstUnreadId;
-      // this is necessary because we can't call memoized components as functions
-      // (they are objects, not functions)
-      const RenderItem = renderItem;
 
       if (item.id === '' && item.type === 'block') {
         return <View height={1} width="50%" backgroundColor="$background" />;
       }
 
       return (
-        <View onLayout={() => handleItemLayout(item, index)}>
-          {isFirstUnread && channelType !== 'gallery' ? (
-            <ChannelDivider
-              timestamp={item.receivedAt}
-              unreadCount={unreadCount ?? 0}
-              isFirstPostOfDay={isFirstPostOfDay}
-              channelInfo={{ id: channelId, type: channelType }}
-              index={index}
-            />
-          ) : isFirstPostOfDay && item.type === 'chat' ? (
-            <ChannelDivider
-              unreadCount={0}
-              timestamp={item.receivedAt}
-              index={index}
-            />
-          ) : null}
-          <PressableMessage
-            ref={activeMessageRefs.current[item.id]}
-            isActive={activeMessage?.id === item.id}
-          >
-            <RenderItem
-              currentUserId={currentUserId}
-              post={item}
-              editing={editingPost && editingPost?.id === item.id}
-              setEditingPost={setEditingPost}
-              editPost={editPost}
-              showAuthor={showAuthor}
-              showReplies={showReplies}
-              onPressReplies={onPressReplies}
-              onPressImage={onPressImage}
-              onLongPress={handlePostLongPressed}
-              onPress={onPressPost}
-            />
-          </PressableMessage>
-          {isFirstUnread && channelType === 'gallery' ? (
-            <ChannelDivider
-              timestamp={item.receivedAt}
-              unreadCount={unreadCount ?? 0}
-              isFirstPostOfDay={isFirstPostOfDay}
-              channelInfo={{ id: channelId, type: channelType }}
-              index={index}
-            />
-          ) : null}
-        </View>
+        <ScrollerItem
+          item={item}
+          index={index}
+          showUnreadDivider={isFirstUnread}
+          showDayDivider={isFirstPostOfDay}
+          showAuthor={showAuthor}
+          Component={renderItem}
+          currentUserId={currentUserId}
+          unreadCount={unreadCount}
+          editingPost={editingPost}
+          onLayout={handleItemLayout}
+          channelId={channelId}
+          channelType={channelType}
+          setEditingPost={setEditingPost}
+          editPost={editPost}
+          showReplies={showReplies}
+          onPressImage={onPressImage}
+          onPressReplies={onPressReplies}
+          onPressPost={onPressPost}
+          onLongPressPost={handlePostLongPressed}
+          activeMessage={activeMessage}
+          messageRef={activeMessageRefs.current[item.id]}
+        />
       );
     },
     [
       filteredPosts,
-      unreadCount,
       firstUnreadId,
-      handleItemLayout,
       renderItem,
+      currentUserId,
+      unreadCount,
+      editingPost,
+      handleItemLayout,
       channelId,
       channelType,
-      activeMessage?.id,
-      currentUserId,
-      showReplies,
-      onPressPost,
-      onPressReplies,
-      onPressImage,
-      handlePostLongPressed,
-      editingPost,
       setEditingPost,
       editPost,
+      showReplies,
+      onPressImage,
+      onPressReplies,
+      onPressPost,
+      handlePostLongPressed,
+      activeMessage,
     ]
   );
 
@@ -499,6 +477,104 @@ export default function Scroller({
 function getPostId(post: db.Post) {
   return post.id;
 }
+
+const ScrollerItem = ({
+  item,
+  index,
+  showUnreadDivider,
+  showDayDivider,
+  showAuthor,
+  Component,
+  currentUserId,
+  unreadCount,
+  editingPost,
+  onLayout,
+  channelId,
+  channelType,
+  setEditingPost,
+  editPost,
+  showReplies,
+  onPressImage,
+  onPressReplies,
+  onPressPost,
+  onLongPressPost,
+  activeMessage,
+  messageRef,
+}: {
+  showUnreadDivider: boolean;
+  showAuthor: boolean;
+  showDayDivider: boolean;
+  item: db.Post;
+  index: number;
+  Component: RenderItemType;
+  currentUserId: string;
+  unreadCount?: number | null;
+  onLayout: (post: db.Post, index: number) => void;
+  channelId: string;
+  channelType: db.ChannelType;
+  onPressImage?: (post: db.Post, imageUri?: string) => void;
+  onPressReplies?: (post: db.Post) => void;
+  showReplies?: boolean;
+  editingPost?: db.Post;
+  setEditingPost?: (post: db.Post | undefined) => void;
+  editPost?: (post: db.Post, content: Story) => void;
+  onPressPost?: (post: db.Post) => void;
+  onLongPressPost: (post: db.Post) => void;
+  activeMessage?: db.Post | null;
+  messageRef: RefObject<RNView>;
+}) => {
+  const { usePost } = useRequests();
+  const { data: updatedPost } = usePost({ id: item.id }, item);
+  const post = updatedPost ?? item;
+
+  const handleLayout = useCallback(() => {
+    onLayout?.(post, index);
+  }, [onLayout, post, index]);
+
+  const unreadDivider = showUnreadDivider ? (
+    <ChannelDivider
+      timestamp={post.receivedAt}
+      unreadCount={unreadCount ?? 0}
+      isFirstPostOfDay={showDayDivider}
+      channelInfo={{ id: channelId, type: channelType }}
+      index={index}
+    />
+  ) : null;
+
+  const dayDivider =
+    showDayDivider && !showUnreadDivider && channelType === 'chat' ? (
+      <ChannelDivider
+        unreadCount={0}
+        timestamp={post.receivedAt}
+        index={index}
+      />
+    ) : null;
+
+  return (
+    <View onLayout={handleLayout}>
+      {channelType !== 'gallery' ? unreadDivider ?? dayDivider : null}
+      <PressableMessage
+        ref={messageRef}
+        isActive={activeMessage?.id === post.id}
+      >
+        <Component
+          currentUserId={currentUserId}
+          post={post}
+          editing={editingPost && editingPost?.id === item.id}
+          setEditingPost={setEditingPost}
+          editPost={editPost}
+          showAuthor={showAuthor}
+          showReplies={showReplies}
+          onPressReplies={onPressReplies}
+          onPressImage={onPressImage}
+          onLongPress={onLongPressPost}
+          onPress={onPressPost}
+        />
+      </PressableMessage>
+      {channelType === 'gallery' ? unreadDivider : null}
+    </View>
+  );
+};
 
 const PressableMessage = forwardRef<
   RNView,

--- a/packages/ui/src/contexts/requests.tsx
+++ b/packages/ui/src/contexts/requests.tsx
@@ -3,6 +3,7 @@ import {
   useGroupPreview,
   usePostWithRelations,
 } from '@tloncorp/shared/dist';
+import * as db from 'packages/shared/dist/db';
 import { PropsWithChildren, createContext, useContext, useMemo } from 'react';
 
 type State = {
@@ -50,4 +51,10 @@ export const RequestsProvider = ({
     [usePost, useChannel, useGroup, useApp]
   );
   return <Context.Provider value={value}>{children}</Context.Provider>;
+};
+
+export const useLivePost = (post: db.Post): db.Post => {
+  const { usePost } = useRequests();
+  const { data: updatedPost } = usePost({ id: post.id }, post);
+  return updatedPost ?? post;
 };


### PR DESCRIPTION
This pr refactors the way we update channel data. Instead of refetching the entire query when a relevant table updates, we now listen to database change events + make targeted events.
- When a new post is created, we use `setQueryData` to manually add that post to any matching `channelPosts` queries.
- We now wrap data for each individual post in a query, which we invalidate when that post (or its reactions) are updated. When the post row in the database changes, we rerun the query.