### PR TITLE
native: add missing key prop for useRegisterChannelHeaderItem children

### DIFF
--- a/packages/ui/src/components/draftInputs/GalleryInput.tsx
+++ b/packages/ui/src/components/draftInputs/GalleryInput.tsx
@@ -76,6 +76,7 @@ export function GalleryInput({
       () =>
         showBigInput ? null : (
           <ScreenHeader.IconButton
+            key="gallery"
             type="Add"
             onPress={() => setShowAddGalleryPost(true)}
           />

--- a/packages/ui/src/components/draftInputs/NotebookInput.tsx
+++ b/packages/ui/src/components/draftInputs/NotebookInput.tsx
@@ -39,6 +39,7 @@ export function NotebookInput({
       () =>
         showBigInput ? null : (
           <ScreenHeader.IconButton
+            key="notebook"
             type="Add"
             onPress={() => setShowBigInput(true)}
           />


### PR DESCRIPTION
React was raising a warning here – added a `key` to fix. @patosullivan figured you have most context since you reviewed the PR that introduced this