### PR TITLE
custom channels: fix handling of omitted standard parameters

### DIFF
--- a/packages/shared/src/api/channelContentConfig.ts
+++ b/packages/shared/src/api/channelContentConfig.ts
@@ -14,12 +14,12 @@ export interface ComponentSpec<EnumTag extends string = string> {
 
 function standardCollectionParameters(): Record<string, ParameterSpec> {
   return {
-    showAuthor: {
-      displayName: 'Show author',
+    hideAuthors: {
+      displayName: 'Hide authors',
       type: 'boolean',
     },
-    showReplies: {
-      displayName: 'Show replies',
+    hideReplies: {
+      displayName: 'Hide replies',
       type: 'boolean',
     },
   };

--- a/packages/shared/src/api/channelContentConfig.ts
+++ b/packages/shared/src/api/channelContentConfig.ts
@@ -14,12 +14,12 @@ export interface ComponentSpec<EnumTag extends string = string> {
 
 function standardCollectionParameters(): Record<string, ParameterSpec> {
   return {
-    hideAuthors: {
-      displayName: 'Hide authors',
+    showAuthors: {
+      displayName: 'Show authors',
       type: 'boolean',
     },
-    hideReplies: {
-      displayName: 'Hide replies',
+    showReplies: {
+      displayName: 'Show replies',
       type: 'boolean',
     },
   };
@@ -258,12 +258,26 @@ export namespace StructuredChannelDescriptionPayload {
         }
         // add a little robustness - if the configuration is missing a field,
         // just add a default in to avoid crashing
-        out.channelContentConfiguration = {
-          draftInput: DraftInputId.chat,
-          defaultPostContentRenderer: PostContentRendererId.chat,
-          defaultPostCollectionRenderer: CollectionRendererId.chat,
-          ...out.channelContentConfiguration,
-        };
+        out.channelContentConfiguration = ((raw) => {
+          const cfg = {
+            draftInput: DraftInputId.chat,
+            defaultPostContentRenderer: PostContentRendererId.chat,
+            defaultPostCollectionRenderer: CollectionRendererId.chat,
+            ...raw,
+          } as ChannelContentConfiguration;
+
+          // add defaults to some standard params
+          const collCfgWithDefaults = ParameterizedId.coerce(
+            cfg.defaultPostCollectionRenderer
+          );
+          collCfgWithDefaults.configuration = {
+            showAuthors: true,
+            showReplies: true,
+            ...collCfgWithDefaults.configuration,
+          };
+
+          return cfg;
+        })(out.channelContentConfiguration);
       }
       return out;
     } catch (_err) {

--- a/packages/shared/src/api/channelContentConfig.ts
+++ b/packages/shared/src/api/channelContentConfig.ts
@@ -251,7 +251,21 @@ export namespace StructuredChannelDescriptionPayload {
       return {};
     }
     try {
-      return JSON.parse(encoded);
+      const out = JSON.parse(encoded);
+      if ('channelContentConfiguration' in out) {
+        if (typeof out.channelContentConfiguration !== 'object') {
+          throw new Error('Invalid configuration');
+        }
+        // add a little robustness - if the configuration is missing a field,
+        // just add a default in to avoid crashing
+        out.channelContentConfiguration = {
+          draftInput: DraftInputId.chat,
+          defaultPostContentRenderer: PostContentRendererId.chat,
+          defaultPostCollectionRenderer: CollectionRendererId.chat,
+          ...out.channelContentConfiguration,
+        };
+      }
+      return out;
     } catch (_err) {
       return { description: encoded.length === 0 ? undefined : encoded };
     }

--- a/packages/shared/src/types/JSONValue.ts
+++ b/packages/shared/src/types/JSONValue.ts
@@ -1,4 +1,4 @@
-export type JSONValue = number | string; // can add more JSON-compliant types as needed
+export type JSONValue = number | string | boolean; // can add more JSON-compliant types as needed
 
 // eslint-disable-next-line @typescript-eslint/no-namespace
 export namespace JSONValue {

--- a/packages/ui/src/components/Channel/PostView.tsx
+++ b/packages/ui/src/components/Channel/PostView.tsx
@@ -1,4 +1,5 @@
 import { ChannelContentConfiguration } from '@tloncorp/shared/api';
+import { JSONValue } from 'packages/shared/src';
 import { useMemo } from 'react';
 
 import { useChannelContext } from '../../contexts';
@@ -59,10 +60,30 @@ export const PostView: RenderItemType = (props) => {
     ).configuration;
   }, [channel.contentConfiguration]);
 
+  // this code is duplicated in packages/ui/src/components/postCollectionViews/shared.tsx
+  const standardConfig = useMemo(() => {
+    if (channel.contentConfiguration == null) {
+      return null;
+    }
+    const cfg = ChannelContentConfiguration.defaultPostCollectionRenderer(
+      channel.contentConfiguration
+    ).configuration;
+    if (cfg == null) {
+      return null;
+    }
+    return {
+      showAuthor:
+        props.showAuthor && JSONValue.asBoolean(cfg.showAuthors, false),
+      showReplies:
+        props.showReplies && JSONValue.asBoolean(cfg.showReplies, false),
+    } as const;
+  }, [channel.contentConfiguration, props.showAuthor, props.showReplies]);
+
   return (
     <SpecificPostComponent
       contentRendererConfiguration={contentRendererConfiguration}
       {...props}
+      {...standardConfig}
     />
   );
 };

--- a/packages/ui/src/components/Channel/PostView.tsx
+++ b/packages/ui/src/components/Channel/PostView.tsx
@@ -1,5 +1,5 @@
+import { JSONValue } from '@tloncorp/shared';
 import { ChannelContentConfiguration } from '@tloncorp/shared/api';
-import { JSONValue } from 'packages/shared/src';
 import { useMemo } from 'react';
 
 import { useChannelContext } from '../../contexts';

--- a/packages/ui/src/components/ChatOptionsSheet.tsx
+++ b/packages/ui/src/components/ChatOptionsSheet.tsx
@@ -699,10 +699,14 @@ export function ChannelOptions({
             {
               accent: 'neutral',
               actions: [
-                {
-                  title: 'Configure view',
-                  action: onPressConfigureChannel,
-                },
+                ...(channel.contentConfiguration == null
+                  ? []
+                  : [
+                      {
+                        title: 'Configure view',
+                        action: onPressConfigureChannel,
+                      },
+                    ]),
                 {
                   title: 'Manage channels',
                   endIcon: 'ChevronRight',

--- a/packages/ui/src/components/postCollectionViews/shared.tsx
+++ b/packages/ui/src/components/postCollectionViews/shared.tsx
@@ -19,6 +19,7 @@ export function ConnectedPostView({
 }: { post: db.Post } & Partial<ComponentPropsWithoutRef<typeof PostView>>) {
   const ctx = usePostCollectionContextUnsafelyUnwrapped();
 
+  // this code is duplicated in packages/ui/src/components/Channel/PostView.tsx
   const standardConfig = useMemo(() => {
     const cfg = ctx.collectionConfiguration;
     if (cfg == null) {

--- a/packages/ui/src/components/postCollectionViews/shared.tsx
+++ b/packages/ui/src/components/postCollectionViews/shared.tsx
@@ -25,8 +25,8 @@ export function ConnectedPostView({
       return null;
     }
     return {
-      hideAuthors: JSONValue.asBoolean(cfg.hideAuthors, false),
-      hideReplies: JSONValue.asBoolean(cfg.hideReplies, false),
+      showAuthor: JSONValue.asBoolean(cfg.showAuthors, false),
+      showReplies: JSONValue.asBoolean(cfg.showReplies, false),
     };
   }, [ctx.collectionConfiguration]);
 
@@ -43,8 +43,8 @@ export function ConnectedPostView({
 
       ...overrides,
 
-      showAuthor: !standardConfig?.hideAuthors,
-      showReplies: !standardConfig?.hideReplies,
+      showAuthor: standardConfig?.showAuthor,
+      showReplies: standardConfig?.showReplies,
     }),
     [ctx, post, overrides, standardConfig]
   );

--- a/packages/ui/src/components/postCollectionViews/shared.tsx
+++ b/packages/ui/src/components/postCollectionViews/shared.tsx
@@ -25,8 +25,8 @@ export function ConnectedPostView({
       return null;
     }
     return {
-      showAuthor: JSONValue.asBoolean(cfg.showAuthors, false),
-      showReplies: JSONValue.asBoolean(cfg.showReplies, false),
+      hideAuthors: JSONValue.asBoolean(cfg.hideAuthors, false),
+      hideReplies: JSONValue.asBoolean(cfg.hideReplies, false),
     };
   }, [ctx.collectionConfiguration]);
 
@@ -43,8 +43,8 @@ export function ConnectedPostView({
 
       ...overrides,
 
-      showAuthor: standardConfig?.showAuthor,
-      showReplies: standardConfig?.showReplies,
+      showAuthor: !standardConfig?.hideAuthors,
+      showReplies: !standardConfig?.hideReplies,
     }),
     [ctx, post, overrides, standardConfig]
   );


### PR DESCRIPTION
Without this PR, older custom channels have authors and replies hidden by default.

- Set param defaults when parsing `StructuredChannelDescriptionPayload`
- In same code block, add any missing fields to `ChannelContentConfiguration` (missing fields here was causing a crash in one of my test channels)
- Hide `Configure view` menu item when config is missing (this would cause a crash otherwise)
- Apply standard params (`Show replies`, `Show authors`) on legacy post types (we were not doing this before)