### PR TITLE
activity: web match mobile bell tab

### DIFF
--- a/apps/tlon-web/src/chat/ChatScroller/ChatScroller.tsx
+++ b/apps/tlon-web/src/chat/ChatScroller/ChatScroller.tsx
@@ -185,8 +185,8 @@ export interface ChatScrollerProps {
   parent?: MessageKey;
   messages: PostTuple[] | WritTuple[] | ReplyTuple[];
   isBroadcast?: boolean;
-  onAtTop?: () => void;
-  onAtBottom?: () => void;
+  onAtTopChange?: (atBottom: boolean) => void;
+  onAtBottomChange?: (atBottom: boolean) => void;
   isLoadingOlder: boolean;
   isLoadingNewer: boolean;
   replying?: boolean;
@@ -208,8 +208,8 @@ export default function ChatScroller({
   parent,
   messages,
   isBroadcast,
-  onAtTop,
-  onAtBottom,
+  onAtTopChange,
+  onAtBottomChange,
   isLoadingOlder,
   isLoadingNewer,
   replying = false,
@@ -505,26 +505,19 @@ export default function ChatScroller({
 
   // Load more items when list reaches the top or bottom.
   useEffect(() => {
-    if (isLoadingOlder || isLoadingNewer || !userHasScrolled) return;
+    if (isLoadingNewer || !userHasScrolled) return;
 
-    if (isAtTop && !hasLoadedOldest) {
-      logger.log('triggering onAtTop');
-      onAtTop?.();
-    } else if (isAtBottom) {
-      logger.log('triggering onAtBottom');
-      onAtBottom?.();
-    }
-  }, [
-    isLoadingOlder,
-    isLoadingNewer,
-    hasLoadedNewest,
-    hasLoadedOldest,
-    isAtTop,
-    isAtBottom,
-    onAtTop,
-    onAtBottom,
-    userHasScrolled,
-  ]);
+    logger.log('triggering onAtBottomChange');
+    onAtBottomChange?.(isAtBottom);
+  }, [isLoadingNewer, userHasScrolled, isAtBottom, onAtBottomChange]);
+
+  // Load more items when list reaches the top or bottom.
+  useEffect(() => {
+    if (isLoadingOlder || !userHasScrolled) return;
+
+    logger.log('triggering onAtTop');
+    onAtTopChange?.(isAtTop);
+  }, [isLoadingOlder, isAtTop, userHasScrolled, onAtTopChange]);
 
   // When the list inverts, we need to flip the scroll position in order to appear to stay in the same place.
   // We do this here as opposed to in an effect so that virtualItems is correct in time for this render.

--- a/apps/tlon-web/src/chat/ChatThread/ChatThread.tsx
+++ b/apps/tlon-web/src/chat/ChatThread/ChatThread.tsx
@@ -142,9 +142,10 @@ export default function ChatThread() {
     [chName, chShip, name, ship, activeTab]
   );
 
-  const onAtBottom = useCallback(() => {
-    const { bottom } = useChatStore.getState();
-    bottom(true);
+  const onAtBottom = useCallback((atBottom: boolean) => {
+    console.log('thread bottom called', atBottom);
+    const { threadBottom } = useChatStore.getState();
+    threadBottom(atBottom);
   }, []);
 
   const onEscape = useCallback(
@@ -156,6 +157,22 @@ export default function ChatThread() {
     [navigate, returnURL, leapIsOpen]
   );
   useEventListener('keydown', onEscape, threadRef);
+
+  useEffect(() => {
+    useChatStore.getState().threadBottom(true);
+
+    return () => {
+      useChatStore.getState().threadBottom(false);
+    };
+  }, []);
+
+  useEffect(() => {
+    useChatStore.getState().setCurrentThread(msgKey);
+
+    return () => {
+      useChatStore.getState().setCurrentThread(null);
+    };
+  }, [msgKey]);
 
   useEffect(() => {
     if (!idTimeIsNumber) {
@@ -309,7 +326,7 @@ export default function ChatThread() {
             isScrolling={isScrolling}
             hasLoadedNewest={false}
             hasLoadedOldest={false}
-            onAtBottom={onAtBottom}
+            onAtBottomChange={onAtBottom}
           />
         )}
       </div>

--- a/apps/tlon-web/src/chat/useChatStore.ts
+++ b/apps/tlon-web/src/chat/useChatStore.ts
@@ -1,4 +1,7 @@
-import { ActivitySummary } from '@tloncorp/shared/dist/urbit/activity';
+import {
+  ActivitySummary,
+  MessageKey,
+} from '@tloncorp/shared/dist/urbit/activity';
 import { Block } from '@tloncorp/shared/dist/urbit/channel';
 import produce from 'immer';
 import { useCallback } from 'react';
@@ -14,12 +17,21 @@ export interface ChatInfo {
   failedToLoadContent: Record<string, Record<number, boolean>>;
 }
 
+interface CurrentChat {
+  whom: string;
+  group?: string;
+}
+
+type CurrentChatThread = MessageKey;
+
 export interface ChatStore {
   chats: {
     [flag: string]: ChatInfo;
   };
   atBottom: boolean;
-  current: string;
+  atThreadBottom: boolean;
+  current: CurrentChat | null;
+  currentThread: CurrentChatThread | null;
   reply: (flag: string, msgId: string | null) => void;
   setBlocks: (whom: string, blocks: Block[]) => void;
   setDialogs: (
@@ -35,7 +47,9 @@ export interface ChatStore {
   ) => void;
   setHovering: (whom: string, writId: string, hovering: boolean) => void;
   bottom: (atBottom: boolean) => void;
-  setCurrent: (whom: string) => void;
+  threadBottom: (atBottom: boolean) => void;
+  setCurrent: (current: CurrentChat | null) => void;
+  setCurrentThread: (current: CurrentChatThread | null) => void;
 }
 
 const emptyInfo: () => ChatInfo = () => ({
@@ -55,8 +69,10 @@ export function isUnread(unread: ActivitySummary): boolean {
 
 export const useChatStore = create<ChatStore>((set, get) => ({
   chats: {},
-  current: '',
+  current: null,
+  currentThread: null,
   atBottom: false,
+  atThreadBottom: false,
   setBlocks: (whom, blocks) => {
     set(
       produce((draft) => {
@@ -133,6 +149,22 @@ export const useChatStore = create<ChatStore>((set, get) => ({
       produce((draft) => {
         chatStoreLogger.log('current', current);
         draft.current = current;
+      })
+    );
+  },
+  setCurrentThread: (current) => {
+    set(
+      produce((draft) => {
+        chatStoreLogger.log('currentThread', current);
+        draft.currentThread = current;
+      })
+    );
+  },
+  threadBottom: (atBottom) => {
+    set(
+      produce((draft) => {
+        chatStoreLogger.log('atThreadBottom', atBottom);
+        draft.atThreadBottom = atBottom;
       })
     );
   },

--- a/apps/tlon-web/src/components/VolumeSetting.tsx
+++ b/apps/tlon-web/src/components/VolumeSetting.tsx
@@ -71,7 +71,7 @@ export default function VolumeSetting({ source }: { source: Source }) {
   );
 
   return (
-    <div className="space-y-4 min-w-[400px]">
+    <div className="space-y-4 flex-1 sm:flex-none sm:min-w-[400px]">
       <Setting
         on={currentUnreads}
         name="Show Unread Indicator"

--- a/apps/tlon-web/src/dms/BroadcastWindow.tsx
+++ b/apps/tlon-web/src/dms/BroadcastWindow.tsx
@@ -49,12 +49,6 @@ export default function BroadcastWindow({
           scrollElementRef={scrollElementRef}
           isScrolling={isScrolling}
           topLoadEndMarker={prefixedElement}
-          onAtTop={() => {
-            return;
-          }}
-          onAtBottom={() => {
-            return;
-          }}
           hasLoadedOldest={true}
           hasLoadedNewest={true}
         />

--- a/apps/tlon-web/src/dms/DMThread.tsx
+++ b/apps/tlon-web/src/dms/DMThread.tsx
@@ -1,19 +1,9 @@
-import {
-  MessageKey,
-  getKey,
-  getThreadKey,
-} from '@tloncorp/shared/dist/urbit/activity';
+import { MessageKey } from '@tloncorp/shared/dist/urbit/activity';
 import { ReplyTuple } from '@tloncorp/shared/dist/urbit/channel';
 import { formatUd } from '@urbit/aura';
 import bigInt from 'big-integer';
 import cn from 'classnames';
-import React, {
-  useCallback,
-  useEffect,
-  useMemo,
-  useRef,
-  useState,
-} from 'react';
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { useLocation, useNavigate, useParams } from 'react-router';
 import { Link } from 'react-router-dom';
 import { VirtuosoHandle } from 'react-virtuoso';
@@ -23,11 +13,7 @@ import { useEventListener } from 'usehooks-ts';
 import ChatInput from '@/chat/ChatInput/ChatInput';
 import ChatScroller from '@/chat/ChatScroller/ChatScroller';
 import ChatScrollerPlaceholder from '@/chat/ChatScroller/ChatScrollerPlaceholder';
-import {
-  chatStoreLogger,
-  useChatInfo,
-  useChatStore,
-} from '@/chat/useChatStore';
+import { useChatStore } from '@/chat/useChatStore';
 import useLeap from '@/components/Leap/useLeap';
 import MobileHeader from '@/components/MobileHeader';
 import BranchIcon from '@/components/icons/BranchIcon';
@@ -115,12 +101,28 @@ export default function DMThread() {
     [navigate, returnURL, leapIsOpen]
   );
 
-  const onAtBottom = useCallback(() => {
-    const { bottom } = useChatStore.getState();
-    bottom(true);
+  const onAtBottom = useCallback((atBottom: boolean) => {
+    const { threadBottom } = useChatStore.getState();
+    threadBottom(atBottom);
   }, []);
 
   useEventListener('keydown', onEscape, threadRef);
+
+  useEffect(() => {
+    useChatStore.getState().threadBottom(true);
+
+    return () => {
+      useChatStore.getState().threadBottom(false);
+    };
+  }, []);
+
+  useEffect(() => {
+    useChatStore.getState().setCurrentThread(msgKey);
+
+    return () => {
+      useChatStore.getState().setCurrentThread(null);
+    };
+  }, [msgKey]);
 
   if (!writ || isLoading) return null;
 
@@ -205,7 +207,7 @@ export default function DMThread() {
             isScrolling={isScrolling}
             hasLoadedNewest={false}
             hasLoadedOldest={false}
-            onAtBottom={onAtBottom}
+            onAtBottomChange={onAtBottom}
           />
         )}
       </div>

--- a/apps/tlon-web/src/dms/DmWindow.tsx
+++ b/apps/tlon-web/src/dms/DmWindow.tsx
@@ -76,21 +76,27 @@ export default function DmWindow({
     [scrollToInMessages, scrollToIndex, latestMessageIndex]
   );
 
-  const onAtBottom = useCallback(() => {
-    const { bottom } = useChatStore.getState();
-    bottom(true);
-    if (hasPreviousPage && !isFetching) {
-      log('fetching previous page');
-      fetchPreviousPage();
-    }
-  }, [fetchPreviousPage, hasPreviousPage, isFetching]);
+  const onAtBottom = useCallback(
+    (atBottom: boolean) => {
+      const { bottom } = useChatStore.getState();
+      bottom(atBottom);
+      if (atBottom && hasPreviousPage && !isFetching) {
+        log('fetching previous page');
+        fetchPreviousPage();
+      }
+    },
+    [fetchPreviousPage, hasPreviousPage, isFetching]
+  );
 
-  const onAtTop = useCallback(() => {
-    if (hasNextPage && !isFetching) {
-      log('fetching next page');
-      fetchNextPage();
-    }
-  }, [fetchNextPage, hasNextPage, isFetching]);
+  const onAtTop = useCallback(
+    (atTop: boolean) => {
+      if (atTop && hasNextPage && !isFetching) {
+        log('fetching next page');
+        fetchNextPage();
+      }
+    },
+    [fetchNextPage, hasNextPage, isFetching]
+  );
 
   const goToLatest = useCallback(async () => {
     if (idTime) {
@@ -121,10 +127,10 @@ export default function DmWindow({
   ]);
 
   useEffect(() => {
-    useChatStore.getState().setCurrent(whom);
+    useChatStore.getState().setCurrent({ whom });
 
     return () => {
-      useChatStore.getState().setCurrent('');
+      useChatStore.getState().setCurrent(null);
     };
   }, [whom]);
 
@@ -174,8 +180,8 @@ export default function DmWindow({
           scrollElementRef={scrollElementRef}
           isScrolling={isScrolling}
           topLoadEndMarker={prefixedElement}
-          onAtTop={onAtTop}
-          onAtBottom={onAtBottom}
+          onAtTopChange={onAtTop}
+          onAtBottomChange={onAtBottom}
           hasLoadedOldest={!hasNextPage}
           hasLoadedNewest={!hasPreviousPage}
         />

--- a/apps/tlon-web/src/notifications/Notifications.tsx
+++ b/apps/tlon-web/src/notifications/Notifications.tsx
@@ -5,14 +5,12 @@ import { PropsWithChildren, useCallback } from 'react';
 import { Helmet } from 'react-helmet';
 import { Virtuoso } from 'react-virtuoso';
 
-import LoadingSpinner from '@/components/LoadingSpinner/LoadingSpinner';
 import MobileHeader from '@/components/MobileHeader';
 import ReconnectingSpinner from '@/components/ReconnectingSpinner';
 import WelcomeCard from '@/components/WelcomeCard';
 import { useBottomPadding } from '@/logic/position';
 import { useIsMobile } from '@/logic/useMedia';
 import { makePrettyDay, randomElement, randomIntInRange } from '@/logic/utils';
-import { useMarkReadMutation } from '@/state/activity';
 
 import Notification from './Notification';
 import { useNotifications } from './useNotifications';
@@ -91,47 +89,14 @@ function getKey(i: number, { bundle }: NotificationItem): string {
 export default function Notifications({ title }: NotificationsProps) {
   const isMobile = useIsMobile();
   const { paddingBottom } = useBottomPadding();
-  const { loaded, notifications, activity, fetchNextPage, hasNextPage } =
+  const { loaded, notifications, fetchNextPage, hasNextPage } =
     useNotifications();
-  const { mutate, isLoading } = useMarkReadMutation(true);
-  const isMarkReadPending = isLoading;
-  const hasUnreads = activity['notify-count'] > 0;
 
   const getMore = useCallback(() => {
     if (hasNextPage) {
       fetchNextPage();
     }
   }, [hasNextPage]);
-
-  const markAllRead = useCallback(async () => {
-    mutate({ source: { base: null } });
-  }, []);
-
-  const MarkAsRead = (
-    <button
-      disabled={isMarkReadPending || !hasUnreads}
-      className={cn('small-button whitespace-nowrap text-sm', {
-        'bg-gray-400 text-gray-800': isMarkReadPending || !hasUnreads,
-      })}
-      onClick={markAllRead}
-    >
-      {isMarkReadPending ? (
-        <LoadingSpinner className="h-4 w-4" />
-      ) : (
-        `Mark Everything as Read`
-      )}
-    </button>
-  );
-
-  const MobileMarkAsRead = (
-    <button
-      disabled={isMarkReadPending || !hasUnreads}
-      className="whitespace-nowrap text-[17px] font-normal text-gray-800"
-      onClick={markAllRead}
-    >
-      Read Everything
-    </button>
-  );
 
   return (
     <>
@@ -141,7 +106,6 @@ export default function Notifications({ title }: NotificationsProps) {
           action={
             <div className="flex h-12 items-center justify-end space-x-2">
               <ReconnectingSpinner />
-              {hasUnreads && MobileMarkAsRead}
             </div>
           }
         />
@@ -163,7 +127,6 @@ export default function Notifications({ title }: NotificationsProps) {
               <WelcomeCard />
               <div className="mb-6 flex w-full items-center justify-between">
                 <h2 className="text-lg font-bold">Activity</h2>
-                {hasUnreads && MarkAsRead}
               </div>
             </div>
           )}

--- a/apps/tlon-web/src/notifications/Notifications.tsx
+++ b/apps/tlon-web/src/notifications/Notifications.tsx
@@ -1,7 +1,7 @@
 import { ActivityBundle, ActivitySummary } from '@tloncorp/shared/dist/urbit';
 import { ViewProps } from '@tloncorp/shared/dist/urbit/groups';
 import cn from 'classnames';
-import { PropsWithChildren, useCallback } from 'react';
+import { PropsWithChildren, useCallback, useEffect } from 'react';
 import { Helmet } from 'react-helmet';
 import { Virtuoso } from 'react-virtuoso';
 
@@ -11,6 +11,11 @@ import WelcomeCard from '@/components/WelcomeCard';
 import { useBottomPadding } from '@/logic/position';
 import { useIsMobile } from '@/logic/useMedia';
 import { makePrettyDay, randomElement, randomIntInRange } from '@/logic/utils';
+import {
+  emptySummary,
+  useActivity,
+  useOptimisticMarkRead,
+} from '@/state/activity';
 
 import Notification from './Notification';
 import { useNotifications } from './useNotifications';
@@ -91,6 +96,21 @@ export default function Notifications({ title }: NotificationsProps) {
   const { paddingBottom } = useBottomPadding();
   const { loaded, notifications, fetchNextPage, hasNextPage } =
     useNotifications();
+  const { activity, isLoading } = useActivity();
+  const markRead = useOptimisticMarkRead('base');
+
+  useEffect(() => {
+    const hasActivity = Object.keys(activity).length > 0;
+    const base = activity['base'] || emptySummary;
+    const baseIsRead =
+      base.count === 0 &&
+      base.unread === null &&
+      !base.notify &&
+      base['notify-count'] === 0;
+    if (hasActivity && !baseIsRead && !isLoading) {
+      markRead();
+    }
+  }, [activity, isLoading]);
 
   const getMore = useCallback(() => {
     if (hasNextPage) {

--- a/apps/tlon-web/src/state/activity.ts
+++ b/apps/tlon-web/src/state/activity.ts
@@ -16,6 +16,7 @@ import {
   VolumeMap,
   VolumeSettings,
   getKey,
+  getThreadKey,
   sourceToString,
   stripSourcePrefix,
 } from '@tloncorp/shared/dist/urbit/activity';
@@ -25,7 +26,7 @@ import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import api from '@/api';
 import { useChatStore } from '@/chat/useChatStore';
 import useReactQueryScry from '@/logic/useReactQueryScry';
-import { createDevLogger } from '@/logic/utils';
+import { createDevLogger, whomIsDm, whomIsFlag } from '@/logic/utils';
 import queryClient from '@/queryClient';
 
 import { useLocalState } from './local';
@@ -146,6 +147,10 @@ function optimisticActivityUpdate(d: Activity, source: string): Activity {
   };
 }
 
+function isRead(summary: ActivitySummary) {
+  return summary.unread === null;
+}
+
 function updateActivity({
   main,
   threads,
@@ -153,19 +158,88 @@ function updateActivity({
   main: Activity;
   threads: Record<string, Activity>;
 }) {
-  // TODO: actually mark read here
-  // const { current, atBottom } = useChatStore.getState();
-  // const source = getKey(current);
-  // const inFocus = useLocalState.getState().inFocus;
-  // const filteredMain =
-  //   inFocus && atBottom && source in main
-  //     ? optimisticActivityUpdate(main, source)
-  //     : main;
-  // console.log({ inFocus, source, atBottom, filteredMain });
+  const { current, currentThread, atBottom, atThreadBottom } =
+    useChatStore.getState();
+  const source = current ? getKey(current.whom) : null;
+  const threadSource =
+    current && currentThread
+      ? getThreadKey(
+          current.whom,
+          whomIsFlag(current.whom) ? currentThread.time : currentThread.id
+        )
+      : null;
+  const threadActivity = source ? threads[source] || null : null;
+  const inFocus = useLocalState.getState().inFocus;
+  const filteredMain =
+    inFocus &&
+    atBottom &&
+    source &&
+    source in main &&
+    threadActivity === null &&
+    !isRead(main[source])
+      ? optimisticActivityUpdate(main, source)
+      : undefined;
+  const filteredThread =
+    inFocus &&
+    atThreadBottom &&
+    threadActivity &&
+    threadSource &&
+    threadSource in threadActivity &&
+    !isRead(threadActivity[threadSource])
+      ? optimisticActivityUpdate(threadActivity, threadSource)
+      : undefined;
+
+  if (filteredMain && current) {
+    const nest = `chat/${current.whom}`;
+    const source = whomIsFlag(current.whom)
+      ? current.group
+        ? { channel: { group: current.group, nest } }
+        : null
+      : {
+          dm: whomIsDm(current.whom)
+            ? { ship: current.whom }
+            : { club: current.whom },
+        };
+
+    if (source) {
+      api.poke<ActivityAction>(
+        activityAction({
+          read: { source, action: { all: { time: null, deep: false } } },
+        })
+      );
+    }
+  }
+
+  if (filteredThread && current && currentThread) {
+    const nest = `chat/${current.whom}`;
+    const source = whomIsFlag(current.whom)
+      ? current.group
+        ? {
+            thread: { group: current.group, channel: nest, key: currentThread },
+          }
+        : null
+      : {
+          'dm-thread': {
+            whom: whomIsDm(current.whom)
+              ? { ship: current.whom }
+              : { club: current.whom },
+            key: currentThread,
+          },
+        };
+
+    if (source) {
+      api.poke<ActivityAction>(
+        activityAction({
+          read: { source, action: { all: { time: null, deep: false } } },
+        })
+      );
+    }
+  }
+
   queryClient.setQueryData(unreadsKey(), (d: Activity | undefined) => {
     return {
       ...d,
-      ...main,
+      ...(filteredMain ? filteredMain : main),
     };
   });
 
@@ -175,7 +249,7 @@ function updateActivity({
       (d: Activity | undefined) => {
         return {
           ...d,
-          ...value,
+          ...(filteredThread && key === source ? filteredThread : value),
         };
       }
     );

--- a/apps/tlon-web/src/state/activity.ts
+++ b/apps/tlon-web/src/state/activity.ts
@@ -131,7 +131,14 @@ function activityVolumeUpdates(events: ActivityVolumeUpdate[]) {
   }, {} as VolumeSettings);
 }
 
-function optimisticActivityUpdate(d: Activity, source: string): Activity {
+function optimisticActivityUpdate(
+  d: Activity | undefined,
+  source: string
+): Activity | undefined {
+  if (!d) {
+    return d;
+  }
+
   const old = d[source];
   return {
     ...d,
@@ -141,7 +148,7 @@ function optimisticActivityUpdate(d: Activity, source: string): Activity {
       count: Math.min(0, old.count - (old.unread?.count || 0)),
       'notify-count':
         old.unread && old.unread.notify
-          ? Math.min(old['notify-count'] - old.unread.count)
+          ? Math.min(0, old['notify-count'] - old.unread.count)
           : old['notify-count'],
     },
   };
@@ -609,4 +616,25 @@ export function useCombinedGroupUnreads() {
       notify: acc.notify || source.notify,
     };
   }, defaultUnread);
+}
+
+export function useOptimisticMarkRead(source: string) {
+  return useCallback(() => {
+    queryClient.setQueryData<Activity>(unreadsKey(), (d) => {
+      if (d === undefined) {
+        return undefined;
+      }
+
+      return {
+        ...d,
+        [source]: {
+          ...d[source],
+          unread: null,
+          count: 0,
+          notify: false,
+          'notify-count': 0,
+        },
+      };
+    });
+  }, [source]);
 }

--- a/apps/tlon-web/src/state/activity.ts
+++ b/apps/tlon-web/src/state/activity.ts
@@ -131,14 +131,7 @@ function activityVolumeUpdates(events: ActivityVolumeUpdate[]) {
   }, {} as VolumeSettings);
 }
 
-function optimisticActivityUpdate(
-  d: Activity | undefined,
-  source: string
-): Activity | undefined {
-  if (!d) {
-    return d;
-  }
-
+function optimisticActivityUpdate(d: Activity, source: string): Activity {
   const old = d[source];
   return {
     ...d,
@@ -374,8 +367,8 @@ export function useMarkReadMutation(recursive = false) {
   const mutationFn = async (variables: {
     source: Source;
     action?: ReadAction;
-  }) => {
-    await api.poke(
+  }) =>
+    api.poke(
       activityAction({
         read: {
           source: variables.source,
@@ -383,12 +376,14 @@ export function useMarkReadMutation(recursive = false) {
         },
       })
     );
-  };
 
   return useMutation({
     mutationFn,
     onMutate: async (variables) => {
       const current = queryClient.getQueryData<Activity>(unreadsKey());
+      variables.action = variables.action || {
+        all: { time: null, deep: recursive },
+      };
       queryClient.setQueryData<Activity>(unreadsKey(), (d) => {
         if (d === undefined) {
           return undefined;


### PR DESCRIPTION
Fixes TLON-2419 by mimicking what mobile does, basically clearing the bell any time you visit and bringing it back upon new relevant activity. This also fixes optimistic reads which were not happening because we defaulted `variables.action` in the mutation function and didn't account for that later on.

Button moved to settings but not sure what language we want here:
<img width="640" alt="image" src="https://github.com/user-attachments/assets/4e404b44-02ed-4689-b301-8dfc5c0a818d">


PR Checklist
- [ ] Includes changes to desk files
- [ ] Describes how you tested the PR locally (test ship vs livenet)
- [ ] If a new feature, includes automated tests
- [ ] Comments added anywhere logic may be confusing without context