### PR TITLE
native: allow user to retry or delete posts that failed to send

### DIFF
--- a/apps/tlon-mobile/src/fixtures/Channel.fixture.tsx
+++ b/apps/tlon-mobile/src/fixtures/Channel.fixture.tsx
@@ -95,6 +95,8 @@ export const ChannelFixture = (props: {
         goToDm={() => {}}
         goToPost={() => {}}
         goToImageViewer={() => {}}
+        onPressRetry={() => {}}
+        onPressDelete={() => {}}
         messageSender={async () => {}}
         markRead={() => {}}
         editPost={async () => {}}
@@ -133,6 +135,8 @@ export const NotebookChannelFixture = (props: { theme?: 'light' | 'dark' }) => {
         goToDm={() => {}}
         goToPost={() => {}}
         goToImageViewer={() => {}}
+        onPressRetry={() => {}}
+        onPressDelete={() => {}}
         messageSender={async () => {}}
         markRead={() => {}}
         editPost={async () => {}}
@@ -190,6 +194,8 @@ const ChannelFixtureWithImage = () => {
         goToPost={() => {}}
         goToDm={() => {}}
         goToImageViewer={() => {}}
+        onPressRetry={() => {}}
+        onPressDelete={() => {}}
         messageSender={async () => {}}
         markRead={() => {}}
         editPost={async () => {}}

--- a/apps/tlon-mobile/src/fixtures/DetailView.fixture.tsx
+++ b/apps/tlon-mobile/src/fixtures/DetailView.fixture.tsx
@@ -27,6 +27,8 @@ const NotebookDetailViewFixture = () => {
         channel={tlonLocalGettingStarted}
         currentUserId={notebookPost.authorId}
         sendReply={async () => {}}
+        onPressRetry={() => {}}
+        onPressDelete={() => {}}
         groupMembers={[]}
         negotiationMatch={true}
         editPost={async () => {}}
@@ -58,6 +60,8 @@ const GalleryDetailViewFixture = () => {
         channel={tlonLocalBulletinBoard}
         currentUserId={galleryPost.authorId}
         sendReply={async () => {}}
+        onPressRetry={() => {}}
+        onPressDelete={() => {}}
         groupMembers={[]}
         negotiationMatch={true}
         editPost={async () => {}}

--- a/apps/tlon-mobile/src/fixtures/PostScreen.fixture.tsx
+++ b/apps/tlon-mobile/src/fixtures/PostScreen.fixture.tsx
@@ -13,6 +13,8 @@ export default (
   <>
     <PostScreenView
       editPost={async () => {}}
+      onPressRetry={() => {}}
+      onPressDelete={() => {}}
       editingPost={undefined}
       negotiationMatch={true}
       setEditingPost={() => {}}

--- a/apps/tlon-mobile/src/screens/ChannelScreen.tsx
+++ b/apps/tlon-mobile/src/screens/ChannelScreen.tsx
@@ -146,6 +146,31 @@ export default function ChannelScreen(props: ChannelScreenProps) {
     [currentUserId, channel, uploadInfo]
   );
 
+  const handleDeletePost = useCallback(
+    async (post: db.Post) => {
+      if (!channel) {
+        throw new Error('Tried to delete message before channel loaded');
+      }
+      await store.deleteFailedPost({
+        post,
+      });
+    },
+    [channel]
+  );
+
+  const handleRetrySend = useCallback(
+    async (post: db.Post) => {
+      if (!channel) {
+        throw new Error('Tried to retry send before channel loaded');
+      }
+      await store.retrySendPost({
+        channel,
+        post,
+      });
+    },
+    [channel]
+  );
+
   const handleChannelNavButtonPressed = useCallback(() => {
     setChannelNavOpen(true);
   }, []);
@@ -210,6 +235,8 @@ export default function ChannelScreen(props: ChannelScreenProps) {
         clearDraft={clearDraft}
         getDraft={getDraft}
         editingPost={editingPost}
+        onPressDelete={handleDeletePost}
+        onPressRetry={handleRetrySend}
         setEditingPost={setEditingPost}
         editPost={editPost}
         negotiationMatch={negotiationStatus.matchedOrPending}

--- a/apps/tlon-mobile/src/screens/PostScreen.tsx
+++ b/apps/tlon-mobile/src/screens/PostScreen.tsx
@@ -1,4 +1,5 @@
 import type { NativeStackScreenProps } from '@react-navigation/native-stack';
+import * as db from '@tloncorp/shared/dist/db';
 import * as store from '@tloncorp/shared/dist/store';
 import * as urbit from '@tloncorp/shared/dist/urbit';
 import { PostScreenView } from '@tloncorp/ui';
@@ -71,6 +72,31 @@ export default function PostScreen(props: PostScreenProps) {
     [channel, currentUserId, post, uploadInfo]
   );
 
+  const handleDeletePost = useCallback(
+    async (post: db.Post) => {
+      if (!channel) {
+        throw new Error('Tried to delete message before channel loaded');
+      }
+      await store.deleteFailedPost({
+        post,
+      });
+    },
+    [channel]
+  );
+
+  const handleRetrySend = useCallback(
+    async (post: db.Post) => {
+      if (!channel) {
+        throw new Error('Tried to retry send before channel loaded');
+      }
+      await store.retrySendPost({
+        channel,
+        post,
+      });
+    },
+    [channel]
+  );
+
   return currentUserId && channel && post ? (
     <PostScreenView
       contacts={contacts ?? null}
@@ -89,6 +115,8 @@ export default function PostScreen(props: PostScreenProps) {
       clearDraft={clearDraft}
       markRead={markRead}
       editingPost={editingPost}
+      onPressDelete={handleDeletePost}
+      onPressRetry={handleRetrySend}
       setEditingPost={setEditingPost}
       editPost={editPost}
       negotiationMatch={negotiationStatus.matchedOrPending}

--- a/packages/shared/src/api/postsApi.ts
+++ b/packages/shared/src/api/postsApi.ts
@@ -188,6 +188,7 @@ export const sendPost = async ({
       add: essay,
     })
   );
+  logger.log('post sent', { channelId, authorId, sentAt, content });
 };
 
 export const editPost = async ({
@@ -972,6 +973,22 @@ export function toPostContent(story?: ub.Story): PostContentAndFlags {
     return verse;
   });
   return [convertedContent, flags];
+}
+
+export function toUrbitStory(content: PostContent): Story {
+  if (!content) {
+    return [];
+  }
+  return content.map((item) => {
+    if ('type' in item) {
+      return {
+        block: {
+          cite: contentReferenceToCite(item),
+        },
+      };
+    }
+    return item;
+  });
 }
 
 export function toContentReference(cite: ub.Cite): ContentReference | null {

--- a/packages/shared/src/db/modelBuilders.ts
+++ b/packages/shared/src/db/modelBuilders.ts
@@ -141,12 +141,14 @@ export function buildPendingPost({
   author,
   channel,
   content,
+  metadata,
   parentId,
 }: {
   authorId: string;
   author?: types.Contact | null;
   channel: types.Channel;
   content: ub.Story;
+  metadata?: db.PostMetadata;
   parentId?: string;
 }): types.Post {
   const sentAt = Date.now();
@@ -173,8 +175,8 @@ export function buildPendingPost({
     type,
     sentAt,
     receivedAt: sentAt,
-    title: '',
-    image: '',
+    title: metadata?.title ?? '',
+    image: metadata?.image ?? '',
     content: JSON.stringify(postContent),
     textContent: ub.getTextContent(content),
     images: api.getContentImages(id, content),

--- a/packages/shared/src/db/queries.ts
+++ b/packages/shared/src/db/queries.ts
@@ -2065,6 +2065,8 @@ export const markPostAsDeleted = createWriteQuery(
         content: null,
         textContent: null,
         authorId: undefined,
+        title: null,
+        image: null,
       })
       .where(eq($posts.id, postId));
   },

--- a/packages/ui/src/components/Channel/Scroller.tsx
+++ b/packages/ui/src/components/Channel/Scroller.tsx
@@ -48,6 +48,8 @@ type RenderItemFunction = (props: {
   editing?: boolean;
   setEditingPost?: (post: db.Post | undefined) => void;
   editPost?: (post: db.Post, content: Story) => Promise<void>;
+  onPressRetry: (post: db.Post) => void;
+  onPressDelete: (post: db.Post) => void;
 }) => ReactElement | null;
 
 type RenderItemType =
@@ -89,6 +91,8 @@ function Scroller({
   editingPost,
   setEditingPost,
   editPost,
+  onPressRetry,
+  onPressDelete,
   hasNewerPosts,
   hasOlderPosts,
   activeMessage,
@@ -112,6 +116,8 @@ function Scroller({
   editingPost?: db.Post;
   setEditingPost?: (post: db.Post | undefined) => void;
   editPost?: (post: db.Post, content: Story) => Promise<void>;
+  onPressRetry: (post: db.Post) => void;
+  onPressDelete: (post: db.Post) => void;
   hasNewerPosts?: boolean;
   hasOlderPosts?: boolean;
   activeMessage: db.Post | null;
@@ -224,6 +230,8 @@ function Scroller({
           channelType={channelType}
           setEditingPost={setEditingPost}
           editPost={editPost}
+          onPressRetry={onPressRetry}
+          onPressDelete={onPressDelete}
           showReplies={showReplies}
           onPressImage={onPressImage}
           onPressReplies={onPressReplies}
@@ -459,6 +467,8 @@ const BaseScrollerItem = ({
   onPressReplies,
   onPressPost,
   onLongPressPost,
+  onPressRetry,
+  onPressDelete,
   activeMessage,
   messageRef,
 }: {
@@ -480,6 +490,8 @@ const BaseScrollerItem = ({
   editPost?: (post: db.Post, content: Story) => Promise<void>;
   onPressPost?: (post: db.Post) => void;
   onLongPressPost: (post: db.Post) => void;
+  onPressRetry: (post: db.Post) => void;
+  onPressDelete: (post: db.Post) => void;
   activeMessage?: db.Post | null;
   messageRef: RefObject<RNView>;
 }) => {
@@ -532,6 +544,8 @@ const BaseScrollerItem = ({
           onPressImage={post.isDeleted ? () => {} : onPressImage}
           onLongPress={post.isDeleted ? () => {} : onLongPressPost}
           onPress={post.isDeleted ? () => {} : onPressPost}
+          onPressRetry={onPressRetry}
+          onPressDelete={onPressDelete}
         />
       </PressableMessage>
     </View>

--- a/packages/ui/src/components/Channel/index.tsx
+++ b/packages/ui/src/components/Channel/index.tsx
@@ -81,6 +81,8 @@ export function Channel({
   editingPost,
   setEditingPost,
   editPost,
+  onPressRetry,
+  onPressDelete,
   negotiationMatch,
   hasNewerPosts,
   hasOlderPosts,
@@ -117,6 +119,8 @@ export function Channel({
   editingPost?: db.Post;
   setEditingPost?: (post: db.Post | undefined) => void;
   editPost: (post: db.Post, content: Story) => Promise<void>;
+  onPressRetry: (post: db.Post) => void;
+  onPressDelete: (post: db.Post) => void;
   negotiationMatch: boolean;
   hasNewerPosts?: boolean;
   hasOlderPosts?: boolean;
@@ -307,6 +311,8 @@ export function Channel({
                                       onPressImage={goToImageViewer}
                                       onEndReached={onScrollEndReached}
                                       onStartReached={onScrollStartReached}
+                                      onPressRetry={onPressRetry}
+                                      onPressDelete={onPressDelete}
                                       activeMessage={activeMessage}
                                       setActiveMessage={setActiveMessage}
                                     />

--- a/packages/ui/src/components/DetailView/DetailView.tsx
+++ b/packages/ui/src/components/DetailView/DetailView.tsx
@@ -30,6 +30,8 @@ export interface DetailViewProps {
   clearDraft: () => void;
   getDraft: () => Promise<urbit.JSONContent>;
   goBack?: () => void;
+  onPressRetry: (post: db.Post) => void;
+  onPressDelete: (post: db.Post) => void;
 }
 
 const DetailViewMetaDataComponent = ({
@@ -101,6 +103,8 @@ const DetailViewFrameComponent = ({
   getDraft,
   children,
   goBack,
+  onPressRetry,
+  onPressDelete,
 }: DetailViewProps) => {
   const [messageInputHeight, setMessageInputHeight] = useState(
     DEFAULT_MESSAGE_INPUT_HEIGHT
@@ -130,6 +134,8 @@ const DetailViewFrameComponent = ({
               posts={posts ?? null}
               showReplies={false}
               onPressImage={onPressImage}
+              onPressRetry={onPressRetry}
+              onPressDelete={onPressDelete}
               firstUnreadId={
                 threadUnread?.count ?? 0 > 0
                   ? threadUnread?.firstUnreadPostId

--- a/packages/ui/src/components/DetailView/GalleryDetailView.tsx
+++ b/packages/ui/src/components/DetailView/GalleryDetailView.tsx
@@ -21,6 +21,8 @@ export default function GalleryDetailView({
   clearDraft,
   getDraft,
   goBack,
+  onPressRetry,
+  onPressDelete,
 }: DetailViewProps) {
   // We want the content of the detail view to take up 70% of the screen height
   const HEIGHT_DETAIL_VIEW_CONTENT = Dimensions.get('window').height * 0.5;
@@ -70,6 +72,8 @@ export default function GalleryDetailView({
       clearDraft={clearDraft}
       getDraft={getDraft}
       goBack={goBack}
+      onPressRetry={onPressRetry}
+      onPressDelete={onPressDelete}
     >
       <DetailView.Header replyCount={post.replyCount ?? 0}>
         <View paddingHorizontal="$xl" key={post.id} alignItems="center">

--- a/packages/ui/src/components/DetailView/NotebookDetailView.tsx
+++ b/packages/ui/src/components/DetailView/NotebookDetailView.tsx
@@ -22,6 +22,8 @@ export default function NotebookDetailView({
   clearDraft,
   getDraft,
   goBack,
+  onPressRetry,
+  onPressDelete,
 }: DetailViewProps) {
   const handleImagePressed = useCallback(() => {
     if (post.image) {
@@ -48,6 +50,8 @@ export default function NotebookDetailView({
       clearDraft={clearDraft}
       getDraft={getDraft}
       goBack={goBack}
+      onPressRetry={onPressRetry}
+      onPressDelete={onPressDelete}
     >
       <DetailView.Header replyCount={post.replyCount ?? 0}>
         {post.image && (

--- a/packages/ui/src/components/PostScreenView.tsx
+++ b/packages/ui/src/components/PostScreenView.tsx
@@ -40,6 +40,8 @@ export function PostScreenView({
   editingPost,
   setEditingPost,
   editPost,
+  onPressRetry,
+  onPressDelete,
   negotiationMatch,
   headerMode,
 }: {
@@ -62,6 +64,8 @@ export function PostScreenView({
   editingPost?: db.Post;
   setEditingPost?: (post: db.Post | undefined) => void;
   editPost: (post: db.Post, content: Story) => Promise<void>;
+  onPressRetry: (post: db.Post) => void;
+  onPressDelete: (post: db.Post) => void;
   negotiationMatch: boolean;
   headerMode?: 'default' | 'next';
 }) {
@@ -119,6 +123,8 @@ export function PostScreenView({
                     editingPost={editingPost}
                     setEditingPost={setEditingPost}
                     editPost={editPost}
+                    onPressRetry={onPressRetry}
+                    onPressDelete={onPressDelete}
                     posts={postsWithoutParent}
                     sendReply={sendReply}
                     groupMembers={groupMembers}
@@ -136,6 +142,8 @@ export function PostScreenView({
                     editingPost={editingPost}
                     setEditingPost={setEditingPost}
                     editPost={editPost}
+                    onPressRetry={onPressRetry}
+                    onPressDelete={onPressDelete}
                     posts={postsWithoutParent}
                     sendReply={sendReply}
                     groupMembers={groupMembers}
@@ -164,6 +172,8 @@ export function PostScreenView({
                         editingPost={editingPost}
                         setEditingPost={setEditingPost}
                         editPost={editPost}
+                        onPressRetry={onPressRetry}
+                        onPressDelete={onPressDelete}
                         posts={posts}
                         showReplies={false}
                         onPressImage={handleGoToImage}


### PR DESCRIPTION
Fixes TLON-2407 by notifying a user when the post failed to send and allowing them to tap the post that will show a sheet which allows them to retry or delete the post.