### PR TITLE
native: fix issue with pasted ref strings appearing in input

### DIFF
--- a/packages/ui/src/components/MessageInput/index.native.tsx
+++ b/packages/ui/src/components/MessageInput/index.native.tsx
@@ -226,8 +226,22 @@ export const MessageInput = forwardRef<MessageInputHandle, MessageInputProps>(
         try {
           getDraft().then((draft) => {
             if (draft) {
+              const inlines = tiptap.JSONToInlines(draft);
+              const newInlines = inlines
+                .map((inline) => {
+                  if (typeof inline === 'string') {
+                    if (inline.match(tiptap.REF_REGEX)) {
+                      return null;
+                    }
+                    return inline;
+                  }
+                  return inline;
+                })
+                .filter((inline) => inline !== null) as Inline[];
+              const newStory = constructStory(newInlines);
+              const tiptapContent = tiptap.diaryMixedToJSON(newStory);
               // @ts-expect-error setContent does accept JSONContent
-              editor.setContent(draft);
+              editor.setContent(tiptapContent);
               setHasSetInitialContent(true);
               setEditorIsEmpty(false);
             }


### PR DESCRIPTION
Fixes TLON-2120

This one is difficult to reproduce, but my theory is that the editor within the webview is rerendering and we're sticking the ref string back in via drafts, this should fix that by removing ref strings from draft content before inserting it.