### PR TITLE
AttachmentSheet: wait 300ms before popping image picker/camera

### DIFF
--- a/packages/ui/src/components/AttachmentSheet.tsx
+++ b/packages/ui/src/components/AttachmentSheet.tsx
@@ -21,6 +21,7 @@ export default function AttachmentSheet({
 
   const takePicture = async () => {
     setShowAttachmentSheet(false);
+    await new Promise((resolve) => setTimeout(resolve, 300));
     const result = await ImagePicker.launchCameraAsync({
       mediaTypes: ImagePicker.MediaTypeOptions.Images,
       allowsEditing: false,
@@ -34,7 +35,9 @@ export default function AttachmentSheet({
   };
 
   const pickImage = async () => {
+    console.log('pickImage');
     setShowAttachmentSheet(false);
+    await new Promise((resolve) => setTimeout(resolve, 300));
     const result = await ImagePicker.launchImageLibraryAsync({
       mediaTypes: ImagePicker.MediaTypeOptions.Images,
       allowsEditing: false,

--- a/packages/ui/src/components/AttachmentSheet.tsx
+++ b/packages/ui/src/components/AttachmentSheet.tsx
@@ -21,6 +21,9 @@ export default function AttachmentSheet({
 
   const takePicture = async () => {
     setShowAttachmentSheet(false);
+    // The image picker is attempting to mount inside the sheet, but
+    // the sheet closes before the picker can mount. This adds
+    // a slight timeout to let the picker have enough time to mount.
     await new Promise((resolve) => setTimeout(resolve, 300));
     const result = await ImagePicker.launchCameraAsync({
       mediaTypes: ImagePicker.MediaTypeOptions.Images,
@@ -36,6 +39,7 @@ export default function AttachmentSheet({
 
   const pickImage = async () => {
     setShowAttachmentSheet(false);
+    // See the comment above about the picker not mounting in time.
     await new Promise((resolve) => setTimeout(resolve, 300));
     const result = await ImagePicker.launchImageLibraryAsync({
       mediaTypes: ImagePicker.MediaTypeOptions.Images,

--- a/packages/ui/src/components/AttachmentSheet.tsx
+++ b/packages/ui/src/components/AttachmentSheet.tsx
@@ -35,7 +35,6 @@ export default function AttachmentSheet({
   };
 
   const pickImage = async () => {
-    console.log('pickImage');
     setShowAttachmentSheet(false);
     await new Promise((resolve) => setTimeout(resolve, 300));
     const result = await ImagePicker.launchImageLibraryAsync({


### PR DESCRIPTION
Ugly hotfix for an issue where the pickImage and takePicture functions are attempting to access the PHPickerViewController in the current view hierarchy, but the AttachmentSheet detaches itself (hides) before the controller can fire.

Will look into moving the image picker logic higher up into the component tree so we can ensure it's always attached. I can do this in a follow-up PR, or amend this one (or abandon if you have better ideas, @dnbrwstr).

Fixes TLON-2665