### PR TITLE
Revert "fix sheet close animations (#4040)"

### DIFF
--- a/apps/tlon-mobile/src/fixtures/ActionSheet/GenericActionSheet.fixture.tsx
+++ b/apps/tlon-mobile/src/fixtures/ActionSheet/GenericActionSheet.fixture.tsx
@@ -3,12 +3,10 @@ import {
   ActionGroup,
   ActionSheet,
 } from '@tloncorp/ui/src/components/ActionSheet';
-import { useFixtureInput } from 'react-cosmos/client';
 
 import { FixtureWrapper } from '../FixtureWrapper';
 
 const ActionSheetFixture = () => {
-  const [open] = useFixtureInput('open', true);
   const actionGroups: ActionGroup[] = [
     {
       accent: 'positive',
@@ -69,7 +67,7 @@ const ActionSheetFixture = () => {
       <ActionSheet
         snapPointsMode="mixed"
         snapPoints={['90%']}
-        open={open}
+        open={true}
         onOpenChange={(open: boolean) => console.log('Open Change', open)}
       >
         <ActionSheet.Header>

--- a/packages/ui/src/components/ActionSheet.tsx
+++ b/packages/ui/src/components/ActionSheet.tsx
@@ -5,10 +5,8 @@ import {
   PropsWithChildren,
   ReactElement,
   useContext,
-  useEffect,
   useMemo,
   useRef,
-  useState,
 } from 'react';
 import { Modal } from 'react-native';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
@@ -89,30 +87,12 @@ const ActionSheetComponent = ({
     hasOpened.current = true;
   }
 
-  // Delay hiding modal until sheet animation completes
-  const [modalIsVisible, setModalIsVisible] = useState(open);
-  useEffect(() => {
-    let timeout: ReturnType<typeof setTimeout> | null = null;
-    if (open) {
-      setModalIsVisible(true);
-    } else {
-      timeout = setTimeout(() => {
-        setModalIsVisible(false);
-      }, 800);
-    }
-    return () => {
-      if (timeout) {
-        clearTimeout(timeout);
-      }
-    };
-  }, [open]);
-
   // Sheets are heavy; we don't want to render until we need to
   if (!hasOpened.current) return null;
 
   return (
     <Modal
-      visible={modalIsVisible}
+      visible={open}
       onRequestClose={() => onOpenChange(false)}
       transparent
       animationType="none"

--- a/packages/ui/src/components/ChatOptionsSheet.tsx
+++ b/packages/ui/src/components/ChatOptionsSheet.tsx
@@ -41,9 +41,6 @@ const ChatOptionsSheetComponent = React.forwardRef<
   ChatOptionsSheetProps
 >(function ChatOptionsSheetImpl(props, ref) {
   const [open, setOpen] = useState(false);
-  const hasOpenedRef = useRef(open);
-  hasOpenedRef.current = hasOpenedRef.current || open;
-
   const [chat, setChat] = useState<{ type: ChatType; id: string } | null>(null);
 
   useImperativeHandle(
@@ -57,7 +54,7 @@ const ChatOptionsSheetComponent = React.forwardRef<
     []
   );
 
-  if (!chat || !hasOpenedRef.current) {
+  if (!chat || !open) {
     return null;
   }
 
@@ -706,7 +703,7 @@ export function ChannelOptions({
             } as ActionGroup,
           ]
         : []),
-      // TODO: redefine in a more readable way.
+     // TODO: redefine in a more readable way.
       ...(group &&
       !['groupDm', 'dm'].includes(channel.type) &&
       (group.privacy === 'public' ||


### PR DESCRIPTION
Reverts sheet close animation fix. As it turns out, it's only possible to open one native modal at a time, which cause issues in situations where one sheet opened another. Will need a refactoring to fix.