### PR TITLE
BareChatInput: avoid aggressive prefixing for link-like words

### DIFF
--- a/packages/ui/src/components/BareChatInput/helpers.ts
+++ b/packages/ui/src/components/BareChatInput/helpers.ts
@@ -102,17 +102,17 @@ const processLine = (line: string, mentions: Mention[]): JSONContent => {
 
       parsedContent.push({
         type: 'text',
-        text: cleanUrl.startsWith('http') ? cleanUrl : `https://${cleanUrl}`,
-        marks: [
-          {
-            type: 'link',
-            attrs: {
-              href: cleanUrl.startsWith('http')
-                ? cleanUrl
-                : `https://${cleanUrl}`,
-            },
-          },
-        ],
+        text: cleanUrl,
+        marks: cleanUrl.startsWith('http')
+          ? [
+              {
+                type: 'link',
+                attrs: {
+                  href: cleanUrl,
+                },
+              },
+            ]
+          : undefined,
       });
 
       if (trailingPunct) {


### PR DESCRIPTION
We were unnecessarily adding `https://` before any single word sent that looked like a URL. This would result in messages such as `https://support@tlon.io` when the user simply typed `support@tlon.io`.

Screenshot from simulator.
<img width="259" alt="image" src="https://github.com/user-attachments/assets/43fb324a-42e0-4858-88c7-197d6119d0ae">
