### PR TITLE
profile: hide block if no bio text, no placeholder

### DIFF
--- a/packages/ui/src/components/UserProfileScreenView.tsx
+++ b/packages/ui/src/components/UserProfileScreenView.tsx
@@ -205,13 +205,15 @@ const PaddedBlock = styled(YStack, {
 });
 
 export function BioDisplay({ bio }: { bio: string }) {
-  return (
+  return bio.length ? (
     <WidgetPane borderRadius={'$2xl'} padding="$2xl" width="100%">
       <WidgetPane.Title>About</WidgetPane.Title>
       <Text size="$body" trimmed={false}>
-        {bio.length ? bio : 'An enigma'}
+        {bio}
       </Text>
     </WidgetPane>
+  ) : (
+    <></>
   );
 }
 

--- a/packages/ui/src/components/UserProfileScreenView.tsx
+++ b/packages/ui/src/components/UserProfileScreenView.tsx
@@ -212,9 +212,7 @@ export function BioDisplay({ bio }: { bio: string }) {
         {bio}
       </Text>
     </WidgetPane>
-  ) : (
-    <></>
-  );
+  ) : null;
 }
 
 function UserInfoRow(props: { userId: string; hasNickname: boolean }) {


### PR DESCRIPTION
Eliminates the "An enigma" bio block for ships that don't have about text set.

<img width="599" alt="image" src="https://github.com/user-attachments/assets/02335c3a-ac00-4e12-9ae2-fbcf38bf235b">
