### PR TITLE
native: make inverted empty FlatList resilient to upstream fixes 

### DIFF
--- a/apps/tlon-mobile/src/fixtures/Channel.fixture.tsx
+++ b/apps/tlon-mobile/src/fixtures/Channel.fixture.tsx
@@ -362,6 +362,7 @@ function ChannelWithControlledPostLoading() {
             channel: baseProps.channel,
             post: anchorPost,
           }),
+          hasNewerPosts: true,
         })}
       />
       <FixtureToolbar>

--- a/apps/tlon-mobile/src/fixtures/Channel.fixture.tsx
+++ b/apps/tlon-mobile/src/fixtures/Channel.fixture.tsx
@@ -465,6 +465,16 @@ export default {
       headerMode={'default'}
     />
   ),
+  emptyChat: (
+    <ChannelFixture
+      negotiationMatch={true}
+      theme={'light'}
+      headerMode={'default'}
+      passedProps={() => ({
+        posts: [],
+      })}
+    />
+  ),
   chatWithSimulatedLoad: <ChannelWithControlledPostLoading />,
   chatWithUnreadAnchor: (
     <ChannelFixture

--- a/packages/ui/src/components/Channel/EmptyChannelNotice.tsx
+++ b/packages/ui/src/components/Channel/EmptyChannelNotice.tsx
@@ -1,6 +1,6 @@
 import * as db from '@tloncorp/shared/dist/db';
 import { useMemo, useState } from 'react';
-import { Platform, View as RNView } from 'react-native';
+import { View as RNView } from 'react-native';
 import { SizableText } from 'tamagui';
 
 import { useIsAdmin } from '../../utils';
@@ -8,11 +8,9 @@ import { useIsAdmin } from '../../utils';
 export function EmptyChannelNotice({
   channel,
   userId,
-  withBugAdjust,
 }: {
   channel: db.Channel;
   userId: string;
-  withBugAdjust?: boolean;
 }) {
   const isGroupAdmin = useIsAdmin(channel.groupId ?? '', userId);
   const [isFirstVisit] = useState(() => channel.lastViewedAt == null);
@@ -28,21 +26,8 @@ export function EmptyChannelNotice({
   // this component is usually used within a list view, but there's a bug in RN
   // with rotating empty placeholders if the list is inverted. This custom styling is a workaround
   // that gives callers the ability to optionally account for that issue
-  let contentStyle = undefined;
-  if (withBugAdjust) {
-    if (Platform.OS === 'ios') {
-      contentStyle = {
-        transform: [{ scaleY: -1 }],
-      };
-    } else if (Platform.OS === 'android') {
-      contentStyle = {
-        transform: [{ scaleY: -1 }, { scaleX: -1 }],
-      };
-    }
-  }
-
   return (
-    <RNView style={contentStyle}>
+    <RNView>
       <SizableText textAlign="center" color="$tertiaryText">
         {noticeText}
       </SizableText>

--- a/packages/ui/src/components/Channel/Scroller.tsx
+++ b/packages/ui/src/components/Channel/Scroller.tsx
@@ -22,7 +22,6 @@ import {
   FlatList,
   LayoutChangeEvent,
   ListRenderItem,
-  Platform,
   View as RNView,
   StyleProp,
   ViewStyle,
@@ -364,9 +363,6 @@ const Scroller = forwardRef(
       return (
         <View
           flex={1}
-          // Flatlist doesn't handle inverting this component, so we do it manually.
-          scaleY={inverted ? -1 : 1}
-          rotateY={inverted && Platform.OS === 'android' ? '180deg' : undefined}
           paddingBottom={'$l'}
           paddingHorizontal="$l"
           alignItems="center"
@@ -375,7 +371,7 @@ const Scroller = forwardRef(
           {renderEmptyComponentFn?.()}
         </View>
       );
-    }, [renderEmptyComponentFn, inverted]);
+    }, [renderEmptyComponentFn]);
 
     const handleScroll = useScrollDirectionTracker(setIsAtBottom);
 
@@ -391,7 +387,7 @@ const Scroller = forwardRef(
         {/* {unreadCount && !hasPressedGoToBottom ? (
         <UnreadsButton onPress={pressedGoToBottom} />
       ) : null} */}
-        {posts && (
+        {postsWithNeighbors && (
           <Animated.FlatList<PostWithNeighbors>
             ref={flatListRef as React.RefObject<Animated.FlatList<db.Post>>}
             // This is needed so that we can force a refresh of the list when
@@ -404,7 +400,13 @@ const Scroller = forwardRef(
             keyboardDismissMode="on-drag"
             contentContainerStyle={contentContainerStyle}
             columnWrapperStyle={channelType === 'gallery' && columnWrapperStyle}
-            inverted={inverted}
+            inverted={
+              // https://github.com/facebook/react-native/issues/21196
+              // It looks like this bug has regressed a few times - to avoid
+              // our UI breaking when the bug is fixed, disable `inverted` when
+              // list is empty instead of adversarily transforming the empty component.
+              postsWithNeighbors.length === 0 ? false : inverted
+            }
             initialNumToRender={INITIAL_POSTS_PER_PAGE}
             maxToRenderPerBatch={8}
             windowSize={8}

--- a/packages/ui/src/components/Channel/index.tsx
+++ b/packages/ui/src/components/Channel/index.tsx
@@ -151,13 +151,7 @@ export function Channel({
       : GalleryPost;
 
   const renderEmptyComponent = useCallback(() => {
-    return (
-      <EmptyChannelNotice
-        channel={channel}
-        userId={currentUserId}
-        withBugAdjust
-      />
-    );
+    return <EmptyChannelNotice channel={channel} userId={currentUserId} />;
   }, [currentUserId, channel]);
 
   const onPressGroupRef = useCallback((group: db.Group) => {


### PR DESCRIPTION
https://github.com/facebook/react-native/issues/21196 seems like it has regressed a few times. We previously manually flipped the broken empty list view to counteract the bugged transform; but this ends up with a bugged flipped view if the bug is fixed (which may likely happen without being marked as a breaking release).

To avoid Tlon breaking whenever the upstream bug gets fixed, disabled FlatList's `inverted` when we're showing an empty list – i.e. avoid dealing with any transforms.

I tested by running the new empty chat channel fixture on iOS and Android simulators. I also temporarily changed the `chatWithSimulatedLoad` to show an empty indicator when no posts are loaded, and checked that going from empty -> non-empty had no visible jank.