### PR TITLE
native: avoid erroneous logout after managing account

### DIFF
--- a/apps/tlon-mobile/src/lib/hostingApi.ts
+++ b/apps/tlon-mobile/src/lib/hostingApi.ts
@@ -1,3 +1,4 @@
+import * as logic from '@tloncorp/shared/dist/logic';
 import { Buffer } from 'buffer';
 import { Platform } from 'react-native';
 
@@ -295,3 +296,22 @@ export const inviteShipWithLure = async (params: {
       'Content-Type': 'application/json',
     },
   });
+
+export const checkIfAccountDeleted = async (): Promise<boolean> => {
+  const hostingUserId = await getHostingUserId();
+  if (hostingUserId) {
+    try {
+      const user = await logic.withRetry(() => getHostingUser(hostingUserId), {
+        startingDelay: 500,
+        numOfAttempts: 5,
+      });
+      if (!user.verified) {
+        return true;
+      }
+    } catch (err) {
+      return true;
+    }
+  }
+
+  return false;
+};

--- a/apps/tlon-mobile/src/navigation/RootStack.tsx
+++ b/apps/tlon-mobile/src/navigation/RootStack.tsx
@@ -75,7 +75,11 @@ export function RootStack() {
       />
 
       <Root.Screen name="AppSettings" component={AppSettingsScreen} />
-      <Root.Screen name="ManageAccount" component={ManageAccountScreen} />
+      <Root.Screen
+        name="ManageAccount"
+        component={ManageAccountScreen}
+        options={{ gestureEnabled: false }}
+      />
       <Root.Screen name="BlockedUsers" component={BlockedUsersScreen} />
       <Root.Screen name="AppInfo" component={AppInfoScreen} />
       <Root.Screen name="FeatureFlags" component={FeatureFlagScreen} />


### PR DESCRIPTION
After you manage your account, we need to make sure you didn't delete it and log you out if you did. False positives (where you get logged out when you shouldn't) were happening too frequently, so this adds retry logic to avoid that situation.

Fixes TLON-2396