### PR TITLE
web: fix issue with sending DM replies

### DIFF
--- a/apps/tlon-web/src/state/chat/chat.ts
+++ b/apps/tlon-web/src/state/chat/chat.ts
@@ -544,7 +544,7 @@ function infiniteDMsUpdater(queryKey: QueryKey, data: WritDiff | WritResponse) {
               return;
             }
 
-            const newReplyId = unixToDa(memo.sent).toString();
+            const newReplyId = formatUd(unixToDa(memo.sent));
             const newReply: Reply = {
               seal: {
                 id: replyId,

--- a/apps/tlon-web/src/state/chat/chat.ts
+++ b/apps/tlon-web/src/state/chat/chat.ts
@@ -541,10 +541,15 @@ function infiniteDMsUpdater(queryKey: QueryKey, data: WritDiff | WritResponse) {
             });
 
             if (hasInCache) {
-              return;
+              delete prevReplies[hasInCache[0]];
             }
 
-            const newReplyId = formatUd(unixToDa(memo.sent));
+            const newReplyId =
+              reply.delta.add.time === null
+                ? // handles the optimistic case
+                  formatUd(unixToDa(memo.sent))
+                : // handles the case where we hear the fact
+                  formatUd(bigInt(reply.delta.add.time));
             const newReply: Reply = {
               seal: {
                 id: replyId,

--- a/apps/tlon-web/src/state/chat/chat.ts
+++ b/apps/tlon-web/src/state/chat/chat.ts
@@ -544,6 +544,7 @@ function infiniteDMsUpdater(queryKey: QueryKey, data: WritDiff | WritResponse) {
               return;
             }
 
+            const newReplyId = unixToDa(memo.sent).toString();
             const newReply: Reply = {
               seal: {
                 id: replyId,
@@ -555,7 +556,7 @@ function infiniteDMsUpdater(queryKey: QueryKey, data: WritDiff | WritResponse) {
 
             const newReplies = {
               ...prevReplies,
-              [formatUd(bigInt(reply.delta.add.time!))]: newReply,
+              [newReplyId]: newReply,
             };
 
             draft.seal.replies = newReplies;


### PR DESCRIPTION
Fixes TLON-2107. We were attempting to use `time` (which is null when we create a new reply) as a key for optimistically adding a new reply on a parent message. We used to use `sent` on `memo` to do this (not sure why this changed), reverting back to using `memo.sent` here fixes the issue.