### PR TITLE
ChatOptionsSheet: mark group as read

### DIFF
--- a/packages/app/features/top/ChatListScreen.tsx
+++ b/packages/app/features/top/ChatListScreen.tsx
@@ -208,7 +208,11 @@ export function ChatListScreenView({
       if (item.pin?.type === 'channel' || !item.group) {
         chatOptionsSheetRef.current?.open(item.id, item.type);
       } else {
-        chatOptionsSheetRef.current?.open(item.group.id, 'group');
+        chatOptionsSheetRef.current?.open(
+          item.group.id,
+          'group',
+          item.group.unread?.count ?? undefined
+        );
       }
     }
   }, []);

--- a/packages/shared/src/api/activityApi.ts
+++ b/packages/shared/src/api/activityApi.ts
@@ -499,10 +499,10 @@ export function activityAction(action: ub.ActivityAction) {
   };
 }
 
-export const readGroup = async (group: db.Group) => {
+export const readGroup = async (group: db.Group, deep: boolean = false) => {
   const source: ub.Source = { group: group.id };
   const action = activityAction({
-    read: { source, action: { all: { time: null, deep: false } } },
+    read: { source, action: { all: { time: null, deep } } },
   });
   logger.log(`reading group ${group.id}`, action);
 

--- a/packages/shared/src/store/groupActions.ts
+++ b/packages/shared/src/store/groupActions.ts
@@ -984,7 +984,7 @@ export async function leaveGroup(groupId: string) {
   }
 }
 
-export async function markGroupRead(group: db.Group) {
+export async function markGroupRead(group: db.Group, deep: boolean = false) {
   // optimistic update
   const existingUnread = await db.getGroupUnread({ groupId: group.id });
   if (existingUnread) {
@@ -992,7 +992,7 @@ export async function markGroupRead(group: db.Group) {
   }
 
   try {
-    await api.readGroup(group);
+    await api.readGroup(group, deep);
   } catch (e) {
     console.error('Failed to read group', e);
     // rollback optimistic update

--- a/packages/ui/src/components/ChatOptionsSheet.tsx
+++ b/packages/ui/src/components/ChatOptionsSheet.tsx
@@ -1,3 +1,4 @@
+import { useQuery } from '@tanstack/react-query';
 import { sync } from '@tloncorp/shared';
 import * as db from '@tloncorp/shared/db';
 import * as logic from '@tloncorp/shared/logic';
@@ -253,6 +254,17 @@ export function GroupOptions({
     onOpenChange,
   ]);
 
+  const { data: groupUnread } = useQuery({
+    queryKey: ['groupUnread', group.id],
+
+    queryFn: async () => db.getGroupUnread({ groupId: group.id }),
+  });
+
+  const handleMarkAllRead = useCallback(() => {
+    store.markGroupRead(group, true);
+    onOpenChange(false);
+  }, [group, onOpenChange]);
+
   const actionGroups = useMemo(() => {
     const groupRef = logic.getGroupReferencePath(group.id);
 
@@ -267,6 +279,16 @@ export function GroupOptions({
             },
             endIcon: 'ChevronRight',
           },
+          ...(groupUnread?.count
+            ? [
+                {
+                  title: 'Mark all as read',
+                  action: () => {
+                    handleMarkAllRead();
+                  },
+                },
+              ]
+            : []),
           {
             title: isPinned ? 'Unpin' : 'Pin',
             endIcon: 'Pin',


### PR DESCRIPTION
Adds an optional prop to readGroup in activityApi to either mark the group read "deeply" or not (we badge it for new members requesting approval and clear the dot when navigating to it via Activity—this has nothing to do with unread messages in channels).

Adds a menu item to the ChatOptionsSheet for groups with unreads to deep-mark as read.

Fixes TLON-3240