### PR TITLE
native: fix newly created dms missing from chatlist

### DIFF
--- a/packages/shared/src/db/modelBuilders.ts
+++ b/packages/shared/src/db/modelBuilders.ts
@@ -239,11 +239,13 @@ export function buildPendingSingleDmChannel(
 
   return {
     id,
+    contactId: dmPartnerId,
     type: 'dm',
     currentUserIsMember: true,
     postCount: 0,
     unreadCount: 0,
     isPendingChannel: true,
+    isDmInvite: false,
     members: [partnerMember],
   };
 }

--- a/packages/shared/src/db/schema.ts
+++ b/packages/shared/src/db/schema.ts
@@ -680,7 +680,7 @@ export const channels = sqliteTable(
     lastPostId: text('last_post_id'),
     lastPostAt: timestamp('last_post_at'),
     isPendingChannel: boolean('is_cached_pending_channel'),
-    isDmInvite: boolean('is_dm_invite'),
+    isDmInvite: boolean('is_dm_invite').default(false),
 
     /**
      * Last time we ran a sync, in local time


### PR DESCRIPTION
The `isDmInvite` column of the built model for newly created DMs needs to be explicitly set to false. If it's null, it will fail the check to show up in the chatlist query.

Fixes TLON-2938