### PR TITLE
groups-ui: suggested contacts and pal import

### DIFF
--- a/desk/app/groups-ui.hoon
+++ b/desk/app/groups-ui.hoon
@@ -8,6 +8,7 @@
   +$  card  card:agent:gall
   +$  current-state
     $:  %2
+        hidden-contact-suggestions=(set ship)
         pins=(list whom:u)
         first-load=?
     ==
@@ -88,8 +89,6 @@
       =+  !<(old=versioned-state vase)
       =?  old  ?=(~ old)     *current-state
       =?  old  ?=(%0 -.old)  (state-0-to-1 old)
-      =?  cor  ?=(%1 -.old)
-        (emit %pass /preload-contacts %agent [our dap]:bowl %poke noun+!>(%preload-contacts))
       =?  old  ?=(%1 -.old)  (state-1-to-2 old)
       ?>  ?=(%2 -.old)
       =.  state  old
@@ -104,7 +103,7 @@
     ==
   ::
   ++  state-1-to-2
-    |=(state-1 [%2 pins first-load])
+    |=(state-1 [%2 ~ pins first-load])
   +$  state-0  [%0 first-load=?]
   ++  state-0-to-1
     |=(state-0 [%1 ~ first-load])
@@ -115,6 +114,12 @@
   ^-  (unit (unit cage))
   ?+    pole  [~ ~]
       [%x %pins ~]  ``ui-pins+!>(pins)
+  ::
+      [%x %hidden-contact-suggestions ~]
+    ``ships+!>(hidden-contact-suggestions)
+  ::
+      [%x %suggested-contacts ~]
+    ``ships+!>(get-suggested-contacts)
   ::
       [%x %init ~]
     =+  .^([=groups-ui:g =gangs:g] (scry %gx %groups /init/v1/noun))
@@ -209,11 +214,19 @@
   ^+  cor
   ?+    mark  ~|(bad-mark/mark !!)
     %ui-vita  (emit (active:vita-client bowl))
+    %ui-import-pals  import-pals
   ::
-      %noun
-    ?+  q.vase  ~|(bad-poke+mark !!)
-      %preload-contacts  preload-contacts
-    ==
+      %ui-show-contact
+    =+  !<(=ship vase)
+    =.  hidden-contact-suggestions
+      (~(del in hidden-contact-suggestions) ship)
+    cor
+  ::
+      %ui-hide-contact
+    =+  !<(=ship vase)
+    =.  hidden-contact-suggestions
+      (~(put in hidden-contact-suggestions) ship)
+    cor
   ::
       %ui-vita-toggle
     =+  !<(=vita-enabled:u vase)
@@ -254,13 +267,15 @@
   ?+  wire  !!
     [%build ~]  cor
   ==
-++  preload-contacts
+++  get-suggested-contacts
   =+  .^(chat-running=? (scry %gu %chat /$))
-  =?  cor  chat-running
+  =|  suggestions=(set ship)
+  =?  suggestions  chat-running
     =+  .^  [dms=(map ship dm:c) *]
       (scry %gx %chat /full/noun)
     ==
-    %-  emil
+    %-  ~(uni in suggestions)
+    %-  sy
     %+  murn
       ~(tap by dms)
     |=  [=ship =dm:c]
@@ -268,14 +283,19 @@
     =/  count  (wyt:on:writs:c wit.pact.dm)
     =/  cutoff  (sub now.bowl ~d30)
     ?.  &((gth count 10) (gth -.u.latest cutoff))  ~
-    `[%pass /contact %agent [our.bowl %contacts] %poke contact-action-1+!>([%page ship ~])]
+    `ship
   =+  .^(pals-running=? (scry %gu %pals /$))
-  =?  cor  pals-running
+  =?  suggestions  pals-running
     =+  .^(targets=(set ship) (scry %gx %pals /targets/noun))
-    %-  emil
-    %+  turn
-      ~(tap in targets)
-    |=  =ship
-    [%pass /contact %agent [our.bowl %contacts] %poke contact-action-1+!>([%page ship ~])]
-  cor
+    (~(uni in suggestions) targets)
+  (~(dif in suggestions) hidden-contact-suggestions)
+++  import-pals
+  =+  .^(pals-running=? (scry %gu %pals /$))
+  ?.  pals-running  cor
+  =+  .^(targets=(set ship) (scry %gx %pals /targets/noun))
+  %-  emil
+  %+  turn
+    ~(tap in targets)
+  |=  =ship
+  [%pass /contact %agent [our.bowl %contacts] %poke contact-action-1+!>([%page ship ~])]
 --

--- a/desk/app/groups-ui.hoon
+++ b/desk/app/groups-ui.hoon
@@ -258,8 +258,8 @@
   =+  .^(chat-running=? (scry %gu %chat /$))
   =?  cor  chat-running
     =+  .^  [dms=(map ship dm:c) *]
