### PR TITLE
native: match NSE min iOS version to host min iOS version

### DIFF
--- a/apps/tlon-mobile/ios/Landscape.xcodeproj/project.pbxproj
+++ b/apps/tlon-mobile/ios/Landscape.xcodeproj/project.pbxproj
@@ -1479,7 +1479,7 @@
 				INFOPLIST_FILE = "Notifications/Info-preview.plist";
 				INFOPLIST_KEY_CFBundleDisplayName = "Notifications-preview";
 				INFOPLIST_KEY_NSHumanReadableCopyright = "";
-				IPHONEOS_DEPLOYMENT_TARGET = 17.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 16.0;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
@@ -1524,7 +1524,7 @@
 				INFOPLIST_FILE = "Notifications/Info-preview.plist";
 				INFOPLIST_KEY_CFBundleDisplayName = "Notifications-preview";
 				INFOPLIST_KEY_NSHumanReadableCopyright = "";
-				IPHONEOS_DEPLOYMENT_TARGET = 17.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 16.0;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
@@ -1570,7 +1570,7 @@
 				INFOPLIST_FILE = Notifications/Info.plist;
 				INFOPLIST_KEY_CFBundleDisplayName = Notifications;
 				INFOPLIST_KEY_NSHumanReadableCopyright = "";
-				IPHONEOS_DEPLOYMENT_TARGET = 17.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 16.0;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
@@ -1615,7 +1615,7 @@
 				INFOPLIST_FILE = Notifications/Info.plist;
 				INFOPLIST_KEY_CFBundleDisplayName = Notifications;
 				INFOPLIST_KEY_NSHumanReadableCopyright = "";
-				IPHONEOS_DEPLOYMENT_TARGET = 17.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 16.0;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",


### PR DESCRIPTION
The notification service extension had a min iOS deployment target of 17.0, while the host app has a target of 16.0. There's no reason for the mismatch – changed all targets to 16.0.

Before this change, users <17.0 would not get the behavior of the NSE (falling back to our legacy notification path).