### PR TITLE
native: fix lingering blue dots on activity items after clicking into them

### DIFF
--- a/packages/shared/src/db/queries.ts
+++ b/packages/shared/src/db/queries.ts
@@ -648,6 +648,8 @@ export const getThreadPosts = createReadQuery(
 export const getThreadUnreadState = createReadQuery(
   'getThreadUnreadState',
   ({ parentId }: { parentId: string }, ctx: QueryCtx) => {
+    if (!parentId) return Promise.resolve(null);
+
     return ctx.db.query.threadUnreads.findFirst({
       where: eq($threadUnreads.threadId, parentId),
     });
@@ -1055,6 +1057,7 @@ export const clearVolumeSetting = createWriteQuery(
 export const getChannelUnread = createReadQuery(
   'getChannelUnread',
   async ({ channelId }: { channelId: string }, ctx: QueryCtx) => {
+    if (!channelId) return Promise.resolve(null);
     return ctx.db.query.channelUnreads.findFirst({
       where: and(eq($channelUnreads.channelId, channelId)),
     });

--- a/packages/shared/src/store/dbHooks.ts
+++ b/packages/shared/src/store/dbHooks.ts
@@ -8,7 +8,7 @@ import { useMemo } from 'react';
 import * as api from '../api';
 import * as db from '../db';
 import { syncPostReference } from './sync';
-import { useKeyFromQueryDeps } from './useKeyFromQueryDeps';
+import { keyFromQueryDeps, useKeyFromQueryDeps } from './useKeyFromQueryDeps';
 
 export * from './useChannelSearch';
 
@@ -139,6 +139,63 @@ export const useHaveUnreadUnseenActivity = () => {
   });
 
   return (meaningfulUnseenActivity?.length ?? 0) > 0;
+};
+
+export const useLiveThreadUnread = (unread: db.ThreadUnreadState | null) => {
+  const depsKey = useMemo(
+    () => (unread ? keyFromQueryDeps(db.getThreadUnreadState) : null),
+    [unread]
+  );
+
+  return useQuery({
+    queryKey: [
+      'liveUnreadCount',
+      depsKey,
+      'thread',
+      unread ? unread.threadId : null,
+    ],
+    queryFn: async () => {
+      if (unread) {
+        return db.getThreadUnreadState({ parentId: unread.threadId ?? '' });
+      }
+      return null;
+    },
+  });
+};
+
+export const useLiveChannelUnread = (unread: db.ChannelUnread | null) => {
+  const depsKey = useMemo(
+    () => (unread ? keyFromQueryDeps(db.getChannelUnread) : null),
+    [unread]
+  );
+
+  return useQuery({
+    queryKey: [
+      'liveUnreadCount',
+      depsKey,
+      'channel',
+      unread ? unread.channelId : null,
+    ],
+    queryFn: async () => {
+      if (unread) {
+        return db.getChannelUnread({ channelId: unread.channelId ?? '' });
+      }
+      return null;
+    },
+  });
+};
+
+export const useLiveUnread = (
+  unread: db.ChannelUnread | db.ThreadUnreadState | null
+) => {
+  const isThread = useMemo(() => unread && 'threadId' in unread, [unread]);
+  const threadUnread = useLiveThreadUnread(
+    isThread ? (unread as db.ThreadUnreadState) : null
+  );
+  const channelUnread = useLiveChannelUnread(
+    isThread ? null : (unread as db.ChannelUnread | null)
+  );
+  return isThread ? threadUnread : channelUnread;
 };
 
 export const useGroups = (options: db.GetGroupsOptions) => {

--- a/packages/shared/src/store/useKeyFromQueryDeps.ts
+++ b/packages/shared/src/store/useKeyFromQueryDeps.ts
@@ -18,7 +18,7 @@ export function useKeyFromQueryDeps(
   return useMemo(() => keyFromQueryDeps(query, options), [query, options]);
 }
 
-function keyFromQueryDeps(query: WrappedQuery<any, any>, options?: any) {
+export function keyFromQueryDeps(query: WrappedQuery<any, any>, options?: any) {
   return new Set(
     query.meta.tableDependencies instanceof Function
       ? query.meta.tableDependencies(options)

--- a/packages/ui/src/components/Activity/ChannelActivitySummary.tsx
+++ b/packages/ui/src/components/Activity/ChannelActivitySummary.tsx
@@ -1,5 +1,7 @@
 import * as db from '@tloncorp/shared/dist/db';
 import * as logic from '@tloncorp/shared/dist/logic';
+import * as store from '@tloncorp/shared/dist/store';
+import { useMemo } from 'react';
 
 import { SizableText, View, XStack, YStack } from '../../core';
 import { getChannelTitle } from '../../utils';
@@ -20,10 +22,12 @@ export function ChannelActivitySummary({
   const newestPost = summary.newest;
   const group = newestPost.group ?? undefined;
   const channel: db.Channel | undefined = newestPost.channel ?? undefined;
-  const unreadCount =
+  const modelUnread =
     summary.type === 'post'
-      ? newestPost.channel?.unread?.countWithoutThreads ?? 0
-      : newestPost.parent?.threadUnread?.count ?? 0;
+      ? newestPost.channel?.unread ?? null
+      : newestPost.parent?.threadUnread ?? null;
+  const { data: unread } = store.useLiveUnread(modelUnread);
+  const unreadCount = useMemo(() => unread?.count ?? 0, [unread]);
 
   const newestIsBlockOrNote =
     (summary.type === 'post' && newestPost.channel?.type === 'gallery') ||


### PR DESCRIPTION
This was happening because of a stale reference to the unread. Avoids this by way of a new `useLiveUnread` hook to avoid refetching the full activity query anytime unreads change. 

Fixes TLON-2234