### PR TITLE
input: disable autofocus to fix backspace issue

### DIFF
--- a/packages/ui/src/components/BigInput.native.tsx
+++ b/packages/ui/src/components/BigInput.native.tsx
@@ -1,4 +1,3 @@
-import { EditorBridge } from '@10play/tentap-editor';
 import * as db from '@tloncorp/shared/dist/db';
 import { useMemo, useRef, useState } from 'react';
 import { Dimensions, KeyboardAvoidingView, Platform } from 'react-native';
@@ -154,7 +153,8 @@ export function BigInput({
           placeholder={placeholder}
           bigInput
           channelType={channelType}
-          shouldAutoFocus
+          // TODO: figure out why autofocus breaks backspace
+          // shouldAutoFocus
           draftType={channelType === 'gallery' ? 'text' : undefined}
           ref={editorRef}
         />

--- a/packages/ui/src/components/PostScreenView.tsx
+++ b/packages/ui/src/components/PostScreenView.tsx
@@ -221,10 +221,11 @@ export function PostScreenView({
                   editPost={editPost}
                   channelType="chat"
                   getDraft={getDraft}
-                  shouldAutoFocus={
-                    (channel.type === 'chat' && parentPost?.replyCount === 0) ||
-                    !!editingPost
-                  }
+                  // TODO: figure out why autofocus breaks backspace
+                  // shouldAutoFocus={
+                  // (channel.type === 'chat' && parentPost?.replyCount === 0) ||
+                  // !!editingPost
+                  // }
                   ref={editorRef}
                 />
               )}

--- a/packages/ui/src/components/draftInputs/ChatInput.tsx
+++ b/packages/ui/src/components/draftInputs/ChatInput.tsx
@@ -39,7 +39,8 @@ export function ChatInput({
           setEditingPost={setEditingPost}
           editPost={editPost}
           channelType={channel.type}
-          shouldAutoFocus={!!editingPost}
+          // TODO: figure out why autoFocus breaks backspace
+          // shouldAutoFocus={!!editingPost}
           showInlineAttachments
           showAttachmentButton
         />


### PR DESCRIPTION
The issue is that if we call `editor.focus()` (or if we update the editor state directly to focus it), we lose the ability to backspace.

I can see that we get editor content updates when the backspace button is pressed, but the content never updates.

Tried digging into tentap to figure out if the issue is happening there, doesn't seem to be. 

Tried overriding the default backspace functionality and manually deleting the current node when we hear the backspace key in the webview, doesn't work.

Have ruled out the idea that we're focusing more than once, or attempting to focus when the editor is ready, or we're focusing to the wrong selection.

Have looked through the tentap and tiptap repos for issues that seem similar, can't find any.

Figuring out why this is happening is going to take a while, for now, let's just disable autofocus.

fixes TLON-3102