### PR TITLE
channels: store updated times for changes endpoint

### DIFF
--- a/desk/app/activity.hoon
+++ b/desk/app/activity.hoon
@@ -298,7 +298,8 @@
         %.  indices
         %~  uni  by
         %-  ~(run by indices:bak)
-        |=  index
+        |=  index:a
+        ^-  index:a
         :_  [[floor.reads ~] bump]
         ?~  hed=(ram:on-event:a stream)
           *stream:a

--- a/desk/app/channels-server.hoon
+++ b/desk/app/channels-server.hoon
@@ -16,7 +16,7 @@
   |%
   +$  card  card:agent:gall
   +$  current-state
-    $:  %5
+    $:  %6
         =v-channels:c
         =pimp:imp
     ==
@@ -91,15 +91,32 @@
   =?  old  ?=(%2 -.old)  (state-2-to-3 old)
   =?  old  ?=(%3 -.old)  (state-3-to-4 old)
   =?  old  ?=(%4 -.old)  (state-4-to-5 old)
-  ?>  ?=(%5 -.old)
+  =?  old  ?=(%5 -.old)  (state-5-to-6 old)
+  ?>  ?=(%6 -.old)
   =.  state  old
   inflate-io
   ::
-  +$  versioned-state  $%(state-5 state-4 state-3 state-2 state-1 state-0)
-  +$  state-5  current-state
+  +$  versioned-state  $%(state-6 state-5 state-4 state-3 state-2 state-1 state-0)
+  +$  state-6  current-state
+  +$  state-5
+    $:  %5
+        =v-channels:v6:old:c
+        =pimp:imp
+    ==
+  ++  state-5-to-6
+    |=  state-5
+    ^-  state-6
+    [%6 (v-channels-5-to-6 v-channels) pimp]
+  ++  v-channels-5-to-6
+    |=  vc=v-channels:v6:old:c
+    ^-  v-channels:c
+    %-  ~(run by vc)
+    |=  v=v-channel:v6:old:c
+    ^-  v-channel:c
+    v(pending [pending.v *(map time id-post:c)])
   +$  state-4
     $:  %4
-        =v-channels:c
+        =v-channels:v6:old:c
     ==
   ++  state-4-to-5
     |=  state-4
@@ -113,7 +130,7 @@
   ::
   ++  v-channel-2-to-3
     |=  v=v-channel-2
-    ^-  v-channel:c
+    ^-  v-channel:v6:old:c
     v(future [future.v *pending-messages:c])
   ++  v-channels-2  (map nest:c v-channel-2)
   ++  v-channel-2

--- a/desk/app/channels-server.hoon
+++ b/desk/app/channels-server.hoon
@@ -113,7 +113,7 @@
     %-  ~(run by vc)
     |=  v=v-channel:v6:old:c
     ^-  v-channel:c
-    v(pending [pending.v *(map time id-post:c)])
+    v(pending [pending.v *last-updated:c])
   +$  state-4
     $:  %4
         =v-channels:v6:old:c

--- a/desk/app/channels.hoon
+++ b/desk/app/channels.hoon
@@ -15,7 +15,7 @@
 ::  performance, keep warm
 /+  channel-json
 ::
-=/  verbose  &
+=/  verbose  |
 %-  %-  agent:neg
     :+  notify=&
       [~.channels^%1 ~ ~]
@@ -2008,7 +2008,15 @@
       =;  posts=v-posts:c
         ?:  ?=(%v2 version)
           =/  =paged-posts:c
