### PR TITLE
ManageAccount: wrap wasDeleted in try/catch, avoid crashing

### DIFF
--- a/packages/app/features/settings/ManageAccountScreen.tsx
+++ b/packages/app/features/settings/ManageAccountScreen.tsx
@@ -31,20 +31,22 @@ interface HostingSession {
 export function ManageAccountScreen(props: Props) {
   const resetDb = useResetDb();
   const webview = useWebView();
-  const [goingBack, setGoingBack] = useState(false);
   const handleLogout = useHandleLogout({ resetDb });
   const [hostingSession, setHostingSession] = useState<HostingSession | null>(
     null
   );
 
   const handleBack = useCallback(async () => {
-    setGoingBack(true);
-    const wasDeleted = await checkIfAccountDeleted();
-    if (wasDeleted) {
-      handleLogout();
-    } else {
+    try {
+      const wasDeleted = await checkIfAccountDeleted();
+      if (wasDeleted) {
+        handleLogout();
+      } else {
+        props.navigation.goBack();
+      }
+    } catch (error) {
+      console.error('Error checking if account was deleted:', error);
       props.navigation.goBack();
-      setGoingBack(false);
     }
   }, [handleLogout, props.navigation]);
 
@@ -91,13 +93,7 @@ export function ManageAccountScreen(props: Props) {
   return (
     <View flex={1} backgroundColor="$background">
       <ScreenHeader
-        leftControls={
-          goingBack ? (
-            <LoadingSpinner />
-          ) : (
-            <ScreenHeader.BackButton onPress={handleBack} />
-          )
-        }
+        leftControls={<ScreenHeader.BackButton onPress={handleBack} />}
         title="Manage account"
       />
       {isWeb && (

--- a/packages/ui/src/components/ProfileScreenView.tsx
+++ b/packages/ui/src/components/ProfileScreenView.tsx
@@ -94,7 +94,7 @@ export function ProfileScreenView(props: Props) {
           />
           {props.hasHostedAuth && (
             <ProfileAction
-              title="Tlon Hosting account"
+              title="Manage Tlon account"
               rightIcon={'ChevronRight'}
               leftIcon={
                 <View


### PR DESCRIPTION
Wraps the check if the account was deleted in a try/catch block on ManageAccountScreen. This avoids crashing the app if we press the back button. Also eliminates the spinner in the navigation.

Here's a video of the back action working (!):

https://github.com/user-attachments/assets/a61041cb-a8b7-4e99-9fb1-b5225e90d8b9

