### PR TITLE
lib-negotiate: set src.bowl in +on-load when simulating kicks

### DIFF
--- a/desk/lib/negotiate.hoon
+++ b/desk/lib/negotiate.hoon
@@ -522,7 +522,10 @@
         =*  sub         i.suz
         =.  cards       (snoc cards [%pass wire.sub %agent gill.sub %leave ~])
         =.  wex.bowl    (~(del by wex.bowl) -.sub)
-        =^  caz  inner  (on-agent:og wire.sub %kick ~)
+        =^  caz  inner
+          %.  [wire.sub %kick ~]
+          =.  src.bowl  p.gill.i.suz
+          ~(on-agent inner inner-bowl:up)
         =^  caz  state  (play-cards:up caz)
         $(cards (weld cards caz), suz t.suz)
       ::


### PR DESCRIPTION
`lib-negotiate` does not properly set `src.bowl` when issuing kicks in `+on-load`. This PR fixes this, by properly setting the kicks source according to the `gill` from `wex.bowl`