### PR TITLE
navigation: fix navigate to dm from members list, fix navigate to search results

### DIFF
--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -58,6 +58,19 @@ module.exports = {
         message:
           'Do not use onLongPress on Stack, View or ListItem components. Use Pressable instead.',
       },
+      {
+        selector:
+          'MemberExpression[object.name="CommonActions"][property.name="reset"]',
+        message:
+          'Please use the useTypedReset() hook instead of CommonActions.reset() for type safety.',
+      },
+      {
+        // Also catch it when imported as a different name
+        selector:
+          'ImportSpecifier[imported.name="reset"][parent.parent.source.value="@react-navigation/native"]',
+        message:
+          'Please use the useTypedReset() hook instead of importing reset from @react-navigation/native for type safety.',
+      },
     ],
   },
 };

--- a/apps/tlon-mobile/src/hooks/useNotificationListener.ts
+++ b/apps/tlon-mobile/src/hooks/useNotificationListener.ts
@@ -1,9 +1,10 @@
 import crashlytics from '@react-native-firebase/crashlytics';
 import type { NavigationProp } from '@react-navigation/native';
-import { CommonActions, useNavigation } from '@react-navigation/native';
+import { useNavigation } from '@react-navigation/native';
 import { useFeatureFlag } from '@tloncorp/app/lib/featureFlags';
 import { connectNotifications } from '@tloncorp/app/lib/notifications';
 import { RootStackParamList } from '@tloncorp/app/navigation/types';
+import { createTypedReset } from '@tloncorp/app/navigation/utils';
 import * as posthog from '@tloncorp/app/utils/posthog';
 import { syncDms, syncGroups } from '@tloncorp/shared';
 import { markChatRead } from '@tloncorp/shared/api';
@@ -187,12 +188,9 @@ export default function useNotificationListener() {
           });
         }
 
-        navigation.dispatch(
-          CommonActions.reset({
-            index: 1,
-            routes: routeStack,
-          })
-        );
+        const typedReset = createTypedReset(navigation);
+
+        typedReset(routeStack, 1);
         setNotifToProcess(null);
         return true;
       };

--- a/packages/app/features/groups/GroupMembersScreen.tsx
+++ b/packages/app/features/groups/GroupMembersScreen.tsx
@@ -1,12 +1,11 @@
-import { CommonActions } from '@react-navigation/native';
 import { NativeStackScreenProps } from '@react-navigation/native-stack';
-import * as store from '@tloncorp/shared/store';
 import { GroupMembersScreenView } from '@tloncorp/ui';
 import { useCallback } from 'react';
 
 import { useCurrentUserId } from '../../hooks/useCurrentUser';
 import { useGroupContext } from '../../hooks/useGroupContext';
 import { GroupSettingsStackParamList } from '../../navigation/types';
+import { useResetToDm } from '../../navigation/utils';
 
 type Props = NativeStackScreenProps<
   GroupSettingsStackParamList,
