### PR TITLE
native: relocate group options context + actions

### DIFF
--- a/apps/tlon-mobile/src/screens/ChannelScreen.tsx
+++ b/apps/tlon-mobile/src/screens/ChannelScreen.tsx
@@ -258,8 +258,17 @@ export default function ChannelScreen(props: ChannelScreenProps) {
     return null;
   }
 
-  const channelContent = (
-    <>
+  return (
+    <GroupOptionsProvider
+      groupId={groupParam?.id}
+      pinned={pinnedItems}
+      useGroup={store.useGroup}
+      onPressGroupMeta={handleGoToGroupMeta}
+      onPressGroupMembers={handleGoToGroupMembers}
+      onPressManageChannels={handleGoToManageChannels}
+      onPressInvitesAndPrivacy={handleGoToInvitesAndPrivacy}
+      onPressRoles={handleGoToRoles}
+    >
       <Channel
         headerMode={headerMode}
         channel={channel}
@@ -310,23 +319,6 @@ export default function ChannelScreen(props: ChannelScreenProps) {
           onSelect={handleChannelSelected}
         />
       )}
-    </>
-  );
-
-  return groupParam ? (
-    <GroupOptionsProvider
-      groupId={groupParam.id}
-      pinned={pinnedItems}
-      useGroup={store.useGroup}
-      onPressGroupMeta={handleGoToGroupMeta}
-      onPressGroupMembers={handleGoToGroupMembers}
-      onPressManageChannels={handleGoToManageChannels}
-      onPressInvitesAndPrivacy={handleGoToInvitesAndPrivacy}
-      onPressRoles={handleGoToRoles}
-    >
-      {channelContent}
     </GroupOptionsProvider>
-  ) : (
-    channelContent
   );
 }

--- a/apps/tlon-mobile/src/screens/ChannelScreen.tsx
+++ b/apps/tlon-mobile/src/screens/ChannelScreen.tsx
@@ -1,4 +1,4 @@
-import { useFocusEffect } from '@react-navigation/native';
+import { useFocusEffect, useIsFocused } from '@react-navigation/native';
 import type { NativeStackScreenProps } from '@react-navigation/native-stack';
 import * as db from '@tloncorp/shared/dist/db';
 import * as store from '@tloncorp/shared/dist/store';
@@ -13,11 +13,12 @@ import { Story } from '@tloncorp/shared/dist/urbit';
 import {
   Channel,
   ChannelSwitcherSheet,
+  GroupOptionsProvider,
   INITIAL_POSTS_PER_PAGE,
 } from '@tloncorp/ui';
 import React, { useCallback, useMemo } from 'react';
 
-import type { RootStackParamList } from '../types';
+import type { GroupSettingsStackParamList, RootStackParamList } from '../types';
 import { useChannelContext } from './useChannelContext';
 
 type ChannelScreenProps = NativeStackScreenProps<RootStackParamList, 'Channel'>;
