### PR TITLE
streamline init sync

### DIFF
--- a/apps/tlon-mobile/ios/Landscape/UrbitModule.swift
+++ b/apps/tlon-mobile/ios/Landscape/UrbitModule.swift
@@ -77,6 +77,8 @@ class UrbitModule: NSObject {
         UrbitModule.shipUrl = shipUrl
         UrbitModule.authCookie = authCookie
         Task {
+            // Delay this a bit so that js init requests have time to fire
+            try? await Task.sleep(for: .seconds(10))
             try? await UrbitAPI.shared.open(for: shipUrl)
             try? await PocketUserAPI.fetchSettings()
         }

--- a/apps/tlon-mobile/src/components/AuthenticatedApp.tsx
+++ b/apps/tlon-mobile/src/components/AuthenticatedApp.tsx
@@ -46,7 +46,7 @@ function AuthenticatedApp({
   }, [currentUserId, ship, shipUrl]);
 
   useAppForegrounded(() => {
-    sync.syncUnreads(sync.SyncPriority.High);
+    sync.syncUnreads({ priority: sync.SyncPriority.High });
   });
 
   return (

--- a/apps/tlon-mobile/src/screens/ChannelScreen.tsx
+++ b/apps/tlon-mobile/src/screens/ChannelScreen.tsx
@@ -28,10 +28,9 @@ export default function ChannelScreen(props: ChannelScreenProps) {
       if (props.route.params.channel.group?.isNew) {
         store.markGroupVisited(props.route.params.channel.group);
       }
-      store.syncChannelThreadUnreads(
-        props.route.params.channel.id,
-        store.SyncPriority.High
-      );
+      store.syncChannelThreadUnreads(props.route.params.channel.id, {
+        priority: store.SyncPriority.High,
+      });
     }, [props.route.params.channel])
   );
   useFocusEffect(

--- a/apps/tlon-mobile/src/screens/ChatListScreen.tsx
+++ b/apps/tlon-mobile/src/screens/ChatListScreen.tsx
@@ -21,7 +21,7 @@ import {
   View,
   WelcomeSheet,
 } from '@tloncorp/ui';
-import { useCallback, useEffect, useMemo, useState } from 'react';
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import ContextMenu from 'react-native-context-menu-view';
 
 import AddGroupSheet from '../components/AddGroupSheet';
@@ -81,9 +81,14 @@ export default function ChatListScreen(
     };
   }, [chats]);
 
+  const isInitialFocus = useRef(true);
+
   useFocusEffect(
     useCallback(() => {
-      store.syncPinnedItems({ priority: store.SyncPriority.High });
+      if (!isInitialFocus) {
+        store.syncPinnedItems({ priority: store.SyncPriority.High });
+      }
+      isInitialFocus.current = false;
     }, [])
   );
 

