### PR TITLE
native: manually close database instead of using deinit

### DIFF
--- a/apps/tlon-mobile/ios/Intents/ChannelEntity.swift
+++ b/apps/tlon-mobile/ios/Intents/ChannelEntity.swift
@@ -1,0 +1,105 @@
+import AppIntents
+import Intents
+
+struct ChannelEntity: AppEntity {
+  struct Group {
+    let title: String
+  }
+  
+  static var defaultQuery = ChannelQuery()
+  
+  var id: String
+  let title: String
+  let group: ChannelEntity.Group
+  
+  static var typeDisplayRepresentation: TypeDisplayRepresentation {
+    TypeDisplayRepresentation(
+      name: "Channel",
+      numericFormat: "\(placeholder: .int) channels"
+    )
+  }
+  
+  var displayRepresentation: DisplayRepresentation {
+    DisplayRepresentation(
+      title: "\(title)",
+      subtitle: "\(group.title)",
+      image: nil
+    )
+  }
+}
+
+struct ChannelQuery: EntityStringQuery {
+  private var database: SQLiteDB? {
+    SQLiteDB.openApplicationDatabase()
+  }
+
+  func entities(matching string: String) async throws -> [ChannelEntity] {
+    guard let database else { return [] }
+    
+    let results = database.exec("""
+      select
+        c.id,
+        c.title, 
+        g.title as group_title
+      from channels c
+      join groups g on c.group_id = g.id
+      where c.title like ?
+    """, parameters: ["%\(string)%"])
+    
+    return results.map { result in
+      ChannelEntity(
+        id: result["id"]!!,
+        title: result["title"]!!,
+        group: ChannelEntity.Group(title: result["group_title"]!!)
+      )
+    }
+  }
+  
+  func entities(for identifiers: [ChannelEntity.ID]) async throws -> [ChannelEntity] {
+    guard let database else { return [] }
+    
+    let results = database.exec("""
+      with query(id) as (
+         values \(identifiers.map { _ in "(?)" }.joined(separator: ", "))
+      )
+      select
+        c.id,
+        c.title,
+        g.title as group_title
+      from query
+      join channels c on query.id = c.id
+      join groups g on c.group_id = g.id
+    """, parameters: identifiers)
+
+    return results.map { result in
+      ChannelEntity(
+        id: result["id"]!!,
+        title: result["title"]!!,
+        group: ChannelEntity.Group(title: result["group_title"]!!)
+      )
+    }
+  }
+  
+  func suggestedEntities() async throws -> [ChannelEntity] {
+    guard let database else { return [] }
+    
+    let results = database.exec("""
+      select
+        c.id,
+        c.title, 
+        g.title as group_title
+      from channels c
+      join groups g on c.group_id = g.id
+      order by max(c.last_viewed_at, c.last_post_at) desc
+      limit 10
+    """)
+    
+    return results.map { result in
+      ChannelEntity(
+        id: result["id"]!!,
+        title: result["title"]!!,
+        group: ChannelEntity.Group(title: result["group_title"]!!)
+      )
+    }
+  }
+}

--- a/apps/tlon-mobile/ios/Intents/OpenAppIntent.swift
+++ b/apps/tlon-mobile/ios/Intents/OpenAppIntent.swift
@@ -1,0 +1,26 @@
+import AppIntents
+
+struct OpenAppIntent: AppIntent {
+  static var title: LocalizedStringResource = "Open channel"
+  static var description = IntentDescription("Opens the app to the specified channel.")
+  static var openAppWhenRun = true
+  
+  @Parameter(title: "Channel", description: "The app will open to this channel.")
+  var channel: ChannelEntity?
+  
+  @Parameter(title: "Start draft", description: "True if you want to start a new draft in the channel.")
+  var startDraft: Bool?
+  
+  @Dependency
+  private var intentNotepad: IntentNotepad
+  
+  @MainActor
+  func perform() async throws -> some IntentResult {
+    if let channelId = channel?.id {
+      intentNotepad.action = .openChannel(channelId: channelId, startDraft: startDraft ?? false)
+    } else {
+      intentNotepad.action = nil
+    }
+    return .result()
+  }
+}

