### PR TITLE
native: handle failed authentication

### DIFF
--- a/packages/shared/src/api/landscapeApi.ts
+++ b/packages/shared/src/api/landscapeApi.ts
@@ -11,5 +11,9 @@ export const getLandscapeAuthCookie = async (
     credentials: 'include',
   });
 
+  if (response.status < 200 || response.status > 299) {
+    throw new Error('Failed to authenticate. Is your access code correct?');
+  }
+
   return response.headers.get('set-cookie')?.split(';')[0];
 };


### PR DESCRIPTION
We now check the response for the authentication request. Bad access code returns `400`, so we just look to see that the response falls within the `200`s. The throw causes red error text to be displayed on the login screen and the user can try again.

Fixes TLON-2262