### PR TITLE
fix tlon-web-new deploy issues and add internal deploy

### DIFF
--- a/.github/workflows/deploy-canary.yml
+++ b/.github/workflows/deploy-canary.yml
@@ -121,7 +121,7 @@ jobs:
         run: |
           git config --global user.name github-actions
           git config --global user.email github-actions@github.com
-          git add desk/desk.docket-0
+          git add tm-alpha-desk/desk.docket-0
           git commit -n -m "update glob: ${{ steps.glob.outputs.hash }} [skip actions]" || echo "No changes to commit"
           INPUT=${{ env.tag }}
           BRANCH=${INPUT:-"staging"}

--- a/.github/workflows/deploy-internal.yml
+++ b/.github/workflows/deploy-internal.yml
@@ -26,3 +26,22 @@ jobs:
           SSH_SEC_KEY: ${{ secrets.GCP_SSH_SEC_KEY }}
           SSH_PUB_KEY: ${{ secrets.GCP_SSH_PUB_KEY }}
           URBIT_REPO_TAG: ${{ vars.URBIT_REPO_TAG }}
+  deploy-new:
+    runs-on: ubuntu-latest
+    name: "Release new frontend to ~marnec-dozzod-marnus (internal)"
+    steps:
+      - uses: actions/checkout@v3
+      - id: 'auth'
+        uses: 'google-github-actions/auth@v1'
+        with:
+          credentials_json: '${{ secrets.GCP_SERVICE_KEY }}'
+      - name: 'Set up Cloud SDK'
+        uses: 'google-github-actions/setup-gcloud@v1'
+      - id: deploy
+        name: Deploy
+        run:
+          ./.github/helpers/deploy.sh tloncorp/tlon-apps tm-alpha marnec-dozzod-marnus us-central1-a mainnet-tlon-other-2d ${{ github.event.inputs.tag }}
+        env:
+          SSH_SEC_KEY: ${{ secrets.GCP_SSH_SEC_KEY }}
+          SSH_PUB_KEY: ${{ secrets.GCP_SSH_PUB_KEY }}
+          URBIT_REPO_TAG: ${{ vars.URBIT_REPO_TAG }}

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -107,10 +107,11 @@ jobs:
       - uses: actions/checkout@v3
         with:
           ref: ${{ env.tag }}
+          ssh-key: ${{ secrets.DEPLOY_KEY }}
       - uses: actions/download-artifact@v3
         with:
           name: "ui-dist-new"
-          path: apps/tlon-web/dist
+          path: apps/tlon-web-new/dist
       - id: "auth"
         uses: "google-github-actions/auth@v1"
         with:
@@ -126,7 +127,7 @@ jobs:
         run: |
           git config --global user.name github-actions
           git config --global user.email github-actions@github.com
-          git add desk/desk.docket-0
+          git add tm-alpha-desk/desk.docket-0
           git commit -n -m "update new frontend glob: ${{ steps.glob.outputs.hash }} [skip actions]" || echo "No changes to commit"
           INPUT=${{ env.tag }}
           BRANCH=${INPUT:-"develop"}


### PR DESCRIPTION
Fixes TLON-3140

There were a few places that still didn't point to the new frontend, and we needed to add the ssh-key to the glob and commit step for the new frontend glob and commit action.

I also noticed some tm-alpha directory permissions issues on wannec, went in and fixed those.

Also adds an internal deploy action since we'll need that soon.

Copilot summary:

This pull request includes several updates to the deployment workflows to improve the deployment process and add new deployment steps. The most important changes include adding a new deployment step for the internal environment, updating the paths for artifacts, and modifying the git add commands.

### Deployment Workflow Improvements:

* [`.github/workflows/deploy-internal.yml`](diffhunk://#diff-fc5ecbf361628e32305ee4f8c2662c3a905701d0dd9699a3127e4ac8d3b8afeeR29-R47): Added a new job `deploy-new` to release the new frontend to `~marnec-dozzod-marnus` (internal) with necessary steps for authentication and deployment.

* [`.github/workflows/deploy.yml`](diffhunk://#diff-28802fbf11c83a2eee09623fb192785e7ca92a3f40602a517c011b947a1822d3R110-R114): Added `ssh-key` to the `actions/checkout@v3` step and updated the artifact path to `apps/tlon-web-new/dist`.

### Path and Configuration Updates:

* [`.github/workflows/deploy-canary.yml`](diffhunk://#diff-0d47256a275a0b272487a2f980153a4fb13a50901c4d051db562766282519861L124-R124): Updated the git add command to `tm-alpha-desk/desk.docket-0` for the canary deployment.

* [`.github/workflows/deploy.yml`](diffhunk://#diff-28802fbf11c83a2eee09623fb192785e7ca92a3f40602a517c011b947a1822d3L129-R130): Updated the git add command to `tm-alpha-desk/desk.docket-0` for the main deployment.