### PR TITLE
fix type issue so CI can start passing again

### DIFF
--- a/packages/app/features/top/ChannelScreen.tsx
+++ b/packages/app/features/top/ChannelScreen.tsx
@@ -1,3 +1,5 @@
+import { useFocusEffect } from '@react-navigation/native';
+import { useIsFocused } from '@react-navigation/native';
 import type { NativeStackScreenProps } from '@react-navigation/native-stack';
 import { createDevLogger } from '@tloncorp/shared/dist';
 import * as db from '@tloncorp/shared/dist/db';
@@ -22,9 +24,7 @@ import React, { useCallback, useEffect, useMemo } from 'react';
 import { useChannelContext } from '../../hooks/useChannelContext';
 import { useChannelNavigation } from '../../hooks/useChannelNavigation';
 import { useChatSettingsNavigation } from '../../hooks/useChatSettingsNavigation';
-import { useFocusEffect } from '@react-navigation/native';
 import { useGroupActions } from '../../hooks/useGroupActions';
-import { useIsFocused } from '@react-navigation/native';
 import type { RootStackParamList } from '../../navigation/types';
 
 const logger = createDevLogger('ChannelScreen', false);
@@ -119,7 +119,7 @@ export default function ChannelScreen(props: Props) {
     //
     //   ------------------------| syncedAt
     //     session.startTime |---------------
-    if (syncedAt >= session.startTime) {
+    if (session.startTime && syncedAt >= session.startTime) {
       return true;
     }
 


### PR DESCRIPTION
we need to check that `session.startTime` actually exists before we check to see if `syncedAt` is greater than or equal to it.

this is currently causing type checks in CI to fail.