### PR TITLE
native and web: use new memex upload endpoint

### DIFF
--- a/packages/shared/src/store/storage/storage.ts
+++ b/packages/shared/src/store/storage/storage.ts
@@ -83,10 +83,28 @@ export const useStorage = create<StorageState>((set, get) => ({
     try {
       // we apparently need to specifically scry for these on android since
       // the subscription isn't working
-      await get().getCredentials();
-      await get().getConfiguration();
+      const credentials = (await get().getCredentials()) ?? null;
+      const configuration = (await get().getConfiguration()) ?? {
+        buckets: new Set(),
+        currentBucket: '',
+        region: '',
+        publicUrlBase: '',
+        presignedUrl: '',
+        service: 'credentials',
+      };
+      // set({
+      //   loaded: true,
+      // });
       set({
         loaded: true,
+        s3: {
+          credentials,
+          configuration: {
+            ...configuration,
+            presignedUrl: configuration.presignedUrl || hostingUploadURL,
+            service: 'presigned-url',
+          },
+        },
       });
     } catch (e) {
       logger.error(e);
@@ -98,6 +116,7 @@ export const useStorage = create<StorageState>((set, get) => ({
         path: '/all',
       },
       (e) => {
+        console.log(`bl: got storage event`, e);
         const data = _.get(e, 'storage-update', false);
         if (data) {
           reduceStateN(get(), data, reduce);

--- a/packages/shared/src/store/storage/storage.ts
+++ b/packages/shared/src/store/storage/storage.ts
@@ -83,28 +83,10 @@ export const useStorage = create<StorageState>((set, get) => ({
     try {
       // we apparently need to specifically scry for these on android since
       // the subscription isn't working
-      const credentials = (await get().getCredentials()) ?? null;
-      const configuration = (await get().getConfiguration()) ?? {
-        buckets: new Set(),
-        currentBucket: '',
-        region: '',
-        publicUrlBase: '',
-        presignedUrl: '',
-        service: 'credentials',
-      };
-      // set({
-      //   loaded: true,
-      // });
+      await get().getCredentials();
+      await get().getConfiguration();
       set({
         loaded: true,
-        s3: {
-          credentials,
-          configuration: {
-            ...configuration,
-            presignedUrl: configuration.presignedUrl || hostingUploadURL,
-            service: 'presigned-url',
-          },
-        },
       });
     } catch (e) {
       logger.error(e);
@@ -116,7 +98,6 @@ export const useStorage = create<StorageState>((set, get) => ({
         path: '/all',
       },
       (e) => {
-        console.log(`bl: got storage event`, e);
         const data = _.get(e, 'storage-update', false);
         if (data) {
           reduceStateN(get(), data, reduce);

--- a/packages/shared/src/store/storage/upload.ts
+++ b/packages/shared/src/store/storage/upload.ts
@@ -16,13 +16,7 @@ import type {
 import * as api from '../../api';
 import { createDevLogger } from '../../debug';
 import { useStorage } from './storage';
-import {
-  getFinalMemexUrl,
-  getMemexUpload,
-  getMemexUploadUrl,
-  getShipInfo,
-  hasCustomS3Creds,
-} from './utils';
+import { getMemexUpload, getShipInfo } from './utils';
 
 const logger = createDevLogger('upload state', true);
 

--- a/packages/shared/src/store/storage/utils.ts
+++ b/packages/shared/src/store/storage/utils.ts
@@ -153,30 +153,3 @@ export const getHostingUploadURL = async () => {
   const isHosted = await getIsHosted();
   return isHosted ? MEMEX_BASE_URL : '';
 };
-
-export const getMemexUploadUrl = async (key: string) => {
-  const baseUrl = 'https://memex.tlon.network';
-  const url = `${baseUrl}/${key}`;
-  const token = await scry<string>({
-    app: 'genuine',
-    path: '/secret',
-  }).catch((e) => {
-    logger.log('failed to get secret', { e });
-    return '';
-  });
-  return `${url}?token=${token}`;
-};
-
-export function getUploadObjectKey(ship: string, fileName: string) {
-  return `${deSig(ship)}/${deSig(formatDa(unixToDa(new Date().getTime())))}-${fileName.split(' ').join('-')}`;
-}
-
-export const getFinalMemexUrl = async (memexUploadUrl: string) => {
-  const fileUrlResponse = await fetch(memexUploadUrl);
-  const fileUrl = await fileUrlResponse.json().catch(() => {
-    logger.log('Error parsing response body, fileUrlResponse');
-    return '';
-  });
-
-  return fileUrl;
-};


### PR DESCRIPTION
Uses the new memex endpoint from [this PR](https://github.com/tloncorp/ylem/pull/1995) to handle file uploads without relying on redirect semantics. Confirmed this works on iOS sim and resolved our issue on Android (checked via emulator). Will confirm it also resolves the issue with hosted uploads on web once it hits wannec.

We should hold on merging until the hosting PR makes it to prod (tested against staging).

Fixes TLON-2241
Fixes TLON-2365