### PR TITLE
native: fix post editing issues

### DIFF
--- a/apps/tlon-mobile/src/fixtures/Channel.fixture.tsx
+++ b/apps/tlon-mobile/src/fixtures/Channel.fixture.tsx
@@ -95,9 +95,9 @@ export const ChannelFixture = (props: {
         goToDm={() => {}}
         goToPost={() => {}}
         goToImageViewer={() => {}}
-        messageSender={() => {}}
+        messageSender={async () => {}}
         markRead={() => {}}
-        editPost={() => {}}
+        editPost={async () => {}}
         uploadInfo={defaultUploadInfo}
         onPressRef={() => {}}
         usePost={usePostWithRelations}
@@ -133,9 +133,9 @@ export const NotebookChannelFixture = (props: { theme?: 'light' | 'dark' }) => {
         goToDm={() => {}}
         goToPost={() => {}}
         goToImageViewer={() => {}}
-        messageSender={() => {}}
+        messageSender={async () => {}}
         markRead={() => {}}
-        editPost={() => {}}
+        editPost={async () => {}}
         getDraft={async () => ({})}
         storeDraft={() => {}}
         clearDraft={() => {}}
@@ -190,9 +190,9 @@ const ChannelFixtureWithImage = () => {
         goToPost={() => {}}
         goToDm={() => {}}
         goToImageViewer={() => {}}
-        messageSender={() => {}}
+        messageSender={async () => {}}
         markRead={() => {}}
-        editPost={() => {}}
+        editPost={async () => {}}
         negotiationMatch={true}
         isLoadingPosts={false}
         uploadInfo={{

--- a/apps/tlon-mobile/src/fixtures/DetailView.fixture.tsx
+++ b/apps/tlon-mobile/src/fixtures/DetailView.fixture.tsx
@@ -26,10 +26,10 @@ const NotebookDetailViewFixture = () => {
         contacts={[]}
         channel={tlonLocalGettingStarted}
         currentUserId={notebookPost.authorId}
-        sendReply={() => {}}
+        sendReply={async () => {}}
         groupMembers={[]}
         negotiationMatch={true}
-        editPost={() => {}}
+        editPost={async () => {}}
         uploadInfo={{
           uploading: false,
           uploadedImage: null,
@@ -57,10 +57,10 @@ const GalleryDetailViewFixture = () => {
         contacts={[]}
         channel={tlonLocalBulletinBoard}
         currentUserId={galleryPost.authorId}
-        sendReply={() => {}}
+        sendReply={async () => {}}
         groupMembers={[]}
         negotiationMatch={true}
-        editPost={() => {}}
+        editPost={async () => {}}
         uploadInfo={{
           uploading: false,
           uploadedImage: null,

--- a/apps/tlon-mobile/src/fixtures/MessageInput.fixture.tsx
+++ b/apps/tlon-mobile/src/fixtures/MessageInput.fixture.tsx
@@ -14,7 +14,7 @@ const ChatMessageInputFixture = () => {
         <MessageInput
           shouldBlur={inputShouldBlur}
           setShouldBlur={setInputShouldBlur}
-          send={() => {}}
+          send={async () => {}}
           channelId="channel-id"
           uploadInfo={{
             imageAttachment: null,
@@ -44,7 +44,7 @@ const NotebookInputFixture = () => {
           channelType="notebook"
           shouldBlur={inputShouldBlur}
           setShouldBlur={setInputShouldBlur}
-          send={() => {}}
+          send={async () => {}}
           channelId="channel-id"
           groupMembers={group.members ?? []}
           getDraft={async () => ({})}

--- a/apps/tlon-mobile/src/fixtures/PostScreen.fixture.tsx
+++ b/apps/tlon-mobile/src/fixtures/PostScreen.fixture.tsx
@@ -12,7 +12,7 @@ const posts = createFakePosts(10);
 export default (
   <>
     <PostScreenView
-      editPost={() => {}}
+      editPost={async () => {}}
       editingPost={undefined}
       negotiationMatch={true}
       setEditingPost={() => {}}
@@ -33,7 +33,7 @@ export default (
       }}
       channel={tlonLocalBulletinBoard}
       posts={posts}
-      sendReply={() => {}}
+      sendReply={async () => {}}
       markRead={() => {}}
       groupMembers={group.members ?? []}
       getDraft={async () => ({})}

--- a/apps/tlon-mobile/src/screens/ChannelScreen.tsx
+++ b/apps/tlon-mobile/src/screens/ChannelScreen.tsx
@@ -117,7 +117,7 @@ export default function ChannelScreen(props: ChannelScreenProps) {
       if (!channel) {
         throw new Error('Tried to send message before channel loaded');
       }
-      store.sendPost({
+      await store.sendPost({
         channel: channel,
         authorId: currentUserId,
         content,

--- a/apps/tlon-mobile/src/screens/useChannelContext.ts
+++ b/apps/tlon-mobile/src/screens/useChannelContext.ts
@@ -52,7 +52,7 @@ export const useChannelContext = ({
   const [editingPost, setEditingPost] = useState<db.Post>();
 
   const editPost = useCallback(
-    async (post: db.Post, content: urbit.Story) => {
+    async (post: db.Post, content: urbit.Story, parentId?: string) => {
       if (!channelQuery.data) {
         return;
       }
@@ -60,6 +60,7 @@ export const useChannelContext = ({
       store.editPost({
         post,
         content,
+        parentId,
       });
       setEditingPost(undefined);
     },

--- a/packages/shared/src/api/postsApi.ts
+++ b/packages/shared/src/api/postsApi.ts
@@ -2,6 +2,7 @@ import { unixToDa } from '@urbit/api';
 import { Poke } from '@urbit/http-api';
 
 import * as db from '../db';
+import { createDevLogger } from '../debug';
 import * as ub from '../urbit';
 import {
   ClubAction,
@@ -33,6 +34,8 @@ import {
   with404Handler,
 } from './apiUtils';
 import { poke, scry, subscribeOnce } from './urbit';
+
+const logger = createDevLogger('postsApi', false);
 
 export type Cursor = string | Date;
 export type PostContent = (ub.Verse | ContentReference)[] | null;
@@ -203,12 +206,15 @@ export const editPost = async ({
   parentId?: string;
   metadata?: db.PostMetadata;
 }) => {
+  logger.log('editing post', { channelId, postId, authorId, sentAt, content });
   const channelType = getChannelType(channelId);
   if (isDmChannelId(channelId) || isGroupDmChannelId(channelId)) {
+    logger.error('Cannot edit a post in a DM or group DM');
     throw new Error('Cannot edit a post in a DM or group DM');
   }
 
   if (parentId) {
+    logger.log('editing a reply');
     const memo: ub.Memo = {
       author: authorId,
       content,
@@ -229,9 +235,13 @@ export const editPost = async ({
       },
     };
 
+    logger.log('sending action', action);
     await poke(channelAction(channelId, action));
+    logger.log('action sent');
     return;
   }
+
+  logger.log('editing a post');
 
   const essay = toPostEssay({
     content,
@@ -248,7 +258,9 @@ export const editPost = async ({
     },
   });
 
+  logger.log('sending action', action);
   await poke(action);
+  logger.log('action sent');
 };
 
 export const sendReply = async ({

--- a/packages/shared/src/store/postActions.ts
+++ b/packages/shared/src/store/postActions.ts
@@ -1,7 +1,10 @@
 import * as api from '../api';
 import * as db from '../db';
+import { createDevLogger } from '../debug';
 import * as urbit from '../urbit';
 import * as sync from './sync';
+
+const logger = createDevLogger('postActions', false);
 
 export async function sendPost({
   channel,
@@ -58,8 +61,10 @@ export async function editPost({
   parentId?: string;
   metadata?: db.PostMetadata;
 }) {
+  logger.log('editPost', { post, content, parentId, metadata });
   // optimistic update
   await db.updatePost({ id: post.id, content: JSON.stringify(content) });
+  logger.log('editPost optimistic update done');
 
   try {
     await api.editPost({
@@ -71,12 +76,16 @@ export async function editPost({
       metadata,
       parentId,
     });
+    logger.log('editPost api call done');
     sync.syncChannelMessageDelivery({ channelId: post.channelId });
+    logger.log('editPost sync done');
   } catch (e) {
     console.error('Failed to edit post', e);
+    logger.log('editPost failed', e);
 
     // rollback optimistic update
     await db.updatePost({ id: post.id, content: post.content });
+    logger.log('editPost rollback done');
   }
 }
 

--- a/packages/ui/src/components/Channel/Scroller.tsx
+++ b/packages/ui/src/components/Channel/Scroller.tsx
@@ -2,6 +2,7 @@ import { createDevLogger } from '@tloncorp/shared/dist';
 import * as db from '@tloncorp/shared/dist/db';
 import { isSameDay } from '@tloncorp/shared/dist/logic';
 import { Story } from '@tloncorp/shared/dist/urbit';
+import { isEqual } from 'lodash';
 import { MotiView } from 'moti';
 import React, {
   PropsWithChildren,
@@ -47,7 +48,7 @@ type RenderItemFunction = (props: {
   onLongPress?: (post: db.Post) => void;
   editing?: boolean;
   setEditingPost?: (post: db.Post | undefined) => void;
-  editPost?: (post: db.Post, content: Story) => void;
+  editPost?: (post: db.Post, content: Story) => Promise<void>;
 }) => ReactElement | null;
 
 type RenderItemType =
@@ -111,7 +112,7 @@ function Scroller({
   showReplies?: boolean;
   editingPost?: db.Post;
   setEditingPost?: (post: db.Post | undefined) => void;
-  editPost?: (post: db.Post, content: Story) => void;
+  editPost?: (post: db.Post, content: Story) => Promise<void>;
   hasNewerPosts?: boolean;
   hasOlderPosts?: boolean;
 }) {
@@ -482,7 +483,7 @@ const BaseScrollerItem = ({
   showReplies?: boolean;
   editingPost?: db.Post;
   setEditingPost?: (post: db.Post | undefined) => void;
-  editPost?: (post: db.Post, content: Story) => void;
+  editPost?: (post: db.Post, content: Story) => Promise<void>;
   onPressPost?: (post: db.Post) => void;
   onLongPressPost: (post: db.Post) => void;
   activeMessage?: db.Post | null;
@@ -544,7 +545,25 @@ const BaseScrollerItem = ({
   );
 };
 
-const ScrollerItem = React.memo(BaseScrollerItem);
+const ScrollerItem = React.memo(BaseScrollerItem, (prev, next) => {
+  const isItemEqual = isEqual(prev.item, next.item);
+  const isIndexEqual = prev.index === next.index;
+
+  const areOtherPropsEqual =
+    prev.showAuthor === next.showAuthor &&
+    prev.showReplies === next.showReplies &&
+    prev.currentUserId === next.currentUserId &&
+    prev.editingPost === next.editingPost &&
+    prev.editPost === next.editPost &&
+    prev.setEditingPost === next.setEditingPost &&
+    prev.onPressReplies === next.onPressReplies &&
+    prev.onPressImage === next.onPressImage &&
+    prev.onPressPost === next.onPressPost &&
+    prev.onLongPressPost === next.onLongPressPost &&
+    prev.activeMessage === next.activeMessage;
+
+  return isItemEqual && areOtherPropsEqual && isIndexEqual;
+});
 
 const PressableMessage = React.memo(
   forwardRef<RNView, PropsWithChildren<{ isActive: boolean }>>(

--- a/packages/ui/src/components/Channel/index.tsx
+++ b/packages/ui/src/components/Channel/index.tsx
@@ -99,7 +99,7 @@ export function Channel({
   goToDm: (participants: string[]) => void;
   goToImageViewer: (post: db.Post, imageUri?: string) => void;
   goToSearch: () => void;
-  messageSender: (content: Story, channelId: string) => void;
+  messageSender: (content: Story, channelId: string) => Promise<void>;
   uploadInfo: UploadInfo;
   onScrollEndReached?: () => void;
   onScrollStartReached?: () => void;
@@ -116,7 +116,7 @@ export function Channel({
   getDraft: () => Promise<JSONContent>;
   editingPost?: db.Post;
   setEditingPost?: (post: db.Post | undefined) => void;
-  editPost: (post: db.Post, content: Story) => void;
+  editPost: (post: db.Post, content: Story) => Promise<void>;
   negotiationMatch: boolean;
   hasNewerPosts?: boolean;
   hasOlderPosts?: boolean;

--- a/packages/ui/src/components/ChatMessage/ChatMessage.tsx
+++ b/packages/ui/src/components/ChatMessage/ChatMessage.tsx
@@ -1,11 +1,11 @@
 import * as db from '@tloncorp/shared/dist/db';
 import { Story } from '@tloncorp/shared/dist/urbit';
+import { isEqual } from 'lodash';
 import { memo, useCallback } from 'react';
 
 import { SizableText, View, XStack, YStack } from '../../core';
 import AuthorRow from '../AuthorRow';
 import ChatContent from '../ContentRenderer';
-import { Icon } from '../Icon';
 import { MessageInput } from '../MessageInput';
 import { ChatMessageReplySummary } from './ChatMessageReplySummary';
 import { ReactionsDisplay } from './ReactionsDisplay';
@@ -55,7 +55,7 @@ const ChatMessage = ({
   onPressImage?: (post: db.Post, imageUri?: string) => void;
   onLongPress?: (post: db.Post) => void;
   editing?: boolean;
-  editPost?: (post: db.Post, content: Story) => void;
+  editPost?: (post: db.Post, content: Story) => Promise<void>;
   setEditingPost?: (post: db.Post | undefined) => void;
 }) => {
   const isNotice = post.type === 'notice';
@@ -124,7 +124,7 @@ const ChatMessage = ({
             getDraft={async () => ({})}
             shouldBlur={false}
             setShouldBlur={() => {}}
-            send={() => {}}
+            send={async () => {}}
             channelId={post.channelId}
             editingPost={post}
             editPost={editPost}
@@ -159,4 +159,19 @@ const ChatMessage = ({
   );
 };
 
-export default memo(ChatMessage);
+export default memo(ChatMessage, (prev, next) => {
+  const isPostEqual = isEqual(prev.post, next.post);
+
+  const areOtherPropsEqual =
+    prev.showAuthor === next.showAuthor &&
+    prev.showReplies === next.showReplies &&
+    prev.currentUserId === next.currentUserId &&
+    prev.editing === next.editing &&
+    prev.editPost === next.editPost &&
+    prev.setEditingPost === next.setEditingPost &&
+    prev.onPressReplies === next.onPressReplies &&
+    prev.onPressImage === next.onPressImage &&
+    prev.onLongPress === next.onLongPress;
+
+  return isPostEqual && areOtherPropsEqual;
+});

--- a/packages/ui/src/components/ContentRenderer.tsx
+++ b/packages/ui/src/components/ContentRenderer.tsx
@@ -916,20 +916,21 @@ export default function ContentRenderer({
           );
         }
       })}
-      {post.type === 'chat' && (
-        <View position="absolute" bottom={0} right={0}>
-          {isEdited ? (
-            <Text color="$tertiaryText" fontSize="$xs" flexWrap="nowrap">
-              Edited
-            </Text>
-          ) : null}
-          {deliveryStatus ? (
-            <View flexShrink={1}>
-              <ChatMessageDeliveryStatus status={deliveryStatus} />
-            </View>
-          ) : null}
-        </View>
-      )}
+      {post.type === 'chat' ||
+        (post.type === 'reply' && (
+          <View position="absolute" bottom={0} right={0}>
+            {isEdited ? (
+              <Text color="$tertiaryText" fontSize="$xs" flexWrap="nowrap">
+                Edited
+              </Text>
+            ) : null}
+            {deliveryStatus ? (
+              <View flexShrink={1}>
+                <ChatMessageDeliveryStatus status={deliveryStatus} />
+              </View>
+            ) : null}
+          </View>
+        ))}
     </YStack>
   );
 }

--- a/packages/ui/src/components/DetailView/DetailView.tsx
+++ b/packages/ui/src/components/DetailView/DetailView.tsx
@@ -21,8 +21,8 @@ export interface DetailViewProps {
   currentUserId?: string;
   editingPost?: db.Post;
   setEditingPost?: (post: db.Post | undefined) => void;
-  editPost?: (post: db.Post, content: urbit.Story) => void;
-  sendReply: (content: urbit.Story, channelId: string) => void;
+  editPost?: (post: db.Post, content: urbit.Story) => Promise<void>;
+  sendReply: (content: urbit.Story, channelId: string) => Promise<void>;
   groupMembers: db.ChatMember[];
   posts?: db.Post[];
   onPressImage?: (post: db.Post, imageUri?: string) => void;

--- a/packages/ui/src/components/MessageInput/MessageInputBase.tsx
+++ b/packages/ui/src/components/MessageInput/MessageInputBase.tsx
@@ -17,7 +17,11 @@ import ReferencePreview from './ReferencePreview';
 export interface MessageInputProps {
   shouldBlur: boolean;
   setShouldBlur: (shouldBlur: boolean) => void;
-  send: (content: Story, channelId: string, metadata?: db.PostMetadata) => void;
+  send: (
+    content: Story,
+    channelId: string,
+    metadata?: db.PostMetadata
+  ) => Promise<void>;
   channelId: string;
   uploadInfo?: UploadInfo;
   groupMembers: db.ChatMember[];
@@ -26,7 +30,11 @@ export interface MessageInputProps {
   getDraft: () => Promise<JSONContent>;
   editingPost?: db.Post;
   setEditingPost?: (post: db.Post | undefined) => void;
-  editPost?: (post: db.Post, content: Story) => void;
+  editPost?: (
+    post: db.Post,
+    content: Story,
+    parentId?: string
+  ) => Promise<void>;
   setShowBigInput?: (showBigInput: boolean) => void;
   showAttachmentButton?: boolean;
   floatingActionButton?: boolean;

--- a/packages/ui/src/components/MessageInput/index.native.tsx
+++ b/packages/ui/src/components/MessageInput/index.native.tsx
@@ -467,6 +467,9 @@ export const MessageInput = forwardRef<MessageInputHandle, MessageInputProps>(
         }
 
         if (isEdit && editingPost) {
+          if (editingPost.parentId) {
+            await editPost?.(editingPost, story, editingPost.parentId);
+          }
           await editPost?.(editingPost, story);
           setEditingPost?.(undefined);
         } else {

--- a/packages/ui/src/components/PostScreenView.tsx
+++ b/packages/ui/src/components/PostScreenView.tsx
@@ -50,7 +50,7 @@ export function PostScreenView({
   group?: db.Group | null;
   parentPost: db.Post | null;
   posts: db.Post[] | null;
-  sendReply: (content: urbit.Story, channelId: string) => void;
+  sendReply: (content: urbit.Story, channelId: string) => Promise<void>;
   markRead: () => void;
   goBack?: () => void;
   groupMembers: db.ChatMember[];
@@ -61,7 +61,7 @@ export function PostScreenView({
   getDraft: () => Promise<urbit.JSONContent>;
   editingPost?: db.Post;
   setEditingPost?: (post: db.Post | undefined) => void;
-  editPost: (post: db.Post, content: Story) => void;
+  editPost: (post: db.Post, content: Story) => Promise<void>;
   negotiationMatch: boolean;
   headerMode?: 'default' | 'next';
 }) {


### PR DESCRIPTION
Fixes TLON-2332, which addressed an issue where reply edits were not being processed and any edits, if processed, were not triggering a re-render of the post.

summary:

1. the parentId is now sent to the editPost function, which allows us to actually edit them.
2. updated the types to accurately reflect that editPost and sendPost are async.
3. added memo comparison functions and updated useLivePost to ensure that the latest post is always rendered.
4. added new loggers in postsApi and postActions.