### PR TITLE
web: reference assets correctly

### DIFF
--- a/apps/tlon-web/index.html
+++ b/apps/tlon-web/index.html
@@ -7,9 +7,9 @@
       content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no"
     />
     <title data-react-helmet="true">Tlon</title>
-    <link rel="icon" href="favicon.ico" sizes="32x32" />
-    <link rel="icon" href="icon.svg" sizes="any" type="image/svg+xml" />
-    <link rel="apple-touch-icon" href="apple-touch-icon.png" />
+    <link rel="icon" href="/favicon.ico" sizes="32x32" />
+    <link rel="icon" href="/icon.svg" sizes="any" type="image/svg+xml" />
+    <link rel="apple-touch-icon" href="/apple-touch-icon.png" />
     <meta name="theme-color" content="#ffffff" data-react-helmet="true" />
     <meta name="mobile-web-app-capable" content="yes" />
   </head>


### PR DESCRIPTION
Will from shrub team reported this, seems that the way we referenced favicons didn't work in some cases this should resolve that.

PR Checklist
- [ ] Includes changes to desk files
- [ ] Describes how you tested the PR locally (test ship vs livenet)
- [ ] If a new feature, includes automated tests
- [ ] Comments added anywhere logic may be confusing without context