### PR TITLE
various: %egg-any import support

### DIFF
--- a/desk/app/activity.hoon
+++ b/desk/app/activity.hoon
@@ -290,7 +290,7 @@
         (load -:!>(*versioned-state:load) +>.old-state.egg-any)
       ::  restore volume settings, but keep any we've explicitly set ourselves
       ::
-      =.  allowed  allowed:bak  ::REVIEW
+      =.  allowed  allowed:bak
       =.  volume-settings  (~(uni by volume-settings:bak) volume-settings)
       cor
     ==

--- a/desk/app/activity.hoon
+++ b/desk/app/activity.hoon
@@ -286,12 +286,13 @@
         ~&  [dap.bowl %egg-any-not-live]
         cor
       =/  bak
-        ::TODO  test
         (load -:!>(*versioned-state:load) +>.old-state.egg-any)
-      ::  restore volume settings, but keep any we've explicitly set ourselves
+      ::  restore volume settings, but keep any we've explicitly set ourselves,
+      ::  and restore activity summaries  ::REVIEW  for unintended side-effects
       ::
       =.  allowed  allowed:bak
       =.  volume-settings  (~(uni by volume-settings:bak) volume-settings)
+      =.  activity         (~(uni by activity:bak) activity)
       cor
     ==
   ==

--- a/desk/app/activity.hoon
+++ b/desk/app/activity.hoon
@@ -125,8 +125,8 @@
   (emit %pass /migrate %agent [our.bowl dap.bowl] %poke noun+!>(%migrate))
 ::
 ++  load
-  |=  =vase
-  |^  ^+  cor
+  |^  |=  =vase
+  ^+  cor
   ?:  ?=([%0 *] q.vase)  init
   =+  !<(old=versioned-state vase)
   =?  old  ?=(%1 -.old)  (state-1-to-2 old)
@@ -276,6 +276,23 @@
       %read     (read source.action read-action.action |)
       %adjust   (adjust +.action)
       %allow-notifications  (allow +.action)
+    ==
+  ::
+      %egg-any
+    =+  !<(=egg-any:gall vase)
+    ?-  -.egg-any
+        ?(%15 %16)
+      ?.  ?=(%live +<.egg-any)
+        ~&  [dap.bowl %egg-any-not-live]
+        cor
+      =/  bak
+        ::TODO  test
+        (load -:!>(*versioned-state:load) +>.old-state.egg-any)
+      ::  restore volume settings, but keep any we've explicitly set ourselves
+      ::
+      =.  allowed  allowed:bak  ::REVIEW
+      =.  volume-settings  (~(uni by volume-settings:bak) volume-settings)
+      cor
     ==
   ==
 ::

--- a/desk/app/activity.hoon
+++ b/desk/app/activity.hoon
@@ -290,7 +290,7 @@
       ::  restore volume settings, but keep any we've explicitly set ourselves,
       ::  and restore activity summaries  ::REVIEW  for unintended side-effects
       ::
-      =.  allowed  allowed:bak
+      =.  allowed          allowed:bak
       =.  volume-settings  (~(uni by volume-settings:bak) volume-settings)
       =.  activity         (~(uni by activity:bak) activity)
       cor

--- a/desk/app/channels-server.hoon
+++ b/desk/app/channels-server.hoon
@@ -81,8 +81,8 @@
   (emit %pass wire %agent dock %watch path)
 ::
 ++  load
-  |=  =vase
-  |^  ^+  cor
+  |^  |=  =vase
+  ^+  cor
   =+  !<(old=versioned-state vase)
   =?  old  ?=(%0 -.old)  (state-0-to-1 old)
   =?  old  ?=(%1 -.old)  (state-1-to-2 old)
@@ -274,6 +274,25 @@
     %+  roll  ~(tap by v-channels)
     |=  [[=nest:c =v-channel:c] cr=_cor]
     ca-abet:ca-migrate:(ca-abed:ca-core:cr nest)
