### PR TITLE
activity: only direct kids from +get-children

### DIFF
--- a/desk/lib/activity.hoon
+++ b/desk/lib/activity.hoon
@@ -19,17 +19,18 @@
       ==
     ==
   ::
-  ++  get-children
+  ++  get-children  ::  direct children only
     |=  [=indices:a =source:a]
     ^-  (list source:a)
+    ?:  ?=(?(%thread %dm-thread) -.source)  ~
     %+  skim
       ~(tap in ~(key by indices))
     |=  src=source:a
-    ?+  -.source  |
-        %base  ?!(?=(%base -.src))
-        %group  &(?=(%channel -.src) =(flag.source group.src))
+    ?-  -.source
+        %base     ?=(?(%group %dm) -.src)
+        %group    &(?=(%channel -.src) =(flag.source group.src))
         %channel  &(?=(%thread -.src) =(nest.source channel.src))
-        %dm  &(?=(%dm-thread -.src) =(whom.source whom.src))
+        %dm       &(?=(%dm-thread -.src) =(whom.source whom.src))
     ==
   ::
   ++  get-order


### PR DESCRIPTION
Previously, we were giving all sources as children of base. But this doesn't fit with our source hierarchy, and is not how `+get-children` is used in `/app/activity`.

Now, we only return `%group` and `%dm` sources as children of %base, and let the code iterate further on those for deeper processing.

With this change, we no longer do repeated processing of `%thread` and `%dm-thread` sources, resulting in (on ~palfun) a 20% speedup in unread summarization.
