### PR TITLE
native: move group options handlers, tap bauble to show group options

### DIFF
--- a/apps/tlon-mobile/src/fixtures/Channel.fixture.tsx
+++ b/apps/tlon-mobile/src/fixtures/Channel.fixture.tsx
@@ -1,6 +1,7 @@
 import { useQuery } from '@tanstack/react-query';
 import {
   useChannel,
+  useGroup,
   useGroupPreview,
   usePostWithRelations,
 } from '@tloncorp/shared/dist';
@@ -95,7 +96,8 @@ const baseProps: ComponentProps<typeof Channel> = {
   usePost: usePostWithRelations,
   usePostReference: usePostReference,
   useChannel: useChannel,
-  useGroup: useGroupPreview,
+  useGroupInfo: useGroupPreview,
+  useGroup: useGroup,
   onGroupAction: () => {},
   getDraft: async () => ({}),
   storeDraft: () => {},
@@ -103,6 +105,14 @@ const baseProps: ComponentProps<typeof Channel> = {
   canUpload: true,
   onPressRetry: () => {},
   onPressDelete: () => {},
+  onPressGroupMeta: () => {},
+  onPressGroupMembers: () => {},
+  onPressManageChannels: () => {},
+  onPressInvitesAndPrivacy: () => {},
+  onPressRoles: () => {},
+  onPressLeave: () => Promise.resolve(),
+  onTogglePinned: () => {},
+  pinned: [],
 } as const;
 
 export const ChannelFixture = (props: {

--- a/apps/tlon-mobile/src/fixtures/ChannelHeader.fixture.tsx
+++ b/apps/tlon-mobile/src/fixtures/ChannelHeader.fixture.tsx
@@ -1,14 +1,25 @@
+import { useGroup } from '@tloncorp/shared/dist';
 import { ChannelHeader } from '@tloncorp/ui';
 
 import { tlonLocalBulletinBoard } from './fakeData';
 
 const channel = tlonLocalBulletinBoard;
 
-export default (
-  <ChannelHeader
-    title={channel.title ?? ''}
-    channel={channel}
-    showSearchButton={true}
-    showSpinner={true}
-  />
-);
+const baseProps: Parameters<typeof ChannelHeader>[0] = {
+  title: channel.title ?? '',
+  channel: channel,
+  showSearchButton: true,
+  showSpinner: true,
+  currentUserId: '~zod',
+  useGroup: useGroup,
+  onPressGroupMeta: () => {},
+  onPressGroupMembers: () => {},
+  onPressManageChannels: () => {},
+  onPressInvitesAndPrivacy: () => {},
+  onPressRoles: () => {},
+  onPressLeave: () => Promise.resolve(),
+  onTogglePinned: () => {},
+  pinned: [],
+} as const;
+
+export default <ChannelHeader {...baseProps} />;

--- a/apps/tlon-mobile/src/fixtures/DetailView.fixture.tsx
+++ b/apps/tlon-mobile/src/fixtures/DetailView.fixture.tsx
@@ -1,3 +1,5 @@
+import { useGroup } from '@tloncorp/shared/dist';
+import type * as db from '@tloncorp/shared/dist/db';
 import { PostScreenView } from '@tloncorp/ui/src';
 
 import { FixtureWrapper } from './FixtureWrapper';
@@ -17,28 +19,48 @@ const galleryPost = createFakePost(
 );
 const galleryReplies = createFakePosts(galleryPost.replyCount ?? 5, 'reply');
 
+const baseProps: Parameters<typeof PostScreenView>[0] = {
+  currentUserId: '~zod',
+  contacts: [],
+  channel: {} as db.Channel,
+  parentPost: null,
+  posts: [],
+  sendReply: async () => {},
+  markRead: () => {},
+  goBack: () => {},
+  group: null,
+  groupMembers: [],
+  pinned: [],
+  calmSettings: null,
+  uploadAsset: async () => {},
+  handleGoToImage: () => {},
+  storeDraft: () => {},
+  clearDraft: () => {},
+  getDraft: async () => ({}),
+  editPost: async () => {},
+  onPressRetry: () => {},
+  onPressDelete: () => {},
+  negotiationMatch: true,
+  canUpload: true,
+  useGroup: useGroup,
+  onPressGroupMeta: () => {},
+  onPressGroupMembers: () => {},
+  onPressManageChannels: () => {},
+  onPressInvitesAndPrivacy: () => {},
+  onPressRoles: () => {},
+  onPressLeave: async () => {},
+  onTogglePinned: () => {},
+};
+
 const NotebookDetailViewFixture = () => {
   return (
     <FixtureWrapper>
       <PostScreenView
+        {...baseProps}
         parentPost={notebookPost}
         posts={notebookReplies}
-        contacts={[]}
         channel={tlonLocalGettingStarted}
         currentUserId={notebookPost.authorId}
-        sendReply={async () => {}}
-        onPressRetry={() => {}}
-        onPressDelete={() => {}}
-        groupMembers={[]}
-        negotiationMatch={true}
-        editPost={async () => {}}
-        uploadAsset={async () => {}}
-        storeDraft={() => {}}
-        clearDraft={() => {}}
-        getDraft={async () => ({})}
-        goBack={() => {}}
-        markRead={() => {}}
-        canUpload={true}
       />
     </FixtureWrapper>
   );
@@ -48,24 +70,11 @@ const GalleryDetailViewFixture = () => {
   return (
     <FixtureWrapper>
       <PostScreenView
+        {...baseProps}
         parentPost={galleryPost}
         posts={galleryReplies}
-        contacts={[]}
         channel={tlonLocalBulletinBoard}
         currentUserId={galleryPost.authorId}
-        sendReply={async () => {}}
-        onPressRetry={() => {}}
-        onPressDelete={() => {}}
-        groupMembers={[]}
-        negotiationMatch={true}
-        editPost={async () => {}}
-        uploadAsset={async () => {}}
-        storeDraft={() => {}}
-        clearDraft={() => {}}
-        getDraft={async () => ({})}
-        goBack={() => {}}
-        markRead={() => {}}
-        canUpload={true}
       />
     </FixtureWrapper>
   );

--- a/apps/tlon-mobile/src/fixtures/PostScreen.fixture.tsx
+++ b/apps/tlon-mobile/src/fixtures/PostScreen.fixture.tsx
@@ -1,3 +1,4 @@
+import { useGroup } from '@tloncorp/shared/dist';
 import { PostScreenView } from '@tloncorp/ui';
 
 import {
@@ -9,33 +10,45 @@ import {
 
 const posts = createFakePosts(10);
 
+const baseProps: Parameters<typeof PostScreenView>[0] = {
+  editPost: async () => {},
+  onPressRetry: () => {},
+  onPressDelete: () => {},
+  editingPost: undefined,
+  negotiationMatch: true,
+  setEditingPost: () => {},
+  parentPost: null,
+  currentUserId: '~solfer-magfed',
+  contacts: initialContacts,
+  calmSettings: {
+    disableAvatars: false,
+    disableNicknames: false,
+    disableRemoteContent: false,
+  },
+  uploadAsset: async () => {},
+  channel: tlonLocalBulletinBoard,
+  posts: posts,
+  sendReply: async () => {},
+  markRead: () => {},
+  groupMembers: group.members ?? [],
+  getDraft: async () => ({}),
+  storeDraft: () => {},
+  clearDraft: () => {},
+  canUpload: true,
+  useGroup: useGroup,
+  group: null,
+  pinned: [],
+  onPressGroupMeta: () => {},
+  onPressGroupMembers: () => {},
+  onPressManageChannels: () => {},
+  onPressInvitesAndPrivacy: () => {},
+  onPressRoles: () => {},
+  onPressLeave: async () => {},
+  onTogglePinned: () => {},
+};
+
 export default (
   <>
-    <PostScreenView
-      editPost={async () => {}}
-      onPressRetry={() => {}}
-      onPressDelete={() => {}}
-      editingPost={undefined}
-      negotiationMatch={true}
-      setEditingPost={() => {}}
-      parentPost={null}
-      currentUserId="~solfer-magfed"
-      contacts={initialContacts}
-      calmSettings={{
-        disableAvatars: false,
-        disableNicknames: false,
-        disableRemoteContent: false,
-      }}
-      uploadAsset={async () => {}}
-      channel={tlonLocalBulletinBoard}
-      posts={posts}
-      sendReply={async () => {}}
-      markRead={() => {}}
-      groupMembers={group.members ?? []}
-      getDraft={async () => ({})}
-      storeDraft={() => {}}
-      clearDraft={() => {}}
-      canUpload={true}
-    />
+    <PostScreenView {...baseProps} />
   </>
 );

--- a/apps/tlon-mobile/src/screens/ChannelScreen.tsx
+++ b/apps/tlon-mobile/src/screens/ChannelScreen.tsx
@@ -1,10 +1,11 @@
-import { useFocusEffect } from '@react-navigation/native';
+import { useFocusEffect, useIsFocused } from '@react-navigation/native';
 import type { NativeStackScreenProps } from '@react-navigation/native-stack';
 import * as db from '@tloncorp/shared/dist/db';
 import * as store from '@tloncorp/shared/dist/store';
 import {
   useCanUpload,
   useChannel,
+  useGroup,
   useGroupPreview,
   usePostReference,
   usePostWithRelations,
@@ -18,6 +19,7 @@ import {
 import React, { useCallback, useMemo } from 'react';
 
 import type { RootStackParamList } from '../types';
+import { useGroupContext } from './GroupSettings/useGroupContext';
 import { useChannelContext } from './useChannelContext';
 
 type ChannelScreenProps = NativeStackScreenProps<RootStackParamList, 'Channel'>;
@@ -73,6 +75,24 @@ export default function ChannelScreen(props: ChannelScreenProps) {
     draftKey: currentChannelId,
     uploaderKey: `${currentChannelId}`,
   });
+
+  const {
+    handleGoToGroupMeta,
+    handleGoToGroupMembers,
+    handleGoToManageChannels,
+    handleGoToInvitesAndPrivacy,
+    handleGoToRoles,
+    leaveGroup,
+    togglePinned,
+  } = useGroupContext({ groupId: channel?.group?.id || '' });
+
+  const isFocused = useIsFocused();
+  const { data: chats } = store.useCurrentChats({
+    enabled: isFocused,
+  });
+  const pinnedItems = useMemo(() => {
+    return chats?.pinned ?? [];
+  }, [chats]);
 
   const session = store.useCurrentSession();
   const hasCachedNewest = useMemo(() => {
@@ -226,7 +246,8 @@ export default function ChannelScreen(props: ChannelScreenProps) {
         markRead={handleMarkRead}
         usePost={usePostWithRelations}
         usePostReference={usePostReference}
-        useGroup={useGroupPreview}
+        useGroup={useGroup}
+        useGroupInfo={useGroupPreview}
         onGroupAction={performGroupAction}
         useChannel={useChannel}
         storeDraft={storeDraft}
@@ -239,6 +260,14 @@ export default function ChannelScreen(props: ChannelScreenProps) {
         editPost={editPost}
         negotiationMatch={negotiationStatus.matchedOrPending}
         canUpload={canUpload}
+        onPressGroupMeta={handleGoToGroupMeta}
+        onPressGroupMembers={handleGoToGroupMembers}
+        onPressManageChannels={handleGoToManageChannels}
+        onPressInvitesAndPrivacy={handleGoToInvitesAndPrivacy}
+        onPressRoles={handleGoToRoles}
+        onPressLeave={leaveGroup}
+        onTogglePinned={togglePinned}
+        pinned={pinnedItems ?? []}
       />
       {group && (
         <ChannelSwitcherSheet

--- a/apps/tlon-mobile/src/screens/GroupChannelsScreen.tsx
+++ b/apps/tlon-mobile/src/screens/GroupChannelsScreen.tsx
@@ -1,12 +1,12 @@
 import { useIsFocused } from '@react-navigation/native';
 import type { NativeStackScreenProps } from '@react-navigation/native-stack';
-import * as db from '@tloncorp/shared/dist/db';
 import * as store from '@tloncorp/shared/dist/store';
-import { AppDataContextProvider, GroupChannelsScreenView } from '@tloncorp/ui';
-import { useCallback, useMemo } from 'react';
+import { GroupChannelsScreenView } from '@tloncorp/ui';
+import { useMemo } from 'react';
 
 import { useCurrentUserId } from '../hooks/useCurrentUser';
-import type { GroupSettingsStackParamList, RootStackParamList } from '../types';
+// Adjust the import path as needed
+import type { RootStackParamList } from '../types';
 import { useGroupContext } from './GroupSettings/useGroupContext';
 
 type GroupChannelsScreenProps = NativeStackScreenProps<
@@ -14,115 +14,47 @@ type GroupChannelsScreenProps = NativeStackScreenProps<
   'GroupChannels'
 >;
 
-export function GroupChannelsScreen({
-  route,
-  navigation,
-}: GroupChannelsScreenProps) {
+export function GroupChannelsScreen({ route }: GroupChannelsScreenProps) {
   const groupParam = route.params.group;
-  const groupQuery = store.useGroup({ id: groupParam.id });
+  const {
+    group,
+    groupChannels,
+    handleChannelSelected,
+    handleGoBackPressed,
+    handleGoToGroupMeta,
+    handleGoToGroupMembers,
+    handleGoToManageChannels,
+    handleGoToInvitesAndPrivacy,
+    handleGoToRoles,
+    leaveGroup,
+    togglePinned,
+  } = useGroupContext({ groupId: groupParam.id });
+
   const currentUser = useCurrentUserId();
   const isFocused = useIsFocused();
   const { data: chats } = store.useCurrentChats({
     enabled: isFocused,
   });
-
   const pinnedItems = useMemo(() => {
     return chats?.pinned ?? [];
   }, [chats]);
 
-  const handleChannelSelected = useCallback(
-    (channel: db.Channel) => {
-      navigation.navigate('Channel', {
-        channel: channel,
-      });
-    },
-    [navigation]
-  );
-  const handleGoBackPressed = useCallback(() => {
-    navigation.goBack();
-  }, [navigation]);
-
-  const contactsQuery = store.useContacts();
-
-  const { leaveGroup, togglePinned } = useGroupContext({
-    groupId: groupParam.id,
-  });
-
-  const navigateToGroupSettings = useCallback(
-    <T extends keyof GroupSettingsStackParamList>(
-      screen: T,
-      params: GroupSettingsStackParamList[T]
-    ) => {
-      navigation.navigate('GroupSettings', {
-        screen,
-        params,
-      } as any);
-    },
-    [navigation]
-  );
-
-  const handleGoToGroupMeta = useCallback(
-    (groupId: string) => {
-      navigateToGroupSettings('GroupMeta', { groupId });
-    },
-    [navigateToGroupSettings]
-  );
-
-  const handleGoToGroupMembers = useCallback(
-    (groupId: string) => {
-      navigateToGroupSettings('GroupMembers', { groupId });
-    },
-    [navigateToGroupSettings]
-  );
-
-  const handleGoToManageChannels = useCallback(
-    (groupId: string) => {
-      navigateToGroupSettings('ManageChannels', { groupId });
-    },
-    [navigateToGroupSettings]
-  );
-
-  const handleGoToInvitesAndPrivacy = useCallback(
-    (groupId: string) => {
-      navigateToGroupSettings('InvitesAndPrivacy', { groupId });
-    },
-    [navigateToGroupSettings]
-  );
-
-  const handleGoToRoles = useCallback(
-    (groupId: string) => {
-      navigateToGroupSettings('GroupRoles', { groupId });
-    },
-    [navigateToGroupSettings]
-  );
-
-  const handleLeaveGroup = useCallback(async () => {
-    leaveGroup();
-    navigation.goBack();
-  }, [leaveGroup, navigation]);
-
-  const handleTogglePinned = useCallback(() => {
-    togglePinned();
-  }, [togglePinned]);
-
   return (
-    <AppDataContextProvider contacts={contactsQuery.data ?? null}>
-      <GroupChannelsScreenView
-        onChannelPressed={handleChannelSelected}
-        onBackPressed={handleGoBackPressed}
-        group={groupQuery.data ?? route.params.group}
-        channels={groupQuery.data?.channels ?? route.params.group.channels}
-        currentUser={currentUser}
-        pinned={pinnedItems ?? []}
-        useGroup={store.useGroup}
-        onPressGroupMeta={handleGoToGroupMeta}
-        onPressGroupMembers={handleGoToGroupMembers}
-        onPressManageChannels={handleGoToManageChannels}
-        onPressInvitesAndPrivacy={handleGoToInvitesAndPrivacy}
-        onPressRoles={handleGoToRoles}
-        onPressLeave={handleLeaveGroup}
-        onTogglePinned={handleTogglePinned}
-      />
-    </AppDataContextProvider>
+    <GroupChannelsScreenView
+      onChannelPressed={handleChannelSelected}
+      onBackPressed={handleGoBackPressed}
+      group={group ?? route.params.group}
+      channels={groupChannels}
+      currentUser={currentUser}
+      pinned={pinnedItems ?? []}
+      useGroup={store.useGroup}
+      onPressGroupMeta={handleGoToGroupMeta}
+      onPressGroupMembers={handleGoToGroupMembers}
+      onPressManageChannels={handleGoToManageChannels}
+      onPressInvitesAndPrivacy={handleGoToInvitesAndPrivacy}
+      onPressRoles={handleGoToRoles}
+      onPressLeave={leaveGroup}
+      onTogglePinned={togglePinned}
+    />
   );
 }

--- a/apps/tlon-mobile/src/screens/GroupSettings/useGroupContext.ts
+++ b/apps/tlon-mobile/src/screens/GroupSettings/useGroupContext.ts
@@ -1,3 +1,4 @@
+import { NavigationProp, useNavigation } from '@react-navigation/native';
 import { sync } from '@tloncorp/shared';
 import * as db from '@tloncorp/shared/dist/db';
 import { assembleNewChannelIdAndName } from '@tloncorp/shared/dist/db';
@@ -5,6 +6,10 @@ import * as store from '@tloncorp/shared/dist/store';
 import { useCallback, useEffect, useMemo } from 'react';
 
 import { useCurrentUserId } from '../../hooks/useCurrentUser';
+import type {
+  GroupSettingsStackParamList,
+  RootStackParamList,
+} from '../../types';
 
 export const useGroupContext = ({ groupId }: { groupId: string }) => {
   const currentUserId = useCurrentUserId();
@@ -95,6 +100,70 @@ export const useGroupContext = ({ groupId }: { groupId: string }) => {
   }, [group]);
 
   const { data: currentChatData } = store.useCurrentChats();
+
+  // Everything needed for the group settings sheet
+  const navigation = useNavigation<NavigationProp<RootStackParamList>>();
+
+  const handleChannelSelected = useCallback(
+    (channel: db.Channel) => {
+      navigation.navigate('Channel', {
+        channel: channel,
+      } as never);
+    },
+    [navigation]
+  );
+
+  const handleGoBackPressed = useCallback(() => {
+    navigation.goBack();
+  }, [navigation]);
+
+  const navigateToGroupSettings = useCallback(
+    <T extends keyof GroupSettingsStackParamList>(
+      screen: T,
+      params: GroupSettingsStackParamList[T]
+    ) => {
+      navigation.navigate('GroupSettings', {
+        screen,
+        params,
+      } as never);
+    },
+    [navigation]
+  );
+
+  const handleGoToGroupMeta = useCallback(
+    (groupId: string) => {
+      navigateToGroupSettings('GroupMeta', { groupId });
+    },
+    [navigateToGroupSettings]
+  );
+
+  const handleGoToGroupMembers = useCallback(
+    (groupId: string) => {
+      navigateToGroupSettings('GroupMembers', { groupId });
+    },
+    [navigateToGroupSettings]
+  );
+
+  const handleGoToManageChannels = useCallback(
+    (groupId: string) => {
+      navigateToGroupSettings('ManageChannels', { groupId });
+    },
+    [navigateToGroupSettings]
+  );
+
+  const handleGoToInvitesAndPrivacy = useCallback(
+    (groupId: string) => {
+      navigateToGroupSettings('InvitesAndPrivacy', { groupId });
+    },
+    [navigateToGroupSettings]
+  );
+
+  const handleGoToRoles = useCallback(
+    (groupId: string) => {
+      navigateToGroupSettings('GroupRoles', { groupId });
+    },
+    [navigateToGroupSettings]
+  );
 
   const createChannel = useCallback(
     async ({
@@ -357,5 +426,12 @@ export const useGroupContext = ({ groupId }: { groupId: string }) => {
     setUserRoles,
     leaveGroup,
     groupPrivacyType,
+    handleChannelSelected,
+    handleGoBackPressed,
+    handleGoToGroupMeta,
+    handleGoToGroupMembers,
+    handleGoToManageChannels,
+    handleGoToInvitesAndPrivacy,
+    handleGoToRoles,
   };
 };

--- a/apps/tlon-mobile/src/screens/PostScreen.tsx
+++ b/apps/tlon-mobile/src/screens/PostScreen.tsx
@@ -1,3 +1,4 @@
+import { useIsFocused } from '@react-navigation/native';
 import type { NativeStackScreenProps } from '@react-navigation/native-stack';
 import * as db from '@tloncorp/shared/dist/db';
 import * as store from '@tloncorp/shared/dist/store';
@@ -6,6 +7,7 @@ import { PostScreenView } from '@tloncorp/ui';
 import { useCallback, useMemo } from 'react';
 
 import type { RootStackParamList } from '../types';
+import { useGroupContext } from './GroupSettings/useGroupContext';
 import { useChannelContext } from './useChannelContext';
 
 type PostScreenProps = NativeStackScreenProps<RootStackParamList, 'Post'>;
@@ -33,6 +35,24 @@ export default function PostScreen(props: PostScreenProps) {
     draftKey: postParam.id,
     uploaderKey: `${postParam.channelId}/${postParam.id}`,
   });
+
+  const {
+    handleGoToGroupMeta,
+    handleGoToGroupMembers,
+    handleGoToManageChannels,
+    handleGoToInvitesAndPrivacy,
+    handleGoToRoles,
+    leaveGroup,
+    togglePinned,
+  } = useGroupContext({ groupId: channel?.group?.id || '' });
+
+  const isFocused = useIsFocused();
+  const { data: chats } = store.useCurrentChats({
+    enabled: isFocused,
+  });
+  const pinnedItems = useMemo(() => {
+    return chats?.pinned ?? [];
+  }, [chats]);
 
   const { data: post } = store.usePostWithThreadUnreads({
     id: postParam.id,
@@ -121,6 +141,15 @@ export default function PostScreen(props: PostScreenProps) {
       editPost={editPost}
       negotiationMatch={negotiationStatus.matchedOrPending}
       headerMode={headerMode}
+      useGroup={store.useGroup}
+      onPressGroupMeta={handleGoToGroupMeta}
+      onPressGroupMembers={handleGoToGroupMembers}
+      onPressManageChannels={handleGoToManageChannels}
+      onPressInvitesAndPrivacy={handleGoToInvitesAndPrivacy}
+      onPressRoles={handleGoToRoles}
+      onPressLeave={leaveGroup}
+      onTogglePinned={togglePinned}
+      pinned={pinnedItems ?? []}
     />
   ) : null;
 }

--- a/packages/ui/src/components/Channel/BaubleHeader.tsx
+++ b/packages/ui/src/components/Channel/BaubleHeader.tsx
@@ -82,6 +82,12 @@ export function BaubleHeader({
     };
   }, [easedValue, insets.top]);
 
+  const handleBaublePress = useCallback(() => {
+    if (channel.type !== 'dm' && channel.type !== 'groupDm') {
+      setShowChatOptions(true);
+    }
+  }, [channel.type]);
+
   const handleAction = useCallback((action: () => void) => {
     setShowChatOptions(false);
     action();
@@ -119,7 +125,7 @@ export function BaubleHeader({
             borderColor={'$border'}
             borderRadius="$l"
             overflow="hidden"
-            onPress={() => setShowChatOptions(true)}
+            onPress={handleBaublePress}
           >
             <BlurView intensity={32}>
               {showSpinner ? (

--- a/packages/ui/src/components/Channel/BaubleHeader.tsx
+++ b/packages/ui/src/components/Channel/BaubleHeader.tsx
@@ -1,5 +1,7 @@
 import * as db from '@tloncorp/shared/dist/db';
+import * as store from '@tloncorp/shared/dist/store';
 import { BlurView } from 'expo-blur';
+import { useCallback, useState } from 'react';
 import { OpaqueColorValue } from 'react-native';
 import Animated, {
   Easing,
@@ -18,6 +20,7 @@ import {
 import { useScrollContext } from '../../contexts/scroll';
 import { Image, LinearGradient, Spinner, Text, View } from '../../core';
 import { ContactAvatar } from '../Avatar';
+import { ChatOptionsSheet } from '../GroupOptionsSheet';
 import { Icon } from '../Icon';
 
 export function BaubleHeader({
@@ -25,15 +28,37 @@ export function BaubleHeader({
   showIcon = true,
   group,
   channel,
+  currentUserId,
+  pinned,
+  useGroup,
+  onPressGroupMeta,
+  onPressGroupMembers,
+  onPressManageChannels,
+  onPressInvitesAndPrivacy,
+  onPressRoles,
+  onPressLeave,
+  onTogglePinned,
 }: {
   showIcon?: boolean;
   channel: db.Channel;
   showSpinner?: boolean;
   group?: db.Group | null;
+  currentUserId: string;
+  pinned: db.Channel[];
+  useGroup: typeof store.useGroup;
+  onPressGroupMeta: () => void;
+  onPressGroupMembers: () => void;
+  onPressManageChannels: () => void;
+  onPressInvitesAndPrivacy: () => void;
+  onPressRoles: () => void;
+  onPressLeave: () => void;
+  onTogglePinned: () => void;
 }) {
   const [scrollValue] = useScrollContext();
   const insets = useSafeAreaInsets();
   const frame = useSafeAreaFrame();
+
+  const [showChatOptions, setShowChatOptions] = useState(false);
 
   const easedValue = useDerivedValue(
     () => Easing.ease(scrollValue.value),
@@ -56,6 +81,15 @@ export function BaubleHeader({
       opacity: opacity,
     };
   }, [easedValue, insets.top]);
+
+  const handleAction = useCallback((action: () => void) => {
+    setShowChatOptions(false);
+    action();
+  }, []);
+
+  const handleChatOptionsOpenChange = useCallback((open: boolean) => {
+    setShowChatOptions(open);
+  }, []);
 
   return (
     <View
@@ -85,6 +119,7 @@ export function BaubleHeader({
             borderColor={'$border'}
             borderRadius="$l"
             overflow="hidden"
+            onPress={() => setShowChatOptions(true)}
           >
             <BlurView intensity={32}>
               {showSpinner ? (
@@ -164,6 +199,25 @@ export function BaubleHeader({
           </View>
         </Animated.View>
       )}
+      <ChatOptionsSheet
+        open={showChatOptions}
+        onOpenChange={handleChatOptionsOpenChange}
+        currentUser={currentUserId}
+        pinned={pinned}
+        group={group ?? undefined}
+        useGroup={useGroup}
+        onPressGroupMeta={() => handleAction(() => onPressGroupMeta())}
+        onPressGroupMembers={() => handleAction(() => onPressGroupMembers())}
+        onPressManageChannels={() =>
+          handleAction(() => onPressManageChannels())
+        }
+        onPressInvitesAndPrivacy={() =>
+          handleAction(() => onPressInvitesAndPrivacy())
+        }
+        onPressRoles={() => handleAction(() => onPressRoles())}
+        onPressLeave={() => handleAction(onPressLeave)}
+        onTogglePinned={() => handleAction(onTogglePinned)}
+      />
     </View>
   );
 }

--- a/packages/ui/src/components/Channel/ChannelHeader.tsx
+++ b/packages/ui/src/components/Channel/ChannelHeader.tsx
@@ -1,8 +1,8 @@
 import * as db from '@tloncorp/shared/dist/db';
+import * as store from '@tloncorp/shared/dist/store';
 import { useMemo, useState } from 'react';
 
 import { Dots, Search } from '../../assets/icons';
-import { useCurrentUserId } from '../../contexts/appDataContext';
 import { ActionSheet } from '../ActionSheet';
 import { getPostActions } from '../ChatMessage/ChatMessageActions/MessageActions';
 import { GenericHeader } from '../GenericHeader';
@@ -13,6 +13,9 @@ export function ChannelHeader({
   title,
   mode = 'default',
   channel,
+  currentUserId,
+  useGroup,
+  pinned,
   group,
   goBack,
   goToSearch,
@@ -21,11 +24,21 @@ export function ChannelHeader({
   showMenuButton = false,
   post,
   channelType,
+  onPressGroupMeta,
+  onPressGroupMembers,
+  onPressManageChannels,
+  onPressInvitesAndPrivacy,
+  onPressRoles,
+  onPressLeave,
+  onTogglePinned,
 }: {
   title: string;
   mode?: 'default' | 'next';
   channel: db.Channel;
   group?: db.Group | null;
+  currentUserId: string;
+  pinned: db.Channel[];
+  useGroup: typeof store.useGroup;
   goBack?: () => void;
   goToSearch?: () => void;
   showSpinner?: boolean;
@@ -33,9 +46,15 @@ export function ChannelHeader({
   showMenuButton?: boolean;
   post?: db.Post;
   channelType?: db.ChannelType;
+  onPressGroupMeta: () => void;
+  onPressGroupMembers: () => void;
+  onPressManageChannels: () => void;
+  onPressInvitesAndPrivacy: () => void;
+  onPressRoles: () => void;
+  onPressLeave: () => void;
+  onTogglePinned: () => void;
 }) {
   const [showActionSheet, setShowActionSheet] = useState(false);
-  const currentUserId = useCurrentUserId();
 
   const postActions = useMemo(() => {
     if (!post || !channelType || !currentUserId) return [];
@@ -55,7 +74,23 @@ export function ChannelHeader({
   }, [post, channelType, currentUserId]);
 
   if (mode === 'next') {
-    return <BaubleHeader channel={channel} group={group} />;
+    return (
+      <BaubleHeader
+        channel={channel}
+        group={group}
+        useGroup={useGroup}
+        showSpinner={showSpinner}
+        currentUserId={currentUserId}
+        onPressGroupMeta={onPressGroupMeta}
+        onPressGroupMembers={onPressGroupMembers}
+        onPressManageChannels={onPressManageChannels}
+        onPressInvitesAndPrivacy={onPressInvitesAndPrivacy}
+        onPressRoles={onPressRoles}
+        onPressLeave={onPressLeave}
+        onTogglePinned={onTogglePinned}
+        pinned={pinned}
+      />
+    );
   }
 
   return (

--- a/packages/ui/src/components/Channel/index.tsx
+++ b/packages/ui/src/components/Channel/index.tsx
@@ -6,6 +6,7 @@ import {
   usePostWithRelations,
 } from '@tloncorp/shared/dist';
 import * as db from '@tloncorp/shared/dist/db';
+import * as store from '@tloncorp/shared/dist/store';
 import { JSONContent, Story } from '@tloncorp/shared/dist/urbit';
 import { ImagePickerAsset } from 'expo-image-picker';
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
@@ -55,6 +56,7 @@ export function Channel({
   posts,
   selectedPostId,
   contacts,
+  pinned,
   group,
   calmSettings,
   headerMode,
@@ -72,6 +74,7 @@ export function Channel({
   onPressRef,
   usePost,
   useGroup,
+  useGroupInfo,
   usePostReference,
   onGroupAction,
   useChannel,
@@ -89,6 +92,13 @@ export function Channel({
   hasNewerPosts,
   hasOlderPosts,
   initialAttachments,
+  onPressGroupMeta,
+  onPressGroupMembers,
+  onPressManageChannels,
+  onPressInvitesAndPrivacy,
+  onPressRoles,
+  onPressLeave,
+  onTogglePinned,
 }: {
   channel: db.Channel;
   currentUserId: string;
@@ -96,6 +106,7 @@ export function Channel({
   headerMode?: 'default' | 'next';
   posts: db.Post[] | null;
   contacts: db.Contact[] | null;
+  pinned: db.Channel[];
   group: db.Group | null;
   calmSettings?: CalmState | null;
   goBack: () => void;
@@ -112,7 +123,8 @@ export function Channel({
   onPressRef: (channel: db.Channel, post: db.Post) => void;
   markRead: () => void;
   usePost: typeof usePostWithRelations;
-  useGroup: typeof useGroupPreview;
+  useGroup: typeof store.useGroup;
+  useGroupInfo: typeof useGroupPreview;
   usePostReference: typeof usePostReferenceHook;
   onGroupAction: (action: string, group: db.Group) => void;
   useChannel: typeof useChannelFromStore;
@@ -129,6 +141,13 @@ export function Channel({
   hasNewerPosts?: boolean;
   hasOlderPosts?: boolean;
   canUpload: boolean;
+  onPressGroupMeta: (groupId: string) => void;
+  onPressGroupMembers: (groupId: string) => void;
+  onPressManageChannels: (groupId: string) => void;
+  onPressInvitesAndPrivacy: (groupId: string) => void;
+  onPressRoles: (groupId: string) => void;
+  onPressLeave: () => Promise<void>;
+  onTogglePinned: () => void;
 }) {
   const [activeMessage, setActiveMessage] = useState<db.Post | null>(null);
   const [inputShouldBlur, setInputShouldBlur] = useState(false);
@@ -245,7 +264,7 @@ export function Channel({
                 usePost={usePost}
                 usePostReference={usePostReference}
                 useChannel={useChannel}
-                useGroup={useGroup}
+                useGroup={useGroupInfo}
                 useApp={useApp}
                 // useBlockUser={() => {}}
               >
@@ -276,7 +295,10 @@ export function Channel({
                         <ChannelHeader
                           channel={channel}
                           group={group}
+                          currentUserId={currentUserId}
                           mode={headerMode}
+                          pinned={pinned}
+                          useGroup={useGroup}
                           title={title}
                           goBack={() =>
                             showBigInput ? bigInputGoBack() : goBack()
@@ -285,6 +307,21 @@ export function Channel({
                           goToSearch={goToSearch}
                           showSpinner={isLoadingPosts}
                           showMenuButton={!isChatChannel}
+                          onPressGroupMeta={() =>
+                            onPressGroupMeta(group?.id || '')
+                          }
+                          onPressGroupMembers={() =>
+                            onPressGroupMembers(group?.id || '')
+                          }
+                          onPressManageChannels={() =>
+                            onPressManageChannels(group?.id || '')
+                          }
+                          onPressInvitesAndPrivacy={() =>
+                            onPressInvitesAndPrivacy(group?.id || '')
+                          }
+                          onPressRoles={() => onPressRoles(group?.id || '')}
+                          onPressLeave={onPressLeave}
+                          onTogglePinned={onTogglePinned}
                         />
                         <KeyboardAvoidingView enabled={!activeMessage}>
                           <YStack alignItems="center" flex={1}>

--- a/packages/ui/src/components/PostScreenView.tsx
+++ b/packages/ui/src/components/PostScreenView.tsx
@@ -1,5 +1,6 @@
 import { isChatChannel as getIsChatChannel } from '@tloncorp/shared/dist';
 import type * as db from '@tloncorp/shared/dist/db';
+import * as store from '@tloncorp/shared/dist/store';
 import * as urbit from '@tloncorp/shared/dist/urbit';
 import { Story } from '@tloncorp/shared/dist/urbit';
 import { ImagePickerAsset } from 'expo-image-picker';
@@ -29,7 +30,9 @@ export function PostScreenView({
   sendReply,
   markRead,
   goBack,
+  group,
   groupMembers,
+  pinned,
   calmSettings,
   uploadAsset,
   handleGoToImage,
@@ -44,12 +47,21 @@ export function PostScreenView({
   negotiationMatch,
   headerMode,
   canUpload,
+  useGroup,
+  onPressGroupMeta,
+  onPressGroupMembers,
+  onPressManageChannels,
+  onPressInvitesAndPrivacy,
+  onPressRoles,
+  onPressLeave,
+  onTogglePinned,
 }: {
   currentUserId: string;
   calmSettings?: CalmState | null;
   contacts: db.Contact[] | null;
   channel: db.Channel;
   group?: db.Group | null;
+  pinned: db.Channel[];
   parentPost: db.Post | null;
   posts: db.Post[] | null;
   sendReply: (content: urbit.Story, channelId: string) => Promise<void>;
@@ -69,6 +81,14 @@ export function PostScreenView({
   negotiationMatch: boolean;
   headerMode?: 'default' | 'next';
   canUpload: boolean;
+  useGroup: typeof store.useGroup;
+  onPressGroupMeta: (groupId: string) => void;
+  onPressGroupMembers: (groupId: string) => void;
+  onPressManageChannels: (groupId: string) => void;
+  onPressInvitesAndPrivacy: (groupId: string) => void;
+  onPressRoles: (groupId: string) => void;
+  onPressLeave: () => Promise<void>;
+  onTogglePinned: () => void;
 }) {
   const [activeMessage, setActiveMessage] = useState<db.Post | null>(null);
   const [inputShouldBlur, setInputShouldBlur] = useState(false);
@@ -115,6 +135,20 @@ export function PostScreenView({
                 post={parentPost ?? undefined}
                 channelType={channel.type}
                 mode={headerMode}
+                currentUserId={currentUserId}
+                useGroup={useGroup}
+                pinned={pinned}
+                onPressGroupMeta={() => onPressGroupMeta(group?.id || '')}
+                onPressGroupMembers={() => onPressGroupMembers(group?.id || '')}
+                onPressManageChannels={() =>
+                  onPressManageChannels(group?.id || '')
+                }
+                onPressInvitesAndPrivacy={() =>
+                  onPressInvitesAndPrivacy(group?.id || '')
+                }
+                onPressRoles={() => onPressRoles(group?.id || '')}
+                onPressLeave={onPressLeave}
+                onTogglePinned={onTogglePinned}
               />
               <KeyboardAvoidingView enabled={!activeMessage}>
                 {parentPost && channel.type === 'gallery' && (


### PR DESCRIPTION
- Moves the group options handlers out to useGroupContext
- Uses the group context in the channel, the post view, and anywhere we need it
- Passes all the handlers down to the bauble, which is within ChannelHeader
- Fixes a collision where we had reassigned useGroup to useGroupPreview (now "useGroup" vs "useGroupInfo")
- Updates all fixtures to match
- Finally, shows the group options sheet when tapping on the bauble for everything but DMs and groupDMs