### PR TITLE
notebooks: represent hidden and deleted states for posts

### DIFF
--- a/packages/app/features/top/ChannelScreen.tsx
+++ b/packages/app/features/top/ChannelScreen.tsx
@@ -198,6 +198,12 @@ export default function ChannelScreen(props: Props) {
         }),
   });
 
+  const filteredPosts = useMemo(
+    () =>
+      channel?.type !== 'chat' ? posts?.filter((p) => !p.isDeleted) : posts,
+    [posts, channel]
+  );
+
   const sendPost = useCallback(
     async (content: Story, _channelId: string, metadata?: db.PostMetadata) => {
       if (!channel) {
@@ -313,7 +319,7 @@ export default function ChannelScreen(props: Props) {
         hasNewerPosts={postsQuery.hasPreviousPage}
         hasOlderPosts={postsQuery.hasNextPage}
         group={group}
-        posts={posts}
+        posts={filteredPosts ?? null}
         selectedPostId={selectedPostId}
         goBack={props.navigation.goBack}
         messageSender={sendPost}

--- a/packages/ui/src/components/GalleryPost/GalleryPost.tsx
+++ b/packages/ui/src/components/GalleryPost/GalleryPost.tsx
@@ -64,6 +64,10 @@ export function GalleryPost({
 
   const handleLongPress = useBoundHandler(post, onLongPress);
 
+  if (post.isDeleted) {
+    return null;
+  }
+
   return (
     <GalleryPostFrame
       onPress={handlePress}

--- a/packages/ui/src/components/NotebookPost/NotebookPost.tsx
+++ b/packages/ui/src/components/NotebookPost/NotebookPost.tsx
@@ -74,7 +74,7 @@ export function NotebookPost({
     onPress?.(post);
   }, [post, onPress]);
 
-  if (!post) {
+  if (!post || post.isDeleted) {
     return null;
   }
 
@@ -88,7 +88,7 @@ export function NotebookPost({
         pressStyle={{ backgroundColor: '$secondaryBackground' }}
         disabled={viewMode === 'activity'}
       >
-        {post.hidden || post.isDeleted ? (
+        {post.hidden ? (
           <XStack
             gap="$s"
             paddingVertical="$xl"
@@ -96,9 +96,7 @@ export function NotebookPost({
             alignItems="center"
           >
             <Text color="$tertiaryText" size="$body">
-              {post.hidden
-                ? 'You have hidden this post.'
-                : 'This post has been deleted.'}
+              You have hidden this post.
             </Text>
           </XStack>
         ) : (

--- a/packages/ui/src/components/NotebookPost/NotebookPost.tsx
+++ b/packages/ui/src/components/NotebookPost/NotebookPost.tsx
@@ -88,31 +88,48 @@ export function NotebookPost({
         pressStyle={{ backgroundColor: '$secondaryBackground' }}
         disabled={viewMode === 'activity'}
       >
-        <NotebookPostHeader
-          post={post}
-          showDate={showDate}
-          showAuthor={showAuthor && viewMode !== 'activity'}
-          size={size}
-        />
-
-        {viewMode !== 'activity' && (
-          <Text
-            size="$body"
-            color="$secondaryText"
-            numberOfLines={3}
-            paddingBottom={showReplies && hasReplies ? 0 : '$m'}
+        {post.hidden || post.isDeleted ? (
+          <XStack
+            gap="$s"
+            paddingVertical="$xl"
+            justifyContent="center"
+            alignItems="center"
           >
-            {post.textContent}
-          </Text>
-        )}
+            <Text color="$tertiaryText" size="$body">
+              {post.hidden
+                ? 'You have hidden this post.'
+                : 'This post has been deleted.'}
+            </Text>
+          </XStack>
+        ) : (
+          <>
+            <NotebookPostHeader
+              post={post}
+              showDate={showDate}
+              showAuthor={showAuthor && viewMode !== 'activity'}
+              size={size}
+            />
 
-        {showReplies && hasReplies ? (
-          <ChatMessageReplySummary
-            post={post}
-            showTime={false}
-            textColor="$tertiaryText"
-          />
-        ) : null}
+            {viewMode !== 'activity' && (
+              <Text
+                size="$body"
+                color="$secondaryText"
+                numberOfLines={3}
+                paddingBottom={showReplies && hasReplies ? 0 : '$m'}
+              >
+                {post.textContent}
+              </Text>
+            )}
+
+            {showReplies && hasReplies ? (
+              <ChatMessageReplySummary
+                post={post}
+                showTime={false}
+                textColor="$tertiaryText"
+              />
+            ) : null}
+          </>
+        )}
 
         {post.deliveryStatus === 'failed' ? (
           <XStack alignItems="center" justifyContent="flex-end">


### PR DESCRIPTION
fixes TLON-2981
fixes TLON-2982

We weren't representing hidden or deleted states on notebook posts.

Edit: no longer rendering deleted posts. Note that the issue with deleted posts previously was that we would render an "Untitled", empty note.