### PR TITLE
drafts: allow storage of different draft types for gallery channels

### DIFF
--- a/packages/app/hooks/useChannelContext.ts
+++ b/packages/app/hooks/useChannelContext.ts
@@ -67,20 +67,29 @@ export const useChannelContext = ({
 
   // Draft
 
-  const getDraft = useCallback(async () => {
-    try {
-      const draft = await storage.load({ key: `draft-${draftKey}` });
+  type GalleryDraftType = 'caption' | 'text';
 
-      return draft;
-    } catch (e) {
-      return null;
-    }
-  }, [draftKey]);
+  const getDraft = useCallback(
+    async (draftType?: GalleryDraftType) => {
+      try {
+        const draft = await storage.load({
+          key: `draft-${draftKey}${draftType ? `-${draftType}` : ''}`,
+        });
+        return draft;
+      } catch (e) {
+        return null;
+      }
+    },
+    [draftKey]
+  );
 
   const storeDraft = useCallback(
-    async (draft: JSONContent) => {
+    async (draft: JSONContent, draftType?: GalleryDraftType) => {
       try {
-        await storage.save({ key: `draft-${draftKey}`, data: draft });
+        await storage.save({
+          key: `draft-${draftKey}${draftType ? `-${draftType}` : ''}`,
+          data: draft,
+        });
       } catch (e) {
         return;
       }
@@ -88,13 +97,18 @@ export const useChannelContext = ({
     [draftKey]
   );
 
-  const clearDraft = useCallback(async () => {
-    try {
-      await storage.remove({ key: `draft-${draftKey}` });
-    } catch (e) {
-      return;
-    }
-  }, [draftKey]);
+  const clearDraft = useCallback(
+    async (draftType?: GalleryDraftType) => {
+      try {
+        await storage.remove({
+          key: `draft-${draftKey}${draftType ? `-${draftType}` : ''}`,
+        });
+      } catch (e) {
+        return;
+      }
+    },
+    [draftKey]
+  );
 
   // Contacts
 

--- a/packages/ui/src/components/BigInput.native.tsx
+++ b/packages/ui/src/components/BigInput.native.tsx
@@ -155,6 +155,7 @@ export function BigInput({
           placeholder={placeholder}
           bigInput
           channelType={channelType}
+          draftType={channelType === 'gallery' ? 'text' : undefined}
           ref={editorRef}
         />
       </View>

--- a/packages/ui/src/components/Channel/index.tsx
+++ b/packages/ui/src/components/Channel/index.tsx
@@ -34,7 +34,7 @@ import {
   GalleryInput,
   NotebookInput,
 } from '../draftInputs';
-import { DraftInputHandle } from '../draftInputs/shared';
+import { DraftInputHandle, GalleryDraftType } from '../draftInputs/shared';
 import { ChannelFooter } from './ChannelFooter';
 import { ChannelHeader, ChannelHeaderItemsProvider } from './ChannelHeader';
 import { DmInviteOptions } from './DmInviteOptions';
@@ -111,9 +111,9 @@ export function Channel({
   usePostReference: typeof usePostReferenceHook;
   onGroupAction: (action: GroupPreviewAction, group: db.Group) => void;
   useChannel: typeof useChannelFromStore;
-  storeDraft: (draft: JSONContent) => void;
-  clearDraft: () => void;
-  getDraft: () => Promise<JSONContent>;
+  storeDraft: (draft: JSONContent, draftType?: GalleryDraftType) => void;
+  clearDraft: (draftType?: GalleryDraftType) => void;
+  getDraft: (draftType?: GalleryDraftType) => Promise<JSONContent>;
   editingPost?: db.Post;
   setEditingPost?: (post: db.Post | undefined) => void;
   editPost: (post: db.Post, content: Story) => Promise<void>;

--- a/packages/ui/src/components/MessageInput/MessageInputBase.tsx
+++ b/packages/ui/src/components/MessageInput/MessageInputBase.tsx
@@ -13,6 +13,7 @@ import { Button } from '../Button';
 import { FloatingActionButton } from '../FloatingActionButton';
 import { Icon } from '../Icon';
 import { LoadingSpinner } from '../LoadingSpinner';
+import { GalleryDraftType } from '../draftInputs/shared';
 import AttachmentButton from './AttachmentButton';
 import InputMentionPopup from './InputMentionPopup';
 
@@ -26,9 +27,9 @@ export interface MessageInputProps {
   ) => Promise<void>;
   channelId: string;
   groupMembers: db.ChatMember[];
-  storeDraft: (draft: JSONContent) => void;
-  clearDraft: () => void;
-  getDraft: () => Promise<JSONContent>;
+  storeDraft: (draft: JSONContent, draftType?: GalleryDraftType) => void;
+  clearDraft: (draftType?: GalleryDraftType) => void;
+  getDraft: (draftType?: GalleryDraftType) => Promise<JSONContent>;
   editingPost?: db.Post;
   setEditingPost?: (post: db.Post | undefined) => void;
   editPost?: (
@@ -44,6 +45,7 @@ export interface MessageInputProps {
   backgroundColor?: ThemeTokens;
   placeholder?: string;
   bigInput?: boolean;
+  draftType?: GalleryDraftType;
   title?: string;
   image?: ImagePickerAsset;
   showInlineAttachments?: boolean;

--- a/packages/ui/src/components/MessageInput/index.native.tsx
+++ b/packages/ui/src/components/MessageInput/index.native.tsx
@@ -133,6 +133,7 @@ export const MessageInput = forwardRef<MessageInputHandle, MessageInputProps>(
       initialHeight = DEFAULT_MESSAGE_INPUT_HEIGHT,
       placeholder = 'Message',
       bigInput = false,
+      draftType,
       title,
       image,
       channelType,
@@ -241,7 +242,7 @@ export const MessageInput = forwardRef<MessageInputHandle, MessageInputProps>(
     useEffect(() => {
       if (!hasSetInitialContent && editorState.isReady) {
         try {
-          getDraft().then((draft) => {
+          getDraft(draftType).then((draft) => {
             if (!editingPost && draft) {
               const inlines = tiptap.JSONToInlines(draft);
               const newInlines = inlines
@@ -336,6 +337,7 @@ export const MessageInput = forwardRef<MessageInputHandle, MessageInputProps>(
     }, [
       editor,
       getDraft,
+      draftType,
       hasSetInitialContent,
       editorState.isReady,
       editingPost,
@@ -435,7 +437,7 @@ export const MessageInput = forwardRef<MessageInputHandle, MessageInputProps>(
 
       messageInputLogger.log('Storing draft', json);
 
-      storeDraft(json);
+      storeDraft(json, draftType);
     };
 
     const handlePaste = useCallback(
@@ -589,11 +591,11 @@ export const MessageInput = forwardRef<MessageInputHandle, MessageInputProps>(
         messageInputLogger.log('onSelectMention, setting new content', newJson);
         // @ts-expect-error setContent does accept JSONContent
         editor.setContent(newJson);
-        storeDraft(newJson);
+        storeDraft(newJson, draftType);
         setMentionText('');
         setShowMentionPopup(false);
       },
-      [editor, storeDraft]
+      [editor, storeDraft, draftType]
     );
 
     const sendMessage = useCallback(
@@ -691,7 +693,7 @@ export const MessageInput = forwardRef<MessageInputHandle, MessageInputProps>(
         onSend?.();
         editor.setContent('');
         clearAttachments();
-        clearDraft();
+        clearDraft(draftType);
         setShowBigInput?.(false);
       },
       [
@@ -709,6 +711,7 @@ export const MessageInput = forwardRef<MessageInputHandle, MessageInputProps>(
         channelType,
         send,
         channelId,
+        draftType,
       ]
     );
 
@@ -894,9 +897,9 @@ export const MessageInput = forwardRef<MessageInputHandle, MessageInputProps>(
     const handleCancelEditing = useCallback(() => {
       setEditingPost?.(undefined);
       editor.setContent('');
-      clearDraft();
+      clearDraft(draftType);
       clearAttachments();
-    }, [setEditingPost, editor, clearDraft, clearAttachments]);
+    }, [setEditingPost, editor, clearDraft, clearAttachments, draftType]);
 
     return (
       <MessageInputContainer

--- a/packages/ui/src/components/draftInputs/GalleryInput.tsx
+++ b/packages/ui/src/components/draftInputs/GalleryInput.tsx
@@ -136,6 +136,7 @@ export function GalleryInput({
               groupMembers={group?.members ?? []}
               storeDraft={storeDraft}
               clearDraft={clearDraft}
+              draftType="caption"
               getDraft={getDraft}
               editingPost={editingPost}
               setEditingPost={setEditingPost}

--- a/packages/ui/src/components/draftInputs/shared.ts
+++ b/packages/ui/src/components/draftInputs/shared.ts
@@ -2,6 +2,8 @@ import * as db from '@tloncorp/shared/dist/db';
 import { JSONContent, Story } from '@tloncorp/shared/dist/urbit';
 import { Dispatch, SetStateAction } from 'react';
 
+export type GalleryDraftType = 'caption' | 'text';
+
 export interface DraftInputHandle {
   /**
    * @deprecated
@@ -19,11 +21,11 @@ export interface DraftInputHandle {
  */
 export interface DraftInputContext {
   channel: db.Channel;
-  clearDraft: () => void;
+  clearDraft: (draftType?: GalleryDraftType) => void;
   draftInputRef?: React.Ref<DraftInputHandle>;
   editPost: (post: db.Post, content: Story) => Promise<void>;
   editingPost?: db.Post;
-  getDraft: () => Promise<JSONContent>;
+  getDraft: (draftType?: GalleryDraftType) => Promise<JSONContent>;
   group: db.Group | null;
   headerMode: 'default' | 'next';
 
@@ -45,5 +47,5 @@ export interface DraftInputContext {
   setEditingPost?: (update: db.Post | undefined) => void;
   setShouldBlur: Dispatch<SetStateAction<boolean>>;
   shouldBlur: boolean;
-  storeDraft: (content: JSONContent) => void;
+  storeDraft: (content: JSONContent, draftType?: GalleryDraftType) => void;
 }


### PR DESCRIPTION
fixes TLON-2824 by adding an optional parameter used in gallery channels to separate the different types of drafts we can have for gallery posts (either a rich text post or a caption for an image post). Showing draft text for an abandoned rich text post in the input for a new image post is confusing for users.

Note for testing: the AddGalleryPost flow is currently broken on develop because of the sheet changes that were merged yesterday, I recommend testing against develop on a commit behind that one.