### PR TITLE
native: tee up group settings work

### DIFF
--- a/apps/tlon-mobile/src/navigation/GroupSettingsStack.tsx
+++ b/apps/tlon-mobile/src/navigation/GroupSettingsStack.tsx
@@ -1,0 +1,31 @@
+import { createNativeStackNavigator } from '@react-navigation/native-stack';
+
+import { GroupMembersScreen } from '../screens/GroupSettings/GroupMembersScreen';
+import { GroupMetaScreen } from '../screens/GroupSettings/GroupMetaScreen';
+import { GroupRolesScreen } from '../screens/GroupSettings/GroupRolesScreen';
+import { InvitesAndPrivacyScreen } from '../screens/GroupSettings/InvitesAndPrivacyScreen';
+import { ManageChannelsScreen } from '../screens/GroupSettings/ManageChannelsScreen';
+import { GroupSettingsStackParamList } from '../types';
+
+const GroupSettings = createNativeStackNavigator<GroupSettingsStackParamList>();
+
+export function GroupSettingsStack() {
+  return (
+    <GroupSettings.Navigator screenOptions={{ headerShown: false }}>
+      <GroupSettings.Screen name="GroupMeta" component={GroupMetaScreen} />
+      <GroupSettings.Screen
+        name="GroupMembers"
+        component={GroupMembersScreen}
+      />
+      <GroupSettings.Screen
+        name="ManageChannels"
+        component={ManageChannelsScreen}
+      />
+      <GroupSettings.Screen
+        name="InvitesAndPrivacy"
+        component={InvitesAndPrivacyScreen}
+      />
+      <GroupSettings.Screen name="GroupRoles" component={GroupRolesScreen} />
+    </GroupSettings.Navigator>
+  );
+}

--- a/apps/tlon-mobile/src/navigation/RootStack.tsx
+++ b/apps/tlon-mobile/src/navigation/RootStack.tsx
@@ -5,6 +5,7 @@ import { Platform, StatusBar } from 'react-native';
 import { useIsDarkMode } from '../hooks/useIsDarkMode';
 import ImageViewerScreen from '../screens/ImageViewerScreen';
 import type { RootStackParamList } from '../types';
+import { GroupSettingsStack } from './GroupSettingsStack';
 import { TabStack } from './TabStack';
 
 const Root = createNativeStackNavigator<RootStackParamList>();
@@ -31,6 +32,7 @@ export function RootStack() {
         component={ImageViewerScreen}
         options={{ animation: 'fade' }}
       />
+      <Root.Screen name="GroupSettings" component={GroupSettingsStack} />
     </Root.Navigator>
   );
 }

