### PR TITLE
perf: no-op on svg avatars, add a key to image and sigil avatars

### DIFF
--- a/packages/ui/src/components/Avatar.tsx
+++ b/packages/ui/src/components/Avatar.tsx
@@ -219,11 +219,15 @@ export const ImageAvatar = function ImageAvatarComponent({
     setLoadFailed(true);
   }, []);
   const handleLoadEnd = useCallback(() => setIsLoading(false), []);
+  // TODO: figure out how to sanitize svgs so we can support svg avatars
+  const isSVG = imageUrl?.endsWith('.svg');
 
   return imageUrl &&
+    !isSVG &&
     (props.ignoreCalm || !calmSettings.disableAvatars) &&
     !loadFailed ? (
     <AvatarFrame
+      key={imageUrl}
       {...props}
       {...(isLoading ? { backgroundColor: '$secondaryBackground' } : {})}
     >
@@ -307,6 +311,7 @@ export const SigilAvatar = React.memo(function SigilAvatarComponent({
       backgroundColor={colors.backgroundColor}
     >
       <UrbitSigil
+        key={contactId}
         colors={colors}
         size={innerSigilSize ?? sigilSize * 0.5}
         contactId={contactId}


### PR DESCRIPTION
Fixes the crashing we were seeing on scroll in the ChatList in iOS 18 (may have been happening on other iOS versions, but iOS 18 was the only one we noticed) by adding a key to the UrbitSigil in SigilAvatar.

Fixes a bug that would cause high CPU usage while apparently idle, which was caused by rendering SVG icons for groups/contacts (we now just no-op on SVG icons, at some later date we could dig into this and figure out which kinds of SVGs could be causing this issue and maybe figure out how to sanitize them).