### PR TITLE
ChatOptionsSheet: fixes for notifications, leave

### DIFF
--- a/packages/app/features/top/ChannelScreen.tsx
+++ b/packages/app/features/top/ChannelScreen.tsx
@@ -1,3 +1,5 @@
+import { useFocusEffect } from '@react-navigation/native';
+import { useIsFocused } from '@react-navigation/native';
 import type { NativeStackScreenProps } from '@react-navigation/native-stack';
 import { createDevLogger } from '@tloncorp/shared/dist';
 import * as db from '@tloncorp/shared/dist/db';
@@ -22,9 +24,7 @@ import React, { useCallback, useEffect, useMemo } from 'react';
 import { useChannelContext } from '../../hooks/useChannelContext';
 import { useChannelNavigation } from '../../hooks/useChannelNavigation';
 import { useChatSettingsNavigation } from '../../hooks/useChatSettingsNavigation';
-import { useFocusEffect } from '@react-navigation/native';
 import { useGroupActions } from '../../hooks/useGroupActions';
-import { useIsFocused } from '@react-navigation/native';
 import type { RootStackParamList } from '../../navigation/types';
 
 const logger = createDevLogger('ChannelScreen', false);
@@ -119,7 +119,8 @@ export default function ChannelScreen(props: Props) {
     //
     //   ------------------------| syncedAt
     //     session.startTime |---------------
-    if (syncedAt >= session.startTime) {
+    // NOTE: inserted a guard to prevent session.startTime from being undefined
+    if (syncedAt >= session.startTime!) {
       return true;
     }
 

--- a/packages/app/features/top/ChannelScreen.tsx
+++ b/packages/app/features/top/ChannelScreen.tsx
@@ -1,5 +1,3 @@
-import { useFocusEffect } from '@react-navigation/native';
-import { useIsFocused } from '@react-navigation/native';
 import type { NativeStackScreenProps } from '@react-navigation/native-stack';
 import { createDevLogger } from '@tloncorp/shared/dist';
 import * as db from '@tloncorp/shared/dist/db';
@@ -24,7 +22,9 @@ import React, { useCallback, useEffect, useMemo } from 'react';
 import { useChannelContext } from '../../hooks/useChannelContext';
 import { useChannelNavigation } from '../../hooks/useChannelNavigation';
 import { useChatSettingsNavigation } from '../../hooks/useChatSettingsNavigation';
+import { useFocusEffect } from '@react-navigation/native';
 import { useGroupActions } from '../../hooks/useGroupActions';
+import { useIsFocused } from '@react-navigation/native';
 import type { RootStackParamList } from '../../navigation/types';
 
 const logger = createDevLogger('ChannelScreen', false);
@@ -119,8 +119,7 @@ export default function ChannelScreen(props: Props) {
     //
     //   ------------------------| syncedAt
     //     session.startTime |---------------
-    // NOTE: inserted a guard to prevent session.startTime from being undefined
-    if (syncedAt >= session.startTime!) {
+    if (syncedAt >= session.startTime) {
       return true;
     }
 

--- a/packages/ui/src/components/ActionSheet.tsx
+++ b/packages/ui/src/components/ActionSheet.tsx
@@ -35,6 +35,7 @@ export type Action = {
   render?: (props: ActionRenderProps) => ReactElement;
   endIcon?: IconType | ReactElement;
   startIcon?: IconType | ReactElement;
+  accent?: Accent;
 };
 
 export type ActionRenderProps = {
@@ -296,16 +297,19 @@ const ActionSheetActionFrame = styled(ListItem, {
   variants: {
     type: {
       positive: {
+        backgroundColor: '$positiveBackground',
         pressStyle: {
           backgroundColor: '$positiveBackground',
         },
       },
       negative: {
+        backgroundColor: '$negativeBackground',
         pressStyle: {
           backgroundColor: '$negativeBackground',
         },
       },
       neutral: {},
+      disabled: {},
     },
   } as const,
 });
@@ -349,11 +353,15 @@ function ActionSheetAction({ action }: { action: Action }) {
     action.render({ action })
   ) : (
     <ActionSheetActionFrame
+      type={action.accent ?? (accent as Accent)}
       onPress={accent !== 'disabled' ? action.action : undefined}
     >
-      {action.startIcon && resolveIcon(action.startIcon)}
+      {action.startIcon &&
+        resolveIcon(action.startIcon, action.accent ?? accent)}
       <ListItem.MainContent>
-        <ActionSheet.ActionTitle>{action.title}</ActionSheet.ActionTitle>
+        <ActionSheet.ActionTitle accent={action.accent ?? accent}>
+          {action.title}
+        </ActionSheet.ActionTitle>
         {action.description && (
           <ActionSheet.ActionDescription>
             {action.description}
@@ -361,15 +369,17 @@ function ActionSheetAction({ action }: { action: Action }) {
         )}
       </ListItem.MainContent>
       {action.endIcon && (
-        <ListItem.EndContent>{resolveIcon(action.endIcon)}</ListItem.EndContent>
+        <ListItem.EndContent>
+          {resolveIcon(action.endIcon, action.accent ?? accent)}
+        </ListItem.EndContent>
       )}
     </ActionSheetActionFrame>
   );
 }
 
-function resolveIcon(icon: IconType | ReactElement) {
+function resolveIcon(icon: IconType | ReactElement, accent: Accent) {
   if (typeof icon === 'string') {
-    return <ActionSheetActionIcon type={icon} />;
+    return <ActionSheetActionIcon accent={accent} type={icon} />;
   }
   return icon;
 }
@@ -386,6 +396,9 @@ const ActionSheetActionIcon = styled(Icon, {
         color: '$negativeActionText',
       },
       neutral: {},
+      disabled: {
+        color: '$tertiaryText',
+      },
     },
   } as const,
 });

--- a/packages/ui/src/components/ChatOptionsSheet.tsx
+++ b/packages/ui/src/components/ChatOptionsSheet.tsx
@@ -162,6 +162,7 @@ export function GroupOptions({
         actions: [
           {
             title: 'All activity',
+            accent: currentVolumeLevel === 'loud' ? 'positive' : 'neutral',
             action: () => {
               handleVolumeUpdate('loud');
             },
@@ -169,6 +170,7 @@ export function GroupOptions({
           },
           {
             title: 'Posts, mentions, and replies',
+            accent: currentVolumeLevel === 'medium' ? 'positive' : 'neutral',
             action: () => {
               handleVolumeUpdate('medium');
             },
@@ -176,6 +178,7 @@ export function GroupOptions({
           },
           {
             title: 'Only mentions and replies',
+            accent: currentVolumeLevel === 'soft' ? 'positive' : 'neutral',
             action: () => {
               handleVolumeUpdate('soft');
             },
@@ -183,6 +186,7 @@ export function GroupOptions({
           },
           {
             title: 'Nothing',
+            accent: currentVolumeLevel === 'hush' ? 'positive' : 'neutral',
             action: () => {
               handleVolumeUpdate('hush');
             },
@@ -457,6 +461,7 @@ export function ChannelOptions({
         actions: [
           {
             title: 'All activity',
+            accent: currentVolumeLevel === 'loud' ? 'positive' : 'neutral',
             action: () => {
               handleVolumeUpdate('loud');
             },
@@ -464,6 +469,7 @@ export function ChannelOptions({
           },
           {
             title: 'Posts, mentions, and replies',
+            accent: currentVolumeLevel === 'medium' ? 'positive' : 'neutral',
             action: () => {
               handleVolumeUpdate('medium');
             },
@@ -471,6 +477,7 @@ export function ChannelOptions({
           },
           {
             title: 'Only mentions and replies',
+            accent: currentVolumeLevel === 'soft' ? 'positive' : 'neutral',
             action: () => {
               handleVolumeUpdate('soft');
             },
@@ -478,6 +485,7 @@ export function ChannelOptions({
           },
           {
             title: 'Nothing',
+            accent: currentVolumeLevel === 'hush' ? 'positive' : 'neutral',
             action: () => {
               handleVolumeUpdate('hush');
             },

--- a/packages/ui/src/components/ChatOptionsSheet.tsx
+++ b/packages/ui/src/components/ChatOptionsSheet.tsx
@@ -15,9 +15,11 @@ import React, {
 import { Alert } from 'react-native';
 import { useSheet } from 'tamagui';
 
+import { ChevronLeft } from '../assets/icons';
 import { useCalm, useChatOptions, useCurrentUserId } from '../contexts';
 import * as utils from '../utils';
 import { Action, ActionGroup, ActionSheet } from './ActionSheet';
+import { IconButton } from './IconButton';
 import { ListItem } from './ListItem';
 
 export type ChatType = 'group' | db.ChannelType;
@@ -163,39 +165,33 @@ export function GroupOptions({
             action: () => {
               handleVolumeUpdate('loud');
             },
-            icon: currentVolumeLevel === 'loud' ? 'Checkmark' : undefined,
+            endIcon: currentVolumeLevel === 'loud' ? 'Checkmark' : undefined,
           },
           {
             title: 'Posts, mentions, and replies',
             action: () => {
               handleVolumeUpdate('medium');
             },
-            icon: currentVolumeLevel === 'medium' ? 'Checkmark' : undefined,
+            endIcon: currentVolumeLevel === 'medium' ? 'Checkmark' : undefined,
           },
           {
             title: 'Only mentions and replies',
             action: () => {
               handleVolumeUpdate('soft');
             },
-            icon: currentVolumeLevel === 'soft' ? 'Checkmark' : undefined,
+            endIcon: currentVolumeLevel === 'soft' ? 'Checkmark' : undefined,
           },
           {
             title: 'Nothing',
             action: () => {
               handleVolumeUpdate('hush');
             },
-            icon: currentVolumeLevel === 'hush' ? 'Checkmark' : undefined,
-          },
-          {
-            title: 'Back',
-            action: () => {
-              setPane('initial');
-            },
+            endIcon: currentVolumeLevel === 'hush' ? 'Checkmark' : undefined,
           },
         ],
       },
     ],
-    [currentVolumeLevel, handleVolumeUpdate, setPane]
+    [currentVolumeLevel, handleVolumeUpdate]
   );
 
   const actionGroups = useMemo(() => {
@@ -331,9 +327,19 @@ export function GroupOptions({
   return (
     <ChatOptionsSheetContent
       actionGroups={pane === 'initial' ? actionGroups : actionNotifications}
-      title={title}
-      subtitle={subtitle}
-      icon={<ListItem.GroupIcon model={group} />}
+      title={pane === 'initial' ? title : 'Notifications for ' + title}
+      subtitle={
+        pane === 'initial' ? subtitle : 'Set what you want to be notified about'
+      }
+      icon={
+        pane === 'initial' ? (
+          <ListItem.GroupIcon model={group} />
+        ) : (
+          <IconButton width="$4xl" onPress={() => setPane('initial')}>
+            <ChevronLeft />
+          </IconButton>
+        )
+      }
     />
   );
 }
@@ -394,6 +400,11 @@ export function ChannelOptions({
   const { onPressChannelMembers, onPressChannelMeta, onPressManageChannels } =
     useChatOptions() ?? {};
 
+  const currentUserIsHost = useMemo(
+    () => group?.currentUserIsHost ?? false,
+    [group?.currentUserIsHost]
+  );
+
   const currentUserIsAdmin = useMemo(
     () =>
       group?.members?.some(
@@ -449,39 +460,33 @@ export function ChannelOptions({
             action: () => {
               handleVolumeUpdate('loud');
             },
-            icon: currentVolumeLevel === 'loud' ? 'Checkmark' : undefined,
+            endIcon: currentVolumeLevel === 'loud' ? 'Checkmark' : undefined,
           },
           {
             title: 'Posts, mentions, and replies',
             action: () => {
               handleVolumeUpdate('medium');
             },
-            icon: currentVolumeLevel === 'medium' ? 'Checkmark' : undefined,
+            endIcon: currentVolumeLevel === 'medium' ? 'Checkmark' : undefined,
           },
           {
             title: 'Only mentions and replies',
             action: () => {
               handleVolumeUpdate('soft');
             },
-            icon: currentVolumeLevel === 'soft' ? 'Checkmark' : undefined,
+            endIcon: currentVolumeLevel === 'soft' ? 'Checkmark' : undefined,
           },
           {
             title: 'Nothing',
             action: () => {
               handleVolumeUpdate('hush');
             },
-            icon: currentVolumeLevel === 'hush' ? 'Checkmark' : undefined,
-          },
-          {
-            title: 'Back',
-            action: () => {
-              setPane('initial');
-            },
+            endIcon: currentVolumeLevel === 'hush' ? 'Checkmark' : undefined,
           },
         ],
       },
     ],
-    [currentVolumeLevel, handleVolumeUpdate, setPane]
+    [currentVolumeLevel, handleVolumeUpdate]
   );
 
   const actionGroups: ActionGroup[] = useMemo(() => {
@@ -491,6 +496,7 @@ export function ChannelOptions({
         actions: [
           {
             title: 'Notifications',
+            endIcon: 'ChevronRight',
             action: () => {
               if (!channel) {
                 return;
@@ -501,7 +507,7 @@ export function ChannelOptions({
           },
           {
             title: channel?.pin ? 'Unpin' : 'Pin',
-            icon: 'Pin',
+            endIcon: 'Pin',
             action: () => {
               if (!channel) {
                 return;
@@ -573,38 +579,43 @@ export function ChannelOptions({
             } as ActionGroup,
           ]
         : []),
-      {
-        accent: 'negative',
-        actions: [
-          {
-            title: `Leave chat`,
-            action: () => {
-              if (!channel) {
-                return;
-              }
-              Alert.alert(
-                `Leave ${title}?`,
-                'This chat will be removed from list',
-                [
-                  {
-                    text: 'Cancel',
-                    onPress: () => console.log('Cancel Pressed'),
-                    style: 'cancel',
+      ...(!currentUserIsHost
+        ? [
+            {
+              accent: 'negative',
+              actions: [
+                {
+                  title: `Leave`,
+                  endIcon: 'LogOut',
+                  action: () => {
+                    if (!channel) {
+                      return;
+                    }
+                    Alert.alert(
+                      `Leave ${title}?`,
+                      'This will be removed from the list',
+                      [
+                        {
+                          text: 'Cancel',
+                          onPress: () => console.log('Cancel Pressed'),
+                          style: 'cancel',
+                        },
+                        {
+                          text: 'Leave',
+                          style: 'destructive',
+                          onPress: () => {
+                            sheetRef.current.setOpen(false);
+                            store.respondToDMInvite({ channel, accept: false });
+                          },
+                        },
+                      ]
+                    );
                   },
-                  {
-                    text: 'Leave',
-                    style: 'destructive',
-                    onPress: () => {
-                      sheetRef.current.setOpen(false);
-                      store.respondToDMInvite({ channel, accept: false });
-                    },
-                  },
-                ]
-              );
-            },
-          },
-        ],
-      },
+                },
+              ],
+            } as ActionGroup,
+          ]
+        : []),
     ];
   }, [
     channel,
@@ -613,15 +624,26 @@ export function ChannelOptions({
     setPane,
     title,
     currentUserIsAdmin,
+    currentUserIsHost,
     group,
     onPressManageChannels,
   ]);
   return (
     <ChatOptionsSheetContent
       actionGroups={pane === 'initial' ? actionGroups : actionNotifications}
-      title={title}
-      subtitle={subtitle}
-      icon={<ListItem.ChannelIcon model={channel} />}
+      title={pane === 'initial' ? title : 'Notifications for ' + title}
+      subtitle={
+        pane === 'initial' ? subtitle : 'Set what you want to be notified about'
+      }
+      icon={
+        pane === 'initial' ? (
+          <ListItem.ChannelIcon model={channel} />
+        ) : (
+          <IconButton width="$4xl" onPress={() => setPane('initial')}>
+            <ChevronLeft />
+          </IconButton>
+        )
+      }
     />
   );
 }


### PR DESCRIPTION
- Guards against channel hosts being able to leave channels they host. This would fail to complete on the back-end but would be reflected in the client and in SQLite. (Fixes TLON-2785)
- Moves "Back" in notification level options to sheet header, adjusts title (fixes TLON-2737)
- Adds active selection icons for notification level selections (fixes TLON-2737)
- Changes ActionSheet to render (optional) accent styling for individual actions within a group (which can have its own accent)
- Provides a "positive" accent to the active selection for notification level in ChatOptionsSheet

I can now no longer leave a channel I host:
<img width="583" alt="image" src="https://github.com/user-attachments/assets/8efe248a-c069-492c-b5b5-572393b83384">

Changes to the notification selection menu(s):
<img width="583" alt="image" src="https://github.com/user-attachments/assets/f1b9c434-0f1e-4049-bfe8-c9e806195a91">
