### PR TITLE
pressable: fix onPress issue in ContactRow

### DIFF
--- a/packages/ui/src/components/ContactRow.tsx
+++ b/packages/ui/src/components/ContactRow.tsx
@@ -13,6 +13,8 @@ function ContactRowItemRaw({
   selected = false,
   selectable = false,
   onPress,
+  pressStyle,
+  backgroundColor,
   ...rest
 }: {
   contact: db.Contact;
@@ -33,7 +35,12 @@ function ContactRowItemRaw({
   );
 
   return (
-    <Pressable pressStyle={undefined} onPress={handlePress(contact.id)}>
+    <Pressable
+      backgroundColor={backgroundColor}
+      pressStyle={pressStyle}
+      borderRadius="$xl"
+      onPress={handlePress(contact.id)}
+    >
       <ListItem {...rest}>
         <ListItem.ContactIcon contactId={contact.id} />
         <ListItem.MainContent>


### PR DESCRIPTION
Fixes the issue where pressing a ContactRow does nothing.

The problem was that we were passing `{...rest}` into ListItem, which included `pressStyle`, which ended up making ListItem the pressable element rather than Pressable.

To fix, I pulled `pressStyle` out of props and passed it to Pressable instead, along with some style related props.