### PR TITLE
fix filter open

### DIFF
--- a/packages/ui/src/components/ChatList.tsx
+++ b/packages/ui/src/components/ChatList.tsx
@@ -1,4 +1,3 @@
-//tamagui-ignore
 import * as db from '@tloncorp/shared/dist/db';
 import * as logic from '@tloncorp/shared/dist/logic';
 import * as store from '@tloncorp/shared/dist/store';
@@ -252,7 +251,7 @@ function ChatListFiltersComponent({
       height: contentHeight * openProgress.value,
       opacity: openProgress.value,
     };
-  }, [openProgress]);
+  }, [openProgress, contentHeight]);
 
   const handleContentLayout = useCallback((e: LayoutChangeEvent) => {
     setContentHeight(e.nativeEvent.layout.height);


### PR DESCRIPTION
`useAnimatedStyle` was missing a dependency which caused the filters to fail to open. The `tamagui-ignore` the top of the file was an earlier attempt to fix the issue, so is now extraneous.