### PR TITLE
native: manually close database instead of using deinit

### DIFF
--- a/apps/tlon-mobile/ios/Intents/ChannelEntity.swift
+++ b/apps/tlon-mobile/ios/Intents/ChannelEntity.swift
@@ -46,6 +46,8 @@ struct ChannelQuery: EntityStringQuery {
       where c.title like ?
     """, parameters: ["%\(string)%"])
     
+    database.close()
+    
     return results.map { result in
       ChannelEntity(
         id: result["id"]!!,
@@ -70,6 +72,7 @@ struct ChannelQuery: EntityStringQuery {
       join channels c on query.id = c.id
       join groups g on c.group_id = g.id
     """, parameters: identifiers)
+    database.close()
 
     return results.map { result in
       ChannelEntity(
@@ -93,7 +96,8 @@ struct ChannelQuery: EntityStringQuery {
       order by max(c.last_viewed_at, c.last_post_at) desc
       limit 10
     """)
-    
+    database.close()
+
     return results.map { result in
       ChannelEntity(
         id: result["id"]!!,

--- a/apps/tlon-mobile/ios/SQLiteDB.swift
+++ b/apps/tlon-mobile/ios/SQLiteDB.swift
@@ -2,7 +2,7 @@ import sqlite3
 
 let SQLITE_TRANSIENT = unsafeBitCast(-1, to: sqlite3_destructor_type.self)
 
-struct SQLiteDB: ~Copyable {
+struct SQLiteDB {
   let db: OpaquePointer
   
   init?(dbUrl: URL) {
@@ -14,7 +14,7 @@ struct SQLiteDB: ~Copyable {
     }
   }
   
-  deinit {
+  func close() {
     sqlite3_close(db)
   }
   


### PR DESCRIPTION
Apparently `~Copyable` protocol can't be used with generics (at least in the Swift version in our CD).

I had used `~Copyable` so that we could implement a `deinit` to close the DB on GC – without being able to handle the case that opening the DB results in an error, I had to remove `~Copyable`, replacing the `deinit` with a manually-called `close()` method.