### PR TITLE
activity: dont mix maps and mops

### DIFF
--- a/desk/app/activity.hoon
+++ b/desk/app/activity.hoon
@@ -669,7 +669,8 @@
         ::  without "losing" any unreads, and the call to +refresh-index
         ::  below will clean up unnecessary items.reads entries.
         ::
-        =-  index(items.reads (malt -))
+        =-  index(items.reads -)
+        %+  gas:on-read-items:a  *read-items:a
         %+  murn
           %-  tap:on-event:a
           (lot:on-event:a stream.index `floor.reads.index ~)


### PR DESCRIPTION
witness my sin, accidentally used map instead of mop leading to out of order issues

PR Checklist
- [X] Includes changes to desk files
- [ ] Describes how you tested the PR locally (test ship vs livenet)
- [ ] If a new feature, includes automated tests
- [ ] Comments added anywhere logic may be confusing without context