### PR TITLE
desktop: fix longpress issue, update Pressable component, make it mandatory

### DIFF
--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -46,6 +46,18 @@ module.exports = {
         message:
           'Please use getTokenValue() instead of getToken() to ensure web compatibility. See: https://tamagui.dev/docs/core/exports#gettokenvalue',
       },
+      {
+        selector:
+          'JSXOpeningElement[name.name=/^(Stack|XStack|YStack|View|ListItem)$/] > JSXAttribute[name.name="onPress"]',
+        message:
+          'Do not use onPress on Stack, View or ListItem components. Use Pressable instead.',
+      },
+      {
+        selector:
+          'JSXOpeningElement[name.name=/^(Stack|XStack|YStack|View|ListItem)$/] > JSXAttribute[name.name="onLongPress"]',
+        message:
+          'Do not use onLongPress on Stack, View or ListItem components. Use Pressable instead.',
+      },
     ],
   },
 };

--- a/apps/tlon-mobile/src/fixtures/Text.fixture.tsx
+++ b/apps/tlon-mobile/src/fixtures/Text.fixture.tsx
@@ -1,5 +1,5 @@
 // tamagui-ignore
-import { ScrollView, View, XStack, YStack } from '@tloncorp/ui';
+import { Pressable, ScrollView, View, XStack, YStack } from '@tloncorp/ui';
 import { FontStyle, Text } from '@tloncorp/ui/src/components/TextV2';
 import { useCopy } from '@tloncorp/ui/src/hooks/useCopy';
 import { PropsWithChildren, useCallback, useEffect, useState } from 'react';
@@ -64,11 +64,11 @@ const TrimmedTextFixture = () => {
           paddingHorizontal: 24,
         }}
       >
-        <View onPress={doCopy} padding={10}>
+        <Pressable onPress={doCopy} padding={10}>
           <Text size="$label/s">
             {didCopy ? 'Copied!' : 'Copy margin settings'}
           </Text>
