### PR TITLE
ChatOptions, InviteUsersWidget: guard against non-admins of private||secret groups

### DIFF
--- a/packages/ui/src/components/ChatOptionsSheet.tsx
+++ b/packages/ui/src/components/ChatOptionsSheet.tsx
@@ -273,6 +273,12 @@ export function GroupOptions({
       endIcon: 'ChevronRight',
     };
 
+    const inviteNotice: Action = {
+      accent: 'disabled',
+      title: 'Invites disabled',
+      description: 'Only admins may invite people to this group.',
+    };
+
     if (currentUserIsAdmin) {
       actionGroups.push({
         accent: 'neutral',
@@ -289,9 +295,9 @@ export function GroupOptions({
       actionGroups.push({
         accent: 'neutral',
         actions:
-          group.privacy === 'public' || group.privacy === 'private'
+          group.privacy === 'public'
             ? [goToMembersAction, inviteAction]
-            : [goToMembersAction],
+            : [goToMembersAction, inviteNotice],
       });
     }
 

--- a/packages/ui/src/components/InviteFriendsToTlonButton.tsx
+++ b/packages/ui/src/components/InviteFriendsToTlonButton.tsx
@@ -68,8 +68,8 @@ export function InviteFriendsToTlonButton({ group }: { group?: db.Group }) {
   }, [group, branchDomain, branchKey, toggle, status, isGroupAdmin, describe]);
 
   if (
-    group?.privacy === 'private' ||
-    (group?.privacy === 'secret' && !isGroupAdmin)
+    (group?.privacy === 'private' ||
+    group?.privacy === 'secret') && !isGroupAdmin
   ) {
     return <Text>Only administrators may invite people to this group.</Text>;
   }

--- a/packages/ui/src/components/InviteFriendsToTlonButton.tsx
+++ b/packages/ui/src/components/InviteFriendsToTlonButton.tsx
@@ -67,6 +67,13 @@ export function InviteFriendsToTlonButton({ group }: { group?: db.Group }) {
     }
   }, [group, branchDomain, branchKey, toggle, status, isGroupAdmin, describe]);
 
+  if (
+    group?.privacy === 'private' ||
+    (group?.privacy === 'secret' && !isGroupAdmin)
+  ) {
+    return <Text>Only administrators may invite people to this group.</Text>;
+  }
+
   return (
     <Button
       hero
@@ -77,18 +84,26 @@ export function InviteFriendsToTlonButton({ group }: { group?: db.Group }) {
       justifyContent="space-between"
     >
       <XStack gap="$xl" alignItems="center">
-        <View borderRadius="$3xl" backgroundColor="$background" padding="$s">
+        <View
+          borderRadius="$3xl"
+          backgroundColor={
+            status !== 'ready' || typeof shareUrl !== 'string'
+              ? '$background'
+              : '$transparent'
+          }
+          padding="$s"
+        >
           {status !== 'ready' || typeof shareUrl !== 'string' ? (
-            <LoadingSpinner size="small" />
+            <LoadingSpinner size="small" color="$background" />
           ) : (
-            <Icon type="Send" size="$l" />
+            <Icon type="Send" size="$l" color="$background" />
           )}
         </View>
         <Text color="$background" fontSize="$l">
           Invite Friends to Tlon
         </Text>
       </XStack>
-      <Icon type="ChevronRight" size="$xl" color="$background" />
+      <Icon type="ChevronRight" size="$l" color="$background" />
     </Button>
   );
 }


### PR DESCRIPTION
Fixes TLON-2856 by disallowing non-admins of private and secret groups from sending invitations (both on-network and issuing Lure invites). On-network invites fail on the back-end; off-network invites fail when the user logs in and sees no invite. Only admins can perform inviting actions in non-public groups, so we should take them out of the UI.

Also drastically simplifies the InviteUsersWidget by breaking apart the primary button into distinct on- and off-network invitation buttons. Makes good reuse of InviteFriendsToTlonButton (which contains all the hooks we need).

Here is what a non-admin member of a private||secret group will see:
![Simulator Screenshot - iPhone 15 Pro - 2024-09-30 at 19 51 07](https://github.com/user-attachments/assets/15e02173-e7be-4e4b-8b87-8102410f4258)

Here is what admins of private||secret groups and everyone in public groups will see:
![Simulator Screenshot - iPhone 15 Pro - 2024-09-30 at 19 50 09](https://github.com/user-attachments/assets/4d54312a-bd34-486e-9a50-df3e6471ed9e)

