### PR TITLE
profile & expose: fix integration with contacts

### DIFF
--- a/desk/app/expose.hoon
+++ b/desk/app/expose.hoon
@@ -5,7 +5,7 @@
 ::    then visit in the browser:
 ::    /expose/that/reference/as/copied/123456789
 ::
-/-  c=cite, d=channels, t=contacts-0
+/-  c=cite, d=channels, co=contacts-0
 /+  u=channel-utils, hutils=http-utils,
     dbug, verb
 ::
@@ -13,8 +13,8 @@
 /=  widget  /app/expose/widget
 ::
 |%
-+$  state-0
-  $:  %0
++$  state-1
+  $:  %1
       open=(set cite:c)
   ==
 ::
@@ -79,7 +79,7 @@
 %+  verb  |
 ^-  agent:gall
 ::
-=|  state-0
+=|  state-1
 =*  state  -
 |_  =bowl:gall
 +*  this  .
@@ -93,13 +93,37 @@
 ::
 ++  on-save  !>(state)
 ++  on-load
-  |=  ole=vase
+  |^  |=  ole=vase
   ^-  (quip card _this)
-  =.  state  !<(state-0 ole)
-  :_  this
-  ::  we must defer refreshing the cache because rendering scries
+  =+  !<(old=versioned-state ole)
+  =+  ver=-.old
+  =?  old  ?=(%0 -.old)  old(- %1)
+  ?>  ?=(%1 -.old)
+  =.  state  old
+  =/  caz=(list card)
+    ::  we must defer refreshing the cache because rendering scries
+    ::
+    [%pass /refresh %arvo %b %wait now.bowl]~
+  ::  leave obsolete %contacts endpoint
   ::
-  [%pass /refresh %arvo %b %wait now.bowl]~
+  =?  caz  ?=(%0 ver)
+    %+  weld  caz
+    ^-  (list card)
+    :~  [%pass /contacts %agent [our.bowl %contacts] %leave ~]
+        :: leave %conacts (sic) agent sub
+        [%pass /contacts %agent [our.bowl %conacts] %leave ~]
+    ==
+  [caz this]
+  ::
+  +$  versioned-state
+    $%  state-1
+        state-0
+    ==
+  +$  state-0
+    $:  %0
+        open=(set cite:c)
+    ==
+  --
 ::
 ++  on-poke
   |=  [=mark =vase]
@@ -274,7 +298,7 @@
       ::  fresh(er), we should just set an hourly timer that re-render the
       ::  entire cache.
       ::
-      =+  !<(=news-0:t q.cage.sign)
+      =+  !<(=news-0:co q.cage.sign)
       ?.  =(our.bowl who.news-0)  `this
       :_  this
       %+  weld

--- a/desk/app/expose.hoon
+++ b/desk/app/expose.hoon
@@ -104,7 +104,7 @@
     ::  we must defer refreshing the cache because rendering scries
     ::
     [%pass /refresh %arvo %b %wait now.bowl]~
-  ::  leave obsolete %contacts endpoint
+  ::  leave obsolete %contacts endpoint and connect
   ::
   =?  caz  ?=(%0 ver)
     %+  weld  caz
@@ -112,6 +112,7 @@
     :~  [%pass /contacts %agent [our.bowl %contacts] %leave ~]
         :: leave %conacts (sic) agent sub
         [%pass /contacts %agent [our.bowl %conacts] %leave ~]
+        [%pass /contacts/news %agent [our.bowl %contacts] %watch /news]
     ==
   [caz this]
   ::

--- a/desk/app/expose.hoon
+++ b/desk/app/expose.hoon
@@ -5,7 +5,7 @@
 ::    then visit in the browser:
 ::    /expose/that/reference/as/copied/123456789
 ::
-/-  c=cite, d=channels, co=contacts
+/-  c=cite, d=channels, t=contacts-0
 /+  u=channel-utils, hutils=http-utils,
     dbug, verb
 ::
@@ -88,7 +88,7 @@
   :_  this
   :~  [%pass /eyre/connect %arvo %e %connect [~ /expose] dap.bowl]
       [%pass /channels %agent [our.bowl %channels] %watch /v1]
-      [%pass /contacts %agent [our.bowl %contacts] %watch /contact]
+      [%pass /contacts/news %agent [our.bowl %contacts] %watch /news]
   ==
 ::
 ++  on-save  !>(state)
@@ -254,10 +254,10 @@
       ==
     ==
   ::
-      [%contacts ~]
+      [%contacts %news ~]
     ?-  -.sign
       %poke-ack  !!
-      %kick      [[%pass /contacts %agent [our.bowl %conacts] %watch /contact]~ this]
+      %kick      [[%pass /contacts/news %agent [our.bowl %contacts] %watch /news]~ this]
     ::
         %watch-ack
       ?~  p.sign  [~ this]
@@ -274,6 +274,8 @@
       ::  fresh(er), we should just set an hourly timer that re-render the
       ::  entire cache.
       ::
+      =+  !<(=news-0:t q.cage.sign)
+      ?.  =(our.bowl who.news-0)  `this
       :_  this
       %+  weld
         (refresh-widget:e bowl open)