-        (scry %gx %chat /full/noun)
-      ==
+      (scry %gx %chat /full/noun)
+    ==
     %-  emil
     %+  murn
       ~(tap by dms)

--- a/desk/app/groups-ui.hoon
+++ b/desk/app/groups-ui.hoon
@@ -7,7 +7,7 @@
   |%
   +$  card  card:agent:gall
   +$  current-state
-    $:  %1
+    $:  %2
         pins=(list whom:u)
         first-load=?
     ==
@@ -88,13 +88,23 @@
       =+  !<(old=versioned-state vase)
       =?  old  ?=(~ old)     *current-state
       =?  old  ?=(%0 -.old)  (state-0-to-1 old)
-      ?>  ?=(%1 -.old)
+      =?  cor  ?=(%1 -.old)
+        (emit %pass /preload-contacts %agent [our dap]:bowl %poke noun+!>(%preload-contacts))
+      =?  old  ?=(%1 -.old)  (state-1-to-2 old)
+      ?>  ?=(%2 -.old)
       =.  state  old
       init
   ::
-  +$  versioned-state  $@(~ $%(state-1 state-0))
-  +$  state-1  current-state
+  +$  versioned-state  $@(~ $%(state-2 state-1 state-0))
+  +$  state-2  current-state
+  +$  state-1
+    $:  %1
+        pins=(list whom:u)
+        first-load=?
+    ==
   ::
+  ++  state-1-to-2
+    |=(state-1 [%2 pins first-load])
   +$  state-0  [%0 first-load=?]
   ++  state-0-to-1
     |=(state-0 [%1 ~ first-load])
@@ -200,6 +210,11 @@
   ?+    mark  ~|(bad-mark/mark !!)
     %ui-vita  (emit (active:vita-client bowl))
   ::
+      %noun
+    ?+  q.vase  ~|(bad-poke+mark !!)
+      %preload-contacts  preload-contacts
+    ==
+  ::
       %ui-vita-toggle
     =+  !<(=vita-enabled:u vase)
     (emit %pass /vita-toggle %agent [our.bowl dap.bowl] %poke vita-client+!>([%set-enabled vita-enabled]))
@@ -228,8 +243,9 @@
   ^+  cor
   ?+    pole  ~|(bad-agent-take/pole !!)
     ~  cor
-    [%set-activity ~]  cor
+    [%contact ~]  cor
     [%vita-toggle ~]  cor
+    [%set-activity ~]  cor
   ==
 ::
 ++  arvo
@@ -238,4 +254,28 @@
   ?+  wire  !!
     [%build ~]  cor
   ==
+++  preload-contacts
+  =+  .^(chat-running=? (scry %gu %chat /$))
+  =?  cor  chat-running
+    =+  .^  [dms=(map ship dm:c) *]
+        (scry %gx %chat /full/noun)
+      ==
+    %-  emil
+    %+  murn
+      ~(tap by dms)
+    |=  [=ship =dm:c]
+    ?~  latest=(ram:on:writs:c wit.pact.dm)  ~
+    =/  count  (wyt:on:writs:c wit.pact.dm)
+    =/  cutoff  (sub now.bowl ~d30)
+    ?.  &((gth count 10) (gth -.u.latest cutoff))  ~
+    `[%pass /contact %agent [our.bowl %contacts] %poke contact-action-1+!>([%page ship ~])]
+  =+  .^(pals-running=? (scry %gu %pals /$))
+  =?  cor  pals-running
+    =+  .^(targets=(set ship) (scry %gx %pals /targets/noun))
+    %-  emil
+    %+  turn
+      ~(tap in targets)
+    |=  =ship
+    [%pass /contact %agent [our.bowl %contacts] %poke contact-action-1+!>([%page ship ~])]
+  cor
 --

--- a/desk/mar/ui/hide-contact.hoon
+++ b/desk/mar/ui/hide-contact.hoon
@@ -1,0 +1,2 @@
+/=  mark  /mar/ship
+mark

--- a/desk/mar/ui/import-pals.hoon
+++ b/desk/mar/ui/import-pals.hoon
@@ -1,0 +1,2 @@
+/=  mark  /mar/dummy
+mark

--- a/desk/mar/ui/show-contact.hoon
+++ b/desk/mar/ui/show-contact.hoon
@@ -1,0 +1,2 @@
+/=  mark  /mar/ship
+mark


### PR DESCRIPTION
This grabs both our pals and our DMs and uses those to make contacts. For pals we take all `targets` which are people we've asked to be pals. For DMs, we take anyone you've DM'd in the last 30 days that has more than 10 messages. This will only run once upon receiving the update.

Fixes TLON-3146

PR Checklist
- [ ] Includes changes to desk files
- [ ] Describes how you tested the PR locally (test ship vs livenet)
- [ ] If a new feature, includes automated tests
- [ ] Comments added anywhere logic may be confusing without context