### PR TITLE
native: fix context passing for Sheets

### DIFF
--- a/packages/ui/src/components/ActionSheet.tsx
+++ b/packages/ui/src/components/ActionSheet.tsx
@@ -8,6 +8,7 @@ import {
   useMemo,
   useRef,
 } from 'react';
+import { Modal } from 'react-native';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
 import {
   SheetProps,
@@ -89,21 +90,31 @@ const ActionSheetComponent = ({
   if (!hasOpened.current) return null;
 
   return (
-    <Sheet
-      open={open}
-      onOpenChange={onOpenChange}
-      modal
-      dismissOnSnapToBottom
-      snapPointsMode="fit"
-      animation="quick"
-      {...props}
+    <Modal
+      visible={open}
+      onRequestClose={() => onOpenChange(false)}
+      transparent
+      animationType="none"
     >
-      <Sheet.Overlay animation="quick" />
-      <Sheet.Frame>
-        <Sheet.Handle />
-        {children}
-      </Sheet.Frame>
-    </Sheet>
+      <Sheet
+        open={open}
+        onOpenChange={onOpenChange}
+        dismissOnSnapToBottom
+        snapPointsMode="fit"
+        animation="quick"
+        {...props}
+      >
+        <Sheet.Overlay animation="quick" />
+        {/* 
+          press style is set here to ensure touch responders are added and drag gestures
+          bubble up accordingly (unclear why needed after adding modal wrapper)
+        */}
+        <Sheet.Frame pressStyle={{}}>
+          <Sheet.Handle />
+          {children}
+        </Sheet.Frame>
+      </Sheet>
+    </Modal>
   );
 };
 

--- a/packages/ui/src/components/ActionSheet.tsx
+++ b/packages/ui/src/components/ActionSheet.tsx
@@ -102,6 +102,7 @@ const ActionSheetComponent = ({
         dismissOnSnapToBottom
         snapPointsMode="fit"
         animation="quick"
+        handleDisableScroll
         {...props}
       >
         <Sheet.Overlay animation="quick" />

--- a/packages/ui/src/components/AddChats/AddDmSheet.tsx
+++ b/packages/ui/src/components/AddChats/AddDmSheet.tsx
@@ -1,16 +1,13 @@
-import { QueryClientProvider, queryClient } from '@tloncorp/shared/dist/api';
 import * as store from '@tloncorp/shared/dist/store';
 import { useCallback, useEffect, useState } from 'react';
-import React from 'react';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
 import { XStack, YStack, ZStack } from 'tamagui';
 
-import { AppDataContextProvider, useContacts } from '../../contexts';
 import { triggerHaptic } from '../../utils';
+import { ActionSheet } from '../ActionSheet';
 import { Button } from '../Button';
 import { ContactBook } from '../ContactBook';
 import { LoadingSpinner } from '../LoadingSpinner';
-import { Sheet } from '../Sheet';
 
 function StartDmSheetComponent({
   open,
@@ -21,9 +18,6 @@ function StartDmSheetComponent({
   onOpenChange: (open: boolean) => void;
   goToDm: (participants: string[]) => void;
 }) {
-  // we have to pull contacts here and create a new context because of an
-  // issue with Android
-  const contacts = useContacts();
   const insets = useSafeAreaInsets();
   const [contentScrolling, setContentScrolling] = useState(false);
   const [dmParticipants, setDmParticipants] = useState<string[]>([]);
@@ -55,52 +49,46 @@ function StartDmSheetComponent({
   }, [dmParticipants, goToDm, onOpenChange]);
 
   return (
-    <Sheet
+    <ActionSheet
       open={open}
       onOpenChange={handleDismiss}
+      snapPointsMode="percent"
       snapPoints={[85]}
-      modal
       disableDrag={contentScrolling}
-      dismissOnSnapToBottom
-      animation="quick"
     >
-      <Sheet.Overlay />
-      <Sheet.LazyFrame paddingTop="$s" paddingHorizontal="$2xl">
-        <QueryClientProvider client={queryClient}>
-          <AppDataContextProvider contacts={contacts ?? []}>
-            <Sheet.Handle marginBottom="$l" />
-            <ZStack flex={1}>
-              <YStack flex={1} gap="$2xl">
-                <ContactBook
-                  key={contactBookKey}
-                  multiSelect
-                  onSelectedChange={setDmParticipants}
-                  searchable
-                  searchPlaceholder="Start a DM with..."
-                  onScrollChange={setContentScrolling}
-                />
-                {dmParticipants.length > 0 && (
-                  <XStack
-                    position="absolute"
-                    bottom={insets.bottom + 12}
-                    justifyContent="center"
-                  >
-                    <StartDMButton
-                      participants={dmParticipants}
-                      onPress={handleGoToDm}
-                    />
-                  </XStack>
-                )}
-              </YStack>
-            </ZStack>
-          </AppDataContextProvider>
-        </QueryClientProvider>
-      </Sheet.LazyFrame>
-    </Sheet>
+      <ActionSheet.Content flex={1} paddingBottom={0}>
+        <ActionSheet.ContentBlock flex={1} paddingBottom={0}>
+          <ZStack flex={1}>
+            <YStack flex={1} gap="$2xl">
+              <ContactBook
+                key={contactBookKey}
+                multiSelect
+                onSelectedChange={setDmParticipants}
+                searchable
+                searchPlaceholder="Start a DM with..."
+                onScrollChange={setContentScrolling}
+              />
+              {dmParticipants.length > 0 && (
+                <XStack
+                  position="absolute"
+                  bottom={insets.bottom + 12}
+                  justifyContent="center"
+                >
+                  <StartDMButton
+                    participants={dmParticipants}
+                    onPress={handleGoToDm}
+                  />
+                </XStack>
+              )}
+            </YStack>
+          </ZStack>
+        </ActionSheet.ContentBlock>
+      </ActionSheet.Content>
+    </ActionSheet>
   );
 }
 
-export const StartDmSheet = React.memo(StartDmSheetComponent);
+export const StartDmSheet = StartDmSheetComponent;
 
 function StartDMButton({
   participants,

--- a/packages/ui/src/components/ChatMessage/ViewReactionsPane.tsx
+++ b/packages/ui/src/components/ChatMessage/ViewReactionsPane.tsx
@@ -58,7 +58,10 @@ export function ViewReactionsPane({ post }: { post: db.Post }) {
           options={tabs}
         />
       </ActionSheet.FormBlock>
-      <ActionSheet.ScrollableContent paddingTop="$xl">
+      <ActionSheet.ScrollableContent
+        paddingTop="$xl"
+        contentContainerStyle={{ flex: 1 }}
+      >
         <ActionSheet.FormBlock flex={1}>
           <ActionSheet.ActionGroupContent borderWidth={0}>
             {tabData.map((reaction) => (

--- a/packages/ui/src/components/ChatOptionsSheet.tsx
+++ b/packages/ui/src/components/ChatOptionsSheet.tsx
@@ -46,28 +46,26 @@ const ChatOptionsSheetComponent = React.forwardRef<ChatOptionsSheetMethods>(
       []
     );
 
-    if (!chat && !open) {
+    if (!chat || !open) {
       return null;
     }
 
+    if (chat.type === 'group') {
+      return (
+        <GroupOptionsSheetLoader
+          groupId={chat.id}
+          open={open}
+          onOpenChange={setOpen}
+        />
+      );
+    }
+
     return (
-      <ActionSheet open={open} onOpenChange={setOpen}>
-        {chat ? (
-          chat.type === 'group' ? (
-            <GroupOptionsSheetLoader
-              groupId={chat.id}
-              open={open}
-              onOpenChange={setOpen}
-            />
-          ) : (
-            <ChannelOptionsSheetLoader
-              channelId={chat.id}
-              open={open}
-              onOpenChange={setOpen}
-            />
-          )
-        ) : null}
-      </ActionSheet>
+      <ChannelOptionsSheetLoader
+        channelId={chat.id}
+        open={open}
+        onOpenChange={setOpen}
+      />
     );
   }
 );


### PR DESCRIPTION
Uses a new strategy for Sheets that maintains the modal like feel while avoiding portal'ing the component to another location in the tree. This means context passing works as expected on both platforms.

I updated existing components that were using context instantiation hacks. The one exception is _AddGroupSheet_ which mounts its own navigation container making a refactor to use the now standard _ActionSheet_ non-trivial. I don't think we should use that pattern elsewhere (we should mimic that effect in Reanimated where needed) , but rewriting it entirely seemed outside the scope of this PR.

I tried to audit all the existing sheets to make sure this didn't cause any display weirdness, but let me know if anyone sees any regressions during review!

Fixes chat actions and reaction viewing on Android as a sideffect.

Fixes TLON-2657