### PR TITLE
Visual tweaks for Activity screen

### DIFF
--- a/packages/ui/src/components/Activity/ActivityHeader.tsx
+++ b/packages/ui/src/components/Activity/ActivityHeader.tsx
@@ -18,7 +18,7 @@ function ActivityHeaderRaw({
     <View>
       <View width="100%">
         <ScreenHeader>
-          <ScreenHeader.Title textAlign="center">Activity</ScreenHeader.Title>
+          <ScreenHeader.Title textAlign="left">Activity</ScreenHeader.Title>
         </ScreenHeader>
       </View>
       <Tabs>

--- a/packages/ui/src/components/Activity/ActivityScreenView.tsx
+++ b/packages/ui/src/components/Activity/ActivityScreenView.tsx
@@ -98,13 +98,11 @@ export function ActivityScreenView({
   const renderItem = useCallback(
     ({ item }: { item: logic.SourceActivityEvents }) => {
       return (
-        <View marginHorizontal="$l">
-          <SourceActivityDisplay
-            sourceActivity={item}
-            onPress={handlePressEvent}
-            seenMarker={activitySeenMarker ?? Date.now()}
-          />
-        </View>
+        <SourceActivityDisplay
+          sourceActivity={item}
+          onPress={handlePressEvent}
+          seenMarker={activitySeenMarker ?? Date.now()}
+        />
       );
     },
     [activitySeenMarker, handlePressEvent]
@@ -149,7 +147,7 @@ export function ActivityScreenView({
           data={events}
           renderItem={renderItem}
           keyExtractor={keyExtractor}
-          contentContainerStyle={{ paddingTop: 16 }}
+          contentContainerStyle={{ paddingTop: 16, paddingHorizontal: 16 }}
           onEndReached={handleEndReached}
           ListFooterComponent={
             currentFetcher.isFetching ? <LoadingSpinner /> : null
@@ -177,7 +175,7 @@ function ActivityEventRaw({
 
   if (db.isGroupEvent(event)) {
     return (
-      <View onPress={handlePress}>
+      <View onPress={handlePress} marginBottom="$xl">
         <GroupActivitySummary
           summary={sourceActivity}
           seenMarker={seenMarker}
@@ -194,7 +192,7 @@ function ActivityEventRaw({
     event.type === 'flag-reply'
   ) {
     return (
-      <View onPress={handlePress}>
+      <View onPress={handlePress} marginBottom="$xl">
         <ChannelActivitySummary
           summary={sourceActivity}
           seenMarker={seenMarker}

--- a/packages/ui/src/components/Activity/ActivitySourceContent.tsx
+++ b/packages/ui/src/components/Activity/ActivitySourceContent.tsx
@@ -30,11 +30,7 @@ export function ActivitySourceContent({
 
   // thread or comment
   if (summary.newest.parentId) {
-    return (
-      <View marginTop="$s" marginRight="$xl">
-        <ContentRenderer post={post} viewMode="activity" />
-      </View>
-    );
+    return <ContentRenderer post={post} viewMode="activity" />;
   }
 
   if (
@@ -43,8 +39,6 @@ export function ActivitySourceContent({
   ) {
     return (
       <ScrollView
-        marginTop="$s"
-        marginRight="$xl"
         gap="$s"
         horizontal
         alwaysBounceHorizontal={false}
@@ -81,11 +75,7 @@ export function ActivitySourceContent({
     );
   }
 
-  return (
-    <View marginTop="$s" marginRight="$xl">
-      <ContentRenderer post={post} viewMode="activity" />
-    </View>
-  );
+  return <ContentRenderer post={post} viewMode="activity" />;
 }
 
 function getPost(event: db.ActivityEvent): db.Post {

--- a/packages/ui/src/components/Activity/ActivitySummaryMessage.tsx
+++ b/packages/ui/src/components/Activity/ActivitySummaryMessage.tsx
@@ -26,7 +26,12 @@ function SummaryMessageRaw({
 
   const NewestAuthor = useMemo(() => {
     return (
-      <ContactName fontSize="$s" userId={newest.authorId ?? ''} showNickname />
+      <ContactName
+        fontSize="$s"
+        lineHeight={18}
+        userId={newest.authorId ?? ''}
+        showNickname
+      />
     );
   }, [newest.authorId]);
 
@@ -35,19 +40,30 @@ function SummaryMessageRaw({
       <>
         <ContactName
           fontSize="$s"
+          lineHeight={18}
           userId={newest.authorId ?? ''}
           showNickname
         />
         {otherAuthors[0] && (
           <>
             {`${otherAuthors[1] ? ', ' : ' and '}`}
-            <ContactName fontSize="$s" userId={otherAuthors[0]} showNickname />
+            <ContactName
+              fontSize="$s"
+              lineHeight={18}
+              userId={otherAuthors[0]}
+              showNickname
+            />
           </>
         )}
         {otherAuthors[1] && (
           <>
             {', and '}
-            <ContactName fontSize="$s" userId={otherAuthors[1]} showNickname />
+            <ContactName
+              fontSize="$s"
+              lineHeight={18}
+              userId={otherAuthors[1]}
+              showNickname
+            />
           </>
         )}
       </>
@@ -159,7 +175,7 @@ function SummaryMessageRaw({
 
   if (summary.all.length === 1) {
     return (
-      <SizableText color="$secondaryText">
+      <SizableText color="$secondaryText" lineHeight="$s">
         <ContactName userId={newest.authorId ?? ''} showNickname />
         {` ${postVerb(newest.channel?.type ?? 'chat')} a ${postName(newest)}`}
       </SizableText>
@@ -170,17 +186,13 @@ function SummaryMessageRaw({
   summary.all.forEach((event) => uniqueAuthors.add(event.authorId ?? ''));
   if (uniqueAuthors.size === 1) {
     return (
-      <SizableText color="$secondaryText">
-        <ContactName
-          userId={newest.authorId ?? ''}
-          fontWeight="$xl"
-          showNickname
-        />
+      <SizableText color="$secondaryText" lineHeight="$s">
+        <ContactName userId={newest.authorId ?? ''} showNickname />
         {` ${postVerb(newest.channel?.type ?? 'chat')} ${count} ${postName(newest, count > 1)}`}
       </SizableText>
     );
   } else {
-    <SizableText color="$secondaryText">
+    <SizableText color="$secondaryText" lineHeight="$s">
       {`${postVerb(newest.channel?.type ?? 'chat')} ${count} ${postName(newest, count > 1)}`}
     </SizableText>;
   }
@@ -190,7 +202,7 @@ export const SummaryMessage = React.memo(SummaryMessageRaw);
 
 function SummaryMessageWrapper({ children }: PropsWithChildren) {
   return (
-    <SizableText color="$secondaryText" size="$s" marginRight="$xl">
+    <SizableText color="$secondaryText" size="$s" lineHeight="$s">
       {children}
     </SizableText>
   );

--- a/packages/ui/src/components/Activity/ChannelActivitySummary.tsx
+++ b/packages/ui/src/components/Activity/ChannelActivitySummary.tsx
@@ -44,23 +44,22 @@ export function ChannelActivitySummary({
 
   return (
     <View
-      padding="$l"
-      marginBottom="$l"
+      padding="$m"
       backgroundColor={
-        newestPost.timestamp > seenMarker && unreadCount > 0
+        newestPost.timestamp > seenMarker || unreadCount > 0
           ? '$positiveBackground'
           : 'unset'
       }
       borderRadius="$l"
       onPress={newestIsBlockOrNote ? undefined : pressHandler}
     >
-      <XStack>
+      <XStack gap="$m">
         <ContactAvatar
           contactId={newestPost.authorId ?? ''}
           size="$3xl"
           innerSigilSize={14}
         />
-        <YStack marginLeft="$m">
+        <YStack gap="$xs" flex={1}>
           {channel && (
             <ActivitySummaryHeader
               unreadCount={unreadCount}

--- a/packages/ui/src/components/Activity/GroupActivitySummary.tsx
+++ b/packages/ui/src/components/Activity/GroupActivitySummary.tsx
@@ -67,7 +67,7 @@ export function GroupActivitySummary({
     <View
       padding="$m"
       backgroundColor={
-        newest.timestamp > seenMarker && unreadCount > 0
+        newest.timestamp > seenMarker || unreadCount > 0
           ? '$positiveBackground'
           : 'unset'
       }

--- a/packages/ui/src/components/Activity/GroupActivitySummary.tsx
+++ b/packages/ui/src/components/Activity/GroupActivitySummary.tsx
@@ -65,8 +65,7 @@ export function GroupActivitySummary({
 
   return (
     <View
-      padding="$l"
-      marginBottom="$l"
+      padding="$m"
       backgroundColor={
         newest.timestamp > seenMarker && unreadCount > 0
           ? '$positiveBackground'
@@ -75,13 +74,13 @@ export function GroupActivitySummary({
       borderRadius="$l"
       onPress={pressHandler}
     >
-      <XStack>
+      <XStack gap="$m">
         <ContactAvatar
           contactId={newest.groupEventUserId ?? ''}
           size="$3xl"
           innerSigilSize={14}
         />
-        <YStack marginLeft="$m">
+        <YStack gap="$xs" flex={1}>
           {group && (
             <ActivitySummaryHeader
               unreadCount={unreadCount}
@@ -92,7 +91,7 @@ export function GroupActivitySummary({
             </ActivitySummaryHeader>
           )}
           <View>
-            <SizableText color="$secondaryText" size="$s" marginRight="$xl">
+            <SizableText color="$secondaryText" size="$s">
               {Authors}
               {` ${plural ? 'have' : 'has'} requested to join the group`}
             </SizableText>

--- a/packages/ui/src/components/ContentReference/ContentReference.tsx
+++ b/packages/ui/src/components/ContentReference/ContentReference.tsx
@@ -125,7 +125,7 @@ export const PostReference = ({
               )}
               <PostAuthor contactId={post.authorId} />
               <ContentRenderer
-                viewMode={viewMode}
+                viewMode={props.viewMode}
                 shortened={shortened}
                 post={post}
               />
@@ -134,7 +134,7 @@ export const PostReference = ({
             <>
               <PostAuthor contactId={post.authorId} />
               <ContentRenderer
-                viewMode={viewMode}
+                viewMode={props.viewMode}
                 shortened={shortened}
                 post={post}
               />

--- a/packages/ui/src/components/ContentRenderer.tsx
+++ b/packages/ui/src/components/ContentRenderer.tsx
@@ -524,7 +524,7 @@ export function InlineContent({
     return (
       <ShipMention
         userId={inline.ship}
-        fontSize={viewMode === 'activity' ? '$s' : undefined}
+        size={viewMode === 'block' || viewMode === 'activity' ? '$s' : '$m'}
         fontFamily={serif ? '$serif' : '$body'}
       />
     );
@@ -715,7 +715,11 @@ const LineRenderer = memo(
           <ShipMention
             key={`ship-${index}`}
             userId={inline.ship}
-            fontSize={isNotice || viewMode === 'activity' ? '$s' : 'unset'}
+            size={
+              viewMode === 'block' || viewMode === 'activity' || isNotice
+                ? '$s'
+                : '$m'
+            }
             fontFamily={serif ? '$serif' : '$body'}
           />
         );
@@ -883,7 +887,9 @@ export default function ContentRenderer({
         }
 
         if ('type' in s && s.type === 'reference') {
-          return <ContentReferenceLoader key={k} reference={s} />;
+          return (
+            <ContentReferenceLoader viewMode={viewMode} key={k} reference={s} />
+          );
         }
 
         if ('inline' in s) {


### PR DESCRIPTION
- Correctly references `props.viewMode` in ContentReference to correctly size reference text in the activity context (we were relying on a similarly-named `useReferenceContext` hook which only gives us the immediate parent `viewMode`, not the one we're passing down through the Activity screen).
- Renames a prop for ContactName (we use `size` rather than `fontSize`) so we don't have medium-sized ship nicknames in the activity item content (which is small-sized)
- Cleans up the inter-item layout of the Activity screen to prevent unsightly wrapping and  margin inconsistencies
- Restores the faint blue background for unread items
- Left-aligns the screen title

Before & after:
![image](https://github.com/user-attachments/assets/539dc586-791a-4af0-98fb-89b4df11e95b)
