### PR TITLE
native: fix issue with dark/light mode switching

### DIFF
--- a/packages/ui/src/components/Channel/index.tsx
+++ b/packages/ui/src/components/Channel/index.tsx
@@ -16,7 +16,14 @@ import { ImagePickerAsset } from 'expo-image-picker';
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { FlatList } from 'react-native';
 import { SafeAreaView } from 'react-native-safe-area-context';
-import { AnimatePresence, SizableText, View, YStack } from 'tamagui';
+import {
+  AnimatePresence,
+  SizableText,
+  View,
+  YStack,
+  getVariableValue,
+  useTheme,
+} from 'tamagui';
 
 import {
   ChannelProvider,
@@ -283,6 +290,8 @@ export function Channel({
 
   const isNarrow = useIsWindowNarrow();
 
+  const backgroundColor = getVariableValue(useTheme().background);
+
   return (
     <ScrollContextProvider>
       <GroupsProvider groups={groups}>
@@ -307,7 +316,10 @@ export function Channel({
                   initialAttachments={initialAttachments}
                   uploadAsset={uploadAsset}
                 >
-                  <View backgroundColor="$background" flex={1}>
+                  <View
+                    backgroundColor={backgroundColor}
+                    flex={1}
+                  >
                     <YStack
                       justifyContent="space-between"
                       width="100%"

--- a/packages/ui/src/components/MessageInput/MessageInputBase.tsx
+++ b/packages/ui/src/components/MessageInput/MessageInputBase.tsx
@@ -5,7 +5,14 @@ import { ImagePickerAsset } from 'expo-image-picker';
 import { memo } from 'react';
 import { PropsWithChildren } from 'react';
 import { SpaceTokens } from 'tamagui';
-import { ThemeTokens, View, XStack, YStack } from 'tamagui';
+import {
+  ThemeTokens,
+  View,
+  XStack,
+  YStack,
+  getVariableValue,
+  useTheme,
+} from 'tamagui';
 
 import { useAttachmentContext } from '../../contexts/attachment';
 import { Button } from '../Button';
@@ -100,10 +107,17 @@ export const MessageInputContainer = memo(
   }>) => {
     const { canUpload } = useAttachmentContext();
 
+    const defaultBackgroundColor = getVariableValue(useTheme().background);
+    const secondaryBackgroundColor = getVariableValue(
+      useTheme().secondaryBackground
+    );
+
     return (
       <YStack
         width="100%"
-        backgroundColor={isEditing ? '$secondaryBackground' : '$background'}
+        backgroundColor={
+          isEditing ? secondaryBackgroundColor : defaultBackgroundColor
+        }
       >
         <InputMentionPopup
           containerHeight={containerHeight}


### PR DESCRIPTION
fixes tlon-3111 (the symptom, anyway).

Looks like this is related to this issue https://github.com/tamagui/tamagui/issues/2856

I attempted updating to the latest tamagui, no dice. I tried setting `fastSchemeChange:false` in the tamagui config, didn't work.

It seems like the issue is happening only with the Channel/index.tsx and and MessageInputBase.tsx components in particular. The backgrounds just don't update when the theme context changes.

If we pull the background variable out manually with getVariableValue(useTheme().background)) it always updates appropriately. I did that here.

We could go with this for now and figure out why this is happening later, or I could keep digging to try to figure out the root cause and hopefully fix that. Fine with me either way.