### PR TITLE
input: fix input height and scrolling issues when input is 'full'

### DIFF
--- a/packages/editor/src/MessageInputEditor.tsx
+++ b/packages/editor/src/MessageInputEditor.tsx
@@ -76,7 +76,7 @@ export const MessageInputEditor = () => {
         overflow: 'auto',
         height: 'auto',
         fontSize: 16,
-        overflowY: 'hidden',
+        overflowY: 'auto',
         color: useIsDark() ? 'white' : 'black',
         fontFamily:
           "System, -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Ubuntu, 'Helvetica Neue', sans-serif",

--- a/packages/ui/src/components/BigInput.native.tsx
+++ b/packages/ui/src/components/BigInput.native.tsx
@@ -127,16 +127,10 @@ export function BigInput({
           </View>
         </View>
       )}
-      <ScrollView
-        scrollEventThrottle={16}
-        scrollToOverflowEnabled
-        overScrollMode="always"
-        contentContainerStyle={{
-          paddingTop:
-            channelType === 'notebook'
-              ? titleInputHeight + imageButtonHeight
-              : 0,
-        }}
+      <View
+        paddingTop={
+          channelType === 'notebook' ? titleInputHeight + imageButtonHeight : 0
+        }
       >
         <MessageInput
           shouldBlur={shouldBlur}
@@ -163,7 +157,7 @@ export function BigInput({
           channelType={channelType}
           ref={editorRef}
         />
-      </ScrollView>
+      </View>
       {channelType === 'notebook' &&
         editorRef.current &&
         editorRef.current.editor && (

--- a/packages/ui/src/components/MessageInput/index.native.tsx
+++ b/packages/ui/src/components/MessageInput/index.native.tsx
@@ -159,10 +159,18 @@ export const MessageInput = forwardRef<MessageInputHandle, MessageInputProps>(
     const titleInputHeight = 48;
     const inputBasePadding = getToken('$s', 'space');
     const imageInputButtonHeight = 50;
-    const basicOffset =
-      top + headerHeight + titleInputHeight + imageInputButtonHeight;
-    const bigInputHeightBasic =
-      height - basicOffset - bottom - inputBasePadding * 2;
+    const maxInputHeight = useMemo(
+      () => height - headerHeight - bottom - top,
+      [height, bottom, top, headerHeight]
+    );
+    const basicOffset = useMemo(
+      () => top + headerHeight + titleInputHeight + imageInputButtonHeight,
+      [top, headerHeight, titleInputHeight, imageInputButtonHeight]
+    );
+    const bigInputHeightBasic = useMemo(
+      () => height - basicOffset - bottom - inputBasePadding * 2,
+      [height, basicOffset, bottom, inputBasePadding]
+    );
     const [bigInputHeight, setBigInputHeight] = useState(bigInputHeightBasic);
     const [mentionText, setMentionText] = useState<string>();
     const [showMentionPopup, setShowMentionPopup] = useState(false);
@@ -728,6 +736,12 @@ export const MessageInput = forwardRef<MessageInputHandle, MessageInputProps>(
         }
 
         if (type === 'contentHeight') {
+          if (payload === containerHeight) {
+            return;
+          }
+          if (containerHeight > maxInputHeight) {
+            return;
+          }
           setContainerHeight(payload);
           setHeight?.(payload);
           return;
@@ -768,6 +782,8 @@ export const MessageInput = forwardRef<MessageInputHandle, MessageInputProps>(
         webviewRef,
         editorCrashed,
         setEditorCrashed,
+        containerHeight,
+        maxInputHeight,
       ]
     );
 
@@ -827,12 +843,14 @@ export const MessageInput = forwardRef<MessageInputHandle, MessageInputProps>(
           borderColor="$border"
           borderWidth={1}
           borderRadius="$xl"
+          maxHeight={maxInputHeight}
         >
           {showInlineAttachments && <AttachmentPreviewList />}
           <XStack height={bigInput ? bigInputHeight : containerHeight}>
             <RichText
               style={{
                 backgroundColor: 'transparent',
+                maxHeight: maxInputHeight - getToken('$s', 'space'),
               }}
               editor={editor}
               onMessage={handleMessage}


### PR DESCRIPTION
Fixes TLON-2112
Fixes TLON-2719

Fixes an issue with the input not being scrollable (which is a big problem in notebooks where there might be a lot of text).

Replaces Scrollview (which was originally included because of an animation) that wraps the message input in BigInput with View.

Fixes an issue where a very long message would cause the input to fill the screen and cause the send message and add attachment buttons to no longer be visible.

Memoizes some values in the message input