### PR TITLE
nav: add routes for DMs and GroupDMs

### DIFF
--- a/apps/tlon-mobile/src/hooks/useNotificationListener.ts
+++ b/apps/tlon-mobile/src/hooks/useNotificationListener.ts
@@ -4,7 +4,10 @@ import { useNavigation } from '@react-navigation/native';
 import { useFeatureFlag } from '@tloncorp/app/lib/featureFlags';
 import { connectNotifications } from '@tloncorp/app/lib/notifications';
 import { RootStackParamList } from '@tloncorp/app/navigation/types';
-import { createTypedReset } from '@tloncorp/app/navigation/utils';
+import {
+  createTypedReset,
+  screenNameFromChannelId,
+} from '@tloncorp/app/navigation/utils';
 import * as posthog from '@tloncorp/app/utils/posthog';
 import { syncDms, syncGroups } from '@tloncorp/shared';
 import { markChatRead } from '@tloncorp/shared/api';
@@ -157,8 +160,9 @@ export default function useNotificationListener() {
             params: { groupId: channel.groupId },
           });
         }
+        const screenName = screenNameFromChannelId(channelId);
         routeStack.push({
-          name: 'Channel',
+          name: screenName,
           params: { channelId: channel.id },
         });
 

--- a/packages/app/features/top/ActivityScreen.tsx
+++ b/packages/app/features/top/ActivityScreen.tsx
@@ -8,6 +8,7 @@ import { useCallback, useMemo } from 'react';
 // import ErrorBoundary from '../../ErrorBoundary';
 import { useCurrentUserId } from '../../hooks/useCurrentUser';
 import { RootStackParamList } from '../../navigation/types';
+import { screenNameFromChannelId } from '../../navigation/utils';
 
 type Props = NativeStackScreenProps<RootStackParamList, 'Activity'>;
 
