### PR TITLE
native: more search fixes

### DIFF
--- a/apps/tlon-mobile/src/screens/ChannelSearchScreen.tsx
+++ b/apps/tlon-mobile/src/screens/ChannelSearchScreen.tsx
@@ -30,7 +30,7 @@ export default function ChannelSearch({
   const { channel } = route.params;
   const [query, setQuery] = useState('');
   const { posts, loading, errored, hasMore, loadMore, searchedThroughDate } =
-    useChannelSearch(channel.id, query);
+    useChannelSearch(channel, query);
 
   const navigateToPost = useCallback(
     (post: db.Post) => {

--- a/packages/shared/src/store/useChannelSearch.ts
+++ b/packages/shared/src/store/useChannelSearch.ts
@@ -3,7 +3,8 @@ import { daToUnix } from '@urbit/api';
 import bigInt from 'big-integer';
 import { useEffect, useMemo } from 'react';
 
-import { searchChatChannel } from '../api/channelsApi';
+import { searchChannel } from '../api/channelsApi';
+import * as db from '../db';
 import { createDevLogger } from '../debug';
 import { useAttachAuthorToPosts } from './useAttachAuthorToPosts';
 
@@ -11,7 +12,7 @@ const MIN_RESULT_LOAD_THRESHOLD = 20;
 
 const logger = createDevLogger('channel search', true);
 
-export function useChannelSearch(channelId: string, query: string) {
+export function useChannelSearch(channel: db.Channel, query: string) {
   const {
     results,
     searchedThroughDate,
@@ -19,7 +20,7 @@ export function useChannelSearch(channelId: string, query: string) {
     isError: apiError,
     hasNextPage,
     fetchNextPage,
-  } = useInfiniteChannelSearch(channelId, query);
+  } = useInfiniteChannelSearch(channel, query);
 
   const posts = useAttachAuthorToPosts(results);
 
@@ -44,14 +45,14 @@ export function useChannelSearch(channelId: string, query: string) {
   };
 }
 
-export function useInfiniteChannelSearch(channelId: string, query: string) {
+export function useInfiniteChannelSearch(channel: db.Channel, query: string) {
   const { data, ...rest } = useInfiniteQuery({
-    queryKey: ['channel', channelId, 'search', query],
+    queryKey: ['channel', channel.id, 'search', query],
     enabled: query !== '',
     queryFn: async ({ pageParam }) => {
       logger.log(`searching`, query, pageParam);
-      const response = await searchChatChannel({
-        channelId,
+      const response = await searchChannel({
+        channel,
         query,
         cursor: pageParam,
       });

--- a/packages/ui/src/components/Channel/index.tsx
+++ b/packages/ui/src/components/Channel/index.tsx
@@ -327,7 +327,9 @@ export function Channel({
                                       unreadCount={
                                         channelUnread?.countWithoutThreads ?? 0
                                       }
-                                      onPressPost={goToPost}
+                                      onPressPost={
+                                        isChatChannel ? undefined : goToPost
+                                      }
                                       onPressReplies={goToPost}
                                       onPressImage={goToImageViewer}
                                       onEndReached={onScrollEndReached}


### PR DESCRIPTION
A couple lingering search issues from the PR last week:

- Fixes search for DM's (1:1 and group)
- Resolves the issue with message presses overeagerly navigating you to the thread
  - restores previous behavior of needing to click the reply summary or long press to start a new thread