### PR TITLE
native: editable group privacy

### DIFF
--- a/apps/tlon-mobile/src/navigation/GroupSettingsStack.tsx
+++ b/apps/tlon-mobile/src/navigation/GroupSettingsStack.tsx
@@ -3,8 +3,8 @@ import { createNativeStackNavigator } from '@react-navigation/native-stack';
 import { EditChannelScreen } from '../screens/GroupSettings/EditChannelScreen';
 import { GroupMembersScreen } from '../screens/GroupSettings/GroupMembersScreen';
 import { GroupMetaScreen } from '../screens/GroupSettings/GroupMetaScreen';
+import { GroupPrivacyScreen } from '../screens/GroupSettings/GroupPrivacyScreen';
 import { GroupRolesScreen } from '../screens/GroupSettings/GroupRolesScreen';
-import { InvitesAndPrivacyScreen } from '../screens/GroupSettings/InvitesAndPrivacyScreen';
 import { ManageChannelsScreen } from '../screens/GroupSettings/ManageChannelsScreen';
 import { GroupSettingsStackParamList } from '../types';
 
@@ -23,10 +23,7 @@ export function GroupSettingsStack() {
         component={ManageChannelsScreen}
       />
       <GroupSettings.Screen name="EditChannel" component={EditChannelScreen} />
-      <GroupSettings.Screen
-        name="InvitesAndPrivacy"
-        component={InvitesAndPrivacyScreen}
-      />
+      <GroupSettings.Screen name="Privacy" component={GroupPrivacyScreen} />
       <GroupSettings.Screen name="GroupRoles" component={GroupRolesScreen} />
     </GroupSettings.Navigator>
   );

--- a/apps/tlon-mobile/src/screens/GroupSettings/GroupPrivacyScreen.tsx
+++ b/apps/tlon-mobile/src/screens/GroupSettings/GroupPrivacyScreen.tsx
@@ -14,10 +14,10 @@ import { GroupSettingsStackParamList } from '../../types';
 
 type InvitesAndPrivacyScreenProps = NativeStackScreenProps<
   GroupSettingsStackParamList,
-  'InvitesAndPrivacy'
+  'Privacy'
 >;
 
