### PR TITLE
notify: self-poke conditional on being provider

### DIFF
--- a/desk/app/notify.hoon
+++ b/desk/app/notify.hoon
@@ -165,10 +165,12 @@
   ::
   ++  on-init
     :_  this
-    :~  (~(watch-our pass:io /activity) %activity /notifications)
+    :*  (~(watch-our pass:io /activity) %activity /notifications)
         (~(wait pass:io /clear) (add now.bowl clear-interval))
-        [%pass / %agent [our.bowl %notify] %poke %provider-state-message !>(0)]
         [%pass /eyre %arvo %e %connect [~ /apps/groups/~/notify] dap.bowl]
+      ::
+        :: ?.  =(~rivfur-livmet our.bowl)  ~
+        [%pass / %agent [our.bowl %notify] %poke %provider-state-message !>(0)]~
     ==
   ::
   ++  on-save   !>(state)
@@ -181,11 +183,11 @@
       [%pass /eyre %arvo %e %connect [~ /apps/groups/~/notify] dap.bowl]~
     =/  migrated  (migrate-state old-state)
     :_  this(state migrated)
-    :-  [%pass / %agent [our.bowl %notify] %poke %provider-state-message !>(0)]
     ?:  (~(has by wex.bowl) [/activity our.bowl %activity])
       caz
-    :_  caz
-    [(~(watch-our pass:io /activity) %activity /notifications)]
+    :-  (~(watch-our pass:io /activity) %activity /notifications)
+    ?.  =(~rivfur-livmet our.bowl)  caz
+    [[%pass / %agent [our.bowl %notify] %poke %provider-state-message !>(0)] caz]
   ::
   ++  on-poke
     |=  [=mark =vase]

--- a/desk/app/notify.hoon
+++ b/desk/app/notify.hoon
@@ -169,7 +169,7 @@
         (~(wait pass:io /clear) (add now.bowl clear-interval))
         [%pass /eyre %arvo %e %connect [~ /apps/groups/~/notify] dap.bowl]
       ::
-        :: ?.  =(~rivfur-livmet our.bowl)  ~
+        ?.  =(~rivfur-livmet our.bowl)  ~
         [%pass / %agent [our.bowl %notify] %poke %provider-state-message !>(0)]~
     ==
   ::


### PR DESCRIPTION
Instead of always poking ourselves, and it maybe crashing, resulting in a crash trace being printed due to us not handling the / wire in +on-agent, we should just not poke ourselves if we're not the provider.

Gets rid of the crash trace that shows during groups desk reloads and boot.
