### PR TITLE
[wip] native: carousel view

### DIFF
--- a/apps/tlon-mobile/src/fixtures/Carousel.fixture.tsx
+++ b/apps/tlon-mobile/src/fixtures/Carousel.fixture.tsx
@@ -1,7 +1,7 @@
-import { Carousel, IconButton } from '@tloncorp/ui';
-import { Close } from 'packages/ui/src/assets/icons';
-import { useCallback, useState } from 'react';
+import { Button, Carousel } from '@tloncorp/ui';
+import { useCallback, useRef, useState } from 'react';
 import { useSelect, useValue } from 'react-cosmos/client';
+import { Alert } from 'react-native';
 import { GestureHandlerRootView } from 'react-native-gesture-handler';
 import { SafeAreaView } from 'react-native-safe-area-context';
 import { Text, View } from 'tamagui';
@@ -27,10 +27,13 @@ export default function CarouselFixture() {
 
   const [visibleIndex, setVisibleIndex] = useState<number | null>(null);
 
+  const carouselRef = useRef<React.ElementRef<typeof Carousel>>(null);
+
   return (
     <GestureHandlerRootView style={{ flex: 1 }}>
       <View flex={1} {...(fullscreen ? null : { padding: 100 })}>
         <Carousel
+          ref={carouselRef}
           flex={1}
           scrollDirection={direction}
           onVisibleIndexChange={setVisibleIndex}
@@ -48,7 +51,6 @@ export default function CarouselFixture() {
                         edges={['top', 'right', 'left']}
                         style={{
                           padding: 40,
-                          // backgroundColor: 'rgba(0, 0, 0, 0.5)',
                           backgroundColor: colors[i % colors.length],
                         }}
                       >
@@ -60,7 +62,7 @@ export default function CarouselFixture() {
                         edges={['bottom', 'right', 'left']}
                         style={{
                           padding: 40,
-                          backgroundColor: 'rgba(0, 0, 0, 0.5)',
+                          backgroundColor: 'rgba(255, 255, 255, 0.5)',
                         }}
                       >
                         <Text>{uri}</Text>
@@ -76,8 +78,25 @@ export default function CarouselFixture() {
               </Carousel.Item>
             ))}
         </Carousel>
-        <View position="absolute" top={60} right={40}>
-          <Text>Showing index: {visibleIndex}</Text>
+        <View position="absolute" top={60} right={20}>
+          <Button
+            onPress={() => {
+              Alert.prompt('Go to index', undefined, (input: string) => {
+                try {
+                  const n = parseInt(input);
+                  if (n >= 0 && n < pageCount) {
+                    carouselRef.current?.scrollToIndex(n);
+                  } else {
+                    throw null;
+                  }
+                } catch {
+                  Alert.alert('Invalid index');
+                }
+              });
+            }}
+          >
+            <Text>Showing index: {visibleIndex}</Text>
+          </Button>
         </View>
       </View>
     </GestureHandlerRootView>

--- a/apps/tlon-mobile/src/fixtures/Carousel.fixture.tsx
+++ b/apps/tlon-mobile/src/fixtures/Carousel.fixture.tsx
@@ -1,0 +1,85 @@
+import { Carousel, IconButton } from '@tloncorp/ui';
+import { Close } from 'packages/ui/src/assets/icons';
+import { useCallback, useState } from 'react';
+import { useSelect, useValue } from 'react-cosmos/client';
+import { GestureHandlerRootView } from 'react-native-gesture-handler';
+import { SafeAreaView } from 'react-native-safe-area-context';
+import { Text, View } from 'tamagui';
+
+const colors = ['red', 'blue', 'green', 'yellow', 'purple'];
+
+export default function CarouselFixture() {
+  const [fullscreen] = useValue('Fullscreen', {
+    defaultValue: true,
+  });
+  const [pageCount] = useValue('Number of pages', {
+    defaultValue: 3,
+  });
+  const [direction] = useSelect('Direction', {
+    defaultValue: 'vertical',
+    options: ['horizontal', 'vertical'],
+  });
+
+  const uriForPage = useCallback(
+    (i: number) => `https://picsum.photos/seed/${i}/400/400`,
+    []
+  );
+
+  const [visibleIndex, setVisibleIndex] = useState<number | null>(null);
+
+  return (
+    <GestureHandlerRootView style={{ flex: 1 }}>
+      <View flex={1} {...(fullscreen ? null : { padding: 100 })}>
+        <Carousel
+          flex={1}
+          scrollDirection={direction}
+          onVisibleIndexChange={setVisibleIndex}
+        >
+          {Array(pageCount)
+            .fill(undefined)
+            .map((_, i) => uriForPage(i))
+            .map((uri, i) => (
+              <Carousel.Item
+                key={i}
+                overlay={
+                  <Carousel.Overlay
+                    header={
+                      <SafeAreaView
+                        edges={['top', 'right', 'left']}
+                        style={{
+                          padding: 40,
+                          // backgroundColor: 'rgba(0, 0, 0, 0.5)',
+                          backgroundColor: colors[i % colors.length],
+                        }}
+                      >
+                        <Text>Header {i}</Text>
+                      </SafeAreaView>
+                    }
+                    footer={
+                      <SafeAreaView
+                        edges={['bottom', 'right', 'left']}
+                        style={{
+                          padding: 40,
+                          backgroundColor: 'rgba(0, 0, 0, 0.5)',
+                        }}
+                      >
+                        <Text>{uri}</Text>
+                      </SafeAreaView>
+                    }
+                  />
+                }
+              >
+                <Carousel.ContentImage
+                  uri={uri}
+                  safeAreaEdges={fullscreen ? undefined : []}
+                />
+              </Carousel.Item>
+            ))}
+        </Carousel>
+        <View position="absolute" top={60} right={40}>
+          <Text>Showing index: {visibleIndex}</Text>
+        </View>
+      </View>
+    </GestureHandlerRootView>
+  );
+}

--- a/packages/ui/src/components/Carousel.tsx
+++ b/packages/ui/src/components/Carousel.tsx
@@ -178,15 +178,19 @@ const _Carousel = React.forwardRef<
 function Item({
   children,
   overlay,
-}: {
-  children: JSX.Element;
+  ...forwardedProps
+}: ForwardingProps<
+  React.ComponentPropsWithoutRef<typeof View>,
+  {
+    children?: React.ReactNode;
 
-  /**
-   * If provided, shows the provided element over the scroll viewport when
-   * this item is visible.
-   */
-  overlay?: JSX.Element;
-}) {
+    /**
+     * If provided, shows the provided element over the scroll viewport when
+     * this item is visible.
+     */
+    overlay?: JSX.Element;
+  }
+>) {
   const ctxValue = React.useContext(CarouselContext);
 
   // Show `overlay` in Carousel-managed overlay when this item is visible.
@@ -204,6 +208,7 @@ function Item({
       {...(ctxValue?.direction === 'horizontal'
         ? { width: ctxValue.rect?.width }
         : { height: ctxValue.rect?.height })}
+      {...forwardedProps}
     >
       {children}
     </View>

--- a/packages/ui/src/index.tsx
+++ b/packages/ui/src/index.tsx
@@ -10,6 +10,7 @@ export * from './components/InviteUsersWidget';
 export * from './components/InviteUsersSheet';
 export * from './components/Button';
 export * from './components/Buttons';
+export * from './components/Carousel';
 export * from './components/Channel';
 export * from './components/Channel/BaubleHeader';
 export * from './components/Channel/ChannelDivider';


### PR DESCRIPTION
apps/tlon-mobile/src/fixtures/Carousel.fixture.tsx looks like:

https://github.com/user-attachments/assets/0749892f-542b-4db3-b0f1-5c8a0a2cd64e

(blip in middle is switching fixture from vertical to horizontal)
you can also pinch to zoom in – letting go just snaps back, like old instagram (so I didn't need to handle panning image and not carousel)

I did tricky stuff to make the overlay fixed-position while different for each item, but we can just toss that 😢 if it doesn't make sense for a chat
(maybe this fullscreen carousel only shows up when you tap on an image in the channel)