### PR TITLE
activity: dont use now.bowl when reading

### DIFF
--- a/desk/app/activity.hoon
+++ b/desk/app/activity.hoon
@@ -801,7 +801,10 @@
       ?^  time.action  u.time.action
       =/  latest=(unit [=time event:a])
         (ram:on-event:a stream.index)
-      ?~(latest now.bowl time.u.latest)
+      ::  if we don't have an event, then this is read anyway so we can
+      ::  just reuse the floor. likely if a recursive read is happening
+      ::  from one of our parents
+      ?~(latest floor.reads.index time.u.latest)
     ::  if we're marking deeply we need to recursively read all
     ::  children
     =/  children  (get-children:src indices source)


### PR DESCRIPTION
This was posted in Homestead. The Bulletins channel was randomly getting bumped to the top. We use a null `time` in the `read` action to signify "latest", however if we came up with no events we were erroneously saying set it to `now.bowl`. Since the floor gets taken into account for the recency, this was bumping sources to the top that were empty themselves or contained empty sources. This instead leaves the floor unchanged if there are no events.

PR Checklist
- [ ] Includes changes to desk files
- [ ] Describes how you tested the PR locally (test ship vs livenet)
- [ ] If a new feature, includes automated tests
- [ ] Comments added anywhere logic may be confusing without context