### PR TITLE
AddGalleryPost: avoid saying "Video" or "Rich" (text)

### DIFF
--- a/packages/ui/src/components/AddGalleryPost.tsx
+++ b/packages/ui/src/components/AddGalleryPost.tsx
@@ -21,14 +21,14 @@ export default function AddGalleryPost({
 
   const actions = [
     {
-      title: 'Photo or Video',
+      title: 'Image',
       action: () => {
         setShowAddGalleryPost(false);
         setShowAttachmentSheet(true);
       },
     },
     {
-      title: 'Rich Text',
+      title: 'Text',
       action: () => {
         setShowAddGalleryPost(false);
         setShowGalleryInput(true);


### PR DESCRIPTION
Changes the labels on AddGalleryPost to be less confusing.

![image](https://github.com/user-attachments/assets/0dbf15d8-de0f-492a-ac21-20a87cd983f4)
