### PR TITLE
channel manager: prevent deleting last channel in group

### DIFF
--- a/packages/app/features/groups/EditChannelScreen.tsx
+++ b/packages/app/features/groups/EditChannelScreen.tsx
@@ -21,9 +21,9 @@ export function EditChannelScreen(props: Props) {
     const prevChannel = data;
     if (prevChannel) {
       deleteChannel(prevChannel.id);
-      props.navigation.goBack();
+      props.navigation.navigate('ManageChannels', { groupId });
     }
-  }, [data, deleteChannel, props.navigation]);
+  }, [data, deleteChannel, props.navigation, groupId]);
 
   const handleSubmit = useCallback(
     (title: string, description?: string) => {

--- a/packages/app/features/groups/ManageChannelsScreen.tsx
+++ b/packages/app/features/groups/ManageChannelsScreen.tsx
@@ -25,7 +25,9 @@ export function ManageChannelsScreen(props: Props) {
 
   return (
     <ManageChannelsScreenView
-      goBack={() => props.navigation.goBack()}
+      goBack={() =>
+        props.navigation.getParent()?.navigate('GroupChannels', { groupId })
+      }
       goToEditChannel={(channelId) => {
         props.navigation.navigate('EditChannel', { groupId, channelId });
       }}

--- a/packages/app/features/top/GroupChannelsScreen.tsx
+++ b/packages/app/features/top/GroupChannelsScreen.tsx
@@ -55,7 +55,7 @@ export function GroupChannelsScreenContent({
   );
 
   const handleGoBackPressed = useCallback(() => {
-    navigation.goBack();
+    navigation.navigate('ChatList');
   }, [navigation]);
 
   const [enableCustomChannels] = useFeatureFlag('customChannelCreation');

--- a/packages/ui/src/components/ChatOptionsSheet.tsx
+++ b/packages/ui/src/components/ChatOptionsSheet.tsx
@@ -599,6 +599,12 @@ export function ChannelOptions({
     [currentVolumeLevel, handleVolumeUpdate]
   );
 
+  const handleMarkRead = useCallback(() => {
+    if (channel && !channel.isPendingChannel) {
+      store.markChannelRead(channel);
+    }
+  }, [channel]);
+
   const actionGroups: ActionGroup[] = useMemo(() => {
     return [
       {
@@ -629,6 +635,21 @@ export function ChannelOptions({
           },
         ],
       },
+      ...((channel.unread?.count ?? 0) > 0
+        ? [
+            {
+              accent: 'neutral',
+              actions: [
+                {
+                  title: 'Mark as read',
+                  action: () => {
+                    handleMarkRead(), onOpenChange(false);
+                  },
+                },
+              ],
+            } as ActionGroup,
+          ]
+        : []),
       ...(channel.type === 'groupDm'
         ? [
             {
@@ -793,12 +814,13 @@ export function ChannelOptions({
     group,
     currentUserIsHost,
     setPane,
+    handleMarkRead,
+    onOpenChange,
     onPressChannelMeta,
     onPressChannelMembers,
     onPressManageChannels,
     onPressInvite,
     title,
-    onOpenChange,
   ]);
 
   const displayTitle = useMemo((): string => {

--- a/packages/ui/src/components/ChatOptionsSheet.tsx
+++ b/packages/ui/src/components/ChatOptionsSheet.tsx
@@ -599,12 +599,6 @@ export function ChannelOptions({
     [currentVolumeLevel, handleVolumeUpdate]
   );
 
-  const handleMarkRead = useCallback(() => {
-    if (channel && !channel.isPendingChannel) {
-      store.markChannelRead(channel);
-    }
-  }, [channel]);
-
   const actionGroups: ActionGroup[] = useMemo(() => {
     return [
       {
@@ -635,21 +629,6 @@ export function ChannelOptions({
           },
         ],
       },
-      ...((channel.unread?.count ?? 0) > 0
-        ? [
-            {
-              accent: 'neutral',
-              actions: [
-                {
-                  title: 'Mark as read',
-                  action: () => {
-                    handleMarkRead(), onOpenChange(false);
-                  },
-                },
-              ],
-            } as ActionGroup,
-          ]
-        : []),
       ...(channel.type === 'groupDm'
         ? [
             {
@@ -814,13 +793,12 @@ export function ChannelOptions({
     group,
     currentUserIsHost,
     setPane,
-    handleMarkRead,
-    onOpenChange,
     onPressChannelMeta,
     onPressChannelMembers,
     onPressManageChannels,
     onPressInvite,
     title,
+    onOpenChange,
   ]);
 
   const displayTitle = useMemo((): string => {

--- a/packages/ui/src/components/ChatOptionsSheet.tsx
+++ b/packages/ui/src/components/ChatOptionsSheet.tsx
@@ -1,4 +1,3 @@
-import { useQuery } from '@tanstack/react-query';
 import { sync } from '@tloncorp/shared';
 import * as db from '@tloncorp/shared/db';
 import * as logic from '@tloncorp/shared/logic';
@@ -134,10 +133,6 @@ export function GroupOptions({
 }) {
   const currentUser = useCurrentUserId();
   const { data: currentVolumeLevel } = store.useGroupVolumeLevel(group.id);
-  const { data: groupUnread } = useQuery({
-    queryKey: ['groupUnread', group.id],
-    queryFn: async () => db.getGroupUnread({ groupId: group.id }),
-  });
 
   const {
     onPressGroupMembers,
@@ -258,21 +253,6 @@ export function GroupOptions({
     onOpenChange,
   ]);
 
-  const handleMarkAllRead = useCallback(async () => {
-    if (!group) return;
-    onOpenChange(false);
-    if (group.channels) {
-      await Promise.all(
-        group.channels.map(async (channel) => {
-          if (!channel.isPendingChannel) {
-            await store.markChannelRead(channel);
-          }
-        })
-      );
-    }
-    await store.markGroupRead(group);
-  }, [group, onOpenChange]);
-
   const actionGroups = useMemo(() => {
     const groupRef = logic.getGroupReferencePath(group.id);
 
@@ -292,16 +272,6 @@ export function GroupOptions({
             endIcon: 'Pin',
             action: onTogglePinned,
           },
-          ...(groupUnread?.count
-            ? [
-                {
-                  title: 'Mark all as read',
-                  action: () => {
-                    handleMarkAllRead();
-                  },
-                },
-              ]
-            : []),
           {
             title: 'Copy group reference',
             description: groupRef,

--- a/packages/ui/src/components/ManageChannels/EditChannelScreenView.tsx
+++ b/packages/ui/src/components/ManageChannels/EditChannelScreenView.tsx
@@ -1,6 +1,8 @@
 import * as db from '@tloncorp/shared/db';
+import * as store from '@tloncorp/shared/store';
 import { useCallback, useEffect, useState } from 'react';
 import { useForm } from 'react-hook-form';
+import { Alert } from 'react-native';
 import { View, YStack } from 'tamagui';
 
 import { Button } from '../Button';
@@ -36,14 +38,9 @@ export function EditChannelScreenView({
     },
   });
 
-  useEffect(() => {
-    if (channel) {
-      reset({
-        title: channel.title,
-        description: channel.description,
-      });
-    }
-  }, [channel, reset]);
+  const { data: group } = store.useGroup({
+    id: channel?.groupId ?? '',
+  });
 
   const handleSave = useCallback(
     (data: {
@@ -57,6 +54,28 @@ export function EditChannelScreenView({
     },
     [onSubmit]
   );
+
+  const handlePressDelete = useCallback(() => {
+    const channelCount = group?.channels?.length ?? 0;
+    if (channelCount <= 1) {
+      Alert.alert(
+        'Cannot Delete Channel',
+        'A group must have at least one channel. Create another channel before deleting this one.',
+        [{ text: 'OK' }]
+      );
+      return;
+    }
+    setShowDeleteSheet(true);
+  }, [group?.channels?.length]);
+
+  useEffect(() => {
+    if (channel) {
+      reset({
+        title: channel.title,
+        description: channel.description,
+      });
+    }
+  }, [channel, reset]);
 
   return (
     <View backgroundColor="$background" flex={1}>
@@ -99,7 +118,7 @@ export function EditChannelScreenView({
           <Button hero onPress={handleSubmit(handleSave)}>
             <Button.Text>Save</Button.Text>
           </Button>
-          <Button heroDestructive onPress={() => setShowDeleteSheet(true)}>
+          <Button heroDestructive onPress={handlePressDelete}>
             <Button.Text>Delete channel for everyone</Button.Text>
           </Button>
           <DeleteSheet


### PR DESCRIPTION
Does what it says on the tin; fixes TLON-3134, which is a bit of an edge-case.

If the user tries to delete the last channel in a group, we pop a warning and tell them to create another channel (or delete the entire group).

This is a particularly interesting bug—it was possible to enter the channel manager _from_ a channel, delete that channel, then .goBack() your way out of it only to be dumped into a channel that doesn't exist (and therefore get a blank screen). 

To complicate matters, you get to the channel manager from ChatOptionsSheet, which is either (A) in the channel itself via the "..." menu, or (B) from GroupChannelsScreen via the "..." menu, or (C) from long-pressing the group on the ChatList screen.

I brute-forced this and just made all the back-navigation explicit for these screens. It would be nice to rely on the native stack order but, as illustrated above, we have multiple ways into the same screen and I think it's better to be much more explicit.

From the channel:

https://github.com/user-attachments/assets/2d4e03ba-0a19-429a-b61a-6b5ba737a231


From long-press on ChatList:

https://github.com/user-attachments/assets/68b1c6c8-b0c2-49ce-b19e-e5d1ec22c284
