### PR TITLE
new web: update globber

### DIFF
--- a/.github/helpers/glob.sh
+++ b/.github/helpers/glob.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-# this script globs a folder of files, then subsequently uploads the 
+# this script globs a folder of files, then subsequently uploads the
 # glob to bootstrap.urbit.org and replaces the hash in the docket file.
 # assumes gcloud credentials are loaded and gsutil installed.
 
@@ -8,15 +8,15 @@
 # $2: the location of the docket file
 
 # globber is a prebooted and docked fakezod
-curl https://bootstrap.urbit.org/globberv3.tgz | tar xzk
+curl https://storage.googleapis.com/bootstrap.urbit.org/globberv4.tar.gz | tar xzk
 ./zod/.run -d
 
 dojo () {
-  curl -s --data '{"source":{"dojo":"'"$1"'"},"sink":{"stdout":null}}' http://localhost:12321    
+  curl -s --data '{"source":{"dojo":"'"$1"'"},"sink":{"stdout":null}}' http://localhost:12321
 }
 
 hood () {
-  curl -s --data '{"source":{"dojo":"+hood/'"$1"'"},"sink":{"app":"hood"}}' http://localhost:12321    
+  curl -s --data '{"source":{"dojo":"+hood/'"$1"'"},"sink":{"app":"hood"}}' http://localhost:12321
 }
 
 rsync -avL $1 zod/work/glob

--- a/desk/mar/jpg.hoon
+++ b/desk/mar/jpg.hoon
@@ -1,0 +1,13 @@
+:: This is needed because we have a jpg in the dist
+|_  dat=@
+++  grow
+  |%
+  ++  mime  [/image/jpeg (as-octs:mimes:html dat)]
+  --
+++  grab
+  |%
+  ++  mime  |=([p=mite q=octs] q.q)
+  ++  noun  @
+  --
+++  grad  %mime
+--


### PR DESCRIPTION
Fixes TLON-2590 by adding the wasm mark to the globber. Tested locally by creating a glob, uploading it to my own s3, then pointing the desk.docket-0 file at the glob and committing it on a local moon.

Also needed to add a jpg.hoon mark (which apparently has never existed? wat) because the new-web-app includes `welcome_flowers.jpg` in the dist (because it's referenced in `WelcomeSheet.web.tsx`).