### PR TITLE
misc: cleanup activity layout and fix groups preview fetch

### DIFF
--- a/apps/tlon-web/src/logic/useScrollerMessages.ts
+++ b/apps/tlon-web/src/logic/useScrollerMessages.ts
@@ -42,11 +42,8 @@ const getNewDayAndNewAuthorFromLastWrit = (
     prevWrit &&
     'essay' in prevWrit &&
     !!getKindDataFromEssay(prevWrit.essay).notice;
-  const newAuthor = prevIsNotice
-    ? false
-    : !author || !prevAuthor
-      ? true
-      : author !== prevAuthor;
+  const newAuthor =
+    prevIsNotice || !author || !prevAuthor ? true : author !== prevAuthor;
   const newDay = !prevKey
     ? true
     : getDay(prevKey, messageDays) !== getDay(key, messageDays);

--- a/apps/tlon-web/src/notifications/DMNotification.tsx
+++ b/apps/tlon-web/src/notifications/DMNotification.tsx
@@ -50,10 +50,8 @@ function DMNotification({
           <Avatar size="default-sm" ship={author} />
         </div>
         <div className="min-w-0 grow-0 break-words p-1 space-y-2">
-          <div className="flex items-center space-x-1">
-            <ChatSmallIcon className="h-4 w-4" />
-            <ActivitySummary top={top} bundle={bundle} relevancy={relevancy} />
-          </div>
+          <ChatSmallIcon className="h-4 w-4" />
+          <ActivitySummary top={top} bundle={bundle} relevancy={relevancy} />
           {content ? (
             <div className="text-black py-1 leading-5">
               <ChatContent story={truncateProse(content, 360)} />

--- a/apps/tlon-web/src/notifications/Notifications.tsx
+++ b/apps/tlon-web/src/notifications/Notifications.tsx
@@ -78,7 +78,7 @@ function VirtualNotification(
   return (
     <div key={bundle.latest} className="py-2">
       {newDay && (
-        <h2 className="mt-2 mb-4 font-sans text-[17px] font-normal leading-[22px] text-gray-400">
+        <h2 className="mb-4 font-sans text-[17px] font-normal leading-[22px] text-gray-400">
           {makePrettyDay(date)}
         </h2>
       )}
@@ -141,7 +141,7 @@ export default function Notifications({ title }: NotificationsProps) {
           <title>{title}</title>
         </Helmet>
 
-        <div className="flex flex-col card h-full pt-6 sm:py-6 sm:mb-6">
+        <div className="flex flex-col card h-full p-2 pr-0 sm:p-6 sm:mb-6">
           {!isMobile && (
             <div className="flex-none">
               <WelcomeCard />

--- a/apps/tlon-web/src/state/chat/chat.ts
+++ b/apps/tlon-web/src/state/chat/chat.ts
@@ -747,9 +747,7 @@ export function useDmRsvpMutation() {
     markRead({
       source: { dm: { ship } },
       action: {
-        event: {
-          'dm-invite': { ship },
-        },
+        all: { time: null, deep: false },
       },
     });
 
@@ -920,9 +918,7 @@ export function useMutliDmRsvpMutation() {
     markRead({
       source: { dm: { club: id } },
       action: {
-        event: {
-          'dm-invite': { club: id },
-        },
+        all: { time: null, deep: false },
       },
     });
     return api.poke(action);

--- a/desk/app/groups.hoon
+++ b/desk/app/groups.hoon
@@ -1927,7 +1927,7 @@
       =/  =wire  (welp ga-area /preview)
       =/  =dock  [p.flag dap.bowl]
       =/  =path  /groups/(scot %p p.flag)/[q.flag]/preview
-      =/  watch  [%pass wire %agent dock %watch wire]
+      =/  watch  [%pass wire %agent dock %watch path]
       ^+  cor
       %-  emil
       ?:  =(p.flag our.bowl)  ~[watch]


### PR DESCRIPTION
We had some weird spacing on mobile here so I removed some of the padding to help it have more room. Also found the issue with group preview fetching (although I still think there are other problems with it). Also fixed an issue where the author row wouldn't show up after a notice.

PR Checklist
- [X] Includes changes to desk files
- [ ] Describes how you tested the PR locally (test ship vs livenet)
- [ ] If a new feature, includes automated tests
- [ ] Comments added anywhere logic may be confusing without context