### PR TITLE
native: fix chat actions sheet on Android

### DIFF
--- a/packages/app/features/top/ChatListScreen.tsx
+++ b/packages/app/features/top/ChatListScreen.tsx
@@ -18,6 +18,7 @@ import {
   StartDmSheet,
   View,
   WelcomeSheet,
+  useChatOptionsContextValue,
 } from '@tloncorp/ui';
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 
@@ -119,7 +120,6 @@ export default function ChatListScreen({
     [navigateToDm, setStartDmOpen]
   );
 
-
   const [isChannelSwitcherEnabled] = useFeatureFlag('channelSwitcher');
 
   const onPressChat = useCallback(
@@ -165,7 +165,6 @@ export default function ChatListScreen({
       setSelectedGroup(null);
     }
   }, []);
-
 
   const { pinned: pinnedChats, unpinned } = resolvedChats;
   const allChats = [...pinnedChats, ...unpinned];
@@ -220,6 +219,13 @@ export default function ChatListScreen({
       <ShowFiltersButton onPress={() => setShowFilters((prev) => !prev)} />
     );
   }, []);
+
+  const chatOptionsContext = useChatOptionsContextValue({
+    channelId: chatOptionsChannelId,
+    groupId: chatOptionsGroupId,
+    pinned,
+    ...useChatSettingsNavigation(),
+  });
 
   return (
     <CalmProvider calmSettings={calmSettings}>
@@ -279,7 +285,10 @@ export default function ChatListScreen({
                 open={splashVisible}
                 onOpenChange={handleWelcomeOpenChange}
               />
-              <ChatOptionsSheet ref={chatOptionsSheetRef} />
+              <ChatOptionsSheet
+                ref={chatOptionsSheetRef}
+                chatOptionsContext={chatOptionsContext}
+              />
               <StartDmSheet
                 goToDm={goToDm}
                 open={startDmOpen}

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -32,6 +32,7 @@
     "@tamagui/image": "1.101.3",
     "@tloncorp/editor": "workspace:*",
     "@tloncorp/shared": "workspace:*",
+    "@tloncorp/app": "workspace:*",
     "@uidotdev/usehooks": "^2.4.1",
     "any-ascii": "^0.3.1",
     "color2k": "^2.0.0",

--- a/packages/ui/src/components/Channel/BaubleHeader.tsx
+++ b/packages/ui/src/components/Channel/BaubleHeader.tsx
@@ -182,7 +182,10 @@ export function BaubleHeader({
         </Animated.View>
       )}
       {isGroupContext && groupOptions && (
-        <ChatOptionsSheet ref={chatOptionsSheetRef} />
+        <ChatOptionsSheet
+          ref={chatOptionsSheetRef}
+          chatOptionsContext={groupOptions}
+        />
       )}
     </View>
   );

--- a/packages/ui/src/components/Channel/ChannelHeader.tsx
+++ b/packages/ui/src/components/Channel/ChannelHeader.tsx
@@ -1,6 +1,9 @@
+import { useChatSettingsNavigation } from '@tloncorp/app/hooks/useChatSettingsNavigation';
 import * as db from '@tloncorp/shared/dist/db';
+import * as store from '@tloncorp/shared/dist/store';
 import { useCallback, useRef } from 'react';
 
+import { useChatOptionsContextValue } from '../../contexts';
 import { Button } from '../Button';
 import { ChatOptionsSheet, ChatOptionsSheetMethods } from '../ChatOptionsSheet';
 import { GenericHeader } from '../GenericHeader';
@@ -30,7 +33,15 @@ export function ChannelHeader({
   post?: db.Post;
   setEditingPost?: (post: db.Post) => void;
 }) {
+  const { data: pinned } = store.usePins();
   const chatOptionsSheetRef = useRef<ChatOptionsSheetMethods>(null);
+
+  const chatOptionsContext = useChatOptionsContextValue({
+    channelId: channel.id,
+    groupId: undefined,
+    pinned: pinned ?? [],
+    ...useChatSettingsNavigation(),
+  });
 
   const handlePressOverflowMenu = useCallback(() => {
     chatOptionsSheetRef.current?.open(channel.id, channel.type);
@@ -69,7 +80,7 @@ export function ChannelHeader({
           </>
         }
       />
-      <ChatOptionsSheet />
+      <ChatOptionsSheet chatOptionsContext={chatOptionsContext} />
     </>
   );
 }

--- a/packages/ui/src/components/ChatList.tsx
+++ b/packages/ui/src/components/ChatList.tsx
@@ -305,7 +305,7 @@ function ChatListFiltersComponent({
   );
 }
 
-const ChatListFilters = React.memo(ChatListFiltersComponent);
+const ChatListFilters = ChatListFiltersComponent;
 
 function useFilteredChats({
   pinned,

--- a/packages/ui/src/components/ChatOptionsSheet.tsx
+++ b/packages/ui/src/components/ChatOptionsSheet.tsx
@@ -15,7 +15,11 @@ import React, {
 import { Alert } from 'react-native';
 import { useSheet } from 'tamagui';
 
-import { useCalm, useChatOptions, useCurrentUserId } from '../contexts';
+import {
+  ChatOptionsContextValue,
+  useCalm,
+  useCurrentUserId,
+} from '../contexts';
 import * as utils from '../utils';
 import { Action, ActionGroup, ActionSheet } from './ActionSheet';
 import { ListItem } from './ListItem';
@@ -28,58 +32,66 @@ export type ChatOptionsSheetMethods = {
 
 export type ChatOptionsSheetRef = React.Ref<ChatOptionsSheetMethods>;
 
-const ChatOptionsSheetComponent = React.forwardRef<ChatOptionsSheetMethods>(
-  function ChatOptionsSheetImpl(props, ref) {
-    const [open, setOpen] = useState(false);
-    const [chat, setChat] = useState<{ type: ChatType; id: string } | null>(
-      null
-    );
+const ChatOptionsSheetComponent = React.forwardRef<
+  ChatOptionsSheetMethods,
+  { chatOptionsContext: ChatOptionsContextValue }
+>(function ChatOptionsSheetImpl(
+  props: {
+    chatOptionsContext: ChatOptionsContextValue;
+  },
+  ref
+) {
+  const [open, setOpen] = useState(false);
+  const [chat, setChat] = useState<{ type: ChatType; id: string } | null>(null);
 
-    useImperativeHandle(
-      ref,
-      () => ({
-        open: (chatId, chatType) => {
-          setOpen(true);
-          setChat({ id: chatId, type: chatType });
-        },
-      }),
-      []
-    );
+  useImperativeHandle(
+    ref,
+    () => ({
+      open: (chatId, chatType) => {
+        setOpen(true);
+        setChat({ id: chatId, type: chatType });
+      },
+    }),
+    []
+  );
 
-    if (!chat && !open) {
-      return null;
-    }
-
-    return (
-      <ActionSheet open={open} onOpenChange={setOpen}>
-        {chat ? (
-          chat.type === 'group' ? (
-            <GroupOptionsSheetLoader
-              groupId={chat.id}
-              open={open}
-              onOpenChange={setOpen}
-            />
-          ) : (
-            <ChannelOptionsSheetLoader
-              channelId={chat.id}
-              open={open}
-              onOpenChange={setOpen}
-            />
-          )
-        ) : null}
-      </ActionSheet>
-    );
+  if (!chat && !open) {
+    return null;
   }
-);
+
+  return (
+    <ActionSheet open={open} onOpenChange={setOpen}>
+      {chat ? (
+        chat.type === 'group' ? (
+          <GroupOptionsSheetLoader
+            groupId={chat.id}
+            chatOptionsContext={props.chatOptionsContext}
+            open={open}
+            onOpenChange={setOpen}
+          />
+        ) : (
+          <ChannelOptionsSheetLoader
+            channelId={chat.id}
+            chatOptionsContext={props.chatOptionsContext}
+            open={open}
+            onOpenChange={setOpen}
+          />
+        )
+      ) : null}
+    </ActionSheet>
+  );
+});
 
 export const ChatOptionsSheet = React.memo(ChatOptionsSheetComponent);
 
 export function GroupOptionsSheetLoader({
   groupId,
+  chatOptionsContext,
   open,
   onOpenChange,
 }: {
   groupId: string;
+  chatOptionsContext: ChatOptionsContextValue;
   open: boolean;
   onOpenChange: (open: boolean) => void;
 }) {
@@ -97,17 +109,24 @@ export function GroupOptionsSheetLoader({
 
   return groupQuery.data ? (
     <ActionSheet open={open} onOpenChange={openChangeHandler}>
-      <GroupOptions group={groupQuery.data} pane={pane} setPane={setPane} />
+      <GroupOptions
+        group={groupQuery.data}
+        pane={pane}
+        setPane={setPane}
+        chatOptionsContext={chatOptionsContext}
+      />
     </ActionSheet>
   ) : null;
 }
 
 export function GroupOptions({
   group,
+  chatOptionsContext,
   pane,
   setPane,
 }: {
   group: db.Group;
+  chatOptionsContext: ChatOptionsContextValue;
   pane: 'initial' | 'notifications';
   setPane: (pane: 'initial' | 'notifications') => void;
 }) {
@@ -124,7 +143,7 @@ export function GroupOptions({
     onPressGroupPrivacy,
     onPressLeave,
     onTogglePinned,
-  } = useChatOptions() ?? {};
+  } = chatOptionsContext ?? {};
 
   useEffect(() => {
     sync.syncGroup(group.id, { priority: store.SyncPriority.High });
@@ -298,12 +317,13 @@ export function GroupOptions({
     }
     return actionGroups;
   }, [
-    isPinned,
-    onTogglePinned,
     group,
+    isPinned,
     currentUserIsAdmin,
     setPane,
+    onTogglePinned,
     onPressManageChannels,
+    onPressGroupPrivacy,
     onPressGroupMembers,
     onPressGroupMeta,
     onPressLeave,
@@ -324,10 +344,12 @@ export function GroupOptions({
 
 export function ChannelOptionsSheetLoader({
   channelId,
+  chatOptionsContext,
   open,
   onOpenChange,
 }: {
   channelId: string;
+  chatOptionsContext: ChatOptionsContextValue;
   open: boolean;
   onOpenChange: (open: boolean) => void;
 }) {
@@ -350,6 +372,7 @@ export function ChannelOptionsSheetLoader({
     <ActionSheet open={open} onOpenChange={openChangeHandler}>
       <ChannelOptions
         channel={channelQuery.data}
+        chatOptionsContext={chatOptionsContext}
         pane={pane}
         setPane={setPane}
       />
@@ -359,10 +382,12 @@ export function ChannelOptionsSheetLoader({
 
 export function ChannelOptions({
   channel,
+  chatOptionsContext,
   pane,
   setPane,
 }: {
   channel: db.Channel;
+  chatOptionsContext: ChatOptionsContextValue;
   pane: 'initial' | 'notifications';
   setPane: (pane: 'initial' | 'notifications') => void;
 }) {
@@ -374,7 +399,8 @@ export function ChannelOptions({
   const sheetRef = useRef(sheet);
   sheetRef.current = sheet;
 
-  const { onPressChannelMembers, onPressChannelMeta } = useChatOptions() ?? {};
+  const { onPressChannelMembers, onPressChannelMeta } =
+    chatOptionsContext ?? {};
 
   const { disableNicknames } = useCalm();
   const title = useMemo(() => {

--- a/packages/ui/src/components/GroupChannelsScreenView.tsx
+++ b/packages/ui/src/components/GroupChannelsScreenView.tsx
@@ -101,7 +101,10 @@ export function GroupChannelsScreenView({
         onOpenChange={setShowSortOptions}
         onSelectSort={handleSortByChanged}
       />
-      <ChatOptionsSheet ref={chatOptionsSheetRef} />
+      <ChatOptionsSheet
+        ref={chatOptionsSheetRef}
+        chatOptionsContext={groupOptions}
+      />
     </View>
   );
 }

--- a/packages/ui/src/contexts/chatOptions.tsx
+++ b/packages/ui/src/contexts/chatOptions.tsx
@@ -57,6 +57,8 @@ export const ChatOptionsProvider = (props: ChatOptionsProviderProps) => {
   );
 };
 
+// remove use of this free from its context once android bug is fixed
+// https://github.com/reactwg/react-native-new-architecture/discussions/186
 export const useChatOptionsContextValue = ({
   groupId,
   pinned = [],

--- a/packages/ui/src/contexts/chatOptions.tsx
+++ b/packages/ui/src/contexts/chatOptions.tsx
@@ -30,8 +30,7 @@ export const useChatOptions = () => {
   return useContext(ChatOptionsContext);
 };
 
-type ChatOptionsProviderProps = {
-  children: ReactNode;
+export type ChatOptionsContextValueProps = {
   groupId?: string;
   channelId?: string;
   pinned: db.Pin[];
@@ -45,8 +44,20 @@ type ChatOptionsProviderProps = {
   onPressRoles: (groupId: string) => void;
 };
 
-export const ChatOptionsProvider = ({
-  children,
+type ChatOptionsProviderProps = ChatOptionsContextValueProps & {
+  children: ReactNode;
+};
+
+export const ChatOptionsProvider = (props: ChatOptionsProviderProps) => {
+  const contextValue = useChatOptionsContextValue(props);
+  return (
+    <ChatOptionsContext.Provider value={contextValue}>
+      {props.children}
+    </ChatOptionsContext.Provider>
+  );
+};
+
+export const useChatOptionsContextValue = ({
   groupId,
   pinned = [],
   useGroup = store.useGroup,
@@ -57,7 +68,7 @@ export const ChatOptionsProvider = ({
   onPressChannelMembers,
   onPressChannelMeta,
   onPressRoles,
-}: ChatOptionsProviderProps) => {
+}: ChatOptionsContextValueProps): ChatOptionsContextValue => {
   const groupQuery = useGroup({ id: groupId ?? '' });
   const group = groupId ? groupQuery.data ?? null : null;
 
@@ -93,9 +104,5 @@ export const ChatOptionsProvider = ({
     onPressChannelMeta,
   };
 
-  return (
-    <ChatOptionsContext.Provider value={contextValue}>
-      {children}
-    </ChatOptionsContext.Provider>
-  );
+  return contextValue;
 };

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1678,6 +1678,9 @@ importers:
       '@tamagui/image':
         specifier: 1.101.3
         version: 1.101.3(react@18.2.0)
+      '@tloncorp/app':
+        specifier: workspace:*
+        version: link:../app
       '@tloncorp/editor':
         specifier: workspace:*
         version: link:../editor


### PR DESCRIPTION
This was another instance of the Android modal context bug (see TLON-2618 for details). The pattern of using context to grab these handlers feels good, so I wanted to avoid removing it in hopes we can return to normal use once the bug gets squashed (sounded like Facebook RN core team has it on their radar).

To that end, the workaround introduced is to update the sheets to take a new prop that matches the missing context value. The context file itself exports a hook for returning the needed value in addition to its existing provider based API. My thinking was this way we can avoid modifying the business logic as much as possible and instead just remove the new prop threading once the normal usage is restored.

Open to better ideas on solutions if y'all have any!

Fixes TLON-2618