### PR TITLE
native: dynamic channel welcome notice

### DIFF
--- a/apps/tlon-mobile/src/screens/ChannelScreen.tsx
+++ b/apps/tlon-mobile/src/screens/ChannelScreen.tsx
@@ -29,6 +29,14 @@ export default function ChannelScreen(props: ChannelScreenProps) {
       }
     }, [props.route.params.channel.group])
   );
+  useFocusEffect(
+    useCallback(
+      () => () => {
+        store.markChannelVisited(props.route.params.channel);
+      },
+      [props.route.params.channel]
+    )
+  );
 
   const [channelNavOpen, setChannelNavOpen] = React.useState(false);
   const [currentChannelId, setCurrentChannelId] = React.useState(

--- a/apps/tlon-mobile/src/screens/ChannelScreen.tsx
+++ b/apps/tlon-mobile/src/screens/ChannelScreen.tsx
@@ -31,9 +31,11 @@ export default function ChannelScreen(props: ChannelScreenProps) {
   );
   useFocusEffect(
     useCallback(
-      () => () => {
-        store.markChannelVisited(props.route.params.channel);
-      },
+      () =>
+        // Mark the channel as visited when we unfocus/leave this screen
+        () => {
+          store.markChannelVisited(props.route.params.channel);
+        },
       [props.route.params.channel]
     )
   );

--- a/packages/shared/src/api/postsApi.test.ts
+++ b/packages/shared/src/api/postsApi.test.ts
@@ -1,21 +1,15 @@
-import { beforeAll, beforeEach, expect, test } from 'vitest';
+import { expect, test } from 'vitest';
 
 import { Post } from '../db';
 import rawChannelPostWithRepliesData from '../test/channelPostWithReplies.json';
 import rawChannelPostsData from '../test/channelPosts.json';
 import rawDmPostWithRepliesData from '../test/dmPostWithReplies.json';
 import rawGroupDmPostWithRepliesData from '../test/groupDmPostWithReplies.json';
-import { resetDb, setupDb } from '../test/helpers';
+import { setupDatabaseTestSuite } from '../test/helpers';
 import { PagedPosts, Posts } from '../urbit';
 import { toPostsData } from './postsApi';
 
-beforeAll(() => {
-  setupDb();
-});
-
-beforeEach(async () => {
-  resetDb();
-});
+setupDatabaseTestSuite();
 
 test('toPostData', async () => {
   const postsData = rawChannelPostsData as unknown as PagedPosts;

--- a/packages/shared/src/db/migrations/0000_curvy_exodus.sql
+++ b/packages/shared/src/db/migrations/0000_curvy_exodus.sql
@@ -61,6 +61,8 @@ CREATE TABLE `channels` (
 	`is_dm_invite` integer,
 	`synced_at` integer,
 	`remote_updated_at` integer,
+	`last_viewed_at` integer,
+	`is_default_welcome_channel` integer,
 	FOREIGN KEY (`group_id`) REFERENCES `groups`(`id`) ON UPDATE no action ON DELETE cascade
 );
 --> statement-breakpoint

--- a/packages/shared/src/db/migrations/meta/0000_snapshot.json
+++ b/packages/shared/src/db/migrations/meta/0000_snapshot.json
@@ -1,7 +1,7 @@
 {
   "version": "5",
   "dialect": "sqlite",
-  "id": "5fa6c36d-ce08-4b92-ae6d-305c6fbc307b",
+  "id": "430ef366-6b5b-4d84-b3f6-d846603c2e60",
   "prevId": "00000000-0000-0000-0000-000000000000",
   "tables": {
     "activity_events": {
@@ -391,6 +391,20 @@
         },
         "remote_updated_at": {
           "name": "remote_updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "last_viewed_at": {
+          "name": "last_viewed_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "is_default_welcome_channel": {
+          "name": "is_default_welcome_channel",
           "type": "integer",
           "primaryKey": false,
           "notNull": false,

--- a/packages/shared/src/db/migrations/meta/_journal.json
+++ b/packages/shared/src/db/migrations/meta/_journal.json
@@ -5,8 +5,8 @@
     {
       "idx": 0,
       "version": "5",
-      "when": 1720805158211,
-      "tag": "0000_furry_king_cobra",
+      "when": 1721084560967,
+      "tag": "0000_curvy_exodus",
       "breakpoints": true
     }
   ]

--- a/packages/shared/src/db/migrations/migrations.js
+++ b/packages/shared/src/db/migrations/migrations.js
@@ -1,7 +1,7 @@
 // This file is required for Expo/React Native SQLite migrations - https://orm.drizzle.team/quick-sqlite/expo
 
 import journal from './meta/_journal.json';
-import m0000 from './0000_furry_king_cobra.sql';
+import m0000 from './0000_curvy_exodus.sql';
 
   export default {
     journal,

--- a/packages/shared/src/db/queries.test.ts
+++ b/packages/shared/src/db/queries.test.ts
@@ -1,10 +1,14 @@
-import { beforeAll, beforeEach, expect, test } from 'vitest';
+import { expect, test } from 'vitest';
 
 import { toClientGroups } from '../api/groupsApi';
 import * as schema from '../db/schema';
 import { syncInitData } from '../store/sync';
 import groupsResponse from '../test/groups.json';
-import { getClient, resetDb, setScryOutputs, setupDb } from '../test/helpers';
+import {
+  getClient,
+  setScryOutputs,
+  setupDatabaseTestSuite,
+} from '../test/helpers';
 import initResponse from '../test/init.json';
 import type * as ub from '../urbit/groups';
 import * as queries from './queries';
@@ -15,13 +19,7 @@ const groupsData = toClientGroups(
   true
 );
 
-beforeAll(() => {
-  setupDb();
-});
-
-beforeEach(async () => {
-  resetDb();
-});
+setupDatabaseTestSuite();
 
 test('inserts a group', async () => {
   const groupData = groupsData[3];

--- a/packages/shared/src/db/schema.ts
+++ b/packages/shared/src/db/schema.ts
@@ -648,6 +648,12 @@ export const channels = sqliteTable(
      * From `recency` on unreads on the Urbit side
      */
     remoteUpdatedAt: timestamp('remote_updated_at'),
+
+    /**
+     * Local time that this channel was last viewed by this client;
+     * null if never viewed (or after a database reset)
+     */
+    lastViewedAt: timestamp('last_viewed_at'),
   },
   (table) => ({
     lastPostIdIndex: index('last_post_id').on(table.lastPostId),

--- a/packages/shared/src/db/schema.ts
+++ b/packages/shared/src/db/schema.ts
@@ -654,6 +654,11 @@ export const channels = sqliteTable(
      * null if never viewed (or after a database reset)
      */
     lastViewedAt: timestamp('last_viewed_at'),
+
+    /**
+     * True if this channel was autocreated during new group creation (on this client)
+     */
+    isDefaultWelcomeChannel: boolean('is_default_welcome_channel'),
   },
   (table) => ({
     lastPostIdIndex: index('last_post_id').on(table.lastPostId),

--- a/packages/shared/src/store/channelActions.ts
+++ b/packages/shared/src/store/channelActions.ts
@@ -1,5 +1,6 @@
 import * as api from '../api';
 import * as db from '../db';
+import { createDevLogger } from '../debug';
 import * as logic from '../logic';
 import { GroupChannel, getChannelKindFromType } from '../urbit';
 
@@ -112,6 +113,8 @@ export async function updateChannel({
   }
 }
 
+const logger = createDevLogger('channelActions', false);
+
 export async function pinItem(channel: db.Channel) {
   // optimistic update
   const partialPin = logic.getPinPartial(channel);
@@ -137,6 +140,15 @@ export async function unpinItem(pin: db.Pin) {
     // rollback optimistic update
     db.insertPinnedItem(pin);
   }
+}
+
+export async function markChannelVisited(channel: db.Channel) {
+  const now = Date.now();
+  logger.log(
+    `marking channel as visited (${channel.lastViewedAt} -> ${now})`,
+    channel.id
+  );
+  await db.updateChannel({ id: channel.id, lastViewedAt: now });
 }
 
 export async function markChannelRead(channel: db.Channel) {

--- a/packages/shared/src/store/groupActions.ts
+++ b/packages/shared/src/store/groupActions.ts
@@ -34,6 +34,9 @@ export async function createGroup({
 
     if (group && group.channels.length) {
       const channel = group.channels[0];
+
+      await db.updateChannel({ id: channel.id, isDefaultWelcomeChannel: true });
+
       return { group, channel };
     }
 

--- a/packages/shared/src/store/sync.test.ts
+++ b/packages/shared/src/store/sync.test.ts
@@ -1,7 +1,7 @@
 import * as $ from 'drizzle-orm';
-import { beforeAll, beforeEach, expect, test } from 'vitest';
+import { expect, test } from 'vitest';
 
-import { toClientGroup, toPagedPostsData } from '../api';
+import { toClientGroup } from '../api';
 import * as db from '../db';
 import rawNewestPostData from '../test/channelNewestPost.json';
 import rawChannelPostWithRepliesData from '../test/channelPostWithReplies.json';
@@ -12,10 +12,9 @@ import rawGroupsData from '../test/groups.json';
 import rawGroupsInitData from '../test/groupsInit.json';
 import {
   getClient,
-  resetDb,
   setScryOutput,
   setScryOutputs,
-  setupDb,
+  setupDatabaseTestSuite,
 } from '../test/helpers';
 import { GroupsInit, PagedPosts, PostDataResponse } from '../urbit';
 import { Contact as UrbitContact } from '../urbit/contact';
@@ -36,13 +35,7 @@ const contactsData = rawContactsData as unknown as Record<string, UrbitContact>;
 const groupsData = rawGroupsData as unknown as Record<string, UrbitGroup>;
 const groupsInitData = rawGroupsInitData as unknown as GroupsInit;
 
-beforeAll(() => {
-  setupDb();
-});
-
-beforeEach(async () => {
-  resetDb();
-});
+setupDatabaseTestSuite();
 
 const inputData = [
   '0v4.00000.qd4mk.d4htu.er4b8.eao21',

--- a/packages/shared/src/store/sync.test.ts
+++ b/packages/shared/src/store/sync.test.ts
@@ -156,6 +156,8 @@ test('syncs dms', async () => {
     remoteUpdatedAt: null,
     isPendingChannel: null,
     isDmInvite: false,
+    isDefaultWelcomeChannel: null,
+    lastViewedAt: null,
     members: [
       {
         chatId: '~solfer-magfed',
@@ -193,6 +195,8 @@ test('syncs dms', async () => {
     remoteUpdatedAt: null,
     isPendingChannel: null,
     isDmInvite: false,
+    isDefaultWelcomeChannel: null,
+    lastViewedAt: null,
     members: [
       {
         chatId: '0v4.00000.qd4p2.it253.qs53q.s53qs',

--- a/packages/shared/src/test/helpers.ts
+++ b/packages/shared/src/test/helpers.ts
@@ -2,7 +2,7 @@ import Database from 'better-sqlite3';
 import { BetterSQLite3Database, drizzle } from 'drizzle-orm/better-sqlite3';
 import { migrate } from 'drizzle-orm/better-sqlite3/migrator';
 import tmp from 'tmp';
-import { MockedFunction, beforeAll, beforeEach } from 'vitest';
+import { MockedFunction, beforeAll, beforeEach, vi } from 'vitest';
 
 import { scry } from '../api/urbit';
 import { setClient } from '../db';
@@ -47,13 +47,9 @@ export function setupDatabaseTestSuite() {
 }
 
 export function setScryOutput<T>(output: T) {
-  (scry as MockedFunction<() => Promise<T>>).mockImplementationOnce(
-    async () => output
-  );
+  vi.mocked(scry).mockImplementationOnce(async () => output);
 }
 
 export function setScryOutputs<T>(outputs: T[]) {
-  (scry as MockedFunction<() => Promise<T>>).mockImplementation(
-    async () => outputs.shift()!
-  );
+  vi.mocked(scry).mockImplementation(async () => outputs.shift()!);
 }

--- a/packages/shared/src/test/helpers.ts
+++ b/packages/shared/src/test/helpers.ts
@@ -2,7 +2,7 @@ import Database from 'better-sqlite3';
 import { BetterSQLite3Database, drizzle } from 'drizzle-orm/better-sqlite3';
 import { migrate } from 'drizzle-orm/better-sqlite3/migrator';
 import tmp from 'tmp';
-import { MockedFunction } from 'vitest';
+import { MockedFunction, beforeAll, beforeEach } from 'vitest';
 
 import { scry } from '../api/urbit';
 import { setClient } from '../db';
@@ -30,6 +30,19 @@ export function resetDb() {
   setClient(client);
   migrate(client as unknown as BetterSQLite3Database, {
     migrationsFolder: __dirname + '/../db/migrations',
+  });
+}
+
+/**
+ * Sets up a test database before any test is run, then resets the database before each test.
+ */
+export function setupDatabaseTestSuite() {
+  beforeAll(() => {
+    setupDb();
+  });
+
+  beforeEach(async () => {
+    resetDb();
   });
 }
 

--- a/packages/shared/src/test/setup.ts
+++ b/packages/shared/src/test/setup.ts
@@ -20,10 +20,14 @@ vi.mock('@react-native-firebase/crashlytics', () => {
 });
 
 export function mockUrbit() {
-  vi.mock('../api/urbit', async () => {
-    return {
+  vi.mock('../api/urbit', async (importOriginal) => {
+    const mod = await importOriginal<typeof import('../api/urbit')>();
+    const out: typeof mod = {
+      ...mod,
       scry: vi.fn(),
+      trackedPoke: vi.fn(),
       getCurrentUserId: () => '~solfer-magfed',
     };
+    return out;
   });
 }

--- a/packages/ui/src/components/Channel/EmptyChannelNotice.tsx
+++ b/packages/ui/src/components/Channel/EmptyChannelNotice.tsx
@@ -13,13 +13,14 @@ export function EmptyChannelNotice({
 }) {
   const isGroupAdmin = useIsAdmin(channel.groupId ?? '', userId);
   const [isFirstVisit] = useState(() => channel.lastViewedAt == null);
+  const isWelcomeChannel = !!channel.isDefaultWelcomeChannel;
   const noticeText = useMemo(() => {
-    if (isGroupAdmin && isFirstVisit) {
+    if (isGroupAdmin && isFirstVisit && isWelcomeChannel) {
       return 'This is your group’s default welcome channel. Feel free to rename it or create additional channels.';
     }
 
     return 'There are no messages... yet.';
-  }, [isGroupAdmin, isFirstVisit]);
+  }, [isGroupAdmin, isFirstVisit, isWelcomeChannel]);
 
   return (
     <View alignItems="center" paddingHorizontal="$2xl">

--- a/packages/ui/src/components/Channel/EmptyChannelNotice.tsx
+++ b/packages/ui/src/components/Channel/EmptyChannelNotice.tsx
@@ -1,5 +1,5 @@
 import * as db from 'packages/shared/dist/db';
-import { useMemo } from 'react';
+import { useMemo, useState } from 'react';
 
 import { SizableText, View } from '../../core';
 import { useIsAdmin } from '../../utils';
@@ -12,7 +12,14 @@ export function EmptyChannelNotice({
   userId: string;
 }) {
   const isGroupAdmin = useIsAdmin(channel.groupId ?? '', userId);
-  const noticeText = useMemo(() => getNoticeText(isGroupAdmin), [isGroupAdmin]);
+  const [isFirstVisit] = useState(() => channel.lastViewedAt == null);
+  const noticeText = useMemo(() => {
+    if (isGroupAdmin && isFirstVisit) {
+      return 'This is your group’s default welcome channel. Feel free to rename it or create additional channels.';
+    }
+
+    return 'There are no messages... yet.';
+  }, [isGroupAdmin, isFirstVisit]);
 
   return (
     <View alignItems="center" paddingHorizontal="$2xl">
@@ -21,12 +28,4 @@ export function EmptyChannelNotice({
       </SizableText>
     </View>
   );
-}
-
-function getNoticeText(isAdmin: boolean) {
-  if (isAdmin) {
-    return 'This is your group’s default welcome channel. Feel free to rename it or create additional channels.';
-  }
-
-  return 'There are no messages... yet.';
 }


### PR DESCRIPTION
fixes TLON-1970

- Added `channels` sqlite columns: `last_viewed_at`, `is_default_welcome_channel`
- Only show welcome notice when all are true: (1) visiting the channel for the first time, and (2) we know that this is the channel we autocreated on this client during a group creation, and (3) user is admin