### PR TITLE
desktop: fix profile screen navigation, leave chat button

### DIFF
--- a/packages/app/features/settings/AppInfoScreen.tsx
+++ b/packages/app/features/settings/AppInfoScreen.tsx
@@ -101,7 +101,7 @@ export function AppInfoScreen(props: Props) {
   }, [hasClients]);
 
   return (
-    <View flex={1}>
+    <View flex={1} backgroundColor="$background">
       <ScreenHeader
         title="App info"
         backAction={() => props.navigation.goBack()}

--- a/packages/app/features/settings/BlockedUsersScreen.tsx
+++ b/packages/app/features/settings/BlockedUsersScreen.tsx
@@ -36,7 +36,7 @@ export function BlockedUsersScreen(props: Props) {
   );
 
   return (
-    <View flex={1}>
+    <View flex={1} backgroundColor="$background">
       <ScreenHeader
         backAction={() => props.navigation.goBack()}
         title="Blocked users"

--- a/packages/app/features/settings/ManageAccountScreen.tsx
+++ b/packages/app/features/settings/ManageAccountScreen.tsx
@@ -6,13 +6,13 @@ import {
   YStack,
   isWeb,
 } from '@tloncorp/ui';
-import { useResetDb } from '../../hooks/useResetDb';
-import { useWebView } from '../../hooks/useWebview';
 import { useCallback, useEffect, useState } from 'react';
 import { Alert } from 'react-native';
 import { WebView } from 'react-native-webview';
 
 import { useHandleLogout } from '../../hooks/useHandleLogout';
+import { useResetDb } from '../../hooks/useResetDb';
+import { useWebView } from '../../hooks/useWebview';
 import { checkIfAccountDeleted } from '../../lib/hostingApi';
 import { RootStackParamList } from '../../navigation/types';
 import { getHostingToken, getHostingUserId } from '../../utils/hosting';
@@ -89,7 +89,7 @@ export function ManageAccountScreen(props: Props) {
   }, [hostingSession?.isExpired, handleLogout, props.navigation]);
 
   return (
-    <View flex={1}>
+    <View flex={1} backgroundColor="$background">
       <ScreenHeader
         leftControls={
           goingBack ? (

--- a/packages/app/features/settings/PushNotificationSettingsScreen.tsx
+++ b/packages/app/features/settings/PushNotificationSettingsScreen.tsx
@@ -8,6 +8,7 @@ import {
   GroupListItem,
   Icon,
   ListItem,
+  Pressable,
   ScreenHeader,
   ScrollView,
   SizableText,
@@ -79,7 +80,7 @@ export function PushNotificationSettingsScreen({ navigation }: Props) {
   );
 
   return (
-    <View flex={1}>
+    <View flex={1} backgroundColor="$background">
       <ScreenHeader
         title="Push Notifications"
         backAction={() => navigation.goBack()}
@@ -90,30 +91,36 @@ export function PushNotificationSettingsScreen({ navigation }: Props) {
         </SizableText>
 
         <YStack marginLeft="$m" marginTop="$3xl">
-          <XStack onPress={() => setLevel('medium')}>
-            <LevelIndicator levels={['loud', 'medium']} />
-            <SizableText marginLeft="$l">All group activity</SizableText>
-          </XStack>
+          <Pressable onPress={() => setLevel('medium')}>
+            <XStack>
+              <LevelIndicator levels={['loud', 'medium']} />
+              <SizableText marginLeft="$l">All group activity</SizableText>
+            </XStack>
+          </Pressable>
 
-          <XStack marginTop="$xl" onPress={() => setLevel('soft')}>
-            <LevelIndicator levels={['soft', 'default']} />
-            <YStack marginLeft="$l">
-              <SizableText>Mentions and replies only</SizableText>
-              <SizableText
-                width="80%"
-                marginTop="$m"
-                size="$s"
-                color="$secondaryText"
-              >
-                Direct messages will still notify unless you mute them.
-              </SizableText>
-            </YStack>
-          </XStack>
+          <Pressable marginTop="$xl" onPress={() => setLevel('soft')}>
+            <XStack>
+              <LevelIndicator levels={['soft', 'default']} />
+              <YStack marginLeft="$l">
+                <SizableText>Mentions and replies only</SizableText>
+                <SizableText
+                  width="80%"
+                  marginTop="$m"
+                  size="$s"
+                  color="$secondaryText"
+                >
+                  Direct messages will still notify unless you mute them.
+                </SizableText>
+              </YStack>
+            </XStack>
+          </Pressable>
 
-          <XStack marginTop="$xl" onPress={() => setLevel('hush')}>
-            <LevelIndicator levels={['hush']} />
-            <SizableText marginLeft="$l">Nothing</SizableText>
-          </XStack>
+          <Pressable marginTop="$xl" onPress={() => setLevel('hush')}>
+            <XStack>
+              <LevelIndicator levels={['hush']} />
+              <SizableText marginLeft="$l">Nothing</SizableText>
+            </XStack>
+          </Pressable>
         </YStack>
 
         {numExceptions > 0 ? (

--- a/packages/app/features/settings/UserBugReportScreen.tsx
+++ b/packages/app/features/settings/UserBugReportScreen.tsx
@@ -7,7 +7,7 @@ import {
   FormText,
   ScreenHeader,
   ScrollView,
-  YStack,
+  View,
 } from '@tloncorp/ui';
 import { useCallback } from 'react';
 import { useForm } from 'react-hook-form';
@@ -43,7 +43,7 @@ export function UserBugReportScreen({ navigation }: Props) {
   );
 
   return (
-    <>
+    <View backgroundColor="$background">
       <ScreenHeader
         title="Report a bug"
         backAction={() => navigation.goBack()}
@@ -81,6 +81,6 @@ export function UserBugReportScreen({ navigation }: Props) {
           </FormFrame>
         </ScrollView>
       </KeyboardAvoidingView>
-    </>
+    </View>
   );
 }

--- a/packages/app/navigation/desktop/ProfileScreenNavigator.tsx
+++ b/packages/app/navigation/desktop/ProfileScreenNavigator.tsx
@@ -1,0 +1,53 @@
+import { createNativeStackNavigator } from '@react-navigation/native-stack';
+
+import { AppInfoScreen } from '../../features/settings/AppInfoScreen';
+import { BlockedUsersScreen } from '../../features/settings/BlockedUsersScreen';
+import { FeatureFlagScreen } from '../../features/settings/FeatureFlagScreen';
+import { ManageAccountScreen } from '../../features/settings/ManageAccountScreen';
+import ProfileScreen from '../../features/settings/ProfileScreen';
+import { PushNotificationSettingsScreen } from '../../features/settings/PushNotificationSettingsScreen';
+import { UserBugReportScreen } from '../../features/settings/UserBugReportScreen';
+import { UserProfileScreen } from '../../features/top/UserProfileScreen';
+
+const ProfileScreenStack = createNativeStackNavigator();
+
+export const ProfileScreenNavigator = () => {
+  return (
+    <ProfileScreenStack.Navigator
+      initialRouteName="ProfileScreen"
+      screenOptions={{
+        headerShown: false,
+      }}
+    >
+      <ProfileScreenStack.Screen
+        name="ProfileScreen"
+        component={ProfileScreen}
+      />
+      <ProfileScreenStack.Screen name="AppInfo" component={AppInfoScreen} />
+      <ProfileScreenStack.Screen
+        name="PushNotificationSettings"
+        component={PushNotificationSettingsScreen}
+      />
+      <ProfileScreenStack.Screen
+        name="BlockedUsers"
+        component={BlockedUsersScreen}
+      />
+      <ProfileScreenStack.Screen
+        name="ManageAccount"
+        component={ManageAccountScreen}
+      />
+      <ProfileScreenStack.Screen
+        name="FeatureFlags"
+        component={FeatureFlagScreen}
+      />
+      <ProfileScreenStack.Screen
+        name="WompWomp"
+        component={UserBugReportScreen}
+      />
+      <ProfileScreenStack.Screen
+        name="UserProfile"
+        component={UserProfileScreen}
+      />
+    </ProfileScreenStack.Navigator>
+  );
+};

--- a/packages/app/navigation/desktop/TopLevelDrawer.tsx
+++ b/packages/app/navigation/desktop/TopLevelDrawer.tsx
@@ -5,11 +5,11 @@ import {
 import * as store from '@tloncorp/shared/store';
 import { AvatarNavIcon, NavIcon, YStack, useWebAppUpdate } from '@tloncorp/ui';
 
-import ProfileScreen from '../../features/settings/ProfileScreen';
 import { ActivityScreen } from '../../features/top/ActivityScreen';
 import { useCurrentUserId } from '../../hooks/useCurrentUser';
 import { RootDrawerParamList } from '../types';
 import { HomeNavigator } from './HomeNavigator';
+import { ProfileScreenNavigator } from './ProfileScreenNavigator';
 
 const Drawer = createDrawerNavigator<RootDrawerParamList>();
 
@@ -77,7 +77,7 @@ export const TopLevelDrawer = () => {
     >
       <Drawer.Screen name="Home" component={HomeNavigator} />
       <Drawer.Screen name="Activity" component={ActivityScreen} />
-      <Drawer.Screen name="Profile" component={ProfileScreen} />
+      <Drawer.Screen name="Profile" component={ProfileScreenNavigator} />
     </Drawer.Navigator>
   );
 };

--- a/packages/ui/src/components/ChatOptionsSheet.tsx
+++ b/packages/ui/src/components/ChatOptionsSheet.tsx
@@ -12,6 +12,7 @@ import React, {
   useState,
 } from 'react';
 import { Alert } from 'react-native';
+import { isWeb } from 'tamagui';
 
 import { ChevronLeft } from '../assets/icons';
 import { useChatOptions, useCurrentUserId } from '../contexts';
@@ -738,35 +739,47 @@ export function ChannelOptions({
                     if (!channel) {
                       return;
                     }
-                    Alert.alert(
-                      `Leave ${title}?`,
-                      'This will be removed from the list',
-                      [
-                        {
-                          text: 'Cancel',
-                          onPress: () => console.log('Cancel Pressed'),
-                          style: 'cancel',
-                        },
-                        {
-                          text: 'Leave',
-                          style: 'destructive',
-                          onPress: () => {
-                            onOpenChange(false);
-                            if (
-                              channel.type === 'dm' ||
-                              channel.type === 'groupDm'
-                            ) {
-                              store.respondToDMInvite({
-                                channel,
-                                accept: false,
-                              });
-                            } else {
-                              store.leaveGroupChannel(channel.id);
-                            }
+                    if (!isWeb) {
+                      Alert.alert(
+                        `Leave ${title}?`,
+                        'This will be removed from the list',
+                        [
+                          {
+                            text: 'Cancel',
+                            onPress: () => console.log('Cancel Pressed'),
+                            style: 'cancel',
                           },
-                        },
-                      ]
-                    );
+                          {
+                            text: 'Leave',
+                            style: 'destructive',
+                            onPress: () => {
+                              onOpenChange(false);
+                              if (
+                                channel.type === 'dm' ||
+                                channel.type === 'groupDm'
+                              ) {
+                                store.respondToDMInvite({
+                                  channel,
+                                  accept: false,
+                                });
+                              } else {
+                                store.leaveGroupChannel(channel.id);
+                              }
+                            },
+                          },
+                        ]
+                      );
+                      return;
+                    }
+                    onOpenChange(false);
+                    if (channel.type === 'dm' || channel.type === 'groupDm') {
+                      store.respondToDMInvite({
+                        channel,
+                        accept: false,
+                      });
+                    } else {
+                      store.leaveGroupChannel(channel.id);
+                    }
                   },
                 },
               ],

--- a/packages/ui/src/components/FeatureFlagScreenView.tsx
+++ b/packages/ui/src/components/FeatureFlagScreenView.tsx
@@ -14,10 +14,9 @@ export function FeatureFlagScreenView({
   onFlagToggled: (flagName: string, enabled: boolean) => void;
 }) {
   const insets = useSafeAreaInsets();
-  console.log('render', features);
 
   return (
-    <View flex={1}>
+    <View flex={1} backgroundColor="$background">
       <ScreenHeader title={'Feature Previews'} backAction={onBackPressed} />
       <ScrollView
         contentContainerStyle={{


### PR DESCRIPTION
fixes TLON-3224

Adds a new stack navigator for the profile screen on desktop, fixes the "Leave" button on channels (which used the react-native `Alert` dialog, which doesn't work on web).