### PR TITLE
BlockRenderer: avoid setting aspect ratio if unset

### DIFF
--- a/packages/ui/src/components/PostContent/BlockRenderer.tsx
+++ b/packages/ui/src/components/PostContent/BlockRenderer.tsx
@@ -244,6 +244,8 @@ export function ImageBlock({
     });
   }, []);
 
+  const shouldUseAspectRatio = imageProps?.aspectRatio !== 'unset';
+
   return (
     <Pressable
       borderRadius="$s"
@@ -257,7 +259,9 @@ export function ImageBlock({
           uri: block.src,
         }}
         style={{
-          aspectRatio: dimensions.aspect || undefined,
+          ...(shouldUseAspectRatio
+            ? { aspectRatio: dimensions.aspect || undefined }
+            : {}),
         }}
         alt={block.alt}
         onLoad={handleImageLoaded}


### PR DESCRIPTION
Fixes a regression introduced in #4160 where Gallery blocks (in 2-column grid format) had their aspect ratio explicitly set and were not square-cropped as before.

This looks to the 'unset' aspect set in SmallContentRenderer (which is used in Gallery blocks) and passed down through props. If the aspect ratio is explicitly unset, we set nothing in the style prop for `Pressable`.

Proof: 
<img width="508" alt="Screenshot 2024-11-14 at 6 06 45 PM" src="https://github.com/user-attachments/assets/e52ba7f2-07fd-40ac-9a37-3ed0ebbc7711">
