### PR TITLE
external-resources: add crossorigin anonymous to everything dynamically

### DIFF
--- a/apps/tlon-web/externalResourceScript.ts
+++ b/apps/tlon-web/externalResourceScript.ts
@@ -1,0 +1,96 @@
+export default function injectExternalResourceScript() {
+  return {
+    name: 'inject-external-resource-script',
+    transformIndexHtml(html: string) {
+      const script = `
+        <script>
+          (function() {
+            // Function to add crossorigin to link elements
+            function addCrossOriginToLinks() {
+              const links = document.getElementsByTagName('link');
+              for (let link of links) {
+                if (link.rel === 'stylesheet' || link.rel === 'preload') {
+                  if (!link.hasAttribute('crossorigin')) {
+                    link.setAttribute('crossorigin', 'anonymous');
+                  }
+                }
+              }
+            }
+
+            // Function to add crossorigin to script elements
+            function addCrossOriginToScripts() {
+              const scripts = document.getElementsByTagName('script');
+              for (let script of scripts) {
+                if (script.src && !script.hasAttribute('crossorigin')) {
+                  script.setAttribute('crossorigin', 'anonymous');
+                }
+              }
+            }
+
+            // Override fetch to add crossorigin
+            const originalFetch = window.fetch;
+            window.fetch = function(...args) {
+              if (args[1] && args[1].mode === 'cors' && !args[1].credentials) {
+                if (!args[1].headers) {
+                  args[1].headers = {};
+                }
+                args[1].crossOrigin = 'anonymous';
+              }
+              return originalFetch.apply(this, args);
+            };
+
+            // Override XMLHttpRequest to add crossorigin
+            const originalXhrOpen = XMLHttpRequest.prototype.open;
+            XMLHttpRequest.prototype.open = function(...args) {
+              const result = originalXhrOpen.apply(this, args);
+              this.crossOrigin = 'anonymous';
+              return result;
+            };
+
+            // Run immediately and periodically
+            function init() {
+              addCrossOriginToLinks();
+              addCrossOriginToScripts();
+            }
+
+            if (document.readyState === 'loading') {
+              document.addEventListener('DOMContentLoaded', init);
+            } else {
+              init();
+            }
+
+            // Also run periodically to catch any dynamically added resources
+            setInterval(init, 1000);
+
+            // Set up MutationObserver for dynamically added link and script elements
+            const observer = new MutationObserver((mutations) => {
+              mutations.forEach((mutation) => {
+                if (mutation.type === 'childList') {
+                  mutation.addedNodes.forEach((node) => {
+                    if (node.nodeType === 1 && (node.tagName === 'LINK' || node.tagName === 'SCRIPT')) {
+                      if (node.tagName === 'LINK') {
+                        if ((node.rel === 'stylesheet' || node.rel === 'preload') && !node.hasAttribute('crossorigin')) {
+                          node.setAttribute('crossorigin', 'anonymous');
+                        }
+                      } else if (node.tagName === 'SCRIPT') {
+                        if (node.src && !node.hasAttribute('crossorigin')) {
+                          node.setAttribute('crossorigin', 'anonymous');
+                        }
+                      }
+                    }
+                  });
+                }
+              });
+            });
+
+            observer.observe(document.documentElement, {
+              childList: true,
+              subtree: true
+            });
+          })();
+        </script>
+      `;
+      return html.replace('</head>', `${script}</head>`);
+    },
+  };
+}

