### PR TITLE
channels: add ability to leave group channels on mobile

### DIFF
--- a/packages/shared/src/api/channelsApi.ts
+++ b/packages/shared/src/api/channelsApi.ts
@@ -375,3 +375,24 @@ export const searchChannel = async (params: {
 
   return { posts, cursor };
 };
+
+export const leaveChannel = async (channelId: string) => {
+  return trackedPoke<ub.ChannelsResponse>(
+    {
+      app: 'channels',
+      mark: 'channel-action',
+      json: {
+        channel: {
+          nest: channelId,
+          action: {
+            leave: null,
+          },
+        },
+      },
+    },
+    { app: 'channels', path: '/v1' },
+    (event) => {
+      return 'leave' in event.response && event.response.leave === channelId;
+    }
+  );
+};

--- a/packages/ui/src/components/ChatOptionsSheet.tsx
+++ b/packages/ui/src/components/ChatOptionsSheet.tsx
@@ -754,7 +754,17 @@ export function ChannelOptions({
                           onPress: () => {
                             sheetRef.current.setOpen(false);
                             onPressLeave?.();
-                            store.respondToDMInvite({ channel, accept: false });
+                            if (
+                              channel.type === 'dm' ||
+                              channel.type === 'groupDm'
+                            ) {
+                              store.respondToDMInvite({
+                                channel,
+                                accept: false,
+                              });
+                            } else {
+                              store.leaveGroupChannel(channel.id);
+                            }
                           },
                         },
                       ]


### PR DESCRIPTION
fixes TLON-2987

We actually didn't have any logic related to leaving a group channel in the mobile app before, and the `leave` action in ChatOptions just assumed we were leaving a dm, so it makes sense that it was failing.