+  ::
+      %egg-any
+    =+  !<(=egg-any:gall vase)
+    ?-  -.egg-any
+        ?(%15 %16)
+      ?.  ?=(%live +<.egg-any)
+        ~&  [dap.bowl %egg-any-not-live]
+        cor
+      =/  bak
+        ::TODO  test
+        (load -:!>(*versioned-state:load) +>.old-state.egg-any)
+      ::  if both the backup and our latest have a channel, keep only our
+      ::  version. we could do a "deep merge" but presently unclear how that
+      ::  would affect existing subscribers/what would be the correct behavior
+      ::  wrt them.
+      ::
+      =.  v-channels  (~(uni by v-channels:bak) v-channels)
+      (emit %pass /pimp %agent [our.bowl %groups] %poke %noun !>(%pimp-ready))
+    ==
   ==
 ::
 ++  watch
@@ -327,6 +346,8 @@
   |=  [=(pole knot) =sign:agent:gall]
   ^+  cor
   ?+    pole  ~|(bad-agent-wire+pole !!)
+    [%pimp ~]  cor
+  ::
       [=kind:c *]
     ?+    -.sign  !!
         %poke-ack

--- a/desk/app/channels.hoon
+++ b/desk/app/channels.hoon
@@ -477,6 +477,7 @@
       ::  we only restore miscellanea. groups' import should prompt us to
       ::  re-join channels, we won't bother pre-loading their content for now.
       ::
+      =.  v-channels    (~(uni by v-channels:bak) v-channels)
       =.  voc           (~(uni by voc:bak) voc)
       =.  hidden-posts  (~(uni in hidden-posts:bak) hidden-posts)
       cor
@@ -890,8 +891,13 @@
   ++  ca-join
     |=  [n=nest:c group=flag:g]
     =.  nest  n
-    ?<  (~(has by v-channels) nest)
     ?>  |(=(p.group src.bowl) from-self)
+    ?:  (~(has by v-channels) nest)
+      ::  we should already be in, but make sure our subscriptions still exist
+      ::  just in case
+      ::
+      =.  channel  (~(got by v-channels) nest)
+      (ca-safe-sub |)
     =.  channel  *v-channel:c
     =.  group.perm.perm.channel  group
     =.  last-read.remark.channel  now.bowl

--- a/desk/app/channels.hoon
+++ b/desk/app/channels.hoon
@@ -112,8 +112,8 @@
   (emil caz)
 ::
 ++  load
-  |=  =vase
-  |^  ^+  cor
+  |^  |=  =vase
+  ^+  cor
   =+  !<(old=versioned-state vase)
   =?  old  ?=(%0 -.old)  (state-0-to-1 old)
   =?  old  ?=(%1 -.old)  (state-1-to-2 old)
@@ -463,6 +463,24 @@
       ::NOTE  %chat-migrate-refs, etc
       (cat 3 kind '-migrate-refs')
     !>([host name])
+  ::
+      %egg-any
+    =+  !<(=egg-any:gall vase)
+    ?-  -.egg-any
+        ?(%15 %16)
+      ?.  ?=(%live +<.egg-any)
+        ~&  [dap.bowl %egg-any-not-live]
+        cor
+      =/  bak
+        ::TODO  test
+        (load -:!>(*versioned-state:load) +>.old-state.egg-any)
+      ::  we only restore miscellanea. groups' import should prompt us to
+      ::  re-join channels, we won't bother pre-loading their content for now.
+      ::
+      =.  voc           (~(uni by voc:bak) voc)
+      =.  hidden-posts  (~(uni in hidden-posts:bak) hidden-posts)
+      cor
+    ==
   ==
   ++  toggle-post
     |=  toggle=post-toggle:c

--- a/desk/app/chat.hoon
+++ b/desk/app/chat.hoon
@@ -113,8 +113,8 @@
 ++  init  cor
 ::  +load: load next state
 ++  load
-  |=  =vase
-  |^  ^+  cor
+  |^  |=  =vase
+  ^+  cor
   =+  !<([old=versioned-state cool=@ud] vase)
   |-
   ?-  -.old
