### PR TITLE
login: show tlon password, +code

### DIFF
--- a/apps/tlon-mobile/src/screens/Onboarding/ShipLoginScreen.tsx
+++ b/apps/tlon-mobile/src/screens/Onboarding/ShipLoginScreen.tsx
@@ -17,6 +17,7 @@ import {
   OnboardingTextBlock,
   ScreenHeader,
   TextInput,
+  TextInputWithButton,
   TlonText,
   View,
   YStack,
@@ -57,6 +58,8 @@ export const ShipLoginScreen = ({ navigation }: Props) => {
     },
   });
   const { setShip } = useShip();
+
+  const [codevisible, setCodeVisible] = useState(false);
 
   const isValidUrl = useCallback((url: string) => {
     const urlPattern =
@@ -199,7 +202,7 @@ export const ShipLoginScreen = ({ navigation }: Props) => {
               }}
               render={({ field: { onChange, onBlur, value } }) => (
                 <Field label="Access Code" error={errors.accessCode?.message}>
-                  <TextInput
+                  <TextInputWithButton
                     testID="textInput accessCode"
                     placeholder="xxxxxx-xxxxxx-xxxxxx-xxxxxx"
                     onBlur={() => {
@@ -209,11 +212,13 @@ export const ShipLoginScreen = ({ navigation }: Props) => {
                     onChangeText={onChange}
                     onSubmitEditing={onSubmit}
                     value={value}
-                    secureTextEntry
+                    secureTextEntry={!codevisible}
                     autoCapitalize="none"
                     autoCorrect={false}
                     returnKeyType="send"
                     enablesReturnKeyAutomatically
+                    buttonText={codevisible ? 'Hide' : 'Show'}
+                    onButtonPress={() => setCodeVisible(!codevisible)}
                   />
                 </Field>
               )}

--- a/apps/tlon-mobile/src/screens/Onboarding/TlonLoginScreen.tsx
+++ b/apps/tlon-mobile/src/screens/Onboarding/TlonLoginScreen.tsx
@@ -22,6 +22,7 @@ import {
   OnboardingTextBlock,
   ScreenHeader,
   TextInput,
+  TextInputWithButton,
   TlonText,
   View,
   YStack,
@@ -62,6 +63,8 @@ export const TlonLoginScreen = ({ navigation }: Props) => {
     mode: 'onChange',
   });
   const { setShip } = useShip();
+
+  const [passwordVisible, setPasswordVisible] = useState(false);
 
   const handleForgotPassword = () => {
     const { email } = getValues();
@@ -227,7 +230,7 @@ export const TlonLoginScreen = ({ navigation }: Props) => {
               }}
               render={({ field: { onChange, onBlur, value } }) => (
                 <Field label="Password" error={errors.password?.message}>
-                  <TextInput
+                  <TextInputWithButton
                     placeholder="Password"
                     onBlur={() => {
                       onBlur();
@@ -236,11 +239,13 @@ export const TlonLoginScreen = ({ navigation }: Props) => {
                     onChangeText={onChange}
                     onSubmitEditing={onSubmit}
                     value={value}
-                    secureTextEntry
+                    secureTextEntry={!passwordVisible}
                     autoCapitalize="none"
                     autoCorrect={false}
                     returnKeyType="send"
                     enablesReturnKeyAutomatically
+                    buttonText={passwordVisible ? 'Hide' : 'Show'}
+                    onButtonPress={() => setPasswordVisible(!passwordVisible)}
                   />
                 </Field>
               )}


### PR DESCRIPTION
More password-entry friendliness. Allows users to show/hide text entry for their Tlon login and their self-hosted +code.

<img width="440" alt="Screenshot 2024-10-24 at 4 53 10 PM" src="https://github.com/user-attachments/assets/fe5d5de6-8ee6-4a55-8221-8d898ad46148">
<img width="440" alt="Screenshot 2024-10-24 at 4 55 51 PM" src="https://github.com/user-attachments/assets/184387c6-98de-4e6f-b5fe-7fe9bfb630d7">
