### PR TITLE
channel: improve return loading performance

### DIFF
--- a/apps/tlon-mobile/ios/Podfile.lock
+++ b/apps/tlon-mobile/ios/Podfile.lock
@@ -1130,7 +1130,7 @@ PODS:
     - React-Core
   - react-native-netinfo (11.1.0):
     - React-Core
-  - react-native-safe-area-context (4.9.0):
+  - react-native-safe-area-context (4.8.2):
     - React-Core
   - react-native-webview (13.6.4):
     - glog
@@ -1787,7 +1787,7 @@ SPEC CHECKSUMS:
   react-native-context-menu-view: dcec18eb8882e20596dbb75802e7d19cb87dac02
   react-native-get-random-values: 21325b2244dfa6b58878f51f9aa42821e7ba3d06
   react-native-netinfo: 3aa5637c18834966e0c932de8ae1ae56fea20a97
-  react-native-safe-area-context: b97eb6f9e3b7f437806c2ce5983f479f8eb5de4b
+  react-native-safe-area-context: 0ee144a6170530ccc37a0fd9388e28d06f516a89
   react-native-webview: 1f6c37318115b6e96285e0b06770307d9a751bb8
   React-nativeconfig: ca8b90c736cf3be019cb332ca42d93dd95b32e05
   React-NativeModulesApple: 1fdffcce7772e274baeab33a1900f45feba86cbd