-export function InvitesAndPrivacyScreen(props: InvitesAndPrivacyScreenProps) {
+export function GroupPrivacyScreen(props: InvitesAndPrivacyScreenProps) {
   const { groupId } = props.route.params;
 
   const { group } = useGroupContext({ groupId });

--- a/apps/tlon-mobile/src/screens/GroupSettings/InvitesAndPrivacyScreen.tsx
+++ b/apps/tlon-mobile/src/screens/GroupSettings/InvitesAndPrivacyScreen.tsx
@@ -1,6 +1,9 @@
 import { NativeStackScreenProps } from '@react-navigation/native-stack';
-import { Text } from '@tloncorp/ui';
-import { SafeAreaView } from 'react-native-safe-area-context';
+import { GroupPrivacy } from '@tloncorp/shared/dist/db/schema';
+import * as store from '@tloncorp/shared/dist/store';
+import { GenericHeader, GroupPrivacySelector, View } from '@tloncorp/ui';
+import { useGroupContext } from 'packages/app/hooks/useGroupContext';
+import { useCallback } from 'react';
 
 import { GroupSettingsStackParamList } from '../../types';
 
@@ -10,9 +13,28 @@ type InvitesAndPrivacyScreenProps = NativeStackScreenProps<
 >;
 
 export function InvitesAndPrivacyScreen(props: InvitesAndPrivacyScreenProps) {
+  const { groupId } = props.route.params;
+
+  const { group } = useGroupContext({ groupId });
+
+  const handlePrivacyChange = useCallback(
+    (newPrivacy: GroupPrivacy) => {
+      if (group && group.privacy !== newPrivacy) {
+        store.updateGroupPrivacy(group, newPrivacy);
+      }
+    },
+    [group]
+  );
+
   return (
-    <SafeAreaView>
-      <Text>InvitesAndPrivacy</Text>
-    </SafeAreaView>
+    <View>
+      <GenericHeader title="Privacy" goBack={props.navigation.goBack} />
+      {group ? (
+        <GroupPrivacySelector
+          currentValue={group.privacy ?? 'private'}
+          onChange={handlePrivacyChange}
+        />
+      ) : null}
+    </View>
   );
 }

--- a/apps/tlon-mobile/src/screens/GroupSettings/InvitesAndPrivacyScreen.tsx
+++ b/apps/tlon-mobile/src/screens/GroupSettings/InvitesAndPrivacyScreen.tsx
@@ -2,7 +2,12 @@ import { NativeStackScreenProps } from '@react-navigation/native-stack';
 import { useGroupContext } from '@tloncorp/app/hooks/useGroupContext';
 import { GroupPrivacy } from '@tloncorp/shared/dist/db/schema';
 import * as store from '@tloncorp/shared/dist/store';
-import { GenericHeader, GroupPrivacySelector, View } from '@tloncorp/ui';
+import {
+  GenericHeader,
+  GroupPrivacySelector,
+  View,
+  triggerHaptic,
+} from '@tloncorp/ui';
 import { useCallback } from 'react';
 
 import { GroupSettingsStackParamList } from '../../types';
@@ -20,6 +25,7 @@ export function InvitesAndPrivacyScreen(props: InvitesAndPrivacyScreenProps) {
   const handlePrivacyChange = useCallback(
     (newPrivacy: GroupPrivacy) => {
       if (group && group.privacy !== newPrivacy) {
+        triggerHaptic('baseButtonClick');
         store.updateGroupPrivacy(group, newPrivacy);
       }
     },

--- a/apps/tlon-mobile/src/screens/GroupSettings/InvitesAndPrivacyScreen.tsx
+++ b/apps/tlon-mobile/src/screens/GroupSettings/InvitesAndPrivacyScreen.tsx
@@ -1,8 +1,8 @@
 import { NativeStackScreenProps } from '@react-navigation/native-stack';
+import { useGroupContext } from '@tloncorp/app/hooks/useGroupContext';
 import { GroupPrivacy } from '@tloncorp/shared/dist/db/schema';
 import * as store from '@tloncorp/shared/dist/store';
 import { GenericHeader, GroupPrivacySelector, View } from '@tloncorp/ui';
-import { useGroupContext } from 'packages/app/hooks/useGroupContext';
 import { useCallback } from 'react';
 
 import { GroupSettingsStackParamList } from '../../types';

--- a/apps/tlon-mobile/src/types.ts
+++ b/apps/tlon-mobile/src/types.ts
@@ -77,7 +77,7 @@ export type GroupSettingsStackParamList = {
   ManageChannels: {
     groupId: string;
   };
-  InvitesAndPrivacy: {
+  Privacy: {
     groupId: string;
   };
   GroupRoles: {

--- a/packages/app/hooks/useChatSettingsNavigation.native.ts
+++ b/packages/app/hooks/useChatSettingsNavigation.native.ts
@@ -16,7 +16,7 @@ type GroupSettingsStackParamList = {
   ManageChannels: {
     groupId: string;
   };
-  InvitesAndPrivacy: {
+  Privacy: {
     groupId: string;
   };
   GroupRoles: {
@@ -65,9 +65,9 @@ export const useChatSettingsNavigation = () => {
     [navigateToGroupSettings]
   );
 
-  const onPressInvitesAndPrivacy = useCallback(
+  const onPressGroupPrivacy = useCallback(
     (groupId: string) => {
-      navigateToGroupSettings('InvitesAndPrivacy', { groupId });
+      navigateToGroupSettings('Privacy', { groupId });
     },
     [navigateToGroupSettings]
   );
@@ -99,7 +99,7 @@ export const useChatSettingsNavigation = () => {
     onPressGroupMeta,
     onPressGroupMembers,
     onPressManageChannels,
-    onPressInvitesAndPrivacy,
+    onPressGroupPrivacy,
     onPressRoles,
   };
 };

--- a/packages/app/hooks/useChatSettingsNavigation.ts
+++ b/packages/app/hooks/useChatSettingsNavigation.ts
@@ -16,7 +16,7 @@ type GroupSettingsStackParamList = {
   ManageChannels: {
     groupId: string;
   };
-  InvitesAndPrivacy: {
+  Privacy: {
     groupId: string;
   };
   GroupRoles: {
@@ -34,8 +34,8 @@ export const useChatSettingsNavigation = () => {
     ) => {
       if (Platform.OS !== 'web') {
         // navigation.navigate('GroupSettings', {
-          // screen,
-          // params,
+        // screen,
+        // params,
         // } as any);
       } else {
         console.log('web navigation not implemented');
@@ -65,9 +65,9 @@ export const useChatSettingsNavigation = () => {
     [navigateToGroupSettings]
   );
 
-  const onPressInvitesAndPrivacy = useCallback(
+  const onPressGroupPrivacy = useCallback(
     (groupId: string) => {
-      navigateToGroupSettings('InvitesAndPrivacy', { groupId });
+      navigateToGroupSettings('Privacy', { groupId });
     },
     [navigateToGroupSettings]
   );
@@ -79,19 +79,13 @@ export const useChatSettingsNavigation = () => {
     [navigateToGroupSettings]
   );
 
-  const onPressChannelMembers = useCallback(
-    (channelId: string) => {
-      // navigation.navigate('ChannelMembers', { channelId });
-    },
-    []
-  );
+  const onPressChannelMembers = useCallback((channelId: string) => {
+    // navigation.navigate('ChannelMembers', { channelId });
+  }, []);
 
-  const onPressChannelMeta = useCallback(
-    (channelId: string) => {
-      // navigation.navigate('ChannelMeta', { channelId });
-    },
-    []
-  );
+  const onPressChannelMeta = useCallback((channelId: string) => {
+    // navigation.navigate('ChannelMeta', { channelId });
+  }, []);
 
   return {
     onPressChannelMembers,
@@ -99,7 +93,7 @@ export const useChatSettingsNavigation = () => {
     onPressGroupMeta,
     onPressGroupMembers,
     onPressManageChannels,
-    onPressInvitesAndPrivacy,
+    onPressGroupPrivacy,
     onPressRoles,
   };
 };

--- a/packages/shared/src/api/groupsApi.ts
+++ b/packages/shared/src/api/groupsApi.ts
@@ -1,6 +1,7 @@
 import { Poke } from '@urbit/http-api';
 
 import * as db from '../db';
+import { GroupPrivacy } from '../db/schema';
 import { createDevLogger } from '../debug';
 import type * as ub from '../urbit';
 import {
@@ -188,6 +189,47 @@ export function requestGroupInvitation(groupId: string) {
     mark: 'group-knock',
     json: groupId,
   });
+}
+
+export async function updateGroupPrivacy(params: {
+  groupId: string;
+  oldPrivacy: GroupPrivacy;
+  newPrivacy: GroupPrivacy;
+}) {
+  if (params.newPrivacy === 'public') {
+    const action = groupAction(params.groupId, {
+      cordon: {
+        swap: {
+          open: {
+            ships: [],
+            ranks: [],
+          },
+        },
+      },
+    });
+    await poke(action);
+  } else {
+    // Only swap if it's currently public. If moving between secret and private, we keep
+    // the existing cordon to avoid losing pending requests.
+    if (params.oldPrivacy === 'public') {
+      const cordonSwapAction = groupAction(params.groupId, {
+        cordon: {
+          swap: {
+            shut: {
+              pending: [],
+              ask: [],
+            },
+          },
+        },
+      });
+      await poke(cordonSwapAction);
+    }
+
+    const secretAction = groupAction(params.groupId, {
+      secret: params.newPrivacy === 'secret',
+    });
+    await poke(secretAction);
+  }
 }
 
 export const getPinnedItemType = (rawItem: string) => {

--- a/packages/shared/src/store/groupActions.ts
+++ b/packages/shared/src/store/groupActions.ts
@@ -1,5 +1,6 @@
 import * as api from '../api';
 import * as db from '../db';
+import { GroupPrivacy } from '../db/schema';
 import { createDevLogger } from '../debug';
 import { createSectionId } from '../urbit';
 import * as sync from './sync';
@@ -142,6 +143,39 @@ export async function markGroupNew(group: db.Group) {
 export async function markGroupVisited(group: db.Group) {
   logger.log('marking new group as visited', group.id);
   await db.updateGroup({ id: group.id, isNew: false });
+}
+
+export async function updateGroupPrivacy(
+  group: db.Group,
+  newPrivacy: GroupPrivacy
+) {
+  logger.log('updating group privacy', group.id, newPrivacy);
+
+  const oldPrivacy = group.privacy ?? 'public';
+
+  if (oldPrivacy === newPrivacy) {
+    return;
+  }
+
+  // optimistic update
+  await db.updateGroup({
+    id: group.id,
+    privacy: newPrivacy,
+  });
+
+  try {
+    await api.updateGroupPrivacy({
+      groupId: group.id,
+      oldPrivacy,
+      newPrivacy,
+    });
+  } catch (e) {
+    // rollback optimistic update
+    await db.updateGroup({
+      id: group.id,
+      privacy: oldPrivacy,
+    });
+  }
 }
 
 export async function updateGroupMeta(group: db.Group) {

--- a/packages/ui/src/components/ChatOptionsSheet.tsx
+++ b/packages/ui/src/components/ChatOptionsSheet.tsx
@@ -121,7 +121,7 @@ export function GroupOptions({
     onPressGroupMembers,
     onPressGroupMeta,
     onPressManageChannels,
-    onPressInvitesAndPrivacy,
+    onPressGroupPrivacy,
     onPressLeave,
     onTogglePinned,
   } = useChatOptions() ?? {};
@@ -242,7 +242,7 @@ export function GroupOptions({
       title: 'Privacy',
       action: () => {
         sheetRef.current.setOpen(false);
-        onPressInvitesAndPrivacy?.(group.id);
+        onPressGroupPrivacy?.(group.id);
       },
       endIcon: 'ChevronRight',
     };

--- a/packages/ui/src/components/ChatOptionsSheet.tsx
+++ b/packages/ui/src/components/ChatOptionsSheet.tsx
@@ -121,6 +121,7 @@ export function GroupOptions({
     onPressGroupMembers,
     onPressGroupMeta,
     onPressManageChannels,
+    onPressInvitesAndPrivacy,
     onPressLeave,
     onTogglePinned,
   } = useChatOptions() ?? {};
@@ -237,6 +238,15 @@ export function GroupOptions({
       endIcon: 'ChevronRight',
     };
 
+    const managePrivacyAction: Action = {
+      title: 'Privacy',
+      action: () => {
+        sheetRef.current.setOpen(false);
+        onPressInvitesAndPrivacy?.(group.id);
+      },
+      endIcon: 'ChevronRight',
+    };
+
     const goToMembersAction: Action = {
       title: 'Members',
       endIcon: 'ChevronRight',
@@ -262,7 +272,12 @@ export function GroupOptions({
       accent: 'neutral',
       actions:
         group && currentUserIsAdmin
-          ? [manageChannelsAction, goToMembersAction, metadataAction]
+          ? [
+              manageChannelsAction,
+              managePrivacyAction,
+              goToMembersAction,
+              metadataAction,
+            ]
           : [goToMembersAction],
     });
 

--- a/packages/ui/src/components/Form/inputs.tsx
+++ b/packages/ui/src/components/Form/inputs.tsx
@@ -128,6 +128,11 @@ export function RadioInputRow<T>({
         <LabelText size="$xl" color="$primaryText">
           {option.title}
         </LabelText>
+        {option.description ? (
+          <LabelText size="$m" color="$secondaryText">
+            {option.description}
+          </LabelText>
+        ) : null}
       </YStack>
     </RadioInputRowFrame>
   );

--- a/packages/ui/src/components/GroupPrivacySelector.tsx
+++ b/packages/ui/src/components/GroupPrivacySelector.tsx
@@ -1,0 +1,43 @@
+import { GroupPrivacy } from '@tloncorp/shared/dist/db/schema';
+import React from 'react';
+
+import * as Form from './Form';
+
+function GroupPrivacySelectorRaw(props: {
+  currentValue: GroupPrivacy;
+  onChange: (newValue: GroupPrivacy) => void;
+}) {
+  return (
+    <Form.FormFrame>
+      <Form.RadioInputRow
+        option={{
+          title: 'Public',
+          value: 'public',
+          description: 'Everyone can find and join',
+        }}
+        checked={props.currentValue === 'public'}
+        onPress={props.onChange}
+      />
+      <Form.RadioInputRow
+        option={{
+          title: 'Private',
+          value: 'private',
+          description: 'New members require approval',
+        }}
+        checked={props.currentValue === 'private'}
+        onPress={props.onChange}
+      />
+      <Form.RadioInputRow
+        option={{
+          title: 'Secret',
+          value: 'secret',
+          description: 'Invite-only',
+        }}
+        checked={props.currentValue === 'secret'}
+        onPress={props.onChange}
+      />
+    </Form.FormFrame>
+  );
+}
+
+export const GroupPrivacySelector = React.memo(GroupPrivacySelectorRaw);

--- a/packages/ui/src/contexts/chatOptions.tsx
+++ b/packages/ui/src/contexts/chatOptions.tsx
@@ -16,7 +16,7 @@ export type ChatOptionsContextValue = {
   onPressGroupMeta: (groupId: string) => void;
   onPressGroupMembers: (groupId: string) => void;
   onPressManageChannels: (groupId: string) => void;
-  onPressInvitesAndPrivacy: (groupId: string) => void;
+  onPressGroupPrivacy: (groupId: string) => void;
   onPressRoles: (groupId: string) => void;
   onPressChannelMembers: (channelId: string) => void;
   onPressChannelMeta: (channelId: string) => void;
@@ -39,7 +39,7 @@ type ChatOptionsProviderProps = {
   onPressGroupMeta: (groupId: string) => void;
   onPressGroupMembers: (groupId: string) => void;
   onPressManageChannels: (groupId: string) => void;
-  onPressInvitesAndPrivacy: (groupId: string) => void;
+  onPressGroupPrivacy: (groupId: string) => void;
   onPressChannelMembers: (channelId: string) => void;
   onPressChannelMeta: (channelId: string) => void;
   onPressRoles: (groupId: string) => void;
@@ -53,7 +53,7 @@ export const ChatOptionsProvider = ({
   onPressGroupMeta,
   onPressGroupMembers,
   onPressManageChannels,
-  onPressInvitesAndPrivacy,
+  onPressGroupPrivacy,
   onPressChannelMembers,
   onPressChannelMeta,
   onPressRoles,
@@ -85,7 +85,7 @@ export const ChatOptionsProvider = ({
     onPressGroupMeta,
     onPressGroupMembers,
     onPressManageChannels,
-    onPressInvitesAndPrivacy,
+    onPressGroupPrivacy,
     onPressRoles,
     onPressLeave,
     onTogglePinned,

--- a/packages/ui/src/index.tsx
+++ b/packages/ui/src/index.tsx
@@ -40,6 +40,7 @@ export * from './components/GenericHeader';
 export * from './components/GroupChannelsScreenView';
 export * from './components/GroupMembersScreenView';
 export * from './components/GroupPreviewSheet';
+export * from './components/GroupPrivacySelector';
 export * from './components/Icon';
 export * from './components/MetaEditorScreenView';
 export * from './components/IconButton';


### PR DESCRIPTION
Adds an option to the _Group Options Sheet_ to modify the group's privacy if you're an admin. Looks like this:

https://github.com/user-attachments/assets/78f75d1e-893c-4959-9a5f-066223786d5e



Note, in the mocks there was also group invite functionality on this screen, but that has its own ticket (TLON-1717).

Fixes TLON-1713