### PR TITLE
native: handle Lure link click when already signed in

### DIFF
--- a/apps/tlon-mobile/src/controllers/ChatListScreenController.tsx
+++ b/apps/tlon-mobile/src/controllers/ChatListScreenController.tsx
@@ -10,9 +10,11 @@ type ChatListControllerProps = NativeStackScreenProps<
 
 export function ChatListScreenController({
   navigation,
+  route: { params },
 }: ChatListControllerProps) {
   return (
     <ChatListScreen
+      previewGroup={params?.previewGroup}
       navigateToChannel={(channel) => {
         navigation.push('Channel', { channel });
       }}

--- a/apps/tlon-mobile/src/hooks/useDeepLinkListener.ts
+++ b/apps/tlon-mobile/src/hooks/useDeepLinkListener.ts
@@ -23,7 +23,7 @@ export const useDeepLinkListener = () => {
       (async () => {
         isHandlingLinkRef.current = true;
         // if the lure was clicked prior to authenticating, trigger the automatic join & DM
-        if (lure.clickedPreAuth) {
+        if (lure.shouldAutoJoin) {
           try {
             logger.log(`inviting ship with lure`, ship, signupParams.lureId);
             await inviteShipWithLure({ ship, lure: signupParams.lureId });

--- a/apps/tlon-mobile/src/hooks/useDeepLinkListener.ts
+++ b/apps/tlon-mobile/src/hooks/useDeepLinkListener.ts
@@ -1,36 +1,59 @@
+import { NavigationProp, useNavigation } from '@react-navigation/native';
 import { useBranch, useSignupParams } from '@tloncorp/app/contexts/branch';
 import { useShip } from '@tloncorp/app/contexts/ship';
 import { inviteShipWithLure } from '@tloncorp/app/lib/hostingApi';
 import { trackError } from '@tloncorp/app/utils/posthog';
+import { createDevLogger } from '@tloncorp/shared/dist';
+import * as store from '@tloncorp/shared/dist/store';
 import { useEffect, useRef } from 'react';
 
+import { RootStackParamList } from '../types';
+
+const logger = createDevLogger('deeplinkHandler', true);
+
 export const useDeepLinkListener = () => {
-  const isInvitingRef = useRef(false);
+  const navigation = useNavigation<NavigationProp<RootStackParamList>>();
+  const isHandlingLinkRef = useRef(false);
   const { ship } = useShip();
   const signupParams = useSignupParams();
   const { clearLure, lure } = useBranch();
 
-  // If lure is present, invite it and mark as handled
   useEffect(() => {
-    if (ship && lure && !isInvitingRef.current) {
+    if (ship && lure && !isHandlingLinkRef.current) {
       (async () => {
-        try {
-          isInvitingRef.current = true;
-          console.log(`inviting ship with lure`, ship, signupParams.lureId);
-          await inviteShipWithLure({ ship, lure: signupParams.lureId });
-        } catch (err) {
-          console.error(
-            '[useDeepLinkListener] Error inviting ship with lure:',
-            err
-          );
-          if (err instanceof Error) {
-            trackError(err);
+        isHandlingLinkRef.current = true;
+        // if the lure was clicked prior to authenticating, trigger the automatic join & DM
+        if (lure.clickedPreAuth) {
+          try {
+            logger.log(`inviting ship with lure`, ship, signupParams.lureId);
+            await inviteShipWithLure({ ship, lure: signupParams.lureId });
+          } catch (err) {
+            logger.error('Error inviting ship with lure:', err);
+            if (err instanceof Error) {
+              trackError(err);
+            }
           }
-        } finally {
-          clearLure();
-          isInvitingRef.current = false;
+        } else {
+          // otherwise, treat it as a deeplink and navigate to the group
+          if (lure.invitedGroupId) {
+            const group = await store.getGroupPreview(lure.invitedGroupId);
+            if (group) {
+              navigation.reset({
+                index: 1,
+                routes: [{ name: 'ChatList', params: { previewGroup: group } }],
+              });
+            } else {
+              logger.error(
+                'Failed to navigate to group deeplink',
+                lure.invitedGroupId
+              );
+            }
+          }
         }
+
+        clearLure();
+        isHandlingLinkRef.current = false;
       })();
     }
-  }, [ship, signupParams, clearLure, lure]);
+  }, [ship, signupParams, clearLure, lure, navigation]);
 };

--- a/apps/tlon-mobile/src/hooks/useDeepLinkListener.ts
+++ b/apps/tlon-mobile/src/hooks/useDeepLinkListener.ts
@@ -36,7 +36,9 @@ export const useDeepLinkListener = () => {
         } else {
           // otherwise, treat it as a deeplink and navigate to the group
           if (lure.invitedGroupId) {
-            const group = await store.getGroupPreview(lure.invitedGroupId);
+            const [group] = await store.syncGroupPreviews([
+              lure.invitedGroupId,
+            ]);
             if (group) {
               navigation.reset({
                 index: 1,

--- a/apps/tlon-mobile/src/types.ts
+++ b/apps/tlon-mobile/src/types.ts
@@ -19,7 +19,7 @@ export type WebViewStackParamList = {
 };
 
 export type RootStackParamList = {
-  ChatList: undefined;
+  ChatList: { previewGroup: db.Group } | undefined;
   Activity: undefined;
   Profile: undefined;
   Channel: {

--- a/packages/app/contexts/branch.tsx
+++ b/packages/app/contexts/branch.tsx
@@ -17,7 +17,7 @@ import { useShip } from './ship';
 
 interface LureData extends DeepLinkMetadata {
   id: string;
-  clickedPreAuth: boolean;
+  shouldAutoJoin: boolean;
 }
 
 type Lure = {
@@ -123,7 +123,8 @@ export const BranchProvider = ({ children }: { children: ReactNode }) => {
               lure: {
                 ...extractLureMetadata(params),
                 id: params.lure as string,
-                clickedPreAuth: Boolean(ship),
+                // if not already authenticated, we should run Lure's invite auto-join capability after signing in
+                shouldAutoJoin: Boolean(!ship),
               },
               priorityToken: params.token as string | undefined,
             };

--- a/packages/app/contexts/branch.tsx
+++ b/packages/app/contexts/branch.tsx
@@ -13,9 +13,11 @@ import branch from 'react-native-branch';
 import { DEFAULT_LURE, DEFAULT_PRIORITY_TOKEN } from '../constants';
 import storage from '../lib/storage';
 import { getPathFromWer } from '../utils/string';
+import { useShip } from './ship';
 
 interface LureData extends DeepLinkMetadata {
   id: string;
+  clickedPreAuth: boolean;
 }
 
 type Lure = {
@@ -102,6 +104,7 @@ export const useLureMetadata = () => {
 export const BranchProvider = ({ children }: { children: ReactNode }) => {
   const [{ deepLinkPath, lure, priorityToken }, setState] =
     useState(INITIAL_STATE);
+  const { ship } = useShip();
 
   useEffect(() => {
     console.debug('[branch] Subscribing to Branch listener');
@@ -120,6 +123,7 @@ export const BranchProvider = ({ children }: { children: ReactNode }) => {
               lure: {
                 ...extractLureMetadata(params),
                 id: params.lure as string,
+                clickedPreAuth: Boolean(ship),
               },
               priorityToken: params.token as string | undefined,
             };

--- a/packages/app/features/top/ChatListScreen.tsx
+++ b/packages/app/features/top/ChatListScreen.tsx
@@ -37,6 +37,7 @@ const ShowFiltersButton = ({ onPress }: { onPress: () => void }) => {
 };
 
 export default function ChatListScreen({
+  previewGroup,
   navigateToChannel,
   navigateToGroupChannels,
   navigateToSelectedPost,
@@ -54,6 +55,7 @@ export default function ChatListScreen({
   navigateToProfile: () => void;
   navigateToFindGroups: () => void;
   navigateToCreateGroup: () => void;
+  previewGroup?: db.Group;
 }) {
   const [addGroupOpen, setAddGroupOpen] = useState(false);
   const [screenTitle, setScreenTitle] = useState('Home');
@@ -81,7 +83,9 @@ export default function ChatListScreen({
   const [activeTab, setActiveTab] = useState<'all' | 'groups' | 'messages'>(
     'all'
   );
-  const [selectedGroup, setSelectedGroup] = useState<db.Group | null>(null);
+  const [selectedGroup, setSelectedGroup] = useState<db.Group | null>(
+    previewGroup ?? null
+  );
   const [showFilters, setShowFilters] = useState(false);
   const isFocused = useIsFocused();
   const { data: pins } = store.usePins({

--- a/packages/app/hooks/useNavigationLogger.ts
+++ b/packages/app/hooks/useNavigationLogger.ts
@@ -11,12 +11,12 @@ export function useNavigationLogging() {
   useEffect(() => {
     // Set initial route
     const state = navigation.getState();
-    routeNameRef.current = state ? state.routes[state.index].name : '';
+    routeNameRef.current = state ? state.routes[state.index]?.name : '';
 
     const unsubscribe = navigation.addListener('state', () => {
       const previousRouteName = routeNameRef?.current ?? '';
       const state = navigation.getState();
-      const currentRouteName = state ? state.routes[state.index].name : '';
+      const currentRouteName = state ? state.routes[state.index]?.name : '';
 
       if (
         previousRouteName &&
@@ -31,5 +31,5 @@ export function useNavigationLogging() {
     });
 
     return unsubscribe;
-  }, [logger, navigation]);
+  }, [navigation]);
 }

--- a/packages/shared/src/store/dbHooks.ts
+++ b/packages/shared/src/store/dbHooks.ts
@@ -8,9 +8,8 @@ import { useMemo } from 'react';
 import * as api from '../api';
 import * as db from '../db';
 import * as ub from '../urbit';
-import { getGroupPreview } from './groupActions';
 import { hasCustomS3Creds, hasHostingUploadCreds } from './storage';
-import { syncPostReference } from './sync';
+import { syncGroupPreviews, syncPostReference } from './sync';
 import { keyFromQueryDeps, useKeyFromQueryDeps } from './useKeyFromQueryDeps';
 
 export * from './useChannelSearch';
@@ -313,14 +312,6 @@ export const useGroups = (options: db.GetGroupsOptions) => {
   });
 };
 
-export const useGroupPreviews = (groupIds: string[]) => {
-  const depsKey = useKeyFromQueryDeps(db.getGroupPreviews);
-  return useQuery({
-    queryKey: ['groupPreviews', depsKey, groupIds],
-    queryFn: () => db.getGroupPreviews(groupIds),
-  });
-};
-
 export const useGroup = (options: { id?: string }) => {
   return useQuery({
     enabled: !!options.id,
@@ -362,7 +353,10 @@ export const useGroupPreview = (groupId: string) => {
   const tableDeps = useKeyFromQueryDeps(db.getGroup);
   return useQuery({
     queryKey: ['groupPreview', tableDeps, groupId],
-    queryFn: async () => getGroupPreview(groupId),
+    queryFn: async () => {
+      const [preview] = await syncGroupPreviews([groupId]);
+      return preview;
+    },
   });
 };
 

--- a/packages/shared/src/store/dbHooks.ts
+++ b/packages/shared/src/store/dbHooks.ts
@@ -8,6 +8,7 @@ import { useMemo } from 'react';
 import * as api from '../api';
 import * as db from '../db';
 import * as ub from '../urbit';
+import { getGroupPreview } from './groupActions';
 import { hasCustomS3Creds, hasHostingUploadCreds } from './storage';
 import { syncPostReference } from './sync';
 import { keyFromQueryDeps, useKeyFromQueryDeps } from './useKeyFromQueryDeps';
@@ -361,16 +362,7 @@ export const useGroupPreview = (groupId: string) => {
   const tableDeps = useKeyFromQueryDeps(db.getGroup);
   return useQuery({
     queryKey: ['groupPreview', tableDeps, groupId],
-    queryFn: async () => {
-      const group = await db.getGroup({ id: groupId });
-      if (group) {
-        return group;
-      }
-
-      const groupPreview = await api.getGroupPreview(groupId);
-      await db.insertUnjoinedGroups([groupPreview]);
-      return groupPreview;
-    },
+    queryFn: async () => getGroupPreview(groupId),
   });
 };
 

--- a/packages/shared/src/store/groupActions.ts
+++ b/packages/shared/src/store/groupActions.ts
@@ -50,6 +50,17 @@ export async function createGroup({
   }
 }
 
+export async function getGroupPreview(groupId: string) {
+  const group = await db.getGroup({ id: groupId });
+  if (group) {
+    return group;
+  }
+
+  const groupPreview = await api.getGroupPreview(groupId);
+  await db.insertUnjoinedGroups([groupPreview]);
+  return groupPreview;
+}
+
 export async function acceptGroupInvitation(group: db.Group) {
   logger.log('accepting group invitation', group.id);
   await db.updateGroup({ id: group.id, joinStatus: 'joining' });

--- a/packages/shared/src/store/groupActions.ts
+++ b/packages/shared/src/store/groupActions.ts
@@ -50,17 +50,6 @@ export async function createGroup({
   }
 }
 
-export async function getGroupPreview(groupId: string) {
-  const group = await db.getGroup({ id: groupId });
-  if (group) {
-    return group;
-  }
-
-  const groupPreview = await api.getGroupPreview(groupId);
-  await db.insertUnjoinedGroups([groupPreview]);
-  return groupPreview;
-}
-
 export async function acceptGroupInvitation(group: db.Group) {
   logger.log('accepting group invitation', group.id);
   await db.updateGroup({ id: group.id, joinStatus: 'joining' });


### PR DESCRIPTION
Adds logic to handle the case where you click a lure link after already being authenticated. Instead of triggering the automatic join + dm, we treat it as a deeplink to that group and pop a preview sheet.

Fixes TLON-2758