### PR TITLE
channel screen: make sure we actually mark the group as visited if it's new

### DIFF
--- a/packages/app/features/top/ChannelScreen.tsx
+++ b/packages/app/features/top/ChannelScreen.tsx
@@ -34,48 +34,9 @@ type Props = NativeStackScreenProps<RootStackParamList, 'Channel'>;
 export default function ChannelScreen(props: Props) {
   const channelFromParams = props.route.params.channel;
   const selectedPostId = props.route.params.selectedPostId;
-
-  const currentUserId = useCurrentUserId();
-  useFocusEffect(
-    useCallback(() => {
-      if (channelFromParams.group?.isNew) {
-        store.markGroupVisited(channelFromParams.group);
-      }
-
-      if (!channelFromParams.isPendingChannel) {
-        store.syncChannelThreadUnreads(channelFromParams.id, {
-          priority: store.SyncPriority.High,
-        });
-      }
-    }, [channelFromParams])
-  );
-  useFocusEffect(
-    useCallback(
-      () =>
-        // Mark the channel as visited when we unfocus/leave this screen
-        () => {
-          store.markChannelVisited(channelFromParams);
-        },
-      [channelFromParams]
-    )
-  );
-
-  const [channelNavOpen, setChannelNavOpen] = React.useState(false);
   const [currentChannelId, setCurrentChannelId] = React.useState(
     channelFromParams.id
   );
-
-  // for the unread channel divider, we care about the unread state when you enter but don't want it to update over
-  // time
-  const [initialChannelUnread, setInitialChannelUnread] =
-    React.useState<db.ChannelUnread | null>(null);
-  useEffect(() => {
-    async function initializeChannelUnread() {
-      const unread = await db.getChannelUnread({ channelId: currentChannelId });
-      setInitialChannelUnread(unread ?? null);
-    }
-    initializeChannelUnread();
-  }, [currentChannelId]);
 
   const {
     negotiationStatus,
@@ -93,6 +54,45 @@ export default function ChannelScreen(props: Props) {
     draftKey: currentChannelId,
     uploaderKey: `${currentChannelId}`,
   });
+
+  const currentUserId = useCurrentUserId();
+  useFocusEffect(
+    useCallback(() => {
+      if (group?.isNew) {
+        store.markGroupVisited(group);
+      }
+
+      if (!channelFromParams.isPendingChannel) {
+        store.syncChannelThreadUnreads(channelFromParams.id, {
+          priority: store.SyncPriority.High,
+        });
+      }
+    }, [channelFromParams, group])
+  );
+  useFocusEffect(
+    useCallback(
+      () =>
+        // Mark the channel as visited when we unfocus/leave this screen
+        () => {
+          store.markChannelVisited(channelFromParams);
+        },
+      [channelFromParams]
+    )
+  );
+
+  const [channelNavOpen, setChannelNavOpen] = React.useState(false);
+
+  // for the unread channel divider, we care about the unread state when you enter but don't want it to update over
+  // time
+  const [initialChannelUnread, setInitialChannelUnread] =
+    React.useState<db.ChannelUnread | null>(null);
+  useEffect(() => {
+    async function initializeChannelUnread() {
+      const unread = await db.getChannelUnread({ channelId: currentChannelId });
+      setInitialChannelUnread(unread ?? null);
+    }
+    initializeChannelUnread();
+  }, [currentChannelId]);
 
   const { navigateToImage, navigateToPost, navigateToRef, navigateToSearch } =
     useChannelNavigation({ channelId: currentChannelId });


### PR DESCRIPTION
fixes TLON-2868

We were depending on the existence of the `group` property on the `channelFromParams`, which doesn't always exist. We know we'll get a `group` from `useChannelContext` if it exists, so we should just use that.