### PR TITLE
native: include involved threads in group/channel count

### DIFF
--- a/packages/shared/src/api/activityApi.ts
+++ b/packages/shared/src/api/activityApi.ts
@@ -675,13 +675,9 @@ export const toGroupUnread = (
   groupId: string,
   summary: ub.ActivitySummary
 ): db.GroupUnread => {
-  const count = Object.values(summary.children ?? {}).reduce((acc, entry) => {
-    const childCount = entry.unread?.count ?? 0;
-    return acc + childCount;
-  }, 0);
   return {
     groupId,
-    count,
+    count: summary.count,
     notify: summary.notify,
     updatedAt: summary.recency,
   };

--- a/packages/shared/src/api/unreads.test.ts
+++ b/packages/shared/src/api/unreads.test.ts
@@ -236,7 +236,7 @@ const groupUnread: Record<string, ub.ActivitySummary> = {
 const expectedGroupUnread = {
   groupId: '~latter-bolden/woodshop',
   updatedAt: 946684800000,
-  count: 5,
+  count: 6,
   notify: true,
 };
 

--- a/packages/shared/src/db/queries.ts
+++ b/packages/shared/src/db/queries.ts
@@ -296,7 +296,7 @@ export const getChats = createReadQuery(
       .orderBy(
         ascNullsLast($pins.index),
         sql`(CASE WHEN ${$groups.isNew} = 1 THEN 1 ELSE 0 END) DESC`,
-        sql`COALESCE(${allChannels.lastPostAt}, ${$channelUnreads.updatedAt}) DESC`
+        sql`COALESCE(${$channelUnreads.updatedAt}, ${allChannels.lastPostAt}) DESC`
       );
 
     const [chatMembers, filteredChannels] = result.reduce<

--- a/packages/ui/src/components/Activity/ChannelActivitySummary.tsx
+++ b/packages/ui/src/components/Activity/ChannelActivitySummary.tsx
@@ -25,7 +25,7 @@ export function ChannelActivitySummary({
   const unreadCount =
     summary.type === 'post'
       ? newestPost.channel?.unread?.countWithoutThreads ?? 0
-      : newestPost.post?.threadUnread?.count ?? 0;
+      : newestPost.parent?.threadUnread?.count ?? 0;
 
   const newestIsBlockOrNote =
     (summary.type === 'post' && newestPost.channel?.type === 'gallery') ||

--- a/packages/ui/src/components/ChannelListItem/index.tsx
+++ b/packages/ui/src/components/ChannelListItem/index.tsx
@@ -20,7 +20,7 @@ export default function ChannelListItem({
 }: {
   useTypeIcon?: boolean;
 } & ListItemProps<db.Channel>) {
-  const countToShow = model.unread?.countWithoutThreads ?? 0;
+  const countToShow = model.unread?.count ?? 0;
   const title = utils.getChannelTitle(model);
 
   return (


### PR DESCRIPTION
OTT

The way @arthyn updated the backend, changes needed here are actually pretty light!

Fixes TLON-2157