### PR TITLE
native: fix issue with non-inline content clearing on edit

### DIFF
--- a/packages/shared/src/logic/utils.ts
+++ b/packages/shared/src/logic/utils.ts
@@ -309,8 +309,6 @@ export const extractContentTypes = (
   const references = extractReferencesFromContent(story);
   const blocks = extractBlocksFromContent(story);
 
-  // console.log(`extracted inlines:`, inlines);
-
   return { inlines, references, blocks, story };
 };
 

--- a/packages/shared/src/store/postActions.ts
+++ b/packages/shared/src/store/postActions.ts
@@ -1,4 +1,5 @@
 import * as api from '../api';
+import { toPostContent } from '../api';
 import * as db from '../db';
 import { createDevLogger } from '../debug';
 import * as urbit from '../urbit';
@@ -63,7 +64,8 @@ export async function editPost({
 }) {
   logger.log('editPost', { post, content, parentId, metadata });
   // optimistic update
-  await db.updatePost({ id: post.id, content: JSON.stringify(content) });
+  const [contentForDb, flags] = toPostContent(content);
+  await db.updatePost({ id: post.id, content: contentForDb, ...flags });
   logger.log('editPost optimistic update done');
 
   try {

--- a/packages/shared/src/store/sync.ts
+++ b/packages/shared/src/store/sync.ts
@@ -660,6 +660,7 @@ export async function handleAddPost(
   post: db.Post,
   replyMeta?: db.ReplyMeta | null
 ) {
+  logger.log('event: add post', post);
   // We frequently get duplicate addPost events from the api,
   // so skip if we've just added this.
   if (post.id === lastAdded) {

--- a/packages/ui/src/components/MessageInput/index.native.tsx
+++ b/packages/ui/src/components/MessageInput/index.native.tsx
@@ -15,14 +15,24 @@ import {
   MentionsBridge,
   ShortcutsBridge,
 } from '@tloncorp/editor/src/bridges';
-import { createDevLogger, tiptap } from '@tloncorp/shared/dist';
-import { PostContent, toContentReference } from '@tloncorp/shared/dist/api';
+import {
+  createDevLogger,
+  extractContentTypesFromPost,
+  findFirstImageBlock,
+  tiptap,
+} from '@tloncorp/shared/dist';
+import {
+  contentReferenceToCite,
+  toContentReference,
+} from '@tloncorp/shared/dist/api';
 import * as db from '@tloncorp/shared/dist/db';
 import {
   Block,
+  Image,
   Inline,
   JSONContent,
   Story,
+  citeToPath,
   constructStory,
   isInline,
   pathToCite,
@@ -41,7 +51,7 @@ import { useSafeAreaInsets } from 'react-native-safe-area-context';
 import type { WebViewMessageEvent } from 'react-native-webview';
 import { getToken, useWindowDimensions } from 'tamagui';
 
-import { useReferences } from '../../contexts/references';
+import { RefEditorRecord, useReferences } from '../../contexts/references';
 import { XStack } from '../../core';
 import { MessageInputContainer, MessageInputProps } from './MessageInputBase';
 
@@ -135,6 +145,7 @@ export const MessageInput = forwardRef<MessageInputHandle, MessageInputProps>(
     }));
 
     const [hasSetInitialContent, setHasSetInitialContent] = useState(false);
+    const [imageOnEditedPost, setImageOnEditedPost] = useState<Image | null>();
     const [editorCrashed, setEditorCrashed] = useState<string | undefined>();
     const [containerHeight, setContainerHeight] = useState(initialHeight);
     const { bottom, top } = useSafeAreaInsets();
@@ -205,19 +216,49 @@ export const MessageInput = forwardRef<MessageInputHandle, MessageInputProps>(
               setEditorIsEmpty(false);
             }
             if (editingPost?.content) {
-              const content = JSON.parse(
-                editingPost.content as string
-              ) as PostContent;
+              const {
+                story,
+                references: postReferences,
+                blocks,
+              } = extractContentTypesFromPost(editingPost);
 
-              if (!content) {
+              if (
+                !story ||
+                story?.length === 0 ||
+                !postReferences ||
+                blocks.length === 0
+              ) {
                 return;
               }
 
-              const story =
-                (content.filter(
-                  (c) => 'inline' in c || 'block' in c
-                ) as Story) ?? [];
-              const tiptapContent = tiptap.diaryMixedToJSON(story);
+              if (postReferences) {
+                const newRefs: RefEditorRecord = postReferences.reduce(
+                  (acc, ref) => {
+                    const cite = contentReferenceToCite(ref);
+                    const path = citeToPath(cite);
+                    acc[path] = ref;
+                    return acc;
+                  },
+                  {
+                    ...references,
+                  }
+                );
+
+                setReferences(newRefs);
+              }
+
+              if (blocks.some((c) => 'image' in c)) {
+                const image = findFirstImageBlock(blocks);
+                if (image) {
+                  setImageOnEditedPost(image);
+                }
+              }
+
+              const tiptapContent = tiptap.diaryMixedToJSON(
+                story.filter(
+                  (c) => !('type' in c) && !('block' in c && 'image' in c.block)
+                ) as Story
+              );
               // @ts-expect-error setContent does accept JSONContent
               editor.setContent(tiptapContent);
               setHasSetInitialContent(true);
@@ -233,6 +274,8 @@ export const MessageInput = forwardRef<MessageInputHandle, MessageInputProps>(
       hasSetInitialContent,
       editorState.isReady,
       editingPost,
+      setReferences,
+      references,
     ]);
 
     useEffect(() => {
@@ -462,6 +505,17 @@ export const MessageInput = forwardRef<MessageInputHandle, MessageInputProps>(
           });
         }
 
+        if (imageOnEditedPost) {
+          blocks.push({
+            image: {
+              src: imageOnEditedPost.image.src,
+              height: imageOnEditedPost.image.height,
+              width: imageOnEditedPost.image.width,
+              alt: imageOnEditedPost.image.alt,
+            },
+          });
+        }
+
         if (blocks && blocks.length > 0) {
           story.push(...blocks.map((block) => ({ block })));
         }
@@ -491,6 +545,7 @@ export const MessageInput = forwardRef<MessageInputHandle, MessageInputProps>(
         setReferences({});
         clearDraft();
         setShowBigInput?.(false);
+        setImageOnEditedPost(null);
       },
       [
         editor,
@@ -506,6 +561,7 @@ export const MessageInput = forwardRef<MessageInputHandle, MessageInputProps>(
         setShowBigInput,
         title,
         image,
+        imageOnEditedPost,
       ]
     );
 

--- a/packages/ui/src/contexts/references.tsx
+++ b/packages/ui/src/contexts/references.tsx
@@ -1,8 +1,11 @@
 import { ContentReference } from '@tloncorp/shared/dist/api';
 import { PropsWithChildren, createContext, useContext, useState } from 'react';
 
+type refPath = string;
+export type RefEditorRecord = Record<refPath, ContentReference | null>;
+
 export type ReferencesState = {
-  references: Record<string, ContentReference | null>;
+  references: RefEditorRecord;
   setReferences: (references: Record<string, ContentReference | null>) => void;
 };
 


### PR DESCRIPTION
Fixes TLON-2338. We need to keep track of any attachments (images, references) to messages we're editing and make sure they're not overwritten when we insert the existing post content into the editor.