### PR TITLE
onboarding: "next" usability 

### DIFF
--- a/apps/tlon-mobile/src/screens/Onboarding/SignupScreen.tsx
+++ b/apps/tlon-mobile/src/screens/Onboarding/SignupScreen.tsx
@@ -12,11 +12,13 @@ import { HostingError } from '@tloncorp/app/lib/hostingApi';
 import { trackOnboardingAction } from '@tloncorp/app/utils/posthog';
 import { createDevLogger } from '@tloncorp/shared';
 import {
+  Button,
   Field,
   KeyboardAvoidingView,
   OnboardingInviteBlock,
   OnboardingTextBlock,
   ScreenHeader,
+  Spinner,
   TextInput,
   TlonText,
   View,
@@ -184,11 +186,6 @@ export const SignupScreen = ({ navigation }: Props) => {
         showSessionStatus={false}
         backAction={goBack}
         isLoading={isSubmitting}
-        rightControls={
-          <ScreenHeader.TextButton onPress={onSubmit} disabled={isSubmitting}>
-            Next
-          </ScreenHeader.TextButton>
-        }
       />
       <KeyboardAvoidingView behavior="height" keyboardVerticalOffset={180}>
         <YStack gap="$2xl" paddingHorizontal="$2xl" paddingVertical="$l">
@@ -231,18 +228,43 @@ export const SignupScreen = ({ navigation }: Props) => {
                       autoCorrect={false}
                       returnKeyType="next"
                       enablesReturnKeyAutomatically
+                      onSubmitEditing={onSubmit}
                     />
                   </Field>
                 )}
                 name="email"
               />
             )}
+            <Button
+              onPress={onSubmit}
+              hero
+              disabled={
+                isSubmitting ||
+                remoteError !== undefined ||
+                (otpMethod === 'phone'
+                  ? !phoneForm.formState.isValid
+                  : !emailForm.formState.isValid)
+              }
+            >
+              {isSubmitting ? (
+                <>
+                  <Spinner />
+                  <TlonText.Text>Please wait&hellip;</TlonText.Text>
+                </>
+              ) : (
+                <TlonText.Text color="$background" size="$label/l">
+                  Sign up with{' '}
+                  {otpMethod === 'phone' ? 'phone number' : 'email'}
+                </TlonText.Text>
+              )}
+            </Button>
           </YStack>
-          <View marginLeft="$l">
+          <View>
             <TlonText.Text
-              size="$label/s"
-              color="$tertiaryText"
+              size="$label/m"
+              color="$secondaryText"
               onPress={toggleSignupMode}
+              textAlign="center"
             >
               Or if you&apos;d prefer,{' '}
               <TlonText.RawText