@@ -468,6 +468,55 @@
     =+  !<(=action:club:old vase)
     ?.  ?=(%writ -.q.q.action)  action
     action(diff.q.q (new-diff diff.q.q.action))
+  ::
+      %egg-any
+    =+  !<(=egg-any:gall vase)
+    ?-  -.egg-any
+        ?(%15 %16)
+      ?.  ?=(%live +<.egg-any)
+        ~&  [dap.bowl %egg-any-not-live]
+        cor
+      =/  bak
+        ::TODO  test
+        (load -:!>(*versioned-state:load) +>.old-state.egg-any)
+      ::  restore previous data, doing a "deep merge" where possible
+      ::
+      =.  dms
+        %+  roll  ~(tap by dms:bak)
+        |=  [[=ship =dm:c] =_dms]
+        %+  ~(put by dms)  ship
+        ?.  (~(has by dms) ship)
+          dm
+        =/  hav  (~(got by dms) ship)
+        :*  :-  (uni:on:writs:c wit.pact.dm wit.pact.hav)
+            (~(uni by dex.pact.dm) dex.pact.hav)
+          ::
+            remark.hav
+            net.hav  ::REVIEW
+            |(pin.hav pin.dm)
+        ==
+      =.  clubs
+        %+  roll  ~(tap by clubs:bak)
+        |=  [[=id:club:c =club:c] =_clubs]
+        %+  ~(put by clubs)  id
+        ?.  (~(has by clubs) id)
+          club
+        =/  hav  (~(got by clubs) id)
+        :*  (~(uni in heard.club) heard.hav)
+            remark.hav
+          ::
+            :-  (uni:on:writs:c wit.pact.club wit.pact.hav)
+            (~(uni by dex.pact.club) dex.pact.hav)
+          ::
+            crew.hav
+        ==
+      ::REVIEW  bad and inv not used?
+      =.  pins             pins:bak
+      =.  blocked          (~(uni in blocked:bak) blocked)
+      =.  blocked-by       (~(uni in blocked-by:bak) blocked-by)
+      =.  hidden-messages  (~(uni in hidden-messages:bak) hidden-messages)
+      cor
+    ==
   ==
   ++  pin
     |=  ps=(list whom:c)

--- a/desk/app/chat.hoon
+++ b/desk/app/chat.hoon
@@ -36,8 +36,8 @@
         dms=(map ship dm:c)
         clubs=(map id:club:c club:c)
         pins=(list whom:c)
-        bad=(set ship)
-        inv=(set ship)
+        bad=(set ship)  ::TODO  vestigial, remove me
+        inv=(set ship)  ::TODO  vestigial, remove me
         blocked=(set ship)
         blocked-by=(set ship)
         hidden-messages=(set id:c)
@@ -492,7 +492,7 @@
             (~(uni by dex.pact.dm) dex.pact.hav)
           ::
             remark.hav
-            net.hav  ::REVIEW
+            net.hav
             |(pin.hav pin.dm)
         ==
       =.  clubs
@@ -510,7 +510,6 @@
           ::
             crew.hav
         ==
-      ::REVIEW  bad and inv not used?
       =.  pins             pins:bak
       =.  blocked          (~(uni in blocked:bak) blocked)
       =.  blocked-by       (~(uni in blocked-by:bak) blocked-by)

--- a/desk/app/chat.hoon
+++ b/desk/app/chat.hoon
@@ -476,9 +476,8 @@
       ?.  ?=(%live +<.egg-any)
         ~&  [dap.bowl %egg-any-not-live]
         cor
-      =/  bak
-        ::TODO  test
-        (load -:!>(*versioned-state:load) +>.old-state.egg-any)
+      =/  bak=_cor
+        (load -:!>(*[versioned-state:load @ud]) q.old-state.egg-any)
       ::  restore previous data, doing a "deep merge" where possible
       ::
       =.  dms

