### PR TITLE
meta: add nightly mobile builds action

### DIFF
--- a/.github/workflows/mobile-build-nightly.yml
+++ b/.github/workflows/mobile-build-nightly.yml
@@ -16,9 +16,10 @@ jobs:
         id: changes
         run: |
           git fetch origin develop
-          if [ $(git rev-list HEAD...origin/develop --count) -eq 0 ]; then
-            echo "No changes in develop"
+          if [ $(git rev-list --since="24 hours ago" origin/develop --count) -eq 0 ]; then
+            echo "No changes in develop in the past 24 hours"
             exit 0
+          fi
       - name: Set up Node.js
         if: steps.changes.outputs.changes != '0'
         uses: actions/setup-node@v4

--- a/.github/workflows/mobile-build-nightly.yml
+++ b/.github/workflows/mobile-build-nightly.yml
@@ -18,7 +18,10 @@ jobs:
           git fetch origin develop
           if [ $(git rev-list --since="24 hours ago" origin/develop --count) -eq 0 ]; then
             echo "No changes in develop in the past 24 hours"
+            echo "::set-output name=changes::0"
             exit 0
+          else
+            echo "::set-output name=changes::1"
           fi
       - name: Set up Node.js
         if: steps.changes.outputs.changes != '0'

--- a/.github/workflows/mobile-build-nightly.yml
+++ b/.github/workflows/mobile-build-nightly.yml
@@ -1,0 +1,34 @@
+name: Build Tlon Mobile Nightly
+on:
+  schedule:
+    - cron: "0 0 * * *"
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    name: Create mobile builds
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version-file: .nvmrc
+      - name: Set up Expo and EAS
+        uses: expo/expo-github-action@v8
+        with:
+          eas-version: latest
+          token: ${{ secrets.EXPO_TOKEN }}
+      - name: Setup PNPM
+        uses: pnpm/action-setup@v3
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+      - name: Build for selected platforms
+        working-directory: ./apps/tlon-mobile
+        run: |
+          eas build --profile preview --platform all --non-interactive --auto-submit
+        env:
+          EXPO_APPLE_ID: ${{ secrets.EXPO_APPLE_ID }}
+          EXPO_APPLE_PASSWORD: ${{ secrets.EXPO_APPLE_PASSWORD }}
+          NOTIFY_PROVIDER: "binnec-dozzod-marnus"
+          NOTIFY_SERVICE: "tlon-preview-release"

--- a/.github/workflows/mobile-build-nightly.yml
+++ b/.github/workflows/mobile-build-nightly.yml
@@ -10,20 +10,34 @@ jobs:
     steps:
       - name: Check out repository
         uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - name: Check for changes in develop
+        id: changes
+        run: |
+          git fetch origin develop
+          if [ $(git rev-list HEAD...origin/develop --count) -eq 0 ]; then
+            echo "No changes in develop"
+            exit 0
       - name: Set up Node.js
+        if: steps.changes.outputs.changes != '0'
         uses: actions/setup-node@v4
         with:
           node-version-file: .nvmrc
       - name: Set up Expo and EAS
+        if: steps.changes.outputs.changes != '0'
         uses: expo/expo-github-action@v8
         with:
           eas-version: latest
           token: ${{ secrets.EXPO_TOKEN }}
       - name: Setup PNPM
+        if: steps.changes.outputs.changes != '0'
         uses: pnpm/action-setup@v3
       - name: Install dependencies
+        if: steps.changes.outputs.changes != '0'
         run: pnpm install --frozen-lockfile
       - name: Build for selected platforms
+        if: steps.changes.outputs.changes != '0'
         working-directory: ./apps/tlon-mobile
         run: |
           eas build --profile preview --platform all --non-interactive --auto-submit


### PR DESCRIPTION
Adds a GitHub action to build our mobile app with Expo every night at midnight. Hard-codes the "preview" and "all" options into the EAS build command. Only runs if we see changes to `develop` since the last run.