### PR TITLE
chat: add club invites

### DIFF
--- a/desk/app/chat.hoon
+++ b/desk/app/chat.hoon
@@ -1213,6 +1213,7 @@
     =.  cu-core  (cu-init %done create)
     =.  cu-core  (cu-diff 0v0 [%init team hive met]:crew.club)
     =.  cor  (give-unread club/id cu-unread)
+    =.  cor  (pass-activity [%club id] [%invite ~] *story:d |)
     =/  =delta:writs:c
       %+  make-notice  our.bowl
       %+  rap  3
@@ -1366,6 +1367,7 @@
       =.  hive.crew.club  (~(del in hive.crew.club) ship)
       ?.  ok.delta
         (cu-post-notice ship ' declined the invite')
+      =.  cor  (pass-activity [%club id] [%invite ~] *story:d |)
       =.  cor  (give-unread club/id cu-unread)
       =.  team.crew.club  (~(put in team.crew.club) ship)
       =?  last-read.remark.club  =(ship our.bowl)  now.bowl

--- a/desk/app/chat.hoon
+++ b/desk/app/chat.hoon
@@ -1587,12 +1587,17 @@
   ::
   ++  di-abed-soft
     |=  s=@p
-    =/  d
-      %+  ~(gut by dms)  s
-      =|  =remark:c
-      =.  watching.remark  &
-      [*pact:c remark ?:(=(src our):bowl %inviting %invited) |]
-    di-core(ship s, dm d)
+    =/  dm  (~(get by dms) s)
+    ?^  dm  di-core(ship s, dm u.dm)
+    =|  =remark:c
+    =/  new=dm:c
+      :*  *pact:c
+          remark(watching &)
+          ?:(=(src our):bowl %inviting %invited)
+          |
+      ==
+    =.  di-core  di-core(ship s, dm new)
+    (di-activity [%invite ~] *story:d &)
   ::
   ++  di-area  `path`/dm/(scot %p ship)
   ++  di-area-writs  `path`/dm/(scot %p ship)/writs
@@ -1640,8 +1645,6 @@
     =.  pact.dm  (reduce:di-pact now.bowl diff)
     =?  cor  &(=(net.dm %invited) !=(ship our.bowl))
       (give-invites ship)
-    =?  di-core  &(=(net.dm %invited) !=(ship our.bowl))
-      (di-activity [%invite ~] *story:d &)
     ?-  -.q.diff
         ?(%del %add-react %del-react)  (di-give-writs-diff diff)
     ::
@@ -1724,7 +1727,6 @@
     =?  cor  =(our src):bowl
       (emit (proxy-rsvp:di-pass ok))
     ?>  |(=(src.bowl ship) =(our src):bowl)
-    =.  cor  (pass-activity [%ship ship] [%invite ~] *story:d |)
     ::  TODO hook into archive
     ?.  ok
       %-  (note:wood %odd leaf/"gone {<ship>}" ~)

--- a/desk/app/chat.hoon
+++ b/desk/app/chat.hoon
@@ -1213,7 +1213,6 @@
     =.  cu-core  (cu-init %done create)
     =.  cu-core  (cu-diff 0v0 [%init team hive met]:crew.club)
     =.  cor  (give-unread club/id cu-unread)
-    =.  cor  (pass-activity [%club id] [%invite ~] *story:d |)
     =/  =delta:writs:c
       %+  make-notice  our.bowl
       %+  rap  3
@@ -1273,6 +1272,7 @@
       cu-core
     ::
         %init
+      =.  cor  (pass-activity [%club id] [%invite ~] *story:d |)
       ::  ignore if already initialized
       ?:  ?|  !=(~ hive.crew.club)
               !=(~ team.crew.club)
@@ -1367,7 +1367,6 @@
       =.  hive.crew.club  (~(del in hive.crew.club) ship)
       ?.  ok.delta
         (cu-post-notice ship ' declined the invite')
-      =.  cor  (pass-activity [%club id] [%invite ~] *story:d |)
       =.  cor  (give-unread club/id cu-unread)
       =.  team.crew.club  (~(put in team.crew.club) ship)
       =?  last-read.remark.club  =(ship our.bowl)  now.bowl


### PR DESCRIPTION
We forgot to add an activity entry for clubs when they're initialized. Fixes TLON-2117

PR Checklist
- [X] Includes changes to desk files
- [ ] Describes how you tested the PR locally (test ship vs livenet)
- [ ] If a new feature, includes automated tests
- [ ] Comments added anywhere logic may be confusing without context