--- a/apps/tlon-mobile/ios/Intents/ShortcutsManager.swift
+++ b/apps/tlon-mobile/ios/Intents/ShortcutsManager.swift
@@ -1,0 +1,62 @@
+import Foundation
+import Combine
+import AppIntents
+
+final class IntentNotepad: ObservableObject, @unchecked Sendable {
+  static let shared = IntentNotepad()
+  
+  enum Action {
+    case openChannel(channelId: String, startDraft: Bool)
+  }
+  
+  @Published var action: Action?
+}
+
+@objc class ShortcutsManager: NSObject {
+  // reference necessary to retain subscription
+  private static var subscription: AnyCancellable?
+  
+  @objc static func setup() {
+    AppDependencyManager.shared.add(dependency: IntentNotepad.shared)
+    
+    subscription = IntentNotepad.shared
+      .$action
+      .sink { action in
+        switch action {
+        case let .openChannel(channelId, startDraft):
+          if let url = URL.deeplinkToOpenChannel(withId: channelId, startDraft: startDraft) {
+            UIApplication.shared.open(url)
+          }
+          
+        default: break
+        }
+      }
+  }
+}
+
+extension URL {
+  static var schemeForDeeplinking: String? {
+    if let urlTypes = Bundle.main.object(forInfoDictionaryKey: "CFBundleURLTypes") as? [[String: Any]] {
+      if let urlSchemes = urlTypes.first?["CFBundleURLSchemes"] as? [String] {
+        return urlSchemes.first
+      }
+    }
+    return nil
+  }
+  
+  static func deeplinkToOpenChannel(withId channelId: String, startDraft: Bool = false) -> URL? {
+    guard let scheme = URL.schemeForDeeplinking else { return nil }
+    var urlComponents = URLComponents()
+    urlComponents.scheme = scheme
+    urlComponents.host = "channel"
+    urlComponents.path = "/open"
+    var queryItems: [URLQueryItem] = [
+      URLQueryItem(name: "id", value: channelId),
+    ]
+    if startDraft {
+      queryItems.append(URLQueryItem(name: "startDraft", value: "true"))
+    }
+    urlComponents.queryItems = queryItems
+    return urlComponents.url
+  }
+}

--- a/apps/tlon-mobile/ios/Landscape.xcodeproj/project.pbxproj
+++ b/apps/tlon-mobile/ios/Landscape.xcodeproj/project.pbxproj
@@ -73,6 +73,8 @@
 		632793D42C4AEA6800F942B1 /* UrsusSigil in Frameworks */ = {isa = PBXBuildFile; productRef = 632793D32C4AEA6800F942B1 /* UrsusSigil */; };
 		63566D1C2C530A370048E3C4 /* INPerson+Extension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 70D386662A60A37000AFB46E /* INPerson+Extension.swift */; };
 		63566D1D2C530A370048E3C4 /* INPerson+Extension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 70D386662A60A37000AFB46E /* INPerson+Extension.swift */; };
+		635BCB0B2CC6F969004D52AA /* OpenAppIntent.swift in Sources */ = {isa = PBXBuildFile; fileRef = 635BCB0A2CC6F969004D52AA /* OpenAppIntent.swift */; };
+		635BCB0C2CC6F969004D52AA /* OpenAppIntent.swift in Sources */ = {isa = PBXBuildFile; fileRef = 635BCB0A2CC6F969004D52AA /* OpenAppIntent.swift */; };
 		6374ACE22C49DA9600E637C0 /* NotificationService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6374ACE12C49DA9600E637C0 /* NotificationService.swift */; };
 		6374ACF92C4ACD5100E637C0 /* LoginStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6374ACF82C4ACD5000E637C0 /* LoginStore.swift */; };
 		6374ACFA2C4ACD5100E637C0 /* LoginStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6374ACF82C4ACD5000E637C0 /* LoginStore.swift */; };
