### PR TITLE
James/ add button in the channel list view

### DIFF
--- a/packages/app/features/top/GroupChannelsScreen.tsx
+++ b/packages/app/features/top/GroupChannelsScreen.tsx
@@ -1,3 +1,4 @@
+import { useIsFocused } from '@react-navigation/native';
 import type { NativeStackScreenProps } from '@react-navigation/native-stack';
 import * as db from '@tloncorp/shared/dist/db';
 import * as store from '@tloncorp/shared/dist/store';
@@ -10,13 +11,15 @@ import { useCallback, useMemo, useState } from 'react';
 
 import { useChatSettingsNavigation } from '../../hooks/useChatSettingsNavigation';
 import { useCurrentUserId } from '../../hooks/useCurrentUser';
-import { useIsFocused } from '@react-navigation/native';
+import { useGroupContext } from '../../hooks/useGroupContext';
 import type { RootStackParamList } from '../../navigation/types';
 
 type Props = NativeStackScreenProps<RootStackParamList, 'GroupChannels'>;
 
 export function GroupChannelsScreen({ navigation, route }: Props) {
   const groupParam = route.params.group;
+  const { id } = route.params.group;
+
   const currentUser = useCurrentUserId();
   const isFocused = useIsFocused();
   const { data: pins } = store.usePins({
@@ -25,6 +28,7 @@ export function GroupChannelsScreen({ navigation, route }: Props) {
   const [inviteSheetGroup, setInviteSheetGroup] = useState<db.Group | null>(
     null
   );
+  const { createChannel } = useGroupContext({ groupId: id });
 
   const pinnedItems = useMemo(() => {
     return pins ?? [];
@@ -57,6 +61,7 @@ export function GroupChannelsScreen({ navigation, route }: Props) {
         onChannelPressed={handleChannelSelected}
         onBackPressed={handleGoBackPressed}
         currentUser={currentUser}
+        createChannel={createChannel}
       />
       <InviteUsersSheet
         open={inviteSheetGroup !== null}

--- a/packages/ui/src/components/GroupChannelsScreenView.tsx
+++ b/packages/ui/src/components/GroupChannelsScreenView.tsx
@@ -4,7 +4,6 @@ import { useSafeAreaInsets } from 'react-native-safe-area-context';
 import { ScrollView, View } from 'tamagui';
 
 import { useChatOptions } from '../contexts/chatOptions';
-import { SimpleActionSheet } from './ActionSheet';
 import ChannelNavSections from './ChannelNavSections';
 import { ChatOptionsSheet, ChatOptionsSheetMethods } from './ChatOptionsSheet';
 import {
@@ -37,8 +36,6 @@ export function GroupChannelsScreenView({
   const group = groupOptions?.group;
   const chatOptionsSheetRef = useRef<ChatOptionsSheetMethods>(null);
   const [showCreateChannel, setShowCreateChannel] = useState(false);
-
-  // const [showSortOptions, setShowSortOptions] = useState(false);
   const [sortBy, setSortBy] = useState<db.ChannelSortPreference>('recency');
   const insets = useSafeAreaInsets();
 
@@ -50,15 +47,6 @@ export function GroupChannelsScreenView({
 
     getSortByPreference();
   }, [setSortBy]);
-
-  // const handleSortByChanged = useCallback(
-  //   (newSortBy: 'recency' | 'arranged') => {
-  //     setSortBy(newSortBy);
-  //     setShowSortOptions(false);
-  //     db.storeChannelSortPreference(newSortBy);
-  //   },
-  //   []
-  // );
 
   const handlePressOverflowButton = useCallback(() => {
     if (group) {
@@ -85,10 +73,6 @@ export function GroupChannelsScreenView({
               type="Add"
               onPress={() => setShowCreateChannel(true)}
             />
-            {/* <ScreenHeader.IconButton
-              type="Filter"
-              onPress={() => setShowSortOptions(true)}
-            /> */}
             <ScreenHeader.IconButton
               type="Overflow"
               onPress={handlePressOverflowButton}
@@ -109,7 +93,7 @@ export function GroupChannelsScreenView({
             group={group}
             channels={groupOptions.groupChannels}
             onSelect={onChannelPressed}
-            sortBy={sortBy}
+            sortBy={sortBy || 'recency'}
           />
         ) : null}
       </ScrollView>
@@ -126,44 +110,7 @@ export function GroupChannelsScreenView({
           }
         />
       )}
-
-      {/* <ChannelSortActionsSheet
-        open={showSortOptions}
-        onOpenChange={setShowSortOptions}
-        onSelectSort={handleSortByChanged}
-      /> */}
-      <ChatOptionsSheet ref={chatOptionsSheetRef} />
+      <ChatOptionsSheet ref={chatOptionsSheetRef} setSortBy={setSortBy} />
     </View>
-  );
-}
-
-export function ChannelSortActionsSheet({
-  open,
-  onOpenChange,
-  onSelectSort,
-}: {
-  open: boolean;
-  onOpenChange: (open: boolean) => void;
-  onSelectSort: (sortBy: db.ChannelSortPreference) => void;
-}) {
-  return (
-    <SimpleActionSheet
-      open={open}
-      onOpenChange={onOpenChange}
-      actions={[
-        {
-          title: 'Sort by recency',
-          action: () => {
-            onSelectSort('recency');
-          },
-        },
-        {
-          title: 'Sort by arrangement',
-          action: () => {
-            onSelectSort('arranged');
-          },
-        },
-      ]}
-    />
   );
 }

--- a/packages/ui/src/components/GroupChannelsScreenView.tsx
+++ b/packages/ui/src/components/GroupChannelsScreenView.tsx
@@ -7,23 +7,38 @@ import { useChatOptions } from '../contexts/chatOptions';
 import { SimpleActionSheet } from './ActionSheet';
 import ChannelNavSections from './ChannelNavSections';
 import { ChatOptionsSheet, ChatOptionsSheetMethods } from './ChatOptionsSheet';
+import {
+  ChannelTypeName,
+  CreateChannelSheet,
+} from './ManageChannels/CreateChannelSheet';
 import { ScreenHeader } from './ScreenHeader';
 
 type GroupChannelsScreenViewProps = {
   onChannelPressed: (channel: db.Channel) => void;
   onBackPressed: () => void;
   currentUser: string;
+  createChannel: ({
+    title,
+    description,
+    channelType,
+  }: {
+    title: string;
+    description: string;
+    channelType: ChannelTypeName;
+  }) => Promise<void>;
 };
 
 export function GroupChannelsScreenView({
   onChannelPressed,
   onBackPressed,
+  createChannel,
 }: GroupChannelsScreenViewProps) {
   const groupOptions = useChatOptions();
   const group = groupOptions?.group;
   const chatOptionsSheetRef = useRef<ChatOptionsSheetMethods>(null);
+  const [showCreateChannel, setShowCreateChannel] = useState(false);
 
-  const [showSortOptions, setShowSortOptions] = useState(false);
+  // const [showSortOptions, setShowSortOptions] = useState(false);
   const [sortBy, setSortBy] = useState<db.ChannelSortPreference>('recency');
   const insets = useSafeAreaInsets();
 
@@ -36,14 +51,14 @@ export function GroupChannelsScreenView({
     getSortByPreference();
   }, [setSortBy]);
 
-  const handleSortByChanged = useCallback(
-    (newSortBy: 'recency' | 'arranged') => {
-      setSortBy(newSortBy);
-      setShowSortOptions(false);
-      db.storeChannelSortPreference(newSortBy);
-    },
-    []
-  );
+  // const handleSortByChanged = useCallback(
+  //   (newSortBy: 'recency' | 'arranged') => {
+  //     setSortBy(newSortBy);
+  //     setShowSortOptions(false);
+  //     db.storeChannelSortPreference(newSortBy);
+  //   },
+  //   []
+  // );
 
   const handlePressOverflowButton = useCallback(() => {
     if (group) {
@@ -67,9 +82,13 @@ export function GroupChannelsScreenView({
         rightControls={
           <>
             <ScreenHeader.IconButton
+              type="Add"
+              onPress={() => setShowCreateChannel(true)}
+            />
+            {/* <ScreenHeader.IconButton
               type="Filter"
               onPress={() => setShowSortOptions(true)}
-            />
+            /> */}
             <ScreenHeader.IconButton
               type="Overflow"
               onPress={handlePressOverflowButton}
@@ -94,11 +113,25 @@ export function GroupChannelsScreenView({
           />
         ) : null}
       </ScrollView>
-      <ChannelSortActionsSheet
+
+      {showCreateChannel && (
+        <CreateChannelSheet
+          onOpenChange={(open) => setShowCreateChannel(open)}
+          createChannel={async ({ title, description, channelType }) =>
+            createChannel({
+              title,
+              description,
+              channelType,
+            })
+          }
+        />
+      )}
+
+      {/* <ChannelSortActionsSheet
         open={showSortOptions}
         onOpenChange={setShowSortOptions}
         onSelectSort={handleSortByChanged}
-      />
+      /> */}
       <ChatOptionsSheet ref={chatOptionsSheetRef} />
     </View>
   );

--- a/packages/ui/src/contexts/chatOptions.tsx
+++ b/packages/ui/src/contexts/chatOptions.tsx
@@ -23,6 +23,7 @@ export type ChatOptionsContextValue = {
   onPressChannelMeta: (channelId: string) => void;
   onTogglePinned: () => void;
   onPressLeave: () => Promise<void>;
+  onSelectSort: (sortBy: 'recency' | 'arranged') => void;
 } | null;
 
 const ChatOptionsContext = createContext<ChatOptionsContextValue>(null);
@@ -45,6 +46,7 @@ type ChatOptionsProviderProps = {
   onPressChannelMembers: (channelId: string) => void;
   onPressChannelMeta: (channelId: string) => void;
   onPressRoles: (groupId: string) => void;
+  onSelectSort: (sortBy: 'recency' | 'arranged') => void;
 };
 
 export const ChatOptionsProvider = ({
@@ -80,6 +82,10 @@ export const ChatOptionsProvider = ({
     }
   }, [group]);
 
+  const onSelectSort = useCallback((sortBy: 'recency' | 'arranged') => {
+    db.storeChannelSortPreference(sortBy);
+  }, []);
+
   const contextValue: ChatOptionsContextValue = {
     pinned,
     useGroup,
@@ -95,6 +101,7 @@ export const ChatOptionsProvider = ({
     onTogglePinned,
     onPressChannelMembers,
     onPressChannelMeta,
+    onSelectSort,
   };
 
   return (


### PR DESCRIPTION
Adds a "+" button to the header of GroupChannelsScreen, which allows the user to add a new channel to the group.

Also moves the channel sort options for a group with >1 channel to the ChatOptionsSheet. I had to drill the update function because the GroupChannelsScreen uses both AsyncStorage (via db) and local state (via useState on the screen) to show the channel arrangement.

Fixes TLON-2873.