### PR TITLE
native: unreads hotfix

### DIFF
--- a/packages/shared/src/api/activityApi.ts
+++ b/packages/shared/src/api/activityApi.ts
@@ -13,7 +13,7 @@ const logger = createDevLogger('activityApi', false);
 export async function getUnreads() {
   const activity = await scry<ub.Activity>({
     app: 'activity',
-    path: '/activity',
+    path: '/v1/activity',
   });
   const deserialized = toClientUnreads(activity);
   return deserialized;

--- a/packages/ui/src/components/ChatMessage/ChatMessageReplySummary.tsx
+++ b/packages/ui/src/components/ChatMessage/ChatMessageReplySummary.tsx
@@ -48,7 +48,7 @@ export const ChatMessageReplySummary = React.memo(
             size="$s"
             color={
               threadUnread?.count
-                ? post.volumeSettings?.isMuted
+                ? post.volumeSettings?.isMuted || !threadUnread.notify
                   ? '$tertiaryText'
                   : '$positiveActionText'
                 : undefined
@@ -60,6 +60,7 @@ export const ChatMessageReplySummary = React.memo(
           <ThreadStatus
             unreadCount={threadUnread?.count ?? 0}
             isMuted={post.volumeSettings?.isMuted ?? false}
+            isNotify={post.threadUnread?.notify ?? false}
           />
         </XStack>
         <SizableText size="$s" color="$tertiaryText">
@@ -73,13 +74,18 @@ export const ChatMessageReplySummary = React.memo(
 function ThreadStatus({
   unreadCount,
   isMuted,
+  isNotify,
 }: {
   unreadCount: number;
   isMuted: boolean;
+  isNotify: boolean;
 }) {
   if (unreadCount) {
     return (
-      <UnreadDot marginLeft="$s" color={isMuted ? 'neutral' : 'primary'} />
+      <UnreadDot
+        marginLeft="$s"
+        color={isMuted || !isNotify ? 'neutral' : 'primary'}
+      />
     );
   }
 


### PR DESCRIPTION
I missed versioning the new unreads scry, so we were getting correct data on init but pulling incorrect data on updates. This fixes it to consistently use the new API.

Also leaves unread thread indicator dots gray if you're uninvolved (not just muted)

Fixes TLON-2212