### PR TITLE
expose: make author link to local /profile

### DIFF
--- a/desk/app/expose/page.hoon
+++ b/desk/app/expose/page.hoon
@@ -123,7 +123,11 @@
     ^-  marl
     =/  main=manx
       ;div.author-row
-        ;+  (author:r bowl author.msg)
+        ;+  =;  link=(unit @t)
+              (%*(. author:r link link) bowl author.msg)
+            ?.  =(our.bowl author.msg)  ~
+            ?.  .^(? %gu /(scot %p our.bowl)/profile/(scot %da now.bowl)/$)  ~
+            `'/profile'
         ;+  (datetime:r sent.msg)
       ==
     ?~  title  [main]~

--- a/desk/app/expose/render.hoon
+++ b/desk/app/expose/render.hoon
@@ -5,12 +5,25 @@
 ::
 |%
 ++  author
+  =/  link=(unit @t)  ~
   |=  [=bowl:gall author=ship]
   ^-  manx
   =/  aco=(unit contact:co)
     (get-contact:co bowl author)
-  ;div.author
-    ;div.avatar
+  |^  ::TODO  we should just have a bunch of manx construction helpers
+      ::      for stuff like this
+      ?~  link
+        ;div.author
+          ;*  inner
+        ==
+      ;div.author  ;a(href (trip u.link))
+        ;*  inner
+      ==  ==
+  ::
+  ++  inner  ~[avatar name]
+  ::
+  ++  avatar
+    ;span.avatar
       ;+
       ?:  &(?=(^ aco) ?=(^ avatar.u.aco) !=('' u.avatar.u.aco))
         ;img@"{(trip u.avatar.u.aco)}"(alt "Author's avatar");
@@ -25,12 +38,12 @@
       ==
     ==
   ::
-    ;+
+  ++  name
     =*  nom  ;span:"{(scow %p author)}"
     ?~  aco  nom
     ?:  =('' nickname.u.aco)  nom
     ;span(title "{(scow %p author)}"):"{(trip nickname.u.aco)}"
-  ==
+  --
 ::
 ++  datetime  ::TODO  date-only mode
   |=  =time

--- a/desk/app/expose/style/page.css
+++ b/desk/app/expose/style/page.css
@@ -66,7 +66,8 @@
   color: var(--text-muted);
 }
 
-.author a {
+.author,
+.author > a {
   display: flex;
   align-items: center;
   color: var(--text-muted);
@@ -80,6 +81,7 @@
   overflow: hidden;
   width: 1.5625em;
   height: 1.5625em;
+  border-radius: 0.25em !important;
 }
 
 .author .avatar img {

--- a/desk/app/expose/style/page.css
+++ b/desk/app/expose/style/page.css
@@ -21,6 +21,12 @@
   margin-bottom: 2em;
 }
 
+.expose-content > header > img {
+  width: 100%;
+  aspect-ratio: 16/10;
+  object-fit: cover;
+}
+
 .expose-content p:empty {
   display: none;
 }
@@ -60,20 +66,24 @@
   color: var(--text-muted);
 }
 
-.author {
+.author a {
   display: flex;
   align-items: center;
   color: var(--text-muted);
   font-weight: 500;
   gap: 0.5em;
+  text-decoration: none;
 }
 
 .author .avatar {
+  display: inline-block;
   overflow: hidden;
-  border-radius: 0.25em;
+  width: 1.5625em;
+  height: 1.5625em;
 }
 
 .author .avatar img {
+  border-radius: 0.25em !important;
   width: 1.5625em;
   height: 1.5625em;
   object-fit: cover;

--- a/desk/app/expose/style/widget.css
+++ b/desk/app/expose/style/widget.css
@@ -42,6 +42,12 @@
 .exposed img {
   border-radius: 0.5em;
   margin-bottom: 1em;
+  width: 100%;
+}
+
+.exposed .diary img {
+  aspect-ratio: 16/10;
+  object-fit: cover;
 }
 
 .exposed h3 {
@@ -79,8 +85,15 @@
 }
 
 .exposed .author .avatar {
+  display: inline-block;
   overflow: hidden;
   border-radius: 0.25em;
+  width: 1.5625em;
+  height: 1.5625em;
+}
+
+.exposed .author .avatar img {
+  border-radius: 0.25em !important;
   width: 1.5625em;
   height: 1.5625em;
   object-fit: cover;

--- a/desk/app/profile/widgets.hoon
+++ b/desk/app/profile/widgets.hoon
@@ -119,7 +119,7 @@
       margin-left: -2em;
     }
     .profile-with-header {
-      aspect-ratio: 1/1;
+      aspect-ratio: 16/10;
       display: flex;
       align-items: flex-end;
     }


### PR DESCRIPTION
when we can. Right now, we only know this for the local ship, where it's simply /profile, assuming the public profile agent is running.

Still pending some styling adjustments from @jamesacklin.