### PR TITLE
notifications: get group invites working as pushes

### DIFF
--- a/apps/tlon-mobile/android/app/src/main/java/io/tlon/landscape/api/TalkApi.java
+++ b/apps/tlon-mobile/android/app/src/main/java/io/tlon/landscape/api/TalkApi.java
@@ -137,6 +137,10 @@ public class TalkApi {
         fetchObject("/~/scry/groups/groups/light", callback);
     }
 
+    public void fetchGangs(TalkObjectCallback callback) {
+        fetchObject("/~/scry/groups/gangs", callback);
+    }
+
     public void fetchGroupChannel(String channelId, TalkObjectCallback callback) {
         fetchGroups(new TalkObjectCallback() {
             @Override

--- a/apps/tlon-mobile/android/app/src/main/java/io/tlon/landscape/models/Yarn.java
+++ b/apps/tlon-mobile/android/app/src/main/java/io/tlon/landscape/models/Yarn.java
@@ -5,6 +5,7 @@ import org.json.JSONException;
 import org.json.JSONObject;
 
 import java.util.ArrayList;
+import java.util.Optional;
 
 public class Yarn {
 
@@ -12,7 +13,8 @@ public class Yarn {
     public Boolean isGroup;
     public Boolean isClub;
     public String wer;
-    public String channelId;
+    public Optional<String> channelId;
+    public Optional<String> groupId;
     public String senderId;
     public String contentText;
 
@@ -62,18 +64,22 @@ public class Yarn {
 
         isGroup = !rope.isNull("group");
         isValidNotification = rope.getString("desk").equals("groups") &&
-                !thread.endsWith("/channel/edit") &&
+                (!thread.endsWith("/channel/edit") &&
                 !thread.endsWith("/channel/add") &&
                 !thread.endsWith("/channel/del") &&
                 !thread.endsWith("/joins") &&
-                !thread.endsWith("/leaves") &&
-                (!rope.isNull("channel") || !isGroup);
+                !thread.endsWith("/leaves") ||
+                !isGroup);
         wer = yarnObject.getString("wer");
-        channelId = isGroup ? rope.getString("channel") : thread.replace("/dm/", "").replace("/club/", "");
-        isClub = channelId.startsWith("0v");
+        groupId = !isGroup ? Optional.empty() :
+                Optional.of(rope.getString("group"));
+        channelId = isGroup ?
+                rope.isNull("channel") ? Optional.empty() : Optional.of(rope.getString("channel"))
+                : Optional.of(thread.replace("/dm/", "").replace("/club/", ""));
+        isClub = channelId.isPresent() && channelId.get().startsWith("0v");
         contentText = String.join("", parts);
-        if (senderId == null && channelId.startsWith("~")) {
-            senderId = channelId;
+        if (senderId == null && channelId.isPresent() && channelId.get().startsWith("~")) {
+            senderId = channelId.get();
         }
     }
 

--- a/apps/tlon-mobile/ios/Landscape.xcodeproj/project.pbxproj
+++ b/apps/tlon-mobile/ios/Landscape.xcodeproj/project.pbxproj
@@ -12,6 +12,11 @@
 		3DC46BC1B669DF8F5F059CA8 /* ExpoModulesProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8ACB38DC4FF4D6377774BF5F /* ExpoModulesProvider.swift */; };
 		3E461D99554A48A4959DE609 /* SplashScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = AA286B85B6C04FC6940260E9 /* SplashScreen.storyboard */; };
 		4ACCD7281520ED84DDC2759A /* PrivacyInfo.xcprivacy in Resources */ = {isa = PBXBuildFile; fileRef = 74D2BEF1344CF71A07C17F5E /* PrivacyInfo.xcprivacy */; };
+		5A1EB9532CAC451A00029EDC /* GroupStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5A1EB9522CAC451A00029EDC /* GroupStore.swift */; };
+		5A1EB9542CAC451A00029EDC /* GroupStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5A1EB9522CAC451A00029EDC /* GroupStore.swift */; };
+		5A1EB9552CAC451A00029EDC /* GroupStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5A1EB9522CAC451A00029EDC /* GroupStore.swift */; };
+		5A1EB9562CAC451A00029EDC /* GroupStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5A1EB9522CAC451A00029EDC /* GroupStore.swift */; };
+		5A1EB9572CAC451A00029EDC /* GroupStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5A1EB9522CAC451A00029EDC /* GroupStore.swift */; };
 		630DE0B72C51A0F80053603B /* Error+isAFTimeout.swift in Sources */ = {isa = PBXBuildFile; fileRef = 632793BD2C4AE4B500F942B1 /* Error+isAFTimeout.swift */; };
 		630DE0C52C51A8780053603B /* UIColor+Extension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 70D386702A60A3E600AFB46E /* UIColor+Extension.swift */; };
 		630DE0C62C51A8780053603B /* Contact.swift in Sources */ = {isa = PBXBuildFile; fileRef = 700B635C2A71DFE90017F40F /* Contact.swift */; };
