### PR TITLE
native: batch add post sub updates

### DIFF
--- a/packages/shared/src/db/queries.ts
+++ b/packages/shared/src/db/queries.ts
@@ -2196,6 +2196,21 @@ export const getPostByCacheId = createReadQuery(
   ['posts']
 );
 
+export const getPostsByCacheId = createReadQuery(
+  'getPostsByCacheId',
+  async ({ sentAtTimes }: { sentAtTimes: number[] }, ctx: QueryCtx) => {
+    if (sentAtTimes.length === 0) return [];
+
+    const postData = await ctx.db
+      .select()
+      .from($posts)
+      .where(inArray($posts.sentAt, sentAtTimes));
+    if (!postData.length) return [];
+    return postData;
+  },
+  ['posts']
+);
+
 export const addReplyToPost = createWriteQuery(
   'addReplyToPost',
   async (

--- a/packages/shared/src/store/useChannelPosts.ts
+++ b/packages/shared/src/store/useChannelPosts.ts
@@ -21,7 +21,7 @@ const postsLogger = createDevLogger('useChannelPosts', false);
 
 type UseChannelPostsPageParams = db.GetChannelPostsOptions;
 type PostQueryData = InfiniteData<db.Post[], unknown>;
-type SubscriptionPost = [db.Post, string | undefined];
+type SubscriptionPost = [db.Post];
 
 type UseChanelPostsParams = UseChannelPostsPageParams & {
   enabled: boolean;


### PR DESCRIPTION
Trying to prevent that interaction where you open the app after a long while and see the last message update iteratively as it processes the events you missed.