### PR TITLE
native: small-fix omnibus

### DIFF
--- a/apps/tlon-mobile/src/screens/Onboarding/SetTelemetryScreen.tsx
+++ b/apps/tlon-mobile/src/screens/Onboarding/SetTelemetryScreen.tsx
@@ -1,6 +1,13 @@
 import type { NativeStackScreenProps } from '@react-navigation/native-stack';
 import { useSignupContext } from '@tloncorp/app/contexts/signup';
-import { ScreenHeader, SizableText, View, XStack, YStack } from '@tloncorp/ui';
+import {
+  PrimaryButton,
+  ScreenHeader,
+  SizableText,
+  View,
+  XStack,
+  YStack,
+} from '@tloncorp/ui';
 import { usePostHog } from 'posthog-react-native';
 import { useCallback, useState } from 'react';
 import { Switch } from 'react-native';
@@ -35,15 +42,7 @@ export const SetTelemetryScreen = ({
 
   return (
     <View flex={1}>
-      <ScreenHeader
-        title="Usage Statistics"
-        showSessionStatus={false}
-        rightControls={
-          <ScreenHeader.TextButton onPress={handleNext}>
-            Next
-          </ScreenHeader.TextButton>
-        }
-      />
+      <ScreenHeader title="Usage Statistics" showSessionStatus={false} />
       <YStack gap="$3xl" padding="$2xl">
         <SizableText color="$primaryText">
           We&rsquo;re trying to make the app better and knowing how people use
@@ -64,6 +63,7 @@ export const SetTelemetryScreen = ({
           </SizableText>
           <Switch value={isEnabled} onValueChange={setIsEnabled} />
         </XStack>
+        <PrimaryButton onPress={handleNext}>Next</PrimaryButton>
       </YStack>
     </View>
   );

--- a/packages/app/features/top/ChannelScreen.tsx
+++ b/packages/app/features/top/ChannelScreen.tsx
@@ -17,6 +17,7 @@ import {
   ChannelSwitcherSheet,
   ChatOptionsProvider,
   INITIAL_POSTS_PER_PAGE,
+  InviteUsersSheet,
   useCurrentUserId,
 } from '@tloncorp/ui';
 import React, { useCallback, useEffect, useMemo } from 'react';
@@ -61,6 +62,8 @@ export default function ChannelScreen(props: Props) {
   );
 
   const [channelNavOpen, setChannelNavOpen] = React.useState(false);
+  const [inviteSheetGroup, setInviteSheetGroup] =
+    React.useState<db.Group | null>();
   const [currentChannelId, setCurrentChannelId] = React.useState(
     channelFromParams.id
   );
@@ -282,6 +285,12 @@ export default function ChannelScreen(props: Props) {
     [props.navigation]
   );
 
+  const handleInviteSheetOpenChange = useCallback((open: boolean) => {
+    if (!open) {
+      setInviteSheetGroup(null);
+    }
+  }, []);
+
   if (!channel) {
     return null;
   }
@@ -291,6 +300,9 @@ export default function ChannelScreen(props: Props) {
       groupId={channelFromParams?.id}
       pinned={pinnedItems}
       useGroup={store.useGroup}
+      onPressInvite={(group) => {
+        setInviteSheetGroup(group);
+      }}
       {...chatOptionsNavProps}
     >
       <Channel
@@ -333,13 +345,21 @@ export default function ChannelScreen(props: Props) {
         canUpload={canUpload}
       />
       {group && (
-        <ChannelSwitcherSheet
-          open={channelNavOpen}
-          onOpenChange={(open) => setChannelNavOpen(open)}
-          group={group}
-          channels={group?.channels || []}
-          onSelect={handleChannelSelected}
-        />
+        <>
+          <ChannelSwitcherSheet
+            open={channelNavOpen}
+            onOpenChange={(open) => setChannelNavOpen(open)}
+            group={group}
+            channels={group?.channels || []}
+            onSelect={handleChannelSelected}
+          />
+          <InviteUsersSheet
+            open={inviteSheetGroup !== null}
+            onOpenChange={handleInviteSheetOpenChange}
+            onInviteComplete={() => setInviteSheetGroup(null)}
+            group={inviteSheetGroup ?? undefined}
+          />
+        </>
       )}
     </ChatOptionsProvider>
   );

--- a/packages/ui/src/components/AddChats/CreateGroupWidget.tsx
+++ b/packages/ui/src/components/AddChats/CreateGroupWidget.tsx
@@ -52,7 +52,7 @@ export function CreateGroupWidget(props: {
   }, [groupName, props]);
 
   return (
-    <YStack flex={1} gap="$2xl">
+    <YStack flex={1} gap="$2xl" padding="$2xl">
       <Field label="Group Name (Required)" required>
         <TextInput
           autoFocus

--- a/packages/ui/src/components/AddGroupSheet.tsx
+++ b/packages/ui/src/components/AddGroupSheet.tsx
@@ -55,7 +55,7 @@ export function AddGroupSheet({
       snapPointsMode="percent"
     >
       <ActionSheet.SimpleHeader title="Start a chat"></ActionSheet.SimpleHeader>
-      <YStack flex={1} paddingHorizontal={isWeb ? '$xl' : 0}>
+      <YStack flex={1} paddingHorizontal="$2xl">
         <ContactBook
           searchable
           searchPlaceholder="Username or ID"

--- a/packages/ui/src/components/Channel/EmptyChannelNotice.tsx
+++ b/packages/ui/src/components/Channel/EmptyChannelNotice.tsx
@@ -37,7 +37,7 @@ export function EmptyChannelNotice({
           {noticeText}
         </SizableText>
       </YStack>
-      {isGroupAdmin && isFirstVisit && isWelcomeChannel && (
+      {isGroupAdmin && isWelcomeChannel && (
         <InviteFriendsToTlonButton group={group} />
       )}
     </YStack>

--- a/packages/ui/src/components/ChatOptionsSheet.tsx
+++ b/packages/ui/src/components/ChatOptionsSheet.tsx
@@ -639,6 +639,7 @@ export function ChannelOptions({
             } as ActionGroup,
           ]
         : []),
+     // TODO: redefine in a more readable way.
       ...(group &&
       !['groupDm', 'dm'].includes(channel.type) &&
       (group.privacy === 'public' ||

--- a/packages/ui/src/components/ChatOptionsSheet.tsx
+++ b/packages/ui/src/components/ChatOptionsSheet.tsx
@@ -640,11 +640,10 @@ export function ChannelOptions({
           ]
         : []),
       ...(group &&
-      channel.type !== 'groupDm' &&
-      channel.type !== 'dm' &&
+      !['groupDm', 'dm'].includes(channel.type) &&
       (group.privacy === 'public' ||
         (currentUserIsAdmin &&
-          (group.privacy === 'private' || group.privacy === 'secret')))
+          ['private', 'secret'].includes(group.privacy ?? '')))
         ? [
             {
               accent: 'neutral',
@@ -662,10 +661,9 @@ export function ChannelOptions({
           ]
         : []),
       ...(group &&
-      channel.type !== 'groupDm' &&
-      channel.type !== 'dm' &&
+      !['groupDm', 'dm'].includes(channel.type) &&
       !currentUserIsAdmin &&
-      (group.privacy === 'private' || group.privacy === 'secret')
+      ['private', 'secret'].includes(group.privacy ?? '')
         ? [
             {
               accent: 'disabled',

--- a/packages/ui/src/components/ChatOptionsSheet.tsx
+++ b/packages/ui/src/components/ChatOptionsSheet.tsx
@@ -449,8 +449,12 @@ export function ChannelOptions({
   const sheetRef = useRef(sheet);
   sheetRef.current = sheet;
 
-  const { onPressChannelMembers, onPressChannelMeta, onPressManageChannels } =
-    useChatOptions() ?? {};
+  const {
+    onPressChannelMembers,
+    onPressChannelMeta,
+    onPressManageChannels,
+    onPressInvite,
+  } = useChatOptions() ?? {};
 
   const currentUserIsHost = useMemo(
     () => group?.currentUserIsHost ?? false,
@@ -635,6 +639,45 @@ export function ChannelOptions({
             } as ActionGroup,
           ]
         : []),
+      ...(group &&
+      channel.type !== 'groupDm' &&
+      channel.type !== 'dm' &&
+      (group.privacy === 'public' ||
+        (currentUserIsAdmin &&
+          (group.privacy === 'private' || group.privacy === 'secret')))
+        ? [
+            {
+              accent: 'neutral',
+              actions: [
+                {
+                  title: 'Invite people',
+                  action: () => {
+                    sheetRef.current.setOpen(false);
+                    onPressInvite?.(group);
+                  },
+                  endIcon: 'ChevronRight',
+                },
+              ],
+            } as ActionGroup,
+          ]
+        : []),
+      ...(group &&
+      channel.type !== 'groupDm' &&
+      channel.type !== 'dm' &&
+      !currentUserIsAdmin &&
+      (group.privacy === 'private' || group.privacy === 'secret')
+        ? [
+            {
+              accent: 'disabled',
+              actions: [
+                {
+                  title: 'Invites disabled',
+                  description: 'Only admins may invite people to this group.',
+                },
+              ],
+            } as ActionGroup,
+          ]
+        : []),
       ...(!currentUserIsHost
         ? [
             {
@@ -675,14 +718,15 @@ export function ChannelOptions({
     ];
   }, [
     channel,
-    onPressChannelMembers,
-    onPressChannelMeta,
-    setPane,
-    title,
     currentUserIsAdmin,
-    currentUserIsHost,
     group,
+    currentUserIsHost,
+    setPane,
+    onPressChannelMeta,
+    onPressChannelMembers,
     onPressManageChannels,
+    onPressInvite,
+    title,
   ]);
   return (
     <ChatOptionsSheetContent

--- a/packages/ui/src/components/ContactBook.tsx
+++ b/packages/ui/src/components/ContactBook.tsx
@@ -124,7 +124,6 @@ export function ContactBook({
   const contentContainerStyle = useStyle({
     paddingBottom: insets.bottom,
     paddingTop: '$s',
-    paddingHorizontal: '$xl',
   }) as StyleProp<ViewStyle>;
 
   const scrollIndicatorInsets = useStyle({
@@ -142,7 +141,6 @@ export function ContactBook({
           paddingBottom="$s"
         >
           <SearchBar
-            paddingHorizontal="$xl"
             height="$4xl"
             debounceTime={100}
             onChangeQuery={setQuery}

--- a/packages/ui/src/components/Form/Form.tsx
+++ b/packages/ui/src/components/Form/Form.tsx
@@ -57,4 +57,5 @@ export const FieldLabel = React.memo(
 
 export const FieldErrorMessage = styled(FieldLabel, {
   color: '$negativeActionText',
+  paddingTop: '$l',
 });

--- a/packages/ui/src/components/InviteFriendsToTlonButton.tsx
+++ b/packages/ui/src/components/InviteFriendsToTlonButton.tsx
@@ -68,8 +68,8 @@ export function InviteFriendsToTlonButton({ group }: { group?: db.Group }) {
   }, [group, branchDomain, branchKey, toggle, status, isGroupAdmin, describe]);
 
   if (
-    (group?.privacy === 'private' ||
-    group?.privacy === 'secret') && !isGroupAdmin
+    (group?.privacy === 'private' || group?.privacy === 'secret') &&
+    !isGroupAdmin
   ) {
     return <Text>Only administrators may invite people to this group.</Text>;
   }
@@ -83,27 +83,31 @@ export function InviteFriendsToTlonButton({ group }: { group?: db.Group }) {
       width="100%"
       justifyContent="space-between"
     >
-      <XStack gap="$xl" alignItems="center">
-        <View
-          borderRadius="$3xl"
-          backgroundColor={
-            status !== 'ready' || typeof shareUrl !== 'string'
-              ? '$background'
-              : '$transparent'
-          }
-          padding="$s"
-        >
-          {status !== 'ready' || typeof shareUrl !== 'string' ? (
+      <XStack gap="$xl" paddingHorizontal="$m" alignItems="center">
+        <View>
+          {status === 'error' || status === 'disabled' || status === 'stale' ? (
+            <Icon type="Close" size="$l" color="$background" />
+          ) : null}
+          {status === 'loading' && (
             <LoadingSpinner size="small" color="$background" />
-          ) : (
+          )}
+          {status === 'ready' && (
             <Icon type="Send" size="$l" color="$background" />
           )}
         </View>
-        <Text color="$background" fontSize="$l">
-          Invite Friends to Tlon
+        <Text flex={1} color="$background" fontSize="$l">
+          {status === 'disabled' && 'Public invite links are disabled'}
+          {status === 'stale' && 'Public invite links is stale'}
+          {status === 'error' && 'Error generating invite link'}
+          {status === 'loading' && 'Generating invite link...'}
+          {status === 'ready' &&
+            typeof shareUrl === 'string' &&
+            'Invite Friends to Tlon'}
         </Text>
+        {status === 'ready' && (
+          <Icon type="ChevronRight" size="$l" color="$background" />
+        )}
       </XStack>
-      <Icon type="ChevronRight" size="$l" color="$background" />
     </Button>
   );
 }


### PR DESCRIPTION
- Adds additional icon and label states to InviteFriendsToTlonButton (fixes TLON-2881).
- Adds an "Invite people" button to ChannelOptions in the correct administrative/privacy contexts (fixes TLON-2880).
- Moves the "Next" button in SetTelemetryScreen from the header to a full-width button in the screen content (fixes TLON-2883).
- Always show InviteFriendsToTlonButton in EmptyChannelNotice for admins on subsequent visits to an empty channel (fixes TLON-2879).
- Adds padding to the top of form field validation messages (fixes TLON-2815).
- Fixes an issue where screen elements were too wide in group creation (fixes TLON-2877).