### PR TITLE
syncPosts: handle situation where deleted posts total in response == count

### DIFF
--- a/packages/shared/src/store/sync.ts
+++ b/packages/shared/src/store/sync.ts
@@ -903,6 +903,22 @@ export async function syncPosts(
       older: response.older,
     });
   }
+
+  if (response.deletedPosts?.length) {
+    if (options.count && response.deletedPosts.length === options.count) {
+      // if the number of deleted ("null") posts matches the requested count,
+      // we should fetch more posts to ensure we're not missing any.
+      // if we don't do this, we may assume we're up to date when we're not.
+      await syncPosts(
+        {
+          ...options,
+          count: options.count * 2,
+        },
+        ctx
+      );
+    }
+  }
+
   if (!response.newer) {
     await db.updateChannel({
       id: options.channelId,


### PR DESCRIPTION
Fixes TLON-2797.

Previously, if we synced a channel and requested 15 (for example, the default count for a channel) posts and got back 0 actual posts and Y deleted posts, and Y was equal to 15, we would insert nothing into the db since the actual posts array would be empty. This is a problem if there are not-deleted posts "behind" those deleted posts. We would think we're up to date with everything in that channel when we're not.

If we're in that state, we need to call syncPosts again with a greater count to check to see if there are more posts behind it (and again if we end up in the same situation).

A good example where this was occurring is the "Books" channel in Tlon Studio, which had over 50 deleted posts after the first three posts.