### PR TITLE
Posts, Channels: relocate overflow menu

### DIFF
--- a/packages/ui/src/components/Channel/index.tsx
+++ b/packages/ui/src/components/Channel/index.tsx
@@ -284,7 +284,7 @@ export function Channel({
                       showSearchButton={isChatChannel}
                       goToSearch={goToSearch}
                       showSpinner={isLoadingPosts}
-                      showMenuButton={false}
+                      showMenuButton={true}
                     />
                     <KeyboardAvoidingView enabled={!activeMessage}>
                       <YStack alignItems="center" flex={1}>

--- a/packages/ui/src/components/PostScreenView.tsx
+++ b/packages/ui/src/components/PostScreenView.tsx
@@ -112,7 +112,6 @@ export function PostScreenView({
               showSearchButton={false}
               post={parentPost ?? undefined}
               mode={headerMode}
-              showMenuButton={true}
             />
             <KeyboardAvoidingView enabled={!activeMessage}>
               {parentPost ? (


### PR DESCRIPTION
Fixes an inconsistency where post detail views have Channel-level action menus (which have nothing to do with the post itself), and Channels have no menu whatsoever (so muting a channel involves navigating into a child post and accessing the menu in the incorrect place).

Note that this adds a '...' button to the channel header. This is probably correct and not reflected in design.

![Screenshot 2024-09-17 at 9 59 42 AM](https://github.com/user-attachments/assets/76ee1b1f-4f8f-4457-92e3-ecc45d983897)

![Screenshot 2024-09-17 at 10 00 03 AM](https://github.com/user-attachments/assets/4e382826-42a6-4bde-a759-34a3b5279d54)
