### PR TITLE
Add dev menu items to log sqlite query durations

### DIFF
--- a/packages/app/lib/devMenuItems.ts
+++ b/packages/app/lib/devMenuItems.ts
@@ -1,6 +1,18 @@
 import { registerDevMenuItems } from 'expo-dev-menu';
-import { NativeModules } from 'react-native';
+import {
+  Alert,
+  Clipboard,
+  DevSettings,
+  NativeModules,
+  Share,
+} from 'react-native';
 
+// Since we're relying on state local to this module, we need to ensure that we
+// import from the same location that other callers import it from (i.e. don't
+// import from `@tloncorp/shared/src/db` because `tlon-mobile` largely imports
+// from `@tloncorp/shared/dist/store`, which transitively hits `QueryLogger`
+// via the post-bundler `dist`).
+import { QueryLogger } from '../../../packages/shared/dist/db';
 import { getDbPath, purgeDb } from './nativeDb';
 
 let metroBundlerURL: string | null = null;
@@ -26,6 +38,67 @@ const devMenuItems = [
     callback: async () => {
       const path = getDbPath() ?? '';
       sendBundlerRequest('dump-sqlite', { path });
+    },
+  },
+  {
+    name: 'Start capturing query logs',
+    callback: async () => {
+      const logger = QueryLogger.shared;
+      logger.clear();
+      logger.paused = false;
+
+      Alert.alert('Enabled query logging');
+    },
+  },
+  {
+    name: 'Print query logs',
+    callback: async () => {
+      const logger = QueryLogger.shared;
+      const csv = logger.toCsv();
+      if (csv == null) {
+        Alert.alert(
+          'No query logs captured',
+          logger.paused ? 'Query logs are paused' : undefined,
+
+          logger.paused
+            ? [
+                {
+                  text: 'Start capturing',
+                  onPress: () => {
+                    logger.clear();
+                    logger.paused = false;
+                  },
+                },
+                { text: 'Close' },
+              ]
+            : undefined
+        );
+        return;
+      }
+
+      logger.paused = true;
+      logger.clear();
+
+      console.log('\n' + csv);
+      Alert.alert(
+        'Query logs printed to console',
+        'Logs have also been paused',
+        [
+          { text: 'Close', style: 'cancel' },
+          {
+            text: 'Copy to clipboard',
+            onPress: () => {
+              Clipboard.setString(csv);
+            },
+          },
+          {
+            text: 'Share...',
+            onPress: async () => {
+              await Share.share({ message: csv });
+            },
+          },
+        ]
+      );
     },
   },
 ];

--- a/packages/shared/src/db/index.ts
+++ b/packages/shared/src/db/index.ts
@@ -6,3 +6,4 @@ export * from './modelBuilders';
 export * from './keyValue';
 export { setClient } from './client';
 export * from './changeListener';
+export { QueryLogger } from './queryLogger';

--- a/packages/shared/src/db/queryLogger.ts
+++ b/packages/shared/src/db/queryLogger.ts
@@ -1,0 +1,73 @@
+export type QueryLogLine = [
+  timestamp: number,
+  label: string,
+  durationMs: number,
+];
+// eslint-disable-next-line @typescript-eslint/no-namespace
+export namespace QueryLogLine {
+  export function create(
+    timestamp: number,
+    label: string,
+    durationMs: number
+  ): QueryLogLine {
+    return [timestamp, label, durationMs];
+  }
+
+  export function timestamp(log: QueryLogLine): number {
+    return log[0];
+  }
+  export function label(log: QueryLogLine): string {
+    return log[1];
+  }
+  export function durationMs(log: QueryLogLine): number {
+    return log[2];
+  }
+}
+
+export class QueryLogger {
+  static shared = new QueryLogger();
+
+  // Set to `false` to enable logging from app start
+  paused: boolean = true;
+
+  private logs: QueryLogLine[] = [];
+
+  log(label: string, durationMs: number) {
+    if (this.paused) {
+      return;
+    }
+    this.logs.push(QueryLogLine.create(Date.now(), label, durationMs));
+  }
+
+  clear() {
+    this.logs = [];
+  }
+
+  toCsv(): string | null {
+    if (this.logs.length === 0) {
+      return null;
+    }
+
+    const grouped: { [timestamp: number]: { [label: string]: QueryLogLine } } =
+      {};
+    const allLabels: Set<string> = new Set();
+    for (const log of this.logs) {
+      const timestamp = QueryLogLine.timestamp(log);
+      const label = QueryLogLine.label(log);
+      allLabels.add(label);
+      if (!grouped[timestamp]) {
+        grouped[timestamp] = {};
+      }
+      grouped[timestamp][label] = log;
+    }
+    const sortedLabels = Array.from(allLabels).sort();
+    const dataLines = Object.entries(grouped)
+      .sort(([a], [b]) => parseFloat(a) - parseFloat(b))
+      .map(
+        ([timestamp, logs]) =>
+          `${timestamp},${sortedLabels.map((label) => (logs[label] == null ? '' : QueryLogLine.durationMs(logs[label]))).join(',')}`
+      );
+
+    return [`timestamp,${sortedLabels.join(',')}`, ...dataLines].join('\n');
+  }
+}


### PR DESCRIPTION
Not sure if we want to merge this, although I think it'd be safe to do so (we add a call to `QueryLogger#log` in all queries, but that exits early if the logger is paused).

Adds shake menu items to (1) start capturing query durations, and (2) print out (or otherwise share) a CSV representation of the captured query durations for easy import into a visualization spreadsheet.

Exporting the CSV from this tool into a spreadsheet lets us visualize our query load easily (the following was navigating from home screen -> channel):
![Screenshot 2024-08-16 at 11 14 41 AM](https://github.com/user-attachments/assets/16e17fdd-a695-4fb4-ac29-784334ba356b)
