### PR TITLE
native: disable verbose logging on urbit http client in dev

### DIFF
--- a/apps/tlon-mobile/src/components/AuthenticatedApp.tsx
+++ b/apps/tlon-mobile/src/components/AuthenticatedApp.tsx
@@ -42,7 +42,6 @@ function AuthenticatedApp({
       shipName: ship ?? '',
       shipUrl: shipUrl ?? '',
       onReset: () => sync.syncStart(),
-      verbose: __DEV__,
       onChannelReset: () => sync.handleDiscontinuity(),
       onChannelStatusChange: sync.handleChannelStatusChange,
     });


### PR DESCRIPTION
This logging was causing a lot of `Received SSE` logs, which is noisy for normal client dev.