### PR TITLE
throw actual error on migration failure

### DIFF
--- a/apps/tlon-mobile/src/App.main.tsx
+++ b/apps/tlon-mobile/src/App.main.tsx
@@ -199,7 +199,7 @@ function MigrationCheck({ children }: PropsWithChildren) {
     return null;
   }
   if (error) {
-    throw Error();
+    throw error;
   }
   return <>{children}</>;
 }


### PR DESCRIPTION
Previously, we were throwing a generic, uninformative error.