### PR TITLE
use bare text input for chat input

### DIFF
--- a/packages/shared/src/logic/index.ts
+++ b/packages/shared/src/logic/index.ts
@@ -7,3 +7,4 @@ export * from './activity';
 export * from './branch';
 export * from './deeplinks';
 export * from './analytics';
+export * from './tiptap';

--- a/packages/shared/src/logic/tiptap.ts
+++ b/packages/shared/src/logic/tiptap.ts
@@ -503,7 +503,7 @@ export function JSONToInlines(
   }
 }
 
-const makeText = (t: string) => ({ type: 'text', text: t });
+export const makeText = (t: string) => ({ type: 'text', text: t });
 const makeLink = (link: Link['link']) => ({
   type: 'text',
   marks: [{ type: 'link', attrs: { href: link.href } }],
@@ -846,7 +846,7 @@ export function normalizeInline(inline: Inline[]): Inline[] {
   );
 }
 
-export const REF_REGEX = /\/1\/(chan|group|desk)\/[^\s]+/g;
+const REF_REGEX = /\/1\/(chan|group|desk)\/[^\s]+/g;
 
 export function refPasteRule(onReference: (r: Cite) => void) {
   return new PasteRule({

--- a/packages/ui/src/components/BareChatInput.tsx
+++ b/packages/ui/src/components/BareChatInput.tsx
@@ -1,0 +1,550 @@
+import { extractContentTypesFromPost } from '@tloncorp/shared';
+import { contentReferenceToCite } from '@tloncorp/shared/dist/api';
+import * as db from '@tloncorp/shared/dist/db';
+import {
+  Block,
+  Story,
+  citeToPath,
+  pathToCite,
+} from '@tloncorp/shared/dist/urbit';
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import { Keyboard, TextInput } from 'react-native';
+import { useSafeAreaInsets } from 'react-native-safe-area-context';
+import { getFontSize } from 'tamagui';
+import { Text, View, YStack, getToken, useWindowDimensions } from 'tamagui';
+
+import {
+  Attachment,
+  UploadedImageAttachment,
+  useAttachmentContext,
+} from '../contexts';
+import { DEFAULT_MESSAGE_INPUT_HEIGHT } from './MessageInput';
+import { AttachmentPreviewList } from './MessageInput/AttachmentPreviewList';
+import {
+  MessageInputContainer,
+  MessageInputProps,
+} from './MessageInput/MessageInputBase';
+
+interface Mention {
+  id: string;
+  display: string;
+  start: number;
+  end: number;
+}
+
+export default function BareChatInput({
+  shouldBlur,
+  setShouldBlur,
+  send,
+  channelId,
+  groupMembers,
+  storeDraft,
+  clearDraft,
+  getDraft,
+  editingPost,
+  setEditingPost,
+  editPost,
+  showAttachmentButton,
+  paddingHorizontal,
+  initialHeight = DEFAULT_MESSAGE_INPUT_HEIGHT,
+  backgroundColor,
+  placeholder = 'Message',
+  image,
+  showInlineAttachments,
+  channelType,
+  onSend,
+  goBack,
+  shouldAutoFocus,
+}: MessageInputProps) {
+  const { bottom, top } = useSafeAreaInsets();
+  const { height } = useWindowDimensions();
+  const headerHeight = 48;
+  const maxInputHeightBasic = useMemo(
+    () => height - headerHeight - bottom - top,
+    [height, bottom, top, headerHeight]
+  );
+  const {
+    attachments,
+    addAttachment,
+    clearAttachments,
+    resetAttachments,
+    waitForAttachmentUploads,
+  } = useAttachmentContext();
+  const [text, setText] = useState('');
+  const [mentions, setMentions] = useState<Mention[]>([]);
+  const [isSending, setIsSending] = useState(false);
+  const [sendError, setSendError] = useState(false);
+  const [hasSetInitialContent, setHasSetInitialContent] = useState(false);
+  const [editorIsEmpty, setEditorIsEmpty] = useState(attachments.length === 0);
+  const [showMentionPopup, setShowMentionPopup] = useState(false);
+  const [hasAutoFocused, setHasAutoFocused] = useState(false);
+  const [mentionStartIndex, setMentionStartIndex] = useState<number | null>(
+    null
+  );
+  const [mentionSearchText, setMentionSearchText] = useState<string>('');
+  const [maxInputHeight, setMaxInputHeight] = useState(maxInputHeightBasic);
+  const inputRef = useRef<TextInput>(null);
+
+  const handleTextChange = (newText: string) => {
+    const oldText = text;
+    setText(newText);
+
+    // Check if we're deleting a trigger symbol
+    if (newText.length < oldText.length && showMentionPopup) {
+      const deletedChar = oldText[newText.length];
+      if (deletedChar === '@' || deletedChar === '~') {
+        setShowMentionPopup(false);
+        setMentionStartIndex(null);
+        setMentionSearchText('');
+        return;
+      }
+    }
+
+    // Check for @ symbol
+    const lastAtSymbol = newText.lastIndexOf('@');
+    if (lastAtSymbol >= 0 && lastAtSymbol === newText.length - 1) {
+      setShowMentionPopup(true);
+      setMentionStartIndex(lastAtSymbol);
+      setMentionSearchText('');
+    } else if (showMentionPopup && mentionStartIndex !== null) {
+      // Update mention search text
+      const searchText = newText.slice(mentionStartIndex + 1);
+      if (!searchText.includes(' ')) {
+        setMentionSearchText(searchText);
+      } else {
+        setShowMentionPopup(false);
+        setMentionStartIndex(null);
+        setMentionSearchText('');
+      }
+    }
+
+    // Check for ~ symbol
+    const lastSig = newText.lastIndexOf('~');
+    if (lastSig >= 0 && lastSig === newText.length - 1) {
+      setShowMentionPopup(true);
+      setMentionStartIndex(lastSig);
+      setMentionSearchText('');
+    } else if (showMentionPopup && mentionStartIndex !== null) {
+      // Update mention search text
+      const searchText = newText.slice(mentionStartIndex + 1);
+      if (!searchText.includes(' ')) {
+        setMentionSearchText(searchText);
+      } else {
+        setShowMentionPopup(false);
+        setMentionStartIndex(null);
+        setMentionSearchText('');
+      }
+    }
+
+    // Update mention positions when text changes
+    if (mentions.length > 0) {
+      const updatedMentions = mentions.filter(
+        (mention) =>
+          mention.start <= newText.length &&
+          newText.slice(mention.start, mention.end) === mention.display
+      );
+      if (updatedMentions.length !== mentions.length) {
+        setMentions(updatedMentions);
+      }
+    }
+  };
+
+  const handleSelectMention = useCallback(
+    (contact: db.Contact) => {
+      if (mentionStartIndex === null) return;
+
+      const mentionDisplay = `${contact.id}`;
+      const beforeMention = text.slice(0, mentionStartIndex);
+      const afterMention = text.slice(
+        mentionStartIndex + (mentionSearchText?.length || 0) + 1
+      );
+
+      const newText = beforeMention + mentionDisplay + ' ' + afterMention;
+      const newMention: Mention = {
+        id: contact.id,
+        display: mentionDisplay,
+        start: mentionStartIndex,
+        end: mentionStartIndex + mentionDisplay.length,
+      };
+
+      setText(newText);
+      setMentions((prev) => [...prev, newMention]);
+      setShowMentionPopup(false);
+      setMentionStartIndex(null);
+      setMentionSearchText('');
+
+      // Force focus back to input after mention selection
+      inputRef.current?.focus();
+    },
+    [mentionStartIndex, text, mentionSearchText]
+  );
+
+  const renderTextWithMentions = useMemo(() => {
+    if (!text) {
+      return null;
+    }
+
+    if (mentions.length === 0) {
+      return null;
+    }
+
+    const textParts: JSX.Element[] = [];
+    let lastIndex = 0;
+
+    mentions
+      .sort((a, b) => a.start - b.start)
+      .forEach((mention, index) => {
+        if (mention.start > lastIndex) {
+          textParts.push(
+            <Text key={`text-${index}`} color="transparent">
+              {text.slice(lastIndex, mention.start)}
+            </Text>
+          );
+        }
+
+        textParts.push(
+          <Text
+            key={`mention-${mention.id}`}
+            color="$positiveActionText"
+            backgroundColor="$positiveBackground"
+          >
+            {mention.display}
+          </Text>
+        );
+
+        lastIndex = mention.end;
+      });
+
+    if (lastIndex < text.length) {
+      textParts.push(
+        <Text key="text-end" color="transparent">
+          {text.slice(lastIndex)}
+        </Text>
+      );
+    }
+
+    return (
+      <Text
+        minHeight={initialHeight}
+        maxHeight={maxInputHeight}
+        width="100%"
+        paddingHorizontal="$l"
+        paddingVertical="$s"
+        fontSize="$m"
+        lineHeight="$m"
+      >
+        {textParts}
+      </Text>
+    );
+  }, [mentions, text, initialHeight, maxInputHeight]);
+
+  const sendMessage = useCallback(
+    async (isEdit?: boolean) => {
+      const story: Story = [];
+      // This is where we'll need to parse the text into inlines
+
+      const finalAttachments = await waitForAttachmentUploads();
+
+      const blocks = finalAttachments.flatMap((attachment): Block[] => {
+        if (attachment.type === 'reference') {
+          const cite = pathToCite(attachment.path);
+          return cite ? [{ cite }] : [];
+        }
+        if (
+          attachment.type === 'image' &&
+          (!image || attachment.file.uri !== image?.uri)
+        ) {
+          return [
+            {
+              image: {
+                src: attachment.uploadState.remoteUri,
+                height: attachment.file.height,
+                width: attachment.file.width,
+                alt: 'image',
+              },
+            },
+          ];
+        }
+
+        if (
+          image &&
+          attachment.type === 'image' &&
+          attachment.file.uri === image?.uri &&
+          isEdit &&
+          channelType === 'gallery'
+        ) {
+          return [
+            {
+              image: {
+                src: image.uri,
+                height: image.height,
+                width: image.width,
+                alt: 'image',
+              },
+            },
+          ];
+        }
+
+        return [];
+      });
+
+      if (blocks && blocks.length > 0) {
+        if (channelType === 'chat') {
+          story.unshift(...blocks.map((block) => ({ block })));
+        } else {
+          story.push(...blocks.map((block) => ({ block })));
+        }
+      }
+
+      const metadata: db.PostMetadata = {};
+
+      if (image) {
+        const attachment = finalAttachments.find(
+          (a): a is UploadedImageAttachment =>
+            a.type === 'image' && a.file.uri === image.uri
+        );
+        if (!attachment) {
+          throw new Error('unable to attach image');
+        }
+        metadata['image'] = attachment.uploadState.remoteUri;
+      }
+
+      if (isEdit && editingPost) {
+        if (editingPost.parentId) {
+          await editPost?.(editingPost, story, editingPost.parentId, metadata);
+        }
+        await editPost?.(editingPost, story, undefined, metadata);
+        setEditingPost?.(undefined);
+      } else {
+        // not awaiting since we don't want to wait for the send to complete
+        // before clearing the draft and the editor content
+        send(story, channelId, metadata);
+      }
+
+      onSend?.();
+      setText('');
+      setMentions([]);
+      clearAttachments();
+      clearDraft();
+    },
+    [
+      onSend,
+      waitForAttachmentUploads,
+      editingPost,
+      clearAttachments,
+      clearDraft,
+      editPost,
+      setEditingPost,
+      image,
+      channelType,
+      send,
+      channelId,
+    ]
+  );
+
+  const runSendMessage = useCallback(
+    async (isEdit: boolean) => {
+      setIsSending(true);
+      try {
+        await sendMessage(isEdit);
+      } catch (e) {
+        console.error('failed to send', e);
+        setSendError(true);
+      }
+      setIsSending(false);
+      setSendError(false);
+    },
+    [sendMessage]
+  );
+
+  const handleSend = useCallback(async () => {
+    Keyboard.dismiss();
+    runSendMessage(false);
+  }, [runSendMessage]);
+
+  const handleEdit = useCallback(async () => {
+    Keyboard.dismiss();
+    if (!editingPost) {
+      return;
+    }
+    runSendMessage(true);
+  }, [runSendMessage, editingPost]);
+
+  // Make sure the user can still see some of the scroller when the keyboard is up
+  useEffect(() => {
+    Keyboard.addListener('keyboardDidShow', () => {
+      const keyboardHeight = Keyboard.metrics()?.height || 300;
+      setMaxInputHeight(maxInputHeightBasic - keyboardHeight);
+    });
+
+    Keyboard.addListener('keyboardDidHide', () => {
+      setMaxInputHeight(maxInputHeightBasic);
+    });
+  }, [maxInputHeightBasic]);
+
+  // Handle autofocus
+  useEffect(() => {
+    if (!shouldBlur && shouldAutoFocus && !hasAutoFocused) {
+      inputRef.current?.focus();
+      setHasAutoFocused(true);
+    }
+  }, [shouldBlur, shouldAutoFocus, hasAutoFocused]);
+
+  // Blur input when needed
+  useEffect(() => {
+    if (shouldBlur) {
+      inputRef.current?.blur();
+      setShouldBlur(false);
+    }
+  }, [shouldBlur, setShouldBlur]);
+
+  // Check if editor is empty
+  useEffect(() => {
+    setEditorIsEmpty(text === '' && attachments.length === 0);
+  }, [text, attachments]);
+
+  // Set initial content from draft or post that is being edited
+  useEffect(() => {
+    if (!hasSetInitialContent) {
+      // messageInputLogger.log('Setting initial content');
+      try {
+        getDraft().then((draft) => {
+          if (!editingPost && draft) {
+            // We'll need to parse the draft content here
+            // NOTE: drafts are currently stored as tiptap JSONContent
+            setEditorIsEmpty(false);
+            setHasSetInitialContent(true);
+          }
+
+          if (editingPost && editingPost.content) {
+            const {
+              story,
+              references: postReferences,
+              blocks,
+            } = extractContentTypesFromPost(editingPost);
+
+            if (story === null && !postReferences && blocks.length === 0) {
+              return;
+            }
+
+            const attachments: Attachment[] = [];
+
+            postReferences.forEach((p) => {
+              const cite = contentReferenceToCite(p);
+              const path = citeToPath(cite);
+              attachments.push({
+                type: 'reference',
+                reference: p,
+                path,
+              });
+            });
+
+            blocks.forEach((b) => {
+              if ('image' in b) {
+                attachments.push({
+                  type: 'image',
+                  file: {
+                    uri: b.image.src,
+                    height: b.image.height,
+                    width: b.image.width,
+                  },
+                });
+              }
+            });
+
+            resetAttachments(attachments);
+
+            // We'll need to parse the post content here
+            setEditorIsEmpty(false);
+            setHasSetInitialContent(true);
+          }
+
+          if (editingPost?.image) {
+            addAttachment({
+              type: 'image',
+              file: {
+                uri: editingPost.image,
+                height: 0,
+                width: 0,
+              },
+            });
+          }
+        });
+      } catch (e) {
+        console.error('Error setting initial content', e);
+      }
+    }
+  }, [
+    getDraft,
+    hasSetInitialContent,
+    editingPost,
+    resetAttachments,
+    addAttachment,
+  ]);
+
+  // Store draft when text changes
+  useEffect(() => {
+    // NOTE: drafts are currently stored as tiptap JSONContent
+    // storeDraft(text);
+  }, [text, storeDraft]);
+
+  return (
+    <MessageInputContainer
+      onPressSend={handleSend}
+      setShouldBlur={setShouldBlur}
+      containerHeight={48}
+      disableSend={editorIsEmpty}
+      sendError={sendError}
+      showMentionPopup={showMentionPopup}
+      mentionText={mentionSearchText}
+      showAttachmentButton={showAttachmentButton}
+      groupMembers={groupMembers}
+      onSelectMention={handleSelectMention}
+      isSending={isSending}
+      isEditing={!!editingPost}
+      cancelEditing={() => setEditingPost?.(undefined)}
+      onPressEdit={handleEdit}
+      goBack={goBack}
+    >
+      <YStack
+        flex={1}
+        backgroundColor={backgroundColor}
+        paddingHorizontal={paddingHorizontal}
+        borderColor="$border"
+        borderWidth={1}
+        borderRadius="$xl"
+        maxHeight={maxInputHeight}
+        justifyContent="center"
+      >
+        {showInlineAttachments && <AttachmentPreviewList />}
+        <TextInput
+          ref={inputRef}
+          value={text}
+          onChangeText={handleTextChange}
+          multiline
+          style={{
+            backgroundColor: 'transparent',
+            minHeight: initialHeight,
+            maxHeight: maxInputHeight - getToken('$s', 'size'),
+            paddingHorizontal: getToken('$l', 'space'),
+            paddingVertical: getToken('$s', 'space'),
+            fontSize: getFontSize('$m'),
+            textAlignVertical: 'center',
+            lineHeight: getFontSize('$m') * 1.5,
+          }}
+          placeholder={placeholder}
+        />
+        {mentions.length > 0 && (
+          <View
+            backgroundColor="transparent"
+            position="absolute"
+            pointerEvents="none"
+            justifyContent="center"
+          >
+            {renderTextWithMentions}
+          </View>
+        )}
+      </YStack>
+    </MessageInputContainer>
+  );
+}

--- a/packages/ui/src/components/BareChatInput/helpers.ts
+++ b/packages/ui/src/components/BareChatInput/helpers.ts
@@ -1,0 +1,218 @@
+import { makeMention, makeParagraph, makeText } from '@tloncorp/shared';
+import { JSONContent } from '@tloncorp/shared/dist/urbit';
+
+import { Mention } from './useMentions';
+
+const isBoldStart = (text: string): boolean => {
+  return text.startsWith('**');
+};
+
+const isBoldEnd = (text: string): boolean => {
+  return text.endsWith('**');
+};
+
+const isItalicStart = (text: string): boolean => {
+  return text.startsWith('*');
+};
+
+const isItalicEnd = (text: string): boolean => {
+  return text.endsWith('*');
+};
+
+const isCodeStart = (text: string): boolean => {
+  return text.startsWith('`');
+};
+
+const isCodeEnd = (text: string): boolean => {
+  return text.endsWith('`');
+};
+
+const urlRegex =
+  /(^|[^\w\s])((https?:\/\/|www\.)[^\s,?!.]+(?:[.][^\s,?!.]+)*(?:[^\s,?!.])*)([,?!.])?/;
+
+const isUrl = (text: string): boolean => {
+  return urlRegex.test(text);
+};
+
+const processLine = (line: string, mentions: Mention[]): JSONContent => {
+  const parsedContent: JSONContent[] = [];
+  let isBolding = false;
+  let isItalicizing = false;
+  let isCoding = false;
+  line.split(' ').forEach((word) => {
+    const marks = [];
+    const mention = mentions.find((mention) => mention.display === word);
+    if (mention) {
+      parsedContent.push(makeMention(mention.id));
+      parsedContent.push(makeText(' '));
+      return;
+    }
+
+    if (isUrl(word)) {
+      const match = urlRegex.exec(word);
+      if (match) {
+        const [_, precedingChar, url, , followingChar] = match;
+
+        if (precedingChar && precedingChar !== '') {
+          parsedContent.push(makeText(precedingChar));
+        }
+
+        parsedContent.push({
+          type: 'text',
+          text: url,
+          marks: [
+            {
+              type: 'link',
+              attrs: {
+                href: url,
+              },
+            },
+          ],
+        });
+
+        if (followingChar) {
+          parsedContent.push(makeText(followingChar));
+        }
+
+        parsedContent.push(makeText(' '));
+        return;
+      }
+    }
+
+    if (isCodeStart(word)) {
+      isCoding = true;
+      word = word.slice(1);
+    }
+
+    if (isCoding) {
+      marks.push({ type: 'code' });
+      if (isCodeEnd(word)) {
+        isCoding = false;
+        word = word.slice(0, -1);
+      }
+
+      parsedContent.push({
+        ...makeText(word),
+        marks,
+      });
+
+      parsedContent.push(makeText(' '));
+      return;
+    }
+
+    if (isBoldStart(word)) {
+      isBolding = true;
+      word = word.slice(2);
+    }
+
+    if (isItalicStart(word)) {
+      isItalicizing = true;
+      word = word.slice(1);
+    }
+
+    if (isBolding) {
+      marks.push({ type: 'bold' });
+      if (isBoldEnd(word)) {
+        isBolding = false;
+        word = word.slice(0, -2);
+      }
+    }
+
+    if (isItalicizing) {
+      marks.push({ type: 'italics' });
+      if (isItalicEnd(word)) {
+        isItalicizing = false;
+        word = word.slice(0, -1);
+      }
+    }
+
+    if (marks.length > 0) {
+      parsedContent.push({
+        ...makeText(word),
+        marks,
+      });
+    } else {
+      parsedContent.push(makeText(word));
+    }
+
+    parsedContent.push(makeText(' '));
+  });
+
+  return makeParagraph(parsedContent);
+};
+
+function processTextLines(lines: string[], mentions: Mention[]): JSONContent[] {
+  return lines.map((line) => processLine(line.trim(), mentions));
+}
+
+export function textAndMentionsToContent(
+  text: string,
+  mentions: Mention[]
+): JSONContent {
+  if (text === '') {
+    return [];
+  }
+
+  const lines = text.split('\n');
+  const content: JSONContent[] = [];
+  let currentLines: string[] = [];
+  let inCodeBlock = false;
+  let currentCodeBlock: string[] = [];
+  const language = 'plaintext';
+
+  lines.forEach((line) => {
+    if (line.startsWith('```')) {
+      if (!inCodeBlock) {
+        if (currentLines.length > 0) {
+          content.push(...processTextLines(currentLines, mentions));
+          currentLines = [];
+        }
+
+        inCodeBlock = true;
+      } else {
+        inCodeBlock = false;
+        content.push({
+          type: 'codeBlock',
+          content: [
+            {
+              type: 'text',
+              text: currentCodeBlock.join('\n'),
+            },
+          ],
+          attrs: {
+            language,
+          },
+        });
+        currentCodeBlock = [];
+      }
+    } else if (inCodeBlock) {
+      currentCodeBlock.push(line);
+    } else {
+      currentLines.push(line);
+    }
+  });
+
+  if (inCodeBlock && currentCodeBlock.length > 0) {
+    content.push({
+      type: 'codeBlock',
+      content: [
+        {
+          type: 'text',
+          text: currentCodeBlock.join('\n'),
+        },
+      ],
+      attrs: {
+        language,
+      },
+    });
+  }
+
+  if (currentLines.length > 0) {
+    content.push(...processTextLines(currentLines, mentions));
+  }
+
+  return {
+    type: 'doc',
+    content,
+  };
+}

--- a/packages/ui/src/components/BareChatInput/index.tsx
+++ b/packages/ui/src/components/BareChatInput/index.tsx
@@ -3,7 +3,6 @@ import { contentReferenceToCite } from '@tloncorp/shared/dist/api';
 import * as db from '@tloncorp/shared/dist/db';
 import {
   Block,
-  Story,
   citeToPath,
   constructStory,
   pathToCite,
@@ -170,6 +169,8 @@ export default function BareChatInput({
       const jsonContent = textAndMentionsToContent(text, mentions);
       const inlines = JSONToInlines(jsonContent);
       const story = constructStory(inlines);
+      console.log('jsonContent', jsonContent);
+      console.log('inlines', inlines);
 
       const finalAttachments = await waitForAttachmentUploads();
 

--- a/packages/ui/src/components/BareChatInput/index.tsx
+++ b/packages/ui/src/components/BareChatInput/index.tsx
@@ -20,9 +20,17 @@ import {
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { Keyboard, TextInput } from 'react-native';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
-import { getFontSize } from 'tamagui';
-import { Text, View, YStack, getToken, useWindowDimensions } from 'tamagui';
+import {
+  View,
+  YStack,
+  getFontSize,
+  getToken,
+  getVariableValue,
+  useTheme,
+  useWindowDimensions,
+} from 'tamagui';
 
+import { TlonText } from '../..';
 import {
   Attachment,
   UploadedImageAttachment,
@@ -167,31 +175,31 @@ export default function BareChatInput({
     // Handle text before first mention
     if (sortedMentions[0].start > 0) {
       textParts.push(
-        <Text key="text-start" color="transparent">
+        <TlonText.RawText key="text-start" color="transparent">
           {text.slice(0, sortedMentions[0].start)}
-        </Text>
+        </TlonText.RawText>
       );
     }
 
     // Handle mentions and text between them
     sortedMentions.forEach((mention, index) => {
       textParts.push(
-        <Text
+        <TlonText.Text
           key={`mention-${mention.id}-${index}`}
           color="$positiveActionText"
           backgroundColor="$positiveBackground"
         >
           {mention.display}
-        </Text>
+        </TlonText.Text>
       );
 
       // Add text between this mention and the next one (or end of text)
       const nextStart = sortedMentions[index + 1]?.start ?? text.length;
       if (mention.end < nextStart) {
         textParts.push(
-          <Text key={`text-${index}`} color="transparent">
+          <TlonText.RawText key={`text-${index}`} color="transparent">
             {text.slice(mention.end, nextStart)}
-          </Text>
+          </TlonText.RawText>
         );
       }
     });
@@ -517,23 +525,28 @@ export default function BareChatInput({
             minHeight: initialHeight,
             maxHeight: maxInputHeight - getToken('$s', 'size'),
             paddingHorizontal: getToken('$l', 'space'),
-            paddingVertical: getToken('$s', 'space'),
+            paddingTop: getToken('$m', 'space') + 2,
+            paddingBottom: getToken('$s', 'space'),
             fontSize: getFontSize('$m'),
             textAlignVertical: 'center',
             lineHeight: getFontSize('$m') * 1.5,
+            letterSpacing: -0.032,
+            color: getVariableValue(useTheme().primaryText),
           }}
           placeholder={placeholder}
         />
         {mentions.length > 0 && (
           <View position="absolute" pointerEvents="none">
-            <Text
+            <TlonText.RawText
               paddingHorizontal="$l"
-              paddingBottom="$s"
+              paddingBottom="$xs"
               fontSize="$m"
               lineHeight={getFontSize('$m') * 1.3}
+              letterSpacing={-0.032}
+              color="$primaryText"
             >
               {renderTextWithMentions}
-            </Text>
+            </TlonText.RawText>
           </View>
         )}
       </YStack>

--- a/packages/ui/src/components/BareChatInput/index.tsx
+++ b/packages/ui/src/components/BareChatInput/index.tsx
@@ -30,7 +30,6 @@ import {
   useWindowDimensions,
 } from 'tamagui';
 
-import { TlonText } from '../..';
 import {
   Attachment,
   UploadedImageAttachment,
@@ -42,6 +41,7 @@ import {
   MessageInputContainer,
   MessageInputProps,
 } from '../MessageInput/MessageInputBase';
+import { RawText, Text } from '../TextV2/Text';
 import { contentToTextAndMentions, textAndMentionsToContent } from './helpers';
 import { useMentions } from './useMentions';
 
@@ -175,31 +175,31 @@ export default function BareChatInput({
     // Handle text before first mention
     if (sortedMentions[0].start > 0) {
       textParts.push(
-        <TlonText.RawText key="text-start" color="transparent">
+        <RawText key="text-start" color="transparent">
           {text.slice(0, sortedMentions[0].start)}
-        </TlonText.RawText>
+        </RawText>
       );
     }
 
     // Handle mentions and text between them
     sortedMentions.forEach((mention, index) => {
       textParts.push(
-        <TlonText.Text
+        <Text
           key={`mention-${mention.id}-${index}`}
           color="$positiveActionText"
           backgroundColor="$positiveBackground"
         >
           {mention.display}
-        </TlonText.Text>
+        </Text>
       );
 
       // Add text between this mention and the next one (or end of text)
       const nextStart = sortedMentions[index + 1]?.start ?? text.length;
       if (mention.end < nextStart) {
         textParts.push(
-          <TlonText.RawText key={`text-${index}`} color="transparent">
+          <RawText key={`text-${index}`} color="transparent">
             {text.slice(mention.end, nextStart)}
-          </TlonText.RawText>
+          </RawText>
         );
       }
     });
@@ -540,7 +540,7 @@ export default function BareChatInput({
         />
         {mentions.length > 0 && (
           <View position="absolute" pointerEvents="none">
-            <TlonText.RawText
+            <RawText
               paddingHorizontal="$l"
               paddingTop={Platform.OS === 'android' ? '$s' : 0}
               paddingBottom="$xs"
@@ -550,7 +550,7 @@ export default function BareChatInput({
               color="$primaryText"
             >
               {renderTextWithMentions}
-            </TlonText.RawText>
+            </RawText>
           </View>
         )}
       </YStack>

--- a/packages/ui/src/components/BareChatInput/index.tsx
+++ b/packages/ui/src/components/BareChatInput/index.tsx
@@ -18,7 +18,7 @@ import {
   pathToCite,
 } from '@tloncorp/shared/dist/urbit';
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
-import { Keyboard, TextInput } from 'react-native';
+import { Keyboard, Platform, TextInput } from 'react-native';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
 import {
   View,
@@ -486,6 +486,9 @@ export default function BareChatInput({
     clearAttachments();
   }, [setEditingPost, clearDraft, clearAttachments]);
 
+  const paddingTopAdjustment = Platform.OS === 'ios' ? 2 : 4;
+  const mentionLineHeightAdjustment = Platform.OS === 'ios' ? 1.3 : 1.5;
+
   return (
     <MessageInputContainer
       onPressSend={handleSend}
@@ -525,10 +528,10 @@ export default function BareChatInput({
             minHeight: initialHeight,
             maxHeight: maxInputHeight - getToken('$s', 'size'),
             paddingHorizontal: getToken('$l', 'space'),
-            paddingTop: getToken('$m', 'space') + 2,
+            paddingTop: getToken('$s', 'space') + paddingTopAdjustment,
             paddingBottom: getToken('$s', 'space'),
             fontSize: getFontSize('$m'),
-            textAlignVertical: 'center',
+            textAlignVertical: 'top',
             lineHeight: getFontSize('$m') * 1.5,
             letterSpacing: -0.032,
             color: getVariableValue(useTheme().primaryText),
@@ -539,9 +542,10 @@ export default function BareChatInput({
           <View position="absolute" pointerEvents="none">
             <TlonText.RawText
               paddingHorizontal="$l"
+              paddingTop={Platform.OS === 'android' ? '$s' : 0}
               paddingBottom="$xs"
               fontSize="$m"
-              lineHeight={getFontSize('$m') * 1.3}
+              lineHeight={getFontSize('$m') * mentionLineHeightAdjustment}
               letterSpacing={-0.032}
               color="$primaryText"
             >

--- a/packages/ui/src/components/BareChatInput/index.tsx
+++ b/packages/ui/src/components/BareChatInput/index.tsx
@@ -513,7 +513,6 @@ export default function BareChatInput({
             backgroundColor="transparent"
             position="absolute"
             pointerEvents="none"
-            justifyContent="center"
           >
             {renderTextWithMentions}
           </View>

--- a/packages/ui/src/components/BareChatInput/useMentions.tsx
+++ b/packages/ui/src/components/BareChatInput/useMentions.tsx
@@ -1,7 +1,7 @@
 import * as db from '@tloncorp/shared/dist/db';
 import { useState } from 'react';
 
-interface Mention {
+export interface Mention {
   id: string;
   display: string;
   start: number;

--- a/packages/ui/src/components/BareChatInput/useMentions.tsx
+++ b/packages/ui/src/components/BareChatInput/useMentions.tsx
@@ -1,0 +1,115 @@
+import * as db from '@tloncorp/shared/dist/db';
+import { useState } from 'react';
+
+interface Mention {
+  id: string;
+  display: string;
+  start: number;
+  end: number;
+}
+
+export const useMentions = () => {
+  const [showMentionPopup, setShowMentionPopup] = useState(false);
+  const [mentionStartIndex, setMentionStartIndex] = useState<number | null>(
+    null
+  );
+  const [mentionSearchText, setMentionSearchText] = useState<string>('');
+  const [mentions, setMentions] = useState<Mention[]>([]);
+
+  const handleMention = (oldText: string, newText: string) => {
+    // Check if we're deleting a trigger symbol
+    if (newText.length < oldText.length && showMentionPopup) {
+      const deletedChar = oldText[newText.length];
+      if (deletedChar === '@' || deletedChar === '~') {
+        setShowMentionPopup(false);
+        setMentionStartIndex(null);
+        setMentionSearchText('');
+        return;
+      }
+    }
+
+    // Check for @ symbol
+    const lastAtSymbol = newText.lastIndexOf('@');
+    if (lastAtSymbol >= 0 && lastAtSymbol === newText.length - 1) {
+      setShowMentionPopup(true);
+      setMentionStartIndex(lastAtSymbol);
+      setMentionSearchText('');
+    } else if (showMentionPopup && mentionStartIndex !== null) {
+      // Update mention search text
+      const searchText = newText.slice(mentionStartIndex + 1);
+      if (!searchText.includes(' ')) {
+        setMentionSearchText(searchText);
+      } else {
+        setShowMentionPopup(false);
+        setMentionStartIndex(null);
+        setMentionSearchText('');
+      }
+    }
+
+    // Check for ~ symbol
+    const lastSig = newText.lastIndexOf('~');
+    if (lastSig >= 0 && lastSig === newText.length - 1) {
+      setShowMentionPopup(true);
+      setMentionStartIndex(lastSig);
+      setMentionSearchText('');
+    } else if (showMentionPopup && mentionStartIndex !== null) {
+      // Update mention search text
+      const searchText = newText.slice(mentionStartIndex + 1);
+      if (!searchText.includes(' ')) {
+        setMentionSearchText(searchText);
+      } else {
+        setShowMentionPopup(false);
+        setMentionStartIndex(null);
+        setMentionSearchText('');
+      }
+    }
+
+    // Update mention positions when text changes
+    if (mentions.length > 0) {
+      const updatedMentions = mentions.filter(
+        (mention) =>
+          mention.start <= newText.length &&
+          newText.slice(mention.start, mention.end) === mention.display
+      );
+      if (updatedMentions.length !== mentions.length) {
+        setMentions(updatedMentions);
+      }
+    }
+  };
+
+  const handleSelectMention = (contact: db.Contact, text: string) => {
+    if (mentionStartIndex === null) return;
+
+    const mentionDisplay = `${contact.id}`;
+    const beforeMention = text.slice(0, mentionStartIndex);
+    const afterMention = text.slice(
+      mentionStartIndex + (mentionSearchText?.length || 0) + 1
+    );
+
+    const newText = beforeMention + mentionDisplay + ' ' + afterMention;
+    const newMention: Mention = {
+      id: contact.id,
+      display: mentionDisplay,
+      start: mentionStartIndex,
+      end: mentionStartIndex + mentionDisplay.length,
+    };
+
+    setMentions((prev) => [...prev, newMention]);
+    setShowMentionPopup(false);
+    setMentionStartIndex(null);
+    setMentionSearchText('');
+
+    return newText;
+  };
+
+  return {
+    mentions,
+    setMentions,
+    mentionSearchText,
+    setMentionSearchText,
+    handleMention,
+    handleSelectMention,
+    showMentionPopup,
+    setShowMentionPopup,
+  };
+};

--- a/packages/ui/src/components/MessageInput/index.native.tsx
+++ b/packages/ui/src/components/MessageInput/index.native.tsx
@@ -16,6 +16,7 @@ import {
   ShortcutsBridge,
 } from '@tloncorp/editor/src/bridges';
 import {
+  REF_REGEX,
   createDevLogger,
   extractContentTypesFromPost,
   tiptap,
@@ -238,7 +239,7 @@ export const MessageInput = forwardRef<MessageInputHandle, MessageInputProps>(
               const newInlines = inlines
                 .map((inline) => {
                   if (typeof inline === 'string') {
-                    if (inline.match(tiptap.REF_REGEX)) {
+                    if (inline.match(REF_REGEX)) {
                       return null;
                     }
                     return inline;
@@ -461,7 +462,7 @@ export const MessageInput = forwardRef<MessageInputHandle, MessageInputProps>(
           editor,
           editorJson,
           pastedText,
-          matchRegex: tiptap.REF_REGEX,
+          matchRegex: REF_REGEX,
           processMatch: async (match) => {
             const cite = pathToCite(match);
             if (cite) {

--- a/packages/ui/src/components/MessageInput/index.tsx
+++ b/packages/ui/src/components/MessageInput/index.tsx
@@ -14,6 +14,7 @@ import Strike from '@tiptap/extension-strike';
 import Text from '@tiptap/extension-text';
 import { EditorContent, useEditor } from '@tiptap/react';
 import {
+  REF_REGEX,
   createDevLogger,
   extractContentTypesFromPost,
   tiptap,
@@ -283,7 +284,7 @@ export function MessageInput({
         return;
       }
       if (pastedText) {
-        const isRef = pastedText.match(tiptap.REF_REGEX);
+        const isRef = pastedText.match(REF_REGEX);
 
         if (isRef) {
           const cite = pathToCite(isRef[0]);
@@ -317,13 +318,13 @@ export function MessageInput({
                 if (typeof inline === 'string') {
                   const inlineLength = inline.length;
                   const refLength =
-                    inline.match(tiptap.REF_REGEX)?.[0].length || 0;
+                    inline.match(REF_REGEX)?.[0].length || 0;
 
                   if (inlineLength === refLength) {
                     return null;
                   }
 
-                  return inline.replace(tiptap.REF_REGEX, '');
+                  return inline.replace(REF_REGEX, '');
                 }
                 return inline;
               })

--- a/packages/ui/src/components/PostScreenView.tsx
+++ b/packages/ui/src/components/PostScreenView.tsx
@@ -11,13 +11,13 @@ import { Text, View, YStack } from 'tamagui';
 import { NavigationProvider, useCurrentUserId } from '../contexts';
 import { AttachmentProvider } from '../contexts/attachment';
 import * as utils from '../utils';
+import BareChatInput from './BareChatInput';
 import { BigInput } from './BigInput';
 import { ChannelFooter } from './Channel/ChannelFooter';
 import { ChannelHeader } from './Channel/ChannelHeader';
 import { DetailView } from './DetailView';
 import { GroupPreviewAction, GroupPreviewSheet } from './GroupPreviewSheet';
 import KeyboardAvoidingView from './KeyboardAvoidingView';
-import { MessageInput } from './MessageInput';
 import { TlonEditorBridge } from './MessageInput/toolbarActions.native';
 
 export function PostScreenView({
@@ -209,7 +209,7 @@ export function PostScreenView({
               ) : null}
 
               {negotiationMatch && channel && canWrite && (
-                <MessageInput
+                <BareChatInput
                   placeholder="Reply"
                   shouldBlur={inputShouldBlur}
                   setShouldBlur={setInputShouldBlur}
@@ -227,7 +227,6 @@ export function PostScreenView({
                     (channel.type === 'chat' && parentPost?.replyCount === 0) ||
                     !!editingPost
                   }
-                  ref={editorRef}
                 />
               )}
               {!negotiationMatch && channel && canWrite && (

--- a/packages/ui/src/components/draftInputs/ChatInput.tsx
+++ b/packages/ui/src/components/draftInputs/ChatInput.tsx
@@ -1,7 +1,6 @@
 import { SafeAreaView } from 'react-native-safe-area-context';
 
 import BareChatInput from '../BareChatInput';
-// import { MessageInput } from '../MessageInput';
 import { ParentAgnosticKeyboardAvoidingView } from '../ParentAgnosticKeyboardAvoidingView';
 import { DraftInputContext } from './shared';
 

--- a/packages/ui/src/components/draftInputs/ChatInput.tsx
+++ b/packages/ui/src/components/draftInputs/ChatInput.tsx
@@ -1,6 +1,7 @@
 import { SafeAreaView } from 'react-native-safe-area-context';
 
-import { MessageInput } from '../MessageInput';
+import BareChatInput from '../BareChatInput';
+// import { MessageInput } from '../MessageInput';
 import { ParentAgnosticKeyboardAvoidingView } from '../ParentAgnosticKeyboardAvoidingView';
 import { DraftInputContext } from './shared';
 
@@ -26,7 +27,7 @@ export function ChatInput({
   return (
     <SafeAreaView edges={['right', 'left', 'bottom']}>
       <ParentAgnosticKeyboardAvoidingView>
-        <MessageInput
+        <BareChatInput
           shouldBlur={shouldBlur}
           setShouldBlur={setShouldBlur}
           send={send}


### PR DESCRIPTION
If we were to use a bare text input for chat input, this is what it might look like.

~Rendering mentions in the input itself works fine, the biggest remaining pieces here, afaict right now, are:~
~- Adding basic markdown for italics/bold~
~- Parsing the text into inlines for the backend.~
~- New chat draft storage that doesn't use the JSONContent type from tiptap.~

Fixes TLON-3128
Fixes TLON-2867