@@ -225,6 +230,7 @@
 		13B07FB61A68108700A75B9A /* Info.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; name = Info.plist; path = Landscape/Info.plist; sourceTree = "<group>"; };
 		13B07FB71A68108700A75B9A /* main.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = main.m; path = Landscape/main.m; sourceTree = "<group>"; };
 		3B0B210E999A7E0E1A345468 /* Pods-Landscape-preview.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Landscape-preview.release.xcconfig"; path = "Target Support Files/Pods-Landscape-preview/Pods-Landscape-preview.release.xcconfig"; sourceTree = "<group>"; };
+		5A1EB9522CAC451A00029EDC /* GroupStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GroupStore.swift; sourceTree = "<group>"; };
 		630DE0B82C51A1500053603B /* LandscapePreview-Bridging-Header.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = "LandscapePreview-Bridging-Header.h"; path = "Landscape/LandscapePreview-Bridging-Header.h"; sourceTree = "<group>"; };
 		630DE0E22C51A8790053603B /* Notifications-preview.appex */ = {isa = PBXFileReference; explicitFileType = "wrapper.app-extension"; includeInIndex = 0; path = "Notifications-preview.appex"; sourceTree = BUILT_PRODUCTS_DIR; };
 		630DE0EB2C51AC840053603B /* UserDefaults+appGroup.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UserDefaults+appGroup.swift"; sourceTree = "<group>"; };
@@ -269,11 +275,11 @@
 		70F99A8E2B2D2B5700D77256 /* LandscapeTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = LandscapeTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		70F99A972B2D2B6E00D77256 /* YarnTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = YarnTests.swift; sourceTree = "<group>"; };
 		74633B6584F10A6AA2FEE339 /* Pods-Landscape.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Landscape.release.xcconfig"; path = "Target Support Files/Pods-Landscape/Pods-Landscape.release.xcconfig"; sourceTree = "<group>"; };
-		74D2BEF1344CF71A07C17F5E /* PrivacyInfo.xcprivacy */ = {isa = PBXFileReference; includeInIndex = 1; name = PrivacyInfo.xcprivacy; path = Landscape/PrivacyInfo.xcprivacy; sourceTree = "<group>"; };
+		74D2BEF1344CF71A07C17F5E /* PrivacyInfo.xcprivacy */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xml; name = PrivacyInfo.xcprivacy; path = Landscape/PrivacyInfo.xcprivacy; sourceTree = "<group>"; };
 		79BDD5DCE15A385BB361AED1 /* Pods_Landscape.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_Landscape.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		7A4D352CD337FB3A3BF06240 /* Pods-Landscape.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Landscape.release.xcconfig"; path = "Target Support Files/Pods-Landscape/Pods-Landscape.release.xcconfig"; sourceTree = "<group>"; };
 		8ACB38DC4FF4D6377774BF5F /* ExpoModulesProvider.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = ExpoModulesProvider.swift; path = "Pods/Target Support Files/Pods-Landscape-preview/ExpoModulesProvider.swift"; sourceTree = "<group>"; };
-		9D6B23EFDEDD5888235A22BB /* PrivacyInfo.xcprivacy */ = {isa = PBXFileReference; includeInIndex = 1; name = PrivacyInfo.xcprivacy; path = Landscape/PrivacyInfo.xcprivacy; sourceTree = "<group>"; };
+		9D6B23EFDEDD5888235A22BB /* PrivacyInfo.xcprivacy */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xml; name = PrivacyInfo.xcprivacy; path = Landscape/PrivacyInfo.xcprivacy; sourceTree = "<group>"; };
 		AA286B85B6C04FC6940260E9 /* SplashScreen.storyboard */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.storyboard; name = SplashScreen.storyboard; path = Landscape/SplashScreen.storyboard; sourceTree = "<group>"; };
 		B35AC6CF758CAFC9D112A69F /* Pods-Landscape.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Landscape.debug.xcconfig"; path = "Target Support Files/Pods-Landscape/Pods-Landscape.debug.xcconfig"; sourceTree = "<group>"; };
 		BB2F792C24A3F905000567C9 /* Expo.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = Expo.plist; sourceTree = "<group>"; };
@@ -438,6 +444,7 @@
 				6374ACF82C4ACD5000E637C0 /* LoginStore.swift */,
 				700B635F2A71E0810017F40F /* SettingsStore.swift */,
 				7036E3532ACD0FC90020A9FB /* UserDefaultsStore.swift */,
