### PR TITLE
native: vendor http api

### DIFF
--- a/packages/app/features/top/PostScreen.tsx
+++ b/packages/app/features/top/PostScreen.tsx
@@ -64,7 +64,7 @@ export default function PostScreen(props: Props) {
   }, [post, threadPosts]);
 
   const markRead = useCallback(() => {
-    if (channel && post && threadPosts) {
+    if (channel && post && threadPosts && threadPosts.length > 0) {
       store.markThreadRead({
         channel,
         parentPost: post,

--- a/packages/app/hooks/useConfigureUrbitClient.ts
+++ b/packages/app/hooks/useConfigureUrbitClient.ts
@@ -1,18 +1,7 @@
-import {
-  createDevLogger,
-  getSession,
-  sync,
-  updateSession,
-} from '@tloncorp/shared/dist';
+import { createDevLogger, sync } from '@tloncorp/shared/dist';
 import { ClientParams } from '@tloncorp/shared/dist/api';
 import { configureClient } from '@tloncorp/shared/dist/store';
 import { useCallback } from 'react';
-//@ts-expect-error no typedefs
-import { fetch as streamingFetch } from 'react-native-fetch-api';
-//@ts-expect-error no typedefs
-import { polyfill as polyfillEncoding } from 'react-native-polyfill-globals/src/encoding';
-//@ts-expect-error no typedefs
-import { polyfill as polyfillReadableStream } from 'react-native-polyfill-globals/src/readable-stream';
 
 import { ENABLED_LOGGERS } from '../constants';
 import { useShip } from '../contexts/ship';
@@ -20,47 +9,7 @@ import { getShipAccessCode } from '../lib/hostingApi';
 import { resetDb } from '../lib/nativeDb';
 import { useHandleLogout } from './useHandleLogout';
 
-polyfillReadableStream();
-polyfillEncoding();
-
-let abortController = new AbortController();
-
-const apiFetch: typeof fetch = (input, { ...init } = {}) => {
-  // Wire our injected AbortController up to the one passed in by the client.
-  if (init.signal) {
-    init.signal.onabort = () => {
-      abortController.abort();
-      abortController = new AbortController();
-    };
-  }
-
-  const headers = new Headers(init.headers);
-  // The urbit client is inconsistent about sending cookies, sometimes causing
-  // the server to send back a new, anonymous, cookie, which is sent on all
-  // subsequent requests and screws everything up. This ensures that explicit
-  // cookie headers are never set, delegating all cookie handling to the
-  // native http client.
-  headers.delete('Cookie');
-  headers.delete('cookie');
-  const newInit: RequestInit = {
-    ...init,
-    headers,
-    // Avoid setting credentials method for same reason as above.
-    credentials: undefined,
-    signal: abortController.signal,
-    // @ts-expect-error This is used by the SSE polyfill to determine whether
-    // to stream the request.
-    reactNative: { textStreaming: true },
-  };
-  return streamingFetch(input, newInit);
-};
-
-export const cancelFetch = () => {
-  abortController.abort();
-  abortController = new AbortController();
-};
-
-const clientLogger = createDevLogger('configure client', false);
+const clientLogger = createDevLogger('configure client', true);
 
 export function useConfigureUrbitClient() {
   const shipInfo = useShip();
@@ -78,24 +27,7 @@ export function useConfigureUrbitClient() {
         shipName: params?.shipName ?? ship ?? '',
         shipUrl: params?.shipUrl ?? shipUrl ?? '',
         verbose: ENABLED_LOGGERS.includes('urbit'),
-        fetchFn: apiFetch,
-        cancelFetch,
-        onReconnect: () => {
-          const threshold = 5 * 60 * 1000; // 5 minutes
-          const lastReconnect = getSession()?.startTime ?? 0;
-          if (Date.now() - lastReconnect >= threshold) {
-            sync.handleDiscontinuity();
-          } else {
-            updateSession({ startTime: Date.now() });
-          }
-        },
-        onChannelReset: () => {
-          const threshold = __DEV__ ? 60 * 1000 : 12 * 60 * 60 * 1000; // 12 hours
-          const lastReconnect = getSession()?.startTime ?? 0;
-          if (Date.now() - lastReconnect >= threshold) {
-            sync.handleDiscontinuity();
-          }
-        },
+        onQuitOrReset: sync.handleDiscontinuity,
         onChannelStatusChange: sync.handleChannelStatusChange,
         getCode:
           authType === 'self'
@@ -116,6 +48,9 @@ export function useConfigureUrbitClient() {
                 return code;
               },
         handleAuthFailure: async () => {
+          clientLogger.error(
+            'Failed to authenticate with ship, redirecting to login'
+          );
           clientLogger.trackError(
             'Failed to authenticate with ship, redirecting to login'
           );

--- a/packages/app/hooks/useHandleLogout.native.ts
+++ b/packages/app/hooks/useHandleLogout.native.ts
@@ -1,5 +1,6 @@
 import { createDevLogger } from '@tloncorp/shared/dist';
 import * as api from '@tloncorp/shared/dist/api';
+import * as store from '@tloncorp/shared/dist/store';
 import { useCallback } from 'react';
 
 import { useBranch } from '../contexts/branch';
@@ -14,7 +15,7 @@ export function useHandleLogout({ resetDb }: { resetDb: () => void }) {
 
   const handleLogout = useCallback(async () => {
     api.queryClient.clear();
-    api.removeUrbitClient();
+    store.removeClient();
     clearShip();
     clearShipInfo();
     removeHostingToken();

--- a/packages/app/hooks/useHandleLogout.ts
+++ b/packages/app/hooks/useHandleLogout.ts
@@ -1,8 +1,6 @@
-import {
-  createDevLogger,
-  updateInitializedClient,
-} from '@tloncorp/shared/dist';
+import { createDevLogger } from '@tloncorp/shared/dist';
 import * as api from '@tloncorp/shared/dist/api';
+import * as store from '@tloncorp/shared/dist/store';
 import { useCallback } from 'react';
 
 import { useBranch } from '../contexts/branch';
@@ -21,7 +19,7 @@ export function useHandleLogout({ resetDb }: { resetDb?: () => void }) {
 
   const handleLogout = useCallback(async () => {
     api.queryClient.clear();
-    api.removeUrbitClient();
+    store.removeClient();
     clearShip();
     clearShipInfo();
     removeHostingToken();

--- a/packages/app/package.json
+++ b/packages/app/package.json
@@ -7,8 +7,10 @@
     "test": "vitest --watch false"
   },
   "dependencies": {
-    "@tloncorp/ui": "workspace:*",
     "@tloncorp/shared": "workspace:*",
+    "@tloncorp/ui": "workspace:*",
+    "react-native-fetch-api": "^3.0.0",
+    "react-native-polyfill-globals": "^3.1.0",
     "sqlocal": "^0.11.1"
   },
   "devDependencies": {
@@ -17,8 +19,8 @@
   },
   "peerDependencies": {
     "@react-native-firebase/perf": "19.2.2",
-    "react-native-device-info": "^10.8.0",
     "lodash": "^4.17.21",
+    "react-native-device-info": "^10.8.0",
     "zustand": "^3.7.2"
   }
 }

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -28,13 +28,10 @@
   "dependencies": {
     "@react-native-async-storage/async-storage": "1.21.0",
     "@urbit/aura": "^1.0.0",
-    "@urbit/http-api": "3.2.0-dev",
     "any-ascii": "^0.3.1",
     "big-integer": "^1.6.52",
     "browser-or-node": "^3.0.0",
     "exponential-backoff": "^3.1.1",
-    "react-native-fetch-api": "^3.0.0",
-    "react-native-polyfill-globals": "^3.1.0",
     "sorted-btree": "^1.8.1"
   },
   "devDependencies": {

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -31,7 +31,10 @@
     "@urbit/http-api": "3.2.0-dev",
     "any-ascii": "^0.3.1",
     "big-integer": "^1.6.52",
+    "browser-or-node": "^3.0.0",
     "exponential-backoff": "^3.1.1",
+    "react-native-fetch-api": "^3.0.0",
+    "react-native-polyfill-globals": "^3.1.0",
     "sorted-btree": "^1.8.1"
   },
   "devDependencies": {

--- a/packages/shared/src/api/urbit.ts
+++ b/packages/shared/src/api/urbit.ts
@@ -1,8 +1,8 @@
 import { deSig, preSig } from '@urbit/aura';
-import { ChannelStatus, PokeInterface, Urbit } from '@urbit/http-api';
 import _ from 'lodash';
 
 import { createDevLogger, escapeLog, runIfDev } from '../debug';
+import { AuthError, ChannelStatus, PokeInterface, Urbit } from '../http-api';
 import { getLandscapeAuthCookie } from './landscapeApi';
 
 const logger = createDevLogger('urbit', false);
@@ -10,11 +10,7 @@ const logger = createDevLogger('urbit', false);
 interface Config
   extends Pick<
     ClientParams,
-    | 'getCode'
-    | 'handleAuthFailure'
-    | 'shipUrl'
-    | 'onChannelReset'
-    | 'cancelFetch'
+    'getCode' | 'handleAuthFailure' | 'shipUrl' | 'onQuitOrReset'
   > {
   client: Urbit | null;
   subWatchers: Watchers;
@@ -55,12 +51,9 @@ export interface ClientParams {
   shipName: string;
   shipUrl: string;
   verbose?: boolean;
-  fetchFn?: typeof fetch;
-  cancelFetch?: () => void;
   getCode?: () => Promise<string>;
   handleAuthFailure?: () => void;
-  onReconnect?: () => void;
-  onChannelReset?: () => void;
+  onQuitOrReset?: () => void;
   onChannelStatusChange?: (status: ChannelStatus) => void;
 }
 
@@ -69,7 +62,7 @@ const config: Config = {
   shipUrl: '',
   subWatchers: {},
   pendingAuth: null,
-  onChannelReset: undefined,
+  onQuitOrReset: undefined,
   getCode: undefined,
   handleAuthFailure: undefined,
 };
@@ -105,40 +98,26 @@ export function internalConfigureClient({
   shipName,
   shipUrl,
   verbose,
-  fetchFn,
-  cancelFetch,
   getCode,
   handleAuthFailure,
-  onReconnect,
-  onChannelReset,
+  onQuitOrReset,
   onChannelStatusChange,
 }: ClientParams) {
   logger.log('configuring client', shipName, shipUrl);
-  config.client = config.client || new Urbit(shipUrl, '', '', fetchFn);
+  config.client = config.client || new Urbit(shipUrl, '', '');
   config.client.ship = deSig(shipName);
   config.client.our = preSig(shipName);
   config.client.verbose = verbose;
   config.shipUrl = shipUrl;
-  config.cancelFetch = cancelFetch;
-  config.onChannelReset = onChannelReset;
+  config.onQuitOrReset = onQuitOrReset;
   config.getCode = getCode;
   config.handleAuthFailure = handleAuthFailure;
   config.subWatchers = {};
 
-  config.client.onReconnect = () => {
-    logger.log('client reconnected');
-    onChannelStatusChange?.('reconnected');
-    onReconnect?.();
-  };
-
-  config.client.onRetry = () => {
-    logger.log('client retrying');
-    onChannelStatusChange?.('reconnecting');
-  };
-
   // the below event handlers will only fire if verbose is set to true
   config.client.on('status-update', (event) => {
     logger.log('status-update', event);
+    onChannelStatusChange?.(event.status);
   });
 
   config.client.on('fact', (fact) => {
@@ -150,6 +129,7 @@ export function internalConfigureClient({
 
   config.client.on('seamless-reset', () => {
     logger.log('client seamless-reset');
+    config.onQuitOrReset?.();
   });
 
   config.client.on('error', (error) => {
@@ -163,7 +143,6 @@ export function internalConfigureClient({
 
 export function internalRemoveClient() {
   config.client?.delete();
-  config.cancelFetch?.();
   config.client = null;
   config.subWatchers = {};
 }
@@ -214,7 +193,7 @@ export async function subscribe<T>(
       },
       quit: () => {
         logger.log('subscription quit on', printEndpoint(endpoint));
-        config.onChannelReset?.();
+        config.onQuitOrReset?.();
       },
       err: (error, id) => {
         logger.error(`subscribe error on ${printEndpoint(endpoint)}:`, error);
@@ -232,6 +211,10 @@ export async function subscribe<T>(
 
   const retry = async (err: any) => {
     logger.error('bad subscribe', printEndpoint(endpoint), err);
+    if (!(err instanceof AuthError)) {
+      throw err;
+    }
+
     config.pendingAuth = reauth();
     return doSub();
   };
@@ -258,6 +241,10 @@ export async function subscribeOnce<T>(
     return config.client.subscribeOnce<T>(endpoint.app, endpoint.path, timeout);
   } catch (err) {
     logger.error('bad subscribeOnce', printEndpoint(endpoint), err);
+    if (!(err instanceof AuthError)) {
+      throw err;
+    }
+
     await reauth();
     return config.client.subscribeOnce<T>(endpoint.app, endpoint.path, timeout);
   }
@@ -274,8 +261,10 @@ export async function unsubscribe(id: number) {
     return config.client.unsubscribe(id);
   } catch (err) {
     logger.error('bad unsubscribe', id, err);
-    await reauth();
-    return config.client.unsubscribe(id);
+    if (err instanceof AuthError) {
+      await reauth();
+      return config.client.unsubscribe(id);
+    }
   }
 }
 
@@ -297,6 +286,10 @@ export async function poke({ app, mark, json }: PokeParams) {
   };
   const retry = async (err: any) => {
     logger.log('bad poke', app, mark, json, err);
+    if (!(err instanceof AuthError)) {
+      throw err;
+    }
+
     await reauth();
     return doPoke();
   };
@@ -368,8 +361,9 @@ export async function scry<T>({ app, path }: { app: string; path: string }) {
 
 async function reauth() {
   if (!config.getCode) {
-    console.warn('No getCode function provided for auth');
+    logger.log('No getCode function provided for auth');
     if (config.handleAuthFailure) {
+      logger.log('calling auth failure handler');
       return config.handleAuthFailure();
     }
 

--- a/packages/shared/src/api/urbit.ts
+++ b/packages/shared/src/api/urbit.ts
@@ -105,8 +105,6 @@ export function internalConfigureClient({
 }: ClientParams) {
   logger.log('configuring client', shipName, shipUrl);
   config.client = config.client || new Urbit(shipUrl, '', '');
-  config.client.ship = deSig(shipName);
-  config.client.our = preSig(shipName);
   config.client.verbose = verbose;
   config.shipUrl = shipUrl;
   config.onQuitOrReset = onQuitOrReset;

--- a/packages/shared/src/api/urbit.ts
+++ b/packages/shared/src/api/urbit.ts
@@ -1,4 +1,3 @@
-import { deSig, preSig } from '@urbit/aura';
 import _ from 'lodash';
 
 import { createDevLogger, escapeLog, runIfDev } from '../debug';
@@ -51,6 +50,7 @@ export interface ClientParams {
   shipName: string;
   shipUrl: string;
   verbose?: boolean;
+  fetchFn?: typeof fetch;
   getCode?: () => Promise<string>;
   handleAuthFailure?: () => void;
   onQuitOrReset?: () => void;
@@ -98,13 +98,14 @@ export function internalConfigureClient({
   shipName,
   shipUrl,
   verbose,
+  fetchFn,
   getCode,
   handleAuthFailure,
   onQuitOrReset,
   onChannelStatusChange,
 }: ClientParams) {
   logger.log('configuring client', shipName, shipUrl);
-  config.client = config.client || new Urbit(shipUrl, '', '');
+  config.client = config.client || new Urbit(shipUrl, '', '', fetchFn);
   config.client.verbose = verbose;
   config.shipUrl = shipUrl;
   config.onQuitOrReset = onQuitOrReset;

--- a/packages/shared/src/http-api/Urbit.ts
+++ b/packages/shared/src/http-api/Urbit.ts
@@ -525,6 +525,9 @@ export class Urbit {
 
       if (this.our !== this.ship) {
         console.log('our name does not match ship name');
+        console.log('our:', this.our);
+        console.log('ship:', this.ship);
+        console.log('messages:', json);
         throw new AuthError('invalid session');
       }
 

--- a/packages/shared/src/http-api/Urbit.ts
+++ b/packages/shared/src/http-api/Urbit.ts
@@ -1,0 +1,795 @@
+import { isBrowser } from 'browser-or-node';
+//@ts-expect-error no typedefs
+import { fetch as streamingFetch } from 'react-native-fetch-api';
+//@ts-expect-error no typedefs
+import { polyfill as polyfillEncoding } from 'react-native-polyfill-globals/src/encoding';
+//@ts-expect-error no typedefs
+import { polyfill as polyfillReadableStream } from 'react-native-polyfill-globals/src/readable-stream';
+
+import { UrbitHttpApiEvent, UrbitHttpApiEventType } from './events';
+import { EventSourceMessage, fetchEventSource } from './fetch-event-source';
+import {
+  Ack,
+  AuthError,
+  AuthenticationInterface,
+  FatalError,
+  Message,
+  PokeHandlers,
+  PokeInterface,
+  ReapError,
+  SSEOptions,
+  Scry,
+  SubscriptionRequestInterface,
+  Thread,
+  headers,
+} from './types';
+import EventEmitter, { hexString } from './utils';
+
+polyfillReadableStream();
+polyfillEncoding();
+
+let abortController = new AbortController();
+
+/**
+ * A class for interacting with an urbit ship, given its URL and code
+ */
+export class Urbit {
+  /**
+   * Event emitter for debugging, see events.ts for full list of events
+   */
+  private emitter = new EventEmitter();
+
+  /**
+   * UID will be used for the channel: The current unix time plus a random hex string
+   */
+  private uid: string = `${Math.floor(Date.now() / 1000)}-${hexString(6)}`;
+
+  /**
+   * lastEventId is an auto-updated index of which events have been *sent* over this channel.
+   * lastHeardEventId is the latest event we have heard back about.
+   * lastAcknowledgedEventId is the latest event we have sent an ack for.
+   */
+  private lastEventId: number = 0;
+  private lastHeardEventId: number = -1;
+  private lastAcknowledgedEventId: number = -1;
+
+  /**
+   * SSE Client is null for now; we don't want to start polling until it the channel exists
+   */
+  private sseClientInitialized: boolean = false;
+
+  /**
+   * Cookie gets set when we log in.
+   */
+  cookie?: string;
+
+  /**
+   * A registry of requestId to successFunc/failureFunc
+   *
+   * These functions are registered during a +poke and are executed
+   * in the onServerEvent()/onServerError() callbacks. Only one of
+   * the functions will be called, and the outstanding poke will be
+   * removed after calling the success or failure function.
+   */
+
+  private outstandingPokes: Map<number, PokeHandlers> = new Map();
+
+  /**
+   * A registry of requestId to subscription functions.
+   *
+   * These functions are registered during a +subscribe and are
+   * executed in the onServerEvent()/onServerError() callbacks. The
+   * event function will be called whenever a new piece of data on this
+   * subscription is available, which may be 0, 1, or many times. The
+   * disconnect function may be called exactly once.
+   */
+  private outstandingSubscriptions: Map<number, SubscriptionRequestInterface> =
+    new Map();
+
+  /**
+   * Identity of the ship we're connected to
+   */
+  ship?: string | null;
+
+  /**
+   * Our identity, with which we are authenticated into the ship
+   */
+  our?: string | null;
+
+  /**
+   * If verbose, logs output eagerly.
+   */
+  verbose?: boolean;
+
+  /**
+   * number of consecutive errors in connecting to the eventsource
+   */
+  private errorCount = 0;
+
+  /** This is basic interpolation to get the channel URL of an instantiated Urbit connection. */
+  private get channelUrl(): string {
+    return `${this.url}/~/channel/${this.uid}`;
+  }
+
+  private get fetchOptions(): any {
+    const headers: headers = {
+      'Content-Type': 'application/json',
+    };
+
+    return {
+      credentials: isBrowser ? 'include' : undefined,
+      accept: '*',
+      headers,
+      signal: abortController.signal,
+      reactNative: { textStreaming: true },
+    };
+  }
+
+  /**
+   * Constructs a new Urbit connection.
+   *
+   * @param url  The URL (with protocol and port) of the ship to be accessed. If
+   * the airlock is running in a webpage served by the ship, this should just
+   * be the empty string.
+   * @param code The access code for the ship at that address
+   */
+  constructor(
+    public url: string,
+    public code?: string,
+    public desk?: string
+  ) {
+    if (isBrowser) {
+      window.addEventListener('beforeunload', this.delete);
+    }
+    return this;
+  }
+
+  /**
+   * All-in-one hook-me-up.
+   *
+   * Given a ship, url, and code, this returns an airlock connection
+   * that is ready to go. It `|hi`s itself to create the channel,
+   * then opens the channel via EventSource.
+   *
+   */
+  //TODO  rename this to connect() and only do constructor & event source setup.
+  //      that way it can be used with the assumption that you're already
+  //      authenticated.
+  static async authenticate({
+    ship,
+    url,
+    code,
+    verbose = false,
+  }: AuthenticationInterface) {
+    const airlock = new Urbit(
+      url.startsWith('http') ? url : `http://${url}`,
+      code
+    );
+    airlock.verbose = verbose;
+    airlock.ship = ship;
+    await airlock.connect();
+    await airlock.poke({
+      app: 'hood',
+      mark: 'helm-hi',
+      json: 'opening airlock',
+    });
+    await airlock.eventSource();
+    return airlock;
+  }
+
+  private emit<T extends UrbitHttpApiEventType>(
+    event: T,
+    data: UrbitHttpApiEvent[T]
+  ) {
+    this.emitter.emit(event, data);
+  }
+
+  on<T extends UrbitHttpApiEventType>(
+    event: T,
+    callback: (data: UrbitHttpApiEvent[T]) => void
+  ): void {
+    this.emitter.on(event, callback);
+
+    this.verbose && console.log(event, 'listening active');
+    if (event === 'init') {
+      this.emitter.emit(event, {
+        uid: this.uid,
+        subscriptions: [...this.outstandingSubscriptions.entries()].map(
+          ([k, v]) => ({ id: k, app: v.app, path: v.path })
+        ),
+      });
+    }
+  }
+
+  /**
+   * Gets the name of the ship accessible at this.url and stores it to this.ship
+   *
+   */
+  async getShipName(): Promise<void> {
+    if (this.ship) {
+      return Promise.resolve();
+    }
+
+    const nameResp = await streamingFetch(`${this.url}/~/host`, {
+      method: 'get',
+      credentials: 'include',
+    });
+    const name = await nameResp.text();
+    this.ship = name.substring(1);
+  }
+
+  /**
+   * Gets the name of the ship accessible at this.url and stores it to this.ship
+   *
+   */
+  async getOurName(): Promise<void> {
+    if (this.our) {
+      return Promise.resolve();
+    }
+
+    const nameResp = await streamingFetch(`${this.url}/~/name`, {
+      method: 'get',
+      credentials: 'include',
+    });
+    const name = await nameResp.text();
+    this.our = name.substring(1);
+  }
+
+  /**
+   * Connects to the Urbit ship. Nothing can be done until this is called.
+   * That's why we roll it into this.authenticate
+   * TODO  as of urbit/urbit#6561, this is no longer true, and we are able
+   *       to interact with the ship using a guest identity.
+   */
+  //TODO  rename to authenticate() and call connect() at the end
+  async connect(): Promise<void> {
+    if (this.verbose) {
+      console.log(
+        `password=${this.code} `,
+        isBrowser
+          ? 'Connecting in browser context at ' + `${this.url}/~/login`
+          : 'Connecting from node context'
+      );
+    }
+    return streamingFetch(`${this.url}/~/login`, {
+      method: 'post',
+      body: `password=${this.code}`,
+      credentials: 'include',
+    }).then(async (response: Response) => {
+      if (this.verbose) {
+        console.log('Received authentication response', response);
+      }
+      if (response.status >= 200 && response.status < 300) {
+        throw new Error('Login failed with status ' + response.status);
+      }
+      const cookie = response.headers.get('set-cookie');
+      if (!this.ship && cookie) {
+        this.ship = new RegExp(/urbauth-~([\w-]+)/).exec(cookie)?.[1];
+      }
+      if (!isBrowser) {
+        this.cookie = cookie || undefined;
+      }
+      this.getShipName();
+      this.getOurName();
+    });
+  }
+
+  /**
+   * Initializes the SSE pipe for the appropriate channel.
+   */
+  async eventSource(): Promise<void> {
+    if (this.sseClientInitialized) {
+      return Promise.resolve();
+    }
+    if (this.lastEventId === 0) {
+      this.emit('status-update', { status: 'opening' });
+      // Can't receive events until the channel is open,
+      // so poke and open then
+      await this.poke({
+        app: 'hood',
+        mark: 'helm-hi',
+        json: 'Opening API channel',
+      });
+      return;
+    }
+    this.sseClientInitialized = true;
+    return new Promise((resolve, reject) => {
+      const sseOptions: SSEOptions = {
+        headers: {},
+      };
+      if (isBrowser) {
+        sseOptions.withCredentials = true;
+      }
+      fetchEventSource(this.channelUrl, {
+        ...this.fetchOptions,
+        openWhenHidden: true,
+        responseTimeout: 25000,
+        fetch: streamingFetch,
+        onopen: async (response, isReconnect) => {
+          if (this.verbose) {
+            console.log('Opened eventsource', response);
+          }
+          if (response.ok) {
+            this.errorCount = 0;
+            this.emit('status-update', {
+              status: isReconnect ? 'reconnected' : 'active',
+            });
+            resolve();
+            return; // everything's good
+          } else {
+            const err = new Error('failed to open eventsource');
+            reject(err);
+          }
+        },
+        onmessage: (event: EventSourceMessage) => {
+          if (this.verbose) {
+            console.log('Received SSE: ', event);
+          }
+          if (!event.id) return;
+          const eventId = parseInt(event.id, 10);
+          this.emit('fact', {
+            id: eventId,
+            data: event.data,
+            time: Date.now(),
+          });
+          if (eventId <= this.lastHeardEventId) {
+            if (this.verbose) {
+              console.log('dropping old or out-of-order event', {
+                eventId,
+                lastHeard: this.lastHeardEventId,
+              });
+            }
+            return;
+          }
+          this.lastHeardEventId = eventId;
+          this.emit('id-update', { lastHeard: this.lastHeardEventId });
+          if (eventId - this.lastAcknowledgedEventId > 20) {
+            this.ack(eventId);
+          }
+
+          if (event.data && JSON.parse(event.data)) {
+            const data: any = JSON.parse(event.data);
+
+            if (
+              data.response === 'poke' &&
+              this.outstandingPokes.has(data.id)
+            ) {
+              const funcs = this.outstandingPokes.get(data.id);
+              if ('ok' in data && funcs) {
+                funcs.onSuccess?.();
+              } else if ('err' in data && funcs) {
+                console.error(data.err);
+                funcs.onError?.(data.err);
+              } else {
+                console.error('Invalid poke response', data);
+              }
+              this.outstandingPokes.delete(data.id);
+            } else if (
+              data.response === 'subscribe' &&
+              this.outstandingSubscriptions.has(data.id)
+            ) {
+              const funcs = this.outstandingSubscriptions.get(data.id);
+              if ('err' in data && funcs) {
+                console.error(data.err);
+                funcs.err?.(data.err, data.id);
+                this.outstandingSubscriptions.delete(data.id);
+              }
+            } else if (
+              data.response === 'diff' &&
+              this.outstandingSubscriptions.has(data.id)
+            ) {
+              const funcs = this.outstandingSubscriptions.get(data.id);
+              try {
+                funcs?.event?.(data.json, data.mark ?? 'json', data.id);
+              } catch (e) {
+                console.error('Failed to call subscription event callback', e);
+              }
+            } else if (
+              data.response === 'quit' &&
+              this.outstandingSubscriptions.has(data.id)
+            ) {
+              const sub = this.outstandingSubscriptions.get(data.id);
+              sub?.quit?.(data);
+              this.outstandingSubscriptions.delete(data.id);
+              this.emit('subscription', {
+                id: data.id,
+                status: 'close',
+              });
+              if (sub?.resubOnQuit) {
+                this.subscribe(sub);
+              }
+            } else if (this.verbose) {
+              console.log([...this.outstandingSubscriptions.keys()]);
+              console.log('Unrecognized response', data);
+            }
+          }
+        },
+        onerror: (error) => {
+          this.errorCount++;
+          this.emit('error', {
+            time: Date.now(),
+            msg: JSON.stringify(error),
+            error,
+          });
+          if (error instanceof ReapError) {
+            this.emit('channel-reaped', { time: Date.now() });
+            this.seamlessReset();
+            return;
+          }
+          if (!(error instanceof FatalError)) {
+            this.emit('status-update', { status: 'reconnecting' });
+            return Math.min(5000, Math.pow(2, this.errorCount - 1) * 750);
+          }
+          this.emit('status-update', { status: 'errored' });
+          throw error;
+        },
+        onclose: () => {
+          console.log('e');
+          throw new Error('Ship unexpectedly closed the connection');
+        },
+      });
+    });
+  }
+
+  /**
+   * Reset airlock, abandoning current subscriptions and wiping state
+   *
+   */
+  reset() {
+    if (this.verbose) {
+      console.log('resetting');
+    }
+    this.delete();
+    this.uid = `${Math.floor(Date.now() / 1000)}-${hexString(6)}`;
+    this.emit('reset', { uid: this.uid });
+    this.lastEventId = 0;
+    this.lastHeardEventId = -1;
+    this.lastAcknowledgedEventId = -1;
+    this.outstandingSubscriptions = new Map();
+    this.outstandingPokes = new Map();
+    this.sseClientInitialized = false;
+  }
+
+  private seamlessReset() {
+    // called if a channel was reaped by %eyre before we reconnected
+    // so we have to make a new channel.
+    this.uid = `${Math.floor(Date.now() / 1000)}-${hexString(6)}`;
+    this.emit('seamless-reset', { uid: this.uid });
+    this.emit('status-update', { status: 'initial' });
+    this.sseClientInitialized = false;
+    this.lastEventId = 0;
+    this.lastHeardEventId = -1;
+    this.lastAcknowledgedEventId = -1;
+    const oldSubs = [...this.outstandingSubscriptions.entries()];
+    this.outstandingSubscriptions = new Map();
+    oldSubs.forEach(([id, sub]) => {
+      sub.quit?.({
+        id,
+        response: 'quit',
+      });
+      this.emit('subscription', {
+        id,
+        status: 'close',
+      });
+
+      if (sub.resubOnQuit) {
+        this.subscribe(sub);
+      }
+    });
+
+    this.outstandingPokes.forEach((poke, id) => {
+      poke.onError?.('Channel was reaped');
+    });
+    this.outstandingPokes = new Map();
+  }
+
+  /**
+   * Autoincrements the next event ID for the appropriate channel.
+   */
+  private getEventId(): number {
+    this.lastEventId += 1;
+    this.emit('id-update', { current: this.lastEventId });
+    return this.lastEventId;
+  }
+
+  /**
+   * Acknowledges an event.
+   *
+   * @param eventId The event to acknowledge.
+   */
+  private async ack(eventId: number): Promise<number | void> {
+    this.lastAcknowledgedEventId = eventId;
+    this.emit('id-update', { lastAcknowledged: eventId });
+    const message: Ack = {
+      action: 'ack',
+      'event-id': eventId,
+    };
+    await this.sendJSONtoChannel(message);
+    return eventId;
+  }
+
+  private async sendJSONtoChannel(...json: (Message | Ack)[]): Promise<void> {
+    const response = await streamingFetch(this.channelUrl, {
+      ...this.fetchOptions,
+      method: 'PUT',
+      body: JSON.stringify(json),
+    });
+    if (!response.ok) {
+      throw new Error('Failed to PUT channel');
+    }
+    if (!this.sseClientInitialized) {
+      if (this.verbose) {
+        console.log('initializing event source');
+      }
+      await Promise.all([this.getOurName(), this.getShipName()]);
+
+      if (this.our !== this.ship) {
+        console.log('our name does not match ship name');
+        throw new AuthError('invalid session');
+      }
+
+      await this.eventSource();
+    }
+  }
+
+  /**
+   * Creates a subscription, waits for a fact and then unsubscribes
+   *
+   * @param app Name of gall agent to subscribe to
+   * @param path Path to subscribe to
+   * @param timeout Optional timeout before ending subscription
+   *
+   * @returns The first fact on the subcription
+   */
+  async subscribeOnce<T = any>(app: string, path: string, timeout?: number) {
+    return new Promise<T>((resolve, reject) => {
+      let done = false;
+      const quit = () => {
+        if (!done) {
+          reject('quit');
+        }
+      };
+      const event = (e: T, mark: string, id: number) => {
+        if (!done) {
+          resolve(e);
+          this.unsubscribe(id);
+        }
+      };
+      const request = {
+        app,
+        path,
+        resubOnQuit: false,
+        event,
+        err: reject,
+        quit,
+      };
+
+      this.subscribe(request).then((subId) => {
+        if (timeout) {
+          setTimeout(() => {
+            if (!done) {
+              done = true;
+              reject('timeout');
+              this.unsubscribe(subId);
+            }
+          }, timeout);
+        }
+      });
+    });
+  }
+
+  /**
+   * Pokes a ship with data.
+   *
+   * @param app The app to poke
+   * @param mark The mark of the data being sent
+   * @param json The data to send
+   */
+  async poke<T>(params: PokeInterface<T>): Promise<number> {
+    const { app, mark, json, ship, onSuccess, onError } = {
+      onSuccess: () => {},
+      onError: () => {},
+      ship: this.ship,
+      ...params,
+    };
+
+    if (this.lastEventId === 0) {
+      this.emit('status-update', { status: 'opening' });
+    }
+
+    const message: Message = {
+      id: this.getEventId(),
+      action: 'poke',
+      ship,
+      app,
+      mark,
+      json,
+    };
+    this.outstandingPokes.set(message.id, {
+      onSuccess: () => {
+        onSuccess();
+      },
+      onError: (err) => {
+        onError(err);
+      },
+    });
+    await this.sendJSONtoChannel(message);
+    return message.id;
+  }
+
+  /**
+   * Subscribes to a path on an app on a ship.
+   *
+   *
+   * @param app The app to subsribe to
+   * @param path The path to which to subscribe
+   * @param handlers Handlers to deal with various events of the subscription
+   */
+  async subscribe(params: SubscriptionRequestInterface): Promise<number> {
+    const { app, path, ship, resubOnQuit, err, event, quit } = {
+      err: () => {},
+      event: () => {},
+      quit: () => {},
+      ship: this.ship,
+      resubOnQuit: true,
+      ...params,
+    };
+
+    if (this.lastEventId === 0) {
+      this.emit('status-update', { status: 'opening' });
+    }
+
+    const message: Message = {
+      id: this.getEventId(),
+      action: 'subscribe',
+      ship,
+      app,
+      path,
+    };
+
+    this.outstandingSubscriptions.set(message.id, {
+      app,
+      path,
+      resubOnQuit,
+      err,
+      event,
+      quit,
+    });
+
+    this.emit('subscription', {
+      id: message.id,
+      app,
+      path,
+      status: 'open',
+    });
+
+    await this.sendJSONtoChannel(message);
+
+    return message.id;
+  }
+
+  /**
+   * Unsubscribes to a given subscription.
+   *
+   * @param subscription
+   */
+  async unsubscribe(subscription: number) {
+    return this.sendJSONtoChannel({
+      id: this.getEventId(),
+      action: 'unsubscribe',
+      subscription,
+    }).then(() => {
+      this.emit('subscription', {
+        id: subscription,
+        status: 'close',
+      });
+      this.outstandingSubscriptions.delete(subscription);
+    });
+  }
+
+  abort() {
+    abortController.abort();
+    abortController = new AbortController();
+  }
+
+  /**
+   * Deletes the connection to a channel.
+   */
+  async delete() {
+    this.abort();
+    const body = JSON.stringify([
+      {
+        id: this.getEventId(),
+        action: 'delete',
+      },
+    ]);
+    if (isBrowser) {
+      navigator.sendBeacon(this.channelUrl, body);
+    } else {
+      const response = await streamingFetch(this.channelUrl, {
+        ...this.fetchOptions,
+        method: 'POST',
+        body: body,
+      });
+      if (!response.ok) {
+        throw new Error('Failed to DELETE channel in node context');
+      }
+    }
+  }
+
+  /**
+   * Scry into an gall agent at a path
+   *
+   * @typeParam T - Type of the scry result
+   *
+   * @remarks
+   *
+   * Equivalent to
+   * ```hoon
+   * .^(T %gx /(scot %p our)/[app]/(scot %da now)/[path]/json)
+   * ```
+   * The returned cage must have a conversion to JSON for the scry to succeed
+   *
+   * @param params The scry request
+   * @returns The scry result
+   */
+  async scry<T = any>(params: Scry): Promise<T> {
+    const { app, path } = params;
+    const response = await streamingFetch(
+      `${this.url}/~/scry/${app}${path}.json`,
+      this.fetchOptions
+    );
+
+    if (!response.ok) {
+      return Promise.reject(response);
+    }
+
+    return await response.json();
+  }
+
+  /**
+   * Run a thread
+   *
+   *
+   * @param inputMark   The mark of the data being sent
+   * @param outputMark  The mark of the data being returned
+   * @param threadName  The thread to run
+   * @param body        The data to send to the thread
+   * @returns  The return value of the thread
+   */
+  async thread<R, T = any>(params: Thread<T>): Promise<R> {
+    const {
+      inputMark,
+      outputMark,
+      threadName,
+      body,
+      desk = this.desk,
+    } = params;
+    if (!desk) {
+      throw new Error('Must supply desk to run thread from');
+    }
+    const res = await streamingFetch(
+      `${this.url}/spider/${desk}/${inputMark}/${threadName}/${outputMark}.json`,
+      {
+        ...this.fetchOptions,
+        method: 'POST',
+        body: JSON.stringify(body),
+      }
+    );
+
+    return res.json();
+  }
+
+  /**
+   * Utility function to connect to a ship that has its *.arvo.network domain configured.
+   *
+   * @param name Name of the ship e.g. zod
+   * @param code Code to log in
+   */
+  static async onArvoNetwork(ship: string, code: string): Promise<Urbit> {
+    const url = `https://${ship}.arvo.network`;
+    return await Urbit.authenticate({ ship, url, code });
+  }
+}
+
+export default Urbit;

--- a/packages/shared/src/http-api/events.ts
+++ b/packages/shared/src/http-api/events.ts
@@ -1,0 +1,71 @@
+export type ChannelStatus =
+  | 'initial'
+  | 'opening'
+  | 'active'
+  | 'reconnecting'
+  | 'reconnected'
+  | 'errored';
+
+export interface StatusUpdateEvent {
+  status: ChannelStatus;
+}
+
+export interface FactEvent {
+  id: number;
+  time: number;
+  data: any;
+}
+
+export interface SubscriptionEvent {
+  id: number;
+  app?: string;
+  path?: string;
+  status: 'open' | 'close';
+}
+
+export interface ErrorEvent {
+  time: number;
+  msg: string;
+  error: any;
+}
+
+export type IdUpdateEvent = Partial<{
+  current: number;
+  lastHeard: number;
+  lastAcknowledged: number;
+}>;
+
+export interface ResetEvent {
+  uid: string;
+}
+
+export interface InitEvent extends ResetEvent {
+  subscriptions: Omit<SubscriptionEvent, 'status'>[];
+}
+
+export interface ChannelReapedEvent {
+  time: number;
+}
+
+export type UrbitHttpApiEvent = {
+  subscription: SubscriptionEvent;
+  'status-update': StatusUpdateEvent;
+  'id-update': IdUpdateEvent;
+  fact: FactEvent;
+  error: ErrorEvent;
+  reset: ResetEvent;
+  'seamless-reset': ResetEvent;
+  'channel-reaped': ChannelReapedEvent;
+  init: InitEvent;
+};
+
+export type UrbitHttpApiEventType =
+  | 'subscription'
+  | 'status-update'
+  | 'id-update'
+  | 'fact'
+  | 'error'
+  | 'reset'
+  | 'seamless-reset'
+  | 'channel-reaped'
+  | 'init';

--- a/packages/shared/src/http-api/fetch-event-source/fetch.ts
+++ b/packages/shared/src/http-api/fetch-event-source/fetch.ts
@@ -1,0 +1,202 @@
+import { FatalError, ReapError } from '../types';
+import { EventSourceMessage, getBytes, getLines, getMessages } from './parse';
+
+export const EventStreamContentType = 'text/event-stream';
+
+const DefaultRetryInterval = 1000;
+const LastEventId = 'last-event-id';
+
+export interface FetchEventSourceInit extends RequestInit {
+  /**
+   * The request headers. FetchEventSource only supports the Record<string,string> format.
+   */
+  headers?: Record<string, string>;
+
+  /**
+   * Called when a response is received. Use this to validate that the response
+   * actually matches what you expect (and throw if it doesn't.) If not provided,
+   * will default to a basic validation to ensure the content-type is text/event-stream.
+   */
+  onopen?: (response: Response, reconnection: boolean) => Promise<void>;
+
+  /**
+   * Called when a message is received. NOTE: Unlike the default browser
+   * EventSource.onmessage, this callback is called for _all_ events,
+   * even ones with a custom `event` field.
+   */
+  onmessage?: (ev: EventSourceMessage) => void;
+
+  /**
+   * Called when a response finishes. If you don't expect the server to kill
+   * the connection, you can throw an exception here and retry using onerror.
+   */
+  onclose?: () => void;
+
+  /**
+   * Called when there is any error making the request / processing messages /
+   * handling callbacks etc. Use this to control the retry strategy: if the
+   * error is fatal, rethrow the error inside the callback to stop the entire
+   * operation. Otherwise, you can return an interval (in milliseconds) after
+   * which the request will automatically retry (with the last-event-id).
+   * If this callback is not specified, or it returns undefined, fetchEventSource
+   * will treat every error as retriable and will try again after 1 second.
+   */
+  onerror?: (err: any) => number | null | undefined | void;
+
+  /**
+   * If true, will keep the request open even if the document is hidden.
+   * By default, fetchEventSource will close the request and reopen it
+   * automatically when the document becomes visible again.
+   */
+  openWhenHidden?: boolean;
+
+  /** The Fetch function to use. Defaults to window.fetch */
+  fetch?: typeof fetch;
+
+  /** How many millisedonds to wait for bytes before timing out */
+  responseTimeout?: number;
+}
+
+export function fetchEventSource(
+  input: RequestInfo,
+  {
+    signal: inputSignal,
+    headers: inputHeaders,
+    onopen: inputOnOpen,
+    onmessage,
+    onclose,
+    onerror,
+    openWhenHidden,
+    fetch: inputFetch,
+    responseTimeout,
+    ...rest
+  }: FetchEventSourceInit
+) {
+  return new Promise<void>((resolve, reject) => {
+    // make a copy of the input headers since we may modify it below:
+    const headers = { ...inputHeaders };
+    if (!headers.accept) {
+      headers.accept = EventStreamContentType;
+    }
+
+    let curRequestController: AbortController;
+    function onVisibilityChange() {
+      curRequestController.abort(); // close existing request on every visibility change
+      if (!document.hidden) {
+        create(); // page is now visible again, recreate request.
+      }
+    }
+
+    if (typeof document !== 'undefined' && !openWhenHidden) {
+      document.addEventListener('visibilitychange', onVisibilityChange);
+    }
+
+    let retryInterval = DefaultRetryInterval;
+    let retryTimer: ReturnType<typeof setTimeout>;
+    function dispose() {
+      if (typeof document !== 'undefined' && !openWhenHidden) {
+        document.removeEventListener('visibilitychange', onVisibilityChange);
+      }
+      clearTimeout(retryTimer);
+      curRequestController.abort();
+    }
+
+    // if the incoming signal aborts, dispose resources and resolve:
+    inputSignal?.addEventListener('abort', () => {
+      dispose();
+      resolve(); // don't waste time constructing/logging errors
+    });
+
+    const fetchFn = inputFetch ?? fetch;
+    const onopen = inputOnOpen ?? defaultOnOpen;
+    let isReconnect = false;
+    async function create() {
+      curRequestController = new AbortController();
+      try {
+        const response = (await Promise.race([
+          fetchFn(input, {
+            ...rest,
+            headers,
+            signal: curRequestController.signal,
+          }),
+          new Promise((_, reject) => {
+            setTimeout(
+              () => reject(new Error('fetch timed out')),
+              responseTimeout
+            );
+          }),
+        ])) as Response;
+
+        if (response.status === 404) {
+          onerror?.(new ReapError('Channel reaped'));
+          dispose();
+          resolve();
+          return;
+        }
+
+        if (response.status < 200 || response.status >= 300) {
+          throw new Error(`Invalid server response: ${response.status}`);
+        }
+
+        await onopen(response, isReconnect);
+        // reset reconnect status
+        if (isReconnect) {
+          isReconnect = false;
+        }
+
+        await getBytes(
+          response.body!,
+          getLines(
+            getMessages(
+              onmessage,
+              (id) => {
+                if (id) {
+                  // store the id and send it back on the next retry:
+                  headers[LastEventId] = id;
+                } else {
+                  // don't send the last-event-id header anymore:
+                  delete headers[LastEventId];
+                }
+              },
+              (retry) => {
+                retryInterval = retry;
+              }
+            )
+          ),
+          responseTimeout
+        );
+
+        onclose?.();
+        dispose();
+        resolve();
+      } catch (err) {
+        if (!curRequestController.signal.aborted) {
+          // if we haven't aborted the request ourselves:
+          try {
+            isReconnect = true;
+            // check if we need to retry:
+            const interval: any = onerror?.(err) ?? retryInterval;
+            clearTimeout(retryTimer);
+            curRequestController.abort();
+            retryTimer = setTimeout(create, interval);
+          } catch (innerErr) {
+            // we should not retry anymore:
+            dispose();
+            reject(innerErr);
+          }
+        }
+      }
+    }
+
+    create();
+  });
+}
+
+function defaultOnOpen(response: Response) {
+  const contentType = response.headers.get('content-type');
+  if (!contentType?.startsWith(EventStreamContentType)) {
+    throw new Error(
+      `Expected content-type to be ${EventStreamContentType}, Actual: ${contentType}`
+    );
+  }
+}

--- a/packages/shared/src/http-api/fetch-event-source/index.ts
+++ b/packages/shared/src/http-api/fetch-event-source/index.ts
@@ -1,0 +1,4 @@
+// copied from https://github.com/gfortaine/fetch-event-source with added modifications
+export { fetchEventSource, EventStreamContentType } from './fetch';
+export type { FetchEventSourceInit } from './fetch';
+export type { EventSourceMessage } from './parse';

--- a/packages/shared/src/http-api/fetch-event-source/parse.ts
+++ b/packages/shared/src/http-api/fetch-event-source/parse.ts
@@ -1,0 +1,217 @@
+/**
+ * Represents a message sent in an event stream
+ * https://developer.mozilla.org/en-US/docs/Web/API/Server-sent_events/Using_server-sent_events#Event_stream_format
+ */
+export interface EventSourceMessage {
+  /** The event ID to set the EventSource object's last event ID value. */
+  id: string;
+  /** A string identifying the type of event described. */
+  event: string;
+  /** The event data */
+  data: string;
+  /** The reconnection interval (in milliseconds) to wait before retrying the connection */
+  retry?: number;
+}
+
+/**
+ * Converts a ReadableStream into a callback pattern.
+ * @param stream The input ReadableStream.
+ * @param onChunk A function that will be called on each new byte chunk in the stream.
+ * @returns {Promise<void>} A promise that will be resolved when the stream closes.
+ */
+export async function getBytes(
+  stream: ReadableStream<Uint8Array>,
+  onChunk: (arr: Uint8Array) => void,
+  responseTimeout?: number
+) {
+  const reader = stream.getReader();
+  let result: ReadableStreamReadResult<Uint8Array> = {
+    done: false,
+    value: new Uint8Array(),
+  };
+
+  while (result && !result.done) {
+    result = await Promise.race([
+      reader.read(),
+      new Promise<ReadableStreamReadResult<Uint8Array>>((_, reject) => {
+        setTimeout(
+          () => reject(new Error('getBytes timed out')),
+          responseTimeout
+        );
+      }),
+    ]);
+
+    if (!result.value) {
+      // empty chunk, skip it
+      console.warn('Empty chunk received from server');
+      continue;
+    }
+
+    try {
+      onChunk(result.value);
+    } catch (err) {
+      console.error('Error processing chunk:', err);
+    }
+  }
+}
+
+const enum ControlChars {
+  NewLine = 10,
+  CarriageReturn = 13,
+  Space = 32,
+  Colon = 58,
+}
+
+/**
+ * Parses arbitary byte chunks into EventSource line buffers.
+ * Each line should be of the format "field: value" and ends with \r, \n, or \r\n.
+ * @param onLine A function that will be called on each new EventSource line.
+ * @returns A function that should be called for each incoming byte chunk.
+ */
+export function getLines(
+  onLine: (line: Uint8Array, fieldLength: number) => void
+) {
+  let buffer: Uint8Array | undefined;
+  let position: number; // current read position
+  let fieldLength: number; // length of the `field` portion of the line
+  let discardTrailingNewline = false;
+
+  // return a function that can process each incoming byte chunk:
+  return function onChunk(arr: Uint8Array) {
+    if (buffer === undefined) {
+      buffer = arr;
+      position = 0;
+      fieldLength = -1;
+    } else {
+      // we're still parsing the old line. Append the new bytes into buffer:
+      buffer = concat(buffer, arr);
+    }
+
+    const bufLength = buffer.length;
+    let lineStart = 0; // index where the current line starts
+    while (position < bufLength) {
+      if (discardTrailingNewline) {
+        if (buffer[position] === ControlChars.NewLine) {
+          lineStart = ++position; // skip to next char
+        }
+
+        discardTrailingNewline = false;
+      }
+
+      // start looking forward till the end of line:
+      let lineEnd = -1; // index of the \r or \n char
+      for (; position < bufLength && lineEnd === -1; ++position) {
+        switch (buffer[position]) {
+          case ControlChars.Colon:
+            if (fieldLength === -1) {
+              // first colon in line
+              fieldLength = position - lineStart;
+            }
+            break;
+          case ControlChars.CarriageReturn:
+            discardTrailingNewline = true;
+          // eslint-disable-next-line no-fallthrough
+          case ControlChars.NewLine:
+            lineEnd = position;
+            break;
+        }
+      }
+
+      if (lineEnd === -1) {
+        // We reached the end of the buffer but the line hasn't ended.
+        // Wait for the next arr and then continue parsing:
+        break;
+      }
+
+      // we've reached the line end, send it out:
+      onLine(buffer.subarray(lineStart, lineEnd), fieldLength);
+      lineStart = position; // we're now on the next line
+      fieldLength = -1;
+    }
+
+    if (lineStart === bufLength) {
+      buffer = undefined; // we've finished reading it
+    } else if (lineStart !== 0) {
+      // Create a new view into buffer beginning at lineStart so we don't
+      // need to copy over the previous lines when we get the new arr:
+      buffer = buffer.subarray(lineStart);
+      position -= lineStart;
+    }
+  };
+}
+
+/**
+ * Parses line buffers into EventSourceMessages.
+ * @param onId A function that will be called on each `id` field.
+ * @param onRetry A function that will be called on each `retry` field.
+ * @param onMessage A function that will be called on each message.
+ * @returns A function that should be called for each incoming line buffer.
+ */
+export function getMessages(
+  onMessage?: (msg: EventSourceMessage) => void,
+  onId?: (id: string) => void,
+  onRetry?: (retry: number) => void
+) {
+  let message = newMessage();
+  const decoder = new TextDecoder();
+
+  // return a function that can process each incoming line buffer:
+  return function onLine(line: Uint8Array, fieldLength: number) {
+    if (line.length === 0) {
+      // empty line denotes end of message. Trigger the callback and start a new message:
+      onMessage?.(message);
+      message = newMessage();
+    } else if (fieldLength > 0) {
+      // exclude comments and lines with no values
+      // line is of format "<field>:<value>" or "<field>: <value>"
+      // https://html.spec.whatwg.org/multipage/server-sent-events.html#event-stream-interpretation
+      const field = decoder.decode(line.subarray(0, fieldLength));
+      const valueOffset =
+        fieldLength + (line[fieldLength + 1] === ControlChars.Space ? 2 : 1);
+      const value = decoder.decode(line.subarray(valueOffset));
+
+      switch (field) {
+        case 'data':
+          // if this message already has data, append the new value to the old.
+          // otherwise, just set to the new value:
+          message.data = message.data ? message.data + '\n' + value : value; // otherwise,
+          break;
+        case 'event':
+          message.event = value;
+          break;
+        case 'id':
+          message = newMessage();
+          onId?.((message.id = value));
+          break;
+        case 'retry':
+          // eslint-disable-next-line no-case-declarations
+          const retry = parseInt(value, 10);
+          if (!isNaN(retry)) {
+            // per spec, ignore non-integers
+            onRetry?.((message.retry = retry));
+          }
+          break;
+      }
+    }
+  };
+}
+
+function concat(a: Uint8Array, b: Uint8Array) {
+  const res = new Uint8Array(a.length + b.length);
+  res.set(a);
+  res.set(b, a.length);
+  return res;
+}
+
+function newMessage(): EventSourceMessage {
+  // data, event, and id must be initialized to empty strings:
+  // https://html.spec.whatwg.org/multipage/server-sent-events.html#event-stream-interpretation
+  // retry should be initialized to undefined so we return a consistent shape
+  // to the js engine all the time: https://mathiasbynens.be/notes/shapes-ics#takeaways
+  return {
+    data: '',
+    event: '',
+    id: '',
+    retry: undefined,
+  };
+}

--- a/packages/shared/src/http-api/index.ts
+++ b/packages/shared/src/http-api/index.ts
@@ -1,0 +1,4 @@
+export * from './types';
+export * from './events';
+import { Urbit } from './Urbit';
+export { Urbit as default, Urbit };

--- a/packages/shared/src/http-api/types.ts
+++ b/packages/shared/src/http-api/types.ts
@@ -1,0 +1,211 @@
+/**
+ * An urbit style path, rendered as a Javascript string
+ * @example
+ * `"/updates"`
+ */
+export type Path = string;
+
+/**
+ * @p including leading sig, rendered as a string
+ *
+ * @example
+ * ```typescript
+ * "~sampel-palnet"
+ * ```
+ *
+ */
+export type Patp = string;
+
+/**
+ * @p not including leading sig, rendered as a string
+ *
+ * @example
+ * ```typescript
+ * "sampel-palnet"
+ * ```
+ *
+ */
+export type PatpNoSig = string;
+
+/**
+ * The name of a clay mark, as a string
+ *
+ * @example
+ * ```typescript
+ * "graph-update"
+ * ```
+ */
+export type Mark = string;
+
+/**
+ * The name of a gall agent, as a string
+ *
+ * @example
+ *
+ * ```typescript
+ * "graph-store"
+ * ```
+ */
+export type GallAgent = string;
+
+/**
+ * Description of an outgoing poke
+ *
+ * @typeParam Action - Typescript type of the data being poked
+ */
+export interface Poke<Action> {
+  /**
+   * Ship to poke. If left empty, the api lib will populate it with the ship that it is connected to.
+   *
+   * @remarks
+   *
+   * This should always be the ship that you are connected to
+   *
+   */
+  ship?: PatpNoSig;
+  /**
+   */
+  app: GallAgent;
+  /**
+   * Mark of the cage to be poked
+   *
+   */
+  mark: Mark;
+  /**
+   * Vase of the cage of to be poked, as JSON
+   */
+  json: Action;
+}
+
+/**
+ * Description of a scry request
+ */
+export interface Scry {
+  /** {@inheritDoc GallAgent} */
+  app: GallAgent;
+  /** {@inheritDoc Path} */
+  path: Path;
+}
+
+/**
+ * Description of a thread request
+ *
+ * @typeParam Action - Typescript type of the data being poked
+ */
+export interface Thread<Action> {
+  /**
+   * The mark of the input vase
+   */
+  inputMark: Mark;
+  /**
+   * The mark of the output vase
+   */
+  outputMark: Mark;
+  /**
+   * Name of the thread
+   *
+   * @example
+   * ```typescript
+   * "graph-add-nodes"
+   * ```
+   */
+  threadName: string;
+  /**
+   * Desk of thread
+   */
+  desk?: string;
+  /**
+   * Data of the input vase
+   */
+  body: Action;
+}
+
+export type Action = 'poke' | 'subscribe' | 'ack' | 'unsubscribe' | 'delete';
+
+export interface PokeHandlers {
+  onSuccess?: () => void;
+  onError?: (e: any) => void;
+}
+
+export type PokeInterface<T> = PokeHandlers & Poke<T>;
+
+export interface AuthenticationInterface {
+  ship: string;
+  url: string;
+  code: string;
+  verbose?: boolean;
+}
+
+/**
+ * Subscription event handlers
+ *
+ */
+export interface SubscriptionInterface {
+  /**
+   * Handle negative %watch-ack
+   */
+  err?(error: any, id: string): void;
+  /**
+   * Handle %fact
+   */
+  event?(data: any, mark: string, id: number): void;
+  /**
+   * Handle %kick
+   */
+  quit?(data: any): void;
+}
+
+export type OnceSubscriptionErr = 'quit' | 'nack' | 'timeout';
+
+export interface SubscriptionRequestInterface extends SubscriptionInterface {
+  /**
+   * The app to subscribe to
+   * @example
+   * `"graph-store"`
+   */
+  app: GallAgent;
+  /**
+   * The path to which to subscribe
+   * @example
+   * `"/keys"`
+   */
+  path: Path;
+  /**
+   * Whether to resubscribe this exact subscription on quit
+   */
+  resubOnQuit?: boolean;
+}
+
+export interface headers {
+  'Content-Type': string;
+  Cookie?: string;
+}
+
+export interface CustomEventHandler {
+  (data: any, response: string): void;
+}
+
+export interface SSEOptions {
+  headers: {
+    Cookie?: string;
+  };
+  withCredentials?: boolean;
+}
+
+export interface Ack extends Record<string, any> {
+  action: Action;
+  'event-id': number;
+}
+
+export interface Message extends Record<string, any> {
+  action: Action;
+  id: number;
+}
+
+export class ResumableError extends Error {}
+
+export class FatalError extends Error {}
+
+export class ReapError extends Error {}
+
+export class AuthError extends Error {}

--- a/packages/shared/src/http-api/utils.ts
+++ b/packages/shared/src/http-api/utils.ts
@@ -1,0 +1,79 @@
+export function camelize(str: string) {
+  return str
+    .replace(/\s(.)/g, function ($1: string) {
+      return $1.toUpperCase();
+    })
+    .replace(/\s/g, '')
+    .replace(/^(.)/, function ($1: string) {
+      return $1.toLowerCase();
+    });
+}
+
+export function uncamelize(str: string, separator = '-') {
+  // Replace all capital letters by separator followed by lowercase one
+  str = str.replace(/[A-Z]/g, function (letter: string) {
+    return separator + letter.toLowerCase();
+  });
+  return str.replace(new RegExp('^' + separator), '');
+}
+
+/**
+ * Returns a hex string of given length.
+ *
+ * Poached from StackOverflow.
+ *
+ * @param len Length of hex string to return.
+ */
+export function hexString(len: number): string {
+  const maxlen = 8;
+  const min = Math.pow(16, Math.min(len, maxlen) - 1);
+  const max = Math.pow(16, Math.min(len, maxlen)) - 1;
+  const n = Math.floor(Math.random() * (max - min + 1)) + min;
+  let r = n.toString(16);
+  while (r.length < len) {
+    r = r + hexString(len - maxlen);
+  }
+  return r;
+}
+
+/**
+ * Generates a random UID.
+ *
+ * Copied from https://github.com/urbit/urbit/blob/137e4428f617c13f28ed31e520eff98d251ed3e9/pkg/interface/src/lib/util.js#L3
+ */
+export function uid(): string {
+  let str = '0v';
+  str += Math.ceil(Math.random() * 8) + '.';
+  for (let i = 0; i < 5; i++) {
+    let _str = Math.ceil(Math.random() * 10000000).toString(32);
+    _str = ('00000' + _str).substr(-5, 5);
+    str += _str + '.';
+  }
+  return str.slice(0, -1);
+}
+
+export default class EventEmitter {
+  private listeners: Record<string, ((...data: any[]) => void)[]> = {};
+
+  on(event: string, callback: (...data: any[]) => void) {
+    if (!(event in this.listeners)) {
+      this.listeners[event] = [];
+    }
+
+    this.listeners[event].push(callback);
+
+    return this;
+  }
+
+  emit(event: string, ...data: any): any {
+    if (!(event in this.listeners)) {
+      return null;
+    }
+
+    for (let i = 0; i < this.listeners[event].length; i++) {
+      const callback = this.listeners[event][i];
+
+      callback.call(this, ...data);
+    }
+  }
+}

--- a/packages/shared/src/store/channelActions.ts
+++ b/packages/shared/src/store/channelActions.ts
@@ -173,7 +173,7 @@ export async function markChannelRead(params: MarkChannelReadParams) {
   try {
     await api.readChannel(params);
   } catch (e) {
-    console.error('Failed to read channel', e);
+    console.error('Failed to read channel', params, e);
     // rollback optimistic update
     if (existingUnread) {
       await db.insertChannelUnreads([existingUnread]);

--- a/packages/shared/src/store/groupActions.ts
+++ b/packages/shared/src/store/groupActions.ts
@@ -994,7 +994,7 @@ export async function markGroupRead(group: db.Group) {
   try {
     await api.readGroup(group);
   } catch (e) {
-    console.error('Failed to read channel', e);
+    console.error('Failed to read group', e);
     // rollback optimistic update
     if (existingUnread) {
       await db.insertGroupUnreads([existingUnread]);

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -342,7 +342,7 @@ importers:
         version: 29.7.0
       '@react-native/metro-config':
         specifier: ^0.73.5
-        version: 0.73.5(@babel/core@7.25.2)(@babel/preset-env@7.23.7(@babel/core@7.25.2))(encoding@0.1.13)
+        version: 0.73.5(@babel/core@7.25.2)(@babel/preset-env@7.23.7(@babel/core@7.25.2))
       '@tamagui/babel-plugin':
         specifier: ~1.112.12
         version: 1.112.12(@swc/helpers@0.5.13)(encoding@0.1.13)(react@18.2.0)
@@ -1566,7 +1566,7 @@ importers:
     dependencies:
       '@10play/tentap-editor':
         specifier: 0.5.11
-        version: 0.5.11(@tiptap/core@2.6.6(@tiptap/pm@2.6.6))(react-native-webview@13.6.4(react-native@0.73.9(@babel/core@7.23.7)(@babel/preset-env@7.23.7(@babel/core@7.23.7))(encoding@0.1.13)(react@18.2.0))(react@18.2.0))(react-native@0.73.9(@babel/core@7.23.7)(@babel/preset-env@7.23.7(@babel/core@7.23.7))(encoding@0.1.13)(react@18.2.0))(react@18.2.0)
+        version: 0.5.11(@tiptap/core@2.6.6(@tiptap/pm@2.6.6))(react-native-webview@13.6.4(react-native@0.73.9(@babel/core@7.25.2)(@babel/preset-env@7.23.7(@babel/core@7.25.2))(encoding@0.1.13)(react@18.2.0))(react@18.2.0))(react-native@0.73.9(@babel/core@7.25.2)(@babel/preset-env@7.23.7(@babel/core@7.25.2))(encoding@0.1.13)(react@18.2.0))(react@18.2.0)
       '@tiptap/core':
         specifier: ^2.6.6
         version: 2.6.6(@tiptap/pm@2.6.6)
@@ -1634,9 +1634,6 @@ importers:
       '@urbit/aura':
         specifier: ^1.0.0
         version: 1.0.0(big-integer@1.6.52)
-      '@urbit/http-api':
-        specifier: 3.2.0-dev
-        version: 3.2.0-dev
       any-ascii:
         specifier: ^0.3.1
         version: 0.3.2(patch_hash=5ofxtlxe6za2xqrbq5pqbz7wb4)
@@ -1655,12 +1652,6 @@ importers:
       react:
         specifier: ^18.2.0
         version: 18.2.0
-      react-native-fetch-api:
-        specifier: ^3.0.0
-        version: 3.0.0
-      react-native-polyfill-globals:
-        specifier: ^3.1.0
-        version: 3.1.0(base-64@1.0.0)(react-native-fetch-api@3.0.0)(react-native-get-random-values@1.11.0(react-native@0.73.9(@babel/core@7.25.2)(@babel/preset-env@7.23.7(@babel/core@7.25.2))(encoding@0.1.13)(react@18.2.0)))(react-native-url-polyfill@2.0.0(react-native@0.73.9(@babel/core@7.25.2)(@babel/preset-env@7.23.7(@babel/core@7.25.2))(encoding@0.1.13)(react@18.2.0)))(text-encoding@0.7.0)(web-streams-polyfill@3.3.3)
       sorted-btree:
         specifier: ^1.8.1
         version: 1.8.1
@@ -13678,43 +13669,6 @@ packages:
 
 snapshots:
 
-  '@10play/tentap-editor@0.5.11(@tiptap/core@2.6.6(@tiptap/pm@2.6.6))(react-native-webview@13.6.4(react-native@0.73.9(@babel/core@7.23.7)(@babel/preset-env@7.23.7(@babel/core@7.23.7))(encoding@0.1.13)(react@18.2.0))(react@18.2.0))(react-native@0.73.9(@babel/core@7.23.7)(@babel/preset-env@7.23.7(@babel/core@7.23.7))(encoding@0.1.13)(react@18.2.0))(react@18.2.0)':
-    dependencies:
-      '@tiptap/extension-blockquote': 2.3.0(@tiptap/core@2.6.6(@tiptap/pm@2.6.6))
-      '@tiptap/extension-bold': 2.3.0(@tiptap/core@2.6.6(@tiptap/pm@2.6.6))
-      '@tiptap/extension-bullet-list': 2.3.0(@tiptap/core@2.6.6(@tiptap/pm@2.6.6))
-      '@tiptap/extension-code': 2.3.0(@tiptap/core@2.6.6(@tiptap/pm@2.6.6))
-      '@tiptap/extension-code-block': 2.3.0(@tiptap/core@2.6.6(@tiptap/pm@2.6.6))(@tiptap/pm@2.6.6)
-      '@tiptap/extension-color': 2.3.0(@tiptap/core@2.6.6(@tiptap/pm@2.6.6))(@tiptap/extension-text-style@2.3.0(@tiptap/core@2.6.6(@tiptap/pm@2.6.6)))
-      '@tiptap/extension-document': 2.3.0(@tiptap/core@2.6.6(@tiptap/pm@2.6.6))
-      '@tiptap/extension-dropcursor': 2.3.0(@tiptap/core@2.6.6(@tiptap/pm@2.6.6))(@tiptap/pm@2.6.6)
-      '@tiptap/extension-hard-break': 2.6.0(@tiptap/core@2.6.6(@tiptap/pm@2.6.6))
-      '@tiptap/extension-heading': 2.3.0(@tiptap/core@2.6.6(@tiptap/pm@2.6.6))
-      '@tiptap/extension-highlight': 2.3.0(@tiptap/core@2.6.6(@tiptap/pm@2.6.6))
-      '@tiptap/extension-history': 2.3.0(@tiptap/core@2.6.6(@tiptap/pm@2.6.6))(@tiptap/pm@2.6.6)
-      '@tiptap/extension-horizontal-rule': 2.3.0(@tiptap/core@2.6.6(@tiptap/pm@2.6.6))(@tiptap/pm@2.6.6)
-      '@tiptap/extension-image': 2.3.0(@tiptap/core@2.6.6(@tiptap/pm@2.6.6))
-      '@tiptap/extension-italic': 2.3.0(@tiptap/core@2.6.6(@tiptap/pm@2.6.6))
-      '@tiptap/extension-link': 2.3.0(@tiptap/core@2.6.6(@tiptap/pm@2.6.6))(@tiptap/pm@2.6.6)
-      '@tiptap/extension-list-item': 2.3.0(@tiptap/core@2.6.6(@tiptap/pm@2.6.6))
-      '@tiptap/extension-ordered-list': 2.3.0(@tiptap/core@2.6.6(@tiptap/pm@2.6.6))
-      '@tiptap/extension-placeholder': 2.3.0(@tiptap/core@2.6.6(@tiptap/pm@2.6.6))(@tiptap/pm@2.6.6)
-      '@tiptap/extension-strike': 2.3.0(@tiptap/core@2.6.6(@tiptap/pm@2.6.6))
-      '@tiptap/extension-task-item': 2.3.0(@tiptap/core@2.6.6(@tiptap/pm@2.6.6))(@tiptap/pm@2.6.6)
-      '@tiptap/extension-task-list': 2.3.0(@tiptap/core@2.6.6(@tiptap/pm@2.6.6))
-      '@tiptap/extension-text-style': 2.3.0(@tiptap/core@2.6.6(@tiptap/pm@2.6.6))
-      '@tiptap/extension-underline': 2.3.0(@tiptap/core@2.6.6(@tiptap/pm@2.6.6))
-      '@tiptap/pm': 2.6.6
-      '@tiptap/react': 2.3.0(@tiptap/core@2.6.6(@tiptap/pm@2.6.6))(@tiptap/pm@2.6.6)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
-      '@tiptap/starter-kit': 2.3.0(@tiptap/pm@2.6.6)
-      lodash: 4.17.21
-      react: 18.2.0
-      react-dom: 18.2.0(react@18.2.0)
-      react-native: 0.73.9(@babel/core@7.23.7)(@babel/preset-env@7.23.7(@babel/core@7.23.7))(encoding@0.1.13)(react@18.2.0)
-      react-native-webview: 13.6.4(react-native@0.73.9(@babel/core@7.23.7)(@babel/preset-env@7.23.7(@babel/core@7.23.7))(encoding@0.1.13)(react@18.2.0))(react@18.2.0)
-    transitivePeerDependencies:
-      - '@tiptap/core'
-
   '@10play/tentap-editor@0.5.11(@tiptap/core@2.6.6(@tiptap/pm@2.6.6))(react-native-webview@13.6.4(react-native@0.73.9(@babel/core@7.25.2)(@babel/preset-env@7.23.7(@babel/core@7.25.2))(encoding@0.1.13)(react@18.2.0))(react@18.2.0))(react-native@0.73.9(@babel/core@7.25.2)(@babel/preset-env@7.23.7(@babel/core@7.25.2))(encoding@0.1.13)(react@18.2.0))(react@18.2.0)':
     dependencies:
       '@tiptap/extension-blockquote': 2.3.0(@tiptap/core@2.6.6(@tiptap/pm@2.6.6))
@@ -14608,19 +14562,6 @@ snapshots:
       lru-cache: 5.1.1
       semver: 6.3.1
 
-  '@babel/helper-create-class-features-plugin@7.23.10(@babel/core@7.23.7)':
-    dependencies:
-      '@babel/core': 7.23.7
-      '@babel/helper-annotate-as-pure': 7.22.5
-      '@babel/helper-environment-visitor': 7.22.20
-      '@babel/helper-function-name': 7.23.0
-      '@babel/helper-member-expression-to-functions': 7.23.0
-      '@babel/helper-optimise-call-expression': 7.22.5
-      '@babel/helper-replace-supers': 7.22.20(@babel/core@7.23.7)
-      '@babel/helper-skip-transparent-expression-wrappers': 7.22.5
-      '@babel/helper-split-export-declaration': 7.22.6
-      semver: 6.3.1
-
   '@babel/helper-create-class-features-plugin@7.23.10(@babel/core@7.25.2)':
     dependencies:
       '@babel/core': 7.25.2
@@ -14634,13 +14575,6 @@ snapshots:
       '@babel/helper-split-export-declaration': 7.22.6
       semver: 6.3.1
 
-  '@babel/helper-create-regexp-features-plugin@7.22.15(@babel/core@7.23.7)':
-    dependencies:
-      '@babel/core': 7.23.7
-      '@babel/helper-annotate-as-pure': 7.24.7
-      regexpu-core: 5.3.2
-      semver: 6.3.1
-
   '@babel/helper-create-regexp-features-plugin@7.22.15(@babel/core@7.25.2)':
     dependencies:
       '@babel/core': 7.25.2
@@ -14648,31 +14582,9 @@ snapshots:
       regexpu-core: 5.3.2
       semver: 6.3.1
 
-  '@babel/helper-define-polyfill-provider@0.4.4(@babel/core@7.23.7)':
-    dependencies:
-      '@babel/core': 7.23.7
-      '@babel/helper-compilation-targets': 7.25.2
-      '@babel/helper-plugin-utils': 7.24.8
-      debug: 4.3.4
-      lodash.debounce: 4.0.8
-      resolve: 1.22.4
-    transitivePeerDependencies:
-      - supports-color
-
   '@babel/helper-define-polyfill-provider@0.4.4(@babel/core@7.25.2)':
     dependencies:
       '@babel/core': 7.25.2
-      '@babel/helper-compilation-targets': 7.25.2
-      '@babel/helper-plugin-utils': 7.24.8
-      debug: 4.3.4
-      lodash.debounce: 4.0.8
-      resolve: 1.22.4
-    transitivePeerDependencies:
-      - supports-color
-
-  '@babel/helper-define-polyfill-provider@0.5.0(@babel/core@7.23.7)':
-    dependencies:
-      '@babel/core': 7.23.7
       '@babel/helper-compilation-targets': 7.25.2
       '@babel/helper-plugin-utils': 7.24.8
       debug: 4.3.4
@@ -14727,16 +14639,6 @@ snapshots:
       '@babel/helper-split-export-declaration': 7.22.6
       '@babel/helper-validator-identifier': 7.22.20
 
-  '@babel/helper-module-transforms@7.25.2(@babel/core@7.23.7)':
-    dependencies:
-      '@babel/core': 7.23.7
-      '@babel/helper-module-imports': 7.24.7
-      '@babel/helper-simple-access': 7.24.7
-      '@babel/helper-validator-identifier': 7.24.7
-      '@babel/traverse': 7.25.6
-    transitivePeerDependencies:
-      - supports-color
-
   '@babel/helper-module-transforms@7.25.2(@babel/core@7.25.2)':
     dependencies:
       '@babel/core': 7.25.2
@@ -14755,26 +14657,12 @@ snapshots:
 
   '@babel/helper-plugin-utils@7.24.8': {}
 
-  '@babel/helper-remap-async-to-generator@7.22.20(@babel/core@7.23.7)':
-    dependencies:
-      '@babel/core': 7.23.7
-      '@babel/helper-annotate-as-pure': 7.24.7
-      '@babel/helper-environment-visitor': 7.22.20
-      '@babel/helper-wrap-function': 7.22.20
-
   '@babel/helper-remap-async-to-generator@7.22.20(@babel/core@7.25.2)':
     dependencies:
       '@babel/core': 7.25.2
       '@babel/helper-annotate-as-pure': 7.24.7
       '@babel/helper-environment-visitor': 7.22.20
       '@babel/helper-wrap-function': 7.22.20
-
-  '@babel/helper-replace-supers@7.22.20(@babel/core@7.23.7)':
-    dependencies:
-      '@babel/core': 7.23.7
-      '@babel/helper-environment-visitor': 7.22.20
-      '@babel/helper-member-expression-to-functions': 7.23.0
-      '@babel/helper-optimise-call-expression': 7.22.5
 
   '@babel/helper-replace-supers@7.22.20(@babel/core@7.25.2)':
     dependencies:
@@ -14858,22 +14746,10 @@ snapshots:
     dependencies:
       '@babel/types': 7.25.6
 
-  '@babel/plugin-bugfix-safari-id-destructuring-collision-in-function-expression@7.23.3(@babel/core@7.23.7)':
-    dependencies:
-      '@babel/core': 7.23.7
-      '@babel/helper-plugin-utils': 7.24.8
-
   '@babel/plugin-bugfix-safari-id-destructuring-collision-in-function-expression@7.23.3(@babel/core@7.25.2)':
     dependencies:
       '@babel/core': 7.25.2
       '@babel/helper-plugin-utils': 7.24.8
-
-  '@babel/plugin-bugfix-v8-spread-parameters-in-optional-chaining@7.23.3(@babel/core@7.23.7)':
-    dependencies:
-      '@babel/core': 7.23.7
-      '@babel/helper-plugin-utils': 7.24.8
-      '@babel/helper-skip-transparent-expression-wrappers': 7.22.5
-      '@babel/plugin-transform-optional-chaining': 7.23.4(@babel/core@7.23.7)
 
   '@babel/plugin-bugfix-v8-spread-parameters-in-optional-chaining@7.23.3(@babel/core@7.25.2)':
     dependencies:
@@ -14882,25 +14758,11 @@ snapshots:
       '@babel/helper-skip-transparent-expression-wrappers': 7.22.5
       '@babel/plugin-transform-optional-chaining': 7.23.4(@babel/core@7.25.2)
 
-  '@babel/plugin-bugfix-v8-static-class-fields-redefine-readonly@7.23.7(@babel/core@7.23.7)':
-    dependencies:
-      '@babel/core': 7.23.7
-      '@babel/helper-environment-visitor': 7.22.20
-      '@babel/helper-plugin-utils': 7.24.8
-
   '@babel/plugin-bugfix-v8-static-class-fields-redefine-readonly@7.23.7(@babel/core@7.25.2)':
     dependencies:
       '@babel/core': 7.25.2
       '@babel/helper-environment-visitor': 7.22.20
       '@babel/helper-plugin-utils': 7.24.8
-
-  '@babel/plugin-proposal-async-generator-functions@7.20.7(@babel/core@7.23.7)':
-    dependencies:
-      '@babel/core': 7.23.7
-      '@babel/helper-environment-visitor': 7.22.20
-      '@babel/helper-plugin-utils': 7.24.8
-      '@babel/helper-remap-async-to-generator': 7.22.20(@babel/core@7.23.7)
-      '@babel/plugin-syntax-async-generators': 7.8.4(@babel/core@7.23.7)
 
   '@babel/plugin-proposal-async-generator-functions@7.20.7(@babel/core@7.25.2)':
     dependencies:
@@ -14909,12 +14771,6 @@ snapshots:
       '@babel/helper-plugin-utils': 7.24.8
       '@babel/helper-remap-async-to-generator': 7.22.20(@babel/core@7.25.2)
       '@babel/plugin-syntax-async-generators': 7.8.4(@babel/core@7.25.2)
-
-  '@babel/plugin-proposal-class-properties@7.18.6(@babel/core@7.23.7)':
-    dependencies:
-      '@babel/core': 7.23.7
-      '@babel/helper-create-class-features-plugin': 7.23.10(@babel/core@7.23.7)
-      '@babel/helper-plugin-utils': 7.24.8
 
   '@babel/plugin-proposal-class-properties@7.18.6(@babel/core@7.25.2)':
     dependencies:
@@ -14929,12 +14785,6 @@ snapshots:
       '@babel/helper-plugin-utils': 7.22.5
       '@babel/plugin-syntax-decorators': 7.23.3(@babel/core@7.25.2)
 
-  '@babel/plugin-proposal-export-default-from@7.23.3(@babel/core@7.23.7)':
-    dependencies:
-      '@babel/core': 7.23.7
-      '@babel/helper-plugin-utils': 7.24.8
-      '@babel/plugin-syntax-export-default-from': 7.23.3(@babel/core@7.23.7)
-
   '@babel/plugin-proposal-export-default-from@7.23.3(@babel/core@7.25.2)':
     dependencies:
       '@babel/core': 7.25.2
@@ -14947,38 +14797,17 @@ snapshots:
       '@babel/helper-plugin-utils': 7.22.5
       '@babel/plugin-syntax-export-namespace-from': 7.8.3(@babel/core@7.25.2)
 
-  '@babel/plugin-proposal-nullish-coalescing-operator@7.18.6(@babel/core@7.23.7)':
-    dependencies:
-      '@babel/core': 7.23.7
-      '@babel/helper-plugin-utils': 7.24.8
-      '@babel/plugin-syntax-nullish-coalescing-operator': 7.8.3(@babel/core@7.23.7)
-
   '@babel/plugin-proposal-nullish-coalescing-operator@7.18.6(@babel/core@7.25.2)':
     dependencies:
       '@babel/core': 7.25.2
       '@babel/helper-plugin-utils': 7.24.8
       '@babel/plugin-syntax-nullish-coalescing-operator': 7.8.3(@babel/core@7.25.2)
 
-  '@babel/plugin-proposal-numeric-separator@7.18.6(@babel/core@7.23.7)':
-    dependencies:
-      '@babel/core': 7.23.7
-      '@babel/helper-plugin-utils': 7.24.8
-      '@babel/plugin-syntax-numeric-separator': 7.10.4(@babel/core@7.23.7)
-
   '@babel/plugin-proposal-numeric-separator@7.18.6(@babel/core@7.25.2)':
     dependencies:
       '@babel/core': 7.25.2
       '@babel/helper-plugin-utils': 7.24.8
       '@babel/plugin-syntax-numeric-separator': 7.10.4(@babel/core@7.25.2)
-
-  '@babel/plugin-proposal-object-rest-spread@7.20.7(@babel/core@7.23.7)':
-    dependencies:
-      '@babel/compat-data': 7.25.2
-      '@babel/core': 7.23.7
-      '@babel/helper-compilation-targets': 7.25.2
-      '@babel/helper-plugin-utils': 7.24.8
-      '@babel/plugin-syntax-object-rest-spread': 7.8.3(@babel/core@7.23.7)
-      '@babel/plugin-transform-parameters': 7.23.3(@babel/core@7.23.7)
 
   '@babel/plugin-proposal-object-rest-spread@7.20.7(@babel/core@7.25.2)':
     dependencies:
@@ -14989,24 +14818,11 @@ snapshots:
       '@babel/plugin-syntax-object-rest-spread': 7.8.3(@babel/core@7.25.2)
       '@babel/plugin-transform-parameters': 7.23.3(@babel/core@7.25.2)
 
-  '@babel/plugin-proposal-optional-catch-binding@7.18.6(@babel/core@7.23.7)':
-    dependencies:
-      '@babel/core': 7.23.7
-      '@babel/helper-plugin-utils': 7.24.8
-      '@babel/plugin-syntax-optional-catch-binding': 7.8.3(@babel/core@7.23.7)
-
   '@babel/plugin-proposal-optional-catch-binding@7.18.6(@babel/core@7.25.2)':
     dependencies:
       '@babel/core': 7.25.2
       '@babel/helper-plugin-utils': 7.24.8
       '@babel/plugin-syntax-optional-catch-binding': 7.8.3(@babel/core@7.25.2)
-
-  '@babel/plugin-proposal-optional-chaining@7.21.0(@babel/core@7.23.7)':
-    dependencies:
-      '@babel/core': 7.23.7
-      '@babel/helper-plugin-utils': 7.24.8
-      '@babel/helper-skip-transparent-expression-wrappers': 7.22.5
-      '@babel/plugin-syntax-optional-chaining': 7.8.3(@babel/core@7.23.7)
 
   '@babel/plugin-proposal-optional-chaining@7.21.0(@babel/core@7.25.2)':
     dependencies:
@@ -15015,18 +14831,9 @@ snapshots:
       '@babel/helper-skip-transparent-expression-wrappers': 7.22.5
       '@babel/plugin-syntax-optional-chaining': 7.8.3(@babel/core@7.25.2)
 
-  '@babel/plugin-proposal-private-property-in-object@7.21.0-placeholder-for-preset-env.2(@babel/core@7.23.7)':
-    dependencies:
-      '@babel/core': 7.23.7
-
   '@babel/plugin-proposal-private-property-in-object@7.21.0-placeholder-for-preset-env.2(@babel/core@7.25.2)':
     dependencies:
       '@babel/core': 7.25.2
-
-  '@babel/plugin-syntax-async-generators@7.8.4(@babel/core@7.23.7)':
-    dependencies:
-      '@babel/core': 7.23.7
-      '@babel/helper-plugin-utils': 7.24.8
 
   '@babel/plugin-syntax-async-generators@7.8.4(@babel/core@7.25.2)':
     dependencies:
@@ -15038,19 +14845,9 @@ snapshots:
       '@babel/core': 7.25.2
       '@babel/helper-plugin-utils': 7.24.8
 
-  '@babel/plugin-syntax-class-properties@7.12.13(@babel/core@7.23.7)':
-    dependencies:
-      '@babel/core': 7.23.7
-      '@babel/helper-plugin-utils': 7.24.8
-
   '@babel/plugin-syntax-class-properties@7.12.13(@babel/core@7.25.2)':
     dependencies:
       '@babel/core': 7.25.2
-      '@babel/helper-plugin-utils': 7.24.8
-
-  '@babel/plugin-syntax-class-static-block@7.14.5(@babel/core@7.23.7)':
-    dependencies:
-      '@babel/core': 7.23.7
       '@babel/helper-plugin-utils': 7.24.8
 
   '@babel/plugin-syntax-class-static-block@7.14.5(@babel/core@7.25.2)':
@@ -15063,19 +14860,9 @@ snapshots:
       '@babel/core': 7.25.2
       '@babel/helper-plugin-utils': 7.24.8
 
-  '@babel/plugin-syntax-dynamic-import@7.8.3(@babel/core@7.23.7)':
-    dependencies:
-      '@babel/core': 7.23.7
-      '@babel/helper-plugin-utils': 7.24.8
-
   '@babel/plugin-syntax-dynamic-import@7.8.3(@babel/core@7.25.2)':
     dependencies:
       '@babel/core': 7.25.2
-      '@babel/helper-plugin-utils': 7.24.8
-
-  '@babel/plugin-syntax-export-default-from@7.23.3(@babel/core@7.23.7)':
-    dependencies:
-      '@babel/core': 7.23.7
       '@babel/helper-plugin-utils': 7.24.8
 
   '@babel/plugin-syntax-export-default-from@7.23.3(@babel/core@7.25.2)':
@@ -15083,29 +14870,14 @@ snapshots:
       '@babel/core': 7.25.2
       '@babel/helper-plugin-utils': 7.24.8
 
-  '@babel/plugin-syntax-export-namespace-from@7.8.3(@babel/core@7.23.7)':
-    dependencies:
-      '@babel/core': 7.23.7
-      '@babel/helper-plugin-utils': 7.22.5
-
   '@babel/plugin-syntax-export-namespace-from@7.8.3(@babel/core@7.25.2)':
     dependencies:
       '@babel/core': 7.25.2
       '@babel/helper-plugin-utils': 7.22.5
 
-  '@babel/plugin-syntax-flow@7.23.3(@babel/core@7.23.7)':
-    dependencies:
-      '@babel/core': 7.23.7
-      '@babel/helper-plugin-utils': 7.24.8
-
   '@babel/plugin-syntax-flow@7.23.3(@babel/core@7.25.2)':
     dependencies:
       '@babel/core': 7.25.2
-      '@babel/helper-plugin-utils': 7.24.8
-
-  '@babel/plugin-syntax-import-assertions@7.23.3(@babel/core@7.23.7)':
-    dependencies:
-      '@babel/core': 7.23.7
       '@babel/helper-plugin-utils': 7.24.8
 
   '@babel/plugin-syntax-import-assertions@7.23.3(@babel/core@7.25.2)':
@@ -15113,29 +14885,14 @@ snapshots:
       '@babel/core': 7.25.2
       '@babel/helper-plugin-utils': 7.24.8
 
-  '@babel/plugin-syntax-import-attributes@7.23.3(@babel/core@7.23.7)':
-    dependencies:
-      '@babel/core': 7.23.7
-      '@babel/helper-plugin-utils': 7.24.8
-
   '@babel/plugin-syntax-import-attributes@7.23.3(@babel/core@7.25.2)':
     dependencies:
       '@babel/core': 7.25.2
       '@babel/helper-plugin-utils': 7.24.8
 
-  '@babel/plugin-syntax-import-meta@7.10.4(@babel/core@7.23.7)':
-    dependencies:
-      '@babel/core': 7.23.7
-      '@babel/helper-plugin-utils': 7.24.8
-
   '@babel/plugin-syntax-import-meta@7.10.4(@babel/core@7.25.2)':
     dependencies:
       '@babel/core': 7.25.2
-      '@babel/helper-plugin-utils': 7.24.8
-
-  '@babel/plugin-syntax-json-strings@7.8.3(@babel/core@7.23.7)':
-    dependencies:
-      '@babel/core': 7.23.7
       '@babel/helper-plugin-utils': 7.24.8
 
   '@babel/plugin-syntax-json-strings@7.8.3(@babel/core@7.25.2)':
@@ -15148,19 +14905,9 @@ snapshots:
       '@babel/core': 7.25.2
       '@babel/helper-plugin-utils': 7.22.5
 
-  '@babel/plugin-syntax-jsx@7.24.7(@babel/core@7.23.7)':
-    dependencies:
-      '@babel/core': 7.23.7
-      '@babel/helper-plugin-utils': 7.24.8
-
   '@babel/plugin-syntax-jsx@7.24.7(@babel/core@7.25.2)':
     dependencies:
       '@babel/core': 7.25.2
-      '@babel/helper-plugin-utils': 7.24.8
-
-  '@babel/plugin-syntax-logical-assignment-operators@7.10.4(@babel/core@7.23.7)':
-    dependencies:
-      '@babel/core': 7.23.7
       '@babel/helper-plugin-utils': 7.24.8
 
   '@babel/plugin-syntax-logical-assignment-operators@7.10.4(@babel/core@7.25.2)':
@@ -15168,29 +14915,14 @@ snapshots:
       '@babel/core': 7.25.2
       '@babel/helper-plugin-utils': 7.24.8
 
-  '@babel/plugin-syntax-nullish-coalescing-operator@7.8.3(@babel/core@7.23.7)':
-    dependencies:
-      '@babel/core': 7.23.7
-      '@babel/helper-plugin-utils': 7.22.5
-
   '@babel/plugin-syntax-nullish-coalescing-operator@7.8.3(@babel/core@7.25.2)':
     dependencies:
       '@babel/core': 7.25.2
       '@babel/helper-plugin-utils': 7.22.5
 
-  '@babel/plugin-syntax-numeric-separator@7.10.4(@babel/core@7.23.7)':
-    dependencies:
-      '@babel/core': 7.23.7
-      '@babel/helper-plugin-utils': 7.24.8
-
   '@babel/plugin-syntax-numeric-separator@7.10.4(@babel/core@7.25.2)':
     dependencies:
       '@babel/core': 7.25.2
-      '@babel/helper-plugin-utils': 7.24.8
-
-  '@babel/plugin-syntax-object-rest-spread@7.8.3(@babel/core@7.23.7)':
-    dependencies:
-      '@babel/core': 7.23.7
       '@babel/helper-plugin-utils': 7.24.8
 
   '@babel/plugin-syntax-object-rest-spread@7.8.3(@babel/core@7.25.2)':
@@ -15198,39 +14930,19 @@ snapshots:
       '@babel/core': 7.25.2
       '@babel/helper-plugin-utils': 7.24.8
 
-  '@babel/plugin-syntax-optional-catch-binding@7.8.3(@babel/core@7.23.7)':
-    dependencies:
-      '@babel/core': 7.23.7
-      '@babel/helper-plugin-utils': 7.24.8
-
   '@babel/plugin-syntax-optional-catch-binding@7.8.3(@babel/core@7.25.2)':
     dependencies:
       '@babel/core': 7.25.2
       '@babel/helper-plugin-utils': 7.24.8
-
-  '@babel/plugin-syntax-optional-chaining@7.8.3(@babel/core@7.23.7)':
-    dependencies:
-      '@babel/core': 7.23.7
-      '@babel/helper-plugin-utils': 7.22.5
 
   '@babel/plugin-syntax-optional-chaining@7.8.3(@babel/core@7.25.2)':
     dependencies:
       '@babel/core': 7.25.2
       '@babel/helper-plugin-utils': 7.22.5
 
-  '@babel/plugin-syntax-private-property-in-object@7.14.5(@babel/core@7.23.7)':
-    dependencies:
-      '@babel/core': 7.23.7
-      '@babel/helper-plugin-utils': 7.24.8
-
   '@babel/plugin-syntax-private-property-in-object@7.14.5(@babel/core@7.25.2)':
     dependencies:
       '@babel/core': 7.25.2
-      '@babel/helper-plugin-utils': 7.24.8
-
-  '@babel/plugin-syntax-top-level-await@7.14.5(@babel/core@7.23.7)':
-    dependencies:
-      '@babel/core': 7.23.7
       '@babel/helper-plugin-utils': 7.24.8
 
   '@babel/plugin-syntax-top-level-await@7.14.5(@babel/core@7.25.2)':
@@ -15238,20 +14950,9 @@ snapshots:
       '@babel/core': 7.25.2
       '@babel/helper-plugin-utils': 7.24.8
 
-  '@babel/plugin-syntax-typescript@7.23.3(@babel/core@7.23.7)':
-    dependencies:
-      '@babel/core': 7.23.7
-      '@babel/helper-plugin-utils': 7.24.8
-
   '@babel/plugin-syntax-typescript@7.23.3(@babel/core@7.25.2)':
     dependencies:
       '@babel/core': 7.25.2
-      '@babel/helper-plugin-utils': 7.24.8
-
-  '@babel/plugin-syntax-unicode-sets-regex@7.18.6(@babel/core@7.23.7)':
-    dependencies:
-      '@babel/core': 7.23.7
-      '@babel/helper-create-regexp-features-plugin': 7.22.15(@babel/core@7.23.7)
       '@babel/helper-plugin-utils': 7.24.8
 
   '@babel/plugin-syntax-unicode-sets-regex@7.18.6(@babel/core@7.25.2)':
@@ -15260,23 +14961,10 @@ snapshots:
       '@babel/helper-create-regexp-features-plugin': 7.22.15(@babel/core@7.25.2)
       '@babel/helper-plugin-utils': 7.24.8
 
-  '@babel/plugin-transform-arrow-functions@7.23.3(@babel/core@7.23.7)':
-    dependencies:
-      '@babel/core': 7.23.7
-      '@babel/helper-plugin-utils': 7.22.5
-
   '@babel/plugin-transform-arrow-functions@7.23.3(@babel/core@7.25.2)':
     dependencies:
       '@babel/core': 7.25.2
       '@babel/helper-plugin-utils': 7.22.5
-
-  '@babel/plugin-transform-async-generator-functions@7.23.9(@babel/core@7.23.7)':
-    dependencies:
-      '@babel/core': 7.23.7
-      '@babel/helper-environment-visitor': 7.22.20
-      '@babel/helper-plugin-utils': 7.24.8
-      '@babel/helper-remap-async-to-generator': 7.22.20(@babel/core@7.23.7)
-      '@babel/plugin-syntax-async-generators': 7.8.4(@babel/core@7.23.7)
 
   '@babel/plugin-transform-async-generator-functions@7.23.9(@babel/core@7.25.2)':
     dependencies:
@@ -15285,15 +14973,6 @@ snapshots:
       '@babel/helper-plugin-utils': 7.24.8
       '@babel/helper-remap-async-to-generator': 7.22.20(@babel/core@7.25.2)
       '@babel/plugin-syntax-async-generators': 7.8.4(@babel/core@7.25.2)
-
-  '@babel/plugin-transform-async-to-generator@7.23.3(@babel/core@7.23.7)':
-    dependencies:
-      '@babel/core': 7.23.7
-      '@babel/helper-module-imports': 7.24.7
-      '@babel/helper-plugin-utils': 7.24.8
-      '@babel/helper-remap-async-to-generator': 7.22.20(@babel/core@7.23.7)
-    transitivePeerDependencies:
-      - supports-color
 
   '@babel/plugin-transform-async-to-generator@7.23.3(@babel/core@7.25.2)':
     dependencies:
@@ -15304,30 +14983,14 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@babel/plugin-transform-block-scoped-functions@7.23.3(@babel/core@7.23.7)':
-    dependencies:
-      '@babel/core': 7.23.7
-      '@babel/helper-plugin-utils': 7.24.8
-
   '@babel/plugin-transform-block-scoped-functions@7.23.3(@babel/core@7.25.2)':
     dependencies:
       '@babel/core': 7.25.2
       '@babel/helper-plugin-utils': 7.24.8
 
-  '@babel/plugin-transform-block-scoping@7.23.4(@babel/core@7.23.7)':
-    dependencies:
-      '@babel/core': 7.23.7
-      '@babel/helper-plugin-utils': 7.24.8
-
   '@babel/plugin-transform-block-scoping@7.23.4(@babel/core@7.25.2)':
     dependencies:
       '@babel/core': 7.25.2
-      '@babel/helper-plugin-utils': 7.24.8
-
-  '@babel/plugin-transform-class-properties@7.23.3(@babel/core@7.23.7)':
-    dependencies:
-      '@babel/core': 7.23.7
-      '@babel/helper-create-class-features-plugin': 7.23.10(@babel/core@7.23.7)
       '@babel/helper-plugin-utils': 7.24.8
 
   '@babel/plugin-transform-class-properties@7.23.3(@babel/core@7.25.2)':
@@ -15336,31 +14999,12 @@ snapshots:
       '@babel/helper-create-class-features-plugin': 7.23.10(@babel/core@7.25.2)
       '@babel/helper-plugin-utils': 7.24.8
 
-  '@babel/plugin-transform-class-static-block@7.23.4(@babel/core@7.23.7)':
-    dependencies:
-      '@babel/core': 7.23.7
-      '@babel/helper-create-class-features-plugin': 7.23.10(@babel/core@7.23.7)
-      '@babel/helper-plugin-utils': 7.24.8
-      '@babel/plugin-syntax-class-static-block': 7.14.5(@babel/core@7.23.7)
-
   '@babel/plugin-transform-class-static-block@7.23.4(@babel/core@7.25.2)':
     dependencies:
       '@babel/core': 7.25.2
       '@babel/helper-create-class-features-plugin': 7.23.10(@babel/core@7.25.2)
       '@babel/helper-plugin-utils': 7.24.8
       '@babel/plugin-syntax-class-static-block': 7.14.5(@babel/core@7.25.2)
-
-  '@babel/plugin-transform-classes@7.23.8(@babel/core@7.23.7)':
-    dependencies:
-      '@babel/core': 7.23.7
-      '@babel/helper-annotate-as-pure': 7.22.5
-      '@babel/helper-compilation-targets': 7.25.2
-      '@babel/helper-environment-visitor': 7.22.20
-      '@babel/helper-function-name': 7.23.0
-      '@babel/helper-plugin-utils': 7.24.8
-      '@babel/helper-replace-supers': 7.22.20(@babel/core@7.23.7)
-      '@babel/helper-split-export-declaration': 7.22.6
-      globals: 11.12.0
 
   '@babel/plugin-transform-classes@7.23.8(@babel/core@7.25.2)':
     dependencies:
@@ -15374,32 +15018,15 @@ snapshots:
       '@babel/helper-split-export-declaration': 7.22.6
       globals: 11.12.0
 
-  '@babel/plugin-transform-computed-properties@7.23.3(@babel/core@7.23.7)':
-    dependencies:
-      '@babel/core': 7.23.7
-      '@babel/helper-plugin-utils': 7.24.8
-      '@babel/template': 7.25.0
-
   '@babel/plugin-transform-computed-properties@7.23.3(@babel/core@7.25.2)':
     dependencies:
       '@babel/core': 7.25.2
       '@babel/helper-plugin-utils': 7.24.8
       '@babel/template': 7.25.0
 
-  '@babel/plugin-transform-destructuring@7.23.3(@babel/core@7.23.7)':
-    dependencies:
-      '@babel/core': 7.23.7
-      '@babel/helper-plugin-utils': 7.24.8
-
   '@babel/plugin-transform-destructuring@7.23.3(@babel/core@7.25.2)':
     dependencies:
       '@babel/core': 7.25.2
-      '@babel/helper-plugin-utils': 7.24.8
-
-  '@babel/plugin-transform-dotall-regex@7.23.3(@babel/core@7.23.7)':
-    dependencies:
-      '@babel/core': 7.23.7
-      '@babel/helper-create-regexp-features-plugin': 7.22.15(@babel/core@7.23.7)
       '@babel/helper-plugin-utils': 7.24.8
 
   '@babel/plugin-transform-dotall-regex@7.23.3(@babel/core@7.25.2)':
@@ -15408,21 +15035,10 @@ snapshots:
       '@babel/helper-create-regexp-features-plugin': 7.22.15(@babel/core@7.25.2)
       '@babel/helper-plugin-utils': 7.24.8
 
-  '@babel/plugin-transform-duplicate-keys@7.23.3(@babel/core@7.23.7)':
-    dependencies:
-      '@babel/core': 7.23.7
-      '@babel/helper-plugin-utils': 7.24.8
-
   '@babel/plugin-transform-duplicate-keys@7.23.3(@babel/core@7.25.2)':
     dependencies:
       '@babel/core': 7.25.2
       '@babel/helper-plugin-utils': 7.24.8
-
-  '@babel/plugin-transform-dynamic-import@7.23.4(@babel/core@7.23.7)':
-    dependencies:
-      '@babel/core': 7.23.7
-      '@babel/helper-plugin-utils': 7.24.8
-      '@babel/plugin-syntax-dynamic-import': 7.8.3(@babel/core@7.23.7)
 
   '@babel/plugin-transform-dynamic-import@7.23.4(@babel/core@7.25.2)':
     dependencies:
@@ -15430,23 +15046,11 @@ snapshots:
       '@babel/helper-plugin-utils': 7.24.8
       '@babel/plugin-syntax-dynamic-import': 7.8.3(@babel/core@7.25.2)
 
-  '@babel/plugin-transform-exponentiation-operator@7.23.3(@babel/core@7.23.7)':
-    dependencies:
-      '@babel/core': 7.23.7
-      '@babel/helper-builder-binary-assignment-operator-visitor': 7.22.15
-      '@babel/helper-plugin-utils': 7.24.8
-
   '@babel/plugin-transform-exponentiation-operator@7.23.3(@babel/core@7.25.2)':
     dependencies:
       '@babel/core': 7.25.2
       '@babel/helper-builder-binary-assignment-operator-visitor': 7.22.15
       '@babel/helper-plugin-utils': 7.24.8
-
-  '@babel/plugin-transform-export-namespace-from@7.23.4(@babel/core@7.23.7)':
-    dependencies:
-      '@babel/core': 7.23.7
-      '@babel/helper-plugin-utils': 7.22.5
-      '@babel/plugin-syntax-export-namespace-from': 7.8.3(@babel/core@7.23.7)
 
   '@babel/plugin-transform-export-namespace-from@7.23.4(@babel/core@7.25.2)':
     dependencies:
@@ -15454,36 +15058,17 @@ snapshots:
       '@babel/helper-plugin-utils': 7.22.5
       '@babel/plugin-syntax-export-namespace-from': 7.8.3(@babel/core@7.25.2)
 
-  '@babel/plugin-transform-flow-strip-types@7.23.3(@babel/core@7.23.7)':
-    dependencies:
-      '@babel/core': 7.23.7
-      '@babel/helper-plugin-utils': 7.24.8
-      '@babel/plugin-syntax-flow': 7.23.3(@babel/core@7.23.7)
-
   '@babel/plugin-transform-flow-strip-types@7.23.3(@babel/core@7.25.2)':
     dependencies:
       '@babel/core': 7.25.2
       '@babel/helper-plugin-utils': 7.24.8
       '@babel/plugin-syntax-flow': 7.23.3(@babel/core@7.25.2)
 
-  '@babel/plugin-transform-for-of@7.23.6(@babel/core@7.23.7)':
-    dependencies:
-      '@babel/core': 7.23.7
-      '@babel/helper-plugin-utils': 7.24.8
-      '@babel/helper-skip-transparent-expression-wrappers': 7.22.5
-
   '@babel/plugin-transform-for-of@7.23.6(@babel/core@7.25.2)':
     dependencies:
       '@babel/core': 7.25.2
       '@babel/helper-plugin-utils': 7.24.8
       '@babel/helper-skip-transparent-expression-wrappers': 7.22.5
-
-  '@babel/plugin-transform-function-name@7.23.3(@babel/core@7.23.7)':
-    dependencies:
-      '@babel/core': 7.23.7
-      '@babel/helper-compilation-targets': 7.25.2
-      '@babel/helper-function-name': 7.23.0
-      '@babel/helper-plugin-utils': 7.24.8
 
   '@babel/plugin-transform-function-name@7.23.3(@babel/core@7.25.2)':
     dependencies:
@@ -15492,33 +15077,16 @@ snapshots:
       '@babel/helper-function-name': 7.23.0
       '@babel/helper-plugin-utils': 7.24.8
 
-  '@babel/plugin-transform-json-strings@7.23.4(@babel/core@7.23.7)':
-    dependencies:
-      '@babel/core': 7.23.7
-      '@babel/helper-plugin-utils': 7.24.8
-      '@babel/plugin-syntax-json-strings': 7.8.3(@babel/core@7.23.7)
-
   '@babel/plugin-transform-json-strings@7.23.4(@babel/core@7.25.2)':
     dependencies:
       '@babel/core': 7.25.2
       '@babel/helper-plugin-utils': 7.24.8
       '@babel/plugin-syntax-json-strings': 7.8.3(@babel/core@7.25.2)
 
-  '@babel/plugin-transform-literals@7.23.3(@babel/core@7.23.7)':
-    dependencies:
-      '@babel/core': 7.23.7
-      '@babel/helper-plugin-utils': 7.24.8
-
   '@babel/plugin-transform-literals@7.23.3(@babel/core@7.25.2)':
     dependencies:
       '@babel/core': 7.25.2
       '@babel/helper-plugin-utils': 7.24.8
-
-  '@babel/plugin-transform-logical-assignment-operators@7.23.4(@babel/core@7.23.7)':
-    dependencies:
-      '@babel/core': 7.23.7
-      '@babel/helper-plugin-utils': 7.24.8
-      '@babel/plugin-syntax-logical-assignment-operators': 7.10.4(@babel/core@7.23.7)
 
   '@babel/plugin-transform-logical-assignment-operators@7.23.4(@babel/core@7.25.2)':
     dependencies:
@@ -15526,23 +15094,10 @@ snapshots:
       '@babel/helper-plugin-utils': 7.24.8
       '@babel/plugin-syntax-logical-assignment-operators': 7.10.4(@babel/core@7.25.2)
 
-  '@babel/plugin-transform-member-expression-literals@7.23.3(@babel/core@7.23.7)':
-    dependencies:
-      '@babel/core': 7.23.7
-      '@babel/helper-plugin-utils': 7.24.8
-
   '@babel/plugin-transform-member-expression-literals@7.23.3(@babel/core@7.25.2)':
     dependencies:
       '@babel/core': 7.25.2
       '@babel/helper-plugin-utils': 7.24.8
-
-  '@babel/plugin-transform-modules-amd@7.23.3(@babel/core@7.23.7)':
-    dependencies:
-      '@babel/core': 7.23.7
-      '@babel/helper-module-transforms': 7.25.2(@babel/core@7.23.7)
-      '@babel/helper-plugin-utils': 7.24.8
-    transitivePeerDependencies:
-      - supports-color
 
   '@babel/plugin-transform-modules-amd@7.23.3(@babel/core@7.25.2)':
     dependencies:
@@ -15552,31 +15107,12 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@babel/plugin-transform-modules-commonjs@7.23.3(@babel/core@7.23.7)':
-    dependencies:
-      '@babel/core': 7.23.7
-      '@babel/helper-module-transforms': 7.25.2(@babel/core@7.23.7)
-      '@babel/helper-plugin-utils': 7.24.8
-      '@babel/helper-simple-access': 7.22.5
-    transitivePeerDependencies:
-      - supports-color
-
   '@babel/plugin-transform-modules-commonjs@7.23.3(@babel/core@7.25.2)':
     dependencies:
       '@babel/core': 7.25.2
       '@babel/helper-module-transforms': 7.25.2(@babel/core@7.25.2)
       '@babel/helper-plugin-utils': 7.24.8
       '@babel/helper-simple-access': 7.22.5
-    transitivePeerDependencies:
-      - supports-color
-
-  '@babel/plugin-transform-modules-systemjs@7.23.9(@babel/core@7.23.7)':
-    dependencies:
-      '@babel/core': 7.23.7
-      '@babel/helper-hoist-variables': 7.22.5
-      '@babel/helper-module-transforms': 7.25.2(@babel/core@7.23.7)
-      '@babel/helper-plugin-utils': 7.24.8
-      '@babel/helper-validator-identifier': 7.22.20
     transitivePeerDependencies:
       - supports-color
 
@@ -15590,14 +15126,6 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@babel/plugin-transform-modules-umd@7.23.3(@babel/core@7.23.7)':
-    dependencies:
-      '@babel/core': 7.23.7
-      '@babel/helper-module-transforms': 7.25.2(@babel/core@7.23.7)
-      '@babel/helper-plugin-utils': 7.24.8
-    transitivePeerDependencies:
-      - supports-color
-
   '@babel/plugin-transform-modules-umd@7.23.3(@babel/core@7.25.2)':
     dependencies:
       '@babel/core': 7.25.2
@@ -15606,21 +15134,10 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@babel/plugin-transform-named-capturing-groups-regex@7.22.5(@babel/core@7.23.7)':
-    dependencies:
-      '@babel/core': 7.23.7
-      '@babel/helper-create-regexp-features-plugin': 7.22.15(@babel/core@7.23.7)
-      '@babel/helper-plugin-utils': 7.24.8
-
   '@babel/plugin-transform-named-capturing-groups-regex@7.22.5(@babel/core@7.25.2)':
     dependencies:
       '@babel/core': 7.25.2
       '@babel/helper-create-regexp-features-plugin': 7.22.15(@babel/core@7.25.2)
-      '@babel/helper-plugin-utils': 7.24.8
-
-  '@babel/plugin-transform-new-target@7.23.3(@babel/core@7.23.7)':
-    dependencies:
-      '@babel/core': 7.23.7
       '@babel/helper-plugin-utils': 7.24.8
 
   '@babel/plugin-transform-new-target@7.23.3(@babel/core@7.25.2)':
@@ -15628,38 +15145,17 @@ snapshots:
       '@babel/core': 7.25.2
       '@babel/helper-plugin-utils': 7.24.8
 
-  '@babel/plugin-transform-nullish-coalescing-operator@7.23.4(@babel/core@7.23.7)':
-    dependencies:
-      '@babel/core': 7.23.7
-      '@babel/helper-plugin-utils': 7.22.5
-      '@babel/plugin-syntax-nullish-coalescing-operator': 7.8.3(@babel/core@7.23.7)
-
   '@babel/plugin-transform-nullish-coalescing-operator@7.23.4(@babel/core@7.25.2)':
     dependencies:
       '@babel/core': 7.25.2
       '@babel/helper-plugin-utils': 7.22.5
       '@babel/plugin-syntax-nullish-coalescing-operator': 7.8.3(@babel/core@7.25.2)
 
-  '@babel/plugin-transform-numeric-separator@7.23.4(@babel/core@7.23.7)':
-    dependencies:
-      '@babel/core': 7.23.7
-      '@babel/helper-plugin-utils': 7.24.8
-      '@babel/plugin-syntax-numeric-separator': 7.10.4(@babel/core@7.23.7)
-
   '@babel/plugin-transform-numeric-separator@7.23.4(@babel/core@7.25.2)':
     dependencies:
       '@babel/core': 7.25.2
       '@babel/helper-plugin-utils': 7.24.8
       '@babel/plugin-syntax-numeric-separator': 7.10.4(@babel/core@7.25.2)
-
-  '@babel/plugin-transform-object-rest-spread@7.23.4(@babel/core@7.23.7)':
-    dependencies:
-      '@babel/compat-data': 7.23.5
-      '@babel/core': 7.23.7
-      '@babel/helper-compilation-targets': 7.23.6
-      '@babel/helper-plugin-utils': 7.22.5
-      '@babel/plugin-syntax-object-rest-spread': 7.8.3(@babel/core@7.23.7)
-      '@babel/plugin-transform-parameters': 7.23.3(@babel/core@7.23.7)
 
   '@babel/plugin-transform-object-rest-spread@7.23.4(@babel/core@7.25.2)':
     dependencies:
@@ -15670,36 +15166,17 @@ snapshots:
       '@babel/plugin-syntax-object-rest-spread': 7.8.3(@babel/core@7.25.2)
       '@babel/plugin-transform-parameters': 7.23.3(@babel/core@7.25.2)
 
-  '@babel/plugin-transform-object-super@7.23.3(@babel/core@7.23.7)':
-    dependencies:
-      '@babel/core': 7.23.7
-      '@babel/helper-plugin-utils': 7.24.8
-      '@babel/helper-replace-supers': 7.22.20(@babel/core@7.23.7)
-
   '@babel/plugin-transform-object-super@7.23.3(@babel/core@7.25.2)':
     dependencies:
       '@babel/core': 7.25.2
       '@babel/helper-plugin-utils': 7.24.8
       '@babel/helper-replace-supers': 7.22.20(@babel/core@7.25.2)
 
-  '@babel/plugin-transform-optional-catch-binding@7.23.4(@babel/core@7.23.7)':
-    dependencies:
-      '@babel/core': 7.23.7
-      '@babel/helper-plugin-utils': 7.24.8
-      '@babel/plugin-syntax-optional-catch-binding': 7.8.3(@babel/core@7.23.7)
-
   '@babel/plugin-transform-optional-catch-binding@7.23.4(@babel/core@7.25.2)':
     dependencies:
       '@babel/core': 7.25.2
       '@babel/helper-plugin-utils': 7.24.8
       '@babel/plugin-syntax-optional-catch-binding': 7.8.3(@babel/core@7.25.2)
-
-  '@babel/plugin-transform-optional-chaining@7.23.4(@babel/core@7.23.7)':
-    dependencies:
-      '@babel/core': 7.23.7
-      '@babel/helper-plugin-utils': 7.22.5
-      '@babel/helper-skip-transparent-expression-wrappers': 7.22.5
-      '@babel/plugin-syntax-optional-chaining': 7.8.3(@babel/core@7.23.7)
 
   '@babel/plugin-transform-optional-chaining@7.23.4(@babel/core@7.25.2)':
     dependencies:
@@ -15708,35 +15185,16 @@ snapshots:
       '@babel/helper-skip-transparent-expression-wrappers': 7.22.5
       '@babel/plugin-syntax-optional-chaining': 7.8.3(@babel/core@7.25.2)
 
-  '@babel/plugin-transform-parameters@7.23.3(@babel/core@7.23.7)':
-    dependencies:
-      '@babel/core': 7.23.7
-      '@babel/helper-plugin-utils': 7.22.5
-
   '@babel/plugin-transform-parameters@7.23.3(@babel/core@7.25.2)':
     dependencies:
       '@babel/core': 7.25.2
       '@babel/helper-plugin-utils': 7.22.5
-
-  '@babel/plugin-transform-private-methods@7.23.3(@babel/core@7.23.7)':
-    dependencies:
-      '@babel/core': 7.23.7
-      '@babel/helper-create-class-features-plugin': 7.23.10(@babel/core@7.23.7)
-      '@babel/helper-plugin-utils': 7.24.8
 
   '@babel/plugin-transform-private-methods@7.23.3(@babel/core@7.25.2)':
     dependencies:
       '@babel/core': 7.25.2
       '@babel/helper-create-class-features-plugin': 7.23.10(@babel/core@7.25.2)
       '@babel/helper-plugin-utils': 7.24.8
-
-  '@babel/plugin-transform-private-property-in-object@7.23.4(@babel/core@7.23.7)':
-    dependencies:
-      '@babel/core': 7.23.7
-      '@babel/helper-annotate-as-pure': 7.22.5
-      '@babel/helper-create-class-features-plugin': 7.23.10(@babel/core@7.23.7)
-      '@babel/helper-plugin-utils': 7.24.8
-      '@babel/plugin-syntax-private-property-in-object': 7.14.5(@babel/core@7.23.7)
 
   '@babel/plugin-transform-private-property-in-object@7.23.4(@babel/core@7.25.2)':
     dependencies:
@@ -15746,19 +15204,9 @@ snapshots:
       '@babel/helper-plugin-utils': 7.24.8
       '@babel/plugin-syntax-private-property-in-object': 7.14.5(@babel/core@7.25.2)
 
-  '@babel/plugin-transform-property-literals@7.23.3(@babel/core@7.23.7)':
-    dependencies:
-      '@babel/core': 7.23.7
-      '@babel/helper-plugin-utils': 7.24.8
-
   '@babel/plugin-transform-property-literals@7.23.3(@babel/core@7.25.2)':
     dependencies:
       '@babel/core': 7.25.2
-      '@babel/helper-plugin-utils': 7.24.8
-
-  '@babel/plugin-transform-react-display-name@7.23.3(@babel/core@7.23.7)':
-    dependencies:
-      '@babel/core': 7.23.7
       '@babel/helper-plugin-utils': 7.24.8
 
   '@babel/plugin-transform-react-display-name@7.23.3(@babel/core@7.25.2)':
@@ -15802,17 +15250,6 @@ snapshots:
       '@babel/plugin-syntax-jsx': 7.23.3(@babel/core@7.25.2)
       '@babel/types': 7.25.6
 
-  '@babel/plugin-transform-react-jsx@7.25.2(@babel/core@7.23.7)':
-    dependencies:
-      '@babel/core': 7.23.7
-      '@babel/helper-annotate-as-pure': 7.24.7
-      '@babel/helper-module-imports': 7.24.7
-      '@babel/helper-plugin-utils': 7.24.8
-      '@babel/plugin-syntax-jsx': 7.24.7(@babel/core@7.23.7)
-      '@babel/types': 7.25.6
-    transitivePeerDependencies:
-      - supports-color
-
   '@babel/plugin-transform-react-jsx@7.25.2(@babel/core@7.25.2)':
     dependencies:
       '@babel/core': 7.25.2
@@ -15830,39 +15267,16 @@ snapshots:
       '@babel/helper-annotate-as-pure': 7.22.5
       '@babel/helper-plugin-utils': 7.24.8
 
-  '@babel/plugin-transform-regenerator@7.23.3(@babel/core@7.23.7)':
-    dependencies:
-      '@babel/core': 7.23.7
-      '@babel/helper-plugin-utils': 7.24.8
-      regenerator-transform: 0.15.2
-
   '@babel/plugin-transform-regenerator@7.23.3(@babel/core@7.25.2)':
     dependencies:
       '@babel/core': 7.25.2
       '@babel/helper-plugin-utils': 7.24.8
       regenerator-transform: 0.15.2
 
-  '@babel/plugin-transform-reserved-words@7.23.3(@babel/core@7.23.7)':
-    dependencies:
-      '@babel/core': 7.23.7
-      '@babel/helper-plugin-utils': 7.24.8
-
   '@babel/plugin-transform-reserved-words@7.23.3(@babel/core@7.25.2)':
     dependencies:
       '@babel/core': 7.25.2
       '@babel/helper-plugin-utils': 7.24.8
-
-  '@babel/plugin-transform-runtime@7.23.9(@babel/core@7.23.7)':
-    dependencies:
-      '@babel/core': 7.23.7
-      '@babel/helper-module-imports': 7.24.7
-      '@babel/helper-plugin-utils': 7.24.8
-      babel-plugin-polyfill-corejs2: 0.4.8(@babel/core@7.23.7)
-      babel-plugin-polyfill-corejs3: 0.9.0(@babel/core@7.23.7)
-      babel-plugin-polyfill-regenerator: 0.5.5(@babel/core@7.23.7)
-      semver: 6.3.1
-    transitivePeerDependencies:
-      - supports-color
 
   '@babel/plugin-transform-runtime@7.23.9(@babel/core@7.25.2)':
     dependencies:
@@ -15876,21 +15290,10 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@babel/plugin-transform-shorthand-properties@7.23.3(@babel/core@7.23.7)':
-    dependencies:
-      '@babel/core': 7.23.7
-      '@babel/helper-plugin-utils': 7.22.5
-
   '@babel/plugin-transform-shorthand-properties@7.23.3(@babel/core@7.25.2)':
     dependencies:
       '@babel/core': 7.25.2
       '@babel/helper-plugin-utils': 7.22.5
-
-  '@babel/plugin-transform-spread@7.23.3(@babel/core@7.23.7)':
-    dependencies:
-      '@babel/core': 7.23.7
-      '@babel/helper-plugin-utils': 7.24.8
-      '@babel/helper-skip-transparent-expression-wrappers': 7.22.5
 
   '@babel/plugin-transform-spread@7.23.3(@babel/core@7.25.2)':
     dependencies:
@@ -15898,43 +15301,20 @@ snapshots:
       '@babel/helper-plugin-utils': 7.24.8
       '@babel/helper-skip-transparent-expression-wrappers': 7.22.5
 
-  '@babel/plugin-transform-sticky-regex@7.23.3(@babel/core@7.23.7)':
-    dependencies:
-      '@babel/core': 7.23.7
-      '@babel/helper-plugin-utils': 7.24.8
-
   '@babel/plugin-transform-sticky-regex@7.23.3(@babel/core@7.25.2)':
     dependencies:
       '@babel/core': 7.25.2
       '@babel/helper-plugin-utils': 7.24.8
-
-  '@babel/plugin-transform-template-literals@7.23.3(@babel/core@7.23.7)':
-    dependencies:
-      '@babel/core': 7.23.7
-      '@babel/helper-plugin-utils': 7.22.5
 
   '@babel/plugin-transform-template-literals@7.23.3(@babel/core@7.25.2)':
     dependencies:
       '@babel/core': 7.25.2
       '@babel/helper-plugin-utils': 7.22.5
 
-  '@babel/plugin-transform-typeof-symbol@7.23.3(@babel/core@7.23.7)':
-    dependencies:
-      '@babel/core': 7.23.7
-      '@babel/helper-plugin-utils': 7.24.8
-
   '@babel/plugin-transform-typeof-symbol@7.23.3(@babel/core@7.25.2)':
     dependencies:
       '@babel/core': 7.25.2
       '@babel/helper-plugin-utils': 7.24.8
-
-  '@babel/plugin-transform-typescript@7.23.6(@babel/core@7.23.7)':
-    dependencies:
-      '@babel/core': 7.23.7
-      '@babel/helper-annotate-as-pure': 7.22.5
-      '@babel/helper-create-class-features-plugin': 7.23.10(@babel/core@7.23.7)
-      '@babel/helper-plugin-utils': 7.22.5
-      '@babel/plugin-syntax-typescript': 7.23.3(@babel/core@7.23.7)
 
   '@babel/plugin-transform-typescript@7.23.6(@babel/core@7.25.2)':
     dependencies:
@@ -15944,20 +15324,9 @@ snapshots:
       '@babel/helper-plugin-utils': 7.22.5
       '@babel/plugin-syntax-typescript': 7.23.3(@babel/core@7.25.2)
 
-  '@babel/plugin-transform-unicode-escapes@7.23.3(@babel/core@7.23.7)':
-    dependencies:
-      '@babel/core': 7.23.7
-      '@babel/helper-plugin-utils': 7.24.8
-
   '@babel/plugin-transform-unicode-escapes@7.23.3(@babel/core@7.25.2)':
     dependencies:
       '@babel/core': 7.25.2
-      '@babel/helper-plugin-utils': 7.24.8
-
-  '@babel/plugin-transform-unicode-property-regex@7.23.3(@babel/core@7.23.7)':
-    dependencies:
-      '@babel/core': 7.23.7
-      '@babel/helper-create-regexp-features-plugin': 7.22.15(@babel/core@7.23.7)
       '@babel/helper-plugin-utils': 7.24.8
 
   '@babel/plugin-transform-unicode-property-regex@7.23.3(@babel/core@7.25.2)':
@@ -15966,22 +15335,10 @@ snapshots:
       '@babel/helper-create-regexp-features-plugin': 7.22.15(@babel/core@7.25.2)
       '@babel/helper-plugin-utils': 7.24.8
 
-  '@babel/plugin-transform-unicode-regex@7.23.3(@babel/core@7.23.7)':
-    dependencies:
-      '@babel/core': 7.23.7
-      '@babel/helper-create-regexp-features-plugin': 7.22.15(@babel/core@7.23.7)
-      '@babel/helper-plugin-utils': 7.24.8
-
   '@babel/plugin-transform-unicode-regex@7.23.3(@babel/core@7.25.2)':
     dependencies:
       '@babel/core': 7.25.2
       '@babel/helper-create-regexp-features-plugin': 7.22.15(@babel/core@7.25.2)
-      '@babel/helper-plugin-utils': 7.24.8
-
-  '@babel/plugin-transform-unicode-sets-regex@7.23.3(@babel/core@7.23.7)':
-    dependencies:
-      '@babel/core': 7.23.7
-      '@babel/helper-create-regexp-features-plugin': 7.22.15(@babel/core@7.23.7)
       '@babel/helper-plugin-utils': 7.24.8
 
   '@babel/plugin-transform-unicode-sets-regex@7.23.3(@babel/core@7.25.2)':
@@ -15989,92 +15346,6 @@ snapshots:
       '@babel/core': 7.25.2
       '@babel/helper-create-regexp-features-plugin': 7.22.15(@babel/core@7.25.2)
       '@babel/helper-plugin-utils': 7.24.8
-
-  '@babel/preset-env@7.23.7(@babel/core@7.23.7)':
-    dependencies:
-      '@babel/compat-data': 7.23.5
-      '@babel/core': 7.23.7
-      '@babel/helper-compilation-targets': 7.23.6
-      '@babel/helper-plugin-utils': 7.22.5
-      '@babel/helper-validator-option': 7.23.5
-      '@babel/plugin-bugfix-safari-id-destructuring-collision-in-function-expression': 7.23.3(@babel/core@7.23.7)
-      '@babel/plugin-bugfix-v8-spread-parameters-in-optional-chaining': 7.23.3(@babel/core@7.23.7)
-      '@babel/plugin-bugfix-v8-static-class-fields-redefine-readonly': 7.23.7(@babel/core@7.23.7)
-      '@babel/plugin-proposal-private-property-in-object': 7.21.0-placeholder-for-preset-env.2(@babel/core@7.23.7)
-      '@babel/plugin-syntax-async-generators': 7.8.4(@babel/core@7.23.7)
-      '@babel/plugin-syntax-class-properties': 7.12.13(@babel/core@7.23.7)
-      '@babel/plugin-syntax-class-static-block': 7.14.5(@babel/core@7.23.7)
-      '@babel/plugin-syntax-dynamic-import': 7.8.3(@babel/core@7.23.7)
-      '@babel/plugin-syntax-export-namespace-from': 7.8.3(@babel/core@7.23.7)
-      '@babel/plugin-syntax-import-assertions': 7.23.3(@babel/core@7.23.7)
-      '@babel/plugin-syntax-import-attributes': 7.23.3(@babel/core@7.23.7)
-      '@babel/plugin-syntax-import-meta': 7.10.4(@babel/core@7.23.7)
-      '@babel/plugin-syntax-json-strings': 7.8.3(@babel/core@7.23.7)
-      '@babel/plugin-syntax-logical-assignment-operators': 7.10.4(@babel/core@7.23.7)
-      '@babel/plugin-syntax-nullish-coalescing-operator': 7.8.3(@babel/core@7.23.7)
-      '@babel/plugin-syntax-numeric-separator': 7.10.4(@babel/core@7.23.7)
-      '@babel/plugin-syntax-object-rest-spread': 7.8.3(@babel/core@7.23.7)
-      '@babel/plugin-syntax-optional-catch-binding': 7.8.3(@babel/core@7.23.7)
-      '@babel/plugin-syntax-optional-chaining': 7.8.3(@babel/core@7.23.7)
-      '@babel/plugin-syntax-private-property-in-object': 7.14.5(@babel/core@7.23.7)
-      '@babel/plugin-syntax-top-level-await': 7.14.5(@babel/core@7.23.7)
-      '@babel/plugin-syntax-unicode-sets-regex': 7.18.6(@babel/core@7.23.7)
-      '@babel/plugin-transform-arrow-functions': 7.23.3(@babel/core@7.23.7)
-      '@babel/plugin-transform-async-generator-functions': 7.23.9(@babel/core@7.23.7)
-      '@babel/plugin-transform-async-to-generator': 7.23.3(@babel/core@7.23.7)
-      '@babel/plugin-transform-block-scoped-functions': 7.23.3(@babel/core@7.23.7)
-      '@babel/plugin-transform-block-scoping': 7.23.4(@babel/core@7.23.7)
-      '@babel/plugin-transform-class-properties': 7.23.3(@babel/core@7.23.7)
-      '@babel/plugin-transform-class-static-block': 7.23.4(@babel/core@7.23.7)
-      '@babel/plugin-transform-classes': 7.23.8(@babel/core@7.23.7)
-      '@babel/plugin-transform-computed-properties': 7.23.3(@babel/core@7.23.7)
-      '@babel/plugin-transform-destructuring': 7.23.3(@babel/core@7.23.7)
-      '@babel/plugin-transform-dotall-regex': 7.23.3(@babel/core@7.23.7)
-      '@babel/plugin-transform-duplicate-keys': 7.23.3(@babel/core@7.23.7)
-      '@babel/plugin-transform-dynamic-import': 7.23.4(@babel/core@7.23.7)
-      '@babel/plugin-transform-exponentiation-operator': 7.23.3(@babel/core@7.23.7)
-      '@babel/plugin-transform-export-namespace-from': 7.23.4(@babel/core@7.23.7)
-      '@babel/plugin-transform-for-of': 7.23.6(@babel/core@7.23.7)
-      '@babel/plugin-transform-function-name': 7.23.3(@babel/core@7.23.7)
-      '@babel/plugin-transform-json-strings': 7.23.4(@babel/core@7.23.7)
-      '@babel/plugin-transform-literals': 7.23.3(@babel/core@7.23.7)
-      '@babel/plugin-transform-logical-assignment-operators': 7.23.4(@babel/core@7.23.7)
-      '@babel/plugin-transform-member-expression-literals': 7.23.3(@babel/core@7.23.7)
-      '@babel/plugin-transform-modules-amd': 7.23.3(@babel/core@7.23.7)
-      '@babel/plugin-transform-modules-commonjs': 7.23.3(@babel/core@7.23.7)
-      '@babel/plugin-transform-modules-systemjs': 7.23.9(@babel/core@7.23.7)
-      '@babel/plugin-transform-modules-umd': 7.23.3(@babel/core@7.23.7)
-      '@babel/plugin-transform-named-capturing-groups-regex': 7.22.5(@babel/core@7.23.7)
-      '@babel/plugin-transform-new-target': 7.23.3(@babel/core@7.23.7)
-      '@babel/plugin-transform-nullish-coalescing-operator': 7.23.4(@babel/core@7.23.7)
-      '@babel/plugin-transform-numeric-separator': 7.23.4(@babel/core@7.23.7)
-      '@babel/plugin-transform-object-rest-spread': 7.23.4(@babel/core@7.23.7)
-      '@babel/plugin-transform-object-super': 7.23.3(@babel/core@7.23.7)
-      '@babel/plugin-transform-optional-catch-binding': 7.23.4(@babel/core@7.23.7)
-      '@babel/plugin-transform-optional-chaining': 7.23.4(@babel/core@7.23.7)
-      '@babel/plugin-transform-parameters': 7.23.3(@babel/core@7.23.7)
-      '@babel/plugin-transform-private-methods': 7.23.3(@babel/core@7.23.7)
-      '@babel/plugin-transform-private-property-in-object': 7.23.4(@babel/core@7.23.7)
-      '@babel/plugin-transform-property-literals': 7.23.3(@babel/core@7.23.7)
-      '@babel/plugin-transform-regenerator': 7.23.3(@babel/core@7.23.7)
-      '@babel/plugin-transform-reserved-words': 7.23.3(@babel/core@7.23.7)
-      '@babel/plugin-transform-shorthand-properties': 7.23.3(@babel/core@7.23.7)
-      '@babel/plugin-transform-spread': 7.23.3(@babel/core@7.23.7)
-      '@babel/plugin-transform-sticky-regex': 7.23.3(@babel/core@7.23.7)
-      '@babel/plugin-transform-template-literals': 7.23.3(@babel/core@7.23.7)
-      '@babel/plugin-transform-typeof-symbol': 7.23.3(@babel/core@7.23.7)
-      '@babel/plugin-transform-unicode-escapes': 7.23.3(@babel/core@7.23.7)
-      '@babel/plugin-transform-unicode-property-regex': 7.23.3(@babel/core@7.23.7)
-      '@babel/plugin-transform-unicode-regex': 7.23.3(@babel/core@7.23.7)
-      '@babel/plugin-transform-unicode-sets-regex': 7.23.3(@babel/core@7.23.7)
-      '@babel/preset-modules': 0.1.6-no-external-plugins(@babel/core@7.23.7)
-      babel-plugin-polyfill-corejs2: 0.4.8(@babel/core@7.23.7)
-      babel-plugin-polyfill-corejs3: 0.8.7(@babel/core@7.23.7)
-      babel-plugin-polyfill-regenerator: 0.5.5(@babel/core@7.23.7)
-      core-js-compat: 3.35.1
-      semver: 6.3.1
-    transitivePeerDependencies:
-      - supports-color
 
   '@babel/preset-env@7.23.7(@babel/core@7.25.2)':
     dependencies:
@@ -16168,13 +15439,6 @@ snapshots:
       '@babel/helper-plugin-utils': 7.24.8
       '@babel/helper-validator-option': 7.24.8
       '@babel/plugin-transform-flow-strip-types': 7.23.3(@babel/core@7.25.2)
-
-  '@babel/preset-modules@0.1.6-no-external-plugins(@babel/core@7.23.7)':
-    dependencies:
-      '@babel/core': 7.23.7
-      '@babel/helper-plugin-utils': 7.24.8
-      '@babel/types': 7.25.6
-      esutils: 2.0.3
 
   '@babel/preset-modules@0.1.6-no-external-plugins(@babel/core@7.25.2)':
     dependencies:
@@ -18552,64 +17816,9 @@ snapshots:
 
   '@react-native/assets-registry@0.73.1': {}
 
-  '@react-native/babel-plugin-codegen@0.73.4(@babel/preset-env@7.23.7(@babel/core@7.23.7))':
-    dependencies:
-      '@react-native/codegen': 0.73.3(@babel/preset-env@7.23.7(@babel/core@7.23.7))
-    transitivePeerDependencies:
-      - '@babel/preset-env'
-      - supports-color
-
   '@react-native/babel-plugin-codegen@0.73.4(@babel/preset-env@7.23.7(@babel/core@7.25.2))':
     dependencies:
       '@react-native/codegen': 0.73.3(@babel/preset-env@7.23.7(@babel/core@7.25.2))
-    transitivePeerDependencies:
-      - '@babel/preset-env'
-      - supports-color
-
-  '@react-native/babel-preset@0.73.21(@babel/core@7.23.7)(@babel/preset-env@7.23.7(@babel/core@7.23.7))':
-    dependencies:
-      '@babel/core': 7.23.7
-      '@babel/plugin-proposal-async-generator-functions': 7.20.7(@babel/core@7.23.7)
-      '@babel/plugin-proposal-class-properties': 7.18.6(@babel/core@7.23.7)
-      '@babel/plugin-proposal-export-default-from': 7.23.3(@babel/core@7.23.7)
-      '@babel/plugin-proposal-nullish-coalescing-operator': 7.18.6(@babel/core@7.23.7)
-      '@babel/plugin-proposal-numeric-separator': 7.18.6(@babel/core@7.23.7)
-      '@babel/plugin-proposal-object-rest-spread': 7.20.7(@babel/core@7.23.7)
-      '@babel/plugin-proposal-optional-catch-binding': 7.18.6(@babel/core@7.23.7)
-      '@babel/plugin-proposal-optional-chaining': 7.21.0(@babel/core@7.23.7)
-      '@babel/plugin-syntax-dynamic-import': 7.8.3(@babel/core@7.23.7)
-      '@babel/plugin-syntax-export-default-from': 7.23.3(@babel/core@7.23.7)
-      '@babel/plugin-syntax-flow': 7.23.3(@babel/core@7.23.7)
-      '@babel/plugin-syntax-nullish-coalescing-operator': 7.8.3(@babel/core@7.23.7)
-      '@babel/plugin-syntax-optional-chaining': 7.8.3(@babel/core@7.23.7)
-      '@babel/plugin-transform-arrow-functions': 7.23.3(@babel/core@7.23.7)
-      '@babel/plugin-transform-async-to-generator': 7.23.3(@babel/core@7.23.7)
-      '@babel/plugin-transform-block-scoping': 7.23.4(@babel/core@7.23.7)
-      '@babel/plugin-transform-classes': 7.23.8(@babel/core@7.23.7)
-      '@babel/plugin-transform-computed-properties': 7.23.3(@babel/core@7.23.7)
-      '@babel/plugin-transform-destructuring': 7.23.3(@babel/core@7.23.7)
-      '@babel/plugin-transform-flow-strip-types': 7.23.3(@babel/core@7.23.7)
-      '@babel/plugin-transform-function-name': 7.23.3(@babel/core@7.23.7)
-      '@babel/plugin-transform-literals': 7.23.3(@babel/core@7.23.7)
-      '@babel/plugin-transform-modules-commonjs': 7.23.3(@babel/core@7.23.7)
-      '@babel/plugin-transform-named-capturing-groups-regex': 7.22.5(@babel/core@7.23.7)
-      '@babel/plugin-transform-parameters': 7.23.3(@babel/core@7.23.7)
-      '@babel/plugin-transform-private-methods': 7.23.3(@babel/core@7.23.7)
-      '@babel/plugin-transform-private-property-in-object': 7.23.4(@babel/core@7.23.7)
-      '@babel/plugin-transform-react-display-name': 7.23.3(@babel/core@7.23.7)
-      '@babel/plugin-transform-react-jsx': 7.25.2(@babel/core@7.23.7)
-      '@babel/plugin-transform-react-jsx-self': 7.23.3(@babel/core@7.23.7)
-      '@babel/plugin-transform-react-jsx-source': 7.23.3(@babel/core@7.23.7)
-      '@babel/plugin-transform-runtime': 7.23.9(@babel/core@7.23.7)
-      '@babel/plugin-transform-shorthand-properties': 7.23.3(@babel/core@7.23.7)
-      '@babel/plugin-transform-spread': 7.23.3(@babel/core@7.23.7)
-      '@babel/plugin-transform-sticky-regex': 7.23.3(@babel/core@7.23.7)
-      '@babel/plugin-transform-typescript': 7.23.6(@babel/core@7.23.7)
-      '@babel/plugin-transform-unicode-regex': 7.23.3(@babel/core@7.23.7)
-      '@babel/template': 7.25.0
-      '@react-native/babel-plugin-codegen': 0.73.4(@babel/preset-env@7.23.7(@babel/core@7.23.7))
-      babel-plugin-transform-flow-enums: 0.0.2(@babel/core@7.23.7)
-      react-refresh: 0.14.0
     transitivePeerDependencies:
       - '@babel/preset-env'
       - supports-color
@@ -18662,19 +17871,6 @@ snapshots:
       - '@babel/preset-env'
       - supports-color
 
-  '@react-native/codegen@0.73.3(@babel/preset-env@7.23.7(@babel/core@7.23.7))':
-    dependencies:
-      '@babel/parser': 7.25.3
-      '@babel/preset-env': 7.23.7(@babel/core@7.23.7)
-      flow-parser: 0.206.0
-      glob: 7.2.3
-      invariant: 2.2.4
-      jscodeshift: 0.14.0(@babel/preset-env@7.23.7(@babel/core@7.23.7))
-      mkdirp: 0.5.6
-      nullthrows: 1.1.1
-    transitivePeerDependencies:
-      - supports-color
-
   '@react-native/codegen@0.73.3(@babel/preset-env@7.23.7(@babel/core@7.25.2))':
     dependencies:
       '@babel/parser': 7.25.3
@@ -18694,27 +17890,6 @@ snapshots:
       '@react-native-community/cli-tools': 12.3.6(encoding@0.1.13)
       '@react-native/dev-middleware': 0.73.8(encoding@0.1.13)
       '@react-native/metro-babel-transformer': 0.73.15(@babel/core@7.25.2)(@babel/preset-env@7.23.7(@babel/core@7.25.2))
-      chalk: 4.1.2
-      execa: 5.1.1
-      metro: 0.80.5(encoding@0.1.13)
-      metro-config: 0.80.5(encoding@0.1.13)
-      metro-core: 0.80.5
-      node-fetch: 2.6.12(encoding@0.1.13)
-      readline: 1.3.0
-    transitivePeerDependencies:
-      - '@babel/core'
-      - '@babel/preset-env'
-      - bufferutil
-      - encoding
-      - supports-color
-      - utf-8-validate
-
-  '@react-native/community-cli-plugin@0.73.18(@babel/core@7.23.7)(@babel/preset-env@7.23.7(@babel/core@7.23.7))(encoding@0.1.13)':
-    dependencies:
-      '@react-native-community/cli-server-api': 12.3.7(encoding@0.1.13)
-      '@react-native-community/cli-tools': 12.3.7(encoding@0.1.13)
-      '@react-native/dev-middleware': 0.73.8(encoding@0.1.13)
-      '@react-native/metro-babel-transformer': 0.73.15(@babel/core@7.23.7)(@babel/preset-env@7.23.7(@babel/core@7.23.7))
       chalk: 4.1.2
       execa: 5.1.1
       metro: 0.80.5(encoding@0.1.13)
@@ -18776,16 +17951,6 @@ snapshots:
 
   '@react-native/js-polyfills@0.73.1': {}
 
-  '@react-native/metro-babel-transformer@0.73.15(@babel/core@7.23.7)(@babel/preset-env@7.23.7(@babel/core@7.23.7))':
-    dependencies:
-      '@babel/core': 7.23.7
-      '@react-native/babel-preset': 0.73.21(@babel/core@7.23.7)(@babel/preset-env@7.23.7(@babel/core@7.23.7))
-      hermes-parser: 0.15.0
-      nullthrows: 1.1.1
-    transitivePeerDependencies:
-      - '@babel/preset-env'
-      - supports-color
-
   '@react-native/metro-babel-transformer@0.73.15(@babel/core@7.25.2)(@babel/preset-env@7.23.7(@babel/core@7.25.2))':
     dependencies:
       '@babel/core': 7.25.2
@@ -18796,7 +17961,7 @@ snapshots:
       - '@babel/preset-env'
       - supports-color
 
-  '@react-native/metro-config@0.73.5(@babel/core@7.25.2)(@babel/preset-env@7.23.7(@babel/core@7.25.2))(encoding@0.1.13)':
+  '@react-native/metro-config@0.73.5(@babel/core@7.25.2)(@babel/preset-env@7.23.7(@babel/core@7.25.2))':
     dependencies:
       '@react-native/js-polyfills': 0.73.1
       '@react-native/metro-babel-transformer': 0.73.15(@babel/core@7.25.2)(@babel/preset-env@7.23.7(@babel/core@7.25.2))
@@ -18805,22 +17970,13 @@ snapshots:
     transitivePeerDependencies:
       - '@babel/core'
       - '@babel/preset-env'
-      - bufferutil
-      - encoding
       - supports-color
-      - utf-8-validate
 
   '@react-native/normalize-color@2.1.0': {}
 
   '@react-native/normalize-colors@0.73.2': {}
 
   '@react-native/normalize-colors@0.74.84': {}
-
-  '@react-native/virtualized-lists@0.73.4(react-native@0.73.9(@babel/core@7.23.7)(@babel/preset-env@7.23.7(@babel/core@7.23.7))(encoding@0.1.13)(react@18.2.0))':
-    dependencies:
-      invariant: 2.2.4
-      nullthrows: 1.1.1
-      react-native: 0.73.9(@babel/core@7.23.7)(@babel/preset-env@7.23.7(@babel/core@7.23.7))(encoding@0.1.13)(react@18.2.0)
 
   '@react-native/virtualized-lists@0.73.4(react-native@0.73.9(@babel/core@7.25.2)(@babel/preset-env@7.23.7(@babel/core@7.25.2))(encoding@0.1.13)(react@18.2.0))':
     dependencies:
@@ -21658,29 +20814,12 @@ snapshots:
       cosmiconfig: 7.1.0
       resolve: 1.22.4
 
-  babel-plugin-polyfill-corejs2@0.4.8(@babel/core@7.23.7):
-    dependencies:
-      '@babel/compat-data': 7.25.2
-      '@babel/core': 7.23.7
-      '@babel/helper-define-polyfill-provider': 0.5.0(@babel/core@7.23.7)
-      semver: 6.3.1
-    transitivePeerDependencies:
-      - supports-color
-
   babel-plugin-polyfill-corejs2@0.4.8(@babel/core@7.25.2):
     dependencies:
       '@babel/compat-data': 7.25.2
       '@babel/core': 7.25.2
       '@babel/helper-define-polyfill-provider': 0.5.0(@babel/core@7.25.2)
       semver: 6.3.1
-    transitivePeerDependencies:
-      - supports-color
-
-  babel-plugin-polyfill-corejs3@0.8.7(@babel/core@7.23.7):
-    dependencies:
-      '@babel/core': 7.23.7
-      '@babel/helper-define-polyfill-provider': 0.4.4(@babel/core@7.23.7)
-      core-js-compat: 3.35.1
     transitivePeerDependencies:
       - supports-color
 
@@ -21692,26 +20831,11 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  babel-plugin-polyfill-corejs3@0.9.0(@babel/core@7.23.7):
-    dependencies:
-      '@babel/core': 7.23.7
-      '@babel/helper-define-polyfill-provider': 0.5.0(@babel/core@7.23.7)
-      core-js-compat: 3.35.1
-    transitivePeerDependencies:
-      - supports-color
-
   babel-plugin-polyfill-corejs3@0.9.0(@babel/core@7.25.2):
     dependencies:
       '@babel/core': 7.25.2
       '@babel/helper-define-polyfill-provider': 0.5.0(@babel/core@7.25.2)
       core-js-compat: 3.35.1
-    transitivePeerDependencies:
-      - supports-color
-
-  babel-plugin-polyfill-regenerator@0.5.5(@babel/core@7.23.7):
-    dependencies:
-      '@babel/core': 7.23.7
-      '@babel/helper-define-polyfill-provider': 0.5.0(@babel/core@7.23.7)
     transitivePeerDependencies:
       - supports-color
 
@@ -21725,12 +20849,6 @@ snapshots:
   babel-plugin-react-native-web@0.18.12: {}
 
   babel-plugin-syntax-trailing-function-commas@7.0.0-beta.0: {}
-
-  babel-plugin-transform-flow-enums@0.0.2(@babel/core@7.23.7):
-    dependencies:
-      '@babel/plugin-syntax-flow': 7.23.3(@babel/core@7.23.7)
-    transitivePeerDependencies:
-      - '@babel/core'
 
   babel-plugin-transform-flow-enums@0.0.2(@babel/core@7.25.2):
     dependencies:
@@ -25262,31 +24380,6 @@ snapshots:
 
   jsc-safe-url@0.2.4: {}
 
-  jscodeshift@0.14.0(@babel/preset-env@7.23.7(@babel/core@7.23.7)):
-    dependencies:
-      '@babel/core': 7.25.2
-      '@babel/parser': 7.25.6
-      '@babel/plugin-proposal-class-properties': 7.18.6(@babel/core@7.25.2)
-      '@babel/plugin-proposal-nullish-coalescing-operator': 7.18.6(@babel/core@7.25.2)
-      '@babel/plugin-proposal-optional-chaining': 7.21.0(@babel/core@7.25.2)
-      '@babel/plugin-transform-modules-commonjs': 7.23.3(@babel/core@7.25.2)
-      '@babel/preset-env': 7.23.7(@babel/core@7.23.7)
-      '@babel/preset-flow': 7.23.3(@babel/core@7.25.2)
-      '@babel/preset-typescript': 7.23.3(@babel/core@7.25.2)
-      '@babel/register': 7.23.7(@babel/core@7.25.2)
-      babel-core: 7.0.0-bridge.0(@babel/core@7.25.2)
-      chalk: 4.1.2
-      flow-parser: 0.206.0
-      graceful-fs: 4.2.10
-      micromatch: 4.0.5
-      neo-async: 2.6.2
-      node-dir: 0.1.17
-      recast: 0.21.5
-      temp: 0.8.4
-      write-file-atomic: 2.4.3
-    transitivePeerDependencies:
-      - supports-color
-
   jscodeshift@0.14.0(@babel/preset-env@7.23.7(@babel/core@7.25.2)):
     dependencies:
       '@babel/core': 7.25.2
@@ -27320,13 +26413,6 @@ snapshots:
     transitivePeerDependencies:
       - encoding
 
-  react-native-webview@13.6.4(react-native@0.73.9(@babel/core@7.23.7)(@babel/preset-env@7.23.7(@babel/core@7.23.7))(encoding@0.1.13)(react@18.2.0))(react@18.2.0):
-    dependencies:
-      escape-string-regexp: 2.0.0
-      invariant: 2.2.4
-      react: 18.2.0
-      react-native: 0.73.9(@babel/core@7.23.7)(@babel/preset-env@7.23.7(@babel/core@7.23.7))(encoding@0.1.13)(react@18.2.0)
-
   react-native-webview@13.6.4(react-native@0.73.9(@babel/core@7.25.2)(@babel/preset-env@7.23.7(@babel/core@7.25.2))(encoding@0.1.13)(react@18.2.0))(react@18.2.0):
     dependencies:
       escape-string-regexp: 2.0.0
@@ -27383,55 +26469,6 @@ snapshots:
       - '@babel/core'
       - '@babel/preset-env'
       - applicationinsights-native-metrics
-      - bufferutil
-      - encoding
-      - supports-color
-      - utf-8-validate
-
-  react-native@0.73.9(@babel/core@7.23.7)(@babel/preset-env@7.23.7(@babel/core@7.23.7))(encoding@0.1.13)(react@18.2.0):
-    dependencies:
-      '@jest/create-cache-key-function': 29.7.0
-      '@react-native-community/cli': 12.3.7(encoding@0.1.13)
-      '@react-native-community/cli-platform-android': 12.3.7(encoding@0.1.13)
-      '@react-native-community/cli-platform-ios': 12.3.7(encoding@0.1.13)
-      '@react-native/assets-registry': 0.73.1
-      '@react-native/codegen': 0.73.3(@babel/preset-env@7.23.7(@babel/core@7.23.7))
-      '@react-native/community-cli-plugin': 0.73.18(@babel/core@7.23.7)(@babel/preset-env@7.23.7(@babel/core@7.23.7))(encoding@0.1.13)
-      '@react-native/gradle-plugin': 0.73.4
-      '@react-native/js-polyfills': 0.73.1
-      '@react-native/normalize-colors': 0.73.2
-      '@react-native/virtualized-lists': 0.73.4(react-native@0.73.9(@babel/core@7.23.7)(@babel/preset-env@7.23.7(@babel/core@7.23.7))(encoding@0.1.13)(react@18.2.0))
-      abort-controller: 3.0.0
-      anser: 1.4.10
-      ansi-regex: 5.0.1
-      base64-js: 1.5.1
-      chalk: 4.1.2
-      deprecated-react-native-prop-types: 5.0.0
-      event-target-shim: 5.0.1
-      flow-enums-runtime: 0.0.6
-      invariant: 2.2.4
-      jest-environment-node: 29.7.0
-      jsc-android: 250231.0.0
-      memoize-one: 5.2.1
-      metro-runtime: 0.80.5
-      metro-source-map: 0.80.5
-      mkdirp: 0.5.6
-      nullthrows: 1.1.1
-      pretty-format: 26.6.2
-      promise: 8.3.0
-      react: 18.2.0
-      react-devtools-core: 4.28.5
-      react-refresh: 0.14.0
-      react-shallow-renderer: 16.15.0(react@18.2.0)
-      regenerator-runtime: 0.13.11
-      scheduler: 0.24.0-canary-efb381bbf-20230505
-      stacktrace-parser: 0.1.10
-      whatwg-fetch: 3.6.20
-      ws: 6.2.2
-      yargs: 17.7.2
-    transitivePeerDependencies:
-      - '@babel/core'
-      - '@babel/preset-env'
       - bufferutil
       - encoding
       - supports-color

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -342,7 +342,7 @@ importers:
         version: 29.7.0
       '@react-native/metro-config':
         specifier: ^0.73.5
-        version: 0.73.5(@babel/core@7.25.2)(@babel/preset-env@7.23.7(@babel/core@7.25.2))
+        version: 0.73.5(@babel/core@7.25.2)(@babel/preset-env@7.23.7(@babel/core@7.25.2))(encoding@0.1.13)
       '@tamagui/babel-plugin':
         specifier: ~1.112.12
         version: 1.112.12(@swc/helpers@0.5.13)(encoding@0.1.13)(react@18.2.0)
@@ -1637,6 +1637,9 @@ importers:
       big-integer:
         specifier: ^1.6.52
         version: 1.6.52
+      browser-or-node:
+        specifier: ^3.0.0
+        version: 3.0.0
       drizzle-orm:
         specifier: 0.30.9
         version: 0.30.9(patch_hash=cegrec33e6f7d6ltk7vff5r7w4)(@op-engineering/op-sqlite@5.0.5(react-native@0.73.9(@babel/core@7.25.2)(@babel/preset-env@7.23.7(@babel/core@7.25.2))(encoding@0.1.13)(react@18.2.0))(react@18.2.0))(@opentelemetry/api@1.8.0)(@types/better-sqlite3@7.6.9)(@types/react@18.2.55)(better-sqlite3@9.4.5)(react@18.2.0)
@@ -1646,6 +1649,12 @@ importers:
       react:
         specifier: ^18.2.0
         version: 18.2.0
+      react-native-fetch-api:
+        specifier: ^3.0.0
+        version: 3.0.0
+      react-native-polyfill-globals:
+        specifier: ^3.1.0
+        version: 3.1.0(base-64@1.0.0)(react-native-fetch-api@3.0.0)(react-native-get-random-values@1.11.0(react-native@0.73.9(@babel/core@7.25.2)(@babel/preset-env@7.23.7(@babel/core@7.25.2))(encoding@0.1.13)(react@18.2.0)))(react-native-url-polyfill@2.0.0(react-native@0.73.9(@babel/core@7.25.2)(@babel/preset-env@7.23.7(@babel/core@7.25.2))(encoding@0.1.13)(react@18.2.0)))(text-encoding@0.7.0)(web-streams-polyfill@3.3.3)
       sorted-btree:
         specifier: ^1.8.1
         version: 1.8.1
@@ -7170,6 +7179,9 @@ packages:
   browser-or-node@1.3.0:
     resolution: {integrity: sha512-0F2z/VSnLbmEeBcUrSuDH5l0HxTXdQQzLjkmBR4cYfvg1zJrKSlmIZFqyFR8oX0NrwPhy3c3HQ6i3OxMbew4Tg==}
 
+  browser-or-node@3.0.0:
+    resolution: {integrity: sha512-iczIdVJzGEYhP5DqQxYM9Hh7Ztpqqi+CXZpSmX8ALFs9ecXkQIeqRyM6TfxEfMVpwhl3dSuDvxdzzo9sUOIVBQ==}
+
   browserslist@4.22.2:
     resolution: {integrity: sha512-0UgcrvQmBDvZHFGdYUehrCNIazki7/lUP3kkoi/r3YB2amZbFM9J43ZRkJTXBUZK4gmx56+Sqk9+Vs9mwZx9+A==}
     engines: {node: ^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7}
@@ -8328,11 +8340,13 @@ packages:
   eslint@8.56.0:
     resolution: {integrity: sha512-Go19xM6T9puCOWntie1/P997aXxFsOi37JIHRWI514Hc6ZnaHGKY9xFhrU65RT6CcBEzZoGG1e6Nq+DT04ZtZQ==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
+    deprecated: This version is no longer supported. Please see https://eslint.org/version-support for other options.
     hasBin: true
 
   eslint@8.57.0:
     resolution: {integrity: sha512-dZ6+mexnaTIbSBZWgou51U6OmzIhYM2VcNdtiTtI7qPNZm35Akpr0f6vtw3w1Kmn5PYo+tZVfh13WrhpS6oLqQ==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
+    deprecated: This version is no longer supported. Please see https://eslint.org/version-support for other options.
     hasBin: true
 
   esm-resolve@1.0.11:
@@ -18776,7 +18790,7 @@ snapshots:
       - '@babel/preset-env'
       - supports-color
 
-  '@react-native/metro-config@0.73.5(@babel/core@7.25.2)(@babel/preset-env@7.23.7(@babel/core@7.25.2))':
+  '@react-native/metro-config@0.73.5(@babel/core@7.25.2)(@babel/preset-env@7.23.7(@babel/core@7.25.2))(encoding@0.1.13)':
     dependencies:
       '@react-native/js-polyfills': 0.73.1
       '@react-native/metro-babel-transformer': 0.73.15(@babel/core@7.25.2)(@babel/preset-env@7.23.7(@babel/core@7.25.2))
@@ -18785,7 +18799,10 @@ snapshots:
     transitivePeerDependencies:
       - '@babel/core'
       - '@babel/preset-env'
+      - bufferutil
+      - encoding
       - supports-color
+      - utf-8-validate
 
   '@react-native/normalize-color@2.1.0': {}
 
@@ -21888,6 +21905,8 @@ snapshots:
       uzip: 0.20201231.0
 
   browser-or-node@1.3.0: {}
+
+  browser-or-node@3.0.0: {}
 
   browserslist@4.22.2:
     dependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1542,6 +1542,12 @@ importers:
       react-native-device-info:
         specifier: ^10.8.0
         version: 10.12.0(react-native@0.73.9(@babel/core@7.25.2)(@babel/preset-env@7.23.7(@babel/core@7.25.2))(encoding@0.1.13)(react@18.2.0))
+      react-native-fetch-api:
+        specifier: ^3.0.0
+        version: 3.0.0
+      react-native-polyfill-globals:
+        specifier: ^3.1.0
+        version: 3.1.0(base-64@1.0.0)(react-native-fetch-api@3.0.0)(react-native-get-random-values@1.11.0(react-native@0.73.9(@babel/core@7.25.2)(@babel/preset-env@7.23.7(@babel/core@7.25.2))(encoding@0.1.13)(react@18.2.0)))(react-native-url-polyfill@2.0.0(react-native@0.73.9(@babel/core@7.25.2)(@babel/preset-env@7.23.7(@babel/core@7.25.2))(encoding@0.1.13)(react@18.2.0)))(text-encoding@0.7.0)(web-streams-polyfill@3.3.3)
       sqlocal:
         specifier: ^0.11.1
         version: 0.11.1(drizzle-orm@0.30.9(patch_hash=cegrec33e6f7d6ltk7vff5r7w4)(@op-engineering/op-sqlite@5.0.5(react-native@0.73.9(@babel/core@7.25.2)(@babel/preset-env@7.23.7(@babel/core@7.25.2))(encoding@0.1.13)(react@18.2.0))(react@18.2.0))(@opentelemetry/api@1.8.0)(@types/better-sqlite3@7.6.9)(@types/react@18.2.55)(better-sqlite3@9.4.5)(react@18.2.0))


### PR DESCRIPTION
This fixes TLON-3092 by changing how we detect when to shove you to login page. We now only do so if we receive a 403 in a scry or if we receive an `AuthError` bubbled up from the http-api.

PR Checklist
- [ ] Includes changes to desk files
- [ ] Describes how you tested the PR locally (test ship vs livenet)
- [ ] If a new feature, includes automated tests
- [ ] Comments added anywhere logic may be confusing without context