### PR TITLE
native: make sure images/refs always appear before text in chat messages

### DIFF
--- a/apps/tlon-mobile/src/fixtures/MessageInput.fixture.tsx
+++ b/apps/tlon-mobile/src/fixtures/MessageInput.fixture.tsx
@@ -12,6 +12,7 @@ const ChatMessageInputFixture = () => {
     <FixtureWrapper fillWidth>
       <View backgroundColor="$background">
         <MessageInput
+          channelType="notebook"
           shouldBlur={inputShouldBlur}
           setShouldBlur={setInputShouldBlur}
           send={async () => {}}

--- a/packages/ui/src/components/Channel/index.tsx
+++ b/packages/ui/src/components/Channel/index.tsx
@@ -344,6 +344,7 @@ export function Channel({
                                   editingPost={editingPost}
                                   setEditingPost={setEditingPost}
                                   editPost={editPost}
+                                  channelType={channel.type}
                                   showAttachmentButton={
                                     channel.type !== 'gallery'
                                   }

--- a/packages/ui/src/components/ChatMessage/ChatMessage.tsx
+++ b/packages/ui/src/components/ChatMessage/ChatMessage.tsx
@@ -182,6 +182,7 @@ const ChatMessage = ({
             editingPost={post}
             editPost={editPost}
             setEditingPost={setEditingPost}
+            channelType="chat"
           />
         ) : post.hidden ? (
           <Text color="$secondaryText">

--- a/packages/ui/src/components/ContentRenderer.tsx
+++ b/packages/ui/src/components/ContentRenderer.tsx
@@ -1,4 +1,5 @@
 import { extractContentTypesFromPost, utils } from '@tloncorp/shared';
+import { Post, PostDeliveryStatus } from '@tloncorp/shared/dist/db';
 import {
   Block,
   Code,
@@ -26,7 +27,6 @@ import {
 } from '@tloncorp/shared/dist/urbit/content';
 import { ImageLoadEventData } from 'expo-image';
 import { truncate } from 'lodash';
-import { Post, PostDeliveryStatus } from 'packages/shared/dist/db';
 import {
   ComponentProps,
   ReactElement,

--- a/packages/ui/src/components/DetailView/DetailView.tsx
+++ b/packages/ui/src/components/DetailView/DetailView.tsx
@@ -168,6 +168,7 @@ const DetailViewFrameComponent = ({
           getDraft={getDraft}
           backgroundColor="$background"
           showAttachmentButton={false}
+          channelType="chat"
           placeholder="Reply"
           setHeight={setMessageInputHeight}
           // TODO: add back in when we switch to bottom nav

--- a/packages/ui/src/components/MessageInput/MessageInputBase.tsx
+++ b/packages/ui/src/components/MessageInput/MessageInputBase.tsx
@@ -45,7 +45,7 @@ export interface MessageInputProps {
   title?: string;
   image?: UploadedFile;
   showToolbar?: boolean;
-  channelType?: db.ChannelType;
+  channelType: db.ChannelType;
   initialHeight?: number;
   // for external access to height
   setHeight?: (height: number) => void;

--- a/packages/ui/src/components/MessageInput/index.native.tsx
+++ b/packages/ui/src/components/MessageInput/index.native.tsx
@@ -518,7 +518,11 @@ export const MessageInput = forwardRef<MessageInputHandle, MessageInputProps>(
         }
 
         if (blocks && blocks.length > 0) {
-          story.push(...blocks.map((block) => ({ block })));
+          if (channelType === 'chat') {
+            story.unshift(...blocks.map((block) => ({ block })));
+          } else {
+            story.push(...blocks.map((block) => ({ block })));
+          }
         }
 
         if (isEdit && editingPost) {
@@ -563,6 +567,7 @@ export const MessageInput = forwardRef<MessageInputHandle, MessageInputProps>(
         title,
         image,
         imageOnEditedPost,
+        channelType,
       ]
     );
 

--- a/packages/ui/src/components/PostScreenView.tsx
+++ b/packages/ui/src/components/PostScreenView.tsx
@@ -203,6 +203,7 @@ export function PostScreenView({
                       groupMembers={groupMembers}
                       storeDraft={storeDraft}
                       clearDraft={clearDraft}
+                      channelType="chat"
                       getDraft={getDraft}
                     />
                   )}


### PR DESCRIPTION
fixes TLON-2416

Only affects images/refs inserted into the story at the time the message is sent. Feels cleaner than modifying the content renderer with a special case for chat.