### PR TITLE
MessageInput: gray out button before send, cosmetic changes to edit mode

### DIFF
--- a/packages/ui/src/components/MessageInput/MessageInputBase.tsx
+++ b/packages/ui/src/components/MessageInput/MessageInputBase.tsx
@@ -103,8 +103,8 @@ export const MessageInputContainer = ({
         onSelectMention={onSelectMention}
       />
       <XStack
+        paddingVertical="$s"
         paddingHorizontal="$m"
-        paddingBottom="$s"
         gap="$l"
         alignItems="flex-end"
         justifyContent="space-between"
@@ -153,13 +153,13 @@ export const MessageInputContainer = ({
             )}
           </View>
         ) : (
-          <View paddingBottom="$xs">
+          <View marginBottom="$xs">
             <Button
               disabled={disableSend || isSending}
               onPress={isEditing && onPressEdit ? onPressEdit : onPressSend}
               backgroundColor="unset"
               borderColor="transparent"
-              opacity={disableSend ? 0 : 1}
+              opacity={disableSend ? 0.5 : 1}
             >
               {isSending ? (
                 <View width="$2xl" height="$2xl">

--- a/packages/ui/src/components/MessageInput/MessageInputBase.tsx
+++ b/packages/ui/src/components/MessageInput/MessageInputBase.tsx
@@ -93,6 +93,58 @@ export const MessageInputContainer = ({
   goBack?: () => void;
 }>) => {
   const { canUpload } = useAttachmentContext();
+  if (isEditing) {
+    return (
+      <YStack
+        width="100%"
+        backgroundColor="$secondaryBackground"
+        borderRadius="$xl"
+      >
+        <InputMentionPopup
+          containerHeight={containerHeight}
+          showMentionPopup={showMentionPopup}
+          mentionText={mentionText}
+          groupMembers={groupMembers}
+          onSelectMention={onSelectMention}
+        />
+        <XStack
+          paddingVertical="$s"
+          paddingHorizontal="$s"
+          gap="$xs"
+          alignItems="flex-end"
+          justifyContent="space-around"
+        >
+          <Button
+            backgroundColor="unset"
+            borderColor="transparent"
+            onPress={cancelEditing}
+            marginBottom="$xs"
+          >
+            <Icon size="$m" type="Close" />
+          </Button>
+          {children}
+          <View marginBottom="$xs">
+            <Button
+              disabled={disableSend || isSending}
+              onPress={onPressEdit}
+              backgroundColor="unset"
+              borderColor="transparent"
+              opacity={disableSend ? 0.5 : 1}
+            >
+              {isSending ? (
+                <View width="$2xl" height="$2xl">
+                  <LoadingSpinner size="small" color="$secondaryText" />
+                </View>
+              ) : (
+                <Icon size="$m" type="Checkmark" />
+              )}
+            </Button>
+          </View>
+        </XStack>
+      </YStack>
+    );
+  }
+
   return (
     <YStack width="100%">
       <InputMentionPopup
@@ -104,7 +156,7 @@ export const MessageInputContainer = ({
       />
       <XStack
         paddingVertical="$s"
-        paddingHorizontal="$m"
+        paddingHorizontal="$xl"
         gap="$l"
         alignItems="flex-end"
         justifyContent="space-between"
@@ -120,19 +172,8 @@ export const MessageInputContainer = ({
             </Button>
           </View>
         ) : null}
-        {isEditing ? (
-          <View paddingBottom="$xs">
-            <Button
-              backgroundColor="unset"
-              borderColor="transparent"
-              onPress={cancelEditing}
-            >
-              <Icon type="Close" />
-            </Button>
-          </View>
-        ) : null}
         {canUpload && showAttachmentButton ? (
-          <View paddingBottom="$xs">
+          <View marginBottom="$xs">
             <AttachmentButton setShouldBlur={setShouldBlur} />
           </View>
         ) : null}
@@ -141,14 +182,8 @@ export const MessageInputContainer = ({
           <View position="absolute" bottom="$l" right="$l">
             {disableSend ? null : (
               <FloatingActionButton
-                onPress={isEditing && onPressEdit ? onPressEdit : onPressSend}
-                icon={
-                  isEditing ? (
-                    <Icon type="Checkmark" />
-                  ) : (
-                    <Icon type="ArrowUp" />
-                  )
-                }
+                onPress={onPressSend}
+                icon={<Icon type="ArrowUp" />}
               />
             )}
           </View>
@@ -156,7 +191,7 @@ export const MessageInputContainer = ({
           <View marginBottom="$xs">
             <Button
               disabled={disableSend || isSending}
-              onPress={isEditing && onPressEdit ? onPressEdit : onPressSend}
+              onPress={onPressSend}
               backgroundColor="unset"
               borderColor="transparent"
               opacity={disableSend ? 0.5 : 1}
@@ -166,7 +201,7 @@ export const MessageInputContainer = ({
                   <LoadingSpinner size="small" color="$secondaryText" />
                 </View>
               ) : (
-                <Icon size="$m" type={isEditing ? 'Checkmark' : 'ArrowUp'} />
+                <Icon size="$m" type="ArrowUp" />
               )}
             </Button>
           </View>


### PR DESCRIPTION
Makes some changes to MessageInputBase:
- Returns an entirely different Y-stack/wrapper if we are in editing mode; the conditionals were becoming unwieldy and component memoization made it impossible to adjust styling properties by themselves
- Changes the opacity of the UpArrow send button to 0.5 rather than 0 when the user has not inputted any text or made any changes to the MessageInput field

---

No input:

![Simulator Screenshot - iPhone 15 Pro - 2024-09-16 at 15 33 47](https://github.com/user-attachments/assets/9bb69e7d-95aa-4aea-8574-274049121e3a)

---

With input:

![Simulator Screenshot - iPhone 15 Pro - 2024-09-16 at 15 33 51](https://github.com/user-attachments/assets/48b6c29c-1de5-4263-bf6e-8bb7ae963864)

---

Editing a chat message:

![Simulator Screenshot - iPhone 15 Pro - 2024-09-16 at 15 33 58](https://github.com/user-attachments/assets/f19b8092-adad-4056-86df-90cce8431a0d)