### PR TITLE
GroupChannelsScreen: show unjoined channels, tap to join

### DIFF
--- a/packages/app/features/top/GroupChannelsScreen.tsx
+++ b/packages/app/features/top/GroupChannelsScreen.tsx
@@ -5,7 +5,6 @@ import {
 } from '@react-navigation/native';
 import type { NativeStackScreenProps } from '@react-navigation/native-stack';
 import { useQuery } from '@tanstack/react-query';
-import * as api from '@tloncorp/shared/api';
 import * as db from '@tloncorp/shared/db';
 import * as store from '@tloncorp/shared/store';
 import {

--- a/packages/app/features/top/GroupChannelsScreen.tsx
+++ b/packages/app/features/top/GroupChannelsScreen.tsx
@@ -68,12 +68,14 @@ export function GroupChannelsScreenContent({
 
   const handleJoinChannel = useCallback(
     async (channel: db.Channel) => {
-      await api.addChannelToGroup({
-        channelId: channel.id,
-        groupId: id,
-        sectionId: 'default',
-      });
-      await db.addJoinedGroupChannel({ channelId: channel.id });
+      try {
+        await store.joinGroupChannel({
+          channelId: channel.id,
+          groupId: id,
+        });
+      } catch (error) {
+        console.error('Failed to join channel:', error);
+      }
     },
     [id]
   );

--- a/packages/app/features/top/GroupChannelsScreen.tsx
+++ b/packages/app/features/top/GroupChannelsScreen.tsx
@@ -4,7 +4,6 @@ import {
   useNavigation,
 } from '@react-navigation/native';
 import type { NativeStackScreenProps } from '@react-navigation/native-stack';
-import { useQuery } from '@tanstack/react-query';
 import * as db from '@tloncorp/shared/db';
 import * as store from '@tloncorp/shared/store';
 import {

--- a/packages/app/features/top/GroupChannelsScreen.tsx
+++ b/packages/app/features/top/GroupChannelsScreen.tsx
@@ -40,10 +40,9 @@ export function GroupChannelsScreenContent({
     null
   );
   const { group } = useGroupContext({ groupId: id, isFocused });
-  const { data: unjoinedChannels } = useQuery({
-    queryKey: ['unjoinedChannels', id],
-    queryFn: () => db.getUnjoinedGroupChannels(id),
-  });
+  const { data: unjoinedChannels } = store.useUnjoinedGroupChannels(
+    group?.id ?? ''
+  );
 
   const pinnedItems = useMemo(() => {
     return pins ?? [];

--- a/packages/shared/src/api/channelsApi.ts
+++ b/packages/shared/src/api/channelsApi.ts
@@ -396,3 +396,24 @@ export const leaveChannel = async (channelId: string) => {
     }
   );
 };
+
+export const joinChannel = async (channelId: string, groupId: string) => {
+  return trackedPoke<ub.ChannelsResponse>(
+    {
+      app: 'channels',
+      mark: 'channel-action',
+      json: {
+        channel: {
+          nest: channelId,
+          action: {
+            join: groupId,
+          },
+        },
+      },
+    },
+    { app: 'channels', path: '/v1' },
+    (event) => {
+      return 'join' in event.response && event.nest === channelId;
+    }
+  );
+};

--- a/packages/shared/src/db/changeListener.ts
+++ b/packages/shared/src/db/changeListener.ts
@@ -47,12 +47,4 @@ export function handleChange({
       queryKey: ['post', row.thread_id],
     });
   }
-
-  // Handle channel membership changes
-  if (table === 'channels' && row) {
-    // If currentUserIsMember changed, invalidate unjoined channels query
-    queryClient.invalidateQueries({
-      queryKey: ['unjoinedChannels', row.group_id],
-    });
-  }
 }

--- a/packages/shared/src/db/changeListener.ts
+++ b/packages/shared/src/db/changeListener.ts
@@ -47,4 +47,12 @@ export function handleChange({
       queryKey: ['post', row.thread_id],
     });
   }
+
+  // Handle channel membership changes
+  if (table === 'channels' && row) {
+    // If currentUserIsMember changed, invalidate unjoined channels query
+    queryClient.invalidateQueries({
+      queryKey: ['unjoinedChannels', row.group_id],
+    });
+  }
 }

--- a/packages/shared/src/db/queries.ts
+++ b/packages/shared/src/db/queries.ts
@@ -1773,18 +1773,14 @@ export const addJoinedGroupChannel = createWriteQuery(
       })
       .where(eq($channels.id, channelId));
 
