### PR TITLE
editing: use the normal chat input for editing chat messages, don't edit in the scroller

### DIFF
--- a/packages/shared/src/debug.ts
+++ b/packages/shared/src/debug.ts
@@ -242,3 +242,20 @@ export const useLogLifecycleEvents = (
     return () => console.log(label, 'unmounted');
   }, []);
 };
+
+/**
+ * Logs a message when any property of an object changes. Uses shallow equality
+ * check to determine whether a change has occurred.
+ */
+export function useObjectChangeLogging(
+  o: Record<string, unknown>,
+  logger: Console = window.console
+) {
+  const lastValues = useRef(o);
+  Object.entries(o).forEach(([k, v]) => {
+    if (v !== lastValues.current[k]) {
+      logger.log('[change]', k, 'old:', lastValues.current[k], 'new:', v);
+      lastValues.current[k] = v;
+    }
+  });
+}

--- a/packages/ui/src/components/Channel/Scroller.tsx
+++ b/packages/ui/src/components/Channel/Scroller.tsx
@@ -101,7 +101,6 @@ const Scroller = forwardRef(
       showReplies = true,
       editingPost,
       setEditingPost,
-      editPost,
       onPressRetry,
       onPressDelete,
       hasNewerPosts,
@@ -127,7 +126,6 @@ const Scroller = forwardRef(
       showReplies?: boolean;
       editingPost?: db.Post;
       setEditingPost?: (post: db.Post | undefined) => void;
-      editPost?: (post: db.Post, content: Story) => Promise<void>;
       onPressRetry: (post: db.Post) => void;
       onPressDelete: (post: db.Post) => void;
       hasNewerPosts?: boolean;
@@ -245,12 +243,9 @@ const Scroller = forwardRef(
             isLastPostOfBlock={isLastPostOfBlock}
             Component={renderItem}
             unreadCount={unreadCount}
-            editingPost={editingPost}
             channelId={channelId}
             channelType={channelType}
-            setEditingPost={setEditingPost}
             setViewReactionsPost={setViewReactionsPost}
-            editPost={editPost}
             onPressRetry={onPressRetry}
             onPressDelete={onPressDelete}
             showReplies={showReplies}
@@ -270,12 +265,9 @@ const Scroller = forwardRef(
         firstUnreadId,
         renderItem,
         unreadCount,
-        editingPost,
         anchorScrollLockScrollerItemProps,
         channelId,
         channelType,
-        setEditingPost,
-        editPost,
         showReplies,
         onPressImage,
         onPressReplies,
@@ -398,6 +390,9 @@ const Scroller = forwardRef(
             // we need to switch from 1 to 2 columns or vice versa.
             key={channelType}
             data={postsWithNeighbors}
+            // Disabled to prevent the user from accidentally blurring the edit
+            // input while they're typing.
+            scrollEnabled={!editingPost}
             renderItem={listRenderItem}
             ListEmptyComponent={renderEmptyComponent}
             keyExtractor={getPostId}
@@ -476,13 +471,10 @@ const BaseScrollerItem = ({
   showAuthor,
   Component,
   unreadCount,
-  editingPost,
   onLayout,
   channelId,
   channelType,
   setViewReactionsPost,
-  setEditingPost,
-  editPost,
   showReplies,
   onPressImage,
   onPressReplies,
@@ -508,10 +500,7 @@ const BaseScrollerItem = ({
   onPressImage?: (post: db.Post, imageUri?: string) => void;
   onPressReplies?: (post: db.Post) => void;
   showReplies?: boolean;
-  editingPost?: db.Post;
   setViewReactionsPost?: (post: db.Post) => void;
-  setEditingPost?: (post: db.Post | undefined) => void;
-  editPost?: (post: db.Post, content: Story) => Promise<void>;
   onPressPost?: (post: db.Post) => void;
   onLongPressPost: (post: db.Post) => void;
   onPressRetry: (post: db.Post) => void;
@@ -593,10 +582,7 @@ const BaseScrollerItem = ({
         <Component
           isHighlighted={isSelected}
           post={post}
-          editing={editingPost && editingPost?.id === item.id}
-          setEditingPost={setEditingPost}
           setViewReactionsPost={setViewReactionsPost}
-          editPost={editPost}
           showAuthor={showAuthor}
           showReplies={showReplies}
           onPressReplies={post.isDeleted ? undefined : onPressReplies}
@@ -625,9 +611,6 @@ const ScrollerItem = React.memo(BaseScrollerItem, (prev, next) => {
   const areOtherPropsEqual =
     prev.showAuthor === next.showAuthor &&
     prev.showReplies === next.showReplies &&
-    prev.editingPost === next.editingPost &&
-    prev.editPost === next.editPost &&
-    prev.setEditingPost === next.setEditingPost &&
     prev.onPressReplies === next.onPressReplies &&
     prev.onPressImage === next.onPressImage &&
     prev.onPressPost === next.onPressPost &&

--- a/packages/ui/src/components/Channel/index.tsx
+++ b/packages/ui/src/components/Channel/index.tsx
@@ -306,7 +306,6 @@ export function Channel({
                                     hasOlderPosts={hasOlderPosts}
                                     editingPost={editingPost}
                                     setEditingPost={setEditingPost}
-                                    editPost={editPost}
                                     channelType={channel.type}
                                     channelId={channel.id}
                                     firstUnreadId={

--- a/packages/ui/src/components/ChatMessage/ChatMessage.tsx
+++ b/packages/ui/src/components/ChatMessage/ChatMessage.tsx
@@ -1,13 +1,10 @@
 import * as db from '@tloncorp/shared/dist/db';
-import { Story } from '@tloncorp/shared/dist/urbit';
 import { isEqual } from 'lodash';
 import { ComponentProps, memo, useCallback, useMemo, useState } from 'react';
 import { View, XStack, YStack } from 'tamagui';
 
 import AuthorRow from '../AuthorRow';
 import { Icon } from '../Icon';
-import { MessageInput } from '../MessageInput';
-import { ParentAgnosticKeyboardAvoidingView } from '../ParentAgnosticKeyboardAvoidingView';
 import { createContentRenderer } from '../PostContent/ContentRenderer';
 import { usePostContent } from '../PostContent/contentUtils';
 import { SendPostRetrySheet } from '../SendPostRetrySheet';
@@ -26,9 +23,6 @@ const ChatMessage = ({
   onPressRetry,
   onPressDelete,
   showReplies,
-  editing,
-  editPost,
-  setEditingPost,
   setViewReactionsPost,
   isHighlighted,
 }: {
@@ -43,9 +37,6 @@ const ChatMessage = ({
   onLongPress?: (post: db.Post) => void;
   onPressRetry?: (post: db.Post) => void;
   onPressDelete?: (post: db.Post) => void;
-  editing?: boolean;
-  editPost?: (post: db.Post, content: Story) => Promise<void>;
-  setEditingPost?: (post: db.Post | undefined) => void;
   setViewReactionsPost?: (post: db.Post) => void;
   isHighlighted?: boolean;
 }) => {
@@ -92,28 +83,6 @@ const ChatMessage = ({
     onPressDelete?.(post);
     setShowRetrySheet(false);
   }, [onPressDelete, post]);
-
-  const messageInputForEditing = useMemo(
-    () => (
-      <ParentAgnosticKeyboardAvoidingView>
-        <MessageInput
-          groupMembers={[]}
-          storeDraft={() => {}}
-          clearDraft={() => {}}
-          getDraft={async () => ({})}
-          shouldBlur={false}
-          setShouldBlur={() => {}}
-          send={async () => {}}
-          channelId={post.channelId}
-          editingPost={post}
-          editPost={editPost}
-          setEditingPost={setEditingPost}
-          channelType="chat"
-        />
-      </ParentAgnosticKeyboardAvoidingView>
-    ),
-    [post, editPost, setEditingPost]
-  );
 
   const content = usePostContent(post);
 
@@ -165,16 +134,12 @@ const ChatMessage = ({
         />
       ) : null}
       <View paddingLeft={!isNotice && '$4xl'}>
-        {editing ? (
-          messageInputForEditing
-        ) : (
-          <ChatContentRenderer
-            content={content}
-            isNotice={post.type === 'notice'}
-            onPressImage={handleImagePressed}
-            onLongPress={handleLongPress}
-          />
-        )}
+        <ChatContentRenderer
+          content={content}
+          isNotice={post.type === 'notice'}
+          onPressImage={handleImagePressed}
+          onLongPress={handleLongPress}
+        />
       </View>
 
       <ReactionsDisplay
@@ -235,9 +200,6 @@ export default memo(ChatMessage, (prev, next) => {
   const areOtherPropsEqual =
     prev.showAuthor === next.showAuthor &&
     prev.showReplies === next.showReplies &&
-    prev.editing === next.editing &&
-    prev.editPost === next.editPost &&
-    prev.setEditingPost === next.setEditingPost &&
     prev.onPressReplies === next.onPressReplies &&
     prev.onPressImage === next.onPressImage &&
     prev.onLongPress === next.onLongPress &&

--- a/packages/ui/src/components/DetailView.tsx
+++ b/packages/ui/src/components/DetailView.tsx
@@ -16,12 +16,6 @@ export interface DetailViewProps {
   children?: JSX.Element;
   editingPost?: db.Post;
   setEditingPost?: (post: db.Post | undefined) => void;
-  editPost?: (
-    post: db.Post,
-    content: urbit.Story,
-    parentId?: string,
-    metadata?: db.PostMetadata
-  ) => Promise<void>;
   posts?: db.Post[];
   onPressImage?: (post: db.Post, imageUri?: string) => void;
   goBack?: () => void;
@@ -37,7 +31,6 @@ export const DetailView = ({
   initialPostUnread,
   editingPost,
   setEditingPost,
-  editPost,
   posts,
   onPressImage,
   onPressRetry,
@@ -65,7 +58,6 @@ export const DetailView = ({
           channelId={post.channelId}
           editingPost={editingPost}
           setEditingPost={setEditingPost}
-          editPost={editPost}
           posts={resolvedPosts ?? null}
           showReplies={false}
           showDividers={isChat}
@@ -87,7 +79,6 @@ export const DetailView = ({
     );
   }, [
     activeMessage,
-    editPost,
     editingPost,
     initialPostUnread,
     isChat,

--- a/packages/ui/src/components/MessageInput/index.native.tsx
+++ b/packages/ui/src/components/MessageInput/index.native.tsx
@@ -236,11 +236,13 @@ export const MessageInput = forwardRef<MessageInputHandle, MessageInputProps>(
       }
     }, [editor, ref]);
 
+    const lastEditingPost = useRef<db.Post | undefined>(editingPost);
+
     useEffect(() => {
       if (!hasSetInitialContent && editorState.isReady) {
         try {
           getDraft().then((draft) => {
-            if (draft) {
+            if (!editingPost && draft) {
               const inlines = tiptap.JSONToInlines(draft);
               const newInlines = inlines
                 .map((inline) => {
@@ -255,12 +257,14 @@ export const MessageInput = forwardRef<MessageInputHandle, MessageInputProps>(
                 .filter((inline) => inline !== null) as Inline[];
               const newStory = constructStory(newInlines);
               const tiptapContent = tiptap.diaryMixedToJSON(newStory);
+              messageInputLogger.log('Setting draft content', tiptapContent);
               // @ts-expect-error setContent does accept JSONContent
               editor.setContent(tiptapContent);
               setEditorIsEmpty(false);
             }
 
-            if (editingPost?.content) {
+            if (editingPost && editingPost.content) {
+              messageInputLogger.log('Editing post', editingPost);
               const {
                 story,
                 references: postReferences,
@@ -303,8 +307,13 @@ export const MessageInput = forwardRef<MessageInputHandle, MessageInputProps>(
                   (c) => !('type' in c) && !('block' in c && 'image' in c.block)
                 ) as Story
               );
+              messageInputLogger.log(
+                'Setting edit post content',
+                tiptapContent
+              );
               // @ts-expect-error setContent does accept JSONContent
               editor.setContent(tiptapContent);
+              setEditorIsEmpty(false);
             }
 
             if (editingPost?.image) {
@@ -335,6 +344,14 @@ export const MessageInput = forwardRef<MessageInputHandle, MessageInputProps>(
     ]);
 
     useEffect(() => {
+      if (editingPost && lastEditingPost.current?.id !== editingPost.id) {
+        messageInputLogger.log('Editing post changed', editingPost);
+        lastEditingPost.current = editingPost;
+        setHasSetInitialContent(false);
+      }
+    }, [editingPost]);
+
+    useEffect(() => {
       if (editor && !shouldBlur && !editorState.isFocused && !!editingPost) {
         editor.focus();
       }
@@ -348,6 +365,8 @@ export const MessageInput = forwardRef<MessageInputHandle, MessageInputProps>(
     }, [shouldBlur, editor, editorState, setShouldBlur]);
 
     useEffect(() => {
+      messageInputLogger.log('Checking if editor is empty');
+
       editor.getJSON().then((json: JSONContent) => {
         const inlines = tiptap
           .JSONToInlines(json)
@@ -372,13 +391,18 @@ export const MessageInput = forwardRef<MessageInputHandle, MessageInputProps>(
           blocks.length === 0 &&
           attachments.length === 0;
 
+        messageInputLogger.log('Editor is empty', isEmpty);
+
         if (isEmpty !== editorIsEmpty) {
+          messageInputLogger.log('Setting editorIsEmpty', isEmpty);
           setEditorIsEmpty(isEmpty);
+          setContainerHeight(initialHeight);
         }
       });
-    }, [editor, attachments, editorIsEmpty]);
+    }, [editor, attachments, editorIsEmpty, initialHeight]);
 
     editor._onContentUpdate = async () => {
+      messageInputLogger.log('Content updated');
       const json = await editor.getJSON();
       const inlines = (
         tiptap
@@ -403,6 +427,8 @@ export const MessageInput = forwardRef<MessageInputHandle, MessageInputProps>(
       } else {
         setShowMentionPopup(false);
       }
+
+      messageInputLogger.log('Storing draft', json);
 
       storeDraft(json);
     };
@@ -540,6 +566,7 @@ export const MessageInput = forwardRef<MessageInputHandle, MessageInputProps>(
 
         const newJson = tiptap.diaryMixedToJSON(newStory);
 
+        messageInputLogger.log('Setting new content', newJson);
         // @ts-expect-error setContent does accept JSONContent
         editor.setContent(newJson);
         storeDraft(newJson);
@@ -844,6 +871,13 @@ export const MessageInput = forwardRef<MessageInputHandle, MessageInputProps>(
 
     const titleIsEmpty = useMemo(() => !title || title.length === 0, [title]);
 
+    const handleCancelEditing = useCallback(() => {
+      setEditingPost?.(undefined);
+      editor.setContent('');
+      clearDraft();
+      clearAttachments();
+    }, [setEditingPost, editor, clearDraft, clearAttachments]);
+
     return (
       <MessageInputContainer
         setShouldBlur={setShouldBlur}
@@ -856,7 +890,7 @@ export const MessageInput = forwardRef<MessageInputHandle, MessageInputProps>(
         showMentionPopup={showMentionPopup}
         isEditing={!!editingPost}
         isSending={isSending}
-        cancelEditing={() => setEditingPost?.(undefined)}
+        cancelEditing={handleCancelEditing}
         showAttachmentButton={showAttachmentButton}
         floatingActionButton={floatingActionButton}
         disableSend={

--- a/packages/ui/src/components/PostScreenView.tsx
+++ b/packages/ui/src/components/PostScreenView.tsx
@@ -121,7 +121,6 @@ export function PostScreenView({
                   onPressImage={handleGoToImage}
                   editingPost={editingPost}
                   setEditingPost={setEditingPost}
-                  editPost={editPost}
                   onPressRetry={onPressRetry}
                   onPressDelete={onPressDelete}
                   posts={postsWithoutParent}

--- a/packages/ui/src/components/draftInputs/ChatInput.tsx
+++ b/packages/ui/src/components/draftInputs/ChatInput.tsx
@@ -22,9 +22,6 @@ export function ChatInput({
     shouldBlur,
     storeDraft,
   } = draftInputContext;
-  if (editingPost != null) {
-    return null;
-  }
 
   return (
     <SafeAreaView edges={['right', 'left', 'bottom']}>


### PR DESCRIPTION
Fixes TLON-2900

Seems to fix all of the weird issues we're seeing on both platforms when we're editing a chat message in an input inside the scroller. Also makes the Scroller and ChatMessage components less complex.

I also went ahead and updated the send button so that it dims when we know we're disconnected.