### PR TITLE
native: fix joined channel detection

### DIFF
--- a/packages/shared/src/store/useActivityFetchers.ts
+++ b/packages/shared/src/store/useActivityFetchers.ts
@@ -81,7 +81,7 @@ export function useInfiniteBucketedActivity(
       // if we got some stuff, insert it into the DB & update the cusor
       if (apiResponse.events.length > 0) {
         await db.insertActivityEvents(apiResponse.events);
-        await sync.persistUnreads(apiResponse.relevantUnreads);
+        await sync.persistUnreads({ unreads: apiResponse.relevantUnreads });
         const events = await db.getBucketedActivityPage({
           bucket,
           startCursor: cursor,


### PR DESCRIPTION
After moving to activity v4, there was an issue with the partial unread updates we get from activity causing a full reconfiguration of which channels we're joined to.

This just adds an optional flag to specify when you do and do not have the full set of unreads and accordingly branches on that when deciding to update channel joins.

Fixes TLON-2420