### PR TITLE
activity: don't mark read if tab not focused and automatically mark read at chat bottom

### DIFF
--- a/apps/tlon-web/src/app.tsx
+++ b/apps/tlon-web/src/app.tsx
@@ -678,6 +678,23 @@ function RoutedApp() {
   const isDarkMode = useIsDark();
 
   useEffect(() => {
+    const onFocus = () => {
+      useLocalState.setState({ inFocus: true });
+    };
+    window.addEventListener('focus', onFocus);
+
+    const onBlur = () => {
+      useLocalState.setState({ inFocus: false });
+    };
+    window.addEventListener('blur', onBlur);
+
+    return () => {
+      window.removeEventListener('focus', onFocus);
+      window.removeEventListener('blur', onBlur);
+    };
+  }, []);
+
+  useEffect(() => {
     window.toggleDevTools = () => toggleDevTools();
   }, []);
 

--- a/apps/tlon-web/src/chat/ChatMessage/ChatMessage.tsx
+++ b/apps/tlon-web/src/chat/ChatMessage/ChatMessage.tsx
@@ -65,6 +65,7 @@ import {
   useTrackedMessageStatus,
 } from '@/state/chat';
 import { useRouteGroup } from '@/state/groups';
+import { useInFocus } from '@/state/local';
 
 import ReactionDetails from '../ChatReactions/ReactionDetails';
 import {
@@ -219,6 +220,7 @@ const ChatMessage = React.memo<
         [isMessageHidden, isPostHidden]
       );
 
+      const inFocus = useInFocus();
       const { ref: viewRef, inView } = useInView({
         threshold: 1,
       });
@@ -226,7 +228,7 @@ const ChatMessage = React.memo<
       useEffect(() => {
         const mainUnread =
           unreadDisplay === 'top' || unreadDisplay === 'top-with-thread';
-        if (!inView || !mainUnread) {
+        if (!inFocus || !inView || !mainUnread) {
           return;
         }
 
@@ -235,7 +237,14 @@ const ChatMessage = React.memo<
         } else {
           markReadChannel();
         }
-      }, [inView, unreadDisplay, isDMOrMultiDM, markReadChannel, markDmRead]);
+      }, [
+        inFocus,
+        inView,
+        unreadDisplay,
+        isDMOrMultiDM,
+        markReadChannel,
+        markDmRead,
+      ]);
 
       const cacheId = {
         author: window.our,

--- a/apps/tlon-web/src/chat/ChatMessage/DeletedChatMessage.tsx
+++ b/apps/tlon-web/src/chat/ChatMessage/DeletedChatMessage.tsx
@@ -11,6 +11,7 @@ import DateDivider from '@/chat/ChatMessage/DateDivider';
 import { useMarkChannelRead } from '@/logic/channel';
 import { useStickyUnread } from '@/logic/useStickyUnread';
 import { useSourceActivity } from '@/state/activity';
+import { useInFocus } from '@/state/local';
 
 export interface DeletedChatMessageProps {
   whom: string;
@@ -61,17 +62,18 @@ const DeletedChatMessage = React.memo<
       );
       const { markRead: markReadChannel } = useMarkChannelRead(`chat/${whom}`);
 
+      const inFocus = useInFocus();
       const { ref: viewRef, inView } = useInView({
         threshold: 1,
       });
 
       useEffect(() => {
-        if (!inView || !isUnread) {
+        if (!inFocus || !inView || !isUnread) {
           return;
         }
 
         markReadChannel();
-      }, [inView, isUnread, markReadChannel]);
+      }, [inFocus, inView, isUnread, markReadChannel]);
 
       return (
         <div

--- a/apps/tlon-web/src/chat/ChatScroller/ChatScroller.tsx
+++ b/apps/tlon-web/src/chat/ChatScroller/ChatScroller.tsx
@@ -510,7 +510,7 @@ export default function ChatScroller({
     if (isAtTop && !hasLoadedOldest) {
       logger.log('triggering onAtTop');
       onAtTop?.();
-    } else if (isAtBottom && !hasLoadedNewest) {
+    } else if (isAtBottom) {
       logger.log('triggering onAtBottom');
       onAtBottom?.();
     }

--- a/apps/tlon-web/src/replies/ReplyMessage.tsx
+++ b/apps/tlon-web/src/replies/ReplyMessage.tsx
@@ -59,6 +59,7 @@ import {
   useTrackedMessageStatus,
 } from '@/state/chat';
 import { useRouteGroup } from '@/state/groups';
+import { useInFocus } from '@/state/local';
 
 import ReplyMessageOptions from './ReplyMessageOptions';
 import ReplyReactions from './ReplyReactions/ReplyReactions';
@@ -160,13 +161,14 @@ const ReplyMessage = React.memo<
         () => isMessageHidden || isPostHidden,
         [isMessageHidden, isPostHidden]
       );
+      const inFocus = useInFocus();
       const { ref: viewRef, inView } = useInView({
         threshold: 1,
       });
 
       useEffect(() => {
         // if no tracked unread we don't need to take any action
-        if (!inView || !isUnread) {
+        if (!inFocus || !inView || !isUnread) {
           return;
         }
 
@@ -175,7 +177,15 @@ const ReplyMessage = React.memo<
         } else {
           markChannelRead();
         }
-      }, [whom, inView, isUnread, isDMOrMultiDM, markChannelRead, markDmRead]);
+      }, [
+        whom,
+        inFocus,
+        inView,
+        isUnread,
+        isDMOrMultiDM,
+        markChannelRead,
+        markDmRead,
+      ]);
 
       const msgStatus = useTrackedMessageStatus({
         author: window.our,

--- a/apps/tlon-web/src/state/activity.ts
+++ b/apps/tlon-web/src/state/activity.ts
@@ -2,7 +2,6 @@ import { useInfiniteQuery, useMutation } from '@tanstack/react-query';
 import {
   Activity,
   ActivityAction,
-  ActivityBundle,
   ActivityDeleteUpdate,
   ActivityFeed,
   ActivityReadUpdate,
@@ -16,6 +15,7 @@ import {
   Source,
   VolumeMap,
   VolumeSettings,
+  getKey,
   sourceToString,
   stripSourcePrefix,
 } from '@tloncorp/shared/dist/urbit/activity';
@@ -23,10 +23,12 @@ import _ from 'lodash';
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 
 import api from '@/api';
+import { useChatStore } from '@/chat/useChatStore';
 import useReactQueryScry from '@/logic/useReactQueryScry';
 import { createDevLogger } from '@/logic/utils';
 import queryClient from '@/queryClient';
 
+import { useLocalState } from './local';
 import { SidebarFilter } from './settings';
 
 const actLogger = createDevLogger('activity', false);
@@ -128,6 +130,22 @@ function activityVolumeUpdates(events: ActivityVolumeUpdate[]) {
   }, {} as VolumeSettings);
 }
 
+function optimisticActivityUpdate(d: Activity, source: string): Activity {
+  const old = d[source];
+  return {
+    ...d,
+    [source]: {
+      ...old,
+      unread: null,
+      count: Math.min(0, old.count - (old.unread?.count || 0)),
+      'notify-count':
+        old.unread && old.unread.notify
+          ? Math.min(old['notify-count'] - old.unread.count)
+          : old['notify-count'],
+    },
+  };
+}
+
 function updateActivity({
   main,
   threads,
@@ -135,10 +153,18 @@ function updateActivity({
   main: Activity;
   threads: Record<string, Activity>;
 }) {
+  const { current, atBottom } = useChatStore.getState();
+  const source = getKey(current);
+  const inFocus = useLocalState.getState().inFocus;
+  const filteredMain =
+    inFocus && atBottom && source in main
+      ? optimisticActivityUpdate(main, source)
+      : main;
+  console.log({ inFocus, source, atBottom, filteredMain });
   queryClient.setQueryData(unreadsKey(), (d: Activity | undefined) => {
     return {
       ...d,
-      ...main,
+      ...filteredMain,
     };
   });
 
@@ -279,9 +305,43 @@ export function useMarkReadMutation(recursive = false) {
 
   return useMutation({
     mutationFn,
-    onSuccess: () => {
-      queryClient.invalidateQueries(unreadsKey(), undefined, {
-        cancelRefetch: true,
+    onMutate: async (variables) => {
+      const current = queryClient.getQueryData<Activity>(unreadsKey());
+      queryClient.setQueryData<Activity>(unreadsKey(), (d) => {
+        if (d === undefined) {
+          return undefined;
+        }
+
+        if (!variables.action || !('all' in variables.action)) {
+          return d;
+        }
+
+        const source = sourceToString(variables.source);
+        if (variables.action.all.deep) {
+          return {
+            ...d,
+            [source]: {
+              ...d[source],
+              unread: null,
+              count: 0,
+              notify: false,
+              'notify-count': 0,
+            },
+          };
+        }
+
+        return optimisticActivityUpdate(d, source);
+      });
+
+      return { current };
+    },
+    onError: (err, variables, context) => {
+      queryClient.setQueryData(unreadsKey(), context?.current);
+    },
+    onSettled: () => {
+      queryClient.invalidateQueries({
+        queryKey: unreadsKey(),
+        refetchType: 'none',
       });
     },
   });

--- a/apps/tlon-web/src/state/local.ts
+++ b/apps/tlon-web/src/state/local.ts
@@ -22,6 +22,7 @@ interface LocalState {
   errorCount: number;
   airLockErrorCount: number;
   lastReconnect: number;
+  inFocus: boolean;
   onReconnect: (() => void) | null;
   logs: string[];
   log: (msg: string) => void;
@@ -44,6 +45,7 @@ export const useLocalState = create<LocalState>(
       lastReconnect: Date.now(),
       onReconnect: null,
       logs: [],
+      inFocus: true,
       log: (msg: string) => {
         set(
           produce((s) => {
@@ -106,4 +108,9 @@ export function useSubscriptionStatus() {
 const selLast = (s: LocalState) => s.lastReconnect;
 export function useLastReconnect() {
   return useLocalState(selLast);
+}
+
+const selInFocus = (s: LocalState) => s.inFocus;
+export function useInFocus() {
+  return useLocalState(selInFocus);
 }


### PR DESCRIPTION
This didn't have an issue, but it was old behavior we had that I think is better than what's currently in there. Basically there's three situations:
- tab is out of focus, so don't do any read marking and let them accumulate
- tab is in focus, and we're at the bottom of the channel, automatically mark read w/o showing markers
- tab is in focus, but we're not at the bottom of the channel, don't automatically mark read, let the normal "seeing" trigger mark read

PR Checklist
- [ ] Includes changes to desk files
- [ ] Describes how you tested the PR locally (test ship vs livenet)
- [ ] If a new feature, includes automated tests
- [ ] Comments added anywhere logic may be confusing without context