### PR TITLE
fix load regression

### DIFF
--- a/packages/shared/src/store/useChannelPosts.ts
+++ b/packages/shared/src/store/useChannelPosts.ts
@@ -110,10 +110,13 @@ export const useChannelPosts = (options: UseChanelPostsParams) => {
     getPreviousPageParam: (
       firstPage,
       _allPages,
-      _firstPageParam
+      firstPageParam
     ): UseChannelPostsPageParams | undefined => {
       const firstPageIsEmpty = !firstPage[0]?.id;
-      if (firstPageIsEmpty || options.hasCachedNewest) {
+      if (
+        firstPageIsEmpty ||
+        (firstPageParam.mode === 'newest' && options.hasCachedNewest)
+      ) {
         return undefined;
       }
       return {


### PR DESCRIPTION
Fixes the failure to load Pat found last night. Turned out to be super easy to reproduce/fix in channels with unreads. We were shortcircuiting loads based on whether we had newest posts, regardless of where in the scrollback we were trying to load.

Fixes TLON-2249
