### PR TITLE
SetTelemetryScreen: additional assurances

### DIFF
--- a/apps/tlon-mobile/src/screens/Onboarding/SetTelemetryScreen.tsx
+++ b/apps/tlon-mobile/src/screens/Onboarding/SetTelemetryScreen.tsx
@@ -53,9 +53,13 @@ export const SetTelemetryScreen = ({
       />
       <YStack gap="$xl" paddingHorizontal="$2xl">
         <View padding="$xl">
-          <TlonText.Text size="$body" color="$primaryText">
+          <TlonText.Text size="$body" color="$primaryText" marginBottom="$2xl">
             We&rsquo;re trying to make the app better and knowing how people use
             the app really helps.
+          </TlonText.Text>
+          <TlonText.Text size="$body" color="$primaryText">
+            These stats are anonymous, for product development purposes only,
+            and we don&rsquo;t share them with anyone.
           </TlonText.Text>
         </View>
 


### PR DESCRIPTION
Adds a line to SetTelemetryScreen indicating what we don't do with users' usage stats.


![Screenshot 2024-10-10 at 5 01 00 PM](https://github.com/user-attachments/assets/afa44fa8-eed8-4f0b-8973-9f31e39070c9)
