### PR TITLE
native: fix reply references

### DIFF
--- a/packages/ui/src/components/ContentReference/ChannelReference.tsx
+++ b/packages/ui/src/components/ContentReference/ChannelReference.tsx
@@ -7,11 +7,13 @@ import ReferenceSkeleton from './ReferenceSkeleton';
 export default function ChannelReference({
   channelId,
   postId,
+  replyId,
   asAttachment = false,
   viewMode = 'chat',
 }: {
   channelId: string;
   postId: string;
+  replyId?: string;
   asAttachment?: boolean;
   viewMode?: PostViewMode;
 }) {
@@ -24,6 +26,7 @@ export default function ChannelReference({
         viewMode={viewMode}
         channelId={channelId}
         postId={postId}
+        replyId={replyId}
       />
     );
   }

--- a/packages/ui/src/components/ContentReference/ChatReferenceWrapper.tsx
+++ b/packages/ui/src/components/ContentReference/ChatReferenceWrapper.tsx
@@ -7,16 +7,23 @@ import ReferenceSkeleton from './ReferenceSkeleton';
 export default function ChatReferenceWrapper({
   channelId,
   postId,
+  replyId,
   asAttachment = false,
   viewMode = 'chat',
 }: {
   channelId: string;
   postId: string;
+  replyId?: string;
   asAttachment?: boolean;
   viewMode?: PostViewMode;
 }) {
   const { usePost, useChannel } = useRequests();
-  const { data: post, isError, error, isLoading } = usePost({ id: postId });
+  const {
+    data: post,
+    isError,
+    error,
+    isLoading,
+  } = usePost({ id: replyId ? replyId : postId });
   const { data: channel } = useChannel({ id: channelId });
 
   const { onPressRef } = useNavigation();

--- a/packages/ui/src/components/ContentReference/index.tsx
+++ b/packages/ui/src/components/ContentReference/index.tsx
@@ -20,6 +20,7 @@ export default function ContentReference({
       <ChannelReference
         channelId={reference.channelId}
         postId={reference.postId}
+        replyId={reference.replyId}
         asAttachment={asAttachment}
         viewMode={viewMode}
       />


### PR DESCRIPTION
We weren't passing the replyId into ChannelReference or ChatReferenceWrapper, previously.

Fixes TLON-2213.