@@ -80,12 +82,18 @@
 		6374ACFD2C4ACD7500E637C0 /* Login.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6374ACFC2C4ACD7500E637C0 /* Login.swift */; };
 		6374ACFE2C4ACD7500E637C0 /* Login.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6374ACFC2C4ACD7500E637C0 /* Login.swift */; };
 		6374ACFF2C4ACD7500E637C0 /* Login.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6374ACFC2C4ACD7500E637C0 /* Login.swift */; };
+		638753082CC7036C003942F5 /* ShortcutsManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 638753072CC7036C003942F5 /* ShortcutsManager.swift */; };
+		638753092CC7036C003942F5 /* ShortcutsManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 638753072CC7036C003942F5 /* ShortcutsManager.swift */; };
+		63A5A04E2CD05CB900928EED /* ChannelEntity.swift in Sources */ = {isa = PBXBuildFile; fileRef = 63A5A04D2CD05CB600928EED /* ChannelEntity.swift */; };
+		63A5A04F2CD05CB900928EED /* ChannelEntity.swift in Sources */ = {isa = PBXBuildFile; fileRef = 63A5A04D2CD05CB600928EED /* ChannelEntity.swift */; };
 		63E27E0B2C5AF26C008ACB45 /* Alamofire+sessionWithSharedCookieStorage.swift in Sources */ = {isa = PBXBuildFile; fileRef = 63E27E0A2C5AF26C008ACB45 /* Alamofire+sessionWithSharedCookieStorage.swift */; };
 		63E27E0C2C5AF26C008ACB45 /* Alamofire+sessionWithSharedCookieStorage.swift in Sources */ = {isa = PBXBuildFile; fileRef = 63E27E0A2C5AF26C008ACB45 /* Alamofire+sessionWithSharedCookieStorage.swift */; };
 		63E27E0D2C5AF26C008ACB45 /* Alamofire+sessionWithSharedCookieStorage.swift in Sources */ = {isa = PBXBuildFile; fileRef = 63E27E0A2C5AF26C008ACB45 /* Alamofire+sessionWithSharedCookieStorage.swift */; };
 		63E27E0E2C5AF26C008ACB45 /* Alamofire+sessionWithSharedCookieStorage.swift in Sources */ = {isa = PBXBuildFile; fileRef = 63E27E0A2C5AF26C008ACB45 /* Alamofire+sessionWithSharedCookieStorage.swift */; };
 		63E27E132C5AF5B9008ACB45 /* HTTPCookieStorage+forwardChanges.swift in Sources */ = {isa = PBXBuildFile; fileRef = 63E27E122C5AF5B8008ACB45 /* HTTPCookieStorage+forwardChanges.swift */; };
 		63E27E142C5AF5B9008ACB45 /* HTTPCookieStorage+forwardChanges.swift in Sources */ = {isa = PBXBuildFile; fileRef = 63E27E122C5AF5B8008ACB45 /* HTTPCookieStorage+forwardChanges.swift */; };
+		63EC5CC02CD0495B0098C343 /* SQLiteDB.swift in Sources */ = {isa = PBXBuildFile; fileRef = 63EC5CBF2CD049540098C343 /* SQLiteDB.swift */; };
+		63EC5CC12CD0495B0098C343 /* SQLiteDB.swift in Sources */ = {isa = PBXBuildFile; fileRef = 63EC5CBF2CD049540098C343 /* SQLiteDB.swift */; };
 		700B635B2A71DF860017F40F /* PocketUserAPI.swift in Sources */ = {isa = PBXBuildFile; fileRef = 700B635A2A71DF860017F40F /* PocketUserAPI.swift */; };
 		700B635D2A71DFE90017F40F /* Contact.swift in Sources */ = {isa = PBXBuildFile; fileRef = 700B635C2A71DFE90017F40F /* Contact.swift */; };
 		700B63602A71E0810017F40F /* SettingsStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 700B635F2A71E0810017F40F /* SettingsStore.swift */; };