--- a/apps/tlon-mobile/src/screens/ChatListScreen.tsx
+++ b/apps/tlon-mobile/src/screens/ChatListScreen.tsx
@@ -83,7 +83,7 @@ export default function ChatListScreen(
 
   useFocusEffect(
     useCallback(() => {
-      store.syncPinnedItems(store.SyncPriority.High);
+      store.syncPinnedItems({ priority: store.SyncPriority.High });
     }, [])
   );
 

--- a/apps/tlon-mobile/src/screens/GroupSettings/useGroupContext.ts
+++ b/apps/tlon-mobile/src/screens/GroupSettings/useGroupContext.ts
@@ -14,7 +14,7 @@ export const useGroupContext = ({ groupId }: { groupId: string }) => {
 
   useEffect(() => {
     if (groupId) {
-      sync.syncGroup(groupId, store.SyncPriority.High);
+      sync.syncGroup(groupId, { priority: store.SyncPriority.High });
     }
   }, [groupId]);
 

--- a/apps/tlon-mobile/src/screens/useChannelContext.ts
+++ b/apps/tlon-mobile/src/screens/useChannelContext.ts
@@ -37,7 +37,9 @@ export const useChannelContext = ({
 
   useEffect(() => {
     if (channelQuery.data?.groupId) {
-      store.syncGroup(channelQuery.data?.groupId, store.SyncPriority.Low);
+      store.syncGroup(channelQuery.data?.groupId, {
+        priority: store.SyncPriority.Low,
+      });
     }
   }, [channelQuery.data?.groupId]);
 

--- a/packages/shared/src/api/postsApi.ts
+++ b/packages/shared/src/api/postsApi.ts
@@ -382,23 +382,20 @@ export type GetLatestPostsResponse = PostWithUpdateTime[];
 export const getLatestPosts = async ({
   afterCursor,
   count,
-  type,
 }: {
   afterCursor?: Cursor;
   count?: number;
-  type: 'channels' | 'chats';
 }): Promise<GetLatestPostsResponse> => {
-  const response = await scry<ub.ChannelHeadsResponse | ub.ChatHeadsResponse>({
-    app: type === 'channels' ? 'channels' : 'chat',
+  const { channels, dms } = await scry<ub.CombinedHeads>({
+    app: 'groups-ui',
     path: formatScryPath(
-      type === 'channels' ? 'v2' : null,
-      'heads',
+      'v1/heads',
       afterCursor ? formatCursor(afterCursor) : null,
       count
     ),
   });
 
-  return response.map((head) => {
+  return [...channels, ...dms].map((head) => {
     const channelId = 'nest' in head ? head.nest : head.whom;
     const latestPost = toPostData(channelId, head.latest);
     return {

--- a/packages/shared/src/db/queries.ts
+++ b/packages/shared/src/db/queries.ts
@@ -1013,8 +1013,8 @@ export const getAllUnreadsCounts = createReadQuery(
   'getAllUnreadCounts',
   async (ctx: QueryCtx) => {
     const [channelUnreadCount, dmUnreadCount] = await Promise.all([
-      getUnreadsCount({ type: 'channel' }),
-      getUnreadsCount({ type: 'dm' }),
+      getUnreadsCount({ type: 'channel' }, ctx),
+      getUnreadsCount({ type: 'dm' }, ctx),
     ]);
     return {
       channels: channelUnreadCount ?? 0,
@@ -1837,17 +1837,17 @@ async function insertPosts(posts: Post[], ctx: QueryCtx) {
   logger.log('clear matched pending');
 }
 
-export const insertHiddenPosts = createWriteQuery(
-  'insertHiddenPosts',
+export const resetHiddenPosts = createWriteQuery(
+  'resetHiddenPosts',
   async (postIds: string[], ctx: QueryCtx) => {
     if (postIds.length === 0) return;
 
-    logger.log('insertHiddenPosts', postIds);
+    logger.log('resetHiddenPosts', postIds);
 
     await ctx.db
       .update($posts)
-      .set({ hidden: true })
-      .where(inArray($posts.id, postIds));
+      .set({ hidden: inArray($posts.id, postIds) })
+      .where(or($posts.hidden, inArray($posts.id, postIds)));
   },
   ['posts']
 );

--- a/packages/shared/src/logic/utils.ts
+++ b/packages/shared/src/logic/utils.ts
@@ -502,10 +502,11 @@ export const getCompositeGroups = (
   });
 };
 
-interface RetryConfig {
+export interface RetryConfig {
   startingDelay?: number;
   numOfAttempts?: number;
 }
+
 export const withRetry = (fn: () => Promise<any>, config?: RetryConfig) => {
   return backOff(fn, {
     delayFirstAttempt: false,

--- a/packages/shared/src/store/sync.ts
+++ b/packages/shared/src/store/sync.ts
@@ -971,9 +971,6 @@ export const syncStart = async (alreadySubscribed?: boolean) => {
     syncPushNotificationsSetting({ priority: SyncPriority.Low }).then(() =>
       reporter.log(`finished syncing push notifications setting`)
     ),
-    syncBlockedUsers({ priority: SyncPriority.Low }).then(() => {
-      reporter.log(`finished syncing blocked users`);
-    }),
     syncAppInfo({ priority: SyncPriority.Low }).then(() => {
       reporter.log(`finished syncing app info`);
     }),

--- a/packages/shared/src/store/syncQueue.ts
+++ b/packages/shared/src/store/syncQueue.ts
@@ -1,13 +1,14 @@
 import { createDevLogger, runIfDev } from '../debug';
+import { RetryConfig, withRetry } from '../logic';
 
-const logger = createDevLogger('syncQueue', false);
+const logger = createDevLogger('syncQueue', true);
 
 interface SyncOperation {
   label: string;
+  ctx: SyncCtx;
   action: () => Promise<any>;
   resolve: (result: any) => void;
   reject: (err: unknown) => void;
-  priority: number;
   addedAt: number;
 }
 
@@ -18,11 +19,17 @@ export const SyncPriority = {
   High: 10,
 };
 
+export type SyncCtx = {
+  priority: number;
+  retry?: boolean | RetryConfig;
+};
+
 export class QueueClearedError extends Error {}
 
 class SyncQueue {
-  concurrency = 3;
+  concurrency = 5;
   queue: SyncOperation[];
+  pendingOperations: SyncOperation[] = [];
   isSyncing: boolean;
   activeThreads = 0;
 
@@ -32,57 +39,74 @@ class SyncQueue {
   }
 
   highPriority<T>(label: string, action: () => Promise<T>) {
-    return this.add(label, SyncPriority.High, action);
+    return this.add(label, { priority: SyncPriority.High }, action);
   }
 
   mediumPriority<T>(label: string, action: () => Promise<T>) {
-    return this.add(label, SyncPriority.Medium, action);
+    return this.add(label, { priority: SyncPriority.Medium }, action);
   }
 
   lowPriority<T>(label: string, action: () => Promise<T>) {
-    return this.add(label, SyncPriority.Low, action);
+    return this.add(label, { priority: SyncPriority.Low }, action);
   }
 
-  add<T>(label: string, priority: number, action: () => Promise<T>) {
+  add<T>(
+    label: string,
+    ctx: SyncCtx | undefined | null,
+    action: () => Promise<T>
+  ) {
+    const defaults = { priority: SyncPriority.Medium };
+    const ctxWithDefaults = ctx ? { ...defaults, ...ctx } : defaults;
     const startTime = Date.now();
-    logger.log('pending:' + label, 'priority', priority);
+    logger.log('pending:' + label, 'priority', ctxWithDefaults.priority);
 
     return new Promise<T>((resolve, reject) => {
-      const enqueueOperation = () => {
-        const operation = {
-          label,
-          action,
-          resolve,
-          reject,
-          priority,
-          addedAt: startTime,
-        };
-        this.queue.push(operation);
-        this.queue.sort((a, b) => {
-          if (a.priority === b.priority) {
-            return b.addedAt - a.addedAt;
-          }
-          return b.priority - a.priority;
-        });
-        logger.log(
-          'enqueued:' + label,
-          'priority',
-          priority,
-          'position',
-          runIfDev(() => {
-            return this.queue.indexOf(operation) + 1 + '/' + this.queue.length;
-          })
-        );
-        this.syncNext();
+      const operation = {
+        label,
+        ctx: ctxWithDefaults,
+        action,
+        resolve,
+        reject,
+        addedAt: startTime,
       };
-      if (priority < SyncPriority.High) {
-        delay(priority < SyncPriority.Medium ? 500 : 200).then(
-          enqueueOperation
-        );
-      } else {
-        enqueueOperation();
+      this.pendingOperations.unshift(operation);
+      if (this.pendingOperations.length === 1) {
+        queueMicrotask(() => this.flushPending());
       }
     });
+  }
+
+  flushPending() {
+    const pendingOperations = this.pendingOperations;
+    this.pendingOperations = [];
+    this.queue.push(...pendingOperations);
+    this.queue.sort((a, b) => {
+      if (a.ctx.priority === b.ctx.priority) {
+        return b.addedAt - a.addedAt;
+      }
+      return b.ctx.priority - a.ctx.priority;
+    });
+    pendingOperations
+      .sort((a, b) => {
+        if (a.ctx.priority === b.ctx.priority) {
+          return b.addedAt - a.addedAt;
+        }
+        return b.ctx.priority - a.ctx.priority;
+      })
+      .forEach((op) => {
+        logger.log(
+          'enqueued:' + op.label,
+          'priority',
+          op.ctx.priority,
+          'position',
+          runIfDev(() => {
+            return this.queue.indexOf(op) + 1 + '/' + this.queue.length;
+          })()
+        );
+      });
+    for (let i = 0; i < pendingOperations.length; i++) {
+      this.syncNext();
+    }
   }
 
   clear() {
@@ -96,8 +120,8 @@ class SyncQueue {
     if (this.queue.length === 0) return;
     // Try to ensure that low priority tasks don't block the queue
     if (
-      this.queue[0].priority < SyncPriority.Medium &&
-      this.activeThreads > 0
+      this.queue[0].ctx.priority < SyncPriority.Medium &&
+      this.activeThreads > this.concurrency - 2
     ) {
       return;
     }
@@ -105,10 +129,23 @@ class SyncQueue {
     while (this.queue.length) {
       logger.log('next:thread:' + threadId, 'remaining:' + this.queue.length);
       const loadStartTime = Date.now();
-      const { label, action, resolve, reject, addedAt } = this.queue.shift()!;
+      const { ctx, label, action, resolve, reject, addedAt } =
+        this.queue.shift()!;
       try {
-        logger.log('loading:' + label, threadId);
-        const result = await action();
+        logger.log('loading:' + label, 'on thread', threadId);
+        const baseRetryOptions = {
+          delayFirstAttempt: false,
+          startingDelay: 1000,
+          numOfAttempts: 4,
+        };
+        const retryOptions = ctx.retry
+          ? typeof ctx.retry === 'boolean'
+            ? baseRetryOptions
+            : { ...baseRetryOptions, ...ctx.retry }
+          : null;
+        const result = await (retryOptions
+          ? withRetry(action, retryOptions)
+          : action());
         setTimeout(() => resolve(result), 0);
       } catch (e) {
         logger.log('failed:' + label, threadId, e);
@@ -128,10 +165,6 @@ class SyncQueue {
     }
     --this.activeThreads;
   }
-}
-
-function delay(duration: number) {
-  return new Promise((resolve) => setTimeout(resolve, duration));
 }
 
 export const syncQueue = new SyncQueue();

--- a/packages/shared/src/store/useChannelPosts.ts
+++ b/packages/shared/src/store/useChannelPosts.ts
@@ -56,7 +56,7 @@ export const useChannelPosts = (options: UseChanelPostsParams) => {
       const queryOptions = ctx.pageParam || options;
       postsLogger.log('loading posts', queryOptions);
       if (queryOptions.mode === 'newest' && !options.hasCachedNewest) {
-        await sync.syncPosts(queryOptions, SyncPriority.High);
+        await sync.syncPosts(queryOptions, { priority: SyncPriority.High });
       }
       const cached = await db.getChannelPosts(queryOptions);
       if (cached?.length) {
@@ -69,7 +69,7 @@ export const useChannelPosts = (options: UseChanelPostsParams) => {
           ...queryOptions,
           count: options.count ?? 50,
         },
-        SyncPriority.High
+        { priority: SyncPriority.High }
       );
       postsLogger.log('loaded', res.posts?.length, 'posts from api');
       const secondResult = await db.getChannelPosts(queryOptions);
@@ -227,7 +227,7 @@ function useRefreshPosts(channelId: string, posts: db.Post[] | null) {
             channelId,
             authorId: post.authorId,
           },
-          4
+          { priority: 4 }
         );
         pendingStalePosts.current.add(post.id);
       }

--- a/packages/shared/src/urbit/ui.ts
+++ b/packages/shared/src/urbit/ui.ts
@@ -1,6 +1,6 @@
 import { Activity } from './activity';
-import { Channels } from './channel';
-import { DMInit, DMInit2 } from './dms';
+import { ChannelHeadsResponse, Channels } from './channel';
+import { ChatHeadsResponse, DMInit, DMInit2 } from './dms';
 import { Gangs, Groups } from './groups';
 
 // v4
@@ -23,4 +23,9 @@ export interface GroupsInit4 {
   activity: Activity;
   pins: string[];
   chat: DMInit2;
+}
+
+export interface CombinedHeads {
+  dms: ChatHeadsResponse;
+  channels: ChannelHeadsResponse;
 }

--- a/packages/ui/src/components/GroupOptionsSheet.tsx
+++ b/packages/ui/src/components/GroupOptionsSheet.tsx
@@ -46,11 +46,11 @@ export function ChatOptionsSheet({
 
   useEffect(() => {
     if (group?.id) {
-      sync.syncGroup(group.id, store.SyncPriority.High);
+      sync.syncGroup(group.id, { priority: store.SyncPriority.High });
     }
 
     if (channel?.groupId) {
-      sync.syncGroup(channel.groupId, store.SyncPriority.High);
+      sync.syncGroup(channel.groupId, { priority: store.SyncPriority.High });
     }
   }, [group?.id, channel?.groupId]);
 


### PR DESCRIPTION
Before
<img width="1321" alt="Screenshot 2024-07-22 at 5 42 02 PM" src="https://github.com/user-attachments/assets/348ce8cf-d589-4034-80f0-59267e4937c9">

After (critical info pops in faster + total duration is ~3-4s less)
<img width="1321" alt="Screenshot 2024-07-22 at 5 40 56 PM" src="https://github.com/user-attachments/assets/db51199d-2796-4cfd-9812-7cede07dbd37">
