### PR TITLE
native: show 'delete message' when post has been deleted, clear out content in db

### DIFF
--- a/packages/shared/src/api/channelsApi.ts
+++ b/packages/shared/src/api/channelsApi.ts
@@ -19,7 +19,11 @@ export type PostReactionsUpdate = {
 };
 export type UnknownUpdate = { type: 'unknown' };
 export type PendingUpdate = { type: 'markPostSent'; cacheId: string };
-export type DeletePostUpdate = { type: 'deletePost'; postId: string };
+export type DeletePostUpdate = {
+  type: 'deletePost';
+  postId: string;
+  channelId: string;
+};
 export type HidePostUpdate = { type: 'hidePost'; postId: string };
 export type ShowPostUpdate = { type: 'showPost'; postId: string };
 export type WritersUpdate = {
@@ -218,7 +222,7 @@ export const toChannelsUpdate = (
           }
 
           logger.log('delete post event');
-          return { type: 'deletePost', postId };
+          return { type: 'deletePost', postId, channelId };
         } else if ('reacts' in postResponse && postResponse.reacts !== null) {
           const updatedReacts = toReactionsData(postResponse.reacts, postId);
           logger.log('update reactions event');
@@ -244,7 +248,7 @@ export const toChannelsUpdate = (
           }
 
           logger.log('delete reply event');
-          return { type: 'deletePost', postId: replyId };
+          return { type: 'deletePost', postId: replyId, channelId };
         } else if ('reacts' in replyResponse && replyResponse.reacts !== null) {
           const updatedReacts = toReactionsData(replyResponse.reacts, replyId);
           logger.log('update reply reactions event');

--- a/packages/shared/src/db/migrations/0000_overrated_leopardon.sql
+++ b/packages/shared/src/db/migrations/0000_overrated_leopardon.sql
@@ -251,6 +251,7 @@ CREATE TABLE `posts` (
 	`has_image` integer,
 	`hidden` integer DEFAULT false,
 	`is_edited` integer,
+	`is_deleted` integer,
 	`delivery_status` text,
 	`synced_at` integer NOT NULL,
 	`backend_time` text

--- a/packages/shared/src/db/migrations/meta/0000_snapshot.json
+++ b/packages/shared/src/db/migrations/meta/0000_snapshot.json
@@ -1,7 +1,7 @@
 {
   "version": "5",
   "dialect": "sqlite",
-  "id": "430ef366-6b5b-4d84-b3f6-d846603c2e60",
+  "id": "f4f2ae74-3687-485f-ac82-85cc2b687cd2",
   "prevId": "00000000-0000-0000-0000-000000000000",
   "tables": {
     "activity_events": {
@@ -1655,6 +1655,13 @@
         },
         "is_edited": {
           "name": "is_edited",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "is_deleted": {
+          "name": "is_deleted",
           "type": "integer",
           "primaryKey": false,
           "notNull": false,

--- a/packages/shared/src/db/migrations/meta/_journal.json
+++ b/packages/shared/src/db/migrations/meta/_journal.json
@@ -5,8 +5,8 @@
     {
       "idx": 0,
       "version": "5",
-      "when": 1721084560967,
-      "tag": "0000_curvy_exodus",
+      "when": 1721313221143,
+      "tag": "0000_overrated_leopardon",
       "breakpoints": true
     }
   ]

--- a/packages/shared/src/db/migrations/migrations.js
+++ b/packages/shared/src/db/migrations/migrations.js
@@ -1,7 +1,7 @@
 // This file is required for Expo/React Native SQLite migrations - https://orm.drizzle.team/quick-sqlite/expo
 
 import journal from './meta/_journal.json';
-import m0000 from './0000_curvy_exodus.sql';
+import m0000 from './0000_overrated_leopardon.sql';
 
   export default {
     journal,

--- a/packages/shared/src/db/queries.ts
+++ b/packages/shared/src/db/queries.ts
@@ -2055,6 +2055,22 @@ export const deletePost = createWriteQuery(
   ['posts']
 );
 
+export const markPostAsDeleted = createWriteQuery(
+  'markPostAsDeleted',
+  async (postId: string, ctx: QueryCtx) => {
+    return ctx.db
+      .update($posts)
+      .set({
+        isDeleted: true,
+        content: null,
+        textContent: null,
+        authorId: undefined,
+      })
+      .where(eq($posts.id, postId));
+  },
+  ['posts']
+);
+
 export const getPostReaction = createReadQuery(
   'getPostReaction',
   async (

--- a/packages/shared/src/db/schema.ts
+++ b/packages/shared/src/db/schema.ts
@@ -728,6 +728,7 @@ export const posts = sqliteTable(
     hasImage: boolean('has_image'),
     hidden: boolean('hidden').default(false),
     isEdited: boolean('is_edited'),
+    isDeleted: boolean('is_deleted'),
     deliveryStatus: text('delivery_status').$type<PostDeliveryStatus>(),
     syncedAt: timestamp('synced_at').notNull(),
     // backendTime translates to an unfortunate alternative timestamp that is used

--- a/packages/shared/src/store/sync.ts
+++ b/packages/shared/src/store/sync.ts
@@ -579,7 +579,7 @@ export const handleChannelsUpdate = async (update: api.ChannelsUpdate) => {
       });
       break;
     case 'deletePost':
-      await db.deletePosts({ ids: [update.postId] });
+      await db.markPostAsDeleted(update.postId);
       break;
     case 'hidePost':
       await db.updatePost({ id: update.postId, hidden: true });

--- a/packages/shared/src/store/sync.ts
+++ b/packages/shared/src/store/sync.ts
@@ -580,6 +580,7 @@ export const handleChannelsUpdate = async (update: api.ChannelsUpdate) => {
       break;
     case 'deletePost':
       await db.markPostAsDeleted(update.postId);
+      await db.updateChannel({ id: update.channelId, lastPostId: null });
       break;
     case 'hidePost':
       await db.updatePost({ id: update.postId, hidden: true });

--- a/packages/ui/src/components/Channel/Scroller.tsx
+++ b/packages/ui/src/components/Channel/Scroller.tsx
@@ -505,6 +505,33 @@ const BaseScrollerItem = ({
       <ChannelDivider unreadCount={0} post={post} index={index} />
     ) : null;
 
+  if (post.isDeleted) {
+    return (
+      <View
+        onLayout={handleLayout}
+        {...(channelType === 'gallery' ? { aspectRatio: 1, flex: 0.5 } : {})}
+      >
+        {channelType === 'chat' ||
+        channelType === 'dm' ||
+        channelType === 'groupDm'
+          ? unreadDivider ?? dayDivider
+          : null}
+        <Component
+          post={post}
+          editing={editingPost && editingPost?.id === item.id}
+          setEditingPost={setEditingPost}
+          editPost={editPost}
+          showAuthor={showAuthor}
+          showReplies={showReplies}
+          onPressReplies={onPressReplies}
+          onPressImage={onPressImage}
+          onLongPress={onLongPressPost}
+          onPress={onPressPost}
+        />
+      </View>
+    );
+  }
+
   return (
     <View
       onLayout={handleLayout}

--- a/packages/ui/src/components/Channel/Scroller.tsx
+++ b/packages/ui/src/components/Channel/Scroller.tsx
@@ -505,33 +505,6 @@ const BaseScrollerItem = ({
       <ChannelDivider unreadCount={0} post={post} index={index} />
     ) : null;
 
-  if (post.isDeleted) {
-    return (
-      <View
-        onLayout={handleLayout}
-        {...(channelType === 'gallery' ? { aspectRatio: 1, flex: 0.5 } : {})}
-      >
-        {channelType === 'chat' ||
-        channelType === 'dm' ||
-        channelType === 'groupDm'
-          ? unreadDivider ?? dayDivider
-          : null}
-        <Component
-          post={post}
-          editing={editingPost && editingPost?.id === item.id}
-          setEditingPost={setEditingPost}
-          editPost={editPost}
-          showAuthor={showAuthor}
-          showReplies={showReplies}
-          onPressReplies={onPressReplies}
-          onPressImage={onPressImage}
-          onLongPress={onLongPressPost}
-          onPress={onPressPost}
-        />
-      </View>
-    );
-  }
-
   return (
     <View
       onLayout={handleLayout}
@@ -553,10 +526,10 @@ const BaseScrollerItem = ({
           editPost={editPost}
           showAuthor={showAuthor}
           showReplies={showReplies}
-          onPressReplies={onPressReplies}
-          onPressImage={onPressImage}
-          onLongPress={onLongPressPost}
-          onPress={onPressPost}
+          onPressReplies={post.isDeleted ? () => {} : onPressReplies}
+          onPressImage={post.isDeleted ? () => {} : onPressImage}
+          onLongPress={post.isDeleted ? () => {} : onLongPressPost}
+          onPress={post.isDeleted ? () => {} : onPressPost}
         />
       </PressableMessage>
     </View>

--- a/packages/ui/src/components/ChatMessage/ChatMessage.tsx
+++ b/packages/ui/src/components/ChatMessage/ChatMessage.tsx
@@ -5,7 +5,7 @@ import { memo, useCallback } from 'react';
 
 import { SizableText, View, XStack, YStack } from '../../core';
 import AuthorRow from '../AuthorRow';
-import ChatContent from '../ContentRenderer';
+import ContentRenderer from '../ContentRenderer';
 import { MessageInput } from '../MessageInput';
 import { ChatMessageReplySummary } from './ChatMessageReplySummary';
 import { ReactionsDisplay } from './ReactionsDisplay';
@@ -94,6 +94,25 @@ const ChatMessage = ({
   // return utils.makePrettyDay(date);
   // }, [post.sentAt]);
 
+  if (post.isDeleted) {
+    return (
+      <XStack
+        alignItems="center"
+        key={post.id}
+        gap="$s"
+        paddingVertical="$m"
+        paddingRight="$l"
+        marginVertical="$s"
+        backgroundColor="$secondaryBackground"
+        borderRadius="$m"
+      >
+        <SizableText paddingLeft="$4xl" color="$secondaryText">
+          This message was deleted.
+        </SizableText>
+      </XStack>
+    );
+  }
+
   return (
     <YStack
       onLongPress={handleLongPress}
@@ -134,7 +153,7 @@ const ChatMessage = ({
           </SizableText>
         ) : (
           <NoticeWrapper isNotice={isNotice}>
-            <ChatContent
+            <ContentRenderer
               post={post}
               isNotice={isNotice}
               onPressImage={handleImagePressed}

--- a/packages/ui/src/components/GalleryPost/GalleryPost.tsx
+++ b/packages/ui/src/components/GalleryPost/GalleryPost.tsx
@@ -90,12 +90,20 @@ export default function GalleryPost({
       onPress={handlePress}
       onLongPress={handleLongPress}
     >
-      {post.hidden ? (
-        <View flex={1} padding="$m">
-          <SizableText size="$l" color="$tertiaryText">
-            You have hidden or flagged this post.
-          </SizableText>
-        </View>
+      {post.hidden || post.isDeleted ? (
+        post.hidden ? (
+          <View flex={1} padding="$m">
+            <SizableText size="$l" color="$tertiaryText">
+              You have hidden or flagged this post.
+            </SizableText>
+          </View>
+        ) : post.isDeleted ? (
+          <View flex={1} padding="$m">
+            <SizableText size="$l" color="$tertiaryText">
+              This post has been deleted.
+            </SizableText>
+          </View>
+        ) : null
       ) : (
         <View flex={1} pointerEvents="none">
           {/** Image post */}

--- a/packages/ui/src/components/NotebookPost/NotebookPost.tsx
+++ b/packages/ui/src/components/NotebookPost/NotebookPost.tsx
@@ -43,7 +43,9 @@ export default function NotebookPost({
 
   return (
     <Pressable
-      onPress={() => (post.hidden ? () => {} : onPress?.(post))}
+      onPress={() =>
+        post.hidden || post.isDeleted ? () => {} : onPress?.(post)
+      }
       onLongPress={handleLongPress}
       delayLongPress={250}
       disabled={viewMode === 'activity'}
@@ -57,10 +59,16 @@ export default function NotebookPost({
         borderColor="$border"
         overflow={viewMode === 'activity' ? 'hidden' : undefined}
       >
-        {post.hidden ? (
-          <Text color="$tertiaryText" fontWeight="$s" fontSize="$l">
-            You have hidden or flagged this post.
-          </Text>
+        {post.hidden || post.isDeleted ? (
+          post.hidden ? (
+            <Text color="$tertiaryText" fontWeight="$s" fontSize="$l">
+              You have hidden or flagged this post.
+            </Text>
+          ) : post.isDeleted ? (
+            <Text color="$tertiaryText" fontWeight="$s" fontSize="$l">
+              This post has been deleted.
+            </Text>
+          ) : null
         ) : (
           <>
             {post.image && (


### PR DESCRIPTION
Fixes TLON-2339

Also disables the ability to long press on the message once it is marked as deleted.

Looks like this in chat:

![Simulator Screenshot - iPhone 15 Pro - 2024-07-18 at 10 40 56](https://github.com/user-attachments/assets/556679f8-72de-4eac-8d22-321e9eca3f27)
