### PR TITLE
custom channels: add parameters to component configurations

### DIFF
--- a/apps/tlon-mobile/src/fixtures/ChannelConfigurationBar.fixture.tsx
+++ b/apps/tlon-mobile/src/fixtures/ChannelConfigurationBar.fixture.tsx
@@ -8,15 +8,16 @@ import {
 } from '@tloncorp/shared';
 import { UnconnectedChannelConfigurationBar as ChannelConfigurationBar } from '@tloncorp/ui/src/components/ManageChannels/CreateChannelSheet';
 import { useState } from 'react';
-import { View } from 'tamagui';
+import { SafeAreaView } from 'react-native-safe-area-context';
+import { TextArea, View } from 'tamagui';
 
 import { tlonLocalIntros } from './fakeData';
 
 const baseChannel = {
   ...tlonLocalIntros,
   contentConfiguration: {
-    defaultPostCollectionRenderer: { id: CollectionRendererId.chat },
-    defaultPostContentRenderer: { id: PostContentRendererId.chat },
+    defaultPostCollectionRenderer: CollectionRendererId.chat,
+    defaultPostContentRenderer: PostContentRendererId.chat,
     draftInput: { id: DraftInputId.chat },
   } as ChannelContentConfiguration,
 };
@@ -26,7 +27,13 @@ export default function Basic() {
 
   return (
     <QueryClientProvider client={queryClient}>
-      <View flex={1} />
+      <View flex={1}>
+        <SafeAreaView edges={['top', 'left', 'right']}>
+          <TextArea editable={false} fontFamily={'$mono'} fontSize={'$s'}>
+            {JSON.stringify(channel.contentConfiguration, null, 2)}
+          </TextArea>
+        </SafeAreaView>
+      </View>
       <ChannelConfigurationBar
         channel={channel}
         updateChannelConfiguration={(update) => {

--- a/apps/tlon-mobile/src/fixtures/ChannelConfigurationBar.fixture.tsx
+++ b/apps/tlon-mobile/src/fixtures/ChannelConfigurationBar.fixture.tsx
@@ -1,0 +1,43 @@
+import {
+  ChannelContentConfiguration,
+  CollectionRendererId,
+  DraftInputId,
+  PostContentRendererId,
+  QueryClientProvider,
+  queryClient,
+} from '@tloncorp/shared';
+import { UnconnectedChannelConfigurationBar as ChannelConfigurationBar } from '@tloncorp/ui/src/components/ManageChannels/CreateChannelSheet';
+import { useState } from 'react';
+import { View } from 'tamagui';
+
+import { tlonLocalIntros } from './fakeData';
+
+const baseChannel = {
+  ...tlonLocalIntros,
+  contentConfiguration: {
+    defaultPostCollectionRenderer: { id: CollectionRendererId.chat },
+    defaultPostContentRenderer: { id: PostContentRendererId.chat },
+    draftInput: { id: DraftInputId.chat },
+  } as ChannelContentConfiguration,
+};
+
+export default function Basic() {
+  const [channel, setChannel] = useState(baseChannel);
+
+  return (
+    <QueryClientProvider client={queryClient}>
+      <View flex={1} />
+      <ChannelConfigurationBar
+        channel={channel}
+        updateChannelConfiguration={(update) => {
+          setChannel((prev) => ({
+            ...prev,
+            contentConfiguration: update(
+              prev.contentConfiguration ?? undefined
+            ),
+          }));
+        }}
+      />
+    </QueryClientProvider>
+  );
+}

--- a/packages/shared/src/api/channelContentConfig.ts
+++ b/packages/shared/src/api/channelContentConfig.ts
@@ -118,9 +118,21 @@ export type DraftInputId = ValuesOf<typeof DraftInputId>;
 export const PostContentRendererId = makeEnum(allContentRenderers);
 export type PostContentRendererId = ValuesOf<typeof PostContentRendererId>;
 
-interface ParameterizedId<Id extends string> {
+type ParameterizedId<Id extends string> = {
   id: Id;
   configuration?: Record<string, JSONValue>;
+};
+
+// eslint-disable-next-line @typescript-eslint/no-namespace
+namespace ParameterizedId {
+  export function id<Id extends string>(id: ParameterizedId<Id>): Id {
+    return typeof id === 'string' ? id : id.id;
+  }
+  export function coerce<Id extends string>(
+    id: Id | ParameterizedId<Id>
+  ): ParameterizedId<Id> {
+    return typeof id === 'string' ? { id } : id;
+  }
 }
 
 /**
@@ -130,7 +142,7 @@ export interface ChannelContentConfiguration {
   /**
    * Which controls are available when composing a new post?
    */
-  draftInput: ParameterizedId<DraftInputId>;
+  draftInput: DraftInputId | ParameterizedId<DraftInputId>;
 
   /**
    * How should we render a given post content type?
@@ -138,12 +150,35 @@ export interface ChannelContentConfiguration {
    * This spec takes precedence over the client's default renderer mapping, but
    * does not take precedence over any mapping specified in a post's metadata.
    */
-  defaultPostContentRenderer: ParameterizedId<PostContentRendererId>;
+  defaultPostContentRenderer:
+    | PostContentRendererId
+    | ParameterizedId<PostContentRendererId>;
 
   /**
    * How should we render the entire collection of posts? (list, grid, etc)
    */
-  defaultPostCollectionRenderer: ParameterizedId<CollectionRendererId>;
+  defaultPostCollectionRenderer:
+    | CollectionRendererId
+    | ParameterizedId<CollectionRendererId>;
+}
+
+// eslint-disable-next-line @typescript-eslint/no-namespace
+export namespace ChannelContentConfiguration {
+  export function draftInput(
+    configuration: ChannelContentConfiguration
+  ): ParameterizedId<DraftInputId> {
+    return ParameterizedId.coerce(configuration.draftInput);
+  }
+  export function defaultPostContentRenderer(
+    configuration: ChannelContentConfiguration
+  ): ParameterizedId<PostContentRendererId> {
+    return ParameterizedId.coerce(configuration.defaultPostContentRenderer);
+  }
+  export function defaultPostCollectionRenderer(
+    configuration: ChannelContentConfiguration
+  ): ParameterizedId<CollectionRendererId> {
+    return ParameterizedId.coerce(configuration.defaultPostCollectionRenderer);
+  }
 }
 
 /**

--- a/packages/shared/src/api/channelContentConfig.ts
+++ b/packages/shared/src/api/channelContentConfig.ts
@@ -12,35 +12,55 @@ export interface ComponentSpec<EnumTag extends string = string> {
   parametersSchema?: Record<string, ParameterSpec>;
 }
 
+function standardCollectionParameters(): Record<string, ParameterSpec> {
+  return {
+    showAuthor: {
+      displayName: 'Show author',
+      type: 'boolean',
+    },
+    showReplies: {
+      displayName: 'Show replies',
+      type: 'boolean',
+    },
+  };
+}
+
 export const allCollectionRenderers = {
   'tlon.r0.collection.chat': {
     displayName: 'Chat',
     enumTag: 'chat',
+    parametersSchema: standardCollectionParameters(),
   },
   'tlon.r0.collection.gallery': {
     displayName: 'Gallery',
     enumTag: 'gallery',
+    parametersSchema: standardCollectionParameters(),
   },
   'tlon.r0.collection.notebook': {
     displayName: 'Notebook',
     enumTag: 'notebook',
+    parametersSchema: standardCollectionParameters(),
   },
   'tlon.r0.collection.cards': {
     displayName: 'Cards',
     enumTag: 'cards',
+    parametersSchema: standardCollectionParameters(),
   },
   'tlon.r0.collection.sign': {
     displayName: 'Sign',
     enumTag: 'sign',
+    parametersSchema: standardCollectionParameters(),
   },
   'tlon.r0.collection.boardroom': {
     displayName: 'Boardroom',
     enumTag: 'boardroom',
+    parametersSchema: standardCollectionParameters(),
   },
   'tlon.r0.collection.strobe': {
     displayName: 'Strobe',
     enumTag: 'strobe',
     parametersSchema: {
+      ...standardCollectionParameters(),
       interval: {
         displayName: 'Frame rate in milliseconds',
         type: 'string',

--- a/packages/shared/src/api/channelContentConfig.ts
+++ b/packages/shared/src/api/channelContentConfig.ts
@@ -40,6 +40,12 @@ export const allCollectionRenderers = {
   'tlon.r0.collection.strobe': {
     displayName: 'Strobe',
     enumTag: 'strobe',
+    parametersSchema: {
+      interval: {
+        displayName: 'Frame rate in milliseconds',
+        type: 'string',
+      },
+    },
   },
 } as const satisfies Record<string, ComponentSpec>;
 
@@ -59,6 +65,12 @@ export const allDraftInputs = {
   'tlon.r0.input.yo': {
     displayName: 'Yo',
     enumTag: 'yo',
+    parametersSchema: {
+      text: {
+        displayName: 'Message text',
+        type: 'string',
+      },
+    },
   },
   'tlon.r0.input.mic': {
     displayName: 'Mic',
@@ -102,6 +114,12 @@ export const allContentRenderers = {
   'tlon.r0.content.raw': {
     displayName: 'Raw',
     enumTag: 'raw',
+    parametersSchema: {
+      fontFamily: {
+        displayName: 'Font family',
+        type: 'string',
+      },
+    },
   },
   'tlon.r0.content.yell': {
     displayName: 'Yell',

--- a/packages/shared/src/api/channelContentConfig.ts
+++ b/packages/shared/src/api/channelContentConfig.ts
@@ -6,53 +6,40 @@ interface ParameterSpec {
   type: 'boolean' | 'string';
 }
 
-export interface ComponentSpec<
-  EnumTag extends string = string,
-  Parameters extends { [key: string]: ParameterSpec } = Record<
-    string,
-    ParameterSpec
-  >,
-> {
+export interface ComponentSpec<EnumTag extends string = string> {
   displayName: string;
   enumTag: EnumTag;
-  parametersSchema: Parameters;
+  parametersSchema?: Record<string, ParameterSpec>;
 }
 
 export const allCollectionRenderers = {
   'tlon.r0.collection.chat': {
     displayName: 'Chat',
     enumTag: 'chat',
-    parametersSchema: {},
   },
   'tlon.r0.collection.gallery': {
     displayName: 'Gallery',
     enumTag: 'gallery',
-    parametersSchema: {},
   },
   'tlon.r0.collection.notebook': {
     displayName: 'Notebook',
     enumTag: 'notebook',
-    parametersSchema: {},
   },
   'tlon.r0.collection.cards': {
     displayName: 'Cards',
     enumTag: 'cards',
-    parametersSchema: {},
   },
   'tlon.r0.collection.sign': {
     displayName: 'Sign',
     enumTag: 'sign',
-    parametersSchema: {},
   },
   'tlon.r0.collection.boardroom': {
     displayName: 'Boardroom',
     enumTag: 'boardroom',
-    parametersSchema: {},
   },
   'tlon.r0.collection.strobe': {
     displayName: 'Strobe',
     enumTag: 'strobe',
-    parametersSchema: {},
   },
 } as const satisfies Record<string, ComponentSpec>;
 
@@ -60,83 +47,65 @@ export const allDraftInputs = {
   'tlon.r0.input.chat': {
     displayName: 'Chat',
     enumTag: 'chat',
-    parametersSchema: {},
   },
   'tlon.r0.input.gallery': {
     displayName: 'Gallery',
     enumTag: 'gallery',
-    parametersSchema: {},
   },
   'tlon.r0.input.notebook': {
     displayName: 'Notebook',
     enumTag: 'notebook',
-    parametersSchema: {},
   },
   'tlon.r0.input.yo': {
     displayName: 'Yo',
     enumTag: 'yo',
-    parametersSchema: {},
   },
   'tlon.r0.input.mic': {
     displayName: 'Mic',
     enumTag: 'mic',
-    parametersSchema: {},
   },
   'tlon.r0.input.picto': {
     displayName: 'Picto',
     enumTag: 'picto',
-    parametersSchema: {},
   },
   'tlon.r0.input.color': {
     displayName: 'Color',
     enumTag: 'color',
-    parametersSchema: {},
   },
-} as const satisfies Record<
-  string,
-  ComponentSpec<string, Record<string, ParameterSpec>>
->;
+} as const satisfies Record<string, ComponentSpec>;
 
 export const allContentRenderers = {
   'tlon.r0.content.chat': {
     displayName: 'Chat',
     enumTag: 'chat',
-    parametersSchema: {},
   },
   'tlon.r0.content.gallery': {
     displayName: 'Gallery',
     enumTag: 'gallery',
-    parametersSchema: {},
   },
   'tlon.r0.content.notebook': {
     displayName: 'Notebook',
     enumTag: 'notebook',
-    parametersSchema: {},
   },
   'tlon.r0.content.picto': {
     displayName: 'Picto',
     enumTag: 'picto',
-    parametersSchema: {},
   },
   'tlon.r0.content.audio': {
     displayName: 'Audio',
     enumTag: 'audio',
-    parametersSchema: {},
   },
   'tlon.r0.content.color': {
     displayName: 'Color',
     enumTag: 'color',
-    parametersSchema: {},
   },
   'tlon.r0.content.raw': {
     displayName: 'Raw',
     enumTag: 'raw',
-    parametersSchema: {},
   },
   'tlon.r0.content.yell': {
     displayName: 'Yell',
     enumTag: 'yell',
-    parametersSchema: {},
   },
 } as const satisfies Record<string, ComponentSpec>;
 

--- a/packages/shared/src/api/channelContentConfig.ts
+++ b/packages/shared/src/api/channelContentConfig.ts
@@ -1,38 +1,58 @@
+import type { JSONValue } from '../types/JSONValue';
 import { ValuesOf } from '../utils';
 
-interface ComponentSpec<EnumTag extends string = string> {
+interface ParameterSpec {
+  displayName: string;
+  type: 'boolean' | 'string';
+}
+
+export interface ComponentSpec<
+  EnumTag extends string = string,
+  Parameters extends { [key: string]: ParameterSpec } = Record<
+    string,
+    ParameterSpec
+  >,
+> {
   displayName: string;
   enumTag: EnumTag;
+  parametersSchema: Parameters;
 }
 
 export const allCollectionRenderers = {
   'tlon.r0.collection.chat': {
     displayName: 'Chat',
     enumTag: 'chat',
+    parametersSchema: {},
   },
   'tlon.r0.collection.gallery': {
     displayName: 'Gallery',
     enumTag: 'gallery',
+    parametersSchema: {},
   },
   'tlon.r0.collection.notebook': {
     displayName: 'Notebook',
     enumTag: 'notebook',
+    parametersSchema: {},
   },
   'tlon.r0.collection.cards': {
     displayName: 'Cards',
     enumTag: 'cards',
+    parametersSchema: {},
   },
   'tlon.r0.collection.sign': {
     displayName: 'Sign',
     enumTag: 'sign',
+    parametersSchema: {},
   },
   'tlon.r0.collection.boardroom': {
     displayName: 'Boardroom',
     enumTag: 'boardroom',
+    parametersSchema: {},
   },
   'tlon.r0.collection.strobe': {
     displayName: 'Strobe',
     enumTag: 'strobe',
+    parametersSchema: {},
   },
 } as const satisfies Record<string, ComponentSpec>;
 
@@ -40,65 +60,83 @@ export const allDraftInputs = {
   'tlon.r0.input.chat': {
     displayName: 'Chat',
     enumTag: 'chat',
+    parametersSchema: {},
   },
   'tlon.r0.input.gallery': {
     displayName: 'Gallery',
     enumTag: 'gallery',
+    parametersSchema: {},
   },
   'tlon.r0.input.notebook': {
     displayName: 'Notebook',
     enumTag: 'notebook',
+    parametersSchema: {},
   },
   'tlon.r0.input.yo': {
     displayName: 'Yo',
     enumTag: 'yo',
+    parametersSchema: {},
   },
   'tlon.r0.input.mic': {
     displayName: 'Mic',
     enumTag: 'mic',
+    parametersSchema: {},
   },
   'tlon.r0.input.picto': {
     displayName: 'Picto',
     enumTag: 'picto',
+    parametersSchema: {},
   },
   'tlon.r0.input.color': {
     displayName: 'Color',
     enumTag: 'color',
+    parametersSchema: {},
   },
-} as const satisfies Record<string, ComponentSpec>;
+} as const satisfies Record<
+  string,
+  ComponentSpec<string, Record<string, ParameterSpec>>
+>;
 
 export const allContentRenderers = {
   'tlon.r0.content.chat': {
     displayName: 'Chat',
     enumTag: 'chat',
+    parametersSchema: {},
   },
   'tlon.r0.content.gallery': {
     displayName: 'Gallery',
     enumTag: 'gallery',
+    parametersSchema: {},
   },
   'tlon.r0.content.notebook': {
     displayName: 'Notebook',
     enumTag: 'notebook',
+    parametersSchema: {},
   },
   'tlon.r0.content.picto': {
     displayName: 'Picto',
     enumTag: 'picto',
+    parametersSchema: {},
   },
   'tlon.r0.content.audio': {
     displayName: 'Audio',
     enumTag: 'audio',
+    parametersSchema: {},
   },
   'tlon.r0.content.color': {
     displayName: 'Color',
     enumTag: 'color',
+    parametersSchema: {},
   },
   'tlon.r0.content.raw': {
     displayName: 'Raw',
     enumTag: 'raw',
+    parametersSchema: {},
   },
   'tlon.r0.content.yell': {
     displayName: 'Yell',
     enumTag: 'yell',
+    parametersSchema: {},
   },
 } as const satisfies Record<string, ComponentSpec>;
 
@@ -111,6 +149,11 @@ export type DraftInputId = ValuesOf<typeof DraftInputId>;
 export const PostContentRendererId = makeEnum(allContentRenderers);
 export type PostContentRendererId = ValuesOf<typeof PostContentRendererId>;
 
+interface ParameterizedId<Id extends string> {
+  id: Id;
+  configuration?: Record<string, JSONValue>;
+}
+
 /**
  * Configures the custom components used to create content in a channel.
  */
@@ -118,7 +161,7 @@ export interface ChannelContentConfiguration {
   /**
    * Which controls are available when composing a new post?
    */
-  draftInput: DraftInputId;
+  draftInput: ParameterizedId<DraftInputId>;
 
   /**
    * How should we render a given post content type?
@@ -126,12 +169,12 @@ export interface ChannelContentConfiguration {
    * This spec takes precedence over the client's default renderer mapping, but
    * does not take precedence over any mapping specified in a post's metadata.
    */
-  defaultPostContentRenderer: PostContentRendererId;
+  defaultPostContentRenderer: ParameterizedId<PostContentRendererId>;
 
   /**
    * How should we render the entire collection of posts? (list, grid, etc)
    */
-  defaultPostCollectionRenderer: CollectionRendererId;
+  defaultPostCollectionRenderer: ParameterizedId<CollectionRendererId>;
 }
 
 /**

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -37,3 +37,4 @@ export * as tiptap from './logic/tiptap';
 export * as utilHooks from './logic/utilHooks';
 export * from './debug';
 export * from './perf';
+export type { JSONValue } from './types/JSONValue';

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -1,5 +1,6 @@
 export * as ChannelAction from './types/ChannelActions';
 export type { GroupMeta } from './types/groups';
+export { JSONValue } from './types/JSONValue';
 export type {
   NativeWebViewOptions,
   NativeCommand,
@@ -37,4 +38,3 @@ export * as tiptap from './logic/tiptap';
 export * as utilHooks from './logic/utilHooks';
 export * from './debug';
 export * from './perf';
-export type { JSONValue } from './types/JSONValue';

--- a/packages/shared/src/store/sync.test.ts
+++ b/packages/shared/src/store/sync.test.ts
@@ -314,9 +314,9 @@ test('syncs groups, decoding structured description payloads', async () => {
   const channel = groupWithScdp['~fabled-faster/new-york'].channels[channelId];
   const descriptionText = 'cheers';
   const channelContentConfiguration = {
-    draftInput: DraftInputId.chat,
-    defaultPostContentRenderer: PostContentRendererId.notebook,
-    defaultPostCollectionRenderer: CollectionRendererId.gallery,
+    draftInput: { id: DraftInputId.chat },
+    defaultPostContentRenderer: { id: PostContentRendererId.notebook },
+    defaultPostCollectionRenderer: { id: CollectionRendererId.gallery },
   };
   channel.meta.description = StructuredChannelDescriptionPayload.encode({
     description: descriptionText,

--- a/packages/shared/src/store/useCreateChannel.ts
+++ b/packages/shared/src/store/useCreateChannel.ts
@@ -73,21 +73,21 @@ function channelContentConfigurationForChannelType(
   switch (channelType) {
     case 'chat':
       return {
-        draftInput: DraftInputId.chat,
-        defaultPostContentRenderer: PostContentRendererId.chat,
-        defaultPostCollectionRenderer: CollectionRendererId.chat,
+        draftInput: { id: DraftInputId.chat },
+        defaultPostContentRenderer: { id: PostContentRendererId.chat },
+        defaultPostCollectionRenderer: { id: CollectionRendererId.chat },
       };
     case 'notebook':
       return {
-        draftInput: DraftInputId.notebook,
-        defaultPostContentRenderer: PostContentRendererId.notebook,
-        defaultPostCollectionRenderer: CollectionRendererId.notebook,
+        draftInput: { id: DraftInputId.notebook },
+        defaultPostContentRenderer: { id: PostContentRendererId.notebook },
+        defaultPostCollectionRenderer: { id: CollectionRendererId.notebook },
       };
     case 'gallery':
       return {
-        draftInput: DraftInputId.gallery,
-        defaultPostContentRenderer: PostContentRendererId.gallery,
-        defaultPostCollectionRenderer: CollectionRendererId.gallery,
+        draftInput: { id: DraftInputId.gallery },
+        defaultPostContentRenderer: { id: PostContentRendererId.gallery },
+        defaultPostCollectionRenderer: { id: CollectionRendererId.gallery },
       };
   }
 

--- a/packages/shared/src/types/JSONValue.ts
+++ b/packages/shared/src/types/JSONValue.ts
@@ -1,0 +1,1 @@
+export type JSONValue = number | string; // can add more JSON-compliant types as needed

--- a/packages/shared/src/types/JSONValue.ts
+++ b/packages/shared/src/types/JSONValue.ts
@@ -1,1 +1,11 @@
 export type JSONValue = number | string; // can add more JSON-compliant types as needed
+
+// eslint-disable-next-line @typescript-eslint/no-namespace
+export namespace JSONValue {
+  export function asString<DefaultValue>(
+    value: unknown,
+    defaultValue: DefaultValue
+  ): string | DefaultValue {
+    return typeof value === 'string' ? value : defaultValue;
+  }
+}

--- a/packages/shared/src/types/JSONValue.ts
+++ b/packages/shared/src/types/JSONValue.ts
@@ -8,4 +8,11 @@ export namespace JSONValue {
   ): string | DefaultValue {
     return typeof value === 'string' ? value : defaultValue;
   }
+
+  export function asBoolean<DefaultValue>(
+    value: unknown,
+    defaultValue: DefaultValue
+  ): boolean | DefaultValue {
+    return typeof value === 'boolean' ? value : defaultValue;
+  }
 }

--- a/packages/shared/src/types/PostCollectionConfiguration.ts
+++ b/packages/shared/src/types/PostCollectionConfiguration.ts
@@ -1,4 +1,4 @@
-import { CollectionRendererId } from '../api';
+import { ChannelContentConfiguration, CollectionRendererId } from '../api';
 import * as db from '../db';
 import * as ChannelAction from './ChannelActions';
 
@@ -22,8 +22,11 @@ export function layoutTypeFromChannel(
 export function layoutTypeFromChannel(
   channel: db.Channel | null
 ): PostCollectionLayoutType | null {
+  const config = channel?.contentConfiguration;
   const configCollectionRenderer =
-    channel?.contentConfiguration?.defaultPostCollectionRenderer;
+    config == null
+      ? null
+      : ChannelContentConfiguration.defaultPostCollectionRenderer(config);
   if (configCollectionRenderer != null) {
     switch (configCollectionRenderer.id) {
       case CollectionRendererId.notebook:

--- a/packages/shared/src/types/PostCollectionConfiguration.ts
+++ b/packages/shared/src/types/PostCollectionConfiguration.ts
@@ -22,10 +22,10 @@ export function layoutTypeFromChannel(
 export function layoutTypeFromChannel(
   channel: db.Channel | null
 ): PostCollectionLayoutType | null {
-  const configCollectionRendererId =
+  const configCollectionRenderer =
     channel?.contentConfiguration?.defaultPostCollectionRenderer;
-  if (configCollectionRendererId != null) {
-    switch (configCollectionRendererId) {
+  if (configCollectionRenderer != null) {
+    switch (configCollectionRenderer.id) {
       case CollectionRendererId.notebook:
         return 'comfy-list-top-to-bottom';
 

--- a/packages/ui/src/components/Channel/DraftInputView.tsx
+++ b/packages/ui/src/components/Channel/DraftInputView.tsx
@@ -1,4 +1,4 @@
-import { DraftInputId } from '@tloncorp/shared';
+import { DraftInputId } from '@tloncorp/shared/api';
 
 import { useComponentsKitContext } from '../../contexts/componentsKits';
 import { DraftInputContext } from '../draftInputs';

--- a/packages/ui/src/components/Channel/PostView.tsx
+++ b/packages/ui/src/components/Channel/PostView.tsx
@@ -50,5 +50,19 @@ export const PostView: RenderItemType = (props) => {
     }
   }, [channel.type, channel.contentConfiguration, renderers]);
 
-  return <SpecificPostComponent {...props} />;
+  const contentRendererConfiguration = useMemo(() => {
+    if (channel.contentConfiguration == null) {
+      return undefined;
+    }
+    return ChannelContentConfiguration.defaultPostContentRenderer(
+      channel.contentConfiguration
+    ).configuration;
+  }, [channel.contentConfiguration]);
+
+  return (
+    <SpecificPostComponent
+      contentRendererConfiguration={contentRendererConfiguration}
+      {...props}
+    />
+  );
 };

--- a/packages/ui/src/components/Channel/PostView.tsx
+++ b/packages/ui/src/components/Channel/PostView.tsx
@@ -21,9 +21,9 @@ export const PostView: RenderItemType = (props) => {
       const contentConfig = channel.contentConfiguration;
       if (
         contentConfig != null &&
-        renderers[contentConfig.defaultPostContentRenderer] != null
+        renderers[contentConfig.defaultPostContentRenderer.id] != null
       ) {
-        return renderers[contentConfig.defaultPostContentRenderer];
+        return renderers[contentConfig.defaultPostContentRenderer.id];
       }
     })();
     if (rendererFromContentConfig != null) {

--- a/packages/ui/src/components/Channel/PostView.tsx
+++ b/packages/ui/src/components/Channel/PostView.tsx
@@ -1,3 +1,4 @@
+import { ChannelContentConfiguration } from '@tloncorp/shared/api';
 import { useMemo } from 'react';
 
 import { useChannelContext } from '../../contexts';
@@ -18,12 +19,14 @@ export const PostView: RenderItemType = (props) => {
     // without it, TypeScript thinks the value from `renderers[]` may be null.
     // sad!
     const rendererFromContentConfig = (() => {
-      const contentConfig = channel.contentConfiguration;
-      if (
-        contentConfig != null &&
-        renderers[contentConfig.defaultPostContentRenderer.id] != null
-      ) {
-        return renderers[contentConfig.defaultPostContentRenderer.id];
+      const contentConfig =
+        channel.contentConfiguration == null
+          ? null
+          : ChannelContentConfiguration.defaultPostContentRenderer(
+              channel.contentConfiguration
+            );
+      if (contentConfig != null && renderers[contentConfig.id] != null) {
+        return renderers[contentConfig.id];
       }
     })();
     if (rendererFromContentConfig != null) {

--- a/packages/ui/src/components/Channel/index.tsx
+++ b/packages/ui/src/components/Channel/index.tsx
@@ -1,4 +1,3 @@
-import { DraftInputId } from '@tloncorp/shared';
 import {
   isChatChannel as getIsChatChannel,
   useChannel as useChannelFromStore,
@@ -6,6 +5,10 @@ import {
   usePostReference as usePostReferenceHook,
   usePostWithRelations,
 } from '@tloncorp/shared';
+import {
+  ChannelContentConfiguration,
+  DraftInputId,
+} from '@tloncorp/shared/api';
 import * as db from '@tloncorp/shared/db';
 import { JSONContent, Story } from '@tloncorp/shared/urbit';
 import { ImagePickerAsset } from 'expo-image-picker';
@@ -350,7 +353,9 @@ export function Channel({
                                 <DraftInputView
                                   draftInputContext={draftInputContext}
                                   type={
-                                    channel.contentConfiguration.draftInput.id
+                                    ChannelContentConfiguration.draftInput(
+                                      channel.contentConfiguration
+                                    ).id
                                   }
                                 />
                               ))}

--- a/packages/ui/src/components/Channel/index.tsx
+++ b/packages/ui/src/components/Channel/index.tsx
@@ -190,6 +190,11 @@ export function Channel({
     (): DraftInputContext => ({
       channel,
       clearDraft,
+      configuration:
+        channel.contentConfiguration == null
+          ? undefined
+          : ChannelContentConfiguration.draftInput(channel.contentConfiguration)
+              .configuration,
       draftInputRef,
       editPost,
       editingPost,
@@ -290,6 +295,12 @@ export function Channel({
                                   <PostCollectionContext.Provider
                                     value={{
                                       channel,
+                                      collectionConfiguration:
+                                        channel.contentConfiguration == null
+                                          ? undefined
+                                          : ChannelContentConfiguration.defaultPostCollectionRenderer(
+                                              channel.contentConfiguration
+                                            ).configuration,
                                       editingPost,
                                       goToImageViewer,
                                       goToPost,

--- a/packages/ui/src/components/Channel/index.tsx
+++ b/packages/ui/src/components/Channel/index.tsx
@@ -349,7 +349,9 @@ export function Channel({
                               ) : (
                                 <DraftInputView
                                   draftInputContext={draftInputContext}
-                                  type={channel.contentConfiguration.draftInput}
+                                  type={
+                                    channel.contentConfiguration.draftInput.id
+                                  }
                                 />
                               ))}
 

--- a/packages/ui/src/components/ManageChannels/CreateChannelSheet.tsx
+++ b/packages/ui/src/components/ManageChannels/CreateChannelSheet.tsx
@@ -319,14 +319,12 @@ export function UnconnectedChannelConfigurationBar({
       })();
 
       const componentId = channel.contentConfiguration?.[field]?.id;
+      // @ts-expect-error - above code ensures that `componentId` is an index into `kit`
+      const componentSpec = componentId == null ? undefined : kit[componentId];
 
       return {
         value: channel.contentConfiguration?.[field],
-        parametersSchema:
-          componentId == null
-            ? undefined
-            : // @ts-expect-error we know that componentId matches kit
-              kit[componentId].parametersSchema,
+        parametersSchema: componentSpec?.parametersSchema,
         onChange: (update) =>
           updateChannelConfiguration?.((prev) => ({
             ...prev!,

--- a/packages/ui/src/components/PostCollectionView.tsx
+++ b/packages/ui/src/components/PostCollectionView.tsx
@@ -1,3 +1,4 @@
+import { ChannelContentConfiguration } from '@tloncorp/shared/api';
 import * as db from '@tloncorp/shared/db';
 import { Ref, useMemo } from 'react';
 
@@ -19,14 +20,18 @@ export function PostCollectionView({
   const SpecificComponent: IPostCollectionView = useMemo(() => {
     const rendererFromContentConfig = (() => {
       const contentConfig = channel.contentConfiguration;
+      if (contentConfig == null) {
+        return null;
+      }
+      const collectionConfig =
+        ChannelContentConfiguration.defaultPostCollectionRenderer(
+          contentConfig
+        );
       if (
         contentConfig != null &&
-        collectionRenderers[contentConfig.defaultPostCollectionRenderer.id] !=
-          null
+        collectionRenderers[collectionConfig.id] != null
       ) {
-        return collectionRenderers[
-          contentConfig.defaultPostCollectionRenderer.id
-        ];
+        return collectionRenderers[collectionConfig.id];
       }
     })();
     return rendererFromContentConfig ?? ListPostCollection;

--- a/packages/ui/src/components/PostCollectionView.tsx
+++ b/packages/ui/src/components/PostCollectionView.tsx
@@ -21,9 +21,12 @@ export function PostCollectionView({
       const contentConfig = channel.contentConfiguration;
       if (
         contentConfig != null &&
-        collectionRenderers[contentConfig.defaultPostCollectionRenderer] != null
+        collectionRenderers[contentConfig.defaultPostCollectionRenderer.id] !=
+          null
       ) {
-        return collectionRenderers[contentConfig.defaultPostCollectionRenderer];
+        return collectionRenderers[
+          contentConfig.defaultPostCollectionRenderer.id
+        ];
       }
     })();
     return rendererFromContentConfig ?? ListPostCollection;

--- a/packages/ui/src/components/YellPost.tsx
+++ b/packages/ui/src/components/YellPost.tsx
@@ -4,7 +4,7 @@ import { RenderItemType } from '../contexts/componentsKits';
 import { ChatAuthorRow } from './AuthorRow';
 import { createContentRenderer } from './PostContent';
 import { usePostContent } from './PostContent/contentUtils';
-import { RawText, Text } from './TextV2';
+import { RawText } from './TextV2';
 
 export const YellPost: RenderItemType = (props) => {
   const content = usePostContent(props.post);

--- a/packages/ui/src/components/draftInputs/shared.ts
+++ b/packages/ui/src/components/draftInputs/shared.ts
@@ -1,3 +1,4 @@
+import { JSONValue } from '@tloncorp/shared';
 import * as db from '@tloncorp/shared/db';
 import { JSONContent, Story } from '@tloncorp/shared/urbit';
 import { Dispatch, SetStateAction } from 'react';
@@ -22,6 +23,7 @@ export interface DraftInputHandle {
 export interface DraftInputContext {
   channel: db.Channel;
   clearDraft: (draftType?: GalleryDraftType) => void;
+  configuration?: Record<string, JSONValue>;
   draftInputRef?: React.Ref<DraftInputHandle>;
   editPost: (post: db.Post, content: Story) => Promise<void>;
   editingPost?: db.Post;

--- a/packages/ui/src/components/postCollectionViews/StrobePostCollectionView.tsx
+++ b/packages/ui/src/components/postCollectionViews/StrobePostCollectionView.tsx
@@ -1,6 +1,6 @@
+import { JSONValue } from '@tloncorp/shared';
 import * as db from '@tloncorp/shared/db';
 import { shuffle } from 'lodash';
-import { JSONValue } from 'packages/shared/src';
 import {
   forwardRef,
   useCallback,

--- a/packages/ui/src/components/postCollectionViews/StrobePostCollectionView.tsx
+++ b/packages/ui/src/components/postCollectionViews/StrobePostCollectionView.tsx
@@ -1,10 +1,12 @@
 import * as db from '@tloncorp/shared/db';
 import { shuffle } from 'lodash';
+import { JSONValue } from 'packages/shared/src';
 import {
   forwardRef,
   useCallback,
   useEffect,
   useImperativeHandle,
+  useMemo,
   useRef,
   useState,
 } from 'react';
@@ -90,7 +92,21 @@ export const StrobePostCollectionView: IPostCollectionView = forwardRef(
       },
     }));
 
-    return <_StrobePostCollectionView />;
+    const { collectionConfiguration } =
+      usePostCollectionContextUnsafelyUnwrapped();
+
+    const strobeDurationMs = useMemo(() => {
+      try {
+        return parseFloat(
+          JSONValue.asString(collectionConfiguration?.interval, '80')
+        );
+      } catch (_) {
+        // ignore
+        return 80;
+      }
+    }, [collectionConfiguration]);
+
+    return <_StrobePostCollectionView strobeDurationMs={strobeDurationMs} />;
   }
 );
 

--- a/packages/ui/src/components/postCollectionViews/shared.tsx
+++ b/packages/ui/src/components/postCollectionViews/shared.tsx
@@ -1,4 +1,5 @@
 import * as db from '@tloncorp/shared/db';
+import { JSONValue } from 'packages/shared/src';
 import { ComponentPropsWithoutRef, useMemo } from 'react';
 
 import { usePostCollectionContextUnsafelyUnwrapped } from '../../contexts/postCollection';
@@ -17,6 +18,18 @@ export function ConnectedPostView({
   ...overrides
 }: { post: db.Post } & Partial<ComponentPropsWithoutRef<typeof PostView>>) {
   const ctx = usePostCollectionContextUnsafelyUnwrapped();
+
+  const standardConfig = useMemo(() => {
+    const cfg = ctx.collectionConfiguration;
+    if (cfg == null) {
+      return null;
+    }
+    return {
+      showAuthor: JSONValue.asBoolean(cfg.showAuthors, false),
+      showReplies: JSONValue.asBoolean(cfg.showReplies, false),
+    };
+  }, [ctx.collectionConfiguration]);
+
   const postProps = useMemo(
     () => ({
       // TODO: useLivePost?
@@ -29,8 +42,11 @@ export function ConnectedPostView({
       // TODO: more props to get parity with BaseScrollerItem
 
       ...overrides,
+
+      showAuthor: standardConfig?.showAuthor,
+      showReplies: standardConfig?.showReplies,
     }),
-    [ctx, post, overrides]
+    [ctx, post, overrides, standardConfig]
   );
 
   return <PostView {...postProps} />;

--- a/packages/ui/src/components/postCollectionViews/shared.tsx
+++ b/packages/ui/src/components/postCollectionViews/shared.tsx
@@ -1,5 +1,5 @@
+import { JSONValue } from '@tloncorp/shared';
 import * as db from '@tloncorp/shared/db';
-import { JSONValue } from 'packages/shared/src';
 import { ComponentPropsWithoutRef, useMemo } from 'react';
 
 import { usePostCollectionContextUnsafelyUnwrapped } from '../../contexts/postCollection';

--- a/packages/ui/src/contexts/componentsKits.tsx
+++ b/packages/ui/src/contexts/componentsKits.tsx
@@ -50,6 +50,7 @@ type RenderItemProps = {
   onPressRetry: (post: db.Post) => void;
   onPressDelete: (post: db.Post) => void;
   isHighlighted?: boolean;
+  contentRendererConfiguration?: Record<string, unknown>;
 };
 
 type RenderItemFunction = (props: RenderItemProps) => ReactElement | null;
@@ -73,6 +74,7 @@ export type MinimalRenderItemProps = {
   onPressRetry?: (post: db.Post) => void;
   onPressDelete?: (post: db.Post) => void;
   isHighlighted?: boolean;
+  contentRendererConfiguration?: Record<string, unknown>;
 };
 export type MinimalRenderItemType = React.ComponentType<MinimalRenderItemProps>;
 

--- a/packages/ui/src/contexts/componentsKits.tsx
+++ b/packages/ui/src/contexts/componentsKits.tsx
@@ -1,11 +1,13 @@
 import {
   CollectionRendererId,
   DraftInputId,
+  JSONValue,
   PostContentRendererId,
 } from '@tloncorp/shared';
 import * as db from '@tloncorp/shared/db';
 import { Story } from '@tloncorp/shared/urbit';
 import { ReactElement, createContext, useContext, useMemo } from 'react';
+import { Text } from 'react-native';
 
 import { AudioPost } from '../components/AudioPost';
 import { PictoMessage } from '../components/Channel/PictoMessage';
@@ -15,7 +17,6 @@ import { useContactName } from '../components/ContactNameV2';
 import { StandaloneDrawingInput } from '../components/DrawingInput';
 import { GalleryPost } from '../components/GalleryPost';
 import { NotebookPost } from '../components/NotebookPost';
-import { Text } from '../components/TextV2';
 import { YellPost } from '../components/YellPost';
 import {
   ChatInput,
@@ -114,10 +115,17 @@ const BUILTIN_CONTENT_RENDERERS: { [id: string]: RenderItemType } = {
   [PostContentRendererId.picto]: PictoMessage,
   [PostContentRendererId.audio]: AudioPost,
   [PostContentRendererId.color]: ColorPost,
-  [PostContentRendererId.raw]: ({ post }) => {
+  [PostContentRendererId.raw]: ({ post, contentRendererConfiguration }) => {
     const contactName = useContactName(post.author!.id);
     return (
-      <Text>
+      <Text
+        style={{
+          fontFamily: JSONValue.asString(
+            contentRendererConfiguration?.fontFamily,
+            undefined
+          ),
+        }}
+      >
         {contactName}: {JSON.stringify(post.content)}
       </Text>
     );
@@ -131,8 +139,14 @@ const BUILTIN_DRAFT_INPUTS: { [id: string]: DraftInputRendererComponent } = {
   [DraftInputId.yo]: ({ draftInputContext }) => (
     <ButtonInput
       draftInputContext={draftInputContext}
-      messageText="Yo"
-      labelText="Yo"
+      messageText={JSONValue.asString(
+        draftInputContext.configuration?.text,
+        'Yo'
+      )}
+      labelText={JSONValue.asString(
+        draftInputContext.configuration?.text,
+        'Yo'
+      )}
     />
   ),
   [DraftInputId.picto]: StandaloneDrawingInput,

--- a/packages/ui/src/contexts/postCollection.ts
+++ b/packages/ui/src/contexts/postCollection.ts
@@ -1,3 +1,4 @@
+import { JSONValue } from '@tloncorp/shared';
 import * as db from '@tloncorp/shared/db';
 import { createContext, useContext } from 'react';
 
@@ -5,6 +6,7 @@ import { MinimalRenderItemType, RenderItemType } from './componentsKits';
 
 export interface PostCollectionContextValue {
   channel: db.Channel;
+  collectionConfiguration?: Record<string, JSONValue>;
   editingPost?: db.Post;
   goToImageViewer: (post: db.Post, imageUri?: string) => void;
   goToPost: (post: db.Post) => void;


### PR DESCRIPTION
> I'm not super happy with how this PR turned out, it feels like way more code than it should be. I think this is because I didn't use a strict pattern when implementing inputs vs collections vs post content config – these all ended up looking almost identical, but we reference them in slightly different ways, so I needed to add adapters whenever trying to operate over all of them.
> But in the interest of having a demo, here's the diff:

- Changed component configs in `ChannelContentConfiguration` (`draftInput` / `defaultCollectionRendererId` / `defaultPostContentRendererId`) from type `ID` -> `ID | { id: ID, configuration?: Record<string, JSONValue> }` – this was to avoid breaking existing channels (which I think would be okay to do, but it wasn't _that_ hard to maintain backwards compatibility)
- Added a `parametersSchema` field to each component spec, which the `ChannelConfigurationBar` uses to populate a sheet with available customizable parameters.
- Provide any available parameters to the post / collection / input components as a loosely-typed `Record<string, JSONValue>`
- Added some example uses of parameters, including a small set of standard parameters available on all collections (I wrote this as opt-in per collection, but enabled on all existing collections)

| New ChannelConfigurationBar | Tapping on one of those cogs |
| --- | --- |
| ![Simulator Screenshot - iPhone 15 - 2024-10-31 at 09 48 41](https://github.com/user-attachments/assets/3e7ab845-fb21-4239-855e-d04b6284f167) | ![Simulator Screenshot - iPhone 15 - 2024-10-31 at 09 48 12](https://github.com/user-attachments/assets/290e17c9-2ec7-47c1-8273-4b5537955216) |