### PR TITLE
activity: dont set channel defaults if group has setting during migration

### DIFF
--- a/desk/app/activity.hoon
+++ b/desk/app/activity.hoon
@@ -227,6 +227,7 @@
   (welp writs replies)
 ++  set-volumes
   |=  =channels:c
+  =+  .^(=volume:v %gx (scry-path %groups /volume/all/noun))
   ::  set all existing channels to old default since new default is different
   =^  checkers  cor
     =/  checkers=(map flag:g $-([ship nest:g] ?))  ~
@@ -247,11 +248,12 @@
         .^($-([ship nest] ?) %gx path)
       [test (~(put by checkers) group test)]
     =.  cor
+      ::  don't set channel default if group above it has setting
+      ?^  (~(get by area.volume) group)  cor
       %+  adjust  [%channel nest group]
       ?:  (can-read our.bowl nest)  `(my [%post & |] ~)
       `mute:a
     $(entries t.entries)
-  =+  .^(=volume:v %gx (scry-path %groups /volume/all/noun))
   ::  set any overrides from previous volume settings
   =.  cor  (adjust [%base ~] `(~(got by old-volumes:a) base.volume))
   =.  cor

--- a/desk/app/activity.hoon
+++ b/desk/app/activity.hoon
@@ -249,7 +249,7 @@
       [test (~(put by checkers) group test)]
     =.  cor
       ::  don't set channel default if group above it has setting
-      ?^  (~(get by area.volume) group)  cor
+      ?:  (~(has by area.volume) group)  cor
       %+  adjust  [%channel nest group]
       ?:  (can-read our.bowl nest)  `(my [%post & |] ~)
       `mute:a


### PR DESCRIPTION
This fixes TLON-2087 by checking to see if the group has a setting and if so we don't set the old "default" on channels under that group.

Tested by setting a group volume with `:groups &volume-set [[%group ~nibset-napwyn %tlon] %loud]` and then running the migration

PR Checklist
- [X] Includes changes to desk files
- [X] Describes how you tested the PR locally (test ship vs livenet)
- [ ] If a new feature, includes automated tests
- [ ] Comments added anywhere logic may be confusing without context