### PR TITLE
native: remove skip button in invite sheet

### DIFF
--- a/packages/ui/src/components/InviteUsersWidget.tsx
+++ b/packages/ui/src/components/InviteUsersWidget.tsx
@@ -103,10 +103,6 @@ const InviteUsersWidgetComponent = ({
     describe,
   ]);
 
-  const handleSkipButtonPress = useCallback(() => {
-    onInviteComplete();
-  }, [onInviteComplete]);
-
   const buttonText = useMemo(() => {
     if (invitees.length === 0 && status === 'ready') {
       return `Invite friends that aren't on Tlon`;
@@ -129,7 +125,7 @@ const InviteUsersWidgetComponent = ({
           onSelectedChange={setInvitees}
         />
       </ActionSheet.ContentBlock>
-      <ActionSheet.ContentBlock gap="$l">
+      <ActionSheet.ContentBlock>
         <Button
           hero
           onPress={handleInviteButtonPress}
@@ -139,9 +135,6 @@ const InviteUsersWidgetComponent = ({
           }
         >
           <Button.Text>{buttonText}</Button.Text>
-        </Button>
-        <Button hero secondary onPress={handleSkipButtonPress}>
-          <Button.Text color="$primaryText">Skip</Button.Text>
         </Button>
       </ActionSheet.ContentBlock>
     </>


### PR DESCRIPTION
Now that the updated group creation flow is in and we display the invite in the channel itself, we don't need the skip button in the sheet. This will help avoid confusion since it was always shown and doesn't make sense outside the group creation context.