### PR TITLE
profile: pass channelId when navigating to DMs

### DIFF
--- a/packages/app/features/top/UserProfileScreen.tsx
+++ b/packages/app/features/top/UserProfileScreen.tsx
@@ -41,7 +41,7 @@ export function UserProfileScreen({ route: { params }, navigation }: Props) {
             index: 1,
             routes: [
               { name: 'ChatList' },
-              { name: 'Channel', params: { channelId: dmChannel.id } }, // Pass just the ID
+              { name: 'Channel', params: { channelId: dmChannel.id } },
             ],
           })
         );

--- a/packages/app/features/top/UserProfileScreen.tsx
+++ b/packages/app/features/top/UserProfileScreen.tsx
@@ -26,18 +26,28 @@ export function UserProfileScreen({ route: { params }, navigation }: Props) {
 
   const handleGoToDm = useCallback(
     async (participants: string[]) => {
-      const dmChannel = await store.upsertDmChannel({
-        participants,
-      });
-      navigation.dispatch(
-        CommonActions.reset({
-          index: 1,
-          routes: [
-            { name: 'ChatList' },
-            { name: 'Channel', params: { channel: dmChannel } },
-          ],
-        })
-      );
+      try {
+        const dmChannel = await store.upsertDmChannel({
+          participants,
+        });
+
+        if (!dmChannel?.id) {
+          console.error('Failed to create DM channel: no channel ID');
+          return;
+        }
+
+        navigation.dispatch(
+          CommonActions.reset({
+            index: 1,
+            routes: [
+              { name: 'ChatList' },
+              { name: 'Channel', params: { channelId: dmChannel.id } }, // Pass just the ID
+            ],
+          })
+        );
+      } catch (error) {
+        console.error('Error creating DM channel:', error);
+      }
     },
     [navigation]
   );

--- a/packages/ui/src/components/UserProfileScreenView.tsx
+++ b/packages/ui/src/components/UserProfileScreenView.tsx
@@ -287,8 +287,21 @@ function UserInfoRow(props: { userId: string; hasNickname: boolean }) {
 function ProfileButtons(props: { userId: string; contact: db.Contact | null }) {
   const navContext = useNavigation();
   const handleMessageUser = useCallback(() => {
-    navContext.onPressGoToDm?.([props.userId]);
-  }, [navContext, props.userId]);
+    if (!navContext.onPressGoToDm) {
+      console.warn('Navigation context missing onPressGoToDm handler');
+      return;
+    }
+
+    if (props.contact?.isBlocked) {
+      return;
+    }
+
+    try {
+      navContext.onPressGoToDm([props.userId]);
+    } catch (error) {
+      console.error('Error navigating to DM:', error);
+    }
+  }, [navContext, props.userId, props.contact?.isBlocked]);
 
   const handleBlock = useCallback(() => {
     if (props.contact && props.contact.isBlocked) {
@@ -304,7 +317,9 @@ function ProfileButtons(props: { userId: string; contact: db.Contact | null }) {
 
   return (
     <XStack gap="$m" width={'100%'}>
-      <ProfileButton title="Message" onPress={handleMessageUser} hero />
+      {!isBlocked && (
+        <ProfileButton title="Message" onPress={handleMessageUser} hero />
+      )}
       <ProfileButton
         title={isBlocked ? 'Unblock' : 'Block'}
         onPress={handleBlock}


### PR DESCRIPTION
Clicking the "Message" button on a user profile would crash the app with a "Cannot read property 'split' of undefined" error. This occurred because we were passing the full channel object to navigation instead of just the channel ID that the Channel screen expects.

- Adds validation to ensure channel ID exists before navigation.
- Also adds error handling around DM channel creation and navigation

https://github.com/user-attachments/assets/8a3a153b-8780-4e7e-a593-7c1c50191266


Fixes TLON-3197