### PR TITLE
native: avoid showing "scroll to" button on message send

### DIFF
--- a/packages/ui/src/components/Channel/Scroller.tsx
+++ b/packages/ui/src/components/Channel/Scroller.tsx
@@ -141,8 +141,6 @@ const Scroller = forwardRef(
       [channel]
     );
 
-    const [isAtBottom, setIsAtBottom] = useState(true);
-
     const [hasPressedGoToBottom, setHasPressedGoToBottom] = useState(false);
     const [viewReactionsPost, setViewReactionsPost] = useState<null | db.Post>(
       null
@@ -396,7 +394,8 @@ const Scroller = forwardRef(
       );
     }, [renderEmptyComponentFn]);
 
-    const handleScroll = useScrollDirectionTracker(setIsAtBottom);
+    const [isAtBottom, setIsAtBottom] = useState(true);
+    const handleScroll = useScrollDirectionTracker({ setIsAtBottom });
 
     const scrollIndicatorInsets = useMemo(() => {
       return {


### PR DESCRIPTION
Looks like this was showing on send since we scroll slightly as part of rendering the new message. The hook we're using interprets any non-zero scroll whatsoever as worthy of signaling "not at bottom".

This just updates that hook to use a configurable threshold instead (as implemented, uses height of the screen/viewport). As a side effect, this also prevents us from showing the go to bottom button unless you've scrolled back a little further in the chat which is probably preferable?


https://github.com/user-attachments/assets/ae2aca72-9b1b-437c-9065-fb31d1e2dd85


Fixes TLON-3205