### PR TITLE
web: fix routing from group reference to group preview modal

### DIFF
--- a/apps/tlon-web/src/app.tsx
+++ b/apps/tlon-web/src/app.tsx
@@ -163,11 +163,13 @@ interface RoutesProps {
   isSmall: boolean;
 }
 
-const GroupsRoutes = React.memo(({ isMobile, isSmall }: RoutesProps) => {
+const GroupsRoutes = React.memo(function GroupsRoutesComponent({
+  isMobile,
+  isSmall,
+}: RoutesProps) {
   const groupsTitle = 'Tlon';
   const loaded = useSettingsLoaded();
   const location = useLocation();
-  const currentTheme = useLocalState((s) => s.currentTheme);
 
   const state = location.state as { backgroundLocation?: Location } | null;
 
@@ -606,7 +608,7 @@ function Firehose() {
   return null;
 }
 
-const App = React.memo(() => {
+const App = React.memo(function AppComponent() {
   useNativeBridge();
   const navigate = useNavigate();
   const handleError = useErrorHandler();

--- a/apps/tlon-web/src/app.tsx
+++ b/apps/tlon-web/src/app.tsx
@@ -7,6 +7,7 @@ import { ErrorBoundary } from 'react-error-boundary';
 import { Helmet } from 'react-helmet';
 import {
   Location,
+  Navigate,
   NavigateFunction,
   Route,
   BrowserRouter as Router,
@@ -262,6 +263,7 @@ const GroupsRoutes = React.memo(function GroupsRoutesComponent({
                 path="channels"
                 element={<GroupChannelManager title={` • ${groupsTitle}`} />}
               />
+              <Route path="activity" element={<Navigate to="../channels" />} />
               <Route path="members" element={<Members />} />
               <Route path="/groups/:ship/:name/edit" element={<GroupAdmin />}>
                 {!isMobile && (

--- a/apps/tlon-web/src/components/Sidebar/util.tsx
+++ b/apps/tlon-web/src/components/Sidebar/util.tsx
@@ -76,8 +76,8 @@ export function useNavWithinTab() {
       const opts = modal
         ? {
             ...options,
-            state: location.state || {
-              ...options?.state,
+            state: {
+              ...(options?.state ?? location.state),
               backgroundLocation: location,
             },
           }

--- a/apps/tlon-web/src/groups/GroupSidebar/GroupSidebar.tsx
+++ b/apps/tlon-web/src/groups/GroupSidebar/GroupSidebar.tsx
@@ -129,7 +129,7 @@ function GroupHeader() {
   );
 }
 
-const GroupSidebar = React.memo(() => {
+const GroupSidebar = React.memo(function GroupSidebarComponent() {
   const flag = useGroupFlag();
   const realGroup = useGroup(flag);
   const lastGroupRef = useRef(realGroup);
@@ -153,18 +153,6 @@ const GroupSidebar = React.memo(() => {
       <div className="flex min-h-0 flex-col">
         <div className="flex flex-col space-y-0.5 px-2 pb-4 pt-2">
           <GroupHeader />
-          <SidebarItem
-            icon={
-              <HomeIcon
-                className={cn('h-6 w-6 rounded', {
-                  'mix-blend-multiply': !isDark,
-                })}
-              />
-            }
-            to={`/groups/${flag}/activity`}
-          >
-            Home
-          </SidebarItem>
           <SidebarItem
             icon={
               <HashIcon

--- a/apps/tlon-web/src/groups/useGroupJoin.ts
+++ b/apps/tlon-web/src/groups/useGroupJoin.ts
@@ -43,6 +43,7 @@ export default function useGroupJoin(
     | undefined = undefined
 ) {
   const location = useLocation();
+  const navigateAcrossTabs = useNavigate();
   const { navigate } = useNavWithinTab();
   const modalIsOpen =
     !!location.state?.backgroundLocation &&
@@ -70,7 +71,7 @@ export default function useGroupJoin(
 
   const open = useCallback(() => {
     if (group && !groupIsInitializing(group)) {
-      return navigate(`/groups/${flag}`);
+      return navigateAcrossTabs(`/groups/${flag}`);
     }
 
     return navigate(`/gangs/${flag}`, true);


### PR DESCRIPTION
This was an issue with navigation logic. The path in our router for modals requires `location.state.backgroundLocation` to be present. There was a bug in a navigation helper that causes that prop not to get set _if_  there's pre-existing location state. When navigating to the gallery detail view, we set the preloaded block to `location.state` causing that bugged conditional to override the prop we care about. This just tweaks the logic to avoid that override. 

After tracing around a bit, I'm still unsure why this is only happening now. Seemed like none of the chokepoints have been touched in the last ~3 months.

Also fixes a tiny issue I noticed while testing. If you click a group reference from a DM, it was failing to navigate if you're already joined.

Fixes TLON-2441
Fixes TLON-2445