### PR TITLE
native: dim header when session inactive

### DIFF
--- a/packages/ui/src/components/GenericHeader.tsx
+++ b/packages/ui/src/components/GenericHeader.tsx
@@ -1,3 +1,4 @@
+import { useCurrentSession } from '@tloncorp/shared';
 import Animated, { FadeInDown, FadeOutUp } from 'react-native-reanimated';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
 import { SizableText, View, XStack } from 'tamagui';
@@ -17,6 +18,7 @@ export function GenericHeader({
   rightContent?: React.ReactNode;
 }) {
   const insets = useSafeAreaInsets();
+  const currentSession = useCurrentSession();
 
   return (
     <View paddingTop={insets.top}>
@@ -47,7 +49,7 @@ export function GenericHeader({
             <SizableText
               flexShrink={1}
               numberOfLines={1}
-              color="$primaryText"
+              color={currentSession ? '$primaryText' : '$tertiaryText'}
               size="$m"
               fontWeight="$xl"
             >

--- a/packages/ui/src/components/ScreenHeader.tsx
+++ b/packages/ui/src/components/ScreenHeader.tsx
@@ -1,3 +1,4 @@
+import { useCurrentSession } from '@tloncorp/shared';
 import { PropsWithChildren, ReactNode } from 'react';
 import Animated, { FadeInDown, FadeOutUp } from 'react-native-reanimated';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
@@ -18,6 +19,7 @@ export const ScreenHeaderComponent = ({
   rightControls?: ReactNode | null;
 }>) => {
   const { top } = useSafeAreaInsets();
+  const currentSession = useCurrentSession();
 
   return (
     <View paddingTop={top} zIndex={50} backgroundColor="$background">
@@ -34,7 +36,11 @@ export const ScreenHeaderComponent = ({
             exiting={FadeOutUp}
             style={{ flex: 1 }}
           >
-            <HeaderTitle>{title}</HeaderTitle>
+            <HeaderTitle
+              color={currentSession ? '$primaryText' : '$tertiaryText'}
+            >
+              {title}
+            </HeaderTitle>
           </Animated.View>
         ) : (
           title


### PR DESCRIPTION
Visually indicates whether we have an active session using screen header (grays it out if we haven't initialized session). Fixes TLON-2254; more advanced introspection soon.