### PR TITLE
logs: new agent to gather and submit app logs

### DIFF
--- a/desk/app/activity.hoon
+++ b/desk/app/activity.hoon
@@ -41,7 +41,7 @@
 /-  a=activity, c=channels, ch=chat, g=groups
 /+  *activity, ch-utils=channel-utils, v=volume, aj=activity-json,
     imp=import-aid
-/+  default-agent, verb, dbug
+/+  default-agent, verb, dbug, logs
 ::
 =/  verbose  |
 =>
@@ -107,7 +107,11 @@
   ++  on-agent   on-agent:def
   ++  on-peek    peek:cor
   ++  on-leave   on-leave:def
-  ++  on-fail    on-fail:def
+  ++  on-fail
+    |=  [=term =tang]
+    ^-  (quip card _this)
+    :_  this
+    [(log-fail:logs /logs our.bowl (fail-event:logs term tang))]~
   --
 |_  [=bowl:gall cards=(list card)]
 ++  abet  [(flop cards) state]

--- a/desk/app/channels-server.hoon
+++ b/desk/app/channels-server.hoon
@@ -417,6 +417,7 @@
   |=  [=(pole knot) =sign:agent:gall]
   ^+  cor
   ?+    pole  ~|(bad-agent-wire+pole !!)
+    [%logs ~]  cor
     [%pimp ~]  cor
     [%wake ~]  cor
   ::

--- a/desk/app/channels-server.hoon
+++ b/desk/app/channels-server.hoon
@@ -4,7 +4,7 @@
 ::
 /-  c=channels, g=groups
 /+  utils=channel-utils, imp=import-aid
-/+  default-agent, verb, dbug, neg=negotiate
+/+  default-agent, verb, dbug, neg=negotiate, logs
 ::
 %-  %-  agent:neg
     [| [~.channels^%1 ~ ~] ~]
@@ -58,7 +58,12 @@
   ::
   ++  on-peek    on-peek:def
   ++  on-leave   on-leave:def
-  ++  on-fail    on-fail:def
+  ++  on-fail
+    |=  [=term =tang]
+    ^-  (quip card _this)
+    :_  this
+    [(log-fail:logs /logs our.bowl (fail-event:logs term tang))]~
+  ::
   ++  on-agent
     |=  [=wire =sign:agent:gall]
     ^-  (quip card _this)

--- a/desk/app/channels.hoon
+++ b/desk/app/channels.hoon
@@ -10,7 +10,7 @@
 ::
 /-  c=channels, g=groups, ha=hark, activity
 /-  meta
-/+  default-agent, verb, dbug, sparse, neg=negotiate, imp=import-aid
+/+  default-agent, verb, dbug, sparse, neg=negotiate, imp=import-aid, logs
 /+  utils=channel-utils, volume, s=subscriber
 ::  performance, keep warm
 /+  channel-json
@@ -78,7 +78,12 @@
   ::
   ++  on-peek    peek:cor
   ++  on-leave   on-leave:def
-  ++  on-fail    on-fail:def
+  ++  on-fail
+    |=  [=term =tang]
+    ^-  (quip card _this)
+    :_  this
+    [(log-fail:logs /logs our.bowl (fail-event:logs term tang))]~
+  ::
   ++  on-agent
     |=  [=wire =sign:agent:gall]
     ^-  (quip card _this)
@@ -641,6 +646,13 @@
   ?+    pole  ~|(bad-agent-wire+pole !!)
       ~          cor
       [%pimp ~]  cor
+    ::
+      [%logs ~]
+    ?>  ?=(%poke-ack -.sign)
+    ?~  p.sign  cor
+    %-  (slog leaf+"Failed to log" u.p.sign)
+    cor
+    ::
       [%hark ~]
     ?>  ?=(%poke-ack -.sign)
     ?~  p.sign  cor

--- a/desk/app/channels.hoon
+++ b/desk/app/channels.hoon
@@ -646,12 +646,7 @@
   ?+    pole  ~|(bad-agent-wire+pole !!)
       ~          cor
       [%pimp ~]  cor
