### PR TITLE
native: avoid notification parsing crash

### DIFF
--- a/packages/shared/src/api/harkApi.ts
+++ b/packages/shared/src/api/harkApi.ts
@@ -1,32 +1,42 @@
+import { createDevLogger } from '../debug';
 import { getCanonicalPostId } from './apiUtils';
+
+const logger = createDevLogger('harkApi', true);
 
 export const getPostInfoFromWer = (
   wer: string
-): { id: string; authorId: string } | null => {
-  const isDm = getIsDmFromWer(wer);
-  const isChannelPost = getIsChannelPostFromWer(wer);
-  const parts = wer.split('/');
-  const isGroupChannelReply = parts.length > 10;
+): { id: string; authorId: string; isDm: boolean } | null => {
+  try {
+    const isDm = getIsDmFromWer(wer);
+    const isChannelPost = getIsChannelPostFromWer(wer);
+    const parts = wer.split('/');
+    const isGroupChannelReply = parts.length > 10;
 
-  if (parts.length < 2) {
+    if (parts.length < 2) {
+      return null;
+    }
+
+    if (isDm && parts[5]) {
+      return {
+        id: getCanonicalPostId(parts[5]),
+        authorId: parts[4],
+        isDm,
+      };
+    }
+
+    if (isChannelPost && isGroupChannelReply && parts[9]) {
+      return {
+        id: getCanonicalPostId(parts[9]),
+        authorId: '',
+        isDm,
+      };
+    }
+
+    return null;
+  } catch (e) {
+    logger.error('getPostInfoFromWer failed', e, wer);
     return null;
   }
-
-  if (isDm && parts[5]) {
-    return {
-      id: getCanonicalPostId(parts[5]),
-      authorId: parts[4],
-    };
-  }
-
-  if (isChannelPost && isGroupChannelReply && parts[9]) {
-    return {
-      id: getCanonicalPostId(parts[9]),
-      authorId: '',
-    };
-  }
-
-  return null;
 };
 
 export const getIsDmFromWer = (wer: string): boolean => {


### PR DESCRIPTION
Adds protections to avoid breaking on notification payload parsing from the RN side. This should resolve the one crash report we have from Corrina.

Tried to streamline validation and cleanup some of the legacy naming while I was in there.