### PR TITLE
lure backend: keep local enabled set in sync with what we hear remotely

### DIFF
--- a/desk/app/grouper.hoon
+++ b/desk/app/grouper.hoon
@@ -58,8 +58,10 @@
   ::
       %grouper-answer-enabled
     =/  [name=cord enabled=?]  !<([cord ?] vase)
-    :_  this
-    ~[[%give %fact ~[[%group-enabled (scot %p src.bowl) name ~]] %json !>(b+enabled)]]
+    :-  ~[[%give %fact ~[[%group-enabled (scot %p src.bowl) name ~]] %json !>(b+enabled)]]
+    ?:  enabled
+      this(enabled-groups (~(put in enabled-groups) name))
+    this(enabled-groups (~(del in enabled-groups) name))
   ::
       %grouper-check-link
     =+  !<(=(pole knot) vase)


### PR DESCRIPTION
There was a bug with how we were tracking Lure enabled status for remote groups in `%grouper`. Before allowing a Lure to be created, the client app performs a check to see if Lure's are enabled for that group. If you're not the group host, the backend would query that from the host and pass it along to the client. If set, the client can create the Lure. 

However we weren't updating `%grouper`'s local view of which Lures are enabled, meaning when the Lure is actually claimed it will fail a check against its list of enabled groups. This small change just tweaks the logic so that when we hear about the enabled status of remote groups, we propagate that info to our local store. 

Tested by creating a secret group on Ship A, joining it from Ship B, and running through a signup with an invite link from Ship B to confirm the group is successfully joined.