### PR TITLE
chat-input: fix invisible links

### DIFF
--- a/apps/tlon-web/src/styles/components.css
+++ b/apps/tlon-web/src/styles/components.css
@@ -60,6 +60,10 @@
   @apply my-0;
 }
 
+.Prosemirror a {
+  @apply underline;
+}
+
 /* hack to prevent auto-zoom on em-emoji-picker */
 @media screen and (max-width: 767px) {
   em-emoji-picker {

--- a/apps/tlon-web/src/styles/components.css
+++ b/apps/tlon-web/src/styles/components.css
@@ -60,7 +60,7 @@
   @apply my-0;
 }
 
-.Prosemirror a {
+.ProseMirror a {
   @apply underline;
 }
 


### PR DESCRIPTION
As reported in Tlon Local, links with classes were getting pasted in and showing up with no underline

PR Checklist
- [ ] Includes changes to desk files
- [ ] Describes how you tested the PR locally (test ship vs livenet)
- [ ] If a new feature, includes automated tests
- [ ] Comments added anywhere logic may be confusing without context