### PR TITLE
broadcasts: update cohortToUnread for new Unread

### DIFF
--- a/apps/tlon-web/src/state/broadcasts.ts
+++ b/apps/tlon-web/src/state/broadcasts.ts
@@ -60,9 +60,10 @@ export function cohortToUnread(cohort: Cohort): Unread {
     count: 0,
     combined: { status: 'read', count: 0, notify: false },
     recency,
-    children: [],
+    children: null,
+    parents: [],
     readTimeout: 0,
-    summary: { recency, count: 0, notify: false, unread: null, children: [] }
+    summary: { recency, count: 0, notify: false, unread: null, children: null }
   };
 }
 


### PR DESCRIPTION
The type of `Unread` was changed slightly before #3535 got merged. Here, we update `cohortToUnread` to construct a proper new `Unread` object.
