### PR TITLE
privacy-selector: dont accidentally clear cordon

### DIFF
--- a/apps/tlon-web/src/groups/GroupAdmin/PrivacySelector.tsx
+++ b/apps/tlon-web/src/groups/GroupAdmin/PrivacySelector.tsx
@@ -176,37 +176,46 @@ export function PrivacySelectorForm() {
           describe(values);
         }
 
-        const privacyChanged = newPrivacy !== privacy;
-        if (privacyChanged) {
+        const oldPrivacy = privacy;
+        if (newPrivacy === oldPrivacy) {
+          return;
+        }
+
+        if (newPrivacy === 'public') {
           swapCordonMutation({
             flag: groupFlag,
-            cordon:
-              newPrivacy === 'public'
-                ? {
-                    open: {
-                      ships: [],
-                      ranks: [],
-                    },
-                  }
-                : {
-                    shut: {
-                      pending: [],
-                      ask: [],
-                    },
-                  },
+            cordon: {
+              open: {
+                ships: [],
+                ranks: [],
+              },
+            },
           });
+        } else {
+          // if we're swapping between private and secret, we need to
+          // keep the cordon else we risk losing the pending requests
+          if (oldPrivacy === 'public') {
+            swapCordonMutation({
+              flag: groupFlag,
+              cordon: {
+                shut: {
+                  pending: [],
+                  ask: [],
+                },
+              },
+            });
+          }
+        }
 
-          setSecretMutation({
-            flag: groupFlag,
-            isSecret: newPrivacy === 'secret',
-          });
-        }
-        if (privacyChanged) {
-          form.reset({
-            ...values,
-            privacy: newPrivacy,
-          });
-        }
+        setSecretMutation({
+          flag: groupFlag,
+          isSecret: newPrivacy === 'secret',
+        });
+
+        form.reset({
+          ...values,
+          privacy: newPrivacy,
+        });
       } catch (e) {
         console.log("GroupInfoEditor: couldn't edit group", e);
       }


### PR DESCRIPTION
Fixes TLON-2177 by making sure that the frontend doesn't accidentally clear the cordon when swapping between private/secret

PR Checklist
- [ ] Includes changes to desk files
- [ ] Describes how you tested the PR locally (test ship vs livenet)
- [ ] If a new feature, includes automated tests
- [ ] Comments added anywhere logic may be confusing without context