### PR TITLE
native: hardcode detail view layout

### DIFF
--- a/packages/shared/src/types/PostCollectionConfiguration.ts
+++ b/packages/shared/src/types/PostCollectionConfiguration.ts
@@ -13,16 +13,13 @@ export type PostCollectionLayoutType =
 // If the caller has a non-nullable `channel`, they can then get a
 // non-nullable return value - nice, right?
 export function layoutTypeFromChannel(
-  channel: db.Channel,
-  detailView?: boolean
+  channel: db.Channel
 ): PostCollectionLayoutType;
 export function layoutTypeFromChannel(
-  channel: db.Channel | null,
-  detailView?: boolean
+  channel: db.Channel | null
 ): PostCollectionLayoutType | null;
 export function layoutTypeFromChannel(
-  channel: db.Channel | null,
-  detailView?: boolean
+  channel: db.Channel | null
 ): PostCollectionLayoutType | null {
   switch (channel?.type) {
     case null:
@@ -38,15 +35,9 @@ export function layoutTypeFromChannel(
       return 'compact-list-bottom-to-top';
 
     case 'notebook':
-      if (detailView) {
-        return 'compact-list-bottom-to-top';
-      }
       return 'comfy-list-top-to-bottom';
 
     case 'gallery':
-      if (detailView) {
-        return 'compact-list-bottom-to-top';
-      }
       return 'grid';
   }
 }

--- a/packages/ui/src/components/Channel/Scroller.tsx
+++ b/packages/ui/src/components/Channel/Scroller.tsx
@@ -1,4 +1,5 @@
 import {
+  PostCollectionLayoutType,
   configurationFromChannel,
   layoutForType,
   layoutTypeFromChannel,
@@ -94,7 +95,7 @@ const Scroller = forwardRef(
       renderEmptyComponent: renderEmptyComponentFn,
       posts,
       channel,
-      detailView,
+      collectionLayoutType,
       firstUnreadId,
       unreadCount,
       onStartReached,
@@ -119,7 +120,7 @@ const Scroller = forwardRef(
       renderEmptyComponent?: () => ReactElement;
       posts: db.Post[] | null;
       channel: db.Channel;
-      detailView?: boolean;
+      collectionLayoutType: PostCollectionLayoutType;
       firstUnreadId?: string | null;
       unreadCount?: number | null;
       onStartReached?: () => void;
@@ -142,10 +143,6 @@ const Scroller = forwardRef(
     },
     ref
   ) => {
-    const collectionLayoutType = useMemo(
-      () => layoutTypeFromChannel(channel, detailView),
-      [channel]
-    );
     const collectionLayout = useMemo(
       () => layoutForType(collectionLayoutType),
       [collectionLayoutType]

--- a/packages/ui/src/components/Channel/index.tsx
+++ b/packages/ui/src/components/Channel/index.tsx
@@ -271,6 +271,11 @@ export function Channel({
     }
   }, [goBack, draftInputPresentationMode, draftInputRef, setEditingPost]);
 
+  const collectionLayoutType = useMemo(
+    () => layoutTypeFromChannel(channel),
+    [channel]
+  );
+
   return (
     <ScrollContextProvider>
       <GroupsProvider groups={groups}>
@@ -328,6 +333,7 @@ export function Channel({
                                     renderEmptyComponent={renderEmptyComponent}
                                     anchor={scrollerAnchor}
                                     posts={posts}
+                                    collectionLayoutType={collectionLayoutType}
                                     hasNewerPosts={hasNewerPosts}
                                     hasOlderPosts={hasOlderPosts}
                                     editingPost={editingPost}

--- a/packages/ui/src/components/DetailView.tsx
+++ b/packages/ui/src/components/DetailView.tsx
@@ -64,7 +64,7 @@ export const DetailView = ({
           inverted
           renderItem={ChatMessage}
           channel={channel}
-          detailView
+          collectionLayoutType="compact-list-bottom-to-top"
           editingPost={editingPost}
           setEditingPost={setEditingPost}
           posts={resolvedPosts ?? null}
@@ -98,7 +98,7 @@ export const DetailView = ({
     setActiveMessage,
     setEditingPost,
     headerMode,
-    channel
+    channel,
   ]);
 
   return isChat ? (


### PR DESCRIPTION
Hardcodes detail view layout instead of adding to `layoutTypeFromChannel`. We may want to revert this in the future to customize detail view layouts, but I would prefer to avoid the complication until we need it – we don't have enough usage yet to know if this is the config "shape" we want yet, and by hardcoding, we can be more agile with the base collection layout type code.

This is a followup from #4087 – [context](https://github.com/tloncorp/tlon-apps/pull/4087#pullrequestreview-2378872029)

Screenshots proving that this still works:
| Notebook detail view | Gallery detail view |
| --- | --- |
| ![Simulator Screenshot - iPhone 16 Pro - 2024-10-22 at 12 07 01](https://github.com/user-attachments/assets/f7852bb0-0f7b-4b06-9c82-ec2e25624688) | ![Simulator Screenshot - iPhone 16 Pro - 2024-10-22 at 12 06 55](https://github.com/user-attachments/assets/e5cfabb0-e042-452d-bae9-b58d17f75392) |
