### PR TITLE
fix optimistically generated notebook + gallery ids

### DIFF
--- a/packages/shared/src/db/modelBuilders.ts
+++ b/packages/shared/src/db/modelBuilders.ts
@@ -43,8 +43,7 @@ export function assembleNewChannelIdAndName({
     ? `${tempChannelName}-${randomSmallNumber}`
     : tempChannelName;
   const newChannelFlag = `${currentUserId}/${channelName}`;
-  const newChannelNest = `${channelType}/${newChannelFlag}`;
-
+  const newChannelNest = `${channelKind}/${newChannelFlag}`;
   return {
     name: channelName,
     id: newChannelNest,


### PR DESCRIPTION
Fixes issue with creating notes immediately after creating a channel. The optimistically generated channel ids for notebooks + galleries were incorrect, which meant that they wouldn't function correctly until updated from the server. This PR fixes that, so they can now be posted to immediately.

Fixes TLON-3211