-    ::
-      [%logs ~]
-    ?>  ?=(%poke-ack -.sign)
-    ?~  p.sign  cor
-    %-  (slog leaf+"Failed to log" u.p.sign)
-    cor
+      [%logs ~]  cor
     ::
       [%hark ~]
     ?>  ?=(%poke-ack -.sign)

--- a/desk/app/groups.hoon
+++ b/desk/app/groups.hoon
@@ -640,6 +640,7 @@
   ?+    pole  ~|(bad-agent-take/pole !!)
       ~   cor
       [%epic ~]  (take-epic sign)
+      [%logs ~]  cor
       [%helm *]  cor
       [%activity %submit *]  cor
       [%groups %role ~]  cor

--- a/desk/app/groups.hoon
+++ b/desk/app/groups.hoon
@@ -8,7 +8,7 @@
 /-  meta
 /-  e=epic
 /+  default-agent, verb, dbug
-/+  v=volume, s=subscriber, imp=import-aid
+/+  v=volume, s=subscriber, imp=import-aid, logs
 /+  of
 /+  epos-lib=saga
 ::  performance, keep warm
@@ -69,7 +69,11 @@
   ++  on-peek   peek:cor
   ::
   ++  on-leave   on-leave:def
-  ++  on-fail    on-fail:def
+  ++  on-fail
+    |=  [=term =tang]
+    ^-  (quip card _this)
+    :_  this
+    [(log-fail:logs /logs our.bowl (fail-event:logs term tang))]~
   ::
   ++  on-agent
     |=  [=wire =sign:agent:gall]

--- a/desk/app/logs.hoon
+++ b/desk/app/logs.hoon
@@ -61,8 +61,7 @@
     =+  !<(=a-log:l vase)
     ?-    -.a-log
         %log
-      =/  =log-item:l  [now.bowl +.a-log]
-      (send-posthog-event sap.bowl log-item)
+      (send-posthog-event sap.bowl now.bowl +.a-log)
     ==
   ==
 ::

--- a/desk/app/logs.hoon
+++ b/desk/app/logs.hoon
@@ -5,7 +5,7 @@
 =>
   |%
   +$  card  card:agent:gall
-  +$  current-state  [%0 =logs:l]
+  +$  current-state  [%0 ~]
   --
 =|  current-state
 =*  state  -
@@ -44,29 +44,13 @@
 ++  emil  |=(caz=(list card) cor(cards (welp (flop caz) cards)))
 ++  give  |=(=gift:agent:gall (emit %give gift))
 ::
-++  tick  ^~((div ~s1 (bex 16)))
-++  add-log-event
-  |=  [agent=@tas =log-event:l]
-  ^-  [id-event:l _logs]
-  =/  =log:l
-    (fall (~(get by logs) agent) ~)
-  =/  =id-event:l
-    |-
-    ?.  (has:on-log:l log now.bowl)  now.bowl
-    $(now.bowl (add now.bowl tick))
-  :-  id-event
-  %+  ~(put by logs)  agent
-  (put:on-log:l log id-event log-event)
-::
 ++  send-posthog-event
-  |=  [agent=@tas =id-event:l =log-event:l]
+  |=  [origin=path =time =log-event:l]
   ^+  cor
   =/  fard=(fyrd:khan cage)
-    [q.byk.bowl %posthog noun+!>(`[agent ^-(log-item:l [id-event log-event])])]
+    [q.byk.bowl %posthog noun+!>(`[origin time log-event])]
   ::
-  %^  emit  %pass
-    /posthog/[agent]/(scot %da id-event)
-  [%arvo ^-(note-arvo [%k %fard fard])]
+  (emit %pass /posthog [%arvo %k %fard fard])
 ::
 ++  poke
   |=  [=mark =vase]
@@ -77,21 +61,17 @@
     =+  !<(=a-log:l vase)
     ?-    -.a-log
         %log
-      ?>  ?=([@ @ ~] sap.bowl)
-      =+  agent=i.t.sap.bowl
-      =^  id-event  logs  (add-log-event agent +.a-log)
-      (send-posthog-event agent id-event +.a-log)
+      =/  =log-item:l  [now.bowl +.a-log]
+      (send-posthog-event sap.bowl log-item)
     ==
   ==
 ::
 ++  arvo
   |=  [=(pole knot) =sign-arvo]
   ?+    pole  ~|(bad-arvo-wire+pole !!)
