### PR TITLE
nav-within-tab: make sure we send groups only stuff to the right place

### DIFF
--- a/apps/tlon-web/src/components/References/NoteReference.tsx
+++ b/apps/tlon-web/src/components/References/NoteReference.tsx
@@ -1,6 +1,5 @@
 import bigInt from 'big-integer';
 import React, { useMemo } from 'react';
-import { useLocation, useNavigate } from 'react-router-dom';
 
 import Avatar from '@/components/Avatar';
 import { NOTE_REF_DISPLAY_LIMIT } from '@/constants';

--- a/apps/tlon-web/src/components/Sidebar/util.tsx
+++ b/apps/tlon-web/src/components/Sidebar/util.tsx
@@ -74,12 +74,14 @@ export function useNavWithinTab() {
 
       const isStringPath = typeof to === 'string';
       let path = isStringPath ? to : to.pathname || '';
+      const groupsOnly =
+        path.includes('channels/diary') || path.includes('channels/heap');
 
       if (isActive('/groups') || location.pathname === '/') {
         path = path.replace(/^\/dm/, '');
       }
 
-      if (isActive('/messages') || isActive('/dm')) {
+      if ((isActive('/messages') || isActive('/dm')) && !groupsOnly) {
         path = path.replace(/^\/groups/, '/dm/groups');
       }
 


### PR DESCRIPTION
OTT, if you currently click a ref in the messages tab that goes to notebook or gallery item it just sends you to blank page.

PR Checklist
- [ ] Includes changes to desk files
- [ ] Describes how you tested the PR locally (test ship vs livenet)
- [ ] If a new feature, includes automated tests
- [ ] Comments added anywhere logic may be confusing without context