### PR TITLE
refs: allow users to join groups from content refs

### DIFF
--- a/apps/tlon-mobile/src/fixtures/Channel.fixture.tsx
+++ b/apps/tlon-mobile/src/fixtures/Channel.fixture.tsx
@@ -1,6 +1,6 @@
 import { useQuery } from '@tanstack/react-query';
 import {
-  useChannel,
+  useChannelPreview,
   useGroupPreview,
   usePostWithRelations,
 } from '@tloncorp/shared';
@@ -102,7 +102,7 @@ const baseProps: ComponentProps<typeof Channel> = {
   onPressRef: () => {},
   usePost: usePostWithRelations,
   usePostReference: usePostReference,
-  useChannel: useChannel,
+  useChannel: useChannelPreview,
   useGroup: useGroupPreview,
   onGroupAction: () => {},
   getDraft: async () => ({}),

--- a/packages/app/features/top/ChannelScreen.tsx
+++ b/packages/app/features/top/ChannelScreen.tsx
@@ -5,7 +5,7 @@ import * as db from '@tloncorp/shared/db';
 import * as store from '@tloncorp/shared/store';
 import {
   useCanUpload,
-  useChannel,
+  useChannelPreview,
   useGroupPreview,
   usePostReference,
   usePostWithRelations,
@@ -371,7 +371,7 @@ export default function ChannelScreen(props: Props) {
         usePostReference={usePostReference}
         useGroup={useGroupPreview}
         onGroupAction={performGroupAction}
-        useChannel={useChannel}
+        useChannel={useChannelPreview}
         storeDraft={storeDraft}
         clearDraft={clearDraft}
         getDraft={getDraft}

--- a/packages/app/features/top/ChatListScreen.tsx
+++ b/packages/app/features/top/ChatListScreen.tsx
@@ -283,7 +283,7 @@ export function ChatListScreenView({
   return (
     <RequestsProvider
       usePostReference={store.usePostReference}
-      useChannel={store.useChannelWithRelations}
+      useChannel={store.useChannelPreview}
       usePost={store.usePostWithRelations}
       useApp={store.useAppInfo}
       useGroup={store.useGroupPreview}

--- a/packages/shared/src/api/groupsApi.ts
+++ b/packages/shared/src/api/groupsApi.ts
@@ -311,6 +311,25 @@ export const pinItem = async (itemId: string) => {
   });
 };
 
+export const getChannelPreview = async (
+  channelId: string
+): Promise<db.Channel | null> => {
+  const channelPreview = await subscribeOnce<ub.ChannelPreview>({
+    app: 'groups',
+    path: `/chan/${channelId}`,
+  });
+
+  if (!channelPreview) {
+    return null;
+  }
+
+  return toClientChannelFromPreview({
+    id: channelId,
+    channel: channelPreview,
+    groupId: channelPreview.group.flag,
+  });
+};
+
 export const getGroupPreview = async (groupId: string) => {
   const result = await subscribeOnce<ub.GroupPreview>({
     app: 'groups',
@@ -1458,6 +1477,30 @@ function toClientChannel({
 }): db.Channel {
   const { description, channelContentConfiguration } =
     StructuredChannelDescriptionPayload.decode(channel.meta.description);
+  return {
+    id,
+    groupId,
+    type: getChannelType(id),
+    iconImage: omitEmpty(channel.meta.image),
+    title: omitEmpty(channel.meta.title),
+    coverImage: omitEmpty(channel.meta.cover),
+    description,
+    contentConfiguration: channelContentConfiguration,
+  };
+}
+
+function toClientChannelFromPreview({
+  id,
+  channel,
+  groupId,
+}: {
+  id: string;
+  channel: ub.ChannelPreview;
+  groupId: string;
+}): db.Channel {
+  const { description, channelContentConfiguration } =
+    StructuredChannelDescriptionPayload.decode(channel.meta.description);
+
   return {
     id,
     groupId,

--- a/packages/shared/src/store/dbHooks.ts
+++ b/packages/shared/src/store/dbHooks.ts
@@ -9,7 +9,11 @@ import * as api from '../api';
 import * as db from '../db';
 import * as ub from '../urbit';
 import { hasCustomS3Creds, hasHostingUploadCreds } from './storage';
-import { syncGroupPreviews, syncPostReference } from './sync';
+import {
+  syncChannelPreivews,
+  syncGroupPreviews,
+  syncPostReference,
+} from './sync';
 import { keyFromQueryDeps, useKeyFromQueryDeps } from './useKeyFromQueryDeps';
 
 export * from './useChannelSearch';
@@ -373,6 +377,18 @@ export const useGroupPreview = (groupId: string) => {
     queryFn: async () => {
       const [preview] = await syncGroupPreviews([groupId]);
       return preview;
+    },
+  });
+};
+
+export const useChannelPreview = ({ id }: { id: string }) => {
+  return useQuery({
+    queryKey: ['channelPreview', id],
+    refetchOnReconnect: false,
+    refetchOnMount: false,
+    queryFn: async () => {
+      const [channel] = await syncChannelPreivews([id]);
+      return channel;
     },
   });
 };

--- a/packages/shared/src/store/sync.ts
+++ b/packages/shared/src/store/sync.ts
@@ -953,6 +953,24 @@ export async function syncGroupPreviews(groupIds: string[]) {
   return Promise.all(promises);
 }
 
+export async function syncChannelPreivews(channelIds: string[]) {
+  const promises = channelIds.map(async (channelId) => {
+    const channel = await db.getChannelWithRelations({ id: channelId });
+    if (channel) {
+      return channel;
+    }
+
+    const channelPreview = await api.getChannelPreview(channelId);
+    if (!channelPreview) {
+      return;
+    }
+    await db.insertChannels([channelPreview]);
+    return channelPreview;
+  });
+
+  return Promise.all(promises);
+}
+
 const currentPendingMessageSyncs = new Map<string, Promise<boolean>>();
 export async function syncChannelMessageDelivery({
   channelId,

--- a/packages/ui/src/components/Channel/index.tsx
+++ b/packages/ui/src/components/Channel/index.tsx
@@ -5,7 +5,7 @@ import {
 } from '@tloncorp/shared';
 import {
   isChatChannel as getIsChatChannel,
-  useChannel as useChannelFromStore,
+  useChannelPreview,
   useGroupPreview,
   usePostReference as usePostReferenceHook,
   usePostWithRelations,
@@ -111,7 +111,7 @@ export function Channel({
   useGroup: typeof useGroupPreview;
   usePostReference: typeof usePostReferenceHook;
   onGroupAction: (action: GroupPreviewAction, group: db.Group) => void;
-  useChannel: typeof useChannelFromStore;
+  useChannel: typeof useChannelPreview;
   storeDraft: (draft: JSONContent, draftType?: GalleryDraftType) => void;
   clearDraft: (draftType?: GalleryDraftType) => void;
   getDraft: (draftType?: GalleryDraftType) => Promise<JSONContent>;

--- a/packages/ui/src/contexts/requests.tsx
+++ b/packages/ui/src/contexts/requests.tsx
@@ -1,5 +1,5 @@
 import {
-  useChannel as useChannelFromStore,
+  useChannelPreview,
   useGroupPreview,
   usePostReference,
   usePostWithRelations,
@@ -18,7 +18,7 @@ import {
 
 type State = {
   usePost: typeof usePostWithRelations;
-  useChannel: typeof useChannelFromStore;
+  useChannel: typeof useChannelPreview;
   useGroup: typeof useGroupPreview;
   useApp: (id: string) => void;
   usePostReference: typeof usePostReference;
@@ -28,7 +28,7 @@ type ContextValue = State;
 
 const Context = createContext<ContextValue>({
   usePost: usePostWithRelations,
-  useChannel: useChannelFromStore,
+  useChannel: useChannelPreview,
   useGroup: useGroupPreview,
   useApp: () => {},
   usePostReference: usePostReference,
@@ -46,7 +46,7 @@ export const useRequests = () => {
 
 type RequestProviderProps = {
   usePost: typeof usePostWithRelations;
-  useChannel: typeof useChannelFromStore;
+  useChannel: typeof useChannelPreview;
   useGroup: typeof useGroupPreview;
   useApp: (id: string) => void;
   usePostReference: typeof usePostReference;


### PR DESCRIPTION
Fixes TLON-3130 by creating a new useChannelPreview hook that works similarly to useGroupPreview, but uses the `/chan/${channelId}` subscribeOnce path in %groups to grab a `ChannelPreview`. We used this same path/subscribeOnce for the same purpose in the old web app.

copilot description:

This pull request focuses on replacing the `useChannel` hook with a new `useChannelPreview` hook across various files to improve the handling of channel previews. Additionally, it introduces new functions to support the functionality of channel previews.

### Hook Replacement:

* Replaced `useChannel` with `useChannelPreview` in `Channel.fixture.tsx` [[1]](diffhunk://#diff-8c819e75a2f7a08e39352817cd38138e1e3dac6c4680e357062ce2841111f5cdL3-R3) [[2]](diffhunk://#diff-8c819e75a2f7a08e39352817cd38138e1e3dac6c4680e357062ce2841111f5cdL105-R105).
* Replaced `useChannel` with `useChannelPreview` in `ChannelScreen.tsx` [[1]](diffhunk://#diff-51cebbab427a6c9a3a7cafadd4a3736895fbd5d93391eaa3a3ffa309fc650e0fL8-R8) [[2]](diffhunk://#diff-51cebbab427a6c9a3a7cafadd4a3736895fbd5d93391eaa3a3ffa309fc650e0fL374-R374).
* Replaced `useChannelWithRelations` with `useChannelPreview` in `ChatListScreen.tsx`.
* Replaced `useChannelFromStore` with `useChannelPreview` in `Channel/index.tsx` [[1]](diffhunk://#diff-9053dd6f8091d9b2ba08d6e0594831122fcb21f7e2dec6210033cf1f33566285L8-R8) [[2]](diffhunk://#diff-9053dd6f8091d9b2ba08d6e0594831122fcb21f7e2dec6210033cf1f33566285L114-R114).
* Replaced `useChannelFromStore` with `useChannelPreview` in `requests.tsx` [[1]](diffhunk://#diff-20ef6f6951aa4848c48fed9a01aa9e40fea6e721abf8270ac71b8936bbc0a531L2-R2) [[2]](diffhunk://#diff-20ef6f6951aa4848c48fed9a01aa9e40fea6e721abf8270ac71b8936bbc0a531L21-R21) [[3]](diffhunk://#diff-20ef6f6951aa4848c48fed9a01aa9e40fea6e721abf8270ac71b8936bbc0a531L31-R31) [[4]](diffhunk://#diff-20ef6f6951aa4848c48fed9a01aa9e40fea6e721abf8270ac71b8936bbc0a531L49-R49).

### New Functions:

* Added `getChannelPreview` function to fetch channel previews in `groupsApi.ts`.
* Added `toClientChannelFromPreview` function to convert channel previews to client channels in `groupsApi.ts`.
* Added `syncChannelPreivews` function to synchronize channel previews in `sync.ts`.

### Component Updates:

* Updated `ContentReference.tsx` to include state management for selected groups and handle group preview sheet display [[1]](diffhunk://#diff-6e4e1933b81ba7864e1a3c7ab7c1aaa565bec8ff0491ab51ce0e75846adb940cL5-R5) [[2]](diffhunk://#diff-6e4e1933b81ba7864e1a3c7ab7c1aaa565bec8ff0491ab51ce0e75846adb940cR14) [[3]](diffhunk://#diff-6e4e1933b81ba7864e1a3c7ab7c1aaa565bec8ff0491ab51ce0e75846adb940cL78-R103) [[4]](diffhunk://#diff-6e4e1933b81ba7864e1a3c7ab7c1aaa565bec8ff0491ab51ce0e75846adb940cR114-R120).

### Import Adjustments:

* Adjusted imports in `dbHooks.ts` to include `syncChannelPreivews` [[1]](diffhunk://#diff-4a3203a86e723809f72151295be37e7ccbed4052850db54bc82518d3aa726802L12-R16) [[2]](diffhunk://#diff-4a3203a86e723809f72151295be37e7ccbed4052850db54bc82518d3aa726802R384-R395).