### PR TITLE
native: fix editing messages

### DIFF
--- a/packages/shared/src/store/postActions.ts
+++ b/packages/shared/src/store/postActions.ts
@@ -134,7 +134,11 @@ export async function editPost({
   logger.log('editPost', { post, content, parentId, metadata });
   // optimistic update
   const [contentForDb, flags] = toPostContent(content);
-  await db.updatePost({ id: post.id, content: contentForDb, ...flags });
+  await db.updatePost({
+    id: post.id,
+    content: JSON.stringify(contentForDb),
+    ...flags,
+  });
   logger.log('editPost optimistic update done');
 
   try {


### PR DESCRIPTION
On edit, we weren't stringifying the JSON content before writing to the DB as part of the optimistic update. This broke things after the recent content render changes due to an unprotected JSON parse.

Fixes TLON-2627