### PR TITLE
input: show ref previews and allow attachments in chat threads

### DIFF
--- a/packages/ui/src/components/PostScreenView.tsx
+++ b/packages/ui/src/components/PostScreenView.tsx
@@ -223,6 +223,8 @@ export function PostScreenView({
                   editPost={editPost}
                   channelType="chat"
                   getDraft={getDraft}
+                  showAttachmentButton={channel.type === 'chat'}
+                  showInlineAttachments={channel.type === 'chat'}
                   shouldAutoFocus={
                     (channel.type === 'chat' && parentPost?.replyCount === 0) ||
                     !!editingPost


### PR DESCRIPTION
Looks like we didn't pass these props with the old input either.