### PR TITLE
native: dump/restore SQLite database via dev menu

### DIFF
--- a/apps/tlon-mobile/.env.sample
+++ b/apps/tlon-mobile/.env.sample
@@ -14,6 +14,14 @@ DEFAULT_SHIP_LOGIN_ACCESS_CODE=
 API_URL=https://test.tlon.systems
 SHIP_URL_PATTERN=https://{shipId}.test.tlon.systems
 
+# Paths used when dumping / restoring SQLite database via dev menu, relative to
+# workspace root.
+# Set these to the same value to easily dump and then restore the dump.
+# Defaults to `dump.sqlite3` and `restore.sqlite3`.
+# Recommended to add these paths to your `.git/info/exclude` file.
+SQLITE_DUMP_PATH=dump.db
+SQLITE_RESTORE_PATH=$SQLITE_DUMP_PATH
+
 # Other env vars that are set in production, use as needed
 # for local testing
 POST_HOG_API_KEY=

--- a/packages/app/package.json
+++ b/packages/app/package.json
@@ -16,6 +16,7 @@
   },
   "peerDependencies": {
     "@react-native-firebase/perf": "19.2.2",
+    "react-native-device-info": "^10.8.0",
     "lodash": "^4.17.21",
     "zustand": "^3.7.2"
   }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1530,6 +1530,9 @@ importers:
       lodash:
         specifier: ^4.17.21
         version: 4.17.21
+      react-native-device-info:
+        specifier: ^10.8.0
+        version: 10.12.0(react-native@0.73.4(@babel/core@7.25.2)(@babel/preset-env@7.23.7(@babel/core@7.25.2))(encoding@0.1.13)(react@18.2.0))
       zustand:
         specifier: ^3.7.2
         version: 3.7.2(react@18.2.0)


### PR DESCRIPTION
| Simulator | Physical device |
| --- | --- |
| <img width="300" src="https://github.com/user-attachments/assets/ad0a44c6-5bfe-44bd-935d-d03837c6d915" /> | <img width="300" src="https://github.com/user-attachments/assets/e19e7ce2-994b-4785-a650-f4d2fd259a20" /> |

- Restores / adds dev menu items to dump / restore SQLite database, relying on database paths on Metro host
- Adds `.env` entries (illustrated in `.env.sample`) for dump / restore paths
- Adds check to dev menu setup to only add simulator-exclusive items when `DeviceInfo.isEmulator`