### PR TITLE
web: include all children, as appropriate, in combined unread data

### DIFF
--- a/apps/tlon-web/src/components/Sidebar/GroupsSidebarItem.tsx
+++ b/apps/tlon-web/src/components/Sidebar/GroupsSidebarItem.tsx
@@ -73,4 +73,6 @@ const GroupsSidebarItem = React.memo(
   }
 );
 
+GroupsSidebarItem.displayName = 'GroupsSidebarItem';
+
 export default GroupsSidebarItem;

--- a/apps/tlon-web/src/components/Sidebar/Sidebar.tsx
+++ b/apps/tlon-web/src/components/Sidebar/Sidebar.tsx
@@ -260,6 +260,8 @@ const Sidebar = React.memo(() => {
   );
 });
 
+Sidebar.displayName = 'Sidebar';
+
 const SidebarTopSection = React.memo(
   ({
     title,
@@ -289,5 +291,7 @@ const SidebarTopSection = React.memo(
     );
   }
 );
+
+SidebarTopSection.displayName = 'SidebarTopSection';
 
 export default Sidebar;

--- a/apps/tlon-web/src/groups/GroupActions.tsx
+++ b/apps/tlon-web/src/groups/GroupActions.tsx
@@ -387,4 +387,6 @@ const GroupActions = React.memo(
   }
 );
 
+GroupActions.displayName = 'GroupActions';
+
 export default GroupActions;

--- a/apps/tlon-web/src/state/unreads.ts
+++ b/apps/tlon-web/src/state/unreads.ts
@@ -104,15 +104,43 @@ function sumChildren(
         return acc;
       }
 
-      if (childStatus === 'unread') {
+      const {
+        count: grandChildCount,
+        notify: grandChildNotify,
+        status: grandChildStatus,
+      } = Object.entries(unreads[key].children || {}).reduce(
+        (grandAcc, [grandKey, grandChild]) => {
+          const grandChildStatus = unreads[grandKey]?.status;
+          const grandChildNotify = unreads[grandKey]?.notify;
+
+          return {
+            count: grandChildNotify
+              ? grandAcc.count + grandChild.count
+              : grandAcc.count,
+            notify: grandAcc.notify || grandChildNotify,
+            status: grandChildNotify
+              ? combineStatus(childStatus, grandChildStatus || 'read')
+              : grandAcc.status,
+          };
+        },
+        {
+          count: 0,
+          notify: false,
+          status: 'read',
+        }
+      );
+
+      if (childStatus === 'unread' || grandChildStatus === 'unread') {
         status = 'unread';
       } else if (childStatus === 'seen' && status === 'read') {
         status = 'seen';
       }
 
       return {
-        count: !sumCounts ? acc.count : acc.count + (child.unread?.count || 0),
-        notify: acc.notify || Boolean(child.notify),
+        count: !sumCounts
+          ? acc.count
+          : acc.count + (child.unread?.count || 0) + grandChildCount,
+        notify: acc.notify || Boolean(child.notify) || grandChildNotify,
         status,
       };
     },
@@ -270,6 +298,17 @@ export const useUnreadsStore = create<UnreadsStore>((set, get) => ({
                 parents: childSrc.parents.includes(key)
                   ? childSrc.parents
                   : [...childSrc.parents, key],
+              };
+
+              const parent = draft.sources[key];
+              const childSummary = summaries[child];
+
+              draft.sources[key] = {
+                ...parent,
+                children: {
+                  ...parent.children,
+                  [child]: childSummary,
+                },
               };
             });
           });


### PR DESCRIPTION
Fixes TLON-2109 by:

a) including all children starting from the top (i.e., groups will have channels as children, channels will have threads, this will be accessible from the group unread itself. Before, groups would have channels and the channels would not have their own children).
b) making sure we rollup status/count/notify when nested children call for it (i.e., someone has replied to you in a thread).