### PR TITLE
activity: fix init unreads

### DIFF
--- a/desk/app/activity.hoon
+++ b/desk/app/activity.hoon
@@ -148,13 +148,7 @@
         state-1
     ==
   +$  state-6  current-state
-  +$  state-5
-    $:  %5
-        allowed=notifications-allowed:a
-        =indices:a
-        =activity:a
-        =volume-settings:a
-    ==
+  +$  state-5  _%*(. *state-6 - %5)
   ++  state-5-to-6
     |=  old=state-5
     ^-  state-6

--- a/desk/app/activity.hoon
+++ b/desk/app/activity.hoon
@@ -927,7 +927,7 @@
       %gx  (scry-path %chat /full/noun)
     ==
   =.  indices  (fix-dm-init-unreads indices dms clubs)
-  cor
+  refresh-all-summaries
 ++  fix-channel-init-unreads
   |=  [=indices:a =channels:c]
   %-  ~(urn by indices)

--- a/desk/app/activity.hoon
+++ b/desk/app/activity.hoon
@@ -892,7 +892,6 @@
     [~ %.n ?:((gth time-id st) time-id st)]
   =.  reads.index  [new-floor ~]
   ::  with new reads, update our index and summary
-  :: =.  cor  (refresh-index source index)
   =.  indices  (~(put by indices) source index)
   =/  new-summary
     %+  ~(summarize-unreads urd indices activity vs log)

--- a/desk/app/activity.hoon
+++ b/desk/app/activity.hoon
@@ -159,7 +159,7 @@
     |=  old=state-5
     ^-  state-6
     =/  [=indices:a =activity:a]
-      (sync-reads indices.old activity.old)
+      (sync-reads indices.old activity.old volume-settings.old)
     :*  %6
         allowed.old
         indices
@@ -263,7 +263,7 @@
     ::
         %sync-reads
       =^  indices  activity
-        (sync-reads indices activity)
+        (sync-reads indices activity volume-settings)
       cor(indices indices)
     ::
         %migrate
@@ -880,7 +880,7 @@
 ::  tracking individual reads
 ::
 ++  sync-reads
-  |=  [=indices:a =activity:a]
+  |=  [=indices:a =activity:a vs=volume-settings:a]
   =/  sources  (sort-sources:src ~(tap in ~(key by indices)))
   |-
   ?~  sources  [indices activity]
@@ -901,7 +901,10 @@
   ::  with new reads, update our index and summary
   :: =.  cor  (refresh-index source index)
   =.  indices  (~(put by indices) source index)
-  =/  new-summary  (summarize-unreads source (get-index source))
+  =/  new-summary
+    %+  ~(summarize-unreads urd indices activity vs log)
+      source
+    index
   =.  activity
     (~(put by activity) source new-summary)
   ?:  !=(?~(old ~ u.old(reads ~)) new-summary(reads ~))

--- a/desk/app/activity.hoon
+++ b/desk/app/activity.hoon
@@ -861,7 +861,6 @@
   |=  [=source:a =index:a]
   ::  if we're a DM with only the %dm-invite event, we need to set
   ::  the floor to the last-read time
-  ~!  stream.index
   ?.  ?&  ?=(%dm -.source)
           ?=([[* [[%dm-invite *] *]] ~ ~] stream.index)
       ==

--- a/desk/lib/test-agent.hoon
+++ b/desk/lib/test-agent.hoon
@@ -352,9 +352,7 @@
     ::
     %+  skip  caz
     |=  =card
-    ?|  ?=([%give %fact [[%verb %events ~] ~] *] card)
-        ?=([%give %fact [[%verb %events-plus ~] ~] *] card)
-    ==
+    ?=([%give %fact [[%verb ?(%events %events-plus) ~] ~] *] card)
   =/  m  (mare ,~)
   ^-  form:m
   |=  s=state

--- a/desk/lib/test-agent.hoon
+++ b/desk/lib/test-agent.hoon
@@ -352,7 +352,9 @@
     ::
     %+  skip  caz
     |=  =card
-    ?=([%give %fact [[%verb %events ~] ~] *] card)
+    ?|  ?=([%give %fact [[%verb %events ~] ~] *] card)
+        ?=([%give %fact [[%verb %events-plus ~] ~] *] card)
+    ==
   =/  m  (mare ,~)
   ^-  form:m
   |=  s=state

--- a/desk/tests/app/activity.hoon
+++ b/desk/tests/app/activity.hoon
@@ -29,12 +29,12 @@
   ;<  *  bind:m  (ex-equal !>(~(wyt by pre)) !>(count))
   ;<  new=vase  bind:m  get-save
   =/  want-indices  post
-  =+  !<(new-state=current-state new)
+  =+  !<(=new-state new)
   =/  new-indices  indices.new-state
   (ex-equal !>(new-indices) !>(want-indices))
 ::
-+$  current-state
-  $:  %5
++$  new-state
+  $:  %6
       allowed=notifications-allowed:a
       =indices:a
       =activity:a

