### PR TITLE
native: small perf optimizations

### DIFF
--- a/packages/shared/src/logic/utils.ts
+++ b/packages/shared/src/logic/utils.ts
@@ -197,6 +197,14 @@ export function getPinPartial(channel: db.Channel): {
 const MS_PER_DAY = 24 * 60 * 60 * 1000;
 const timezoneOffset = new Date().getTimezoneOffset() * 60 * 1000;
 
+/**
+ * Returns true if the two dates happened on current calendar day, in local
+ * timezone.
+ *
+ * TODO: Currently this calculation will be off by an hour when crossing
+ * daylight savings time. We're doing it this way because date operations are
+ * quite slow in RN/Hermes.
+ */
 export const isSameDay = (a: number, b: number) => {
   const dayA = Math.floor((a - timezoneOffset) / MS_PER_DAY);
   const dayB = Math.floor((b - timezoneOffset) / MS_PER_DAY);

--- a/packages/shared/src/logic/utils.ts
+++ b/packages/shared/src/logic/utils.ts
@@ -194,8 +194,13 @@ export function getPinPartial(channel: db.Channel): {
   return { type: 'channel', itemId: channel.id };
 }
 
+const MS_PER_DAY = 24 * 60 * 60 * 1000;
+const timezoneOffset = new Date().getTimezoneOffset() * 60 * 1000;
+
 export const isSameDay = (a: number, b: number) => {
-  return differenceInCalendarDays(a, b) === 0;
+  const dayA = Math.floor((a - timezoneOffset) / MS_PER_DAY);
+  const dayB = Math.floor((b - timezoneOffset) / MS_PER_DAY);
+  return dayA === dayB;
 };
 
 export const isToday = (date: number) => {


### PR DESCRIPTION
- Replaces `isSameDay` with a faster, numeric version (previously it was taking up an inordinate amount of time during render).
- Optimizes `setLastPosts` and `setPostGroups` to only update changed rows, which prevents database traffic jams when posts are updated.