### PR TITLE
native: handle pasting Lure deeplinks in chat

### DIFF
--- a/packages/app/contexts/branch.tsx
+++ b/packages/app/contexts/branch.tsx
@@ -104,7 +104,7 @@ export const useLureMetadata = () => {
 export const BranchProvider = ({ children }: { children: ReactNode }) => {
   const [{ deepLinkPath, lure, priorityToken }, setState] =
     useState(INITIAL_STATE);
-  const { ship } = useShip();
+  const { isAuthenticated } = useShip();
 
   useEffect(() => {
     console.debug('[branch] Subscribing to Branch listener');
@@ -124,7 +124,7 @@ export const BranchProvider = ({ children }: { children: ReactNode }) => {
                 ...extractLureMetadata(params),
                 id: params.lure as string,
                 // if not already authenticated, we should run Lure's invite auto-join capability after signing in
-                shouldAutoJoin: Boolean(!ship),
+                shouldAutoJoin: !isAuthenticated,
               },
               priorityToken: params.token as string | undefined,
             };
@@ -163,7 +163,7 @@ export const BranchProvider = ({ children }: { children: ReactNode }) => {
       console.debug('[branch] Unsubscribing from Branch listener');
       unsubscribe();
     };
-  }, []);
+  }, [isAuthenticated]);
 
   const clearLure = useCallback(() => {
     console.debug('[branch] Clearing lure state');

--- a/packages/shared/src/logic/branch.ts
+++ b/packages/shared/src/logic/branch.ts
@@ -26,6 +26,26 @@ export const getDeepLink = async (
   return url;
 };
 
+export const getBranchLinkMeta = async (
+  branchUrl: string,
+  branchKey: string
+) => {
+  const params = new URLSearchParams();
+  params.set('url', branchUrl);
+  params.set('branch_key', branchKey);
+  const response = await fetchBranchApi(`/v1/url?${params}`);
+  if (!response.ok) {
+    return undefined;
+  }
+
+  const payload = await response.json();
+  if (!payload || !payload.data) {
+    return undefined;
+  }
+
+  return payload.data;
+};
+
 export type DeepLinkType = 'lure' | 'wer';
 
 export interface DeepLinkMetadata {
@@ -60,6 +80,14 @@ export function extractLureMetadata(branchParams: any) {
     invitedGroupIconImageUrl: branchParams.invitedGroupIconImageUrl,
     invitedGroupiconImageColor: branchParams.invitedGroupiconImageColor,
   };
+}
+
+export function isLureMeta(input: unknown): input is DeepLinkMetadata {
+  if (!input || typeof input !== 'object') {
+    return false;
+  }
+
+  return 'invitedGroupId' in input;
 }
 
 export async function getDmLink(

--- a/packages/shared/src/logic/branch.ts
+++ b/packages/shared/src/logic/branch.ts
@@ -1,7 +1,10 @@
 import { isValidPatp } from '@urbit/aura';
 
 import { getPostInfoFromWer } from '../api/harkApi';
+import { createDevLogger } from '../debug';
 import * as urbit from '../urbit';
+
+const logger = createDevLogger('branch', true);
 
 const fetchBranchApi = async (path: string, init?: RequestInit) =>
   fetch(`https://api2.branch.io${path}`, init);
@@ -130,7 +133,7 @@ export const createDeepLink = async ({
     const isDMLure =
       parts.length === 2 && parts[0] === 'dm' && isValidPatp(parts[1]);
     if (!isDMLure && !getPostInfoFromWer(path)) {
-      console.log(`Invalid path: ${path}`);
+      logger.crumb(`Invalid path: ${path}`);
       return undefined;
     }
   }
@@ -153,7 +156,7 @@ export const createDeepLink = async ({
   }
   let url = await getDeepLink(alias, branchDomain, branchKey).catch(() => null);
   if (!url) {
-    console.log(`No existing deeplink for ${alias}, creating new one`);
+    logger.crumb(`No existing deeplink for ${alias}, creating new one`);
     const response = await fetchBranchApi('/v1/url', {
       method: 'POST',
       body: JSON.stringify({
@@ -167,5 +170,6 @@ export const createDeepLink = async ({
     }
     ({ url } = (await response.json()) as { url: string });
   }
+  logger.crumb('returning deeplink', url);
   return url;
 };

--- a/packages/shared/src/logic/branch.ts
+++ b/packages/shared/src/logic/branch.ts
@@ -151,9 +151,7 @@ export const createDeepLink = async ({
   } else {
     data.wer = path;
   }
-  let url = await getDeepLink(alias, branchDomain, branchKey).catch(
-    () => fallbackUrl
-  );
+  let url = await getDeepLink(alias, branchDomain, branchKey).catch(() => null);
   if (!url) {
     console.log(`No existing deeplink for ${alias}, creating new one`);
     const response = await fetchBranchApi('/v1/url', {

--- a/packages/shared/src/logic/deeplinks.ts
+++ b/packages/shared/src/logic/deeplinks.ts
@@ -1,0 +1,25 @@
+import { ContentReference } from '../api';
+import { citeToPath } from '../urbit';
+import { getBranchLinkMeta, isLureMeta } from './branch';
+
+export async function getReferenceFromDeeplink(
+  url: string,
+  branchKey: string
+): Promise<{ reference: ContentReference; path: string } | null> {
+  const linkMeta = await getBranchLinkMeta(url, branchKey);
+
+  if (linkMeta && typeof linkMeta === 'object') {
+    if (isLureMeta(linkMeta) && linkMeta.invitedGroupId) {
+      return {
+        reference: {
+          type: 'reference',
+          referenceType: 'group',
+          groupId: linkMeta.invitedGroupId,
+        },
+        path: citeToPath({ group: linkMeta.invitedGroupId }),
+      };
+    }
+  }
+
+  return null;
+}

--- a/packages/shared/src/logic/index.ts
+++ b/packages/shared/src/logic/index.ts
@@ -5,3 +5,4 @@ export * from './embed';
 export * from './types';
 export * from './activity';
 export * from './branch';
+export * from './deeplinks';

--- a/packages/shared/src/store/lure.ts
+++ b/packages/shared/src/store/lure.ts
@@ -78,14 +78,14 @@ export const useLureState = create<LureState>((set, get) => ({
       },
     });
 
-    return get().fetchLure(flag, branchDomain, branchKey);
+    // return get().fetchLure(flag, branchDomain, branchKey);
   },
   toggle: async (flag, meta, branchDomain, branchKey) => {
     const { name } = getFlagParts(flag);
     const lure = get().lures[flag];
     const enabled = !lure?.enabled;
     if (!enabled) {
-      lureLogger.log('not enabled, poking reel-undescribe', flag);
+      lureLogger.crumb('not enabled, poking reel-undescribe', flag);
       await poke({
         app: 'reel',
         mark: 'reel-undescribe',
@@ -112,7 +112,7 @@ export const useLureState = create<LureState>((set, get) => ({
       json: name,
     });
 
-    return get().fetchLure(flag, branchDomain, branchKey);
+    // return get().fetchLure(flag, branchDomain, branchKey);
   },
   start: async () => {
     const bait = await scry<Bait>({
@@ -129,11 +129,11 @@ export const useLureState = create<LureState>((set, get) => ({
   fetchLure: async (flag, branchDomain, branchKey) => {
     const { name } = getFlagParts(flag);
     const prevLure = get().lures[flag];
-    lureLogger.log('fetching', flag, 'prevLure', prevLure);
+    lureLogger.crumb('fetching', flag, 'prevLure', prevLure);
     const [enabled, url] = await Promise.all([
       // enabled
       asyncWithDefault(async () => {
-        lureLogger.log(performance.now(), 'fetching enabled', flag);
+        lureLogger.crumb(performance.now(), 'fetching enabled', flag);
         return subscribeOnce<boolean>(
           {
             app: 'grouper',
@@ -142,7 +142,7 @@ export const useLureState = create<LureState>((set, get) => ({
           LURE_REQUEST_TIMEOUT
         )
           .then((en) => {
-            lureLogger.log(performance.now(), 'enabled fetched', flag);
+            lureLogger.crumb(performance.now(), 'enabled fetched', flag);
 
             return en;
           })
@@ -153,13 +153,13 @@ export const useLureState = create<LureState>((set, get) => ({
       }, prevLure?.enabled),
       // url (includes the token as last element of the path)
       asyncWithDefault<string | undefined>(async () => {
-        lureLogger.log(performance.now(), 'fetching url', flag);
+        lureLogger.crumb(performance.now(), 'fetching url', flag);
         return subscribeOnce<string>(
           { app: 'reel', path: `/v1/id-link/${flag}` },
           LURE_REQUEST_TIMEOUT
         )
           .then((u) => {
-            lureLogger.log(performance.now(), 'url fetched', u, flag);
+            lureLogger.crumb(performance.now(), 'url fetched', u, flag);
             return u;
           })
           .catch((e) => {
@@ -169,10 +169,10 @@ export const useLureState = create<LureState>((set, get) => ({
       }, prevLure?.url),
     ]);
 
-    lureLogger.log('fetched', { flag, enabled, url });
+    lureLogger.crumb('fetched', { flag, enabled, url });
 
     let deepLinkUrl: string | undefined;
-    lureLogger.log('enabled', enabled);
+    lureLogger.crumb('enabled', enabled);
     if (enabled && checkLureToken(url)) {
       const currentUserId = getCurrentUserId();
       const group = await db.getGroup({ id: flag });
@@ -196,7 +196,7 @@ export const useLureState = create<LureState>((set, get) => ({
         branchKey,
         metadata,
       });
-      lureLogger.log('deepLinkUrl created', deepLinkUrl);
+      lureLogger.crumb('deepLinkUrl created', deepLinkUrl);
     }
 
     set(
@@ -231,8 +231,8 @@ export function useLure({
   const fetchLure = useLureState((state) => state.fetchLure);
   const { bait, lure } = useLureState(selLure(flag));
 
-  lureLogger.log('bait', bait);
-  lureLogger.log('lure', lure);
+  lureLogger.crumb('bait', bait);
+  lureLogger.crumb('lure', lure);
 
   const canCheckForUpdate = useMemo(() => {
     return Boolean(bait && !disableLoading);
@@ -245,11 +245,11 @@ export function useLure({
     );
   }, [lure]);
 
-  lureLogger.log('lure fetcher', { canCheckForUpdate, uninitialized });
+  lureLogger.crumb('lure fetcher', { canCheckForUpdate, uninitialized });
   useQuery({
     queryKey: ['lureFetcher', flag],
     queryFn: async () => {
-      lureLogger.log('fetching', flag, branchDomain, branchKey);
+      lureLogger.crumb('fetching', flag, branchDomain, branchKey);
       await fetchLure(flag, branchDomain, branchKey);
       return true;
     },
@@ -258,7 +258,7 @@ export function useLure({
   });
 
   const toggle = async (meta: GroupMeta) => {
-    lureLogger.log('toggling', flag, meta, branchDomain, branchKey);
+    lureLogger.crumb('toggling', flag, meta, branchDomain, branchKey);
     return useLureState.getState().toggle(flag, meta, branchDomain, branchKey);
   };
 
@@ -271,7 +271,7 @@ export function useLure({
     [flag, branchDomain, branchKey]
   );
 
-  lureLogger.log('useLure', flag, bait, lure, describe);
+  lureLogger.crumb('useLure', flag, bait, lure, describe);
 
   return {
     ...lure,
@@ -297,7 +297,7 @@ export function useLureLinkChecked(url: string | undefined, enabled: boolean) {
 
   prevData.current = data;
 
-  lureLogger.log('useLureLinkChecked', url, data);
+  lureLogger.crumb('useLureLinkChecked', url, data);
 
   return {
     ...query,
@@ -323,7 +323,7 @@ export function useLureLinkStatus({
     });
   const { good, checked } = useLureLinkChecked(url, !!enabled);
 
-  lureLogger.log('useLureLinkStatus', {
+  lureLogger.crumb('useLureLinkStatus', {
     flag,
     supported,
     fetched,
@@ -348,7 +348,7 @@ export function useLureLinkStatus({
     }
 
     if (!url || !checkLureToken(url) || !fetched || !checked || !deepLinkUrl) {
-      lureLogger.log('loading', fetched, checked, url, deepLinkUrl);
+      lureLogger.crumb('loading', fetched, checked, url, deepLinkUrl);
       return 'loading';
     }
 
@@ -359,7 +359,7 @@ export function useLureLinkStatus({
     return 'ready';
   }, [supported, fetched, enabled, url, checked, deepLinkUrl, good]);
 
-  lureLogger.log('url', url, 'deepLinkUrl', deepLinkUrl, 'status', status);
+  lureLogger.crumb('url', url, 'deepLinkUrl', deepLinkUrl, 'status', status);
 
   return { status, shareUrl: deepLinkUrl, toggle, describe };
 }

--- a/packages/shared/src/store/lure.ts
+++ b/packages/shared/src/store/lure.ts
@@ -111,7 +111,6 @@ export const useLureState = create<LureState>((set, get) => ({
       json: name,
     });
 
-    // return get().fetchLure(flag, branchDomain, branchKey);
   },
   start: async () => {
     const bait = await scry<Bait>({

--- a/packages/shared/src/store/lure.ts
+++ b/packages/shared/src/store/lure.ts
@@ -78,7 +78,6 @@ export const useLureState = create<LureState>((set, get) => ({
       },
     });
 
-    // return get().fetchLure(flag, branchDomain, branchKey);
   },
   toggle: async (flag, meta, branchDomain, branchKey) => {
     const { name } = getFlagParts(flag);

--- a/packages/ui/src/components/InviteFriendsToTlonButton.tsx
+++ b/packages/ui/src/components/InviteFriendsToTlonButton.tsx
@@ -9,6 +9,7 @@ import { useCopy } from '../hooks/useCopy';
 import { useIsAdmin } from '../utils';
 import { Button } from './Button';
 import { Icon } from './Icon';
+import { LoadingSpinner } from './LoadingSpinner';
 
 export function InviteFriendsToTlonButton({ group }: { group?: db.Group }) {
   const userId = useCurrentUserId();
@@ -77,7 +78,11 @@ export function InviteFriendsToTlonButton({ group }: { group?: db.Group }) {
     >
       <XStack gap="$xl" alignItems="center">
         <View borderRadius="$3xl" backgroundColor="$background" padding="$s">
-          <Icon type="Send" size="$l" />
+          {status !== 'ready' || typeof shareUrl !== 'string' ? (
+            <LoadingSpinner size="small" />
+          ) : (
+            <Icon type="Send" size="$l" />
+          )}
         </View>
         <Text color="$background" fontSize="$l">
           Invite Friends to Tlon

--- a/packages/ui/src/components/InviteUsersWidget.tsx
+++ b/packages/ui/src/components/InviteUsersWidget.tsx
@@ -9,6 +9,8 @@ import { useCopy } from '../hooks/useCopy';
 import { ActionSheet } from './ActionSheet';
 import { Button } from './Button';
 import { ContactBook } from './ContactBook';
+import { Icon } from './Icon';
+import { LoadingSpinner } from './LoadingSpinner';
 
 const InviteUsersWidgetComponent = ({
   group,
@@ -133,8 +135,12 @@ const InviteUsersWidgetComponent = ({
             invitees.length === 0 &&
             (status !== 'ready' || typeof shareUrl !== 'string')
           }
+          gap="$xl"
         >
-          <Button.Text>{buttonText}</Button.Text>
+          <Button.Text width="auto">{buttonText}</Button.Text>
+          {status !== 'ready' || typeof shareUrl !== 'string' ? (
+            <LoadingSpinner color="$white" size="small" />
+          ) : null}
         </Button>
       </ActionSheet.ContentBlock>
     </>

--- a/packages/ui/src/components/MessageInput/helpers.ts
+++ b/packages/ui/src/components/MessageInput/helpers.ts
@@ -1,0 +1,96 @@
+import { EditorBridge } from '@10play/tentap-editor';
+import { createDevLogger, tiptap } from '@tloncorp/shared/dist';
+import {
+  Block,
+  Inline,
+  constructStory,
+  isInline,
+} from '@tloncorp/shared/dist/urbit';
+
+import { Attachment } from '../../contexts';
+
+const logger = createDevLogger('processReference', true);
+
+export async function processReferenceAndUpdateEditor({
+  editor,
+  pastedText,
+  matchRegex,
+  processMatch,
+}: {
+  editor: EditorBridge;
+  pastedText: string;
+  matchRegex: RegExp;
+  processMatch: (match: string) => Promise<Attachment | null>;
+}): Promise<Attachment | null> {
+  try {
+    logger.log('checking against', matchRegex);
+    const match = pastedText.match(matchRegex);
+
+    if (match) {
+      logger.log('found match', match[0]);
+      const attachment = await processMatch(match[0]);
+
+      if (attachment) {
+        logger.log('extracted attachment', attachment);
+
+        // remove the attachments corresponding text from the editor
+        const json = await editor.getJSON();
+        const filteredJson = filterRegexFromJson(json, matchRegex);
+
+        logger.log(`updating editor`, filteredJson);
+        // @ts-expect-error setContent does accept JSONContent
+        editor.setContent(filteredJson);
+
+        return attachment;
+      }
+    }
+  } catch (e) {
+    logger.error('error processing reference', e);
+  }
+
+  return null;
+}
+
+// check editor JSON for text or link matches and remove them
+function filterRegexFromJson(initialJson: object, matchRegex: RegExp): object {
+  const allContent = tiptap.JSONToInlines(initialJson);
+
+  const filteredContent = allContent
+    .map((content) => {
+      if (typeof content === 'string') {
+        return content.replace(matchRegex, '');
+      } else if (isInline(content) && 'link' in content) {
+        if (content.link?.href && content.link?.href.match(matchRegex)) {
+          return null;
+        }
+      }
+      return content;
+    })
+    .filter((content) => content !== null && content !== '') as (
+    | Inline
+    | Block
+  )[];
+
+  const filteredInlines = filteredContent.filter(
+    (c) => typeof c === 'string' || (typeof c === 'object' && isInline(c))
+  ) as Inline[];
+
+  const filteredBlocks = (filteredContent.filter(
+    (c) => typeof c !== 'string' && 'block' in c
+  ) || []) as unknown as Block[];
+
+  // it looks like construct story can handle blocks. Do we have to push them separately?
+  const newStory = constructStory(filteredInlines);
+
+  if (filteredBlocks && filteredBlocks.length > 0) {
+    newStory.push(
+      ...filteredBlocks.map((block) => ({
+        block: block,
+      }))
+    );
+  }
+
+  const newJson = tiptap.diaryMixedToJSON(newStory);
+
+  return newJson;
+}

--- a/packages/ui/src/components/MessageInput/index.tsx
+++ b/packages/ui/src/components/MessageInput/index.tsx
@@ -274,6 +274,8 @@ export function MessageInput({
     storeDraft(json);
   });
 
+  // TODO: Looks like paste isn't handled on web yet? When adding support, check
+  // against the corresponding native implementaion
   const handlePaste = useCallback(
     async (pastedText: string) => {
       if (!editor) {


### PR DESCRIPTION
We've seen users get confused about how to properly link to a group. Dropping an off-network share link into chat is a reasonable instinct that we should support. This PR adds the ability to extract group refs from Lure deeplinks in the same way we do if you paste a copied cite ref. Handles links at the branch level (_join.tlon.io_) and after fallback redirect (_tlon.network/lure_).

I tried to add support in a way that would make it easier to add more of these paste handlers down the road, but I could use eyes on the extracted logic — @patosullivan I think you're most familiar?

Fixes TLON-2760