### PR TITLE
notebooks: fix title focus and toolbar issues

### DIFF
--- a/packages/ui/src/components/BigInput.native.tsx
+++ b/packages/ui/src/components/BigInput.native.tsx
@@ -38,7 +38,6 @@ export function BigInput({
   const [showAttachmentSheet, setShowAttachmentSheet] = useState(false);
   const editorRef = useRef<{
     editor: TlonEditorBridge | null;
-    setEditor: (editor: EditorBridge) => void;
   }>(null);
   const { top } = useSafeAreaInsets();
   const { width } = Dimensions.get('screen');

--- a/packages/ui/src/components/MessageInput/MessageInputBase.tsx
+++ b/packages/ui/src/components/MessageInput/MessageInputBase.tsx
@@ -58,7 +58,6 @@ export interface MessageInputProps {
   shouldAutoFocus?: boolean;
   ref?: React.RefObject<{
     editor: EditorBridge | null;
-    setEditor: (editor: EditorBridge) => void;
   }>;
 }
 


### PR DESCRIPTION
fixes TLON-3072 

Fixes the title input focus issue (without sacrificing the autofocus) by adding a `hasAutoFocused` state to the MessaageInput component and only focusing the editor and setting that value to true if the editor is ready and we haven't previously set it to true.

Fixes the toolbar issue by passing the editor directly to the parent ref rather than passing a local ref of the editor. Also removes the unnecessary `setEditor` method.