### PR TITLE
native: message send improvements

### DIFF
--- a/apps/tlon-mobile/src/App.main.tsx
+++ b/apps/tlon-mobile/src/App.main.tsx
@@ -198,6 +198,9 @@ function MigrationCheck({ children }: PropsWithChildren) {
   if (!success && !error) {
     return null;
   }
+  if (error) {
+    throw Error();
+  }
   return <>{children}</>;
 }
 

--- a/packages/shared/src/db/migrations/0000_productive_vision.sql
+++ b/packages/shared/src/db/migrations/0000_productive_vision.sql
@@ -292,5 +292,12 @@ CREATE TABLE `volume_settings` (
 	`is_noisy` integer DEFAULT false
 );
 --> statement-breakpoint
+CREATE INDEX `last_post_id` ON `channels` (`last_post_id`);--> statement-breakpoint
+CREATE INDEX `last_post_at` ON `channels` (`last_post_at`);--> statement-breakpoint
+CREATE INDEX `channel_id` ON `post_windows` (`channel_id`);--> statement-breakpoint
+CREATE INDEX `channel_oldest_post` ON `post_windows` (`channel_id`,`oldest_post_id`);--> statement-breakpoint
+CREATE INDEX `channel_newest_post` ON `post_windows` (`channel_id`,`newest_post_id`);--> statement-breakpoint
 CREATE UNIQUE INDEX `posts_sent_at_unique` ON `posts` (`sent_at`);--> statement-breakpoint
-CREATE UNIQUE INDEX `cache_id` ON `posts` (`author_id`,`sent_at`);
+CREATE UNIQUE INDEX `cache_id` ON `posts` (`author_id`,`sent_at`);--> statement-breakpoint
+CREATE INDEX `posts_channel_id` ON `posts` (`channel_id`,`id`);--> statement-breakpoint
+CREATE INDEX `posts_group_id` ON `posts` (`group_id`,`id`);

--- a/packages/shared/src/db/migrations/meta/0000_snapshot.json
+++ b/packages/shared/src/db/migrations/meta/0000_snapshot.json
@@ -1,7 +1,7 @@
 {
   "version": "5",
   "dialect": "sqlite",
-  "id": "28987603-440d-42eb-9c7c-a471f8946c51",
+  "id": "5b22f005-5d8a-445c-83fa-2c8ad5f2e8dc",
   "prevId": "00000000-0000-0000-0000-000000000000",
   "tables": {
     "activity_events": {
@@ -390,7 +390,22 @@
           "autoincrement": false
         }
       },
-      "indexes": {},
+      "indexes": {
+        "last_post_id": {
+          "name": "last_post_id",
+          "columns": [
+            "last_post_id"
+          ],
+          "isUnique": false
+        },
+        "last_post_at": {
+          "name": "last_post_at",
+          "columns": [
+            "last_post_at"
+          ],
+          "isUnique": false
+        }
+      },
       "foreignKeys": {
         "channels_group_id_groups_id_fk": {
           "name": "channels_group_id_groups_id_fk",
@@ -1421,7 +1436,31 @@
           "autoincrement": false
         }
       },
-      "indexes": {},
+      "indexes": {
+        "channel_id": {
+          "name": "channel_id",
+          "columns": [
+            "channel_id"
+          ],
+          "isUnique": false
+        },
+        "channel_oldest_post": {
+          "name": "channel_oldest_post",
+          "columns": [
+            "channel_id",
+            "oldest_post_id"
+          ],
+          "isUnique": false
+        },
+        "channel_newest_post": {
+          "name": "channel_newest_post",
+          "columns": [
+            "channel_id",
+            "newest_post_id"
+          ],
+          "isUnique": false
+        }
+      },
       "foreignKeys": {},
       "compositePrimaryKeys": {
         "post_windows_channel_id_oldest_post_id_newest_post_id_pk": {
@@ -1623,6 +1662,22 @@
             "sent_at"
           ],
           "isUnique": true
+        },
+        "posts_channel_id": {
+          "name": "posts_channel_id",
+          "columns": [
+            "channel_id",
+            "id"
+          ],
+          "isUnique": false
+        },
+        "posts_group_id": {
+          "name": "posts_group_id",
+          "columns": [
+            "group_id",
+            "id"
+          ],
+          "isUnique": false
         }
       },
       "foreignKeys": {},

