### PR TITLE
native: fetch pins on main list focus

### DIFF
--- a/apps/tlon-mobile/src/screens/ChatListScreen.tsx
+++ b/apps/tlon-mobile/src/screens/ChatListScreen.tsx
@@ -70,6 +70,7 @@ export default function ChatListScreen(
   useFocusEffect(
     useCallback(() => {
       store.syncUnreads(store.SyncPriority.High);
+      store.syncPinnedItems(store.SyncPriority.High);
     }, [])
   );
 

--- a/packages/shared/src/store/sync.ts
+++ b/packages/shared/src/store/sync.ts
@@ -158,9 +158,11 @@ export const syncContacts = async (priority = SyncPriority.Medium) => {
 };
 
 export const syncPinnedItems = async (priority = SyncPriority.Medium) => {
+  logger.log('syncing pinned items');
   const pinnedItems = await syncQueue.add('pinnedItems', priority, () =>
     api.getPinnedItems()
   );
+  logger.log('got pinned items from api', pinnedItems.length);
   await db.insertPinnedItems(pinnedItems);
 };
 


### PR DESCRIPTION
Fixes TLON-2133 (kinda) by fetching pins on focus of the main list. We don't have a subscription for pin events, so this is the best we can do for a quick fix.