@@ -194,11 +195,70 @@ export default function ChannelScreen(props: ChannelScreenProps) {
 
   const canUpload = useCanUpload();
 
+  const groupParam = props.route.params.channel.group;
+  const isFocused = useIsFocused();
+
+  const { data: chats } = store.useCurrentChats({
+    enabled: isFocused,
+  });
+
+  const pinnedItems = useMemo(() => {
+    return chats?.pinned ?? [];
+  }, [chats]);
+
+  const navigateToGroupSettings = useCallback(
+    <T extends keyof GroupSettingsStackParamList>(
+      screen: T,
+      params: GroupSettingsStackParamList[T]
+    ) => {
+      props.navigation.navigate('GroupSettings', {
+        screen,
+        params,
+      } as any);
+    },
+    [props.navigation]
+  );
+
+  const handleGoToGroupMeta = useCallback(
+    (groupId: string) => {
+      navigateToGroupSettings('GroupMeta', { groupId });
+    },
+    [navigateToGroupSettings]
+  );
+
+  const handleGoToGroupMembers = useCallback(
+    (groupId: string) => {
+      navigateToGroupSettings('GroupMembers', { groupId });
+    },
+    [navigateToGroupSettings]
+  );
+
+  const handleGoToManageChannels = useCallback(
+    (groupId: string) => {
+      navigateToGroupSettings('ManageChannels', { groupId });
+    },
+    [navigateToGroupSettings]
+  );
+
+  const handleGoToInvitesAndPrivacy = useCallback(
+    (groupId: string) => {
+      navigateToGroupSettings('InvitesAndPrivacy', { groupId });
+    },
+    [navigateToGroupSettings]
+  );
+
+  const handleGoToRoles = useCallback(
+    (groupId: string) => {
+      navigateToGroupSettings('GroupRoles', { groupId });
+    },
+    [navigateToGroupSettings]
+  );
+
   if (!channel) {
     return null;
   }
 
-  return (
+  const channelContent = (
     <>
       <Channel
         headerMode={headerMode}
@@ -251,5 +311,22 @@ export default function ChannelScreen(props: ChannelScreenProps) {
         />
       )}
     </>
+  );
+
+  return groupParam ? (
+    <GroupOptionsProvider
+      groupId={groupParam.id}
+      pinned={pinnedItems}
+      useGroup={store.useGroup}
+      onPressGroupMeta={handleGoToGroupMeta}
+      onPressGroupMembers={handleGoToGroupMembers}
+      onPressManageChannels={handleGoToManageChannels}
+      onPressInvitesAndPrivacy={handleGoToInvitesAndPrivacy}
+      onPressRoles={handleGoToRoles}
+    >
+      {channelContent}
+    </GroupOptionsProvider>
+  ) : (
+    channelContent
   );
 }

--- a/packages/ui/src/components/GroupChannelsScreenView.tsx
+++ b/packages/ui/src/components/GroupChannelsScreenView.tsx
@@ -1,8 +1,8 @@
 import * as db from '@tloncorp/shared/dist/db';
-import * as store from '@tloncorp/shared/dist/store';
 import { useCallback, useEffect, useState } from 'react';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
 
+import { useGroupOptions } from '../contexts/groupOptions';
 import { ScrollView, View } from '../core';
 import { ActionSheet } from './ActionSheet';
 import { Button } from './Button';
@@ -23,37 +23,31 @@ const ChannelSortOptions = ({
   );
 };
 
