### PR TITLE
native: remove custom perf trace

### DIFF
--- a/apps/tlon-mobile/src/App.main.tsx
+++ b/apps/tlon-mobile/src/App.main.tsx
@@ -66,8 +66,6 @@ const App = ({
   const { lure, priorityToken } = useBranch();
   const screenOptions = useScreenOptions();
 
-  perf().startScreenTrace('App');
-
   useEffect(() => {
     const unsubscribeFromNetInfo = NetInfo.addEventListener(
       ({ isConnected }) => {


### PR DESCRIPTION
iOS is barking about not supporting custom traces quite yet