### PR TITLE
notify/chat: correct dm thread paths and prep for activity cutover

### DIFF
--- a/desk/app/chat.hoon
+++ b/desk/app/chat.hoon
@@ -1340,7 +1340,7 @@
           =*  op  writ.u.entry
           =/  new-yarn
             %^  cu-spin
-              /(rsh 4 (scot %ui time.u.entry))
+              /message/(scot %p p.id.op)/(scot %ud q.id.op)
               :~  [%ship author.memo]  ' replied to '
                   [%emph (flatten:utils content.op)]  ': '
                   [%ship author.memo]  ': '
@@ -1697,7 +1697,7 @@
         ?~  entry  (di-give-writs-diff diff)
         =*  op  writ.u.entry
         =/  new-yarn
-          %^  di-spin  /(rsh 4 (scot %ui time.u.entry))
+          %^  di-spin  /message/(scot %p p.id.op)/(scot %ud q.id.op)
             :~  [%ship author.memo]  ' replied to '
                 [%emph (flatten:utils content.op)]  ': '
                 [%ship author.memo]  ': '

--- a/desk/app/notify.hoon
+++ b/desk/app/notify.hoon
@@ -642,6 +642,7 @@
     :~  identity+(rsh [3 1] (scot %p who))
         action+`@t`action.update
         uid+(scot %uv uid.update)
+        id+(scot %da uid.update)
     ==
   %:  post-form
       /send-notification/(scot %uv (sham eny.bowl))

--- a/desk/lib/notify.hoon
+++ b/desk/lib/notify.hoon
@@ -184,7 +184,7 @@
           ::
               %dm-reply
             ::REVIEW
-            (weld (dm-path whom.event) /(rsh 4 (scot %ui time.key.event)))
+            (weld (dm-path whom.event) /message/(scot %p p.id.parent.event)/(scot %ud q.id.parent.event))
           ::
             %group-ask     (weld (group-path group.event) /edit/members)
             %group-invite  /find


### PR DESCRIPTION
Fixes TLON-2269 by changing the paths we send to hark. Also includes the `@da` version of the activity ID that we send to Twilio so that we can use it instead of the old `@uv` version. Either version is supported in notify so this is just some cleanup.

PR Checklist
- [X] Includes changes to desk files
- [ ] Describes how you tested the PR locally (test ship vs livenet)
- [ ] If a new feature, includes automated tests
- [ ] Comments added anywhere logic may be confusing without context