-export function GroupChannelsScreenView({
-  group,
-  channels,
-  onChannelPressed,
-  onBackPressed,
-  currentUser,
-  pinned,
-  useGroup,
-  onPressGroupMeta,
-  onPressGroupMembers,
-  onPressManageChannels,
-  onPressInvitesAndPrivacy,
-  onPressRoles,
-  onPressLeave,
-  onTogglePinned,
-}: {
-  group: db.Group | undefined | null;
-  channels: db.Channel[] | undefined | null;
+type GroupChannelsScreenViewProps = {
   onChannelPressed: (channel: db.Channel) => void;
   onBackPressed: () => void;
   currentUser: string;
-  pinned: db.Channel[];
-  useGroup: typeof store.useGroup;
-  onPressGroupMeta: (groupId: string) => void;
-  onPressGroupMembers: (groupId: string) => void;
-  onPressManageChannels: (groupId: string) => void;
-  onPressInvitesAndPrivacy: (groupId: string) => void;
-  onPressRoles: (groupId: string) => void;
-  onPressLeave: () => void;
-  onTogglePinned: () => void;
-}) {
+};
+
+export function GroupChannelsScreenView({
+  onChannelPressed,
+  onBackPressed,
+  currentUser,
+}: GroupChannelsScreenViewProps) {
+  const {
+    group,
+    groupChannels,
+    pinned,
+    useGroup,
+    onPressGroupMeta,
+    onPressGroupMembers,
+    onPressManageChannels,
+    onPressInvitesAndPrivacy,
+    onPressRoles,
+    onPressLeave,
+    onTogglePinned,
+  } = useGroupOptions();
+
   const [showChatOptions, setShowChatOptions] = useState(false);
   const [showSortOptions, setShowSortOptions] = useState(false);
   const [sortBy, setSortBy] = useState<db.ChannelSortPreference>('recency');
@@ -107,10 +101,10 @@ export function GroupChannelsScreenView({
           paddingBottom: insets.bottom,
         }}
       >
-        {group && channels ? (
+        {group && groupChannels ? (
           <ChannelNavSections
             group={group}
-            channels={channels}
+            channels={groupChannels}
             onSelect={onChannelPressed}
             sortBy={sortBy}
           />

--- a/packages/ui/src/components/GroupChannelsScreenView.tsx
+++ b/packages/ui/src/components/GroupChannelsScreenView.tsx
@@ -34,19 +34,8 @@ export function GroupChannelsScreenView({
   onBackPressed,
   currentUser,
 }: GroupChannelsScreenViewProps) {
-  const {
-    group,
-    groupChannels,
-    pinned,
-    useGroup,
-    onPressGroupMeta,
-    onPressGroupMembers,
-    onPressManageChannels,
-    onPressInvitesAndPrivacy,
-    onPressRoles,
-    onPressLeave,
-    onTogglePinned,
-  } = useGroupOptions();
+  const groupOptions = useGroupOptions();
+  const group = groupOptions?.group;
 
   const [showChatOptions, setShowChatOptions] = useState(false);
   const [showSortOptions, setShowSortOptions] = useState(false);
@@ -101,10 +90,10 @@ export function GroupChannelsScreenView({
           paddingBottom: insets.bottom,
         }}
       >
-        {group && groupChannels ? (
+        {group && groupOptions.groupChannels ? (
           <ChannelNavSections
             group={group}
-            channels={groupChannels}
+            channels={groupOptions.groupChannels}
             onSelect={onChannelPressed}
             sortBy={sortBy}
           />
@@ -130,29 +119,23 @@ export function GroupChannelsScreenView({
           <ActionSheet.ActionTitle>Sort by arrangement</ActionSheet.ActionTitle>
         </ActionSheet.Action>
       </ActionSheet>
-      <ChatOptionsSheet
-        open={showChatOptions}
-        onOpenChange={handleChatOptionsOpenChange}
-        currentUser={currentUser}
-        pinned={pinned}
-        group={group ?? undefined}
-        useGroup={useGroup}
-        onPressGroupMeta={(groupId) =>
-          handleAction(() => onPressGroupMeta(groupId))
-        }
-        onPressGroupMembers={(groupId) =>
-          handleAction(() => onPressGroupMembers(groupId))
-        }
-        onPressManageChannels={(groupId) =>
-          handleAction(() => onPressManageChannels(groupId))
-        }
-        onPressInvitesAndPrivacy={(groupId) =>
-          handleAction(() => onPressInvitesAndPrivacy(groupId))
-        }
-        onPressRoles={(groupId) => handleAction(() => onPressRoles(groupId))}
-        onPressLeave={() => handleAction(onPressLeave)}
-        onTogglePinned={() => handleAction(onTogglePinned)}
-      />
+      {groupOptions && (
+        <ChatOptionsSheet
+          open={showChatOptions}
+          onOpenChange={handleChatOptionsOpenChange}
+          currentUser={currentUser}
+          pinned={groupOptions.pinned}
+          group={group!}
+          useGroup={groupOptions.useGroup}
+          onPressGroupMeta={groupOptions.onPressGroupMeta}
+          onPressGroupMembers={groupOptions.onPressGroupMembers}
+          onPressManageChannels={groupOptions.onPressManageChannels}
+          onPressInvitesAndPrivacy={groupOptions.onPressInvitesAndPrivacy}
+          onPressRoles={groupOptions.onPressRoles}
+          onPressLeave={groupOptions.onPressLeave}
+          onTogglePinned={groupOptions.onTogglePinned}
+        />
+      )}
     </View>
   );
 }

--- a/packages/ui/src/contexts/groupOptions.tsx
+++ b/packages/ui/src/contexts/groupOptions.tsx
@@ -20,38 +20,39 @@ export type GroupOptionsContextValue = {
   onPressRoles: (groupId: string) => void;
   onPressLeave: () => Promise<void>;
   onTogglePinned: () => void;
-};
+} | null;
 
-const GroupOptionsContext = createContext<GroupOptionsContextValue | null>(
-  null
-);
+const GroupOptionsContext = createContext<GroupOptionsContextValue>(null);
 
 export const useGroupOptions = () => {
-  const context = useContext(GroupOptionsContext);
-  if (!context) {
-    // Return null instead of throwing an error since we might try to call this
-    // outside of a group context (e.g. in the BaubleHeader)
-    return null;
-  }
-  return context;
+  return useContext(GroupOptionsContext);
+};
+
+type GroupOptionsProviderProps = {
+  children: ReactNode;
+  groupId?: string;
+  pinned?: db.Channel[];
+  useGroup?: typeof store.useGroup;
+  onPressGroupMeta?: (groupId: string) => void;
+  onPressGroupMembers?: (groupId: string) => void;
+  onPressManageChannels?: (groupId: string) => void;
+  onPressInvitesAndPrivacy?: (groupId: string) => void;
+  onPressRoles?: (groupId: string) => void;
 };
 
 export const GroupOptionsProvider = ({
   children,
   groupId,
-  pinned,
-  useGroup,
-  onPressGroupMeta,
-  onPressGroupMembers,
-  onPressManageChannels,
-  onPressInvitesAndPrivacy,
-  onPressRoles,
-}: Omit<
-  GroupOptionsContextValue,
-  'group' | 'groupChannels' | 'onPressLeave' | 'onTogglePinned'
-> & { children: ReactNode; groupId: string }) => {
-  const groupQuery = useGroup({ id: groupId });
-  const group = groupQuery.data ?? null;
+  pinned = [],
+  useGroup = store.useGroup,
+  onPressGroupMeta = () => {},
+  onPressGroupMembers = () => {},
+  onPressManageChannels = () => {},
+  onPressInvitesAndPrivacy = () => {},
+  onPressRoles = () => {},
+}: GroupOptionsProviderProps) => {
+  const groupQuery = useGroup({ id: groupId ?? '' });
+  const group = groupId ? groupQuery.data ?? null : null;
 
   const groupChannels = useMemo(() => {
     return group?.channels ?? [];
@@ -69,19 +70,21 @@ export const GroupOptionsProvider = ({
     }
   }, [group]);
 
-  const contextValue: GroupOptionsContextValue = {
-    pinned,
-    useGroup,
-    group,
-    groupChannels,
-    onPressGroupMeta,
-    onPressGroupMembers,
-    onPressManageChannels,
-    onPressInvitesAndPrivacy,
-    onPressRoles,
-    onPressLeave,
-    onTogglePinned,
-  };
+  const contextValue: GroupOptionsContextValue = groupId
+    ? {
+        pinned,
+        useGroup,
+        group,
+        groupChannels,
+        onPressGroupMeta,
+        onPressGroupMembers,
+        onPressManageChannels,
+        onPressInvitesAndPrivacy,
+        onPressRoles,
+        onPressLeave,
+        onTogglePinned,
+      }
+    : null;
 
   return (
     <GroupOptionsContext.Provider value={contextValue}>

--- a/packages/ui/src/contexts/groupOptions.tsx
+++ b/packages/ui/src/contexts/groupOptions.tsx
@@ -29,9 +29,9 @@ const GroupOptionsContext = createContext<GroupOptionsContextValue | null>(
 export const useGroupOptions = () => {
   const context = useContext(GroupOptionsContext);
   if (!context) {
-    throw new Error(
-      'Must call `useGroupOptions` within a `GroupOptionsProvider` component.'
-    );
+    // Return null instead of throwing an error since we might try to call this
+    // outside of a group context (e.g. in the BaubleHeader)
+    return null;
   }
   return context;
 };

--- a/packages/ui/src/contexts/groupOptions.tsx
+++ b/packages/ui/src/contexts/groupOptions.tsx
@@ -1,0 +1,91 @@
+import * as db from '@tloncorp/shared/dist/db';
+import * as store from '@tloncorp/shared/dist/store';
+import {
+  ReactNode,
+  createContext,
+  useCallback,
+  useContext,
+  useMemo,
+} from 'react';
+
+export type GroupOptionsContextValue = {
+  pinned: db.Channel[];
+  useGroup: typeof store.useGroup;
+  group: db.Group | null;
+  groupChannels: db.Channel[];
+  onPressGroupMeta: (groupId: string) => void;
+  onPressGroupMembers: (groupId: string) => void;
+  onPressManageChannels: (groupId: string) => void;
+  onPressInvitesAndPrivacy: (groupId: string) => void;
+  onPressRoles: (groupId: string) => void;
+  onPressLeave: () => Promise<void>;
+  onTogglePinned: () => void;
+};
+
+const GroupOptionsContext = createContext<GroupOptionsContextValue | null>(
+  null
+);
+
+export const useGroupOptions = () => {
+  const context = useContext(GroupOptionsContext);
+  if (!context) {
+    throw new Error(
+      'Must call `useGroupOptions` within a `GroupOptionsProvider` component.'
+    );
+  }
+  return context;
+};
+
+export const GroupOptionsProvider = ({
+  children,
+  groupId,
+  pinned,
+  useGroup,
+  onPressGroupMeta,
+  onPressGroupMembers,
+  onPressManageChannels,
+  onPressInvitesAndPrivacy,
+  onPressRoles,
+}: Omit<
+  GroupOptionsContextValue,
+  'group' | 'groupChannels' | 'onPressLeave' | 'onTogglePinned'
+> & { children: ReactNode; groupId: string }) => {
+  const groupQuery = useGroup({ id: groupId });
+  const group = groupQuery.data ?? null;
+
+  const groupChannels = useMemo(() => {
+    return group?.channels ?? [];
+  }, [group?.channels]);
+
+  const onTogglePinned = useCallback(() => {
+    if (group && group.channels[0]) {
+      group.pin ? store.unpinItem(group.pin) : store.pinItem(group.channels[0]);
+    }
+  }, [group]);
+
+  const onPressLeave = useCallback(async () => {
+    if (group) {
+      await store.leaveGroup(group.id);
+    }
+  }, [group]);
+
+  const contextValue: GroupOptionsContextValue = {
+    pinned,
+    useGroup,
+    group,
+    groupChannels,
+    onPressGroupMeta,
+    onPressGroupMembers,
+    onPressManageChannels,
+    onPressInvitesAndPrivacy,
+    onPressRoles,
+    onPressLeave,
+    onTogglePinned,
+  };
+
+  return (
+    <GroupOptionsContext.Provider value={contextValue}>
+      {children}
+    </GroupOptionsContext.Provider>
+  );
+};

--- a/packages/ui/src/contexts/index.ts
+++ b/packages/ui/src/contexts/index.ts
@@ -1,5 +1,6 @@
 export * from './calm';
 export * from './groups';
+export * from './groupOptions';
 export * from './navigation';
 export * from './thread';
 export * from './channel';


### PR DESCRIPTION
Move from in-app context/drilled props to GroupOptionsContext + provider.

Uses group option sheet + new provider + hook in ChannelScreen -> BaubleHeader.

Fixes TLON-2451