-    // Then try to add to nav section if not already there
-    const existing = await ctx.db
+    // Then check if channel exists in any section
+    const existingInAnySection = await ctx.db
       .select()
       .from($groupNavSectionChannels)
-      .where(
-        and(
-          eq($groupNavSectionChannels.channelId, channelId),
-          eq($groupNavSectionChannels.groupNavSectionId, 'default')
-        )
-      );
+      .where(eq($groupNavSectionChannels.channelId, channelId));
 
-    if (existing.length === 0) {
+    // Only add to default if it's not
+    if (existingInAnySection.length === 0) {
       await ctx.db.insert($groupNavSectionChannels).values({
         channelId,
         groupNavSectionId: 'default',

--- a/packages/shared/src/db/queries.ts
+++ b/packages/shared/src/db/queries.ts
@@ -225,12 +225,53 @@ export const getPendingChats = createReadQuery(
 export const getUnjoinedGroupChannels = createReadQuery(
   'getUnjoinedGroupChannels',
   async (groupId: string, ctx: QueryCtx) => {
-    return ctx.db.query.channels.findMany({
+    const currentUserId = getCurrentUserId();
+    const allUnjoined = await ctx.db.query.channels.findMany({
       where: and(
         eq($channels.groupId, groupId),
         eq($channels.currentUserIsMember, false)
       ),
+      with: {
+        readerRoles: true,
+        group: {
+          with: {
+            roles: {
+              with: {
+                members: true,
+              },
+            },
+          },
+        },
+      },
     });
+
+    const unjoinedIds = allUnjoined.map((c) => c.id);
+    const unjoinedIndex = new Map<string, Channel>();
+    for (const channel of allUnjoined) {
+      unjoinedIndex.set(channel.id, channel);
+    }
+
+    const joinableSubset = unjoinedIds.filter((id) => {
+      const channel = unjoinedIndex.get(id);
+      const isOpenChannel = channel?.readerRoles?.length === 0;
+
+      const userRolesForGroup =
+        channel?.group?.roles
+          ?.filter((role) =>
+            role.members?.map((m) => m.contactId).includes(currentUserId)
+          )
+          .map((role) => role.id) ?? [];
+
+      const isClosedButCanRead = channel?.readerRoles
+        ?.map((r) => r.roleId)
+        .some((r) => userRolesForGroup.includes(r));
+
+      return isOpenChannel || isClosedButCanRead;
+    });
+
+    return joinableSubset
+      .map((id) => unjoinedIndex.get(id))
+      .filter((c) => c !== undefined) as Channel[];
   },
   ['channels']
 );

--- a/packages/shared/src/db/queries.ts
+++ b/packages/shared/src/db/queries.ts
@@ -222,6 +222,19 @@ export const getPendingChats = createReadQuery(
   ['groups', 'channels']
 );
 
+export const getUnjoinedGroupChannels = createReadQuery(
+  'getUnjoinedGroupChannels',
+  async (groupId: string, ctx: QueryCtx) => {
+    return ctx.db.query.channels.findMany({
+      where: and(
+        eq($channels.groupId, groupId),
+        eq($channels.currentUserIsMember, false)
+      ),
+    });
+  },
+  ['channels']
+);
+
 export const getPins = createReadQuery(
   'getPins',
   async (ctx: QueryCtx): Promise<Pin[]> => {

--- a/packages/shared/src/store/channelActions.ts
+++ b/packages/shared/src/store/channelActions.ts
@@ -323,7 +323,7 @@ export async function leaveGroupChannel(channelId: string) {
   try {
     await api.leaveChannel(channelId);
   } catch (e) {
-    console.error('Failed to leave chat channel', e);
+    console.error('Failed to leave channel', e);
     // rollback optimistic update
     await db.updateChannel({ id: channelId, currentUserIsMember: true });
   }

--- a/packages/shared/src/store/channelActions.ts
+++ b/packages/shared/src/store/channelActions.ts
@@ -328,3 +328,23 @@ export async function leaveGroupChannel(channelId: string) {
     await db.updateChannel({ id: channelId, currentUserIsMember: true });
   }
 }
+
+export async function joinGroupChannel({
+  channelId,
+  groupId,
+}: {
+  channelId: string;
+  groupId: string;
+}) {
+  // optimistic update - this already adds to nav section
+  await db.addJoinedGroupChannel({ channelId });
+
+  try {
+    await api.joinChannel(channelId, groupId);
+  } catch (e) {
+    console.error('Failed to join channel', e);
+    // rollback optimistic update
+    await db.removeJoinedGroupChannel({ channelId });
+    throw e;
+  }
+}

--- a/packages/shared/src/store/dbHooks.ts
+++ b/packages/shared/src/store/dbHooks.ts
@@ -82,6 +82,20 @@ export const usePendingChats = (
   });
 };
 
+export const useUnjoinedGroupChannels = (groupId: string) => {
+  const deps = useKeyFromQueryDeps(db.getUnjoinedGroupChannels);
+  return useQuery({
+    queryKey: [['unjoinedChannels', groupId], deps],
+    queryFn: async () => {
+      if (!groupId) {
+        return [];
+      }
+      const unjoined = await db.getUnjoinedGroupChannels(groupId);
+      return unjoined;
+    },
+  });
+};
+
 export const usePins = (
   queryConfig?: CustomQueryConfig<db.Pin[]>
 ): UseQueryResult<db.Pin[] | null> => {

--- a/packages/ui/src/components/Avatar.tsx
+++ b/packages/ui/src/components/Avatar.tsx
@@ -129,15 +129,17 @@ export const GroupAvatar = React.memo(function GroupAvatarComponent({
 export const ChannelAvatar = React.memo(function ChannelAvatarComponent({
   model,
   useTypeIcon,
+  dimmed,
   ...props
 }: {
   model: db.Channel;
   useTypeIcon?: boolean;
+  dimmed?: boolean;
 } & AvatarProps) {
   const channelTitle = utils.useChannelTitle(model);
 
   if (useTypeIcon) {
-    return <ChannelTypeAvatar channel={model} {...props} />;
+    return <ChannelTypeAvatar channel={model} dimmed={dimmed} {...props} />;
   } else if (model.type === 'dm') {
     return (
       <ContactAvatar
@@ -168,13 +170,17 @@ export const ChannelAvatar = React.memo(function ChannelAvatarComponent({
 export const ChannelTypeAvatar = React.memo(
   function ChannelTypeAvatarComponent({
     channel,
+    dimmed,
     ...props
   }: {
     channel: db.Channel;
+    dimmed?: boolean;
   } & ComponentProps<typeof AvatarFrame>) {
     return (
       <SystemIconAvatar
         {...props}
+        color={dimmed ? '$tertiaryText' : undefined}
+        backgroundColor={dimmed ? '$secondaryBackground' : undefined}
         icon={getChannelTypeIcon(channel.type) || 'Channel'}
       />
     );

--- a/packages/ui/src/components/ChannelNavSection.tsx
+++ b/packages/ui/src/components/ChannelNavSection.tsx
@@ -1,6 +1,6 @@
 import * as db from '@tloncorp/shared/db';
 import { useCallback, useMemo } from 'react';
-import { SizableText, YStack } from 'tamagui';
+import { SizableText, YStack, getVariableValue, useTheme } from 'tamagui';
 
 import { ChannelListItem } from './ListItem';
 
@@ -32,13 +32,15 @@ export default function ChannelNavSection({
     [channels]
   );
 
+  const listSectionTitleColor = getVariableValue(useTheme().secondaryText);
+
   return (
     <YStack key={section.id}>
       <SizableText
         paddingHorizontal="$l"
         paddingVertical="$xl"
         fontSize="$s"
-        color="$secondaryText"
+        color={listSectionTitleColor}
       >
         {section.title}
       </SizableText>

--- a/packages/ui/src/components/ChannelNavSections.tsx
+++ b/packages/ui/src/components/ChannelNavSections.tsx
@@ -1,6 +1,6 @@
 import * as db from '@tloncorp/shared/db';
 import { useMemo } from 'react';
-import { SizableText, YStack } from 'tamagui';
+import { SizableText, YStack, getVariableValue, useTheme } from 'tamagui';
 
 import ChannelNavSection from './ChannelNavSection';
 import { ChannelListItem } from './ListItem';
@@ -49,6 +49,8 @@ export default function ChannelNavSections({
     [unGroupedChannels]
   );
 
+  const listSectionTitleColor = getVariableValue(useTheme().secondaryText);
+
   if (sortBy === 'recency') {
     return (
       <YStack paddingBottom={paddingBottom} alignSelf="stretch" gap="$s">
@@ -92,7 +94,7 @@ export default function ChannelNavSections({
             paddingHorizontal="$l"
             paddingVertical="$xl"
             fontSize="$s"
-            color="$secondaryText"
+            color={listSectionTitleColor}
           >
             All Channels
           </SizableText>

--- a/packages/ui/src/components/ChatOptionsSheet.tsx
+++ b/packages/ui/src/components/ChatOptionsSheet.tsx
@@ -798,7 +798,7 @@ export function ChannelOptions({
                     if (!isWeb) {
                       Alert.alert(
                         `Leave ${title}?`,
-                        'This will be removed from the list',
+                        'You will no longer receive updates from this channel.',
                         [
                           {
                             text: 'Cancel',

--- a/packages/ui/src/components/GroupChannelsScreenView.tsx
+++ b/packages/ui/src/components/GroupChannelsScreenView.tsx
@@ -1,26 +1,33 @@
 import * as db from '@tloncorp/shared/db';
 import { useCallback, useEffect, useRef, useState } from 'react';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
-import { ScrollView, View, YStack } from 'tamagui';
+import { Button, ScrollView, View, YStack } from 'tamagui';
 
 import { useCurrentUserId } from '../contexts';
 import { useIsAdmin } from '../utils/channelUtils';
+import { Badge } from './Badge';
 import ChannelNavSections from './ChannelNavSections';
 import { ChatOptionsSheet, ChatOptionsSheetMethods } from './ChatOptionsSheet';
+import { ChannelListItem } from './ListItem/ChannelListItem';
 import { LoadingSpinner } from './LoadingSpinner';
 import { CreateChannelSheet } from './ManageChannels/CreateChannelSheet';
 import { ScreenHeader } from './ScreenHeader';
+import { Text } from './TextV2';
 
 type GroupChannelsScreenViewProps = {
   group: db.Group | null;
+  unjoinedChannels?: db.Channel[];
   onChannelPressed: (channel: db.Channel) => void;
+  onJoinChannel: (channel: db.Channel) => void;
   onBackPressed: () => void;
   enableCustomChannels?: boolean;
 };
 
 export function GroupChannelsScreenView({
   group,
+  unjoinedChannels = [],
   onChannelPressed,
+  onJoinChannel,
   onBackPressed,
   enableCustomChannels = false,
 }: GroupChannelsScreenViewProps) {
@@ -108,6 +115,28 @@ export function GroupChannelsScreenView({
             sortBy={sortBy || 'recency'}
             onLongPress={handleOpenChannelOptions}
           />
+
+          {unjoinedChannels.length > 0 && (
+            <YStack gap="$s">
+              <Text
+                paddingHorizontal="$l"
+                paddingVertical="$xl"
+                fontSize="$s"
+                color="$secondaryText"
+              >
+                Available Channels
+              </Text>
+              {unjoinedChannels.map((channel) => (
+                <ChannelListItem
+                  key={channel.id}
+                  model={channel}
+                  onPress={() => onJoinChannel(channel)}
+                  useTypeIcon={true}
+                  EndContent={<Badge text="Join" />}
+                />
+              ))}
+            </YStack>
+          )}
         </ScrollView>
       ) : (
         <YStack flex={1} justifyContent="center" alignItems="center">

--- a/packages/ui/src/components/GroupChannelsScreenView.tsx
+++ b/packages/ui/src/components/GroupChannelsScreenView.tsx
@@ -132,7 +132,11 @@ export function GroupChannelsScreenView({
                   model={channel}
                   onPress={() => onJoinChannel(channel)}
                   useTypeIcon={true}
-                  EndContent={<Badge text="Join" />}
+                  EndContent={
+                    <View>
+                      <Badge text="Join" />
+                    </View>
+                  }
                 />
               ))}
             </YStack>

--- a/packages/ui/src/components/GroupChannelsScreenView.tsx
+++ b/packages/ui/src/components/GroupChannelsScreenView.tsx
@@ -1,7 +1,14 @@
 import * as db from '@tloncorp/shared/db';
 import { useCallback, useEffect, useRef, useState } from 'react';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
-import { Button, ScrollView, View, YStack } from 'tamagui';
+import {
+  Button,
+  ScrollView,
+  View,
+  YStack,
+  getVariableValue,
+  useTheme,
+} from 'tamagui';
 
 import { useCurrentUserId } from '../contexts';
 import { useIsAdmin } from '../utils/channelUtils';
@@ -72,6 +79,8 @@ export function GroupChannelsScreenView({
     }
   }, [isGroupAdmin]);
 
+  const listSectionTitleColor = getVariableValue(useTheme().secondaryText);
+
   return (
     <View flex={1}>
       <ScreenHeader
@@ -117,12 +126,12 @@ export function GroupChannelsScreenView({
           />
 
           {unjoinedChannels.length > 0 && (
-            <YStack gap="$s">
+            <YStack>
               <Text
                 paddingHorizontal="$l"
                 paddingVertical="$xl"
                 fontSize="$s"
-                color="$secondaryText"
+                color={listSectionTitleColor}
               >
                 Available Channels
               </Text>
@@ -132,8 +141,9 @@ export function GroupChannelsScreenView({
                   model={channel}
                   onPress={() => onJoinChannel(channel)}
                   useTypeIcon={true}
+                  dimmed={true}
                   EndContent={
-                    <View>
+                    <View justifyContent="center">
                       <Badge text="Join" />
                     </View>
                   }

--- a/packages/ui/src/components/ListItem/ChannelListItem.tsx
+++ b/packages/ui/src/components/ListItem/ChannelListItem.tsx
@@ -20,10 +20,12 @@ export function ChannelListItem({
   onPress,
   onLongPress,
   EndContent,
+  dimmed,
   ...props
 }: {
   useTypeIcon?: boolean;
   customSubtitle?: string;
+  dimmed?: boolean;
 } & ListItemProps<Chat> & { model: db.Channel }) {
   const unreadCount = model.unread?.count ?? 0;
   const title = utils.useChannelTitle(model);
@@ -65,9 +67,13 @@ export function ChannelListItem({
         onLongPress={handleLongPress}
       >
         <ListItem {...props}>
-          <ListItem.ChannelIcon model={model} useTypeIcon={useTypeIcon} />
+          <ListItem.ChannelIcon
+            model={model}
+            useTypeIcon={useTypeIcon}
+            dimmed={dimmed}
+          />
           <ListItem.MainContent>
-            <ListItem.Title>{title}</ListItem.Title>
+            <ListItem.Title dimmed={dimmed}>{title}</ListItem.Title>
             {customSubtitle ? (
               <ListItem.Subtitle>{customSubtitle}</ListItem.Subtitle>
             ) : (

--- a/packages/ui/src/components/ListItem/ListItem.tsx
+++ b/packages/ui/src/components/ListItem/ListItem.tsx
@@ -88,6 +88,13 @@ const ListItemTitle = styled(SizableText, {
   name: 'ListItemTitle',
   color: '$primaryText',
   numberOfLines: 1,
+  variants: {
+    dimmed: {
+      true: {
+        color: '$tertiaryText',
+      },
+    },
+  },
 });
 
 const ListItemSubtitleWithIcon = XStack.styleable<{ icon?: IconType }>(


### PR DESCRIPTION
Fixes TLON-3257

We need to show users the channels they aren't joined to and give them a way to join them.

- Adds a query for channels that are in the group but you aren't joined to.
- Adds channelActions and a tracked poke in the channelsApi for joining a channel in a group.
- Modifies the addJoinedGroupChannel query to avoid collision.
- Adds the result of the unjoined channel query to GroupChannelScreen to create a list of unjoined channels visible to the user.
- Modifies changeListener to account for changes in the db to the channels table and live-update the unjoined channels list.

This produces the following effect:

https://github.com/user-attachments/assets/a1c0fc7b-12a6-4e5a-a8fc-364d7191c2d0

