### PR TITLE
web: fix image upload content-length

### DIFF
--- a/apps/tlon-web/src/state/storage/upload.ts
+++ b/apps/tlon-web/src/state/storage/upload.ts
@@ -165,8 +165,8 @@ export const useFileStore = create<FileStore>((set, get) => ({
         // Second, hit memex with the secret to obtain an upload
         const uploadParams = {
           token,
-          contentLength: file.size,
-          contentType: file.type,
+          contentLength: compressedFile.size,
+          contentType: compressedFile.type,
           fileName: key,
         };
 


### PR DESCRIPTION
Web image upload is finally working (locally). I need to have this pushed to a hosted ship so we can do further testing.

For context, there were two remaining issues:
1. The bucket was misconfigured, which was causing the cors issues seen when using the new memex `upload` endpoint. The pre-existing cors config was
```
$ gcloud storage buckets describe gs://tlon-test-memex-assets --format="default(cors_config)"
cors_config:
- maxAgeSeconds: 3600
  method:
  - GET
  - PUT
  origin:
  - '*'
  responseHeader:
  - Content-Type
```
I initially changed that to have 
```
  responseHeader:
  - Content-Type
  - Access-Control-Allow-Origin
```
and later
```
  responseHeader:
  - Content-Type
  - Access-Control-Allow-Origin
  - Access-Control-Allow-Methods
```
Both of these didn't work. What worked was updating it to the current config, which set `responseHeader: [ "*" ]`.
```
$ gcloud storage buckets describe gs://tlon-test-memex-assets --format="default(cors_config)"
cors_config:
- maxAgeSeconds: 3600
  method:
  - GET
  - PUT
  origin:
  - '*'
  responseHeader:
  - '*'
```
cc @dosullivan, please let me know if this makes sense.

2. after fixing cors I hit the second remaining issue, about signature mismatch which this PR aims to fix, since we were using different content-lengths.