--- a/packages/app/features/top/ChannelScreen.tsx
+++ b/packages/app/features/top/ChannelScreen.tsx
@@ -214,7 +214,7 @@ export default function ChannelScreen({
     if (channel && !channel.isPendingChannel) {
       store.markChannelRead(channel);
     }
-  }, [channel]);
+  }, [channel?.id, channel?.groupId, channel?.type]);
 
   const canUpload = useCanUpload();
 

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -27,12 +27,11 @@
   },
   "dependencies": {
     "@react-native-async-storage/async-storage": "1.21.0",
-    "@urbit/api": "^2.2.0",
+    "@urbit/aura": "^1.0.0",
     "any-ascii": "^0.3.1",
     "big-integer": "^1.6.52",
-    "exponential-backoff": "^3.1.1",
     "sorted-btree": "^1.8.1",
-    "urbit-ob": "^5.0.1"
+    "exponential-backoff": "^3.1.1"
   },
   "devDependencies": {
     "@types/better-sqlite3": "^7.6.9",

--- a/packages/shared/src/api/activityApi.ts
+++ b/packages/shared/src/api/activityApi.ts
@@ -1,4 +1,4 @@
-import { unixToDa } from '@urbit/api';
+import { unixToDa } from '@urbit/aura';
 import { backOff } from 'exponential-backoff';
 
 import * as db from '../db';
@@ -321,10 +321,7 @@ export function subscribeToActivity(handler: (event: ActivityEvent) => void) {
   subscribe<ub.ActivityUpdate>(
     { app: 'activity', path: '/v4' },
     async (update: ub.ActivityUpdate) => {
-      logger.log(
-        'activity update',
-        runIfDev(() => JSON.stringify(update))
-      );
+      logger.log('activity update', runIfDev(() => JSON.stringify(update))());
       // handle unreads
       if ('activity' in update) {
         Object.entries(update.activity).forEach((activityEntry) => {

--- a/packages/shared/src/api/apiUtils.ts
+++ b/packages/shared/src/api/apiUtils.ts
@@ -1,5 +1,9 @@
-import { daToUnix, decToUd, unixToDa } from '@urbit/api';
-import { formatUd as baseFormatUd, parseUd } from '@urbit/aura';
+import {
+  formatUd as baseFormatUd,
+  daToUnix,
+  parseUd,
+  unixToDa,
+} from '@urbit/aura';
 import bigInt from 'big-integer';
 
 import * as db from '../db/types';
@@ -60,10 +64,6 @@ export function udToDate(da: string) {
 
 export function formatDateParam(date: Date) {
   return baseFormatUd(unixToDa(date!.getTime()));
-}
-
-export function formatPostIdParam(sealId: string) {
-  return decToUd(sealId);
 }
 
 export function isDmChannelId(channelId: string) {

--- a/packages/shared/src/api/channelsApi.ts
+++ b/packages/shared/src/api/channelsApi.ts
@@ -1,4 +1,5 @@
-import { decToUd, unixToDa } from '@urbit/api';
+import { formatUd, unixToDa } from '@urbit/aura';
+import bigInt from 'big-integer';
 
 import * as db from '../db';
 import { createDevLogger } from '../debug';
@@ -332,7 +333,7 @@ export const searchChannel = async (params: {
     response = await scry<ub.ChannelScam>({
       app: 'channels',
       path: `/${params.channel.id}/search/bounded/text/${
-        params.cursor ? decToUd(params.cursor.toString()) : ''
+        params.cursor ? formatUd(bigInt(params.cursor ?? 0)) : ''
       }/${SINGLE_PAGE_SEARCH_DEPTH}/${encodedQuery}`,
     });
   } else {
@@ -341,7 +342,7 @@ export const searchChannel = async (params: {
     response = await scry<ub.ChatScam>({
       app: 'chat',
       path: `/${type}/${params.channel.id}/search/bounded/text/${
-        params.cursor ? decToUd(params.cursor.toString()) : ''
+        params.cursor ? formatUd(bigInt(params.cursor ?? 0)) : ''
       }/${SINGLE_PAGE_SEARCH_DEPTH}/${encodedQuery}`,
     });
   }

--- a/packages/shared/src/api/groupsApi.ts
+++ b/packages/shared/src/api/groupsApi.ts
@@ -1,4 +1,4 @@
-import { Poke } from '@urbit/api';
+import { Poke } from '@urbit/http-api';
 
 import * as db from '../db';
 import { createDevLogger } from '../debug';

--- a/packages/shared/src/api/postsApi.ts
+++ b/packages/shared/src/api/postsApi.ts
@@ -1,4 +1,4 @@
-import { unixToDa } from '@urbit/api';
+import { unixToDa } from '@urbit/aura';
 import { Poke } from '@urbit/http-api';
 
 import * as db from '../db';
@@ -408,16 +408,18 @@ export const getLatestPosts = async ({
 
 export interface GetChangedPostsOptions {
   channelId: string;
-  afterCursor?: Cursor;
-  count?: number;
+  startCursor: Cursor;
+  endCursor: Cursor;
+  afterTime: Date;
 }
 
 export type GetChangedPostsResponse = GetChannelPostsResponse;
 
 export const getChangedPosts = async ({
   channelId,
-  afterCursor,
-  count = 50,
+  startCursor,
+  endCursor,
+  afterTime,
 }: GetChangedPostsOptions): Promise<GetChangedPostsResponse> => {
   if (!isGroupChannelId(channelId)) {
     throw new Error(
@@ -429,8 +431,9 @@ export const getChangedPosts = async ({
     app: 'channels',
     path: formatScryPath(
       `v1/${channelId}/posts/changes`,
-      afterCursor ? formatCursor(afterCursor) : null,
-      count
+      formatCursor(startCursor),
+      formatCursor(endCursor),
+      formatUd(unixToDa(afterTime.valueOf()).toString())
     ),
   });
   return toPagedPostsData(channelId, response);

--- a/packages/shared/src/api/settingsApi.ts
+++ b/packages/shared/src/api/settingsApi.ts
@@ -1,5 +1,3 @@
-import { ChargeUpdateInitial, Pikes, getPikes, scryCharges } from '@urbit/api';
-
 import * as db from '../db';
 import * as ub from '../urbit';
 import { client, scry } from './urbit';
@@ -60,9 +58,79 @@ export const toClientSettings = (
   };
 };
 
+export interface ChargeUpdateInitial {
+  initial: {
+    [desk: string]: Charge;
+  };
+}
+
+export declare type DocketHref = DocketHrefSite | DocketHrefGlob;
+export interface DocketHrefGlob {
+  glob: {
+    base: string;
+  };
+}
+export interface DocketHrefSite {
+  site: string;
+}
+export interface Docket {
+  title: string;
+  info?: string;
+  color: string;
+  href: DocketHref;
+  website: string;
+  license: string;
+  version: string;
+  image?: string;
+}
+export interface Charge extends Docket {
+  chad: Chad;
+}
+export declare type Chad =
+  | HungChad
+  | GlobChad
+  | SiteChad
+  | InstallChad
+  | SuspendChad;
+export interface HungChad {
+  hung: string;
+}
+export interface GlobChad {
+  glob: null;
+}
+export interface SiteChad {
+  site: null;
+}
+export interface InstallChad {
+  install: null;
+}
+export interface SuspendChad {
+  suspend: null;
+}
+
+export interface Pike {
+  hash: string;
+  sync: {
+    desk: string;
+    ship: string;
+  } | null;
+  zest: 'live' | 'dead' | 'held';
+}
+export interface Pikes {
+  [desk: string]: Pike;
+}
+
 export async function getAppInfo(): Promise<db.AppInfo> {
-  const pikes = await scry<Pikes>(getPikes);
-  const charges = (await scry<ChargeUpdateInitial>(scryCharges)).initial;
+  const pikes = await scry<Pikes>({
+    app: 'hood',
+    path: '/kiln/pikes',
+  });
+  const charges = (
+    await scry<ChargeUpdateInitial>({
+      app: 'docket',
+      path: '/charges',
+    })
+  ).initial;
 
   const groupsPike = pikes?.['groups'] ?? {};
   const groupsCharge = charges?.['groups'] ?? {};

--- a/packages/shared/src/api/urbit.ts
+++ b/packages/shared/src/api/urbit.ts
@@ -1,5 +1,4 @@
-import { preSig } from '@urbit/api';
-import { deSig } from '@urbit/aura';
+import { deSig, preSig } from '@urbit/aura';
 import { Urbit } from '@urbit/http-api';
 import _ from 'lodash';
 
@@ -79,7 +78,7 @@ export function configureClient({
   clientInstance.on('fact', (fact) => {
     logger.log(
       'received message',
-      runIfDev(() => escapeLog(JSON.stringify(fact)))
+      runIfDev(() => escapeLog(JSON.stringify(fact)))()
     );
   });
 

--- a/packages/shared/src/db/modelBuilders.ts
+++ b/packages/shared/src/db/modelBuilders.ts
@@ -1,4 +1,4 @@
-import { unixToDa } from '@urbit/api';
+import { unixToDa } from '@urbit/aura';
 
 import * as api from '../api';
 import {

--- a/packages/shared/src/db/query.ts
+++ b/packages/shared/src/db/query.ts
@@ -174,10 +174,6 @@ export async function withCtxOrDefault<T>(
         const shouldInvalidate =
           tableKey instanceof Set && setsOverlap(tableKey, pendingEffects);
         if (shouldInvalidate) {
-          logger.log(
-            `${meta.label} attempting invalidation`,
-            runIfDev(() => JSON.stringify([query.queryHash, query.isActive()]))
-          );
           invalidated.push(query.queryHash);
         }
         return shouldInvalidate;

--- a/packages/shared/src/logic/references.ts
+++ b/packages/shared/src/logic/references.ts
@@ -1,13 +1,17 @@
-import { udToDec } from '@urbit/api';
+import { parseUd } from '@urbit/aura';
 
 import { ContentReference } from '../api';
 import * as db from '../db';
 
+function formatId(id: string) {
+  return parseUd(id).toString();
+}
+
 export function getPostReferencePath(post: db.Post) {
   if (post.parentId) {
-    return `/1/chan/${post.channelId}/msg/${udToDec(post.parentId)}/${udToDec(post.id)}`;
+    return `/1/chan/${post.channelId}/msg/${formatId(post.parentId)}/${formatId(post.id)}`;
   }
-  return `/1/chan/${post.channelId}/msg/${udToDec(post.id)}`;
+  return `/1/chan/${post.channelId}/msg/${formatId(post.id)}`;
 }
 
 export function getGroupReferencePath(groupId: string) {

--- a/packages/shared/src/logic/tiptap.ts
+++ b/packages/shared/src/logic/tiptap.ts
@@ -5,7 +5,7 @@ import {
   PasteRule,
 } from '@tiptap/core';
 import { JSONContent } from '@tiptap/react';
-import { deSig } from '@urbit/api';
+import { deSig } from '@urbit/aura';
 import { isEqual, reduce } from 'lodash';
 
 import { Block, Cite, HeaderLevel, Listing, Story } from '../urbit/channel';

--- a/packages/shared/src/store/storage/storageActions.ts
+++ b/packages/shared/src/store/storage/storageActions.ts
@@ -1,6 +1,6 @@
 import { PutObjectCommand, S3Client } from '@aws-sdk/client-s3';
 import { getSignedUrl } from '@aws-sdk/s3-request-presigner';
-import { deSig, unixToDa } from '@urbit/api';
+import { deSig, unixToDa } from '@urbit/aura';
 import { formatDa } from '@urbit/aura';
 import * as FileSystem from 'expo-file-system';
 import { manipulateAsync } from 'expo-image-manipulator';

--- a/packages/shared/src/store/storage/storageUtils.ts
+++ b/packages/shared/src/store/storage/storageUtils.ts
@@ -1,4 +1,4 @@
-import { preSig } from '@urbit/api';
+import { preSig } from '@urbit/aura';
 
 import * as api from '../../api';
 import {

--- a/packages/shared/src/store/sync.ts
+++ b/packages/shared/src/store/sync.ts
@@ -2,9 +2,10 @@ import { backOff } from 'exponential-backoff';
 import _ from 'lodash';
 
 import * as api from '../api';
+import { GetChangedPostsOptions } from '../api';
 import * as db from '../db';
 import { QueryCtx, batchEffects } from '../db/query';
-import { createDevLogger } from '../debug';
+import { createDevLogger, runIfDev } from '../debug';
 import { extractClientVolumes } from '../logic/activity';
 import {
   INFINITE_ACTIVITY_QUERY_KEY,
@@ -264,6 +265,28 @@ export async function syncPostReference(options: {
     channelId: options.channelId,
     posts: [response],
   });
+}
+
+export async function syncUpdatedPosts(
+  options: GetChangedPostsOptions,
+  ctx?: SyncCtx
+) {
+  logger.log(
+    'syncing updated posts',
+    runIfDev(() => JSON.stringify(options))()
+  );
+  const response = await syncQueue.add('syncUpdatedPosts', ctx, async () =>
+    api.getChangedPosts(options)
+  );
+  logger.log(`got ${response.posts.length} updated posts, inserting...`);
+
+  // ignore cursors since we're always fetching from old posts we have
+  await db.insertChannelPosts({
+    channelId: options.channelId,
+    posts: response.posts,
+  });
+
+  return response;
 }
 
 export async function syncThreadPosts(
@@ -604,6 +627,7 @@ const createActivityUpdateHandler = (queueDebounce: number = 100) => {
       if (activitySnapshot.activityEvents.length > 0) {
         api.queryClient.invalidateQueries({
           queryKey: [INFINITE_ACTIVITY_QUERY_KEY],
+          refetchType: 'active',
         });
       }
 

--- a/packages/shared/src/store/useChannelPosts.ts
+++ b/packages/shared/src/store/useChannelPosts.ts
@@ -215,24 +215,42 @@ function addPostToNewPosts(post: db.Post, newPosts: db.Post[]) {
 function useRefreshPosts(channelId: string, posts: db.Post[] | null) {
   const session = useCurrentSession();
 
-  const pendingStalePosts = useRef(new Set());
+  const pendingStalePosts = useRef(new Set<string>());
   useEffect(() => {
-    posts?.forEach((post) => {
-      if (
-        session &&
-        post.syncedAt < (session?.startTime ?? 0) &&
-        !pendingStalePosts.current.has(post.id)
-      ) {
-        sync.syncThreadPosts(
-          {
-            postId: post.id,
-            channelId,
-            authorId: post.authorId,
-          },
-          { priority: 4 }
-        );
-        pendingStalePosts.current.add(post.id);
-      }
+    const toSync =
+      posts?.filter(
+        (post) =>
+          session &&
+          post.syncedAt < (session?.startTime ?? 0) &&
+          !pendingStalePosts.current.has(post.id)
+      ) || [];
+
+    postsLogger.log('stale posts to sync', toSync.length);
+
+    const chunked = [];
+    const chunkSize = 50;
+    for (let i = 0; i < toSync.length; i += chunkSize) {
+      chunked.push(toSync.slice(i, i + chunkSize));
+    }
+
+    postsLogger.log('chunked', chunked.length);
+    chunked.forEach((chunk, i) => {
+      const startCursor = chunk[chunk.length - 1].id;
+      const endCursor = chunk[0].id;
+      postsLogger.log('syncing chunk', startCursor, 'through', endCursor);
+      sync.syncUpdatedPosts(
+        {
+          channelId,
+          startCursor,
+          endCursor,
+          afterTime: new Date(session?.startTime ?? 0),
+        },
+        { priority: 4 }
+      );
+      pendingStalePosts.current = new Set<string>([
+        ...chunk.map((p) => p.id),
+        ...pendingStalePosts.current,
+      ]);
     });
   }, [channelId, posts, session]);
 }

--- a/packages/shared/src/store/useChannelSearch.ts
+++ b/packages/shared/src/store/useChannelSearch.ts
@@ -1,5 +1,5 @@
 import { useInfiniteQuery } from '@tanstack/react-query';
-import { daToUnix } from '@urbit/api';
+import { daToUnix } from '@urbit/aura';
 import bigInt from 'big-integer';
 import { useEffect, useMemo } from 'react';
 

--- a/packages/shared/src/urbit/channel.ts
+++ b/packages/shared/src/urbit/channel.ts
@@ -1,5 +1,5 @@
-import { udToDec } from '@urbit/api';
-import bigInt, { BigInteger } from 'big-integer';
+import { parseUd } from '@urbit/aura';
+import { BigInteger } from 'big-integer';
 import _ from 'lodash';
 import BTree from 'sorted-btree';
 
@@ -660,7 +660,7 @@ export function newPostTupleArray(
     data.pages
       .map((page) => {
         const pagePosts = Object.entries(page.posts).map(
-          ([k, v]) => [bigInt(udToDec(k)), v] as PostTuple
+          ([k, v]) => [parseUd(k), v] as PostTuple
         );
 
         return pagePosts;

--- a/packages/shared/src/urbit/dms.ts
+++ b/packages/shared/src/urbit/dms.ts
@@ -1,5 +1,5 @@
-import { udToDec } from '@urbit/api';
-import bigInt, { BigInteger } from 'big-integer';
+import { parseUd } from '@urbit/aura';
+import { BigInteger } from 'big-integer';
 import _ from 'lodash';
 import BTree from 'sorted-btree';
 
@@ -196,7 +196,7 @@ export function newWritTupleArray(
     data?.pages
       ?.map((page) => {
         const writPages = Object.entries(page.writs).map(
-          ([k, v]) => [bigInt(udToDec(k)), v] as WritTuple
+          ([k, v]) => [parseUd(k), v] as WritTuple
         );
         return writPages;
       })

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -77,10 +77,10 @@ importers:
         version: 15.2.0
       tsup:
         specifier: ^8.0.1
-        version: 8.0.1(@swc/core@1.4.16(@swc/helpers@0.5.10))(postcss@8.4.35)(typescript@5.4.5)
+        version: 8.0.1(@swc/core@1.4.16)(postcss@8.4.35)(typescript@5.4.5)
       vitest:
         specifier: ^1.2.2
-        version: 1.2.2(@types/node@20.14.10)(jsdom@23.2.0)(lightningcss@1.19.0)(terser@5.19.1)
+        version: 1.2.2(@types/node@20.14.10)(jsdom@23.2.0)(terser@5.19.1)
 
   apps/tlon-mobile:
     dependencies:
@@ -239,7 +239,7 @@ importers:
         version: 4.17.21
       posthog-react-native:
         specifier: ^2.7.1
-        version: 2.11.3(@react-native-async-storage/async-storage@1.21.0(react-native@0.73.4(@babel/core@7.23.7)(@babel/preset-env@7.23.7(@babel/core@7.23.7))(encoding@0.1.13)(react@18.2.0)))(@react-navigation/native@6.1.10(react-native@0.73.4(@babel/core@7.23.7)(@babel/preset-env@7.23.7(@babel/core@7.23.7))(encoding@0.1.13)(react@18.2.0))(react@18.2.0))(expo-application@5.8.3(expo@50.0.6(@babel/core@7.23.7)(@react-native/babel-preset@0.73.21(@babel/core@7.23.7)(@babel/preset-env@7.23.7(@babel/core@7.23.7)))(encoding@0.1.13)))(expo-device@5.9.3(expo@50.0.6(@babel/core@7.23.7)(@react-native/babel-preset@0.73.21(@babel/core@7.23.7)(@babel/preset-env@7.23.7(@babel/core@7.23.7)))(encoding@0.1.13)))(expo-file-system@16.0.9(expo@50.0.6(@babel/core@7.23.7)(@react-native/babel-preset@0.73.21(@babel/core@7.23.7)(@babel/preset-env@7.23.7(@babel/core@7.23.7)))(encoding@0.1.13)))(expo-localization@14.8.3(expo@50.0.6(@babel/core@7.23.7)(@react-native/babel-preset@0.73.21(@babel/core@7.23.7)(@babel/preset-env@7.23.7(@babel/core@7.23.7)))(encoding@0.1.13)))(react-native-device-info@10.12.0(react-native@0.73.4(@babel/core@7.23.7)(@babel/preset-env@7.23.7(@babel/core@7.23.7))(encoding@0.1.13)(react@18.2.0)))
+        version: 2.11.3(oi5hx7o6oxzkjy7oghrlxekpbi)
       react:
         specifier: ^18.2.0
         version: 18.2.0
@@ -318,7 +318,7 @@ importers:
         version: 29.7.0
       '@react-native/metro-config':
         specifier: ^0.73.5
-        version: 0.73.5(@babel/core@7.23.7)(@babel/preset-env@7.23.7(@babel/core@7.23.7))(encoding@0.1.13)
+        version: 0.73.5(@babel/core@7.23.7)(@babel/preset-env@7.23.7(@babel/core@7.23.7))
       '@tamagui/babel-plugin':
         specifier: 1.101.3
         version: 1.101.3(encoding@0.1.13)(react@18.2.0)
@@ -399,7 +399,7 @@ importers:
         version: 3.4.1
       vitest:
         specifier: ^1.0.4
-        version: 1.2.2(@types/node@20.14.10)(jsdom@23.2.0)(lightningcss@1.19.0)(terser@5.19.1)
+        version: 1.2.2(@types/node@20.14.10)(jsdom@23.2.0)(terser@5.19.1)
 
   apps/tlon-web:
     dependencies:
@@ -453,13 +453,13 @@ importers:
         version: 1.101.3(encoding@0.1.13)(react@18.2.0)
       '@tanstack/react-query':
         specifier: ^4.28.0
-        version: 4.36.1(react-dom@18.2.0(react@18.2.0))(react-native@0.73.4(@babel/core@7.23.7)(@babel/preset-env@7.23.7(@babel/core@7.23.7))(encoding@0.1.13)(react@18.2.0))(react@18.2.0)
+        version: 4.36.1(react-dom@18.2.0(react@18.2.0))(react-native@0.73.4(@babel/core@7.25.2)(encoding@0.1.13)(react@18.2.0))(react@18.2.0)
       '@tanstack/react-query-devtools':
         specifier: ^4.28.0
-        version: 4.29.0(@tanstack/react-query@4.36.1(react-dom@18.2.0(react@18.2.0))(react-native@0.73.4(@babel/core@7.23.7)(@babel/preset-env@7.23.7(@babel/core@7.23.7))(encoding@0.1.13)(react@18.2.0))(react@18.2.0))(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
+        version: 4.29.0(@tanstack/react-query@4.36.1(react-dom@18.2.0(react@18.2.0))(react-native@0.73.4(@babel/core@7.25.2)(encoding@0.1.13)(react@18.2.0))(react@18.2.0))(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
       '@tanstack/react-query-persist-client':
         specifier: ^4.28.0
-        version: 4.28.0(@tanstack/react-query@4.36.1(react-dom@18.2.0(react@18.2.0))(react-native@0.73.4(@babel/core@7.23.7)(@babel/preset-env@7.23.7(@babel/core@7.23.7))(encoding@0.1.13)(react@18.2.0))(react@18.2.0))
+        version: 4.28.0(@tanstack/react-query@4.36.1(react-dom@18.2.0(react@18.2.0))(react-native@0.73.4(@babel/core@7.25.2)(encoding@0.1.13)(react@18.2.0))(react@18.2.0))
       '@tanstack/react-virtual':
         specifier: ^3.0.0-beta.60
         version: 3.0.0-beta.65(react@18.2.0)
@@ -678,7 +678,7 @@ importers:
         version: 18.2.0
       react-beautiful-dnd:
         specifier: ^13.1.1
-        version: 13.1.1(react-dom@18.2.0(react@18.2.0))(react-native@0.73.4(@babel/core@7.23.7)(@babel/preset-env@7.23.7(@babel/core@7.23.7))(encoding@0.1.13)(react@18.2.0))(react@18.2.0)
+        version: 13.1.1(react-dom@18.2.0(react@18.2.0))(react-native@0.73.4(@babel/core@7.25.2)(encoding@0.1.13)(react@18.2.0))(react@18.2.0)
       react-colorful:
         specifier: ^5.5.1
         version: 5.6.1(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
@@ -714,7 +714,7 @@ importers:
         version: https://codeload.github.com/stefkampen/react-oembed-container/tar.gz/802eee0dba7986faa9c931b1c016acba5369d5f9(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
       react-qr-code:
         specifier: ^2.0.12
-        version: 2.0.12(react-native-svg@15.0.0(react-native@0.73.4(@babel/core@7.23.7)(@babel/preset-env@7.23.7(@babel/core@7.23.7))(encoding@0.1.13)(react@18.2.0))(react@18.2.0))(react@18.2.0)
+        version: 2.0.12(react-native-svg@15.0.0(react-native@0.73.4(@babel/core@7.25.2)(encoding@0.1.13)(react@18.2.0))(react@18.2.0))(react@18.2.0)
       react-router:
         specifier: ^6.22.1
         version: 6.22.2(react@18.2.0)
@@ -723,7 +723,7 @@ importers:
         version: 6.22.2(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
       react-select:
         specifier: ^5.3.2
-        version: 5.4.0(@babel/core@7.23.7)(@types/react@18.2.55)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
+        version: 5.4.0(@babel/core@7.25.2)(@types/react@18.2.55)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
       react-tweet:
         specifier: ^3.0.4
         version: 3.1.1(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
@@ -771,7 +771,7 @@ importers:
         version: 0.16.0(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
       vite-plugin-svgr:
         specifier: ^4.2.0
-        version: 4.2.0(rollup@4.13.0)(typescript@5.4.5)(vite@5.1.6(@types/node@20.10.8)(lightningcss@1.19.0)(terser@5.19.1))
+        version: 4.2.0(rollup@2.79.1)(typescript@5.4.5)(vite@5.1.6(@types/node@20.10.8)(terser@5.19.1))
       workbox-precaching:
         specifier: ^6.5.4
         version: 6.6.0
@@ -862,10 +862,10 @@ importers:
         version: 2.0.1
       '@vitejs/plugin-basic-ssl':
         specifier: ^1.1.0
-        version: 1.1.0(vite@5.1.6(@types/node@20.10.8)(lightningcss@1.19.0)(terser@5.19.1))
+        version: 1.1.0(vite@5.1.6(@types/node@20.10.8)(terser@5.19.1))
       '@vitejs/plugin-react':
         specifier: ^4.2.1
-        version: 4.2.1(vite@5.1.6(@types/node@20.10.8)(lightningcss@1.19.0)(terser@5.19.1))
+        version: 4.2.1(vite@5.1.6(@types/node@20.10.8)(terser@5.19.1))
       '@welldone-software/why-did-you-render':
         specifier: ^7.0.1
         version: 7.0.1(react@18.2.0)
@@ -907,7 +907,7 @@ importers:
         version: 6.1.1
       react-cosmos-plugin-vite:
         specifier: 6.1.1
-        version: 6.1.1(vite@5.1.6(@types/node@20.10.8)(lightningcss@1.19.0)(terser@5.19.1))
+        version: 6.1.1(vite@5.1.6(@types/node@20.10.8)(terser@5.19.1))
       react-test-renderer:
         specifier: ^18.2.0
         version: 18.2.0(react@18.2.0)
@@ -916,7 +916,7 @@ importers:
         version: 4.0.0
       rollup-plugin-visualizer:
         specifier: ^5.6.0
-        version: 5.12.0(rollup@4.13.0)
+        version: 5.12.0(rollup@2.79.1)
       tailwindcss:
         specifier: ^3.2.7
         version: 3.4.1
@@ -931,13 +931,13 @@ importers:
         version: 1.1.4(typescript@5.4.5)
       vite:
         specifier: ^5.1.6
-        version: 5.1.6(@types/node@20.10.8)(lightningcss@1.19.0)(terser@5.19.1)
+        version: 5.1.6(@types/node@20.10.8)(terser@5.19.1)
       vite-plugin-pwa:
         specifier: ^0.17.5
-        version: 0.17.5(vite@5.1.6(@types/node@20.10.8)(lightningcss@1.19.0)(terser@5.19.1))(workbox-build@7.0.0(@types/babel__core@7.20.5))(workbox-window@7.0.0)
+        version: 0.17.5(vite@5.1.6(@types/node@20.10.8)(terser@5.19.1))(workbox-build@7.0.0(@types/babel__core@7.20.5))(workbox-window@7.0.0)
       vitest:
         specifier: ^0.34.1
-        version: 0.34.6(jsdom@23.2.0)(lightningcss@1.19.0)(terser@5.19.1)
+        version: 0.34.6(jsdom@23.2.0)(terser@5.19.1)
       workbox-window:
         specifier: ^7.0.0
         version: 7.0.0
@@ -956,7 +956,7 @@ importers:
         version: 18.2.55
       '@types/react-native':
         specifier: 0.73.0
-        version: 0.73.0(@babel/core@7.23.7)(@babel/preset-env@7.23.7(@babel/core@7.23.7))(encoding@0.1.13)(react@18.2.0)
+        version: 0.73.0(react@18.2.0)
 
   packages/editor:
     dependencies:
@@ -987,7 +987,7 @@ importers:
         version: 6.21.0(eslint@8.56.0)(typescript@5.4.5)
       '@vitejs/plugin-react':
         specifier: ^4.2.1
-        version: 4.2.1(vite@5.1.6(@types/node@20.14.10)(lightningcss@1.19.0)(terser@5.19.1))
+        version: 4.2.1(vite@5.1.6(@types/node@20.14.10)(terser@5.19.1))
       eslint:
         specifier: ^8.50.0
         version: 8.56.0
@@ -999,13 +999,13 @@ importers:
         version: 5.4.5
       vite:
         specifier: ^5.1.6
-        version: 5.1.6(@types/node@20.14.10)(lightningcss@1.19.0)(terser@5.19.1)
+        version: 5.1.6(@types/node@20.14.10)(terser@5.19.1)
       vite-plugin-singlefile:
         specifier: ^2.0.1
-        version: 2.0.1(rollup@4.13.0)(vite@5.1.6(@types/node@20.14.10)(lightningcss@1.19.0)(terser@5.19.1))
+        version: 2.0.1(rollup@4.13.0)(vite@5.1.6(@types/node@20.14.10)(terser@5.19.1))
       vitest:
         specifier: ^1.0.4
-        version: 1.5.0(@types/node@20.14.10)(jsdom@23.2.0)(lightningcss@1.19.0)(terser@5.19.1)
+        version: 1.5.0(@types/node@20.14.10)(jsdom@23.2.0)(terser@5.19.1)
 
   packages/shared:
     dependencies:
@@ -1030,6 +1030,9 @@ importers:
       '@urbit/api':
         specifier: ^2.2.0
         version: 2.2.0
+      '@urbit/aura':
+        specifier: ^1.0.0
+        version: 1.0.0(big-integer@1.6.52)
       any-ascii:
         specifier: ^0.3.1
         version: 0.3.2(patch_hash=5ofxtlxe6za2xqrbq5pqbz7wb4)
@@ -1067,13 +1070,13 @@ importers:
         version: 0.20.17
       tsup:
         specifier: ^8.0.1
-        version: 8.0.1(@swc/core@1.4.16(@swc/helpers@0.5.10))(postcss@8.4.35)(typescript@5.4.5)
+        version: 8.0.1(@swc/core@1.4.16)(postcss@8.4.35)(typescript@5.4.5)
       typescript:
         specifier: 5.4.5
         version: 5.4.5
       vitest:
         specifier: ^1.4.0
-        version: 1.5.0(@types/node@20.14.10)(jsdom@23.2.0)(lightningcss@1.19.0)(terser@5.19.1)
+        version: 1.5.0(@types/node@20.14.10)(jsdom@23.2.0)(terser@5.19.1)
 
   packages/ui:
     dependencies:
@@ -14759,6 +14762,13 @@ snapshots:
       '@babel/helper-create-class-features-plugin': 7.23.10(@babel/core@7.25.2)
       '@babel/helper-plugin-utils': 7.22.5
 
+  '@babel/plugin-transform-private-property-in-object@7.23.4':
+    dependencies:
+      '@babel/helper-annotate-as-pure': 7.22.5
+      '@babel/helper-create-class-features-plugin': 7.23.10(@babel/core@7.25.2)
+      '@babel/helper-plugin-utils': 7.22.5
+      '@babel/plugin-syntax-private-property-in-object': 7.14.5(@babel/core@7.23.7)
+
   '@babel/plugin-transform-private-property-in-object@7.23.4(@babel/core@7.23.7)':
     dependencies:
       '@babel/core': 7.23.7
@@ -15337,11 +15347,11 @@ snapshots:
       emoji-mart: 5.2.2
       react: 18.2.0
 
-  '@emotion/babel-plugin@11.10.0(@babel/core@7.23.7)':
+  '@emotion/babel-plugin@11.10.0(@babel/core@7.25.2)':
     dependencies:
-      '@babel/core': 7.23.7
+      '@babel/core': 7.25.2
       '@babel/helper-module-imports': 7.22.15
-      '@babel/plugin-syntax-jsx': 7.23.3(@babel/core@7.23.7)
+      '@babel/plugin-syntax-jsx': 7.23.3(@babel/core@7.25.2)
       '@babel/runtime': 7.23.8
       '@emotion/hash': 0.9.0
       '@emotion/memoize': 0.8.1
@@ -15373,10 +15383,10 @@ snapshots:
 
   '@emotion/memoize@0.8.1': {}
 
-  '@emotion/react@11.10.0(@babel/core@7.23.7)(@types/react@18.2.55)(react@18.2.0)':
+  '@emotion/react@11.10.0(@babel/core@7.25.2)(@types/react@18.2.55)(react@18.2.0)':
     dependencies:
       '@babel/runtime': 7.23.8
-      '@emotion/babel-plugin': 11.10.0(@babel/core@7.23.7)
+      '@emotion/babel-plugin': 11.10.0(@babel/core@7.25.2)
       '@emotion/cache': 11.10.1
       '@emotion/serialize': 1.1.0
       '@emotion/utils': 1.2.0
@@ -15384,7 +15394,7 @@ snapshots:
       hoist-non-react-statics: 3.3.2
       react: 18.2.0
     optionalDependencies:
-      '@babel/core': 7.23.7
+      '@babel/core': 7.25.2
       '@types/react': 18.2.55
 
   '@emotion/serialize@1.1.0':
@@ -17549,6 +17559,53 @@ snapshots:
       - '@babel/preset-env'
       - supports-color
 
+  '@react-native/babel-preset@0.73.21':
+    dependencies:
+      '@babel/plugin-proposal-async-generator-functions': 7.20.7(@babel/core@7.23.7)
+      '@babel/plugin-proposal-class-properties': 7.18.6(@babel/core@7.25.2)
+      '@babel/plugin-proposal-export-default-from': 7.23.3(@babel/core@7.23.7)
+      '@babel/plugin-proposal-nullish-coalescing-operator': 7.18.6(@babel/core@7.25.2)
+      '@babel/plugin-proposal-numeric-separator': 7.18.6(@babel/core@7.23.7)
+      '@babel/plugin-proposal-object-rest-spread': 7.20.7(@babel/core@7.23.7)
+      '@babel/plugin-proposal-optional-catch-binding': 7.18.6(@babel/core@7.23.7)
+      '@babel/plugin-proposal-optional-chaining': 7.21.0(@babel/core@7.25.2)
+      '@babel/plugin-syntax-dynamic-import': 7.8.3(@babel/core@7.23.7)
+      '@babel/plugin-syntax-export-default-from': 7.23.3(@babel/core@7.23.7)
+      '@babel/plugin-syntax-flow': 7.23.3(@babel/core@7.25.2)
+      '@babel/plugin-syntax-nullish-coalescing-operator': 7.8.3(@babel/core@7.25.2)
+      '@babel/plugin-syntax-optional-chaining': 7.8.3(@babel/core@7.25.2)
+      '@babel/plugin-transform-arrow-functions': 7.23.3(@babel/core@7.23.7)
+      '@babel/plugin-transform-async-to-generator': 7.23.3(@babel/core@7.23.7)
+      '@babel/plugin-transform-block-scoping': 7.23.4(@babel/core@7.23.7)
+      '@babel/plugin-transform-classes': 7.23.8(@babel/core@7.25.2)
+      '@babel/plugin-transform-computed-properties': 7.23.3(@babel/core@7.23.7)
+      '@babel/plugin-transform-destructuring': 7.23.3(@babel/core@7.23.7)
+      '@babel/plugin-transform-flow-strip-types': 7.23.3(@babel/core@7.25.2)
+      '@babel/plugin-transform-function-name': 7.23.3(@babel/core@7.23.7)
+      '@babel/plugin-transform-literals': 7.23.3(@babel/core@7.23.7)
+      '@babel/plugin-transform-modules-commonjs': 7.23.3(@babel/core@7.25.2)
+      '@babel/plugin-transform-named-capturing-groups-regex': 7.22.5(@babel/core@7.23.7)
+      '@babel/plugin-transform-parameters': 7.23.3(@babel/core@7.23.7)
+      '@babel/plugin-transform-private-methods': 7.23.3(@babel/core@7.25.2)
+      '@babel/plugin-transform-private-property-in-object': 7.23.4
+      '@babel/plugin-transform-react-display-name': 7.23.3(@babel/core@7.23.7)
+      '@babel/plugin-transform-react-jsx': 7.23.4(@babel/core@7.25.2)
+      '@babel/plugin-transform-react-jsx-self': 7.23.3(@babel/core@7.23.7)
+      '@babel/plugin-transform-react-jsx-source': 7.23.3(@babel/core@7.23.7)
+      '@babel/plugin-transform-runtime': 7.23.9(@babel/core@7.23.7)
+      '@babel/plugin-transform-shorthand-properties': 7.23.3(@babel/core@7.23.7)
+      '@babel/plugin-transform-spread': 7.23.3(@babel/core@7.23.7)
+      '@babel/plugin-transform-sticky-regex': 7.23.3(@babel/core@7.23.7)
+      '@babel/plugin-transform-typescript': 7.23.6(@babel/core@7.25.2)
+      '@babel/plugin-transform-unicode-regex': 7.23.3(@babel/core@7.23.7)
+      '@babel/template': 7.22.15
+      '@react-native/babel-plugin-codegen': 0.73.4(@babel/preset-env@7.23.7(@babel/core@7.23.7))
+      babel-plugin-transform-flow-enums: 0.0.2(@babel/core@7.25.2)
+      react-refresh: 0.14.0
+    transitivePeerDependencies:
+      - '@babel/preset-env'
+      - supports-color
+
   '@react-native/babel-preset@0.73.21(@babel/core@7.23.7)(@babel/preset-env@7.23.7(@babel/core@7.23.7))':
     dependencies:
       '@babel/core': 7.23.7
@@ -17596,6 +17653,55 @@ snapshots:
     transitivePeerDependencies:
       - '@babel/preset-env'
       - supports-color
+
+  '@react-native/babel-preset@0.73.21(@babel/core@7.25.2)':
+    dependencies:
+      '@babel/core': 7.25.2
+      '@babel/plugin-proposal-async-generator-functions': 7.20.7(@babel/core@7.25.2)
+      '@babel/plugin-proposal-class-properties': 7.18.6(@babel/core@7.25.2)
+      '@babel/plugin-proposal-export-default-from': 7.23.3(@babel/core@7.25.2)
+      '@babel/plugin-proposal-nullish-coalescing-operator': 7.18.6(@babel/core@7.25.2)
+      '@babel/plugin-proposal-numeric-separator': 7.18.6(@babel/core@7.25.2)
+      '@babel/plugin-proposal-object-rest-spread': 7.20.7(@babel/core@7.25.2)
+      '@babel/plugin-proposal-optional-catch-binding': 7.18.6(@babel/core@7.25.2)
+      '@babel/plugin-proposal-optional-chaining': 7.21.0(@babel/core@7.25.2)
+      '@babel/plugin-syntax-dynamic-import': 7.8.3(@babel/core@7.25.2)
+      '@babel/plugin-syntax-export-default-from': 7.23.3(@babel/core@7.25.2)
+      '@babel/plugin-syntax-flow': 7.23.3(@babel/core@7.25.2)
+      '@babel/plugin-syntax-nullish-coalescing-operator': 7.8.3(@babel/core@7.25.2)
+      '@babel/plugin-syntax-optional-chaining': 7.8.3(@babel/core@7.25.2)
+      '@babel/plugin-transform-arrow-functions': 7.23.3(@babel/core@7.25.2)
+      '@babel/plugin-transform-async-to-generator': 7.23.3(@babel/core@7.25.2)
+      '@babel/plugin-transform-block-scoping': 7.23.4(@babel/core@7.25.2)
+      '@babel/plugin-transform-classes': 7.23.8(@babel/core@7.25.2)
+      '@babel/plugin-transform-computed-properties': 7.23.3(@babel/core@7.25.2)
+      '@babel/plugin-transform-destructuring': 7.23.3(@babel/core@7.25.2)
+      '@babel/plugin-transform-flow-strip-types': 7.23.3(@babel/core@7.25.2)
+      '@babel/plugin-transform-function-name': 7.23.3(@babel/core@7.25.2)
+      '@babel/plugin-transform-literals': 7.23.3(@babel/core@7.25.2)
+      '@babel/plugin-transform-modules-commonjs': 7.23.3(@babel/core@7.25.2)
+      '@babel/plugin-transform-named-capturing-groups-regex': 7.22.5(@babel/core@7.25.2)
+      '@babel/plugin-transform-parameters': 7.23.3(@babel/core@7.25.2)
+      '@babel/plugin-transform-private-methods': 7.23.3(@babel/core@7.25.2)
+      '@babel/plugin-transform-private-property-in-object': 7.23.4(@babel/core@7.25.2)
+      '@babel/plugin-transform-react-display-name': 7.23.3(@babel/core@7.25.2)
+      '@babel/plugin-transform-react-jsx': 7.23.4(@babel/core@7.25.2)
+      '@babel/plugin-transform-react-jsx-self': 7.23.3(@babel/core@7.25.2)
+      '@babel/plugin-transform-react-jsx-source': 7.23.3(@babel/core@7.25.2)
+      '@babel/plugin-transform-runtime': 7.23.9(@babel/core@7.25.2)
+      '@babel/plugin-transform-shorthand-properties': 7.23.3(@babel/core@7.25.2)
+      '@babel/plugin-transform-spread': 7.23.3(@babel/core@7.25.2)
+      '@babel/plugin-transform-sticky-regex': 7.23.3(@babel/core@7.25.2)
+      '@babel/plugin-transform-typescript': 7.23.6(@babel/core@7.25.2)
+      '@babel/plugin-transform-unicode-regex': 7.23.3(@babel/core@7.25.2)
+      '@babel/template': 7.22.15
+      '@react-native/babel-plugin-codegen': 0.73.4(@babel/preset-env@7.23.7(@babel/core@7.23.7))
+      babel-plugin-transform-flow-enums: 0.0.2(@babel/core@7.25.2)
+      react-refresh: 0.14.0
+    transitivePeerDependencies:
+      - '@babel/preset-env'
+      - supports-color
+    optional: true
 
   '@react-native/babel-preset@0.73.21(@babel/core@7.25.2)(@babel/preset-env@7.23.7(@babel/core@7.25.2))':
     dependencies:
@@ -17671,6 +17777,27 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  '@react-native/community-cli-plugin@0.73.16':
+    dependencies:
+      '@react-native-community/cli-server-api': 12.3.2(encoding@0.1.13)
+      '@react-native-community/cli-tools': 12.3.2(encoding@0.1.13)
+      '@react-native/dev-middleware': 0.73.7(encoding@0.1.13)
+      '@react-native/metro-babel-transformer': 0.73.15
+      chalk: 4.1.2
+      execa: 5.1.1
+      metro: 0.80.5
+      metro-config: 0.80.5(encoding@0.1.13)
+      metro-core: 0.80.5
+      node-fetch: 2.6.12(encoding@0.1.13)
+      readline: 1.3.0
+    transitivePeerDependencies:
+      - '@babel/core'
+      - '@babel/preset-env'
+      - bufferutil
+      - encoding
+      - supports-color
+      - utf-8-validate
+
   '@react-native/community-cli-plugin@0.73.16(@babel/core@7.23.7)(@babel/preset-env@7.23.7(@babel/core@7.23.7))(encoding@0.1.13)':
     dependencies:
       '@react-native-community/cli-server-api': 12.3.2(encoding@0.1.13)
@@ -17712,6 +17839,28 @@ snapshots:
       - encoding
       - supports-color
       - utf-8-validate
+
+  '@react-native/community-cli-plugin@0.73.16(@babel/core@7.25.2)(encoding@0.1.13)':
+    dependencies:
+      '@react-native-community/cli-server-api': 12.3.2(encoding@0.1.13)
+      '@react-native-community/cli-tools': 12.3.2(encoding@0.1.13)
+      '@react-native/dev-middleware': 0.73.7(encoding@0.1.13)
+      '@react-native/metro-babel-transformer': 0.73.15(@babel/core@7.25.2)
+      chalk: 4.1.2
+      execa: 5.1.1
+      metro: 0.80.5(encoding@0.1.13)
+      metro-config: 0.80.5(encoding@0.1.13)
+      metro-core: 0.80.5
+      node-fetch: 2.6.12(encoding@0.1.13)
+      readline: 1.3.0
+    transitivePeerDependencies:
+      - '@babel/core'
+      - '@babel/preset-env'
+      - bufferutil
+      - encoding
+      - supports-color
+      - utf-8-validate
+    optional: true
 
   '@react-native/community-cli-plugin@0.73.17(@babel/core@7.23.7)(@babel/preset-env@7.23.7(@babel/core@7.23.7))(encoding@0.1.13)':
     dependencies:
@@ -17775,6 +17924,15 @@ snapshots:
 
   '@react-native/js-polyfills@0.73.1': {}
 
+  '@react-native/metro-babel-transformer@0.73.15':
+    dependencies:
+      '@react-native/babel-preset': 0.73.21
+      hermes-parser: 0.15.0
+      nullthrows: 1.1.1
+    transitivePeerDependencies:
+      - '@babel/preset-env'
+      - supports-color
+
   '@react-native/metro-babel-transformer@0.73.15(@babel/core@7.23.7)(@babel/preset-env@7.23.7(@babel/core@7.23.7))':
     dependencies:
       '@babel/core': 7.23.7
@@ -17784,6 +17942,17 @@ snapshots:
     transitivePeerDependencies:
       - '@babel/preset-env'
       - supports-color
+
+  '@react-native/metro-babel-transformer@0.73.15(@babel/core@7.25.2)':
+    dependencies:
+      '@babel/core': 7.25.2
+      '@react-native/babel-preset': 0.73.21(@babel/core@7.25.2)
+      hermes-parser: 0.15.0
+      nullthrows: 1.1.1
+    transitivePeerDependencies:
+      - '@babel/preset-env'
+      - supports-color
+    optional: true
 
   '@react-native/metro-babel-transformer@0.73.15(@babel/core@7.25.2)(@babel/preset-env@7.23.7(@babel/core@7.25.2))':
     dependencies:
@@ -17795,7 +17964,7 @@ snapshots:
       - '@babel/preset-env'
       - supports-color
 
-  '@react-native/metro-config@0.73.5(@babel/core@7.23.7)(@babel/preset-env@7.23.7(@babel/core@7.23.7))(encoding@0.1.13)':
+  '@react-native/metro-config@0.73.5(@babel/core@7.23.7)(@babel/preset-env@7.23.7(@babel/core@7.23.7))':
     dependencies:
       '@react-native/js-polyfills': 0.73.1
       '@react-native/metro-babel-transformer': 0.73.15(@babel/core@7.23.7)(@babel/preset-env@7.23.7(@babel/core@7.23.7))
@@ -17804,10 +17973,7 @@ snapshots:
     transitivePeerDependencies:
       - '@babel/core'
       - '@babel/preset-env'
-      - bufferutil
-      - encoding
       - supports-color
-      - utf-8-validate
 
   '@react-native/normalize-color@2.1.0': {}
 
@@ -17826,6 +17992,19 @@ snapshots:
       invariant: 2.2.4
       nullthrows: 1.1.1
       react-native: 0.73.4(@babel/core@7.25.2)(@babel/preset-env@7.23.7(@babel/core@7.25.2))(encoding@0.1.13)(react@18.2.0)
+
+  '@react-native/virtualized-lists@0.73.4(react-native@0.73.4(@babel/core@7.25.2)(encoding@0.1.13)(react@18.2.0))':
+    dependencies:
+      invariant: 2.2.4
+      nullthrows: 1.1.1
+      react-native: 0.73.4(@babel/core@7.25.2)(encoding@0.1.13)(react@18.2.0)
+    optional: true
+
+  '@react-native/virtualized-lists@0.73.4(react-native@0.73.4(react@18.2.0))':
+    dependencies:
+      invariant: 2.2.4
+      nullthrows: 1.1.1
+      react-native: 0.73.4(react@18.2.0)
 
   '@react-navigation/bottom-tabs@6.5.12(@react-navigation/native@6.1.10(react-native@0.73.4(@babel/core@7.23.7)(@babel/preset-env@7.23.7(@babel/core@7.23.7))(encoding@0.1.13)(react@18.2.0))(react@18.2.0))(react-native-safe-area-context@4.9.0(react-native@0.73.4(@babel/core@7.23.7)(@babel/preset-env@7.23.7(@babel/core@7.23.7))(encoding@0.1.13)(react@18.2.0))(react@18.2.0))(react-native-screens@3.29.0(react-native@0.73.4(@babel/core@7.23.7)(@babel/preset-env@7.23.7(@babel/core@7.23.7))(encoding@0.1.13)(react@18.2.0))(react@18.2.0))(react-native@0.73.4(@babel/core@7.23.7)(@babel/preset-env@7.23.7(@babel/core@7.23.7))(encoding@0.1.13)(react@18.2.0))(react@18.2.0)':
     dependencies:
@@ -17951,13 +18130,13 @@ snapshots:
       picomatch: 2.3.1
       rollup: 2.79.1
 
-  '@rollup/pluginutils@5.1.0(rollup@4.13.0)':
+  '@rollup/pluginutils@5.1.0(rollup@2.79.1)':
     dependencies:
       '@types/estree': 1.0.5
       estree-walker: 2.0.2
       picomatch: 2.3.1
     optionalDependencies:
-      rollup: 4.13.0
+      rollup: 2.79.1
 
   '@rollup/rollup-android-arm-eabi@4.13.0':
     optional: true
@@ -19040,28 +19219,28 @@ snapshots:
     dependencies:
       '@tanstack/query-core': 4.27.0
 
-  '@tanstack/react-query-devtools@4.29.0(@tanstack/react-query@4.36.1(react-dom@18.2.0(react@18.2.0))(react-native@0.73.4(@babel/core@7.23.7)(@babel/preset-env@7.23.7(@babel/core@7.23.7))(encoding@0.1.13)(react@18.2.0))(react@18.2.0))(react-dom@18.2.0(react@18.2.0))(react@18.2.0)':
+  '@tanstack/react-query-devtools@4.29.0(@tanstack/react-query@4.36.1(react-dom@18.2.0(react@18.2.0))(react-native@0.73.4(@babel/core@7.25.2)(encoding@0.1.13)(react@18.2.0))(react@18.2.0))(react-dom@18.2.0(react@18.2.0))(react@18.2.0)':
     dependencies:
       '@tanstack/match-sorter-utils': 8.8.4
-      '@tanstack/react-query': 4.36.1(react-dom@18.2.0(react@18.2.0))(react-native@0.73.4(@babel/core@7.23.7)(@babel/preset-env@7.23.7(@babel/core@7.23.7))(encoding@0.1.13)(react@18.2.0))(react@18.2.0)
+      '@tanstack/react-query': 4.36.1(react-dom@18.2.0(react@18.2.0))(react-native@0.73.4(@babel/core@7.25.2)(encoding@0.1.13)(react@18.2.0))(react@18.2.0)
       react: 18.2.0
       react-dom: 18.2.0(react@18.2.0)
       superjson: 1.12.2
       use-sync-external-store: 1.2.0(react@18.2.0)
 
-  '@tanstack/react-query-persist-client@4.28.0(@tanstack/react-query@4.36.1(react-dom@18.2.0(react@18.2.0))(react-native@0.73.4(@babel/core@7.23.7)(@babel/preset-env@7.23.7(@babel/core@7.23.7))(encoding@0.1.13)(react@18.2.0))(react@18.2.0))':
+  '@tanstack/react-query-persist-client@4.28.0(@tanstack/react-query@4.36.1(react-dom@18.2.0(react@18.2.0))(react-native@0.73.4(@babel/core@7.25.2)(encoding@0.1.13)(react@18.2.0))(react@18.2.0))':
     dependencies:
       '@tanstack/query-persist-client-core': 4.27.0
-      '@tanstack/react-query': 4.36.1(react-dom@18.2.0(react@18.2.0))(react-native@0.73.4(@babel/core@7.23.7)(@babel/preset-env@7.23.7(@babel/core@7.23.7))(encoding@0.1.13)(react@18.2.0))(react@18.2.0)
+      '@tanstack/react-query': 4.36.1(react-dom@18.2.0(react@18.2.0))(react-native@0.73.4(@babel/core@7.25.2)(encoding@0.1.13)(react@18.2.0))(react@18.2.0)
 
-  '@tanstack/react-query@4.36.1(react-dom@18.2.0(react@18.2.0))(react-native@0.73.4(@babel/core@7.23.7)(@babel/preset-env@7.23.7(@babel/core@7.23.7))(encoding@0.1.13)(react@18.2.0))(react@18.2.0)':
+  '@tanstack/react-query@4.36.1(react-dom@18.2.0(react@18.2.0))(react-native@0.73.4(@babel/core@7.25.2)(encoding@0.1.13)(react@18.2.0))(react@18.2.0)':
     dependencies:
       '@tanstack/query-core': 4.36.1
       react: 18.2.0
       use-sync-external-store: 1.2.0(react@18.2.0)
     optionalDependencies:
       react-dom: 18.2.0(react@18.2.0)
-      react-native: 0.73.4(@babel/core@7.23.7)(@babel/preset-env@7.23.7(@babel/core@7.23.7))(encoding@0.1.13)(react@18.2.0)
+      react-native: 0.73.4(@babel/core@7.25.2)(encoding@0.1.13)(react@18.2.0)
 
   '@tanstack/react-query@5.32.1(react@18.2.0)':
     dependencies:
@@ -19778,6 +19957,19 @@ snapshots:
       - react
       - supports-color
       - utf-8-validate
+    optional: true
+
+  '@types/react-native@0.73.0(react@18.2.0)':
+    dependencies:
+      react-native: 0.73.4(react@18.2.0)
+    transitivePeerDependencies:
+      - '@babel/core'
+      - '@babel/preset-env'
+      - bufferutil
+      - encoding
+      - react
+      - supports-color
+      - utf-8-validate
 
   '@types/react-redux@7.1.24':
     dependencies:
@@ -20079,29 +20271,29 @@ snapshots:
       graphql: 15.8.0
       wonka: 4.0.15
 
-  '@vitejs/plugin-basic-ssl@1.1.0(vite@5.1.6(@types/node@20.10.8)(lightningcss@1.19.0)(terser@5.19.1))':
+  '@vitejs/plugin-basic-ssl@1.1.0(vite@5.1.6(@types/node@20.10.8)(terser@5.19.1))':
     dependencies:
-      vite: 5.1.6(@types/node@20.10.8)(lightningcss@1.19.0)(terser@5.19.1)
+      vite: 5.1.6(@types/node@20.10.8)(terser@5.19.1)
 
-  '@vitejs/plugin-react@4.2.1(vite@5.1.6(@types/node@20.10.8)(lightningcss@1.19.0)(terser@5.19.1))':
+  '@vitejs/plugin-react@4.2.1(vite@5.1.6(@types/node@20.10.8)(terser@5.19.1))':
     dependencies:
       '@babel/core': 7.23.7
       '@babel/plugin-transform-react-jsx-self': 7.23.3(@babel/core@7.23.7)
       '@babel/plugin-transform-react-jsx-source': 7.23.3(@babel/core@7.23.7)
       '@types/babel__core': 7.20.5
       react-refresh: 0.14.0
-      vite: 5.1.6(@types/node@20.10.8)(lightningcss@1.19.0)(terser@5.19.1)
+      vite: 5.1.6(@types/node@20.10.8)(terser@5.19.1)
     transitivePeerDependencies:
       - supports-color
 
-  '@vitejs/plugin-react@4.2.1(vite@5.1.6(@types/node@20.14.10)(lightningcss@1.19.0)(terser@5.19.1))':
+  '@vitejs/plugin-react@4.2.1(vite@5.1.6(@types/node@20.14.10)(terser@5.19.1))':
     dependencies:
       '@babel/core': 7.23.7
       '@babel/plugin-transform-react-jsx-self': 7.23.3(@babel/core@7.23.7)
       '@babel/plugin-transform-react-jsx-source': 7.23.3(@babel/core@7.23.7)
       '@types/babel__core': 7.20.5
       react-refresh: 0.14.0
-      vite: 5.1.6(@types/node@20.14.10)(lightningcss@1.19.0)(terser@5.19.1)
+      vite: 5.1.6(@types/node@20.14.10)(terser@5.19.1)
     transitivePeerDependencies:
       - supports-color
 
@@ -24781,6 +24973,26 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  metro-transform-worker@0.80.5:
+    dependencies:
+      '@babel/core': 7.23.7
+      '@babel/generator': 7.23.6
+      '@babel/parser': 7.23.6
+      '@babel/types': 7.23.9
+      metro: 0.80.5
+      metro-babel-transformer: 0.80.5
+      metro-cache: 0.80.5
+      metro-cache-key: 0.80.5
+      metro-minify-terser: 0.80.5
+      metro-source-map: 0.80.5
+      metro-transform-plugins: 0.80.5
+      nullthrows: 1.1.1
+    transitivePeerDependencies:
+      - bufferutil
+      - encoding
+      - supports-color
+      - utf-8-validate
+
   metro-transform-worker@0.80.5(encoding@0.1.13):
     dependencies:
       '@babel/core': 7.23.7
@@ -24795,6 +25007,57 @@ snapshots:
       metro-source-map: 0.80.5
       metro-transform-plugins: 0.80.5
       nullthrows: 1.1.1
+    transitivePeerDependencies:
+      - bufferutil
+      - encoding
+      - supports-color
+      - utf-8-validate
+
+  metro@0.80.5:
+    dependencies:
+      '@babel/code-frame': 7.23.5
+      '@babel/core': 7.23.7
+      '@babel/generator': 7.23.6
+      '@babel/parser': 7.23.6
+      '@babel/template': 7.22.15
+      '@babel/traverse': 7.23.7
+      '@babel/types': 7.23.9
+      accepts: 1.3.8
+      chalk: 4.1.2
+      ci-info: 2.0.0
+      connect: 3.7.0
+      debug: 2.6.9
+      denodeify: 1.2.1
+      error-stack-parser: 2.1.4
+      graceful-fs: 4.2.10
+      hermes-parser: 0.18.2
+      image-size: 1.1.1
+      invariant: 2.2.4
+      jest-worker: 29.7.0
+      jsc-safe-url: 0.2.4
+      lodash.throttle: 4.1.1
+      metro-babel-transformer: 0.80.5
+      metro-cache: 0.80.5
+      metro-cache-key: 0.80.5
+      metro-config: 0.80.5(encoding@0.1.13)
+      metro-core: 0.80.5
+      metro-file-map: 0.80.5
+      metro-resolver: 0.80.5
+      metro-runtime: 0.80.5
+      metro-source-map: 0.80.5
+      metro-symbolicate: 0.80.5
+      metro-transform-plugins: 0.80.5
+      metro-transform-worker: 0.80.5
+      mime-types: 2.1.35
+      node-fetch: 2.6.12(encoding@0.1.13)
+      nullthrows: 1.1.1
+      rimraf: 3.0.2
+      serialize-error: 2.1.0
+      source-map: 0.5.7
+      strip-ansi: 6.0.1
+      throat: 5.0.0
+      ws: 7.5.9
+      yargs: 17.7.2
     transitivePeerDependencies:
       - bufferutil
       - encoding
@@ -25532,8 +25795,8 @@ snapshots:
     dependencies:
       fflate: 0.4.8
 
-  ? posthog-react-native@2.11.3(@react-native-async-storage/async-storage@1.21.0(react-native@0.73.4(@babel/core@7.23.7)(@babel/preset-env@7.23.7(@babel/core@7.23.7))(encoding@0.1.13)(react@18.2.0)))(@react-navigation/native@6.1.10(react-native@0.73.4(@babel/core@7.23.7)(@babel/preset-env@7.23.7(@babel/core@7.23.7))(encoding@0.1.13)(react@18.2.0))(react@18.2.0))(expo-application@5.8.3(expo@50.0.6(@babel/core@7.23.7)(@react-native/babel-preset@0.73.21(@babel/core@7.23.7)(@babel/preset-env@7.23.7(@babel/core@7.23.7)))(encoding@0.1.13)))(expo-device@5.9.3(expo@50.0.6(@babel/core@7.23.7)(@react-native/babel-preset@0.73.21(@babel/core@7.23.7)(@babel/preset-env@7.23.7(@babel/core@7.23.7)))(encoding@0.1.13)))(expo-file-system@16.0.9(expo@50.0.6(@babel/core@7.23.7)(@react-native/babel-preset@0.73.21(@babel/core@7.23.7)(@babel/preset-env@7.23.7(@babel/core@7.23.7)))(encoding@0.1.13)))(expo-localization@14.8.3(expo@50.0.6(@babel/core@7.23.7)(@react-native/babel-preset@0.73.21(@babel/core@7.23.7)(@babel/preset-env@7.23.7(@babel/core@7.23.7)))(encoding@0.1.13)))(react-native-device-info@10.12.0(react-native@0.73.4(@babel/core@7.23.7)(@babel/preset-env@7.23.7(@babel/core@7.23.7))(encoding@0.1.13)(react@18.2.0)))
-  : optionalDependencies:
+  posthog-react-native@2.11.3(oi5hx7o6oxzkjy7oghrlxekpbi):
+    optionalDependencies:
       '@react-native-async-storage/async-storage': 1.21.0(react-native@0.73.4(@babel/core@7.23.7)(@babel/preset-env@7.23.7(@babel/core@7.23.7))(encoding@0.1.13)(react@18.2.0))
       '@react-navigation/native': 6.1.10(react-native@0.73.4(@babel/core@7.23.7)(@babel/preset-env@7.23.7(@babel/core@7.23.7))(encoding@0.1.13)(react@18.2.0))(react@18.2.0)
       expo-application: 5.8.3(expo@50.0.6(@babel/core@7.23.7)(@react-native/babel-preset@0.73.21(@babel/core@7.23.7)(@babel/preset-env@7.23.7(@babel/core@7.23.7)))(encoding@0.1.13))
@@ -25890,7 +26153,7 @@ snapshots:
       minimist: 1.2.6
       strip-json-comments: 2.0.1
 
-  react-beautiful-dnd@13.1.1(react-dom@18.2.0(react@18.2.0))(react-native@0.73.4(@babel/core@7.23.7)(@babel/preset-env@7.23.7(@babel/core@7.23.7))(encoding@0.1.13)(react@18.2.0))(react@18.2.0):
+  react-beautiful-dnd@13.1.1(react-dom@18.2.0(react@18.2.0))(react-native@0.73.4(@babel/core@7.25.2)(encoding@0.1.13)(react@18.2.0))(react@18.2.0):
     dependencies:
       '@babel/runtime': 7.23.8
       css-box-model: 1.2.1
@@ -25898,7 +26161,7 @@ snapshots:
       raf-schd: 4.0.3
       react: 18.2.0
       react-dom: 18.2.0(react@18.2.0)
-      react-redux: 7.2.8(react-dom@18.2.0(react@18.2.0))(react-native@0.73.4(@babel/core@7.23.7)(@babel/preset-env@7.23.7(@babel/core@7.23.7))(encoding@0.1.13)(react@18.2.0))(react@18.2.0)
+      react-redux: 7.2.8(react-dom@18.2.0(react@18.2.0))(react-native@0.73.4(@babel/core@7.25.2)(encoding@0.1.13)(react@18.2.0))(react@18.2.0)
       redux: 4.2.0
       use-memo-one: 1.1.3(react@18.2.0)
     transitivePeerDependencies:
@@ -25926,11 +26189,11 @@ snapshots:
       react-cosmos-core: 6.1.1
       react-cosmos-renderer: 6.1.1
 
-  react-cosmos-plugin-vite@6.1.1(vite@5.1.6(@types/node@20.10.8)(lightningcss@1.19.0)(terser@5.19.1)):
+  react-cosmos-plugin-vite@6.1.1(vite@5.1.6(@types/node@20.10.8)(terser@5.19.1)):
     dependencies:
       react-cosmos-core: 6.1.1
       react-cosmos-dom: 6.1.1
-      vite: 5.1.6(@types/node@20.10.8)(lightningcss@1.19.0)(terser@5.19.1)
+      vite: 5.1.6(@types/node@20.10.8)(terser@5.19.1)
 
   react-cosmos-renderer@6.1.1:
     dependencies:
@@ -26199,6 +26462,14 @@ snapshots:
       react: 18.2.0
       react-native: 0.73.4(@babel/core@7.23.7)(@babel/preset-env@7.23.7(@babel/core@7.23.7))(encoding@0.1.13)(react@18.2.0)
 
+  react-native-svg@15.0.0(react-native@0.73.4(@babel/core@7.25.2)(encoding@0.1.13)(react@18.2.0))(react@18.2.0):
+    dependencies:
+      css-select: 5.1.0
+      css-tree: 1.1.3
+      react: 18.2.0
+      react-native: 0.73.4(@babel/core@7.25.2)(encoding@0.1.13)(react@18.2.0)
+    optional: true
+
   react-native-url-polyfill@2.0.0(react-native@0.73.4(@babel/core@7.23.7)(@babel/preset-env@7.23.7(@babel/core@7.23.7))(encoding@0.1.13)(react@18.2.0)):
     dependencies:
       react-native: 0.73.4(@babel/core@7.23.7)(@babel/preset-env@7.23.7(@babel/core@7.23.7))(encoding@0.1.13)(react@18.2.0)
@@ -26404,21 +26675,120 @@ snapshots:
       - supports-color
       - utf-8-validate
 
+  react-native@0.73.4(@babel/core@7.25.2)(encoding@0.1.13)(react@18.2.0):
+    dependencies:
+      '@jest/create-cache-key-function': 29.7.0
+      '@react-native-community/cli': 12.3.2(encoding@0.1.13)
+      '@react-native-community/cli-platform-android': 12.3.2(encoding@0.1.13)
+      '@react-native-community/cli-platform-ios': 12.3.2(encoding@0.1.13)
+      '@react-native/assets-registry': 0.73.1
+      '@react-native/codegen': 0.73.3(@babel/preset-env@7.23.7(@babel/core@7.23.7))
+      '@react-native/community-cli-plugin': 0.73.16(@babel/core@7.25.2)(encoding@0.1.13)
+      '@react-native/gradle-plugin': 0.73.4
+      '@react-native/js-polyfills': 0.73.1
+      '@react-native/normalize-colors': 0.73.2
+      '@react-native/virtualized-lists': 0.73.4(react-native@0.73.4(@babel/core@7.25.2)(encoding@0.1.13)(react@18.2.0))
+      abort-controller: 3.0.0
+      anser: 1.4.10
+      ansi-regex: 5.0.1
+      base64-js: 1.5.1
+      chalk: 4.1.2
+      deprecated-react-native-prop-types: 5.0.0
+      event-target-shim: 5.0.1
+      flow-enums-runtime: 0.0.6
+      invariant: 2.2.4
+      jest-environment-node: 29.7.0
+      jsc-android: 250231.0.0
+      memoize-one: 5.2.1
+      metro-runtime: 0.80.5
+      metro-source-map: 0.80.5
+      mkdirp: 0.5.6
+      nullthrows: 1.1.1
+      pretty-format: 26.6.2
+      promise: 8.3.0
+      react: 18.2.0
+      react-devtools-core: 4.28.5
+      react-refresh: 0.14.0
+      react-shallow-renderer: 16.15.0(react@18.2.0)
+      regenerator-runtime: 0.13.11
+      scheduler: 0.24.0-canary-efb381bbf-20230505
+      stacktrace-parser: 0.1.10
+      whatwg-fetch: 3.6.20
+      ws: 6.2.2
+      yargs: 17.7.2
+    transitivePeerDependencies:
+      - '@babel/core'
+      - '@babel/preset-env'
+      - bufferutil
+      - encoding
+      - supports-color
+      - utf-8-validate
+    optional: true
+
+  react-native@0.73.4(react@18.2.0):
+    dependencies:
+      '@jest/create-cache-key-function': 29.7.0
+      '@react-native-community/cli': 12.3.2(encoding@0.1.13)
+      '@react-native-community/cli-platform-android': 12.3.2(encoding@0.1.13)
+      '@react-native-community/cli-platform-ios': 12.3.2(encoding@0.1.13)
+      '@react-native/assets-registry': 0.73.1
+      '@react-native/codegen': 0.73.3(@babel/preset-env@7.23.7(@babel/core@7.23.7))
+      '@react-native/community-cli-plugin': 0.73.16
+      '@react-native/gradle-plugin': 0.73.4
+      '@react-native/js-polyfills': 0.73.1
+      '@react-native/normalize-colors': 0.73.2
+      '@react-native/virtualized-lists': 0.73.4(react-native@0.73.4(react@18.2.0))
+      abort-controller: 3.0.0
+      anser: 1.4.10
+      ansi-regex: 5.0.1
+      base64-js: 1.5.1
+      chalk: 4.1.2
+      deprecated-react-native-prop-types: 5.0.0
+      event-target-shim: 5.0.1
+      flow-enums-runtime: 0.0.6
+      invariant: 2.2.4
+      jest-environment-node: 29.7.0
+      jsc-android: 250231.0.0
+      memoize-one: 5.2.1
+      metro-runtime: 0.80.5
+      metro-source-map: 0.80.5
+      mkdirp: 0.5.6
+      nullthrows: 1.1.1
+      pretty-format: 26.6.2
+      promise: 8.3.0
+      react: 18.2.0
+      react-devtools-core: 4.28.5
+      react-refresh: 0.14.0
+      react-shallow-renderer: 16.15.0(react@18.2.0)
+      regenerator-runtime: 0.13.11
+      scheduler: 0.24.0-canary-efb381bbf-20230505
+      stacktrace-parser: 0.1.10
+      whatwg-fetch: 3.6.20
+      ws: 6.2.2
+      yargs: 17.7.2
+    transitivePeerDependencies:
+      - '@babel/core'
+      - '@babel/preset-env'
+      - bufferutil
+      - encoding
+      - supports-color
+      - utf-8-validate
+
   react-oembed-container@https://codeload.github.com/stefkampen/react-oembed-container/tar.gz/802eee0dba7986faa9c931b1c016acba5369d5f9(react-dom@18.2.0(react@18.2.0))(react@18.2.0):
     dependencies:
       prop-types: 15.8.1
       react: 18.2.0
       react-dom: 18.2.0(react@18.2.0)
 
-  react-qr-code@2.0.12(react-native-svg@15.0.0(react-native@0.73.4(@babel/core@7.23.7)(@babel/preset-env@7.23.7(@babel/core@7.23.7))(encoding@0.1.13)(react@18.2.0))(react@18.2.0))(react@18.2.0):
+  react-qr-code@2.0.12(react-native-svg@15.0.0(react-native@0.73.4(@babel/core@7.25.2)(encoding@0.1.13)(react@18.2.0))(react@18.2.0))(react@18.2.0):
     dependencies:
       prop-types: 15.8.1
       qr.js: 0.0.0
       react: 18.2.0
     optionalDependencies:
-      react-native-svg: 15.0.0(react-native@0.73.4(@babel/core@7.23.7)(@babel/preset-env@7.23.7(@babel/core@7.23.7))(encoding@0.1.13)(react@18.2.0))(react@18.2.0)
+      react-native-svg: 15.0.0(react-native@0.73.4(@babel/core@7.25.2)(encoding@0.1.13)(react@18.2.0))(react@18.2.0)
 
-  react-redux@7.2.8(react-dom@18.2.0(react@18.2.0))(react-native@0.73.4(@babel/core@7.23.7)(@babel/preset-env@7.23.7(@babel/core@7.23.7))(encoding@0.1.13)(react@18.2.0))(react@18.2.0):
+  react-redux@7.2.8(react-dom@18.2.0(react@18.2.0))(react-native@0.73.4(@babel/core@7.25.2)(encoding@0.1.13)(react@18.2.0))(react@18.2.0):
     dependencies:
       '@babel/runtime': 7.23.8
       '@types/react-redux': 7.1.24
@@ -26429,7 +26799,7 @@ snapshots:
       react-is: 17.0.2
     optionalDependencies:
       react-dom: 18.2.0(react@18.2.0)
-      react-native: 0.73.4(@babel/core@7.23.7)(@babel/preset-env@7.23.7(@babel/core@7.23.7))(encoding@0.1.13)(react@18.2.0)
+      react-native: 0.73.4(@babel/core@7.25.2)(encoding@0.1.13)(react@18.2.0)
 
   react-refresh@0.14.0: {}
 
@@ -26464,11 +26834,11 @@ snapshots:
       '@remix-run/router': 1.15.2
       react: 18.2.0
 
-  react-select@5.4.0(@babel/core@7.23.7)(@types/react@18.2.55)(react-dom@18.2.0(react@18.2.0))(react@18.2.0):
+  react-select@5.4.0(@babel/core@7.25.2)(@types/react@18.2.55)(react-dom@18.2.0(react@18.2.0))(react@18.2.0):
     dependencies:
       '@babel/runtime': 7.23.8
       '@emotion/cache': 11.10.1
-      '@emotion/react': 11.10.0(@babel/core@7.23.7)(@types/react@18.2.55)(react@18.2.0)
+      '@emotion/react': 11.10.0(@babel/core@7.25.2)(@types/react@18.2.55)(react@18.2.0)
       '@types/react-transition-group': 4.4.5
       memoize-one: 5.2.1
       prop-types: 15.8.1
@@ -26766,14 +27136,14 @@ snapshots:
       serialize-javascript: 4.0.0
       terser: 5.19.1
 
-  rollup-plugin-visualizer@5.12.0(rollup@4.13.0):
+  rollup-plugin-visualizer@5.12.0(rollup@2.79.1):
     dependencies:
       open: 8.4.2
       picomatch: 2.3.1
       source-map: 0.7.4
       yargs: 17.7.2
     optionalDependencies:
-      rollup: 4.13.0
+      rollup: 2.79.1
 
   rollup@2.79.1:
     optionalDependencies:
@@ -27726,7 +28096,7 @@ snapshots:
 
   tslib@2.6.2: {}
 
-  tsup@8.0.1(@swc/core@1.4.16(@swc/helpers@0.5.10))(postcss@8.4.35)(typescript@5.4.5):
+  tsup@8.0.1(@swc/core@1.4.16)(postcss@8.4.35)(typescript@5.4.5):
     dependencies:
       bundle-require: 4.0.2(esbuild@0.19.12)
       cac: 6.7.14
@@ -28051,14 +28421,14 @@ snapshots:
       react-dom: 18.2.0(react@18.2.0)
       redux: 4.2.0
 
-  vite-node@0.34.6(@types/node@20.10.8)(lightningcss@1.19.0)(terser@5.19.1):
+  vite-node@0.34.6(@types/node@20.10.8)(terser@5.19.1):
     dependencies:
       cac: 6.7.14
       debug: 4.3.4
       mlly: 1.5.0
       pathe: 1.1.2
       picocolors: 1.0.0
-      vite: 5.1.6(@types/node@20.10.8)(lightningcss@1.19.0)(terser@5.19.1)
+      vite: 5.1.6(@types/node@20.10.8)(terser@5.19.1)
     transitivePeerDependencies:
       - '@types/node'
       - less
@@ -28069,13 +28439,13 @@ snapshots:
       - supports-color
       - terser
 
-  vite-node@1.2.2(@types/node@20.14.10)(lightningcss@1.19.0)(terser@5.19.1):
+  vite-node@1.2.2(@types/node@20.14.10)(terser@5.19.1):
     dependencies:
       cac: 6.7.14
       debug: 4.3.4
       pathe: 1.1.2
       picocolors: 1.0.0
-      vite: 5.1.6(@types/node@20.14.10)(lightningcss@1.19.0)(terser@5.19.1)
+      vite: 5.1.6(@types/node@20.14.10)(terser@5.19.1)
     transitivePeerDependencies:
       - '@types/node'
       - less
@@ -28086,13 +28456,13 @@ snapshots:
       - supports-color
       - terser
 
-  vite-node@1.5.0(@types/node@20.14.10)(lightningcss@1.19.0)(terser@5.19.1):
+  vite-node@1.5.0(@types/node@20.14.10)(terser@5.19.1):
     dependencies:
       cac: 6.7.14
       debug: 4.3.4
       pathe: 1.1.2
       picocolors: 1.0.0
-      vite: 5.1.6(@types/node@20.14.10)(lightningcss@1.19.0)(terser@5.19.1)
+      vite: 5.1.6(@types/node@20.14.10)(terser@5.19.1)
     transitivePeerDependencies:
       - '@types/node'
       - less
@@ -28103,35 +28473,35 @@ snapshots:
       - supports-color
       - terser
 
-  vite-plugin-pwa@0.17.5(vite@5.1.6(@types/node@20.10.8)(lightningcss@1.19.0)(terser@5.19.1))(workbox-build@7.0.0(@types/babel__core@7.20.5))(workbox-window@7.0.0):
+  vite-plugin-pwa@0.17.5(vite@5.1.6(@types/node@20.10.8)(terser@5.19.1))(workbox-build@7.0.0(@types/babel__core@7.20.5))(workbox-window@7.0.0):
     dependencies:
       debug: 4.3.4
       fast-glob: 3.3.2
       pretty-bytes: 6.1.1
-      vite: 5.1.6(@types/node@20.10.8)(lightningcss@1.19.0)(terser@5.19.1)
+      vite: 5.1.6(@types/node@20.10.8)(terser@5.19.1)
       workbox-build: 7.0.0(@types/babel__core@7.20.5)
       workbox-window: 7.0.0
     transitivePeerDependencies:
       - supports-color
 
-  vite-plugin-singlefile@2.0.1(rollup@4.13.0)(vite@5.1.6(@types/node@20.14.10)(lightningcss@1.19.0)(terser@5.19.1)):
+  vite-plugin-singlefile@2.0.1(rollup@4.13.0)(vite@5.1.6(@types/node@20.14.10)(terser@5.19.1)):
     dependencies:
       micromatch: 4.0.5
       rollup: 4.13.0
-      vite: 5.1.6(@types/node@20.14.10)(lightningcss@1.19.0)(terser@5.19.1)
+      vite: 5.1.6(@types/node@20.14.10)(terser@5.19.1)
 
-  vite-plugin-svgr@4.2.0(rollup@4.13.0)(typescript@5.4.5)(vite@5.1.6(@types/node@20.10.8)(lightningcss@1.19.0)(terser@5.19.1)):
+  vite-plugin-svgr@4.2.0(rollup@2.79.1)(typescript@5.4.5)(vite@5.1.6(@types/node@20.10.8)(terser@5.19.1)):
     dependencies:
-      '@rollup/pluginutils': 5.1.0(rollup@4.13.0)
+      '@rollup/pluginutils': 5.1.0(rollup@2.79.1)
       '@svgr/core': 8.1.0(typescript@5.4.5)
       '@svgr/plugin-jsx': 8.1.0(@svgr/core@8.1.0(typescript@5.4.5))
-      vite: 5.1.6(@types/node@20.10.8)(lightningcss@1.19.0)(terser@5.19.1)
+      vite: 5.1.6(@types/node@20.10.8)(terser@5.19.1)
     transitivePeerDependencies:
       - rollup
       - supports-color
       - typescript
 
-  vite@5.1.6(@types/node@20.10.8)(lightningcss@1.19.0)(terser@5.19.1):
+  vite@5.1.6(@types/node@20.10.8)(terser@5.19.1):
     dependencies:
       esbuild: 0.19.12
       postcss: 8.4.35
@@ -28139,10 +28509,9 @@ snapshots:
     optionalDependencies:
       '@types/node': 20.10.8
       fsevents: 2.3.3
-      lightningcss: 1.19.0
       terser: 5.19.1
 
-  vite@5.1.6(@types/node@20.14.10)(lightningcss@1.19.0)(terser@5.19.1):
+  vite@5.1.6(@types/node@20.14.10)(terser@5.19.1):
     dependencies:
       esbuild: 0.19.12
       postcss: 8.4.35
@@ -28150,10 +28519,9 @@ snapshots:
     optionalDependencies:
       '@types/node': 20.14.10
       fsevents: 2.3.3
-      lightningcss: 1.19.0
       terser: 5.19.1
 
-  vitest@0.34.6(jsdom@23.2.0)(lightningcss@1.19.0)(terser@5.19.1):
+  vitest@0.34.6(jsdom@23.2.0)(terser@5.19.1):
     dependencies:
       '@types/chai': 4.3.11
       '@types/chai-subset': 1.3.5
@@ -28176,8 +28544,8 @@ snapshots:
       strip-literal: 1.3.0
       tinybench: 2.6.0
       tinypool: 0.7.0
-      vite: 5.1.6(@types/node@20.10.8)(lightningcss@1.19.0)(terser@5.19.1)
-      vite-node: 0.34.6(@types/node@20.10.8)(lightningcss@1.19.0)(terser@5.19.1)
+      vite: 5.1.6(@types/node@20.10.8)(terser@5.19.1)
+      vite-node: 0.34.6(@types/node@20.10.8)(terser@5.19.1)
       why-is-node-running: 2.2.2
     optionalDependencies:
       jsdom: 23.2.0
@@ -28190,7 +28558,7 @@ snapshots:
       - supports-color
       - terser
 
-  vitest@1.2.2(@types/node@20.14.10)(jsdom@23.2.0)(lightningcss@1.19.0)(terser@5.19.1):
+  vitest@1.2.2(@types/node@20.14.10)(jsdom@23.2.0)(terser@5.19.1):
     dependencies:
       '@vitest/expect': 1.2.2
       '@vitest/runner': 1.2.2
@@ -28210,8 +28578,8 @@ snapshots:
       strip-literal: 1.3.0
       tinybench: 2.6.0
       tinypool: 0.8.2
-      vite: 5.1.6(@types/node@20.14.10)(lightningcss@1.19.0)(terser@5.19.1)
-      vite-node: 1.2.2(@types/node@20.14.10)(lightningcss@1.19.0)(terser@5.19.1)
+      vite: 5.1.6(@types/node@20.14.10)(terser@5.19.1)
+      vite-node: 1.2.2(@types/node@20.14.10)(terser@5.19.1)
       why-is-node-running: 2.2.2
     optionalDependencies:
       '@types/node': 20.14.10
@@ -28225,7 +28593,7 @@ snapshots:
       - supports-color
       - terser
 
-  vitest@1.5.0(@types/node@20.14.10)(jsdom@23.2.0)(lightningcss@1.19.0)(terser@5.19.1):
+  vitest@1.5.0(@types/node@20.14.10)(jsdom@23.2.0)(terser@5.19.1):
     dependencies:
       '@vitest/expect': 1.5.0
       '@vitest/runner': 1.5.0
@@ -28244,8 +28612,8 @@ snapshots:
       strip-literal: 2.1.0
       tinybench: 2.6.0
       tinypool: 0.8.4
-      vite: 5.1.6(@types/node@20.14.10)(lightningcss@1.19.0)(terser@5.19.1)
-      vite-node: 1.5.0(@types/node@20.14.10)(lightningcss@1.19.0)(terser@5.19.1)
+      vite: 5.1.6(@types/node@20.14.10)(terser@5.19.1)
+      vite-node: 1.5.0(@types/node@20.14.10)(terser@5.19.1)
       why-is-node-running: 2.2.2
     optionalDependencies:
       '@types/node': 20.14.10


### PR DESCRIPTION
This fixes the most egregious case of TLON-2543 which was that we made a request for every post in a channel who's sync time was less than the current session time when returning to a channel. To prevent this, we made a change in tloncorp/tlon-apps#3847 to a previously written but unused scry endpoint "changes" so that we could hand it a start and end post cursor and then an "after" time. This lets us hand it a range of posts and say give us back any posts that have changed since this time. 

This seems to speed things up when running it, but hard to tell with a local moon. Could use some help on how to get a timing here that we could measure.

Also I did a small drive-by and refactored @urbit/api out of the shared lib, so now it only uses @urbit/aura