### PR TITLE
activity: stop using read items

### DIFF
--- a/apps/tlon-web/src/mocks/chat.ts
+++ b/apps/tlon-web/src/mocks/chat.ts
@@ -135,103 +135,41 @@ export const makeFakeChatWrits = (offset: number) => {
 
 export const chatKeys = ['~zod/test'];
 
+const emptySummary = {
+  recency: 0,
+  count: 0,
+  notify: false,
+  unread: null,
+  'notify-count': 0,
+};
+
 export const dmList: Activity = {
-  '~fabled-faster': {
-    recency: 0,
-    count: 0,
-    notify: false,
-    unread: null,
-    children: {},
-    'notify-count': 0,
-    reads: {
-      floor: 0,
-      items: {},
-    },
-  },
+  '~fabled-faster': emptySummary,
   '~nocsyx-lassul': {
     recency: 1652302200000,
     count: 3,
     notify: false,
     unread: null,
-    children: {},
     'notify-count': 0,
-    reads: {
-      floor: 0,
-      items: {},
-    },
   },
-  '~fallyn-balfus': {
-    recency: 0,
-    count: 0,
-    notify: false,
-    unread: null,
-    children: {},
-    'notify-count': 0,
-    reads: {
-      floor: 0,
-      items: {},
-    },
-  },
+  '~fallyn-balfus': emptySummary,
   '~finned-palmer': {
     recency: 1652302200000,
     count: 2,
     notify: false,
     unread: null,
-    children: {},
     'notify-count': 0,
-    reads: {
-      floor: 0,
-      items: {},
-    },
   },
   '~datder-sonnet': {
     recency: 1652302200000,
     count: 1,
     notify: false,
     unread: null,
-    children: {},
     'notify-count': 0,
-    reads: {
-      floor: 0,
-      items: {},
-    },
   },
-  '~hastuc-dibtux': {
-    recency: 0,
-    count: 0,
-    notify: false,
-    unread: null,
-    children: {},
-    'notify-count': 0,
-    reads: {
-      floor: 0,
-      items: {},
-    },
-  },
-  '~rilfun-lidlen': {
-    recency: 0,
-    count: 0,
-    notify: false,
-    unread: null,
-    children: {},
-    'notify-count': 0,
-    reads: {
-      floor: 0,
-      items: {},
-    },
-  },
-  '~mister-dister-dozzod-dozzod': {
-    recency: 0,
-    count: 0,
-    notify: false,
-    unread: null,
-    children: {},
-    'notify-count': 0,
-    reads: {
-      floor: 0,
-      items: {},
-    },
-  },
+  '~hastuc-dibtux': emptySummary,
+  '~rilfun-lidlen': emptySummary,
+  '~mister-dister-dozzod-dozzod': emptySummary,
 };
 
 export const chatPerm = {

--- a/apps/tlon-web/src/mocks/handlers.ts
+++ b/apps/tlon-web/src/mocks/handlers.ts
@@ -431,12 +431,7 @@ const dms: Handler[] = [
           count: 1,
           notify: false,
           unread: null,
-          children: {},
           'notify-count': 0,
-          reads: {
-            floor: 0,
-            items: {},
-          },
         };
         dmList[req.json.ship] = unread;
 

--- a/apps/tlon-web/src/state/activity.ts
+++ b/apps/tlon-web/src/state/activity.ts
@@ -282,12 +282,7 @@ export const emptySummary: ActivitySummary = {
   count: 0,
   notify: false,
   unread: null,
-  children: {},
   'notify-count': 0,
-  reads: {
-    floor: 0,
-    items: {},
-  },
 };
 
 export function useSourceActivity(source: string) {

--- a/apps/tlon-web/src/state/broadcasts.ts
+++ b/apps/tlon-web/src/state/broadcasts.ts
@@ -62,12 +62,7 @@ export function cohortToUnread(cohort: Cohort): ActivitySummary {
     count: 0,
     notify: false,
     unread: null,
-    children: null,
     'notify-count': 0,
-    reads: {
-      floor: 0,
-      items: {},
-    },
   };
 }
 

--- a/desk/app/activity.hoon
+++ b/desk/app/activity.hoon
@@ -647,13 +647,10 @@
   =/  =index:a  (~(gut by indices) source *index:a)
   =/  new=_stream.index
     (put:on-event:a stream.index time-id event)
-  (refresh-index source index(stream new) |)
+  (refresh-index source index(stream new))
 ++  refresh-index
-  |=  [=source:a new=index:a new-floor=?]
+  |=  [=source:a new=index:a]
   %-  (log |.("refeshing index: {<source>}"))
-  =?  new  new-floor
-    (update-reads:idx new)
-  %-  (log |.("new reads: {<reads.new>}"))
   =.  indices
     (~(put by indices) source new)
   ?:  importing  cor  ::NOTE  deferred until end of migration
@@ -702,43 +699,10 @@
   ^+  cor
   =/  =index:a  (get-index source)
   ?-  -.action
-      %event
-    ?>  ?=(%event -.action)
-    =/  events
-      %+  murn
-        (tap:on-event:a stream.index)
-      |=  [=time =event:a]
-      ?.  =(-.event event.action)  ~
-      `[time event]
-    ?~  events  cor
-    (read source [%item -<.events] |)
-  ::
-      %item
-    =/  new-read  [id.action ~]
-    =/  read-items  (put:on-read-items:a items.reads.index new-read)
-    =.  cor  (propagate-read-items source ~[new-read])
-    (refresh-index source index(items.reads read-items) &)
+      %event  ~&("read %event unsupported" !!)
+      %item   ~&("read %item unsupported" !!)
   ::
       %all
-    ?:  !deep.action
-      =/  new=index:a
-        ::  take every event between the floor and now, and put it into
-        ::  the index's items.reads. this way, the floor can be moved
-        ::  without "losing" any unreads, and the call to +refresh-index
-        ::  below will clean up unnecessary items.reads entries.
-        ::
-        =-  index(items.reads -)
-        %+  gas:on-read-items:a  *read-items:a
-        (get-reads:stm stream.index `floor.reads.index ~ &)
-      ::  we need to refresh our own index to reflect new reads
-      =.  cor  (refresh-index source new &)
-      ::  since we're not marking deep, we already have the items to
-      ::  send up to parents
-      %+  propagate-read-items  source
-      (tap:on-read-items:a items.reads.new)
-    ::
-    ::  marking read "deeply"
-    ::
     =/  new=index:a
       ::  we can short circuit and just mark everything read, because
       ::  we're going to also mark all children read
@@ -747,9 +711,9 @@
       =/  latest=(unit [=time event:a])
         (ram:on-event:a stream.index)
       ?~(latest now.bowl time.u.latest)
-    ::  since we're marking deeply we need to recursively read all
+    ::  if we're marking deeply we need to recursively read all
     ::  children
-    =.  cor
+    =?  cor  deep.action
       =/  children  (get-children:src indices source)
       |-
       ?~  children  cor
@@ -757,33 +721,11 @@
       =.  cor  (read source action &)
       $(children t.children)
     ::  we need to refresh our own index to reflect new reads
-    =.  cor  (refresh-index source new &)
-    ::  if this isn't a recursive read (see 4 lines above), we need to
-    ::  propagate the new read items up the tree so that parents can
-    ::  keep accurate counts, otherwise we can no-op
-    ?:  from-parent  cor
-    %+  propagate-read-items  source
-    ::  if not, we need to generate the new items based on the floor
-    ::  we just came up with
-    %-  get-reads:stm
-    :*  stream.index
-        `floor.reads.index
-        ?:((gte floor.reads.new floor.reads.index) `+(floor.reads.new) ~)
-        |
-    ==
+    %-  (log |.("refeshing index: {<source>}"))
+    =.  indices  (~(put by indices) source new)
+    (refresh source)
   ==
 ::
