### PR TITLE
ScreenHeader: default title width to 100%, conditionally truncate

### DIFF
--- a/packages/ui/src/components/Channel/ChannelHeader.tsx
+++ b/packages/ui/src/components/Channel/ChannelHeader.tsx
@@ -105,10 +105,23 @@ export function ChannelHeader({
     return <BaubleHeader channel={channel} group={group} />;
   }
 
+  const titleWidth = () => {
+    if (showSearchButton && showMenuButton) {
+      return 55;
+    } else if (contextItems.length > 0 && showMenuButton) {
+      return 55;
+    } else if (showSearchButton || showMenuButton) {
+      return 75;
+    } else {
+      return 100;
+    }
+  };
+
   return (
     <>
       <ScreenHeader
         title={title}
+        titleWidth={titleWidth()}
         showSessionStatus
         isLoading={showSpinner}
         leftControls={<ScreenHeader.BackButton onPress={goBack} />}

--- a/packages/ui/src/components/GroupChannelsScreenView.tsx
+++ b/packages/ui/src/components/GroupChannelsScreenView.tsx
@@ -70,6 +70,14 @@ export function GroupChannelsScreenView({
     [group]
   );
 
+  const titleWidth = useCallback(() => {
+    if (isGroupAdmin) {
+      return 55;
+    } else {
+      return 75;
+    }
+  }, [isGroupAdmin]);
+
   return (
     <View flex={1}>
       <ScreenHeader
@@ -80,6 +88,7 @@ export function GroupChannelsScreenView({
         // component mounts.
         key={group?.id}
         title={title}
+        titleWidth={titleWidth()}
         backAction={onBackPressed}
         rightControls={
           <>

--- a/packages/ui/src/components/ScreenHeader.tsx
+++ b/packages/ui/src/components/ScreenHeader.tsx
@@ -16,6 +16,7 @@ import { Text } from './TextV2';
 export const ScreenHeaderComponent = ({
   children,
   title,
+  titleWidth = 100,
   leftControls,
   rightControls,
   isLoading,
@@ -23,6 +24,7 @@ export const ScreenHeaderComponent = ({
   showSessionStatus,
 }: PropsWithChildren<{
   title?: string | ReactNode;
+  titleWidth?: 100 | 75 | 55;
   leftControls?: ReactNode | null;
   rightControls?: ReactNode | null;
   isLoading?: boolean;
@@ -42,13 +44,18 @@ export const ScreenHeaderComponent = ({
   return (
     <View paddingTop={top} zIndex={50}>
       <XStack
-        alignItems="center"
         height="$4xl"
         paddingHorizontal="$2xl"
         paddingVertical="$l"
+        alignItems="center"
+        justifyContent="center"
       >
         {typeof resolvedTitle === 'string' ? (
-          <HeaderTitle title={resolvedTitle} color={textColor} />
+          <HeaderTitle
+            title={resolvedTitle}
+            color={textColor}
+            titleWidth={titleWidth}
+          />
         ) : (
           resolvedTitle
         )}
@@ -102,9 +109,11 @@ const HeaderTitleText = styled(Text, {
 
 function HeaderTitle({
   title,
+  titleWidth = 100,
   ...props
 }: {
   title: string;
+  titleWidth?: 100 | 75 | 55;
 } & ComponentProps<typeof HeaderTitleText>) {
   const hasMounted = useHasMounted();
   const renderedTitle = <HeaderTitleText {...props}>{title}</HeaderTitleText>;
@@ -118,7 +127,10 @@ function HeaderTitle({
       // it first enters.
       entering={hasMounted ? FadeInDown : undefined}
       exiting={FadeOutUp}
-      style={{ flex: 1 }}
+      style={{
+        flex: 1,
+        maxWidth: `${titleWidth}%`,
+      }}
     >
       {renderedTitle}
     </Animated.View>


### PR DESCRIPTION
Truncates the title on GroupChannelsScreenView and everywhere that uses ChannelView. Defaults to 100% (full-width).

<img width="583" alt="image" src="https://github.com/user-attachments/assets/3979a2bd-ee7a-4b51-b643-3c03010c53cb">

<img width="583" alt="image" src="https://github.com/user-attachments/assets/d01b452c-bbdd-441e-8575-47377f17ee72">

<img width="583" alt="image" src="https://github.com/user-attachments/assets/22d7c4be-23d6-436e-80b5-208b47e69038">