--- a/apps/tlon-mobile/src/screens/ChatListScreen.tsx
+++ b/apps/tlon-mobile/src/screens/ChatListScreen.tsx
@@ -161,11 +161,11 @@ export default function ChatListScreen(
   );
 
   const handleGoToGroupMeta = useCallback(
-    (group: db.Group) => {
+    (groupId: string) => {
       // @ts-expect-error TODO fix nested navigator types
       navigation.navigate('GroupSettings', {
         screen: 'GroupMeta',
-        params: { group },
+        params: { groupId },
       });
 
       setLongPressedGroup(null);
@@ -174,11 +174,11 @@ export default function ChatListScreen(
   );
 
   const handleGoToGroupMembers = useCallback(
-    (group: db.Group) => {
+    (groupId: string) => {
       // @ts-expect-error TODO fix nested navigator types
       navigation.navigate('GroupSettings', {
         screen: 'GroupMembers',
-        params: { group },
+        params: { groupId },
       });
 
       setLongPressedGroup(null);
@@ -187,11 +187,11 @@ export default function ChatListScreen(
   );
 
   const handleGoToManageChannels = useCallback(
-    (group: db.Group) => {
+    (groupId: string) => {
       // @ts-expect-error TODO fix nested navigator types
       navigation.navigate('GroupSettings', {
         screen: 'ManageChannels',
-        params: { group },
+        params: { groupId },
       });
 
       setLongPressedGroup(null);
@@ -200,11 +200,11 @@ export default function ChatListScreen(
   );
 
   const handleGoToInvitesAndPrivacy = useCallback(
-    (group: db.Group) => {
+    (groupId: string) => {
       // @ts-expect-error TODO fix nested navigator types
       navigation.navigate('GroupSettings', {
         screen: 'InvitesAndPrivacy',
-        params: { group },
+        params: { groupId },
       });
 
       setLongPressedGroup(null);
@@ -213,11 +213,11 @@ export default function ChatListScreen(
   );
 
   const handleGoToRoles = useCallback(
-    (group: db.Group) => {
+    (groupId: string) => {
       // @ts-expect-error TODO fix nested navigator types
       navigation.navigate('GroupSettings', {
         screen: 'GroupRoles',
-        params: { group },
+        params: { groupId },
       });
 
       setLongPressedGroup(null);

--- a/apps/tlon-mobile/src/screens/ChatListScreen.tsx
+++ b/apps/tlon-mobile/src/screens/ChatListScreen.tsx
@@ -1,11 +1,16 @@
-import { useFocusEffect, useIsFocused } from '@react-navigation/native';
+import {
+  useFocusEffect,
+  useIsFocused,
+  useNavigation,
+} from '@react-navigation/native';
 import type { NativeStackScreenProps } from '@react-navigation/native-stack';
 import * as db from '@tloncorp/shared/dist/db';
 import * as logic from '@tloncorp/shared/dist/logic';
 import * as store from '@tloncorp/shared/dist/store';
 import {
   CalmProvider,
-  ChatList, // ChatOptionsSheet,
+  ChatList,
+  ChatOptionsSheet,
   ContactsProvider,
   FloatingActionButton,
   GroupPreviewSheet,
@@ -20,6 +25,7 @@ import ContextMenu from 'react-native-context-menu-view';
 import AddGroupSheet from '../components/AddGroupSheet';
 import { TLON_EMPLOYEE_GROUP } from '../constants';
 import { useCalmSettings } from '../hooks/useCalmSettings';
+import { useCurrentUserId } from '../hooks/useCurrentUser';
 import * as featureFlags from '../lib/featureFlags';
 import NavBar from '../navigation/NavBarView';
 import type { HomeStackParamList } from '../types';
@@ -33,13 +39,13 @@ type ChatListScreenProps = NativeStackScreenProps<
 export default function ChatListScreen(
   props: ChatListScreenProps & { contacts: db.Contact[] }
 ) {
+  const navigation = useNavigation();
   const [screenTitle, setScreenTitle] = useState('Home');
-  {
-    /* FIXME: Disabling long-press on ChatListScreen items for now */
-  }
-  // const [longPressedItem, setLongPressedItem] = useState<db.Channel | null>(
-  //   null
-  // );
+  const [longPressedChannel, setLongPressedChannel] =
+    useState<db.Channel | null>(null);
+  const [longPressedGroup, setLongPressedGroup] = useState<db.Group | null>(
+    null
+  );
   const [selectedGroup, setSelectedGroup] = useState<db.Group | null>(null);
   const [startDmOpen, setStartDmOpen] = useState(false);
   const [addGroupOpen, setAddGroupOpen] = useState(false);
@@ -47,6 +53,8 @@ export default function ChatListScreen(
   const { data: chats } = store.useCurrentChats({
     enabled: isFocused,
   });
+
+  const currentUser = useCurrentUserId();
 
   const { data: contacts } = store.useContacts();
   const resolvedChats = useMemo(() => {
@@ -105,12 +113,19 @@ export default function ChatListScreen(
     [props.navigation]
   );
 
-  {
-    /* FIXME: Disabling long-press on ChatListScreen items for now */
-  }
-  // const onLongPressItem = useCallback((item: db.Channel | db.Group) => {
-  //   logic.isChannel(item) ? setLongPressedItem(item) : null;
-  // }, []);
+  const onLongPressItem = useCallback((item: db.Channel | db.Group) => {
+    if (logic.isChannel(item)) {
+      if (
+        item.type === 'dm' ||
+        item.type === 'groupDm' ||
+        item.pin?.type === 'channel'
+      ) {
+        setLongPressedChannel(item);
+      } else if (item.group) {
+        setLongPressedGroup(item.group);
+      }
+    }
+  }, []);
 
   const handleDmOpenChange = useCallback((open: boolean) => {
     if (!open) {
@@ -130,21 +145,84 @@ export default function ChatListScreen(
     }
   }, []);
 
-  {
-    /* FIXME: Disabling long-press on ChatListScreen items for now */
-  }
-  // const handleChatOptionsOpenChange = useCallback(
-  //   (open: boolean) => {
-  //     if (!open) {
-  //       setLongPressedItem(null);
-  //     }
-  //   },
-  //   [setLongPressedItem]
-  // );
+  const handleChatOptionsOpenChange = useCallback(
+    (open: boolean) => {
+      if (!open) {
+        setLongPressedChannel(null);
+        setLongPressedGroup(null);
+      }
+    },
+    [setLongPressedChannel]
+  );
 
   const handleGroupCreated = useCallback(
     ({ channel }: { channel: db.Channel }) => goToChannel({ channel }),
     [goToChannel]
+  );
+
+  const handleGoToGroupMeta = useCallback(
+    (group: db.Group) => {
+      // @ts-expect-error TODO fix nested navigator types
+      navigation.navigate('GroupSettings', {
+        screen: 'GroupMeta',
+        params: { group },
+      });
+
+      setLongPressedGroup(null);
+    },
+    [navigation]
+  );
+
+  const handleGoToGroupMembers = useCallback(
+    (group: db.Group) => {
+      // @ts-expect-error TODO fix nested navigator types
+      navigation.navigate('GroupSettings', {
+        screen: 'GroupMembers',
+        params: { group },
+      });
+
+      setLongPressedGroup(null);
+    },
+    [navigation]
+  );
+
+  const handleGoToManageChannels = useCallback(
+    (group: db.Group) => {
+      // @ts-expect-error TODO fix nested navigator types
+      navigation.navigate('GroupSettings', {
+        screen: 'ManageChannels',
+        params: { group },
+      });
+
+      setLongPressedGroup(null);
+    },
+    [navigation]
+  );
+
+  const handleGoToInvitesAndPrivacy = useCallback(
+    (group: db.Group) => {
+      // @ts-expect-error TODO fix nested navigator types
+      navigation.navigate('GroupSettings', {
+        screen: 'InvitesAndPrivacy',
+        params: { group },
+      });
+
+      setLongPressedGroup(null);
+    },
+    [navigation]
+  );
+
+  const handleGoToRoles = useCallback(
+    (group: db.Group) => {
+      // @ts-expect-error TODO fix nested navigator types
+      navigation.navigate('GroupSettings', {
+        screen: 'GroupRoles',
+        params: { group },
+      });
+
+      setLongPressedGroup(null);
+    },
+    [navigation]
   );
 
   const { pinned, unpinned } = resolvedChats;
@@ -162,6 +240,8 @@ export default function ChatListScreen(
     setScreenTitle(title);
   }, []);
 
+  console.log({ pinned });
+
   return (
     <CalmProvider calmSettings={calmSettings}>
       <ContactsProvider contacts={contacts ?? []}>
@@ -178,8 +258,7 @@ export default function ChatListScreen(
               pinned={resolvedChats.pinned}
               unpinned={resolvedChats.unpinned}
               pendingChats={resolvedChats.pendingChats}
-              // FIXME: Disabling long-press on ChatListScreen items for now
-              // onLongPressItem={onLongPressItem}
+              onLongPressItem={onLongPressItem}
               onPressItem={onPressChat}
               onSectionChange={handleSectionChange}
             />
@@ -215,12 +294,20 @@ export default function ChatListScreen(
               />
             </ContextMenu>
           </View>
-          {/* FIXME: Disabling long-press on ChatListScreen items for now */}
-          {/* <ChatOptionsSheet
-          open={longPressedItem !== null}
-          onOpenChange={handleChatOptionsOpenChange}
-          channel={longPressedItem ?? undefined}
-        /> */}
+          <ChatOptionsSheet
+            open={longPressedChannel !== null || longPressedGroup !== null}
+            onOpenChange={handleChatOptionsOpenChange}
+            currentUser={currentUser}
+            pinned={pinned}
+            channel={longPressedChannel ?? undefined}
+            group={longPressedGroup ?? undefined}
+            useGroup={store.useGroup}
+            onPressGroupMeta={handleGoToGroupMeta}
+            onPressGroupMembers={handleGoToGroupMembers}
+            onPressManageChannels={handleGoToManageChannels}
+            onPressInvitesAndPrivacy={handleGoToInvitesAndPrivacy}
+            onPressRoles={handleGoToRoles}
+          />
           <StartDmSheet
             goToDm={goToDm}
             open={startDmOpen}

--- a/apps/tlon-mobile/src/screens/ChatListScreen.tsx
+++ b/apps/tlon-mobile/src/screens/ChatListScreen.tsx
@@ -240,8 +240,6 @@ export default function ChatListScreen(
     setScreenTitle(title);
   }, []);
 
-  console.log({ pinned });
-
   return (
     <CalmProvider calmSettings={calmSettings}>
       <ContactsProvider contacts={contacts ?? []}>

--- a/apps/tlon-mobile/src/screens/GroupSettings/GroupMembersScreen.tsx
+++ b/apps/tlon-mobile/src/screens/GroupSettings/GroupMembersScreen.tsx
@@ -1,0 +1,18 @@
+import { NativeStackScreenProps } from '@react-navigation/native-stack';
+import { Text } from '@tloncorp/ui';
+import { SafeAreaView } from 'react-native-safe-area-context';
+
+import { GroupSettingsStackParamList } from '../../types';
+
+type GroupMembersScreenProps = NativeStackScreenProps<
+  GroupSettingsStackParamList,
+  'GroupMembers'
+>;
+
+export function GroupMembersScreen(props: GroupMembersScreenProps) {
+  return (
+    <SafeAreaView>
+      <Text>GroupMembers</Text>
+    </SafeAreaView>
+  );
+}

--- a/apps/tlon-mobile/src/screens/GroupSettings/GroupMetaScreen.tsx
+++ b/apps/tlon-mobile/src/screens/GroupSettings/GroupMetaScreen.tsx
@@ -11,12 +11,10 @@ type GroupMetaScreenProps = NativeStackScreenProps<
 >;
 
 export function GroupMetaScreen(props: GroupMetaScreenProps) {
-  const {
-    group: { id },
-  } = props.route.params;
+  const { groupId } = props.route.params;
 
   const { group, currentUserIsAdmin, setGroupMetadata } = useGroupContext({
-    groupId: id,
+    groupId,
   });
 
   return (

--- a/apps/tlon-mobile/src/screens/GroupSettings/GroupMetaScreen.tsx
+++ b/apps/tlon-mobile/src/screens/GroupSettings/GroupMetaScreen.tsx
@@ -1,0 +1,27 @@
+import { NativeStackScreenProps } from '@react-navigation/native-stack';
+import { Text } from '@tloncorp/ui';
+import { SafeAreaView } from 'react-native-safe-area-context';
+
+import { GroupSettingsStackParamList } from '../../types';
+import { useGroupContext } from './useGroupContext';
+
+type GroupMetaScreenProps = NativeStackScreenProps<
+  GroupSettingsStackParamList,
+  'GroupMeta'
+>;
+
+export function GroupMetaScreen(props: GroupMetaScreenProps) {
+  const {
+    group: { id },
+  } = props.route.params;
+
+  const { group, currentUserIsAdmin, setGroupMetadata } = useGroupContext({
+    groupId: id,
+  });
+
+  return (
+    <SafeAreaView>
+      <Text>GroupMeta</Text>
+    </SafeAreaView>
+  );
+}

--- a/apps/tlon-mobile/src/screens/GroupSettings/GroupRolesScreen.tsx
+++ b/apps/tlon-mobile/src/screens/GroupSettings/GroupRolesScreen.tsx
@@ -1,0 +1,18 @@
+import { NativeStackScreenProps } from '@react-navigation/native-stack';
+import { Text } from '@tloncorp/ui';
+import { SafeAreaView } from 'react-native-safe-area-context';
+
+import { GroupSettingsStackParamList } from '../../types';
+
+type GroupRolesScreenProps = NativeStackScreenProps<
+  GroupSettingsStackParamList,
+  'GroupRoles'
+>;
+
+export function GroupRolesScreen(props: GroupRolesScreenProps) {
+  return (
+    <SafeAreaView>
+      <Text>GroupRoles</Text>
+    </SafeAreaView>
+  );
+}

--- a/apps/tlon-mobile/src/screens/GroupSettings/InvitesAndPrivacyScreen.tsx
+++ b/apps/tlon-mobile/src/screens/GroupSettings/InvitesAndPrivacyScreen.tsx
@@ -1,0 +1,18 @@
+import { NativeStackScreenProps } from '@react-navigation/native-stack';
+import { Text } from '@tloncorp/ui';
+import { SafeAreaView } from 'react-native-safe-area-context';
+
+import { GroupSettingsStackParamList } from '../../types';
+
+type InvitesAndPrivacyScreenProps = NativeStackScreenProps<
+  GroupSettingsStackParamList,
+  'InvitesAndPrivacy'
+>;
+
+export function InvitesAndPrivacyScreen(props: InvitesAndPrivacyScreenProps) {
+  return (
+    <SafeAreaView>
+      <Text>InvitesAndPrivacy</Text>
+    </SafeAreaView>
+  );
+}

--- a/apps/tlon-mobile/src/screens/GroupSettings/ManageChannelsScreen.tsx
+++ b/apps/tlon-mobile/src/screens/GroupSettings/ManageChannelsScreen.tsx
@@ -11,9 +11,7 @@ type ManageChannelsScreenProps = NativeStackScreenProps<
 >;
 
 export function ManageChannelsScreen(props: ManageChannelsScreenProps) {
-  const {
-    group: { id },
-  } = props.route.params;
+  const { groupId } = props.route.params;
 
   const {
     group,
@@ -27,7 +25,7 @@ export function ManageChannelsScreen(props: ManageChannelsScreenProps) {
     createNavSection,
     deleteNavSection,
     updateNavSection,
-  } = useGroupContext({ groupId: id });
+  } = useGroupContext({ groupId });
 
   return (
     <SafeAreaView>

--- a/apps/tlon-mobile/src/screens/GroupSettings/ManageChannelsScreen.tsx
+++ b/apps/tlon-mobile/src/screens/GroupSettings/ManageChannelsScreen.tsx
@@ -1,0 +1,37 @@
+import { NativeStackScreenProps } from '@react-navigation/native-stack';
+import { Text } from '@tloncorp/ui';
+import { SafeAreaView } from 'react-native-safe-area-context';
+
+import { GroupSettingsStackParamList } from '../../types';
+import { useGroupContext } from './useGroupContext';
+
+type ManageChannelsScreenProps = NativeStackScreenProps<
+  GroupSettingsStackParamList,
+  'ManageChannels'
+>;
+
+export function ManageChannelsScreen(props: ManageChannelsScreenProps) {
+  const {
+    group: { id },
+  } = props.route.params;
+
+  const {
+    group,
+    currentUserIsAdmin,
+    groupChannels,
+    groupNavSectionsWithChannels,
+    setGroupMetadata,
+    setGroupPrivacy,
+    createChannel,
+    deleteChannel,
+    createNavSection,
+    deleteNavSection,
+    updateNavSection,
+  } = useGroupContext({ groupId: id });
+
+  return (
+    <SafeAreaView>
+      <Text>ManageChannels</Text>
+    </SafeAreaView>
+  );
+}

--- a/apps/tlon-mobile/src/screens/GroupSettings/useGroupContext.ts
+++ b/apps/tlon-mobile/src/screens/GroupSettings/useGroupContext.ts
@@ -1,0 +1,260 @@
+import { sync } from '@tloncorp/shared';
+import * as db from '@tloncorp/shared/dist/db';
+import * as store from '@tloncorp/shared/dist/store';
+import { useCallback, useEffect, useMemo } from 'react';
+
+import { useCurrentUserId } from '../../hooks/useCurrentUser';
+
+export const useGroupContext = ({ groupId }: { groupId: string }) => {
+  const currentUserId = useCurrentUserId();
+  const groupQuery = store.useGroup({
+    id: groupId,
+  });
+
+  const group = groupQuery.data;
+
+  const currentUserIsAdmin = useMemo(() => {
+    return group?.members.some(
+      (member) =>
+        member.contactId === currentUserId &&
+        member.roles.some((role) => role.roleId === 'admin')
+    );
+  }, [group?.members, currentUserId]);
+
+  const groupMembers = useMemo(() => {
+    return group?.members ?? [];
+  }, [group?.members]);
+
+  const groupChannels = useMemo(() => {
+    return group?.channels ?? [];
+  }, [group?.channels]);
+
+  const groupNavSections = useMemo(() => {
+    return group?.navSections ?? [];
+  }, [group?.navSections]);
+
+  const groupInvites = useMemo(() => {
+    return group?.members.filter((m) => m.status === 'invited') ?? [];
+  }, [group?.members]);
+
+  const groupNavSectionsWithChannels = useMemo(() => {
+    return groupNavSections.map((section) => ({
+      ...section,
+      channels: groupChannels.filter((channel) =>
+        section.channels.map((c) => c.channelId).includes(channel.id)
+      ),
+    }));
+  }, [groupNavSections, groupChannels]);
+
+  const setGroupMetadata = useCallback(
+    async (metadata: db.ClientMeta) => {
+      if (group) {
+        // await store.updateGroupMetadata(group.id, metadata);
+      }
+    },
+    [group]
+  );
+
+  const setGroupPrivacy = useCallback(
+    // need a db type for privacy
+    async () => {
+      if (group) {
+        // await store.updateGroupPrivacy(group.id, privacy);
+      }
+    },
+    [group]
+  );
+
+  const deleteGroup = useCallback(async () => {
+    if (group) {
+      // await store.deleteGroup(group.id);
+    }
+  }, [group]);
+
+  const createChannel = useCallback(
+    async (channel: db.Channel) => {
+      if (group) {
+        // await store.createChannel(group.id, channel);
+      }
+    },
+    [group]
+  );
+
+  const deleteChannel = useCallback(
+    async (channelId: string) => {
+      if (group) {
+        // await store.deleteChannel(group.id, channelId);
+      }
+    },
+    [group]
+  );
+
+  const updateChannel = useCallback(
+    async (channel: db.Channel) => {
+      if (group) {
+        // await store.updateChannel(group.id, channel);
+      }
+    },
+    [group]
+  );
+
+  const createNavSection = useCallback(
+    async (navSection: db.GroupNavSection) => {
+      if (group) {
+        // await store.createNavSection(group.id, navSection);
+      }
+    },
+    [group]
+  );
+
+  const deleteNavSection = useCallback(
+    async (navSectionId: string) => {
+      if (group) {
+        // await store.deleteNavSection(group.id, navSectionId);
+      }
+    },
+    [group]
+  );
+
+  const updateNavSection = useCallback(
+    async (navSection: db.GroupNavSection) => {
+      if (group) {
+        // await store.updateNavSection(group.id, navSection);
+      }
+    },
+    [group]
+  );
+
+  const setChannelOrder = useCallback(
+    async (channelIds: string[], navSectionId: string) => {
+      if (group) {
+        // await store.setChannelOrder(group.id, channelIds);
+      }
+    },
+    [group]
+  );
+
+  const moveChannel = useCallback(
+    async (channelId: string, navSectionId: string) => {
+      if (group) {
+        // await store.moveChannel(group.id, channelId, navSectionId);
+      }
+    },
+    [group]
+  );
+
+  const inviteUsers = useCallback(
+    async (contactId: string[]) => {
+      if (group) {
+        // await store.inviteUser(group.id, contactId);
+      }
+    },
+    [group]
+  );
+
+  const getPublicInviteUrl = useCallback(async () => {
+    if (group) {
+      // return store.getPublicInviteUrl(group.id);
+    }
+  }, [group]);
+
+  const createGroupRole = useCallback(
+    async (role: db.GroupRole) => {
+      if (group) {
+        // await store.createRole(group.id, role);
+      }
+    },
+    [group]
+  );
+
+  const updateGroupRole = useCallback(
+    async (role: db.GroupRole) => {
+      if (group) {
+        // await store.updateRole(group.id, role);
+      }
+    },
+    [group]
+  );
+
+  const deleteGroupRole = useCallback(
+    async (roleId: string) => {
+      if (group) {
+        // await store.deleteRole(group.id, roleId);
+      }
+    },
+    [group]
+  );
+
+  const banUser = useCallback(
+    async (contactId: string) => {
+      if (group) {
+        // await store.banUser(group.id, contactId);
+      }
+    },
+    [group]
+  );
+
+  const unbanUser = useCallback(
+    async (contactId: string) => {
+      if (group) {
+        // await store.unbanUser(group.id, contactId);
+      }
+    },
+    [group]
+  );
+
+  const kickUser = useCallback(
+    async (contactId: string) => {
+      if (group) {
+        // await store.kickUser(group.id, contactId);
+      }
+    },
+    [group]
+  );
+
+  const setUserRoles = useCallback(
+    async (contactId: string, roleIds: string[]) => {
+      if (group) {
+        // await store.setUserRoles(group.id, contactId, roleIds);
+      }
+    },
+    [group]
+  );
+
+  useEffect(() => {
+    if (group) {
+      sync.syncGroup(group.id);
+    }
+  }, [group, group?.id]);
+
+  return {
+    group,
+    groupMembers,
+    groupInvites,
+    groupChannels,
+    groupNavSections,
+    groupNavSectionsWithChannels,
+    currentUserId,
+    currentUserIsAdmin,
+    setGroupMetadata,
+    setGroupPrivacy,
+    deleteGroup,
+    createChannel,
+    deleteChannel,
+    updateChannel,
+    createNavSection,
+    deleteNavSection,
+    updateNavSection,
+    setChannelOrder,
+    moveChannel,
+    inviteUsers,
+    getPublicInviteUrl,
+    createGroupRole,
+    updateGroupRole,
+    deleteGroupRole,
+    banUser,
+    unbanUser,
+    kickUser,
+    setUserRoles,
+  };
+};

--- a/apps/tlon-mobile/src/types.ts
+++ b/apps/tlon-mobile/src/types.ts
@@ -41,12 +41,34 @@ export type RootStackParamList = {
     post: db.Post;
     uri?: string;
   };
+  GroupSettings: {
+    group: db.Group;
+  };
+};
+
+export type GroupSettingsStackParamList = {
+  GroupMeta: {
+    group: db.Group;
+  };
+  GroupMembers: {
+    group: db.Group;
+  };
+  ManageChannels: {
+    group: db.Group;
+  };
+  InvitesAndPrivacy: {
+    group: db.Group;
+  };
+  GroupRoles: {
+    group: db.Group;
+  };
 };
 
 export type TabParamList = {
   Groups: NavigatorScreenParams<HomeStackParamList>;
   Activity: NavigatorScreenParams<WebViewStackParamList>;
   Settings: NavigatorScreenParams<SettingsStackParamList>;
+  Profile: NavigatorScreenParams<SettingsStackParamList>;
 };
 
 export type TabName = keyof TabParamList;

--- a/apps/tlon-mobile/src/types.ts
+++ b/apps/tlon-mobile/src/types.ts
@@ -48,19 +48,19 @@ export type RootStackParamList = {
 
 export type GroupSettingsStackParamList = {
   GroupMeta: {
-    group: db.Group;
+    groupId: string;
   };
   GroupMembers: {
-    group: db.Group;
+    groupId: string;
   };
   ManageChannels: {
-    group: db.Group;
+    groupId: string;
   };
   InvitesAndPrivacy: {
-    group: db.Group;
+    groupId: string;
   };
   GroupRoles: {
-    group: db.Group;
+    groupId: string;
   };
 };
 

--- a/packages/shared/src/db/queries.ts
+++ b/packages/shared/src/db/queries.ts
@@ -2196,6 +2196,7 @@ export const getGroup = createReadQuery(
           members: {
             with: {
               contact: true,
+              roles: true,
             },
           },
           navSections: {

--- a/packages/ui/src/components/GroupOptionsSheet.tsx
+++ b/packages/ui/src/components/GroupOptionsSheet.tsx
@@ -18,11 +18,11 @@ interface Props {
   channel?: db.Channel;
   group?: db.Group;
   useGroup: typeof store.useGroup;
-  onPressGroupMeta: (group: db.Group) => void;
-  onPressGroupMembers: (group: db.Group) => void;
-  onPressManageChannels: (group: db.Group) => void;
-  onPressInvitesAndPrivacy: (group: db.Group) => void;
-  onPressRoles: (group: db.Group) => void;
+  onPressGroupMeta: (groupId: string) => void;
+  onPressGroupMembers: (groupId: string) => void;
+  onPressManageChannels: (groupId: string) => void;
+  onPressInvitesAndPrivacy: (groupId: string) => void;
+  onPressRoles: (groupId: string) => void;
 }
 
 export function ChatOptionsSheet({
@@ -67,17 +67,17 @@ export function ChatOptionsSheet({
     () => [
       {
         title: 'Manage Channels',
-        action: () => (groupData ? onPressManageChannels(groupData) : {}),
+        action: () => (groupData ? onPressManageChannels(groupData.id) : {}),
         icon: 'ChevronRight',
       },
       {
         title: 'Invites & Privacy',
-        action: () => (groupData ? onPressInvitesAndPrivacy(groupData) : {}),
+        action: () => (groupData ? onPressInvitesAndPrivacy(groupData.id) : {}),
         icon: 'ChevronRight',
       },
       {
         title: 'Roles',
-        action: () => (groupData ? onPressRoles(groupData) : {}),
+        action: () => (groupData ? onPressRoles(groupData.id) : {}),
         icon: 'ChevronRight',
       },
     ],
@@ -123,12 +123,12 @@ export function ChatOptionsSheet({
     channel?.description ?? groupData?.description ?? undefined;
   const handleOnPressGroupMeta = useCallback(() => {
     if (groupData) {
-      onPressGroupMeta(groupData);
+      onPressGroupMeta(groupData.id);
     }
   }, [groupData, onPressGroupMeta]);
   const handleOnPressGroupMembers = useCallback(() => {
     if (groupData) {
-      onPressGroupMembers(groupData);
+      onPressGroupMembers(groupData.id);
     }
   }, [groupData, onPressGroupMembers]);
 

--- a/packages/ui/src/components/GroupOptionsSheet.tsx
+++ b/packages/ui/src/components/GroupOptionsSheet.tsx
@@ -1,75 +1,201 @@
 import type * as db from '@tloncorp/shared/dist/db';
+import * as store from '@tloncorp/shared/dist/store';
+import { useCallback, useMemo } from 'react';
 
+import { useCalm } from '../contexts';
+import { Text, View, XStack, YStack } from '../core';
+import { getBackgroundColor } from '../utils/colorUtils';
 import { ActionSheet } from './ActionSheet';
+import { Button } from './Button';
+import { Icon } from './Icon';
+import { ListItem } from './ListItem';
 
 interface Props {
   open: boolean;
   onOpenChange: (open: boolean) => void;
+  currentUser: string;
+  pinned: db.Channel[];
   channel?: db.Channel;
+  group?: db.Group;
+  useGroup: typeof store.useGroup;
+  onPressGroupMeta: (group: db.Group) => void;
+  onPressGroupMembers: (group: db.Group) => void;
+  onPressManageChannels: (group: db.Group) => void;
+  onPressInvitesAndPrivacy: (group: db.Group) => void;
+  onPressRoles: (group: db.Group) => void;
 }
 
-const actions = [
-  {
-    title: 'Connected',
-    variant: 'success',
-    action: () => {},
-  },
-  {
-    title: 'Invite People',
-    variant: 'primary',
-    action: () => {},
-  },
-  {
-    title: 'Group settings',
-    description: 'Configure group details and privacy',
-    action: () => {},
-  },
-  {
-    title: 'Copy group reference',
-    description: 'Copy an in-Urbit link to this group',
-    action: () => {},
-  },
-  {
-    title: 'Group members',
-    description: 'View all members and roles',
-    action: () => {},
-  },
-  {
-    title: 'Channels',
-    description: 'View all channels you have access to',
-    action: () => {},
-  },
-  {
-    title: 'Group notification settings',
-    description: 'Configure your notifications for this group',
-    action: () => {},
-  },
-  // TODO: channel pin state
-];
+export function ChatOptionsSheet({
+  open,
+  onOpenChange,
+  currentUser,
+  pinned,
+  channel,
+  group,
+  useGroup,
+  onPressGroupMeta,
+  onPressGroupMembers,
+  onPressManageChannels,
+  onPressInvitesAndPrivacy,
+  onPressRoles,
+}: Props) {
+  const { data: groupData } = useGroup({
+    id: group?.id ?? channel?.groupId ?? '',
+  });
 
-export function ChatOptionsSheet({ open, onOpenChange, channel }: Props) {
+  const isPinned = useMemo(
+    () =>
+      channel
+        ? pinned.some((p) => p.id === channel.id)
+        : groupData
+          ? pinned.some((p) => p.groupId === groupData.id)
+          : false,
+    [channel, pinned, groupData]
+  );
+
+  const currentUserIsAdmin = useMemo(
+    () =>
+      groupData?.members?.some(
+        (m) =>
+          m.contactId === currentUser &&
+          m.roles?.some((r) => r.roleId === 'admin')
+      ) ?? false,
+    [currentUser, groupData?.members]
+  );
+
+  const adminActions = useMemo(
+    () => [
+      {
+        title: 'Manage Channels',
+        action: () => (groupData ? onPressManageChannels(groupData) : {}),
+        icon: 'ChevronRight',
+      },
+      {
+        title: 'Invites & Privacy',
+        action: () => (groupData ? onPressInvitesAndPrivacy(groupData) : {}),
+        icon: 'ChevronRight',
+      },
+      {
+        title: 'Roles',
+        action: () => (groupData ? onPressRoles(groupData) : {}),
+        icon: 'ChevronRight',
+      },
+    ],
+    [groupData, onPressManageChannels, onPressInvitesAndPrivacy, onPressRoles]
+  );
+
+  const actions = useMemo(
+    () => [
+      { title: 'Copy group reference', action: () => {}, icon: 'ArrowRef' },
+      { title: isPinned ? 'Unpin' : 'Pin', action: () => {} },
+      {
+        title: 'Notifications',
+        action: () => {},
+        icon: 'ChevronRight',
+      },
+      {
+        title: 'Leave group',
+        variant: 'destructive',
+        action: () => {},
+      },
+    ],
+    [isPinned]
+  );
+
+  if (group && currentUserIsAdmin) {
+    // we want to show the admin actions before leave group and notifications
+    actions.splice(actions.length - 2, 0, ...adminActions);
+  }
+
+  const { disableAvatars } = useCalm();
+  const colors = { backgroundColor: '$secondaryBackground' };
+  const iconFallbackText = groupData?.title?.[0] ?? groupData?.id[0];
+  const iconBackgroundColor = getBackgroundColor({
+    disableAvatars,
+    colors,
+    model: groupData ?? {},
+  });
+  const iconImageUrl =
+    !disableAvatars && groupData?.iconImage ? groupData.iconImage : undefined;
+  const memberCount = groupData?.members?.length ?? 0;
+  const title = channel?.title ?? groupData?.title ?? 'Loading…';
+  const description =
+    channel?.description ?? groupData?.description ?? undefined;
+  const handleOnPressGroupMeta = useCallback(() => {
+    if (groupData) {
+      onPressGroupMeta(groupData);
+    }
+  }, [groupData, onPressGroupMeta]);
+  const handleOnPressGroupMembers = useCallback(() => {
+    if (groupData) {
+      onPressGroupMembers(groupData);
+    }
+  }, [groupData, onPressGroupMembers]);
+
   return (
     <ActionSheet open={open} onOpenChange={onOpenChange}>
       <ActionSheet.Header>
-        <ActionSheet.Title>
-          {channel?.title ?? 'Group Options'}
-        </ActionSheet.Title>
-        <ActionSheet.Description>Quick actions</ActionSheet.Description>
+        <View
+          backgroundColor="$secondaryBackground"
+          borderRadius="$xl"
+          paddingVertical="$3xl"
+          paddingHorizontal="$4xl"
+          alignItems="center"
+        >
+          <YStack alignItems="center" space="$m">
+            <ListItem.Icon
+              fallbackText={iconFallbackText}
+              backgroundColor={iconBackgroundColor}
+              imageUrl={iconImageUrl}
+            />
+
+            <Text fontSize="$l">{title}</Text>
+            {description && (
+              <Text fontSize="$s" color="$tertiaryText">
+                {description}
+              </Text>
+            )}
+            <Button backgroundColor="unset" borderWidth="unset">
+              <Button.Text
+                onPress={handleOnPressGroupMembers}
+                fontSize="$s"
+                color="$tertiaryText"
+              >
+                {memberCount} members
+              </Button.Text>
+            </Button>
+          </YStack>
+          {currentUserIsAdmin && (
+            <View
+              position="absolute"
+              top="$space.m"
+              right="$space.m"
+              padding="$m"
+            >
+              <Button
+                onPress={handleOnPressGroupMeta}
+                backgroundColor="unset"
+                borderWidth="unset"
+              >
+                <Button.Text fontSize="$l">Edit</Button.Text>
+              </Button>
+            </View>
+          )}
+        </View>
       </ActionSheet.Header>
       {actions.map((action, index) => (
         <ActionSheet.Action
           key={index}
           action={action.action}
-          primary={action.variant === 'primary'}
-          success={action.variant === 'success'}
           destructive={action.variant === 'destructive'}
         >
-          <ActionSheet.ActionTitle>{action.title}</ActionSheet.ActionTitle>
-          {action.description && (
-            <ActionSheet.ActionDescription>
-              {action.description}
-            </ActionSheet.ActionDescription>
-          )}
+          <XStack space="$s" alignItems="center" justifyContent="space-between">
+            <ActionSheet.ActionTitle>{action.title}</ActionSheet.ActionTitle>
+            {action.icon && (
+              // @ts-expect-error string type is fine here
+              <Icon type={action.icon} size="$l" color="$primaryText" />
+            )}
+          </XStack>
         </ActionSheet.Action>
       ))}
     </ActionSheet>


### PR DESCRIPTION
- Adds the long press sheet back for groups, updating it to match current wireframes.
- Adds a new stack navigator for group settings and new stub screens (some of these screens could end up being navigators themselves).
- Adds useGroupContext where we'll pull data or functions for setting data, with probably nearly all of the functions stubbed out.

Fixes TLON-2181