### PR TITLE
activity: allow clearing unreads for deleted messages

### DIFF
--- a/apps/tlon-web/src/chat/ChatMessage/ChatMessage.tsx
+++ b/apps/tlon-web/src/chat/ChatMessage/ChatMessage.tsx
@@ -68,8 +68,6 @@ import {
   useChatDialogs,
   useChatHovering,
   useChatInfo,
-  useChatKeys,
-  useChatStore,
 } from '../useChatStore';
 
 export interface ChatMessageProps {
@@ -334,18 +332,8 @@ const ChatMessage = React.memo<
 
         // If we're the thread op, don't show options.
         // Options are shown for the threadOp in the main scroll window.
-        setOptionsOpen(
-          (hovering || pickerOpen) &&
-            !isScrolling &&
-            !isThreadOp
-        );
-      }, [
-        isMobile,
-        hovering,
-        pickerOpen,
-        isScrolling,
-        isThreadOp,
-      ]);
+        setOptionsOpen((hovering || pickerOpen) && !isScrolling && !isThreadOp);
+      }, [isMobile, hovering, pickerOpen, isScrolling, isThreadOp]);
 
       const onSubmit = useCallback(
         async (editor: Editor) => {

--- a/apps/tlon-web/src/chat/ChatMessage/ChatMessageOptions.tsx
+++ b/apps/tlon-web/src/chat/ChatMessage/ChatMessageOptions.tsx
@@ -33,6 +33,7 @@ import { inlineSummary } from '@/logic/tiptap';
 import useGroupPrivacy from '@/logic/useGroupPrivacy';
 import { useIsMobile } from '@/logic/useMedia';
 import { useCopy, useIsDmOrMultiDm } from '@/logic/utils';
+import { deleteBroadcast } from '@/state/broadcasts';
 import {
   useAddPostReactMutation,
   useDeletePostMutation,
@@ -52,7 +53,6 @@ import {
   useRouteGroup,
   useVessel,
 } from '@/state/groups';
-import { deleteBroadcast } from '@/state/broadcasts';
 
 function ChatMessageOptions(props: {
   open: boolean;
@@ -138,8 +138,7 @@ function ChatMessageOptions(props: {
         await new Promise<void>((resolve) => {
           deleteBroadcast(whom, seal.id, resolve, resolve);
         });
-      } else
-      if (isDMorMultiDM) {
+      } else if (isDMorMultiDM) {
         await deleteDm({ whom, id: seal.id });
       } else {
         await deleteChatMessage({

--- a/apps/tlon-web/src/chat/ChatMessage/DeletedChatMessage.tsx
+++ b/apps/tlon-web/src/chat/ChatMessage/DeletedChatMessage.tsx
@@ -1,0 +1,121 @@
+/* eslint-disable react/no-unused-prop-types */
+import { getKey } from '@tloncorp/shared/dist/urbit/activity';
+import { daToUnix } from '@urbit/api';
+import { formatUd } from '@urbit/aura';
+import { BigInteger } from 'big-integer';
+import cn from 'classnames';
+import { format } from 'date-fns';
+import React, { useEffect, useMemo, useRef } from 'react';
+import { useInView } from 'react-intersection-observer';
+
+import DateDivider from '@/chat/ChatMessage/DateDivider';
+import { useMarkChannelRead } from '@/logic/channel';
+import { useUnread, useUnreadsStore } from '@/state/unreads';
+
+export interface DeletedChatMessageProps {
+  whom: string;
+  time: BigInteger;
+  newDay?: boolean;
+  isBroadcast?: boolean;
+  isLast?: boolean;
+  isLinked?: boolean;
+  isScrolling?: boolean;
+}
+
+const mergeRefs =
+  (...refs: any[]) =>
+  (node: any) => {
+    refs.forEach((ref) => {
+      if (!ref) {
+        return;
+      }
+
+      /* eslint-disable-next-line no-param-reassign */
+      ref.current = node;
+    });
+  };
+
+const DeletedChatMessage = React.memo<
+  DeletedChatMessageProps & React.RefAttributes<HTMLDivElement>
+>(
+  React.forwardRef<HTMLDivElement, DeletedChatMessageProps>(
+    (
+      {
+        whom,
+        time,
+        newDay = false,
+        isLast = false,
+        isLinked = false,
+      }: DeletedChatMessageProps,
+      ref
+    ) => {
+      const container = useRef<HTMLDivElement>(null);
+      const unix = new Date(daToUnix(time));
+      const unreadsKey = getKey(whom);
+      const unread = useUnread(unreadsKey);
+      const isUnread = useMemo(
+        () => unread && unread.lastUnread?.time === time.toString(),
+        [unread, time]
+      );
+      const { markRead: markReadChannel } = useMarkChannelRead(`chat/${whom}`);
+
+      const { ref: viewRef, inView } = useInView({
+        threshold: 1,
+      });
+
+      useEffect(() => {
+        if (!inView || !unread) {
+          return;
+        }
+
+        const unseen = unread.status === 'unread';
+        const { seen: markSeen, delayedRead } = useUnreadsStore.getState();
+        /* once the unseen marker comes into view we need to mark it
+            as seen and start a timer to mark it read so it goes away.
+            we ensure that the brief matches and hasn't changed before
+            doing so. we don't want to accidentally clear unreads when
+            the state has changed
+        */
+        if (inView && isUnread && unseen) {
+          markSeen(unreadsKey);
+          delayedRead(unreadsKey, markReadChannel);
+        }
+      }, [inView, unread, unreadsKey, isUnread, markReadChannel]);
+
+      return (
+        <div
+          ref={mergeRefs(ref, container)}
+          className={cn('flex flex-col break-words pt-3', {
+            'pb-2': isLast,
+          })}
+          data-testid="deleted-chat-message"
+          id="deleted-chat-message-target"
+        >
+          {unread && isUnread ? (
+            <DateDivider date={unix} unreadCount={unread.count} ref={viewRef} />
+          ) : null}
+          {newDay && !isUnread ? <DateDivider date={unix} /> : null}
+          <div
+            className={cn(
+              'relative z-0 flex w-full select-none sm:select-auto rounded-lg p-3 items-center',
+              isLinked ? 'bg-blue-softer' : 'bg-gray-50'
+            )}
+          >
+            <div className="-ml-1 mr-1 w-[31px] whitespace-nowrap text-xs font-semibold text-gray-400">
+              {format(unix, 'HH:mm')}
+            </div>
+            <div
+              className={cn(
+                'flex w-full min-w-0 grow flex-col px-2 text-gray-400 italic'
+              )}
+            >
+              This message was deleted
+            </div>
+          </div>
+        </div>
+      );
+    }
+  )
+);
+
+export default DeletedChatMessage;

--- a/apps/tlon-web/src/chat/ChatScroller/ChatScroller.tsx
+++ b/apps/tlon-web/src/chat/ChatScroller/ChatScroller.tsx
@@ -37,6 +37,7 @@ import { createDevLogger, useObjectChangeLogging } from '@/logic/utils';
 import ReplyMessage from '@/replies/ReplyMessage';
 import { useShowDevTools } from '@/state/local';
 
+import DeletedChatMessage from '../ChatMessage/DeletedChatMessage';
 import ChatScrollerDebugOverlay from './ChatScrollerDebugOverlay';
 
 const logger = createDevLogger('ChatScroller', false);
@@ -62,6 +63,10 @@ const ChatScrollerItem = React.memo(
     }
 
     const { writ, time, ...rest } = item;
+
+    if (!writ) {
+      return <DeletedChatMessage key={time.toString()} time={time} {...rest} />;
+    }
 
     if ('memo' in writ) {
       if (!rest.parent) {

--- a/apps/tlon-web/src/dms/MessagesList.tsx
+++ b/apps/tlon-web/src/dms/MessagesList.tsx
@@ -71,16 +71,15 @@ export default function MessagesList({
 
   const organizedUnreads = useMemo(() => {
     const filteredMsgs = sortMessages(
-        filter === filters.broadcasts
-          ? Object.fromEntries(
-              Object.entries(broadcasts.data || {}).map(
-                (v): [string, Unread] => {
-                  return [v[0], cohortToUnread(v[1] as Cohort)]; //REVIEW hax
-                }
-              )
-            )
-          : unreads
-      ).filter(([k]) => {
+      filter === filters.broadcasts
+        ? Object.fromEntries(
+            Object.entries(broadcasts.data || {}).map((v): [string, Unread] => {
+              return [v[0], cohortToUnread(v[1] as Cohort)]; //REVIEW hax
+            })
+          )
+        : unreads
+    )
+      .filter(([k]) => {
         if (k.startsWith('~~') && filter === filters.broadcasts) {
           return true;
         }
@@ -143,7 +142,17 @@ export default function MessagesList({
           .filter(searchQuery, filteredMsgs, { extract: (x) => x[0] })
           .sort((a, b) => b.score - a.score)
           .map((x) => x.original);
-  }, [sortMessages, unreads, chats, groups, pinned, searchQuery, allPending, filter, broadcasts]);
+  }, [
+    sortMessages,
+    unreads,
+    chats,
+    groups,
+    pinned,
+    searchQuery,
+    allPending,
+    filter,
+    broadcasts,
+  ]);
 
   const headerHeightRef = useRef<number>(0);
   const headerRef = useRef<HTMLDivElement>(null);

--- a/apps/tlon-web/src/dms/MessagesSidebarItem.tsx
+++ b/apps/tlon-web/src/dms/MessagesSidebarItem.tsx
@@ -9,7 +9,12 @@ import ShipName from '../components/ShipName';
 import SidebarItem from '../components/Sidebar/SidebarItem';
 import GroupAvatar from '../groups/GroupAvatar';
 import useMedia, { useIsMobile } from '../logic/useMedia';
-import { nestToFlag, whomIsBroadcast, whomIsDm, whomIsMultiDm } from '../logic/utils';
+import {
+  nestToFlag,
+  whomIsBroadcast,
+  whomIsDm,
+  whomIsMultiDm,
+} from '../logic/utils';
 import { useMultiDm } from '../state/chat';
 import { useGroup, useGroupChannel, useGroups } from '../state/groups/groups';
 import BroadcastOptions from './BroadcastOptions';

--- a/desk/app/channels.hoon
+++ b/desk/app/channels.hoon
@@ -1210,10 +1210,9 @@
       =?  recency.remark.channel  ?=(^ post.u-post)
         (max recency.remark.channel id-post)
       =?  ca-core  ?&  ?=(^ post.u-post)
-                       |(?=(~ post) (gth rev.u.post.u-post rev.u.u.post))
+                       ?=(~ post)
                    ==
-        ::REVIEW  this might re-submit on edits. is that what we want?
-        ::        it looks like %activity inserts even if it's a duplicate.
+        ::  we don't send an activity event for edits or deletes
         (on-post:ca-activity u.post.u-post)
       ?~  post
         =/  post=(unit post:c)  (bind post.u-post uv-post:utils)


### PR DESCRIPTION
This fixes TLON-2188 by showing a deleted message placeholder so that the unread marker can be displayed. Additionally this stops the %channels agent from sending edits as activity events. If we want this in the future, we'll probably want to handle it differently.

![image](https://github.com/tloncorp/tlon-apps/assets/5466421/f0b4a67c-af6e-4d29-a8af-3f5d6ac3a56a)


PR Checklist
- [X] Includes changes to desk files
- [ ] Describes how you tested the PR locally (test ship vs livenet)
- [ ] If a new feature, includes automated tests
- [ ] Comments added anywhere logic may be confusing without context