### PR TITLE
various: add resource-id-ing ~| into common paths

### DIFF
--- a/desk/app/channels-server.hoon
+++ b/desk/app/channels-server.hoon
@@ -279,7 +279,8 @@
 ++  watch
   |=  =(pole knot)
   ^+  cor
-  ?+    pole  ~|(bad-watch-path+pole !!)
+  ~|  watch-path=`path`pole
+  ?+    pole  ~|(%bad-watch-path !!)
       [=kind:c name=@ %create ~]
     ?>  =(our src):bowl
     =*  nest  [kind.pole our.bowl name.pole]
@@ -288,7 +289,8 @@
   ::
       [=kind:c name=@ %updates ~]
     =/  ca  (ca-abed:ca-core kind.pole our.bowl name.pole)
-    ?>  (can-read:ca-perms:ca src.bowl)
+    ?.  (can-read:ca-perms:ca src.bowl)
+      ~|(%permission-denied !!)
     cor
   ::
       [=kind:c name=@ %updates after=@ ~]
@@ -425,6 +427,7 @@
   ::
   ++  ca-abed
     |=  n=nest:c
+    ~|  nest=n
     ca-core(nest n, channel (~(got by v-channels) n))
   ::
   ++  ca-area  `path`/[kind.nest]/[name.nest]
@@ -436,7 +439,8 @@
   ++  ca-watch-updates
     |=  =@da
     ^+  ca-core
-    ?>  (can-read:ca-perms src.bowl)
+    ?.  (can-read:ca-perms src.bowl)
+      ~|(%permission-denied !!)
     =/  =log:c  (lot:log-on:c log.channel `da ~)
     =.  ca-core  (give %fact ~ %channel-logs !>(log))
     ca-core
@@ -444,7 +448,8 @@
   ++  ca-watch-checkpoint
     |=  [from=@da to=(unit @da)]
     ^+  ca-core
-    ?>  (can-read:ca-perms src.bowl)
+    ?.  (can-read:ca-perms src.bowl)
+      ~|(%permission-denied !!)
     =/  posts=v-posts:c  (lot:on-v-posts:c posts.channel `from to)
     =/  chk=u-checkpoint:c  -.channel(posts posts)
     =.  ca-core  (give %fact ~ %channel-checkpoint !>(chk))
@@ -453,7 +458,8 @@
   ++  ca-watch-checkpoint-page
     |=  n=@
     ^+  ca-core
-    ?>  (can-read:ca-perms src.bowl)
+    ?.  (can-read:ca-perms src.bowl)
+      ~|(%permission-denied !!)
     =/  posts=v-posts:c  (gas:on-v-posts:c *v-posts:c (bat:mo-v-posts:c posts.channel ~ n))
     =/  chk=u-checkpoint:c  -.channel(posts posts)
     =.  ca-core  (give %fact ~ %channel-checkpoint !>(chk))

--- a/desk/app/groups.hoon
+++ b/desk/app/groups.hoon
@@ -379,7 +379,8 @@
 ++  watch
   |=  =(pole knot)
   ^+  cor
-  ?+  pole  ~|(bad-watch/pole !!)
+  ~|  watch-path=`path`pole
+  ?+  pole  ~|(%bad-watch-path !!)
     [%init ~]             (give %kick ~ ~)
     [%groups ~]           cor
     [%groups %ui ~]       cor
@@ -799,6 +800,7 @@
   ++  go-abed
     |=  f=flag:g
     ^+  go-core
+    ~|  flag=f
     =/  [n=net:g gr=group:g]  (~(got by groups) f)
     go-core(flag f, group gr, net n)
   ::


### PR DESCRIPTION
As discussed out of band with @arthyn, we should have some more of these. This is a start.

We see crash traces for all kinds of things. Currently, we print poke and watch nack traces to the user's terminal. These by themselves only point at the codepath, but don't explicate the crash reason (which could also be deduced from the trace) or the resource that was operated on (which might not be recoverable in cases where we don't have/print the wire).

Here, we add a couple of trace hints, to print subscription paths and resource identifiers in common crash pathways.