### PR TITLE
Remove tlon-mobile `cosmos` script

### DIFF
--- a/apps/tlon-mobile/package.json
+++ b/apps/tlon-mobile/package.json
@@ -24,7 +24,6 @@
     "test-ui": "jest",
     "tsc": "tsc --noEmit",
     "build": "pnpm generate",
-    "cosmos": "cosmos-native",
     "eas-build-post-install": "pnpm -w run build:mobile-release"
   },
   "lint-staged": {


### PR DESCRIPTION
I didn't see that the script to start Cosmos had changed locations, so I was running this script, which "works" but is missing a lot of fixtures (and hangs on "waiting for renderer").