### PR TITLE
native: fix unban action

### DIFF
--- a/packages/shared/src/db/queries.ts
+++ b/packages/shared/src/db/queries.ts
@@ -2581,6 +2581,7 @@ export const getGroup = createReadQuery(
     'volumeSettings',
     'channels',
     'groupJoinRequests',
+    'groupMemberBans',
   ]
 );
 


### PR DESCRIPTION
OTT

May have been resolved with the pressable fixes, because it looks like unbans are going through fine. Weren't reflecting changes to the banned users table in the groups query however, so this just fixes the optimistic UI update.

Fixes TLON-3221