### PR TITLE
native: fix onboarding nickname

### DIFF
--- a/apps/tlon-mobile/src/App.main.tsx
+++ b/apps/tlon-mobile/src/App.main.tsx
@@ -13,6 +13,7 @@ import { createNativeStackNavigator } from '@react-navigation/native-stack';
 import ErrorBoundary from '@tloncorp/app/ErrorBoundary';
 import { BranchProvider, useBranch } from '@tloncorp/app/contexts/branch';
 import { ShipProvider, useShip } from '@tloncorp/app/contexts/ship';
+import { SignupProvider } from '@tloncorp/app/contexts/signup';
 import { useIsDarkMode } from '@tloncorp/app/hooks/useIsDarkMode';
 import { useScreenOptions } from '@tloncorp/app/hooks/useScreenOptions';
 import { useMigrations } from '@tloncorp/app/lib/nativeDb';
@@ -208,23 +209,25 @@ export default function ConnectedApp(props: Props) {
                     enable: process.env.NODE_ENV !== 'test',
                   }}
                 >
-                  <GestureHandlerRootView style={{ flex: 1 }}>
-                    <SafeAreaProvider>
-                      <MigrationCheck>
-                        <QueryClientProvider client={queryClient}>
-                          <PortalProvider>
-                            <App {...props} />
-                          </PortalProvider>
+                  <SignupProvider>
+                    <GestureHandlerRootView style={{ flex: 1 }}>
+                      <SafeAreaProvider>
+                        <MigrationCheck>
+                          <QueryClientProvider client={queryClient}>
+                            <PortalProvider>
+                              <App {...props} />
+                            </PortalProvider>
 
-                          {__DEV__ && (
-                            <DevTools
-                              navigationContainerRef={navigationContainerRef}
-                            />
-                          )}
-                        </QueryClientProvider>
-                      </MigrationCheck>
-                    </SafeAreaProvider>
-                  </GestureHandlerRootView>
+                            {__DEV__ && (
+                              <DevTools
+                                navigationContainerRef={navigationContainerRef}
+                              />
+                            )}
+                          </QueryClientProvider>
+                        </MigrationCheck>
+                      </SafeAreaProvider>
+                    </GestureHandlerRootView>
+                  </SignupProvider>
                 </PostHogProvider>
               </BranchProvider>
             </NavigationContainer>

--- a/apps/tlon-mobile/src/components/AuthenticatedApp.tsx
+++ b/apps/tlon-mobile/src/components/AuthenticatedApp.tsx
@@ -1,9 +1,11 @@
 import crashlytics from '@react-native-firebase/crashlytics';
 import { useShip } from '@tloncorp/app/contexts/ship';
+import { useSignupContext } from '@tloncorp/app/contexts/signup';
 import useAppForegrounded from '@tloncorp/app/hooks/useAppForegrounded';
 import { useCurrentUserId } from '@tloncorp/app/hooks/useCurrentUser';
 import { useNavigationLogging } from '@tloncorp/app/hooks/useNavigationLogger';
 import { useNetworkLogger } from '@tloncorp/app/hooks/useNetworkLogger';
+import { usePostSignup } from '@tloncorp/app/hooks/usePostSignup';
 import { configureClient } from '@tloncorp/app/lib/api';
 import { PlatformState } from '@tloncorp/app/lib/platformHelpers';
 import { AppDataProvider } from '@tloncorp/app/provider/AppDataProvider';