@@ -253,7 +275,8 @@ export const SignupScreen = ({ navigation }: Props) => {
                 textDecorationDistance={10}
                 onPress={toggleSignupMode}
               >
-                sign up with {otpMethod === 'phone' ? 'email' : 'phone number'}
+                sign up with{' '}
+                {otpMethod === 'phone' ? 'an email address' : 'a phone number'}
               </TlonText.RawText>
             </TlonText.Text>
           </View>

--- a/apps/tlon-mobile/src/screens/Onboarding/SignupScreen.tsx
+++ b/apps/tlon-mobile/src/screens/Onboarding/SignupScreen.tsx
@@ -12,13 +12,12 @@ import { HostingError } from '@tloncorp/app/lib/hostingApi';
 import { trackOnboardingAction } from '@tloncorp/app/utils/posthog';
 import { createDevLogger } from '@tloncorp/shared';
 import {
-  Button,
   Field,
   KeyboardAvoidingView,
   OnboardingInviteBlock,
   OnboardingTextBlock,
+  PrimaryButton,
   ScreenHeader,
-  Spinner,
   TextInput,
   TlonText,
   View,
@@ -241,9 +240,9 @@ export const SignupScreen = ({ navigation }: Props) => {
               />
             )}
 
-            <Button
+            <PrimaryButton
               onPress={onSubmit}
-              hero
+              loading={isSubmitting}
               disabled={
                 isSubmitting ||
                 remoteError !== undefined ||
@@ -252,18 +251,10 @@ export const SignupScreen = ({ navigation }: Props) => {
                   : !emailForm.formState.isValid)
               }
             >
-              {isSubmitting ? (
-                <>
-                  <Spinner />
-                  <TlonText.Text>Please wait&hellip;</TlonText.Text>
-                </>
-              ) : (
-                <TlonText.Text color="$background" size="$label/l">
-                  Sign up with{' '}
-                  {otpMethod === 'phone' ? 'phone number' : 'email'}
-                </TlonText.Text>
-              )}
-            </Button>
+              <TlonText.Text color="$background" size="$label/l">
+                Sign up
+              </TlonText.Text>
+            </PrimaryButton>
             <TlonText.Text
               marginTop="$m"
               textAlign="center"

--- a/apps/tlon-mobile/src/screens/Onboarding/TlonLogin.tsx
+++ b/apps/tlon-mobile/src/screens/Onboarding/TlonLogin.tsx
@@ -8,10 +8,12 @@ import {
 import { HostingError } from '@tloncorp/app/lib/hostingApi';
 import { createDevLogger } from '@tloncorp/shared';
 import {
+  Button,
   Field,
   KeyboardAvoidingView,
   OnboardingTextBlock,
   ScreenHeader,
+  Spinner,
   TextInput,
   TlonText,
   View,
@@ -131,11 +133,6 @@ export const TlonLoginScreen = ({ navigation, route }: Props) => {
         showSessionStatus={false}
         backAction={goBack}
         isLoading={isSubmitting}
-        rightControls={
-          <ScreenHeader.TextButton onPress={onSubmit} disabled={isSubmitting}>
-            Next
-          </ScreenHeader.TextButton>
-        }
       />
       <KeyboardAvoidingView behavior="height" keyboardVerticalOffset={180}>
         <YStack gap="$2xl" paddingHorizontal="$2xl" paddingVertical="$l">
@@ -179,18 +176,46 @@ export const TlonLoginScreen = ({ navigation, route }: Props) => {
                       autoCorrect={false}
                       returnKeyType="next"
                       enablesReturnKeyAutomatically
+                      onSubmitEditing={onSubmit}
                     />
                   </Field>
                 )}
                 name="email"
               />
             )}
+            <Button
+              onPress={onSubmit}
+              hero
+              disabled={
+                isSubmitting ||
+                remoteError !== undefined ||
+                (otpMethod === 'phone'
+                  ? !phoneForm.formState.isValid
+                  : !emailForm.formState.isValid)
+              }
+            >
+              {isSubmitting ? (
+                <>
+                  <Spinner />
+                  <TlonText.Text>Please wait&hellip;</TlonText.Text>
+                </>
+              ) : (
+                <TlonText.Text color="$background" size="$label/l">
+                  Send code to log in
+                </TlonText.Text>
+              )}
+            </Button>
           </YStack>
-          <View marginLeft="$l">
+          <View>
             {otpMethod === 'email' ? (
               <>
-                <TlonText.Text color="$tertiaryText" marginTop="$xl">
-                  We&apos;ll email you a code to log in. Or you can{' '}
+                <TlonText.Text
+                  color="$secondaryText"
+                  marginTop="$xl"
+                  textAlign="center"
+                >
+                  We&apos;ll email you a 6-digit code to log in. Otherwise, you
+                  can{' '}
                   <TlonText.RawText
                     pressStyle={{
                       opacity: 0.5,
@@ -203,18 +228,20 @@ export const TlonLoginScreen = ({ navigation, route }: Props) => {
                   </TlonText.RawText>
                 </TlonText.Text>
                 <TlonText.Text
-                  color="$tertiaryText"
+                  color="$secondaryText"
                   onPress={handlePressEmailSignup}
                   marginTop="$xl"
                   textDecorationLine="underline"
                   textDecorationDistance={10}
+                  textAlign="center"
                 >
                   Login with phone number instead
                 </TlonText.Text>
               </>
             ) : (
               <TlonText.Text
-                color="$tertiaryText"
+                color="$secondaryText"
+                textAlign="center"
                 onPress={handlePressEmailSignup}
                 marginTop="$xl"
                 textDecorationLine="underline"

--- a/apps/tlon-mobile/src/screens/Onboarding/TlonLogin.tsx
+++ b/apps/tlon-mobile/src/screens/Onboarding/TlonLogin.tsx
@@ -8,12 +8,11 @@ import {
 import { HostingError } from '@tloncorp/app/lib/hostingApi';
 import { createDevLogger } from '@tloncorp/shared';
 import {
-  Button,
   Field,
   KeyboardAvoidingView,
   OnboardingTextBlock,
+  PrimaryButton,
   ScreenHeader,
-  Spinner,
   TextInput,
   TlonText,
   View,
@@ -188,9 +187,9 @@ export const TlonLoginScreen = ({ navigation, route }: Props) => {
               />
             )}
 
-            <Button
+            <PrimaryButton
               onPress={onSubmit}
-              hero
+              loading={isSubmitting}
               disabled={
                 isSubmitting ||
                 remoteError !== undefined ||
@@ -199,17 +198,10 @@ export const TlonLoginScreen = ({ navigation, route }: Props) => {
                   : !emailForm.formState.isValid)
               }
             >
-              {isSubmitting ? (
-                <>
-                  <Spinner />
-                  <TlonText.Text>Please wait&hellip;</TlonText.Text>
-                </>
-              ) : (
-                <TlonText.Text color="$background" size="$label/l">
-                  Send code to log in
-                </TlonText.Text>
-              )}
-            </Button>
+              <TlonText.Text color="$background" size="$label/l">
+                Send code to log in
+              </TlonText.Text>
+            </PrimaryButton>
 
             <TlonText.Text
               textAlign="center"


### PR DESCRIPTION
- Adds onSubmitEditing props to email fields so the user can press "enter" to submit the form via the system soft-keyboard
- Relocates the "Next…" button on signup and login screens to a hero button beneath the field


Signup screen:
![Simulator Screen Recording - iPhone 16 - 2024-11-12 at 14 25 49](https://github.com/user-attachments/assets/eedb9c31-2522-4a1d-9dbc-fa4685766fb5)

Tlon login screen:
![Simulator Screen Recording - iPhone 16 - 2024-11-12 at 14 27 01](https://github.com/user-attachments/assets/d3878408-71a4-4329-b8bb-eb9c023ad1bd)
