### PR TITLE
analytics: track invite added on welcome screen

### DIFF
--- a/apps/tlon-mobile/src/screens/Onboarding/WelcomeScreen.tsx
+++ b/apps/tlon-mobile/src/screens/Onboarding/WelcomeScreen.tsx
@@ -1,5 +1,6 @@
 import type { NativeStackScreenProps } from '@react-navigation/native-stack';
 import { useLureMetadata } from '@tloncorp/app/contexts/branch';
+import { trackOnboardingAction } from '@tloncorp/app/utils/posthog';
 import { setDidShowBenefitsSheet } from '@tloncorp/shared/dist/db';
 import { useDidShowBenefitsSheet } from '@tloncorp/shared/dist/store';
 import {
@@ -15,7 +16,7 @@ import {
   YStack,
 } from '@tloncorp/ui';
 import { OnboardingBenefitsSheet } from '@tloncorp/ui/src/components/Onboarding/OnboardingBenefitsSheet';
-import { useCallback, useState } from 'react';
+import { useCallback, useEffect, useState } from 'react';
 import { Pressable } from 'react-native';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
 
@@ -46,6 +47,15 @@ export const WelcomeScreen = ({ navigation }: Props) => {
   const handlePressInvite = useCallback(() => {
     navigation.navigate('SignUpEmail');
   }, [navigation]);
+
+  useEffect(() => {
+    if (lureMeta) {
+      trackOnboardingAction({
+        actionName: 'Invite Link Added',
+        lure: lureMeta.id,
+      });
+    }
+  }, [lureMeta]);
 
   return (
     <View flex={1} backgroundColor={'$secondaryBackground'} paddingTop={top}>


### PR DESCRIPTION
Right now we only fire the _Invite Link Added_ event if they add it on the paste invite screen. If branch properly captured the invite after install OR you clicked the link while still on the welcome screen, we won't hear about it. This just updates that event to also get sent from the welcome screen.