--- a/desk/app/groups.hoon
+++ b/desk/app/groups.hoon
@@ -1658,14 +1658,11 @@
               ?-  -.cordon
                   ?(%open %afar)  &
                   %shut
-                ::REVIEW  need this for re-join-during-import to work...
-                ::        is that just adding an "or user-join" clause here?
                 =.  pend.cordon  (~(uni in pend.cordon) ~(key by fleet.group))
                 =/  cross  (~(int in pend.cordon) ships)
                 =(~(wyt in ships) ~(wyt in cross))
               ==
           ==
-      ::REVIEW  looks like this line might give invites if host rejoins its own group?
       =?  cor  &(!user-join am-host)  (give-invites flag ships)
       =.  fleet.group
         %-  ~(uni by fleet.group)

--- a/desk/app/groups.hoon
+++ b/desk/app/groups.hoon
@@ -245,8 +245,7 @@
       ~&  [dap.bowl %egg-any-not-live]
       cor
     =/  bak
-      ::TODO  test
-      (load -:!>(*versioned-state:load) +>.old-state.egg-any)
+      (load -:!>(*[versioned-state:load _okay:g]) +>.old-state.egg-any)
     ::  restore any previews & invites we might've had
     ::
     =.  xeno
@@ -273,7 +272,7 @@
         ::      to run its import first
         (poke:cor %group-join !>(`join:g`[flag &]))
       =.  groups.cor  (~(put by groups.cor) flag gr)
-      %-  emil
+      %-  emil:cor
       %-  join-channels:go-pass:(go-abed:group-core:cor flag)
       ~(tap in ~(key by channels.group.gr))
     =.  volume

--- a/desk/app/groups.hoon
+++ b/desk/app/groups.hoon
@@ -268,19 +268,19 @@
       |=  [[=flag:g gr=[=net:g =group:g]] =_cor]
       ?:  (~(has by groups.cor) flag)
         cor
-      =?  groups.cor  =(our.bowl p.flag)
-        (~(put by groups.cor) flag gr)
-      ::REVIEW  sane to do even for locally hosted groups, right?
-      ::NOTE  doing joins here is why we need to wait for channels-server to
-      ::      run its import first
-      (poke:cor %group-join !>(`join:g`[flag &]))
+      ?.  =(our.bowl p.flag)
+        ::NOTE  doing joins here is why we need to wait for channels-server
+        ::      to run its import first
+        (poke:cor %group-join !>(`join:g`[flag &]))
+      =.  groups.cor  (~(put by groups.cor) flag gr)
+      %-  emil
+      %-  join-channels:go-pass:(go-abed:group-core:cor flag)
+      ~(tap in ~(key by channels.group.gr))
     =.  volume
       :+  base.volume:bak
         (~(uni by area.volume:bak) area.volume)
       (~(uni by chan.volume:bak) chan.volume)
-    ::  tell the channels-server we're ready for it to run its import
-    ::
-    (emit %pass /egg-any %agent [our.bowl %channels-server] %poke %noun !>(%pimp-ready))
+    cor
   ==
 ::
 ++  channel-scry

--- a/desk/app/groups.hoon
+++ b/desk/app/groups.hoon
@@ -258,20 +258,18 @@
       :+  cam.hav
         ?~(pev.hav pev.gang pev.hav)
       ?~(vit.hav vit.gang vit.hav)
-    ::  join groups we were previously in,
-    ::  and restore groups we hosted,
-    ::  but no-op for existing groups.
+    ::  restore the groups we were in, taking care to re-establish
+    ::  subscriptions to the group, and to tell %channels to re-establish
+    ::  its subscriptions to the groups' channels as well.
     ::
     =.  cor
       %+  roll  ~(tap by groups:bak)
       |=  [[=flag:g gr=[=net:g =group:g]] =_cor]
       ?:  (~(has by groups.cor) flag)
         cor