--- a/packages/shared/src/db/migrations/meta/_journal.json
+++ b/packages/shared/src/db/migrations/meta/_journal.json
@@ -5,8 +5,8 @@
     {
       "idx": 0,
       "version": "5",
-      "when": 1718734310558,
-      "tag": "0000_far_anita_blake",
+      "when": 1718989049597,
+      "tag": "0000_productive_vision",
       "breakpoints": true
     }
   ]

--- a/packages/shared/src/db/migrations/migrations.js
+++ b/packages/shared/src/db/migrations/migrations.js
@@ -1,7 +1,7 @@
 // This file is required for Expo/React Native SQLite migrations - https://orm.drizzle.team/quick-sqlite/expo
 
 import journal from './meta/_journal.json';
-import m0000 from './0000_far_anita_blake.sql';
+import m0000 from './0000_productive_vision.sql';
 
   export default {
     journal,

--- a/packages/shared/src/db/queries.ts
+++ b/packages/shared/src/db/queries.ts
@@ -9,7 +9,6 @@ import {
   count,
   desc,
   eq,
-  exists,
   getTableColumns,
   gt,
   gte,
@@ -24,7 +23,6 @@ import {
   notInArray,
   or,
   sql,
-  sum,
 } from 'drizzle-orm';
 
 import {
@@ -476,7 +474,7 @@ export const insertGroups = createWriteQuery(
           }
         }
       }
-      await setLastPosts(txCtx);
+      await setLastPosts(null, txCtx);
     });
   },
   [
@@ -1204,7 +1202,7 @@ export const insertChannels = createWriteQuery(
             .onConflictDoNothing();
         }
       }
-      await setLastPosts(txCtx);
+      await setLastPosts(null, txCtx);
     });
   },
   ['channels']
@@ -1407,14 +1405,15 @@ export const setJoinedGroupChannels = createWriteQuery(
         .some((r) => userRolesForGroup.includes(r));
       return isOpenChannel || isClosedButCanRead;
     });
-
-    logger.log('setJoinedGroupChannels', channelIds);
-    return await ctx.db
-      .update($channels)
-      .set({
-        currentUserIsMember: inArray($channels.id, channelsWhereMember),
-      })
-      .where(isNotNull($channels.groupId));
+    if (channelsWhereMember.length) {
+      logger.log('setJoinedGroupChannels', channelIds);
+      return await ctx.db
+        .update($channels)
+        .set({
+          currentUserIsMember: inArray($channels.id, channelsWhereMember),
+        })
+        .where(isNotNull($channels.groupId));
+    }
   },
   ['channels']
 );
@@ -1707,6 +1706,7 @@ export const insertChannelPosts = createWriteQuery(
     }
     return withTransactionCtx(ctx, async (txCtx) => {
       await insertPosts(posts, txCtx);
+      logger.log('inserted posts');
       // If these are non-reply posts, update group + channel last post as well as post windows.
       const topLevelPosts = posts.filter((p) => p.type !== 'reply');
       if (topLevelPosts.length) {
@@ -1719,6 +1719,7 @@ export const insertChannelPosts = createWriteQuery(
           },
           txCtx
         );
+        logger.log('updated windows');
       }
     });
   },
