### PR TITLE
native: account for changes in thread unreads when using live post

### DIFF
--- a/packages/shared/src/db/changeListener.ts
+++ b/packages/shared/src/db/changeListener.ts
@@ -40,4 +40,11 @@ export function handleChange({
       queryKey: ['post', row.post_id],
     });
   }
+
+  // Same for changes to that post's thread unread
+  if (table === 'thread_unreads' && row) {
+    queryClient.refetchQueries({
+      queryKey: ['post', row.thread_id],
+    });
+  }
 }


### PR DESCRIPTION
We were invalidating on changes to the post and post reactions tables, but not the unread. Symptom was you'd have to leave the channel to see the thread marked as read.

Fixes TLON-2214