@@ -236,6 +244,7 @@
 		630DE0EB2C51AC840053603B /* UserDefaults+appGroup.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UserDefaults+appGroup.swift"; sourceTree = "<group>"; };
 		630DE0F02C51AE870053603B /* Info-preview.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = "Info-preview.plist"; sourceTree = "<group>"; };
 		632793BD2C4AE4B500F942B1 /* Error+isAFTimeout.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Error+isAFTimeout.swift"; sourceTree = "<group>"; };
+		635BCB0A2CC6F969004D52AA /* OpenAppIntent.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OpenAppIntent.swift; sourceTree = "<group>"; };
 		636788082C90DC2600F5331E /* Notifications-preview.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = "Notifications-preview.entitlements"; sourceTree = "<group>"; };
 		6374ACDF2C49DA9600E637C0 /* Notifications.appex */ = {isa = PBXFileReference; explicitFileType = "wrapper.app-extension"; includeInIndex = 0; path = Notifications.appex; sourceTree = BUILT_PRODUCTS_DIR; };
 		6374ACE12C49DA9600E637C0 /* NotificationService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NotificationService.swift; sourceTree = "<group>"; };
@@ -243,8 +252,11 @@
 		6374ACEB2C49DAB600E637C0 /* Notifications.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = Notifications.entitlements; sourceTree = "<group>"; };
 		6374ACF82C4ACD5000E637C0 /* LoginStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LoginStore.swift; sourceTree = "<group>"; };
 		6374ACFC2C4ACD7500E637C0 /* Login.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Login.swift; sourceTree = "<group>"; };
+		638753072CC7036C003942F5 /* ShortcutsManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShortcutsManager.swift; sourceTree = "<group>"; };
+		63A5A04D2CD05CB600928EED /* ChannelEntity.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChannelEntity.swift; sourceTree = "<group>"; };
 		63E27E0A2C5AF26C008ACB45 /* Alamofire+sessionWithSharedCookieStorage.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Alamofire+sessionWithSharedCookieStorage.swift"; sourceTree = "<group>"; };
 		63E27E122C5AF5B8008ACB45 /* HTTPCookieStorage+forwardChanges.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = "HTTPCookieStorage+forwardChanges.swift"; path = "Landscape/HTTPCookieStorage+forwardChanges.swift"; sourceTree = "<group>"; };
+		63EC5CBF2CD049540098C343 /* SQLiteDB.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SQLiteDB.swift; sourceTree = "<group>"; };
 		6C2E3173556A471DD304B334 /* Pods-Landscape.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Landscape.debug.xcconfig"; path = "Target Support Files/Pods-Landscape/Pods-Landscape.debug.xcconfig"; sourceTree = "<group>"; };
 		700B635A2A71DF860017F40F /* PocketUserAPI.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PocketUserAPI.swift; sourceTree = "<group>"; };
 		700B635C2A71DFE90017F40F /* Contact.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Contact.swift; sourceTree = "<group>"; };
@@ -345,6 +357,8 @@
 		13B07FAE1A68108700A75B9A /* Landscape */ = {
 			isa = PBXGroup;
 			children = (
+				63EC5CBF2CD049540098C343 /* SQLiteDB.swift */,
+				635BCB092CC6F954004D52AA /* Intents */,
 				BB2F792B24A3F905000567C9 /* Supporting */,
 				008F07F21AC5B25A0029DE68 /* main.jsbundle */,
 				13B07FAF1A68108700A75B9A /* AppDelegate.h */,
@@ -384,6 +398,16 @@
 				8ACB38DC4FF4D6377774BF5F /* ExpoModulesProvider.swift */,
 			);
 			name = "Landscape-preview";
+			sourceTree = "<group>";
+		};
+		635BCB092CC6F954004D52AA /* Intents */ = {
+			isa = PBXGroup;
+			children = (
+				63A5A04D2CD05CB600928EED /* ChannelEntity.swift */,
+				635BCB0A2CC6F969004D52AA /* OpenAppIntent.swift */,
+				638753072CC7036C003942F5 /* ShortcutsManager.swift */,
+			);
+			path = Intents;
 			sourceTree = "<group>";
 		};
 		6374ACE02C49DA9600E637C0 /* Notifications */ = {
@@ -1198,7 +1222,9 @@
 				70D386672A60A37000AFB46E /* INPerson+Extension.swift in Sources */,
 				701A09B02B03081300D8F710 /* Error+logWithDomain.swift in Sources */,
 				70D3866C2A60A38400AFB46E /* Group.swift in Sources */,
+				63A5A04F2CD05CB900928EED /* ChannelEntity.swift in Sources */,
 				700B63602A71E0810017F40F /* SettingsStore.swift in Sources */,
+				635BCB0B2CC6F969004D52AA /* OpenAppIntent.swift in Sources */,
 				70D386712A60A3E600AFB46E /* UIColor+Extension.swift in Sources */,
 				700B635B2A71DF860017F40F /* PocketUserAPI.swift in Sources */,
 				6374ACFD2C4ACD7500E637C0 /* Login.swift in Sources */,
@@ -1207,6 +1233,8 @@
 				7036E3522ACD08E30020A9FB /* GroupChannelStore.swift in Sources */,
 				13B07FBC1A68108700A75B9A /* AppDelegate.mm in Sources */,
 				13B07FC11A68108700A75B9A /* main.m in Sources */,
+				638753082CC7036C003942F5 /* ShortcutsManager.swift in Sources */,
+				63EC5CC02CD0495B0098C343 /* SQLiteDB.swift in Sources */,
 				70EAEAB52A57A99100FE96E4 /* UrbitModule.swift in Sources */,
 				700B63622A71E0D70017F40F /* ContactStore.swift in Sources */,
 				63E27E132C5AF5B9008ACB45 /* HTTPCookieStorage+forwardChanges.swift in Sources */,
@@ -1301,7 +1329,9 @@
 				70DBBFF42B7C60B50021EA96 /* Error+logWithDomain.swift in Sources */,
 				70DBBFF52B7C60B50021EA96 /* Group.swift in Sources */,
 				70DBBFF62B7C60B50021EA96 /* SettingsStore.swift in Sources */,
+				63A5A04E2CD05CB900928EED /* ChannelEntity.swift in Sources */,
 				70DBBFF72B7C60B50021EA96 /* UIColor+Extension.swift in Sources */,
+				635BCB0C2CC6F969004D52AA /* OpenAppIntent.swift in Sources */,
 				70DBBFF82B7C60B50021EA96 /* PocketUserAPI.swift in Sources */,
 				C83014832C7BA74C00D9A5CA /* UIFont+SystemDesign.m in Sources */,
 				6374ACFE2C4ACD7500E637C0 /* Login.swift in Sources */,
@@ -1310,6 +1340,8 @@
 				70DBBFFB2B7C60B50021EA96 /* GroupChannelStore.swift in Sources */,
 				70DBBFFC2B7C60B50021EA96 /* AppDelegate.mm in Sources */,
 				70DBBFFD2B7C60B50021EA96 /* main.m in Sources */,
+				638753092CC7036C003942F5 /* ShortcutsManager.swift in Sources */,
+				63EC5CC12CD0495B0098C343 /* SQLiteDB.swift in Sources */,
 				70DBBFFF2B7C60B50021EA96 /* UrbitModule.swift in Sources */,
 				70DBC0002B7C60B50021EA96 /* ContactStore.swift in Sources */,
 				63E27E142C5AF5B9008ACB45 /* HTTPCookieStorage+forwardChanges.swift in Sources */,
@@ -1883,7 +1915,11 @@
 				ONLY_ACTIVE_ARCH = YES;
 				OTHER_CFLAGS = "$(inherited)";
 				OTHER_CPLUSPLUSFLAGS = "$(inherited)";
-				OTHER_LDFLAGS = "$(inherited)";
+				OTHER_LDFLAGS = (
+					"$(inherited)",
+					"-Wl",
+					"-ld_classic",
+				);
 				REACT_NATIVE_PATH = "${PODS_ROOT}/../../../../node_modules/react-native";
 				SDKROOT = iphoneos;
 				USE_HERMES = true;
@@ -1976,7 +2012,11 @@
 				MTL_ENABLE_DEBUG_INFO = NO;
 				OTHER_CFLAGS = "$(inherited)";
 				OTHER_CPLUSPLUSFLAGS = "$(inherited)";
-				OTHER_LDFLAGS = "$(inherited)";
+				OTHER_LDFLAGS = (
+					"$(inherited)",
+					"-Wl",
+					"-ld_classic",
+				);
 				REACT_NATIVE_PATH = "${PODS_ROOT}/../../../../node_modules/react-native";
 				SDKROOT = iphoneos;
 				USE_HERMES = true;

--- a/apps/tlon-mobile/ios/Landscape/AppDelegate.mm
+++ b/apps/tlon-mobile/ios/Landscape/AppDelegate.mm
@@ -31,6 +31,8 @@
   // Ideally, we'd exclusively use the app group storage for all cookie read/writes, but I could
   // not get the auth cookie to be written to that storage.
   [[NSHTTPCookieStorage sharedHTTPCookieStorage] forwardChangesTo: [NSHTTPCookieStorage forDefaultAppGroup]];
+  
+  [ShortcutsManager setup];
 
   return [super application:application didFinishLaunchingWithOptions:launchOptions];
 }

