### PR TITLE
desktop: fix ChatList/ChannelList height/space weirdness

### DIFF
--- a/packages/ui/src/components/GalleryPost/GalleryPost.tsx
+++ b/packages/ui/src/components/GalleryPost/GalleryPost.tsx
@@ -17,6 +17,7 @@ import {
   PostContent,
   usePostContent,
 } from '../PostContent/contentUtils';
+import Pressable from '../Pressable';
 import { SendPostRetrySheet } from '../SendPostRetrySheet';
 import { Text } from '../TextV2';
 
@@ -76,50 +77,48 @@ export function GalleryPost({
   }
 
   return (
-    <GalleryPostFrame
-      onPress={handlePress}
-      onLongPress={handleLongPress}
-      {...props}
-    >
-      <GalleryContentRenderer post={post} pointerEvents="none" size="$s" />
-      {showAuthor && !post.hidden && !post.isDeleted && (
-        <View
-          position="absolute"
-          bottom={0}
-          left={0}
-          right={0}
-          width="100%"
-          pointerEvents="none"
-        >
-          <XStack alignItems="center" gap="$xl" padding="$m" {...props}>
-            <ContactAvatar size="$2xl" contactId={post.authorId} />
-            {deliveryFailed && (
-              <Text
-                // applying some shadow here because we could be rendering it
-                // on top of an image
-                shadowOffset={{
-                  width: 0,
-                  height: 1,
-                }}
-                shadowOpacity={0.8}
-                shadowColor="$redSoft"
-                color="$negativeActionText"
-                size="$label/s"
-              >
-                Tap to retry
-              </Text>
-            )}
-          </XStack>
-        </View>
-      )}
-      <SendPostRetrySheet
-        open={showRetrySheet}
-        onOpenChange={setShowRetrySheet}
-        post={post}
-        onPressDelete={handleDeletePressed}
-        onPressRetry={handleRetryPressed}
-      />
-    </GalleryPostFrame>
+    <Pressable onPress={handlePress} onLongPress={handleLongPress}>
+      <GalleryPostFrame {...props}>
+        <GalleryContentRenderer post={post} pointerEvents="none" size="$s" />
+        {showAuthor && !post.hidden && !post.isDeleted && (
+          <View
+            position="absolute"
+            bottom={0}
+            left={0}
+            right={0}
+            width="100%"
+            pointerEvents="none"
+          >
+            <XStack alignItems="center" gap="$xl" padding="$m" {...props}>
+              <ContactAvatar size="$2xl" contactId={post.authorId} />
+              {deliveryFailed && (
+                <Text
+                  // applying some shadow here because we could be rendering it
+                  // on top of an image
+                  shadowOffset={{
+                    width: 0,
+                    height: 1,
+                  }}
+                  shadowOpacity={0.8}
+                  shadowColor="$redSoft"
+                  color="$negativeActionText"
+                  size="$label/s"
+                >
+                  Tap to retry
+                </Text>
+              )}
+            </XStack>
+          </View>
+        )}
+        <SendPostRetrySheet
+          open={showRetrySheet}
+          onOpenChange={setShowRetrySheet}
+          post={post}
+          onPressDelete={handleDeletePressed}
+          onPressRetry={handleRetryPressed}
+        />
+      </GalleryPostFrame>
+    </Pressable>
   );
 }
 

--- a/packages/ui/src/components/ListItem/ChannelListItem.tsx
+++ b/packages/ui/src/components/ListItem/ChannelListItem.tsx
@@ -60,8 +60,6 @@ export function ChannelListItem({
     }
   }, [model, firstMemberId, memberCount]);
 