@@ -29,6 +31,8 @@ function AuthenticatedApp({
   const { ship, shipUrl } = useShip();
   const currentUserId = useCurrentUserId();
   const session = store.useCurrentSession();
+  const signupContext = useSignupContext();
+  const handlePostSignup = usePostSignup();
   useNotificationListener(notificationListenerProps);
   useDeepLinkListener();
   useNavigationLogging();
@@ -50,8 +54,12 @@ function AuthenticatedApp({
       store.setErrorTrackingUserId(currentUserId);
     }
 
+    if (signupContext.didSignup) {
+      handlePostSignup();
+    }
+
     sync.syncStart();
-  }, [currentUserId, ship, shipUrl]);
+  }, [currentUserId, handlePostSignup, ship, shipUrl, signupContext.didSignup]);
 
   useAppForegrounded(() => {
     // only run these updates if we've initialized the session

--- a/apps/tlon-mobile/src/screens/Onboarding/ReserveShipScreen.tsx
+++ b/apps/tlon-mobile/src/screens/Onboarding/ReserveShipScreen.tsx
@@ -1,5 +1,4 @@
 import type { NativeStackScreenProps } from '@react-navigation/native-stack';
-import { useBranch } from '@tloncorp/app/contexts/branch';
 import { useShip } from '@tloncorp/app/contexts/ship';
 import { useSignupContext } from '@tloncorp/app/contexts/signup';
 import {
@@ -10,17 +9,13 @@ import {
   getShipsWithStatus,
   reserveShip as reserveShipApi,
 } from '@tloncorp/app/lib/hostingApi';
-import { connectNotifyProvider } from '@tloncorp/app/lib/notificationsApi';
 import { trackError, trackOnboardingAction } from '@tloncorp/app/utils/posthog';
 import { getShipFromCookie, getShipUrl } from '@tloncorp/app/utils/ship';
 import {
   configureApi,
   getLandscapeAuthCookie,
-  updateNickname,
-  updateTelemetrySetting,
 } from '@tloncorp/shared/dist/api';
 import { Spinner, Text, View, YStack } from '@tloncorp/ui';
-import { preSig } from '@urbit/aura';
 import { useCallback, useEffect, useState } from 'react';
 import { Alert } from 'react-native';
 
@@ -84,39 +79,6 @@ export const ReserveShipScreen = ({
       const ship = getShipFromCookie(authCookie);
       configureApi(ship, shipUrl);
 
-      // if (signUpExtras?.nickname) {
-      //   try {
-      //     await updateNickname(signUpExtras.nickname);
-      //   } catch (err) {
-      //     console.error('Error setting nickname:', err);
-      //     if (err instanceof Error) {
-      //       trackError(err);
-      //     }
-      //   }
-      // }
-
-      // if (signUpExtras?.notificationToken) {
-      //   try {
-      //     await connectNotifyProvider(signUpExtras.notificationToken);
-      //   } catch (err) {
-      //     console.error('Error connecting push notifications provider:', err);
-      //     if (err instanceof Error) {
-      //       trackError(err);
-      //     }
-      //   }
-      // }
-
-      // if (signUpExtras?.telemetry !== undefined) {
-      //   try {
-      //     await updateTelemetrySetting(signUpExtras.telemetry);
-      //   } catch (err) {
-      //     console.error('Error setting telemetry:', err);
-      //     if (err instanceof Error) {
-      //       trackError(err);
-      //     }
-      //   }
-      // }
-
       // Set the ship info in the main context to navigate to chat view
       setShip({
         ship,
@@ -124,7 +86,13 @@ export const ReserveShipScreen = ({
         authCookie,
       });
     },
-    [setShip]
+    [
+      navigation,
+      setShip,
+      signupContext.nickname,
+      signupContext.telemetry,
+      user.id,
+    ]
   );
 
   const reserveShip = useCallback(

--- a/apps/tlon-mobile/src/screens/Onboarding/ReserveShipScreen.tsx
+++ b/apps/tlon-mobile/src/screens/Onboarding/ReserveShipScreen.tsx
@@ -1,6 +1,7 @@
 import type { NativeStackScreenProps } from '@react-navigation/native-stack';
 import { useBranch } from '@tloncorp/app/contexts/branch';
 import { useShip } from '@tloncorp/app/contexts/ship';
+import { useSignupContext } from '@tloncorp/app/contexts/signup';
 import {
   allocateReservedShip,
   getHostingUser,
@@ -20,7 +21,6 @@ import {
 } from '@tloncorp/shared/dist/api';
 import { Spinner, Text, View, YStack } from '@tloncorp/ui';
 import { preSig } from '@urbit/aura';
-import { useSignupContext } from 'packages/app/contexts/signup';
 import { useCallback, useEffect, useState } from 'react';
 import { Alert } from 'react-native';
 

--- a/apps/tlon-mobile/src/screens/Onboarding/ReserveShipScreen.tsx
+++ b/apps/tlon-mobile/src/screens/Onboarding/ReserveShipScreen.tsx
@@ -30,7 +30,7 @@ type Props = NativeStackScreenProps<OnboardingStackParamList, 'ReserveShip'>;
 export const ReserveShipScreen = ({
   navigation,
   route: {
-    params: { user, signUpExtras },
+    params: { user },
   },
 }: Props) => {
   const [{ state, error }, setState] = useState<{
@@ -54,15 +54,16 @@ export const ReserveShipScreen = ({
       const { status, shipId } = shipsWithStatus;
 
       // If user is in the sign up flow, send them to fill out some extra details
-      if (
-        signUpExtras?.nickname === undefined &&
-        signUpExtras?.telemetry === undefined
-      ) {
-        return navigation.navigate('SetNickname', {
-          user: await getHostingUser(user.id),
-          signUpExtras: { nickname: preSig(shipId) },
-        });
-      }
+      // TODO: ????
+      // if (
+      //   signUpExtras?.nickname === undefined &&
+      //   signUpExtras?.telemetry === undefined
+      // ) {
+      //   return navigation.navigate('SetNickname', {
+      //     user: await getHostingUser(user.id),
+      //     signUpExtras: { nickname: preSig(shipId) },
+      //   });
+      // }
 
       // If it's not ready, show the booting message
       if (status !== 'Ready') {
@@ -83,38 +84,38 @@ export const ReserveShipScreen = ({
       const ship = getShipFromCookie(authCookie);
       configureApi(ship, shipUrl);
 
-      if (signUpExtras?.nickname) {
-        try {
-          await updateNickname(signUpExtras.nickname);
-        } catch (err) {
-          console.error('Error setting nickname:', err);
-          if (err instanceof Error) {
-            trackError(err);
-          }
-        }
-      }
+      // if (signUpExtras?.nickname) {
+      //   try {
+      //     await updateNickname(signUpExtras.nickname);
+      //   } catch (err) {
+      //     console.error('Error setting nickname:', err);
+      //     if (err instanceof Error) {
+      //       trackError(err);
+      //     }
+      //   }
+      // }
 
-      if (signUpExtras?.notificationToken) {
-        try {
-          await connectNotifyProvider(signUpExtras.notificationToken);
-        } catch (err) {
-          console.error('Error connecting push notifications provider:', err);
-          if (err instanceof Error) {
-            trackError(err);
-          }
-        }
-      }
+      // if (signUpExtras?.notificationToken) {
+      //   try {
+      //     await connectNotifyProvider(signUpExtras.notificationToken);
+      //   } catch (err) {
+      //     console.error('Error connecting push notifications provider:', err);
+      //     if (err instanceof Error) {
+      //       trackError(err);
+      //     }
+      //   }
+      // }
 
-      if (signUpExtras?.telemetry !== undefined) {
-        try {
-          await updateTelemetrySetting(signUpExtras.telemetry);
-        } catch (err) {
-          console.error('Error setting telemetry:', err);
-          if (err instanceof Error) {
-            trackError(err);
-          }
-        }
-      }
+      // if (signUpExtras?.telemetry !== undefined) {
+      //   try {
+      //     await updateTelemetrySetting(signUpExtras.telemetry);
+      //   } catch (err) {
+      //     console.error('Error setting telemetry:', err);
+      //     if (err instanceof Error) {
+      //       trackError(err);
+      //     }
+      //   }
+      // }
 
       // Set the ship info in the main context to navigate to chat view
       setShip({
@@ -123,7 +124,7 @@ export const ReserveShipScreen = ({
         authCookie,
       });
     },
-    [user, signUpExtras, navigation, setShip]
+    [setShip]
   );
 
   const reserveShip = useCallback(

--- a/apps/tlon-mobile/src/screens/Onboarding/ReserveShipScreen.tsx
+++ b/apps/tlon-mobile/src/screens/Onboarding/ReserveShipScreen.tsx
@@ -20,6 +20,7 @@ import {
 } from '@tloncorp/shared/dist/api';
 import { Spinner, Text, View, YStack } from '@tloncorp/ui';
 import { preSig } from '@urbit/aura';
+import { useSignupContext } from 'packages/app/contexts/signup';
 import { useCallback, useEffect, useState } from 'react';
 import { Alert } from 'react-native';
 
@@ -39,6 +40,7 @@ export const ReserveShipScreen = ({
   }>({
     state: 'loading',
   });
+  const signupContext = useSignupContext();
   const { setShip } = useShip();
 
   const startShip = useCallback(
@@ -54,16 +56,14 @@ export const ReserveShipScreen = ({
       const { status, shipId } = shipsWithStatus;
 
       // If user is in the sign up flow, send them to fill out some extra details
-      // TODO: ????
-      // if (
-      //   signUpExtras?.nickname === undefined &&
-      //   signUpExtras?.telemetry === undefined
-      // ) {
-      //   return navigation.navigate('SetNickname', {
-      //     user: await getHostingUser(user.id),
-      //     signUpExtras: { nickname: preSig(shipId) },
-      //   });
-      // }
+      if (
+        signupContext.nickname === undefined &&
+        signupContext.telemetry === undefined
+      ) {
+        return navigation.navigate('SetNickname', {
+          user: await getHostingUser(user.id),
+        });
+      }
 
       // If it's not ready, show the booting message
       if (status !== 'Ready') {

--- a/apps/tlon-mobile/src/screens/Onboarding/SetNicknameScreen.tsx
+++ b/apps/tlon-mobile/src/screens/Onboarding/SetNicknameScreen.tsx
@@ -1,4 +1,5 @@
 import type { NativeStackScreenProps } from '@react-navigation/native-stack';
+import { useSignupContext } from '@tloncorp/app/contexts/signup';
 import { requestNotificationToken } from '@tloncorp/app/lib/notifications';
 import { trackError } from '@tloncorp/app/utils/posthog';
 import {
@@ -26,7 +27,7 @@ type FormData = {
 export const SetNicknameScreen = ({
   navigation,
   route: {
-    params: { user, signUpExtras },
+    params: { user },
   },
 }: Props) => {
   const {
@@ -36,19 +37,24 @@ export const SetNicknameScreen = ({
     setValue,
   } = useForm<FormData>({
     defaultValues: {
-      nickname: signUpExtras.nickname,
+      nickname: '',
       notificationToken: undefined,
     },
   });
 
+  const signupContext = useSignupContext();
+
   const onSubmit = handleSubmit(({ nickname, notificationToken }) => {
+    if (nickname) {
+      signupContext.setNickname(nickname);
+    }
+
+    if (notificationToken) {
+      signupContext.setNotificationToken(notificationToken);
+    }
+
     navigation.navigate('SetTelemetry', {
       user,
-      signUpExtras: {
-        ...signUpExtras,
-        nickname,
-        notificationToken,
-      },
     });
   });
 

--- a/apps/tlon-mobile/src/screens/Onboarding/SetTelemetryScreen.tsx
+++ b/apps/tlon-mobile/src/screens/Onboarding/SetTelemetryScreen.tsx
@@ -8,6 +8,7 @@ import {
   XStack,
   YStack,
 } from '@tloncorp/ui';
+import { useSignupContext } from 'packages/app/contexts/signup';
 import { usePostHog } from 'posthog-react-native';
 import { useCallback, useState } from 'react';
 import { Switch } from 'react-native';
@@ -20,13 +21,16 @@ type Props = NativeStackScreenProps<OnboardingStackParamList, 'SetTelemetry'>;
 export const SetTelemetryScreen = ({
   navigation,
   route: {
-    params: { user, signUpExtras },
+    params: { user },
   },
 }: Props) => {
   const [isEnabled, setIsEnabled] = useState(true);
   const postHog = usePostHog();
+  const signupContext = useSignupContext();
 
   const handleNext = useCallback(() => {
+    signupContext.setTelemetry(isEnabled);
+
     if (!isEnabled) {
       postHog?.optOut();
       branch.disableTracking(true);
@@ -34,9 +38,8 @@ export const SetTelemetryScreen = ({
 
     navigation.push('ReserveShip', {
       user,
-      signUpExtras: { ...signUpExtras, telemetry: isEnabled },
     });
-  }, [isEnabled, user, postHog, navigation, signUpExtras]);
+  }, [isEnabled, user, postHog, navigation, signupContext]);
 
   return (
     <View flex={1}>

--- a/apps/tlon-mobile/src/screens/Onboarding/SetTelemetryScreen.tsx
+++ b/apps/tlon-mobile/src/screens/Onboarding/SetTelemetryScreen.tsx
@@ -1,4 +1,5 @@
 import type { NativeStackScreenProps } from '@react-navigation/native-stack';
+import { useSignupContext } from '@tloncorp/app/contexts/signup';
 import {
   Button,
   GenericHeader,
@@ -8,7 +9,6 @@ import {
   XStack,
   YStack,
 } from '@tloncorp/ui';
-import { useSignupContext } from 'packages/app/contexts/signup';
 import { usePostHog } from 'posthog-react-native';
 import { useCallback, useState } from 'react';
 import { Switch } from 'react-native';

--- a/apps/tlon-mobile/src/screens/Onboarding/SignUpPasswordScreen.tsx
+++ b/apps/tlon-mobile/src/screens/Onboarding/SignUpPasswordScreen.tsx
@@ -31,6 +31,7 @@ import {
   View,
   YStack,
 } from '@tloncorp/ui';
+import { useSignupContext } from 'packages/app/contexts/signup';
 import { useEffect, useState } from 'react';
 import { Controller, useForm } from 'react-hook-form';
 
@@ -51,6 +52,7 @@ export const SignUpPasswordScreen = ({
   },
 }: Props) => {
   const [isSubmitting, setIsSubmitting] = useState(false);
+  const signupContext = useSignupContext();
   const signupParams = useSignupParams();
   const lureMeta = useLureMetadata();
   const {
@@ -116,6 +118,7 @@ export const SignUpPasswordScreen = ({
         lure: signupParams.lureId,
         priorityToken: signupParams.priorityToken,
       });
+      signupContext.setDidSignup(true);
     } catch (err) {
       console.error('Error signing up user:', err);
       if (err instanceof Error) {

--- a/apps/tlon-mobile/src/screens/Onboarding/SignUpPasswordScreen.tsx
+++ b/apps/tlon-mobile/src/screens/Onboarding/SignUpPasswordScreen.tsx
@@ -10,6 +10,7 @@ import {
   useLureMetadata,
   useSignupParams,
 } from '@tloncorp/app/contexts/branch';
+import { useSignupContext } from '@tloncorp/app/contexts/signup';
 import {
   logInHostingUser,
   signUpHostingUser,
@@ -31,7 +32,6 @@ import {
   View,
   YStack,
 } from '@tloncorp/ui';
-import { useSignupContext } from 'packages/app/contexts/signup';
 import { useEffect, useState } from 'react';
 import { Controller, useForm } from 'react-hook-form';
 

--- a/apps/tlon-mobile/src/types.ts
+++ b/apps/tlon-mobile/src/types.ts
@@ -99,10 +99,9 @@ export type OnboardingStackParamList = {
   JoinWaitList: { email?: string };
   RequestPhoneVerify: { user: User };
   CheckVerify: { user: User };
-  ReserveShip: { user: User; signUpExtras?: SignUpExtras };
-  SetNickname: { user: User; signUpExtras: SignUpExtras };
-  SetNotifications: { user: User; signUpExtras: SignUpExtras };
-  SetTelemetry: { user: User; signUpExtras: SignUpExtras };
+  ReserveShip: { user: User };
+  SetNickname: { user: User };
+  SetTelemetry: { user: User };
   TlonLogin: undefined;
   ShipLogin: undefined;
   ResetPassword: { email?: string };

--- a/packages/app/contexts/signup.tsx
+++ b/packages/app/contexts/signup.tsx
@@ -1,0 +1,91 @@
+import { createContext, useCallback, useContext, useState } from 'react';
+
+interface SignupValues {
+  nickname?: string;
+  notificationToken?: string;
+  telemetry?: boolean;
+  didSignup?: boolean;
+}
+
+interface SignupContext extends SignupValues {
+  setNickname: (nickname: string | undefined) => void;
+  setNotificationToken: (notificationToken: string | undefined) => void;
+  setTelemetry: (telemetry: boolean) => void;
+  setDidSignup: (didSignup: boolean) => void;
+  clear: () => void;
+}
+
+const defaultContext = {
+  nickname: undefined,
+  setNickname: () => {},
+  setNotificationToken: () => {},
+  setTelemetry: () => {},
+  setDidSignup: () => {},
+  clear: () => {},
+};
+
+const SignupContext = createContext<SignupContext>(defaultContext);
+
+export const SignupProvider = ({ children }: { children: React.ReactNode }) => {
+  const [values, setValues] = useState<SignupValues>({});
+
+  const setNickname = useCallback((nickname: string | undefined) => {
+    setValues((current) => ({
+      ...current,
+      nickname,
+    }));
+  }, []);
+
+  const setNotificationToken = useCallback(
+    (notificationToken: string | undefined) => {
+      setValues((current) => ({
+        ...current,
+        notificationToken,
+      }));
+    },
+    []
+  );
+
+  const setTelemetry = useCallback((telemetry: boolean) => {
+    setValues((current) => ({
+      ...current,
+      telemetry,
+    }));
+  }, []);
+
+  const setDidSignup = useCallback((didSignup: boolean) => {
+    setValues((current) => ({
+      ...current,
+      didSignup,
+    }));
+  }, []);
+
+  const clear = useCallback(() => {
+    setValues({});
+  }, []);
+
+  return (
+    <SignupContext.Provider
+      value={{
+        ...values,
+        setNickname,
+        setNotificationToken,
+        setTelemetry,
+        setDidSignup,
+        clear,
+      }}
+    >
+      {children}
+    </SignupContext.Provider>
+  );
+};
+
+export function useSignupContext() {
+  const context = useContext(SignupContext);
+
+  if (!context) {
+    throw new Error('useSignupContext must be used within a SignupProvider');
+  }
+
+  return context;
+}

--- a/packages/app/hooks/usePostSignup.ts
+++ b/packages/app/hooks/usePostSignup.ts
@@ -1,0 +1,45 @@
+import { updateTelemetrySetting } from '@tloncorp/shared/dist/api';
+import * as store from '@tloncorp/shared/dist/store';
+import { createDevLogger } from 'packages/shared/dist';
+import { useCallback } from 'react';
+
+import { useSignupContext } from '../contexts/signup';
+import { connectNotifyProvider } from '../lib/notificationsApi';
+
+const logger = createDevLogger('postSignup', false);
+
+export function usePostSignup() {
+  const signupContext = useSignupContext();
+
+  const handlePostSignup = useCallback(async () => {
+    if (signupContext.nickname) {
+      try {
+        await store.updateCurrentUserProfile({
+          nickname: signupContext.nickname,
+        });
+      } catch (e) {
+        logger.error('Failed to set nickname', e);
+      }
+    }
+
+    if (typeof signupContext.telemetry !== 'undefined') {
+      try {
+        await updateTelemetrySetting(signupContext.telemetry);
+      } catch (e) {
+        logger.error('Failed to set telemetry', e);
+      }
+    }
+
+    if (signupContext.notificationToken) {
+      try {
+        await connectNotifyProvider(signupContext.notificationToken);
+      } catch (e) {
+        logger.error('Failed to connect notify provider', e);
+      }
+    }
+
+    signupContext.clear();
+  }, [signupContext]);
+
+  return handlePostSignup;
+}

--- a/packages/app/hooks/usePostSignup.ts
+++ b/packages/app/hooks/usePostSignup.ts
@@ -6,7 +6,7 @@ import { useCallback } from 'react';
 import { useSignupContext } from '../contexts/signup';
 import { connectNotifyProvider } from '../lib/notificationsApi';
 
-const logger = createDevLogger('postSignup', false);
+const logger = createDevLogger('postSignup', true);
 
 export function usePostSignup() {
   const signupContext = useSignupContext();

--- a/packages/app/hooks/usePostSignup.ts
+++ b/packages/app/hooks/usePostSignup.ts
@@ -1,6 +1,6 @@
+import { createDevLogger } from '@tloncorp/shared/dist';
 import { updateTelemetrySetting } from '@tloncorp/shared/dist/api';
 import * as store from '@tloncorp/shared/dist/store';
-import { createDevLogger } from 'packages/shared/dist';
 import { useCallback } from 'react';
 
 import { useSignupContext } from '../contexts/signup';

--- a/packages/shared/src/api/userApi.ts
+++ b/packages/shared/src/api/userApi.ts
@@ -1,14 +1,5 @@
 import { poke } from './urbit';
 
-export const updateNickname = async (nickname: string) =>
-  poke({
-    app: 'contacts',
-    mark: 'contact-action',
-    json: {
-      edit: [{ nickname }],
-    },
-  });
-
 export const updateTelemetrySetting = async (isEnabled: boolean) =>
   poke({
     app: 'settings',


### PR DESCRIPTION
The code that tries to thread through nickname via screen props wasn't working. It was also calling out to a non-standard legacy helpers for setting profile data.

I extracted signup configuration into its own context and pulled post-signup logic up into _AutheticatedApp_ so we can work with our normal api client & store methods. I think this will be more agile moving forward compared to passing along screen props and bundling the logic into the final onboarding screen.

Confirmed setting the nickname worked by running through a full signup.

Fixes TLON-2744