### PR TITLE
activity: use new default when migrating

### DIFF
--- a/desk/app/activity.hoon
+++ b/desk/app/activity.hoon
@@ -1304,7 +1304,11 @@
       `mute:a
     $(entries t.entries)
   ::  set any overrides from previous volume settings
-  =.  cor  (adjust [%base ~] `(~(got by old-volumes:a) base.volume))
+  =.  cor
+    %+  adjust  [%base ~]
+    ::  use new default since we set all channels to old default
+    ?:  =(%soft base.volume)  default-volumes:a
+    `(~(got by old-volumes:a) base.volume)
   =.  cor
     =/  entries  ~(tap by chan.volume)
     |-

--- a/desk/app/activity.hoon
+++ b/desk/app/activity.hoon
@@ -49,7 +49,7 @@
   +$  card  card:agent:gall
   ::
   +$  current-state
-    $:  %6
+    $:  %7
         allowed=notifications-allowed:a
         =indices:a
         =activity:a
@@ -137,20 +137,25 @@
   =?  old  ?=(%3 -.old)  (state-3-to-4 old)
   =?  old  ?=(%4 -.old)  (state-4-to-5 old)
   =?  old  ?=(%5 -.old)  (state-5-to-6 old)
-  ?>  ?=(%6 -.old)
+  =?  cor  ?=(%6 -.old)
+    (emit %pass /adjust-old-default %agent [our.bowl dap.bowl] %poke noun+!>(%adjust-old-default))
+  =?  old  ?=(%6 -.old)  [%7 +.old]
+  ?>  ?=(%7 -.old)
   =.  state  old
   =.  allowed  %all
   (emit %pass /fix-init-unreads %agent [our.bowl dap.bowl] %poke noun+!>(%fix-init-unreads))
   +$  versioned-state
-    $%  state-6
+    $%  state-7
+        state-6
         state-5
         state-4
         state-3
         state-2
         state-1
     ==
-  +$  state-6  current-state
-  +$  state-5  _%*(. *state-6 - %5)
+  +$  state-7  current-state
+  +$  state-6  _%*(. *state-7 - %6)
+  +$  state-5  _%*(. *state-7 - %5)
   ++  state-5-to-6
     |=  old=state-5
     ^-  state-6
@@ -258,6 +263,7 @@
       %fix-init-unreads  fix-init-unreads
       %show-orphans  (drop-orphans &)
       %drop-orphans  (drop-orphans |)
+      %adjust-old-default  adjust-old-default
     ::
         %sync-reads
       =^  indices  activity
@@ -1144,6 +1150,30 @@
   +$  indexes  (list [=source:a =index:a])
   --
 ::
+::  when we migrated from chat and channels, originally we didn't set the
+::  correct new default. if someone is still on the old default, we need
+::  to set the new default for them.
+::
+++  adjust-old-default
+  =/  base-volume  (~(gut by volume-settings) [%base ~] *volume-map:a)
+  =/  soft  (~(got by old-volumes:a) %soft)
+  ::  bail early if we've set something other than the old default
+  ?.  =(soft base-volume)  cor
+  =+  .^(=groups-ui:g %gx (scry-path %groups /groups/light/v1/noun))
+  =/  groups  ~(tap by groups-ui)
+  ::  iterate through all groups and set volume to old default
+  |-
+  ?~  groups
+    ::  finally set the new default
+    =.  volume-settings
+      (~(put by volume-settings) [%base ~] default-volumes:a)
+    cor
+  =*  next  $(groups t.groups)
+  =/  [=flag:g group=group-ui:g]  i.groups
+  ?:  (~(has by volume-settings) [%group flag])  next
+  =.  volume-settings  (~(put by volume-settings) [%group flag] soft)
+  next
+::
 ::  the original migration from old unreads and volume mgmt to %activity
 ::
 ++  migrate
@@ -1307,7 +1337,7 @@
   =.  cor
     %+  adjust  [%base ~]
     ::  use new default since we set all channels to old default
-    ?:  =(%soft base.volume)  default-volumes:a
+    ?:  =(%soft base.volume)  `default-volumes:a
     `(~(got by old-volumes:a) base.volume)
   =.  cor
     =/  entries  ~(tap by chan.volume)


### PR DESCRIPTION
This fixes TLON-2531 by doing a similar migration to the original whereby we set current group's settings to old default and then set the new default gloablly.

PR Checklist
- [ ] Includes changes to desk files
- [ ] Describes how you tested the PR locally (test ship vs livenet)
- [ ] If a new feature, includes automated tests
- [ ] Comments added anywhere logic may be confusing without context