### PR TITLE
native: hide menu button on detail views

### DIFF
--- a/packages/ui/src/components/Channel/index.tsx
+++ b/packages/ui/src/components/Channel/index.tsx
@@ -297,7 +297,6 @@ export function Channel({
                           showSearchButton={isChatChannel}
                           goToSearch={goToSearch}
                           showSpinner={isLoadingPosts}
-                          showMenuButton={!isChatChannel}
                         />
                         <KeyboardAvoidingView enabled={!activeMessage}>
                           <YStack alignItems="center" flex={1}>

--- a/packages/ui/src/components/PostScreenView.tsx
+++ b/packages/ui/src/components/PostScreenView.tsx
@@ -116,7 +116,6 @@ export function PostScreenView({
                 title={headerTitle}
                 goBack={goBack}
                 showSearchButton={false}
-                showMenuButton={!isChatChannel}
                 post={parentPost ?? undefined}
                 channelType={channel.type}
                 mode={headerMode}


### PR DESCRIPTION
Hides the three dots menu in detail views (also hides it from the channel view, where it shouldn't have been visible anyway).