### PR TITLE
native: fix chat list ordering bug

### DIFF
--- a/packages/shared/src/db/queries.ts
+++ b/packages/shared/src/db/queries.ts
@@ -257,7 +257,7 @@ export const getChats = createReadQuery(
       .orderBy(
         ascNullsLast($pins.index),
         sql`(CASE WHEN ${$groups.isNew} = 1 THEN 1 ELSE 0 END) DESC`,
-        desc($unreads.updatedAt)
+        sql`COALESCE(${allChannels.lastPostAt}, ${$unreads.updatedAt}) DESC`
       );
 
     const [chatMembers, filteredChannels] = result.reduce<


### PR DESCRIPTION
We have an ordering bug if the last message sent was from you. Right now we cue off unread recency, but messages sent by you don't trigger changes in `%activity`. 

I believe Hunter is working on a fix for this at the agent level, but we can also utilize the `lastPostAt` which we already have and should be more up to date in the case of messages sent by you. This PR simply updates the ordering for the chat list query to coalesce the two columns instead of purely relying on unread data.


Fixes TLON-2101