--- a/apps/tlon-mobile/ios/SQLiteDB.swift
+++ b/apps/tlon-mobile/ios/SQLiteDB.swift
@@ -1,0 +1,70 @@
+import sqlite3
+
+let SQLITE_TRANSIENT = unsafeBitCast(-1, to: sqlite3_destructor_type.self)
+
+struct SQLiteDB: ~Copyable {
+  let db: OpaquePointer
+  
+  init?(dbUrl: URL) {
+    var db: OpaquePointer?
+    if sqlite3_open(dbUrl.path, &db) == SQLITE_OK {
+      self.db = db!
+    } else {
+      return nil
+    }
+  }
+  
+  deinit {
+    sqlite3_close(db)
+  }
+  
+  func exec(_ sql: String, parameters: [String] = []) -> Array<[String?: String?]> {
+    var results = Array<[String?: String?]>()
+    
+    var statement: OpaquePointer?
+    sqlite3_prepare_v2(
+      db,
+      sql,
+      -1, // max length of sql (we want no max)
+      &statement,
+      nil
+    )
+    
+    parameters.enumerated().forEach { (index, parameter) in
+      sqlite3_bind_text(
+        statement,
+        Int32(index + 1), // 1-indexed
+        parameter,
+        -1, // number of bytes in `parameter` (-1 for automatic to first zero terminator)
+        SQLITE_TRANSIENT // I think
+      )
+    }
+    
+    while sqlite3_step(statement) == SQLITE_ROW {
+      var row = [String?: String?]()
+      for columnIndex in (0..<sqlite3_column_count(statement)) {
+        let name = sqlite3_column_name(statement, columnIndex).map { String(cString: $0) }
+        let value = sqlite3_column_text(statement, columnIndex).map { String(cString: $0) }
+        row.updateValue(value, forKey: name)
+      }
+      results.append(row)
+    }
+    
+    return results
+  }
+}
+
+extension SQLiteDB {
+  static func openApplicationDatabase() -> SQLiteDB? {
+    // This behavior is partially defined in op-sqlite, and partially configured in Tlon app code:
+    // https://github.com/OP-Engineering/op-sqlite/blob/cf5509d02d70460987ee48565dcea06d5b1436e7/cpp/libsql/bridge.cpp#L34
+    // https://github.com/tloncorp/tlon-apps/blob/97bdb35a6a1745c5c208200ae9364f498715a064/packages/app/lib/nativeDb.ts#L22
+    guard let dbUrl = try? FileManager.default
+      .url(for: .libraryDirectory, in: .userDomainMask, appropriateFor: nil, create: false)
+      .appendingPathComponent("default/tlon.sqlite")
+    else {
+      return nil
+    }
+    return SQLiteDB(dbUrl: dbUrl)
+  }
+}

