### PR TITLE
native: better communicate initial app loading state

### DIFF
--- a/packages/app/features/top/ChatListScreen.tsx
+++ b/packages/app/features/top/ChatListScreen.tsx
@@ -98,6 +98,21 @@ export default function ChatListScreen({
 
   const currentUser = useCurrentUserId();
 
+  const connStatus = store.useConnectionStatus();
+  const notReadyMessage: string | null = useMemo(() => {
+    // if not fully connected yet, show status
+    if (connStatus !== 'Connected') {
+      return `${connStatus}...`;
+    }
+
+    // if still loading the screen data, show loading
+    if (!chats || (!chats.unpinned.length && !chats.pinned.length)) {
+      return 'Loading...';
+    }
+
+    return null;
+  }, [connStatus, chats]);
+
   const resolvedChats = useMemo(() => {
     return {
       pinned: chats?.pinned ?? [],
@@ -240,11 +255,7 @@ export default function ChatListScreen({
       >
         <View flex={1}>
           <ScreenHeader
-            title={
-              !chats || (!chats.unpinned.length && !chats.pinned.length)
-                ? 'Loading…'
-                : screenTitle
-            }
+            title={notReadyMessage ?? screenTitle}
             rightControls={headerControls}
           />
           {chats && chats.unpinned.length ? (

--- a/packages/shared/src/store/session.ts
+++ b/packages/shared/src/store/session.ts
@@ -38,7 +38,6 @@ export function getSyncing() {
 }
 
 export function updateIsSyncing(newValue: boolean) {
-  console.log(`updating is syncing`, newValue);
   isSyncing = newValue;
   syncListeners.forEach((listener) => listener(newValue));
 }
@@ -57,8 +56,6 @@ export function useSyncing() {
 export function useConnectionStatus() {
   const currentSession = useCurrentSession();
   const syncing = useSyncing();
-
-  console.log(`con status render`, currentSession, syncing);
 
   if (!currentSession) {
     return 'Connecting';

--- a/packages/shared/src/store/session.ts
+++ b/packages/shared/src/store/session.ts
@@ -2,8 +2,8 @@ import { useSyncExternalStore } from 'react';
 
 export type Session = { startTime: number };
 
-// Session — time when subscriptions were first initialized and we can assume
-// all new events have been heard
+// Session — time when subscriptions were first initialized after which we can assume
+// all new events will be heard
 let session: Session | null = null;
 type SessionListener = (session: Session | null) => void;
 const sessionListeners: SessionListener[] = [];
@@ -28,7 +28,7 @@ export function useCurrentSession() {
   return useSyncExternalStore(subscribeToSession, getSession);
 }
 
-// Syncing — whether our start sync logic is currently running
+// Syncing — whether our initial fetching logic is currently running
 let isSyncing: boolean = false;
 type SyncListener = (syncing: boolean) => void;
 const syncListeners: SyncListener[] = [];

--- a/packages/shared/src/store/session.ts
+++ b/packages/shared/src/store/session.ts
@@ -2,9 +2,10 @@ import { useSyncExternalStore } from 'react';
 
 export type Session = { startTime: number };
 
-type SessionListener = (session: Session | null) => void;
-
+// Session — time when subscriptions were first initialized and we can assume
+// all new events have been heard
 let session: Session | null = null;
+type SessionListener = (session: Session | null) => void;
 const sessionListeners: SessionListener[] = [];
 
 export function getSession() {
@@ -25,4 +26,47 @@ function subscribeToSession(listener: SessionListener) {
 
 export function useCurrentSession() {
   return useSyncExternalStore(subscribeToSession, getSession);
+}
+
+// Syncing — whether our start sync logic is currently running
+let isSyncing: boolean = false;
+type SyncListener = (syncing: boolean) => void;
+const syncListeners: SyncListener[] = [];
+
+export function getSyncing() {
+  return isSyncing;
+}
+
+export function updateIsSyncing(newValue: boolean) {
+  console.log(`updating is syncing`, newValue);
+  isSyncing = newValue;
+  syncListeners.forEach((listener) => listener(newValue));
+}
+
+function subscribeToIsSyncing(listener: SyncListener) {
+  syncListeners.push(listener);
+  return () => {
+    syncListeners.splice(syncListeners.indexOf(listener), 1);
+  };
+}
+
+export function useSyncing() {
+  return useSyncExternalStore(subscribeToIsSyncing, getSyncing);
+}
+
+export function useConnectionStatus() {
+  const currentSession = useCurrentSession();
+  const syncing = useSyncing();
+
+  console.log(`con status render`, currentSession, syncing);
+
+  if (!currentSession) {
+    return 'Connecting';
+  }
+
+  if (syncing) {
+    return 'Syncing';
+  }
+
+  return 'Connected';
 }

--- a/packages/shared/src/store/sync.ts
+++ b/packages/shared/src/store/sync.ts
@@ -19,7 +19,7 @@ import { addToChannelPosts, clearChannelPostsQueries } from './useChannelPosts';
 
 export { SyncPriority, syncQueue } from './syncQueue';
 
-const logger = createDevLogger('sync', true);
+const logger = createDevLogger('sync', false);
 
 // Used to track latest post we've seen for each channel.
 // Updated when:

--- a/packages/ui/src/components/ScreenHeader.tsx
+++ b/packages/ui/src/components/ScreenHeader.tsx
@@ -1,4 +1,3 @@
-import { useCurrentSession } from '@tloncorp/shared';
 import { PropsWithChildren, ReactNode } from 'react';
 import Animated, { FadeInDown, FadeOutUp } from 'react-native-reanimated';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
@@ -20,7 +19,6 @@ export const ScreenHeaderComponent = ({
   rightControls?: ReactNode | null;
 }>) => {
   const { top } = useSafeAreaInsets();
-  const currentSession = useCurrentSession();
 
   return (
     <View paddingTop={top} zIndex={50} backgroundColor="$background">
@@ -32,11 +30,7 @@ export const ScreenHeaderComponent = ({
       >
         {typeof title === 'string' ? (
           isWeb ? (
-            <HeaderTitle
-              color={currentSession ? '$primaryText' : '$tertiaryText'}
-            >
-              {title}
-            </HeaderTitle>
+            <HeaderTitle>{title}</HeaderTitle>
           ) : (
             <Animated.View
               key={title}
@@ -44,11 +38,7 @@ export const ScreenHeaderComponent = ({
               exiting={FadeOutUp}
               style={{ flex: 1 }}
             >
-              <HeaderTitle
-                color={currentSession ? '$primaryText' : '$tertiaryText'}
-              >
-                {title}
-              </HeaderTitle>
+              <HeaderTitle>{title}</HeaderTitle>
             </Animated.View>
           )
         ) : (


### PR DESCRIPTION
Small update to change the indicator on the home screen while the app is running through it's bootstrap logic. Also removes the empty session grey dimmer. Keeping things simple for now, but we can layer in offline status, error states, etc. down the line

Connecting = still scaffolding initial subscriptions
Syncing = still running through initial data fetching
Loading = still fetching the actual data needed to power the screen from the local DB

Fixes TLON-2679



https://github.com/user-attachments/assets/9c9f4992-8ca5-41a2-ab03-4ab5d48669b3

