### PR TITLE
native: fix JS call to UrbitModule.setUrbit again

### DIFF
--- a/packages/app/contexts/ship.tsx
+++ b/packages/app/contexts/ship.tsx
@@ -106,7 +106,7 @@ export const ShipProvider = ({ children }: { children: ReactNode }) => {
           setShipInfo({ ...nextShipInfo, authCookie: fetchedAuthCookie });
           saveShipInfo({ ...nextShipInfo, authCookie: fetchedAuthCookie });
           // Save to native storage
-          UrbitModule.setUrbit(ship, normalizedShipUrl);
+          UrbitModule.setUrbit(ship, normalizedShipUrl, fetchedAuthCookie);
         }
       })();
     }


### PR DESCRIPTION
Looks like change from https://github.com/tloncorp/tlon-apps/pull/3815 was overwritten - this restores it.

I got an error for this recently – I don't know why this wasn't throwing errors regularly. After making this change, I stopped getting the error.

I imagine this was caused by the code moving to `packages/app` – I did a diff on packages/app/contexts/ship.tsx against the last version of https://github.com/tloncorp/tlon-apps/blob/f657fb57ab44c790a6a6ad24cdb74ad743b1da4a/apps/tlon-mobile/src/contexts/ship.tsx and this was the only line. I don't know how one would do a more comprehensive diff against `tlon-mobile` x `app`.