### PR TITLE
fix code paste

### DIFF
--- a/apps/tlon-mobile/src/screens/Onboarding/CheckVerifyScreen.tsx
+++ b/apps/tlon-mobile/src/screens/Onboarding/CheckVerifyScreen.tsx
@@ -182,7 +182,6 @@ function CodeInput({
             onChangeText={(text) => handleChangeText(i, text)}
             value={value.length > i ? value[i] : ''}
             keyboardType="numeric"
-            maxLength={1}
             paddingHorizontal="$xl"
             paddingVertical="$xl"
             width="$4xl"


### PR DESCRIPTION
Fixes pasting verification code on iOS by removing maxLength, which was causing the code to get truncated on paste.

Fixes TLON-2812