### PR TITLE
message actions: fix the view reactions button

### DIFF
--- a/packages/ui/src/components/Channel/Scroller.tsx
+++ b/packages/ui/src/components/Channel/Scroller.tsx
@@ -437,7 +437,10 @@ const Scroller = forwardRef(
                 setEditingPost?.(activeMessage);
                 setActiveMessage(null);
               }}
-              onViewReactions={setViewReactionsPost}
+              onViewReactions={(post) => {
+                setViewReactionsPost(post);
+                setActiveMessage(null);
+              }}
             />
           )}
         </Modal>


### PR DESCRIPTION
fixes TLON-2666

We just need to make sure we kill the modal that's rendering ChatMessageActions before attempting to render the ViewReactionsSheet (which itself contains a modal since it's using ActionSheet).