### PR TITLE
GroupChannelsScreen: include InviteSheet and handler in ChatOptionsProvider

### DIFF
--- a/packages/app/features/top/GroupChannelsScreen.tsx
+++ b/packages/app/features/top/GroupChannelsScreen.tsx
@@ -1,7 +1,7 @@
 import * as db from '@tloncorp/shared/dist/db';
 import * as store from '@tloncorp/shared/dist/store';
 import { ChatOptionsProvider, GroupChannelsScreenView } from '@tloncorp/ui';
-import { useCallback, useMemo } from 'react';
+import { useCallback, useMemo, useState } from 'react';
 
 import { useChatSettingsNavigation } from '../../hooks/useChatSettingsNavigation';
 import { useCurrentUserId } from '../../hooks/useCurrentUser';
@@ -26,6 +26,10 @@ export function GroupChannelsScreen({
     return pins ?? [];
   }, [pins]);
 
+  const [inviteSheetGroup, setInviteSheetGroup] = useState<db.Group | null>(
+    null
+  );
+
   const handleChannelSelected = useCallback(
     (channel: db.Channel) => {
       navigateToChannel(channel);
@@ -37,17 +41,26 @@ export function GroupChannelsScreen({
     goBack();
   }, [goBack]);
 
+  const handleInviteSheetOpenChange = useCallback((open: boolean) => {
+    if (!open) {
+      setInviteSheetGroup(null);
+    }
+  }, []);
+
   return (
     <ChatOptionsProvider
       groupId={groupParam.id}
       pinned={pinnedItems}
       useGroup={store.useGroup}
+      onPressInvite={(group) => setInviteSheetGroup(group)}
       {...useChatSettingsNavigation()}
     >
       <GroupChannelsScreenView
         onChannelPressed={handleChannelSelected}
         onBackPressed={handleGoBackPressed}
         currentUser={currentUser}
+        inviteSheetGroup={inviteSheetGroup}
+        handleInviteSheetOpenChange={handleInviteSheetOpenChange}
       />
     </ChatOptionsProvider>
   );

--- a/packages/ui/src/components/ChatOptionsSheet.tsx
+++ b/packages/ui/src/components/ChatOptionsSheet.tsx
@@ -259,7 +259,7 @@ export function GroupOptions({
     };
 
     const metadataAction: Action = {
-      title: 'Edit metadata',
+      title: 'Edit group info',
       action: () => {
         sheetRef.current.setOpen(false);
         onPressGroupMeta?.(group.id);

--- a/packages/ui/src/components/GroupChannelsScreenView.tsx
+++ b/packages/ui/src/components/GroupChannelsScreenView.tsx
@@ -10,6 +10,7 @@ import ChannelNavSections from './ChannelNavSections';
 import { ChatOptionsSheet, ChatOptionsSheetMethods } from './ChatOptionsSheet';
 import { GenericHeader } from './GenericHeader';
 import { Icon } from './Icon';
+import { InviteUsersSheet } from './InviteUsersSheet';
 
 const ChannelSortOptions = ({
   setShowSortOptions,
@@ -27,11 +28,15 @@ type GroupChannelsScreenViewProps = {
   onChannelPressed: (channel: db.Channel) => void;
   onBackPressed: () => void;
   currentUser: string;
+  inviteSheetGroup: db.Group | null;
+  handleInviteSheetOpenChange: (open: boolean) => void;
 };
 
 export function GroupChannelsScreenView({
   onChannelPressed,
   onBackPressed,
+  inviteSheetGroup,
+  handleInviteSheetOpenChange,
 }: GroupChannelsScreenViewProps) {
   const groupOptions = useChatOptions();
   const group = groupOptions?.group;
@@ -102,6 +107,12 @@ export function GroupChannelsScreenView({
         onSelectSort={handleSortByChanged}
       />
       <ChatOptionsSheet ref={chatOptionsSheetRef} />
+      <InviteUsersSheet
+        open={inviteSheetGroup !== null}
+        onOpenChange={handleInviteSheetOpenChange}
+        onInviteComplete={() => handleInviteSheetOpenChange(false)}
+        group={inviteSheetGroup ?? undefined}
+      />
     </View>
   );
 }


### PR DESCRIPTION
It appears we missed including the invite sheet in the ChatOptionsProvider that wraps the GroupChannelsScreen. This is present on ChatListScreen and handled in a similar manner.

A video of this menu option working (does not work in the current TestFlight build):

https://github.com/user-attachments/assets/9f256569-e34f-40ef-ad18-8de0b8e76f78

Also changes the metadata editing option from "Edit metadata" to "Edit group info" (the title of the subsequent screen and a friendlier phrasing).