### PR TITLE
activity: refine combined count for channels

### DIFF
--- a/desk/app/activity.hoon
+++ b/desk/app/activity.hoon
@@ -100,7 +100,7 @@
   =?  old  ?=(%2 -.old)  (state-2-to-3 old)
   ?>  ?=(%3 -.old)
   =.  state  old
-  cor
+  refresh-all-summaries
   +$  versioned-state  $%(state-3 state-2 state-1)
   +$  state-3  current-state
   +$  state-2
@@ -899,7 +899,11 @@
       notify-count  (^add notify-count.sum notify-count.as)
     ==
   =/  newest=time  :(max newest.cs floor.reads top)
-  =/  total  count.cs
+  =/  total
+    ::  if we're a channel, we only want thread notify counts, not totals
+    ?:  ?=(%channel -.source)
+      notify-count.cs
+    count.cs
   =/  notify-count  notify-count.cs
   =/  main  0
   =/  notified=?  notify.cs

--- a/desk/app/activity.hoon
+++ b/desk/app/activity.hoon
@@ -901,6 +901,7 @@
   =/  newest=time  :(max newest.cs floor.reads top)
   =/  total
     ::  if we're a channel, we only want thread notify counts, not totals
+    ::
     ?:  ?=(%channel -.source)
       notify-count.cs
     count.cs


### PR DESCRIPTION
After discussion with @latter-bolden, we decided to change how `count` in activity summaries gets tallied to better reflect what expect UX-wise, aka ignoring threads that don't involve us. 

We refresh all summaries on load since that shouldn't take very long and likely should be done anytime the agent changes, and in this case we have to for those counts to get updated immediately.

PR Checklist
- [X] Includes changes to desk files
- [ ] Describes how you tested the PR locally (test ship vs livenet)
- [ ] If a new feature, includes automated tests
- [X] Comments added anywhere logic may be confusing without context