--- a/packages/app/contexts/branch.tsx
+++ b/packages/app/contexts/branch.tsx
@@ -11,6 +11,7 @@ import {
 import branch from 'react-native-branch';
 
 import { DEFAULT_LURE, DEFAULT_PRIORITY_TOKEN } from '../constants';
+import { useGroupNavigation } from '../hooks/useGroupNavigation';
 import storage from '../lib/storage';
 import { getPathFromWer } from '../utils/string';
 import { useShip } from './ship';
@@ -107,12 +108,35 @@ export const BranchProvider = ({ children }: { children: ReactNode }) => {
     useState(INITIAL_STATE);
   const { isAuthenticated } = useShip();
 
+  const { goToChannel } = useGroupNavigation();
+
   useEffect(() => {
     console.debug('[branch] Subscribing to Branch listener');
 
     // Subscribe to Branch deep link listener
     const unsubscribe = branch.subscribe({
       onOpenComplete: ({ params }) => {
+        const nonBranchLink = params?.['+non_branch_link'];
+        if (nonBranchLink != null && typeof nonBranchLink === 'string') {
+          const asUrl = new URL(nonBranchLink);
+          if (asUrl.hostname === 'channel') {
+            switch (asUrl.pathname) {
+              // example: io.tlon.groups://channel/open?id=0v4.00000.qd4mk.d4htu.er4b8.eao21&startDraft=true
+              case '/open': {
+                const channelId = asUrl.searchParams.get('id');
+                const startDraft = Boolean(
+                  asUrl.searchParams.get('startDraft')
+                );
+                if (channelId) {
+                  goToChannel(channelId, { startDraft });
+                }
+                break;
+              }
+            }
+          }
+          return;
+        }
+
         // Handle Branch link click
         if (params?.['+clicked_branch_link']) {
           logger.log('detected Branch link click');

--- a/packages/app/features/top/ChannelScreen.tsx
+++ b/packages/app/features/top/ChannelScreen.tsx
@@ -32,7 +32,7 @@ const logger = createDevLogger('ChannelScreen', false);
 type Props = NativeStackScreenProps<RootStackParamList, 'Channel'>;
 
 export default function ChannelScreen(props: Props) {
-  const { channelId, selectedPostId } = props.route.params;
+  const { channelId, selectedPostId, startDraft } = props.route.params;
   const [currentChannelId, setCurrentChannelId] = React.useState(channelId);
 
   useEffect(() => {
@@ -382,6 +382,7 @@ export default function ChannelScreen(props: Props) {
         editPost={editPost}
         negotiationMatch={negotiationStatus.matchedOrPending}
         canUpload={canUpload}
+        startDraft={startDraft}
       />
       {group && (
         <>

--- a/packages/app/hooks/useGroupNavigation.ts
+++ b/packages/app/hooks/useGroupNavigation.ts
@@ -2,6 +2,8 @@ import { useNavigation } from '@react-navigation/native';
 import * as db from '@tloncorp/shared/db';
 import { useCallback } from 'react';
 
+import { RootStackParamList } from '../navigation/types';
+
 export const useGroupNavigation = () => {
   const navigation = useNavigation<
     // @ts-expect-error - TODO: pass navigation handlers into context
@@ -9,8 +11,15 @@ export const useGroupNavigation = () => {
   >();
 
   const goToChannel = useCallback(
-    async (channel: db.Channel) => {
-      navigation.navigate('Channel', { channel });
+    async (
+      channel: db.Channel | string,
+      params?: Omit<RootStackParamList['Channel'], 'channelId'>
+    ) => {
+      if (typeof channel === 'string') {
+        navigation.navigate('Channel', { channelId: channel, ...params });
+      } else {
+        navigation.navigate('Channel', { channelId: channel.id, ...params });
+      }
     },
     [navigation]
   );

--- a/packages/app/lib/nativeDb.ts
+++ b/packages/app/lib/nativeDb.ts
@@ -19,6 +19,8 @@ export function setupDb() {
     return;
   }
   connection = new OPSQLite$SQLiteConnection(
+    // NB: the iOS code in SQLiteDB.swift relies on this path - if you change
+    // this, you should change that too.
     open({ location: 'default', name: 'tlon.sqlite' })
   );
   // Experimental SQLite settings. May cause crashes. More here:

--- a/packages/app/navigation/types.ts
+++ b/packages/app/navigation/types.ts
@@ -8,6 +8,7 @@ export type RootStackParamList = {
     channelId: string;
     groupId?: string;
     selectedPostId?: string | null;
+    startDraft?: boolean;
   };
   FindGroups: undefined;
   ContactHostedGroups: {

--- a/packages/ui/src/components/Channel/index.tsx
+++ b/packages/ui/src/components/Channel/index.tsx
@@ -85,6 +85,7 @@ export function Channel({
   hasNewerPosts,
   hasOlderPosts,
   initialAttachments,
+  startDraft,
 }: {
   channel: db.Channel;
   initialChannelUnread?: db.ChannelUnread | null;
@@ -124,6 +125,7 @@ export function Channel({
   hasNewerPosts?: boolean;
   hasOlderPosts?: boolean;
   canUpload: boolean;
+  startDraft?: boolean;
 }) {
   const [activeMessage, setActiveMessage] = useState<db.Post | null>(null);
   const [inputShouldBlur, setInputShouldBlur] = useState(false);
@@ -270,6 +272,12 @@ export function Channel({
     () => layoutTypeFromChannel(channel),
     [channel]
   );
+
+  useEffect(() => {
+    if (startDraft) {
+      draftInputRef.current?.startDraft?.();
+    }
+  }, [startDraft]);
 
   const isNarrow = useIsWindowNarrow();
 

--- a/packages/ui/src/components/draftInputs/NotebookInput.tsx
+++ b/packages/ui/src/components/draftInputs/NotebookInput.tsx
@@ -52,6 +52,10 @@ export function NotebookInput({
     exitFullscreen: () => {
       setShowBigInput(false);
     },
+
+    startDraft: () => {
+      setShowBigInput(true);
+    },
   }));
 
   return (

--- a/packages/ui/src/components/draftInputs/shared.ts
+++ b/packages/ui/src/components/draftInputs/shared.ts
@@ -6,6 +6,12 @@ export type GalleryDraftType = 'caption' | 'text';
 
 export interface DraftInputHandle {
   /**
+   * Perform anything necessary to put the user in a drafting state for this
+   * input - open a model editor, focus text box, open image picker, etc.
+   */
+  startDraft?: () => void;
+
+  /**
    * @deprecated
    * We are using this to implement a weird navigation pattern where we present
    * draft input in a modal-like presentation, and reuse the container screen's


### PR DESCRIPTION
related discussion: https://forums.swift.org/t/can-inits-of-noncopyable-types-be-throwing/66892/4 probably should end up with a similar solution so we can keep `~Copyable`

that said, https://github.com/swiftlang/swift-evolution/blob/main/proposals/0427-noncopyable-generics.md says that this was implemented in Swift 6, and I did not get this error on my Xcode builds – which makes me think that we're using Swift 5 in builds, which I think is unnecessary.