### PR TITLE
native: use zustand for feature flags to enable reactivity

### DIFF
--- a/apps/tlon-mobile/src/screens/FeatureFlagScreen.tsx
+++ b/apps/tlon-mobile/src/screens/FeatureFlagScreen.tsx
@@ -1,7 +1,7 @@
 import type { NativeStackScreenProps } from '@react-navigation/native-stack';
 import * as featureFlags from '@tloncorp/app/lib/featureFlags';
 import { FeatureFlagScreenView } from '@tloncorp/ui';
-import { useCallback, useState } from 'react';
+import { useCallback, useMemo } from 'react';
 
 import type { RootStackParamList } from '../types';
 
@@ -10,39 +10,34 @@ type FeatureFlagScreenProps = NativeStackScreenProps<
   'FeatureFlags'
 >;
 
-const getFlagState = () => {
-  return Object.entries(featureFlags.featureMeta).map(([name, meta]) => {
-    return {
-      name,
-      label: meta.label,
-      enabled: featureFlags.isEnabled(name as featureFlags.FeatureName),
-    };
-  });
-};
-
-export function FeatureFlagScreen({
-  route,
-  navigation,
-}: FeatureFlagScreenProps) {
+export function FeatureFlagScreen({ navigation }: FeatureFlagScreenProps) {
   const handleGoBackPressed = useCallback(() => {
     navigation.goBack();
   }, [navigation]);
 
-  const [flagState, setFlagState] = useState(() => getFlagState());
+  const { flags, setEnabled } = featureFlags.useFeatureFlagStore();
 
   const handleFeatureFlagToggled = useCallback(
     (name: string, enabled: boolean) => {
       console.log('set enabled', name, enabled);
-      featureFlags.setEnabled(name as featureFlags.FeatureName, enabled);
-      console.log('next flags', getFlagState());
-      setFlagState(getFlagState());
+      setEnabled(name as featureFlags.FeatureName, enabled);
     },
-    []
+    [setEnabled]
+  );
+
+  const features = useMemo(
+    () =>
+      Object.entries(featureFlags.featureMeta).map(([name, meta]) => ({
+        name,
+        label: meta.label,
+        enabled: flags[name as featureFlags.FeatureName],
+      })),
+    [flags]
   );
 
   return (
     <FeatureFlagScreenView
-      features={flagState}
+      features={features}
       onBackPressed={handleGoBackPressed}
       onFlagToggled={handleFeatureFlagToggled}
     />

--- a/packages/app/features/top/ChatListScreen.tsx
+++ b/packages/app/features/top/ChatListScreen.tsx
@@ -27,7 +27,7 @@ import { useCalmSettings } from '../../hooks/useCalmSettings';
 import { useChatSettingsNavigation } from '../../hooks/useChatSettingsNavigation';
 import { useCurrentUserId } from '../../hooks/useCurrentUser';
 import { useIsFocused } from '../../hooks/useIsFocused';
-import * as featureFlags from '../../lib/featureFlags';
+import { useFeatureFlag } from '../../lib/featureFlags';
 import { identifyTlonEmployee } from '../../utils/posthog';
 import { isSplashDismissed, setSplashDismissed } from '../../utils/splash';
 
@@ -131,13 +131,15 @@ export default function ChatListScreen({
   // [props.navigation]
   // );
 
+  const [isChannelSwitcherEnabled] = useFeatureFlag('channelSwitcher');
+
   const onPressChat = useCallback(
     (item: db.Channel | db.Group) => {
       if (logic.isGroup(item)) {
         setSelectedGroup(item);
       } else if (
         item.group &&
-        !featureFlags.isEnabled('channelSwitcher') &&
+        !isChannelSwitcherEnabled &&
         // Should navigate to channel if it's pinned as a channel
         (!item.pin || item.pin.type === 'group')
       ) {
@@ -151,7 +153,7 @@ export default function ChatListScreen({
         navigateToSelectedPost(item, item.firstUnreadPostId);
       }
     },
-    [navigateToGroupChannels, navigateToSelectedPost]
+    [navigateToGroupChannels, navigateToSelectedPost, isChannelSwitcherEnabled]
   );
 
   const onLongPressChat = useCallback((item: db.Channel | db.Group) => {

--- a/packages/app/hooks/useChannelContext.ts
+++ b/packages/app/hooks/useChannelContext.ts
@@ -8,7 +8,7 @@ import { GroupPreviewAction } from '@tloncorp/ui';
 import { useCallback, useEffect, useMemo, useState } from 'react';
 
 import { useCurrentUserId } from '../hooks/useCurrentUser';
-import * as featureFlags from '../lib/featureFlags';
+import { useFeatureFlag } from '../lib/featureFlags';
 import storage from '../lib/storage';
 
 export const useChannelContext = ({
@@ -170,6 +170,7 @@ export const useChannelContext = ({
   // Contacts
 
   const contactsQuery = store.useContacts();
+  const [isChannelSwitcherEnabled] = useFeatureFlag('channelSwitcher');
 
   return {
     negotiationStatus,
@@ -189,6 +190,6 @@ export const useChannelContext = ({
     navigateToSearch,
     currentUserId,
     performGroupAction,
-    headerMode: featureFlags.isEnabled('channelSwitcher') ? 'next' : 'default',
+    headerMode: isChannelSwitcherEnabled ? 'next' : 'default',
   } as const;
 };

--- a/packages/app/lib/featureFlags.ts
+++ b/packages/app/lib/featureFlags.ts
@@ -1,11 +1,15 @@
+import { mapValues } from 'lodash';
+import create from 'zustand';
+
 import storage from './storage';
 
+// Add new feature flags here:
 export const featureMeta = {
   channelSwitcher: {
     default: false,
     label: 'Experimental channel switcher',
   },
-};
+} satisfies Record<string, { default: boolean; label: string }>;
 
 export type FeatureName = keyof typeof featureMeta;
 
@@ -13,21 +17,38 @@ export type FeatureState = {
   [K in FeatureName]: boolean;
 };
 
-const featureState: { [K in FeatureName]: boolean } = {
-  channelSwitcher: false,
-};
-
-export function setEnabled(name: FeatureName, enabled: boolean) {
-  featureState[name] = enabled;
-  saveState();
+interface FeatureStateStore {
+  flags: FeatureState;
+  setEnabled: (name: FeatureName, enabled: boolean) => void;
 }
 
+export const useFeatureFlagStore = create<FeatureStateStore>((set) => ({
+  flags: mapValues(featureMeta, (meta) => meta.default),
+
+  setEnabled: (name: FeatureName, enabled: boolean) =>
+    set((prev) => ({ ...prev, flags: { ...prev.flags, [name]: enabled } })),
+}));
+
+export function setEnabled(name: FeatureName, enabled: boolean) {
+  useFeatureFlagStore.getState().setEnabled(name, enabled);
+}
+
+/**  Prefer `useFeatureFlag` in React for reactivity. */
 export function isEnabled(name: FeatureName) {
-  return featureState[name];
+  return useFeatureFlagStore.getState().flags[name];
+}
+
+export function useFeatureFlag(
+  name: FeatureName
+): readonly [value: boolean, setEnabled: (enabled: boolean) => void] {
+  const enabled = useFeatureFlagStore((state) => state.flags[name]);
+  const setEnabled = useFeatureFlagStore(
+    (s) => (enabled: boolean) => s.setEnabled(name, enabled)
+  );
+  return [enabled, setEnabled];
 }
 
 const storageKey = 'featureFlags';
-
 async function loadInitialState() {
   let state: FeatureState | null = null;
   try {
@@ -36,11 +57,15 @@ async function loadInitialState() {
     // ignore
   }
   if (state) {
-    Object.assign(featureState, state);
+    useFeatureFlagStore.setState((prev) => ({
+      ...prev,
+      flags: state,
+    }));
   }
 }
-loadInitialState();
 
-function saveState() {
-  return storage.save({ key: storageKey, data: featureState });
-}
+// Write to local storage on changes
+useFeatureFlagStore.subscribe(async (state) => {
+  await storage.save({ key: storageKey, data: state.flags });
+});
+loadInitialState();

--- a/packages/app/package.json
+++ b/packages/app/package.json
@@ -13,5 +13,9 @@
   "devDependencies": {
     "@types/react": "^18.2.55",
     "@types/react-native": "0.73.0"
+  },
+  "peerDependencies": {
+    "lodash": "^4.17.21",
+    "zustand": "^3.7.2"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -950,6 +950,12 @@ importers:
       '@tloncorp/ui':
         specifier: workspace:*
         version: link:../ui
+      lodash:
+        specifier: ^4.17.21
+        version: 4.17.21
+      zustand:
+        specifier: ^3.7.2
+        version: 3.7.2(react@18.2.0)
     devDependencies:
       '@types/react':
         specifier: ^18.2.55


### PR DESCRIPTION
- Changes backing store of feature flags to a Zustand store (publishes changes easily, can be accessed from outside of React, and was already installed)
- Flag changes are written to local storage whenever Zustand store is mutated
- Added `useFeatureFlag` hook that acts like `useState`, but for feature flags
- Update call sites to use reactive API

I tested by toggling the experimental channel switcher flag, checking that it took effect in the app, toggled it back off, did the same and quit the app, checked my pref was saved.

I also inserted a console.log in the subscription and checked that it doesn't appear to double-trigger after navigating around the app. Hypothetical bug here (which I did not see, but not convinced it's a non-issue): since we're registering a listener in the top-level scope of the module, it's possible that importing the containing module multiple times could run that top-level `subscribe` multiple times, ending up with redundant subscriptions.