### PR TITLE
native: a few fixes

### DIFF
--- a/packages/shared/src/api/activityApi.ts
+++ b/packages/shared/src/api/activityApi.ts
@@ -637,7 +637,6 @@ export const toClientUnreads = (activity: ub.Activity): ActivityInit => {
   const threadActivity: db.ThreadUnreadState[] = [];
 
   Object.entries(activity).forEach(([sourceId, summary]) => {
-    logger.log(`parsing unreads for ${sourceId}`, summary);
     const [activityId, ...rest] = sourceId.split('/');
     if (activityId === 'ship' || activityId === 'club') {
       const channelId = rest.join('/');

--- a/packages/shared/src/api/initApi.ts
+++ b/packages/shared/src/api/initApi.ts
@@ -18,6 +18,8 @@ export interface InitData {
   activity: ActivityInit;
   channels: db.Channel[];
   channelPerms: ChannelInit[];
+  joinedGroups: string[];
+  joinedChannels: string[];
 }
 
 export const getInitData = async () => {
@@ -36,6 +38,9 @@ export const getInitData = async () => {
   const invitedDms = toClientDms(response.chat.invited, true);
   const unreads = toClientUnreads(response.activity ?? {});
 
+  const joinedGroups = groups.map((group) => group.id);
+  const joinedChannels = channelsInit.map((channel) => channel.channelId);
+
   return {
     pins,
     groups,
@@ -43,5 +48,7 @@ export const getInitData = async () => {
     unreads,
     channels: [...dmChannels, ...groupDmChannels, ...invitedDms],
     channelPerms: channelsInit,
+    joinedGroups,
+    joinedChannels,
   };
 };

--- a/packages/shared/src/api/initApi.ts
+++ b/packages/shared/src/api/initApi.ts
@@ -39,6 +39,8 @@ export const getInitData = async () => {
   const unreads = toClientUnreads(response.activity ?? {});
 
   const joinedGroups = groups.map((group) => group.id);
+  // Not fully reflective of which channels you're a member of, but if a channel is _not_
+  // in here, you're definitely not a member of it
   const joinedChannels = channelsInit.map((channel) => channel.channelId);
 
   return {

--- a/packages/shared/src/db/queries.ts
+++ b/packages/shared/src/db/queries.ts
@@ -1461,7 +1461,6 @@ export const setLeftGroupChannels = createWriteQuery(
     { joinedChannelIds }: { joinedChannelIds: string[] },
     ctx: QueryCtx
   ) => {
-    console.log(`bl: joinedChannelIds`, joinedChannelIds);
     if (joinedChannelIds.length === 0) return;
     return await ctx.db
       .update($channels)
@@ -1482,7 +1481,6 @@ export const setLeftGroupChannels = createWriteQuery(
 export const setLeftGroups = createWriteQuery(
   'setLeftGroups',
   async ({ joinedGroupIds }: { joinedGroupIds: string[] }, ctx: QueryCtx) => {
-    console.log(`bl: joinedGroupIds`, joinedGroupIds);
     if (joinedGroupIds.length === 0) return;
     return await ctx.db
       .update($groups)

--- a/packages/shared/src/db/queries.ts
+++ b/packages/shared/src/db/queries.ts
@@ -143,6 +143,7 @@ export const getSettings = createReadQuery(
 export const getGroupPreviews = createReadQuery(
   'getGroupPreviews',
   async (groupIds: string[], ctx: QueryCtx) => {
+    if (groupIds.length === 0) return [];
     return ctx.db.query.groups.findMany({
       where: inArray($groups.id, groupIds),
     });
@@ -919,6 +920,7 @@ export const removeChatMembersFromRoles = createWriteQuery(
     },
     ctx: QueryCtx
   ) => {
+    if (contactIds.length === 0 || roleIds.length === 0) return;
     return ctx.db
       .delete($chatMemberGroupRoles)
       .where(
@@ -938,6 +940,7 @@ export const removeChatMembers = createWriteQuery(
     { chatId, contactIds }: { chatId: string; contactIds: string[] },
     ctx: QueryCtx
   ) => {
+    if (contactIds.length === 0) return;
     return ctx.db
       .delete($chatMembers)
       .where(
@@ -1411,7 +1414,7 @@ export const setJoinedGroupChannels = createWriteQuery(
       return isOpenChannel || isClosedButCanRead;
     });
 
-    logger.log('setJoinedGroupChannels', channelIds);
+    if (channelsWhereMember.length === 0) return;
     return await ctx.db
       .update($channels)
       .set({
@@ -2246,6 +2249,7 @@ export const getContacts = createReadQuery(
 export const getContactsBatch = createReadQuery(
   'getContactsBatch',
   async ({ contactIds }: { contactIds: string[] }, ctx: QueryCtx) => {
+    if (contactIds.length === 0) return [];
     return ctx.db.query.contacts.findMany({
       where: (contacts, { inArray }) => inArray(contacts.id, contactIds),
     });

--- a/packages/shared/src/store/sync.ts
+++ b/packages/shared/src/store/sync.ts
@@ -61,6 +61,12 @@ export const syncInitData = async (reporter?: ErrorReporter) => {
       db
         .insertChannelPerms(initData.channelPerms, ctx)
         .then(() => reporter?.log('inserted channel perms')),
+      db
+        .setLeftGroups({ joinedGroupIds: initData.joinedGroups }, ctx)
+        .then(() => reporter?.log('set left groups')),
+      db
+        .setLeftGroupChannels({ joinedChannelIds: initData.joinedGroups }, ctx)
+        .then(() => reporter?.log('set left channels')),
     ]);
   });
 };

--- a/packages/ui/src/components/ContentReference/GroupReference.tsx
+++ b/packages/ui/src/components/ContentReference/GroupReference.tsx
@@ -48,12 +48,12 @@ export function GroupReference({ groupId }: { groupId: string }) {
         {group && (
           <ListItem pressable={false}>
             <ListItem.Icon
-              fallbackText={group.title?.[0]}
+              fallbackText={group.title?.[0] ?? group.id[0]}
               backgroundColor={group.iconImageColor ?? undefined}
               imageUrl={group.iconImage ?? undefined}
             />
             <ListItem.MainContent>
-              <ListItem.Title>{group.title}</ListItem.Title>
+              <ListItem.Title>{group.title ?? group.id}</ListItem.Title>
             </ListItem.MainContent>
           </ListItem>
         )}

--- a/packages/ui/src/components/GroupListItem/GroupListItemContent.tsx
+++ b/packages/ui/src/components/GroupListItem/GroupListItemContent.tsx
@@ -35,7 +35,7 @@ export default function GroupListItemContent({
     >
       <View opacity={model.volumeSettings?.isMuted ? 0.2 : 1}>
         <ListItem.Icon
-          fallbackText={model.title?.[0]}
+          fallbackText={model.title?.[0] ?? model.id[0]}
           backgroundColor={getBackgroundColor({
             disableAvatars,
             colors,
@@ -50,7 +50,7 @@ export default function GroupListItemContent({
         <ListItem.Title
           color={model.volumeSettings?.isMuted ? '$tertiaryText' : undefined}
         >
-          {model.title}
+          {model.title ?? model.id}
         </ListItem.Title>
         {model.lastPost && (
           <ListItem.Subtitle color={'$tertiaryText'}>

--- a/packages/ui/src/components/GroupPreviewSheet.tsx
+++ b/packages/ui/src/components/GroupPreviewSheet.tsx
@@ -150,11 +150,11 @@ export function GroupPreviewPane({
           padding="$3xl"
         >
           <ListItem.Icon
-            fallbackText={group?.title?.[0]}
+            fallbackText={group?.title?.[0] ?? group?.id[0]}
             backgroundColor={group?.iconImageColor ?? undefined}
             imageUrl={group?.iconImage ?? undefined}
           />
-          <ActionSheet.Title>{group?.title}</ActionSheet.Title>
+          <ActionSheet.Title>{group?.title ?? group?.id}</ActionSheet.Title>
           {group?.description ? (
             <ActionSheet.Description fontSize="$s" textAlign="center">
               {group.description}


### PR DESCRIPTION
Bit of a hodgepodge, stumbled upon these while investigating missing unreads. I was testing joining/leaving groups and noticing we could get stuck in inconsistent states.

- fixes empty info list item for invites to groups with missing metadata (falls back to displaying the group ID)
- ensures query powering the chat list only considers group channels where you're joined to the group
- adds behavior to reconcile group and channel joins & leaves in cases where we don't explicitly hear the fact
- adds more early returns for `inArray` based queries if the array is empty

Fixes TLON-1946