### PR TITLE
native: show custom channels flag only if user is tlon employee

### DIFF
--- a/apps/tlon-mobile/src/hooks/useNotificationListener.ts
+++ b/apps/tlon-mobile/src/hooks/useNotificationListener.ts
@@ -76,7 +76,7 @@ function payloadFromNotification(
 
 export default function useNotificationListener() {
   const navigation = useNavigation<NavigationProp<RootStackParamList>>();
-  const { data: isTlonEmployee } = store.useIsTlonEmployee();
+  const isTlonEmployee = store.useIsTlonEmployee();
   const [channelSwitcherEnabled] = useFeatureFlag('channelSwitcher');
 
   const [notifToProcess, setNotifToProcess] =

--- a/packages/app/features/settings/FeatureFlagScreen.tsx
+++ b/packages/app/features/settings/FeatureFlagScreen.tsx
@@ -1,5 +1,6 @@
 import type { NativeStackScreenProps } from '@react-navigation/native-stack';
 import { FeatureFlagScreenView } from '@tloncorp/ui';
+import { useIsTlonEmployee } from 'packages/shared/src';
 import { useCallback, useMemo } from 'react';
 
 import * as featureFlags from '../../lib/featureFlags';
@@ -22,14 +23,22 @@ export function FeatureFlagScreen({ navigation }: Props) {
     [setEnabled]
   );
 
+  const isTlonEmployee = useIsTlonEmployee();
   const features = useMemo(
     () =>
-      Object.entries(featureFlags.featureMeta).map(([name, meta]) => ({
-        name,
-        label: meta.label,
-        enabled: flags[name as featureFlags.FeatureName],
-      })),
-    [flags]
+      Object.entries(featureFlags.featureMeta)
+        .filter(([name]) => {
+          if (name === 'customChannels') {
+            return isTlonEmployee;
+          }
+          return true;
+        })
+        .map(([name, meta]) => ({
+          name,
+          label: meta.label,
+          enabled: flags[name as featureFlags.FeatureName],
+        })),
+    [flags, isTlonEmployee]
   );
 
   return (

--- a/packages/app/features/settings/FeatureFlagScreen.tsx
+++ b/packages/app/features/settings/FeatureFlagScreen.tsx
@@ -28,7 +28,7 @@ export function FeatureFlagScreen({ navigation }: Props) {
     () =>
       Object.entries(featureFlags.featureMeta)
         .filter(([name]) => {
-          if (name === 'customChannels') {
+          if (name === 'customChannelCreation') {
             return isTlonEmployee;
           }
           return true;

--- a/packages/app/features/settings/FeatureFlagScreen.tsx
+++ b/packages/app/features/settings/FeatureFlagScreen.tsx
@@ -1,6 +1,6 @@
 import type { NativeStackScreenProps } from '@react-navigation/native-stack';
+import { useIsTlonEmployee } from '@tloncorp/shared';
 import { FeatureFlagScreenView } from '@tloncorp/ui';
-import { useIsTlonEmployee } from 'packages/shared/src';
 import { useCallback, useMemo } from 'react';
 
 import * as featureFlags from '../../lib/featureFlags';

--- a/packages/app/features/top/GroupChannelsScreen.tsx
+++ b/packages/app/features/top/GroupChannelsScreen.tsx
@@ -58,7 +58,7 @@ export function GroupChannelsScreenContent({
     navigation.goBack();
   }, [navigation]);
 
-  const [enableCustomChannels] = useFeatureFlag('customChannels');
+  const [enableCustomChannels] = useFeatureFlag('customChannelCreation');
 
   return (
     <ChatOptionsProvider

--- a/packages/app/lib/featureFlags.ts
+++ b/packages/app/lib/featureFlags.ts
@@ -13,7 +13,7 @@ export const featureMeta = {
     default: false,
     label: 'Enable collecting and reporting performance data',
   },
-  customChannels: {
+  customChannelCreation: {
     default: false,
     label: 'Enable creating custom channels',
   },

--- a/packages/app/utils/posthog.ts
+++ b/packages/app/utils/posthog.ts
@@ -61,6 +61,7 @@ export const trackError = (
 ) => capture(event, { message, properties });
 
 export const identifyTlonEmployee = () => {
+  db.setIsTlonEmployee(true);
   if (!posthog) {
     console.debug('Identifying as Tlon employee before PostHog is initialized');
     return;
@@ -68,5 +69,4 @@ export const identifyTlonEmployee = () => {
 
   const UUID = posthog.getDistinctId();
   posthog.identify(UUID, { isTlonEmployee: true });
-  db.setIsTlonEmployee(true);
 };

--- a/packages/shared/src/store/dbHooks.ts
+++ b/packages/shared/src/store/dbHooks.ts
@@ -138,7 +138,7 @@ export const useIsTlonEmployee = () => {
   return useQuery({
     queryKey: db.IS_TLON_EMPLOYEE_QUERY_KEY,
     queryFn: db.getIsTlonEmployee,
-  });
+  }).data;
 };
 
 export const useCanUpload = () => {


### PR DESCRIPTION
- Hardcode custom channels flag to show only if user is a Tlon employee
- Change custom channels flag key to invalidate for all existing installs (to avoid case where flag was enabled by non-Tlon-employee, disappears for them from this PR, but remains logically/invisibly enabled)
- [extra] I had a hard-to-see bug in my first pass where I did something like
```ts
const isTlonEmployee = useIsTlonEmployee();
if (isTlonEmployee) {
  // do something
}
```
This would always run the if-block because `isTlonEmployee` is actually a react-query query result – i.e. a non-null object, which is truthy. 6d928f46d1327baf0fd2f0342338f1651cd9b1dc changes this to just return an optional boolean.
- [extra] [8666ec8](https://github.com/tloncorp/tlon-apps/pull/4159/commits/8666ec84d5d290986d87d6ac7980c12dae1139d3) Setting `isTlonEmployee` would get skipped if PostHog creds were not set – always set that

I tested by:
1. Load `develop` client on a non-Tlon-employee account
2. Enable custom channels flag
3. Checkout the head of this branch
4. Check that flag is not visible in flags screen
5. Check that channel creation sheet does not show the "custom" option