### PR TITLE
native: group join & add channel fixes

### DIFF
--- a/packages/app/features/top/GroupChannelsScreen.tsx
+++ b/packages/app/features/top/GroupChannelsScreen.tsx
@@ -28,7 +28,7 @@ export function GroupChannelsScreen({ navigation, route }: Props) {
   const [inviteSheetGroup, setInviteSheetGroup] = useState<db.Group | null>(
     null
   );
-  const { createChannel } = useGroupContext({ groupId: id });
+  const { createChannel } = useGroupContext({ groupId: id, isFocused });
 
   const pinnedItems = useMemo(() => {
     return pins ?? [];

--- a/packages/app/features/top/GroupChannelsScreen.tsx
+++ b/packages/app/features/top/GroupChannelsScreen.tsx
@@ -28,7 +28,7 @@ export function GroupChannelsScreen({ navigation, route }: Props) {
   const [inviteSheetGroup, setInviteSheetGroup] = useState<db.Group | null>(
     null
   );
-  const { createChannel } = useGroupContext({ groupId: id, isFocused });
+  const { group, createChannel } = useGroupContext({ groupId: id, isFocused });
 
   const pinnedItems = useMemo(() => {
     return pins ?? [];
@@ -62,6 +62,7 @@ export function GroupChannelsScreen({ navigation, route }: Props) {
         onBackPressed={handleGoBackPressed}
         currentUser={currentUser}
         createChannel={createChannel}
+        group={group}
       />
       <InviteUsersSheet
         open={inviteSheetGroup !== null}

--- a/packages/app/hooks/useGroupContext.ts
+++ b/packages/app/hooks/useGroupContext.ts
@@ -111,7 +111,7 @@ export const useGroupContext = ({
       channelType,
     }: {
       title: string;
-      description: string;
+      description?: string;
       channelType: Omit<db.ChannelType, 'dm' | 'groupDm'>;
     }) => {
       const { name, id } = assembleNewChannelIdAndName({

--- a/packages/app/hooks/useGroupContext.ts
+++ b/packages/app/hooks/useGroupContext.ts
@@ -100,10 +100,7 @@ export const useGroupContext = ({
     }
   }, [group]);
 
-  const { data: pendingChats } = store.usePendingChats({
-    enabled: isFocused,
-  });
-  const { data: currentChatData } = store.useCurrentChats({
+  const { data: existingChannels } = store.useAllChannels({
     enabled: isFocused,
   });
 
@@ -120,8 +117,7 @@ export const useGroupContext = ({
       const { name, id } = assembleNewChannelIdAndName({
         title,
         channelType,
-        currentChatData,
-        pendingChats,
+        existingChannels: existingChannels ?? [],
         currentUserId,
       });
 
@@ -136,7 +132,7 @@ export const useGroupContext = ({
         });
       }
     },
-    [group, currentUserId, currentChatData, pendingChats]
+    [group, currentUserId, existingChannels]
   );
 
   const deleteChannel = useCallback(

--- a/packages/shared/src/api/groupsApi.ts
+++ b/packages/shared/src/api/groupsApi.ts
@@ -921,13 +921,13 @@ export const subscribeGroups = async (
   subscribe<ub.GroupAction>(
     { app: 'groups', path: '/groups/ui' },
     (groupUpdateEvent) => {
-      logger.log('groupUpdateEvent', { groupUpdateEvent });
+      logger.log('groupUpdateEvent', groupUpdateEvent);
       eventHandler(toGroupUpdate(groupUpdateEvent));
     }
   );
 
   subscribe({ app: 'groups', path: '/gangs/updates' }, (rawEvent: ub.Gangs) => {
-    logger.log('gangsUpdateEvent:', rawEvent);
+    logger.log('gangsUpdateEvent', rawEvent);
     eventHandler(toGangsGroupsUpdate(rawEvent));
   });
 };
@@ -1337,6 +1337,8 @@ export function toClientGroup(
     haveInvite: false,
     currentUserIsMember: isJoined,
     currentUserIsHost: hostUserId === currentUserId,
+    // if meta is unset, it's still in the join process
+    joinStatus: !group.meta || group.meta.title === '' ? 'joining' : undefined,
     hostUserId,
     flaggedPosts,
     navSections: group['zone-ord']

--- a/packages/shared/src/db/modelBuilders.ts
+++ b/packages/shared/src/db/modelBuilders.ts
@@ -9,7 +9,6 @@ import {
 import * as db from '../db';
 import * as logic from '../logic';
 import { convertToAscii } from '../logic';
-import { CurrentChats, PendingChats } from '../store';
 import * as ub from '../urbit';
 import { getChannelKindFromType } from '../urbit';
 import * as types from './types';
@@ -17,22 +16,14 @@ import * as types from './types';
 export function assembleNewChannelIdAndName({
   title,
   channelType,
-  currentChatData,
-  pendingChats,
+  existingChannels,
   currentUserId,
 }: {
   title: string;
   channelType: Omit<db.ChannelType, 'dm' | 'groupDm'>;
-  currentChatData?: CurrentChats | null;
-  pendingChats?: PendingChats | null;
+  existingChannels: db.Channel[];
   currentUserId: string;
 }) {
-  const existingChannels = [
-    ...(pendingChats ?? []),
-    ...(currentChatData?.pinned ?? []),
-    ...(currentChatData?.unpinned ?? []),
-  ];
-
   const titleIsNumber = Number.isInteger(Number(title));
   // we need unique channel names that are valid for urbit's @tas type
   const tempChannelName = titleIsNumber
@@ -47,7 +38,7 @@ export function assembleNewChannelIdAndName({
     );
   };
 
-  const randomSmallNumber = Math.floor(Math.random() * 100);
+  const randomSmallNumber = Math.floor(Math.random() * 1000);
   const channelName = existingChannel()
     ? `${tempChannelName}-${randomSmallNumber}`
     : tempChannelName;

--- a/packages/shared/src/db/queries.ts
+++ b/packages/shared/src/db/queries.ts
@@ -230,6 +230,14 @@ export const getPins = createReadQuery(
   ['pins']
 );
 
+export const getAllChannels = createReadQuery(
+  'getAllChannels',
+  async (ctx: QueryCtx) => {
+    return ctx.db.query.channels.findMany();
+  },
+  ['channels']
+);
+
 export const getChats = createReadQuery(
   'getChats',
   async (ctx: QueryCtx): Promise<Channel[]> => {

--- a/packages/shared/src/db/queries.ts
+++ b/packages/shared/src/db/queries.ts
@@ -1463,7 +1463,11 @@ export const insertChannels = createWriteQuery(
         .values(channels)
         .onConflictDoUpdate({
           target: $channels.id,
-          set: conflictUpdateSetAll($channels, ['lastPostId', 'lastPostAt']),
+          set: conflictUpdateSetAll($channels, [
+            'lastPostId',
+            'lastPostAt',
+            'currentUserIsMember',
+          ]),
         });
 
       for (const channel of channels) {

--- a/packages/shared/src/store/channelActions.ts
+++ b/packages/shared/src/store/channelActions.ts
@@ -18,14 +18,14 @@ export async function createChannel({
   channelId: string;
   name: string;
   title: string;
-  description: string;
+  description?: string;
   channelType: Omit<db.ChannelType, 'dm' | 'groupDm'>;
 }) {
   // optimistic update
   const newChannel: db.Channel = {
     id: channelId,
     title,
-    description,
+    description: description ?? '',
     type: channelType as db.ChannelType,
     groupId,
     addedToGroupAt: Date.now(),
@@ -41,7 +41,7 @@ export async function createChannel({
       group: groupId,
       name,
       title,
-      description,
+      description: description ?? '',
       readers: [],
       writers: [],
     });

--- a/packages/shared/src/store/channelActions.ts
+++ b/packages/shared/src/store/channelActions.ts
@@ -29,6 +29,7 @@ export async function createChannel({
     type: channelType as db.ChannelType,
     groupId,
     addedToGroupAt: Date.now(),
+    currentUserIsMember: true,
   };
   await db.insertChannels([newChannel]);
 

--- a/packages/shared/src/store/dbHooks.ts
+++ b/packages/shared/src/store/dbHooks.ts
@@ -27,6 +27,15 @@ export type CustomQueryConfig<T> = Pick<
   'enabled'
 >;
 
+export const useAllChannels = ({ enabled }: { enabled?: boolean }) => {
+  const querykey = useKeyFromQueryDeps(db.getAllChannels);
+  return useQuery({
+    queryKey: ['allChannels', querykey],
+    queryFn: () => db.getAllChannels(),
+    enabled,
+  });
+};
+
 export const useCurrentChats = (
   queryConfig?: CustomQueryConfig<CurrentChats>
 ): UseQueryResult<CurrentChats | null> => {

--- a/packages/shared/src/urbit/utils.ts
+++ b/packages/shared/src/urbit/utils.ts
@@ -378,7 +378,10 @@ export function createMultiDmId(seed = Date.now()) {
 
 export function getJoinStatusFromGang(gang: ubg.Gang): GroupJoinStatus | null {
   if (gang.claim?.progress) {
-    if (gang.claim?.progress === 'adding') {
+    if (
+      gang.claim?.progress === 'adding' ||
+      gang.claim?.progress === 'watching'
+    ) {
       return 'joining';
     }
 

--- a/packages/ui/src/components/GroupChannelsScreenView.tsx
+++ b/packages/ui/src/components/GroupChannelsScreenView.tsx
@@ -25,7 +25,7 @@ type GroupChannelsScreenViewProps = {
     channelType,
   }: {
     title: string;
-    description: string;
+    description?: string;
     channelType: ChannelTypeName;
   }) => Promise<void>;
 };

--- a/packages/ui/src/components/GroupChannelsScreenView.tsx
+++ b/packages/ui/src/components/GroupChannelsScreenView.tsx
@@ -4,7 +4,6 @@ import { useSafeAreaInsets } from 'react-native-safe-area-context';
 import { ScrollView, View, YStack } from 'tamagui';
 
 import { useCurrentUserId } from '../contexts';
-import { useChatOptions } from '../contexts/chatOptions';
 import { useIsAdmin } from '../utils/channelUtils';
 import ChannelNavSections from './ChannelNavSections';
 import { ChatOptionsSheet, ChatOptionsSheetMethods } from './ChatOptionsSheet';
@@ -16,6 +15,7 @@ import {
 import { ScreenHeader } from './ScreenHeader';
 
 type GroupChannelsScreenViewProps = {
+  group: db.Group | null;
   onChannelPressed: (channel: db.Channel) => void;
   onBackPressed: () => void;
   currentUser: string;
@@ -31,12 +31,11 @@ type GroupChannelsScreenViewProps = {
 };
 
 export function GroupChannelsScreenView({
+  group,
   onChannelPressed,
   onBackPressed,
   createChannel,
 }: GroupChannelsScreenViewProps) {
-  const groupOptions = useChatOptions();
-  const group = groupOptions?.group;
   const chatOptionsSheetRef = useRef<ChatOptionsSheetMethods>(null);
   const [showCreateChannel, setShowCreateChannel] = useState(false);
   const [sortBy, setSortBy] = useState<db.ChannelSortPreference>('recency');
@@ -105,9 +104,7 @@ export function GroupChannelsScreenView({
           </>
         }
       />
-      {group &&
-      groupOptions.groupChannels &&
-      groupOptions.groupChannels.length ? (
+      {group && group.channels && group.channels.length ? (
         <ScrollView
           contentContainerStyle={{
             gap: '$s',
@@ -118,7 +115,7 @@ export function GroupChannelsScreenView({
         >
           <ChannelNavSections
             group={group}
-            channels={groupOptions.groupChannels}
+            channels={group.channels}
             onSelect={onChannelPressed}
             sortBy={sortBy || 'recency'}
             onLongPress={handleOpenChannelOptions}

--- a/packages/ui/src/components/ManageChannels/CreateChannelSheet.tsx
+++ b/packages/ui/src/components/ManageChannels/CreateChannelSheet.tsx
@@ -39,27 +39,21 @@ export function CreateChannelSheet({
     channelType,
   }: {
     title: string;
-    description: string;
+    description?: string;
     channelType: ChannelTypeName;
   }) => void;
 }) {
   const { control, handleSubmit } = useForm({
     defaultValues: {
       title: '',
-      description: '',
       channelType: 'chat',
     },
   });
 
   const handlePressSave = useCallback(
-    async (data: {
-      title: string;
-      description: string;
-      channelType: string;
-    }) => {
+    async (data: { title: string; channelType: string }) => {
       createChannel({
         title: data.title,
-        description: data.description,
         channelType: data.channelType as ChannelTypeName,
       });
       onOpenChange(false);
@@ -78,15 +72,6 @@ export function CreateChannelSheet({
             label="Title"
             inputProps={{ placeholder: 'Channel title' }}
             rules={{ required: 'Channel title is required' }}
-          />
-        </ActionSheet.FormBlock>
-        <ActionSheet.FormBlock>
-          <Form.ControlledTextField
-            control={control}
-            name="description"
-            label="Description"
-            inputProps={{ placeholder: 'Channel description' }}
-            rules={{ required: 'Channel description is required' }}
           />
         </ActionSheet.FormBlock>
         <ActionSheet.FormBlock>

--- a/packages/ui/src/components/ManageChannels/ManageChannelsScreenView.tsx
+++ b/packages/ui/src/components/ManageChannels/ManageChannelsScreenView.tsx
@@ -194,7 +194,7 @@ interface ManageChannelsScreenViewProps {
     channelType,
   }: {
     title: string;
-    description: string;
+    description?: string;
     channelType: ChannelTypeName;
   }) => Promise<void>;
   createNavSection: ({ title }: { title: string }) => Promise<void>;


### PR DESCRIPTION
- While joining, continue showing the group as a pending item with the  _Joining_  label
  - this was an issue with correctly interpreting the Urbit types for gangs with ongoing joins
- Stop breaking if you use the same channel name
  - we had name collision checking, but the set of channels we were checking against was incomplete. This adds a new query to give you _all_ channels that should also be cheaper to run
- Fix optimistic updates when adding channels
  - were failing to set `currentUserIsMember` on the optimistic update or channel fact

Also removes channel description from the _Add Channel Sheet_ — we talked about keeping it lighter weight during design review, but can omit that commit if controversial.


Fixes TLON-2975
Fixes TLON-2949