### PR TITLE
action-menu: cleanup all animations involved with opening action menu

### DIFF
--- a/packages/ui/src/components/ActionList/ListFrame.android.tsx
+++ b/packages/ui/src/components/ActionList/ListFrame.android.tsx
@@ -2,12 +2,8 @@ import { YStack, styled } from 'tamagui';
 
 const ListFrame = styled(YStack, {
   overflow: 'hidden',
+  borderRadius: '$m',
   backgroundColor: '$secondaryBackground',
-  shadowColor: '$black',
-  shadowOffset: { width: 0, height: 2 },
-  shadowOpacity: 0.25,
-  shadowRadius: 3.84,
-  elevation: 5,
 });
 
 export default ListFrame;

--- a/packages/ui/src/components/Channel/Scroller.tsx
+++ b/packages/ui/src/components/Channel/Scroller.tsx
@@ -635,19 +635,7 @@ const PressableMessage = React.memo(
     function PressableMessageComponent({ isActive, children }, ref) {
       return isActive ? (
         // need the extra React Native View for ref measurement
-        <MotiView
-          animate={{
-            scale: 0.95,
-          }}
-          transition={{
-            scale: {
-              type: 'timing',
-              duration: 50,
-            },
-          }}
-        >
-          <RNView ref={ref}>{children}</RNView>
-        </MotiView>
+        <RNView ref={ref}>{children}</RNView>
       ) : (
         // this fragment is necessary to avoid the TS error about not being able to
         // return undefined

--- a/packages/ui/src/components/ChatMessage/ChatMessageActions/Component.android.tsx
+++ b/packages/ui/src/components/ChatMessage/ChatMessageActions/Component.android.tsx
@@ -56,8 +56,7 @@ export function ChatMessageActions({
     <MotiView
       from={{ opacity: 0 }}
       animate={{ opacity: 1 }}
-      delay={150}
-      transition={{ duration: 300 }}
+      transition={{ duration: 200 }}
     >
       <View
         position="absolute"

--- a/packages/ui/src/components/Overlay.tsx
+++ b/packages/ui/src/components/Overlay.tsx
@@ -13,7 +13,6 @@ export function Overlay(props: ComponentProps<typeof View>) {
       transition={{
         opacity: {
           type: 'timing',
-          delay: 150,
           duration: 200,
         },
       }}


### PR DESCRIPTION
This fixes TLON-2694. To do so I had to rip out the `delay` we were passing to the animations. This also cleans up the fact that menu had sharp corners and had a bad shadow animation. Apparently `elevation` has issues with being animated so the shadow for the menu would pop first so you just see a black box until the actual menu contents fade in. Seems to be a long standing issue https://github.com/facebook/react-native/issues/23090 I tried their fixes to no avail.

Also removed the shrink animation on the active message because it felt like too many things were moving at once. Feels smoother now.  

PR Checklist
- [ ] Includes changes to desk files
- [ ] Describes how you tested the PR locally (test ship vs livenet)
- [ ] If a new feature, includes automated tests
- [ ] Comments added anywhere logic may be confusing without context