### PR TITLE
native: account for new hosting auth

### DIFF
--- a/apps/tlon-mobile/src/components/AuthenticatedApp.tsx
+++ b/apps/tlon-mobile/src/components/AuthenticatedApp.tsx
@@ -15,6 +15,7 @@ import { useDeepLinkListener } from '../hooks/useDeepLinkListener';
 import useNotificationListener, {
   type Props as NotificationListenerProps,
 } from '../hooks/useNotificationListener';
+import { refreshHostingAuth } from '../lib/refreshHostingAuth';
 import { RootStack } from '../navigation/RootStack';
 
 export interface AuthenticatedAppProps {
@@ -57,6 +58,8 @@ function AuthenticatedApp({
       sync.syncUnreads({ priority: sync.SyncPriority.High });
       sync.syncPinnedItems({ priority: sync.SyncPriority.High });
     }
+
+    refreshHostingAuth();
   });
 
   return (

--- a/apps/tlon-mobile/src/lib/refreshHostingAuth.ts
+++ b/apps/tlon-mobile/src/lib/refreshHostingAuth.ts
@@ -1,0 +1,49 @@
+import { getHostingHeartBeat } from '@tloncorp/app/lib/hostingApi';
+import {
+  getHostingAuthExpired,
+  getLastHostingAuthCheck,
+  setHostingAuthExpired,
+  setLastHostingAuthCheck,
+} from '@tloncorp/app/utils/hosting';
+import { createDevLogger } from '@tloncorp/shared/dist';
+
+const logger = createDevLogger('refreshHostingAuth', false);
+
+// Authentication for hosting uses a token that can last up to a year, but
+// expires after 30 days of without use. We don't regularly interact with hosting after login,
+// so we attempt to manually refresh the token regularly
+export async function refreshHostingAuth() {
+  logger.log(`checking hosting auth`);
+
+  if (__DEV__) {
+    logger.log('development mode, skipping');
+  }
+
+  const expired = await getHostingAuthExpired();
+  const lastCheck = await getLastHostingAuthCheck();
+
+  if (expired) {
+    logger.log('hosting auth is already expired');
+    return;
+  }
+
+  if (wasMoreThanDayAgo(lastCheck)) {
+    logger.log('more than a day since last check, refreshing');
+    try {
+      const result = await getHostingHeartBeat();
+      if (result === 'expired') {
+        logger.crumb('hosting auth has newly expired');
+        setHostingAuthExpired(true);
+      }
+    } catch (e) {
+      logger.error('error checking hosting auth:', e);
+    } finally {
+      setLastHostingAuthCheck(Date.now());
+    }
+  }
+}
+
+function wasMoreThanDayAgo(timestamp: number): boolean {
+  if (!timestamp) return true;
+  return Date.now() - timestamp > 24 * 60 * 60 * 1000;
+}

--- a/packages/app/lib/hostingApi.ts
+++ b/packages/app/lib/hostingApi.ts
@@ -77,6 +77,29 @@ const hostingFetch = async <T extends object>(
   return result as T;
 };
 
+const rawHostingFetch = async (path: string, init?: RequestInit) => {
+  const response = await hostingFetchResponse(path, init);
+  return response;
+};
+
+export type HostingHeartBeatCode = 'expired' | 'ok' | 'unknown';
+export const getHostingHeartBeat = async (): Promise<HostingHeartBeatCode> => {
+  const userId = await getHostingUserId();
+  const response = await rawHostingFetch(`/v1/users/${userId}`);
+
+  // 401 indicates that the authentication token is expired
+  if (response.status === 401) {
+    return 'expired';
+  }
+
+  // if we get a response in the 2xx range, we know it's definitely still valid
+  if (response.status >= 200 && response.status < 300) {
+    return 'ok';
+  }
+
+  return 'unknown';
+};
+
 export const getHostingAvailability = async (params: {
   email?: string;
   lure?: string;

--- a/packages/app/utils/hosting.ts
+++ b/packages/app/utils/hosting.ts
@@ -1,3 +1,4 @@
+import AsyncStorage from '@react-native-async-storage/async-storage';
 import * as SecureStore from 'expo-secure-store';
 
 export const setHostingToken = async (token: string) => {
@@ -23,3 +24,21 @@ export const removeHostingToken = async () => {
 export const removeHostingUserId = async () => {
   await SecureStore.deleteItemAsync('hostingUserId');
 };
+
+export async function getHostingAuthExpired() {
+  const value = await AsyncStorage.getItem('hosting:hostingAuthExpired');
+  return value === 'true';
+}
+
+export async function setHostingAuthExpired(value: boolean) {
+  await AsyncStorage.setItem('hosting:hostingAuthExpired', String(value));
+}
+
+export async function getLastHostingAuthCheck() {
+  const value = await AsyncStorage.getItem('hosting:lastAuthCheck');
+  return Number(value);
+}
+
+export async function setLastHostingAuthCheck(value: number) {
+  await AsyncStorage.setItem('hosting:lastAuthCheck', String(value));
+}


### PR DESCRIPTION
Hosting is changing the way they handle cookies. All current ones will become invalid and the new system will use a token that lasts a full year but expires after 30 days of no use. We want to make sure this doesn't immediately impact app users.

This PR adds a check whenever the app returns from background that pings hosting once a day to make sure we continue refreshing the cookie and track whether our hosting session is expired. 

At the moment the only place where we require hosting auth is on the _Manage Account_ screen. For that case, if your hosting session is expired we pop an alert informing the user that they'll need to log back in if they want to manage their account (in which case we'll have a fresh session).

Fixes TLON-2605