### PR TITLE
message input: should autofocus in certain situations

### DIFF
--- a/packages/ui/src/components/BigInput.native.tsx
+++ b/packages/ui/src/components/BigInput.native.tsx
@@ -155,6 +155,7 @@ export function BigInput({
           placeholder={placeholder}
           bigInput
           channelType={channelType}
+          shouldAutoFocus
           ref={editorRef}
         />
       </View>

--- a/packages/ui/src/components/MessageInput/MessageInputBase.tsx
+++ b/packages/ui/src/components/MessageInput/MessageInputBase.tsx
@@ -53,6 +53,7 @@ export interface MessageInputProps {
   // for external access to height
   setHeight?: (height: number) => void;
   goBack?: () => void;
+  shouldAutoFocus?: boolean;
   ref?: React.RefObject<{
     editor: EditorBridge | null;
     setEditor: (editor: EditorBridge) => void;

--- a/packages/ui/src/components/MessageInput/index.native.tsx
+++ b/packages/ui/src/components/MessageInput/index.native.tsx
@@ -158,7 +158,6 @@ export const MessageInput = forwardRef<MessageInputHandle, MessageInputProps>(
     const [hasSetInitialContent, setHasSetInitialContent] = useState(false);
     const [editorCrashed, setEditorCrashed] = useState<string | undefined>();
     const [containerHeight, setContainerHeight] = useState(initialHeight);
-    const [hasAutoFocused, setHasAutoFocused] = useState(false);
     const { bottom, top } = useSafeAreaInsets();
     const { height } = useWindowDimensions();
     const headerHeight = 48;
@@ -211,7 +210,7 @@ export const MessageInput = forwardRef<MessageInputHandle, MessageInputProps>(
 
     const editor = useEditorBridge({
       customSource: editorHtml,
-      autofocus: false,
+      autofocus: shouldAutoFocus || false,
       bridgeExtensions,
     });
     const editorState = useBridgeState(editor);
@@ -352,29 +351,10 @@ export const MessageInput = forwardRef<MessageInputHandle, MessageInputProps>(
     }, [editingPost]);
 
     useEffect(() => {
-      if (
-        editor &&
-        !shouldBlur &&
-        !editorState.isFocused &&
-        !!editingPost &&
-        !hasAutoFocused
-      ) {
+      if (editor && !shouldBlur && shouldAutoFocus && !editorState.isFocused) {
         editor.focus();
-        setHasAutoFocused(true);
       }
-    }, [shouldBlur, editor, editorState, editingPost, hasAutoFocused]);
-
-    useEffect(() => {
-      if (
-        editor &&
-        shouldAutoFocus &&
-        !editorState.isFocused &&
-        !hasAutoFocused
-      ) {
-        editor.focus();
-        setHasAutoFocused(true);
-      }
-    }, [shouldAutoFocus, editor, editorState, hasAutoFocused]);
+    }, [shouldAutoFocus, editor, editorState, shouldBlur]);
 
     useEffect(() => {
       if (editor && shouldBlur && editorState.isFocused) {

--- a/packages/ui/src/components/MessageInput/index.native.tsx
+++ b/packages/ui/src/components/MessageInput/index.native.tsx
@@ -137,6 +137,7 @@ export const MessageInput = forwardRef<MessageInputHandle, MessageInputProps>(
       image,
       channelType,
       setHeight,
+      shouldAutoFocus,
       goBack,
       onSend,
     },
@@ -157,6 +158,7 @@ export const MessageInput = forwardRef<MessageInputHandle, MessageInputProps>(
     const [hasSetInitialContent, setHasSetInitialContent] = useState(false);
     const [editorCrashed, setEditorCrashed] = useState<string | undefined>();
     const [containerHeight, setContainerHeight] = useState(initialHeight);
+    const [hasAutoFocused, setHasAutoFocused] = useState(false);
     const { bottom, top } = useSafeAreaInsets();
     const { height } = useWindowDimensions();
     const headerHeight = 48;
@@ -209,8 +211,6 @@ export const MessageInput = forwardRef<MessageInputHandle, MessageInputProps>(
 
     const editor = useEditorBridge({
       customSource: editorHtml,
-      // setting autofocus to true if we have editPost here doesn't seem to work
-      // so we're using a useEffect to set it
       autofocus: false,
       bridgeExtensions,
     });
@@ -352,10 +352,29 @@ export const MessageInput = forwardRef<MessageInputHandle, MessageInputProps>(
     }, [editingPost]);
 
     useEffect(() => {
-      if (editor && !shouldBlur && !editorState.isFocused && !!editingPost) {
+      if (
+        editor &&
+        !shouldBlur &&
+        !editorState.isFocused &&
+        !!editingPost &&
+        !hasAutoFocused
+      ) {
         editor.focus();
+        setHasAutoFocused(true);
       }
-    }, [shouldBlur, editor, editorState, editingPost]);
+    }, [shouldBlur, editor, editorState, editingPost, hasAutoFocused]);
+
+    useEffect(() => {
+      if (
+        editor &&
+        shouldAutoFocus &&
+        !editorState.isFocused &&
+        !hasAutoFocused
+      ) {
+        editor.focus();
+        setHasAutoFocused(true);
+      }
+    }, [shouldAutoFocus, editor, editorState, hasAutoFocused]);
 
     useEffect(() => {
       if (editor && shouldBlur && editorState.isFocused) {

--- a/packages/ui/src/components/PostScreenView.tsx
+++ b/packages/ui/src/components/PostScreenView.tsx
@@ -134,7 +134,7 @@ export function PostScreenView({
                 />
               ) : null}
 
-              {negotiationMatch && !editingPost && channel && canWrite && (
+              {negotiationMatch && channel && canWrite && (
                 <MessageInput
                   placeholder="Reply"
                   shouldBlur={inputShouldBlur}
@@ -144,10 +144,14 @@ export function PostScreenView({
                   groupMembers={groupMembers}
                   storeDraft={storeDraft}
                   clearDraft={clearDraft}
+                  editingPost={editingPost}
+                  setEditingPost={setEditingPost}
+                  editPost={editPost}
                   channelType="chat"
                   getDraft={getDraft}
                   shouldAutoFocus={
-                    channel.type === 'chat' && parentPost?.replyCount === 0
+                    (channel.type === 'chat' && parentPost?.replyCount === 0) ||
+                    !!editingPost
                   }
                 />
               )}

--- a/packages/ui/src/components/PostScreenView.tsx
+++ b/packages/ui/src/components/PostScreenView.tsx
@@ -146,6 +146,9 @@ export function PostScreenView({
                   clearDraft={clearDraft}
                   channelType="chat"
                   getDraft={getDraft}
+                  shouldAutoFocus={
+                    channel.type === 'chat' && parentPost?.replyCount === 0
+                  }
                 />
               )}
               {!negotiationMatch && channel && canWrite && (

--- a/packages/ui/src/components/draftInputs/ChatInput.tsx
+++ b/packages/ui/src/components/draftInputs/ChatInput.tsx
@@ -39,6 +39,7 @@ export function ChatInput({
           setEditingPost={setEditingPost}
           editPost={editPost}
           channelType={channel.type}
+          shouldAutoFocus={!!editingPost}
           showInlineAttachments
           showAttachmentButton
         />


### PR DESCRIPTION
fixes TLON-2995
fixes TLON-2997
fixes TLON-2998

Adds a `shouldAutoFocus` prop to the MessageInput, which we turn on in every case for BigInput (so, when making or editing a notebook post or rich text gallery post) and for the case of starting a new thread in chat.