@@ -32,7 +33,8 @@ export function ActivityScreen(props: Props) {
 
   const handleGoToChannel = useCallback(
     (channel: db.Channel, selectedPostId?: string) => {
-      props.navigation.navigate('Channel', {
+      const screenName = screenNameFromChannelId(channel.id);
+      props.navigation.navigate(screenName, {
         channelId: channel.id,
         selectedPostId,
       });

--- a/packages/app/features/top/ChannelScreen.tsx
+++ b/packages/app/features/top/ChannelScreen.tsx
@@ -305,7 +305,7 @@ export default function ChannelScreen(props: Props) {
       const dmChannel = await store.upsertDmChannel({
         participants,
       });
-      props.navigation.push('Channel', { channelId: dmChannel.id });
+      props.navigation.push('DM', { channelId: dmChannel.id });
     },
     [props.navigation]
   );

--- a/packages/app/features/top/ChatListScreen.tsx
+++ b/packages/app/features/top/ChatListScreen.tsx
@@ -29,6 +29,7 @@ import { useChatSettingsNavigation } from '../../hooks/useChatSettingsNavigation
 import { useCurrentUserId } from '../../hooks/useCurrentUser';
 import { useFeatureFlag } from '../../lib/featureFlags';
 import type { RootStackParamList } from '../../navigation/types';
+import { screenNameFromChannelId } from '../../navigation/utils';
 import { identifyTlonEmployee } from '../../utils/posthog';
 import { isSplashDismissed, setSplashDismissed } from '../../utils/splash';
 
@@ -165,7 +166,7 @@ export function ChatListScreenView({
         participants: [userId],
       });
       setAddGroupOpen(false);
-      navigation.navigate('Channel', { channelId: dmChannel.id });
+      navigation.navigate('DM', { channelId: dmChannel.id });
     },
     [navigation, setAddGroupOpen]
   );
@@ -190,7 +191,9 @@ export function ChatListScreenView({
       ) {
         navigation.navigate('GroupChannels', { groupId: item.group.id });
       } else {
-        navigation.navigate('Channel', {
+        const screenName = screenNameFromChannelId(item.id);
+
+        navigation.navigate(screenName, {
           channelId: item.id,
           selectedPostId: item.firstUnreadPostId,
         });

--- a/packages/app/features/top/PostScreen.tsx
+++ b/packages/app/features/top/PostScreen.tsx
@@ -127,7 +127,7 @@ export default function PostScreen(props: Props) {
       const dmChannel = await store.upsertDmChannel({
         participants,
       });
-      props.navigation.push('Channel', { channelId: dmChannel.id });
+      props.navigation.push('DM', { channelId: dmChannel.id });
     },
     [props.navigation]
   );

--- a/packages/app/navigation/RootStack.tsx
+++ b/packages/app/navigation/RootStack.tsx
@@ -77,6 +77,8 @@ export function RootStack() {
       />
       <Root.Screen name="CreateGroup" component={CreateGroupScreen} />
       <Root.Screen name="Channel" component={ChannelScreen} />
+      <Root.Screen name="DM" component={ChannelScreen} />
+      <Root.Screen name="GroupDM" component={ChannelScreen} />
       <Root.Screen name="ChannelSearch" component={ChannelSearchScreen} />
       <Root.Screen name="Post" component={PostScreen} />
       <Root.Screen name="GroupChannels" component={GroupChannelsScreen} />

--- a/packages/app/navigation/desktop/HomeNavigator.tsx
+++ b/packages/app/navigation/desktop/HomeNavigator.tsx
@@ -37,6 +37,8 @@ export const HomeNavigator = () => {
       <HomeDrawer.Screen name="ChatList" component={MainStack} />
       <HomeDrawer.Screen name="GroupChannels" component={Empty} />
       <HomeDrawer.Screen name="Channel" component={ChannelStack} />
+      <HomeDrawer.Screen name="DM" component={ChannelStack} />
+      <HomeDrawer.Screen name="GroupDM" component={ChannelStack} />
     </HomeDrawer.Navigator>
   );
 };

--- a/packages/app/navigation/linking.ts
+++ b/packages/app/navigation/linking.ts
@@ -14,6 +14,14 @@ export const getMobileLinkingConfig = (
       Root: {
         path: basePathForMode(mode),
         screens: {
+          DM: {
+            path: 'dm/:channelId/:selectedPostId?',
+            parse: parsePathParams('channelId', 'selectedPostId'),
+          },
+          GroupDM: {
+            path: 'group-dm/:channelId/:selectedPostId?',
+            parse: parsePathParams('contactId', 'selectedPostId'),
+          },
           Channel: {
             path: 'group/:groupId/channel/:channelId/:selectedPostId?',
             parse: parsePathParams('channelId', 'groupId', 'selectedPostId'),
@@ -84,6 +92,14 @@ export const getDesktopLinkingConfig = (
             screens: {
               ChatList: '',
               GroupChannels: 'group/:groupId',
+              DM: {
+                path: 'dm/:channelId/:selectedPostId?',
+                parse: parsePathParams('channelId', 'selectedPostId'),
+              },
+              GroupDM: {
+                path: 'group-dm/:channelId/:selectedPostId?',
+                parse: parsePathParams('channelId', 'selectedPostId'),
+              },
               Channel: {
                 initialRouteName: 'ChannelRoot',
                 path: 'group/:groupId/channel/:channelId',

--- a/packages/app/navigation/types.ts
+++ b/packages/app/navigation/types.ts
@@ -4,6 +4,16 @@ export type RootStackParamList = {
   ChatList: { previewGroupId: string } | undefined;
   Activity: undefined;
   Profile: undefined;
+  DM: {
+    channelId: string;
+    selectedPostId?: string | null;
+    startDraft?: boolean;
+  };
+  GroupDM: {
+    channelId: string;
+    selectedPostId?: string | null;
+    startDraft?: boolean;
+  };
   Channel: {
     channelId: string;
     groupId?: string;
@@ -56,7 +66,7 @@ export type RootDrawerParamList = {
 
 export type HomeDrawerParamList = Pick<
   RootStackParamList,
-  'ChatList' | 'GroupChannels' | 'Channel'
+  'ChatList' | 'GroupChannels' | 'Channel' | 'DM' | 'GroupDM'
 > & {
   MainContent: undefined;
 };

--- a/packages/app/navigation/utils.ts
+++ b/packages/app/navigation/utils.ts
@@ -3,6 +3,7 @@ import {
   NavigationProp,
   useNavigation,
 } from '@react-navigation/native';
+import * as logic from '@tloncorp/shared/logic';
 import * as store from '@tloncorp/shared/store';
 
 import { RootStackParamList } from './types';
@@ -49,10 +50,12 @@ export function useResetToChannel() {
       startDraft?: boolean;
     }
   ) {
+    const screenName = screenNameFromChannelId(channelId);
+
     reset([
       { name: 'ChatList' },
       {
-        name: 'Channel',
+        name: screenName,
         params: {
           channelId,
           ...options,
@@ -75,4 +78,12 @@ export function useResetToDm() {
       console.error('Error creating DM channel:', error);
     }
   };
+}
+
+export function screenNameFromChannelId(channelId: string) {
+  return logic.isDmChannelId(channelId)
+    ? 'DM'
+    : logic.isGroupChannelId(channelId)
+      ? 'GroupDM'
+      : 'Channel';
 }


### PR DESCRIPTION
fixes TLON-3168 by adding new Screens/routes (`DM` and `GroupDM`) that just point to `ChannelScreen`. Also adds a new helper function, `screenNameFromChannelId` to use in situations where we could navigate to any kind of channel (a normal `Channel`, a `DM`, or a `GroupDM`).

copilot description:
This pull request introduces changes to improve the navigation handling in the app, specifically by distinguishing between different types of channels (DM, GroupDM, and Channel) and updating the navigation logic accordingly. The most important changes include adding new screen names, updating navigation calls, and modifying the linking configuration.

### Navigation Updates:
* Added new screen names `DM` and `GroupDM` to `RootStack` and `HomeNavigator` components. [[1]](diffhunk://#diff-2d017028089577e606a614cca1c2addfe51b6fa580c8a6d22c6ffa229e0e5055R80-R81) [[2]](diffhunk://#diff-cedcba9547d19c0082bc35cd4e8cd97306b93b70ce5d9e413155f810f004fbafR40-R41)
* Updated navigation calls to use `screenNameFromChannelId` function to dynamically determine the screen name based on the channel type. [[1]](diffhunk://#diff-c75cc8909477a57805d0ab8e6cd12c62507a27cb7419f29cac92a5a37b5bbf08R163-R165) [[2]](diffhunk://#diff-2c1e8f7975716ceac5b26273398a0315826932b7ce53dd5c1ccbcd09a7829b7eL35-R37) [[3]](diffhunk://#diff-c2a64e57fa2c6bd13aaeac04ef2142ee7cd65693de41fce561cd020a5f60050cL193-R196)

### Linking Configuration:
* Modified mobile and desktop linking configurations to include paths for `DM` and `GroupDM` screens. [[1]](diffhunk://#diff-7017c1998a79e849c843cb63021d0346e473b10b98afa3066c6604496eff8421R17-R24) [[2]](diffhunk://#diff-7017c1998a79e849c843cb63021d0346e473b10b98afa3066c6604496eff8421R95-R102)

### Type Definitions:
* Updated `RootStackParamList` and `RootDrawerParamList` to include new screen names and their parameters. [[1]](diffhunk://#diff-23d8fd1a0ba7fe7208cf9d84c6a908944a33f207636c5af48d75a3fd2a85c50cR7-R16) [[2]](diffhunk://#diff-23d8fd1a0ba7fe7208cf9d84c6a908944a33f207636c5af48d75a3fd2a85c50cL59-R69)

### Utility Functions:
* Added `screenNameFromChannelId` function in `navigation/utils.ts` to determine the screen name based on the channel ID.