### PR TITLE
editing: make sure edit input is visible and focused when edit button is pressed

### DIFF
--- a/packages/ui/src/components/ChatMessage/ChatMessage.tsx
+++ b/packages/ui/src/components/ChatMessage/ChatMessage.tsx
@@ -7,6 +7,7 @@ import { View, XStack, YStack } from 'tamagui';
 import AuthorRow from '../AuthorRow';
 import { Icon } from '../Icon';
 import { MessageInput } from '../MessageInput';
+import { ParentAgnosticKeyboardAvoidingView } from '../ParentAgnosticKeyboardAvoidingView';
 import { createContentRenderer } from '../PostContent/ContentRenderer';
 import { usePostContent } from '../PostContent/contentUtils';
 import { SendPostRetrySheet } from '../SendPostRetrySheet';
@@ -94,20 +95,22 @@ const ChatMessage = ({
 
   const messageInputForEditing = useMemo(
     () => (
-      <MessageInput
-        groupMembers={[]}
-        storeDraft={() => {}}
-        clearDraft={() => {}}
-        getDraft={async () => ({})}
-        shouldBlur={false}
-        setShouldBlur={() => {}}
-        send={async () => {}}
-        channelId={post.channelId}
-        editingPost={post}
-        editPost={editPost}
-        setEditingPost={setEditingPost}
-        channelType="chat"
-      />
+      <ParentAgnosticKeyboardAvoidingView>
+        <MessageInput
+          groupMembers={[]}
+          storeDraft={() => {}}
+          clearDraft={() => {}}
+          getDraft={async () => ({})}
+          shouldBlur={false}
+          setShouldBlur={() => {}}
+          send={async () => {}}
+          channelId={post.channelId}
+          editingPost={post}
+          editPost={editPost}
+          setEditingPost={setEditingPost}
+          channelType="chat"
+        />
+      </ParentAgnosticKeyboardAvoidingView>
     ),
     [post, editPost, setEditingPost]
   );

--- a/packages/ui/src/components/MessageInput/index.native.tsx
+++ b/packages/ui/src/components/MessageInput/index.native.tsx
@@ -209,6 +209,8 @@ export const MessageInput = forwardRef<MessageInputHandle, MessageInputProps>(
 
     const editor = useEditorBridge({
       customSource: editorHtml,
+      // setting autofocus to true if we have editPost here doesn't seem to work
+      // so we're using a useEffect to set it
       autofocus: false,
       bridgeExtensions,
     });
@@ -331,6 +333,12 @@ export const MessageInput = forwardRef<MessageInputHandle, MessageInputProps>(
       resetAttachments,
       addAttachment,
     ]);
+
+    useEffect(() => {
+      if (editor && !shouldBlur && !editorState.isFocused && !!editingPost) {
+        editor.focus();
+      }
+    }, [shouldBlur, editor, editorState, editingPost]);
 
     useEffect(() => {
       if (editor && shouldBlur && editorState.isFocused) {


### PR DESCRIPTION
fixes TLON-2900

Just wrapped the editor in a ParentAgnosticKeyboardAvoidingView. I also updated the input so that it will focus if we know we're editing, since it's annoying to have to tape once to get into editing mode and then tap again to actually start editing.