### PR TITLE
web: fix bug with new dm creation

### DIFF
--- a/apps/tlon-web/src/logic/useMessageSelector.ts
+++ b/apps/tlon-web/src/logic/useMessageSelector.ts
@@ -52,11 +52,13 @@ export default function useMessageSelector() {
     }
 
     return (
-      Object.entries(unreads).find(([source, _unread]) => {
-        const theShip = ships[0].value;
-        const sameDM = `ship/${theShip}` === source;
-        return sameDM;
-      })?.[0] ?? null
+      Object.entries(unreads)
+        .find(([source, _unread]) => {
+          const theShip = ships[0].value;
+          const sameDM = `ship/${theShip}` === source;
+          return sameDM;
+        })?.[0]
+        .split('/')[1] ?? null
     );
   }, [ships, unreads]);
 


### PR DESCRIPTION
Fixes TLON-2114. We were finding the first unread that matched `ship/${theShip}` and then returning that unread key as the existing DM. This got inserted into the route as `/new/ship/~sampel-palnet`, which puts `new` in the `:ship` parameter place. the `Message` component then checks if the `:ship` parameter is a patp. If it's not, it assumes multidm. We then routed the user to the MultiDm component, and since they're not in a MultiDM with that ID we show the invite accept/reject page (which won't work because this isn't a mutidm and that isn't a valid multidm ID).

The fix is just to return only the patp from the unread key, chopping off the `ship/` portion.