-      ?.  =(our.bowl p.flag)
-        ::NOTE  doing joins here is why we need to wait for channels-server
-        ::      to run its import first
-        (poke:cor %group-join !>(`join:g`[flag &]))
       =.  groups.cor  (~(put by groups.cor) flag gr)
+      =.  cor
+        go-abet:(go-safe-sub:(go-abed:group-core:cor flag) |)
       %-  emil:cor
       %-  join-channels:go-pass:(go-abed:group-core:cor flag)
       ~(tap in ~(key by channels.group.gr))

--- a/desk/app/profile.hoon
+++ b/desk/app/profile.hoon
@@ -491,6 +491,16 @@
       %handle-http-request
     :_  this
     (serve:do !<(order:rudder:do vase))
+  ::
+      %egg-any
+    =+  !<(=egg-any:gall vase)
+    ?-  -.egg-any
+        ?(%15 %16)
+      ?.  ?=(%live +<.egg-any)
+        ~&  [dap.bowl %egg-any-not-live]
+        [~ this]
+      (on-load -:!>(*state-0) +>.old-state.egg-any)
+    ==
   ==
 ::
 ++  on-watch

--- a/desk/lib/negotiate.hoon
+++ b/desk/lib/negotiate.hoon
@@ -435,39 +435,46 @@
     ::
     ++  inner-bowl
       %_  bowl
-          sup
-        ::  hide subscriptions coming in to this library
-        ::
-        %-  ~(gas by *bitt:gall)
-        %+  skip  ~(tap by sup.bowl)
-        |=  [* * =path]
-        ?=([%~.~ %negotiate *] path)
-      ::
-          wex
-        %-  ~(gas by *boat:gall)
-        %+  weld
-          ::  make sure all the desired subscriptions are in the bowl,
-          ::  even if that means we have to simulate an un-acked state
-          ::
-          ^-  (list [[wire ship term] ? path])
-          %-  zing
-          %+  turn  ~(tap by want)
-          |=  [=gill:gall m=(map wire path)]
-          %+  turn  ~(tap by m)
-          |=  [=wire =path]
-          :-  [wire gill]
-          (~(gut by wex.bowl) [wire gill] [| path])
-        ::  hide subscriptions going out from this library.
-        ::  because these go into the +gas:by call _after_ the faked entries
-        ::  generated above, these (the originals) take precedence in the
-        ::  resulting bowl.
-        ::
-        %+  murn  ~(tap by wex.bowl)
-        |=  a=[[=wire gill:gall] ? path]
-        =^  g  wire.a  (trim-wire wire.a)
-        ?^  g  (some a)
-        ?:(?=([%~.~ %negotiate *] wire.a) ~ (some a))
+        sup  (inner-bitt sup.bowl)
+        wex  (inner-boat wex.bowl want)
       ==
+    ::  +inner-bitt: hide subscriptions coming in to this library
+    ::
+    ++  inner-bitt
+      |=  sup=bitt:gall
+      ^+  sup
+      %-  ~(gas by *bitt:gall)
+      %+  skip  ~(tap by sup)
+      |=  [* * =path]
+      ?=([%~.~ %negotiate *] path)
+    ::  +inner-boat: hide/simulate subscriptions managed by the library
+    ::
+    ++  inner-boat
+      |=  [wex=boat:gall want=(map gill:gall (map wire path))]
+      ^+  wex
+      %-  ~(gas by *boat:gall)
+      %+  weld
+        ::  make sure all the desired subscriptions are in the bowl,
+        ::  even if that means we have to simulate an un-acked state
+        ::
+        ^-  (list [[wire ship term] ? path])
+        %-  zing
+        %+  turn  ~(tap by want)
+        |=  [=gill:gall m=(map wire path)]
+        %+  turn  ~(tap by m)
+        |=  [=wire =path]
+        :-  [wire gill]
+        (~(gut by wex) [wire gill] [| path])
+      ::  hide subscriptions going out from this library.
+      ::  because these go into the +gas:by call _after_ the faked entries
+      ::  generated above, these (the originals) take precedence in the
+      ::  resulting bowl.
+      ::
+      %+  murn  ~(tap by wex.bowl)
+      |=  a=[[=wire gill:gall] ? path]
+      =^  g  wire.a  (trim-wire wire.a)
+      ?^  g  (some a)
+      ?:(?=([%~.~ %negotiate *] wire.a) ~ (some a))
     --
   ::
   ++  agent
