### PR TITLE
MetaEditorScreenView: call handleSubmit as a function

### DIFF
--- a/packages/ui/src/components/MetaEditorScreenView.tsx
+++ b/packages/ui/src/components/MetaEditorScreenView.tsx
@@ -56,7 +56,7 @@ export function MetaEditorScreenView({
   }, [chat, modelLoaded, reset, defaultValues]);
 
   const runSubmit = useCallback(
-    () => handleSubmit(onSubmit),
+    () => handleSubmit(onSubmit)(),
     [handleSubmit, onSubmit]
   );
 


### PR DESCRIPTION
Fixes the metadata editor screen by actually calling the function handleSubmit passes in.

https://github.com/user-attachments/assets/14a1139a-8111-4320-8871-57c900fe4111