+				5A1EB9522CAC451A00029EDC /* GroupStore.swift */,
 			);
 			path = Storage;
 			sourceTree = "<group>";
@@ -1180,6 +1187,7 @@
 				7083A16C2AFB01A30022404A /* TlonError.swift in Sources */,
 				632793BE2C4AE4B500F942B1 /* Error+isAFTimeout.swift in Sources */,
 				7036E3542ACD0FC90020A9FB /* UserDefaultsStore.swift in Sources */,
+				5A1EB9532CAC451A00029EDC /* GroupStore.swift in Sources */,
 				70D3865A2A609BFC00AFB46E /* PocketNotificationsAPI.swift in Sources */,
 				C83014822C7BA74C00D9A5CA /* UIFont+SystemDesign.m in Sources */,
 				70D3865B2A609BFC00AFB46E /* PocketAPI.swift in Sources */,
@@ -1226,6 +1234,7 @@
 				63E27E0E2C5AF26C008ACB45 /* Alamofire+sessionWithSharedCookieStorage.swift in Sources */,
 				630DE0CF2C51A8780053603B /* PocketUserAPI.swift in Sources */,
 				630DE0D02C51A8780053603B /* UserDefaultsStore.swift in Sources */,
+				5A1EB9572CAC451A00029EDC /* GroupStore.swift in Sources */,
 				630DE0D12C51A8780053603B /* ContactStore.swift in Sources */,
 				630DE0D22C51A8780053603B /* NotificationService.swift in Sources */,
 				630DE0D32C51A8780053603B /* ClubStore.swift in Sources */,
@@ -1257,6 +1266,7 @@
 				63E27E0D2C5AF26C008ACB45 /* Alamofire+sessionWithSharedCookieStorage.swift in Sources */,
 				632793C62C4AE56F00F942B1 /* PocketUserAPI.swift in Sources */,
 				632793C42C4AE53A00F942B1 /* UserDefaultsStore.swift in Sources */,
+				5A1EB9562CAC451A00029EDC /* GroupStore.swift in Sources */,
 				632793C32C4AE53500F942B1 /* ContactStore.swift in Sources */,
 				6374ACE22C49DA9600E637C0 /* NotificationService.swift in Sources */,
 				632793CB2C4AE7D900F942B1 /* ClubStore.swift in Sources */,
@@ -1280,6 +1290,7 @@
 				70DBBFEC2B7C60B50021EA96 /* TlonError.swift in Sources */,
 				632793BF2C4AE4B500F942B1 /* Error+isAFTimeout.swift in Sources */,
 				70DBBFED2B7C60B50021EA96 /* UserDefaultsStore.swift in Sources */,
+				5A1EB9542CAC451A00029EDC /* GroupStore.swift in Sources */,
 				70DBBFEE2B7C60B50021EA96 /* PocketNotificationsAPI.swift in Sources */,
 				70DBBFEF2B7C60B50021EA96 /* PocketAPI.swift in Sources */,
 				70DBBFF02B7C60B50021EA96 /* PushNotificationManager.swift in Sources */,
@@ -1326,6 +1337,7 @@
 				70F99AA92B2D337600D77256 /* GroupChannelStore.swift in Sources */,
 				70F99A9F2B2D336800D77256 /* Group.swift in Sources */,
 				70F99AA32B2D336E00D77256 /* PocketUserAPI.swift in Sources */,
