### PR TITLE
native: handle deleted unread

### DIFF
--- a/packages/ui/src/components/Channel/Scroller.tsx
+++ b/packages/ui/src/components/Channel/Scroller.tsx
@@ -222,6 +222,7 @@ function Scroller({
   );
 
   const userHasScrolledRef = useRef(false);
+  const renderedPostsRef = useRef(new Set());
   // Whether we've scrolled to the anchor post.
   const [hasFoundAnchor, setHasFoundAnchor] = useState(!anchor);
 
@@ -231,7 +232,14 @@ function Scroller({
   // true, revealing the Scroller.
   const handleItemLayout = useCallback(
     (post: db.Post, index: number) => {
-      if (anchor?.postId === post.id) {
+      renderedPostsRef.current.add(post.id);
+      if (
+        anchor?.postId === post.id ||
+        // if we've got at least a page of posts and we've rendered them all,
+        // reveal the scroller to prevent getting stuck when messages are
+        // deleted.
+        (posts?.length && renderedPostsRef.current.size >= posts?.length)
+      ) {
         if (!hasFoundAnchor) {
           setHasFoundAnchor(true);
         }
@@ -254,7 +262,7 @@ function Scroller({
         }
       }
     },
-    [anchor, hasFoundAnchor, channelType, firstUnreadId]
+    [anchor, hasFoundAnchor, channelType, firstUnreadId, posts?.length]
   );
 
   const theme = useTheme();

--- a/packages/ui/src/components/Channel/Scroller.tsx
+++ b/packages/ui/src/components/Channel/Scroller.tsx
@@ -233,16 +233,7 @@ function Scroller({
   const handleItemLayout = useCallback(
     (post: db.Post, index: number) => {
       renderedPostsRef.current.add(post.id);
-      if (
-        anchor?.postId === post.id ||
-        // if we've got at least a page of posts and we've rendered them all,
-        // reveal the scroller to prevent getting stuck when messages are
-        // deleted.
-        (posts?.length && renderedPostsRef.current.size >= posts?.length)
-      ) {
-        if (!hasFoundAnchor) {
-          setHasFoundAnchor(true);
-        }
+      if (anchor?.postId === post.id) {
         // This gets called every time the anchor post changes size. If the user hasn't
         // scrolled yet, we should still be locked to the anchor post, so this
         // will re-scroll on subsequent layouts as well as the first.
@@ -260,6 +251,16 @@ function Scroller({
             viewPosition: 1,
           });
         }
+      }
+      if (
+        !hasFoundAnchor &&
+        (anchor?.postId === post.id ||
+          // if we've got at least a page of posts and we've rendered them all,
+          // reveal the scroller to prevent getting stuck when messages are
+          // deleted.
+          (posts?.length && renderedPostsRef.current.size >= posts?.length))
+      ) {
+        setHasFoundAnchor(true);
       }
     },
     [anchor, hasFoundAnchor, channelType, firstUnreadId, posts?.length]


### PR DESCRIPTION
Currently, when the first unread of a channel is a deleted message, the channel screen will appear blank. This PR fixes that by:
- Modifying the `getChannelPosts` query so that it can retrieve posts around a given post, even if that post has been deleted, as long as it's covered by a window. If the post is deleted, it will get posts around where the post would have been.
- Adding logic to the `Scroller` that will make it visible once we've rendered the first page of posts, even if we haven't found our anchor post.

Fixes TLON-2142