### PR TITLE
refs: prevent race condition when processing ref paste

### DIFF
--- a/packages/ui/src/components/MessageInput/helpers.ts
+++ b/packages/ui/src/components/MessageInput/helpers.ts
@@ -4,6 +4,7 @@ import { createDevLogger, tiptap } from '@tloncorp/shared/dist';
 import {
   Block,
   Inline,
+  JSONContent,
   constructStory,
   isInline,
 } from '@tloncorp/shared/dist/urbit';
@@ -14,10 +15,12 @@ const logger = createDevLogger('processReference', true);
 
 export async function processReferenceAndUpdateEditor({
   editor,
+  editorJson,
   pastedText,
   matchRegex,
   processMatch,
 }: {
+  editorJson: JSONContent;
   editor: EditorBridge | Editor;
   pastedText: string;
   matchRegex: RegExp;
@@ -29,14 +32,13 @@ export async function processReferenceAndUpdateEditor({
 
     if (match) {
       logger.log('found match', match[0]);
-      const attachment = await processMatch(match[0]);
+      const attachment = processMatch(match[0]);
 
       if (attachment) {
         logger.log('extracted attachment', attachment);
 
         // remove the attachments corresponding text from the editor
-        const json = await editor.getJSON();
-        const filteredJson = filterRegexFromJson(json, matchRegex);
+        const filteredJson = filterRegexFromJson(editorJson, matchRegex);
 
         logger.log(`updating editor`, filteredJson);
         if ('setContent' in editor) {

--- a/packages/ui/src/components/MessageInput/index.native.tsx
+++ b/packages/ui/src/components/MessageInput/index.native.tsx
@@ -419,8 +419,10 @@ export const MessageInput = forwardRef<MessageInputHandle, MessageInputProps>(
       async (pastedText: string) => {
         messageInputLogger.log('Pasted text', pastedText);
         // check for ref from pasted cite paths
+        const editorJson = await editor.getJSON();
         const citePathAttachment = await processReferenceAndUpdateEditor({
           editor,
+          editorJson,
           pastedText,
           matchRegex: tiptap.REF_REGEX,
           processMatch: async (match) => {
@@ -442,6 +444,7 @@ export const MessageInput = forwardRef<MessageInputHandle, MessageInputProps>(
         const DEEPLINK_REGEX = new RegExp(`^(https?://)?${branchDomain}/\\S+$`);
         const deepLinkAttachment = await processReferenceAndUpdateEditor({
           editor,
+          editorJson,
           pastedText,
           matchRegex: DEEPLINK_REGEX,
           processMatch: async (deeplink) => {
@@ -467,6 +470,7 @@ export const MessageInput = forwardRef<MessageInputHandle, MessageInputProps>(
           /^(https?:\/\/)?(tlon\.network\/lure\/)(0v[^/]+)$/;
         const lureLinkAttachment = await processReferenceAndUpdateEditor({
           editor,
+          editorJson,
           pastedText,
           matchRegex: TLON_LURE_REGEX,
           processMatch: async (tlonLure) => {


### PR DESCRIPTION
I *think* this was caused by a race condition where we might call `editor.getJSON` too soon (editor doesn't know about the pasted text yet, somehow) and then we attempt to process the ref and we don't find anything. I updated `handlePaste` so that we get the json content first and then pass it to `processReferenceAndUpdateEditor`.

Fixes TLON-2847