### PR TITLE
native: add lint rules enforcing unidirectional imports from workspace packages

### DIFF
--- a/packages/app/.eslintrc.cjs
+++ b/packages/app/.eslintrc.cjs
@@ -1,0 +1,8 @@
+module.exports = {
+  rules: {
+    'no-restricted-imports': [
+      'error',
+      { patterns: ['tlon-mobile', 'tlon-web'] },
+    ],
+  },
+};

--- a/packages/editor/.eslintrc.cjs
+++ b/packages/editor/.eslintrc.cjs
@@ -1,0 +1,8 @@
+module.exports = {
+  rules: {
+    'no-restricted-imports': [
+      'error',
+      { patterns: ['@tloncorp/*', 'tlon-mobile', 'tlon-web'] },
+    ],
+  },
+};

--- a/packages/shared/.eslintrc.cjs
+++ b/packages/shared/.eslintrc.cjs
@@ -1,0 +1,8 @@
+module.exports = {
+  rules: {
+    'no-restricted-imports': [
+      'error',
+      { patterns: ['@tloncorp/*', 'tlon-mobile', 'tlon-web'] },
+    ],
+  },
+};

--- a/packages/ui/.eslintrc.cjs
+++ b/packages/ui/.eslintrc.cjs
@@ -1,0 +1,8 @@
+module.exports = {
+  rules: {
+    'no-restricted-imports': [
+      'error',
+      { patterns: ['@tloncorp/app', 'tlon-mobile', 'tlon-web'] },
+    ],
+  },
+};


### PR DESCRIPTION
/1/chan/chat/~bitpyx-dildus/interface/msg/170141184507029324882778741826998239232

I was wrong here – the issue of web importing something that eventually imports `ExpoImageManipulator` is not caught by this, since it's not a circular import – just including a web-only dependency in `shared`. But this still seems useful as a check!

I checked by adding some bad imports to the relevant packages and running `pnpm -r lint --quiet`, and saw that there were errors reported.

(It also seems nice to have a structure for package-specific lint rules. I omitted some packages' configs, since we aren't restricting imports from those packages.)