### PR TITLE
native: add button for showing chat list filters

### DIFF
--- a/apps/tlon-mobile/src/fixtures/GroupList.fixture.tsx
+++ b/apps/tlon-mobile/src/fixtures/GroupList.fixture.tsx
@@ -102,6 +102,7 @@ export default {
       <ChatList
         activeTab="all"
         setActiveTab={() => {}}
+        showFilters={false}
         pinned={[groupWithLongTitle, groupWithImage].map((g) =>
           makeChannelSummary({ group: g })
         )}
@@ -120,6 +121,7 @@ export default {
       <ChatList
         activeTab="all"
         setActiveTab={() => {}}
+        showFilters={false}
         pinned={[dmSummary, groupDmSummary]}
         unpinned={[
           groupWithColorAndNoImage,
@@ -136,6 +138,7 @@ export default {
       <ChatList
         activeTab="all"
         setActiveTab={() => {}}
+        showFilters={false}
         pinned={[]}
         unpinned={[]}
         pendingChats={[]}

--- a/apps/tlon-mobile/src/screens/ChatListScreen.tsx
+++ b/apps/tlon-mobile/src/screens/ChatListScreen.tsx
@@ -8,6 +8,7 @@ import * as db from '@tloncorp/shared/dist/db';
 import * as logic from '@tloncorp/shared/dist/logic';
 import * as store from '@tloncorp/shared/dist/store';
 import {
+  Button,
   CalmProvider,
   ChatList,
   ChatOptionsSheet,
@@ -15,6 +16,7 @@ import {
   FloatingActionButton,
   GroupPreviewSheet,
   Icon,
+  IconButton,
   ScreenHeader,
   StartDmSheet,
   View,
@@ -38,6 +40,14 @@ type ChatListScreenProps = NativeStackScreenProps<
   'ChatList'
 >;
 
+const ShowFiltersButton = ({ onPress }: { onPress: () => void }) => {
+  return (
+    <Button borderWidth={0} onPress={onPress}>
+      <Icon type="Filter" size="$m" />
+    </Button>
+  );
+};
+
 export default function ChatListScreen(
   props: ChatListScreenProps & { contacts: db.Contact[] }
 ) {
@@ -54,6 +64,7 @@ export default function ChatListScreen(
   const [selectedGroup, setSelectedGroup] = useState<db.Group | null>(null);
   const [startDmOpen, setStartDmOpen] = useState(false);
   const [addGroupOpen, setAddGroupOpen] = useState(false);
+  const [showFilters, setShowFilters] = useState(false);
   const isFocused = useIsFocused();
   const { data: chats } = store.useCurrentChats({
     enabled: isFocused,
@@ -289,6 +300,11 @@ export default function ChatListScreen(
                 ? 'Loading…'
                 : screenTitle
             }
+            rightControls={
+              <ShowFiltersButton
+                onPress={() => setShowFilters((prev) => !prev)}
+              />
+            }
           />
           {chats && chats.unpinned.length ? (
             <ChatList
@@ -300,6 +316,7 @@ export default function ChatListScreen(
               onLongPressItem={onLongPressItem}
               onPressItem={onPressChat}
               onSectionChange={handleSectionChange}
+              showFilters={showFilters}
             />
           ) : null}
           <View

--- a/packages/ui/src/components/ChatList.tsx
+++ b/packages/ui/src/components/ChatList.tsx
@@ -3,7 +3,7 @@ import * as logic from '@tloncorp/shared/dist/logic';
 import * as store from '@tloncorp/shared/dist/store';
 import fuzzy from 'fuzzy';
 import { debounce } from 'lodash';
-import { useCallback, useMemo, useRef, useState } from 'react';
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import {
   NativeScrollEvent,
   NativeSyntheticEvent,
@@ -48,12 +48,14 @@ export function ChatList({
   onSectionChange,
   activeTab,
   setActiveTab,
+  showFilters,
 }: store.CurrentChats & {
   onPressItem?: (chat: Chat) => void;
   onLongPressItem?: (chat: Chat) => void;
   onSectionChange?: (title: string) => void;
   activeTab: 'all' | 'groups' | 'messages';
   setActiveTab: (tab: 'all' | 'groups' | 'messages') => void;
+  showFilters: boolean;
 }) {
   const [searchQuery, setSearchQuery] = useState('');
   const scrollY = useSharedValue(0);
@@ -269,6 +271,16 @@ export function ChatList({
       }
     },
   });
+
+  useEffect(() => {
+    if (showFilters) {
+      filterVisible.value = true;
+      scrollY.value = withSpring(-FILTER_HEIGHT);
+    } else {
+      filterVisible.value = false;
+      scrollY.value = withSpring(0);
+    }
+  }, [showFilters, filterVisible, scrollY, FILTER_HEIGHT]);
 
   const getChannelKey = useCallback((item: unknown) => {
     const chatItem = item as Chat;


### PR DESCRIPTION
Fixes TLON-2378 by adding a button to show the filters rather than relying entirely on the animation. Left the animation in since we may want to keep that functionality on iOS and fix the issue with Android later.