### PR TITLE
tests: various /lib/test-agent improvements

### DIFF
--- a/desk/lib/test-agent.hoon
+++ b/desk/lib/test-agent.hoon
@@ -69,7 +69,12 @@
   |=  f=form:m
   ^-  tang
   =/  res  (f %*(. *state agent skeleton))
-  ?-(-.res %& ~, %| p.res)
+  ?:  ?=(%& -.res)  ~
+  ::NOTE  in rare cases, execution may crash in such a way that the resulting
+  ::      trace is empty. make sure we catch that here so the /ted/test will
+  ::      consider it failed.
+  ?^  p.res  p.res
+  ~['+eval-mare:test-agent didn\'t finish cleanly']
 ::
 ++  skeleton
   ^-  agent  !:

--- a/desk/lib/test-agent.hoon
+++ b/desk/lib/test-agent.hoon
@@ -347,6 +347,17 @@
   |=  s=state
   &+[~ s(scry f)]
 ::
+++  do-as  ::  temporary src.bowl
+  |=  who=ship
+  =/  m  (mare ,(list card))
+  |=  do=form:m
+  ^-  form:m
+  ;<  pre=bowl:gall    bind:m  get-bowl
+  ;<  ~                bind:m  (set-bowl pre(src who))
+  ;<  cas=(list card)  bind:m  do
+  ;<  ~                bind:m  (jab-bowl |=(b=bowl:gall b(src src.pre)))
+  (pure:m cas)
+::
 ::  testing utilities
 ::
 ++  ex-equal

--- a/desk/lib/test-agent.hoon
+++ b/desk/lib/test-agent.hoon
@@ -68,8 +68,23 @@
   =/  m  (mare ,~)
   |=  f=form:m
   ^-  tang
-  =/  res  (f *state)
+  =/  res  (f %*(. *state agent skeleton))
   ?-(-.res %& ~, %| p.res)
+::
+++  skeleton
+  ^-  agent  !:
+  |_  bowl:gall
+  ++  on-init        ~&(>>> %test-agent-not-initialized !!)
+  ++  on-save        ~&(>>> %test-agent-not-initialized !!)
+  ++  on-load   |=(* ~&(>>> %test-agent-not-initialized !!))
+  ++  on-poke   |=(* ~&(>>> %test-agent-not-initialized !!))
+  ++  on-watch  |=(* ~&(>>> %test-agent-not-initialized !!))
+  ++  on-leave  |=(* ~&(>>> %test-agent-not-initialized !!))
+  ++  on-agent  |=(* ~&(>>> %test-agent-not-initialized !!))
+  ++  on-arvo   |=(* ~&(>>> %test-agent-not-initialized !!))
+  ++  on-peek   |=(* ~&(>>> %test-agent-not-initialized !!))
+  ++  on-fail   |=(* ~&(>>> %test-agent-not-initialized !!))
+  --
 ::
 ::  internal transformations (you shouldn't be calling these directly)
 ::


### PR DESCRIPTION
Most importantly, failing to initialize/set the agent core prior to running your tests could've resulted in false successes. Here we make sure that there's always a crashing skeleton core there, and that crashes with empty traces still result in failing tests.

Additionally, we add a `+do-as` helper for temporarily changing the `src.bowl`. Very convenient for tests that simulate multiple parties interacting with the same agent.