### PR TITLE
native: fix channel write permission check

### DIFF
--- a/packages/shared/src/db/queries.ts
+++ b/packages/shared/src/db/queries.ts
@@ -641,7 +641,7 @@ export const insertChannelPerms = createWriteQuery(
     );
 
     if (readers.length > 0) {
-      return ctx.db
+      await ctx.db
         .insert($channelReaders)
         .values(readers)
         .onConflictDoUpdate({
@@ -650,17 +650,15 @@ export const insertChannelPerms = createWriteQuery(
         });
     }
 
-    if (writers.length === 0) {
-      return;
+    if (writers.length > 0) {
+      await ctx.db
+        .insert($channelWriters)
+        .values(writers)
+        .onConflictDoUpdate({
+          target: [$channelWriters.channelId, $channelWriters.roleId],
+          set: conflictUpdateSetAll($channelWriters),
+        });
     }
-
-    return ctx.db
-      .insert($channelWriters)
-      .values(writers)
-      .onConflictDoUpdate({
-        target: [$channelWriters.channelId, $channelWriters.roleId],
-        set: conflictUpdateSetAll($channelWriters),
-      });
   },
   ['channelWriters', 'channels']
 );
@@ -1249,6 +1247,11 @@ export const getChannelWithRelations = createReadQuery(
         group: true,
         contact: true,
         writerRoles: {
+          with: {
+            role: true,
+          },
+        },
+        readerRoles: {
           with: {
             role: true,
           },

--- a/packages/ui/src/components/Channel/EmptyChannelNotice.tsx
+++ b/packages/ui/src/components/Channel/EmptyChannelNotice.tsx
@@ -1,15 +1,18 @@
 import * as db from '@tloncorp/shared/dist/db';
 import { useMemo, useState } from 'react';
-import { SizableText, View } from 'tamagui';
+import { Platform, View as RNView } from 'react-native';
+import { SizableText } from 'tamagui';
 
 import { useIsAdmin } from '../../utils';
 
 export function EmptyChannelNotice({
   channel,
   userId,
+  withBugAdjust,
 }: {
   channel: db.Channel;
   userId: string;
+  withBugAdjust?: boolean;
 }) {
   const isGroupAdmin = useIsAdmin(channel.groupId ?? '', userId);
   const [isFirstVisit] = useState(() => channel.lastViewedAt == null);
@@ -22,11 +25,27 @@ export function EmptyChannelNotice({
     return 'There are no messages... yet.';
   }, [isGroupAdmin, isFirstVisit, isWelcomeChannel]);
 
+  // this component is usually used within a list view, but there's a bug in RN
+  // with rotating empty placeholders if the list is inverted. This custom styling is a workaround
+  // that gives callers the ability to optionally account for that issue
+  let contentStyle = undefined;
+  if (withBugAdjust) {
+    if (Platform.OS === 'ios') {
+      contentStyle = {
+        transform: [{ scaleY: -1 }],
+      };
+    } else if (Platform.OS === 'android') {
+      contentStyle = {
+        transform: [{ scaleY: -1 }, { scaleX: -1 }],
+      };
+    }
+  }
+
   return (
-    <View alignItems="center" paddingHorizontal="$2xl">
+    <RNView style={contentStyle}>
       <SizableText textAlign="center" color="$tertiaryText">
         {noticeText}
       </SizableText>
-    </View>
+    </RNView>
   );
 }

--- a/packages/ui/src/components/Channel/index.tsx
+++ b/packages/ui/src/components/Channel/index.tsx
@@ -151,7 +151,13 @@ export function Channel({
       : GalleryPost;
 
   const renderEmptyComponent = useCallback(() => {
-    return <EmptyChannelNotice channel={channel} userId={currentUserId} />;
+    return (
+      <EmptyChannelNotice
+        channel={channel}
+        userId={currentUserId}
+        withBugAdjust
+      />
+    );
   }, [currentUserId, channel]);
 
   const onPressGroupRef = useCallback((group: db.Group) => {


### PR DESCRIPTION
This was an issue with permissions not getting initially configured correctly. There was a bugged early return preventing writer role insertion. Also fixes a bug I noticed while working on this with the empty channel message still getting displayed inverted.

Fixes TLON-2561