### PR TITLE
activity: correct bad activity keys 

### DIFF
--- a/apps/tlon-web/src/replies/ReplyMessage.tsx
+++ b/apps/tlon-web/src/replies/ReplyMessage.tsx
@@ -152,46 +152,46 @@ const ReplyMessage = React.memo<
         () => isMessageHidden || isPostHidden,
         [isMessageHidden, isPostHidden]
       );
-      const { ref: viewRef } = useInView({
+      const { ref: viewRef, inView } = useInView({
         threshold: 1,
-        onChange: useCallback(
-          (inView: boolean) => {
-            // if no tracked unread we don't need to take any action
-            if (!unread) {
-              return;
-            }
-
-            const unseen = whomIsFlag(whom)
-              ? unread.status === 'unread'
-              : unread.combined.status === 'unread';
-            /* the first fire of this function
-               which we don't to do anything with. */
-            if (!inView && unseen) {
-              return;
-            }
-
-            const { seen: markSeen, delayedRead } = useUnreadsStore.getState();
-
-            /* once the unseen marker comes into view we need to mark it
-               as seen and start a timer to mark it read so it goes away.
-               we ensure that the brief matches and hasn't changed before
-               doing so. we don't want to accidentally clear unreads when
-               the state has changed
-            */
-            if (inView && isUnread && unseen) {
-              markSeen(threadKey);
-              delayedRead(threadKey, () => {
-                if (isDMOrMultiDM) {
-                  markDmRead();
-                } else {
-                  markChannelRead();
-                }
-              });
-            }
-          },
-          [unread, whom, isDMOrMultiDM, markChannelRead, markDmRead, isUnread]
-        ),
       });
+
+      useEffect(() => {
+        // if no tracked unread we don't need to take any action
+        if (!inView || !unread) {
+          return;
+        }
+
+        const unseen = whomIsFlag(whom)
+          ? unread.status === 'unread'
+          : unread.combined.status === 'unread';
+        const { seen: markSeen, delayedRead } = useUnreadsStore.getState();
+
+        /* once the unseen marker comes into view we need to mark it
+             as seen and start a timer to mark it read so it goes away.
+             we ensure that the brief matches and hasn't changed before
+             doing so. we don't want to accidentally clear unreads when
+             the state has changed
+          */
+        if (inView && isUnread && unseen) {
+          markSeen(threadKey);
+          delayedRead(threadKey, () => {
+            if (isDMOrMultiDM) {
+              markDmRead();
+            } else {
+              markChannelRead();
+            }
+          });
+        }
+      }, [
+        whom,
+        inView,
+        isUnread,
+        unread,
+        isDMOrMultiDM,
+        markChannelRead,
+        markDmRead,
+      ]);
 
       const msgStatus = useTrackedMessageStatus({
         author: window.our,

--- a/desk/app/activity.hoon
+++ b/desk/app/activity.hoon
@@ -97,7 +97,7 @@
   =?  old  ?=(%1 -.old)  (state-1-to-2 old)
   ?>  ?=(%2 -.old)
   =.  state  old
-  correct-dm-keys
+  (emit %pass /clean-keys %agent [our.bowl dap.bowl] %poke noun+!>(%clean-keys))
   +$  versioned-state  $%(state-2 state-1)
   +$  state-2  current-state
   +$  state-1

--- a/desk/app/activity.hoon
+++ b/desk/app/activity.hoon
@@ -122,11 +122,9 @@
     =/  whom  ?-(-.source %dm whom.source, %dm-thread whom.source)
     ?.  ?=(%club -.whom)  dms
     (~(add ja dms) whom [source index])
-  ~&  ['got club sources' (turn club-threads |=([* srcs=(list [source:a index:a])] (turn srcs head)))]
   |-
   ?~  club-threads  cor
   =/  [=whom:a =indexes]  -.club-threads
-  ~&  ['working' whom]
   =*  next  $(club-threads +.club-threads)
   ?.  ?=(%club -.whom)  next
   =/  club  (~(get by clubs) p.whom)
@@ -136,14 +134,12 @@
       indexes
     |=  [=source:a *]
     ?=(%dm-thread -.source)
-  ~&  ['separated: dms' (lent dms) ' threads' (lent threads)]
   =;  indxs=^indexes
     |-
     ?~  indxs  next
     =*  source  source.i.indxs
     ::  cleanup old bad keys
     =?  cor  ?=(%dm-thread -.source)
-      ~&  ['deleting old source data' source]
       =/  old-source  source(key [id.key.source q.id.key.source])
       %=  cor
         indices  (~(del by indices) old-source)
@@ -153,7 +149,6 @@
     ::  update source + index, if new key create new index
     =.  cor  (update-index source index.i.indxs &)
     $(indxs t.indxs)
-  =-  ~&  [(lent -) 'indexes']  -
   %+  weld
     (handle-dms u.club dms)
   (handle-threads u.club threads)
@@ -181,19 +176,14 @@
       indexes
     |=  [[=source:a =index:a] acc=[=indices:a keys=(map message-id:a message-key:a)]]
     ?.  ?=(%dm-thread -.source)
-      ~&  'skipping, not dm-thread'
       [(~(put by indices) source index) keys.acc]
     =*  id  id.key.source
     =/  key  (~(get by keys.acc) id)
-    ?:  &(?=(^ key) (~(has by indices.acc) source(key u.key)))
-      ~&  ['already have key' key source]
-      acc
-    ?~  srcs=(~(get by collapsed) id)
-      ~&  ['somehow missing in collapsed' id]  acc
+    ?:  &(?=(^ key) (~(has by indices.acc) source(key u.key)))  acc
+    ?~  srcs=(~(get by collapsed) id)  acc
     =/  post-time  (~(get by dex.pact.club) id)
-    ?~  post-time  ~&(['id missing' id] acc)
+    ?~  post-time  acc
     =/  new-key  [id u.post-time]
-    ~&  ['new key' new-key]
     :_  (~(put by keys.acc) id new-key)
     %-  ~(put by indices.acc)
     ::  new source
@@ -202,7 +192,6 @@
       u.srcs
     |=  [[=source:a =index:a] acc=index:a]
     ?.  ?=(%dm-thread -.source)  acc
-    ~&  ['merging' source]
     :-  (clean-stream-keys club (uni:on-event:a stream.acc stream.index))
     ::  rectify reads
     =/  floor  (max floor.reads.index floor.reads.acc)
@@ -741,7 +730,6 @@
 ++  refresh-summary
   |=  =source:a
   =/  summary  (summarize-unreads source (get-index source))
-  ~&  ['new summary' source summary]
   =.  activity
     (~(put by activity) source summary)
   (give-unreads source)
@@ -878,9 +866,7 @@
   |=  [=source:a updater=$-(index:a index:a)]
   ^+  cor
   =/  index  (get-index source)
-  ~&  ?:(=(index *index:a) 'bad source' 'got index')
   =/  new  (updater index)
-  ~&  ['old' reads.index 'new' reads.new]
   (update-index source new &)
 ++  give-unreads
   |=  =source:a

--- a/desk/app/activity.hoon
+++ b/desk/app/activity.hoon
@@ -106,6 +106,58 @@
     |=  old=state-1
     ^-  state-2
     [%2 %all +.old]
+  ++  correct-dm-reply-keys
+    ^+  cor
+    =+  .^  [dms=(map ship dm:ch) clubs=(map id:club:ch club:ch)]
+      %gx  (scry-path %chat /full/noun)
+    ==
+    =/  club-threads
+      %~  tap  by
+      %+  roll
+        ~(tap by indices)
+      |=  [[=source:a =index:a] dms=(jar whom:a [source:a index:a])]
+      ?.  ?=(?(%dm %dm-thread) -.source)  dms
+      =/  whom  ?-(-.source %dm whom.source, %dm-thread whom.source)
+      ?.  ?=(%club -.whom)  dms
+      (~(add ja dms) whom [source index])
+    |-
+    ?~  club-threads  cor
+    =/  [=whom:a indexes=(list [=source:a =index:a])]  -.club-threads
+    =*  next  $(club-threads +.club-threads)
+    ?.  ?=(%club -.whom)  next
+    =/  club  (~(get by clubs) p.whom)
+    ?~  club  next
+    =;  indxs=(list [=source:a =index:a])
+      |-
+      ?~  indxs  cor
+      =.  cor  (update-index source.i.indxs index.i.indxs &)
+      $(indxs t.indxs)
+    %+  turn
+      indexes
+    |=  [=source:a =index:a]
+    ?.  ?=(?(%dm %dm-thread) -.source)  [source index]
+    =;  new-stream=stream:a
+      [source index(stream new-stream)]
+    %+  gas:on-event:a  *stream:a
+    %+  turn
+      (tap:on-event:a stream.index)
+    |=  [=time =event:a]
+    ::  skip any non post or reply events
+    ?.  ?=(?(%dm-post %dm-reply) -<.event)  [time event]
+    =/  post-id  ?:(?=(%dm-post -<.event) id.key.event id.parent.event)
+    =/  post-time  (~(get by dex.pact.u.club) post-id)
+    ?~  post-time  [time event]
+    ?:  ?=(%dm-post -<.event)
+      [time event(key [post-id u.post-time])]
+    =/  post  (get:on:writs:ch wit.pact.u.club u.post-time)
+    ?~  post  [time event]
+    =/  parent=message-key:a  [id time]:u.post
+    =/  reply-time  (~(get by dex.pact.u.club) id.key.event)
+    ?~  reply-time  [time event]
+    =/  reply  (get:on:replies:ch replies.u.post u.reply-time)
+    ?~  reply  [time event]
+    =/  key=message-key:a  [id time]:u.reply
+    [time event(key key, parent parent)]
   --
 ::
 ++  scry-path

--- a/desk/app/chat.hoon
+++ b/desk/app/chat.hoon
@@ -1346,7 +1346,7 @@
             ~
           =?  cor  (want-hark %to-us)
             (emit (pass-yarn new-yarn))
-          =/  top-con  [. q]:p.diff.delta
+          =/  top-con  [id time]:op
           =/  concern  [%reply [id.q.diff.delta now.bowl] top-con]
           =/  mention  (was-mentioned:utils content.memo our.bowl)
           =.  cu-core  (cu-activity concern content.memo mention)

--- a/desk/desk.docket-0
+++ b/desk/desk.docket-0
@@ -4,7 +4,7 @@
     image+'https://bootstrap.urbit.org/tlon.svg?v=1'
     glob-http+['https://bootstrap.urbit.org/glob-0v3.tf9ap.00d5h.h5u0t.lnbg9.m1h6s.glob' 0v3.tf9ap.00d5h.h5u0t.lnbg9.m1h6s]
     base+'groups'
-    version+[6 0 1]
+    version+[6 0 2]
     website+'https://tlon.io'
     license+'MIT'
 ==


### PR DESCRIPTION
Fixes TLON-2103 by adding some cleanup to the on-load arm. This is some of the most wild juggling, but I'm not sure how to do it any better.

The basic idea is go through all our sources that come from clubs that are dms or dm threads. For DMs we just need to comb through the stream and correct any keys we find. 

For threads we have to do more work since the source identifiers themselves have bad keys. So first we gather all the source index pairs that share the same message ID, then we go through the entire list of threads and look to see what was gathered under the ID they shared. If we don't have an entry for that source yet we create one and merge all the data collected under that same ID. Then we keep going until we have the real threads. Finally once we come back around to actually update the indexes, we make sure that we delete any data associated with old sources.

Tested by installing from binnec, then sending some multi-dms replies to generate bad data, then installed these changes and saw that dm threads successfully cleared.

PR Checklist
- [X] Includes changes to desk files
- [X] Describes how you tested the PR locally (test ship vs livenet)
- [ ] If a new feature, includes automated tests
- [X] Comments added anywhere logic may be confusing without context