### PR TITLE
chat: refine activity check and make sure we transition net in DMs

### DIFF
--- a/desk/app/chat.hoon
+++ b/desk/app/chat.hoon
@@ -1702,6 +1702,7 @@
             mention=?
         ==
     ?.  ?|  =(net.dm %done)
+            =(net.dm %inviting)
             &(=(net.dm %invited) =(%invite -.concern))
         ==
       di-core
@@ -1748,6 +1749,7 @@
   ::
   ++  di-ingest-diff
     |=  =diff:dm:c
+    =?  net.dm  &(?=(%inviting net.dm) !from-self)  %done
     =/  =wire  /contacts/(scot %p ship)
     =/  =cage  [act:mar:contacts !>(`action:contacts`[%heed ~[ship]])]
     =.  cor  (emit %pass wire %agent [our.bowl %contacts] %poke cage)

--- a/desk/app/chat.hoon
+++ b/desk/app/chat.hoon
@@ -1702,7 +1702,6 @@
             mention=?
         ==
     ?.  ?|  =(net.dm %done)
-            =(net.dm %inviting)
             &(=(net.dm %invited) =(%invite -.concern))
         ==
       di-core


### PR DESCRIPTION
We assumed that all DMs eventually resolved to `%done`, which was wrong. If you started the DM, you get stuck in the `%inviting` state, so then you wouldn't get any activity for that DM. This fixes TLON-3066 by altering the check so that if you are in the `%inviting` state we still send activity and also transitions you from `%inviting` to `%done`.

PR Checklist
- [X] Includes changes to desk files
- [ ] Describes how you tested the PR locally (test ship vs livenet)
- [ ] If a new feature, includes automated tests
- [ ] Comments added anywhere logic may be confusing without context