### PR TITLE
native: clear message input immediately on send

### DIFF
--- a/packages/ui/src/components/MessageInput/index.native.tsx
+++ b/packages/ui/src/components/MessageInput/index.native.tsx
@@ -482,7 +482,9 @@ export const MessageInput = forwardRef<MessageInputHandle, MessageInputProps>(
             metadata['image'] = image.url;
           }
 
-          await send(story, channelId, metadata);
+          // not awaiting since we don't want to wait for the send to complete
+          // before clearing the draft and the editor content
+          send(story, channelId, metadata);
         }
 
         editor.setContent('');


### PR DESCRIPTION
We don't want to `await` the `send` because we need to clear the editor content and the draft immediately.

fixes TLON-2386