-      ::  /posthog/agent/id-event
+      ::  /posthog
       ::
-      [%posthog agent=@tas id-event=@da ~]
-    ?~  id-event=(slaw %da id-event.pole)
-      ~|(evil-arvo-wire+pole !!)
+      [%posthog ~]
     ?>  ?=([%khan %arow *] sign-arvo)
     =/  =(avow:khan cage)  p.sign-arvo
     ?:  ?=(%| -.avow)
@@ -100,14 +80,13 @@
     =/  =cage  p.avow
     =+  !<(response=(unit client-response:iris) q.cage)
     ?~  response
-      ((slog leaf+"failed to submit event {<`@da`u.id-event>}" ~) cor)
+      ((slog leaf+"logs: failed to submit event" ~) cor)
     ?.  ?=(%finished -.u.response)
       ~|(bad-client-response+u.response !!)
     =*  status-code  status-code.response-header.u.response
     ?:  !=(200 status-code)
-      %-  (slog leaf+"failed to submit event {<`@da`u.id-event>} to posthog" ~)
+      %-  (slog leaf+"logs: failed to submit event" ~)
       cor
-    ~&  posthog-log-ok+`@da`u.id-event
     cor
   ==
 --

--- a/desk/app/logs.hoon
+++ b/desk/app/logs.hoon
@@ -1,0 +1,113 @@
+::  logs: gather log events and submit reports
+::
+/-  l=logs
+/+  default-agent
+=>
+  |%
+  +$  card  card:agent:gall
+  +$  current-state  [%0 =logs:l]
+  --
+=|  current-state
+=*  state  -
+^-  agent:gall
+=<
+  |_  =bowl:gall
+  +*  this  .
+      def  ~(. (default-agent this %|) bowl)
+      cor  ~(. +> [bowl ~])
+  ::
+  ++  on-init  on-init:def
+  ++  on-save  on-save:def
+  ++  on-load  on-load:def
+  ++  on-poke
+    |=  [=mark =vase]
+    ^-  (quip card _this)
+    =^  cards  state
+      abet:(poke:cor mark vase)
+    [cards this]
+  ++  on-watch  on-watch:def
+  ++  on-peek  on-peek:def
+  ++  on-leave  on-leave:def
+  ++  on-agent  on-agent:def
+  ++  on-arvo
+    |=  [=wire =sign-arvo]
+    =^  cards  state
+      abet:(arvo:cor wire sign-arvo)
+    [cards this]
+  ++  on-fail  on-fail:def
+  --
+::
+|_  [=bowl:gall cards=(list card)]
+++  abet  [(flop cards) state]
+++  cor   .
+++  emit  |=(=card cor(cards [card cards]))
+++  emil  |=(caz=(list card) cor(cards (welp (flop caz) cards)))
+++  give  |=(=gift:agent:gall (emit %give gift))
+::
+++  tick  ^~((div ~s1 (bex 16)))
+++  add-log-event
+  |=  [agent=@tas =log-event:l]
+  ^-  [id-event:l _logs]
+  =/  =log:l
+    (fall (~(get by logs) agent) ~)
+  =/  =id-event:l
+    |-
+    ?.  (has:on-log:l log now.bowl)  now.bowl
+    $(now.bowl (add now.bowl tick))
+  :-  id-event
+  %+  ~(put by logs)  agent
+  (put:on-log:l log id-event log-event)
+::
+++  send-posthog-event
+  |=  [agent=@tas =id-event:l =log-event:l]
+  ^+  cor
+  =/  fard=(fyrd:khan cage)
+    [q.byk.bowl %posthog noun+!>(`[agent ^-(log-item:l [id-event log-event])])]
+  ::
+  %^  emit  %pass
+    /posthog/[agent]/(scot %da id-event)
+  [%arvo ^-(note-arvo [%k %fard fard])]
+::
+++  poke
+  |=  [=mark =vase]
+  ^+  cor
+  ?>  =(our src):bowl
+  ?+    mark  ~|(bad-mark+mark !!)
+      %log-action
+    =+  !<(=a-log:l vase)
+    ?-    -.a-log
+        %log
+      ?>  ?=([@ @ ~] sap.bowl)
+      =+  agent=i.t.sap.bowl
+      =^  id-event  logs  (add-log-event agent +.a-log)
+      (send-posthog-event agent id-event +.a-log)
+    ==
+  ==
+::
+++  arvo
+  |=  [=(pole knot) =sign-arvo]
+  ?+    pole  ~|(bad-arvo-wire+pole !!)
+      ::  /posthog/agent/id-event
+      ::
+      [%posthog agent=@tas id-event=@da ~]
+    ?~  id-event=(slaw %da id-event.pole)
+      ~|(evil-arvo-wire+pole !!)
+    ?>  ?=([%khan %arow *] sign-arvo)
+    =/  =(avow:khan cage)  p.sign-arvo
+    ?:  ?=(%| -.avow)
+      %-  (slog tang.p.avow)
+      cor
+    =/  =cage  p.avow
+    =+  !<(response=(unit client-response:iris) q.cage)
+    ?~  response
+      ((slog leaf+"failed to submit event {<`@da`u.id-event>}" ~) cor)
+    ?.  ?=(%finished -.u.response)
+      ~|(bad-client-response+u.response !!)
+    =*  status-code  status-code.response-header.u.response
+    ?:  !=(200 status-code)
+      %-  (slog leaf+"failed to submit event {<`@da`u.id-event>} to posthog" ~)
+      cor
+    ~&  posthog-log-ok+`@da`u.id-event
+    cor
+  ==
+--

--- a/desk/desk.bill
+++ b/desk/desk.bill
@@ -1,4 +1,5 @@
-:~  %groups
+:~  %logs
+    %groups
     %chat
     %heap
     %diary

--- a/desk/lib/logs.hoon
+++ b/desk/lib/logs.hoon
@@ -1,0 +1,57 @@
+/-  *logs
+|%
+::
+++  fail-event
+  |=  [=term =tang]
+  ^-  $>(%fail log-event)
+  [%fail term tang]
+::
+++  log-fail
+  |=  [=wire our=ship event=$>(%fail log-event)]
+  ^-  card:agent:gall
+  [%pass wire %agent [our %logs] %poke log-action+!>([%log event])]
+::
+++  enjs
+  =,  format
+  |%
+  ++  tang
+    |=  t=^tang
+    ^-  $>(%a json)
+    ?~  t  a+~
+    =/  tame=(list tape)
+      %+  turn  t
+     (cork (cury wash [0 80]) zing)
+    ::XX posthog does not display newlines properly
+    :: s+(crip (zing `(list tape)`(join "\0a" tame)))
+    a+(turn tame tape:enjs)
+  ::
+  ++  d-co-2  (d-co:co 2)
+  ++  id-event
+    |=  id=^id-event
+    ^-  $>(%s json)
+    =+  date=(yore id)
+    =+  frac=(head f.t.date)
+    ::  convert urbit fractosecs to millisecs
+    ::
+    =+  mili=(div (mul frac 1.000) 65.563)
+    :-  %s
+    %-  crip
+    "{((d-co:co 4) y.date)}-{(d-co-2 m.date)}-{(d-co-2 d.t.date)}".
+    "T{(d-co-2 h.t.date)}:{(d-co-2 m.t.date)}:{(d-co-2 s.t.date)}".
+    ".{((d-co:co 3) mili)}"
+  ::
+  ++  log-event
+    |=  e=^log-event
+    ^-  $>(%o json)
+    =*  event-type  -.e
+    ?-    -.e
+        %fail
+      =-  ?>(?=(%o -.-) -)
+      %-  pairs:enjs
+      :~  type/s+event-type
+          description/s+desc.e
+          stacktrace/(tang crash.e)
+      ==
+    ==
+  --
+--

--- a/desk/lib/logs.hoon
+++ b/desk/lib/logs.hoon
@@ -19,26 +19,10 @@
     ^-  $>(%a json)
     ?~  t  a+~
     =/  tame=(list tape)
+      %-  zing
       %+  turn  t
-     (cork (cury wash [0 80]) zing)
-    ::XX posthog does not display newlines properly
-    :: s+(crip (zing `(list tape)`(join "\0a" tame)))
+     (cury wash [0 80])
     a+(turn tame tape:enjs)
-  ::
-  ++  d-co-2  (d-co:co 2)
-  ++  id-event
-    |=  id=^id-event
-    ^-  $>(%s json)
-    =+  date=(yore id)
-    =+  frac=(head f.t.date)
-    ::  convert urbit fractosecs to millisecs
-    ::
-    =+  mili=(div (mul frac 1.000) 65.563)
-    :-  %s
-    %-  crip
-    "{((d-co:co 4) y.date)}-{(d-co-2 m.date)}-{(d-co-2 d.t.date)}".
-    "T{(d-co-2 h.t.date)}:{(d-co-2 m.t.date)}:{(d-co-2 s.t.date)}".
-    ".{((d-co:co 3) mili)}"
   ::
   ++  log-event
     |=  e=^log-event

--- a/desk/lib/logs.hoon
+++ b/desk/lib/logs.hoon
@@ -21,7 +21,7 @@
     =/  tame=(list tape)
       %-  zing
       %+  turn  t
-     (cury wash [0 80])
+      (cury wash [0 80])
     a+(turn tame tape:enjs)
   ::
   ++  log-event

--- a/desk/sur/contacts-0.hoon
+++ b/desk/sur/contacts-0.hoon
@@ -1,0 +1,75 @@
+/-  e=epic, g=groups
+|%
++$  contact-0
+  $:  nickname=@t
+      bio=@t
+      status=@t
+      color=@ux
+      avatar=(unit @t)
+      cover=(unit @t)
+      groups=(set flag:g)
+  ==
+::
++$  foreign-0  [for=$@(~ profile-0) sag=$@(~ saga-0)]
++$  profile-0  [wen=@da con=$@(~ contact-0)]
++$  rolodex  (map ship foreign-0)
+::
++$  saga-0
+  $@  $?  %want    ::  subscribing
+          %fail    ::  %want failed
+          %lost    ::  epic %fail
+          ~        ::  none intended
+      ==
+  saga:e
+::
++$  field-0
+  $%  [%nickname nickname=@t]
+      [%bio bio=@t]
+      [%status status=@t]
+      [%color color=@ux]
+      [%avatar avatar=(unit @t)]
+      [%cover cover=(unit @t)]
+      [%add-group =flag:g]
+      [%del-group =flag:g]
+  ==
+::
++$  action-0
+  ::  %anon: delete our profile
+  ::  %edit: change our profile
+  ::  %meet: track a peer
+  ::  %heed: follow a peer
+  ::  %drop: discard a peer
+  ::  %snub: unfollow a peer
+  ::
+  $%  [%anon ~]
+      [%edit p=(list field-0)]
+      [%meet p=(list ship)]
+      [%heed p=(list ship)]
+      [%drop p=(list ship)]
+      [%snub p=(list ship)]
+  ==
+::  network
+::
++$  update-0
+  $%  [%full profile-0]
+  ==
+::  local
+::
++$  news-0
+  [who=ship con=$@(~ contact-0)]
+::
+++  get-contact
+  |=  [=bowl:gall who=@p]
+  =>  :_  ..get-contact
+      [who=who our=our.bowl now=now.bowl]
+  ~+  ^-  (unit contact-0)
+  =/  base=path  /(scot %p our)/contacts/(scot %da now)
+  ?.  ~+  .^(? %gu (weld base /$))
+    ~
+  =+  ~+  .^(rol=rolodex %gx (weld base /all/contact-rolodex))
+  ?~  for=(~(get by rol) who)
+    ~
+  ?.  ?=([[@ ^] *] u.for)
+    ~
+  `con.for.u.for
+--

--- a/desk/sur/logs.hoon
+++ b/desk/sur/logs.hoon
@@ -3,24 +3,14 @@
 |%
 ::  $log-event
 ::
-::XX  %tell: agent message
 ::  %fail: agent failure
 ::
 +$  log-event
   $%  [%fail desc=term crash=tang]
   ==
-+$  id-event  time
 ::
 ::  $log-item: event with timestamp
-+$  log-item  [id=id-event event=log-event]
-::
-::  $log: time-ordered event log
-+$  log  ((mop id-event log-event) lth)
-++  on-log  ((on id-event log-event) lth)
-++  mo-log  ((mp id-event log-event) lth)
-::
-::  $logs: log per agent
-++  logs  (map @tas log)
++$  log-item  [=time event=log-event]
 ::
 +$  a-log
   $%  [%log log-event]

--- a/desk/sur/logs.hoon
+++ b/desk/sur/logs.hoon
@@ -1,0 +1,28 @@
+/+  mp=mop-extensions
+::
+|%
+::  $log-event
+::
+::XX  %tell: agent message
+::  %fail: agent failure
+::
++$  log-event
+  $%  [%fail desc=term crash=tang]
+  ==
++$  id-event  time
+::
+::  $log-item: event with timestamp
++$  log-item  [id=id-event event=log-event]
+::
+::  $log: time-ordered event log
++$  log  ((mop id-event log-event) lth)
+++  on-log  ((on id-event log-event) lth)
+++  mo-log  ((mp id-event log-event) lth)
+::
+::  $logs: log per agent
+++  logs  (map @tas log)
+::
++$  a-log
+  $%  [%log log-event]
+  ==
+--

--- a/desk/ted/posthog.hoon
+++ b/desk/ted/posthog.hoon
@@ -1,0 +1,61 @@
+::  posthog: submit an log event to PostHog
+::
+/-  spider
+/+  io=strandio, l=logs
+::
+=+  posthog-key='phc_GyI5iD7kM6RRbb1hIU0fiGmTCh4ha44hthJYJ7a89td'
+=+  posthog-url='https://eu.i.posthog.com/capture/'
+=+  posthog-retry=3
+=+  posthog-retry-delay=~s30
+::
+=,  strand=strand:spider
+^-  thread:spider
+::  .arg: a pair of origin agent and log item
+::
+|=  arg=vase
+=/  m  (strand ,vase)
+^-  form:m
+=+  !<(arg=(unit (pair @tas log-item:l)) arg)
+?>  ?=(^ arg)
+=*  agent  p.u.arg
+=*  log-item  q.u.arg
+;<  =bowl:strand  bind:m  get-bowl:io
+=/  log-event-json=$>(%o json)  (log-event:enjs:l event.log-item)
+=/  props=json
+  :-  %o
+  %-  ~(uni by p.log-event-json)
+  ^-  (map @t json)
+  %-  my
+  :~  'distinct_id'^s+(scot %p our.bowl)
+      'agent'^s+agent
+  ==
+=/  event=json
+  %-  pairs:enjs:format
+  :~  'api_key'^s+posthog-key
+      timestamp/(id-event:enjs:l id.log-item)
+      event/s+'Backend Log'
+      properties+props
+  ==
+::
+=/  =request:http
+  :*  %'POST'
+      posthog-url
+      ~['content-type'^'application/json']
+      `(as-octs:mimes:html (en:json:html event))
+  ==
+|-
+?:  =(0 posthog-retry)
+  (pure:m !>(~))
+;<  ~  bind:m  (send-request:io request)
+;<  =client-response:iris  bind:m  take-client-response:io
+::NOTE  this logic must be adjusted when %iris supports
+::      partial responses
+?.  ?&  ?=(%finished -.client-response)
+        =(200 status-code.response-header.client-response)
+    ==
+  ?>  ?=(%finished -.client-response)
+  =*  status-code  status-code.response-header.client-response
+  %-  (slog leaf+"posthog request failed: status {<status-code>}" ~)
+  ;<  ~  bind:m  (sleep:io posthog-retry-delay)
+  $(posthog-retry (dec posthog-retry))
+(pure:m !>(`client-response))

