### PR TITLE
desktop: render desktop appropriate chat message actions

### DIFF
--- a/packages/ui/src/components/ActionList/ListFrame.tsx
+++ b/packages/ui/src/components/ActionList/ListFrame.tsx
@@ -2,6 +2,7 @@ import { BlurView } from 'expo-blur';
 import { ComponentProps, PropsWithChildren } from 'react';
 import { YStack, styled } from 'tamagui';
 
+import useIsWindowNarrow from '../../hooks/useIsWindowNarrow';
 import { ListItemFrame } from '../ListItem';
 
 const ListFrame = styled(YStack, {
@@ -15,6 +16,14 @@ const ListFrameComponent = (
   >
 ) => {
   const { children, intensity, tint, ...rest } = props;
+  const isWindowNarrow = useIsWindowNarrow();
+
+  if (!isWindowNarrow) {
+    // Blur view adds a shadow, we don't want that in the modal that's
+    // rendered on desktop
+    return <ListFrame {...rest}>{children}</ListFrame>;
+  }
+
   return (
     <ListFrame {...rest}>
       <BlurView

--- a/packages/ui/src/components/ChatMessage/ChatMessage.tsx
+++ b/packages/ui/src/components/ChatMessage/ChatMessage.tsx
@@ -1,9 +1,10 @@
 import * as db from '@tloncorp/shared/db';
 import { isEqual } from 'lodash';
 import { ComponentProps, memo, useCallback, useMemo, useState } from 'react';
-import { View, XStack, YStack } from 'tamagui';
+import { View, XStack, YStack, isWeb } from 'tamagui';
 
 import AuthorRow from '../AuthorRow';
+import { Button } from '../Button';
 import { Icon } from '../Icon';
 import { createContentRenderer } from '../PostContent/ContentRenderer';
 import {
@@ -29,6 +30,7 @@ const ChatMessage = ({
   showReplies,
   setViewReactionsPost,
   isHighlighted,
+  hideOverflowMenu,
 }: {
   post: db.Post;
   showAuthor?: boolean;
@@ -43,8 +45,10 @@ const ChatMessage = ({
   onPressDelete?: (post: db.Post) => void;
   setViewReactionsPost?: (post: db.Post) => void;
   isHighlighted?: boolean;
+  hideOverflowMenu?: boolean;
 }) => {
   const [showRetrySheet, setShowRetrySheet] = useState(false);
+  const [showOverflowOnHover, setShowOverflowOnHover] = useState(false);
   const isNotice = post.type === 'notice';
 
   if (isNotice) {
@@ -93,6 +97,18 @@ const ChatMessage = ({
     setShowRetrySheet(false);
   }, [onPressDelete, post]);
 
+  const handleHoverIn = useCallback(() => {
+    if (isWeb) {
+      setShowOverflowOnHover(true);
+    }
+  }, []);
+
+  const handleHoverOut = useCallback(() => {
+    if (isWeb) {
+      setShowOverflowOnHover(false);
+    }
+  }, []);
+
   const content = usePostContent(post);
   const lastEditContent = usePostLastEditContent(post);
 
@@ -127,6 +143,8 @@ const ChatMessage = ({
       // avoid setting the top level press handler at all unless we need to
       onPress={shouldHandlePress ? handlePress : undefined}
       onLongPress={handleLongPress}
+      onHoverIn={handleHoverIn}
+      onHoverOut={handleHoverOut}
     >
       <YStack
         backgroundColor={isHighlighted ? '$secondaryBackground' : undefined}
@@ -178,6 +196,13 @@ const ChatMessage = ({
           onPressDelete={handleDeletePressed}
         />
       </YStack>
+      {isWeb && !hideOverflowMenu && showOverflowOnHover && (
+        <View position="absolute" top={0} right={12} width={0} height={0}>
+          <Button onPress={handleLongPress} borderWidth="unset" size="$l">
+            <Icon type="Overflow" />
+          </Button>
+        </View>
+      )}
     </Pressable>
   );
 };

--- a/packages/ui/src/components/ChatMessage/ChatMessageActions/Component.android.tsx
+++ b/packages/ui/src/components/ChatMessage/ChatMessageActions/Component.android.tsx
@@ -26,6 +26,8 @@ export function ChatMessageActions({
   onReply?: (post: db.Post) => void;
   onViewReactions?: (post: db.Post) => void;
   onEdit?: () => void;
+  // this prop is here just so we match the Component.tsx prop
+  onShowEmojiPicker?: () => void;
 }) {
   const [topOffset, setTopOffset] = useState(0);
   const insets = useSafeAreaInsets();

--- a/packages/ui/src/components/ChatMessage/ChatMessageActions/Component.android.tsx
+++ b/packages/ui/src/components/ChatMessage/ChatMessageActions/Component.android.tsx
@@ -1,12 +1,12 @@
 import { ChannelAction } from '@tloncorp/shared';
 import * as db from '@tloncorp/shared/db';
-import * as Haptics from 'expo-haptics';
 import { MotiView } from 'moti';
 import { RefObject, useEffect, useState } from 'react';
 import { Dimensions, LayoutChangeEvent, View as RNView } from 'react-native';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
 import { View, YStack } from 'tamagui';
 
+import { triggerHaptic } from '../../../utils';
 import { EmojiToolbar } from './EmojiToolbar';
 import MessageActions from './MessageActions';
 import { MessageContainer } from './MessageContainer';
@@ -52,7 +52,7 @@ export function ChatMessageActions({
 
   useEffect(() => {
     // on mount, give initial haptic feeedback
-    Haptics.impactAsync(Haptics.ImpactFeedbackStyle.Medium);
+    triggerHaptic('sheetOpen');
   }, []);
 
   return (

--- a/packages/ui/src/components/ChatMessage/ChatMessageActions/Component.tsx
+++ b/packages/ui/src/components/ChatMessage/ChatMessageActions/Component.tsx
@@ -1,6 +1,5 @@
 import { ChannelAction } from '@tloncorp/shared';
 import * as db from '@tloncorp/shared/db';
-import * as Haptics from 'expo-haptics';
 import { RefObject, useEffect, useState } from 'react';
 import {
   DimensionValue,
@@ -15,9 +14,10 @@ import Animated, {
   withSpring,
 } from 'react-native-reanimated';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
-import { View, XStack, YStack, isWeb } from 'tamagui';
+import { View, XStack, YStack } from 'tamagui';
 
 import useIsWindowNarrow from '../../../hooks/useIsWindowNarrow';
+import { triggerHaptic } from '../../../utils';
 import { ActionSheet } from '../../ActionSheet';
 import { EmojiToolbar } from './EmojiToolbar';
 import MessageActions from './MessageActions';
@@ -98,12 +98,7 @@ export function ChatMessageActions({
   }
 
   useEffect(() => {
-    if (isWeb) {
-      // On web we don't have haptics
-      return;
-    }
-    // on mount, give initial haptic feeedback
-    Haptics.impactAsync(Haptics.ImpactFeedbackStyle.Medium);
+    triggerHaptic('sheetOpen');
   }, []);
 
   useEffect(() => {

--- a/packages/ui/src/components/ChatMessage/ChatMessageActions/Component.tsx
+++ b/packages/ui/src/components/ChatMessage/ChatMessageActions/Component.tsx
@@ -15,8 +15,10 @@ import Animated, {
   withSpring,
 } from 'react-native-reanimated';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
-import { View, YStack } from 'tamagui';
+import { View, XStack, YStack, isWeb } from 'tamagui';
 
+import useIsWindowNarrow from '../../../hooks/useIsWindowNarrow';
+import { ActionSheet } from '../../ActionSheet';
 import { EmojiToolbar } from './EmojiToolbar';
 import MessageActions from './MessageActions';
 import { MessageContainer } from './MessageContainer';
@@ -38,6 +40,7 @@ export function ChatMessageActions({
   onReply,
   onEdit,
   onViewReactions,
+  onShowEmojiPicker,
 }: {
   post: db.Post;
   postActionIds: ChannelAction.Id[];
@@ -48,6 +51,7 @@ export function ChatMessageActions({
   onReply?: (post: db.Post) => void;
   onEdit?: () => void;
   onViewReactions?: (post: db.Post) => void;
+  onShowEmojiPicker?: () => void;
 }) {
   const insets = useSafeAreaInsets();
   const PADDING_THRESHOLD = 40;
@@ -60,6 +64,7 @@ export function ChatMessageActions({
   const translateY = useSharedValue(0);
   const scale = useSharedValue(0.3); // Start with a smaller scale
   const opacity = useSharedValue(0);
+  const isWindowNarrow = useIsWindowNarrow();
 
   function handleLayout(event: LayoutChangeEvent) {
     const { height, width, x, y } = event.nativeEvent.layout;
@@ -93,6 +98,10 @@ export function ChatMessageActions({
   }
 
   useEffect(() => {
+    if (isWeb) {
+      // On web we don't have haptics
+      return;
+    }
     // on mount, give initial haptic feeedback
     Haptics.impactAsync(Haptics.ImpactFeedbackStyle.Medium);
   }, []);
@@ -137,6 +146,35 @@ export function ChatMessageActions({
     }),
     [translateX, translateY, scale]
   );
+
+  if (!isWindowNarrow) {
+    return (
+      <ActionSheet
+        // We use an action sheet on web so that it will render within a dialog
+        open
+        onOpenChange={(open: boolean) => (!open ? onDismiss() : undefined)}
+      >
+        <YStack gap="$xs">
+          <XStack justifyContent="center">
+            <EmojiToolbar
+              post={post}
+              onDismiss={onDismiss}
+              openExternalSheet={onShowEmojiPicker}
+            />
+          </XStack>
+          <MessageContainer post={post} />
+          <MessageActions
+            post={post}
+            postActionIds={postActionIds}
+            dismiss={onDismiss}
+            onReply={onReply}
+            onEdit={onEdit}
+            onViewReactions={onViewReactions}
+          />
+        </YStack>
+      </ActionSheet>
+    );
+  }
 
   return (
     <Animated.View style={animatedStyles}>

--- a/packages/ui/src/components/ChatMessage/ChatMessageActions/MessageActions.tsx
+++ b/packages/ui/src/components/ChatMessage/ChatMessageActions/MessageActions.tsx
@@ -6,6 +6,7 @@ import * as store from '@tloncorp/shared/store';
 import * as Haptics from 'expo-haptics';
 import { useMemo } from 'react';
 import { Alert } from 'react-native';
+import { isWeb } from 'tamagui';
 
 import { useChannelContext, useCurrentUserId } from '../../../contexts';
 import { Attachment, useAttachmentContext } from '../../../contexts/attachment';
@@ -30,9 +31,10 @@ export default function MessageActions({
   post: db.Post;
   postActionIds: ChannelAction.Id[];
 }) {
+  // arbitrary width that looks reasonable given labels
+  const width = isWeb ? 'auto' : 220;
   return (
-    // arbitrary width that looks reasonable given labels
-    <ActionList width={220}>
+    <ActionList width={width}>
       {postActionIds.map((actionId, index, list) => (
         <ConnectedAction
           key={actionId}
@@ -216,7 +218,9 @@ export async function handleAction({
       break;
   }
 
-  await Haptics.notificationAsync(Haptics.NotificationFeedbackType.Success);
+  if (!isWeb) {
+    await Haptics.notificationAsync(Haptics.NotificationFeedbackType.Success);
+  }
   dismiss();
 }
 

--- a/packages/ui/src/components/ChatMessage/ChatMessageActions/MessageActions.tsx
+++ b/packages/ui/src/components/ChatMessage/ChatMessageActions/MessageActions.tsx
@@ -3,7 +3,6 @@ import { ChannelAction } from '@tloncorp/shared';
 import * as db from '@tloncorp/shared/db';
 import * as logic from '@tloncorp/shared/logic';
 import * as store from '@tloncorp/shared/store';
-import * as Haptics from 'expo-haptics';
 import { useMemo } from 'react';
 import { Alert } from 'react-native';
 import { isWeb } from 'tamagui';
@@ -11,7 +10,7 @@ import { isWeb } from 'tamagui';
 import { useChannelContext, useCurrentUserId } from '../../../contexts';
 import { Attachment, useAttachmentContext } from '../../../contexts/attachment';
 import { useCopy } from '../../../hooks/useCopy';
-import { useIsAdmin } from '../../../utils';
+import { triggerHaptic, useIsAdmin } from '../../../utils';
 import ActionList from '../../ActionList';
 
 const ENABLE_COPY_JSON = __DEV__;
@@ -218,9 +217,7 @@ export async function handleAction({
       break;
   }
 
-  if (!isWeb) {
-    await Haptics.notificationAsync(Haptics.NotificationFeedbackType.Success);
-  }
+  triggerHaptic('success');
   dismiss();
 }
 

--- a/packages/ui/src/components/ChatMessage/ChatMessageActions/MessageContainer.tsx
+++ b/packages/ui/src/components/ChatMessage/ChatMessageActions/MessageContainer.tsx
@@ -4,6 +4,7 @@ import { Dimensions } from 'react-native';
 import { ScrollView, View } from 'tamagui';
 
 import { ChatMessage } from '..';
+import useIsWindowNarrow from '../../../hooks/useIsWindowNarrow';
 import AuthorRow from '../../AuthorRow';
 import { NotebookPost } from '../../NotebookPost';
 
@@ -13,6 +14,8 @@ const MAX_MESSAGE_TO_SCREEN_RATIO_NOTE = 0.5;
 export function MessageContainer({ post }: { post: db.Post }) {
   const screenHeight = Dimensions.get('window').height;
   const screenWidth = Dimensions.get('window').width;
+  const isWindowNarrow = useIsWindowNarrow();
+  const width = isWindowNarrow ? screenWidth - getSize('$xl').val * 2 : 400;
 
   if (post.type === 'note') {
     return (
@@ -31,9 +34,9 @@ export function MessageContainer({ post }: { post: db.Post }) {
   return (
     <View
       maxHeight={screenHeight * MAX_MESSAGE_TO_SCREEN_RATIO}
-      maxWidth={screenWidth - getSize('$xl').val * 2}
+      maxWidth={width}
       overflow="hidden"
-      backgroundColor="$background"
+      backgroundColor={isWindowNarrow ? '$background' : '$secondaryBackground'}
       padding="$l"
       borderRadius="$l"
     >
@@ -44,7 +47,7 @@ export function MessageContainer({ post }: { post: db.Post }) {
         type={post.type}
         // roles={roles}
       />
-      <ChatMessage post={post} />
+      <ChatMessage post={post} hideOverflowMenu />
     </View>
   );
 }

--- a/packages/ui/src/components/Embed/AudioEmbed.native.tsx
+++ b/packages/ui/src/components/Embed/AudioEmbed.native.tsx
@@ -5,10 +5,10 @@ import {
   InterruptionModeAndroid,
   InterruptionModeIOS,
 } from 'expo-av';
-import * as Haptics from 'expo-haptics';
 import { useCallback, useEffect, useState } from 'react';
 import { Text, View } from 'tamagui';
 
+import { triggerHaptic } from '../../utils';
 import { Icon } from '../Icon';
 import { LoadingSpinner } from '../LoadingSpinner';
 import { Embed } from './Embed';
@@ -64,7 +64,7 @@ export default function AudioEmbed({ url }: { url: string }) {
 
   useEffect(() => {
     if (showModal) {
-      Haptics.impactAsync(Haptics.ImpactFeedbackStyle.Medium);
+      triggerHaptic('sheetOpen');
     }
   }, [showModal]);
 

--- a/packages/ui/src/components/Emoji/EmojiPickerSheet.tsx
+++ b/packages/ui/src/components/Emoji/EmojiPickerSheet.tsx
@@ -8,7 +8,10 @@ import {
   NativeSyntheticEvent,
 } from 'react-native';
 import { View } from 'tamagui';
+import { Dialog } from 'tamagui';
+import { VisuallyHidden } from 'tamagui';
 
+import useIsWindowNarrow from '../../hooks/useIsWindowNarrow';
 import { Button } from '../Button';
 import KeyboardAvoidingView from '../KeyboardAvoidingView';
 import { SearchBar } from '../SearchBar';
@@ -102,7 +105,63 @@ export function EmojiPickerSheet(
     [handleEmojiSelect]
   );
 
+  const isWindowNarrow = useIsWindowNarrow();
+
   const keyExtractor = useCallback((item: string) => item, []);
+
+  const hasOpened = useRef(props.open);
+  if (!hasOpened.current && props.open) {
+    hasOpened.current = true;
+  }
+
+  // Sheets are heavy; we don't want to render until we need to
+  if (!hasOpened.current) return null;
+
+  if (!isWindowNarrow) {
+    return (
+      <Dialog open={props.open} onOpenChange={props.onOpenChange}>
+        <Dialog.Portal>
+          <Dialog.Overlay
+            backgroundColor="$overlayBackground"
+            key="overlay"
+            opacity={0.4}
+          />
+          <Dialog.Content
+            borderWidth={1}
+            borderColor="$border"
+            padding="$m"
+            minWidth={300}
+            key="content"
+          >
+            <VisuallyHidden>
+              <Dialog.Title>Emoji Picker</Dialog.Title>
+            </VisuallyHidden>
+            <View width="100%" marginBottom="$xl">
+              <SearchBar
+                debounceTime={300}
+                marginHorizontal="$m"
+                onChangeQuery={handleQueryChange}
+                inputProps={{ spellCheck: false, autoComplete: 'off' }}
+              />
+            </View>
+            <FlatList
+              style={{ width: '100%', height: 400 }}
+              horizontal={false}
+              // contentContainerStyle={{ flexGrow: 1 }}
+              onScroll={handleScroll}
+              onTouchStart={onTouchStart}
+              onTouchEnd={onTouchEnd}
+              data={listData}
+              keyExtractor={keyExtractor}
+              numColumns={6}
+              removeClippedSubviews
+              renderItem={renderItem}
+            />
+          </Dialog.Content>
+        </Dialog.Portal>
+      </Dialog>
+    );
+  }
 
   return (
     <Modal transparent visible={props.open} onDismiss={handleDismiss}>

--- a/packages/ui/src/components/Form/inputs.tsx
+++ b/packages/ui/src/components/Form/inputs.tsx
@@ -8,6 +8,7 @@ import React, {
 } from 'react';
 import { Alert, TextInput as RNTextInput } from 'react-native';
 import { ScrollView, Spinner, View, XStack, YStack, styled } from 'tamagui';
+import { isWeb } from 'tamagui';
 
 import {
   useAttachmentContext,
@@ -58,6 +59,7 @@ export const BaseTextInput = styled(StyledTextInput, {
       },
     },
   },
+  ...(isWeb ? { outlineStyle: 'none' } : {}),
 });
 
 export const TextInput = React.memo(BaseTextInput);

--- a/packages/ui/src/components/ImageViewerScreenView.tsx
+++ b/packages/ui/src/components/ImageViewerScreenView.tsx
@@ -1,5 +1,4 @@
 import { ImageZoom } from '@likashefqet/react-native-image-zoom';
-import * as Haptics from 'expo-haptics';
 import { ElementRef, useRef, useState } from 'react';
 import { Dimensions, TouchableOpacity } from 'react-native';
 import {
@@ -12,6 +11,7 @@ import { useSafeAreaInsets } from 'react-native-safe-area-context';
 import { Stack, View, XStack, YStack, ZStack } from 'tamagui';
 
 import { Icon } from './Icon';
+import {triggerHaptic} from '../utils';
 
 export function ImageViewerScreenView(props: {
   uri?: string;
@@ -38,7 +38,7 @@ export function ImageViewerScreenView(props: {
       setMinPanPointers(1);
     } else {
       setMinPanPointers(2);
-      Haptics.impactAsync(Haptics.ImpactFeedbackStyle.Medium);
+      triggerHaptic('zoomable');
     }
   }
 
@@ -49,7 +49,7 @@ export function ImageViewerScreenView(props: {
       setMinPanPointers(2);
       zoomableRef.current?.reset();
       setIsAtMinZoom(true);
-      Haptics.impactAsync(Haptics.ImpactFeedbackStyle.Medium);
+      triggerHaptic('zoomable');
     }
   }
 

--- a/packages/ui/src/components/ListItem/InteractableChatListItem.tsx
+++ b/packages/ui/src/components/ListItem/InteractableChatListItem.tsx
@@ -1,7 +1,6 @@
 import * as db from '@tloncorp/shared/db';
 import * as logic from '@tloncorp/shared/logic';
 import * as store from '@tloncorp/shared/store';
-import * as Haptics from 'expo-haptics';
 import React, {
   ComponentProps,
   useCallback,
@@ -55,7 +54,6 @@ function BaseInteractableChatRow({
 
   const handleAction = logic.useMutableCallback(
     async (actionId: 'pin' | 'mute') => {
-      await Haptics.impactAsync(Haptics.ImpactFeedbackStyle.Light);
       utils.triggerHaptic('swipeAction');
       switch (actionId) {
         case 'pin':

--- a/packages/ui/src/components/SearchBar.tsx
+++ b/packages/ui/src/components/SearchBar.tsx
@@ -61,25 +61,25 @@ export function SearchBar({
         placeholder={placeholder}
         {...inputProps}
       />
-      <Pressable onPress={() => onTextChange('')}>
-        <XStack
+      <Pressable
+        onPress={() => onTextChange('')}
+        alignItems="center"
+        position="absolute"
+        right={'$3xl'}
+        top={18}
+        pressStyle={{ backgroundColor: 'unset' }}
+        height="100%"
+        disabled={value === ''}
+        opacity={value === '' ? 0 : undefined}
+      >
+        <Circle
+          justifyContent="center"
           alignItems="center"
-          position="absolute"
-          right={'$3xl'}
-          top={0}
-          height="100%"
-          disabled={value === ''}
-          opacity={value === '' ? 0 : undefined}
+          size="$xl"
+          backgroundColor="$secondaryText"
         >
-          <Circle
-            justifyContent="center"
-            alignItems="center"
-            size="$xl"
-            backgroundColor="$secondaryText"
-          >
-            <Icon size="$s" type="Close" color="$secondaryBackground" />
-          </Circle>
-        </XStack>
+          <Icon size="$s" type="Close" color="$secondaryBackground" />
+        </Circle>
       </Pressable>
     </View>
   );

--- a/packages/ui/src/hooks/useOnEmojiSelect.tsx
+++ b/packages/ui/src/hooks/useOnEmojiSelect.tsx
@@ -1,10 +1,9 @@
 import * as db from '@tloncorp/shared/db';
 import * as store from '@tloncorp/shared/store';
-import * as Haptics from 'expo-haptics';
 import { useCallback } from 'react';
-import { isWeb } from 'tamagui';
 
 import { useCurrentUserId } from '../contexts';
+import { triggerHaptic } from '../utils';
 import { useReactionDetails } from '../utils/postUtils';
 
 export default function useOnEmojiSelect(
@@ -22,11 +21,9 @@ export default function useOnEmojiSelect(
       details.self.didReact && details.self.value.includes(shortCode)
         ? store.removePostReaction(post, currentUserId)
         : store.addPostReaction(post, shortCode, currentUserId);
-      if (!isWeb) {
-        await Haptics.notificationAsync(
-          Haptics.NotificationFeedbackType.Success
-        );
-      }
+
+      triggerHaptic('success');
+
       setTimeout(() => onDismiss(), 50);
     },
     [onDismiss, post, details.self.didReact, details.self.value, currentUserId]

--- a/packages/ui/src/hooks/useOnEmojiSelect.tsx
+++ b/packages/ui/src/hooks/useOnEmojiSelect.tsx
@@ -1,0 +1,36 @@
+import * as db from '@tloncorp/shared/db';
+import * as store from '@tloncorp/shared/store';
+import * as Haptics from 'expo-haptics';
+import { useCallback } from 'react';
+import { isWeb } from 'tamagui';
+
+import { useCurrentUserId } from '../contexts';
+import { useReactionDetails } from '../utils/postUtils';
+
+export default function useOnEmojiSelect(
+  post: db.Post | null,
+  onDismiss: () => void
+) {
+  const currentUserId = useCurrentUserId();
+  const details = useReactionDetails(post?.reactions ?? [], currentUserId);
+
+  const onEmojiSelect = useCallback(
+    async (shortCode: string) => {
+      if (!post) {
+        return;
+      }
+      details.self.didReact && details.self.value.includes(shortCode)
+        ? store.removePostReaction(post, currentUserId)
+        : store.addPostReaction(post, shortCode, currentUserId);
+      if (!isWeb) {
+        await Haptics.notificationAsync(
+          Haptics.NotificationFeedbackType.Success
+        );
+      }
+      setTimeout(() => onDismiss(), 50);
+    },
+    [onDismiss, post, details.self.didReact, details.self.value, currentUserId]
+  );
+
+  return onEmojiSelect;
+}

--- a/packages/ui/src/utils/hapticIds.ts
+++ b/packages/ui/src/utils/hapticIds.ts
@@ -2,4 +2,5 @@ export type HapticAction =
   | 'baseButtonClick'
   | 'sheetOpen'
   | 'success'
+  | 'zoomable'
   | 'swipeAction';

--- a/packages/ui/src/utils/haptics.native.ts
+++ b/packages/ui/src/utils/haptics.native.ts
@@ -12,6 +12,12 @@ export function triggerHaptic(action: HapticAction) {
         10
       );
       break;
+    case 'zoomable':
+      setTimeout(
+        () => Haptics.impactAsync(Haptics.ImpactFeedbackStyle.Medium),
+        10
+      );
+      break;
     case 'success':
       setTimeout(
         () =>


### PR DESCRIPTION
fixes TLON-3170

On desktop we now render a modal for chat message actions, and a separate modal for the emoji picker.

Also fixed the input outline issue in the BaseTextInput component and an issue with the way the close button was displayed in the SearchBar after the inclusion of the Pressable component there.

copilot description:

This pull request introduces several changes to improve the user experience on different screen sizes and platforms, particularly focusing on handling narrow windows and web-specific behaviors. The key changes involve the addition of hooks to detect window size, modifications to the behavior of modals and action sheets, and the enhancement of emoji picker functionality.

### Handling narrow windows and web-specific behaviors:

* [`packages/ui/src/components/ActionList/ListFrame.tsx`](diffhunk://#diff-c2bff9e7dd5b287de6f2895562fb1fdedc928cb39d70adc27f6ec59ddd5360c2R5): Added `useIsWindowNarrow` hook to conditionally render `BlurView` based on window width. [[1]](diffhunk://#diff-c2bff9e7dd5b287de6f2895562fb1fdedc928cb39d70adc27f6ec59ddd5360c2R5) [[2]](diffhunk://#diff-c2bff9e7dd5b287de6f2895562fb1fdedc928cb39d70adc27f6ec59ddd5360c2R19-R26)
* [`packages/ui/src/components/Channel/Scroller.tsx`](diffhunk://#diff-593723831945abf7a95fe1e7136b4db0f576c5e747ed6bb997aed9f0e1d44ff5R40-R44): Integrated `useIsWindowNarrow` and `useOnEmojiSelect` hooks, and adjusted modal behavior to handle narrow windows and web-specific scenarios. [[1]](diffhunk://#diff-593723831945abf7a95fe1e7136b4db0f576c5e747ed6bb997aed9f0e1d44ff5R40-R44) [[2]](diffhunk://#diff-593723831945abf7a95fe1e7136b4db0f576c5e747ed6bb997aed9f0e1d44ff5R143) [[3]](diffhunk://#diff-593723831945abf7a95fe1e7136b4db0f576c5e747ed6bb997aed9f0e1d44ff5R391-R396) [[4]](diffhunk://#diff-593723831945abf7a95fe1e7136b4db0f576c5e747ed6bb997aed9f0e1d44ff5R446-L440) [[5]](diffhunk://#diff-593723831945abf7a95fe1e7136b4db0f576c5e747ed6bb997aed9f0e1d44ff5R469-R488)
* [`packages/ui/src/components/ChatMessage/ChatMessage.tsx`](diffhunk://#diff-bc2880d57997e9dcce6c7bd86fa993d1e856707622bf991cc7fa4a45edb9555dL4-R7): Added hover effects and overflow menu handling for web, utilizing `isWeb` and `hideOverflowMenu` props. [[1]](diffhunk://#diff-bc2880d57997e9dcce6c7bd86fa993d1e856707622bf991cc7fa4a45edb9555dL4-R7) [[2]](diffhunk://#diff-bc2880d57997e9dcce6c7bd86fa993d1e856707622bf991cc7fa4a45edb9555dR33) [[3]](diffhunk://#diff-bc2880d57997e9dcce6c7bd86fa993d1e856707622bf991cc7fa4a45edb9555dR48-R51) [[4]](diffhunk://#diff-bc2880d57997e9dcce6c7bd86fa993d1e856707622bf991cc7fa4a45edb9555dR100-R111) [[5]](diffhunk://#diff-bc2880d57997e9dcce6c7bd86fa993d1e856707622bf991cc7fa4a45edb9555dR146-R147) [[6]](diffhunk://#diff-bc2880d57997e9dcce6c7bd86fa993d1e856707622bf991cc7fa4a45edb9555dR199-R205)

### Enhancements to emoji picker functionality:

* [`packages/ui/src/components/ChatMessage/ChatMessageActions/Component.tsx`](diffhunk://#diff-0d4975716c3ca91ffdb1851984bd8a7b2de123edb3284682b3fb13618061af2cL18-R21): Added `onShowEmojiPicker` prop and used `useIsWindowNarrow` to conditionally render `ActionSheet` on web. [[1]](diffhunk://#diff-0d4975716c3ca91ffdb1851984bd8a7b2de123edb3284682b3fb13618061af2cL18-R21) [[2]](diffhunk://#diff-0d4975716c3ca91ffdb1851984bd8a7b2de123edb3284682b3fb13618061af2cR43) [[3]](diffhunk://#diff-0d4975716c3ca91ffdb1851984bd8a7b2de123edb3284682b3fb13618061af2cR54) [[4]](diffhunk://#diff-0d4975716c3ca91ffdb1851984bd8a7b2de123edb3284682b3fb13618061af2cR67) [[5]](diffhunk://#diff-0d4975716c3ca91ffdb1851984bd8a7b2de123edb3284682b3fb13618061af2cR101-R104) [[6]](diffhunk://#diff-0d4975716c3ca91ffdb1851984bd8a7b2de123edb3284682b3fb13618061af2cR150-R178)
* [`packages/ui/src/components/ChatMessage/ChatMessageActions/EmojiToolbar.tsx`](diffhunk://#diff-26e2420d883355dfa35e88776f2ef80e7a95054ee3af20cacd7602ce159960f1L2-R7): Refactored to use `useOnEmojiSelect` and handle sheet opening based on window width. [[1]](diffhunk://#diff-26e2420d883355dfa35e88776f2ef80e7a95054ee3af20cacd7602ce159960f1L2-R7) [[2]](diffhunk://#diff-26e2420d883355dfa35e88776f2ef80e7a95054ee3af20cacd7602ce159960f1R17-R28) [[3]](diffhunk://#diff-26e2420d883355dfa35e88776f2ef80e7a95054ee3af20cacd7602ce159960f1R38-R45) [[4]](diffhunk://#diff-26e2420d883355dfa35e88776f2ef80e7a95054ee3af20cacd7602ce159960f1L75-R76)

### Miscellaneous improvements:

* [`packages/ui/src/components/ChatMessage/ChatMessageActions/MessageActions.tsx`](diffhunk://#diff-6b675eb058da874445dff31b4c3f9f77039593e09e3d278c7522c3435f122201R9): Adjusted action list width for web and added conditional haptic feedback. [[1]](diffhunk://#diff-6b675eb058da874445dff31b4c3f9f77039593e09e3d278c7522c3435f122201R9) [[2]](diffhunk://#diff-6b675eb058da874445dff31b4c3f9f77039593e09e3d278c7522c3435f122201L33-R37) [[3]](diffhunk://#diff-6b675eb058da874445dff31b4c3f9f77039593e09e3d278c7522c3435f122201R221-R223)
* [`packages/ui/src/components/ChatMessage/ChatMessageActions/MessageContainer.tsx`](diffhunk://#diff-c016b7fd6e83e26970817794683ee8d9a85b4d09f49332d0b32abb2b55706c06R7): Utilized `useIsWindowNarrow` to set dynamic width and background color based on window size. [[1]](diffhunk://#diff-c016b7fd6e83e26970817794683ee8d9a85b4d09f49332d0b32abb2b55706c06R7) [[2]](diffhunk://#diff-c016b7fd6e83e26970817794683ee8d9a85b4d09f49332d0b32abb2b55706c06R17-R18) [[3]](diffhunk://#diff-c016b7fd6e83e26970817794683ee8d9a85b4d09f49332d0b32abb2b55706c06L34-R39) [[4]](diffhunk://#diff-c016b7fd6e83e26970817794683ee8d9a85b4d09f49332d0b32abb2b55706c06L47-R50)