### PR TITLE
gallery: navigate appropriately when tapping refs

### DIFF
--- a/apps/tlon-mobile/src/fixtures/DetailView/detailViewFixtureBase.tsx
+++ b/apps/tlon-mobile/src/fixtures/DetailView/detailViewFixtureBase.tsx
@@ -56,6 +56,9 @@ export const DetailViewFixture = ({
             canUpload={true}
             handleGoToUserProfile={() => {}}
             headerMode="default"
+            onPressRef={() => {}}
+            onGroupAction={() => {}}
+            goToDm={() => {}}
           />
         </RequestsProvider>
       </AppDataContextProvider>

--- a/apps/tlon-mobile/src/fixtures/PostScreen.fixture.tsx
+++ b/apps/tlon-mobile/src/fixtures/PostScreen.fixture.tsx
@@ -39,6 +39,9 @@ export default (
       clearDraft={() => {}}
       canUpload={true}
       headerMode="default"
+      onPressRef={() => {}}
+      onGroupAction={() => {}}
+      goToDm={() => {}}
     />
   </AppDataContextProvider>
 );

--- a/packages/app/features/top/PostScreen.tsx
+++ b/packages/app/features/top/PostScreen.tsx
@@ -3,6 +3,7 @@ import * as db from '@tloncorp/shared/dist/db';
 import * as store from '@tloncorp/shared/dist/store';
 import * as urbit from '@tloncorp/shared/dist/urbit';
 import { PostScreenView, useCurrentUserId } from '@tloncorp/ui';
+import { useGroupActions } from 'packages/app/hooks/useGroupActions';
 import { useCallback, useEffect, useMemo, useState } from 'react';
 
 import { useChannelContext } from '../../hooks/useChannelContext';
@@ -30,9 +31,10 @@ export default function PostScreen(props: Props) {
     uploaderKey: `${postParam.channelId}/${postParam.id}`,
   });
 
-  const { navigateToImage } = useChannelNavigation({
-    channelId: postParam.channelId,
-  });
+  const { navigateToImage, navigateToRef } =
+    useChannelNavigation({
+      channelId: postParam.channelId,
+    });
 
   const currentUserId = useCurrentUserId();
 
@@ -119,6 +121,18 @@ export default function PostScreen(props: Props) {
     [props.navigation]
   );
 
+  const { performGroupAction } = useGroupActions();
+
+  const handleGoToDm = useCallback(
+    async (participants: string[]) => {
+      const dmChannel = await store.upsertDmChannel({
+        participants,
+      });
+      props.navigation.push('Channel', { channel: dmChannel });
+    },
+    [props.navigation]
+  );
+
   return currentUserId && channel && post ? (
     <PostScreenView
       handleGoToUserProfile={handleGoToUserProfile}
@@ -140,6 +154,9 @@ export default function PostScreen(props: Props) {
       editingPost={editingPost}
       onPressDelete={handleDeletePost}
       onPressRetry={handleRetrySend}
+      onPressRef={navigateToRef}
+      onGroupAction={performGroupAction}
+      goToDm={handleGoToDm}
       setEditingPost={setEditingPost}
       editPost={editPost}
       negotiationMatch={negotiationStatus.matchedOrPending}

--- a/packages/app/features/top/PostScreen.tsx
+++ b/packages/app/features/top/PostScreen.tsx
@@ -3,11 +3,11 @@ import * as db from '@tloncorp/shared/dist/db';
 import * as store from '@tloncorp/shared/dist/store';
 import * as urbit from '@tloncorp/shared/dist/urbit';
 import { PostScreenView, useCurrentUserId } from '@tloncorp/ui';
-import { useGroupActions } from 'packages/app/hooks/useGroupActions';
 import { useCallback, useEffect, useMemo, useState } from 'react';
 
 import { useChannelContext } from '../../hooks/useChannelContext';
 import { useChannelNavigation } from '../../hooks/useChannelNavigation';
+import { useGroupActions } from '../../hooks/useGroupActions';
 import type { RootStackParamList } from '../../navigation/types';
 
 type Props = NativeStackScreenProps<RootStackParamList, 'Post'>;
@@ -31,10 +31,9 @@ export default function PostScreen(props: Props) {
     uploaderKey: `${postParam.channelId}/${postParam.id}`,
   });
 
-  const { navigateToImage, navigateToRef } =
-    useChannelNavigation({
-      channelId: postParam.channelId,
-    });
+  const { navigateToImage, navigateToRef } = useChannelNavigation({
+    channelId: postParam.channelId,
+  });
 
   const currentUserId = useCurrentUserId();
 

--- a/packages/ui/src/components/DetailView.tsx
+++ b/packages/ui/src/components/DetailView.tsx
@@ -1,6 +1,6 @@
 import * as db from '@tloncorp/shared/dist/db';
 import * as urbit from '@tloncorp/shared/dist/urbit';
-import { useEffect, useMemo, useRef } from 'react';
+import { useEffect, useMemo } from 'react';
 import { FlatList } from 'react-native';
 import { View, YStack } from 'tamagui';
 
@@ -25,6 +25,7 @@ export interface DetailViewProps {
   activeMessage: db.Post | null;
   headerMode: 'default' | 'next';
   editorIsFocused: boolean;
+  flatListRef?: React.RefObject<FlatList>;
 }
 
 export const DetailView = ({
@@ -40,6 +41,7 @@ export const DetailView = ({
   activeMessage,
   headerMode,
   editorIsFocused,
+  flatListRef,
 }: DetailViewProps) => {
   const channelType = useMemo(
     () => urbit.getChannelType(post.channelId),
@@ -49,13 +51,12 @@ export const DetailView = ({
   const resolvedPosts = useMemo(() => {
     return isChat && posts ? [...posts, post] : posts;
   }, [posts, post, isChat]);
-  const flatListRef = useRef<FlatList>(null);
 
   useEffect(() => {
-    if (editorIsFocused) {
+    if (editorIsFocused && flatListRef) {
       flatListRef.current?.scrollToIndex({ index: 1, animated: true });
     }
-  }, [editorIsFocused]);
+  }, [editorIsFocused, flatListRef]);
 
   const scroller = useMemo(() => {
     return (

--- a/packages/ui/src/components/PostScreenView.tsx
+++ b/packages/ui/src/components/PostScreenView.tsx
@@ -3,7 +3,8 @@ import type * as db from '@tloncorp/shared/dist/db';
 import * as urbit from '@tloncorp/shared/dist/urbit';
 import { Story } from '@tloncorp/shared/dist/urbit';
 import { ImagePickerAsset } from 'expo-image-picker';
-import { useEffect, useMemo, useRef, useState } from 'react';
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import { FlatList } from 'react-native';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
 import { Text, View, YStack } from 'tamagui';
 
@@ -14,6 +15,7 @@ import { BigInput } from './BigInput';
 import { ChannelFooter } from './Channel/ChannelFooter';
 import { ChannelHeader } from './Channel/ChannelHeader';
 import { DetailView } from './DetailView';
+import { GroupPreviewAction, GroupPreviewSheet } from './GroupPreviewSheet';
 import KeyboardAvoidingView from './KeyboardAvoidingView';
 import { MessageInput } from './MessageInput';
 import { TlonEditorBridge } from './MessageInput/toolbarActions.native';
@@ -39,6 +41,9 @@ export function PostScreenView({
   editPost,
   onPressRetry,
   onPressDelete,
+  onPressRef,
+  onGroupAction,
+  goToDm,
   negotiationMatch,
   headerMode,
   canUpload,
@@ -69,6 +74,9 @@ export function PostScreenView({
   ) => Promise<void>;
   onPressRetry: (post: db.Post) => void;
   onPressDelete: (post: db.Post) => void;
+  onPressRef: (channel: db.Channel, post: db.Post) => void;
+  onGroupAction: (action: GroupPreviewAction, group: db.Group) => void;
+  goToDm: (participants: string[]) => void;
   negotiationMatch: boolean;
   headerMode: 'default' | 'next';
   canUpload: boolean;
@@ -86,6 +94,8 @@ export function PostScreenView({
     editor: TlonEditorBridge | null;
   }>(null);
   const [editorIsFocused, setEditorIsFocused] = useState(false);
+  const [groupPreview, setGroupPreview] = useState<db.Group | null>(null);
+  const flatListRef = useRef<FlatList>(null);
 
   // We track the editor focus state to determine when we need to scroll to the
   // bottom of the screen when the keyboard is opened/editor is focused.
@@ -112,9 +122,49 @@ export function PostScreenView({
     return editingPost && editingPost.id === parentPost?.id;
   }, [editingPost, parentPost]);
 
+  const onPressGroupRef = useCallback((group: db.Group) => {
+    setGroupPreview(group);
+  }, []);
+
+  const handleGroupAction = useCallback(
+    (action: GroupPreviewAction, group: db.Group) => {
+      onGroupAction(action, group);
+      setGroupPreview(null);
+    },
+    [onGroupAction]
+  );
+
+  const handleRefPress = useCallback(
+    (refChannel: db.Channel, post: db.Post) => {
+      const anchorIndex = posts?.findIndex((p) => p.id === post.id) ?? -1;
+
+      if (
+        refChannel.id === channel.id &&
+        anchorIndex !== -1 &&
+        flatListRef.current
+      ) {
+        // If the post is already loaded, scroll to it
+        flatListRef.current?.scrollToIndex({
+          index: anchorIndex,
+          animated: false,
+          viewPosition: 0.5,
+        });
+        return;
+      }
+
+      onPressRef(refChannel, post);
+    },
+    [onPressRef, posts, channel]
+  );
+
   return (
     <AttachmentProvider canUpload={canUpload} uploadAsset={uploadAsset}>
-      <NavigationProvider onGoToUserProfile={handleGoToUserProfile}>
+      <NavigationProvider
+        onGoToUserProfile={handleGoToUserProfile}
+        onPressRef={handleRefPress}
+        onPressGroupRef={onPressGroupRef}
+        onPressGoToDm={goToDm}
+      >
         <View paddingBottom={bottom} backgroundColor="$background" flex={1}>
           <YStack flex={1} backgroundColor={'$background'}>
             <ChannelHeader
@@ -143,6 +193,7 @@ export function PostScreenView({
                   setActiveMessage={setActiveMessage}
                   headerMode={headerMode}
                   editorIsFocused={editorIsFocused}
+                  flatListRef={flatListRef}
                 />
               ) : null}
 
@@ -212,6 +263,12 @@ export function PostScreenView({
                 />
               )}
             </KeyboardAvoidingView>
+            <GroupPreviewSheet
+              group={groupPreview ?? undefined}
+              open={!!groupPreview}
+              onOpenChange={() => setGroupPreview(null)}
+              onActionComplete={handleGroupAction}
+            />
           </YStack>
         </View>
       </NavigationProvider>


### PR DESCRIPTION
fixes TLON-3090
fixes TLON-2835

We weren't passing in the handlers for these things to PostScreenView or the NavigationProvider. We also didn't have the GroupPreviewSheet or any state to track which group we're previewing, so group refs in galleries (like the community catalog in tlon local) didn't do anything when pressed either.