### PR TITLE
unreads: clear lingering unread markers

### DIFF
--- a/apps/tlon-web/src/chat/ChatMessage/ChatMessage.tsx
+++ b/apps/tlon-web/src/chat/ChatMessage/ChatMessage.tsx
@@ -93,7 +93,7 @@ function getUnreadDisplay(
   id: string,
   thread: Unread | undefined
 ): 'none' | 'top' | 'thread' | 'top-with-thread' {
-  const isTop = unread?.lastUnread?.id === id;
+  const isTop = unread?.lastUnread?.id === id && unread.status !== 'read';
 
   // if this message is the oldest unread in the main chat,
   // and has an unread thread, show the divider and thread indicator

--- a/apps/tlon-web/src/chat/ChatMessage/ChatMessage.tsx
+++ b/apps/tlon-web/src/chat/ChatMessage/ChatMessage.tsx
@@ -207,55 +207,47 @@ const ChatMessage = React.memo<
         () => isMessageHidden || isPostHidden,
         [isMessageHidden, isPostHidden]
       );
-      const { ref: viewRef } = useInView({
+
+      const { ref: viewRef, inView } = useInView({
         threshold: 1,
-        onChange: useCallback(
-          (inView: boolean) => {
-            // if no tracked unread we don't need to take any action
-            if (!unread) {
-              return;
-            }
-
-            const unseen = unread.status === 'unread';
-            /* the first fire of this function
-               which we don't to do anything with. */
-            if (!inView && unseen) {
-              return;
-            }
-
-            const { seen: markSeen, delayedRead } = useUnreadsStore.getState();
-            /* once the unseen marker comes into view we need to mark it
-               as seen and start a timer to mark it read so it goes away.
-               we ensure that the brief matches and hasn't changed before
-               doing so. we don't want to accidentally clear unreads when
-               the state has changed
-            */
-            if (
-              inView &&
-              (unreadDisplay === 'top' ||
-                unreadDisplay === 'top-with-thread') &&
-              unseen
-            ) {
-              markSeen(unreadsKey);
-              delayedRead(unreadsKey, () => {
-                if (isDMOrMultiDM) {
-                  markDmRead();
-                } else {
-                  markReadChannel();
-                }
-              });
-            }
-          },
-          [
-            unreadDisplay,
-            unread,
-            unreadsKey,
-            isDMOrMultiDM,
-            markReadChannel,
-            markDmRead,
-          ]
-        ),
       });
+
+      useEffect(() => {
+        if (!inView || !unread) {
+          return;
+        }
+
+        const unseen = unread.status === 'unread';
+        const { seen: markSeen, delayedRead } = useUnreadsStore.getState();
+        /* once the unseen marker comes into view we need to mark it
+            as seen and start a timer to mark it read so it goes away.
+            we ensure that the brief matches and hasn't changed before
+            doing so. we don't want to accidentally clear unreads when
+            the state has changed
+        */
+        if (
+          inView &&
+          (unreadDisplay === 'top' || unreadDisplay === 'top-with-thread') &&
+          unseen
+        ) {
+          markSeen(unreadsKey);
+          delayedRead(unreadsKey, () => {
+            if (isDMOrMultiDM) {
+              markDmRead();
+            } else {
+              markReadChannel();
+            }
+          });
+        }
+      }, [
+        inView,
+        unread,
+        unreadsKey,
+        unreadDisplay,
+        isDMOrMultiDM,
+        markReadChannel,
+        markDmRead,
+      ]);
 
       const cacheId = {
         author: window.our,

--- a/apps/tlon-web/src/chat/UnreadAlerts.tsx
+++ b/apps/tlon-web/src/chat/UnreadAlerts.tsx
@@ -1,4 +1,4 @@
-import { ActivitySummary, getKey } from '@tloncorp/shared/dist/urbit/activity';
+import { getKey } from '@tloncorp/shared/dist/urbit/activity';
 import { daToUnix } from '@urbit/api';
 import bigInt from 'big-integer';
 import { format, isToday } from 'date-fns';
@@ -10,8 +10,6 @@ import { useMarkChannelRead } from '@/logic/channel';
 import { pluralize, whomIsFlag } from '@/logic/utils';
 import { useMarkDmReadMutation } from '@/state/chat';
 import { useUnread, useUnreadsStore } from '@/state/unreads';
-
-import { useChatStore } from './useChatStore';
 
 interface UnreadAlertsProps {
   whom: string;

--- a/apps/tlon-web/src/state/channel/channel.ts
+++ b/apps/tlon-web/src/state/channel/channel.ts
@@ -39,6 +39,7 @@ import { Flag } from '@tloncorp/shared/dist/urbit/hark';
 import { daToUnix, decToUd, udToDec, unixToDa } from '@urbit/api';
 import { Poke } from '@urbit/http-api';
 import bigInt from 'big-integer';
+import produce from 'immer';
 import _, { last } from 'lodash';
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import create from 'zustand';
@@ -468,7 +469,7 @@ function updateReplyMetaData(
     return undefined;
   }
 
-  const newPages = cache.pages.map((page) => {
+  cache.pages = cache.pages.map((page) => {
     const newPage = {
       ...page,
     };
@@ -497,11 +498,6 @@ function updateReplyMetaData(
 
     return newPage;
   });
-
-  return {
-    pages: newPages,
-    pageParams: cache.pageParams,
-  };
 }
 
 const replyUpdater = (
@@ -1050,7 +1046,7 @@ export function useChannelsFirehose() {
         } = postResponse;
         queryClient.setQueryData<PostsInCachePrev | undefined>(
           infinitePostsKey(nest),
-          (d) => updateReplyMetaData(d, time, meta)
+          (d) => produce(d, (draft) => updateReplyMetaData(draft, time, meta))
         );
       });
     }

--- a/apps/tlon-web/src/state/chat/chat.ts
+++ b/apps/tlon-web/src/state/chat/chat.ts
@@ -481,7 +481,7 @@ function infiniteDMsUpdater(queryKey: QueryKey, data: WritDiff | WritResponse) {
             return;
           }
 
-          const opAuthor =
+          const replyingAuthor =
             'add' in reply.delta ? reply.delta.add.memo.author : ''; // should never happen
 
           const updatedWrit = {
@@ -491,7 +491,7 @@ function infiniteDMsUpdater(queryKey: QueryKey, data: WritDiff | WritResponse) {
               meta: {
                 ...opWrit.seal.meta,
                 replyCount: opWrit.seal.meta.replyCount + 1,
-                repliers: [...opWrit.seal.meta.lastRepliers, opAuthor],
+                repliers: [...opWrit.seal.meta.lastRepliers, replyingAuthor],
               },
             },
           };

--- a/apps/tlon-web/src/state/unreads.ts
+++ b/apps/tlon-web/src/state/unreads.ts
@@ -48,7 +48,7 @@ export interface UnreadsStore {
   update: (unreads: Activity) => void;
 }
 
-export const unreadStoreLogger = createDevLogger('UnreadsStore', true);
+export const unreadStoreLogger = createDevLogger('UnreadsStore', false);
 
 function getUnreadStatus(count: number, notify: boolean): ReadStatus {
   if (count > 0 || notify) {
@@ -341,7 +341,6 @@ export const useUnreadsStore = create<UnreadsStore>((set, get) => ({
   delayedRead: (key, cb) => {
     const { sources, read } = get();
     const source = sources[key] || emptyUnread();
-    debugger;
     if (source.status === 'read') {
       return;
     }

--- a/apps/tlon-web/src/state/unreads.ts
+++ b/apps/tlon-web/src/state/unreads.ts
@@ -48,7 +48,7 @@ export interface UnreadsStore {
   update: (unreads: Activity) => void;
 }
 
-export const unreadStoreLogger = createDevLogger('UnreadsStore', false);
+export const unreadStoreLogger = createDevLogger('UnreadsStore', true);
 
 function getUnreadStatus(count: number, notify: boolean): ReadStatus {
   if (count > 0 || notify) {
@@ -254,14 +254,9 @@ export const useUnreadsStore = create<UnreadsStore>((set, get) => ({
           })
           .forEach(([key, summary]) => {
             const source = draft.sources[key];
-            unreadStoreLogger.log(
-              'update',
-              key,
-              source,
-              summary,
-              draft.sources
-            );
+            unreadStoreLogger.log('update', key, { ...source }, { ...summary });
             const unread = getUnread(key, summary, draft.sources);
+            unreadStoreLogger.log('new unread', key, unread);
             draft.sources[key] = unread;
 
             Object.keys(unread.children || {}).forEach((child) => {
@@ -284,11 +279,10 @@ export const useUnreadsStore = create<UnreadsStore>((set, get) => ({
   seen: (key) => {
     set(
       produce((draft: UnreadsStore) => {
-        if (!draft.sources[key]) {
-          draft.sources[key] = emptyUnread();
-        }
-
         const source = draft.sources[key];
+        if (!source || source.status !== 'unread') {
+          return;
+        }
 
         unreadStoreLogger.log('seen', key);
         draft.sources[key] = {
@@ -314,7 +308,7 @@ export const useUnreadsStore = create<UnreadsStore>((set, get) => ({
     set(
       produce((draft: UnreadsStore) => {
         const source = draft.sources[key];
-        if (!source) {
+        if (!source || source.status === 'read') {
           return;
         }
 
@@ -347,12 +341,17 @@ export const useUnreadsStore = create<UnreadsStore>((set, get) => ({
   delayedRead: (key, cb) => {
     const { sources, read } = get();
     const source = sources[key] || emptyUnread();
+    debugger;
+    if (source.status === 'read') {
+      return;
+    }
 
     if (source.readTimeout) {
       clearTimeout(source.readTimeout);
     }
 
     const readTimeout = setTimeout(() => {
+      unreadStoreLogger.log('delayedRead timeout reached', key);
       read(key);
       cb();
     }, 15 * 1000); // 15 seconds


### PR DESCRIPTION
This cleans up how we were clearing unreads when navigating away because it wasn't firing in all the cases we wanted. Also fixes the unread marker never going away because we weren't actually checking status for it exactly. Also fixed reply meta updating as well as replies not showing up in threads.

Fixes TLON-2096

PR Checklist
- [ ] Includes changes to desk files
- [ ] Describes how you tested the PR locally (test ship vs livenet)
- [ ] If a new feature, includes automated tests
- [ ] Comments added anywhere logic may be confusing without context