### PR TITLE
native: simulate pressable event bubbling

### DIFF
--- a/packages/app/fixtures/Pressable.fixture.tsx
+++ b/packages/app/fixtures/Pressable.fixture.tsx
@@ -1,0 +1,93 @@
+import { Pressable, Text, View } from '@tloncorp/ui';
+import { useValue } from 'react-cosmos/client';
+import { Alert, SafeAreaView, Switch } from 'react-native';
+
+export default {
+  Nested() {
+    const [innerPressableEnabled, setInnerPressableEnabled] = useValue(
+      'Enable inner press handler',
+      { defaultValue: true }
+    );
+    const [siblingPressableEnabled, setSiblingPressableEnabled] = useValue(
+      'Enable sibling press handler',
+      { defaultValue: true }
+    );
+    return (
+      <SafeAreaView>
+        <View>
+          <Pressable
+            padding={20}
+            backgroundColor="$negativeBackground"
+            onPress={() => {
+              Alert.alert('Outer: onPress fired');
+            }}
+            onTouchEndCapture={(event) => {
+              event.stopPropagation();
+            }}
+          >
+            <Text padding={20}>Outer view (has onPress handler)</Text>
+            <Pressable
+              padding={20}
+              backgroundColor="$positiveBackground"
+              onPress={
+                innerPressableEnabled
+                  ? (event) => {
+                      event.persist();
+                      console.log(event);
+                      Alert.alert('Inner: onPress fired');
+                    }
+                  : undefined
+              }
+            >
+              <Text padding={20}>
+                Inner view{' '}
+                {innerPressableEnabled
+                  ? '(has onPress handler)'
+                  : '(does not have onPress handler)'}{' '}
+              </Text>
+            </Pressable>
+          </Pressable>
+
+          {/* Sibling floating above the other pressables */}
+          <Pressable
+            position="absolute"
+            bottom={20}
+            right={0}
+            padding={20}
+            backgroundColor="rgba(100, 255, 100, 0.5)"
+            onPress={
+              siblingPressableEnabled
+                ? () => {
+                    Alert.alert('Sibling: onPress fired');
+                  }
+                : undefined
+            }
+          >
+            <Text>
+              Sibling (press handler{' '}
+              {siblingPressableEnabled ? 'enabled' : 'disabled'})
+            </Text>
+          </Pressable>
+        </View>
+
+        {/* Settings panel */}
+        <View gap={8} padding={8}>
+          <View flexDirection="row" alignItems="center" gap={12}>
+            <Switch
+              value={innerPressableEnabled}
+              onValueChange={setInnerPressableEnabled}
+            />
+            <Text>Enable inner press handler</Text>
+          </View>
+          <View flexDirection="row" alignItems="center" gap={12}>
+            <Switch
+              value={siblingPressableEnabled}
+              onValueChange={setSiblingPressableEnabled}
+            />
+            <Text>Enable sibling press handler</Text>
+          </View>
+        </View>
+      </SafeAreaView>
+    );
+  },
+};

--- a/packages/ui/src/components/Pressable.tsx
+++ b/packages/ui/src/components/Pressable.tsx
@@ -62,6 +62,9 @@ export default function Pressable({
     action,
   });
 
+  const hasInteractionHandler =
+    (action == null ? onPress : onPressLink) || onLongPress;
+
   if (action && !to) {
     throw new Error(
       'The `to` prop is required when `action` is specified in `Pressable`'
@@ -76,6 +79,11 @@ export default function Pressable({
         group
         onPress={onPressLink ?? onPress}
         onLongPress={longPressHandler}
+        // Pressable always blocks touches from bubbling to ancestors, even if
+        // no handlers are attached.
+        // To allow bubbling, disable the Pressable (mixin) when no handlers
+        // are attached.
+        disabled={!hasInteractionHandler}
       >
         {children}
       </StackComponent>
@@ -87,6 +95,7 @@ export default function Pressable({
       {...stackProps}
       onPress={onPress}
       onLongPress={longPressHandler}
+      disabled={!hasInteractionHandler}
     >
       {children}
     </StackComponent>


### PR DESCRIPTION
_To preface: I don't know if this is a great thing to add to the `Pressable` primitive – opening this for discussion. Alternatives include (1) plumbing a `disabled` prop to `ChatMessage` for my one use case, (2) adding a flag to `Pressable` to opt-in to this behavior, or (3) creating a new `Pressable`-like component with this behavior (`OptionallyPressable`? 🤷 )._

---

I was trying to add a long-press to a container view holding a `ChatMessage` using `Pressable`. My handler wouldn't get called – swapping out `ChatMessage` for a blank `View` worked.

`ChatMessage` has a `Pressable` which has no bound handlers in this scenario, and I expected events to bubble up the stack like on web – but it looks like RN doesn't have that behavior. Here's a recording of the fixture from this PR demonstrating this – the specific case is when `Enable inner press handler` is **off** and I'm tapping on the inner view – I expect that the inner view does not activate (because no handler) and the outer view's handler does activate (since I'm tapping over the outer view):

https://github.com/user-attachments/assets/b9eb2607-b0ab-4fbb-8c17-55d6c1fb0cf3

To solve my initial problem:
1. If I could "reach across" to the `ChatMessage`'s `Pressable`, setting `pointerEvents="none"` would work
2. Setting `disabled` on the inner `Pressable` passes events through to ancestors

(1) seems violent to do for every use case – I'd prefer a component that can be optionally interactive, and when the component is configured to be non-interactive, events naturally pass through to ancestors.

684721376ce54eba6318f56976672baffdc2dbeb implements (2) – setting `disabled={true}` when there are no bound handlers.

https://github.com/user-attachments/assets/f7a552e3-4c14-405d-83ac-4a2225fbab14

---

I think there's a solution here if we were to move to react-native-gesture-handler instead of the Tamagui pressable mixin, but I don't think it'd be very different in implementation – I think we'd still be disabling interaction when missing handlers. (There are [APIs for composing gestures](https://docs.swmansion.com/react-native-gesture-handler/docs/fundamentals/gesture-composition) but they require references to the relevant gestures, which would be a lot of plumbing.)