### PR TITLE
wip: native: allow users to flag posts and admins to see the flag posts in activity

### DIFF
--- a/desk/app/activity.hoon
+++ b/desk/app/activity.hoon
@@ -356,13 +356,13 @@
   ::  after the start so we always get "new" sources when paging
   ?.  ?&  notified.event
           (lth latest.src-info start)
-          ?=(?(%post %reply %dm-post %dm-reply) -<.event)
+          ?=(?(%post %reply %dm-post %dm-reply %flag-post) -<.event)
       ==
     acc
   =/  mention=(unit activity-bundle:a)
     ?.  |(?=(%all type) ?=(%mentions type))  ~
     =/  is-mention
-      ?-  -<.event
+      ?+  -<.event  |
         %post  mention.event
         %reply  mention.event
         %dm-post  mention.event
@@ -484,6 +484,11 @@
     =.  cor  (add-to-index source time-id event)
     =.  cor  (add-to-index chan-src time-id event(child &))
     (add-to-index group-src time-id event(child &))
+   ::
+      :: %flag-post
+    :: =/  group-src  [%group group.event]
+    :: =.  cor  (add-to-index source time-id event)
+    :: (add-to-index group-src time-id event(child &))
   ==
 ::
 ++  del-source

--- a/desk/app/groups.hoon
+++ b/desk/app/groups.hoon
@@ -827,8 +827,8 @@
     |=  $=  concern
         $%  [%join =ship]
             [%kick =ship]
-            [%flag-post key=message-key =nest:c group=flag:g]
-            [%flag-reply key=message-key parent=message-key =nest:c group=flag:g]
+            [%flag-post key=message-key =nest:d group=flag:g]
+            [%flag-reply key=message-key parent=message-key =nest:d group=flag:g]
             [%role =ship roles=(set sect:g)]
             [%ask =ship]
         ==
@@ -1313,8 +1313,27 @@
           ==
       ==
     =.  cor  (emit (pass-hark new-yarn))
-    ::TODO  want to (go-activity %flag), but we would need
-    ::      a more detailed "key" than just the post-key
+    =/  new-message-id=message-id:activity  [src post.post-key]
+    =/  kind-from-nest=kind:d
+      ?:  =(p.nest %chat)  %chat
+      ?:  =(p.nest %heap)  %heap
+      ?:  =(p.nest %diary)  %diary
+      ~|  "Invalid nest kind"  !!
+    =/  converted-nest=nest:d  [kind-from-nest p.q.nest q.q.nest]
+    =.  go-core
+       ?~  reply.post-key
+          %+  go-activity  %flag-post
+          :*  [new-message-id post.post-key]
+              converted-nest
+              flag
+          ==
+        =/  new-reply-message-id=message-id:activity  [src u.reply.post-key]
+        %+  go-activity  %flag-reply
+        :*  [new-reply-message-id u.reply.post-key]
+            [new-message-id post.post-key]
+            converted-nest
+            flag
+        ==
     go-core
   ++  go-zone-update
     |=  [=zone:g =delta:zone:g]

--- a/desk/lib/groups-json.hoon
+++ b/desk/lib/groups-json.hoon
@@ -154,7 +154,7 @@
     %-  pairs
     :~  nest/s/(nest n)
         src/(ship src)
-        :-  %post
+        :-  %post-key
         %-  pairs
         :~  post/(time-id post.post-key)
             reply/?~(reply.post-key ~ (time-id u.reply.post-key))