@@ -32,22 +31,13 @@ export function GroupMembersScreen({ route, navigation }: Props) {
 
   const currentUserId = useCurrentUserId();
 
+  const resetToDm = useResetToDm();
+
   const handleGoToDm = useCallback(
     async (participants: string[]) => {
-      const dmChannel = await store.upsertDmChannel({
-        participants,
-      });
-      navigation.dispatch(
-        CommonActions.reset({
-          index: 1,
-          routes: [
-            { name: 'ChatList' },
-            { name: 'Channel', params: { channel: dmChannel } },
-          ],
-        })
-      );
+      resetToDm(participants[0]);
     },
-    [navigation]
+    [resetToDm]
   );
 
   return (

--- a/packages/app/features/top/ChannelSearchScreen.tsx
+++ b/packages/app/features/top/ChannelSearchScreen.tsx
@@ -6,11 +6,13 @@ import { useCallback, useState } from 'react';
 import { SafeAreaView } from 'react-native-safe-area-context';
 
 import type { RootStackParamList } from '../../navigation/types';
+import { useResetToChannel } from '../../navigation/utils';
 
 type Props = NativeStackScreenProps<RootStackParamList, 'ChannelSearch'>;
 
 export default function ChannelSearchScreen(props: Props) {
   const channelId = props.route.params.channelId;
+  const groupId = props.route.params.groupId;
   const channelQuery = useChannelWithRelations({
     id: channelId,
   });
@@ -18,6 +20,8 @@ export default function ChannelSearchScreen(props: Props) {
   const [query, setQuery] = useState('');
   const { posts, loading, errored, hasMore, loadMore, searchedThroughDate } =
     useChannelSearch(channelId, query);
+
+  const resetToChannel = useResetToChannel();
 
   const navigateToPost = useCallback(
     (post: db.Post) => {
@@ -28,13 +32,13 @@ export default function ChannelSearchScreen(props: Props) {
           authorId: post.authorId,
         });
       } else {
-        props.navigation.navigate('Channel', {
-          channelId: post.channelId,
+        resetToChannel(post.channelId, {
           selectedPostId: post.id,
+          groupId,
         });
       }
     },
-    [props.navigation]
+    [props.navigation, resetToChannel, groupId]
   );
 
   return (

--- a/packages/app/features/top/UserProfileScreen.tsx
+++ b/packages/app/features/top/UserProfileScreen.tsx
@@ -1,4 +1,3 @@
-import { CommonActions } from '@react-navigation/native';
 import { NativeStackScreenProps } from '@react-navigation/native-stack';
 import type * as db from '@tloncorp/shared/db';
 import * as store from '@tloncorp/shared/store';
@@ -13,6 +12,7 @@ import { useCallback } from 'react';
 
 import { useCurrentUserId } from '../../hooks/useCurrentUser';
 import { RootStackParamList } from '../../navigation/types';
+import { useResetToDm } from '../../navigation/utils';
 import { useConnectionStatus } from './useConnectionStatus';
 
 type Props = NativeStackScreenProps<RootStackParamList, 'UserProfile'>;
@@ -23,33 +23,13 @@ export function UserProfileScreen({ route: { params }, navigation }: Props) {
   const { data: contacts } = store.useContacts();
   const connectionStatus = useConnectionStatus(userId);
   const [selectedGroup, setSelectedGroup] = useState<db.Group | null>(null);
+  const resetToDm = useResetToDm();
 
   const handleGoToDm = useCallback(
     async (participants: string[]) => {
-      try {
-        const dmChannel = await store.upsertDmChannel({
-          participants,
-        });
-
-        if (!dmChannel?.id) {
-          console.error('Failed to create DM channel: no channel ID');
-          return;
-        }
-
-        navigation.dispatch(
-          CommonActions.reset({
-            index: 1,
-            routes: [
-              { name: 'ChatList' },
-              { name: 'Channel', params: { channelId: dmChannel.id } },
-            ],
-          })
-        );
-      } catch (error) {
-        console.error('Error creating DM channel:', error);
-      }
+      resetToDm(participants[0]);
     },
-    [navigation]
+    [resetToDm]
   );
 
   const handleGroupPreviewSheetOpenChange = useCallback(

--- a/packages/app/hooks/useChannelNavigation.ts
+++ b/packages/app/hooks/useChannelNavigation.ts
@@ -58,6 +58,7 @@ export const useChannelNavigation = ({ channelId }: { channelId: string }) => {
     }
     navigation.push('ChannelSearch', {
       channelId: channelQuery.data.id ?? null,
+      groupId: channelQuery.data.groupId ?? '',
     });
   }, [navigation, channelQuery.data]);
 

--- a/packages/app/navigation/types.ts
+++ b/packages/app/navigation/types.ts
@@ -20,6 +20,7 @@ export type RootStackParamList = {
   };
   ChannelSearch: {
     channelId: string;
+    groupId: string;
   };
   Post: {
     postId: string;

--- a/packages/app/navigation/utils.ts
+++ b/packages/app/navigation/utils.ts
@@ -1,0 +1,78 @@
+import {
+  CommonActions,
+  NavigationProp,
+  useNavigation,
+} from '@react-navigation/native';
+import * as store from '@tloncorp/shared/store';
+
+import { RootStackParamList } from './types';
+
+type ResetRouteConfig<T extends Record<string, any>> = {
+  name: Extract<keyof T, string>;
+  params?: T[Extract<keyof T, string>];
+};
+
+export function createTypedReset<T extends Record<string, any>>(
+  navigation: NavigationProp<T>
+) {
+  return function reset(
+    routes: ResetRouteConfig<T>[],
+    index = routes.length - 1
+  ) {
+    navigation.dispatch(
+      // eslint-disable-next-line no-restricted-syntax
+      CommonActions.reset({
+        index,
+        routes,
+      })
+    );
+  };
+}
+
+// This is a custom hook that returns a function that resets the navigation stack
+// to the provided routes. It's useful for resetting the navigation stack to a
+// specific route or set of routes.
+export function useTypedReset() {
+  const navigation = useNavigation<NavigationProp<RootStackParamList>>();
+
+  return createTypedReset(navigation);
+}
+
+export function useResetToChannel() {
+  const reset = useTypedReset();
+
+  return function resetToChannel(
+    channelId: string,
+    options?: {
+      groupId?: string;
+      selectedPostId?: string | null;
+      startDraft?: boolean;
+    }
+  ) {
+    reset([
+      { name: 'ChatList' },
+      {
+        name: 'Channel',
+        params: {
+          channelId,
+          ...options,
+        },
+      },
+    ]);
+  };
+}
+
+export function useResetToDm() {
+  const resetToChannel = useResetToChannel();
+
+  return async function resetToDm(contactId: string) {
+    try {
+      const dmChannel = await store.upsertDmChannel({
+        participants: [contactId],
+      });
+      resetToChannel(dmChannel.id);
+    } catch (error) {
+      console.error('Error creating DM channel:', error);
+    }
+  };
+}


### PR DESCRIPTION
fixes TLON-3220
fixes TLON-3198

First, this fixes navigating to a DM from the ProfileSheet that is accessible via the group member list by passing a channelId rather than a channel param.

The reason this wasn't caught before was because we were using CommonActions.reset() to reset the navigation state (which makes sense given the context, we don't necessarily know where we're going to be navigating from in that sheet). Because we were doing that, we didn't have any type safety around the route/params.

To reset the navigation state in a typesafe way, I added a `createTypedReset` function that we can use to create a reset function using our navigation types. I also created some helper hooks (`useTypedReset`, `useResetToChannel`, etc.) to reduce the boilerplate associated with using it and to encapsulate common navigation patterns.

I also added an eslint rule to prevent usage of CommonActions.reset() and direct developers to use `useTypedReset()` instead, ensuring we maintain type safety across our navigation state changes.

The issue with our chat search results not navigating appropriately had to do with navigating within a nested navigator, and called for using a `reset`. I replaced the existing navigation code with our new `useResetToChannel` hook to demonstrate how this pattern works in that context as well.

Copilot description:
This pull request introduces a new navigation utility for type-safe resets and updates various components to use this utility instead of the previous navigation methods. The main changes include adding the `useTypedReset` hook and updating several screens to use this new hook for navigation resets.

### Navigation Utility Enhancements:

* Added `createTypedReset`, `useTypedReset`, `useResetToChannel`, and `useResetToDm` utility functions in `packages/app/navigation/utils.ts` to handle type-safe navigation resets.

### Component Updates:

* Updated `useNotificationListener` hook to use `createTypedReset` for resetting navigation. [[1]](diffhunk://#diff-c75cc8909477a57805d0ab8e6cd12c62507a27cb7419f29cac92a5a37b5bbf08L3-R7) [[2]](diffhunk://#diff-c75cc8909477a57805d0ab8e6cd12c62507a27cb7419f29cac92a5a37b5bbf08L190-R193)
* Refactored `GroupMembersScreen` to use `useResetToDm` for resetting navigation to DM channels. [[1]](diffhunk://#diff-40128338d3b0f337919fe6734d50399cd83639954ad4961c07eeef03e38d7a08L1-R8) [[2]](diffhunk://#diff-40128338d3b0f337919fe6734d50399cd83639954ad4961c07eeef03e38d7a08R34-R40)
* Modified `ChannelSearchScreen` to use `useResetToChannel` for resetting navigation to specific channels. [[1]](diffhunk://#diff-49c45fe4e06c8344eb27b2330e5e89e05e38fc327eb86a21357f2e68fbaaf985R9-R15) [[2]](diffhunk://#diff-49c45fe4e06c8344eb27b2330e5e89e05e38fc327eb86a21357f2e68fbaaf985R24-R25) [[3]](diffhunk://#diff-49c45fe4e06c8344eb27b2330e5e89e05e38fc327eb86a21357f2e68fbaaf985L31-R41)
* Updated `UserProfileScreen` to use `useResetToDm` for resetting navigation to DM channels. [[1]](diffhunk://#diff-9aa8134081499b69910ed09e5ba5efc508a4c2394a0e38f714a628a9cea5eba4L1) [[2]](diffhunk://#diff-9aa8134081499b69910ed09e5ba5efc508a4c2394a0e38f714a628a9cea5eba4R15) [[3]](diffhunk://#diff-9aa8134081499b69910ed09e5ba5efc508a4c2394a0e38f714a628a9cea5eba4R26-R32)

### Linting Rule Addition:

* Added new linting rules in `.eslintrc.cjs` to enforce the use of `useTypedReset` instead of `CommonActions.reset`.