### PR TITLE
activity: use unreads to determine which sources should change

### DIFF
--- a/desk/app/activity.hoon
+++ b/desk/app/activity.hoon
@@ -829,15 +829,13 @@
 ::  otherwise we end up with a bunch of dms/channels that are
 ::  incorrectly unread.
 ++  fix-init-unreads
-  =+  .^(=channels:c %gx (scry-path %channels /v2/channels/full/noun))
-  =.  indices  (fix-channel-init-unreads indices channels)
-  =+  .^  [dms=(map ship dm:ch) clubs=(map id:club:ch club:ch)]
-      %gx  (scry-path %chat /full/noun)
-    ==
-  =.  indices  (fix-dm-init-unreads indices dms clubs)
+  =+  .^(=unreads:c %gx (scry-path %channels /v1/unreads/noun))
+  =.  indices  (fix-channel-init-unreads indices unreads)
+  =+  .^(=unreads:ch %gx (scry-path %chat /unreads/noun))
+  =.  indices  (fix-dm-init-unreads indices unreads)
   refresh-all-summaries
 ++  fix-channel-init-unreads
-  |=  [=indices:a =channels:c]
+  |=  [=indices:a =unreads:c]
   %-  ~(urn by indices)
   |=  [=source:a =index:a]
   ::  if we're a channel with only the %chan-init event, we need to set
@@ -846,10 +844,11 @@
           ?=([[* [[%chan-init *] *]] ~ ~] stream.index)
       ==
     index
-  ?~  channel=(~(get by channels) nest.source)  index
-  index(floor.reads last-read.remark.u.channel)
+  ?~  channel=(~(get by unreads) nest.source)  index
+  ?.  &(=(count.u.channel 0) =(~ unread.u.channel))  index
+  index(floor.reads recency.u.channel)
 ++  fix-dm-init-unreads
-  |=  [=indices:a dms=(map ship dm:ch) clubs=(map id:club:ch club:ch)]
+  |=  [=indices:a =unreads:ch]
   ^-  indices:a
   %-  ~(urn by indices)
   |=  [=source:a =index:a]
@@ -859,15 +858,14 @@
           ?=([[* [[%dm-invite *] *]] ~ ~] stream.index)
       ==
     index
-  ?-  -.whom.source
-      %ship
-    ?~  dm=(~(get by dms) p.whom.source)  index
-    index(floor.reads last-read.remark.u.dm)
-  ::
-      %club
-    ?~  club=(~(get by clubs) p.whom.source)  index
-    index(floor.reads last-read.remark.u.club)
-  ==
+  =/  whom
+    ?-  -.whom.source
+      %ship  whom.source
+      %club  whom.source
+    ==
+  ?~  dm=(~(get by unreads) whom.source)  index
+  ?.  &(=(count.u.dm 0) =(~ unread.u.dm))  index
+  index(floor.reads recency.u.dm)
 ::  previously we used items as a way to track individual reads because
 ::  floors were not local, but we have reverted to local floors and not
 ::  tracking individual reads
@@ -1052,7 +1050,7 @@
   =;  events=(list [time incoming-event:a])
     |-
     ?~  events
-      cor(indices (fix-channel-init-unreads indices channels))
+      cor(indices (fix-channel-init-unreads indices unreads))
     =.  cor  (%*(. add-event start-time -.i.events) +.i.events)
     $(events t.events)
   |-  ^-  (list [time incoming-event:a])
@@ -1114,7 +1112,7 @@
   =;  events=(list [time incoming-event:a])
     |-
     ?~  events
-      cor(indices (fix-dm-init-unreads indices dms clubs))
+      cor(indices (fix-dm-init-unreads indices unreads))
     =.  cor  (%*(. add-event start-time -.i.events) +.i.events)
     $(events t.events)
   |-  ^-  (list [time incoming-event:a])

--- a/desk/tests/app/activity.hoon
+++ b/desk/tests/app/activity.hoon
@@ -565,54 +565,39 @@
       |=  =path
       ^-  (unit vase)
       ?+  path  ~
-        [%gx @ %chat @ %full *]   `!>(chat-scry)
-        [%gx @ %channels @ %v2 %channels %full *]   `!>(channels-scry)
+        [%gx @ %chat @ %unreads *]   `!>(chat-scry)
+        [%gx @ %channels @ %v1 %unreads *]   `!>(channels-scry)
       ==
     ++  channels-scry
-      ^-  channels:c
+      ^-  unreads:c
       =+  sources
-      =|  empty=channel:c
-      %-  ~(gas by *channels:c)
+      %-  ~(gas by *unreads:c)
       :~  :-  (get-nest source.chnl)
-          empty(remark [d5 d4 & ~])
+          [d5 0 ~ ~]
           :-  (get-nest source.bad-chnl-migration)
-          empty(remark [d1 d1 & ~])
+          [d1 0 ~ ~]
       ==
     ++  chat-scry
-      ^-  [dms clubs]
+      ^-  unreads:ch
       =+  sources
-      =|  empty-club=club:ch
-      =|  empty-dm=dm:ch
-      =/  =dms
-        %-  ~(gas by *dms)
-        :~  :-  (get-ship source.read-dm)
-            empty-dm(remark [d4 d3 & ~])
-            :-  (get-ship source.unread-dm)
-            empty-dm(remark [d3 d0 & ~])
-            :-  (get-ship source.bad-dm-migration)
-            empty-dm(remark [d1 d1 & ~])
-        ==
-      =/  =clubs
-        %+  ~(put by *clubs)  (get-club source.dm-invite)
-        empty-club(remark [d0 d0 & ~])
-      [dms clubs]
+      %-  ~(gas by *unreads:ch)
+      :~  :-  (get-whom source.read-dm)
+          [d4 0 ~ ~]
+          :-  (get-whom source.unread-dm)
+          [d3 2 `[[[~rus d2] d2] 2] ~]
+          :-  (get-whom source.bad-dm-migration)
+          [d1 0 ~ ~]
+      ==
     ++  get-nest
       |=  =source:a
       ^-  nest:c
       ?>  ?=(%channel -.source)
       nest.source
-    ++  get-ship
+    ++  get-whom
       |=  =source:a
-      ^-  ship
+      ^-  whom:ch
       ?>  ?=(%dm -.source)
-      ?>  ?=(%ship -.whom.source)
-      p.whom.source
-    ++  get-club
-      |=  =source:a
-      ^-  id:club:ch
-      ?>  ?=(%dm -.source)
-      ?>  ?=(%club -.whom.source)
-      p.whom.source
+      whom.source
     ++  volumes
       %+  roll
         ~(tap by indices)


### PR DESCRIPTION
This changes the init fix to use unreads. It turns out the last-read/recency comparisons we were doing are invalid because of the way the old agents calculate unreads, so instead we just the unreads themselves.

PR Checklist
- [X] Includes changes to desk files
- [ ] Describes how you tested the PR locally (test ship vs livenet)
- [X] If a new feature, includes automated tests
- [ ] Comments added anywhere logic may be confusing without context