+				5A1EB9552CAC451A00029EDC /* GroupStore.swift in Sources */,
 				70F99AA22B2D336E00D77256 /* UrbitAPI.swift in Sources */,
 				70F99AAA2B2D337600D77256 /* SettingsStore.swift in Sources */,
 				70F99AA62B2D336E00D77256 /* PocketChatAPI.swift in Sources */,

--- a/apps/tlon-mobile/ios/Landscape.xcodeproj/project.pbxproj
+++ b/apps/tlon-mobile/ios/Landscape.xcodeproj/project.pbxproj
@@ -1479,7 +1479,7 @@
 				INFOPLIST_FILE = "Notifications/Info-preview.plist";
 				INFOPLIST_KEY_CFBundleDisplayName = "Notifications-preview";
 				INFOPLIST_KEY_NSHumanReadableCopyright = "";
-				IPHONEOS_DEPLOYMENT_TARGET = 17.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 16.0;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
@@ -1524,7 +1524,7 @@
 				INFOPLIST_FILE = "Notifications/Info-preview.plist";
 				INFOPLIST_KEY_CFBundleDisplayName = "Notifications-preview";
 				INFOPLIST_KEY_NSHumanReadableCopyright = "";
-				IPHONEOS_DEPLOYMENT_TARGET = 17.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 16.0;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",

--- a/apps/tlon-mobile/ios/Landscape/AppDelegate.mm
+++ b/apps/tlon-mobile/ios/Landscape/AppDelegate.mm
@@ -17,15 +17,15 @@
   // You can add your custom initial props in the dictionary below.
   // They will be passed down to the ViewController used by React Native.
   self.initialProps = @{};
-  
+
   [PushNotificationManager configure];
-  
+
 #if PREVIEW
    [RNBranch useTestInstance];
 #endif
-  
+
   [RNBranch initSessionWithLaunchOptions:launchOptions isReferrable:YES];
-  
+
   // Listen to changes in app-specific cookie storage, and push those to the app group shared
   // storage.
   // Ideally, we'd exclusively use the app group storage for all cookie read/writes, but I could
@@ -60,7 +60,7 @@
   if ([RNBranch application:application openURL:url options:options]) {
     return YES;
   }
-  
+
   return [super application:application openURL:url options:options] || [RCTLinkingManager application:application openURL:url options:options];
 }
 
@@ -70,7 +70,7 @@
   if ([RNBranch continueUserActivity:userActivity]) {
     return YES;
   }
-  
+
   BOOL result = [RCTLinkingManager application:application continueUserActivity:userActivity restorationHandler:restorationHandler];
   return [super application:application continueUserActivity:userActivity restorationHandler:restorationHandler] || result;
 }
@@ -85,12 +85,6 @@
 - (void)application:(UIApplication *)application didFailToRegisterForRemoteNotificationsWithError:(NSError *)error
 {
   return [super application:application didFailToRegisterForRemoteNotificationsWithError:error];
-}
-
-// Explicitly define remote notification delegates to ensure compatibility with some third-party libraries
-- (void)application:(UIApplication *)application didReceiveRemoteNotification:(NSDictionary *)userInfo fetchCompletionHandler:(void (^)(UIBackgroundFetchResult))completionHandler
-{
-  return [PushNotificationManager handleBackgroundNotification:userInfo completionHandler:completionHandler];
 }
 
 @end

--- a/apps/tlon-mobile/ios/Shared/Models/Group.swift
+++ b/apps/tlon-mobile/ios/Shared/Models/Group.swift
@@ -21,3 +21,11 @@ struct Group: Codable {
     let channels: [String: GroupChannel]
     let meta: GroupMeta
 }
+
+struct Gang: Codable {
+    let preview: GangPreview?
+}
+
+struct GangPreview: Codable {
+  let meta: GroupMeta
+}

--- a/apps/tlon-mobile/ios/Shared/Models/TlonError.swift
+++ b/apps/tlon-mobile/ios/Shared/Models/TlonError.swift
@@ -14,4 +14,5 @@ enum TlonError {
     static var NotificationsFetchContacts = "notifications_fetch_contacts"
     static var NotificationsShowBanner = "notifications_show_banner"
     static var NotificationsShowFallback = "notifications_show_fallback"
+    static var NotificationsFetchGangs = "notifications_fetch_gangs"
 }