@@ -488,6 +495,7 @@
       =^  cards  state  (play-cards:up cards)
       [cards this]
     ::
+    ::TODO  this should've been doing +slop instead
     ++  on-save  !>([[%negotiate state] on-save:og])
     ++  on-load
       |=  ole=vase
@@ -772,7 +780,30 @@
     ++  on-poke
       |=  [=mark =vase]
       ^-  (quip card _this)
-      =^  cards  inner  (on-poke:og +<)  !:
+      ?.  ?&  ?=(%egg-any mark)
+            !:
+              =+  !<(=egg-any:gall vase)
+          ?&  ?=(%live +<.egg-any)
+              ?=([[%negotiate *] *] q.old-state.egg-any)
+          ==  ==
+        =^  cards  inner  (on-poke:og mark vase)  !:
+        =^  cards  state  (play-cards:up cards)
+        [cards this]
+      ::  strip the negotiate state out of the egg, tidy up its bitt/boat,
+      ::  and pass it on to the inner agent
+      ::
+      =/  =cage  !:
+        :-  mark
+        !>  ^-  egg-any:gall
+        =+  !<(=egg-any:gall vase)
+        ?>  ?=(%live +<.egg-any)
+        %_  egg-any
+          +.old-state  [-:!>(**) q:(slot 7 +.old-state.egg-any)]
+          bitt         (inner-bitt:up bitt.egg-any)
+          boat         (inner-boat:up boat.egg-any want)
+          boar         (~(run by boat.egg-any) |=(* *@))
+        ==
+      =^  cards  inner  (on-poke:og cage)  !:
       =^  cards  state  (play-cards:up cards)
       [cards this]
     ::

--- a/desk/sur/activity.hoon
+++ b/desk/sur/activity.hoon
@@ -5,7 +5,9 @@
 ::  $stream: the activity stream comprised of events from various agents
 +$  stream  ((mop time event) lte)
 ::  $indices: the stream and its read data split into various indices
-+$  indices  (map source index)
++$  indices
+  $~  [[[%base ~] *index] ~ ~]
+  (map source index)
 ::  $volume-settings: the volume settings for each source
 +$  volume-settings  (map source volume-map)
 ::  $activity: the current state of activity for each source


### PR DESCRIPTION
Adds support for restoring agent state from `$egg-any:gall` backups. (That's the backup format [phoenix](https://github.com/urbit/phoenix) supports.)

This restores both locally-hosted and remote data. We do our best to re-establish subscriptions based on the data we have, generally picking up where we left off. It restores state for DMs (chat), groups (groups, channels-server, channels, activity) and public profiles (profile). Contacts data (at least our own profile) should probably support this, but it outside of this repo's scope.

I tested this pretty extensively prior to the addition of restoring non-locally-hosted data, and that seemed to work well. After the latest batch of changes, I'll want to do another serious round of testing.  

(Specifically, I may have introduces some additional ordering concerns that I'll need to address. I suspect we want to do both channels _and_ channels-server before groups now, and maybe activity before all of those... And, need to make sure subscriptions get picked up at the right places under all circumstances. ...To be continued.)

One missing piece here is actually on the "everyone else" side of this code: if a ship that hosts a group breaches, comes back, then re-imports the group, those subscriptions don't get re-established automatically. We may or may not be able to solve this from the group host side. (This may be more complicated for the "hosting a channel in a group I don't host myself" cases, too.) So, some pending work here, but may not be considered strictly blocking.

Realizing now that this was tested only on fully-joined states, not on weird in-between "trying to join the group" states or stuff like that, or on invites for that matter. Those are probably of secondary concern, but we should know what the behavior there is at least.