### PR TITLE
lure: regenerate old links

### DIFF
--- a/apps/tlon-web/src/state/lure/lure.ts
+++ b/apps/tlon-web/src/state/lure/lure.ts
@@ -236,7 +236,15 @@ export function useLure(flag: string, disableLoading = false) {
   );
 
   useEffect(() => {
-    if (lure.enabled && !lure.url && group?.meta) {
+    if (!group?.meta) {
+      return;
+    }
+
+    if (lure.enabled && !lure.url) {
+      describe(group.meta);
+    }
+
+    if (lure.enabled && lure.url && checkOldLureToken(lure.url)) {
       describe(group.meta);
     }
   }, [group]);
@@ -293,6 +301,10 @@ export function useLureLinkStatus(flag: string) {
       return 'disabled';
     }
 
+    if (url && checkOldLureToken(url)) {
+      return 'stale';
+    }
+
     if (!url || !fetched || !checked) {
       return 'loading';
     }
@@ -305,4 +317,12 @@ export function useLureLinkStatus(flag: string) {
   }, [supported, fetched, enabled, url, good, checked]);
 
   return { status, shareUrl: deepLinkUrl ?? url, toggle };
+}
+
+function checkOldLureToken(url: string | undefined) {
+  if (!url) return false;
+  const parts = url.split('/');
+  const token = parts.pop();
+  const ship = parts.pop();
+  return ship && token && ship.startsWith('~');
 }

--- a/packages/shared/src/store/lure.ts
+++ b/packages/shared/src/store/lure.ts
@@ -1,6 +1,6 @@
 import { useQuery } from '@tanstack/react-query';
 import produce from 'immer';
-import { useCallback, useMemo, useRef } from 'react';
+import { useCallback, useEffect, useMemo, useRef } from 'react';
 import create from 'zustand';
 
 import { getCurrentUserId, poke, scry, subscribeOnce } from '../api/urbit';
@@ -315,11 +315,12 @@ export function useLureLinkStatus({
   branchDomain: string;
   branchKey: string;
 }) {
-  const { supported, fetched, enabled, url, deepLinkUrl, toggle } = useLure({
-    flag,
-    branchDomain,
-    branchKey,
-  });
+  const { supported, fetched, enabled, url, deepLinkUrl, toggle, describe } =
+    useLure({
+      flag,
+      branchDomain,
+      branchKey,
+    });
   const { good, checked } = useLureLinkChecked(url, !!enabled);
 
   lureLogger.log('useLureLinkStatus', {
@@ -342,6 +343,10 @@ export function useLureLinkStatus({
       return 'disabled';
     }
 
+    if (url && checkOldLureToken(url)) {
+      return 'stale';
+    }
+
     if (!url || !checkLureToken(url) || !fetched || !checked) {
       lureLogger.log('loading', fetched, checked, url);
       return 'loading';
@@ -356,7 +361,7 @@ export function useLureLinkStatus({
 
   lureLogger.log('url', url, 'deepLinkUrl', deepLinkUrl, 'status', status);
 
-  return { status, shareUrl: deepLinkUrl ?? url, toggle };
+  return { status, shareUrl: deepLinkUrl ?? url, toggle, describe };
 }
 
 // hack: we get an intermediate state while generating lure links where
@@ -366,4 +371,12 @@ function checkLureToken(url: string | undefined) {
   if (!url) return false;
   const token = url.split('/').pop();
   return token && token.startsWith('0v');
+}
+
+function checkOldLureToken(url: string | undefined) {
+  if (!url) return false;
+  const parts = url.split('/');
+  const token = parts.pop();
+  const ship = parts.pop();
+  return ship && token && ship.startsWith('~');
 }

--- a/packages/ui/src/components/InviteUsersWidget.tsx
+++ b/packages/ui/src/components/InviteUsersWidget.tsx
@@ -21,7 +21,7 @@ const InviteUsersWidgetComponent = ({
   const currentUser = useCurrentUserId();
   const branchDomain = useBranchDomain();
   const branchKey = useBranchKey();
-  const { status, shareUrl, toggle } = store.useLureLinkStatus({
+  const { status, shareUrl, toggle, describe } = store.useLureLinkStatus({
     flag: group.id,
     branchDomain: branchDomain,
     branchKey: branchKey,
@@ -77,16 +77,21 @@ const InviteUsersWidgetComponent = ({
   ]);
 
   useEffect(() => {
+    const meta = {
+      title: group.title ?? '',
+      description: group.description ?? '',
+      cover: group.coverImage ?? '',
+      image: group.iconImage ?? '',
+    };
+
     const toggleLink = async () => {
-      await toggle({
-        title: group.title ?? '',
-        description: group.description ?? '',
-        cover: group.coverImage ?? '',
-        image: group.iconImage ?? '',
-      });
+      await toggle(meta);
     };
     if (status === 'disabled' && currentUserIsAdmin) {
       toggleLink();
+    }
+    if (status === 'stale') {
+      describe(meta);
     }
   }, [group, branchDomain, branchKey, toggle, status, currentUserIsAdmin]);
 


### PR DESCRIPTION
This fixes an issue on mobile where you'd never get the "Invite friends who aren't on Tlon" because the current group had an "old" lure link. This makes sure we regenerate any old links so everyone gets the new behavior.

PR Checklist
- [ ] Includes changes to desk files
- [ ] Describes how you tested the PR locally (test ship vs livenet)
- [ ] If a new feature, includes automated tests
- [ ] Comments added anywhere logic may be confusing without context