### PR TITLE
native: add lure metadata to Branch & display during onboarding

### DIFF
--- a/apps/tlon-mobile/src/App.main.tsx
+++ b/apps/tlon-mobile/src/App.main.tsx
@@ -107,7 +107,7 @@ const App = ({
             <OnboardingStack.Screen
               name="SignUpEmail"
               component={SignUpEmailScreen}
-              initialParams={{ lure, priorityToken }}
+              initialParams={{ lure: lure?.id, priorityToken }}
             />
             <OnboardingStack.Screen name="EULA" component={EULAScreen} />
             <OnboardingStack.Screen

--- a/apps/tlon-mobile/src/hooks/useDeepLinkListener.ts
+++ b/apps/tlon-mobile/src/hooks/useDeepLinkListener.ts
@@ -19,7 +19,7 @@ export const useDeepLinkListener = () => {
     if (ship && lure) {
       (async () => {
         try {
-          await inviteShipWithLure({ ship, lure });
+          await inviteShipWithLure({ ship, lure: lure.id });
           Alert.alert(
             '',
             'Your invitation to the group is on its way. It will appear in the Groups list.',

--- a/apps/tlon-mobile/src/screens/Onboarding/SignUpEmailScreen.tsx
+++ b/apps/tlon-mobile/src/screens/Onboarding/SignUpEmailScreen.tsx
@@ -4,6 +4,7 @@ import {
   DEFAULT_PRIORITY_TOKEN,
   EMAIL_REGEX,
 } from '@tloncorp/app/constants';
+import { useLureMetadata } from '@tloncorp/app/contexts/branch';
 import { getHostingAvailability } from '@tloncorp/app/lib/hostingApi';
 import { trackError, trackOnboardingAction } from '@tloncorp/app/utils/posthog';
 import {
@@ -18,7 +19,6 @@ import {
   YStack,
 } from '@tloncorp/ui';
 import { Field } from '@tloncorp/ui';
-import { useLureMetadata } from 'packages/app/contexts/branch';
 import { useState } from 'react';
 import { useForm } from 'react-hook-form';
 import { Controller } from 'react-hook-form';

--- a/apps/tlon-mobile/src/screens/Onboarding/SignUpEmailScreen.tsx
+++ b/apps/tlon-mobile/src/screens/Onboarding/SignUpEmailScreen.tsx
@@ -7,6 +7,7 @@ import {
 import { getHostingAvailability } from '@tloncorp/app/lib/hostingApi';
 import { trackError, trackOnboardingAction } from '@tloncorp/app/utils/posthog';
 import {
+  AppInviteDisplay,
   Button,
   GenericHeader,
   KeyboardAvoidingView,
@@ -17,6 +18,7 @@ import {
   YStack,
 } from '@tloncorp/ui';
 import { Field } from '@tloncorp/ui';
+import { useLureMetadata } from 'packages/app/contexts/branch';
 import { useState } from 'react';
 import { useForm } from 'react-hook-form';
 import { Controller } from 'react-hook-form';
@@ -39,6 +41,8 @@ export const SignUpEmailScreen = ({
   },
 }: Props) => {
   const [isSubmitting, setIsSubmitting] = useState(false);
+
+  const lureMeta = useLureMetadata();
 
   const {
     control,
@@ -106,6 +110,7 @@ export const SignUpEmailScreen = ({
       />
       <KeyboardAvoidingView behavior="height" keyboardVerticalOffset={180}>
         <YStack gap="$2xl" padding="$2xl">
+          {lureMeta ? <AppInviteDisplay metadata={lureMeta} /> : null}
           <SizableText>
             Enter your email address. You&rsquo;ll use it to log in to Tlon and
             we&rsquo;ll email you the occasional service update.

--- a/apps/tlon-mobile/src/screens/Onboarding/SignUpPasswordScreen.tsx
+++ b/apps/tlon-mobile/src/screens/Onboarding/SignUpPasswordScreen.tsx
@@ -12,6 +12,7 @@ import {
 import { isEulaAgreed, setEulaAgreed } from '@tloncorp/app/utils/eula';
 import { trackError, trackOnboardingAction } from '@tloncorp/app/utils/posthog';
 import {
+  AppInviteDisplay,
   Button,
   CheckboxInput,
   Field,
@@ -25,6 +26,7 @@ import {
   View,
   YStack,
 } from '@tloncorp/ui';
+import { useLureMetadata } from 'packages/app/contexts/branch';
 import { useEffect, useState } from 'react';
 import { Controller, useForm } from 'react-hook-form';
 
@@ -45,6 +47,7 @@ export const SignUpPasswordScreen = ({
   },
 }: Props) => {
   const [isSubmitting, setIsSubmitting] = useState(false);
+  const lureMeta = useLureMetadata();
   const {
     control,
     setFocus,
@@ -187,6 +190,7 @@ export const SignUpPasswordScreen = ({
       />
       <KeyboardAvoidingView behavior="height" keyboardVerticalOffset={90}>
         <YStack gap="$xl" padding="$2xl">
+          {lureMeta ? <AppInviteDisplay metadata={lureMeta} /> : null}
           <SizableText color="$primaryText">
             Please set a strong password with at least 8 characters.
           </SizableText>

--- a/apps/tlon-mobile/src/screens/Onboarding/SignUpPasswordScreen.tsx
+++ b/apps/tlon-mobile/src/screens/Onboarding/SignUpPasswordScreen.tsx
@@ -5,6 +5,7 @@ import {
 } from '@google-cloud/recaptcha-enterprise-react-native';
 import type { NativeStackScreenProps } from '@react-navigation/native-stack';
 import { RECAPTCHA_SITE_KEY } from '@tloncorp/app/constants';
+import { useLureMetadata } from '@tloncorp/app/contexts/branch';
 import {
   logInHostingUser,
   signUpHostingUser,
@@ -26,7 +27,6 @@ import {
   View,
   YStack,
 } from '@tloncorp/ui';
-import { useLureMetadata } from 'packages/app/contexts/branch';
 import { useEffect, useState } from 'react';
 import { Controller, useForm } from 'react-hook-form';
 

--- a/apps/tlon-mobile/src/screens/Onboarding/WelcomeScreen.tsx
+++ b/apps/tlon-mobile/src/screens/Onboarding/WelcomeScreen.tsx
@@ -2,11 +2,13 @@ import type { NativeStackScreenProps } from '@react-navigation/native-stack';
 import { useIsDarkMode } from '@tloncorp/app/hooks/useIsDarkMode';
 import {
   ActionSheet,
+  AppInviteDisplay,
   PrimaryButton,
   SizableText,
   View,
   YStack,
 } from '@tloncorp/ui';
+import { useLureMetadata } from 'packages/app/contexts/branch';
 import { useState } from 'react';
 import { ImageBackground, Pressable } from 'react-native';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
@@ -16,6 +18,7 @@ import type { OnboardingStackParamList } from '../../types';
 type Props = NativeStackScreenProps<OnboardingStackParamList, 'Welcome'>;
 
 export const WelcomeScreen = ({ navigation }: Props) => {
+  const lureMeta = useLureMetadata();
   const isDarkMode = useIsDarkMode();
   const { bottom } = useSafeAreaInsets();
   const [open, setOpen] = useState(false);
@@ -35,6 +38,7 @@ export const WelcomeScreen = ({ navigation }: Props) => {
         }}
         source={bgSource}
       >
+        {lureMeta ? <AppInviteDisplay metadata={lureMeta} /> : null}
         <YStack gap="$4xl" justifyContent="center" alignItems="center">
           <PrimaryButton
             backgroundColor="$blue"

--- a/apps/tlon-mobile/src/screens/Onboarding/WelcomeScreen.tsx
+++ b/apps/tlon-mobile/src/screens/Onboarding/WelcomeScreen.tsx
@@ -38,7 +38,13 @@ export const WelcomeScreen = ({ navigation }: Props) => {
         }}
         source={bgSource}
       >
-        {lureMeta ? <AppInviteDisplay metadata={lureMeta} /> : null}
+        {lureMeta ? (
+          <AppInviteDisplay
+            metadata={lureMeta}
+            marginHorizontal="$3xl"
+            marginBottom="$4xl"
+          />
+        ) : null}
         <YStack gap="$4xl" justifyContent="center" alignItems="center">
           <PrimaryButton
             backgroundColor="$blue"

--- a/apps/tlon-mobile/src/screens/Onboarding/WelcomeScreen.tsx
+++ b/apps/tlon-mobile/src/screens/Onboarding/WelcomeScreen.tsx
@@ -1,4 +1,5 @@
 import type { NativeStackScreenProps } from '@react-navigation/native-stack';
+import { useLureMetadata } from '@tloncorp/app/contexts/branch';
 import { useIsDarkMode } from '@tloncorp/app/hooks/useIsDarkMode';
 import {
   ActionSheet,
@@ -8,7 +9,6 @@ import {
   View,
   YStack,
 } from '@tloncorp/ui';
-import { useLureMetadata } from 'packages/app/contexts/branch';
 import { useState } from 'react';
 import { ImageBackground, Pressable } from 'react-native';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';

--- a/packages/app/contexts/branch.tsx
+++ b/packages/app/contexts/branch.tsx
@@ -1,3 +1,5 @@
+import { DeepLinkMetadata } from '@tloncorp/shared/dist';
+import { extractLureMetadata } from 'packages/shared/src/logic';
 import {
   type ReactNode,
   createContext,
@@ -11,8 +13,12 @@ import branch from 'react-native-branch';
 import storage from '../lib/storage';
 import { getPathFromWer } from '../utils/string';
 
+interface LureData extends DeepLinkMetadata {
+  id: string;
+}
+
 type Lure = {
-  lure: string | undefined;
+  lure: LureData | undefined;
   priorityToken: string | undefined;
 };
 
@@ -63,6 +69,18 @@ export const useBranch = () => {
   return context;
 };
 
+export const useLureMetadata = () => {
+  const context = useContext(Context);
+
+  if (!context) {
+    throw new Error(
+      'Must call `useLureMetadata` within a `BranchProvider` component.'
+    );
+  }
+
+  return context.lure ?? null;
+};
+
 export const BranchProvider = ({ children }: { children: ReactNode }) => {
   const [{ deepLinkPath, lure, priorityToken }, setState] =
     useState(INITIAL_STATE);
@@ -81,7 +99,10 @@ export const BranchProvider = ({ children }: { children: ReactNode }) => {
             // Link had a lure field embedded
             console.debug('[branch] Detected lure link:', params.lure);
             const nextLure: Lure = {
-              lure: params.lure as string,
+              lure: {
+                ...extractLureMetadata(params),
+                id: params.lure as string,
+              },
               priorityToken: params.token as string | undefined,
             };
             setState({

--- a/packages/app/contexts/branch.tsx
+++ b/packages/app/contexts/branch.tsx
@@ -1,5 +1,5 @@
 import { DeepLinkMetadata } from '@tloncorp/shared/dist';
-import { extractLureMetadata } from 'packages/shared/src/logic';
+import { extractLureMetadata } from '@tloncorp/shared/src/logic';
 import {
   type ReactNode,
   createContext,

--- a/packages/app/lib/nativeDb.ts
+++ b/packages/app/lib/nativeDb.ts
@@ -1,7 +1,7 @@
 import { open } from '@op-engineering/op-sqlite';
 import { createDevLogger, escapeLog } from '@tloncorp/shared';
 import { handleChange, schema, setClient } from '@tloncorp/shared/dist/db';
-import { AnySqliteDatabase } from 'packages/shared/dist/db/client';
+import { AnySqliteDatabase } from '@tloncorp/shared/dist/db/client';
 import { useEffect, useMemo, useState } from 'react';
 
 import { OPSQLite$SQLiteConnection } from './opsqliteConnection';

--- a/packages/ui/src/components/AppInviteDisplay.tsx
+++ b/packages/ui/src/components/AppInviteDisplay.tsx
@@ -1,6 +1,7 @@
 import { DeepLinkMetadata } from '@tloncorp/shared/dist';
 import React, { ComponentProps } from 'react';
 
+import { AppDataContextProvider } from '../contexts';
 import { ListItem } from './ListItem';
 
 function AppInviteDisplayRaw({
@@ -28,22 +29,25 @@ function AppInviteDisplayRaw({
   };
 
   return (
-    <ListItem backgroundColor="$secondaryBackground" {...rest}>
-      {invitedGroupIconImageUrl ? (
-        <ListItem.GroupIcon
-          model={groupShim}
-          backgroundColor={groupShim.iconImageColor ?? '$secondaryBorder'}
-        />
-      ) : null}
-      <ListItem.MainContent>
-        <ListItem.Title>
-          Join {invitedGroupTitle ?? invitedGroupId}
-        </ListItem.Title>
-        <ListItem.Subtitle>
-          Invited by {inviterNickname ?? inviterUserId}
-        </ListItem.Subtitle>
-      </ListItem.MainContent>
-    </ListItem>
+    // provider needed to support calm settings usage down the tree
+    <AppDataContextProvider>
+      <ListItem backgroundColor="$secondaryBackground" {...rest}>
+        {invitedGroupIconImageUrl ? (
+          <ListItem.GroupIcon
+            model={groupShim}
+            backgroundColor={groupShim.iconImageColor ?? '$secondaryBorder'}
+          />
+        ) : null}
+        <ListItem.MainContent>
+          <ListItem.Title>
+            Join {invitedGroupTitle ?? invitedGroupId}
+          </ListItem.Title>
+          <ListItem.Subtitle>
+            Invited by {inviterNickname ?? inviterUserId}
+          </ListItem.Subtitle>
+        </ListItem.MainContent>
+      </ListItem>
+    </AppDataContextProvider>
   );
 }
 

--- a/packages/ui/src/components/AppInviteDisplay.tsx
+++ b/packages/ui/src/components/AppInviteDisplay.tsx
@@ -1,29 +1,39 @@
 import { DeepLinkMetadata } from '@tloncorp/shared/dist';
-import React from 'react';
+import React, { ComponentProps } from 'react';
 
 import { ListItem } from './ListItem';
 
-function AppInviteDisplayRaw({ metadata }: { metadata: DeepLinkMetadata }) {
+function AppInviteDisplayRaw({
+  metadata,
+  ...rest
+}: { metadata: DeepLinkMetadata } & ComponentProps<typeof ListItem>) {
   const {
     inviterUserId,
     invitedGroupId,
     inviterNickname,
     invitedGroupTitle,
     invitedGroupIconImageUrl,
+    invitedGroupiconImageColor,
   } = metadata;
 
   if (!inviterUserId || !invitedGroupId) {
     return null;
   }
 
+  const groupShim = {
+    id: invitedGroupId,
+    title: invitedGroupTitle,
+    iconImage: invitedGroupIconImageUrl,
+    iconImageColor: invitedGroupiconImageColor,
+  };
+
   return (
-    <ListItem
-      marginHorizontal="$3xl"
-      backgroundColor="$secondaryBackground"
-      marginBottom="$4xl"
-    >
+    <ListItem backgroundColor="$secondaryBackground" {...rest}>
       {invitedGroupIconImageUrl ? (
-        <ListItem.ImageIcon imageUrl={invitedGroupIconImageUrl} />
+        <ListItem.GroupIcon
+          model={groupShim}
+          backgroundColor={groupShim.iconImageColor ?? '$secondaryBorder'}
+        />
       ) : null}
       <ListItem.MainContent>
         <ListItem.Title>

--- a/packages/ui/src/components/AppInviteDisplay.tsx
+++ b/packages/ui/src/components/AppInviteDisplay.tsx
@@ -1,0 +1,40 @@
+import { DeepLinkMetadata } from '@tloncorp/shared/dist';
+import React from 'react';
+
+import { ListItem } from './ListItem';
+
+function AppInviteDisplayRaw({ metadata }: { metadata: DeepLinkMetadata }) {
+  const {
+    inviterUserId,
+    invitedGroupId,
+    inviterNickname,
+    invitedGroupTitle,
+    invitedGroupIconImageUrl,
+  } = metadata;
+
+  if (!inviterUserId || !invitedGroupId) {
+    return null;
+  }
+
+  return (
+    <ListItem
+      marginHorizontal="$3xl"
+      backgroundColor="$secondaryBackground"
+      marginBottom="$4xl"
+    >
+      {invitedGroupIconImageUrl ? (
+        <ListItem.ImageIcon imageUrl={invitedGroupIconImageUrl} />
+      ) : null}
+      <ListItem.MainContent>
+        <ListItem.Title>
+          Join {invitedGroupTitle ?? invitedGroupId}
+        </ListItem.Title>
+        <ListItem.Subtitle>
+          Invited by {inviterNickname ?? inviterUserId}
+        </ListItem.Subtitle>
+      </ListItem.MainContent>
+    </ListItem>
+  );
+}
+
+export const AppInviteDisplay = React.memo(AppInviteDisplayRaw);

--- a/packages/ui/src/components/Avatar.tsx
+++ b/packages/ui/src/components/Avatar.tsx
@@ -201,16 +201,14 @@ export const ImageAvatar = function ImageAvatarComponent({
   imageUrl?: string;
   fallback?: React.ReactNode;
 } & AvatarProps) {
-  const calmSettings = useCalm();
+  // const calmSettings = useCalm();
   const [loadFailed, setLoadFailed] = useState(false);
 
   const handleLoadError = useCallback(() => {
     setLoadFailed(true);
   }, []);
 
-  return imageUrl &&
-    (props.ignoreCalm || !calmSettings.disableAvatars) &&
-    !loadFailed ? (
+  return imageUrl && (props.ignoreCalm || true) && !loadFailed ? (
     <AvatarFrame {...props}>
       <Image
         width={'100%'}

--- a/packages/ui/src/components/Avatar.tsx
+++ b/packages/ui/src/components/Avatar.tsx
@@ -95,10 +95,16 @@ export const ContactAvatar = React.memo(function ContactAvatComponent({
   );
 });
 
+export interface GroupImageShim {
+  id: string;
+  title?: string;
+  iconImage?: string;
+  iconImageColor?: string;
+}
 export const GroupAvatar = React.memo(function GroupAvatarComponent({
   model,
   ...props
-}: { model: db.Group } & AvatarProps) {
+}: { model: GroupImageShim } & AvatarProps) {
   const fallback = (
     <TextAvatar
       text={model.title ?? model.id.replace('~', '')}

--- a/packages/ui/src/components/Avatar.tsx
+++ b/packages/ui/src/components/Avatar.tsx
@@ -104,7 +104,7 @@ export interface GroupImageShim {
 export const GroupAvatar = React.memo(function GroupAvatarComponent({
   model,
   ...props
-}: { model: GroupImageShim } & AvatarProps) {
+}: { model: db.Group | GroupImageShim } & AvatarProps) {
   const fallback = (
     <TextAvatar
       text={model.title ?? model.id.replace('~', '')}

--- a/packages/ui/src/components/Avatar.tsx
+++ b/packages/ui/src/components/Avatar.tsx
@@ -207,14 +207,16 @@ export const ImageAvatar = function ImageAvatarComponent({
   imageUrl?: string;
   fallback?: React.ReactNode;
 } & AvatarProps) {
-  // const calmSettings = useCalm();
+  const calmSettings = useCalm();
   const [loadFailed, setLoadFailed] = useState(false);
 
   const handleLoadError = useCallback(() => {
     setLoadFailed(true);
   }, []);
 
-  return imageUrl && (props.ignoreCalm || true) && !loadFailed ? (
+  return imageUrl &&
+    (props.ignoreCalm || !calmSettings.disableAvatars) &&
+    !loadFailed ? (
     <AvatarFrame {...props}>
       <Image
         width={'100%'}

--- a/packages/ui/src/components/ListItem/ListItem.tsx
+++ b/packages/ui/src/components/ListItem/ListItem.tsx
@@ -9,6 +9,7 @@ import {
   ChannelAvatar,
   ContactAvatar,
   GroupAvatar,
+  ImageAvatar,
   SystemIconAvatar,
 } from '../Avatar';
 import ContactName from '../ContactName';
@@ -80,6 +81,8 @@ const ListItemChannelIcon = ChannelAvatar;
 const ListItemContactIcon = ContactAvatar;
 
 const ListItemSystemIcon = SystemIconAvatar;
+
+const ListItemImageIcon = ImageAvatar;
 
 const ListItemMainContent = styled(YStack, {
   name: 'ListItemMainContent',
@@ -258,6 +261,7 @@ export const ListItem = withStaticProperties(ListItemFrame, {
   ChannelIcon: ListItemChannelIcon,
   ContactIcon: ListItemContactIcon,
   SystemIcon: ListItemSystemIcon,
+  ImageIcon: ListItemImageIcon,
   Dragger,
   Count: ListItemCount,
   MainContent: ListItemMainContent,

--- a/packages/ui/src/index.tsx
+++ b/packages/ui/src/index.tsx
@@ -70,6 +70,7 @@ export * from './components/UrbitSigil';
 export * from './components/UserProfileScreenView';
 export * from './components/View';
 export * from './components/WelcomeSheet';
+export * from './components/AppInviteDisplay';
 export * from './contexts';
 export * from './tamagui.config';
 export * from './types';


### PR DESCRIPTION
- adds information about the inviting user & group to the Branch link
- reads that information after making it to the app and stores it alongside the lure ID
- adds placeholder visual for displaying the new metadata during the onboarding process

Fixes TLON-2712