### PR TITLE
Disable newlines in ListingContent

### DIFF
--- a/apps/tlon-web/src/diary/DiaryContent/DiaryContent.tsx
+++ b/apps/tlon-web/src/diary/DiaryContent/DiaryContent.tsx
@@ -190,9 +190,13 @@ export function InlineContent({ story }: InlineContentProps) {
 
 export function ListingContent({ content }: { content: Listing }) {
   if ('item' in content) {
+    // Filter line breaks at end of list items to avoid doubling the line height
+    const item = isBreak(content.item.at(-1))
+      ? content.item.slice(0, -1)
+      : content.item;
     return (
       <>
-        {content.item.map((con, i) => (
+        {item.map((con, i) => (
           <InlineContent key={`${i}-${con}`} story={con} />
         ))}
       </>


### PR DESCRIPTION
Fixes bug where lists are too spaced out because there's an extra line break added to the end of every item.

The data retrieved from the backend includes line breaks at the end of every item in a list. Rendering this line break as a <br> makes the items in a list too spaced out, because <li> elements already have their own vertical spacing.

This PR filters line breaks at the end of list items on the front end, instead of changing the back end code. I'm not sure if this is the preferred solution, so merge at your discretion. 

Before:
![Screenshot 2024-09-02 at 3 12 25 PM](https://github.com/user-attachments/assets/b3c0bb32-b9cf-4f29-b120-24e2bcf86687)

After:
![Screenshot 2024-09-02 at 3 07 40 PM](https://github.com/user-attachments/assets/d360f76c-e195-405b-8528-d8de6a64981a)


The state with said line breaks:
![Screenshot 2024-09-02 at 2 52 00 PM](https://github.com/user-attachments/assets/6c5d7e23-90be-4405-909e-25369466a02e)

Tested locally with fakeship

PR Checklist
- [ ] Includes changes to desk files
- [x] Describes how you tested the PR locally (test ship vs livenet)
- [ ] If a new feature, includes automated tests
- [x] Comments added anywhere logic may be confusing without context