### PR TITLE
lure: better url fetching

### DIFF
--- a/apps/tlon-web/src/groups/LureInviteBlock.tsx
+++ b/apps/tlon-web/src/groups/LureInviteBlock.tsx
@@ -45,7 +45,7 @@ export default function LureInviteBlock({
         </p>
       </div>
 
-      {status === 'ready' && (
+      {status === 'ready' && shareUrl && (
         <QRWidget
           link={shareUrl}
           navigatorTitle={`Join ${group?.meta.title ?? flag}`}
@@ -83,7 +83,9 @@ export default function LureInviteBlock({
           <span
             className={cn(
               'flex h-5 w-5 shrink-0 items-center justify-center rounded-full',
-              status === 'disabled' ? 'border border-gray-100' : 'bg-blue-500'
+              status === 'disabled' || status === 'loading'
+                ? 'border border-gray-100'
+                : 'bg-blue-500'
             )}
           >
             <CheckIcon className="h-4 w-4 text-white" />

--- a/apps/tlon-web/src/logic/branch.ts
+++ b/apps/tlon-web/src/logic/branch.ts
@@ -68,7 +68,7 @@ export const createDeepLink = async (
     $canonical_url: fallbackUrl,
   };
   if (type === 'lure') {
-    data.lure = path;
+    data.lure = token;
   } else {
     data.wer = path;
   }

--- a/packages/shared/src/store/lure.ts
+++ b/packages/shared/src/store/lure.ts
@@ -20,10 +20,9 @@ const LURE_REQUEST_TIMEOUT = 10 * 1000;
 
 interface Lure {
   fetched: boolean;
-  url: string;
+  url?: string;
   deepLinkUrl?: string;
   enabled?: boolean;
-  enableAcked?: boolean;
   metadata?: LureMetadata;
 }
 
@@ -40,8 +39,7 @@ interface LureState {
   fetchLure: (
     flag: string,
     branchDomain: string,
-    branchKey: string,
-    fetchIfData?: boolean
+    branchKey: string
   ) => Promise<void>;
   describe: (
     flag: string,
@@ -132,7 +130,7 @@ export const useLureState = create<LureState>((set, get) => ({
     const { name } = getFlagParts(flag);
     const prevLure = get().lures[flag];
     lureLogger.log('fetching', flag, 'prevLure', prevLure);
-    const [enabled, url, metadata, outstandingPoke] = await Promise.all([
+    const [enabled, url, metadata] = await Promise.all([
       // enabled
       asyncWithDefault(async () => {
         lureLogger.log(performance.now(), 'fetching enabled', flag);
@@ -149,12 +147,12 @@ export const useLureState = create<LureState>((set, get) => ({
         });
       }, prevLure?.enabled),
       // url
-      asyncWithDefault(async () => {
+      asyncWithDefault<string | undefined>(async () => {
         lureLogger.log(performance.now(), 'fetching url', flag);
-        return scry<string>({
-          app: 'reel',
-          path: `/v1/id-url/${flag}`,
-        }).then((u) => {
+        return subscribeOnce<string>(
+          { app: 'reel', path: `/v1/id-link/${flag}` },
+          4500
+        ).then((u) => {
           lureLogger.log(performance.now(), 'url fetched', u, flag);
           return u;
         });
@@ -168,18 +166,9 @@ export const useLureState = create<LureState>((set, get) => ({
           }),
         prevLure?.metadata
       ),
-      // outstandingPoke
-      asyncWithDefault(
-        async () =>
-          scry<boolean>({
-            app: 'reel',
-            path: `/outstanding-poke/${flag}`,
-          }),
-        false
-      ),
     ]);
 
-    lureLogger.log('fetched', flag, enabled, url, metadata, outstandingPoke);
+    lureLogger.log('fetched', flag, enabled, url, metadata);
 
     let deepLinkUrl: string | undefined;
     lureLogger.log('enabled', enabled);
@@ -199,7 +188,6 @@ export const useLureState = create<LureState>((set, get) => ({
         draft.lures[flag] = {
           fetched: true,
           enabled,
-          enableAcked: !outstandingPoke,
           url,
           deepLinkUrl,
           metadata,
@@ -269,17 +257,17 @@ export function useLure({
   };
 }
 
-export function useLureLinkChecked(url: string, enabled: boolean) {
+export function useLureLinkChecked(url: string | undefined, enabled: boolean) {
   const prevData = useRef<boolean | undefined>(false);
-  const pathEncodedUrl = stringToTa(url);
+  const pathEncodedUrl = stringToTa(url || '');
   const { data, ...query } = useQuery({
     queryKey: ['lure-check', url],
     queryFn: async () =>
       subscribeOnce<boolean>(
-        { app: 'grouper', path: `/check-link/${pathEncodedUrl}` },
+        { app: 'grouper', path: `/v1/check-link/${pathEncodedUrl}` },
         4500
       ),
-    enabled,
+    enabled: enabled && !!url,
     refetchInterval: 5000,
   });
 
@@ -303,12 +291,11 @@ export function useLureLinkStatus({
   branchDomain: string;
   branchKey: string;
 }) {
-  const { supported, fetched, enabled, enableAcked, url, deepLinkUrl, toggle } =
-    useLure({
-      flag,
-      branchDomain,
-      branchKey,
-    });
+  const { supported, fetched, enabled, url, deepLinkUrl, toggle } = useLure({
+    flag,
+    branchDomain,
+    branchKey,
+  });
   const { good, checked } = useLureLinkChecked(url, !!enabled);
 
   lureLogger.log('useLureLinkStatus', {

--- a/packages/ui/src/components/InviteUsersWidget.tsx
+++ b/packages/ui/src/components/InviteUsersWidget.tsx
@@ -26,7 +26,7 @@ const InviteUsersWidgetComponent = ({
     branchDomain: branchDomain,
     branchKey: branchKey,
   });
-  const { doCopy } = useCopy(shareUrl);
+  const { doCopy } = useCopy(shareUrl || '');
   const currentUserIsAdmin = useMemo(
     () =>
       group?.members?.some(


### PR DESCRIPTION
This uses the new endpoint in tloncorp/landscape#286 to fetch URLs instead of the scry since we want to wait for the confirmation to come through from the provider so we give the correct URL. Updates both web and mobile

PR Checklist
- [ ] Includes changes to desk files
- [ ] Describes how you tested the PR locally (test ship vs livenet)
- [ ] If a new feature, includes automated tests
- [ ] Comments added anywhere logic may be confusing without context