### PR TITLE
native: sync start robustness

### DIFF
--- a/packages/shared/src/logic/utils.ts
+++ b/packages/shared/src/logic/utils.ts
@@ -6,6 +6,7 @@ import {
   format,
 } from 'date-fns';
 import emojiRegex from 'emoji-regex';
+import { backOff } from 'exponential-backoff';
 import { useMemo } from 'react';
 
 import * as api from '../api';
@@ -444,5 +445,17 @@ export const getCompositeGroups = (
   return groups.map((group) => {
     const baseGroup = baseIndex[group.id] ?? {};
     return { ...baseGroup, ...group };
+  });
+};
+
+interface RetryConfig {
+  startingDelay?: number;
+  numOfAttempts?: number;
+}
+export const withRetry = (fn: () => Promise<any>, config?: RetryConfig) => {
+  return backOff(fn, {
+    delayFirstAttempt: false,
+    startingDelay: config?.startingDelay ?? 1000,
+    numOfAttempts: config?.numOfAttempts ?? 4,
   });
 };

--- a/packages/shared/src/store/sync.ts
+++ b/packages/shared/src/store/sync.ts
@@ -15,7 +15,7 @@ import { useStorage } from './storage';
 import { syncQueue } from './syncQueue';
 import { addToChannelPosts, clearChannelPostsQueries } from './useChannelPosts';
 
-const logger = createDevLogger('sync', true);
+const logger = createDevLogger('sync', false);
 
 // Used to track latest post we've seen for each channel.
 // Updated when:

--- a/packages/shared/src/store/sync.ts
+++ b/packages/shared/src/store/sync.ts
@@ -5,7 +5,7 @@ import * as api from '../api';
 import * as db from '../db';
 import { QueryCtx, batchEffects } from '../db/query';
 import { createDevLogger } from '../debug';
-import { ErrorReporter } from '../logic';
+import { ErrorReporter, withRetry } from '../logic';
 import { extractClientVolumes } from '../logic/activity';
 import {
   INFINITE_ACTIVITY_QUERY_KEY,
@@ -15,7 +15,7 @@ import { useStorage } from './storage';
 import { syncQueue } from './syncQueue';
 import { addToChannelPosts, clearChannelPostsQueries } from './useChannelPosts';
 
-const logger = createDevLogger('sync', false);
+const logger = createDevLogger('sync', true);
 
 // Used to track latest post we've seen for each channel.
 // Updated when:
@@ -855,40 +855,45 @@ export const syncStart = async (alreadySubscribed?: boolean) => {
   try {
     reporter.log(`sync start running${alreadySubscribed ? ' (recovery)' : ''}`);
     // highest priority, do immediately
-    await syncInitData(reporter);
+    await withRetry(() => syncInitData(reporter));
     reporter.log(`finished syncing init data`);
 
-    await syncLatestPosts(reporter);
+    await withRetry(() => syncLatestPosts(reporter));
     reporter.log(`finished syncing latest posts`);
 
-    await Promise.all([
-      syncContacts().then(() => reporter.log(`finished syncing contacts`)),
-      resetActivity().then(() => reporter.log(`finished resetting activity`)),
-    ]);
+    await withRetry(() =>
+      Promise.all([
+        syncContacts().then(() => reporter.log(`finished syncing contacts`)),
+        resetActivity().then(() => reporter.log(`finished resetting activity`)),
+      ])
+    );
 
     if (!alreadySubscribed) {
-      await setupSubscriptions();
+      await withRetry(() => setupSubscriptions());
       reporter.log(`subscriptions setup`);
     } else {
       reporter.log(`already subscribed, skipping`);
     }
 
-    await Promise.all([
-      syncSettings().then(() => reporter.log(`finished syncing settings`)),
-      syncVolumeSettings().then(() =>
-        reporter.log(`finished syncing volume settings`)
-      ),
-      initializeStorage().then(() =>
-        reporter.log(`finished initializing storage`)
-      ),
-      syncPushNotificationsSetting().then(() =>
-        reporter.log(`finished syncing push notifications setting`)
-      ),
-    ]);
+    await withRetry(() =>
+      Promise.all([
+        syncSettings().then(() => reporter.log(`finished syncing settings`)),
+        syncVolumeSettings().then(() =>
+          reporter.log(`finished syncing volume settings`)
+        ),
+        initializeStorage().then(() =>
+          reporter.log(`finished initializing storage`)
+        ),
+        syncPushNotificationsSetting().then(() =>
+          reporter.log(`finished syncing push notifications setting`)
+        ),
+      ])
+    );
     reporter.log('sync start complete');
   } catch (e) {
     reporter.report(e);
     logger.warn('INITIAL SYNC FAILED', e);
+    throw e;
   }
 };
 


### PR DESCRIPTION
Adds retry logic to the individual pieces of our fetching startup sequence. If after retrying we still fail, we'll pop the error boundary to prevent app use in an unknown state.

Once we support offline mode (where failure here would make sense), we'll need to be more careful about deciding when exactly to throw. But for now, we lock the screen if there's no network connection anyhow.

Fixes TLON-2183