### PR TITLE
native: update notifications to use instrumented endpoint

### DIFF
--- a/apps/tlon-mobile/android/app/src/main/java/io/tlon/landscape/api/TalkApi.java
+++ b/apps/tlon-mobile/android/app/src/main/java/io/tlon/landscape/api/TalkApi.java
@@ -126,7 +126,7 @@ public class TalkApi {
     }
 
     public void fetchYarn(String uid, TalkObjectCallback callback) {
-        fetchObject("/~/scry/hark/yarn/" + uid, 8_000, 3, callback);
+        fetchObject("/apps/groups/~/notify/note/" + uid + "/hark-yarn", 8_000, 3, callback);
     }
 
     public void fetchClub(String channelId, TalkObjectCallback callback) {

--- a/apps/tlon-mobile/ios/Landscape/Networking/PocketNotificationsAPI.swift
+++ b/apps/tlon-mobile/ios/Landscape/Networking/PocketNotificationsAPI.swift
@@ -10,7 +10,7 @@ import Foundation
 
 final class PocketNotificationsAPI: PocketAPI {
     static func fetchPushNotificationContents(_ uid: String) async throws -> Yarn {
-        let yarn: Yarn = try await PocketAPI.fetchDecodable("/~/scry/hark/yarn/\(uid)", timeoutInterval: 8)
+        let yarn: Yarn = try await PocketAPI.fetchDecodable("/apps/groups/~/notify/note/\(uid)/hark-yarn", timeoutInterval: 8)
         return yarn
     }
 }


### PR DESCRIPTION
Updates the Swift and Java code to use the new endpoint with Mark's delivery instrumentation. 

Tested on iOS with posts and threads for groups and DMs. I don't have local testing setup for Android notifications, but will confirm it's working on that platform after merging.

Fixes TLON-2226