--- a/apps/tlon-web/injectCrossOriginScript.ts
+++ b/apps/tlon-web/injectCrossOriginScript.ts
@@ -1,0 +1,87 @@
+export default function injectCrossOriginScript() {
+  return {
+    name: 'inject-crossorigin-script',
+    transformIndexHtml(html: string) {
+      const script = `
+        <script>
+          (function() {
+            // Override Image constructor
+            const originalImageConstructor = window.Image;
+            window.Image = function() {
+              const img = new originalImageConstructor(...arguments);
+              img.crossOrigin = 'anonymous';
+              return img;
+            };
+            window.Image.prototype = originalImageConstructor.prototype;
+
+            // Override fetch
+            const originalFetch = window.fetch;
+            window.fetch = function(input, init) {
+              if (init === undefined) {
+                init = {};
+              }
+              if (init.credentials === undefined) {
+                init.credentials = 'same-origin';
+              }
+              return originalFetch(input, init);
+            };
+
+            function addCrossOriginToElements() {
+              const elements = document.querySelectorAll('img, iframe, embed, audio, video');
+              elements.forEach(el => {
+                if (!el.hasAttribute('crossorigin')) {
+                  el.setAttribute('crossorigin', 'anonymous');
+                }
+              });
+            }
+
+            function setupMutationObserver() {
+              const observer = new MutationObserver((mutations) => {
+                mutations.forEach((mutation) => {
+                  if (mutation.type === 'childList') {
+                    mutation.addedNodes.forEach((node) => {
+                      if (node.nodeType === 1) { // ELEMENT_NODE
+                        if (['IMG', 'IFRAME', 'EMBED', 'AUDIO', 'VIDEO'].includes(node.tagName)) {
+                          if (!node.hasAttribute('crossorigin')) {
+                            node.setAttribute('crossorigin', 'anonymous');
+                          }
+                        } else {
+                          const elements = node.querySelectorAll('img, iframe, embed, audio, video');
+                          elements.forEach(el => {
+                            if (!el.hasAttribute('crossorigin')) {
+                              el.setAttribute('crossorigin', 'anonymous');
+                            }
+                          });
+                        }
+                      }
+                    });
+                  }
+                });
+              });
+
+              observer.observe(document.body, {
+                childList: true,
+                subtree: true
+              });
+            }
+
+            function init() {
+              addCrossOriginToElements();
+              setupMutationObserver();
+            }
+
+            if (document.readyState === 'loading') {
+              document.addEventListener('DOMContentLoaded', init);
+            } else {
+              init();
+            }
+
+            // Also run periodically to catch any missed elements
+            setInterval(addCrossOriginToElements, 1000);
+          })();
+        </script>
+      `;
+      return html.replace('</head>', `${script}</head>`);
+    },
+  };
+}

--- a/apps/tlon-web/tsconfig.json
+++ b/apps/tlon-web/tsconfig.json
@@ -1,12 +1,7 @@
 {
   "extends": "../../tsconfig.json",
   "compilerOptions": {
-    "lib": [
-      "DOM",
-      "DOM.Iterable",
-      "ESNext",
-      "WebWorker"
-    ],
+    "lib": ["DOM", "DOM.Iterable", "ESNext", "WebWorker"],
     "experimentalDecorators": true,
     "strict": true,
     "module": "ESNext",
@@ -22,9 +17,7 @@
     ],
     "composite": true,
     "paths": {
-      "@/*": [
-        "./apps/tlon-web/src/*"
-      ]
+      "@/*": ["./apps/tlon-web/src/*"]
     }
   },
   "include": [
@@ -35,6 +28,8 @@
     "./*.setup.ts",
     "./rube",
     "cosmos/setup.ts",
-    "vite.config.mts"
+    "vite.config.mts",
+    "externalResourceScript.ts",
+    "injectCrossOriginScript.ts"
   ]
 }


### PR DESCRIPTION
This pulls what @patosullivan did out of the cross-compile branch tloncorp/tlon-apps#3805 which should fix the problems we saw with tloncorp/tlon-apps#3810 however some images will still break that don't have proper CORS headers like currently the Tlon icon is missing some key headers https://storage.googleapis.com/assets.tlon.io/tlon-co-group-icon.svg. However most any public image URL should have these headers.

PR Checklist
- [ ] Includes changes to desk files
- [ ] Describes how you tested the PR locally (test ship vs livenet)
- [ ] If a new feature, includes automated tests
- [ ] Comments added anywhere logic may be confusing without context

Fixes TLON-2505