### PR TITLE
nav: unset pressStyle on navicons

### DIFF
--- a/packages/ui/src/components/NavBar/NavIcon.tsx
+++ b/packages/ui/src/components/NavBar/NavIcon.tsx
@@ -15,7 +15,13 @@ export function AvatarNavIcon({
   onPress?: () => void;
 }) {
   return (
-    <Pressable flex={1} onPress={onPress} alignItems="center" paddingTop={'$s'}>
+    <Pressable
+      flex={1}
+      onPress={onPress}
+      alignItems="center"
+      paddingTop={'$s'}
+      pressStyle={{ backgroundColor: 'unset' }}
+    >
       <ContactAvatar
         size={'custom'}
         width={20}
@@ -51,6 +57,7 @@ export default function NavIcon({
       backgroundColor={backgroundColor}
       alignItems="center"
       flex={1}
+      pressStyle={{ backgroundColor: 'unset' }}
       onPress={onPress}
     >
       <Icon


### PR DESCRIPTION
afaict there is no difference in height here, the height is just more noticeable because we were using the default pressStyle of the Pressable component. This PR just removes the pressStyle.

fixes tlon-3202