### PR TITLE
activity: re-enable auto marking active chats/threads

### DIFF
--- a/apps/tlon-web/src/chat/ChatScroller/ChatScroller.tsx
+++ b/apps/tlon-web/src/chat/ChatScroller/ChatScroller.tsx
@@ -185,8 +185,8 @@ export interface ChatScrollerProps {
   parent?: MessageKey;
   messages: PostTuple[] | WritTuple[] | ReplyTuple[];
   isBroadcast?: boolean;
-  onAtTop?: () => void;
-  onAtBottom?: () => void;
+  onAtTopChange?: (atBottom: boolean) => void;
+  onAtBottomChange?: (atBottom: boolean) => void;
   isLoadingOlder: boolean;
   isLoadingNewer: boolean;
   replying?: boolean;
@@ -208,8 +208,8 @@ export default function ChatScroller({
   parent,
   messages,
   isBroadcast,
-  onAtTop,
-  onAtBottom,
+  onAtTopChange,
+  onAtBottomChange,
   isLoadingOlder,
   isLoadingNewer,
   replying = false,
@@ -505,26 +505,19 @@ export default function ChatScroller({
 
   // Load more items when list reaches the top or bottom.
   useEffect(() => {
-    if (isLoadingOlder || isLoadingNewer || !userHasScrolled) return;
+    if (isLoadingNewer || !userHasScrolled) return;
 
-    if (isAtTop && !hasLoadedOldest) {
-      logger.log('triggering onAtTop');
-      onAtTop?.();
-    } else if (isAtBottom) {
-      logger.log('triggering onAtBottom');
-      onAtBottom?.();
-    }
-  }, [
-    isLoadingOlder,
-    isLoadingNewer,
-    hasLoadedNewest,
-    hasLoadedOldest,
-    isAtTop,
-    isAtBottom,
-    onAtTop,
-    onAtBottom,
-    userHasScrolled,
-  ]);
+    logger.log('triggering onAtBottomChange');
+    onAtBottomChange?.(isAtBottom);
+  }, [isLoadingNewer, userHasScrolled, isAtBottom, onAtBottomChange]);
+
+  // Load more items when list reaches the top or bottom.
+  useEffect(() => {
+    if (isLoadingOlder || !userHasScrolled) return;
+
+    logger.log('triggering onAtTop');
+    onAtTopChange?.(isAtTop);
+  }, [isLoadingOlder, isAtTop, userHasScrolled, onAtTopChange]);
 
   // When the list inverts, we need to flip the scroll position in order to appear to stay in the same place.
   // We do this here as opposed to in an effect so that virtualItems is correct in time for this render.

--- a/apps/tlon-web/src/chat/ChatThread/ChatThread.tsx
+++ b/apps/tlon-web/src/chat/ChatThread/ChatThread.tsx
@@ -142,10 +142,10 @@ export default function ChatThread() {
     [chName, chShip, name, ship, activeTab]
   );
 
-  const onAtBottom = useCallback(() => {
-    console.log('thread bottom called');
+  const onAtBottom = useCallback((atBottom: boolean) => {
+    console.log('thread bottom called', atBottom);
     const { threadBottom } = useChatStore.getState();
-    threadBottom(true);
+    threadBottom(atBottom);
   }, []);
 
   const onEscape = useCallback(
@@ -326,7 +326,7 @@ export default function ChatThread() {
             isScrolling={isScrolling}
             hasLoadedNewest={false}
             hasLoadedOldest={false}
-            onAtBottom={onAtBottom}
+            onAtBottomChange={onAtBottom}
           />
         )}
       </div>

--- a/apps/tlon-web/src/chat/ChatThread/ChatThread.tsx
+++ b/apps/tlon-web/src/chat/ChatThread/ChatThread.tsx
@@ -143,8 +143,9 @@ export default function ChatThread() {
   );
 
   const onAtBottom = useCallback(() => {
-    const { bottom } = useChatStore.getState();
-    bottom(true);
+    console.log('thread bottom called');
+    const { threadBottom } = useChatStore.getState();
+    threadBottom(true);
   }, []);
 
   const onEscape = useCallback(
@@ -156,6 +157,22 @@ export default function ChatThread() {
     [navigate, returnURL, leapIsOpen]
   );
   useEventListener('keydown', onEscape, threadRef);
+
+  useEffect(() => {
+    useChatStore.getState().threadBottom(true);
+
+    return () => {
+      useChatStore.getState().threadBottom(false);
+    };
+  }, []);
+
+  useEffect(() => {
+    useChatStore.getState().setCurrentThread(msgKey);
+
+    return () => {
+      useChatStore.getState().setCurrentThread(null);
+    };
+  }, [msgKey]);
 
   useEffect(() => {
     if (!idTimeIsNumber) {

--- a/apps/tlon-web/src/chat/ChatWindow.tsx
+++ b/apps/tlon-web/src/chat/ChatWindow.tsx
@@ -61,7 +61,6 @@ const ChatWindow = React.memo(function ChatWindowRaw({
     isFetchingNextPage,
     isFetchingPreviousPage,
   } = useInfinitePosts(nest, scrollToId);
-  const { markRead } = useMarkChannelRead(nest);
   const scrollerRef = useRef<VirtuosoHandle>(null);
   const fetchingNewest =
     isFetching && (!isFetchingNextPage || !isFetchingPreviousPage);
@@ -126,21 +125,27 @@ const ChatWindow = React.memo(function ChatWindowRaw({
     };
   }, [whom, flag]);
 
-  const onAtBottom = useCallback(() => {
-    const { bottom } = useChatStore.getState();
-    bottom(true);
-    if (hasPreviousPage && !isFetching) {
-      log('fetching previous page');
-      fetchPreviousPage();
-    }
-  }, [markRead, fetchPreviousPage, hasPreviousPage, isFetching]);
+  const onAtBottom = useCallback(
+    (atBottom: boolean) => {
+      const { bottom } = useChatStore.getState();
+      bottom(atBottom);
+      if (atBottom && hasPreviousPage && !isFetching) {
+        log('fetching previous page');
+        fetchPreviousPage();
+      }
+    },
+    [fetchPreviousPage, hasPreviousPage, isFetching]
+  );
 
-  const onAtTop = useCallback(() => {
-    if (hasNextPage && !isFetching) {
-      log('fetching next page');
-      fetchNextPage();
-    }
-  }, [fetchNextPage, hasNextPage, isFetching]);
+  const onAtTop = useCallback(
+    (atTop: boolean) => {
+      if (atTop && hasNextPage && !isFetching) {
+        log('fetching next page');
+        fetchNextPage();
+      }
+    },
+    [fetchNextPage, hasNextPage, isFetching]
+  );
 
   /**
    * we want to show unread banner after messages have had a chance to
@@ -227,8 +232,8 @@ const ChatWindow = React.memo(function ChatWindowRaw({
           topLoadEndMarker={prefixedElement}
           scrollTo={scrollToId ? bigInt(scrollToId) : undefined}
           scrollerRef={scrollerRef}
-          onAtTop={onAtTop}
-          onAtBottom={onAtBottom}
+          onAtTopChange={onAtTop}
+          onAtBottomChange={onAtBottom}
           scrollElementRef={scrollElementRef}
           isScrolling={isScrolling}
           hasLoadedOldest={!hasNextPage}

--- a/apps/tlon-web/src/chat/ChatWindow.tsx
+++ b/apps/tlon-web/src/chat/ChatWindow.tsx
@@ -8,12 +8,7 @@ import React, {
   useRef,
   useState,
 } from 'react';
-import {
-  useLocation,
-  useNavigate,
-  useParams,
-  useSearchParams,
-} from 'react-router-dom';
+import { useNavigate, useParams, useSearchParams } from 'react-router-dom';
 import { VirtuosoHandle } from 'react-virtuoso';
 
 import ChatScroller from '@/chat/ChatScroller/ChatScroller';
@@ -124,12 +119,12 @@ const ChatWindow = React.memo(function ChatWindowRaw({
   ]);
 
   useEffect(() => {
-    useChatStore.getState().setCurrent(whom);
+    useChatStore.getState().setCurrent({ whom, group: flag });
 
     return () => {
-      useChatStore.getState().setCurrent('');
+      useChatStore.getState().setCurrent(null);
     };
-  }, [whom]);
+  }, [whom, flag]);
 
   const onAtBottom = useCallback(() => {
     const { bottom } = useChatStore.getState();

--- a/apps/tlon-web/src/chat/useChatStore.ts
+++ b/apps/tlon-web/src/chat/useChatStore.ts
@@ -1,4 +1,7 @@
-import { ActivitySummary } from '@tloncorp/shared/dist/urbit/activity';
+import {
+  ActivitySummary,
+  MessageKey,
+} from '@tloncorp/shared/dist/urbit/activity';
 import { Block } from '@tloncorp/shared/dist/urbit/channel';
 import produce from 'immer';
 import { useCallback } from 'react';
@@ -14,12 +17,21 @@ export interface ChatInfo {
   failedToLoadContent: Record<string, Record<number, boolean>>;
 }
 
+interface CurrentChat {
+  whom: string;
+  group?: string;
+}
+
+type CurrentChatThread = MessageKey;
+
 export interface ChatStore {
   chats: {
     [flag: string]: ChatInfo;
   };
   atBottom: boolean;
-  current: string;
+  atThreadBottom: boolean;
+  current: CurrentChat | null;
+  currentThread: CurrentChatThread | null;
   reply: (flag: string, msgId: string | null) => void;
   setBlocks: (whom: string, blocks: Block[]) => void;
   setDialogs: (
@@ -35,7 +47,9 @@ export interface ChatStore {
   ) => void;
   setHovering: (whom: string, writId: string, hovering: boolean) => void;
   bottom: (atBottom: boolean) => void;
-  setCurrent: (whom: string) => void;
+  threadBottom: (atBottom: boolean) => void;
+  setCurrent: (current: CurrentChat | null) => void;
+  setCurrentThread: (current: CurrentChatThread | null) => void;
 }
 
 const emptyInfo: () => ChatInfo = () => ({
@@ -55,8 +69,10 @@ export function isUnread(unread: ActivitySummary): boolean {
 
 export const useChatStore = create<ChatStore>((set, get) => ({
   chats: {},
-  current: '',
+  current: null,
+  currentThread: null,
   atBottom: false,
+  atThreadBottom: false,
   setBlocks: (whom, blocks) => {
     set(
       produce((draft) => {
@@ -133,6 +149,22 @@ export const useChatStore = create<ChatStore>((set, get) => ({
       produce((draft) => {
         chatStoreLogger.log('current', current);
         draft.current = current;
+      })
+    );
+  },
+  setCurrentThread: (current) => {
+    set(
+      produce((draft) => {
+        chatStoreLogger.log('currentThread', current);
+        draft.currentThread = current;
+      })
+    );
+  },
+  threadBottom: (atBottom) => {
+    set(
+      produce((draft) => {
+        chatStoreLogger.log('atThreadBottom', atBottom);
+        draft.atThreadBottom = atBottom;
       })
     );
   },

--- a/apps/tlon-web/src/dms/BroadcastWindow.tsx
+++ b/apps/tlon-web/src/dms/BroadcastWindow.tsx
@@ -49,12 +49,6 @@ export default function BroadcastWindow({
           scrollElementRef={scrollElementRef}
           isScrolling={isScrolling}
           topLoadEndMarker={prefixedElement}
-          onAtTop={() => {
-            return;
-          }}
-          onAtBottom={() => {
-            return;
-          }}
           hasLoadedOldest={true}
           hasLoadedNewest={true}
         />

--- a/apps/tlon-web/src/dms/DMThread.tsx
+++ b/apps/tlon-web/src/dms/DMThread.tsx
@@ -1,19 +1,9 @@
-import {
-  MessageKey,
-  getKey,
-  getThreadKey,
-} from '@tloncorp/shared/dist/urbit/activity';
+import { MessageKey } from '@tloncorp/shared/dist/urbit/activity';
 import { ReplyTuple } from '@tloncorp/shared/dist/urbit/channel';
 import { formatUd } from '@urbit/aura';
 import bigInt from 'big-integer';
 import cn from 'classnames';
-import React, {
-  useCallback,
-  useEffect,
-  useMemo,
-  useRef,
-  useState,
-} from 'react';
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { useLocation, useNavigate, useParams } from 'react-router';
 import { Link } from 'react-router-dom';
 import { VirtuosoHandle } from 'react-virtuoso';
@@ -23,11 +13,7 @@ import { useEventListener } from 'usehooks-ts';
 import ChatInput from '@/chat/ChatInput/ChatInput';
 import ChatScroller from '@/chat/ChatScroller/ChatScroller';
 import ChatScrollerPlaceholder from '@/chat/ChatScroller/ChatScrollerPlaceholder';
-import {
-  chatStoreLogger,
-  useChatInfo,
-  useChatStore,
-} from '@/chat/useChatStore';
+import { useChatStore } from '@/chat/useChatStore';
 import useLeap from '@/components/Leap/useLeap';
 import MobileHeader from '@/components/MobileHeader';
 import BranchIcon from '@/components/icons/BranchIcon';
@@ -115,12 +101,28 @@ export default function DMThread() {
     [navigate, returnURL, leapIsOpen]
   );
 
-  const onAtBottom = useCallback(() => {
-    const { bottom } = useChatStore.getState();
-    bottom(true);
+  const onAtBottom = useCallback((atBottom: boolean) => {
+    const { threadBottom } = useChatStore.getState();
+    threadBottom(atBottom);
   }, []);
 
   useEventListener('keydown', onEscape, threadRef);
+
+  useEffect(() => {
+    useChatStore.getState().threadBottom(true);
+
+    return () => {
+      useChatStore.getState().threadBottom(false);
+    };
+  }, []);
+
+  useEffect(() => {
+    useChatStore.getState().setCurrentThread(msgKey);
+
+    return () => {
+      useChatStore.getState().setCurrentThread(null);
+    };
+  }, [msgKey]);
 
   if (!writ || isLoading) return null;
 
@@ -205,7 +207,7 @@ export default function DMThread() {
             isScrolling={isScrolling}
             hasLoadedNewest={false}
             hasLoadedOldest={false}
-            onAtBottom={onAtBottom}
+            onAtBottomChange={onAtBottom}
           />
         )}
       </div>

--- a/apps/tlon-web/src/dms/DmWindow.tsx
+++ b/apps/tlon-web/src/dms/DmWindow.tsx
@@ -76,21 +76,27 @@ export default function DmWindow({
     [scrollToInMessages, scrollToIndex, latestMessageIndex]
   );
 
-  const onAtBottom = useCallback(() => {
-    const { bottom } = useChatStore.getState();
-    bottom(true);
-    if (hasPreviousPage && !isFetching) {
-      log('fetching previous page');
-      fetchPreviousPage();
-    }
-  }, [fetchPreviousPage, hasPreviousPage, isFetching]);
+  const onAtBottom = useCallback(
+    (atBottom: boolean) => {
+      const { bottom } = useChatStore.getState();
+      bottom(atBottom);
+      if (atBottom && hasPreviousPage && !isFetching) {
+        log('fetching previous page');
+        fetchPreviousPage();
+      }
+    },
+    [fetchPreviousPage, hasPreviousPage, isFetching]
+  );
 
-  const onAtTop = useCallback(() => {
-    if (hasNextPage && !isFetching) {
-      log('fetching next page');
-      fetchNextPage();
-    }
-  }, [fetchNextPage, hasNextPage, isFetching]);
+  const onAtTop = useCallback(
+    (atTop: boolean) => {
+      if (atTop && hasNextPage && !isFetching) {
+        log('fetching next page');
+        fetchNextPage();
+      }
+    },
+    [fetchNextPage, hasNextPage, isFetching]
+  );
 
   const goToLatest = useCallback(async () => {
     if (idTime) {
@@ -121,10 +127,10 @@ export default function DmWindow({
   ]);
 
   useEffect(() => {
-    useChatStore.getState().setCurrent(whom);
+    useChatStore.getState().setCurrent({ whom });
 
     return () => {
-      useChatStore.getState().setCurrent('');
+      useChatStore.getState().setCurrent(null);
     };
   }, [whom]);
 
@@ -174,8 +180,8 @@ export default function DmWindow({
           scrollElementRef={scrollElementRef}
           isScrolling={isScrolling}
           topLoadEndMarker={prefixedElement}
-          onAtTop={onAtTop}
-          onAtBottom={onAtBottom}
+          onAtTopChange={onAtTop}
+          onAtBottomChange={onAtBottom}
           hasLoadedOldest={!hasNextPage}
           hasLoadedNewest={!hasPreviousPage}
         />

--- a/apps/tlon-web/src/logic/utils.ts
+++ b/apps/tlon-web/src/logic/utils.ts
@@ -24,6 +24,7 @@ import {
   Group,
   GroupChannel,
   GroupPreview,
+  Groups,
   PrivacyType,
   Rank,
   Saga,
@@ -1307,4 +1308,15 @@ export function getMessageKey(post: Post): MessageKey {
     id: `${post.essay.author}/${formatUd(unixToDa(post.essay.sent))}`,
     time: formatUd(bigInt(post.seal.id)),
   };
+}
+
+export function getGroupFromNest(nest: string, groups: Groups) {
+  let groupFlag: string | undefined = undefined;
+  Object.entries(groups).forEach(([flag, group]) => {
+    if (nest in group.channels) {
+      groupFlag = flag;
+    }
+  });
+
+  return groupFlag;
 }

--- a/apps/tlon-web/src/logic/utils.ts
+++ b/apps/tlon-web/src/logic/utils.ts
@@ -24,7 +24,6 @@ import {
   Group,
   GroupChannel,
   GroupPreview,
-  Groups,
   PrivacyType,
   Rank,
   Saga,
@@ -1308,15 +1307,4 @@ export function getMessageKey(post: Post): MessageKey {
     id: `${post.essay.author}/${formatUd(unixToDa(post.essay.sent))}`,
     time: formatUd(bigInt(post.seal.id)),
   };
-}
-
-export function getGroupFromNest(nest: string, groups: Groups) {
-  let groupFlag: string | undefined = undefined;
-  Object.entries(groups).forEach(([flag, group]) => {
-    if (nest in group.channels) {
-      groupFlag = flag;
-    }
-  });
-
-  return groupFlag;
 }

--- a/apps/tlon-web/src/state/activity.ts
+++ b/apps/tlon-web/src/state/activity.ts
@@ -154,6 +154,10 @@ function optimisticActivityUpdate(d: Activity, source: string): Activity {
   };
 }
 
+function isRead(summary: ActivitySummary) {
+  return summary.unread === null;
+}
+
 function updateActivity({
   main,
   threads,
@@ -171,30 +175,26 @@ function updateActivity({
           whomIsFlag(current.whom) ? currentThread.time : currentThread.id
         )
       : null;
-  const threadActivity = source ? threads[source] : null;
-  const isThreadUpdate =
-    threadActivity && threadSource && threadSource in threadActivity;
+  const threadActivity = source ? threads[source] || null : null;
   const inFocus = useLocalState.getState().inFocus;
   const filteredMain =
-    inFocus && atBottom && source && source in main && !isThreadUpdate
+    inFocus &&
+    atBottom &&
+    source &&
+    source in main &&
+    threadActivity === null &&
+    !isRead(main[source])
       ? optimisticActivityUpdate(main, source)
       : undefined;
   const filteredThread =
-    inFocus && atThreadBottom && isThreadUpdate
+    inFocus &&
+    atThreadBottom &&
+    threadActivity &&
+    threadSource &&
+    threadSource in threadActivity &&
+    !isRead(threadActivity[threadSource])
       ? optimisticActivityUpdate(threadActivity, threadSource)
       : undefined;
-  console.log({ inFocus, source, atBottom, filteredMain });
-  console.log({
-    current,
-    currentThread,
-    source,
-    threadSource,
-    isThreadUpdate,
-    atThreadBottom,
-    filteredThread,
-    threadActivity,
-    threads,
-  });
 
   if (filteredMain && current) {
     const nest = `chat/${current.whom}`;

--- a/apps/tlon-web/src/state/activity.ts
+++ b/apps/tlon-web/src/state/activity.ts
@@ -21,21 +21,14 @@ import {
   stripSourcePrefix,
 } from '@tloncorp/shared/dist/urbit/activity';
 import _ from 'lodash';
-import { Groups } from 'packages/shared/dist/urbit';
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 
 import api from '@/api';
 import { useChatStore } from '@/chat/useChatStore';
 import useReactQueryScry from '@/logic/useReactQueryScry';
-import {
-  createDevLogger,
-  getGroupFromNest,
-  whomIsDm,
-  whomIsFlag,
-} from '@/logic/utils';
+import { createDevLogger, whomIsDm, whomIsFlag } from '@/logic/utils';
 import queryClient from '@/queryClient';
 
-import { GROUPS_KEY } from './groups';
 import { useLocalState } from './local';
 import { SidebarFilter } from './settings';
 

--- a/desk/desk.docket-0
+++ b/desk/desk.docket-0
@@ -2,7 +2,7 @@
     info+'Start, host, and cultivate communities. Own your communications, organize your resources, and share documents. Tlon is a decentralized platform that offers a full, communal suite of tools for messaging, writing and sharing media with others.'
     color+0xde.dede
     image+'https://bootstrap.urbit.org/tlon.svg?v=1'
-    glob-http+['https://bootstrap.urbit.org/glob-0v1.71qpt.066p8.ig25t.if94m.d9hsb.glob' 0v1.71qpt.066p8.ig25t.if94m.d9hsb]
+    glob-http+['https://bootstrap.urbit.org/glob-0v2.ff303.9sd1e.hslh2.d9mcj.22a3t.glob' 0v2.ff303.9sd1e.hslh2.d9mcj.22a3t]
     base+'groups'
     version+[6 1 0]
     website+'https://tlon.io'

--- a/desk/desk.docket-0
+++ b/desk/desk.docket-0
@@ -2,7 +2,7 @@
     info+'Start, host, and cultivate communities. Own your communications, organize your resources, and share documents. Tlon is a decentralized platform that offers a full, communal suite of tools for messaging, writing and sharing media with others.'
     color+0xde.dede
     image+'https://bootstrap.urbit.org/tlon.svg?v=1'
-    glob-http+['https://bootstrap.urbit.org/glob-0vjij3q.upm2l.l5jts.6o74u.2a67q.glob' 0vjij3q.upm2l.l5jts.6o74u.2a67q]
+    glob-http+['https://bootstrap.urbit.org/glob-0v1.71qpt.066p8.ig25t.if94m.d9hsb.glob' 0v1.71qpt.066p8.ig25t.if94m.d9hsb]
     base+'groups'
     version+[6 1 0]
     website+'https://tlon.io'


### PR DESCRIPTION
This re-enables the behavior and fixes it so it actually marks stuff read lol. Required some light changes to `ChatScroller` so will need to make sure this doesn't break any chat loading.

PR Checklist
- [ ] Includes changes to desk files
- [ ] Describes how you tested the PR locally (test ship vs livenet)
- [ ] If a new feature, includes automated tests
- [ ] Comments added anywhere logic may be confusing without context