### PR TITLE
native: prevent URL and +code login for Tlon-hosted ships

### DIFF
--- a/apps/tlon-mobile/src/screens/ShipLoginScreen.tsx
+++ b/apps/tlon-mobile/src/screens/ShipLoginScreen.tsx
@@ -47,12 +47,15 @@ export const ShipLoginScreen = ({ navigation }: Props) => {
   const { setShip } = useShip();
 
   const isValidUrl = useCallback((url: string) => {
-    try {
-      new URL(url);
-      return true;
-    } catch (err) {
+    const urlPattern = /^(https?:\/\/)?([\w.-]+)\.([a-z]{2,})(\/\S*)?$/i;
+    const hostedPattern = /tlon\.network/i;
+    if (!urlPattern.test(url)) {
       return false;
     }
+    if (hostedPattern.test(url)) {
+      return 'hosted';
+    }
+    return true;
   }, []);
 
   const onSubmit = handleSubmit(async ({ shipUrl: rawShipUrl, accessCode }) => {
@@ -128,10 +131,11 @@ export const ShipLoginScreen = ({ navigation }: Props) => {
           rules={{
             required: 'Please enter a valid URL.',
             validate: (value) => {
-              if (!isValidUrl(value)) {
+              const urlValidation = isValidUrl(value);
+              if (urlValidation === false) {
                 return 'Please enter a valid URL.';
               }
-              if (value.toLowerCase().endsWith('.tlon.network')) {
+              if (urlValidation === 'hosted') {
                 return 'Please log in to your hosted Tlon ship using email and password.';
               }
               return true;

--- a/apps/tlon-mobile/src/screens/ShipLoginScreen.tsx
+++ b/apps/tlon-mobile/src/screens/ShipLoginScreen.tsx
@@ -64,7 +64,10 @@ export const ShipLoginScreen = ({ navigation }: Props) => {
     const shipUrl = transformShipURL(rawShipUrl);
     setFormattedShipUrl(shipUrl);
     try {
-      const authCookie = await getLandscapeAuthCookie(shipUrl, accessCode);
+      const authCookie = await getLandscapeAuthCookie(
+        shipUrl,
+        accessCode.trim()
+      );
       if (authCookie) {
         const shipId = getShipFromCookie(authCookie);
         if (await isEulaAgreed()) {
@@ -77,7 +80,9 @@ export const ShipLoginScreen = ({ navigation }: Props) => {
           navigation.navigate('EULA', { shipId, shipUrl, authCookie });
         }
       } else {
-        setRemoteError("Sorry, we couldn't log you into your Urbit ID.");
+        setRemoteError(
+          "Sorry, we couldn't log in to your ship. It may be busy or offline."
+        );
       }
     } catch (err) {
       setRemoteError((err as Error).message);

--- a/apps/tlon-mobile/src/screens/ShipLoginScreen.tsx
+++ b/apps/tlon-mobile/src/screens/ShipLoginScreen.tsx
@@ -1,6 +1,6 @@
 import type { NativeStackScreenProps } from '@react-navigation/native-stack';
 import { getLandscapeAuthCookie } from '@tloncorp/shared/dist/api';
-import { useEffect, useLayoutEffect, useState } from 'react';
+import { useCallback, useEffect, useLayoutEffect, useState } from 'react';
 import { Controller, useForm } from 'react-hook-form';
 import { Text, TextInput, View } from 'react-native';
 import { useTailwind } from 'tailwind-rn';
@@ -45,6 +45,15 @@ export const ShipLoginScreen = ({ navigation }: Props) => {
     },
   });
   const { setShip } = useShip();
+
+  const isValidUrl = useCallback((url: string) => {
+    try {
+      new URL(url);
+      return true;
+    } catch (err) {
+      return false;
+    }
+  }, []);
 
   const onSubmit = handleSubmit(async ({ shipUrl: rawShipUrl, accessCode }) => {
     setIsSubmitting(true);
@@ -101,7 +110,7 @@ export const ShipLoginScreen = ({ navigation }: Props) => {
           'text-lg font-medium text-tlon-black-80 dark:text-white'
         )}
       >
-        Connect an unhosted ship by entering its URL and access code.
+        Connect a self-hosted ship by entering its URL and access code.
       </Text>
       {remoteError ? (
         <Text style={tailwind('mt-4 text-tlon-red')}>{remoteError}</Text>
@@ -118,13 +127,22 @@ export const ShipLoginScreen = ({ navigation }: Props) => {
           control={control}
           rules={{
             required: 'Please enter a valid URL.',
+            validate: (value) => {
+              if (!isValidUrl(value)) {
+                return 'Please enter a valid URL.';
+              }
+              if (value.toLowerCase().endsWith('.tlon.network')) {
+                return 'Please log in to your hosted Tlon ship using email and password.';
+              }
+              return true;
+            },
           }}
           render={({ field: { onChange, onBlur, value } }) => (
             <TextInput
               style={tailwind(
                 'p-4 text-tlon-black-80 dark:text-white border border-tlon-black-20 dark:border-tlon-black-80 rounded-lg'
               )}
-              placeholder="sampel-palnet.tlon.network"
+              placeholder="https://sampel-palnet.arvo.network"
               placeholderTextColor="#999999"
               onBlur={onBlur}
               onChangeText={onChange}

--- a/apps/tlon-mobile/src/screens/ShipLoginScreen.tsx
+++ b/apps/tlon-mobile/src/screens/ShipLoginScreen.tsx
@@ -88,6 +88,9 @@ export const ShipLoginScreen = ({ navigation }: Props) => {
 
   useLayoutEffect(() => {
     navigation.setOptions({
+      headerLeft: () => (
+        <HeaderButton title="Back" onPress={() => navigation.goBack()} />
+      ),
       headerRight: () =>
         isSubmitting ? (
           <View style={tailwind('px-8')}>

--- a/apps/tlon-mobile/src/screens/SignUpEmailScreen.tsx
+++ b/apps/tlon-mobile/src/screens/SignUpEmailScreen.tsx
@@ -91,6 +91,9 @@ export const SignUpEmailScreen = ({
 
   useLayoutEffect(() => {
     navigation.setOptions({
+      headerLeft: () => (
+        <HeaderButton title="Back" onPress={() => navigation.goBack()} />
+      ),
       headerRight: () =>
         isSubmitting ? (
           <View style={tailwind('px-4')}>

--- a/apps/tlon-mobile/src/screens/TlonLoginScreen.tsx
+++ b/apps/tlon-mobile/src/screens/TlonLoginScreen.tsx
@@ -124,6 +124,9 @@ export const TlonLoginScreen = ({ navigation }: Props) => {
 
   useLayoutEffect(() => {
     navigation.setOptions({
+      headerLeft: () => (
+        <HeaderButton title="Back" onPress={() => navigation.goBack()} />
+      ),
       headerRight: () =>
         isSubmitting ? (
           <View style={tailwind('px-8')}>


### PR DESCRIPTION
Prevents users from logging in to the app with a Tlon-hosted ship URL and +code. This means we don't have to do suspension detection and revival in this login flow as well.

Also adds "Back" buttons to all login screens to allow the user to flip between methods without force-killing the app (!).

Fixes TLON-2285

![image](https://github.com/tloncorp/tlon-apps/assets/748181/a9e80e26-e7ef-4381-9ed5-f2461c6f52c0)

