### PR TITLE
native: don't use Deeplink fallback...again

### DIFF
--- a/apps/tlon-web/src/logic/branch.ts
+++ b/apps/tlon-web/src/logic/branch.ts
@@ -92,7 +92,7 @@ export const createDeepLink = async (
     data.wer = path;
   }
 
-  let url = await getDeepLink(alias).catch(() => fallbackUrl);
+  let url = await getDeepLink(alias).catch(() => null);
   if (!url) {
     console.log(`No existing deeplink for ${alias}, creating new one`);
     const response = await fetchBranchApi('/v1/url', {

--- a/packages/shared/src/logic/branch.ts
+++ b/packages/shared/src/logic/branch.ts
@@ -171,7 +171,7 @@ export const createDeepLink = async ({
 
   try {
     let url = await getDeepLink(alias, branchDomain, branchKey).catch(
-      () => fallbackUrl
+      () => null
     );
     if (!url) {
       logger.crumb(`No existing deeplink for ${alias}, creating new one`);


### PR DESCRIPTION
[Somehow this commit got cleared](https://github.com/tloncorp/tlon-apps/pull/3944/commits/c8f53fd286ada5034f2521229788da816e13fadc). Adds it back