--- a/desk/tests/app/activity.hoon
+++ b/desk/tests/app/activity.hoon
@@ -1,22 +1,22 @@
-/-  a=activity, g=groups, c=channels
+/-  a=activity, g=groups, c=channels, ch=chat
 /+  *activity, *test-agent
 /=  activity-agent  /app/activity
 |%
 ++  dap  %activity
 ++  test-sync-reads-0
-  =+  state-0
+  =+  state-0:sync-reads
   (run-sync-reads pre-sync post-sync activity 5)
 ::
 ++  test-sync-reads-1
-  =+  state-1
+  =+  state-1:sync-reads
   (run-sync-reads pre-sync post-sync activity 5)
 ::
 ++  test-sync-reads-2
-  =+  state-2
+  =+  state-2:sync-reads
   (run-sync-reads pre-sync post-sync activity 5)
 ::
 ++  test-sync-reads-3
-  =+  state-3
+  =+  state-3:sync-reads
   (run-sync-reads pre-sync post-sync activity 9)
 ++  run-sync-reads
   |=  [pre=indices:a post=indices:a =activity:a count=@ud]
@@ -33,6 +33,21 @@
   =/  new-indices  indices.new-state
   (ex-equal !>(new-indices) !>(want-indices))
 ::
+++  test-fix-init
+  =+  state-0:fix-init
+  (run-fix-init pre-fix post-fix indices volumes 9)
+++  run-fix-init
+  |=  [pre=activity:a post=activity:a =indices:a vs=volume-settings:a count=@ud]
+  %-  eval-mare
+  =/  m  (mare ,~)
+  ^-  form:m
+  ;<  *  bind:m  (do-init dap activity-agent)
+  ;<  *  bind:m  (jab-bowl |=(b=bowl b(our ~zod, src ~zod)))
+  ;<  *  bind:m  (do-load activity-agent `!>([%6 %some indices pre vs]))
+  ;<  *  bind:m  (ex-equal !>(~(wyt by pre)) !>(count))
+  ;<  new=vase  bind:m  get-save
+  =+  !<(=new-state new)
+  (ex-equal !>(activity.new-state) !>(post))
 +$  new-state
   $:  %6
       allowed=notifications-allowed:a
@@ -41,433 +56,538 @@
       =volume-settings:a
   ==
 +$  index-pair  [=source:a =index:a]
-+$  source-set
-  $:  thrd1=index-pair
-      thrd2=index-pair
-      chnl=index-pair
-      grp=index-pair
-      base=index-pair
-  ==
-::  in this case, we test when a child has unreads before any of the parents,
-::  resulting in a large list of reads and a very early floor
-++  state-0
+++  sync-reads
   |%
-  ++  sources
-    ^-  source-set
-    =/  =reads:a
-      :-  d-1
-      %+  gas:on-read-items:a  *read-items:a
-      :~  [d1 ~]
-          [d2 ~]
-          [d3 ~]
-          [d4 ~]
-          [d5 ~]
-      ==
-    =/  thrd1  (thread-source-1 flag nest i0)
-    =/  thrd2  (thread-source-2 flag nest i0)
-    =/  chnl  (channel-source flag nest reads index.thrd1 index.thrd2 i0)
-    =/  grp  (group-source flag index.chnl)
-    :*  thrd1
-        thrd2
-        chnl
-        grp
-        (base-source index.grp)
+  +$  source-set
+    $:  thrd1=index-pair
+        thrd2=index-pair
+        chnl=index-pair
+        grp=index-pair
+        base=index-pair
     ==
-  ++  pre-sync
-    ^-  indices:a
-    %-  ~(gas by *indices:a)
-    =>  sources
-    .(base [base ~])
-  ++  post-sync
-    ^-  indices:a
-    =+  sources
-    ::  only care about the index
-    %-  my
-    :~  thrd1
-        thrd2
-        chnl(reads.index [d4 ~])
-        grp(reads.index [d-1 ~])
-        base(reads.index [d-1 ~])
-    ==
-  ++  activity
-    ^-  activity:a
-    =+  sources
-    =/  chan-sum=activity-summary:a
-      :*  newest=d5
-          count=0
-          notify-count=0
-          notify=|
-          unread=~
-          children=(sy (get-children:src pre-sync source.chnl))
-          reads=[d-1 (my [d1 ~] [d2 ~] [d3 ~] [d4 ~] [d5 ~] ~)]
+  ::  in this case, we test when a child has unreads before any of the parents,
+  ::  resulting in a large list of reads and a very early floor
+  ++  state-0
+    |%
+    ++  sources
+      ^-  source-set
+      =/  =reads:a
+        :-  d-1
+        %+  gas:on-read-items:a  *read-items:a
+        :~  [d1 ~]
+            [d2 ~]
+            [d3 ~]
+            [d4 ~]
+            [d5 ~]
+        ==
+      =/  thrd1  (thread-source-1 flag nest i0)
+      =/  thrd2  (thread-source-2 flag nest i0)
+      =/  chnl
+        %+  merge-children  (channel-source flag nest reads i0)
+        ~[stream.index.thrd1 stream.index.thrd2]
+      =/  grp
+        %+  merge-children  (group-source flag reads.index.chnl)
+        ~[stream.index.chnl]
+      :*  thrd1
+          thrd2
+          chnl
+          grp
+          (merge-children (base-source reads.index.grp) ~[stream.index.grp])
       ==
-    %-  my
-    :~  :-  source.thrd1
+    ++  pre-sync
+      ^-  indices:a
+      %-  ~(gas by *indices:a)
+      =>  sources
+      .(base [base ~])
+    ++  post-sync
+      ^-  indices:a
+      =+  sources
+      ::  only care about the index
+      %-  my
+      :~  thrd1
+          thrd2
+          chnl(reads.index [d4 ~])
+          grp(reads.index [d-1 ~])
+          base(reads.index [d-1 ~])
+      ==
+    ++  activity
+      ^-  activity:a
+      =+  sources
+      =/  chan-sum=activity-summary:a
         :*  newest=d5
-            count=2
-            notify-count=0
-            notify=|
-            unread=`[[[~dev d0] d0] 2 |]
-            children=(sy (get-children:src pre-sync source.thrd1))
-            reads=[d-1 ~]
-        ==
-      ::
-        :-  source.thrd2
-        :*  newest=d2
             count=0
             notify-count=0
             notify=|
             unread=~
-            children=(sy (get-children:src pre-sync source.thrd2))
-            reads=[d2 ~]
+            children=(sy (get-children:src pre-sync source.chnl))
+            reads=[d-1 (my [d1 ~] [d2 ~] [d3 ~] [d4 ~] [d5 ~] ~)]
         ==
-      ::
-        [source.chnl chan-sum]
-      ::
-        :-  source.grp
-        chan-sum(children (sy (get-children:src pre-sync source.grp)))
-      ::
-        :-  source.base
-        chan-sum(children ~)
-    ==
-  --
-::  in this case, we test when a child has unreads later than any of the
-::  parents, but all other children are read, resulting in a late floor
-::  and no reads
-++  state-1
-  |%
-  ++  sources
-    ^-  source-set
-    =/  thrd1  (thread-source-2 flag nest i0)
-    =/  thrd2  (thread-source-3 flag nest i0)
-    =/  =reads:a  [d-1 (my [d1 ~] [d2 ~] [d3 ~] ~)]
-    =/  chnl  (channel-source flag nest reads index.thrd1 index.thrd2 i0)
-    =/  grp  (group-source flag index.chnl)
-    :*  thrd1
-        thrd2
-        chnl
-        grp
-        (base-source index.grp)
-    ==
-  ++  pre-sync
-    ^-  indices:a
-    %-  ~(gas by *indices:a)
-    =>  sources
-    .(base [base ~])
-  ++  post-sync
-    ^-  indices:a
-    =+  sources
-    %-  my
-    :~  thrd1
-        thrd2
-        chnl(reads.index [d3 ~])
-        grp(reads.index [d-1 ~])
-        base(reads.index [d-1 ~])
-    ==
-  ++  activity
-    ^-  activity:a
-    =+  sources
-    =/  chan-sum=activity-summary:a
-      :*  newest=d5
-          count=1
-          notify-count=0
-          notify=|
-          unread=`[[[~dev d4] d4] 1 |]
-          children=(sy (get-children:src pre-sync source.chnl))
-          reads=[d-1 (my [d1 ~] [d2 ~] [d3 ~] ~)]
+      %-  my
+      :~  :-  source.thrd1
+          :*  newest=d5
+              count=2
+              notify-count=0
+              notify=|
+              unread=`[[[~dev d0] d0] 2 |]
+              children=(sy (get-children:src pre-sync source.thrd1))
+              reads=[d-1 ~]
+          ==
+        ::
+          :-  source.thrd2
+          :*  newest=d2
+              count=0
+              notify-count=0
+              notify=|
+              unread=~
+              children=(sy (get-children:src pre-sync source.thrd2))
+              reads=[d2 ~]
+          ==
+        ::
+          [source.chnl chan-sum]
+        ::
+          :-  source.grp
+          chan-sum(children (sy (get-children:src pre-sync source.grp)))
+        ::
+          :-  source.base
+          chan-sum(children ~)
       ==
-    %-  my
-    :~  :-  source.thrd1
-        :*  newest=d2
-            count=0
-            notify-count=0
-            notify=|
-            unread=~
-            children=(sy (get-children:src pre-sync source.thrd1))
-            reads=[d-1 ~]
-        ==
-      ::
-        :-  source.thrd2
+    --
+  ::  in this case, we test when a child has unreads later than any of the
+  ::  parents, but all other children are read, resulting in a late floor
+  ::  and no reads
+  ++  state-1
+    |%
+    ++  sources
+      ^-  source-set
+      =/  thrd1  (thread-source-2 flag nest i0)
+      =/  thrd2  (thread-source-3 flag nest i0)
+      =/  =reads:a  [d-1 (my [d1 ~] [d2 ~] [d3 ~] ~)]
+      =/  chnl
+        %+  merge-children  (channel-source flag nest reads i0)
+        ~[stream.index.thrd1 stream.index.thrd2]
+      =/  grp
+        %+  merge-children  (group-source flag reads.index.chnl)
+        ~[stream.index.chnl]
+      :*  thrd1
+          thrd2
+          chnl
+          grp
+          (merge-children (base-source reads.index.grp) ~[stream.index.grp])
+      ==
+    ++  pre-sync
+      ^-  indices:a
+      %-  ~(gas by *indices:a)
+      =>  sources
+      .(base [base ~])
+    ++  post-sync
+      ^-  indices:a
+      =+  sources
+      %-  my
+      :~  thrd1
+          thrd2
+          chnl(reads.index [d3 ~])
+          grp(reads.index [d-1 ~])
+          base(reads.index [d-1 ~])
+      ==
+    ++  activity
+      ^-  activity:a
+      =+  sources
+      =/  chan-sum=activity-summary:a
         :*  newest=d5
             count=1
             notify-count=0
             notify=|
-            unread=`[[[~dev d5] d5] 1 |]
-            children=(sy (get-children:src pre-sync source.thrd2))
-            reads=[d0 ~]
+            unread=`[[[~dev d4] d4] 1 |]
+            children=(sy (get-children:src pre-sync source.chnl))
+            reads=[d-1 (my [d1 ~] [d2 ~] [d3 ~] ~)]
         ==
-      ::
-        [source.chnl chan-sum]
-      ::
-        :-  source.grp
-        %=  chan-sum
-          unread  ~
-          children  (sy (get-children:src pre-sync source.grp))
-        ==
-      ::
-        :-  source.base
-        %=  chan-sum
-          unread  ~
-          children  ~
-        ==
-    ==
-  --
-::  in this case we test a parent having mixed reads with children that
-::  are all read, resulting in a floor up to the parent reads and one
-::  read item that comes later
-++  state-2
-  |%
-  ++  sources
-    ^-  source-set
-    =/  thrd1  (thread-source-2 flag nest i0)
-    =/  thrd2  (thread-source-3 flag nest i0)
-    =.  thrd2  thrd2(reads.index [d5 ~])
-    =/  =reads:a  [d3 (my [d5 ~] ~)]
-    =/  chnl  (channel-source flag nest reads index.thrd1 index.thrd2 i0)
-    =/  grp  (group-source flag index.chnl)
-    :*  thrd1
-        thrd2
-        chnl
-        grp
-        (base-source index.grp)
-    ==
-  ++  pre-sync
-    ^-  indices:a
-    %-  ~(gas by *indices:a)
-    =>  sources
-    .(base [base ~])
-  ++  post-sync
-    ^-  indices:a
-    =+  sources
-    %-  my
-    :~  thrd1
-        thrd2
-        chnl(reads.index [d3 ~])
-        grp(reads.index [d3 ~])
-        base(reads.index [d3 ~])
-    ==
-  ++  activity
-    ^-  activity:a
-    =+  sources
-    =/  chan-sum=activity-summary:a
-      :*  newest=d5
-          count=1
-          notify-count=0
-          notify=|
-          unread=`[[[~dev d4] d4] 1 |]
-          children=(sy (get-children:src pre-sync source.chnl))
-          reads=[d3 (my [d3 ~] [d5 ~] ~)]
-      ==
-    %-  my
-    :~  :-  source.thrd1
-        :*  newest=d2
-            count=0
-            notify-count=0
-            notify=|
-            unread=~
-            children=(sy (get-children:src pre-sync source.thrd1))
-            reads=[d2 ~]
-        ==
-      ::
-        :-  source.thrd2
-        :*  newest=d5
-            count=0
-            notify-count=0
-            notify=|
-            unread=~
-            children=(sy (get-children:src pre-sync source.thrd2))
-            reads=[d0 ~]
-        ==
-      ::
-        [source.chnl chan-sum]
-      ::
-        :-  source.grp
-        %=  chan-sum
-          unread  ~
-          children  (sy (get-children:src pre-sync source.grp))
-        ==
-      ::
-        :-  source.base
-        %=  chan-sum
-          unread  ~
-          children  ~
-        ==
-    ==
-  --
-::  in this case we test multiple parents one with mixed reads and one
-::  with all reads
-++  state-3
-  |%
-  ++  sources
-    =/  thrd1-1  (thread-source-1 flag nest i0)
-    =/  thrd1-2  (thread-source-2 flag nest i0)
-    =/  r1=reads:a
-      :-  d-1
-      %+  gas:on-read-items:a  *read-items:a
-      :~  [d1 ~]
-          [d2 ~]
-          [d3 ~]
-          [d4 ~]
-      ==
-    =/  chnl1  (channel-source flag nest r1 index.thrd1-1 index.thrd1-2 i0)
-    =/  grp1  (group-source flag index.chnl1)
-    ::
-    =/  second-grp=flag:g  [~dev %urbit]
-    =/  second-chnl=nest:c  [%chat ~dev %lobby]
-    =/  thrd2-1  (thread-source-2 second-grp second-chnl i1)
-    =/  thrd2-2  (thread-source-3 second-grp second-chnl i1)
-    =/  r2=reads:a  [(add d3 i1) ~]
-    =/  chnl2
-      (channel-source second-grp second-chnl r2 index.thrd2-1 index.thrd2-2 i1)
-    =/  grp2  (group-source second-grp index.chnl2)
-    =/  base
-      %-  base-source
-      :*  (uni:on-event:a stream.index.grp1 stream.index.grp2)
+      %-  my
+      :~  :-  source.thrd1
+          :*  newest=d2
+              count=0
+              notify-count=0
+              notify=|
+              unread=~
+              children=(sy (get-children:src pre-sync source.thrd1))
+              reads=[d-1 ~]
+          ==
         ::
+          :-  source.thrd2
+          :*  newest=d5
+              count=1
+              notify-count=0
+              notify=|
+              unread=`[[[~dev d5] d5] 1 |]
+              children=(sy (get-children:src pre-sync source.thrd2))
+              reads=[d0 ~]
+          ==
+        ::
+          [source.chnl chan-sum]
+        ::
+          :-  source.grp
+          %=  chan-sum
+            unread  ~
+            children  (sy (get-children:src pre-sync source.grp))
+          ==
+        ::
+          :-  source.base
+          %=  chan-sum
+            unread  ~
+            children  ~
+          ==
+      ==
+    --
+  ::  in this case we test a parent having mixed reads with children that
+  ::  are all read, resulting in a floor up to the parent reads and one
+  ::  read item that comes later
+  ++  state-2
+    |%
+    ++  sources
+      ^-  source-set
+      =/  thrd1  (thread-source-2 flag nest i0)
+      =/  thrd2  (thread-source-3 flag nest i0)
+      =.  thrd2  thrd2(reads.index [d5 ~])
+      =/  =reads:a  [d3 (my [d5 ~] ~)]
+      =/  chnl
+        %+  merge-children  (channel-source flag nest reads i0)
+        ~[stream.index.thrd1 stream.index.thrd2]
+      =/  grp
+        %+  merge-children  (group-source flag reads.index.chnl)
+        ~[stream.index.chnl]
+      :*  thrd1
+          thrd2
+          chnl
+          grp
+          (merge-children (base-source reads.index.grp) ~[stream.index.grp])
+      ==
+    ++  pre-sync
+      ^-  indices:a
+      %-  ~(gas by *indices:a)
+      =>  sources
+      .(base [base ~])
+    ++  post-sync
+      ^-  indices:a
+      =+  sources
+      %-  my
+      :~  thrd1
+          thrd2
+          chnl(reads.index [d3 ~])
+          grp(reads.index [d3 ~])
+          base(reads.index [d3 ~])
+      ==
+    ++  activity
+      ^-  activity:a
+      =+  sources
+      =/  chan-sum=activity-summary:a
+        :*  newest=d5
+            count=1
+            notify-count=0
+            notify=|
+            unread=`[[[~dev d4] d4] 1 |]
+            children=(sy (get-children:src pre-sync source.chnl))
+            reads=[d3 (my [d3 ~] [d5 ~] ~)]
+        ==
+      %-  my
+      :~  :-  source.thrd1
+          :*  newest=d2
+              count=0
+              notify-count=0
+              notify=|
+              unread=~
+              children=(sy (get-children:src pre-sync source.thrd1))
+              reads=[d2 ~]
+          ==
+        ::
+          :-  source.thrd2
+          :*  newest=d5
+              count=0
+              notify-count=0
+              notify=|
+              unread=~
+              children=(sy (get-children:src pre-sync source.thrd2))
+              reads=[d0 ~]
+          ==
+        ::
+          [source.chnl chan-sum]
+        ::
+          :-  source.grp
+          %=  chan-sum
+            unread  ~
+            children  (sy (get-children:src pre-sync source.grp))
+          ==
+        ::
+          :-  source.base
+          %=  chan-sum
+            unread  ~
+            children  ~
+          ==
+      ==
+    --
+  ::  in this case we test multiple parents one with mixed reads and one
+  ::  with all reads
+  ++  state-3
+    |%
+    ++  sources
+      =/  thrd1-1  (thread-source-1 flag nest i0)
+      =/  thrd1-2  (thread-source-2 flag nest i0)
+      =/  r1=reads:a
+        :-  d-1
+        %+  gas:on-read-items:a  *read-items:a
+        :~  [d1 ~]
+            [d2 ~]
+            [d3 ~]
+            [d4 ~]
+        ==
+      =/  chnl1
+        %+  merge-children  (channel-source flag nest r1 i0)
+        ~[stream.index.thrd1-1 stream.index.thrd1-2]
+      =/  grp1
+        %+  merge-children  (group-source flag reads.index.chnl1)
+        ~[stream.index.chnl1]
+      ::
+      =/  second-grp=flag:g  [~dev %urbit]
+      =/  second-chnl=nest:c  [%chat ~dev %lobby]
+      =/  thrd2-1  (thread-source-2 second-grp second-chnl i1)
+      =/  thrd2-2  (thread-source-3 second-grp second-chnl i1)
+      =/  r2=reads:a  [(add d3 i1) ~]
+      =/  chnl2
+        %+  merge-children  (channel-source second-grp second-chnl r2 i1)
+        ~[stream.index.thrd2-1 stream.index.thrd2-2]
+      =/  grp2
+        %+  merge-children  (group-source second-grp reads.index.chnl2)
+        ~[stream.index.chnl2]
+      =/  base
+        %+  merge-children
+          %-  base-source
           :-  d-1
           %+  gas:on-read-items:a  items.r1
           :~  [(add d1 i1) ~]
               [(add d2 i1) ~]
               [(add d3 i1) ~]
           ==
-        ::
-          *@da
+        ~[stream.index.grp1 stream.index.grp2]
+      ::
+      :*  thrd1-1=thrd1-1
+          thrd1-2=thrd1-2
+          thrd2-1=thrd2-1
+          thrd2-2=thrd2-2
+          chnl1=chnl1
+          chnl2=chnl2
+          grp1=grp1
+          grp2=grp2
+          base=base
       ==
-    ::
-    :*  thrd1-1=thrd1-1
-        thrd1-2=thrd1-2
-        thrd2-1=thrd2-1
-        thrd2-2=thrd2-2
-        chnl1=chnl1
-        chnl2=chnl2
-        grp1=grp1
-        grp2=grp2
-        base=base
-    ==
-  ++  pre-sync
-    ^-  indices:a
-    %-  ~(gas by *indices:a)
-    =>  sources
-    .(base [base ~])
-  ++  post-sync
-    ^-  indices:a
-    =+  sources
-    %-  my
-    :~  thrd1-1
-        thrd1-2
-        thrd2-1
-        thrd2-2
-        chnl1(reads.index [d4 ~])
-        chnl2
-        grp1(reads.index [d-1 ~])
-        grp2
-        base(reads.index [d-1 ~])
-    ==
-  ++  activity
-    ^-  activity:a
-    =+  sources
-    =/  chan-sum1=activity-summary:a
-      :*  newest=d5
-          count=0
-          notify-count=0
-          notify=|
-          unread=~
-          children=(sy (get-children:src pre-sync source.chnl1))
-          reads=[d-1 (my [d1 ~] [d2 ~] [d3 ~] [d4 ~] ~)]
+    ++  pre-sync
+      ^-  indices:a
+      %-  ~(gas by *indices:a)
+      =>  sources
+      .(base [base ~])
+    ++  post-sync
+      ^-  indices:a
+      =+  sources
+      %-  my
+      :~  thrd1-1
+          thrd1-2
+          thrd2-1
+          thrd2-2
+          chnl1(reads.index [d4 ~])
+          chnl2
+          grp1(reads.index [d-1 ~])
+          grp2
+          base(reads.index [d-1 ~])
       ==
-    =/  time-chan2  (add d4 i1)
-    =/  time2-2  (add d5 i1)
-    =/  chan-sum2=activity-summary:a
-      :*  newest=time2-2
-          count=1
-          notify-count=0
-          notify=|
-          unread=`[[[~dev time-chan2] time-chan2] 1 |]
-          children=(sy (get-children:src pre-sync source.chnl2))
-          reads=[(add d3 i1) ~]
-      ==
-    %-  my
-    :~  :-  source.thrd1-1
+    ++  activity
+      ^-  activity:a
+      =+  sources
+      =/  chan-sum1=activity-summary:a
         :*  newest=d5
-            count=2
-            notify-count=0
-            notify=|
-            unread=`[[[~dev d0] d0] 2 |]
-            children=(sy (get-children:src pre-sync source.thrd1-1))
-            reads=[d-1 ~]
-        ==
-      ::
-        :-  source.thrd1-2
-        :*  newest=d2
             count=0
             notify-count=0
             notify=|
             unread=~
-            children=(sy (get-children:src pre-sync source.thrd1-2))
-            reads=[d2 ~]
+            children=(sy (get-children:src pre-sync source.chnl1))
+            reads=[d-1 (my [d1 ~] [d2 ~] [d3 ~] [d4 ~] ~)]
         ==
-      ::
-        :-  source.thrd2-1
-        :*  newest=(add d2 i1)
-            count=0
-            notify-count=0
-            notify=|
-            unread=~
-            children=(sy (get-children:src pre-sync source.thrd2-1))
-            reads=[(add d2 i1) ~]
-        ==
-      ::
-        :-  source.thrd2-2
+      =/  time-chan2  (add d4 i1)
+      =/  time2-2  (add d5 i1)
+      =/  chan-sum2=activity-summary:a
         :*  newest=time2-2
             count=1
             notify-count=0
             notify=|
-            unread=`[[[~dev time2-2] time2-2] 1 |]
-            children=(sy (get-children:src pre-sync source.thrd2-2))
-            reads=[(add d0 i1) ~]
+            unread=`[[[~dev time-chan2] time-chan2] 1 |]
+            children=(sy (get-children:src pre-sync source.chnl2))
+            reads=[(add d3 i1) ~]
         ==
-      ::
-        [source.chnl1 chan-sum1]
-        [source.chnl2 chan-sum2]
-      ::
-        :-  source.grp1
-        %=  chan-sum1
-          unread  ~
-          children  (sy (get-children:src pre-sync source.grp1))
-        ==
-      ::
-        :-  source.grp2
-        %=  chan-sum2
-          unread  ~
-          children  (sy (get-children:src pre-sync source.grp2))
-        ==
-      ::
-        :-  source.base
-        %=  chan-sum2
-          unread  ~
-          children  ~
-        ==
+      %-  my
+      :~  :-  source.thrd1-1
+          :*  newest=d5
+              count=2
+              notify-count=0
+              notify=|
+              unread=`[[[~dev d0] d0] 2 |]
+              children=(sy (get-children:src pre-sync source.thrd1-1))
+              reads=[d-1 ~]
+          ==
+        ::
+          :-  source.thrd1-2
+          :*  newest=d2
+              count=0
+              notify-count=0
+              notify=|
+              unread=~
+              children=(sy (get-children:src pre-sync source.thrd1-2))
+              reads=[d2 ~]
+          ==
+        ::
+          :-  source.thrd2-1
+          :*  newest=(add d2 i1)
+              count=0
+              notify-count=0
+              notify=|
+              unread=~
+              children=(sy (get-children:src pre-sync source.thrd2-1))
+              reads=[(add d2 i1) ~]
+          ==
+        ::
+          :-  source.thrd2-2
+          :*  newest=time2-2
+              count=1
+              notify-count=0
+              notify=|
+              unread=`[[[~dev time2-2] time2-2] 1 |]
+              children=(sy (get-children:src pre-sync source.thrd2-2))
+              reads=[(add d0 i1) ~]
+          ==
+        ::
+          [source.chnl1 chan-sum1]
+          [source.chnl2 chan-sum2]
+        ::
+          :-  source.grp1
+          %=  chan-sum1
+            unread  ~
+            children  (sy (get-children:src pre-sync source.grp1))
+          ==
+        ::
+          :-  source.grp2
+          %=  chan-sum2
+            unread  ~
+            children  (sy (get-children:src pre-sync source.grp2))
+          ==
+        ::
+          :-  source.base
+          %=  chan-sum2
+            unread  ~
+            children  ~
+          ==
+      ==
+    --
+  --
+++  fix-init
+  |%
+  +$  source-set
+    $:  thrd1=index-pair
+        thrd2=index-pair
+        chnl=index-pair
+        grp=index-pair
+        dm-thread=index-pair
+        read-dm=index-pair
+        unread-dm=index-pair
+        dm-invite=index-pair
+        base=index-pair
     ==
+  ::  we want to test multiple scenarios in one go. we have a dm that's
+  ::  completely read, a dm that's unread, and a dm with only an invite.
+  ::  we also have a channel with threads that is completely read.
+  ++  state-0
+    |%
+    ++  sources
+      ^-  source-set
+      =/  thrd1  (thread-source-2 flag nest i0)
+      =/  thrd2  (thread-source-3 flag nest i0)
+      =.  thrd2  thrd2(reads.index [d5 ~])
+      =/  =reads:a  [d4 ~]
+      =/  chnl
+        %+  merge-children  (channel-source flag nest reads i0)
+        ~[stream.index.thrd1 stream.index.thrd2]
+      =/  grp
+        %+  merge-children  (group-source flag reads)
+        ~[stream.index.chnl]
+      =/  dm-thread  (dm-thread-source [[~dev d0] d0] [%ship ~rus])
+      =/  read-dm
+        %+  merge-children  (dm-source [%ship ~rus] [d3 ~])
+        ~[stream.index.dm-thread]
+      =/  unread-dm
+        (dm-source [%ship ~dyl] [d0 ~])
+      =/  dm-invite=index-pair
+        :-  [%dm [%club 0v1d.u717i.b92pp.aa9oh.u044i.joqln]]
+        :_  [[d0 ~] d0]
+        %+  gas:on-event:a  *stream:a
+        ~[[d1 [[%dm-invite [%club 0v1d.u717i.b92pp.aa9oh.u044i.joqln]] & |]]]
+      :*  thrd1
+          thrd2
+          chnl
+          grp
+          dm-thread
+          read-dm
+          unread-dm
+          dm-invite
+          %+  merge-children  (base-source [d0 ~])
+          :~  stream.index.grp
+              stream.index.read-dm
+              stream.index.unread-dm
+              stream.index.dm-invite
+          ==
+      ==
+    ++  volumes
+      %+  roll
+        ~(tap by indices)
+      |=  [[=source:a =index:a] =volume-settings:a]
+      %+  ~(put by volume-settings)  source
+      default-volumes:a
+    ++  indices
+      %-  ~(gas by *indices:a)
+      =>  sources
+      .(base [base ~])
+    ++  pre-fix
+      ^-  activity:a
+      %+  roll
+        ~(tap by indices)
+      |=  [[=source:a =index:a] =activity:a]
+      %+  ~(put by activity)  source
+      (~(summarize-unreads urd indices *activity:a volumes fake-log) source index)
+    ++  post-fix
+      ^-  activity:a
+      =+  sources
+      %-  ~(uni by pre-fix)
+      %-  ~(gas by *activity:a)
+      :~  :-  source.chnl
+          [d5 0 0 | ~ (sy source.thrd1 source.thrd2 ~) ~]
+          :-  source.grp
+          [d5 0 0 | ~ (sy source.chnl ~) ~]
+          :-  source.read-dm
+          [d4 0 0 | ~ (sy source.dm-thread ~) ~]
+      ==
+    --
   --
 ::  base
 ++  base-source
-  |=  group-idx=index:a
+  |=  =reads:a
   ^-  index-pair
   :-  [%base ~]
-  group-idx(stream (child-stream stream.group-idx))
+  [*stream:a reads d0]
 ::  the group has no posts of its own only from children, it is "unread"
 ++  group-source
-  |=  [=flag:g channel-idx=index:a]
+  |=  [=flag:g =reads:a]
   ^-  index-pair
   :-  [%group flag]
-  channel-idx(stream (child-stream stream.channel-idx))
+  [*stream:a reads d0]
 ::  the channel only has two posts, and it is completely read
 ++  channel-source
-  |=  [=flag:g =nest:c =reads:a thrd1=index:a thrd2=index:a interval=@dr]
+  |=  [=flag:g =nest:c =reads:a interval=@dr]
   ^-  index-pair
   :-  [%channel nest flag]
-  :*  %+  uni:on-event:a  (child-stream stream.thrd1)
-      %+  gas:on-event:a  (child-stream stream.thrd2)
+  :*  %+  gas:on-event:a  *stream:a
       =/  key1  (mod [[~dev d3] d3] interval)
       =/  key2  (mod [[~dev d4] d4] interval)
       :~  [time.key1 [[%post key1 nest flag *story:c |] | |]]
@@ -476,7 +596,16 @@
     ::
       reads
     ::
-      *@da
+      d0
+  ==
+++  dm-source
+  |=  [=whom:ch =reads:a]
+  ^-  index-pair
+  :-  [%dm whom]
+  :_  [reads d0]
+  %+  gas:on-event:a  *stream:a
+  :~  [d2 [[%dm-post [[~rus d2] d2] whom *story:c |] | |]]
+      [d3 [[%dm-post [[~rus d3] d3] whom *story:c |] | |]]
   ==
 ::
 ::  this thread has two messages and is unread
@@ -521,6 +650,15 @@
     ::
       *@da
   ==
+++  dm-thread-source
+  |=  [parent=message-key:a =whom:ch]
+  ^-  index-pair
+  :-  [%dm-thread parent whom]
+  :_  [[d4 ~] d0]
+  %+  gas:on-event:a  *stream:a
+  :~  [d4 [[%dm-reply [[~rus d4] d4] parent whom *story:c |] | |]]
+      [d1 [[%dm-reply [[~rus d1] d1] parent whom *story:c |] | |]]
+  ==
 ++  create-reply-pair
   |=  [key=message-key:a parent=message-key:a interval=@dr]
   =.  key  (mod key interval)
@@ -528,9 +666,24 @@
 ++  mod
   |=  [key=message-key:a interval=@dr]
   key(time (add time.key interval), q.id (add q.id.key interval))
+++  merge-children
+  |=  [index-pair children=(list stream:a)]
+  ^-  index-pair
+  :-  source
+  %=  index
+      stream
+    %+  roll
+      children
+    |=  [=stream:a acc=_stream.index]
+    (uni:on-event:a acc (child-stream stream))
+  ==
 ++  child-stream
   |=  =stream:a
   (run:on-event:a stream |=(=event:a event(child &)))
+++  fake-log
+  |=  msg=(trap tape)
+  same
+  :: (slog leaf+"%activity {(msg)}" ~)
 ++  i0  *@dr
 ++  i1  (add i0 ~s1)
 ++  d-1  (dec *@da)


### PR DESCRIPTION
Fixes TLON-2447 by adding a new state transition that will run a fix. The fix looks for any DM or channel sources with only one event which should be either `%dm-invite` or `%chan-init` and sets the floor to the `last-read` time from the old agents. If this is actually an invite pending, then it will stay unread which is what we want. If it's not pending and they had in fact previously interacted and read that channel, then it will be marked read.

Unfortunately, to call these migration methods I had to factor them out to be pure so that we could call them on old state. Sync reads tests still pass, going to write some for this fix scenario.

PR Checklist
- [X] Includes changes to desk files
- [ ] Describes how you tested the PR locally (test ship vs livenet)
- [X] If a new feature, includes automated tests
- [X] Comments added anywhere logic may be confusing without context