### PR TITLE
native: revert UrbitModule signature to match Android

### DIFF
--- a/apps/tlon-mobile/ios/Landscape/UrbitModule.m
+++ b/apps/tlon-mobile/ios/Landscape/UrbitModule.m
@@ -10,7 +10,7 @@
 
 @interface RCT_EXTERN_MODULE(UrbitModule, NSObject)
 
-RCT_EXTERN_METHOD(setUrbit:(NSString *)shipName shipUrl:(NSString *)shipUrl)
+RCT_EXTERN_METHOD(setUrbit:(NSString *)shipName shipUrl:(NSString *)shipUrl authCookie:(NSString *)authCookie)
 RCT_EXTERN_METHOD(clearUrbit)
 
 + (BOOL)requiresMainQueueSetup

--- a/apps/tlon-mobile/ios/Landscape/UrbitModule.swift
+++ b/apps/tlon-mobile/ios/Landscape/UrbitModule.swift
@@ -11,8 +11,8 @@ import Foundation
 class UrbitModule: NSObject {
     private static let loginStore = LoginStore()
 
-    @objc(setUrbit:shipUrl:)
-    func setUrbit(shipName: String, shipUrl: String) {
+    @objc(setUrbit:shipUrl:authCookie:)
+    func setUrbit(shipName: String, shipUrl: String, authCookie _: String) {
         try? UrbitModule.loginStore.save(Login(shipName: shipName, shipUrl: shipUrl))
 
         Task {

--- a/apps/tlon-mobile/src/contexts/ship.tsx
+++ b/apps/tlon-mobile/src/contexts/ship.tsx
@@ -93,7 +93,7 @@ export const ShipProvider = ({ children }: { children: ReactNode }) => {
     // be stored on successful login.
     if (authCookie) {
       // Save to native storage
-      UrbitModule.setUrbit(ship, normalizedShipUrl);
+      UrbitModule.setUrbit(ship, normalizedShipUrl, authCookie);
     } else {
       // Run this in the background
       (async () => {


### PR DESCRIPTION
#3813 changed `UrbitModule.setUrbit`'s signature in JS + iOS because iOS does not use one of the params, but the change was not reflected in the Android native module. This change makes the signature the same for both Android/iOS, and just ignores the unused param in iOS.

I built this on iOS, but I have not built it on Android