-            [(uv-posts-2:utils posts) ~ ~ (wyt:on-v-posts:c posts)]
+            :*  (uv-posts-2:utils posts)
+                ?~  newer=(tab:on-v-posts:c posts.channel `end 1)
+                  ~
+                `key:(head newer)
+                ?~  older=(bat:mo-v-posts:c posts.channel `start 1)
+                  ~
+                `key:(head older)
+                (wyt:on-v-posts:c posts)
+            ==
           ``channel-posts-2+!>(paged-posts)
         =/  =paged-posts:v1:old:c
           [(uv-posts:utils posts) ~ ~ (wyt:on-v-posts:c posts)]

--- a/desk/app/channels.hoon
+++ b/desk/app/channels.hoon
@@ -2006,20 +2006,20 @@
         ?^  tim=(slaw %da after.pole)  u.tim
         (slav %ud after.pole)
       =;  posts=v-posts:c
+        =/  newer
+          ?~  newer=(tab:on-v-posts:c posts.channel `end 1)
+            ~
+          `key:(head newer)
+        =/  older
+          ?~  older=(bat:mo-v-posts:c posts.channel `start 1)
+            ~
+          `key:(head older)
         ?:  ?=(%v2 version)
           =/  =paged-posts:c
-            :*  (uv-posts-2:utils posts)
-                ?~  newer=(tab:on-v-posts:c posts.channel `end 1)
-                  ~
-                `key:(head newer)
-                ?~  older=(bat:mo-v-posts:c posts.channel `start 1)
-                  ~
-                `key:(head older)
-                (wyt:on-v-posts:c posts)
-            ==
+            [(uv-posts-2:utils posts) newer older (wyt:on-v-posts:c posts)]
           ``channel-posts-2+!>(paged-posts)
         =/  =paged-posts:v1:old:c
-          [(uv-posts:utils posts) ~ ~ (wyt:on-v-posts:c posts)]
+          [(uv-posts:utils posts) newer older (wyt:on-v-posts:c posts)]
         ``channel-posts+!>(paged-posts)
       ::  walk both posts and logs, in chronological order, newest-first,
       ::  until we accumulate the desired amount of results
@@ -2027,7 +2027,6 @@
       ::NOTE  would manually walk the tree, but logic gets rather confusing,
       ::      so we just eat the conversion overhead here
       =/  posts  (lot:on-v-posts:c posts.channel `(sub start 1) `(add end 1))
-      =/  logs   (tap:log-on:c (lot:log-on:c log.channel `after ~))
       =/  updated  (tap:updated-on:c (lot:updated-on:c last-updated.channel `after ~))
       %-  (log |.("posts: {<(lent posts)>}"))
       %-  (log |.("updated: {<(lent updated)>}"))

--- a/desk/app/channels.hoon
+++ b/desk/app/channels.hoon
@@ -1304,6 +1304,7 @@
     |=  [=time =u-channel:c]
     ?>  ca-from-host
     ^+  ca-core
+    =.  log.channel  (put:log-on:c log.channel time u-channel)
     ?-    -.u-channel
         %create
       ?.  =(0 rev.perm.channel)  ca-core

--- a/desk/sur/channels.hoon
+++ b/desk/sur/channels.hoon
@@ -61,6 +61,7 @@
         =window
         =future
         pending=pending-messages
+        last-updated=(map time id-post)
     ==
   --
 ::  $v-post: a channel post
@@ -526,6 +527,21 @@
 ++  on-simple-replies  ((on id-reply simple-reply) lte)
 ++  old
   |%
+  ++  v6
+    |%
+    ++  v-channels  (map nest v-channel)
+    ++  v-channel
+      |^  ,[global:^v-channel local]
+      +$  local
+        $:  =net
+            =log
+            =remark
+            =window:^v-channel
+            =future:^v-channel
+            pending=pending-messages
+        ==
+      --
+    --
   ++  v1
     |%
     +$  post  [seal [rev=@ud essay]]

--- a/desk/sur/channels.hoon
+++ b/desk/sur/channels.hoon
@@ -61,9 +61,11 @@
         =window
         =future
         pending=pending-messages
-        last-updated=(map time id-post)
+        =last-updated
     ==
   --
++$  last-updated  ((mop time id-post) lte)
+++  updated-on   ((on time id-post) lte)
 ::  $v-post: a channel post
 ::
 +$  v-post      [v-seal (rev essay)]


### PR DESCRIPTION
OTT, this PR adds a new version of the `changes` endpoint `/v2/{kind}/{ship}/{name}/posts/changes/{start}/{end}/{after}`

The endpoint has three parameters:
- `start`: the beginning of the range of posts we care about, a `@ud` or `@da` value corresponding to a post ID
- `end`: the end of the range of posts we care about, a `@ud` or `@da` value corresponding to a post ID
- `after`: the point at which we start caring about updates, basically when did we last "sync"

It returns a `paged-posts` type, with cursors pointing at the post IDs adjacent to start and end if there are any.

Also fixes a compiler issue in the current dev branch with activity import.

PR Checklist
- [ ] Includes changes to desk files
- [ ] Describes how you tested the PR locally (test ship vs livenet)
- [ ] If a new feature, includes automated tests
- [ ] Comments added anywhere logic may be confusing without context