### PR TITLE
fix glob deploy + update

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -73,6 +73,7 @@ jobs:
       - uses: actions/checkout@v3
         with:
           ref: ${{ env.tag }}
+          ssh-key: ${{ secrets.DEPLOY_KEY }}
       - uses: actions/download-artifact@v3
         with:
           name: "ui-dist"


### PR DESCRIPTION
I've set up our protection rule to allow deploy keys to bypass checks. I've also added a `DEPLOY_KEY` secret to our actions config. This PR modifies the glob deploy action to use that key when updating the repo.