### PR TITLE
activity: fix bump hiding unreads

### DIFF
--- a/desk/app/activity.hoon
+++ b/desk/app/activity.hoon
@@ -717,7 +717,7 @@
 ++  bump
   |=  =source:a
   ^+  cor
-  =/  index  (get-index source)
+  =/  =index:a  (~(got by indices) source)
   =/  new=index:a  index(bump now.bowl)
   =.  indices
     (~(put by indices) source new)
@@ -732,7 +732,9 @@
 ++  read
   |=  [=source:a action=read-action:a from-parent=?]
   ^+  cor
-  =/  =index:a  (get-index source)
+  ::  we got by here because we don't want reading random sources to
+  ::  inject themselves into the activity summary.
+  =/  =index:a  (~(got by indices) source)
   ?-  -.action
       %event  ~&("read %event unsupported" !!)
       %item   ~&("read %item unsupported" !!)

--- a/desk/app/channels.hoon
+++ b/desk/app/channels.hoon
@@ -861,12 +861,14 @@
       ?(%read %read-at %watch %unwatch)  (ca-a-remark a-channel)
     ::
         %post
-      =/  =source:activity
+      =/  source=(unit source:activity)
         ?.  ?=(%reply -.c-post.a-channel)
-          [%channel nest group.perm.perm.channel]
+          `[%channel nest group.perm.perm.channel]
         =/  id  id.c-post.a-channel
-        [%thread [[our.bowl id] id] nest group.perm.perm.channel]
-      =.  ca-core  (send:ca-activity [%bump source] ~)
+        =/  post  (got:on-v-posts:c posts.channel id)
+        ?~  post  ~
+        `[%thread [[author.u.post id] id] nest group.perm.perm.channel]
+      =?  ca-core  ?=(^ source)  (send:ca-activity [%bump u.source] ~)
       (ca-send-command [%channel nest a-channel])
     ==
   ::


### PR DESCRIPTION
OTT, this was happening occasionally when you reply to a thread and then the OP or someone else responds. This was putting an invalid source in our activity map which was overriding the activity sent to the frontend making it look "read".

PR Checklist
- [ ] Includes changes to desk files
- [ ] Describes how you tested the PR locally (test ship vs livenet)
- [ ] If a new feature, includes automated tests
- [ ] Comments added anywhere logic may be confusing without context