### PR TITLE
notify: only handle authenticated http requests

### DIFF
--- a/desk/app/notify.hoon
+++ b/desk/app/notify.hoon
@@ -325,6 +325,7 @@
     ++  handle-http-request
       |=  [eyre-id=@ta inbound-request:eyre]
       ^-  (quip card _state)
+      ?>  authenticated
       ?.  ?=(%'GET' method.request)
         [~ state]
       =/  [[ext=(unit @ta) site=(pole @t)] args=*]


### PR DESCRIPTION
`/app/notify` serves a custom endpoint for grabbing notification data. It handles raw http requests for this, but we weren't checking them for authentication. Now we do.

Closes TLON-2486.