### PR TITLE
native: fix image upload

### DIFF
--- a/apps/tlon-mobile/src/hooks/useImageUpload.ts
+++ b/apps/tlon-mobile/src/hooks/useImageUpload.ts
@@ -84,10 +84,6 @@ export function useImageUpload(props: UploadParams): UploadInfo {
         width: mostRecentFile.size[1],
       };
       setUploadedImage(uploadedImage);
-
-      if (mostRecentFile.status === 'success' && mostRecentFile.url !== '') {
-        uploader?.clear();
-      }
     }
   }, [mostRecentFile, uploader]);
 


### PR DESCRIPTION
The deleted code has been there for a while, but interacts poorly with the newly added effect on line 39. Since we clear the file uploader after setting the `uploadedImage`, that effect conditional will always immediately reset the state (at least in the case of the channel attachment input flow).

Unclear to me what case that new logic is meant to combat (@patosullivan maybe we can chat about this on Monday). That said, I don't think we need to be clearing the uploader immediately either, not sure why I originally had that line there. 

After removing, I tested situations that might intersect with removing this code (clearing the attachment and adding another, navigating away without sending). Couldn't find any breakages. 

Fixes TLON-2218