### PR TITLE
activity: fix notification paths

### DIFF
--- a/apps/tlon-web/src/notifications/Notification.tsx
+++ b/apps/tlon-web/src/notifications/Notification.tsx
@@ -8,6 +8,7 @@ import {
   getRelevancy,
   getSource,
   getTop,
+  nestToFlag,
 } from '@tloncorp/shared/dist/urbit';
 import { daToUnix, parseUd } from '@urbit/aura';
 import _ from 'lodash';
@@ -39,7 +40,10 @@ function getPath(source: Source, event: ActivityEvent): string {
       'reply' in event
         ? `?reply=${parseUd(event.reply.key.time).toString()}`
         : '';
-    return `/groups/${source.thread.group}/channels/${source.thread.channel}/message/${parseUd(source.thread.key.time).toString()}${suffix}`;
+    const [app] = nestToFlag(source.thread.channel);
+    const postType =
+      app === 'chat' ? 'message' : app === 'diary' ? 'note' : 'curio';
+    return `/groups/${source.thread.group}/channels/${source.thread.channel}/${postType}/${parseUd(source.thread.key.time).toString()}${suffix}`;
   }
 
   if ('dm-thread' in source) {

--- a/desk/app/activity.hoon
+++ b/desk/app/activity.hoon
@@ -548,8 +548,9 @@
   =/  collapsed
     (~(gas in collapsed.acc) (turn top head))
   :-  (~(put by sources.acc) source src-info(added &))
-  =/  happening  [source (head (head top)) top]
-  [(sub limit.acc 1) (snoc happenings.acc happening) collapsed]
+  ?~  top  +.acc
+  =/  latest=^time  -<.top
+  [(sub limit.acc 1) (snoc happenings.acc [source latest top]) collapsed]
   +$  out
     $:  sources=(map source:a [latest=time-id:a added=?])
         limit=@ud

--- a/desk/app/activity.hoon
+++ b/desk/app/activity.hoon
@@ -549,8 +549,7 @@
     (~(gas in collapsed.acc) (turn top head))
   :-  (~(put by sources.acc) source src-info(added &))
   ?~  top  +.acc
-  =/  latest=^time  -<.top
-  [(sub limit.acc 1) (snoc happenings.acc [source latest top]) collapsed]
+  [(sub limit.acc 1) (snoc happenings.acc [source time.i.top top]) collapsed]
   +$  out
     $:  sources=(map source:a [latest=time-id:a added=?])
         limit=@ud

--- a/desk/app/activity.hoon
+++ b/desk/app/activity.hoon
@@ -548,7 +548,8 @@
   =/  collapsed
     (~(gas in collapsed.acc) (turn top head))
   :-  (~(put by sources.acc) source src-info(added &))
-  [(sub limit.acc 1) (snoc happenings.acc [source time top]) collapsed]
+  =/  happening  [source (head (head top)) top]
+  [(sub limit.acc 1) (snoc happenings.acc happening) collapsed]
   +$  out
     $:  sources=(map source:a [latest=time-id:a added=?])
         limit=@ud
@@ -771,7 +772,9 @@
 ++  bump
   |=  =source:a
   ^+  cor
-  =/  =index:a  (~(got by indices) source)
+  ::  we use get-index here because this source may not exist especially
+  ::  if it was a post we created and then commented on w/o any other activity
+  =/  =index:a  (get-index source)
   =/  new=index:a  index(bump now.bowl)
   =.  indices
     (~(put by indices) source new)


### PR DESCRIPTION
Fixes TLON-2423 by adjusting the paths we send people to, reflecting the actual routes instead of all trying to be chats. Also fixed two issues encountered when testing.

- Creating a post and then commenting on it yourself was crashing because the source didn't exist
- Sometimes the feed would produce bundles where the latest time didn't match any event in the bundle, which makes no sense. So I changed it to always pull the "latest" value from the list of events it sends with the bundle (instead of the event on which we built this bundle which may not be present in the bundle itself)

PR Checklist
- [X] Includes changes to desk files
- [ ] Describes how you tested the PR locally (test ship vs livenet)
- [ ] If a new feature, includes automated tests
- [ ] Comments added anywhere logic may be confusing without context