### PR TITLE
expose: refresh for local profile changes

### DIFF
--- a/desk/app/profile.hoon
+++ b/desk/app/profile.hoon
@@ -165,17 +165,7 @@
 ++  render-page
   ^-  manx
   =/  ours=(unit contact:contacts)
-    =,  contacts
-    ::NOTE  we scry for the full rolodex, because we are not guaranteed to
-    ::      have an entry for ourselves, and contacts doesn't expose a "safe"
-    ::      (as in crashless) endpoint for checking
-    =+  .^  =rolodex
-          /gx/(scot %p our.bowl)/contacts/(scot %da now.bowl)/all/contact-rolodex
-        ==
-    =/  =foreign  (~(gut by rolodex) our.bowl *foreign)
-    ?:  ?=([[@ ^] *] foreign)
-      `con.for.foreign
-    ~
+    (get-contact:contacts bowl our.bowl)
   |^  ;html
         ;+  head
         ;+  body

--- a/desk/sur/contacts.hoon
+++ b/desk/sur/contacts.hoon
@@ -89,8 +89,10 @@
 ::
 ++  get-contact
   |=  [=bowl:gall who=@p]
-  ^-  (unit contact)  ~+
-  =/  base=path  /(scot %p our.bowl)/contacts/(scot %da now.bowl)
+  =>  :_  ..get-contact
+      [who=who our=our.bowl now=now.bowl]
+  ~+  ^-  (unit contact)
+  =/  base=path  /(scot %p our)/contacts/(scot %da now)
   ?.  ~+  .^(? %gu (weld base /$))
     ~
   =+  ~+  .^(rol=rolodex %gx (weld base /all/contact-rolodex))


### PR DESCRIPTION
This is a detail that appears on most of the pages that we publish, that the user has control over, so we should reflect is accurately in a timely fashion.

We don't care too much right now about cache busting in response to other people's profile detail changes, because we don't display comments/replies, and publishing someone else's content isn't a primary/supported use-case. If we ever do want that, probably better to just periodically refresh the cache.

Also makes some small adjustments to how the contacts scry helper works, and makes /app/profile use that instead of its own code.

(Doesn't account for doing the contacts subscription on existing instances of exposé, @jamesacklin if you or anyone internal wants the reactivity there you'll need to nuke & restart the agent.)