--- a/desk/app/expose/page.hoon
+++ b/desk/app/expose/page.hoon
@@ -1,6 +1,6 @@
 ::  expose page: rendering for content pages
 ::
-/-  c=cite, d=channels, co=contacts
+/-  c=cite, d=channels, t=contacts-0
 /+  u=channel-utils
 ::
 /=  r  /app/expose/render
@@ -10,8 +10,8 @@
 ++  render
   |=  [=bowl:gall =nest:g:c msg=post:d]
   ^-  (unit manx)
-  =/  aco=(unit contact:co)
-    (get-contact:co bowl author.msg)
+  =/  aco=(unit contact-0:t)
+    (get-contact:t bowl author.msg)
   ::
   ::TODO  if we render replies then we can "unroll" whole chat threads too (:
   |^  ?-  -.kind-data.msg

--- a/desk/app/expose/page.hoon
+++ b/desk/app/expose/page.hoon
@@ -1,6 +1,6 @@
 ::  expose page: rendering for content pages
 ::
-/-  c=cite, d=channels, t=contacts-0
+/-  c=cite, d=channels, co=contacts-0
 /+  u=channel-utils
 ::
 /=  r  /app/expose/render
@@ -10,8 +10,8 @@
 ++  render
   |=  [=bowl:gall =nest:g:c msg=post:d]
   ^-  (unit manx)
-  =/  aco=(unit contact-0:t)
-    (get-contact:t bowl author.msg)
+  =/  aco=(unit contact-0:co)
+    (get-contact:co bowl author.msg)
   ::
   ::TODO  if we render replies then we can "unroll" whole chat threads too (:
   |^  ?-  -.kind-data.msg

--- a/desk/app/expose/render.hoon
+++ b/desk/app/expose/render.hoon
@@ -1,6 +1,6 @@
 ::  expose render: rendering utilities for pages & the widget
 ::
-/-  co=contacts
+/-  c=contacts-0
 /+  sigil
 ::
 |%
@@ -8,8 +8,8 @@
   =/  link=(unit @t)  ~
   |=  [=bowl:gall author=ship]
   ^-  manx
-  =/  aco=(unit contact:co)
-    (get-contact:co bowl author)
+  =/  aco=(unit contact-0:c)
+    (get-contact:c bowl author)
   |^  ::TODO  we should just have a bunch of manx construction helpers
       ::      for stuff like this
       ?~  link
@@ -28,7 +28,7 @@
       ?:  &(?=(^ aco) ?=(^ avatar.u.aco) !=('' u.avatar.u.aco))
         ;img@"{(trip u.avatar.u.aco)}"(alt "Author's avatar");
       =/  val=@ux   ?~(aco 0x0 color.u.aco)
-      =/  col=tape  ((x-co:^co 6) val)
+      =/  col=tape  ((x-co:co 6) val)
       %.  author
       %_  sigil
         size  25
@@ -52,7 +52,7 @@
   =;  utc=tape
     ::NOTE  timestamp-utc class and ms attr used by +time-script,
     ::      which replaces this rendering with the local time
-    ;time.timestamp-utc(ms (a-co:^co (unm time)))
+    ;time.timestamp-utc(ms (a-co:co (unm time)))
       ; {utc}
     ==
   =/  =date  (yore time)
@@ -60,8 +60,8 @@
       "{(num d.t.date)}{(ith d.t.date)}, ".
       "{(num y.date)}, ".
       "{(dum h.t.date)}:{(dum m.t.date)} (UTC)"
-  ++  num  a-co:^co
-  ++  dum  (d-co:^co 2)
+  ++  num  a-co:co
+  ++  dum  (d-co:co 2)
   ++  ith
     |=  n=@ud
     ?-  n

--- a/desk/app/expose/render.hoon
+++ b/desk/app/expose/render.hoon
@@ -1,6 +1,6 @@
 ::  expose render: rendering utilities for pages & the widget
 ::
-/-  c=contacts-0
+/-  co=contacts-0
 /+  sigil
 ::
 |%
@@ -8,8 +8,8 @@
   =/  link=(unit @t)  ~
   |=  [=bowl:gall author=ship]
   ^-  manx
-  =/  aco=(unit contact-0:c)
-    (get-contact:c bowl author)
+  =/  aco=(unit contact-0:co)
+    (get-contact:co bowl author)
   |^  ::TODO  we should just have a bunch of manx construction helpers
       ::      for stuff like this
       ?~  link
@@ -28,7 +28,7 @@
       ?:  &(?=(^ aco) ?=(^ avatar.u.aco) !=('' u.avatar.u.aco))
         ;img@"{(trip u.avatar.u.aco)}"(alt "Author's avatar");
       =/  val=@ux   ?~(aco 0x0 color.u.aco)
-      =/  col=tape  ((x-co:co 6) val)
+      =/  col=tape  ((x-co:^co 6) val)
       %.  author
       %_  sigil
         size  25
@@ -52,7 +52,7 @@
   =;  utc=tape
     ::NOTE  timestamp-utc class and ms attr used by +time-script,
     ::      which replaces this rendering with the local time
-    ;time.timestamp-utc(ms (a-co:co (unm time)))
+    ;time.timestamp-utc(ms (a-co:^co (unm time)))
       ; {utc}
     ==
   =/  =date  (yore time)
@@ -60,8 +60,8 @@
       "{(num d.t.date)}{(ith d.t.date)}, ".
       "{(num y.date)}, ".
       "{(dum h.t.date)}:{(dum m.t.date)} (UTC)"
-  ++  num  a-co:co
-  ++  dum  (d-co:co 2)
+  ++  num  a-co:^co
+  ++  dum  (d-co:^co 2)
   ++  ith
     |=  n=@ud
     ?-  n

--- a/desk/app/profile.hoon
+++ b/desk/app/profile.hoon
@@ -5,7 +5,7 @@
 ::    other apps can poke this agent with widgets of their own, and the user
 ::    can choose which widgets to display on their public page.
 ::
-/-  c=contacts-0
+/-  co=contacts-0
 /+  dbug, verb, sigil, hutils=http-utils
 /=  stock-widgets  /app/profile/widgets
 ::
@@ -13,8 +13,8 @@
 /*  style-page    %css  /app/profile/style/page/css
 ::
 |%
-+$  state-0
-  $:  %0
++$  state-1
+  $:  %1
       bound=_|
     ::
       widgets=(map desk (map term widget))
@@ -44,7 +44,7 @@
 +$  card  $+(card card:agent:gall)
 --
 ::
-|_  [=bowl:gall state-0]
+|_  [=bowl:gall state-1]
 +*  this   .
     state  +<+
 ++  bind
@@ -175,8 +175,8 @@
 ::
 ++  render-page
   ^-  manx
-  =/  ours=(unit contact-0:c)
-    (get-contact:c bowl our.bowl)
+  =/  ours=(unit contact-0:co)
+    (get-contact:co bowl our.bowl)
   |^  ;html
         ;+  head
         ;+  body
@@ -255,7 +255,7 @@
 %-  agent:dbug
 %+  verb  |
 ::
-=|  state-0
+=|  state-1
 =*  state  -
 ^-  agent:gall
 |_  =bowl:gall
@@ -274,7 +274,7 @@
   !>(state)
 ::
 ++  on-load
-  |=  ole=vase
+  |^  |=  ole=vase
   ^-  (quip card _this)
   ::  a different %profile agent has been spotted in the wild. it was not
   ::  compatible with the kelvin at which this agent was first released, made
@@ -287,10 +287,35 @@
           ?=(^ ((soft ,[%0 (map path mime) (set @p) (unit @t)]) q.ole))
       ==
     on-init
-  =.  state  !<(state-0 ole)
-  ::  delay, so we don't end up scrying during load
+  =+  !<(old=versioned-state ole)
+  =+  ver=-.old
+  =?  old  ?=(%0 -.old)  old(- %1)
+  ?>  ?=(%1 -.old)
+  =.  state  old
   ::
-  [[%pass /refresh %arvo %b %wait now.bowl]~ this]
+  =/  caz=(list card)
+    ::  delay, so we don't end up scrying during load
+    [%pass /refresh %arvo %b %wait now.bowl]~
+  ::  leave obsolete %contacts endpoint
+  ::
+  =?  caz  ?=(%0 ver)
+    :_  caz
+    [%pass /contacts/ours %agent [our.bowl %contacts] %leave ~]
+  [caz this]
+  ::
+  +$  versioned-state
+    $%  state-1
+        state-0
+    ==
+  +$  state-0
+    $:  %0
+        bound=_|
+      ::
+        widgets=(map desk (map term widget))
+        layout=(list [=desk =term])
+        tlon-cta=?
+    ==
+  --
 ::
 ++  on-poke
   |=  [=mark =vase]
@@ -328,7 +353,7 @@
       ?.  ?=(%live +<.egg-any)
         ~&  [dap.bowl %egg-any-not-live]
         [~ this]
-      (on-load -:!>(*state-0) +>.old-state.egg-any)
+      (on-load -:!>(*state-1) +>.old-state.egg-any)
     ==
   ==
 ::
@@ -345,7 +370,7 @@
   ?+  wire  ~|(%strange-wire !!)
       [%contacts %news ~]
     ?.  ?=(%fact -.sign)  `this
-    =+  !<(=news-0:c q.cage.sign)
+    =+  !<(=news-0:co q.cage.sign)
     ?.  =(our.bowl who.news-0)  `this
     =^  caz  state  update-group-widgets:do
     [caz this]

--- a/desk/app/profile.hoon
+++ b/desk/app/profile.hoon
@@ -296,11 +296,14 @@
   =/  caz=(list card)
     ::  delay, so we don't end up scrying during load
     [%pass /refresh %arvo %b %wait now.bowl]~
-  ::  leave obsolete %contacts endpoint
+  ::  leave obsolete %contacts endpoint and connect
   ::
   =?  caz  ?=(%0 ver)
-    :_  caz
-    [%pass /contacts/ours %agent [our.bowl %contacts] %leave ~]
+    %+  weld  caz
+    ^-  (list card)
+    :~  [%pass /contacts/ours %agent [our.bowl %contacts] %leave ~]
+        [%pass /contacts/news %agent [our.bowl %contacts] %watch /news]
+    ==
   [caz this]
   ::
   +$  versioned-state

--- a/desk/app/profile.hoon
+++ b/desk/app/profile.hoon
@@ -5,7 +5,7 @@
 ::    other apps can poke this agent with widgets of their own, and the user
 ::    can choose which widgets to display on their public page.
 ::
-/-  contacts-0
+/-  c=contacts-0
 /+  dbug, verb, sigil, hutils=http-utils
 /=  stock-widgets  /app/profile/widgets
 ::
@@ -175,8 +175,8 @@
 ::
 ++  render-page
   ^-  manx
-  =/  ours=(unit contact-0:contacts-0)
-    (get-contact:contacts-0 bowl our.bowl)
+  =/  ours=(unit contact-0:c)
+    (get-contact:c bowl our.bowl)
   |^  ;html
         ;+  head
         ;+  body
@@ -266,7 +266,7 @@
   ::NOTE  we special-case the "internal" widgets
   =.  layout  [[%groups %profile] [%groups %join-button] [%groups %profile-bio] ~]
   :_  this
-  :~  [%pass /contacts/ours %agent [our.bowl %contacts] %watch /contact]
+  :~  [%pass /contacts/news %agent [our.bowl %contacts] %watch /news]
       [%pass /refresh %arvo %b %wait now.bowl]
   ==
 ::
@@ -343,7 +343,10 @@
   |=  [=wire =sign:agent:gall]
   ~|  wire=wire
   ?+  wire  ~|(%strange-wire !!)
-      [%contacts %ours ~]
+      [%contacts %news ~]
+    ?.  ?=(%fact -.sign)  `this
+    =+  !<(=news-0:c q.cage.sign)
+    ?.  =(our.bowl who.news-0)  `this
     =^  caz  state  update-group-widgets:do
     [caz this]
   ==

--- a/desk/app/profile/widgets.hoon
+++ b/desk/app/profile/widgets.hoon
@@ -1,11 +1,11 @@
 ::  profile: construct stock widgets
 ::
-/-  contacts-0
+/-  co=contacts-0
 /+  sigil
 ::
 |=  =bowl:gall
-=/  ours=(unit contact-0:contacts-0)
-  =,  contacts-0
+=/  ours=(unit contact-0:co)
+  =,  co
   ::NOTE  we scry for the full rolodex, because we are not guaranteed to
   ::      have an entry for ourselves, and contacts doesn't expose a "safe"
   ::      (as in crashless) endpoint for checking
@@ -160,7 +160,7 @@
               =src  "{(trip u.avatar.u.ours)}"
               =alt  "Avatar";
           =/  value=@ux   ?~(ours 0x0 color.u.ours)
-          =/  color=tape  ((x-co:co 6) value)
+          =/  color=tape  ((x-co:^co 6) value)
           ;div.profile-headline-avatar-sigil(style "background-color: #{color}")
             ;+  %.  our.bowl
             %_  sigil
@@ -192,7 +192,7 @@
               =src  "{(trip u.avatar.u.ours)}"
               =alt  "Avatar";
           =/  value=@ux   ?~(ours 0x0 color.u.ours)
-          =/  color=tape  ((x-co:co 6) value)
+          =/  color=tape  ((x-co:^co 6) value)
           ;div.profile-headline-avatar-sigil(style "background-color: #{color}")
             ;+  %.  our.bowl
             %_  sigil


### PR DESCRIPTION
There were some outdated type references in %expose that were preventing the upgrade. Additionally, both %profile and %expose were using the removed `/contact` API endpoint. For now we just migrate to subscribing to `/news` and filtering on our own profile updates. We should migrate these two agents to use new %contacts API soon.