### PR TITLE
groups: auto-join new channels in all cases

### DIFF
--- a/desk/app/channels-server.hoon
+++ b/desk/app/channels-server.hoon
@@ -578,7 +578,7 @@
       [now.bowl %default | readers.new]
     =/  =action:g
       [group.new now.bowl %channel nest %add channel]
-    =/  =dock    [our.bowl %groups]
+    =/  =dock    [p.group.new %groups]
     =/  =wire    (snoc ca-area %create)
     (emit %pass wire %agent dock %poke act:mar:g !>(action))
     ::

--- a/desk/app/groups.hoon
+++ b/desk/app/groups.hoon
@@ -1845,7 +1845,6 @@
       =.  zones.group  (go-bump-zone ch channel.diff)
       =.  channels.group  (put:by-ch ch channel.diff)
       ?:  from-self  go-core
-      ?:  =(our.bowl p.flag)  go-core
       =.  cor  (emil (join-channels:go-pass ~[ch]))
       go-core
     ::


### PR DESCRIPTION
Problems with channel auto-join were two-fold:

First, channels-server was always poking the local groups agent with the creation command, instead of the groups agent on the host of the group. Here we make sure to poke the appropriate ship.

Second, groups agent was explicitly no-opping when a channel was added to a group it hosts itself. Here, we remove that condition, letting that case proceed into channel joining logic unhindered.

Closes TLON-3151.