### PR TITLE
add groups sheet style tweaks

### DIFF
--- a/apps/tlon-mobile/src/fixtures/AddGroupSheet.fixture.tsx
+++ b/apps/tlon-mobile/src/fixtures/AddGroupSheet.fixture.tsx
@@ -6,7 +6,7 @@ import { initialContacts } from './fakeData';
 export default {
   basic: (
     <FixtureWrapper>
-      <AppDataContextProvider contacts={initialContacts}>
+      <AppDataContextProvider contacts={initialContacts} currentUserId="zod">
         <AddGroupSheet
           open
           onOpenChange={() => {}}

--- a/apps/tlon-mobile/src/fixtures/FindGroups.fixture.tsx
+++ b/apps/tlon-mobile/src/fixtures/FindGroups.fixture.tsx
@@ -7,7 +7,7 @@ export default {
   basic: (
     <FixtureWrapper fillWidth fillHeight>
       <AppDataContextProvider contacts={initialContacts}>
-        <FindGroupsView onCancel={() => {}} onGroupAction={() => {}} />
+        <FindGroupsView goBack={() => {}} goToContactHostedGroups={() => {}} />
       </AppDataContextProvider>
     </FixtureWrapper>
   ),

--- a/apps/tlon-mobile/src/types.ts
+++ b/apps/tlon-mobile/src/types.ts
@@ -27,6 +27,9 @@ export type RootStackParamList = {
     selectedPostId?: string | null;
   };
   FindGroups: undefined;
+  ContactHostedGroups: {
+    contactId: string;
+  };
   CreateGroup: undefined;
   GroupChannels: {
     group: db.Group;

--- a/packages/app/features/top/ContactHostedGroupsScreen.tsx
+++ b/packages/app/features/top/ContactHostedGroupsScreen.tsx
@@ -1,0 +1,59 @@
+import type { NativeStackScreenProps } from '@react-navigation/native-stack';
+import * as db from '@tloncorp/shared/dist/db';
+import {
+  GenericHeader,
+  GroupPreviewAction,
+  GroupPreviewSheet,
+  ViewUserGroupsWidget,
+  useContactName,
+} from '@tloncorp/ui';
+import { useCallback, useState } from 'react';
+import { View } from 'tamagui';
+
+import { useGroupActions } from '../../hooks/useGroupActions';
+import { RootStackParamList } from '../../navigation/types';
+
+type Props = NativeStackScreenProps<RootStackParamList, 'ContactHostedGroups'>;
+
+export function ContactHostedGroupsScreen({ route, navigation }: Props) {
+  const contactId = route.params.contactId;
+  const contactName = useContactName(contactId);
+  const { performGroupAction } = useGroupActions();
+  const [groupForPreview, setGroupForPreview] = useState<db.Group | null>(null);
+  const goBack = useCallback(() => navigation.goBack(), [navigation]);
+
+  const onSelectGroup = useCallback(
+    (group: db.Group) => {
+      setGroupForPreview(group);
+    },
+    [setGroupForPreview]
+  );
+
+  const handleGroupAction = useCallback(
+    (action: GroupPreviewAction, group: db.Group) => {
+      performGroupAction(action, group);
+      setGroupForPreview(null);
+    },
+    [performGroupAction]
+  );
+
+  return (
+    <View flex={1}>
+      <GenericHeader
+        title={`Groups hosted by ${contactName}`}
+        goBack={goBack}
+      />
+      <ViewUserGroupsWidget userId={contactId} onSelectGroup={onSelectGroup} />
+      <GroupPreviewSheet
+        open={!!groupForPreview}
+        onOpenChange={(open) => {
+          if (!open) {
+            setGroupForPreview(null);
+          }
+        }}
+        onActionComplete={handleGroupAction}
+        group={groupForPreview ?? undefined}
+      />
+    </View>
+  );
+}

--- a/packages/app/features/top/FindGroupsScreen.tsx
+++ b/packages/app/features/top/FindGroupsScreen.tsx
@@ -1,18 +1,17 @@
 import type { NativeStackScreenProps } from '@react-navigation/native-stack';
 import { FindGroupsView } from '@tloncorp/ui';
 
-import { useGroupActions } from '../../hooks/useGroupActions';
+import { useGroupNavigation } from '../../hooks/useGroupNavigation';
 import type { RootStackParamList } from '../../navigation/types';
 
 type Props = NativeStackScreenProps<RootStackParamList, 'ChatList'>;
 
 export function FindGroupsScreen({ navigation }: Props) {
-  const { performGroupAction } = useGroupActions();
-
+  const { goToContactHostedGroups } = useGroupNavigation();
   return (
     <FindGroupsView
-      onCancel={() => navigation.goBack()}
-      onGroupAction={performGroupAction}
+      goBack={() => navigation.goBack()}
+      goToContactHostedGroups={goToContactHostedGroups}
     />
   );
 }

--- a/packages/app/hooks/useGroupNavigation.ts
+++ b/packages/app/hooks/useGroupNavigation.ts
@@ -19,8 +19,16 @@ export const useGroupNavigation = () => {
     navigation.navigate('ChatList');
   }, [navigation]);
 
+  const goToContactHostedGroups = useCallback(
+    ({ contactId }: { contactId: string }) => {
+      navigation.navigate('ContactHostedGroups', { contactId });
+    },
+    [navigation]
+  );
+
   return {
     goToChannel,
     goToHome,
+    goToContactHostedGroups,
   };
 };

--- a/packages/app/navigation/RootStack.tsx
+++ b/packages/app/navigation/RootStack.tsx
@@ -16,6 +16,7 @@ import { ActivityScreen } from '../features/top/ActivityScreen';
 import ChannelScreen from '../features/top/ChannelScreen';
 import ChannelSearchScreen from '../features/top/ChannelSearchScreen';
 import ChatListScreen from '../features/top/ChatListScreen';
+import { ContactHostedGroupsScreen } from '../features/top/ContactHostedGroupsScreen';
 import { CreateGroupScreen } from '../features/top/CreateGroupScreen';
 import { FindGroupsScreen } from '../features/top/FindGroupsScreen';
 import { GroupChannelsScreen } from '../features/top/GroupChannelsScreen';
@@ -70,6 +71,10 @@ export function RootStack() {
       {/* individual screens */}
       <Root.Screen name="GroupSettings" component={GroupSettingsStack} />
       <Root.Screen name="FindGroups" component={FindGroupsScreen} />
+      <Root.Screen
+        name="ContactHostedGroups"
+        component={ContactHostedGroupsScreen}
+      />
       <Root.Screen name="CreateGroup" component={CreateGroupScreen} />
       <Root.Screen name="Channel" component={ChannelScreen} />
       <Root.Screen name="ChannelSearch" component={ChannelSearchScreen} />

--- a/packages/app/navigation/types.ts
+++ b/packages/app/navigation/types.ts
@@ -1,6 +1,5 @@
 import type { NavigatorScreenParams } from '@react-navigation/native';
 import type * as db from '@tloncorp/shared/dist/db';
-import type { WebViewProps } from 'react-native-webview';
 
 export type SignUpExtras = {
   nickname?: string;
@@ -28,6 +27,9 @@ export type RootStackParamList = {
     selectedPostId?: string | null;
   };
   FindGroups: undefined;
+  ContactHostedGroups: {
+    contactId: string;
+  };
   CreateGroup: undefined;
   GroupChannels: {
     group: db.Group;

--- a/packages/shared/src/api/groupsApi.ts
+++ b/packages/shared/src/api/groupsApi.ts
@@ -330,7 +330,7 @@ export const findGroupsHostedBy = async (userId: string) => {
 
   logger.log('findGroupsHostedBy result', result);
 
-  return result;
+  return toClientGroupsFromPreview(result);
 };
 
 export const createGroup = async ({

--- a/packages/shared/src/db/queries.ts
+++ b/packages/shared/src/db/queries.ts
@@ -531,6 +531,31 @@ export const insertGroups = createWriteQuery(
   ]
 );
 
+export const insertGroupPreviews = createWriteQuery(
+  'insert group previews',
+  ({ groups }: { groups: Group[] }, ctx: QueryCtx) => {
+    return withTransactionCtx(ctx, async (txCtx) => {
+      if (groups.length === 0) return;
+      for (const group of groups) {
+        await txCtx.db
+          .insert($groups)
+          .values(group)
+          .onConflictDoUpdate({
+            target: $groups.id,
+            set: conflictUpdateSet(
+              $groups.iconImage,
+              $groups.coverImage,
+              $groups.title,
+              $groups.description,
+              $groups.privacy
+            ),
+          });
+      }
+    });
+  },
+  ['groups']
+);
+
 export const updateGroup = createWriteQuery(
   'updateGroup',
   async (group: Partial<Group> & { id: string }, ctx: QueryCtx) => {

--- a/packages/shared/src/store/dbHooks.ts
+++ b/packages/shared/src/store/dbHooks.ts
@@ -389,12 +389,10 @@ export const useGroupsHostedBy = (userId: string) => {
     queryFn: async () => {
       // query backend for all groups the ship hosts
       const groups = await api.findGroupsHostedBy(userId);
-
-      const clientGroups = api.toClientGroupsFromPreview(groups);
       // insert any we didn't already have
-      await db.insertGroups({ groups: clientGroups, overWrite: false });
+      await db.insertGroupPreviews({ groups });
 
-      const groupIds = clientGroups.map((g) => g.id);
+      const groupIds = groups.map((g) => g.id);
       const groupPreviews = await db.getGroupPreviews(groupIds);
       return groupPreviews;
     },

--- a/packages/ui/src/components/AddGroupSheet.tsx
+++ b/packages/ui/src/components/AddGroupSheet.tsx
@@ -1,11 +1,11 @@
-import { QueryClientProvider, queryClient } from '@tloncorp/shared/dist/api';
 import { useCallback, useEffect, useState } from 'react';
-import { YStack, isWeb } from 'tamagui';
+import { View, YStack, isWeb } from 'tamagui';
 
-import { AppDataContextProvider, useContacts } from '../contexts';
 import { triggerHaptic } from '../utils';
 import { ActionSheet } from './ActionSheet';
 import { ContactBook } from './ContactBook';
+import { IconType } from './Icon';
+import { ListItem } from './ListItem';
 
 export function AddGroupSheet({
   open,
@@ -22,7 +22,6 @@ export function AddGroupSheet({
 }) {
   const [screenScrolling, setScreenScrolling] = useState(false);
   const [screenKey, setScreenKey] = useState<number>(0);
-  const contacts = useContacts();
 
   const dismiss = useCallback(() => {
     onOpenChange(false);
@@ -55,52 +54,58 @@ export function AddGroupSheet({
       snapPoints={[90]}
       snapPointsMode="percent"
     >
-      <QueryClientProvider client={queryClient}>
-        <AppDataContextProvider contacts={contacts ?? null}>
-          <ActionSheet.Content flex={1}>
-            <ActionSheet.ContentBlock
-              flex={1}
-              paddingHorizontal={isWeb ? '$2xl' : '$xl'}
-            >
-              <YStack flex={1} gap="$xl">
-                <ActionSheet.ActionTitle textAlign="center">
-                  New Message
-                </ActionSheet.ActionTitle>
-                <ContactBook
-                  searchable
-                  searchPlaceholder="Username or ID"
-                  onSelect={onSelect}
-                  onScrollChange={setScreenScrolling}
-                  key={screenKey}
-                  quickActions={
-                    <ActionSheet.ActionGroup
-                      paddingVertical="$xl"
-                      padding="unset"
-                    >
-                      <ActionSheet.Action
-                        action={{
-                          title: 'New Group',
-                          description: 'Create a new group from scratch',
-                          endIcon: 'ChevronRight',
-                          action: () => navigateToCreateGroup(),
-                        }}
-                      />
-                      <ActionSheet.Action
-                        action={{
-                          title: 'Join a group by username',
-                          description: 'Find a group to join',
-                          endIcon: 'ChevronRight',
-                          action: () => navigateToFindGroups(),
-                        }}
-                      />
-                    </ActionSheet.ActionGroup>
-                  }
-                />
-              </YStack>
-            </ActionSheet.ContentBlock>
-          </ActionSheet.Content>
-        </AppDataContextProvider>
-      </QueryClientProvider>
+      <ActionSheet.SimpleHeader title="Start a chat"></ActionSheet.SimpleHeader>
+      <YStack flex={1} paddingHorizontal={isWeb ? '$xl' : 0}>
+        <ContactBook
+          searchable
+          searchPlaceholder="Username or ID"
+          onSelect={onSelect}
+          onScrollChange={setScreenScrolling}
+          key={screenKey}
+          quickActions={
+            <View paddingBottom="$l">
+              <QuickAction
+                onPress={navigateToCreateGroup}
+                icon="Bang"
+                title="Create group"
+                subtitle="Create a new group chat"
+              />
+              <QuickAction
+                onPress={navigateToFindGroups}
+                icon="Search"
+                title="Find groups"
+                subtitle="Search for users who host groups"
+              />
+            </View>
+          }
+        />
+      </YStack>
     </ActionSheet>
+  );
+}
+
+function QuickAction({
+  onPress,
+  icon,
+  title,
+  subtitle,
+}: {
+  onPress: () => void;
+  icon: IconType;
+  title: string;
+  subtitle?: string;
+}) {
+  return (
+    <ListItem onPress={onPress}>
+      <ListItem.SystemIcon
+        icon={icon}
+        backgroundColor={'$secondaryBackground'}
+        rounded
+      />
+      <ListItem.MainContent>
+        <ListItem.Title>{title}</ListItem.Title>
+        <ListItem.Subtitle>{subtitle}</ListItem.Subtitle>
+      </ListItem.MainContent>
+    </ListItem>
   );
 }

--- a/packages/ui/src/components/Avatar.tsx
+++ b/packages/ui/src/components/Avatar.tsx
@@ -214,20 +214,25 @@ export const ImageAvatar = function ImageAvatarComponent({
 } & AvatarProps) {
   const calmSettings = useCalm();
   const [loadFailed, setLoadFailed] = useState(false);
-
+  const [isLoading, setIsLoading] = useState(true);
   const handleLoadError = useCallback(() => {
     setLoadFailed(true);
   }, []);
+  const handleLoadEnd = useCallback(() => setIsLoading(false), []);
 
   return imageUrl &&
     (props.ignoreCalm || !calmSettings.disableAvatars) &&
     !loadFailed ? (
-    <AvatarFrame {...props}>
+    <AvatarFrame
+      {...props}
+      {...(isLoading ? { backgroundColor: '$secondaryBackground' } : {})}
+    >
       <Image
         width={'100%'}
         height={'100%'}
         contentFit="cover"
         onError={handleLoadError}
+        onLoadEnd={handleLoadEnd}
         source={{
           uri: imageUrl,
         }}

--- a/packages/ui/src/components/Button.tsx
+++ b/packages/ui/src/components/Button.tsx
@@ -4,13 +4,14 @@ import {
   ColorTokens,
   SizeTokens,
   Stack,
-  Text,
   ThemeTokens,
+  ViewStyle,
   createStyledContext,
   styled,
-  useTheme,
   withStaticProperties,
 } from 'tamagui';
+
+import { Text } from './TextV2';
 
 export const ButtonContext = createStyledContext<{
   size: SizeTokens;
@@ -76,14 +77,12 @@ export const ButtonFrame = styled(Stack, {
     } as const,
     hero: {
       true: {
-        backgroundColor: '$darkBackground',
-        padding: '$xl',
+        backgroundColor: '$primaryText',
+        // placeholder constant -- need to resolve ochre implementation
+        height: 56,
         borderWidth: 0,
-        pressStyle: {
-          backgroundColor: '$gray700',
-        },
         disabledStyle: {
-          backgroundColor: '$gray600',
+          backgroundColor: '$tertiaryText',
         },
       },
     } as const,
@@ -134,6 +133,7 @@ export const ButtonText = styled(Text, {
   context: ButtonContext,
   color: '$primaryText',
   userSelect: 'none',
+  size: '$label/xl',
 
   variants: {
     size: {
@@ -149,13 +149,15 @@ export const ButtonText = styled(Text, {
         },
       },
     },
-    hero: {
-      true: {
-        color: '$white',
-        width: '100%',
-        textAlign: 'center',
-        fontWeight: '400',
-      },
+    hero: (isHero: boolean, { props }: { props: { disabled?: boolean } }) => {
+      return isHero
+        ? {
+            color: props.disabled ? '$secondaryText' : '$background',
+            width: '100%',
+            textAlign: 'center',
+            fontWeight: '400',
+          }
+        : {};
     },
     heroDestructive: {
       true: {
@@ -172,12 +174,7 @@ export const ButtonText = styled(Text, {
         fontWeight: '500',
       },
     },
-
-    // disabled: {
-    //   true: {
-    //     color: '$tertiaryText',
-    //   },
-    // },
+    disabled: {} as Record<'true' | 'false', ViewStyle>,
   } as const,
 });
 

--- a/packages/ui/src/components/ContactRow.tsx
+++ b/packages/ui/src/components/ContactRow.tsx
@@ -32,7 +32,7 @@ function ContactRowItemRaw({
   );
 
   return (
-    <ListItem onPress={handlePress(contact.id)} {...rest}>
+    <ListItem onPress={handlePress(contact.id)} pressable {...rest}>
       <ListItem.ContactIcon contactId={contact.id} />
       <ListItem.MainContent>
         <XStack alignItems="center">

--- a/packages/ui/src/components/CreateGroupView.tsx
+++ b/packages/ui/src/components/CreateGroupView.tsx
@@ -1,13 +1,8 @@
 import * as db from '@tloncorp/shared/dist/db';
 import { useCallback, useState } from 'react';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
-import { Text, View, YStack } from 'tamagui';
+import { View, YStack } from 'tamagui';
 
-import {
-  AppDataContextProvider,
-  useContacts,
-  useCurrentUserId,
-} from '../contexts';
 import { CreateGroupWidget } from './AddChats';
 import { Button } from './Button';
 import { TextButton } from './Buttons';
@@ -26,8 +21,6 @@ export function CreateGroupView({
   const { bottom } = useSafeAreaInsets();
   const [screen, setScreen] = useState<screen>('InviteUsers');
   const [invitees, setInvitees] = useState<string[]>([]);
-  const contacts = useContacts();
-  const currentUserId = useCurrentUserId();
 
   const handleCreatedGroup = useCallback(
     ({ channel }: { channel: db.Channel }) => {
@@ -57,44 +50,36 @@ export function CreateGroupView({
           ) : null
         }
       />
-      <View flex={1} padding="$xl">
-        {screen === 'InviteUsers' ? (
-          <AppDataContextProvider
-            contacts={contacts ?? null}
-            currentUserId={currentUserId}
-          >
-            <YStack flex={1} gap="$xl" paddingBottom={bottom}>
-              <Text textAlign="center" fontSize="$l" fontWeight="$xl">
-                Select members
-              </Text>
-              <ContactBook
-                multiSelect
-                searchable
-                searchPlaceholder="Filter by nickname, @p"
-                onSelectedChange={setInvitees}
-              />
-              <Button
-                hero
-                onPress={() => {
-                  setScreen('CreateGroup');
-                }}
-                disabled={invitees.length === 0}
-              >
-                <Button.Text>
-                  {invitees.length === 0
-                    ? 'Invite'
-                    : `Invite ${invitees.length} and continue`}
-                </Button.Text>
-              </Button>
-            </YStack>
-          </AppDataContextProvider>
-        ) : (
-          <CreateGroupWidget
-            invitees={invitees}
-            onCreatedGroup={handleCreatedGroup}
+      {screen === 'InviteUsers' ? (
+        <YStack flex={1} paddingBottom={bottom}>
+          <ContactBook
+            multiSelect
+            searchable
+            searchPlaceholder="Filter by nickname, @p"
+            onSelectedChange={setInvitees}
           />
-        )}
-      </View>
+          <View padding="$xl">
+            <Button
+              hero
+              onPress={() => {
+                setScreen('CreateGroup');
+              }}
+              disabled={invitees.length === 0}
+            >
+              <Button.Text>
+                {invitees.length === 0
+                  ? 'Invite'
+                  : `Invite ${invitees.length} and continue`}
+              </Button.Text>
+            </Button>
+          </View>
+        </YStack>
+      ) : (
+        <CreateGroupWidget
+          invitees={invitees}
+          onCreatedGroup={handleCreatedGroup}
+        />
+      )}
     </View>
   );
 }

--- a/packages/ui/src/components/Emoji/EmojiPickerSheet.tsx
+++ b/packages/ui/src/components/Emoji/EmojiPickerSheet.tsx
@@ -130,7 +130,7 @@ export function EmojiPickerSheet(
                 marginHorizontal="$m"
                 onChangeQuery={handleQueryChange}
                 onFocus={handleInputFocus}
-                areaProps={{ spellCheck: false, autoComplete: 'off' }}
+                inputProps={{ spellCheck: false, autoComplete: 'off' }}
               />
             </View>
             <View onTouchStart={() => Keyboard.dismiss()}>

--- a/packages/ui/src/components/FindGroupsView.tsx
+++ b/packages/ui/src/components/FindGroupsView.tsx
@@ -1,17 +1,36 @@
-import * as db from '@tloncorp/shared/dist/db';
-import { useCallback, useState } from 'react';
-import { useSafeAreaInsets } from 'react-native-safe-area-context';
-import { Text, View, XStack, YStack } from 'tamagui';
+import { useCallback } from 'react';
+import { Text, View, YStack } from 'tamagui';
 
-import {
-  AppDataContextProvider,
-  useContacts,
-  useCurrentUserId,
-} from '../contexts';
-import { ViewUserGroupsWidget } from './AddChats';
 import { ContactBook } from './ContactBook';
-import { GroupPreviewAction, GroupPreviewSheet } from './GroupPreviewSheet';
-import { Icon } from './Icon';
+import { GenericHeader } from './GenericHeader';
+
+export function FindGroupsView({
+  goBack,
+  goToContactHostedGroups,
+}: {
+  goBack: () => void;
+  goToContactHostedGroups: (params: { contactId: string }) => void;
+}) {
+  const handleContactSelected = useCallback(
+    (contactId: string) => {
+      console.log('go to contact hosted groups', contactId);
+      goToContactHostedGroups({ contactId: contactId });
+    },
+    [goToContactHostedGroups]
+  );
+
+  return (
+    <View flex={1}>
+      <GenericHeader title="Find groups" goBack={goBack} />
+      <ContactBook
+        searchable
+        searchPlaceholder="Search by nickname or user ID"
+        onSelect={handleContactSelected}
+        explanationComponent={<GroupJoinExplanation />}
+      />
+    </View>
+  );
+}
 
 const GroupJoinExplanation = () => (
   <YStack height="80%" justifyContent="center" alignItems="center" gap="$m">
@@ -19,80 +38,3 @@ const GroupJoinExplanation = () => (
     <Text>Look for groups hosted by people above.</Text>
   </YStack>
 );
-
-type screens = 'FindGroups' | 'ViewGroupsByContact';
-
-export function FindGroupsView({
-  onCancel,
-  onGroupAction,
-}: {
-  onCancel: () => void;
-  onGroupAction: (action: GroupPreviewAction, group: db.Group) => void;
-}) {
-  const { top } = useSafeAreaInsets();
-  const contacts = useContacts();
-  const currentUserId = useCurrentUserId();
-  const [screen, setScreen] = useState<screens>('FindGroups');
-  const [viewGroupsForContact, setViewGroupsForContact] = useState<
-    string | null
-  >(null);
-  const [groupForPreview, setGroupForPreview] = useState<db.Group | null>(null);
-
-  const onSelectGroup = useCallback(
-    (group: db.Group) => {
-      setGroupForPreview(group);
-    },
-    [setGroupForPreview]
-  );
-
-  const handleGroupAction = useCallback(
-    (action: GroupPreviewAction, group: db.Group) => {
-      onGroupAction(action, group);
-      setGroupForPreview(null);
-    },
-    [onGroupAction]
-  );
-
-  return (
-    <View flex={1} paddingHorizontal="$xl" paddingTop={top}>
-      {screen === 'FindGroups' ? (
-        <AppDataContextProvider
-          contacts={contacts ?? null}
-          currentUserId={currentUserId}
-        >
-          <ContactBook
-            searchable
-            searchPlaceholder="Search by nickname, @p"
-            onSelect={(contact) => {
-              setViewGroupsForContact(contact);
-              setScreen('ViewGroupsByContact');
-            }}
-            showCancelButton
-            onPressCancel={onCancel}
-            explanationComponent={<GroupJoinExplanation />}
-          />
-        </AppDataContextProvider>
-      ) : (
-        <>
-          <XStack justifyContent="flex-start">
-            <Icon type="ChevronLeft" onPress={() => setScreen('FindGroups')} />
-          </XStack>
-          <ViewUserGroupsWidget
-            userId={viewGroupsForContact ?? ''}
-            onSelectGroup={onSelectGroup}
-          />
-        </>
-      )}
-      <GroupPreviewSheet
-        open={!!groupForPreview}
-        onOpenChange={(open) => {
-          if (!open) {
-            setGroupForPreview(null);
-          }
-        }}
-        onActionComplete={handleGroupAction}
-        group={groupForPreview ?? undefined}
-      />
-    </View>
-  );
-}

--- a/packages/ui/src/components/Form/inputs.tsx
+++ b/packages/ui/src/components/Form/inputs.tsx
@@ -1,5 +1,5 @@
 import React, { ComponentProps, ReactElement } from 'react';
-import { TextInput as BaseTextInput } from 'react-native';
+import { TextInput as RNTextInput } from 'react-native';
 import { ScrollView, View, XStack, YStack, styled } from 'tamagui';
 
 import { Button } from '../Button';
@@ -9,40 +9,67 @@ import { useBoundHandler } from '../ListItem/listItemUtils';
 import { Text } from '../TextV2';
 import { FieldContext } from './Form';
 
+const StyledTextInput = styled(
+  RNTextInput,
+  {},
+  {
+    isInput: true,
+    accept: {
+      placeholderTextColor: 'color',
+      selectionColor: 'color',
+    } as const,
+  }
+);
+
 // Text input
 
-export const TextInput = React.memo(
-  styled(
-    BaseTextInput,
-    {
-      context: FieldContext,
-      color: '$primaryText',
-      borderRadius: '$l',
-      borderWidth: 1,
-      borderColor: '$border',
-      placeholderTextColor: '$tertiaryText',
-      fontSize: '$l',
-      padding: '$xl',
-      fontFamily: '$body',
-      textAlignVertical: 'top',
-      variants: {
-        accent: {
-          negative: {
-            backgroundColor: '$negativeBackground',
-            color: '$negativeActionText',
-            borderColor: '$negativeBorder',
-          },
-        },
+export const BaseTextInput = styled(StyledTextInput, {
+  context: FieldContext,
+  color: '$primaryText',
+  borderRadius: '$l',
+  borderWidth: 1,
+  borderColor: '$border',
+  placeholderTextColor: '$tertiaryText',
+  fontSize: '$l',
+  padding: '$xl',
+  fontFamily: '$body',
+  textAlignVertical: 'top',
+  variants: {
+    accent: {
+      negative: {
+        backgroundColor: '$negativeBackground',
+        color: '$negativeActionText',
+        borderColor: '$negativeBorder',
       },
     },
-    {
-      isInput: true,
-      accept: {
-        placeholderTextColor: 'color',
-        selectionColor: 'color',
-      } as const,
-    }
-  )
+  },
+});
+
+export const TextInput = React.memo(BaseTextInput);
+
+export const TextInputWithIcon = React.memo(
+  BaseTextInput.styleable<{ icon: IconType }>(({ icon, ...props }, ref) => {
+    return (
+      <XStack
+        borderRadius="$l"
+        borderWidth={1}
+        borderColor="$border"
+        alignItems="center"
+        paddingLeft="$xl"
+        gap="$l"
+      >
+        <Icon type={icon} customSize={['$2xl', '$2xl']} />
+        <BaseTextInput
+          paddingLeft={0}
+          borderWidth={0}
+          borderRadius={0}
+          flex={1}
+          ref={ref}
+          {...props}
+        />
+      </XStack>
+    );
+  })
 );
 
 // Toggle group

--- a/packages/ui/src/components/SearchBar.tsx
+++ b/packages/ui/src/components/SearchBar.tsx
@@ -1,8 +1,8 @@
 import { debounce } from 'lodash';
 import { ComponentProps, useCallback, useMemo, useState } from 'react';
-import { Input as TInput, View } from 'tamagui';
-import { Circle } from 'tamagui';
+import { Circle, View, XStack } from 'tamagui';
 
+import { TextInput, TextInputWithIcon } from './Form';
 import { Icon } from './Icon';
 import { Input } from './Input';
 
@@ -10,13 +10,13 @@ export function SearchBar({
   placeholder,
   onChangeQuery,
   debounceTime = 300,
-  areaProps,
+  inputProps,
   ...rest
 }: {
   placeholder?: string;
   onChangeQuery: (query: string) => void;
   debounceTime?: number;
-  areaProps?: ComponentProps<typeof TInput>;
+  inputProps?: ComponentProps<typeof TextInput>;
 } & ComponentProps<typeof Input>) {
   const [value, setValue] = useState('');
   const debouncedOnChangeQuery = useMemo(
@@ -51,34 +51,34 @@ export function SearchBar({
       flexDirection="column"
       justifyContent="center"
       alignItems="center"
+      {...rest}
     >
-      <Input size="$m" {...rest} search>
-        <Input.Icon>
-          <Icon type="Search" color="$secondaryText" />
-        </Input.Icon>
-
-        <Input.Area
-          placeholder={placeholder ?? 'Search...'}
-          value={value}
-          onChangeText={onTextChange}
-          {...areaProps}
-        />
-
-        <Input.Icon
-          onPress={() => onTextChange('')}
-          disabled={value === ''}
-          opacity={value === '' ? 0 : undefined}
+      <TextInputWithIcon
+        icon="Search"
+        value={value}
+        onChangeText={onTextChange}
+        placeholder={placeholder}
+        {...inputProps}
+      />
+      <XStack
+        alignItems="center"
+        position="absolute"
+        right={'$3xl'}
+        top={0}
+        height="100%"
+        onPress={() => onTextChange('')}
+        disabled={value === ''}
+        opacity={value === '' ? 0 : undefined}
+      >
+        <Circle
+          justifyContent="center"
+          alignItems="center"
+          size="$xl"
+          backgroundColor="$secondaryText"
         >
-          <Circle
-            justifyContent="center"
-            alignItems="center"
-            size="$xl"
-            backgroundColor="$secondaryText"
-          >
-            <Icon size="$s" type="Close" color="$secondaryBackground" />
-          </Circle>
-        </Input.Icon>
-      </Input>
+          <Icon size="$s" type="Close" color="$secondaryBackground" />
+        </Circle>
+      </XStack>
     </View>
   );
 }

--- a/packages/ui/src/components/SectionList.tsx
+++ b/packages/ui/src/components/SectionList.tsx
@@ -1,24 +1,23 @@
 import { getRadius } from '@tamagui/get-token';
 import { useCallback, useMemo } from 'react';
 import {
-  Platform,
   SectionList,
   SectionListData,
   SectionListProps,
   SectionListRenderItemInfo,
 } from 'react-native';
 import { View, styled, withStaticProperties } from 'tamagui';
-import { SizableText } from 'tamagui';
+
+import { Text } from './TextV2';
 
 const SectionListHeaderFrame = styled(View, {
   paddingHorizontal: '$l',
   paddingVertical: '$m',
 });
 
-const SectionListHeaderText = styled(SizableText, {
-  size: '$s',
+const SectionListHeaderText = styled(Text, {
+  size: '$label/s',
   color: '$secondaryText',
-  lineHeight: Platform.OS === 'ios' ? 0 : undefined,
 });
 
 export const SectionListHeader = withStaticProperties(SectionListHeaderFrame, {

--- a/packages/ui/src/index.tsx
+++ b/packages/ui/src/index.tsx
@@ -23,6 +23,7 @@ export * from './components/ChatMessage/ChatMessageActions/Component';
 export * from './components/ChatOptionsSheet';
 export * from './components/ContactBook';
 export * from './components/ContactList';
+export { useContactName } from './components/ContactNameV2';
 export { default as ContactName } from './components/ContactName';
 export * from './components/ContactRow';
 export * from './components/ContentReference';


### PR DESCRIPTION
This PR reworks the add groups sheet to improve visual hierarchy + better match spec. It also breaks out the list of a user's groups in the "find groups" screen into its own screen.

| Before | After |
|--------|------|
|<img src="https://github.com/user-attachments/assets/34e08c39-b6b6-4549-be2a-f37b4fd9c79b" width=300> | <img src="https://github.com/user-attachments/assets/521aa8cb-0f6b-47a7-a61b-4476f00fb1f7" width=300>|
