### PR TITLE
native: fix crash on navigating to gallery with one unread

### DIFF
--- a/packages/ui/src/components/Channel/Scroller.tsx
+++ b/packages/ui/src/components/Channel/Scroller.tsx
@@ -242,7 +242,7 @@ function Scroller({
           // If we're in a gallery channel, we need to adjust the index to account
           // for the empty post we added after the first unread post.
           const galleryAdjustedIndex =
-            channelType === 'gallery' && firstUnreadId !== null
+            channelType === 'gallery' && firstUnreadId !== null && index > 0
               ? index - 1
               : index;
 


### PR DESCRIPTION
Fixes TLON-2148, we need to make sure we have an index great than zero, otherwise we'll try to scroll to -1 when the firstUnread is at the 0 position.