### PR TITLE
fix migration error

### DIFF
--- a/apps/tlon-mobile/src/lib/nativeDb.ts
+++ b/apps/tlon-mobile/src/lib/nativeDb.ts
@@ -55,7 +55,6 @@ export async function purgeDb() {
   client = null;
   logger.log('purged sqlite database, recreating');
   setupDb();
-  runMigrations();
 }
 
 export function getDbPath() {


### PR DESCRIPTION
This PR fixes migration failure issues by removing a duplicate call to `runMigrations`.