### PR TITLE
profile: tap group to open GroupPreviewSheet

### DIFF
--- a/apps/tlon-mobile/src/fixtures/UserProfileScreen.fixture.tsx
+++ b/apps/tlon-mobile/src/fixtures/UserProfileScreen.fixture.tsx
@@ -37,6 +37,9 @@ function ProfileScreenFixture() {
           userId="~fabled-faster"
           onBack={() => {}}
           connectionStatus={{ complete: true, status: 'yes' }}
+          onPressGroup={() => {
+            console.log('group pressed');
+          }}
         />
       </AppDataContextProvider>
     </FixtureWrapper>

--- a/packages/app/features/top/UserProfileScreen.tsx
+++ b/packages/app/features/top/UserProfileScreen.tsx
@@ -1,11 +1,14 @@
 import { CommonActions } from '@react-navigation/native';
 import { NativeStackScreenProps } from '@react-navigation/native-stack';
+import type * as db from '@tloncorp/shared/dist/db';
 import * as store from '@tloncorp/shared/dist/store';
 import {
   AppDataContextProvider,
+  GroupPreviewSheet,
   NavigationProvider,
   UserProfileScreenView,
 } from '@tloncorp/ui';
+import { useState } from 'react';
 import { useCallback } from 'react';
 
 import { useCurrentUserId } from '../../hooks/useCurrentUser';
@@ -19,6 +22,7 @@ export function UserProfileScreen({ route: { params }, navigation }: Props) {
   const currentUserId = useCurrentUserId();
   const { data: contacts } = store.useContacts();
   const connectionStatus = useConnectionStatus(userId);
+  const [selectedGroup, setSelectedGroup] = useState<db.Group | null>(null);
 
   const handleGoToDm = useCallback(
     async (participants: string[]) => {
@@ -38,6 +42,13 @@ export function UserProfileScreen({ route: { params }, navigation }: Props) {
     [navigation]
   );
 
+  const handleGroupPreviewSheetOpenChange = useCallback(
+    (open: boolean) => {
+      setSelectedGroup(open ? selectedGroup : null);
+    },
+    [selectedGroup]
+  );
+
   return (
     <AppDataContextProvider
       currentUserId={currentUserId}
@@ -48,6 +59,12 @@ export function UserProfileScreen({ route: { params }, navigation }: Props) {
           userId={userId}
           onBack={() => navigation.goBack()}
           connectionStatus={connectionStatus}
+          onPressGroup={setSelectedGroup}
+        />
+        <GroupPreviewSheet
+          open={selectedGroup !== null}
+          onOpenChange={handleGroupPreviewSheetOpenChange}
+          group={selectedGroup ?? undefined}
         />
       </NavigationProvider>
     </AppDataContextProvider>

--- a/packages/ui/src/components/UserProfileScreenView.tsx
+++ b/packages/ui/src/components/UserProfileScreenView.tsx
@@ -27,6 +27,7 @@ interface Props {
   userId: string;
   onBack: () => void;
   connectionStatus: api.ConnectionStatus | null;
+  onPressGroup: (group: db.Group) => void;
 }
 
 export function UserProfileScreenView(props: Props) {
@@ -57,6 +58,13 @@ export function UserProfileScreenView(props: Props) {
           )
         ? 'offline'
         : 'online';
+
+  const onPressGroup = useCallback(
+    (group: db.Group) => {
+      props.onPressGroup(group);
+    },
+    [props]
+  );
 
   return (
     <View flex={1} backgroundColor={'$secondaryBackground'}>
@@ -95,6 +103,7 @@ export function UserProfileScreenView(props: Props) {
               alignItems="center"
               key={group.id}
               width={i === 0 ? '100%' : (windowDimensions.width - 36) / 2}
+              onPress={() => onPressGroup(group)}
             >
               <GroupAvatar model={group} size="$4xl" />
               <YStack gap="$m" alignItems="center">
@@ -286,7 +295,7 @@ function ProfileButtons(props: { userId: string; contact: db.Contact | null }) {
 
   return (
     <XStack gap="$m" width={'100%'}>
-      <ProfileButton title="Message" onPress={handleMessageUser} />
+      <ProfileButton title="Message" onPress={handleMessageUser} hero />
       <ProfileButton
         title={isBlocked ? 'Unblock' : 'Block'}
         onPress={handleBlock}
@@ -295,7 +304,11 @@ function ProfileButtons(props: { userId: string; contact: db.Contact | null }) {
   );
 }
 
-function ProfileButton(props: { title: string; onPress: () => void }) {
+function ProfileButton(props: {
+  title: string;
+  onPress: () => void;
+  hero?: boolean;
+}) {
   return (
     <Button
       flexGrow={1}
@@ -305,8 +318,14 @@ function ProfileButton(props: { title: string; onPress: () => void }) {
       paddingHorizontal="$2xl"
       borderRadius="$2xl"
       onPress={props.onPress}
+      hero={props.hero}
     >
-      <Text size="$label/xl">{props.title}</Text>
+      <Text
+        size="$label/xl"
+        color={props.hero ? '$background' : '$primaryText'}
+      >
+        {props.title}
+      </Text>
     </Button>
   );
 }


### PR DESCRIPTION
Does what it says on the tin. Tap a group in a profile, see the GroupPreviewSheet. You can either navigate to the group or join the group from here.

Also changes "Message" to be a hero button in order to distinguish it from "Block," which is a piece of feedback @galenwp had a while back.

![image](https://github.com/user-attachments/assets/0f304c16-0142-4903-99f6-20241ebde460)