### PR TITLE
native: ensure new posts in channel render in correct order

### DIFF
--- a/packages/shared/src/store/useChannelPosts.ts
+++ b/packages/shared/src/store/useChannelPosts.ts
@@ -139,14 +139,14 @@ export const useChannelPosts = (options: UseChanelPostsParams) => {
 
   const rawPosts = useMemo<db.Post[] | null>(() => {
     const queryPosts = query.data?.pages.flatMap((p) => p) ?? null;
-    if (!query.hasPreviousPage) {
-      const newestQueryPostId = queryPosts?.[0]?.id;
-      const newerPosts = newPosts.filter(
-        (p) => !newestQueryPostId || p.id > newestQueryPostId
-      );
-      return newestQueryPostId ? [...newerPosts, ...queryPosts] : newPosts;
+    if (!newPosts.length || query.hasPreviousPage) {
+      return queryPosts;
     }
-    return queryPosts;
+    const newestQueryPostId = queryPosts?.[0]?.id;
+    const newerPosts = newPosts.filter(
+      (p) => !newestQueryPostId || p.id > newestQueryPostId
+    );
+    return newestQueryPostId ? [...newerPosts, ...queryPosts] : newPosts;
   }, [query.data, query.hasPreviousPage, newPosts]);
 
   const posts = useOptimizedQueryResults(rawPosts);

--- a/packages/shared/src/store/useChannelPosts.ts
+++ b/packages/shared/src/store/useChannelPosts.ts
@@ -1,10 +1,9 @@
 import {
   InfiniteData,
-  QueryKey,
   UseInfiniteQueryResult,
   useInfiniteQuery,
 } from '@tanstack/react-query';
-import { useCallback, useEffect, useMemo, useRef } from 'react';
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 
 import * as db from '../db';
 import { createDevLogger } from '../debug';
@@ -22,7 +21,6 @@ const postsLogger = createDevLogger('useChannelPosts', false);
 
 type UseChannelPostsPageParams = db.GetChannelPostsOptions;
 type PostQueryData = InfiniteData<db.Post[], unknown>;
-type PostQuery = UseInfiniteQueryResult<PostQueryData, Error>;
 type SubscriptionPost = [db.Post, string | undefined];
 
 type UseChanelPostsParams = UseChannelPostsPageParams & {
@@ -126,40 +124,34 @@ export const useChannelPosts = (options: UseChanelPostsParams) => {
     },
   });
 
-  useEffect(() => {
-    if (query.error) {
-      console.error('useChannelPosts error:', query.error);
-    }
-  }, [query.error]);
-
-  const rawPosts = useMemo<db.Post[] | null>(
-    () => query.data?.pages.flatMap((p) => p) ?? null,
-    [query.data]
-  );
-  const session = useCurrentSession();
-  const posts = useOptimizedQueryResults(rawPosts);
-  const pendingStalePosts = useRef(new Set());
-  useEffect(() => {
-    posts?.forEach((post) => {
-      if (
-        session &&
-        post.syncedAt < (session?.startTime ?? 0) &&
-        !pendingStalePosts.current.has(post.id)
-      ) {
-        sync.syncThreadPosts(
-          {
-            postId: post.id,
-            channelId: options.channelId,
-            authorId: post.authorId,
-          },
-          4
-        );
-        pendingStalePosts.current.add(post.id);
+  // When we get a new post from the listener, add it to the pending list
+  // and attempt to update query data.
+  const [newPosts, setNewPosts] = useState<db.Post[]>([]);
+  const handleNewPost = useCallback(
+    (post: db.Post) => {
+      if (post.channelId === options.channelId) {
+        setNewPosts((posts) => addPostToNewPosts(post, posts));
       }
-    });
-  }, [options.channelId, posts, session]);
+    },
+    [options.channelId]
+  );
+  useSubscriptionPostListener(handleNewPost);
 
-  useAddNewPostsToQuery(queryKey, query);
+  const rawPosts = useMemo<db.Post[] | null>(() => {
+    const queryPosts = query.data?.pages.flatMap((p) => p) ?? null;
+    if (!query.hasPreviousPage) {
+      const newestQueryPostId = queryPosts?.[0]?.id;
+      const newerPosts = newPosts.filter(
+        (p) => !newestQueryPostId || p.id > newestQueryPostId
+      );
+      return newestQueryPostId ? [...newerPosts, ...queryPosts] : newPosts;
+    }
+    return queryPosts;
+  }, [query.data, query.hasPreviousPage, newPosts]);
+
+  const posts = useOptimizedQueryResults(rawPosts);
+
+  useRefreshPosts(options.channelId, posts);
 
   const isLoading = useDebouncedValue(
     query.isPending ||
@@ -176,6 +168,69 @@ export const useChannelPosts = (options: UseChanelPostsParams) => {
     [posts, query, loadOlder, loadNewer, isLoading]
   );
 };
+
+/**
+ * Insert a post into our working posts array, merging + resorting if necessary.
+ */
+function addPostToNewPosts(post: db.Post, newPosts: db.Post[]) {
+  postsLogger.log('new posts');
+  let nextPosts: db.Post[] | null = null;
+  const pendingPostIndex = newPosts?.findIndex(
+    (p) => p.deliveryStatus === 'pending' && p.sentAt === post.sentAt
+  );
+  if (pendingPostIndex !== -1) {
+    nextPosts = [
+      ...newPosts.slice(0, pendingPostIndex),
+      post,
+      ...newPosts.slice(pendingPostIndex + 1),
+    ];
+  } else {
+    const existingPostIndex = newPosts?.findIndex((p) => p.id === post.id);
+    if (existingPostIndex !== -1) {
+      nextPosts = [
+        ...newPosts.slice(0, existingPostIndex),
+        post,
+        ...newPosts.slice(existingPostIndex + 1),
+      ];
+    }
+  }
+
+  postsLogger.log('processsed pending existing');
+
+  const finalPosts = (nextPosts ? nextPosts : [post, ...newPosts]).sort(
+    (a, b) => b.receivedAt - a.receivedAt
+  );
+  postsLogger.log('calculated final');
+  return finalPosts;
+}
+
+/**
+ * Watches for new posts that are older than the current session and reloads them if necessary.
+ */
+function useRefreshPosts(channelId: string, posts: db.Post[] | null) {
+  const session = useCurrentSession();
+
+  const pendingStalePosts = useRef(new Set());
+  useEffect(() => {
+    posts?.forEach((post) => {
+      if (
+        session &&
+        post.syncedAt < (session?.startTime ?? 0) &&
+        !pendingStalePosts.current.has(post.id)
+      ) {
+        sync.syncThreadPosts(
+          {
+            postId: post.id,
+            channelId,
+            authorId: post.authorId,
+          },
+          4
+        );
+        pendingStalePosts.current.add(post.id);
+      }
+    });
+  }, [channelId, posts, session]);
+}
 
 /**
  * Creates loadNewer/loadOlder handlers that will queue up requests if called
@@ -249,106 +304,3 @@ const useSubscriptionPostListener = (listener: SubscriptionPostListener) => {
 export const addToChannelPosts = (...args: SubscriptionPost) => {
   subscriptionPostListeners.forEach((listener) => listener(...args));
 };
-
-/**
- * Attaches to new post listener to actually update query data when the listener
- * triggers.
- */
-function useAddNewPostsToQuery(queryKey: QueryKey, query: PostQuery) {
-  const queryRef = useLiveRef(query);
-  const subscriptionPostsRef = useRef<SubscriptionPost[]>([]);
-
-  const updateQuery = useCallback(() => {
-    // Bail out if we don't have the data yet or if we're fetching, since updating in either of those cases can
-    if (
-      !queryRef.current.data ||
-      queryRef.current.isFetching ||
-      !subscriptionPostsRef.current.length
-    ) {
-      return;
-    }
-    const remainingPosts = addSubscriptionPostsToQuery(
-      queryKey,
-      subscriptionPostsRef.current
-    );
-    subscriptionPostsRef.current = remainingPosts;
-  }, [queryKey, queryRef]);
-
-  // When we get a new post from the listener, add it to the pending list
-  // and attempt to update query data.
-  const handleNewPost = useCallback(
-    (...subscriptionPost: SubscriptionPost) => {
-      subscriptionPostsRef.current.push(subscriptionPost);
-      updateQuery();
-    },
-    [updateQuery]
-  );
-  useSubscriptionPostListener(handleNewPost);
-
-  // Attempt to re-apply pending posts whenever the query finishes fetching.
-  useEffect(() => {
-    updateQuery();
-  }, [query.isFetching, updateQuery]);
-}
-
-function addSubscriptionPostsToQuery(
-  queryKey: QueryKey,
-  subscriptionPosts: SubscriptionPost[]
-): SubscriptionPost[] {
-  const skippedPosts: SubscriptionPost[] = [];
-
-  queryClient.setQueryData(queryKey, (oldData: PostQueryData) => {
-    const result = subscriptionPosts.reduce((workingData, subscriptionPost) => {
-      const [wasAdded, updatedData] = addSubscriptionPostToQueryData(
-        subscriptionPost,
-        workingData
-      );
-      if (!wasAdded) {
-        skippedPosts.push(subscriptionPost);
-      }
-      return updatedData;
-    }, oldData);
-    return result;
-  });
-
-  return skippedPosts;
-}
-
-/**
- * Attempts to update query data with each pending post in sequence.
- */
-function addSubscriptionPostToQueryData(
-  [newPost, previousPostId]: SubscriptionPost,
-  data: PostQueryData
-): [boolean, PostQueryData] {
-  let subscriptionPost = false;
-  const result = mapInfiniteData(data, (post: db.Post) => {
-    // Check if there's a pending post to replace
-    if (post.sentAt === newPost.sentAt) {
-      subscriptionPost = true;
-      return [
-        {
-          ...post,
-          ...newPost,
-        },
-      ];
-    } else if (post.id === previousPostId) {
-      subscriptionPost = true;
-      return [newPost, post];
-    } else if (post.id === newPost.id) {
-      subscriptionPost = true;
-      return [{ ...post, ...newPost }];
-    } else {
-      return [post];
-    }
-  });
-  return [subscriptionPost, result];
-}
-
-function mapInfiniteData<
-  TItem,
-  TInfiniteData extends InfiniteData<TItem[], any>,
->(data: TInfiniteData, cb: (item: TItem) => TItem | TItem[]): TInfiniteData {
-  const nextPages = data?.pages?.map((p) => p.flatMap(cb));
-  return { ...data, pages: nextPages };
-}


### PR DESCRIPTION
Refactors + significantly simplifies `useChannelPosts` to fix an issue where posts could sometimes appear out of order.

- Removed `queryClient` based update logic
- Added a `newPosts` array, tracked separately from query results
- When new posts come in, they get merged into the array, which is manually resorted to preserve order.
- When merging `newPosts` and `queryPosts`:
  - We only include `newPosts` that are newer than the newest `queryPost` to prevent duplicates.
  - This also handles the case where the channel query is invalidated. On refetch, the query will load all posts up the newest in the database, so older `newPosts` will be ignored.
- Not highly optimized, could have perf issues at some point, but seemed fine in testing up to 100 new posts.

Fixes TLON-2243 and TLON-2205