### PR TITLE
native: search fixes

### DIFF
--- a/apps/tlon-mobile/src/screens/ChannelScreen.tsx
+++ b/apps/tlon-mobile/src/screens/ChannelScreen.tsx
@@ -99,9 +99,10 @@ export default function ChannelScreen(props: ChannelScreenProps) {
       (unread.countWithoutThreads ?? 0) > 0 &&
       unread?.firstUnreadPostId;
     return selectedPostId || firstUnreadId;
-    // We only want this to rerun when the channel is loaded for the first time.
+    // We only want this to rerun when the channel is loaded for the first time OR if
+    // the selected post route param changes
     // eslint-disable-next-line
-  }, [!!channel]);
+  }, [!!channel, selectedPostId]);
   const {
     posts,
     query: postsQuery,

--- a/apps/tlon-mobile/src/screens/ChannelSearchScreen.tsx
+++ b/apps/tlon-mobile/src/screens/ChannelSearchScreen.tsx
@@ -9,7 +9,6 @@ import {
   SearchResults,
   XStack,
   YStack,
-  useContacts,
 } from '@tloncorp/ui';
 import { useCallback, useState } from 'react';
 import { SafeAreaView } from 'react-native-safe-area-context';

--- a/apps/tlon-mobile/src/screens/ChannelSearchScreen.tsx
+++ b/apps/tlon-mobile/src/screens/ChannelSearchScreen.tsx
@@ -35,10 +35,20 @@ export default function ChannelSearch({
 
   const navigateToPost = useCallback(
     (post: db.Post) => {
-      navigation.navigate('Channel', {
-        channel,
-        selectedPostId: post.id,
-      });
+      if (post.parentId) {
+        navigation.replace('Post', {
+          post: {
+            id: post.parentId,
+            channelId: channel.id,
+            authorId: post.authorId,
+          },
+        });
+      } else {
+        navigation.navigate('Channel', {
+          channel,
+          selectedPostId: post.id,
+        });
+      }
     },
     [channel, navigation]
   );

--- a/apps/tlon-mobile/src/screens/ChannelSearchScreen.tsx
+++ b/apps/tlon-mobile/src/screens/ChannelSearchScreen.tsx
@@ -1,10 +1,20 @@
 import type { NativeStackScreenProps } from '@react-navigation/native-stack';
 import { useChannelSearch } from '@tloncorp/shared/dist';
 import type * as db from '@tloncorp/shared/dist/db';
-import { Button, SearchBar, SearchResults, XStack, YStack } from '@tloncorp/ui';
+import * as store from '@tloncorp/shared/dist/store';
+import {
+  AppDataContextProvider,
+  Button,
+  SearchBar,
+  SearchResults,
+  XStack,
+  YStack,
+  useContacts,
+} from '@tloncorp/ui';
 import { useCallback, useState } from 'react';
 import { SafeAreaView } from 'react-native-safe-area-context';
 
+import { useCurrentUserId } from '../hooks/useCurrentUser';
 import type { RootStackParamList } from '../types';
 
 type ChannelSearchProps = NativeStackScreenProps<
@@ -16,6 +26,8 @@ export default function ChannelSearch({
   route,
   navigation,
 }: ChannelSearchProps) {
+  const currentUserId = useCurrentUserId();
+  const { data: contacts } = store.useContacts();
   const { channel } = route.params;
   const [query, setQuery] = useState('');
   const { posts, loading, errored, hasMore, loadMore, searchedThroughDate } =
@@ -33,32 +45,37 @@ export default function ChannelSearch({
 
   return (
     <SafeAreaView edges={['top']} style={{ flex: 1 }}>
-      <YStack flex={1} paddingHorizontal="$l">
-        <XStack gap="$l">
-          <SearchBar
-            onChangeQuery={setQuery}
-            placeholder={`Search ${channel.title}`}
-          />
-          <Button minimal onPress={() => navigation.pop()}>
-            <Button.Text>Cancel</Button.Text>
-          </Button>
-        </XStack>
+      <AppDataContextProvider
+        currentUserId={currentUserId}
+        contacts={contacts ?? []}
+      >
+        <YStack flex={1} paddingHorizontal="$l">
+          <XStack gap="$l">
+            <SearchBar
+              onChangeQuery={setQuery}
+              placeholder={`Search ${channel.title}`}
+            />
+            <Button minimal onPress={() => navigation.pop()}>
+              <Button.Text>Cancel</Button.Text>
+            </Button>
+          </XStack>
 
-        <SearchResults
-          posts={posts ?? []}
-          navigateToPost={navigateToPost}
-          search={{
-            query,
-            loading,
-            errored,
-            hasMore,
-            loadMore,
-            searchComplete: !loading && !hasMore,
-            numResults: posts?.length ?? 0,
-            searchedThroughDate,
-          }}
-        />
-      </YStack>
+          <SearchResults
+            posts={posts ?? []}
+            navigateToPost={navigateToPost}
+            search={{
+              query,
+              loading,
+              errored,
+              hasMore,
+              loadMore,
+              searchComplete: !loading && !hasMore,
+              numResults: posts?.length ?? 0,
+              searchedThroughDate,
+            }}
+          />
+        </YStack>
+      </AppDataContextProvider>
     </SafeAreaView>
   );
 }

--- a/packages/shared/src/api/channelsApi.ts
+++ b/packages/shared/src/api/channelsApi.ts
@@ -328,8 +328,6 @@ export const searchChatChannel = async (params: {
     }/${SINGLE_PAGE_SEARCH_DEPTH}/${encodedQuery}`,
   });
 
-  console.log(`bl: response scan`, response.scan);
-
   // note: we avoid incurring the cost of sorting here since the main consumer (useChannelSearch)
   // aggregates results across multiple pages
   const posts: db.Post[] = response.scan

--- a/packages/shared/src/api/channelsApi.ts
+++ b/packages/shared/src/api/channelsApi.ts
@@ -328,10 +328,27 @@ export const searchChatChannel = async (params: {
     }/${SINGLE_PAGE_SEARCH_DEPTH}/${encodedQuery}`,
   });
 
-  const posts = response.scan
-    .filter((scanItem) => 'post' in scanItem && scanItem.post !== undefined)
-    .map((scanItem) => (scanItem as { post: ub.Post }).post)
-    .map((post) => toPostData(params.channelId, post));
+  console.log(`bl: response scan`, response.scan);
+
+  // note: we avoid incurring the cost of sorting here since the main consumer (useChannelSearch)
+  // aggregates results across multiple pages
+  const posts: db.Post[] = response.scan
+    .map((scanItem) => {
+      if ('post' in scanItem) {
+        return toPostData(params.channelId, scanItem.post);
+      }
+      if ('reply' in scanItem) {
+        const parentId = getCanonicalPostId(scanItem.reply['id-post']);
+        return toPostReplyData(
+          params.channelId,
+          parentId,
+          scanItem.reply.reply
+        );
+      }
+      return false;
+    })
+    .filter((post) => post !== false) as db.Post[];
+
   const cursor = response.last;
 
   return { posts, cursor };

--- a/packages/shared/src/store/syncQueue.ts
+++ b/packages/shared/src/store/syncQueue.ts
@@ -1,7 +1,7 @@
 import { createDevLogger, runIfDev } from '../debug';
 import { RetryConfig, withRetry } from '../logic';
 
-const logger = createDevLogger('syncQueue', true);
+const logger = createDevLogger('syncQueue', false);
 
 interface SyncOperation {
   label: string;

--- a/packages/ui/src/components/AuthorRow.tsx
+++ b/packages/ui/src/components/AuthorRow.tsx
@@ -32,14 +32,9 @@ type AuthorRowProps = ComponentProps<typeof XStack> & {
   deliveryStatus?: db.PostDeliveryStatus | null;
   type?: db.PostType;
   detailView?: boolean;
-  nonPressable?: boolean;
 };
 
-export default function AuthorRow({
-  onPress,
-  nonPressable,
-  ...props
-}: AuthorRowProps) {
+export default function AuthorRow({ onPress, ...props }: AuthorRowProps) {
   const [showProfile, setShowProfile] = useState(false);
 
   const handlePress = useCallback(
@@ -55,25 +50,13 @@ export default function AuthorRow({
   return (
     <>
       {props.detailView ? (
-        <DetailViewAuthorRow
-          {...props}
-          onPress={nonPressable ? undefined : handlePress}
-        />
+        <DetailViewAuthorRow {...props} onPress={handlePress} />
       ) : props.type === 'block' ? (
-        <BlockAuthorRow
-          {...props}
-          onPress={nonPressable ? undefined : handlePress}
-        />
+        <BlockAuthorRow {...props} onPress={handlePress} />
       ) : props.type === 'note' ? (
-        <NotebookAuthorRow
-          {...props}
-          onPress={nonPressable ? undefined : handlePress}
-        />
+        <NotebookAuthorRow {...props} onPress={handlePress} />
       ) : (
-        <ChatAuthorRow
-          {...props}
-          onPress={nonPressable ? undefined : handlePress}
-        />
+        <ChatAuthorRow {...props} onPress={handlePress} />
       )}
       {showProfile && props.author && (
         <ProfileSheet

--- a/packages/ui/src/components/AuthorRow.tsx
+++ b/packages/ui/src/components/AuthorRow.tsx
@@ -32,9 +32,14 @@ type AuthorRowProps = ComponentProps<typeof XStack> & {
   deliveryStatus?: db.PostDeliveryStatus | null;
   type?: db.PostType;
   detailView?: boolean;
+  nonPressable?: boolean;
 };
 
-export default function AuthorRow({ onPress, ...props }: AuthorRowProps) {
+export default function AuthorRow({
+  onPress,
+  nonPressable,
+  ...props
+}: AuthorRowProps) {
   const [showProfile, setShowProfile] = useState(false);
 
   const handlePress = useCallback(
@@ -50,13 +55,25 @@ export default function AuthorRow({ onPress, ...props }: AuthorRowProps) {
   return (
     <>
       {props.detailView ? (
-        <DetailViewAuthorRow {...props} onPress={handlePress} />
+        <DetailViewAuthorRow
+          {...props}
+          onPress={nonPressable ? undefined : handlePress}
+        />
       ) : props.type === 'block' ? (
-        <BlockAuthorRow {...props} onPress={handlePress} />
+        <BlockAuthorRow
+          {...props}
+          onPress={nonPressable ? undefined : handlePress}
+        />
       ) : props.type === 'note' ? (
-        <NotebookAuthorRow {...props} onPress={handlePress} />
+        <NotebookAuthorRow
+          {...props}
+          onPress={nonPressable ? undefined : handlePress}
+        />
       ) : (
-        <ChatAuthorRow {...props} onPress={handlePress} />
+        <ChatAuthorRow
+          {...props}
+          onPress={nonPressable ? undefined : handlePress}
+        />
       )}
       {showProfile && props.author && (
         <ProfileSheet

--- a/packages/ui/src/components/ChannelSearch/SearchResults.tsx
+++ b/packages/ui/src/components/ChannelSearch/SearchResults.tsx
@@ -1,5 +1,6 @@
 import * as db from '@tloncorp/shared/dist/db';
 import { useCallback, useMemo } from 'react';
+import React from 'react';
 import { FlatList, Keyboard } from 'react-native';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
 
@@ -7,6 +8,26 @@ import { SizableText, Stack, View, XStack, YStack } from '../../core';
 import { ChatMessage } from '../ChatMessage';
 import { SearchStatus } from './SearchStatus';
 import { SearchState } from './types';
+
+function SearchResultComponent({
+  onPress,
+  post,
+}: {
+  onPress: () => void;
+  post: db.Post;
+}) {
+  return (
+    <View marginBottom="$m" onPress={onPress}>
+      <ChatMessage
+        post={post}
+        showAuthor
+        hideProfilePreview
+        onPress={onPress}
+      />
+    </View>
+  );
+}
+const SearchResult = React.memo(SearchResultComponent);
 
 export function SearchResults({
   posts,
@@ -28,21 +49,9 @@ export function SearchResults({
   const isInitial = search.query === '';
 
   const renderItem = useCallback(
-    ({ item: post }: { item: db.Post }) => {
-      return (
-        <View
-          marginBottom="$m"
-          onPress={() => navigateToPost(post as unknown as db.Post)}
-        >
-          <ChatMessage
-            post={post}
-            showAuthor
-            onPress={() => navigateToPost(post as unknown as db.Post)}
-            authorRowProps={{ nonPressable: true }}
-          />
-        </View>
-      );
-    },
+    ({ item: post }: { item: db.Post }) => (
+      <SearchResult onPress={() => navigateToPost(post)} post={post} />
+    ),
     [navigateToPost]
   );
 

--- a/packages/ui/src/components/ChannelSearch/SearchResults.tsx
+++ b/packages/ui/src/components/ChannelSearch/SearchResults.tsx
@@ -67,12 +67,19 @@ export function SearchResults({
               <FlatList
                 data={posts}
                 onEndReached={onEndReached}
+                initialNumToRender={10}
+                windowSize={20}
                 renderItem={({ item: post }) => (
                   <View
                     marginBottom="$m"
                     onPress={() => navigateToPost(post as unknown as db.Post)}
                   >
-                    <ChatMessage post={post} />
+                    <ChatMessage
+                      post={post}
+                      showAuthor
+                      onPress={() => navigateToPost(post as unknown as db.Post)}
+                      authorRowProps={{ nonPressable: true }}
+                    />
                   </View>
                 )}
                 ListFooterComponent={

--- a/packages/ui/src/components/ChannelSearch/SearchResults.tsx
+++ b/packages/ui/src/components/ChannelSearch/SearchResults.tsx
@@ -17,7 +17,7 @@ function SearchResultComponent({
   post: db.Post;
 }) {
   return (
-    <View marginBottom="$m" onPress={onPress}>
+    <View marginBottom="$m">
       <ChatMessage
         post={post}
         showAuthor

--- a/packages/ui/src/components/ChatMessage/ChatMessage.tsx
+++ b/packages/ui/src/components/ChatMessage/ChatMessage.tsx
@@ -41,7 +41,7 @@ const NoticeWrapper = ({
 const ChatMessage = ({
   post,
   showAuthor,
-  authorRowProps,
+  hideProfilePreview,
   onPressReplies,
   onPressImage,
   onPress,
@@ -55,6 +55,7 @@ const ChatMessage = ({
 }: {
   post: db.Post;
   showAuthor?: boolean;
+  hideProfilePreview?: boolean;
   authorRowProps?: Partial<ComponentProps<typeof AuthorRow>>;
   showReplies?: boolean;
   onPressReplies?: (post: db.Post) => void;
@@ -177,7 +178,7 @@ const ChatMessage = ({
             authorId={post.authorId}
             sent={post.sentAt ?? 0}
             type={post.type}
-            {...authorRowProps}
+            disabled={hideProfilePreview}
             // roles={roles}
           />
         </View>

--- a/packages/ui/src/components/ChatMessage/ChatMessage.tsx
+++ b/packages/ui/src/components/ChatMessage/ChatMessage.tsx
@@ -2,7 +2,7 @@ import { utils } from '@tloncorp/shared';
 import * as db from '@tloncorp/shared/dist/db';
 import { Story } from '@tloncorp/shared/dist/urbit';
 import { isEqual } from 'lodash';
-import { memo, useCallback, useMemo, useState } from 'react';
+import { ComponentProps, memo, useCallback, useMemo, useState } from 'react';
 
 import { Text, View, XStack, YStack } from '../../core';
 import { ActionSheet } from '../ActionSheet';
@@ -41,8 +41,10 @@ const NoticeWrapper = ({
 const ChatMessage = ({
   post,
   showAuthor,
+  authorRowProps,
   onPressReplies,
   onPressImage,
+  onPress,
   onLongPress,
   onPressRetry,
   onPressDelete,
@@ -53,9 +55,11 @@ const ChatMessage = ({
 }: {
   post: db.Post;
   showAuthor?: boolean;
+  authorRowProps?: Partial<ComponentProps<typeof AuthorRow>>;
   showReplies?: boolean;
   onPressReplies?: (post: db.Post) => void;
   onPressImage?: (post: db.Post, imageUri?: string) => void;
+  onPress?: (post: db.Post) => void;
   onLongPress?: (post: db.Post) => void;
   onPressRetry?: (post: db.Post) => void;
   onPressDelete?: (post: db.Post) => void;
@@ -73,6 +77,18 @@ const ChatMessage = ({
   const handleRepliesPressed = useCallback(() => {
     onPressReplies?.(post);
   }, [onPressReplies, post]);
+
+  const shouldHandlePress = useMemo(() => {
+    return Boolean(onPress || post.deliveryStatus === 'failed');
+  }, [onPress, post.deliveryStatus]);
+  const handlePress = useCallback(() => {
+    onPress?.(post);
+    if (onPress) {
+      onPress(post);
+    } else if (post.deliveryStatus === 'failed') {
+      setShowRetrySheet(true);
+    }
+  }, [post, onPress]);
 
   const handleLongPress = useCallback(() => {
     onLongPress?.(post);
@@ -151,11 +167,8 @@ const ChatMessage = ({
       gap="$s"
       paddingVertical="$xs"
       paddingRight="$l"
-      onPress={
-        post.deliveryStatus === 'failed'
-          ? () => setShowRetrySheet(true)
-          : undefined
-      }
+      // avoid setting the top level press handler at all unless we need to
+      onPress={shouldHandlePress ? handlePress : undefined}
     >
       {showAuthor ? (
         <View paddingLeft="$l" paddingTop="$s">
@@ -164,6 +177,7 @@ const ChatMessage = ({
             authorId={post.authorId}
             sent={post.sentAt ?? 0}
             type={post.type}
+            {...authorRowProps}
             // roles={roles}
           />
         </View>
@@ -240,7 +254,8 @@ export default memo(ChatMessage, (prev, next) => {
     prev.setEditingPost === next.setEditingPost &&
     prev.onPressReplies === next.onPressReplies &&
     prev.onPressImage === next.onPressImage &&
-    prev.onLongPress === next.onLongPress;
+    prev.onLongPress === next.onLongPress &&
+    prev.onPress === next.onPress;
 
   return isPostEqual && areOtherPropsEqual;
 });

--- a/packages/ui/src/components/ChatMessage/ChatMessage.tsx
+++ b/packages/ui/src/components/ChatMessage/ChatMessage.tsx
@@ -83,7 +83,6 @@ const ChatMessage = ({
     return Boolean(onPress || post.deliveryStatus === 'failed');
   }, [onPress, post.deliveryStatus]);
   const handlePress = useCallback(() => {
-    onPress?.(post);
     if (onPress) {
       onPress(post);
     } else if (post.deliveryStatus === 'failed') {


### PR DESCRIPTION
- display normal chat message affordances in search results (contact info, date, etc.)
- include and route to thread search results
- make search results clickable again
- fix `selectedPostId` updates not carrying through to the `useChannelPosts` hook
- improve rendering performance for the search result list

There's more optimization that could be done around avoiding jitter in the results, but anecdotally it's less noticeable for real world searches. The scroller thrashing while anchoring on the selected post after clicking remains the dominating pain point, as is the case elsewhere.

Fixes TLON-2052