### PR TITLE
native: fix link open issue

### DIFF
--- a/packages/ui/src/components/ChatMessage/ChatEmbedContent.tsx
+++ b/packages/ui/src/components/ChatMessage/ChatEmbedContent.tsx
@@ -45,11 +45,7 @@ export default function ChatEmbedContent({
   const isOembed = isTrusted && validOembedCheck(embed, url);
   const calm = useCalm();
   const openLink = async () => {
-    const supported = await Linking.canOpenURL(url);
-
-    if (supported) {
-      await Linking.openURL(url);
-    }
+    await Linking.openURL(url);
   };
 
   if (!calm.disableRemoteContent) {


### PR DESCRIPTION
fixes TLON-2085

We didn't need to use `canOpenUrl` here, that's not what it's for, and it was breaking the ability to open links in other apps that support them (i.e., a github link wouldn't open at all if you had github installed on your android phone, now it will open in the app).