### PR TITLE
ChatOptionsSheet: mark group/channel/DM/groupDM as read

### DIFF
--- a/packages/ui/src/components/ChatOptionsSheet.tsx
+++ b/packages/ui/src/components/ChatOptionsSheet.tsx
@@ -599,6 +599,12 @@ export function ChannelOptions({
     [currentVolumeLevel, handleVolumeUpdate]
   );
 
+  const handleMarkRead = useCallback(() => {
+    if (channel && !channel.isPendingChannel) {
+      store.markChannelRead(channel);
+    }
+  }, [channel]);
+
   const actionGroups: ActionGroup[] = useMemo(() => {
     return [
       {
@@ -629,6 +635,21 @@ export function ChannelOptions({
           },
         ],
       },
+      ...((channel.unread?.count ?? 0) > 0
+        ? [
+            {
+              accent: 'neutral',
+              actions: [
+                {
+                  title: 'Mark as read',
+                  action: () => {
+                    handleMarkRead(), onOpenChange(false);
+                  },
+                },
+              ],
+            } as ActionGroup,
+          ]
+        : []),
       ...(channel.type === 'groupDm'
         ? [
             {
@@ -793,12 +814,13 @@ export function ChannelOptions({
     group,
     currentUserIsHost,
     setPane,
+    handleMarkRead,
+    onOpenChange,
     onPressChannelMeta,
     onPressChannelMembers,
     onPressManageChannels,
     onPressInvite,
     title,
-    onOpenChange,
   ]);
 
   const displayTitle = useMemo((): string => {

--- a/packages/ui/src/components/ChatOptionsSheet.tsx
+++ b/packages/ui/src/components/ChatOptionsSheet.tsx
@@ -1,4 +1,3 @@
-import { useQuery } from '@tanstack/react-query';
 import { sync } from '@tloncorp/shared';
 import * as db from '@tloncorp/shared/db';
 import * as logic from '@tloncorp/shared/logic';
@@ -134,10 +133,6 @@ export function GroupOptions({
 }) {
   const currentUser = useCurrentUserId();
   const { data: currentVolumeLevel } = store.useGroupVolumeLevel(group.id);
-  const { data: groupUnread } = useQuery({
-    queryKey: ['groupUnread', group.id],
-    queryFn: async () => db.getGroupUnread({ groupId: group.id }),
-  });
 
   const {
     onPressGroupMembers,
@@ -258,21 +253,6 @@ export function GroupOptions({
     onOpenChange,
   ]);
 
-  const handleMarkAllRead = useCallback(async () => {
-    if (!group) return;
-    onOpenChange(false);
-    if (group.channels) {
-      await Promise.all(
-        group.channels.map(async (channel) => {
-          if (!channel.isPendingChannel) {
-            await store.markChannelRead(channel);
-          }
-        })
-      );
-    }
-    await store.markGroupRead(group);
-  }, [group, onOpenChange]);
-
   const actionGroups = useMemo(() => {
     const groupRef = logic.getGroupReferencePath(group.id);
 
@@ -292,16 +272,6 @@ export function GroupOptions({
             endIcon: 'Pin',
             action: onTogglePinned,
           },
-          ...(groupUnread?.count
-            ? [
-                {
-                  title: 'Mark all as read',
-                  action: () => {
-                    handleMarkAllRead();
-                  },
-                },
-              ]
-            : []),
           {
             title: 'Copy group reference',
             description: groupRef,


### PR DESCRIPTION
Adds a "mark as read" option to the channel actions menu, which handles whole groups, channels, DMs, and group-DMs. 

Video:

https://github.com/user-attachments/assets/e1f8b81c-137c-4ddc-92a2-684bc69f037d


Fixes TLON-2720