### PR TITLE
native: only reload input webview if we know we have an issue

### DIFF
--- a/packages/ui/src/tamagui.config.ts
+++ b/packages/ui/src/tamagui.config.ts
@@ -229,7 +229,11 @@ export const themes = {
 
 export const systemFont = createFont({
   family:
-    "System, -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Ubuntu, 'Helvetica Neue', sans-serif",
+    // Previously used font stack
+    // '-apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, sans-serif',
+    // did not work, threw errors in xcode console on iOS. Fortunately iOS
+    //defaulted to its system font anyway
+    'System',
   size: {
     xs: 12,
     s: 14,


### PR DESCRIPTION
fixes TLON-2130 (again). Previously we were reloading anytime the editor wasn't ready, but this could cause extraneous reloads that then caused other issues. Now we'll only reload the webview if we *know* it has crashed.

Also changes the font used in the system font, happened upon this issue while looking at the xcode console (the app was endlessly spamming the console with: `Unrecognized font family 'System, -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Ubuntu, 'Helvetica Neue', sans-serif'`)