--- a/apps/tlon-mobile/ios/Shared/Networking/PocketChatAPI.swift
+++ b/apps/tlon-mobile/ios/Shared/Networking/PocketChatAPI.swift
@@ -16,6 +16,10 @@ extension PocketAPI {
     func fetchGroups() async throws -> [String: Group] {
         try await fetchDecodable("/~/scry/groups/groups/light")
     }
+  
+    func fetchGangs() async throws -> [String: Gang] {
+        try await fetchDecodable("/~/scry/groups/gangs")
+    }
 
     func fetchGroupChannels() async throws -> [String: GroupChannel] {
         let groups = try await fetchGroups()

--- a/apps/tlon-mobile/ios/Shared/Notifications/PushNotificationManager.swift
+++ b/apps/tlon-mobile/ios/Shared/Notifications/PushNotificationManager.swift
@@ -135,7 +135,7 @@ enum NotificationCategory: String {
         content: UNMutableNotificationContent = UNMutableNotificationContent()
     ) async -> (UNNotificationContent, INSendMessageIntent?) {
         content.interruptionLevel = .active
-        content.threadIdentifier = yarn.channelID
+        content.threadIdentifier = yarn.rope.thread
         content.title = await yarn.getTitle()
         content.body = yarn.body
         content.categoryIdentifier = yarn.category.rawValue

--- a/apps/tlon-mobile/ios/Shared/Storage/GroupStore.swift
+++ b/apps/tlon-mobile/ios/Shared/Storage/GroupStore.swift
@@ -1,0 +1,12 @@
+//
+//  GroupStore.swift
+//  Landscape
+//
+//  Created by Hunter Miller on 10/1/24.
+//
+
+import Foundation
+
+final class GroupStore: UserDefaultsStore<Gang> {
+    static let sharedInstance = GroupStore(storageKey: "store.groups", fetchItems: PocketAPI.shared.fetchGangs)
+}

--- a/desk/lib/activity.hoon
+++ b/desk/lib/activity.hoon
@@ -168,10 +168,12 @@
     ?:  ?=(%none allowed)  |
     =/  type  (event-type incoming-event)
     ?+  type  |
+      %post  &
       %reply  &
-      %dm-invite  &
       %dm-post    &
       %dm-reply   &
+      %dm-invite  &
+      %group-invite  &
       %post-mention  &
       %reply-mention  &
       %dm-post-mention  &

--- a/desk/lib/notify.hoon
+++ b/desk/lib/notify.hoon
@@ -124,7 +124,16 @@
                 (flatten:cu content.event)
             ==
           ::
-              ?(%group-ask %group-invite %group-join %group-kick %group-role)
+              %group-invite
+            =+  .^(=gangs:g:a %gx /(scot %p our)/groups/(scot %da now)/gangs/noun)
+            :~  [%ship ship.event]
+                ' sent you an invite to '
+                ?~  gang=(~(get by gangs) group.event)  'a group'
+                ?~  pev.u.gang  'a group'
+                [%emph title.meta.u.pev.u.gang]
+            ==
+          ::
+              ?(%group-ask %group-join %group-kick %group-role)
             =+  .^  =group:g:a  %gx
                   (scot %p our)
                   %groups
@@ -135,12 +144,6 @@
                 %group-ask
               :~  [%ship ship.event]
                   ' has requested to join '
-                  [%emph title.meta.group]
-              ==
-            ::
-                %group-invite
-              :~  [%ship ship.event]
-                  ' sent you an invite to '
                   [%emph title.meta.group]
               ==
             ::


### PR DESCRIPTION
This fixes TLON-2223 and TLON-2531. This PR allows group invites and post notifications to come through the activity agent. We also had to special case group invites in the notify conversion (we really should move away from hark/yarn format). 

Finally we modify both native notification handlers for iOS and Android so that we can display group invite notifications. The only issue I've seen so far is that the iOS push notification always does the fallback "TLON! You have a new message", but the background notification also fires with the correct information. @davidisaaclee any insight here would be great.

PR Checklist
- [X] Includes changes to desk files
- [ ] Describes how you tested the PR locally (test ship vs livenet)
- [ ] If a new feature, includes automated tests
- [ ] Comments added anywhere logic may be confusing without context