### PR TITLE
native: stop blocking concurrent post loads

### DIFF
--- a/packages/app/features/top/ChannelScreen.tsx
+++ b/packages/app/features/top/ChannelScreen.tsx
@@ -247,16 +247,6 @@ export default function ChannelScreen({
     },
     [navigateToUserProfile]
   );
-  const loadNewerUnlessAlreadyLoading = useCallback(() => {
-    if (!isLoadingPosts) {
-      loadNewer();
-    }
-  }, [loadNewer, isLoadingPosts]);
-  const loadOlderUnlessAlreadyLoading = useCallback(() => {
-    if (!isLoadingPosts) {
-      loadOlder();
-    }
-  }, [loadOlder, isLoadingPosts]);
 
   if (!channel) {
     return null;
@@ -291,8 +281,8 @@ export default function ChannelScreen({
         goToDm={handleGoToDm}
         goToUserProfile={handleGoToUserProfile}
         uploadAsset={store.uploadAsset}
-        onScrollEndReached={loadOlderUnlessAlreadyLoading}
-        onScrollStartReached={loadNewerUnlessAlreadyLoading}
+        onScrollEndReached={loadOlder}
+        onScrollStartReached={loadNewer}
         onPressRef={navigateToRef}
         markRead={handleMarkRead}
         usePost={usePostWithRelations}


### PR DESCRIPTION
https://github.com/tloncorp/tlon-apps/pull/3878 added code to block pagination requests while a load was already in-progress. This has the potential to get a user stuck, unable to load more content.

I wasn't able to trigger this bug – it's dependent on query timing; it needs a specific initial chat state; and the existing content in the chat must maintain a stable height during render (which is not true of most of our chat posts). But removing this load-blocking code only has the effect of loading slightly more posts than we want on each pagination, so it seems worth it. See https://linear.app/tlon/issue/TLON-2670/reduce-double-loads-when-hitting-bottom-of-channel-scroll for more about the downsides of this double-load.