-++  propagate-read-items
-  |=  [=source:a items=(list [=time-id:a ~])]
-  =/  parents  (get-parents:src source)
-  |-
-  ?~  parents  cor
-  =/  parent-index  (get-index i.parents)
-  =/  =read-items:a
-    (gas:on-read-items:a items.reads.parent-index items)
-  =.  cor
-    (refresh-index i.parents parent-index(items.reads read-items) &)
-  $(parents t.parents)
 ++  give-unreads
   |=  =source:a
   ^+  cor
@@ -813,27 +755,20 @@
   ^-  activity-summary:a
   %-  (log |.("summarizing unreads for: {<source>}"))
   =/  top=time  -:(fall (ram:on-event:a stream.index) [*@da ~])
-  ::  for each item in reads
-  ::  omit:
-  ::    if we don't have unreads enabled for that event
-  ::    any items that are unread for some reason
-  ::  then remove the post or reply from the event stream
-  ::  and call stream-to-unreads
-  ::
-  ::  TODO: flip around and iterate over stream once, cleaning reads out
-  ::        and segment replies for unread threads tracking
-  =;  unread-stream=stream:a
-    =/  children  (get-children:src indices source)
-    %-  (log |.("children: {<?:(?=(%base -.source) 'all' children)>}"))
-    (stream-to-unreads source index(stream unread-stream) children top)
-  ?:  ?=(%base -.source)  ~
-  %+  gas:on-event:a  *stream:a
-  %+  murn
-    (tap:on-event:a (lot:on-event:a stream.index `floor.reads.index ~))
-  |=  [=time =event:a]
-  ?:  child.event  ~
-  ?:  (has:on-read-items:a items.reads.index time)  ~
-  `[time event]
+  =/  unread-stream=stream:a
+    ::  all base's events are from children so we can ignore
+    ?:  ?=(%base -.source)  ~
+    ::  we don't need to take child events into account when summarizing
+    ::  the activity, so we filter them out
+    =-  +:-
+    %^  (dip:on-event:a @)  stream.index  ~
+    |=  [st=@ =time-id:a =event:a]
+    :_  [%.n st]
+    ?.  &(!child.event (gth time-id floor.reads.index))  ~
+    `event
+  =/  children  (get-children:src indices source)
+  %-  (log |.("children: {<?:(?=(%base -.source) 'all' children)>}"))
+  (stream-to-unreads source index(stream unread-stream) children top)
 ++  stream-to-unreads
   |=  [=source:a =index:a children=(list source:a) top=time]
   ^-  activity-summary:a
@@ -900,48 +835,31 @@
     last
   $(stream rest)
 ::
-::
-::  previously each source had independent read states that did not get
-::  synced across sources. we set out to rectify that here
+::  previously we used items as a way to track individual reads because
+::  floors were not local, but we have reverted to local floors and not
+::  tracking individual reads
 ::
 ++  sync-reads
-  =/  oldest-floors=(map source:a time)  ~
   =/  sources  (sort-sources:src ~(tap in ~(key by indices)))
   |-
   ?~  sources  cor
   =/  =source:a  i.sources
   =/  =index:a  (~(got by indices) source)
-  =/  our-reads  (get-reads:stm stream.index ~ `floor.reads.index &)
-  =^  min-floors  indices
-    =/  parents  (get-parents:src source)
-    =/  floors=(map source:a time)  ~
-    |-
-    ?~  parents  [floors indices]
-    =/  parent-index  (get-index i.parents)
-    =/  parent-reads
-      :-  floor.reads.parent-index
-      %+  gas:on-read-items:a
-        (uni:on-read-items:a items.reads.parent-index items.reads.index)
-      our-reads
-    ::  keep track of oldest child floor
-    =.  floors
-      %+  ~(put by floors)  i.parents
-      (min floor.reads.index (~(gut by oldest-floors) i.parents now.bowl))
-    ::  update parents with aggregated reads and move floor if appropriate
-    =.  indices  (~(put by indices) i.parents parent-index(reads parent-reads))
-    $(parents t.parents)
-  =.  oldest-floors  (~(uni by oldest-floors) min-floors)
+  =/  old=(unit activity-summary:a)  (~(get by activity) source)
+  ::  get all our reads, removing children
+  =/  our-reads
+    :-  floor.reads.index
+    %+  gas:on-read-items:a  *read-items:a
+    (get-reads:stm stream.index ~ ~ &)
   =.  reads.index
-    ::  if we have no children then the reads are accurate
-    ?~  min-floor=(~(get by oldest-floors) source)  reads.index
-    ::  if we have children, but our floor is oldest, then we're good
-    ?:  (lth floor.reads.index u.min-floor)  reads.index
-    ::  otherwise, we need to adjust our reads
-    =;  main-reads=read-items:a
-      [u.min-floor main-reads]
-    %+  gas:on-read-items:a  items.reads.index
-    (get-reads:stm stream.index `u.min-floor `floor.reads.index &)
-  =.  cor  (refresh-index source index &)
+    ::  find new floor with only our reads
+    =/  new-floor=(unit time)  (find-floor:idx stream.index our-reads)
+    ?~  new-floor  reads.index(items ~)
+    [u.new-floor ~]
+  ::  with new reads, update our index and summary
+  =.  cor  (refresh-index source index)
+  =/  new=(unit activity-summary:a)  (~(get by activity) source)
+  ~?  !=(old new)  "%sync-reads: WARNING old and new summaries differ"
   $(sources t.sources)
 ::
 ::  at some time in the past, for clubs activity, %dm-post and %dm-reply events
@@ -999,7 +917,7 @@
         volume-settings  (~(del by volume-settings) old-source)
       ==
     ::  update source + index, if new key create new index
-    =.  cor  (refresh-index source index.i.idxs &)
+    =.  cor  (refresh-index source index.i.idxs)
     $(idxs t.idxs)
   %+  weld
     (handle-dms u.club dms)
@@ -1046,11 +964,7 @@
     :-  (clean-stream-keys club (uni:on-event:a stream.acc stream.index))
     ::  rectify reads
     =/  floor  (max floor.reads.index floor.reads.acc)
-    :_  bump.index
-    :-  floor
-    =/  combined
-      (uni:on-read-items:a items.reads.index items.reads.acc)
-    (lot:on-read-items:a combined `floor ~)
+    [[floor ~] bump.index]
   ++  clean-stream-keys
     |=  [=club:ch =stream:a]
     ^-  stream:a

--- a/desk/lib/activity.hoon
+++ b/desk/lib/activity.hoon
@@ -88,15 +88,6 @@
   --
 ++  idx
   |_  =index:a
-  ++  update-reads
-    |=  =index:a
-    ^-  index:a
-    =/  new-floor=(unit time)  (find-floor [stream reads]:index)
-    ?~  new-floor  index
-    =/  new-reads=read-items:a
-      (lot:on-read-items:a items.reads.index new-floor ~)
-    index(reads [u.new-floor new-reads])
-  ::
   ++  find-floor
     |=  [orig=stream:a =reads:a]
     ^-  (unit time)

--- a/desk/sur/activity.hoon
+++ b/desk/sur/activity.hoon
@@ -41,10 +41,9 @@
 ::
 ::  $read-action: mark activity read
 ::
-::    $item: mark an individual activity as read, indexed by id
-::    $event: mark an individual activity as read, indexed by the event itself
-::    $all: mark _everything_ as read for this source, but not children
-::    $recursive: mark _everything_ as read for this source and children
+::    $item: (DEPRECATED) mark an individual activity as read, indexed by id
+::    $event: (DEPRECATED) mark an individual activity as read, indexed by the event itself
+::    $all: mark _everything_ as read for this source, and possibly children
 ::
 +$  read-action
   $%  [%item id=time-id]

--- a/packages/shared/src/api/unreads.test.ts
+++ b/packages/shared/src/api/unreads.test.ts
@@ -20,38 +20,6 @@ const channelUnread: Record<string, ub.ActivitySummary> = {
       count: 5,
       recency: 1718513986192,
       'notify-count': 0,
-      reads: {
-        floor: 0,
-        items: {},
-      },
-      children: {
-        'thread/chat/~lishul-marbyl-nisdeb-nalhec--motfed-lodmyn-tinfed-binzod/welcome-5870/170.141.184.506.852.591.089.314.701.116.289.581.056':
-          {
-            unread: null,
-            count: 1,
-            recency: 1718483402625,
-            children: null,
-            notify: true,
-            'notify-count': 0,
-            reads: {
-              floor: 0,
-              items: {},
-            },
-          },
-        'thread/chat/~lishul-marbyl-nisdeb-nalhec--motfed-lodmyn-tinfed-binzod/welcome-5870/170.141.184.506.852.590.556.405.446.059.399.053.312':
-          {
-            unread: null,
-            count: 0,
-            recency: 1718483869007,
-            children: null,
-            notify: false,
-            'notify-count': 0,
-            reads: {
-              floor: 0,
-              items: {},
-            },
-          },
-      },
       notify: true,
     },
 };
@@ -88,13 +56,8 @@ const threadUnread: Record<string, ub.ActivitySummary> = {
       },
       count: 1,
       recency: 1718514344709,
-      children: {},
       notify: false,
       'notify-count': 0,
-      reads: {
-        floor: 0,
-        items: {},
-      },
     },
 };
 
@@ -129,13 +92,8 @@ const dmUnread: Record<string, ub.ActivitySummary> = {
     },
     count: 6,
     recency: 1718523089789,
-    children: {},
     notify: true,
     'notify-count': 0,
-    reads: {
-      floor: 0,
-      items: {},
-    },
   },
 };
 
@@ -170,13 +128,8 @@ const dmThreadUnread: Record<string, ub.ActivitySummary> = {
       },
       count: 1,
       recency: 1718523494618,
-      children: {},
       notify: true,
       'notify-count': 0,
-      reads: {
-        floor: 0,
-        items: {},
-      },
     },
 };
 
@@ -205,31 +158,8 @@ const groupUnread: Record<string, ub.ActivitySummary> = {
     unread: null,
     count: 6,
     recency: 946684800000,
-    children: {
-      'channel/chat/~latter-bolden/welcome-8186': {
-        unread: {
-          count: 5,
-          notify: true,
-          id: '~lisfed-hobtex-tinres-walmyr--donsut-toprep-fanfep-samzod/170.141.184.506.853.155.647.879.036.981.225.717.760',
-          time: '170141184506853155647879036981225717760',
-        },
-        count: 5,
-        recency: 946684800000,
-        children: null,
-        notify: false,
-        'notify-count': 0,
-        reads: {
-          floor: 0,
-          items: {},
-        },
-      },
-    },
     notify: true,
     'notify-count': 0,
-    reads: {
-      floor: 0,
-      items: {},
-    },
   },
 };
 

--- a/packages/shared/src/urbit/activity.ts
+++ b/packages/shared/src/urbit/activity.ts
@@ -189,8 +189,11 @@ export interface ActivitySummary {
   'notify-count': number;
   notify: boolean;
   unread: UnreadPoint | null;
-  children: Activity | null;
-  reads: Reads | null;
+}
+
+export interface ActivitySummaryFull extends ActivitySummary {
+  reads: Reads;
+  children: string[];
 }
 
 export interface ActivityBundle {


### PR DESCRIPTION
We were previously not using individual item reads, but because we were trying to keep floors in sync between children and parents we were incurring huge costs from having to juggle lots of "read" items. This PR removes those from use and returns us to simply just moving floors.

Also included is the updated frontend types based on tloncorp/tlon-apps#3754

PR Checklist
- [X] Includes changes to desk files
- [ ] Describes how you tested the PR locally (test ship vs livenet)
- [ ] If a new feature, includes automated tests
- [X] Comments added anywhere logic may be confusing without context