--- a/desk/ted/posthog.hoon
+++ b/desk/ted/posthog.hoon
@@ -10,14 +10,14 @@
 ::
 =,  strand=strand:spider
 ^-  thread:spider
-::  .arg: a pair of origin agent and log item
+::  .arg: a pair of origin and log item
 ::
 |=  arg=vase
 =/  m  (strand ,vase)
 ^-  form:m
-=+  !<(arg=(unit (pair @tas log-item:l)) arg)
+=+  !<(arg=(unit (pair path log-item:l)) arg)
 ?>  ?=(^ arg)
-=*  agent  p.u.arg
+=*  origin  p.u.arg
 =*  log-item  q.u.arg
 ;<  =bowl:strand  bind:m  get-bowl:io
 =/  log-event-json=$>(%o json)  (log-event:enjs:l event.log-item)
@@ -27,12 +27,12 @@
   ^-  (map @t json)
   %-  my
   :~  'distinct_id'^s+(scot %p our.bowl)
-      'agent'^s+agent
+      'origin'^s+(spat origin)
   ==
 =/  event=json
   %-  pairs:enjs:format
   :~  'api_key'^s+posthog-key
-      timestamp/(id-event:enjs:l id.log-item)
+      timestamp/(time:enjs:format time.log-item)
       event/s+'Backend Log'
       properties+props
   ==

