### PR TITLE
GalleryInput, NotebookInput: plumb headermode through draftInputContext

### DIFF
--- a/apps/tlon-mobile/src/fixtures/DetailView/detailViewFixtureBase.tsx
+++ b/apps/tlon-mobile/src/fixtures/DetailView/detailViewFixtureBase.tsx
@@ -54,6 +54,7 @@ export const DetailViewFixture = ({
             markRead={() => {}}
             canUpload={true}
             handleGoToUserProfile={() => {}}
+            headerMode="default"
           />
         </RequestsProvider>
       </AppDataContextProvider>

--- a/apps/tlon-mobile/src/fixtures/PostScreen.fixture.tsx
+++ b/apps/tlon-mobile/src/fixtures/PostScreen.fixture.tsx
@@ -37,6 +37,7 @@ export default (
       storeDraft={() => {}}
       clearDraft={() => {}}
       canUpload={true}
+      headerMode="default"
     />
   </AppDataContextProvider>
 );

--- a/packages/ui/src/components/Channel/ChannelFooter.tsx
+++ b/packages/ui/src/components/Channel/ChannelFooter.tsx
@@ -49,14 +49,18 @@ export function ChannelFooter({
 
   const animatedStyle = useAnimatedStyle(() => {
     const opacity = interpolate(shownAmount.value, [0, 1], [1, 0]);
-    const height = interpolate(shownAmount.value, [0, 1], [50, 0]);
+    const height = interpolate(
+      shownAmount.value,
+      [0, 1],
+      [insets.bottom + 50, 0]
+    );
 
     return {
       transform: [{ translateY: shownAmount.value * -(insets.top * 0.2) }],
       opacity: opacity,
       height: height,
     };
-  }, [easedValue, insets.top]);
+  }, [shownAmount.value, insets.top]);
 
   return (
     <Animated.View style={[{ flex: 0 }, animatedStyle]}>

--- a/packages/ui/src/components/Channel/Scroller.tsx
+++ b/packages/ui/src/components/Channel/Scroller.tsx
@@ -107,6 +107,7 @@ const Scroller = forwardRef(
       hasNewerPosts,
       activeMessage,
       setActiveMessage,
+      headerMode,
     }: {
       anchor?: ScrollAnchor | null;
       showDividers?: boolean;
@@ -133,7 +134,7 @@ const Scroller = forwardRef(
       activeMessage: db.Post | null;
       setActiveMessage: (post: db.Post | null) => void;
       ref?: RefObject<{ scrollToIndex: (params: { index: number }) => void }>;
-
+      headerMode: 'default' | 'next';
       // Unused
       hasOlderPosts?: boolean;
     },
@@ -295,12 +296,15 @@ const Scroller = forwardRef(
         : channelType === 'gallery'
           ? {
               paddingHorizontal: '$l',
+              paddingTop: headerMode === 'next' ? insets.top + 54 : 0,
               paddingBottom: insets.bottom,
               gap: '$l',
             }
           : channelType === 'notebook'
             ? {
                 paddingHorizontal: '$m',
+                paddingTop: headerMode === 'next' ? insets.top + 54 : 0,
+                paddingBottom: insets.bottom,
                 gap: '$l',
               }
             : {

--- a/packages/ui/src/components/Channel/index.tsx
+++ b/packages/ui/src/components/Channel/index.tsx
@@ -226,6 +226,7 @@ export function Channel({
       setShouldBlur: setInputShouldBlur,
       shouldBlur: inputShouldBlur,
       storeDraft,
+      headerMode: headerMode ?? 'default',
     }),
     [
       channel,
@@ -238,6 +239,7 @@ export function Channel({
       messageSender,
       setEditingPost,
       storeDraft,
+      headerMode,
     ]
   );
 

--- a/packages/ui/src/components/Channel/index.tsx
+++ b/packages/ui/src/components/Channel/index.tsx
@@ -89,7 +89,7 @@ export function Channel({
   channel: db.Channel;
   initialChannelUnread?: db.ChannelUnread | null;
   selectedPostId?: string | null;
-  headerMode?: 'default' | 'next';
+  headerMode: 'default' | 'next';
   posts: db.Post[] | null;
   group: db.Group | null;
   goBack: () => void;
@@ -226,7 +226,7 @@ export function Channel({
       setShouldBlur: setInputShouldBlur,
       shouldBlur: inputShouldBlur,
       storeDraft,
-      headerMode: headerMode ?? 'default',
+      headerMode: headerMode,
     }),
     [
       channel,
@@ -331,6 +331,7 @@ export function Channel({
                                     activeMessage={activeMessage}
                                     setActiveMessage={setActiveMessage}
                                     ref={flatListRef}
+                                    headerMode={headerMode}
                                   />
                                 )}
                               </View>

--- a/packages/ui/src/components/DetailView.tsx
+++ b/packages/ui/src/components/DetailView.tsx
@@ -29,6 +29,7 @@ export interface DetailViewProps {
   onPressDelete: (post: db.Post) => void;
   setActiveMessage: (post: db.Post | null) => void;
   activeMessage: db.Post | null;
+  headerMode: 'default' | 'next';
 }
 
 export const DetailView = ({
@@ -43,6 +44,7 @@ export const DetailView = ({
   onPressDelete,
   setActiveMessage,
   activeMessage,
+  headerMode,
 }: DetailViewProps) => {
   const channelType = useMemo(
     () => urbit.getChannelType(post.channelId),
@@ -79,6 +81,7 @@ export const DetailView = ({
           unreadCount={initialPostUnread?.count ?? 0}
           activeMessage={activeMessage}
           setActiveMessage={setActiveMessage}
+          headerMode={headerMode}
         />
       </View>
     );
@@ -95,6 +98,7 @@ export const DetailView = ({
     resolvedPosts,
     setActiveMessage,
     setEditingPost,
+    headerMode,
   ]);
 
   return isChat ? (

--- a/packages/ui/src/components/PostScreenView.tsx
+++ b/packages/ui/src/components/PostScreenView.tsx
@@ -67,7 +67,7 @@ export function PostScreenView({
   onPressRetry: (post: db.Post) => void;
   onPressDelete: (post: db.Post) => void;
   negotiationMatch: boolean;
-  headerMode?: 'default' | 'next';
+  headerMode: 'default' | 'next';
   canUpload: boolean;
 }) {
   const [activeMessage, setActiveMessage] = useState<db.Post | null>(null);
@@ -128,6 +128,7 @@ export function PostScreenView({
                   goBack={goBack}
                   activeMessage={activeMessage}
                   setActiveMessage={setActiveMessage}
+                  headerMode={headerMode}
                 />
               ) : null}
 

--- a/packages/ui/src/components/draftInputs/GalleryInput.tsx
+++ b/packages/ui/src/components/draftInputs/GalleryInput.tsx
@@ -39,6 +39,7 @@ export function GalleryInput({
     setShouldBlur,
     shouldBlur,
     storeDraft,
+    headerMode,
   } = draftInputContext;
   const safeAreaInsets = useSafeAreaInsets();
 
@@ -97,20 +98,23 @@ export function GalleryInput({
         hidden={!showBigInput}
       />
 
-      {!showBigInput && !showAddGalleryPost && !isUploadingGalleryImage && (
-        <View
-          position="absolute"
-          bottom={safeAreaInsets.bottom}
-          flex={1}
-          width="100%"
-          alignItems="center"
-        >
-          <FloatingActionButton
-            onPress={() => setShowAddGalleryPost(true)}
-            icon={<Icon type="Add" size={'$s'} marginRight={'$s'} />}
-          />
-        </View>
-      )}
+      {headerMode === 'next' &&
+        !showBigInput &&
+        !showAddGalleryPost &&
+        !isUploadingGalleryImage && (
+          <View
+            position="absolute"
+            bottom={safeAreaInsets.bottom}
+            flex={1}
+            width="100%"
+            alignItems="center"
+          >
+            <FloatingActionButton
+              onPress={() => setShowAddGalleryPost(true)}
+              icon={<Icon type="Add" size={'$s'} marginRight={'$s'} />}
+            />
+          </View>
+        )}
 
       {isShowingImagePreview && (
         <YStack

--- a/packages/ui/src/components/draftInputs/GalleryInput.tsx
+++ b/packages/ui/src/components/draftInputs/GalleryInput.tsx
@@ -111,7 +111,7 @@ export function GalleryInput({
           >
             <FloatingActionButton
               onPress={() => setShowAddGalleryPost(true)}
-              icon={<Icon type="Add" size={'$s'} marginRight={'$s'} />}
+              icon={<Icon type="Add" size={'$m'} />}
             />
           </View>
         )}

--- a/packages/ui/src/components/draftInputs/NotebookInput.tsx
+++ b/packages/ui/src/components/draftInputs/NotebookInput.tsx
@@ -18,7 +18,7 @@ export function NotebookInput({
 }: {
   draftInputContext: DraftInputContext;
 }) {
-  const { draftInputRef, editingPost, onPresentationModeChange } =
+  const { draftInputRef, editingPost, onPresentationModeChange, headerMode } =
     draftInputContext;
   const safeAreaInsets = useSafeAreaInsets();
   const [showBigInput, setShowBigInput] = useState(false);
@@ -69,7 +69,7 @@ export function NotebookInput({
           hidden={!showBigInput}
         />
 
-        {!showBigInput && (
+        {headerMode === 'next' && !showBigInput && (
           <View
             position="absolute"
             bottom={safeAreaInsets.bottom}

--- a/packages/ui/src/components/draftInputs/NotebookInput.tsx
+++ b/packages/ui/src/components/draftInputs/NotebookInput.tsx
@@ -79,7 +79,7 @@ export function NotebookInput({
           >
             <FloatingActionButton
               onPress={() => setShowBigInput(true)}
-              icon={<Icon type="Add" size={'$s'} marginRight={'$s'} />}
+              icon={<Icon type="Add" size={'$m'} />}
             />
           </View>
         )}

--- a/packages/ui/src/components/draftInputs/shared.ts
+++ b/packages/ui/src/components/draftInputs/shared.ts
@@ -25,6 +25,7 @@ export interface DraftInputContext {
   editingPost?: db.Post;
   getDraft: () => Promise<JSONContent>;
   group: db.Group | null;
+  headerMode: 'default' | 'next';
 
   /**
    * Called when the draft input takes over the entire screen.


### PR DESCRIPTION
Removes the floating action button for Notebook and Gallery channels if the header mode isn't "next." Plumbs this through draftInputContext from the parent channel.

Also fixes the safe-area insets of channel indexes with the experimental channel switcher.

This doesn't touch the visual presentation of detail views; those components all have the right headerMode prop now but the layout is still busted. Saving for another time.

| Header mode | Notebook | Gallery |
| ----------- | -------- | ------- |
| Default | ![image](https://github.com/user-attachments/assets/4b0901dc-6549-4b44-bba7-4a75b7a8278c) | ![image](https://github.com/user-attachments/assets/6680e86a-0590-4c1a-b2c6-a13063da26ba) |
| Next | ![Screenshot 2024-10-04 at 10 06 20 AM](https://github.com/user-attachments/assets/33015045-bd1a-427d-b107-e2c7a9d220da) | ![image](https://github.com/user-attachments/assets/fd06a49a-841f-402c-a5d5-c63fd3a13b0b) |