### PR TITLE
native: reduce allocations in ChannelMessage codepath

### DIFF
--- a/packages/ui/src/components/Channel/Scroller.tsx
+++ b/packages/ui/src/components/Channel/Scroller.tsx
@@ -562,6 +562,10 @@ const BaseScrollerItem = ({
   const dividerType = useMemo(() => {
     switch (channelType) {
       case 'chat':
+      // fallthrough
+      case 'dm':
+      // fallthrough
+      case 'groupDm':
         if (showUnreadDivider) {
           return 'unread';
         }
@@ -569,11 +573,6 @@ const BaseScrollerItem = ({
           return 'day';
         }
         return null;
-
-      case 'dm':
-      // fallthrough
-      case 'groupDm':
-        return showUnreadDivider ? 'unread' : null;
 
       case 'gallery':
       // fallthrough

--- a/packages/ui/src/components/Channel/Scroller.tsx
+++ b/packages/ui/src/components/Channel/Scroller.tsx
@@ -29,13 +29,11 @@ import {
 import Animated from 'react-native-reanimated';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
 import { useStyle, useTheme } from 'tamagui';
-import { View, XStack } from 'tamagui';
+import { View } from 'tamagui';
 
 import { useLivePost } from '../../contexts/requests';
 import { useScrollDirectionTracker } from '../../contexts/scroll';
-import { Button } from '../Button';
 import { ChatMessageActions } from '../ChatMessage/ChatMessageActions/Component';
-import { Icon } from '../Icon';
 import { Modal } from '../Modal';
 import { ChannelDivider } from './ChannelDivider';
 
@@ -99,7 +97,6 @@ const Scroller = forwardRef(
       onPressRetry,
       onPressDelete,
       hasNewerPosts,
-      hasOlderPosts,
       activeMessage,
       setActiveMessage,
     }: {
@@ -124,10 +121,12 @@ const Scroller = forwardRef(
       onPressRetry: (post: db.Post) => void;
       onPressDelete: (post: db.Post) => void;
       hasNewerPosts?: boolean;
-      hasOlderPosts?: boolean;
       activeMessage: db.Post | null;
       setActiveMessage: (post: db.Post | null) => void;
       ref?: RefObject<{ scrollToIndex: (params: { index: number }) => void }>;
+
+      // Unused
+      hasOlderPosts?: boolean;
     },
     ref
   ) => {
@@ -688,31 +687,3 @@ const PressableMessage = React.memo(
     }
   )
 );
-
-const UnreadsButton = ({ onPress }: { onPress: () => void }) => {
-  return (
-    <XStack position="absolute" zIndex={50} bottom="5%" width="40%" left="30%">
-      <Button
-        backgroundColor="$positiveBackground"
-        paddingVertical="$s"
-        paddingHorizontal="$m"
-        borderRadius="$l"
-        width="100%"
-        alignItems="center"
-        justifyContent="center"
-        gap="$s"
-        onPress={onPress}
-        size="$s"
-      >
-        <Button.Text color="$positiveActionText">Scroll to latest</Button.Text>
-        <Icon
-          type="ArrowDown"
-          color="$positiveActionText"
-          width="$s"
-          height="$s"
-          size="$l"
-        />
-      </Button>
-    </XStack>
-  );
-};

--- a/packages/ui/src/components/ChatMessage/ChatMessage.tsx
+++ b/packages/ui/src/components/ChatMessage/ChatMessage.tsx
@@ -117,6 +117,26 @@ const ChatMessage = ({
     return utils.makePrettyTime(date);
   }, [post.sentAt]);
 
+  const messageInputForEditing = useMemo(
+    () => (
+      <MessageInput
+        groupMembers={[]}
+        storeDraft={() => {}}
+        clearDraft={() => {}}
+        getDraft={async () => ({})}
+        shouldBlur={false}
+        setShouldBlur={() => {}}
+        send={async () => {}}
+        channelId={post.channelId}
+        editingPost={post}
+        editPost={editPost}
+        setEditingPost={setEditingPost}
+        channelType="chat"
+      />
+    ),
+    [post, editPost, setEditingPost]
+  );
+
   if (!post) {
     return null;
   }
@@ -187,20 +207,7 @@ const ChatMessage = ({
       ) : null}
       <View paddingLeft={!isNotice && '$4xl'}>
         {editing ? (
-          <MessageInput
-            groupMembers={[]}
-            storeDraft={() => {}}
-            clearDraft={() => {}}
-            getDraft={async () => ({})}
-            shouldBlur={false}
-            setShouldBlur={() => {}}
-            send={async () => {}}
-            channelId={post.channelId}
-            editingPost={post}
-            editPost={editPost}
-            setEditingPost={setEditingPost}
-            channelType="chat"
-          />
+          messageInputForEditing
         ) : post.hidden ? (
           <Text color="$secondaryText">
             You have hidden or flagged this message.


### PR DESCRIPTION
I noticed we had code that would unnecessarily allocate stuff on every render – not a huge deal, but could build up and cause unnecessary GC since these are being rendered for every channel post. Also deleted some dead code while here.

I've run this code in a simple group channel and it looks okay to me.