-  const isWindowNarrow = useIsWindowNarrow();
-
   return (
     <View>
       <Pressable
@@ -69,7 +67,7 @@ export function ChannelListItem({
         onPress={handlePress}
         onLongPress={handleLongPress}
       >
-        <ListItem {...props} padding={isWindowNarrow ? '$l' : '$m'}>
+        <ListItem {...props}>
           <ListItem.ChannelIcon
             model={model}
             useTypeIcon={useTypeIcon}

--- a/packages/ui/src/components/ListItem/ChannelListItem.tsx
+++ b/packages/ui/src/components/ListItem/ChannelListItem.tsx
@@ -69,7 +69,7 @@ export function ChannelListItem({
         onPress={handlePress}
         onLongPress={handleLongPress}
       >
-        <ListItem {...props} padding={isWindowNarrow ? '$m' : '$l'}>
+        <ListItem {...props} padding={isWindowNarrow ? '$l' : '$m'}>
           <ListItem.ChannelIcon
             model={model}
             useTypeIcon={useTypeIcon}

--- a/packages/ui/src/components/ListItem/ChannelListItem.tsx
+++ b/packages/ui/src/components/ListItem/ChannelListItem.tsx
@@ -4,6 +4,7 @@ import { useMemo } from 'react';
 import { View } from 'tamagui';
 import { isWeb } from 'tamagui';
 
+import useIsWindowNarrow from '../../hooks/useIsWindowNarrow';
 import * as utils from '../../utils';
 import { capitalize } from '../../utils';
 import { Badge } from '../Badge';
@@ -59,6 +60,8 @@ export function ChannelListItem({
     }
   }, [model, firstMemberId, memberCount]);
 
+  const isWindowNarrow = useIsWindowNarrow();
+
   return (
     <View>
       <Pressable
@@ -66,7 +69,7 @@ export function ChannelListItem({
         onPress={handlePress}
         onLongPress={handleLongPress}
       >
-        <ListItem {...props}>
+        <ListItem {...props} padding={isWindowNarrow ? '$m' : '$l'}>
           <ListItem.ChannelIcon
             model={model}
             useTypeIcon={useTypeIcon}

--- a/packages/ui/src/components/ListItem/ChannelListItem.tsx
+++ b/packages/ui/src/components/ListItem/ChannelListItem.tsx
@@ -3,7 +3,6 @@ import * as logic from '@tloncorp/shared/logic';
 import { useMemo } from 'react';
 import { View } from 'tamagui';
 import { isWeb } from 'tamagui';
-import { getVariableValue } from 'tamagui';
 
 import * as utils from '../../utils';
 import { capitalize } from '../../utils';
@@ -102,9 +101,7 @@ export function ChannelListItem({
                 <ListItem.Count
                   count={unreadCount}
                   muted={logic.isMuted(model.volumeSettings?.level, 'channel')}
-                  marginRight={
-                    isWeb ? getVariableValue('3xl', 'space') : 'unset'
-                  }
+                  marginRight={isWeb ? '$s' : 'unset'}
                 />
               )}
             </ListItem.EndContent>
@@ -112,13 +109,13 @@ export function ChannelListItem({
         </ListItem>
       </Pressable>
       {isWeb && (
-        <View position="absolute" right={-2} top={44} zIndex={1}>
+        <View position="absolute" right="$-2xs" top="$2xl" zIndex={1}>
           <Button
             onPress={handleLongPress}
             borderWidth="unset"
-            size="$s"
             paddingHorizontal={0}
             marginHorizontal="$-m"
+            minimal
           >
             <Icon type="Overflow" />
           </Button>

--- a/packages/ui/src/components/ListItem/GroupListItem.tsx
+++ b/packages/ui/src/components/ListItem/GroupListItem.tsx
@@ -68,7 +68,7 @@ export const GroupListItem = ({
                   <ListItem.Count
                     count={unreadCount}
                     muted={logic.isMuted(model.volumeSettings?.level, 'group')}
-                    marginRight={isWeb ? '$l' : 'unset'}
+                    marginRight={isWeb ? '$s' : 'unset'}
                   />
                 </>
               )}
@@ -77,13 +77,13 @@ export const GroupListItem = ({
         </ListItem>
       </Pressable>
       {isWeb && !isPending && (
-        <View position="absolute" right={-2} top={44} zIndex={1}>
+        <View position="absolute" right="$-2xs" top="$2xl" zIndex={1}>
           <Button
             onPress={handleLongPress}
             borderWidth="unset"
-            size="$s"
             paddingHorizontal={0}
             marginHorizontal="$-m"
+            minimal
           >
             <Icon type="Overflow" />
           </Button>

--- a/packages/ui/src/components/ListItem/GroupListItem.tsx
+++ b/packages/ui/src/components/ListItem/GroupListItem.tsx
@@ -2,6 +2,7 @@ import type * as db from '@tloncorp/shared/db';
 import * as logic from '@tloncorp/shared/logic';
 import { View, isWeb } from 'tamagui';
 
+import useIsWindowNarrow from '../../hooks/useIsWindowNarrow';
 import { Badge } from '../Badge';
 import { Button } from '../Button';
 import { Icon } from '../Icon';
@@ -29,6 +30,8 @@ export const GroupListItem = ({
     onLongPress?.(model);
   });
 
+  const isWindowNarrow = useIsWindowNarrow();
+
   return (
     <View>
       <Pressable
@@ -36,7 +39,11 @@ export const GroupListItem = ({
         onPress={handlePress}
         onLongPress={handleLongPress}
       >
-        <ListItem {...props} alignItems={isPending ? 'center' : 'stretch'}>
+        <ListItem
+          {...props}
+          alignItems={isPending ? 'center' : 'stretch'}
+          padding={isWindowNarrow ? '$m' : '$l'}
+        >
           <ListItem.GroupIcon model={model} />
           <ListItem.MainContent>
             <ListItem.Title>{title}</ListItem.Title>

--- a/packages/ui/src/components/ListItem/GroupListItem.tsx
+++ b/packages/ui/src/components/ListItem/GroupListItem.tsx
@@ -2,7 +2,6 @@ import type * as db from '@tloncorp/shared/db';
 import * as logic from '@tloncorp/shared/logic';
 import { View, isWeb } from 'tamagui';
 
-import useIsWindowNarrow from '../../hooks/useIsWindowNarrow';
 import { Badge } from '../Badge';
 import { Button } from '../Button';
 import { Icon } from '../Icon';
@@ -30,8 +29,6 @@ export const GroupListItem = ({
     onLongPress?.(model);
   });
 
-  const isWindowNarrow = useIsWindowNarrow();
-
   return (
     <View>
       <Pressable
@@ -39,11 +36,7 @@ export const GroupListItem = ({
         onPress={handlePress}
         onLongPress={handleLongPress}
       >
-        <ListItem
-          {...props}
-          alignItems={isPending ? 'center' : 'stretch'}
-          padding={isWindowNarrow ? '$l' : '$m'}
-        >
+        <ListItem {...props} alignItems={isPending ? 'center' : 'stretch'}>
           <ListItem.GroupIcon model={model} />
           <ListItem.MainContent>
             <ListItem.Title>{title}</ListItem.Title>

--- a/packages/ui/src/components/ListItem/GroupListItem.tsx
+++ b/packages/ui/src/components/ListItem/GroupListItem.tsx
@@ -42,7 +42,7 @@ export const GroupListItem = ({
         <ListItem
           {...props}
           alignItems={isPending ? 'center' : 'stretch'}
-          padding={isWindowNarrow ? '$m' : '$l'}
+          padding={isWindowNarrow ? '$l' : '$m'}
         >
           <ListItem.GroupIcon model={model} />
           <ListItem.MainContent>

--- a/packages/ui/src/components/ListItem/ListItem.tsx
+++ b/packages/ui/src/components/ListItem/ListItem.tsx
@@ -3,12 +3,11 @@ import * as db from '@tloncorp/shared/db';
 import { ComponentProps, ReactElement, useMemo } from 'react';
 import {
   getVariableValue,
-  isWeb,
   styled,
   useTheme,
   withStaticProperties,
 } from 'tamagui';
-import { SizableText, Stack, View, XStack, YStack } from 'tamagui';
+import { Stack, View, XStack, YStack } from 'tamagui';
 
 import { numberWithMax } from '../../utils';
 import {
@@ -20,6 +19,7 @@ import {
 } from '../Avatar';
 import ContactName from '../ContactName';
 import { Icon, IconType } from '../Icon';
+import { Text } from '../TextV2';
 
 export interface BaseListItemProps<T> {
   model: T;
@@ -80,14 +80,16 @@ const ListItemImageIcon = ImageAvatar;
 const ListItemMainContent = styled(YStack, {
   name: 'ListItemMainContent',
   flex: 1,
-  justifyContent: 'space-evenly',
-  height: isWeb ? '$5xl' : '$4xl',
+  justifyContent: 'space-around',
+  height: '$4xl',
 });
 
-const ListItemTitle = styled(SizableText, {
+const ListItemTitle = styled(Text, {
   name: 'ListItemTitle',
   color: '$primaryText',
   numberOfLines: 1,
+  size: '$label/l',
+  paddingBottom: 1,
   variants: {
     dimmed: {
       true: {
@@ -121,19 +123,19 @@ const ListItemSubtitleIcon = styled(Icon, {
   size: '$s',
 });
 
-const ListItemSubtitle = styled(SizableText, {
+const ListItemSubtitle = styled(Text, {
   name: 'ListItemSubtitle',
   numberOfLines: 1,
-  size: '$s',
+  size: '$label/m',
   color: '$tertiaryText',
 });
 
-export const ListItemTimeText = styled(SizableText, {
+export const ListItemTimeText = styled(Text, {
   name: 'ListItemTimeText',
   numberOfLines: 1,
   color: '$tertiaryText',
-  size: '$s',
-  lineHeight: '$xs',
+  size: '$label/m',
+  paddingBottom: '$xs',
 });
 
 const ListItemTime = ListItemTimeText.styleable<{
@@ -185,9 +187,9 @@ const ListItemCount = ({
         {muted && (
           <Icon type="Muted" customSize={[12, 12]} color={foregroundColor} />
         )}
-        <SizableText size="$s" color={foregroundColor}>
+        <Text size="$label/m" color={foregroundColor}>
           {numberWithMax(count, 99)}
-        </SizableText>
+        </Text>
       </ListItemCountNumber>
     </Stack>
   );
@@ -197,6 +199,7 @@ const ListItemCountNumber = styled(XStack, {
   name: 'ListItemCountNumber',
   gap: '$s',
   alignItems: 'center',
+  paddingVertical: '$s',
   variants: {
     hidden: {
       true: {

--- a/packages/ui/src/components/TextV2/Text.tsx
+++ b/packages/ui/src/components/TextV2/Text.tsx
@@ -59,7 +59,7 @@ export const typeStyles = {
     fontSize: 16,
     lineHeight: 24,
     letterSpacing: -0.2,
-    fontWeight: '500',
+    fontWeight: '400',
   },
   '$label/xl': {
     fontSize: 17,


### PR DESCRIPTION
edit: now also fixes TLON-3279
fixes TLON-3271

We're now using the new Text component to render text in the chat list, this fixes the line height issue that required setting a specific (larger) height for ListItem on web. Also updates the $label/l value to something less heavy (Dan's recommendation) and updates the margin/position of the overflow menu button (and the count pill next to it).

Looks much more "normal" now:
![image](https://github.com/user-attachments/assets/041255ad-de8c-4d11-a539-df34d5eeec08)

Also looks good on iOS:
![Simulator Screenshot - iPhone 15 - default - 2024-11-26 at 15 03 16](https://github.com/user-attachments/assets/d1b85c89-398a-4616-8b25-87e302d09022)

and Android:
![Screenshot_1732655065](https://github.com/user-attachments/assets/43fd72ac-710d-4d89-91f4-685c749a1a74)

