### PR TITLE
native: admin note edit + note edit button

### DIFF
--- a/packages/shared/src/store/dbHooks.ts
+++ b/packages/shared/src/store/dbHooks.ts
@@ -357,7 +357,10 @@ export const useGroupByChannel = (channelId: string) => {
 
 export const useMemberRoles = (chatId: string, userId: string) => {
   const { data: chatMember } = useQuery({
-    queryKey: ['memberRoles', chatId, userId],
+    queryKey: [
+      ['memberRoles', chatId, userId],
+      useKeyFromQueryDeps(db.getChatMember),
+    ],
     queryFn: () => db.getChatMember({ chatId, contactId: userId }),
   });
 

--- a/packages/ui/src/components/Channel/ChannelHeader.tsx
+++ b/packages/ui/src/components/Channel/ChannelHeader.tsx
@@ -79,9 +79,11 @@ export function ChannelHeader({
   group,
   goBack,
   goToSearch,
+  goToEdit,
   showSpinner,
   showSearchButton = true,
   showMenuButton = false,
+  showEditButton = false,
 }: {
   title: string;
   mode?: 'default' | 'next';
@@ -89,9 +91,11 @@ export function ChannelHeader({
   group?: db.Group | null;
   goBack?: () => void;
   goToSearch?: () => void;
+  goToEdit?: () => void;
   showSpinner?: boolean;
   showSearchButton?: boolean;
   showMenuButton?: boolean;
+  showEditButton?: boolean;
   post?: db.Post;
 }) {
   const chatOptionsSheetRef = useRef<ChatOptionsSheetMethods>(null);
@@ -137,6 +141,11 @@ export function ChannelHeader({
                 type="Overflow"
                 onPress={handlePressOverflowMenu}
               />
+            )}
+            {showEditButton && (
+              <ScreenHeader.TextButton onPress={goToEdit}>
+                Edit
+              </ScreenHeader.TextButton>
             )}
           </>
         }

--- a/packages/ui/src/components/ChatMessage/ChatMessageActions/MessageActions.tsx
+++ b/packages/ui/src/components/ChatMessage/ChatMessageActions/MessageActions.tsx
@@ -88,8 +88,11 @@ function ConnectedAction({
         // 3. an existing thread for that message doesn't already exist
         return !post.deliveryStatus && !post.parentId && post.replyCount === 0;
       case 'edit':
-        // only show edit for current user's posts
-        return post.authorId === currentUserId;
+        // only show edit for current user's posts OR admins of notebook posts
+        return (
+          post.authorId === currentUserId ||
+          (channel.type === 'notebook' && currentUserIsAdmin)
+        );
       case 'delete':
         // only show delete for current user's posts
         return post.authorId === currentUserId || currentUserIsAdmin;
@@ -98,7 +101,17 @@ function ConnectedAction({
       default:
         return true;
     }
-  }, [post, actionId, currentUserId, currentUserIsAdmin]);
+  }, [
+    actionId,
+    post.deliveryStatus,
+    post.parentId,
+    post.replyCount,
+    post.authorId,
+    post.reactions?.length,
+    currentUserId,
+    channel.type,
+    currentUserIsAdmin,
+  ]);
 
   if (!visible) {
     return null;


### PR DESCRIPTION
We were locking the edit action to only post authors. Sounds like we make a special case for admins of notebook posts, so this just updates the logic to account for that.

Also fixes the member roles query to live update as roles do and adds an _Edit_ button to the _Notebook_ post view.

Fixes TLON-3233