### PR TITLE
retry send: make the whole message tappable

### DIFF
--- a/packages/ui/src/components/AuthorRow.tsx
+++ b/packages/ui/src/components/AuthorRow.tsx
@@ -94,11 +94,18 @@ export function ChatAuthorRow({
 
   const firstRole = roles?.[0];
 
+  const shouldTruncate = showEditedIndicator || firstRole || deliveryStatus === 'failed';
+
   return (
     <XStack gap="$l" alignItems="center" {...props} onPress={openProfile}>
       <ContactAvatar size="$2xl" contactId={authorId} />
       <XStack gap="$l" alignItems="flex-end">
-        <ContactName size="$label/2xl" contactId={authorId} />
+        <ContactName
+          size="$label/2xl"
+          contactId={authorId}
+          numberOfLines={1}
+          maxWidth={shouldTruncate ? '55%' : '100%'}
+        />
         {timeDisplay && (
           <Text color="$secondaryText" size="$label/m">
             {timeDisplay}
@@ -112,7 +119,7 @@ export function ChatAuthorRow({
         {firstRole && <RoleBadge role={firstRole} />}
         {deliveryStatus === 'failed' ? (
           <Text size="$label/m" color="$negativeActionText">
-            Failed to send
+            Tap to retry
           </Text>
         ) : null}
       </XStack>

--- a/packages/ui/src/components/ChatMessage/ChatMessage.tsx
+++ b/packages/ui/src/components/ChatMessage/ChatMessage.tsx
@@ -56,7 +56,7 @@ const ChatMessage = ({
   }, [onPress, post.deliveryStatus]);
 
   const handlePress = useCallback(() => {
-    if (onPress) {
+    if (onPress && post.deliveryStatus !== 'failed') {
       onPress(post);
     } else if (post.deliveryStatus === 'failed') {
       setShowRetrySheet(true);
@@ -139,6 +139,7 @@ const ChatMessage = ({
           isNotice={post.type === 'notice'}
           onPressImage={handleImagePressed}
           onLongPress={handleLongPress}
+          onPress={shouldHandlePress ? handlePress : undefined}
         />
       </View>
 

--- a/packages/ui/src/components/SendPostRetrySheet.tsx
+++ b/packages/ui/src/components/SendPostRetrySheet.tsx
@@ -22,6 +22,7 @@ export const SendPostRetrySheet = ({
       {
         title: 'Delete',
         action: onPressDelete,
+        accent: 'negative'
       },
     ],
     [onPressRetry, onPressDelete]


### PR DESCRIPTION
fixes TLON-2913

Adds onPress to the message content so the user can also tap there to trigger it. Truncates the author's contact name if we know we need to display something next to it (like the "Tap to retry" text). Also makes sure we don't allow normal onPress if the message is currently in a failed send state, and adds a negative accent to the "Delete" action in the retry modal.