--- a/packages/shared/src/api/groupsApi.ts
+++ b/packages/shared/src/api/groupsApi.ts
@@ -957,7 +957,7 @@ export const toGroupUpdate = (
       type: 'flagGroupPost',
       groupId,
       channelId: updateDiff['flag-content'].nest,
-      postId: updateDiff['flag-content']['post-key'].reply
+      postId: updateDiff['flag-content']['post-key']?.reply
         ? updateDiff['flag-content']['post-key'].reply
         : updateDiff['flag-content']['post-key'].post,
       flaggingUser: updateDiff['flag-content'].src,

--- a/packages/shared/src/api/postsApi.ts
+++ b/packages/shared/src/api/postsApi.ts
@@ -2,6 +2,7 @@ import { unixToDa } from '@urbit/api';
 import { Poke } from '@urbit/http-api';
 
 import * as db from '../db';
+import { useCurrentSession } from '../store';
 import * as ub from '../urbit';
 import {
   ClubAction,
@@ -593,6 +594,39 @@ export async function hidePost(channelId: string, postId: string) {
     json: {
       'toggle-post': {
         hide: postId,
+      },
+    },
+  };
+
+  return await poke(action);
+}
+
+export async function reportPost(
+  currentUserId: string,
+  groupId: string,
+  channelId: string,
+  postId: string,
+  replyId?: string
+) {
+  await hidePost(channelId, postId);
+
+  const action = {
+    app: 'groups',
+    mark: 'group-action-3',
+    json: {
+      flag: groupId,
+      update: {
+        time: '',
+        diff: {
+          'flag-content': {
+            nest: channelId,
+            src: currentUserId,
+            'post-key': {
+              post: postId,
+              reply: replyId ?? null,
+            },
+          },
+        },
       },
     },
   };

--- a/packages/ui/src/components/ChatMessage/ChatMessageActions/MessageActions.tsx
+++ b/packages/ui/src/components/ChatMessage/ChatMessageActions/MessageActions.tsx
@@ -60,6 +60,7 @@ export default function MessageActions({
             handleAction({
               id: action.id,
               post,
+              userId: currentUserId,
               channel,
               isMuted: post.volumeSettings?.isMuted ?? false,
               dismiss,
@@ -101,6 +102,7 @@ export function getPostActions({
         { id: 'copyRef', label: 'Copy link to post' },
         { id: 'edit', label: 'Edit message' },
         { id: 'visibility', label: 'Hide' },
+        { id: 'report', label: 'Report post' },
         { id: 'delete', label: 'Delete message', actionType: 'destructive' },
       ];
     case 'notebook':
@@ -111,6 +113,7 @@ export function getPostActions({
         { id: 'copyRef', label: 'Copy link to post' },
         { id: 'edit', label: 'Edit message' },
         { id: 'visibility', label: 'Hide' },
+        { id: 'report', label: 'Report post' },
         { id: 'delete', label: 'Delete message', actionType: 'destructive' },
       ];
     case 'dm':
@@ -133,6 +136,7 @@ export function getPostActions({
         { id: 'copyText', label: 'Copy message text' },
         { id: 'edit', label: 'Edit message' },
         { id: 'visibility', label: post?.hidden ? 'Show post' : 'Hide post' },
+        { id: 'report', label: 'Report message' },
         { id: 'delete', label: 'Delete message', actionType: 'destructive' },
       ];
   }
@@ -141,6 +145,7 @@ export function getPostActions({
 async function handleAction({
   id,
   post,
+  userId,
   channel,
   isMuted,
   dismiss,
@@ -150,6 +155,7 @@ async function handleAction({
 }: {
   id: string;
   post: db.Post;
+  userId: string;
   channel: db.Channel;
   isMuted?: boolean;
   dismiss: () => void;
@@ -183,6 +189,9 @@ async function handleAction({
       break;
     case 'delete':
       store.deletePost({ post });
+      break;
+    case 'report':
+      store.reportPost({ userId, post });
       break;
     case 'visibility':
       post.hidden ? store.showPost({ post }) : store.hidePost({ post });


### PR DESCRIPTION
For now, I've wired up the flagging from the user side and started on getting it to show up in the activity feed we return from %activity, but it's going to involve some more changes to the way the %all mode works for the feed. @Fang- is going to make those changes and then I'll wire up the rest of the frontend part if anything new needs to be done there (just need to navigate to the channel by pressing on the activity item).