-        </View>
+        </Pressable>
         <YStack gap="$4xl">
           {textStyles.map((size) => {
             return (

--- a/apps/tlon-mobile/src/screens/Onboarding/PasteInviteLinkScreen.tsx
+++ b/apps/tlon-mobile/src/screens/Onboarding/PasteInviteLinkScreen.tsx
@@ -15,6 +15,7 @@ import {
 } from '@tloncorp/shared';
 import {
   Field,
+  Pressable,
   ScreenHeader,
   TextInputWithButton,
   TlonText,
@@ -131,50 +132,47 @@ export const PasteInviteLinkScreen = ({ navigation }: Props) => {
           </ScreenHeader.TextButton>
         }
       />
-      <YStack
-        paddingHorizontal="$2xl"
-        gap="$m"
-        onPress={() => Keyboard.dismiss()}
-        flex={1}
-      >
-        <View padding="$xl" gap="$xl">
-          <TlonText.Text size="$body" color="$primaryText">
-            We&apos;re growing slowly. {'\n\n'}Invites let you skip the waitlist
-            because we know someone wants to talk to you here.
-            {'\n\n'}
-            Click your invite link now or paste it below.
-          </TlonText.Text>
-        </View>
-        <Controller
-          control={control}
-          name="inviteLink"
-          rules={{
-            pattern: {
-              value: INVITE_LINK_REGEX,
-              message: 'Invite link not recognized.',
-            },
-          }}
-          render={({ field: { onChange, onBlur, value } }) => (
-            <Field
-              label="Invite Link"
-              error={metadataError ?? errors.inviteLink?.message}
-              paddingTop="$l"
-            >
-              <TextInputWithButton
-                placeholder="join.tlon.io/0v4.pca0n.evapv..."
-                onBlur={onBlur}
-                onChangeText={onChange}
-                value={value}
-                keyboardType="email-address"
-                autoCapitalize="none"
-                autoCorrect={false}
-                buttonText="Paste"
-                onButtonPress={onHandlePasteClick}
-              />
-            </Field>
-          )}
-        />
-      </YStack>
+      <Pressable onPress={() => Keyboard.dismiss()}>
+        <YStack paddingHorizontal="$2xl" gap="$m" flex={1}>
+          <View padding="$xl" gap="$xl">
+            <TlonText.Text size="$body" color="$primaryText">
+              We&apos;re growing slowly. {'\n\n'}Invites let you skip the
+              waitlist because we know someone wants to talk to you here.
+              {'\n\n'}
+              Click your invite link now or paste it below.
+            </TlonText.Text>
+          </View>
+          <Controller
+            control={control}
+            name="inviteLink"
+            rules={{
+              pattern: {
+                value: INVITE_LINK_REGEX,
+                message: 'Invite link not recognized.',
+              },
+            }}
+            render={({ field: { onChange, onBlur, value } }) => (
+              <Field
+                label="Invite Link"
+                error={metadataError ?? errors.inviteLink?.message}
+                paddingTop="$l"
+              >
+                <TextInputWithButton
+                  placeholder="join.tlon.io/0v4.pca0n.evapv..."
+                  onBlur={onBlur}
+                  onChangeText={onChange}
+                  value={value}
+                  keyboardType="email-address"
+                  autoCapitalize="none"
+                  autoCorrect={false}
+                  buttonText="Paste"
+                  onButtonPress={onHandlePasteClick}
+                />
+              </Field>
+            )}
+          />
+        </YStack>
+      </Pressable>
     </View>
   );
 };

--- a/apps/tlon-mobile/src/screens/Onboarding/WelcomeScreen.tsx
+++ b/apps/tlon-mobile/src/screens/Onboarding/WelcomeScreen.tsx
@@ -9,6 +9,7 @@ import {
   Image,
   OnboardingButton,
   OnboardingInviteBlock,
+  Pressable,
   SizableText,
   TlonText,
   View,
@@ -17,7 +18,6 @@ import {
 } from '@tloncorp/ui';
 import { OnboardingBenefitsSheet } from '@tloncorp/ui/src/components/Onboarding/OnboardingBenefitsSheet';
 import { useCallback, useEffect, useState } from 'react';
-import { Pressable } from 'react-native';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
 
 import { useCheckAppInstalled } from '../../hooks/analytics';
@@ -75,24 +75,28 @@ export const WelcomeScreen = ({ navigation }: Props) => {
         <YStack gap="$4xl" paddingHorizontal="$2xl" width={'100%'}>
           <YStack gap="$2xl">
             {lureMeta ? (
-              <YStack
-                alignItems="stretch"
-                gap="$2xl"
-                padding="$3xl"
+              <Pressable
                 borderRadius="$2xl"
-                backgroundColor="$shadow"
-                borderColor="$shadow"
-                borderWidth={1}
                 pressStyle={{
                   opacity: 0.5,
                 }}
                 onPress={handlePressInvite}
               >
-                <OnboardingInviteBlock metadata={lureMeta} />
-                <OnboardingButton onPress={handlePressInvite}>
-                  <Button.Text>Join with new account</Button.Text>
-                </OnboardingButton>
-              </YStack>
+                <YStack
+                  alignItems="stretch"
+                  gap="$2xl"
+                  padding="$3xl"
+                  borderRadius="$2xl"
+                  backgroundColor="$shadow"
+                  borderColor="$shadow"
+                  borderWidth={1}
+                >
+                  <OnboardingInviteBlock metadata={lureMeta} />
+                  <OnboardingButton onPress={handlePressInvite}>
+                    <Button.Text>Join with new account</Button.Text>
+                  </OnboardingButton>
+                </YStack>
+              </Pressable>
             ) : (
               <>
                 <OnboardingButton
@@ -114,7 +118,12 @@ export const WelcomeScreen = ({ navigation }: Props) => {
             )}
           </YStack>
           <XStack justifyContent="center">
-            <Pressable onPress={() => setOpen(true)}>
+            <Pressable
+              pressStyle={{
+                backgroundColor: '$transparent',
+              }}
+              onPress={() => setOpen(true)}
+            >
               <SizableText color="$primaryText">
                 Have an account? Log in
               </SizableText>

--- a/packages/app/features/settings/PushNotificationSettingsScreen.tsx
+++ b/packages/app/features/settings/PushNotificationSettingsScreen.tsx
@@ -27,9 +27,7 @@ export function PushNotificationSettingsScreen({ navigation }: Props) {
   const { data: exceptions } = store.useVolumeExceptions();
 
   const numExceptions = useMemo(
-    () =>
-      (exceptions?.channels.length ?? 0) + (exceptions?.groups.length ?? 0) ??
-      0,
+    () => (exceptions?.channels.length ?? 0) + (exceptions?.groups.length ?? 0),
     [exceptions]
   );
 

--- a/packages/app/features/top/ChatListScreen.tsx
+++ b/packages/app/features/top/ChatListScreen.tsx
@@ -21,7 +21,6 @@ import {
   ScreenHeader,
   View,
   WelcomeSheet,
-  useGroup,
 } from '@tloncorp/ui';
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 
@@ -77,7 +76,7 @@ export function ChatListScreenView({
   const [selectedGroupId, setSelectedGroupId] = useState<string | null>(
     previewGroupId ?? null
   );
-  const selectedGroup = useGroup(selectedGroupId ?? '');
+  const { data: selectedGroup } = store.useGroup({ id: selectedGroupId ?? '' });
 
   const [showSearchInput, setShowSearchInput] = useState(false);
   const isFocused = useIsFocused();
@@ -322,7 +321,6 @@ export function ChatListScreenView({
               pendingChats={resolvedChats.pendingChats}
               onLongPressItem={onLongPressChat}
               onPressItem={onPressChat}
-              onPressMenuButton={onLongPressChat}
               onSectionChange={handleSectionChange}
               showSearchInput={showSearchInput}
               onSearchToggle={handleSearchInputToggled}

--- a/packages/ui/src/components/ActionSheet.tsx
+++ b/packages/ui/src/components/ActionSheet.tsx
@@ -180,7 +180,7 @@ const ActionSheetHeader = ActionSheetHeaderFrame.styleable(
   ({ children, ...props }, ref) => {
     return (
       <ActionSheetHeaderFrame {...props} ref={ref}>
-        <ListItem pressable={false} paddingHorizontal="$2xl">
+        <ListItem paddingHorizontal="$2xl">
           {children}
         </ListItem>
       </ActionSheetHeaderFrame>

--- a/packages/ui/src/components/Activity/ActivityListItem.tsx
+++ b/packages/ui/src/components/Activity/ActivityListItem.tsx
@@ -2,12 +2,13 @@ import * as db from '@tloncorp/shared/db';
 import * as logic from '@tloncorp/shared/logic';
 import * as store from '@tloncorp/shared/store';
 import React, { PropsWithChildren, useCallback, useMemo } from 'react';
-import { View, XStack, YStack, styled } from 'tamagui';
+import { XStack, YStack, styled } from 'tamagui';
 
 import { useCalm } from '../../contexts';
 import { useChannelTitle } from '../../utils';
 import { ChannelAvatar, ContactAvatar, GroupAvatar } from '../Avatar';
 import { Icon } from '../Icon';
+import Pressable from '../Pressable';
 import { Text } from '../TextV2';
 import { UnreadDot } from '../UnreadDot';
 import { ActivitySourceContent } from './ActivitySourceContent';
@@ -33,13 +34,13 @@ export const ActivityListItem = React.memo(function ActivityListItem({
     event.type === 'group-ask'
   ) {
     return (
-      <View onPress={handlePress}>
+      <Pressable onPress={handlePress}>
         <ActivityListItemContent
           summary={sourceActivity}
           pressHandler={handlePress}
           seenMarker={seenMarker}
         />
-      </View>
+      </Pressable>
     );
   }
 

--- a/packages/ui/src/components/AddGroupSheet.tsx
+++ b/packages/ui/src/components/AddGroupSheet.tsx
@@ -1,11 +1,12 @@
 import { useCallback, useEffect, useState } from 'react';
-import { View, YStack, isWeb } from 'tamagui';
+import { View, YStack } from 'tamagui';
 
 import { triggerHaptic } from '../utils';
 import { ActionSheet } from './ActionSheet';
 import { ContactBook } from './ContactBook';
 import { IconType } from './Icon';
 import { ListItem } from './ListItem';
+import Pressable from './Pressable';
 
 export function AddGroupSheet({
   open,
@@ -96,16 +97,18 @@ function QuickAction({
   subtitle?: string;
 }) {
   return (
-    <ListItem onPress={onPress}>
-      <ListItem.SystemIcon
-        icon={icon}
-        backgroundColor={'$secondaryBackground'}
-        rounded
-      />
-      <ListItem.MainContent>
-        <ListItem.Title>{title}</ListItem.Title>
-        <ListItem.Subtitle>{subtitle}</ListItem.Subtitle>
-      </ListItem.MainContent>
-    </ListItem>
+    <Pressable onPress={onPress} borderRadius="$xl">
+      <ListItem>
+        <ListItem.SystemIcon
+          icon={icon}
+          backgroundColor={'$secondaryBackground'}
+          rounded
+        />
+        <ListItem.MainContent>
+          <ListItem.Title>{title}</ListItem.Title>
+          <ListItem.Subtitle>{subtitle}</ListItem.Subtitle>
+        </ListItem.MainContent>
+      </ListItem>
+    </Pressable>
   );
 }

--- a/packages/ui/src/components/AppSetting.tsx
+++ b/packages/ui/src/components/AppSetting.tsx
@@ -3,6 +3,7 @@ import { useCallback, useState } from 'react';
 
 import { Icon } from './Icon';
 import { ListItem } from './ListItem';
+import Pressable from './Pressable';
 
 interface Props {
   title: string;
@@ -23,16 +24,18 @@ export function AppSetting({ title, value, copyable = true }: Props) {
   }, [didCopy, value]);
 
   return (
-    <ListItem onPress={copy} disabled={!copyable}>
-      <ListItem.MainContent>
-        <ListItem.Title>{title}</ListItem.Title>
-        <ListItem.Subtitle>{value}</ListItem.Subtitle>
-      </ListItem.MainContent>
-      {copyable && (
-        <ListItem.EndContent>
-          <Icon color="$tertiaryText" type={didCopy ? 'Checkmark' : 'Copy'} />
-        </ListItem.EndContent>
-      )}
-    </ListItem>
+    <Pressable borderRadius="$xl" onPress={copy}>
+      <ListItem disabled={!copyable}>
+        <ListItem.MainContent>
+          <ListItem.Title>{title}</ListItem.Title>
+          <ListItem.Subtitle>{value}</ListItem.Subtitle>
+        </ListItem.MainContent>
+        {copyable && (
+          <ListItem.EndContent>
+            <Icon color="$tertiaryText" type={didCopy ? 'Checkmark' : 'Copy'} />
+          </ListItem.EndContent>
+        )}
+      </ListItem>
+    </Pressable>
   );
 }

--- a/packages/ui/src/components/AuthorRow.tsx
+++ b/packages/ui/src/components/AuthorRow.tsx
@@ -8,6 +8,7 @@ import { ContactAvatar } from './Avatar';
 import { ChatMessageDeliveryStatus } from './ChatMessage/ChatMessageDeliveryStatus';
 import { ContactName } from './ContactNameV2';
 import { useBoundHandler } from './ListItem/listItemUtils';
+import Pressable from './Pressable';
 import { Text } from './TextV2';
 
 const RoleBadge = View.styleable<{ role: string }>(
@@ -82,21 +83,23 @@ export function DetailViewAuthorRow({
   const shouldTruncate = showEditedIndicator || deliveryFailed;
 
   return (
-    <XStack gap="$l" alignItems="center" {...props} onPress={openProfile}>
-      <ContactAvatar size="$2xl" contactId={authorId} />
-      <ContactName
-        contactId={authorId}
-        size="$label/l"
-        numberOfLines={1}
-        maxWidth={shouldTruncate ? '55%' : '100%'}
-        color={color ?? '$secondaryText'}
-      />
-      {deliveryFailed ? (
-        <Text size="$label/m" color="$negativeActionText">
-          Tap to retry
-        </Text>
-      ) : null}
-    </XStack>
+    <Pressable onPress={openProfile}>
+      <XStack gap="$l" alignItems="center" {...props}>
+        <ContactAvatar size="$2xl" contactId={authorId} />
+        <ContactName
+          contactId={authorId}
+          size="$label/l"
+          numberOfLines={1}
+          maxWidth={shouldTruncate ? '55%' : '100%'}
+          color={color ?? '$secondaryText'}
+        />
+        {deliveryFailed ? (
+          <Text size="$label/m" color="$negativeActionText">
+            Tap to retry
+          </Text>
+        ) : null}
+      </XStack>
+    </Pressable>
   );
 }
 
@@ -130,35 +133,37 @@ export function ChatAuthorRow({
   const shouldTruncate = showEditedIndicator || firstRole || deliveryFailed;
 
   return (
-    <XStack gap="$l" alignItems="center" {...props} onPress={openProfile}>
-      <ContactAvatar size="$2xl" contactId={authorId} />
-      <XStack gap="$l" alignItems="flex-end">
-        <ContactName
-          size="$label/2xl"
-          contactId={authorId}
-          numberOfLines={1}
-          maxWidth={shouldTruncate ? '55%' : '100%'}
-        />
-        {timeDisplay && (
-          <Text color="$secondaryText" size="$label/m">
-            {timeDisplay}
-          </Text>
-        )}
-        {showEditedIndicator && (
-          <Text size="$label/m" color="$secondaryText">
-            Edited
-          </Text>
-        )}
-        {firstRole && <RoleBadge role={firstRole} />}
-        {deliveryFailed ? (
-          <Text size="$label/m" color="$negativeActionText">
-            Tap to retry
-          </Text>
+    <Pressable onPress={openProfile}>
+      <XStack gap="$l" alignItems="center" {...props}>
+        <ContactAvatar size="$2xl" contactId={authorId} />
+        <XStack gap="$l" alignItems="flex-end">
+          <ContactName
+            size="$label/2xl"
+            contactId={authorId}
+            numberOfLines={1}
+            maxWidth={shouldTruncate ? '55%' : '100%'}
+          />
+          {timeDisplay && (
+            <Text color="$secondaryText" size="$label/m">
+              {timeDisplay}
+            </Text>
+          )}
+          {showEditedIndicator && (
+            <Text size="$label/m" color="$secondaryText">
+              Edited
+            </Text>
+          )}
+          {firstRole && <RoleBadge role={firstRole} />}
+          {deliveryFailed ? (
+            <Text size="$label/m" color="$negativeActionText">
+              Tap to retry
+            </Text>
+          ) : null}
+        </XStack>
+        {deliveryStatus && deliveryStatus !== 'failed' ? (
+          <ChatMessageDeliveryStatus status={deliveryStatus} />
         ) : null}
       </XStack>
-      {deliveryStatus && deliveryStatus !== 'failed' ? (
-        <ChatMessageDeliveryStatus status={deliveryStatus} />
-      ) : null}
-    </XStack>
+    </Pressable>
   );
 }

--- a/packages/ui/src/components/Channel/BaubleHeader.tsx
+++ b/packages/ui/src/components/Channel/BaubleHeader.tsx
@@ -24,6 +24,7 @@ import { ContactAvatar } from '../Avatar';
 import { ChatOptionsSheet, ChatOptionsSheetMethods } from '../ChatOptionsSheet';
 import { Icon } from '../Icon';
 import { Image } from '../Image';
+import Pressable from '../Pressable';
 
 export function BaubleHeader({
   showSpinner,
@@ -96,7 +97,7 @@ export function BaubleHeader({
             animatedStyle,
           ]}
         >
-          <View
+          <Pressable
             borderWidth={1}
             borderColor={'$border'}
             borderRadius="$l"
@@ -178,7 +179,7 @@ export function BaubleHeader({
                   </Animated.View>
                 )}
             </BlurView>
-          </View>
+          </Pressable>
         </Animated.View>
       )}
       {isGroupContext && groupOptions && (

--- a/packages/ui/src/components/ChatList.tsx
+++ b/packages/ui/src/components/ChatList.tsx
@@ -39,7 +39,6 @@ export const ChatList = React.memo(function ChatListComponent({
   pendingChats,
   onLongPressItem,
   onPressItem,
-  onPressMenuButton,
   activeTab,
   setActiveTab,
   showSearchInput,
@@ -50,7 +49,6 @@ export const ChatList = React.memo(function ChatListComponent({
   pendingChats: store.PendingChats;
   onPressItem?: (chat: Chat) => void;
   onLongPressItem?: (chat: Chat) => void;
-  onPressMenuButton?: (chat: Chat) => void;
   onSectionChange?: (title: string) => void;
   activeTab: TabName;
   setActiveTab: (tab: TabName) => void;
@@ -100,7 +98,6 @@ export const ChatList = React.memo(function ChatListComponent({
             model={item}
             onPress={onPressItem}
             onLongPress={onLongPressItem}
-            onPressMenuButton={onPressMenuButton}
           />
         );
       } else {
@@ -113,7 +110,7 @@ export const ChatList = React.memo(function ChatListComponent({
         );
       }
     },
-    [onPressItem, onLongPressItem, onPressMenuButton]
+    [onPressItem, onLongPressItem]
   );
 
   const handlePressTryAll = useCallback(() => {

--- a/packages/ui/src/components/ChatMessage/ChatMessage.tsx
+++ b/packages/ui/src/components/ChatMessage/ChatMessage.tsx
@@ -10,6 +10,7 @@ import {
   usePostContent,
   usePostLastEditContent,
 } from '../PostContent/contentUtils';
+import Pressable from '../Pressable';
 import { SendPostRetrySheet } from '../SendPostRetrySheet';
 import { Text } from '../TextV2';
 import { ChatMessageReplySummary } from './ChatMessageReplySummary';
@@ -122,61 +123,62 @@ const ChatMessage = ({
     showReplies && post.replyCount && post.replyTime && post.replyContactIds;
 
   return (
-    <YStack
-      onLongPress={handleLongPress}
-      backgroundColor={isHighlighted ? '$secondaryBackground' : undefined}
-      key={post.id}
+    <Pressable
       // avoid setting the top level press handler at all unless we need to
       onPress={shouldHandlePress ? handlePress : undefined}
+      onLongPress={handleLongPress}
     >
-      {showAuthor ? (
-        <AuthorRow
-          padding="$l"
-          paddingBottom="$2xs"
-          author={post.author}
-          authorId={post.authorId}
-          sent={post.sentAt ?? 0}
-          type={post.type}
-          disabled={hideProfilePreview}
-          deliveryStatus={post.deliveryStatus}
-          editStatus={post.editStatus}
-          deleteStatus={post.deleteStatus}
-          showEditedIndicator={!!post.isEdited}
-        />
-      ) : null}
-      <View paddingLeft={!isNotice && '$4xl'}>
-        <ChatContentRenderer
-          content={post.editStatus === 'failed' ? lastEditContent : content}
-          isNotice={post.type === 'notice'}
-          onPressImage={handleImagePressed}
-          onLongPress={handleLongPress}
-          onPress={shouldHandlePress ? handlePress : undefined}
-        />
-      </View>
+      <YStack
+        backgroundColor={isHighlighted ? '$secondaryBackground' : undefined}
+        key={post.id}
+      >
+        {showAuthor ? (
+          <AuthorRow
+            padding="$l"
+            paddingBottom="$2xs"
+            author={post.author}
+            authorId={post.authorId}
+            sent={post.sentAt ?? 0}
+            type={post.type}
+            disabled={hideProfilePreview}
+            deliveryStatus={post.deliveryStatus}
+            editStatus={post.editStatus}
+            deleteStatus={post.deleteStatus}
+            showEditedIndicator={!!post.isEdited}
+          />
+        ) : null}
+        <View paddingLeft={!isNotice && '$4xl'}>
+          <ChatContentRenderer
+            content={post.editStatus === 'failed' ? lastEditContent : content}
+            isNotice={post.type === 'notice'}
+            onPressImage={handleImagePressed}
+          />
+        </View>
 
-      <ReactionsDisplay
-        post={post}
-        onViewPostReactions={setViewReactionsPost}
-      />
+        <ReactionsDisplay
+          post={post}
+          onViewPostReactions={setViewReactionsPost}
+        />
 
-      {shouldRenderReplies ? (
-        <XStack paddingLeft={'$4xl'} paddingRight="$l" paddingBottom="$l">
-          {shouldRenderReplies ? (
-            <ChatMessageReplySummary
-              post={post}
-              onPress={handleRepliesPressed}
-            />
-          ) : null}
-        </XStack>
-      ) : null}
-      <SendPostRetrySheet
-        open={showRetrySheet}
-        post={post}
-        onOpenChange={setShowRetrySheet}
-        onPressRetry={handleRetryPressed}
-        onPressDelete={handleDeletePressed}
-      />
-    </YStack>
+        {shouldRenderReplies ? (
+          <XStack paddingLeft={'$4xl'} paddingRight="$l" paddingBottom="$l">
+            {shouldRenderReplies ? (
+              <ChatMessageReplySummary
+                post={post}
+                onPress={handleRepliesPressed}
+              />
+            ) : null}
+          </XStack>
+        ) : null}
+        <SendPostRetrySheet
+          open={showRetrySheet}
+          post={post}
+          onOpenChange={setShowRetrySheet}
+          onPressRetry={handleRetryPressed}
+          onPressDelete={handleDeletePressed}
+        />
+      </YStack>
+    </Pressable>
   );
 };
 

--- a/packages/ui/src/components/ChatMessage/ChatMessageReplySummary.tsx
+++ b/packages/ui/src/components/ChatMessage/ChatMessageReplySummary.tsx
@@ -5,6 +5,7 @@ import React, { useMemo } from 'react';
 import { ColorTokens, View, XStack, styled } from 'tamagui';
 
 import { ContactAvatar } from '../Avatar';
+import Pressable from '../Pressable';
 import { Text } from '../TextV2';
 import { UnreadDot } from '../UnreadDot';
 
@@ -30,28 +31,30 @@ export const ChatMessageReplySummary = React.memo(
     }, [replyTime]);
 
     return replyCount && replyContactIds && replyTime ? (
-      <XStack gap="$m" alignItems="center" onPress={onPress}>
-        <AvatarPreviewStack contactIds={replyContactIds} />
-        <Text
-          size="$label/m"
-          color={
-            textColor ??
-            (hasUnreads
-              ? isMuted
-                ? '$tertiaryText'
-                : '$positiveActionText'
-              : '$primaryText')
-          }
-        >
-          {replyCount} {replyCount > 1 ? 'replies' : 'reply'}
-        </Text>
-        <ThreadUnreadDot
-          unreadCount={threadUnread?.count ?? 0}
-          isMuted={logic.isMuted(post.volumeSettings?.level, 'thread')}
-          isNotify={post.threadUnread?.notify ?? false}
-        />
-        {showTime && <ReplyTimeText>{time} ago</ReplyTimeText>}
-      </XStack>
+      <Pressable onPress={onPress}>
+        <XStack gap="$m" alignItems="center">
+          <AvatarPreviewStack contactIds={replyContactIds} />
+          <Text
+            size="$label/m"
+            color={
+              textColor ??
+              (hasUnreads
+                ? isMuted
+                  ? '$tertiaryText'
+                  : '$positiveActionText'
+                : '$primaryText')
+            }
+          >
+            {replyCount} {replyCount > 1 ? 'replies' : 'reply'}
+          </Text>
+          <ThreadUnreadDot
+            unreadCount={threadUnread?.count ?? 0}
+            isMuted={logic.isMuted(post.volumeSettings?.level, 'thread')}
+            isNotify={post.threadUnread?.notify ?? false}
+          />
+          {showTime && <ReplyTimeText>{time} ago</ReplyTimeText>}
+        </XStack>
+      </Pressable>
     ) : null;
   }
 );

--- a/packages/ui/src/components/ChatMessage/ReactionsDisplay.tsx
+++ b/packages/ui/src/components/ChatMessage/ReactionsDisplay.tsx
@@ -7,6 +7,7 @@ import { useCurrentUserId } from '../../contexts/appDataContext';
 import { triggerHaptic } from '../../utils';
 import { useReactionDetails } from '../../utils/postUtils';
 import { SizableEmoji } from '../Emoji/SizableEmoji';
+import Pressable from '../Pressable';
 import { Text } from '../TextV2';
 
 export function ReactionsDisplay({
@@ -45,50 +46,58 @@ export function ReactionsDisplay({
   }
 
   return (
-    <XStack
-      paddingBottom="$l"
-      paddingLeft="$4xl"
-      borderRadius="$m"
-      gap="$xs"
-      flexWrap="wrap"
-      onLongPress={() => handleOpenReactions(post)}
-    >
-      {reactionDetails.list.map((reaction) => (
-        <XStack
-          key={reaction.value}
-          justifyContent="center"
-          alignItems="center"
-          backgroundColor={
-            reaction.value === reactionDetails.self.value
-              ? '$positiveBackground'
-              : '$secondaryBackground'
-          }
-          padding="$xs"
-          paddingHorizontal="$s"
-          height="$3xl"
-          borderRadius="$s"
-          borderColor={
-            reaction.value === reactionDetails.self.value
-              ? '$positiveBorder'
-              : '$border'
-          }
-          borderWidth={1}
-          gap={'$s'}
-          disabled={
-            reactionDetails.self.didReact &&
-            reaction.value !== reactionDetails.self.value
-          }
-          onPress={() => handleModifyYourReaction(reaction.value)}
-          onLongPress={() => handleOpenReactions(post)}
-        >
-          <SizableEmoji
+    <Pressable borderRadius="$m" onLongPress={() => handleOpenReactions(post)}>
+      <XStack
+        paddingBottom="$l"
+        paddingLeft="$4xl"
+        borderRadius="$m"
+        gap="$xs"
+        flexWrap="wrap"
+      >
+        {reactionDetails.list.map((reaction) => (
+          <Pressable
             key={reaction.value}
-            shortCode={reaction.value}
-            fontSize="$s"
-          />
-          {reaction.count > 0 && <Text size="$label/m">{reaction.count}</Text>}
-        </XStack>
-      ))}
-    </XStack>
+            borderRadius="$s"
+            onPress={() => handleModifyYourReaction(reaction.value)}
+            onLongPress={() => handleOpenReactions(post)}
+          >
+            <XStack
+              key={reaction.value}
+              justifyContent="center"
+              alignItems="center"
+              backgroundColor={
+                reaction.value === reactionDetails.self.value
+                  ? '$positiveBackground'
+                  : '$secondaryBackground'
+              }
+              padding="$xs"
+              paddingHorizontal="$s"
+              height="$3xl"
+              borderRadius="$s"
+              borderColor={
+                reaction.value === reactionDetails.self.value
+                  ? '$positiveBorder'
+                  : '$border'
+              }
+              borderWidth={1}
+              gap={'$s'}
+              disabled={
+                reactionDetails.self.didReact &&
+                reaction.value !== reactionDetails.self.value
+              }
+            >
+              <SizableEmoji
+                key={reaction.value}
+                shortCode={reaction.value}
+                fontSize="$s"
+              />
+              {reaction.count > 0 && (
+                <Text size="$label/m">{reaction.count}</Text>
+              )}
+            </XStack>
+          </Pressable>
+        ))}
+      </XStack>
+    </Pressable>
   );
 }

--- a/packages/ui/src/components/ContactRow.tsx
+++ b/packages/ui/src/components/ContactRow.tsx
@@ -6,6 +6,7 @@ import { Stack, View, XStack } from 'tamagui';
 import { getDisplayName, triggerHaptic } from '../utils';
 import { Icon } from './Icon';
 import { ListItem } from './ListItem';
+import Pressable from './Pressable';
 
 function ContactRowItemRaw({
   contact,
@@ -32,37 +33,39 @@ function ContactRowItemRaw({
   );
 
   return (
-    <ListItem onPress={handlePress(contact.id)} pressable {...rest}>
-      <ListItem.ContactIcon contactId={contact.id} />
-      <ListItem.MainContent>
-        <XStack alignItems="center">
-          <ListItem.Title marginLeft="$l">{displayName}</ListItem.Title>
-        </XStack>
-      </ListItem.MainContent>
-      {selectable && (
-        <ListItem.EndContent>
-          <Stack
-            justifyContent="center"
-            alignItems="center"
-            height="$4xl"
-            width="$4xl"
-          >
-            {selected ? (
-              <Icon type="Checkmark" size="$xl" />
-            ) : (
-              <View
-                borderWidth={1}
-                borderRadius="$4xl"
-                borderColor="$tertiaryText"
-                opacity={0.6}
-                height="$3xl"
-                width="$3xl"
-              />
-            )}
-          </Stack>
-        </ListItem.EndContent>
-      )}
-    </ListItem>
+    <Pressable pressStyle={undefined} onPress={handlePress(contact.id)}>
+      <ListItem {...rest}>
+        <ListItem.ContactIcon contactId={contact.id} />
+        <ListItem.MainContent>
+          <XStack alignItems="center">
+            <ListItem.Title marginLeft="$l">{displayName}</ListItem.Title>
+          </XStack>
+        </ListItem.MainContent>
+        {selectable && (
+          <ListItem.EndContent>
+            <Stack
+              justifyContent="center"
+              alignItems="center"
+              height="$4xl"
+              width="$4xl"
+            >
+              {selected ? (
+                <Icon type="Checkmark" size="$xl" />
+              ) : (
+                <View
+                  borderWidth={1}
+                  borderRadius="$4xl"
+                  borderColor="$tertiaryText"
+                  opacity={0.6}
+                  height="$3xl"
+                  width="$3xl"
+                />
+              )}
+            </Stack>
+          </ListItem.EndContent>
+        )}
+      </ListItem>
+    </Pressable>
   );
 }
 export const ContactRow = React.memo(ContactRowItemRaw);

--- a/packages/ui/src/components/ContentReference/ContentReference.tsx
+++ b/packages/ui/src/components/ContentReference/ContentReference.tsx
@@ -329,11 +329,7 @@ export function GroupReference({
               </View>
             )
           ) : (
-            <ListItem
-              pressable={false}
-              backgroundColor={'transparent'}
-              gap="$m"
-            >
+            <ListItem backgroundColor={'transparent'} gap="$m">
               <ListItem.GroupIcon model={data} />
               <ListItem.MainContent>
                 <ListItem.Title>{data.title ?? data.id}</ListItem.Title>

--- a/packages/ui/src/components/DebugInfo.tsx
+++ b/packages/ui/src/components/DebugInfo.tsx
@@ -1,8 +1,8 @@
 import * as Application from 'expo-application';
 import { PropsWithChildren, useEffect, useState } from 'react';
-import { Platform } from 'react-native';
 import { Alert } from 'react-native';
-import { View } from 'tamagui';
+
+import Pressable from './Pressable';
 
 const KONAMI_CLICKS = 5;
 const KONAMI_TIME_WINDOW = 2000;
@@ -28,5 +28,5 @@ export function DebugInfo(props: PropsWithChildren<{ debugMessage: string }>) {
       setClicks(clicks.slice(1));
     }
   }, [clicks]);
-  return <View onPress={handlePress}>{props.children}</View>;
+  return <Pressable onPress={handlePress}>{props.children}</Pressable>;
 }

--- a/packages/ui/src/components/Embed/VideoEmbed.native.tsx
+++ b/packages/ui/src/components/Embed/VideoEmbed.native.tsx
@@ -7,6 +7,7 @@ import { ComponentProps, useCallback, useMemo, useRef, useState } from 'react';
 import { View } from 'tamagui';
 
 import { Icon } from '../Icon';
+import Pressable from '../Pressable';
 
 type VideoEmbedProps = ComponentProps<typeof View> & {
   video: { width: number; height: number; src: string; alt?: string };
@@ -30,7 +31,7 @@ export default function VideoEmbed({ video, ...props }: VideoEmbedProps) {
   const source = useMemo(() => ({ uri: video.src }), [video.src]);
 
   return (
-    <View
+    <Pressable
       onPress={handlePress}
       group="button"
       borderRadius="$m"
@@ -66,6 +67,6 @@ export default function VideoEmbed({ video, ...props }: VideoEmbedProps) {
           $group-button-press={{ opacity: 0.8 }}
         />
       </View>
-    </View>
+    </Pressable>
   );
 }

--- a/packages/ui/src/components/FavoriteGroupsDisplay.tsx
+++ b/packages/ui/src/components/FavoriteGroupsDisplay.tsx
@@ -6,6 +6,7 @@ import { useGroups } from '../contexts';
 import { useAlphabeticallySegmentedGroups } from '../hooks/groupsSorters';
 import { GroupSelectorSheet } from './GroupSelectorSheet';
 import { GroupListItem, ListItem } from './ListItem';
+import Pressable from './Pressable';
 import { WidgetPane } from './WidgetPane';
 
 export function FavoriteGroupsDisplay(props: {
@@ -71,35 +72,33 @@ export function FavoriteGroupsDisplay(props: {
             model={group}
             key={group.id}
             backgroundColor="unset"
-            pressable={false}
             EndContent={
-              <ListItem.SystemIcon
-                icon="Close"
-                onPress={() => handleFavoriteGroupsChange(group)}
-                backgroundColor={'transparent'}
-                color={'$tertiaryText'}
-              />
+              <Pressable onPress={() => handleFavoriteGroupsChange(group)}>
+                <ListItem.SystemIcon
+                  icon="Close"
+                  onPress={() => handleFavoriteGroupsChange(group)}
+                  backgroundColor={'transparent'}
+                  color={'$tertiaryText'}
+                />
+              </Pressable>
             }
           />
         );
       })}
-      <ListItem
-        padding="$m"
-        onPress={() => setSelectorOpen(true)}
-        backgroundColor="unset"
-        pressable
-      >
-        <ListItem.MainContent>
-          <ListItem.Title>Add a group</ListItem.Title>
-        </ListItem.MainContent>
-        <ListItem.EndContent backgroundColor="unset">
-          <ListItem.SystemIcon
-            icon="ChevronRight"
-            backgroundColor="unset"
-            color={'$tertiaryText'}
-          />
-        </ListItem.EndContent>
-      </ListItem>
+      <Pressable borderRadius="$xl" onPress={() => setSelectorOpen(true)}>
+        <ListItem padding="$m" backgroundColor="unset">
+          <ListItem.MainContent>
+            <ListItem.Title>Add a group</ListItem.Title>
+          </ListItem.MainContent>
+          <ListItem.EndContent backgroundColor="unset">
+            <ListItem.SystemIcon
+              icon="ChevronRight"
+              backgroundColor="unset"
+              color={'$tertiaryText'}
+            />
+          </ListItem.EndContent>
+        </ListItem>
+      </Pressable>
       <GroupSelectorSheet
         open={selectorOpen}
         onOpenChange={setSelectorOpen}

--- a/packages/ui/src/components/Form/inputs.tsx
+++ b/packages/ui/src/components/Form/inputs.tsx
@@ -19,6 +19,7 @@ import { Icon, IconType } from '../Icon';
 import { Image } from '../Image';
 import { ListItem } from '../ListItem';
 import { useBoundHandler } from '../ListItem/listItemUtils';
+import Pressable from '../Pressable';
 import { Text } from '../TextV2';
 import { FieldContext } from './Form';
 
@@ -571,24 +572,26 @@ function ListItemInputRow<T>({
 }) {
   const handlePress = useBoundHandler(option.value, onPress);
   return (
-    <ListItem onPress={handlePress}>
-      {option.icon ? (
-        typeof option.icon === 'string' ? (
-          <ListItem.SystemIcon icon={option.icon} />
-        ) : (
-          option.icon
-        )
-      ) : null}
-      <ListItem.MainContent>
-        <ListItem.Title>{option.title}</ListItem.Title>
-        {option.subtitle ? (
-          <ListItem.Subtitle>{option.subtitle}</ListItem.Subtitle>
+    <Pressable borderRadius="$xl" onPress={handlePress}>
+      <ListItem>
+        {option.icon ? (
+          typeof option.icon === 'string' ? (
+            <ListItem.SystemIcon icon={option.icon} />
+          ) : (
+            option.icon
+          )
         ) : null}
-      </ListItem.MainContent>
-      <ListItem.EndContent padding={0}>
-        {checked ? <RadioControl checked /> : null}
-      </ListItem.EndContent>
-    </ListItem>
+        <ListItem.MainContent>
+          <ListItem.Title>{option.title}</ListItem.Title>
+          {option.subtitle ? (
+            <ListItem.Subtitle>{option.subtitle}</ListItem.Subtitle>
+          ) : null}
+        </ListItem.MainContent>
+        <ListItem.EndContent padding={0}>
+          {checked ? <RadioControl checked /> : null}
+        </ListItem.EndContent>
+      </ListItem>
+    </Pressable>
   );
 }
 

--- a/packages/ui/src/components/GroupChannelsScreenView.tsx
+++ b/packages/ui/src/components/GroupChannelsScreenView.tsx
@@ -4,7 +4,6 @@ import { useSafeAreaInsets } from 'react-native-safe-area-context';
 import { ScrollView, View, YStack } from 'tamagui';
 
 import { useCurrentUserId } from '../contexts';
-import useIsWindowNarrow from '../hooks/useIsWindowNarrow';
 import { useIsAdmin } from '../utils/channelUtils';
 import ChannelNavSections from './ChannelNavSections';
 import { ChatOptionsSheet, ChatOptionsSheetMethods } from './ChatOptionsSheet';
@@ -66,8 +65,6 @@ export function GroupChannelsScreenView({
     }
   }, [isGroupAdmin]);
 
-  const isWindowNarrow = useIsWindowNarrow();
-
   return (
     <View flex={1}>
       <ScreenHeader
@@ -109,7 +106,7 @@ export function GroupChannelsScreenView({
             channels={group.channels}
             onSelect={onChannelPressed}
             sortBy={sortBy || 'recency'}
-            onLongPress={isWindowNarrow ? handleOpenChannelOptions : undefined}
+            onLongPress={handleOpenChannelOptions}
           />
         </ScrollView>
       ) : (

--- a/packages/ui/src/components/ListItem/ChannelListItem.tsx
+++ b/packages/ui/src/components/ListItem/ChannelListItem.tsx
@@ -1,10 +1,16 @@
 import type * as db from '@tloncorp/shared/db';
 import * as logic from '@tloncorp/shared/logic';
 import { useMemo } from 'react';
+import { View } from 'tamagui';
+import { isWeb } from 'tamagui';
 
 import * as utils from '../../utils';
 import { capitalize } from '../../utils';
 import { Badge } from '../Badge';
+import { Button } from '../Button';
+import { Chat } from '../ChatList';
+import { Icon } from '../Icon';
+import Pressable from '../Pressable';
 import { ListItem, type ListItemProps } from './ListItem';
 
 export function ChannelListItem({
@@ -18,7 +24,7 @@ export function ChannelListItem({
 }: {
   useTypeIcon?: boolean;
   customSubtitle?: string;
-} & ListItemProps<db.Channel>) {
+} & ListItemProps<Chat> & { model: db.Channel }) {
   const unreadCount = model.unread?.count ?? 0;
   const title = utils.useChannelTitle(model);
   const firstMemberId = model.members?.[0]?.contactId ?? '';
@@ -52,41 +58,56 @@ export function ChannelListItem({
   }, [model, firstMemberId, memberCount]);
 
   return (
-    <ListItem {...props} onPress={handlePress} onLongPress={handleLongPress}>
-      <ListItem.ChannelIcon model={model} useTypeIcon={useTypeIcon} />
-      <ListItem.MainContent>
-        <ListItem.Title>{title}</ListItem.Title>
-        {customSubtitle ? (
-          <ListItem.Subtitle>{customSubtitle}</ListItem.Subtitle>
-        ) : (
-          <ListItem.SubtitleWithIcon icon={subtitleIcon}>
-            {subtitle}
-          </ListItem.SubtitleWithIcon>
-        )}
-        {model.lastPost && (
-          <ListItem.PostPreview
-            post={model.lastPost}
-            showAuthor={model.type !== 'dm'}
-          />
-        )}
-      </ListItem.MainContent>
+    <View>
+      <Pressable
+        borderRadius="$xl"
+        onPress={handlePress}
+        onLongPress={handleLongPress}
+      >
+        <ListItem {...props}>
+          <ListItem.ChannelIcon model={model} useTypeIcon={useTypeIcon} />
+          <ListItem.MainContent>
+            <ListItem.Title>{title}</ListItem.Title>
+            {customSubtitle ? (
+              <ListItem.Subtitle>{customSubtitle}</ListItem.Subtitle>
+            ) : (
+              <ListItem.SubtitleWithIcon icon={subtitleIcon}>
+                {subtitle}
+              </ListItem.SubtitleWithIcon>
+            )}
+            {model.lastPost && (
+              <ListItem.PostPreview
+                post={model.lastPost}
+                showAuthor={model.type !== 'dm'}
+              />
+            )}
+          </ListItem.MainContent>
 
-      {EndContent ?? (
-        <ListItem.EndContent>
-          {model.lastPost?.receivedAt ? (
-            <ListItem.Time time={model.lastPost.receivedAt} />
-          ) : null}
+          {EndContent ?? (
+            <ListItem.EndContent>
+              {model.lastPost?.receivedAt ? (
+                <ListItem.Time time={model.lastPost.receivedAt} />
+              ) : null}
 
-          {model.isDmInvite ? (
-            <Badge text="Invite" />
-          ) : (
-            <ListItem.Count
-              count={unreadCount}
-              muted={logic.isMuted(model.volumeSettings?.level, 'channel')}
-            />
+              {model.isDmInvite ? (
+                <Badge text="Invite" />
+              ) : (
+                <ListItem.Count
+                  count={unreadCount}
+                  muted={logic.isMuted(model.volumeSettings?.level, 'channel')}
+                />
+              )}
+            </ListItem.EndContent>
           )}
-        </ListItem.EndContent>
+        </ListItem>
+      </Pressable>
+      {isWeb && (
+        <View position="absolute" right={-2} top={44} zIndex={1}>
+          <Button onPress={handleLongPress} borderWidth="unset" size="$l">
+            <Icon type="Overflow" />
+          </Button>
+        </View>
       )}
-    </ListItem>
+    </View>
   );
 }

--- a/packages/ui/src/components/ListItem/ContactListItem.tsx
+++ b/packages/ui/src/components/ListItem/ContactListItem.tsx
@@ -1,9 +1,8 @@
-import * as db from '@tloncorp/shared/db';
 import { ComponentProps } from 'react';
-import { SizableText } from 'tamagui';
 
 import { AvatarProps } from '../Avatar';
 import ContactName from '../ContactName';
+import Pressable from '../Pressable';
 import { ListItem } from './ListItem';
 import { useBoundHandler } from './listItemUtils';
 
@@ -37,33 +36,33 @@ export const ContactListItem = ({
   const handleLongPress = useBoundHandler(contactId, onLongPress);
 
   return (
-    <ListItem
+    <Pressable
+      borderRadius="$xl"
       onPress={handlePress}
       onLongPress={handleLongPress}
-      alignItems="center"
-      justifyContent="flex-start"
-      {...props}
     >
-      {showIcon && <ListItem.ContactIcon size={size} contactId={contactId} />}
-      <ListItem.MainContent>
-        <ListItem.Title>
-          <ContactName
-            matchText={matchText}
-            showNickname={showNickname}
-            showUserId={!showNickname && showUserId}
-            full={full}
-            userId={contactId}
-          />
-        </ListItem.Title>
-        {showUserId && showNickname ? (
-          <ListItem.Subtitle>{contactId}</ListItem.Subtitle>
-        ) : null}
-      </ListItem.MainContent>
-      {showEndContent && (
-        <ListItem.EndContent flexGrow={1} justifyContent="flex-end">
-          {endContent}
-        </ListItem.EndContent>
-      )}
-    </ListItem>
+      <ListItem alignItems="center" justifyContent="flex-start" {...props}>
+        {showIcon && <ListItem.ContactIcon size={size} contactId={contactId} />}
+        <ListItem.MainContent>
+          <ListItem.Title>
+            <ContactName
+              matchText={matchText}
+              showNickname={showNickname}
+              showUserId={!showNickname && showUserId}
+              full={full}
+              userId={contactId}
+            />
+          </ListItem.Title>
+          {showUserId && showNickname ? (
+            <ListItem.Subtitle>{contactId}</ListItem.Subtitle>
+          ) : null}
+        </ListItem.MainContent>
+        {showEndContent && (
+          <ListItem.EndContent flexGrow={1} justifyContent="flex-end">
+            {endContent}
+          </ListItem.EndContent>
+        )}
+      </ListItem>
+    </Pressable>
   );
 };

--- a/packages/ui/src/components/ListItem/GroupListItem.tsx
+++ b/packages/ui/src/components/ListItem/GroupListItem.tsx
@@ -1,14 +1,15 @@
 import type * as db from '@tloncorp/shared/db';
 import * as logic from '@tloncorp/shared/logic';
+import { View } from 'tamagui';
+import { isWeb } from 'tamagui';
 
 import { Badge } from '../Badge';
+import { Button } from '../Button';
+import { Icon } from '../Icon';
+import Pressable from '../Pressable';
 import type { ListItemProps } from './ListItem';
 import { ListItem } from './ListItem';
-import {
-  getGroupStatus,
-  getPostTypeIcon,
-  useBoundHandler,
-} from './listItemUtils';
+import { getGroupStatus, getPostTypeIcon } from './listItemUtils';
 
 export const GroupListItem = ({
   model,
@@ -21,49 +22,67 @@ export const GroupListItem = ({
   const title = model.title ?? model.id;
   const { isPending, label: statusLabel, isErrored } = getGroupStatus(model);
 
-  return (
-    <ListItem
-      {...props}
-      alignItems={isPending ? 'center' : 'stretch'}
-      onPress={useBoundHandler(model, onPress)}
-      onLongPress={useBoundHandler(model, onLongPress)}
-    >
-      <ListItem.GroupIcon model={model} />
-      <ListItem.MainContent>
-        <ListItem.Title>{title}</ListItem.Title>
-        {customSubtitle && (
-          <ListItem.Subtitle>{customSubtitle}</ListItem.Subtitle>
-        )}
-        {model.lastPost && !customSubtitle && (
-          <ListItem.SubtitleWithIcon
-            icon={getPostTypeIcon(model.lastPost.type)}
-          >
-            {model.lastChannel}
-          </ListItem.SubtitleWithIcon>
-        )}
-        {!isPending && model.lastPost ? (
-          <ListItem.PostPreview post={model.lastPost} />
-        ) : null}
-      </ListItem.MainContent>
+  const handlePress = logic.useMutableCallback(() => {
+    onPress?.(model);
+  });
 
-      {props.EndContent ?? (
-        <ListItem.EndContent>
-          {statusLabel ? (
-            <Badge
-              text={statusLabel}
-              type={isErrored ? 'warning' : 'positive'}
-            />
-          ) : (
-            <>
-              <ListItem.Time time={model.lastPostAt} />
-              <ListItem.Count
-                count={unreadCount}
-                muted={logic.isMuted(model.volumeSettings?.level, 'group')}
-              />
-            </>
+  const handleLongPress = logic.useMutableCallback(() => {
+    onLongPress?.(model);
+  });
+
+  return (
+    <View>
+      <Pressable
+        borderRadius="$xl"
+        onPress={handlePress}
+        onLongPress={handleLongPress}
+      >
+        <ListItem {...props} alignItems={isPending ? 'center' : 'stretch'}>
+          <ListItem.GroupIcon model={model} />
+          <ListItem.MainContent>
+            <ListItem.Title>{title}</ListItem.Title>
+            {customSubtitle && (
+              <ListItem.Subtitle>{customSubtitle}</ListItem.Subtitle>
+            )}
+            {model.lastPost && !customSubtitle && (
+              <ListItem.SubtitleWithIcon
+                icon={getPostTypeIcon(model.lastPost.type)}
+              >
+                {model.lastChannel}
+              </ListItem.SubtitleWithIcon>
+            )}
+            {!isPending && model.lastPost ? (
+              <ListItem.PostPreview post={model.lastPost} />
+            ) : null}
+          </ListItem.MainContent>
+
+          {props.EndContent ?? (
+            <ListItem.EndContent>
+              {statusLabel ? (
+                <Badge
+                  text={statusLabel}
+                  type={isErrored ? 'warning' : 'positive'}
+                />
+              ) : (
+                <>
+                  <ListItem.Time time={model.lastPostAt} />
+                  <ListItem.Count
+                    count={unreadCount}
+                    muted={logic.isMuted(model.volumeSettings?.level, 'group')}
+                  />
+                </>
+              )}
+            </ListItem.EndContent>
           )}
-        </ListItem.EndContent>
+        </ListItem>
+      </Pressable>
+      {isWeb && !isPending && (
+        <View position="absolute" right={-2} top={44} zIndex={1}>
+          <Button onPress={handleLongPress} borderWidth="unset" size="$l">
+            <Icon type="Overflow" />
+          </Button>
+        </View>
       )}
-    </ListItem>
+    </View>
   );
 };

--- a/packages/ui/src/components/ListItem/InteractableChatListItem.tsx
+++ b/packages/ui/src/components/ListItem/InteractableChatListItem.tsx
@@ -21,7 +21,6 @@ import Animated, {
 import { ColorTokens, Stack, View, getTokenValue, isWeb } from 'tamagui';
 
 import * as utils from '../../utils';
-import { Button } from '../Button';
 import { Chat } from '../ChatList';
 import { Icon, IconType } from '../Icon';
 import { ChatListItem } from './ChatListItem';
@@ -32,7 +31,6 @@ function BaseInteractableChatRow({
   model,
   onPress,
   onLongPress,
-  onPressMenuButton,
 }: ListItemProps<Chat> & { model: db.Channel }) {
   const swipeableRef = useRef<SwipeableMethods>(null);
 
@@ -87,13 +85,6 @@ function BaseInteractableChatRow({
     [handleAction, mutedState]
   );
 
-  const handleMenuPress = useCallback(
-    (chat: Chat) => {
-      onPressMenuButton?.(chat);
-    },
-    [onPressMenuButton]
-  );
-
   if (!isWeb) {
     return (
       <Swipeable
@@ -114,22 +105,7 @@ function BaseInteractableChatRow({
     );
   } else {
     return (
-      <View>
-        <ChatListItem
-          model={model}
-          onPress={onPress}
-          onLongPress={onLongPress}
-        />
-        <View position="absolute" right={-2} top={44} zIndex={1}>
-          <Button
-            onPress={() => handleMenuPress(model)}
-            borderWidth="unset"
-            size="$l"
-          >
-            <Icon type="Overflow" />
-          </Button>
-        </View>
-      </View>
+      <ChatListItem model={model} onPress={onPress} onLongPress={onLongPress} />
     );
   }
 }

--- a/packages/ui/src/components/ListItem/ListItem.tsx
+++ b/packages/ui/src/components/ListItem/ListItem.tsx
@@ -22,7 +22,6 @@ export interface BaseListItemProps<T> {
   EndContent?: ReactElement | null;
   onPress?: (model: T) => void;
   onLongPress?: (model: T) => void;
-  onPressMenuButton?: (model: T) => void;
   unreadCount?: number;
 }
 
@@ -38,19 +37,7 @@ export const ListItemFrame = styled(XStack, {
   gap: '$l',
   justifyContent: 'space-between',
   alignItems: 'stretch',
-  backgroundColor: '$background',
-  variants: {
-    pressable: {
-      true: {
-        pressStyle: {
-          backgroundColor: '$secondaryBackground',
-        },
-      },
-    },
-  } as const,
-  defaultVariants: {
-    pressable: true,
-  },
+  backgroundColor: '$transparent',
 });
 
 const ListItemIconContainer = styled(View, {

--- a/packages/ui/src/components/MessageInput/AttachmentPreviewList.tsx
+++ b/packages/ui/src/components/MessageInput/AttachmentPreviewList.tsx
@@ -6,6 +6,7 @@ import { Attachment, useAttachmentContext } from '../../contexts/attachment';
 import { ContentReferenceLoader } from '../ContentReference';
 import { Icon } from '../Icon';
 import { Image } from '../Image';
+import Pressable from '../Pressable';
 
 export const AttachmentPreviewList = () => {
   const { attachments } = useAttachmentContext();
@@ -99,7 +100,7 @@ const RemoveAttachmentButton = ({ attachment }: { attachment: Attachment }) => {
     removeAttachment(attachment);
   }, [removeAttachment, attachment]);
   return (
-    <View
+    <Pressable
       width="$xl"
       height="$xl"
       borderColor="$border"
@@ -113,6 +114,6 @@ const RemoveAttachmentButton = ({ attachment }: { attachment: Attachment }) => {
       onPress={handlePress}
     >
       <Icon size="$s" type="Close" />
-    </View>
+    </Pressable>
   );
 };

--- a/packages/ui/src/components/Modal.tsx
+++ b/packages/ui/src/components/Modal.tsx
@@ -1,8 +1,9 @@
 import { ComponentProps } from 'react';
 import { Modal as RNModal } from 'react-native';
-import { View, ZStack } from 'tamagui';
+import { ZStack } from 'tamagui';
 
 import { Overlay } from './Overlay';
+import Pressable from './Pressable';
 
 export function Modal(props: ComponentProps<typeof RNModal>) {
   const onDismiss = () => {
@@ -15,9 +16,9 @@ export function Modal(props: ComponentProps<typeof RNModal>) {
     <RNModal transparent={true} {...props}>
       <ZStack flex={1} justifyContent="center" alignItems="center">
         <Overlay onPress={onDismiss} />
-        <View flex={1} position="absolute" onPress={onDismiss}>
+        <Pressable flex={1} position="absolute" onPress={onDismiss}>
           {props.children}
-        </View>
+        </Pressable>
       </ZStack>
     </RNModal>
   );

--- a/packages/ui/src/components/NavBar/NavIcon.tsx
+++ b/packages/ui/src/components/NavBar/NavIcon.tsx
@@ -2,6 +2,7 @@ import { Circle, ColorTokens } from 'tamagui';
 
 import { ContactAvatar } from '../Avatar';
 import { Icon, IconType } from '../Icon';
+import Pressable from '../Pressable';
 import { View } from '../View';
 
 export function AvatarNavIcon({
@@ -14,7 +15,7 @@ export function AvatarNavIcon({
   onPress?: () => void;
 }) {
   return (
-    <View flex={1} onPress={onPress} alignItems="center" paddingTop={'$s'}>
+    <Pressable flex={1} onPress={onPress} alignItems="center" paddingTop={'$s'}>
       <ContactAvatar
         size={'custom'}
         width={20}
@@ -23,7 +24,7 @@ export function AvatarNavIcon({
         contactId={id}
         opacity={focused ? 1 : 0.6}
       />
-    </View>
+    </Pressable>
   );
 }
 
@@ -46,7 +47,7 @@ export default function NavIcon({
 }) {
   const resolvedType = isActive && activeType ? activeType : type;
   return (
-    <View
+    <Pressable
       backgroundColor={backgroundColor}
       alignItems="center"
       flex={1}
@@ -64,6 +65,6 @@ export default function NavIcon({
           />
         </View>
       ) : null}
-    </View>
+    </Pressable>
   );
 }

--- a/packages/ui/src/components/Onboarding/OnboardingInvite.tsx
+++ b/packages/ui/src/components/Onboarding/OnboardingInvite.tsx
@@ -32,7 +32,6 @@ export const OnboardingInviteBlock = React.memo(function OnboardingInviteBlock({
     // provider needed to support calm settings usage down the tree
     <AppDataContextProvider>
       <ListItem
-        pressable={false}
         backgroundColor="$background"
         borderColor="$border"
         borderWidth={1}

--- a/packages/ui/src/components/PostContent/BlockRenderer.tsx
+++ b/packages/ui/src/components/PostContent/BlockRenderer.tsx
@@ -24,6 +24,7 @@ import { ContentReferenceLoader, Reference } from '../ContentReference';
 import { VideoEmbed } from '../Embed';
 import { HighlightedCode } from '../HighlightedCode';
 import { Image } from '../Image';
+import Pressable from '../Pressable';
 import { Text } from '../TextV2';
 import { InlineRenderer } from './InlineRenderer';
 import * as cn from './contentUtils';
@@ -237,7 +238,7 @@ export function ImageBlock({
   }, []);
 
   return (
-    <View
+    <Pressable
       borderRadius="$s"
       overflow="hidden"
       onPress={handlePress}
@@ -255,7 +256,7 @@ export function ImageBlock({
         aspectRatio={aspect ?? 1}
         {...imageProps}
       />
-    </View>
+    </Pressable>
   );
 }
 

--- a/packages/ui/src/components/Pressable.tsx
+++ b/packages/ui/src/components/Pressable.tsx
@@ -1,10 +1,93 @@
-import { TouchableOpacity as RNTouchableOpacity } from 'react-native';
+import { NavigationAction, useLinkProps } from '@react-navigation/native';
+import { To } from '@react-navigation/native/lib/typescript/src/useLinkTo';
+import { GestureResponderEvent } from 'react-native';
+import { Stack, StackProps, isWeb } from 'tamagui';
+
+type PressHandler = ((event: GestureResponderEvent) => void) | undefined | null;
+
+type PressableProps = Omit<StackProps, 'onPress' | 'onLongPress'> & {
+  onLongPress?: PressHandler;
+  onPress?: PressHandler;
+  to?: To;
+  action?: NavigationAction;
+  children: React.ReactNode;
+};
+
+const StackComponent = ({
+  onLongPress,
+  onPress,
+  children,
+  ...stackProps
+}: PressableProps) => {
+  const longPressHandler = isWeb ? undefined : onLongPress;
+
+  return (
+    <Stack
+      pressStyle={{ backgroundColor: '$secondaryBackground' }}
+      {...stackProps}
+      // eslint-disable-next-line no-restricted-syntax
+      onPress={onPress}
+      // eslint-disable-next-line no-restricted-syntax
+      onLongPress={longPressHandler}
+    >
+      {children}
+    </Stack>
+  );
+};
+
+/**
+ * Component that wraps content and makes it pressable.
+ * It provides the same props as `Stack` component.
+ * It also accepts `to` and `action` props to use with `useLinkProps`.
+ * If `action` is provided, `to` must be specified.
+ * More info at https://reactnavigation.org/docs/use-link-props
+ *
+ * @param props.onPress Function to call when the press is released.
+ * @param props.onLongPress Function to call when the press is held. Disabled on web.
+ * @param props.to Absolute path to screen (e.g. `/feeds/hot`).
+ * @param props.action Optional action to use for in-page navigation. By default, the path is parsed to an action based on linking config.
+ */
 
 export default function Pressable({
+  onPress,
+  onLongPress,
+  to,
+  action,
   children,
-  ...props
-}: {
-  children: React.ReactNode;
-} & React.ComponentProps<typeof RNTouchableOpacity>) {
-  return <RNTouchableOpacity {...props}>{children}</RNTouchableOpacity>;
+  ...stackProps
+}: PressableProps) {
+  const longPressHandler = isWeb ? undefined : onLongPress;
+  const { onPress: onPressLink, ...linkProps } = useLinkProps({
+    to: to ?? '',
+    action,
+  });
+
+  if (action && !to) {
+    throw new Error(
+      'The `to` prop is required when `action` is specified in `Pressable`'
+    );
+  }
+
+  if (to || action) {
+    return (
+      <StackComponent
+        {...stackProps}
+        {...linkProps}
+        onPress={onPressLink ?? onPress}
+        onLongPress={longPressHandler}
+      >
+        {children}
+      </StackComponent>
+    );
+  }
+
+  return (
+    <StackComponent
+      {...stackProps}
+      onPress={onPress}
+      onLongPress={longPressHandler}
+    >
+      {children}
+    </StackComponent>
+  );
 }

--- a/packages/ui/src/components/Pressable.tsx
+++ b/packages/ui/src/components/Pressable.tsx
@@ -73,6 +73,7 @@ export default function Pressable({
       <StackComponent
         {...stackProps}
         {...linkProps}
+        group
         onPress={onPressLink ?? onPress}
         onLongPress={longPressHandler}
       >

--- a/packages/ui/src/components/ProfileScreenView.tsx
+++ b/packages/ui/src/components/ProfileScreenView.tsx
@@ -6,6 +6,7 @@ import { ScrollView, View, YStack } from 'tamagui';
 import { ContactAvatar } from './Avatar';
 import { IconType } from './Icon';
 import { ListItem } from './ListItem';
+import Pressable from './Pressable';
 import { ScreenHeader } from './ScreenHeader';
 import { TlonLogo } from './TlonLogo';
 
@@ -154,26 +155,28 @@ function ProfileAction({
   subtitle?: string;
 }) {
   return (
-    <ListItem onPress={onPress}>
-      {typeof leftIcon === 'string' ? (
-        <ListItem.SystemIcon icon={leftIcon} rounded />
-      ) : (
-        leftIcon
-      )}
-      <ListItem.MainContent>
-        <ListItem.Title>{title}</ListItem.Title>
-        {subtitle && <ListItem.Subtitle>{subtitle}</ListItem.Subtitle>}
-      </ListItem.MainContent>
-      {rightIcon ? (
-        typeof rightIcon === 'string' ? (
-          <ListItem.SystemIcon
-            icon={rightIcon}
-            backgroundColor={'transparent'}
-          />
+    <Pressable borderRadius="$xl" onPress={onPress}>
+      <ListItem>
+        {typeof leftIcon === 'string' ? (
+          <ListItem.SystemIcon icon={leftIcon} rounded />
         ) : (
-          rightIcon
-        )
-      ) : null}
-    </ListItem>
+          leftIcon
+        )}
+        <ListItem.MainContent>
+          <ListItem.Title>{title}</ListItem.Title>
+          {subtitle && <ListItem.Subtitle>{subtitle}</ListItem.Subtitle>}
+        </ListItem.MainContent>
+        {rightIcon ? (
+          typeof rightIcon === 'string' ? (
+            <ListItem.SystemIcon
+              icon={rightIcon}
+              backgroundColor={'transparent'}
+            />
+          ) : (
+            rightIcon
+          )
+        ) : null}
+      </ListItem>
+    </Pressable>
   );
 }

--- a/packages/ui/src/components/SearchBar.tsx
+++ b/packages/ui/src/components/SearchBar.tsx
@@ -5,6 +5,7 @@ import { Circle, View, XStack } from 'tamagui';
 import { TextInput, TextInputWithIcon } from './Form';
 import { Icon } from './Icon';
 import { Input } from './Input';
+import Pressable from './Pressable';
 
 export function SearchBar({
   placeholder,
@@ -60,25 +61,26 @@ export function SearchBar({
         placeholder={placeholder}
         {...inputProps}
       />
-      <XStack
-        alignItems="center"
-        position="absolute"
-        right={'$3xl'}
-        top={0}
-        height="100%"
-        onPress={() => onTextChange('')}
-        disabled={value === ''}
-        opacity={value === '' ? 0 : undefined}
-      >
-        <Circle
-          justifyContent="center"
+      <Pressable onPress={() => onTextChange('')}>
+        <XStack
           alignItems="center"
-          size="$xl"
-          backgroundColor="$secondaryText"
+          position="absolute"
+          right={'$3xl'}
+          top={0}
+          height="100%"
+          disabled={value === ''}
+          opacity={value === '' ? 0 : undefined}
         >
-          <Icon size="$s" type="Close" color="$secondaryBackground" />
-        </Circle>
-      </XStack>
+          <Circle
+            justifyContent="center"
+            alignItems="center"
+            size="$xl"
+            backgroundColor="$secondaryText"
+          >
+            <Icon size="$s" type="Close" color="$secondaryBackground" />
+          </Circle>
+        </XStack>
+      </Pressable>
     </View>
   );
 }

--- a/packages/ui/src/components/UserProfileScreenView.tsx
+++ b/packages/ui/src/components/UserProfileScreenView.tsx
@@ -19,6 +19,7 @@ import { ContactAvatar, GroupAvatar } from './Avatar';
 import { Button } from './Button';
 import { ContactName } from './ContactNameV2';
 import { Icon } from './Icon';
+import Pressable from './Pressable';
 import { ScreenHeader } from './ScreenHeader';
 import { Text } from './TextV2';
 import { WidgetPane } from './WidgetPane';
@@ -240,46 +241,46 @@ function UserInfoRow(props: { userId: string; hasNickname: boolean }) {
   }, [doCopy]);
 
   return (
-    <XStack
-      alignItems="center"
-      onPress={handleCopy}
-      padding="$l"
-      gap="$xl"
-      width={'100%'}
-    >
-      <ContactAvatar contactId={props.userId} size="$5xl" />
-      <YStack flex={1} justifyContent="center">
-        {props.hasNickname ? (
-          <>
-            <ContactName
-              contactId={props.userId}
-              mode="nickname"
-              fontSize={24}
-              lineHeight={24}
-              maxWidth="100%"
-              numberOfLines={1}
-            />
-            <XStack alignItems="center">
+    <Pressable onPress={handleCopy}>
+      <XStack alignItems="center" padding="$l" gap="$xl" width={'100%'}>
+        <ContactAvatar contactId={props.userId} size="$5xl" />
+        <YStack flex={1} justifyContent="center">
+          {props.hasNickname ? (
+            <>
               <ContactName
                 contactId={props.userId}
-                color="$secondaryText"
-                mode="contactId"
+                mode="nickname"
+                fontSize={24}
+                lineHeight={24}
+                maxWidth="100%"
+                numberOfLines={1}
               />
-              {didCopy ? (
-                <Icon
-                  type="Checkmark"
-                  customSize={[14, 14]}
-                  position="relative"
-                  top={1}
+              <XStack alignItems="center">
+                <ContactName
+                  contactId={props.userId}
+                  color="$secondaryText"
+                  mode="contactId"
                 />
-              ) : null}
-            </XStack>
-          </>
-        ) : (
-          <ContactName fontSize={24} lineHeight={24} contactId={props.userId} />
-        )}
-      </YStack>
-    </XStack>
+                {didCopy ? (
+                  <Icon
+                    type="Checkmark"
+                    customSize={[14, 14]}
+                    position="relative"
+                    top={1}
+                  />
+                ) : null}
+              </XStack>
+            </>
+          ) : (
+            <ContactName
+              fontSize={24}
+              lineHeight={24}
+              contactId={props.userId}
+            />
+          )}
+        </YStack>
+      </XStack>
+    </Pressable>
   );
 }
 

--- a/packages/ui/src/index.tsx
+++ b/packages/ui/src/index.tsx
@@ -62,6 +62,7 @@ export * from './components/NavBar';
 export * from './components/Onboarding';
 export * from './components/ParentAgnosticKeyboardAvoidingView';
 export * from './components/PostScreenView';
+export { default as Pressable } from './components/Pressable';
 export * from './components/ProfileScreenView';
 export * from './components/ProfileSheet';
 export * from './components/ScreenHeader';


### PR DESCRIPTION
This PR updates the Pressable component so that we can/must use it anywhere (outside of a Button) a press event is occurring, and within that component we no-op on onLongPress if we're on web.

The Pressable component can also function as a Link component, allowing us to implement accessible/browser native links at some future point (forwent that major rewrite for now, just tee'd it up).

Also: 
- Simplified the way we handle displaying "menu" buttons for GroupListItem and ChatListItem (also fixes the issue where we didn't have these buttons in the GroupChannelsList).
- fixed an issue I found with the group join sheet never appearing (see change in ChatListScreen).
- fixed a syntax issue in PushNotificationScreen.

Copilot summary:
This pull request includes several changes to improve the usage of the `Pressable` component across the codebase, remove unused imports, and simplify some calculations. The most important changes include adding new ESLint rules, replacing `View` with `Pressable`, and removing unused methods and imports.

### ESLint Rules:
* Added new rules to enforce the use of `Pressable` instead of `onPress` and `onLongPress` on `Stack`, `View`, and `ListItem` components in `.eslintrc.cjs`.

### Component Updates:
* Replaced `View` with `Pressable` in various components to handle press events more appropriately. This change was applied in `Text.fixture.tsx` [[1]](diffhunk://#diff-7bbf44a8bb0612bf0e7c15fd7090f88d74f8d0afecbb27c356362528fe5402faL2-R2) [[2]](diffhunk://#diff-7bbf44a8bb0612bf0e7c15fd7090f88d74f8d0afecbb27c356362528fe5402faL67-R71) `PasteInviteLinkScreen.tsx` [[3]](diffhunk://#diff-3aa8c33bf944e1723b6b89c911a48fa7520738020cf0566a171f22bd4fa14ecbR18) [[4]](diffhunk://#diff-3aa8c33bf944e1723b6b89c911a48fa7520738020cf0566a171f22bd4fa14ecbL134-R140) [[5]](diffhunk://#diff-3aa8c33bf944e1723b6b89c911a48fa7520738020cf0566a171f22bd4fa14ecbR175) `WelcomeScreen.tsx` [[6]](diffhunk://#diff-859b4f633c950e8f272bc808c7cd6b479ac3cb6d4a503c0a9d9c6c83caabb1dcR12) [[7]](diffhunk://#diff-859b4f633c950e8f272bc808c7cd6b479ac3cb6d4a503c0a9d9c6c83caabb1dcL20) [[8]](diffhunk://#diff-859b4f633c950e8f272bc808c7cd6b479ac3cb6d4a503c0a9d9c6c83caabb1dcR78-R84) [[9]](diffhunk://#diff-859b4f633c950e8f272bc808c7cd6b479ac3cb6d4a503c0a9d9c6c83caabb1dcL86-R99) [[10]](diffhunk://#diff-859b4f633c950e8f272bc808c7cd6b479ac3cb6d4a503c0a9d9c6c83caabb1dcL117-R126) `ActivityListItem.tsx` [[11]](diffhunk://#diff-c92b74283be934064f25819b6274773df26190a5ce4497a3846e9618b280c97bL5-R11) [[12]](diffhunk://#diff-c92b74283be934064f25819b6274773df26190a5ce4497a3846e9618b280c97bL36-R43) `AddGroupSheet.tsx` [[13]](diffhunk://#diff-3375c85f33cdfa3d7550d3341b50aec26e7ba7fe23efb2e94008b4bbc973495aL2-R9) [[14]](diffhunk://#diff-3375c85f33cdfa3d7550d3341b50aec26e7ba7fe23efb2e94008b4bbc973495aL99-R101) [[15]](diffhunk://#diff-3375c85f33cdfa3d7550d3341b50aec26e7ba7fe23efb2e94008b4bbc973495aR112) `AppSetting.tsx` [[16]](diffhunk://#diff-070e257d44aa86b0eeba85903cd945a8fbedd733ed745754f2e2c09c31b3a3c7R6) [[17]](diffhunk://#diff-070e257d44aa86b0eeba85903cd945a8fbedd733ed745754f2e2c09c31b3a3c7L26-R28) [[18]](diffhunk://#diff-070e257d44aa86b0eeba85903cd945a8fbedd733ed745754f2e2c09c31b3a3c7R39) `AuthorRow.tsx` [[19]](diffhunk://#diff-47bd932f249f17d5d4213cbe82b6161dd2ccd8de6366a0b87a03bf1b7f76de64R11) [[20]](diffhunk://#diff-47bd932f249f17d5d4213cbe82b6161dd2ccd8de6366a0b87a03bf1b7f76de64L85-R87) [[21]](diffhunk://#diff-47bd932f249f17d5d4213cbe82b6161dd2ccd8de6366a0b87a03bf1b7f76de64R102) [[22]](diffhunk://#diff-47bd932f249f17d5d4213cbe82b6161dd2ccd8de6366a0b87a03bf1b7f76de64L133-R137) [[23]](diffhunk://#diff-47bd932f249f17d5d4213cbe82b6161dd2ccd8de6366a0b87a03bf1b7f76de64R167) and `BaubleHeader.tsx` [[24]](diffhunk://#diff-4f3312eebb89cce10487bc68515261873103634f674a14bf190df6b9d3d75b4cR27) [[25]](diffhunk://#diff-4f3312eebb89cce10487bc68515261873103634f674a14bf190df6b9d3d75b4cL99-R100) [[26]](diffhunk://#diff-4f3312eebb89cce10487bc68515261873103634f674a14bf190df6b9d3d75b4cL181-R182).

### Code Simplification:
* Removed unused imports and methods to clean up the codebase. This includes removing `useGroup` in `ChatListScreen.tsx` [[1]](diffhunk://#diff-c2a64e57fa2c6bd13aaeac04ef2142ee7cd65693de41fce561cd020a5f60050cL24) [[2]](diffhunk://#diff-c2a64e57fa2c6bd13aaeac04ef2142ee7cd65693de41fce561cd020a5f60050cL80-R79) and removing the `onPressMenuButton` prop in `ChatList.tsx` [[3]](diffhunk://#diff-c269931036f8a436d38d1f8d42e1f90eff96e7a615faeaf6efb8572c6276aad9L42) [[4]](diffhunk://#diff-c269931036f8a436d38d1f8d42e1f90eff96e7a615faeaf6efb8572c6276aad9L53).
* Simplified the calculation for `numExceptions` in `PushNotificationSettingsScreen.tsx`.

These changes aim to enhance code readability, maintainability, and ensure consistent usage of the `Pressable` component for handling press interactions.