### PR TITLE
activity: self activity should change recency

### DIFF
--- a/apps/tlon-web/src/chat/ChatInput/ChatInput.tsx
+++ b/apps/tlon-web/src/chat/ChatInput/ChatInput.tsx
@@ -1,6 +1,6 @@
 import * as Popover from '@radix-ui/react-popover';
 import { Editor } from '@tiptap/react';
-import { getKey } from '@tloncorp/shared/dist/urbit/activity';
+import { getKey, getThreadKey } from '@tloncorp/shared/dist/urbit/activity';
 import {
   CacheId,
   Cite,
@@ -61,7 +61,6 @@ import {
   useIsDmOrMultiDm,
   useThreadParentId,
 } from '@/logic/utils';
-import { useMyLastMessage } from '@/state/channel/channel';
 import {
   SendMessageVariables,
   SendReplyVariables,
@@ -393,8 +392,9 @@ export default function ChatInput({
       onUpdate.current.flush();
       setDraft(inlinesToJSON(['']));
       setTimeout(() => {
-        // TODO: chesterton's fence, but why execute a read here?
-        useUnreadsStore.getState().read(getKey(whom));
+        const key = replying ? getThreadKey(whom, replying) : getKey(whom);
+        useUnreadsStore.getState().read(key);
+        useUnreadsStore.getState().bump(key);
         clearAttachments();
       }, 0);
     },

--- a/apps/tlon-web/src/state/unreads.ts
+++ b/apps/tlon-web/src/state/unreads.ts
@@ -44,11 +44,12 @@ export interface UnreadsStore {
   sources: Unreads;
   seen: (whom: string) => void;
   read: (whom: string) => void;
-  delayedRead: (whom: string, callback: () => void) => void;
+  bump: (whom: string) => void;
   update: (unreads: Activity) => void;
+  delayedRead: (whom: string, callback: () => void) => void;
 }
 
-export const unreadStoreLogger = createDevLogger('UnreadsStore', false);
+export const unreadStoreLogger = createDevLogger('UnreadsStore', true);
 
 function getUnreadStatus(count: number, notify: boolean): ReadStatus {
   if (count > 0 || notify) {
@@ -335,6 +336,22 @@ export const useUnreadsStore = create<UnreadsStore>((set, get) => ({
         };
         unreadStoreLogger.log('post read', JSON.stringify(draft.sources[key]));
         updateParents(source.parents, draft);
+      })
+    );
+  },
+  bump: (key) => {
+    set(
+      produce((draft: UnreadsStore) => {
+        const source = draft.sources[key];
+        if (!source) {
+          return;
+        }
+
+        unreadStoreLogger.log('bump', key);
+        draft.sources[key] = {
+          ...source,
+          recency: Date.now(),
+        };
       })
     );
   },

--- a/desk/app/activity.hoon
+++ b/desk/app/activity.hoon
@@ -731,6 +731,7 @@
   ::
       %all
     |=  =index:a
+    ?^  time.action  index(reads [u.time.action ~])
     =/  latest=(unit [=time event:a])
     ::REVIEW  is this taking the item from the correct end? lol
       (ram:on-event:a stream.index)
@@ -846,7 +847,7 @@
     |(is-msg ?=(?(%dm-invite %chan-init) -<.event))
   ?.  supported  $(stream rest)
   =?  notified  &(notify.volume notified.event)  &
-  =.  newest  time
+  =?  newest  (gth time newest)  time
   ?.  &(unreads.volume ?=(?(%dm-post %dm-reply %post %reply) -<.event))
     $(stream rest)
   =.  total  +(total)

--- a/desk/app/channels.hoon
+++ b/desk/app/channels.hoon
@@ -743,7 +743,9 @@
     ++  on-post
       |=  v-post:c
       ^+  ca-core
-      ?:  =(author our.bowl)  ca-core
+      ?:  =(author our.bowl)
+        =/  =source  [%channel nest group.perm.perm.channel]
+        (send ~[`action`[%read source [%all `now.bowl]]])
       =/  mention=?  (was-mentioned:utils content our.bowl)
       =/  action
         [%add %post [[author id] id] nest group.perm.perm.channel content mention]
@@ -751,7 +753,10 @@
     ++  on-reply
       |=  [parent=v-post:c v-reply:c]
       ^+  ca-core
-      ?:  =(author our.bowl)  ca-core
+      =/  parent-key=message-key  [[author id]:parent id.parent]
+      ?:  =(author our.bowl)
+        =/  =source  [%thread parent-key nest group.perm.perm.channel]
+        (send ~[`action`[%read source [%all `now.bowl]]])
       =/  mention=?  (was-mentioned:utils content our.bowl)
       =/  in-replies
           %+  lien  (tap:on-v-replies:c replies.parent)
@@ -760,7 +765,6 @@
           =(author.u.reply our.bowl)
       =/  =path  (scry-path %activity /volume-settings/noun)
       =+  .^(settings=volume-settings %gx path)
-      =/  parent-key=message-key  [[author id]:parent id.parent]
       =/  =action
         :*  %add  %reply
             [[author id] id]

--- a/desk/app/chat.hoon
+++ b/desk/app/chat.hoon
@@ -773,16 +773,19 @@
           mention=?
       ==
   ^+  cor
-  ?:  ?&  ?=(?(%post %reply) -.concern)
-          .=  our.bowl
-          p.id:?-(-.concern %post key.concern, %reply key.concern)
-      ==
-    cor
   ?.  .^(? %gu /(scot %p our.bowl)/activity/(scot %da now.bowl)/$)
     cor
   %-  emit
   =;  =cage
     [%pass /activity/submit %agent [our.bowl %activity] %poke cage]
+  ?:  ?&  ?=(?(%post %reply) -.concern)
+          .=  our.bowl
+          p.id:?-(-.concern %post key.concern, %reply key.concern)
+      ==
+    =/  =source
+      ?:  ?=(%post -.concern)  [%dm whom]
+      [%dm-thread top.concern whom]
+    activity-action+!>(`action`[%read source [%all `now.bowl]])
   :-  %activity-action
   !>  ^-  action
   :-  %add

--- a/desk/sur/activity.hoon
+++ b/desk/sur/activity.hoon
@@ -46,7 +46,7 @@
 +$  read-action
   $%  [%item id=time-id]
       [%event event=incoming-event]
-      [%all ~]
+      [%all time=(unit time)]
   ==
 ::
 +|  %updates


### PR DESCRIPTION
Fixes TLON-2088 by changing the way we give recency values in that if the "read" floor is greater than the last message, make that the recency. However to get our %read action to put a value other than the last message time, I had to change the action type slightly. 

PR Checklist
- [X] Includes changes to desk files
- [ ] Describes how you tested the PR locally (test ship vs livenet)
- [ ] If a new feature, includes automated tests
- [ ] Comments added anywhere logic may be confusing without context