### PR TITLE
native: fix link pasting

### DIFF
--- a/packages/ui/src/components/MessageInput/index.native.tsx
+++ b/packages/ui/src/components/MessageInput/index.native.tsx
@@ -228,7 +228,6 @@ export const MessageInput = forwardRef<MessageInputHandle, MessageInputProps>(
             if (draft) {
               // @ts-expect-error setContent does accept JSONContent
               editor.setContent(draft);
-              setHasSetInitialContent(true);
               setEditorIsEmpty(false);
             }
 
@@ -277,7 +276,6 @@ export const MessageInput = forwardRef<MessageInputHandle, MessageInputProps>(
               );
               // @ts-expect-error setContent does accept JSONContent
               editor.setContent(tiptapContent);
-              setHasSetInitialContent(true);
             }
 
             if (editingPost?.image) {
@@ -293,6 +291,8 @@ export const MessageInput = forwardRef<MessageInputHandle, MessageInputProps>(
           });
         } catch (e) {
           messageInputLogger.error('Error getting draft', e);
+        } finally {
+          setHasSetInitialContent(true);
         }
       }
     }, [

--- a/packages/ui/src/components/MessageInput/index.tsx
+++ b/packages/ui/src/components/MessageInput/index.tsx
@@ -148,7 +148,6 @@ export function MessageInput({
         getDraft().then((draft) => {
           if (draft) {
             editor.commands.setContent(draft);
-            setHasSetInitialContent(true);
             setEditorIsEmpty(false);
           }
           if (editingPost?.content) {
@@ -200,11 +199,12 @@ export function MessageInput({
               ) as Story
             );
             editor.commands.setContent(tiptapContent);
-            setHasSetInitialContent(true);
           }
         });
       } catch (e) {
         messageInputLogger.error('Error getting draft', e);
+      } finally {
+        setHasSetInitialContent(true);
       }
     }
   }, [editor, getDraft, hasSetInitialContent, editingPost, resetAttachments]);


### PR DESCRIPTION
This was a weird one to nail down the repro for since it was working inconsistently in testing. Turns out if your draft is empty when you enter the channel, we don't mark `setHasSetInitialContent` as true. This means once you do paste something in, it gets saved as a draft and loaded back into the input as a raw text overwrite. This PR just tweaks that logic to always mark initialized after entering the draft/edit content conditional.

I tried to make sure this doesn't break things elsewhere, but @patosullivan you might have more context there. Let me know if you foresee any issues.

Fixes TLON-2660