### PR TITLE
queries: do less

### DIFF
--- a/apps/tlon-mobile/ios/Landscape.xcodeproj/project.pbxproj
+++ b/apps/tlon-mobile/ios/Landscape.xcodeproj/project.pbxproj
@@ -1837,11 +1837,7 @@
 				ONLY_ACTIVE_ARCH = YES;
 				OTHER_CFLAGS = "$(inherited)";
 				OTHER_CPLUSPLUSFLAGS = "$(inherited)";
-				OTHER_LDFLAGS = (
-					"$(inherited)",
-					"-Wl",
-					"-ld_classic",
-				);
+				OTHER_LDFLAGS = "$(inherited)";
 				REACT_NATIVE_PATH = "${PODS_ROOT}/../../../../node_modules/react-native";
 				SDKROOT = iphoneos;
 				USE_HERMES = true;
@@ -1934,11 +1930,7 @@
 				MTL_ENABLE_DEBUG_INFO = NO;
 				OTHER_CFLAGS = "$(inherited)";
 				OTHER_CPLUSPLUSFLAGS = "$(inherited)";
-				OTHER_LDFLAGS = (
-					"$(inherited)",
-					"-Wl",
-					"-ld_classic",
-				);
+				OTHER_LDFLAGS = "$(inherited)";
 				REACT_NATIVE_PATH = "${PODS_ROOT}/../../../../node_modules/react-native";
 				SDKROOT = iphoneos;
 				USE_HERMES = true;

--- a/apps/tlon-mobile/ios/Podfile.lock
+++ b/apps/tlon-mobile/ios/Podfile.lock
@@ -1322,11 +1322,11 @@ PODS:
     - FirebaseCoreExtension
     - React-Core
     - RNFBApp
-  - RNGestureHandler (2.14.1):
+  - RNGestureHandler (2.18.0):
     - glog
     - RCT-Folly (= 2022.05.16.00)
     - React-Core
-  - RNReanimated (3.8.1):
+  - RNReanimated (3.14.0):
     - glog
     - RCT-Folly (= 2022.05.16.00)
     - React-Core
@@ -1816,8 +1816,8 @@ SPEC CHECKSUMS:
   RNDeviceInfo: db5c64a060e66e5db3102d041ebe3ef307a85120
   RNFBApp: 91311b27bc9a33e23b76a62825afd1635501018a
   RNFBCrashlytics: c3219ef7a0c779f2428236215781c38e7892f6f9
-  RNGestureHandler: 28bdf9a766c081e603120f79e925b72817c751c6
-  RNReanimated: fb34efce9255966f5d71bd0fc65e14042c4b88a9
+  RNGestureHandler: 5d118be4e164ed006555b7e5d12bfaf7c0e15422
+  RNReanimated: d954c63a4279ca26aaf9908e58c4cb79278add78
   RNScreens: 2b73f5eb2ac5d94fbd61fa4be0bfebd345716825
   RNSVG: 3f65a03e0c61a8495dee92bf82545ed9041cbf3b
   SDWebImage: 750adf017a315a280c60fde706ab1e552a3ae4e9
@@ -1828,7 +1828,7 @@ SPEC CHECKSUMS:
   sqlite3: f163dbbb7aa3339ad8fc622782c2d9d7b72f7e9c
   tentap: fc7669734b4dea745d6e56f57f5c7dc4fc2977bc
   UMAppLoader: 5df85360d65cabaef544be5424ac64672e648482
-  Yoga: 64cd2a583ead952b0315d5135bf39e053ae9be70
+  Yoga: 1b901a6d6eeba4e8a2e8f308f708691cdb5db312
 
 PODFILE CHECKSUM: 0cb7a78e5777e69c86c1bf4bb5135fd660376dbe
 

--- a/packages/shared/src/store/reactQuery.ts
+++ b/packages/shared/src/store/reactQuery.ts
@@ -1,5 +1,11 @@
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 
-const queryClient = new QueryClient();
+const queryClient = new QueryClient({
+  defaultOptions: {
+    queries: {
+      staleTime: 1000 * 60 * 5, // 5 minutes
+    },
+  },
+});
 
 export { queryClient, QueryClientProvider };

--- a/packages/shared/src/store/useKeyFromQueryDeps.ts
+++ b/packages/shared/src/store/useKeyFromQueryDeps.ts
@@ -15,13 +15,13 @@ export function useKeyFromQueryDeps(
   query: WrappedQuery<any, any>,
   options?: any
 ) {
-  return useMemo(() => keyFromQueryDeps(query, options), [query, options]);
+  return useMemo(() => {
+    return keyFromQueryDeps(query, options);
+  }, [query, options]);
 }
 
 export function keyFromQueryDeps(query: WrappedQuery<any, any>, options?: any) {
-  return new Set(
-    query.meta.tableDependencies instanceof Function
-      ? query.meta.tableDependencies(options)
-      : query.meta.tableDependencies
-  );
+  return query.meta.tableDependencies instanceof Function
+    ? query.meta.tableDependencies(options)
+    : query.meta.tableDependencies;
 }


### PR DESCRIPTION
The way that 'keyFromQueryDeps' generated a key was to create a `Set` out of the dependency array from the query's table dependencies. However, doing so seemed to create a bad value for the key at least when logged, maybe the actual value was fine, but just using the array by itself seems to increase performance pretty significantly and I see way less DB reads. 

Also added a stale time of 5 minutes because we always invalidate queries based on table changes so we shouldn't see stale data.

PR Checklist
- [ ] Includes changes to desk files
- [ ] Describes how you tested the PR locally (test ship vs livenet)
- [ ] If a new feature, includes automated tests
- [ ] Comments added anywhere logic may be confusing without context