### PR TITLE
activity: fix thread marking

### DIFF
--- a/apps/tlon-web/src/chat/ChatThread/ChatThread.tsx
+++ b/apps/tlon-web/src/chat/ChatThread/ChatThread.tsx
@@ -143,7 +143,6 @@ export default function ChatThread() {
   );
 
   const onAtBottom = useCallback((atBottom: boolean) => {
-    console.log('thread bottom called', atBottom);
     const { threadBottom } = useChatStore.getState();
     threadBottom(atBottom);
   }, []);

--- a/apps/tlon-web/src/diary/DiaryChannel.tsx
+++ b/apps/tlon-web/src/diary/DiaryChannel.tsx
@@ -45,7 +45,7 @@ function DiaryChannel({ title }: ViewProps) {
     hasNextPage,
     fetchNextPage,
   } = useInfinitePosts(nest);
-  const { markRead } = useMarkChannelRead(nest);
+  const { markRead } = useMarkChannelRead(nest, undefined, true);
   const loadOlderNotes = useCallback(
     (atBottom: boolean) => {
       if (atBottom && hasNextPage) {

--- a/apps/tlon-web/src/state/activity.ts
+++ b/apps/tlon-web/src/state/activity.ts
@@ -133,6 +133,10 @@ function activityVolumeUpdates(events: ActivityVolumeUpdate[]) {
 
 function optimisticActivityUpdate(d: Activity, source: string): Activity {
   const old = d[source];
+  if (old === undefined) {
+    return d;
+  }
+
   return {
     ...d,
     [source]: {
@@ -384,7 +388,12 @@ export function useMarkReadMutation(recursive = false) {
       variables.action = variables.action || {
         all: { time: null, deep: recursive },
       };
-      queryClient.setQueryData<Activity>(unreadsKey(), (d) => {
+
+      const key =
+        'thread' in variables.source || 'dm-thread' in variables.source
+          ? unreadsKey('threads', sourceToString(variables.source))
+          : unreadsKey();
+      queryClient.setQueryData<Activity>(key, (d) => {
         if (d === undefined) {
           return undefined;
         }

--- a/apps/tlon-web/src/state/activity.ts
+++ b/apps/tlon-web/src/state/activity.ts
@@ -389,10 +389,23 @@ export function useMarkReadMutation(recursive = false) {
         all: { time: null, deep: recursive },
       };
 
-      const key =
-        'thread' in variables.source || 'dm-thread' in variables.source
-          ? unreadsKey('threads', sourceToString(variables.source))
-          : unreadsKey();
+      let key = unreadsKey();
+
+      if ('thread' in variables.source || 'dm-thread' in variables.source) {
+        const parent =
+          'thread' in variables.source
+            ? {
+                channel: {
+                  group: variables.source.thread.group,
+                  nest: variables.source.thread.channel,
+                },
+              }
+            : {
+                dm: variables.source['dm-thread'].whom,
+              };
+        key = unreadsKey('threads', sourceToString(parent));
+      }
+
       queryClient.setQueryData<Activity>(key, (d) => {
         if (d === undefined) {
           return undefined;


### PR DESCRIPTION
In my last PR https://github.com/tloncorp/tlon-apps/pull/3780 I fixed optimistic reading, but there was a bug exposed now that it's being used. This fixes the issue where threads were unable to be read. Also noticed notebooks weren't marking recursively so added that in too.

PR Checklist
- [ ] Includes changes to desk files
- [ ] Describes how you tested the PR locally (test ship vs livenet)
- [ ] If a new feature, includes automated tests
- [ ] Comments added anywhere logic may be confusing without context