### PR TITLE
native: catch issues w/input webview and force reload

### DIFF
--- a/packages/shared/src/api/activityApi.ts
+++ b/packages/shared/src/api/activityApi.ts
@@ -8,7 +8,7 @@ import * as ub from '../urbit';
 import { formatUd, getCanonicalPostId, udToDate } from './apiUtils';
 import { poke, scry, subscribe } from './urbit';
 
-const logger = createDevLogger('activityApi', true);
+const logger = createDevLogger('activityApi', false);
 
 export async function getUnreads() {
   const activity = await scry<ub.Activity>({
@@ -488,7 +488,7 @@ export function getMessageKey(
   };
 }
 
-/* 
+/*
   The following helpers are used to produce "sources" which is what %activity uses to refer
   to particular activity-emitting contexts (groups, channels, threads). They nest under eachother, so
   a thread will have a parent channel source, which in turn will have a parent group source

--- a/packages/ui/src/components/MessageInput/index.native.tsx
+++ b/packages/ui/src/components/MessageInput/index.native.tsx
@@ -15,7 +15,7 @@ import {
   MentionsBridge,
   ShortcutsBridge,
 } from '@tloncorp/editor/src/bridges';
-import { tiptap } from '@tloncorp/shared/dist';
+import { createDevLogger, tiptap } from '@tloncorp/shared/dist';
 import { PostContent, toContentReference } from '@tloncorp/shared/dist/api';
 import * as db from '@tloncorp/shared/dist/db';
 import {
@@ -39,16 +39,13 @@ import {
 import { Keyboard } from 'react-native';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
 import type { WebViewMessageEvent } from 'react-native-webview';
-import {
-  getToken,
-  getTokenValue,
-  useTheme,
-  useWindowDimensions,
-} from 'tamagui';
+import { getToken, useWindowDimensions } from 'tamagui';
 
 import { useReferences } from '../../contexts/references';
 import { XStack } from '../../core';
 import { MessageInputContainer, MessageInputProps } from './MessageInputBase';
+
+const messageInputLogger = createDevLogger('MessageInput', false);
 
 type MessageEditorMessage = {
   type: 'contentHeight';
@@ -138,6 +135,7 @@ export const MessageInput = forwardRef<MessageInputHandle, MessageInputProps>(
     }));
 
     const [hasSetInitialContent, setHasSetInitialContent] = useState(false);
+    const [editorIsReady, setEditorIsReady] = useState(false);
     const [containerHeight, setContainerHeight] = useState(initialHeight);
     const { bottom, top } = useSafeAreaInsets();
     const { height } = useWindowDimensions();
@@ -176,6 +174,14 @@ export const MessageInput = forwardRef<MessageInputHandle, MessageInputProps>(
     });
     const editorState = useBridgeState(editor);
     const webviewRef = editor.webviewRef;
+
+    const reloadWebview = useCallback(
+      (reason: string) => {
+        webviewRef.current?.reload();
+        messageInputLogger.log('[webview] Reloading webview, reason:', reason);
+      },
+      [webviewRef]
+    );
 
     useEffect(() => {
       if (editor) {
@@ -217,7 +223,7 @@ export const MessageInput = forwardRef<MessageInputHandle, MessageInputProps>(
             }
           });
         } catch (e) {
-          console.error('Error getting draft', e);
+          messageInputLogger.error('Error getting draft', e);
         }
       }
     }, [
@@ -568,6 +574,9 @@ export const MessageInput = forwardRef<MessageInputHandle, MessageInputProps>(
               setupMutationObserver();
           `
           );
+
+          setEditorIsReady(true);
+          return;
         }
 
         if (type === 'contentHeight') {
@@ -583,9 +592,32 @@ export const MessageInput = forwardRef<MessageInputHandle, MessageInputProps>(
 
         editor.bridgeExtensions?.forEach((e) => {
           e.onEditorMessage && e.onEditorMessage({ type, payload }, editor);
+          return;
+        });
+
+        if (type === 'content-error') {
+          messageInputLogger.log('[webview] Content error', payload);
+          reloadWebview(`Content error: ${payload}`);
+          return;
+        }
+
+        if (type === 'send-json-back') {
+          return;
+        }
+
+        messageInputLogger.log('[webview] Unknown message from editor', {
+          type,
+          payload,
         });
       },
-      [editor, handleAddNewLine, handlePaste, setHeight, webviewRef]
+      [
+        editor,
+        handleAddNewLine,
+        handlePaste,
+        setHeight,
+        webviewRef,
+        reloadWebview,
+      ]
     );
 
     const tentapInjectedJs = useMemo(
@@ -606,6 +638,21 @@ export const MessageInput = forwardRef<MessageInputHandle, MessageInputProps>(
         });
       }
     }, [bigInput, bigInputHeightBasic]);
+
+    // we need to check if the app within the webview actually loaded
+    useEffect(() => {
+      if (!editorState.isReady && !editorIsReady) {
+        // if it hasn't loaded yet, we need to try loading the content again
+        reloadWebview(`Editor not ready`);
+      }
+    }, [
+      editorState.isReady,
+      reloadWebview,
+      webviewRef,
+      editor,
+      editorIsReady,
+      editorState,
+    ]);
 
     const titleIsEmpty = useMemo(() => !title || title.length === 0, [title]);
 
@@ -644,8 +691,49 @@ export const MessageInput = forwardRef<MessageInputHandle, MessageInputProps>(
             }}
             editor={editor}
             onMessage={handleMessage}
+            onError={(e) => {
+              messageInputLogger.warn(
+                '[webview] Error from webview',
+                e.nativeEvent
+              );
+              reloadWebview('Error from webview');
+            }}
+            onRenderProcessGone={(e) => {
+              // https://github.com/react-native-webview/react-native-webview/blob/master/docs/Reference.md#onrenderprocessgone
+              messageInputLogger.warn(
+                '[webview] Render process gone',
+                e.nativeEvent.didCrash
+              );
+              reloadWebview(`Render process gone: ${e.nativeEvent.didCrash}`);
+            }}
+            onContentProcessDidTerminate={(e) => {
+              // iOS will kill webview in background
+              // https://github.com/react-native-webview/react-native-webview/blob/master/docs/Reference.md#oncontentprocessdidterminate
+              messageInputLogger.warn(
+                '[webview] Content process terminated',
+                e
+              );
+              reloadWebview('Content process terminated');
+            }}
+            // we never want to see a loading indicator
+            renderLoading={() => <></>}
             injectedJavaScript={`
               ${tentapInjectedJs}
+
+              window.onerror = function(message, source, lineno, colno, error) {
+                window.ReactNativeWebView.postMessage(JSON.stringify({ type: 'content-error', payload: message }));
+                return true;
+              }
+
+              window.addEventListener('error', function(e) {
+                window.ReactNativeWebView.postMessage(JSON.stringify({ type: 'content-error', payload: e.message }));
+                return true;
+              });
+
+              window.addEventListener('unhandledrejection', function(e) {
+                window.ReactNativeWebView.postMessage(JSON.stringify({ type: 'content-error', payload: e.message }));
+                return true;
+              });
 
               window.addEventListener('keydown', (e) => {
 

--- a/patches/@10play__tentap-editor@0.4.55.patch
+++ b/patches/@10play__tentap-editor@0.4.55.patch
@@ -11,3 +11,20 @@ index b878f5382cd64a62a6c4a66b52b6a32a9e2cf96a..c95d3513806d85560115d35d12ecf084
  
  export const RichText = ({ editor, ...props }: RichTextProps) => {
    const [loaded, setLoaded] = useState(isFabric());
+diff --git a/src/webEditorUtils/useTenTap.tsx b/src/webEditorUtils/useTenTap.tsx
+index fc6ee31cb727467aedfc97e4f08d2944e76d0f56..ef1bda589cf1475ce939981e8a6f1997e985916d 100644
+--- a/src/webEditorUtils/useTenTap.tsx
++++ b/src/webEditorUtils/useTenTap.tsx
+@@ -87,6 +87,12 @@ export const useTenTap = (options?: useTenTapArgs) => {
+         payload: undefined,
+       });
+     },
++    onContentError: (contentError) => {
++      sendMessage({
++        type: 'content-error',
++        payload: contentError,
++      });
++    },
+     onSelectionUpdate: (onUpdate) => sendStateUpdate(onUpdate.editor),
+     onTransaction: (onUpdate) => sendStateUpdate(onUpdate.editor),
+     ...tiptapOptionsWithExtensions,

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -10,7 +10,7 @@ overrides:
 
 patchedDependencies:
   '@10play/tentap-editor@0.4.55':
-    hash: s2uo542ywkfolgcnjwqbuh6ps4
+    hash: xjpmkpcw463yvoqvocxrxq7ici
     path: patches/@10play__tentap-editor@0.4.55.patch
   '@tiptap/react@2.0.3':
     hash: tt2duu22fpwhmhaws3iaoig4mu
@@ -82,7 +82,7 @@ importers:
     dependencies:
       '@10play/tentap-editor':
         specifier: ^0.4.55
-        version: 0.4.55(patch_hash=s2uo542ywkfolgcnjwqbuh6ps4)(@tiptap/core@2.3.0(@tiptap/pm@2.3.0))(react-native-webview@13.6.4(react-native@0.73.4(@babel/core@7.23.7)(@babel/preset-env@7.23.7(@babel/core@7.23.7))(encoding@0.1.13)(react@18.2.0))(react@18.2.0))(react-native@0.73.4(@babel/core@7.23.7)(@babel/preset-env@7.23.7(@babel/core@7.23.7))(encoding@0.1.13)(react@18.2.0))(react@18.2.0)
+        version: 0.4.55(patch_hash=xjpmkpcw463yvoqvocxrxq7ici)(@tiptap/core@2.3.0(@tiptap/pm@2.3.0))(react-native-webview@13.6.4(react-native@0.73.4(@babel/core@7.23.7)(@babel/preset-env@7.23.7(@babel/core@7.23.7))(encoding@0.1.13)(react@18.2.0))(react@18.2.0))(react-native@0.73.4(@babel/core@7.23.7)(@babel/preset-env@7.23.7(@babel/core@7.23.7))(encoding@0.1.13)(react@18.2.0))(react@18.2.0)
       '@aws-sdk/client-s3':
         specifier: ^3.190.0
         version: 3.190.0
@@ -912,7 +912,7 @@ importers:
     dependencies:
       '@10play/tentap-editor':
         specifier: ^0.4.55
-        version: 0.4.55(patch_hash=s2uo542ywkfolgcnjwqbuh6ps4)(@tiptap/core@2.0.3(@tiptap/pm@2.0.3))(react-native-webview@13.6.4(react-native@0.73.4(@babel/core@7.23.7)(@babel/preset-env@7.23.7(@babel/core@7.23.7))(encoding@0.1.13)(react@18.2.0))(react@18.2.0))(react-native@0.73.4(@babel/core@7.23.7)(@babel/preset-env@7.23.7(@babel/core@7.23.7))(encoding@0.1.13)(react@18.2.0))(react@18.2.0)
+        version: 0.4.55(patch_hash=xjpmkpcw463yvoqvocxrxq7ici)(@tiptap/core@2.0.3(@tiptap/pm@2.0.3))(react-native-webview@13.6.4(react-native@0.73.4(@babel/core@7.23.7)(@babel/preset-env@7.23.7(@babel/core@7.23.7))(encoding@0.1.13)(react@18.2.0))(react@18.2.0))(react-native@0.73.4(@babel/core@7.23.7)(@babel/preset-env@7.23.7(@babel/core@7.23.7))(encoding@0.1.13)(react@18.2.0))(react@18.2.0)
       '@tiptap/core':
         specifier: ^2.0.3
         version: 2.0.3(@tiptap/pm@2.0.3)
@@ -1029,7 +1029,7 @@ importers:
     dependencies:
       '@10play/tentap-editor':
         specifier: ^0.4.55
-        version: 0.4.55(patch_hash=s2uo542ywkfolgcnjwqbuh6ps4)(@tiptap/core@2.3.0(@tiptap/pm@2.3.0))(react-native-webview@13.6.4(react-native@0.73.4(@babel/core@7.23.7)(@babel/preset-env@7.23.7(@babel/core@7.23.7))(encoding@0.1.13)(react@18.2.0))(react@18.2.0))(react-native@0.73.4(@babel/core@7.23.7)(@babel/preset-env@7.23.7(@babel/core@7.23.7))(encoding@0.1.13)(react@18.2.0))(react@18.2.0)
+        version: 0.4.55(patch_hash=xjpmkpcw463yvoqvocxrxq7ici)(@tiptap/core@2.3.0(@tiptap/pm@2.3.0))(react-native-webview@13.6.4(react-native@0.73.4(@babel/core@7.23.7)(@babel/preset-env@7.23.7(@babel/core@7.23.7))(encoding@0.1.13)(react@18.2.0))(react@18.2.0))(react-native@0.73.4(@babel/core@7.23.7)(@babel/preset-env@7.23.7(@babel/core@7.23.7))(encoding@0.1.13)(react@18.2.0))(react@18.2.0)
       '@emoji-mart/data':
         specifier: ^1.1.2
         version: 1.1.2
@@ -12256,7 +12256,7 @@ packages:
 
 snapshots:
 
-  '@10play/tentap-editor@0.4.55(patch_hash=s2uo542ywkfolgcnjwqbuh6ps4)(@tiptap/core@2.0.3(@tiptap/pm@2.0.3))(react-native-webview@13.6.4(react-native@0.73.4(@babel/core@7.23.7)(@babel/preset-env@7.23.7(@babel/core@7.23.7))(encoding@0.1.13)(react@18.2.0))(react@18.2.0))(react-native@0.73.4(@babel/core@7.23.7)(@babel/preset-env@7.23.7(@babel/core@7.23.7))(encoding@0.1.13)(react@18.2.0))(react@18.2.0)':
+  '@10play/tentap-editor@0.4.55(patch_hash=xjpmkpcw463yvoqvocxrxq7ici)(@tiptap/core@2.0.3(@tiptap/pm@2.0.3))(react-native-webview@13.6.4(react-native@0.73.4(@babel/core@7.23.7)(@babel/preset-env@7.23.7(@babel/core@7.23.7))(encoding@0.1.13)(react@18.2.0))(react@18.2.0))(react-native@0.73.4(@babel/core@7.23.7)(@babel/preset-env@7.23.7(@babel/core@7.23.7))(encoding@0.1.13)(react@18.2.0))(react@18.2.0)':
     dependencies:
       '@tiptap/extension-blockquote': 2.3.0(@tiptap/core@2.0.3(@tiptap/pm@2.0.3))
       '@tiptap/extension-bold': 2.3.0(@tiptap/core@2.0.3(@tiptap/pm@2.0.3))
@@ -12292,7 +12292,7 @@ snapshots:
     transitivePeerDependencies:
       - '@tiptap/core'
 
-  '@10play/tentap-editor@0.4.55(patch_hash=s2uo542ywkfolgcnjwqbuh6ps4)(@tiptap/core@2.3.0(@tiptap/pm@2.3.0))(react-native-webview@13.6.4(react-native@0.73.4(@babel/core@7.23.7)(@babel/preset-env@7.23.7(@babel/core@7.23.7))(encoding@0.1.13)(react@18.2.0))(react@18.2.0))(react-native@0.73.4(@babel/core@7.23.7)(@babel/preset-env@7.23.7(@babel/core@7.23.7))(encoding@0.1.13)(react@18.2.0))(react@18.2.0)':
+  '@10play/tentap-editor@0.4.55(patch_hash=xjpmkpcw463yvoqvocxrxq7ici)(@tiptap/core@2.3.0(@tiptap/pm@2.3.0))(react-native-webview@13.6.4(react-native@0.73.4(@babel/core@7.23.7)(@babel/preset-env@7.23.7(@babel/core@7.23.7))(encoding@0.1.13)(react@18.2.0))(react@18.2.0))(react-native@0.73.4(@babel/core@7.23.7)(@babel/preset-env@7.23.7(@babel/core@7.23.7))(encoding@0.1.13)(react@18.2.0))(react@18.2.0)':
     dependencies:
       '@tiptap/extension-blockquote': 2.3.0(@tiptap/core@2.3.0(@tiptap/pm@2.3.0))
       '@tiptap/extension-bold': 2.3.0(@tiptap/core@2.3.0(@tiptap/pm@2.3.0))


### PR DESCRIPTION
Fixes TLON-2130.

This is an attempt to catch all the ways that the editor webview could fail and then force a reload. The particular issue that was happening with TLON-2130 seems to have been a race condition with setting up tiptap within tentap (not all extensions were loaded in time, which seems like it shouldn't happen, but is). I patched tentap to catch any errors with tiptap and send a message to the native side if it happens, the native side then reloads the webview.

We also reload for other various failure modes, and inject some JS in the webview to try catch any errors that might be happening in the JS running within the webview.