### PR TITLE
channel, Scroller: don't show scroll-to-bottom button if sending

### DIFF
--- a/packages/ui/src/components/Channel/Scroller.tsx
+++ b/packages/ui/src/components/Channel/Scroller.tsx
@@ -408,7 +408,7 @@ const Scroller = forwardRef(
     }, [insets.bottom]);
 
     const shouldShowScrollButton = useCallback(() => {
-      if (isSending) {
+      if (isSending && isAtBottom) {
         return false;
       }
 

--- a/packages/ui/src/components/Channel/Scroller.tsx
+++ b/packages/ui/src/components/Channel/Scroller.tsx
@@ -98,6 +98,7 @@ const Scroller = forwardRef(
       setActiveMessage,
       headerMode,
       isLoading,
+      isSending,
       onPressScrollToBottom,
     }: {
       anchor?: ScrollAnchor | null;
@@ -126,6 +127,7 @@ const Scroller = forwardRef(
       ref?: RefObject<{ scrollToIndex: (params: { index: number }) => void }>;
       headerMode: 'default' | 'next';
       isLoading?: boolean;
+      isSending?: boolean;
       // Unused
       hasOlderPosts?: boolean;
       onPressScrollToBottom?: () => void;
@@ -406,6 +408,10 @@ const Scroller = forwardRef(
     }, [insets.bottom]);
 
     const shouldShowScrollButton = useCallback(() => {
+      if (isSending) {
+        return false;
+      }
+
       if (!isAtBottom && hasPressedGoToBottom && !isLoading && !hasNewerPosts) {
         setHasPressedGoToBottom(false);
       }
@@ -427,6 +433,7 @@ const Scroller = forwardRef(
       unreadCount,
       isLoading,
       hasNewerPosts,
+      isSending,
     ]);
 
     const onEmojiSelect = useOnEmojiSelect(activeMessage, () =>

--- a/packages/ui/src/components/Channel/index.tsx
+++ b/packages/ui/src/components/Channel/index.tsx
@@ -225,6 +225,7 @@ export function Channel({
   >(null);
 
   const draftInputRef = useRef<DraftInputHandle>(null);
+  const [isSending, setIsSending] = useState(false);
 
   const draftInputContext = useMemo(
     (): DraftInputContext => ({
@@ -236,7 +237,14 @@ export function Channel({
       getDraft,
       group,
       onPresentationModeChange: setDraftInputPresentationMode,
-      send: messageSender,
+      send: async (...args) => {
+        setIsSending(true);
+        try {
+          await messageSender(args[0], args[1]);
+        } finally {
+          setIsSending(false);
+        }
+      },
       setEditingPost,
       setShouldBlur: setInputShouldBlur,
       shouldBlur: inputShouldBlur,
@@ -375,6 +383,7 @@ export function Channel({
                                       ref={flatListRef}
                                       headerMode={headerMode}
                                       isLoading={isLoadingPosts}
+                                      isSending={isSending}
                                       onPressScrollToBottom={
                                         onPressScrollToBottom
                                       }


### PR DESCRIPTION
In channel/index: 
- Sets an isSending flag on message send
- Awaits messageSender in draftInputContext to complete
- Then flips the isSending flag again to false 

In channel/scroller: 
- Consumes the isSending flag reflected in scroller and further downstream in shouldShowScrollButton()

Fixes TLON-3205 by hiding the scroll-to-bottom button if the user is sending a message.