--- a/desk/tests/app/logs.hoon
+++ b/desk/tests/app/logs.hoon
@@ -15,10 +15,21 @@
   ;<  caz=(list card)  bind:m
     (do-poke log-action+!>([%log ev-fail]))
   =/  fard=(fyrd:khan cage)
-    [q.byk.bowl %posthog noun+!>(`[%test ^-(log-item:l [now.bowl ev-fail])])]
+    [q.byk.bowl %posthog noun+!>(`[`path`/gall/test [now.bowl ev-fail]])]
   ::  expect log submission -posthog
   ::
-  %+  ex-cards  caz
-  :~  (ex-arvo /posthog/test/(scot %da now.bowl) %k %fard fard)
-  ==
+  ?>  ?=([[%pass *] ~] caz)
+  =/  card=card:agent:gall  i.caz
+  ?>  ?=([%pass [%posthog ~] %arvo %k %fard *] card)
+  ::  compare fard args value
+  ::
+  ;<  ~  bind:m
+    %+  ex-equal
+      !>(q.q.args.fard)
+      !>(q.q.args.p.q.card)
+  ::  compare fard type
+  ::
+  %+  ex-equal
+    !>((~(nest ut p.q.args.fard) | p.q.args.p.q.card))
+    !>(&)
 --

--- a/desk/tests/app/logs.hoon
+++ b/desk/tests/app/logs.hoon
@@ -1,0 +1,24 @@
+/-  l=logs
+/+  *test-agent
+/=  agent  /app/logs
+|%
+++  dap  %logs-test
+++  test-log-fail
+  %-  eval-mare
+  =/  m  (mare ,~)
+  ;<  *  bind:m  (do-init dap agent)
+  :: ;<  *  bind:m  (set-scry-gate ,~)
+  ;<  *  bind:m  (jab-bowl |=(b=bowl b(sap /gall/test)))
+  ;<  =bowl:gall  bind:m  get-bowl
+  =/  ev-fail=log-event:l
+    [%fail %test-fail leaf+"test stacktrace" ~]
+  ;<  caz=(list card)  bind:m
+    (do-poke log-action+!>([%log ev-fail]))
+  =/  fard=(fyrd:khan cage)
+    [q.byk.bowl %posthog noun+!>(`[%test ^-(log-item:l [now.bowl ev-fail])])]
+  ::  expect log submission -posthog
+  ::
+  %+  ex-cards  caz
+  :~  (ex-arvo /posthog/test/(scot %da now.bowl) %k %fard fard)
+  ==
+--


### PR DESCRIPTION
The %logs agent gathers log events from other agents in the groups desk and submits them as "Backend Log" events to PostHog. Currently the only event supported is the `%fail` event usually generated in agent `+on-fail` arm.

As a trial, in this PR we enable logging of crashes in %channels, %channels-server, %groups and %activity.