### PR TITLE
GroupChannelsScreenView: long-press channel for options

### DIFF
--- a/packages/ui/src/components/ChannelNavSections.tsx
+++ b/packages/ui/src/components/ChannelNavSections.tsx
@@ -11,12 +11,14 @@ export default function ChannelNavSections({
   onSelect,
   sortBy,
   paddingBottom,
+  onLongPress,
 }: {
   group: db.Group;
   channels: db.Channel[];
   onSelect: (channel: any) => void;
   sortBy: 'recency' | 'arranged';
   paddingBottom?: number;
+  onLongPress: (channel: db.Channel) => void;
 }) {
   const unGroupedChannels = useMemo(
     () =>
@@ -56,6 +58,7 @@ export default function ChannelNavSections({
             model={item}
             onPress={onSelect}
             useTypeIcon={true}
+            onLongPress={onLongPress}
           />
         ))}
       </YStack>
@@ -97,6 +100,7 @@ export default function ChannelNavSections({
               key={item.id}
               model={item}
               onPress={onSelect}
+              onLongPress={onLongPress}
               useTypeIcon={true}
             />
           ))}

--- a/packages/ui/src/components/ChannelNavSections.tsx
+++ b/packages/ui/src/components/ChannelNavSections.tsx
@@ -18,7 +18,7 @@ export default function ChannelNavSections({
   onSelect: (channel: any) => void;
   sortBy: 'recency' | 'arranged';
   paddingBottom?: number;
-  onLongPress: (channel: db.Channel) => void;
+  onLongPress?: (channel: any) => void;
 }) {
   const unGroupedChannels = useMemo(
     () =>

--- a/packages/ui/src/components/GroupChannelsScreenView.tsx
+++ b/packages/ui/src/components/GroupChannelsScreenView.tsx
@@ -56,6 +56,15 @@ export function GroupChannelsScreenView({
 
   const title = group ? group?.title ?? 'Untitled' : '';
 
+  const handleOpenChannelOptions = useCallback(
+    (channel: db.Channel) => {
+      if (group) {
+        chatOptionsSheetRef.current?.open(channel.id, channel.type);
+      }
+    },
+    [group]
+  );
+
   return (
     <View flex={1}>
       <ScreenHeader
@@ -94,6 +103,7 @@ export function GroupChannelsScreenView({
             channels={groupOptions.groupChannels}
             onSelect={onChannelPressed}
             sortBy={sortBy || 'recency'}
+            onLongPress={handleOpenChannelOptions}
           />
         ) : null}
       </ScrollView>


### PR DESCRIPTION
Fixes TLON-2883 by popping ChatOptionsSheet for a long-pressed channel on GroupChannelsScreenView.

![image](https://github.com/user-attachments/assets/2891f35f-417b-4c04-8c26-9832c7b8c48b)
