### PR TITLE
native: a few fixes

### DIFF
--- a/apps/tlon-mobile/src/fixtures/fakeData.ts
+++ b/apps/tlon-mobile/src/fixtures/fakeData.ts
@@ -555,6 +555,8 @@ const tlonLocalNavSections: db.GroupNavSection[] = [
 
 export const group: db.Group = {
   id: '~nibset-napwyn/tlon',
+  hostUserId: '~nibset-napwyn',
+  currentUserIsHost: false,
   title: 'Tlon Local',
   channels: tlonLocalChannels,
   navSections: tlonLocalNavSections,
@@ -770,6 +772,8 @@ const dates = {
 
 export const groupWithColorAndNoImage: db.Group = {
   id: '1',
+  hostUserId: '~nibset-napwyn',
+  currentUserIsHost: false,
   title: 'Test Group',
   privacy: 'private',
   unreadCount: 1,

--- a/apps/tlon-mobile/src/screens/ChatListScreen.tsx
+++ b/apps/tlon-mobile/src/screens/ChatListScreen.tsx
@@ -285,7 +285,7 @@ export default function ChatListScreen(
     }
   }, []);
 
-  const { leaveGroup } = useGroupContext({
+  const { leaveGroup, togglePinned } = useGroupContext({
     groupId: longPressedGroup?.id ?? '',
   });
 
@@ -293,6 +293,11 @@ export default function ChatListScreen(
     setLongPressedGroup(null);
     leaveGroup();
   }, [leaveGroup]);
+
+  const handleTogglePinned = useCallback(() => {
+    togglePinned();
+    setLongPressedGroup(null);
+  }, [togglePinned]);
 
   return (
     <CalmProvider calmSettings={calmSettings}>
@@ -375,6 +380,7 @@ export default function ChatListScreen(
             onPressInvitesAndPrivacy={handleGoToInvitesAndPrivacy}
             onPressRoles={handleGoToRoles}
             onPressLeave={handleLeaveGroup}
+            onTogglePinned={handleTogglePinned}
           />
           <StartDmSheet
             goToDm={goToDm}

--- a/apps/tlon-mobile/src/screens/ChatListScreen.tsx
+++ b/apps/tlon-mobile/src/screens/ChatListScreen.tsx
@@ -131,11 +131,7 @@ export default function ChatListScreen(
   const onLongPressItem = useCallback((item: db.Channel | db.Group) => {
     // noop for now
     if (logic.isChannel(item)) {
-      if (
-        item.type === 'dm' ||
-        item.type === 'groupDm' ||
-        item.pin?.type === 'channel'
-      ) {
+      if (item.pin?.type === 'channel') {
         setLongPressedChannel(item);
       } else if (item.group) {
         setLongPressedGroup(item.group);

--- a/apps/tlon-mobile/src/screens/ChatListScreen.tsx
+++ b/apps/tlon-mobile/src/screens/ChatListScreen.tsx
@@ -289,6 +289,11 @@ export default function ChatListScreen(
     groupId: longPressedGroup?.id ?? '',
   });
 
+  const handleLeaveGroup = useCallback(async () => {
+    setLongPressedGroup(null);
+    leaveGroup();
+  }, [leaveGroup]);
+
   return (
     <CalmProvider calmSettings={calmSettings}>
       <AppDataContextProvider
@@ -369,7 +374,7 @@ export default function ChatListScreen(
             onPressManageChannels={handleGoToManageChannels}
             onPressInvitesAndPrivacy={handleGoToInvitesAndPrivacy}
             onPressRoles={handleGoToRoles}
-            onPressLeave={leaveGroup}
+            onPressLeave={handleLeaveGroup}
           />
           <StartDmSheet
             goToDm={goToDm}

--- a/apps/tlon-mobile/src/screens/ChatListScreen.tsx
+++ b/apps/tlon-mobile/src/screens/ChatListScreen.tsx
@@ -299,6 +299,11 @@ export default function ChatListScreen(
     setLongPressedGroup(null);
   }, [togglePinned]);
 
+  const handleDismissOptionsSheet = useCallback(() => {
+    setLongPressedGroup(null);
+    setLongPressedChannel(null);
+  }, []);
+
   return (
     <CalmProvider calmSettings={calmSettings}>
       <AppDataContextProvider

--- a/apps/tlon-mobile/src/screens/GroupSettings/useGroupContext.ts
+++ b/apps/tlon-mobile/src/screens/GroupSettings/useGroupContext.ts
@@ -256,6 +256,12 @@ export const useGroupContext = ({ groupId }: { groupId: string }) => {
     [group]
   );
 
+  const togglePinned = useCallback(async () => {
+    if (group && group.channels[0]) {
+      group.pin ? store.unpinItem(group.pin) : store.pinItem(group.channels[0]);
+    }
+  }, [group]);
+
   const banUser = useCallback(
     async (contactId: string) => {
       if (group) {
@@ -343,6 +349,7 @@ export const useGroupContext = ({ groupId }: { groupId: string }) => {
     createGroupRole,
     updateGroupRole,
     deleteGroupRole,
+    togglePinned,
     banUser,
     unbanUser,
     bannedUsers,

--- a/packages/shared/src/db/migrations/0000_swift_yellow_claw.sql
+++ b/packages/shared/src/db/migrations/0000_swift_yellow_claw.sql
@@ -191,6 +191,8 @@ CREATE TABLE `groups` (
 	`have_invite` integer,
 	`have_requested_invite` integer,
 	`current_user_is_member` integer NOT NULL,
+	`current_user_is_host` integer NOT NULL,
+	`host_user_id` text NOT NULL,
 	`is_new` integer,
 	`join_status` text,
 	`last_post_id` text,

--- a/packages/shared/src/db/migrations/meta/0000_snapshot.json
+++ b/packages/shared/src/db/migrations/meta/0000_snapshot.json
@@ -1,7 +1,7 @@
 {
   "version": "5",
   "dialect": "sqlite",
-  "id": "f4f2ae74-3687-485f-ac82-85cc2b687cd2",
+  "id": "97f10bf1-b7ef-46e2-9186-38eb82d307b2",
   "prevId": "00000000-0000-0000-0000-000000000000",
   "tables": {
     "activity_events": {
@@ -1253,6 +1253,20 @@
         "current_user_is_member": {
           "name": "current_user_is_member",
           "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "current_user_is_host": {
+          "name": "current_user_is_host",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "host_user_id": {
+          "name": "host_user_id",
+          "type": "text",
           "primaryKey": false,
           "notNull": true,
           "autoincrement": false

--- a/packages/shared/src/db/migrations/meta/_journal.json
+++ b/packages/shared/src/db/migrations/meta/_journal.json
@@ -5,8 +5,8 @@
     {
       "idx": 0,
       "version": "5",
-      "when": 1721313221143,
-      "tag": "0000_overrated_leopardon",
+      "when": 1721769919625,
+      "tag": "0000_swift_yellow_claw",
       "breakpoints": true
     }
   ]

--- a/packages/shared/src/db/migrations/migrations.js
+++ b/packages/shared/src/db/migrations/migrations.js
@@ -1,7 +1,7 @@
 // This file is required for Expo/React Native SQLite migrations - https://orm.drizzle.team/quick-sqlite/expo
 
 import journal from './meta/_journal.json';
-import m0000 from './0000_overrated_leopardon.sql';
+import m0000 from './0000_swift_yellow_claw.sql';
 
   export default {
     journal,

--- a/packages/shared/src/db/queries.ts
+++ b/packages/shared/src/db/queries.ts
@@ -2279,6 +2279,7 @@ export const getGroup = createReadQuery(
       .findFirst({
         where: (groups, { eq }) => eq(groups.id, id),
         with: {
+          pin: true,
           channels: {
             where: (channels, { eq }) => eq(channels.currentUserIsMember, true),
             with: {

--- a/packages/shared/src/db/schema.ts
+++ b/packages/shared/src/db/schema.ts
@@ -246,6 +246,8 @@ export const groups = sqliteTable('groups', {
   haveInvite: boolean('have_invite'),
   haveRequestedInvite: boolean('have_requested_invite'),
   currentUserIsMember: boolean('current_user_is_member').notNull(),
+  currentUserIsHost: boolean('current_user_is_host').notNull(),
+  hostUserId: text('host_user_id').notNull(),
   isNew: boolean('is_new'),
   joinStatus: text('join_status').$type<GroupJoinStatus>(),
   lastPostId: text('last_post_id'),

--- a/packages/shared/src/logic/references.ts
+++ b/packages/shared/src/logic/references.ts
@@ -10,6 +10,10 @@ export function getPostReferencePath(post: db.Post) {
   return `/1/chan/${post.channelId}/msg/${udToDec(post.id)}`;
 }
 
+export function getGroupReferencePath(groupId: string) {
+  return `/1/group/${groupId}`;
+}
+
 export function postToContentReference(
   post: db.Post
 ): [path: string, reference: ContentReference] {

--- a/packages/ui/src/components/ChatMessage/ChatMessageActions/MessageActions.tsx
+++ b/packages/ui/src/components/ChatMessage/ChatMessageActions/MessageActions.tsx
@@ -107,7 +107,6 @@ export function getPostActions({
       return [
         { id: 'startThread', label: 'Comment on post' },
         { id: 'muteThread', label: isMuted ? 'Unmute thread' : 'Mute thread' },
-        { id: 'pin', label: 'Pin post' },
         { id: 'copyRef', label: 'Copy link to post' },
         { id: 'edit', label: 'Edit message' },
         { id: 'report', label: 'Report post' },

--- a/packages/ui/src/components/GroupOptionsSheet.tsx
+++ b/packages/ui/src/components/GroupOptionsSheet.tsx
@@ -74,13 +74,29 @@ export function ChatOptionsSheet({
     [currentUser, groupData?.members]
   );
 
-  const adminActions = useMemo(
-    () => [
+  const actions = useMemo(() => {
+    const actions = [];
+    actions.push(
       {
+        title: 'Copy group reference',
+        action: () => {},
+        icon: 'ArrowRef',
+      },
+      {
+        title: isPinned ? 'Unpin' : 'Pin',
+        action: () => {},
+        icon: 'Pin',
+      }
+    );
+
+    if (group && currentUserIsAdmin) {
+      actions.push({
         title: 'Manage Channels',
         action: () => (groupData ? onPressManageChannels(groupData.id) : {}),
         icon: 'ChevronRight',
-      },
+      });
+
+      // TODO: other admin actions
       // {
       // title: 'Invites & Privacy',
       // action: () => (groupData ? onPressInvitesAndPrivacy(groupData.id) : {}),
@@ -91,37 +107,31 @@ export function ChatOptionsSheet({
       // action: () => (groupData ? onPressRoles(groupData.id) : {}),
       // icon: 'ChevronRight',
       // },
-    ],
-    [
-      groupData,
-      onPressManageChannels,
-      // onPressInvitesAndPrivacy,
-      // onPressRoles
-    ]
-  );
+    }
 
-  const actions = useMemo(
-    () => [
-      { title: 'Copy group reference', action: () => {}, icon: 'ArrowRef' },
-      { title: isPinned ? 'Unpin' : 'Pin', action: () => {}, icon: 'Pin' },
-      {
-        title: 'Notifications',
-        action: () => {},
-        icon: 'ChevronRight',
-      },
-      {
+    actions.push({
+      title: 'Notifications',
+      action: () => {},
+      icon: 'ChevronRight',
+    });
+
+    if (group && !group.currentUserIsHost) {
+      actions.push({
         title: 'Leave group',
         variant: 'destructive',
         action: () => (groupData ? onPressLeave(groupData.id) : {}),
-      },
-    ],
-    [isPinned, groupData, onPressLeave]
-  );
+      });
+    }
 
-  if (group && currentUserIsAdmin && actions.length === 4) {
-    // we want to show the admin actions before leave group and notifications
-    actions.splice(actions.length - 2, 0, ...adminActions);
-  }
+    return actions;
+  }, [
+    isPinned,
+    group,
+    currentUserIsAdmin,
+    groupData,
+    onPressManageChannels,
+    onPressLeave,
+  ]);
 
   const memberCount = groupData?.members?.length ?? 0;
   const title = channel?.title ?? groupData?.title ?? 'Loading…';

--- a/packages/ui/src/components/GroupOptionsSheet.tsx
+++ b/packages/ui/src/components/GroupOptionsSheet.tsx
@@ -23,6 +23,7 @@ interface Props {
   onPressLeave: (groupId: string) => void;
   onPressInvitesAndPrivacy: (groupId: string) => void;
   onPressRoles: (groupId: string) => void;
+  onTogglePinned: () => void;
 }
 
 export function ChatOptionsSheet({
@@ -37,6 +38,7 @@ export function ChatOptionsSheet({
   onPressGroupMembers,
   onPressManageChannels,
   onPressLeave,
+  onTogglePinned,
   onPressInvitesAndPrivacy,
   onPressRoles,
 }: Props) {
@@ -84,7 +86,7 @@ export function ChatOptionsSheet({
       },
       {
         title: isPinned ? 'Unpin' : 'Pin',
-        action: () => {},
+        action: onTogglePinned,
         icon: 'Pin',
       }
     );

--- a/packages/ui/src/components/GroupOptionsSheet.tsx
+++ b/packages/ui/src/components/GroupOptionsSheet.tsx
@@ -1,9 +1,11 @@
 import { sync } from '@tloncorp/shared';
 import type * as db from '@tloncorp/shared/dist/db';
+import * as logic from '@tloncorp/shared/dist/logic';
 import * as store from '@tloncorp/shared/dist/store';
 import { useCallback, useEffect, useMemo } from 'react';
 
 import { Text, View, XStack, YStack } from '../core';
+import { useCopy } from '../hooks/useCopy';
 import { ActionSheet } from './ActionSheet';
 import { GroupAvatar } from './Avatar';
 import { Button } from './Button';
@@ -46,6 +48,10 @@ export function ChatOptionsSheet({
     id: group?.id ?? channel?.groupId ?? '',
   });
 
+  const { didCopy: didCopyRef, doCopy: copyRef } = useCopy(
+    logic.getGroupReferencePath(groupData?.id ?? '')
+  );
+
   useEffect(() => {
     if (group?.id) {
       sync.syncGroup(group.id, store.SyncPriority.High);
@@ -81,8 +87,12 @@ export function ChatOptionsSheet({
     actions.push(
       {
         title: 'Copy group reference',
-        action: () => {},
-        icon: 'ArrowRef',
+        action: () => {
+          if (groupData) {
+            copyRef();
+          }
+        },
+        icon: didCopyRef ? 'Checkmark' : 'ArrowRef',
       },
       {
         title: isPinned ? 'Unpin' : 'Pin',
@@ -127,10 +137,13 @@ export function ChatOptionsSheet({
 
     return actions;
   }, [
+    didCopyRef,
     isPinned,
+    onTogglePinned,
     group,
     currentUserIsAdmin,
     groupData,
+    copyRef,
     onPressManageChannels,
     onPressLeave,
   ]);

--- a/packages/ui/src/hooks/useCopy.ts
+++ b/packages/ui/src/hooks/useCopy.ts
@@ -1,0 +1,22 @@
+import Clipboard from '@react-native-clipboard/clipboard';
+import { useCallback, useState } from 'react';
+
+export function useCopy(copied: string) {
+  const [didCopy, setDidCopy] = useState(false);
+
+  const doCopy = useCallback(async () => {
+    Clipboard.setString(copied);
+    setDidCopy(true);
+
+    const timeout = setTimeout(() => {
+      setDidCopy(false);
+    }, 2000);
+
+    return () => {
+      setDidCopy(false);
+      clearTimeout(timeout);
+    };
+  }, [copied]);
+
+  return { doCopy, didCopy };
+}


### PR DESCRIPTION
Bit of a hodgepodge to start knocking out some of the smaller _Production Readiness_ items.

- removes unused _Pin Post_ notebook action
- prevents showing _Group Preview_ sheet for DMs
- Closes _Group Preview_ sheet upon clicking leave

Also found a bug where we let you try to leave groups you yourself host. Added logic to avoid that and tacked on `hostUserId` and `currentUserIsHost` to the groups table.

Fixes TLON-2427
Fixes TLON-2321
Fixes TLON-2428