### PR TITLE
group channel list: fix long press on arranged channels

### DIFF
--- a/packages/ui/src/components/ChannelNavSection.tsx
+++ b/packages/ui/src/components/ChannelNavSection.tsx
@@ -8,10 +8,12 @@ export default function ChannelNavSection({
   section,
   channels,
   onSelect,
+  onLongPress,
 }: {
   section: db.GroupNavSection;
   channels: db.Channel[];
   onSelect: (channel: any) => void;
+  onLongPress?: (channel: any) => void;
 }) {
   const sectionChannels = useMemo(
     () =>
@@ -46,6 +48,7 @@ export default function ChannelNavSection({
           model={getChannel(item.channelId)!}
           useTypeIcon={true}
           onPress={onSelect}
+          onLongPress={onLongPress}
         />
       ))}
     </YStack>

--- a/packages/ui/src/components/ChannelNavSections.tsx
+++ b/packages/ui/src/components/ChannelNavSections.tsx
@@ -82,6 +82,7 @@ export default function ChannelNavSections({
             section={section}
             channels={sectionChannels}
             onSelect={onSelect}
+            onLongPress={onLongPress}
           />
         );
       })}


### PR DESCRIPTION
OTT, we just weren't passing `onLongPress` to ChannelNavSection and then into ChannelListItem within it.
fixes TLON-3071

