### PR TITLE
desktop: fix issue with base path on service worker update redirect

### DIFF
--- a/apps/tlon-web-new/src/logic/useAppUpdates.ts
+++ b/apps/tlon-web-new/src/logic/useAppUpdates.ts
@@ -71,8 +71,10 @@ export default function useAppUpdates() {
 
   const triggerUpdate = useCallback(
     async (returnToRoot: boolean) => {
+      const mode = import.meta.env.MODE;
+      const basePath = mode === 'alpha' ? '/apps/tm-alpha/' : '/apps/groups/';
       const path = returnToRoot
-        ? `${window.location.origin}/apps/groups/?updatedAt=${Date.now()}`
+        ? `${window.location.origin}${basePath}?updatedAt=${Date.now()}`
         : `${window.location.href}?updatedAt=${Date.now()}`;
 
       if (needRefresh) {


### PR DESCRIPTION
We weren't accounting for whether the app was at `/apps/tm-alpha/` vs `/apps/groups/`