### PR TITLE
fix load freeze

### DIFF
--- a/packages/app/hooks/useConfigureUrbitClient.ts
+++ b/packages/app/hooks/useConfigureUrbitClient.ts
@@ -42,9 +42,6 @@ const apiFetch: typeof fetch = (input, { ...init } = {}) => {
     // Avoid setting credentials method for same reason as above.
     credentials: undefined,
     signal: abortController.signal,
-    // @ts-expect-error This is used by the SSE polyfill to determine whether
-    // to stream the request.
-    reactNative: { textStreaming: true },
   };
   return platformFetch(input, newInit);
 };

--- a/packages/shared/src/http-api/Urbit.ts
+++ b/packages/shared/src/http-api/Urbit.ts
@@ -121,7 +121,6 @@ export class Urbit {
       accept: '*',
       headers,
       signal: this.abort.signal,
-      reactNative: { textStreaming: true },
     };
   }
 
@@ -302,6 +301,7 @@ export class Urbit {
       }
       fetchEventSource(this.channelUrl, {
         ...this.fetchOptions,
+        reactNative: { textStreaming: true },
         openWhenHidden: true,
         responseTimeout: 25000,
         fetch: this.fetchFn,


### PR DESCRIPTION
Text streaming requests perform much worse than normal ones in react native, which was causing freezes during loading of init data. This data modifies the urbit client so that only the `eventSource` request uses text streaming mode.

Fixes TLON-3201.