### PR TITLE
native: reset image attachment after sending

### DIFF
--- a/apps/tlon-mobile/src/screens/ChannelScreen.tsx
+++ b/apps/tlon-mobile/src/screens/ChannelScreen.tsx
@@ -120,9 +120,7 @@ export default function ChannelScreen(props: ChannelScreenProps) {
 
       // clear the attachments immediately so consumers know the upload state is
       // no longer needed
-      setTimeout(() => {
-        uploadInfo.resetImageAttachment();
-      }, 20);
+      uploadInfo.resetImageAttachment();
 
       await store.sendPost({
         channel: channel,

--- a/apps/tlon-mobile/src/screens/ChannelScreen.tsx
+++ b/apps/tlon-mobile/src/screens/ChannelScreen.tsx
@@ -117,17 +117,19 @@ export default function ChannelScreen(props: ChannelScreenProps) {
       if (!channel) {
         throw new Error('Tried to send message before channel loaded');
       }
+
+      // clear the attachments immediately so consumers know the upload state is
+      // no longer needed
+      setTimeout(() => {
+        uploadInfo.resetImageAttachment();
+      }, 20);
+
       await store.sendPost({
         channel: channel,
         authorId: currentUserId,
         content,
         metadata,
       });
-      // prevents state update + render from blocking optimistic post insertion.
-      // may be better ways to handle...
-      setTimeout(() => {
-        uploadInfo.resetImageAttachment();
-      }, 20);
     },
     [currentUserId, channel, uploadInfo]
   );

--- a/packages/ui/src/components/MessageInput/index.native.tsx
+++ b/packages/ui/src/components/MessageInput/index.native.tsx
@@ -492,7 +492,6 @@ export const MessageInput = forwardRef<MessageInputHandle, MessageInputProps>(
         setReferences({});
         clearDraft();
         setShowBigInput?.(false);
-        uploadInfo?.resetImageAttachment();
       },
       [
         editor,

--- a/packages/ui/src/components/MessageInput/index.native.tsx
+++ b/packages/ui/src/components/MessageInput/index.native.tsx
@@ -251,10 +251,9 @@ export const MessageInput = forwardRef<MessageInputHandle, MessageInputProps>(
               typeof c === 'string' || (typeof c === 'object' && isInline(c))
           ) as Inline[];
         const blocks =
-          (tiptap
+          tiptap
             .JSONToInlines(json)
-            .filter((c) => typeof c !== 'string' && 'block' in c) as Block[]) ||
-          [];
+            .filter((c) => typeof c !== 'string' && 'block' in c) || [];
 
         const inlineIsJustBreak = !!(
           inlines.length === 1 &&
@@ -325,11 +324,9 @@ export const MessageInput = forwardRef<MessageInputHandle, MessageInputProps>(
                     (typeof c === 'object' && isInline(c))
                 ) as Inline[];
               const blocks =
-                (tiptap
+                tiptap
                   .JSONToInlines(json)
-                  .filter(
-                    (c) => typeof c !== 'string' && 'block' in c
-                  ) as Block[]) || [];
+                  .filter((c) => typeof c !== 'string' && 'block' in c) || [];
 
               // then we need to find all the inlines without refs
               // so we can render the input text without refs
@@ -355,7 +352,11 @@ export const MessageInput = forwardRef<MessageInputHandle, MessageInputProps>(
               const newStory = constructStory(inlinesWithOutRefs);
 
               if (blocks && blocks.length > 0) {
-                newStory.push(...blocks.map((block) => ({ block })));
+                newStory.push(
+                  ...blocks.map((block) => ({
+                    block: block as unknown as Block,
+                  }))
+                );
               }
 
               const newJson = tiptap.diaryMixedToJSON(newStory);
@@ -491,6 +492,7 @@ export const MessageInput = forwardRef<MessageInputHandle, MessageInputProps>(
         setReferences({});
         clearDraft();
         setShowBigInput?.(false);
+        uploadInfo?.resetImageAttachment();
       },
       [
         editor,


### PR DESCRIPTION
Should fix the issue Pat reported where hitting send with an image attached left the image preview open even though the message _was_ actually sent. Believe this is related to the recent async changes there.

Fixes TLON-2392