### PR TITLE
ops: update Expo OTA script to account for build environment

### DIFF
--- a/.github/workflows/mobile-update.yml
+++ b/.github/workflows/mobile-update.yml
@@ -35,15 +35,19 @@ jobs:
         with:
           eas-version: latest
           token: ${{ secrets.EXPO_TOKEN }}
-      - name: Install dependencies
-        run: pnpm install
+      - name: Setup PNPM
+        uses: pnpm/action-setup@v3
+        with:
+          run_install: |
+            - recursive: true
+              args: [--frozen-lockfile]
       - name: Build packages
         run: pnpm build:all
       - name: Push update for selected platforms
         working-directory: ./apps/tlon-mobile
         run:
           eas update --channel ${{ inputs.profile }} --platform ${{
-          inputs.platform || 'all' }} --message '${{inputs.message}}'
+          inputs.platform || 'all' }} --message '${{ inputs.message }}'
           --non-interactive
         env:
           BRANCH_DOMAIN_PROD: ${{ secrets.BRANCH_DOMAIN_PROD }}

--- a/.github/workflows/mobile-update.yml
+++ b/.github/workflows/mobile-update.yml
@@ -7,7 +7,7 @@ on:
         description: Select profile
         options:
           - preview
-          - production
+          - placeholder
       platform:
         type: choice
         description: Select platform
@@ -15,6 +15,10 @@ on:
           - all
           - android
           - ios
+      message:
+        type: string
+        description: Brief description of what this update contains
+        required: true
 jobs:
   deploy:
     runs-on: ubuntu-latest
@@ -35,19 +39,19 @@ jobs:
         run: pnpm install
       - name: Build packages
         run: pnpm build:all
-      - name: Create build vars
-        id: vars
-        run: |
-          echo "profile=${{ inputs.profile || 'preview' }}" >> $GITHUB_OUTPUT
       - name: Push update for selected platforms
         working-directory: ./apps/tlon-mobile
         run:
-          eas update --auto --profile ${{ steps.vars.outputs.profile }}
-          --platform ${{ inputs.platform || 'all' }} --non-interactive
+          eas update --channel ${{ inputs.profile }} --platform ${{
+          inputs.platform || 'all' }} --message '${{inputs.message}}'
+          --non-interactive
         env:
-          NOTIFY_PROVIDER:
-            "${{ steps.vars.outputs.profile == 'preview' &&
-            'binnec-dozzod-marnus' || 'rivfur-livmet' }}"
-          NOTIFY_SERVICE:
-            "${{ steps.vars.outputs.profile == 'preview' &&
-            'tlon-preview-release' || 'groups-native' }}"
+          BRANCH_DOMAIN_PROD: ${{ secrets.BRANCH_DOMAIN_PROD }}
+          BRANCH_DOMAIN_TEST: ${{ secrets.BRANCH_DOMAIN_TEST }}
+          BRANCH_KEY_PROD: ${{ secrets.BRANCH_KEY_PROD }}
+          BRANCH_KEY_TEST: ${{ secrets.BRANCH_KEY_TEST }}
+          POST_HOG_API_KEY_TEST: ${{ secrets.POST_HOG_API_KEY_TEST }}
+          POST_HOG_API_KEY_PROD: ${{ secrets.POST_HOG_API_KEY_PROD }}
+          RECAPTCHA_SITE_KEY_ANDROID: ${{ secrets.RECAPTCHA_SITE_KEY_ANDROID }}
+          RECAPTCHA_SITE_KEY_IOS: ${{ secrets.RECAPTCHA_SITE_KEY_IOS }}
+          TLON_EMPLOYEE_GROUP: ${{ secrets.TLON_EMPLOYEE_GROUP }}

--- a/.github/workflows/mobile-update.yml
+++ b/.github/workflows/mobile-update.yml
@@ -50,6 +50,7 @@ jobs:
           inputs.platform || 'all' }} --message '${{ inputs.message }}'
           --non-interactive
         env:
+          APP_VARIANT: ${{ inputs.profile }}
           BRANCH_DOMAIN_PROD: ${{ secrets.BRANCH_DOMAIN_PROD }}
           BRANCH_DOMAIN_TEST: ${{ secrets.BRANCH_DOMAIN_TEST }}
           BRANCH_KEY_PROD: ${{ secrets.BRANCH_KEY_PROD }}

--- a/.github/workflows/mobile-update.yml
+++ b/.github/workflows/mobile-update.yml
@@ -7,7 +7,7 @@ on:
         description: Select profile
         options:
           - preview
-          - placeholder
+          - production
       platform:
         type: choice
         description: Select platform

--- a/apps/tlon-mobile/app.config.ts
+++ b/apps/tlon-mobile/app.config.ts
@@ -19,7 +19,9 @@ export default ({ config }: ConfigContext): ExpoConfig => ({
     eas: {
       projectId,
     },
-    postHogApiKey: process.env.POST_HOG_API_KEY,
+    postHogApiKey: isPreview
+      ? process.env.POST_HOG_API_KEY_TEST
+      : process.env.POST_HOG_API_KEY_PROD,
     postHogInDev: process.env.POST_HOG_IN_DEV,
     notifyProvider: process.env.NOTIFY_PROVIDER,
     notifyService: process.env.NOTIFY_SERVICE,


### PR DESCRIPTION
Updates the mobile update script from the old repo to account for needed environment variables. Note: whenever we add new ones, we'll need to do so both here and on Expo.

Also switches posthog to switch projects for preview vs prod.

Tested by using the action to trigger a preview app OTA.