### PR TITLE
new web: fix build issue

### DIFF
--- a/packages/app/hooks/useConfigureUrbitClient.ts
+++ b/packages/app/hooks/useConfigureUrbitClient.ts
@@ -2,21 +2,15 @@ import { createDevLogger, sync } from '@tloncorp/shared/dist';
 import { ClientParams } from '@tloncorp/shared/dist/api';
 import { configureClient } from '@tloncorp/shared/dist/store';
 import { useCallback } from 'react';
-//@ts-expect-error no typedefs
-import { fetch as streamingFetch } from 'react-native-fetch-api';
-//@ts-expect-error no typedefs
-import { polyfill as polyfillEncoding } from 'react-native-polyfill-globals/src/encoding';
-//@ts-expect-error no typedefs
-import { polyfill as polyfillReadableStream } from 'react-native-polyfill-globals/src/readable-stream';
 
 import { ENABLED_LOGGERS } from '../constants';
 import { useShip } from '../contexts/ship';
 import { getShipAccessCode } from '../lib/hostingApi';
 import { resetDb } from '../lib/nativeDb';
+import { initializePolyfills, platformFetch } from '../platform/polyfills';
 import { useHandleLogout } from './useHandleLogout';
 
-polyfillReadableStream();
-polyfillEncoding();
+initializePolyfills();
 
 let abortController = new AbortController();
 
@@ -49,7 +43,7 @@ const apiFetch: typeof fetch = (input, { ...init } = {}) => {
     // to stream the request.
     reactNative: { textStreaming: true },
   };
-  return streamingFetch(input, newInit);
+  return platformFetch(input, newInit);
 };
 
 export function useConfigureUrbitClient() {

--- a/packages/app/platform/polyfills.native.ts
+++ b/packages/app/platform/polyfills.native.ts
@@ -1,0 +1,13 @@
+//@ts-expect-error no typedefs
+import { fetch as streamingFetch } from 'react-native-fetch-api';
+//@ts-expect-error no typedefs
+import { polyfill as polyfillEncoding } from 'react-native-polyfill-globals/src/encoding';
+//@ts-expect-error no typedefs
+import { polyfill as polyfillReadableStream } from 'react-native-polyfill-globals/src/readable-stream';
+
+export const initializePolyfills = () => {
+  polyfillReadableStream();
+  polyfillEncoding();
+}
+
+export const platformFetch = streamingFetch;

--- a/packages/app/platform/polyfills.ts
+++ b/packages/app/platform/polyfills.ts
@@ -1,0 +1,6 @@
+
+export const initializePolyfills = () => {
+  // no-op
+}
+
+export const platformFetch = window.fetch;


### PR DESCRIPTION
A recent change to useConfigureUrbitClient (introduction of some RN polyfill imports which have no RN web equivalent) was causing the new web app build to fail.

This PR moves the native-only polyfill imports out to a `.native.ts` specific file and adds a `polyfill.ts` file that will work for web.

* [`packages/app/hooks/useConfigureUrbitClient.ts`](diffhunk://#diff-bc28930250131b199032e24e30a8d22cbb30dcfb09b0162d69ee70da46f181e2L5-R13): Replaced individual polyfill calls with `initializePolyfills` and changed the fetch method to `platformFetch`. [[1]](diffhunk://#diff-bc28930250131b199032e24e30a8d22cbb30dcfb09b0162d69ee70da46f181e2L5-R13) [[2]](diffhunk://#diff-bc28930250131b199032e24e30a8d22cbb30dcfb09b0162d69ee70da46f181e2L52-R46)
* [`packages/app/platform/polyfills.native.ts`](diffhunk://#diff-1d2959678e938693b7bd200eb2526d15c5318c220a64fc5f1d252f3bc7156030R1-R13): Added `initializePolyfills` function to handle polyfill initialization and exported `platformFetch` for the native environment.
* [`packages/app/platform/polyfills.ts`](diffhunk://#diff-ccb5efb6fff4e940e30ef5e0c6eec248030852b607f90b937333f31fc664dd97R1-R6): Added `initializePolyfills` function as a no-op and exported `platformFetch` for the web environment.

Tested on iOS simulator, network requests appear to function normally.