@@ -1738,7 +1739,12 @@ export const insertLatestPosts = createWriteQuery(
 async function insertPosts(posts: Post[], ctx: QueryCtx) {
   await ctx.db
     .insert($posts)
-    .values(posts.map((p) => ({ ...p })))
+    .values(
+      posts.map((p) => ({
+        ...p,
+        groupId: sql`(SELECT ${$channels.groupId} FROM ${$channels} WHERE ${$channels.id} = ${p.channelId})`,
+      }))
+    )
     .onConflictDoUpdate({
       target: $posts.id,
       set: conflictUpdateSetAll($posts),
@@ -1747,106 +1753,99 @@ async function insertPosts(posts: Post[], ctx: QueryCtx) {
       target: [$posts.authorId, $posts.sentAt],
       set: conflictUpdateSetAll($posts),
     });
-  await setPostGroups(ctx);
-  await setLastPosts(ctx);
+  logger.log('inserted posts');
+  await setLastPosts(posts, ctx);
+  logger.log('set last posts');
   await clearMatchedPendingPosts(
     posts.filter((p) => p.deliveryStatus !== 'pending'),
     ctx
   );
+  logger.log('clear matched pending');
 }
 
-function setPostGroups(ctx: QueryCtx) {
-  return ctx.db
-    .update($posts)
+async function setLastPosts(newPosts: Post[] | null, ctx: QueryCtx) {
+  const channelIds = newPosts?.map((p) => p.channelId) ?? [];
+
+  if (channelIds.length === 0) return;
+
+  // Combine channel and group updates in a single transaction
+  // Update channels
+  await ctx.db
+    .update($channels)
     .set({
-      groupId: sql`${ctx.db
-        .select({ groupId: $channels.groupId })
-        .from($channels)
+      lastPostId: sql`${ctx.db
+        .select({ id: $posts.id })
+        .from($posts)
         .where(
-          and(eq($channels.id, $posts.channelId), isNotNull($channels.groupId))
-        )}`,
+          and(eq($posts.channelId, $channels.id), not(eq($posts.type, 'reply')))
+        )
+        .orderBy(desc($posts.receivedAt))
+        .limit(1)}`,
+      lastPostAt: sql`${ctx.db
+        .select({ receivedAt: $posts.receivedAt })
+        .from($posts)
+        .where(
+          and(eq($posts.channelId, $channels.id), not(eq($posts.type, 'reply')))
+        )
+        .orderBy(desc($posts.receivedAt))
+        .limit(1)}`,
     })
     .where(
       and(
-        isNull($posts.groupId),
-        exists(
-          ctx.db
-            .select()
-            .from($channels)
-            .where(
-              and(eq($channels.id, $posts.id), isNotNull($channels.groupId))
-            )
-        )
-      )
-    );
-}
-
-async function setLastPosts(ctx: QueryCtx) {
-  const $lastPost = ctx.db.$with('lastPost').as(
-    ctx.db
-      .select({
-        id: $posts.id,
-        channelId: $posts.channelId,
-        receivedAt: $posts.receivedAt,
-      })
-      .from($posts)
-      .where(
-        and(eq($posts.channelId, $channels.id), not(eq($posts.type, 'reply')))
-      )
-      .orderBy(desc($posts.receivedAt))
-      .limit(1)
-  );
-
-  await ctx.db
-    .with($lastPost)
-    .update($channels)
-    .set({
-      lastPostId: sql`(select ${$lastPost.id} from ${$lastPost})`,
-      lastPostAt: sql`(select ${$lastPost.receivedAt} from ${$lastPost})`,
-    })
-    .where(
-      or(
-        isNull($channels.lastPostId),
-        lt(
-          $channels.lastPostId,
-          sql`${ctx.db
-            .select({ id: max($posts.id) })
-            .from($posts)
-            .where(eq($posts.channelId, $channels.id))}`
+        inArray($channels.id, channelIds),
+        or(
+          isNull($channels.lastPostId),
+          lt(
+            $channels.lastPostId,
+            ctx.db
+              .select({ maxId: max($posts.id) })
+              .from($posts)
+              .where(eq($posts.channelId, $channels.id))
+          )
         )
       )
     );
 
-  const $groupLastPost = ctx.db.$with('groupLastPost').as(
-    ctx.db
-      .select({
-        groupId: $channels.groupId,
-        lastPostId: max($channels.lastPostId).as('lastPostId'),
-        lastPostAt: max($channels.lastPostAt).as('lastPostAt'),
-      })
-      .from($channels)
-      .where(eq($channels.groupId, $groups.id))
-      .orderBy(desc($channels.lastPostAt))
-      .groupBy($channels.groupId)
-      .limit(1)
-  );
+  // Update groups
+  const updatedChannelIds = await ctx.db
+    .select({ id: $channels.id, groupId: $channels.groupId })
+    .from($channels)
+    .where(inArray($channels.id, channelIds));
+
+  const updatedGroupIds: string[] = [
+    ...new Set(updatedChannelIds.map((c) => c.groupId)),
+  ] as string[];
+
+  if (!updatedGroupIds.length) return;
 
   await ctx.db
-    .with($groupLastPost)
     .update($groups)
     .set({
-      lastPostId: sql`(select ${$groupLastPost.lastPostId} from ${$groupLastPost})`,
-      lastPostAt: sql`(select ${$groupLastPost.lastPostAt} from ${$groupLastPost})`,
+      lastPostId: sql`${ctx.db
+        .select({ lastPostId: $channels.lastPostId })
+        .from($channels)
+        .where(eq($channels.groupId, $groups.id))
+        .orderBy(desc($channels.lastPostAt))
+        .limit(1)}`,
+      lastPostAt: sql`${ctx.db
+        .select({ lastPostAt: $channels.lastPostAt })
+        .from($channels)
+        .where(eq($channels.groupId, $groups.id))
+        .orderBy(desc($channels.lastPostAt))
+        .limit(1)}`,
     })
     .where(
-      or(
-        isNull($groups.lastPostId),
-        lt(
-          $groups.lastPostId,
-          sql`${ctx.db
-            .select({ id: max($posts.id) })
-            .from($posts)
-            .where(eq($posts.groupId, $groups.id))}`
+      and(
+        inArray($groups.id, updatedGroupIds),
+        or(
+          isNull($groups.lastPostId),
+          lt(
+            $groups.lastPostId,
+            ctx.db
+              .select({ maxId: max($posts.id) })
+              .from($posts)
+              .where(eq($posts.groupId, $groups.id))
+          )
         )
       )
     );

--- a/packages/shared/src/db/query.ts
+++ b/packages/shared/src/db/query.ts
@@ -213,6 +213,7 @@ export async function withTransactionCtx<T>(
   ctx: QueryCtx,
   handler: (ctx: QueryCtx) => Promise<T>
 ): Promise<T> {
+  txLogger.log(ctx.meta.label, 'tx:enqueue');
   return new Promise((resolve, reject) =>
     enqueueTransaction(async () => {
       txLogger.log(ctx.meta.label, 'tx:handler');

--- a/packages/shared/src/debug.ts
+++ b/packages/shared/src/debug.ts
@@ -82,8 +82,8 @@ export const listDebugLabel = runIfDev((list: Iterable<string | number>) => {
 
 const sessionStartTime = Date.now();
 
-const LOG_SESSION_TIME = false;
-const LOG_DELTA = false;
+const LOG_SESSION_TIME = true;
+const LOG_DELTA = true;
 
 function sessionTimeLabel() {
   return LOG_SESSION_TIME ? `${Date.now() - sessionStartTime}` : null;

--- a/packages/shared/src/store/sync.ts
+++ b/packages/shared/src/store/sync.ts
@@ -475,6 +475,8 @@ export const handleChannelsUpdate = async (update: api.ChannelsUpdate) => {
 };
 
 export const handleChatUpdate = async (update: api.ChatEvent) => {
+  logger.log('event: chat update', update);
+
   switch (update.type) {
     case 'addPost':
       await handleAddPost(update.post);
@@ -502,14 +504,23 @@ export const handleChatUpdate = async (update: api.ChatEvent) => {
     case 'addDmInvites':
       db.insertChannels(update.channels);
       break;
-
     case 'groupDmsUpdate':
       syncDms();
       break;
   }
 };
 
+let lastAdded: string;
+
 export async function handleAddPost(post: db.Post) {
+  // We frequently get duplicate addPost events from the api,
+  // so skip if we've just added this.
+  if (post.id === lastAdded) {
+    logger.log('skipping duplicate post.');
+  } else {
+    lastAdded = post.id;
+  }
+
   // first check if it's a reply. If it is and we haven't already cached
   // it, we need to add it to the parent post
   if (post.parentId) {

--- a/packages/shared/src/store/useChannelPosts.ts
+++ b/packages/shared/src/store/useChannelPosts.ts
@@ -150,10 +150,10 @@ export const useChannelPosts = (options: UseChanelPostsParams) => {
     getPreviousPageParam: (
       firstPage,
       _allPages,
-      firstPageParam
+      _firstPageParam
     ): UseChannelPostsPageParams | undefined => {
       const firstPageIsEmpty = !firstPage[0]?.id;
-      if (firstPageParam.mode === 'newest' || firstPageIsEmpty) {
+      if (firstPageIsEmpty) {
         return undefined;
       }
       return {

--- a/packages/ui/src/components/Channel/Scroller.tsx
+++ b/packages/ui/src/components/Channel/Scroller.tsx
@@ -69,7 +69,7 @@ export type ScrollAnchor = {
  * - If we're scrolling to an anchor, that anchor should be in the first page of posts
  * - The size of the first page of posts should match `initialNumToRender` here.
  */
-export default function Scroller({
+function Scroller({
   anchor,
   inverted,
   renderItem,
@@ -484,6 +484,8 @@ export default function Scroller({
     </View>
   );
 }
+
+export default React.memo(Scroller);
 
 function getPostId(post: db.Post) {
   return post.id;


### PR DESCRIPTION
This PR includes a bunch of small improvements that have come out of debugging message sending.
- Improves performance of `insertChannelPosts`
- Ensures that migrations errors propagate to the error boundary
- Logs timings by default
- Fixes a bug that could cause `useChannelPosts` to fail to fetch a newer page.
- Deduplicates `addPost` events from the api (they're usually duplicated)
- Memoizes the scroller

Will hopefully address TLON-2141, but need to verify.