### PR TITLE
activity: increment time-ids in "better" steps

### DIFF
--- a/desk/app/activity.hoon
+++ b/desk/app/activity.hoon
@@ -587,7 +587,7 @@
     =/  t  start-time
     |-
     ?.  (has:on-event:a stream:base t)  t
-    $(t +(t))
+    $(t (^add t ~s0..0001))
   =/  notify  notify:(get-volume inc)
   =/  =event:a  [inc notify |]
   =/  =source:a  (determine-source inc)


### PR DESCRIPTION
Instead of incrementing the atom, add a proper fraction to it. This way, we don't end up with crazy long `@da` renderings all over the place.