### PR TITLE
native: capture current EAS update ID

### DIFF
--- a/apps/tlon-mobile/src/screens/AppInfo.tsx
+++ b/apps/tlon-mobile/src/screens/AppInfo.tsx
@@ -1,5 +1,6 @@
 import { NativeStackScreenProps } from '@react-navigation/native-stack';
 import { NOTIFY_PROVIDER, NOTIFY_SERVICE } from '@tloncorp/app/constants';
+import { getEasUpdateDisplay } from '@tloncorp/app/lib/platformHelpers';
 import * as store from '@tloncorp/shared/dist/store';
 import {
   AppSetting,
@@ -12,7 +13,8 @@ import {
 } from '@tloncorp/ui';
 import { preSig } from '@urbit/aura';
 import * as Application from 'expo-application';
-import { useCallback } from 'react';
+import * as Updates from 'expo-updates';
+import { useCallback, useMemo } from 'react';
 import { Platform } from 'react-native';
 import { ScrollView } from 'react-native-gesture-handler';
 
@@ -24,6 +26,7 @@ const BUILD_VERSION = `${Platform.OS === 'ios' ? 'iOS' : 'Android'} ${Applicatio
 
 export function AppInfoScreen(props: Props) {
   const { data: appInfo } = store.useAppInfo();
+  const easUpdateDisplay = useMemo(() => getEasUpdateDisplay(Updates), []);
 
   const onPressPreviewFeatures = useCallback(() => {
     props.navigation.navigate('FeatureFlags');
@@ -38,6 +41,7 @@ export function AppInfoScreen(props: Props) {
       <ScrollView>
         <YStack marginTop="$xl" marginHorizontal="$2xl" gap="$s">
           <AppSetting title="Build version" value={BUILD_VERSION} copyable />
+          <AppSetting title="OTA Version" value={easUpdateDisplay} copyable />
           <AppSetting
             title="Notify provider"
             value={preSig(NOTIFY_PROVIDER)}

--- a/apps/tlon-mobile/src/screens/AppInfo.tsx
+++ b/apps/tlon-mobile/src/screens/AppInfo.tsx
@@ -41,7 +41,7 @@ export function AppInfoScreen(props: Props) {
       <ScrollView>
         <YStack marginTop="$xl" marginHorizontal="$2xl" gap="$s">
           <AppSetting title="Build version" value={BUILD_VERSION} copyable />
-          <AppSetting title="OTA Version" value={easUpdateDisplay} copyable />
+          <AppSetting title="OTA Update" value={easUpdateDisplay} copyable />
           <AppSetting
             title="Notify provider"
             value={preSig(NOTIFY_PROVIDER)}

--- a/packages/app/features/top/ChatListScreen.tsx
+++ b/packages/app/features/top/ChatListScreen.tsx
@@ -263,7 +263,7 @@ export default function ChatListScreen({
             pinned={pinned}
             {...useChatSettingsNavigation()}
           >
-            <View backgroundColor="$background" flex={1}>
+            <View flex={1}>
               <ScreenHeader
                 title={
                   !chats || (!chats.unpinned.length && !chats.pinned.length)

--- a/packages/app/lib/platformHelpers.ts
+++ b/packages/app/lib/platformHelpers.ts
@@ -1,9 +1,11 @@
 import { NetInfoState, fetch } from '@react-native-community/netinfo';
 import * as Battery from 'expo-battery';
+import * as Updates from 'expo-updates';
 
 interface DebugPlatformState {
   network: string;
   battery: string;
+  easUpdate: string;
 }
 
 export const PlatformState = {
@@ -13,9 +15,12 @@ export const PlatformState = {
 async function getDebugPlatformState(): Promise<DebugPlatformState | null> {
   const network = await getNetworkState();
   const battery = await getBatteryState();
+  const easUpdate = getEasUpdateDisplay(Updates);
+
   return {
     network,
     battery,
+    easUpdate,
   };
 }
 
@@ -35,4 +40,12 @@ export function toNetworkTypeDisplay(state: NetInfoState): string {
   return networkType === 'cellular'
     ? `(cellular ${state.details.cellularGeneration})`
     : `(${networkType})`;
+}
+
+export function getEasUpdateDisplay(updates: typeof Updates): string {
+  if (updates.isEmbeddedLaunch) {
+    return 'embedded';
+  }
+
+  return updates.updateId ?? 'unknown';
 }

--- a/packages/shared/src/store/errorReporting.ts
+++ b/packages/shared/src/store/errorReporting.ts
@@ -12,6 +12,7 @@ type CrashReporter = {
 interface DebugPlatformState {
   network: string;
   battery: string;
+  easUpdate: string;
 }
 
 type PlatformState = {
@@ -111,6 +112,7 @@ export class ErrorReporter {
         if (platformState) {
           CrashReporter.log(`network: ${platformState.network}`);
           CrashReporter.log(`battery: ${platformState.battery}`);
+          CrashReporter.log(`OTA update: ${platformState.easUpdate}`);
         }
       }
 


### PR DESCRIPTION
OTT

Since we're now using Expo updates, we need insight into whether or not those are running to help with support and debugging. 

This is a first step that just adds that information on the _App Info_ screen & whenever a crash report is filed with Crashlytics.