### PR TITLE
onboarding: better recaptcha error handling

### DIFF
--- a/apps/tlon-mobile/src/screens/Onboarding/SignUpPasswordScreen.tsx
+++ b/apps/tlon-mobile/src/screens/Onboarding/SignUpPasswordScreen.tsx
@@ -3,7 +3,7 @@ import { RECAPTCHA_SITE_KEY } from '@tloncorp/app/constants';
 import { useSignupParams } from '@tloncorp/app/contexts/branch';
 import { useSignupContext } from '@tloncorp/app/contexts/signup';
 import { setEulaAgreed } from '@tloncorp/app/utils/eula';
-import { trackError, trackOnboardingAction } from '@tloncorp/app/utils/posthog';
+import { trackOnboardingAction } from '@tloncorp/app/utils/posthog';
 import { createDevLogger } from '@tloncorp/shared';
 import {
   Button,
@@ -78,8 +78,9 @@ export const SignUpPasswordScreen = ({
       console.error('Error executing reCAPTCHA:', err);
       if (err instanceof Error) {
         setRecaptchaError(err);
-        logger.crumb('Error executing reCAPTCHA:', err);
-        trackError(err);
+        logger.trackError('Error executing reCAPTCHA', {
+          thrownErrorMessage: err.message,
+        });
       }
     }
 
@@ -108,7 +109,9 @@ export const SignUpPasswordScreen = ({
           type: 'custom',
           message: err.message,
         });
-        trackError(err);
+        logger.trackError('Error signing up user', {
+          thrownErrorMessage: err.message,
+        });
       }
       setIsSubmitting(false);
       return;
@@ -137,8 +140,9 @@ export const SignUpPasswordScreen = ({
           type: 'custom',
           message: err.message,
         });
-        trackError(err);
-        logger.crumb('Error logging in user:', err);
+        logger.trackError('Error logging in user', {
+          thrownErrorMessage: err.message,
+        });
       }
     }
 
@@ -154,8 +158,8 @@ export const SignUpPasswordScreen = ({
         console.error('Error initializing reCAPTCHA client:', err);
         if (err instanceof Error) {
           setRecaptchaError(err);
-          trackError(err);
-          logger.crumb('Error initializing reCAPTCHA client:', err, {
+          logger.trackError('Error initializing reCAPTCHA client', {
+            thrownErrorMessage: err.message,
             siteKey: RECAPTCHA_SITE_KEY,
           });
         }
@@ -174,11 +178,11 @@ export const SignUpPasswordScreen = ({
         } catch (err) {
           console.error('Error re-initializing reCAPTCHA client:', err);
           if (err instanceof Error) {
-            logger.crumb('Error re-initializing reCAPTCHA client:', err, {
+            logger.trackError('Error re-initializing reCAPTCHA client', {
+              thrownErrorMessage: err.message,
               siteKey: RECAPTCHA_SITE_KEY,
             });
             setRecaptchaReInitError(err);
-            trackError(err);
           }
         }
       })();


### PR DESCRIPTION
fixes TLON2-2925

If we detect a recaptcha issue we stop form submission, re-attempt initialization of recaptcha, and attempt form submission again. If the re-init fails, we show a modal to the user letting them know what's going on. They can press "retry" which will allow the reinit and resubmit to run again.

If it continues to fail, we don't really have a way to handle that, it'll just be annoying to the user in that they'll keep seeing that modal and pressing retry. Any thoughts or feedback are appreciated here.

Also, if anyone has a bead on a reliably repro, that would be appreciated. I do wonder how many of these errors are actually coming from the hosting service.