### PR TITLE
GroupMetaScreen, GroupSettingsStack: navigate to home on delete

### DIFF
--- a/packages/app/features/groups/GroupMetaScreen.tsx
+++ b/packages/app/features/groups/GroupMetaScreen.tsx
@@ -14,7 +14,12 @@ import { BRANCH_DOMAIN, BRANCH_KEY } from '../../constants';
 import { useGroupContext } from '../../hooks/useGroupContext';
 import { GroupSettingsStackParamList } from '../../navigation/types';
 
-type Props = NativeStackScreenProps<GroupSettingsStackParamList, 'GroupMeta'>;
+type Props = NativeStackScreenProps<
+  GroupSettingsStackParamList,
+  'GroupMeta'
+> & {
+  navigateToHome: () => void;
+};
 
 export function GroupMetaScreen(props: Props) {
   const { groupId } = props.route.params;
@@ -49,6 +54,11 @@ export function GroupMetaScreen(props: Props) {
     setShowDeleteSheet(true);
   }, []);
 
+  const handleDeleteGroup = useCallback(() => {
+    deleteGroup();
+    props.navigateToHome();
+  }, [deleteGroup, props]);
+
   return (
     <AttachmentProvider canUpload={canUpload} uploadAsset={uploadAsset}>
       <MetaEditorScreenView
@@ -65,7 +75,7 @@ export function GroupMetaScreen(props: Props) {
           itemTypeDescription="group"
           open={showDeleteSheet}
           onOpenChange={setShowDeleteSheet}
-          deleteAction={deleteGroup}
+          deleteAction={handleDeleteGroup}
         />
       </MetaEditorScreenView>
     </AttachmentProvider>

--- a/packages/app/navigation/GroupSettingsStack.tsx
+++ b/packages/app/navigation/GroupSettingsStack.tsx
@@ -39,12 +39,11 @@ export function GroupSettingsStack({
 
   return (
     <GroupSettings.Navigator screenOptions={{ headerShown: false }}>
-      <GroupSettings.Screen
-        name="GroupMeta"
-        component={(props: GroupMetaProps) => (
+      <GroupSettings.Screen name="GroupMeta">
+        {(props: GroupMetaProps) => (
           <GroupMetaScreen {...props} navigateToHome={navigateToHome} />
         )}
-      />
+      </GroupSettings.Screen>
       <GroupSettings.Screen
         name="GroupMembers"
         component={GroupMembersScreen}

--- a/packages/app/navigation/GroupSettingsStack.tsx
+++ b/packages/app/navigation/GroupSettingsStack.tsx
@@ -1,4 +1,8 @@
-import { createNativeStackNavigator } from '@react-navigation/native-stack';
+import { NavigationProp } from '@react-navigation/native';
+import {
+  NativeStackNavigationProp,
+  createNativeStackNavigator,
+} from '@react-navigation/native-stack';
 
 import { EditChannelScreen } from '../features/groups/EditChannelScreen';
 import { GroupMembersScreen } from '../features/groups/GroupMembersScreen';
@@ -10,10 +14,37 @@ import { GroupSettingsStackParamList } from './types';
 
 const GroupSettings = createNativeStackNavigator<GroupSettingsStackParamList>();
 
-export function GroupSettingsStack() {
+type GroupMetaProps = {
+  navigation: NativeStackNavigationProp<
+    GroupSettingsStackParamList,
+    'GroupMeta'
+  >;
+  route: {
+    key: string;
+    name: 'GroupMeta';
+    params: {
+      groupId: string;
+    };
+  };
+};
+
+export function GroupSettingsStack({
+  navigation,
+}: {
+  navigation: NavigationProp<GroupSettingsStackParamList>;
+}) {
+  const navigateToHome = () => {
+    navigation.navigate('ChatList' as never);
+  };
+
   return (
     <GroupSettings.Navigator screenOptions={{ headerShown: false }}>
-      <GroupSettings.Screen name="GroupMeta" component={GroupMetaScreen} />
+      <GroupSettings.Screen
+        name="GroupMeta"
+        component={(props: GroupMetaProps) => (
+          <GroupMetaScreen {...props} navigateToHome={navigateToHome} />
+        )}
+      />
       <GroupSettings.Screen
         name="GroupMembers"
         component={GroupMembersScreen}


### PR DESCRIPTION
Had to do a bit of "soft" type coercion (what I like to call unwieldy unions) to get this to work, but now navigates back to ChatList (defined in RootStackParams) from the depths of GroupSettingsStack. I see some warnings about passing in the screen as a component but I'm not quite sure else how to pass in a prop to just that screen—@patosullivan maybe you have some ideas?

Fixes TLON-2680


https://github.com/user-attachments/assets/57de62b7-b445-4322-ad2b-d332cba8c133

