### PR TITLE
chat options: navigate back to chat list on leave

### DIFF
--- a/packages/app/hooks/useChatSettingsNavigation.ts
+++ b/packages/app/hooks/useChatSettingsNavigation.ts
@@ -71,6 +71,13 @@ export const useChatSettingsNavigation = () => {
     [navigation]
   );
 
+  const navigateOnLeave = useCallback(
+    () => {
+      navigation.navigate('ChatList');
+    },
+    [navigation]
+  );
+
   return {
     onPressChannelMembers,
     onPressChannelMeta,
@@ -79,5 +86,6 @@ export const useChatSettingsNavigation = () => {
     onPressManageChannels,
     onPressGroupPrivacy,
     onPressRoles,
+    navigateOnLeave,
   };
 };

--- a/packages/ui/src/components/ChatOptionsSheet.tsx
+++ b/packages/ui/src/components/ChatOptionsSheet.tsx
@@ -511,6 +511,7 @@ export function ChannelOptions({
     onPressChannelMeta,
     onPressManageChannels,
     onPressInvite,
+    onPressLeave,
   } = useChatOptions() ?? {};
 
   const currentUserIsHost = useMemo(
@@ -752,6 +753,7 @@ export function ChannelOptions({
                           style: 'destructive',
                           onPress: () => {
                             sheetRef.current.setOpen(false);
+                            onPressLeave?.();
                             store.respondToDMInvite({ channel, accept: false });
                           },
                         },
@@ -774,6 +776,7 @@ export function ChannelOptions({
     onPressChannelMembers,
     onPressManageChannels,
     onPressInvite,
+    onPressLeave,
     title,
   ]);
   return (

--- a/packages/ui/src/contexts/chatOptions.tsx
+++ b/packages/ui/src/contexts/chatOptions.tsx
@@ -47,6 +47,7 @@ type ChatOptionsProviderProps = {
   onPressChannelMeta: (channelId: string) => void;
   onPressRoles: (groupId: string) => void;
   onSelectSort?: (sortBy: 'recency' | 'arranged') => void;
+  navigateOnLeave?: () => void;
 };
 
 export const ChatOptionsProvider = ({
@@ -62,6 +63,7 @@ export const ChatOptionsProvider = ({
   onPressChannelMembers,
   onPressChannelMeta,
   onPressRoles,
+  navigateOnLeave,
 }: ChatOptionsProviderProps) => {
   const groupQuery = useGroup({ id: groupId ?? '' });
   const group = groupId ? groupQuery.data ?? null : null;
@@ -80,7 +82,8 @@ export const ChatOptionsProvider = ({
     if (group) {
       await store.leaveGroup(group.id);
     }
-  }, [group]);
+    navigateOnLeave?.();
+  }, [group, navigateOnLeave]);
 
   const onSelectSort = useCallback((sortBy: 'recency' | 'arranged') => {
     db.storeChannelSortPreference(sortBy);


### PR DESCRIPTION
fixes TLON-2988 by adding a new `navigateOnLeave` method to useChatSettingsNavigation that gets called from `onPressLeave` within the context regardless of whether we have a group (and now we call onPressLeave for either groups or dms within the chat options actions).