### PR TITLE
refactor chat query

### DIFF
--- a/packages/app/features/top/ChatListScreen.tsx
+++ b/packages/app/features/top/ChatListScreen.tsx
@@ -202,22 +202,12 @@ export function ChatListScreenView({
     if (item.isPending) {
       return;
     }
-
     setLongPressedChat(item);
-
-    if (item.type === 'channel') {
-      chatOptionsSheetRef.current?.open(
-        item.channel.id,
-        item.channel.type,
-        item.channel.unread?.count
-      );
-    } else {
-      chatOptionsSheetRef.current?.open(
-        item.group.id,
-        'group',
-        item.group.unread?.count ?? undefined
-      );
-    }
+    chatOptionsSheetRef.current?.open(
+      item.id,
+      item.type === 'channel' ? item.channel.type : 'group',
+      item.unreadCount
+    );
   }, []);
 
   const handleGroupPreviewSheetOpenChange = useCallback((open: boolean) => {

--- a/packages/app/fixtures/fakeData.ts
+++ b/packages/app/fixtures/fakeData.ts
@@ -804,7 +804,6 @@ export const groupWithColorAndNoImage: db.Group = {
   currentUserIsHost: false,
   title: 'Test Group',
   privacy: 'private',
-  unreadCount: 1,
   iconImage: null,
   iconImageColor: '#FF00FF',
   coverImage: null,
@@ -813,7 +812,6 @@ export const groupWithColorAndNoImage: db.Group = {
   currentUserIsMember: true,
   lastPostId: 'test-post',
   lastPostAt: dates.now,
-  lastChannel: tlonLocalSupport.title,
   lastPost: { ...createFakePost() },
 };
 
@@ -822,7 +820,6 @@ export const groupWithLongTitle: db.Group = {
   id: '~nibset-napwyn/tlon/long-title',
   title: 'And here, a reallly long title, wazzup, ok',
   lastPostAt: dates.earlierToday,
-  lastChannel: tlonLocalSupport.title,
   lastPost: {
     ...createFakePost(),
     textContent:
@@ -836,8 +833,6 @@ export const groupWithNoColorOrImage: db.Group = {
   iconImageColor: null,
   lastPost: createFakePost(),
   lastPostAt: dates.yesterday,
-  lastChannel: tlonLocalSupport.title,
-  unreadCount: Math.floor(random() * 20),
 };
 
 export const groupWithImage: db.Group = {
@@ -847,8 +842,6 @@ export const groupWithImage: db.Group = {
     'https://dans-gifts.s3.amazonaws.com/dans-gifts/solfer-magfed/2024.4.6..15.49.54..4a7e.f9db.22d0.e560-IMG_4770.jpg',
   lastPost: createFakePost(),
   lastPostAt: dates.lastWeek,
-  lastChannel: tlonLocalSupport.title,
-  unreadCount: Math.floor(random() * 20),
 };
 
 export const groupWithSvgImage: db.Group = {
@@ -857,8 +850,6 @@ export const groupWithSvgImage: db.Group = {
   iconImage: 'https://tlon.io/local-icon.svg',
   lastPost: createFakePost(),
   lastPostAt: dates.lastMonth,
-  lastChannel: tlonLocalSupport.title,
-  unreadCount: Math.floor(random() * 20),
 };
 
 function randInt(min: number, max: number) {

--- a/packages/app/hooks/useBootSequence.ts
+++ b/packages/app/hooks/useBootSequence.ts
@@ -221,7 +221,7 @@ export function useBootSequence({
       if (dmIsGood && groupIsGood) {
         logger.crumb('successfully accepted invites');
         if (updatedTlonTeamDm) {
-          store.pinItem(updatedTlonTeamDm);
+          store.pinChannel(updatedTlonTeamDm);
         }
         return NodeBootPhase.READY;
       }

--- a/packages/app/hooks/useGroupContext.ts
+++ b/packages/app/hooks/useGroupContext.ts
@@ -231,7 +231,7 @@ export const useGroupContext = ({
 
   const togglePinned = useCallback(async () => {
     if (group && group.channels[0]) {
-      group.pin ? store.unpinItem(group.pin) : store.pinItem(group.channels[0]);
+      group.pin ? store.unpinItem(group.pin) : store.pinGroup(group);
     }
   }, [group]);
 

--- a/packages/shared/src/api/activityApi.ts
+++ b/packages/shared/src/api/activityApi.ts
@@ -847,17 +847,19 @@ export function getThreadSource({
   return { source, sourceId };
 }
 
-export function getRootSourceFromChannel(channel: db.Channel): {
+export function getRootSourceFromChat(chat: db.Chat): {
   source: ub.Source;
   sourceId: string;
 } {
   let source: ub.Source;
-  if (channel.type === 'dm') {
-    source = { dm: { ship: channel.id } };
-  } else if (channel.type === 'groupDm') {
-    source = { dm: { club: channel.id } };
+  if (chat.type === 'group') {
+    source = { group: chat.id };
+  } else if (chat.channel.type === 'dm') {
+    source = { dm: { ship: chat.channel.id } };
+  } else if (chat.channel.type === 'groupDm') {
+    source = { dm: { club: chat.channel.id } };
   } else {
-    source = { group: channel.groupId! };
+    throw new Error('Cannot get source for non-dm channel chat');
   }
 
   const sourceId = ub.sourceToString(source);

--- a/packages/shared/src/db/queries.test.ts
+++ b/packages/shared/src/db/queries.test.ts
@@ -42,11 +42,15 @@ test('uses init data to get chat list', async () => {
   await syncInitData();
 
   const result = await queries.getChats();
-  expect(result.map((r) => r.id).slice(0, 8)).toEqual([
+
+  expect(result.pinned.map((r) => r.id)).toEqual([
     '0v4.00000.qd6oi.a3f6t.5sd9v.fjmp2',
-    'chat/~nibset-napwyn/commons',
+  ]);
+
+  expect(result.unpinned.map((r) => r.id).slice(0, 7)).toEqual([
+    '~nibset-napwyn/tlon',
     '~nocsyx-lassul',
-    'chat/~pondus-watbel/new-channel',
+    '~pondus-watbel/testing-facility',
     '~ravseg-nosduc',
     '~solfer-magfed',
     '~hansel-ribbur',

--- a/packages/shared/src/db/types.ts
+++ b/packages/shared/src/db/types.ts
@@ -44,12 +44,8 @@ export type ActivityEvent = BaseModel<'activityEvents'>;
 export type ActivityEventContactUpdateGroups =
   ActivityEvent['contactUpdateGroups'];
 export type ActivityBucket = schema.ActivityBucket;
-// TODO: We need to include unread count here because it's  returned by the chat
-// list query, but doesn't feel great.
-export type Group = BaseModel<'groups'> & {
-  unreadCount?: number | null;
-  lastChannel?: string | null;
-};
+export type Group = BaseModel<'groups'>;
+
 export type ClientMeta = Pick<
   Group,
   | 'title'
@@ -99,6 +95,21 @@ export type PinType = schema.PinType;
 export type Settings = BaseModel<'settings'>;
 export type PostWindow = BaseModel<'postWindows'>;
 export type VolumeSettings = BaseModel<'volumeSettings'>;
+
+export type Chat = {
+  id: string;
+  pin: Pin | null;
+  volumeSettings: VolumeSettings | null;
+  timestamp: number;
+  isPending: boolean;
+  unreadCount: number;
+} & ({ type: 'group'; group: Group } | { type: 'channel'; channel: Channel });
+
+export interface GroupedChats {
+  pinned: Chat[];
+  unpinned: Chat[];
+  pending: Chat[];
+}
 
 export interface GroupEvent extends ActivityEvent {
   type: 'group-ask';

--- a/packages/shared/src/logic/utils.ts
+++ b/packages/shared/src/logic/utils.ts
@@ -212,25 +212,6 @@ export function normalizeUrbitColor(color: string): string {
   return `#${lengthAdjustedColor}`;
 }
 
-export function getPinPartial(channel: db.Channel): {
-  type: db.PinType;
-  itemId: string;
-} {
-  if (channel.groupId) {
-    return { type: 'group', itemId: channel.groupId };
-  }
-
-  if (channel.type === 'dm') {
-    return { type: 'dm', itemId: channel.id };
-  }
-
-  if (channel.type === 'groupDm') {
-    return { type: 'groupDm', itemId: channel.id };
-  }
-
-  return { type: 'channel', itemId: channel.id };
-}
-
 const MS_PER_DAY = 24 * 60 * 60 * 1000;
 const timezoneOffset = new Date().getTimezoneOffset() * 60 * 1000;
 

--- a/packages/shared/src/store/channelActions.ts
+++ b/packages/shared/src/store/channelActions.ts
@@ -149,17 +149,32 @@ export async function updateChannel({
   }
 }
 
-export async function pinItem(channel: db.Channel) {
-  // optimistic update
-  const partialPin = logic.getPinPartial(channel);
-  db.insertPinnedItem(partialPin);
+export async function pinChat(chat: db.Chat) {
+  return chat.type === 'group'
+    ? pinGroup(chat.group)
+    : pinChannel(chat.channel);
+}
 
+export async function pinGroup(group: db.Group) {
+  return savePin({ type: 'group', itemId: group.id });
+}
+
+export async function pinChannel(channel: db.Channel) {
+  const type =
+    channel.type === 'dm' || channel.type === 'groupDm'
+      ? channel.type
+      : 'channel';
+  return savePin({ type, itemId: channel.id });
+}
+
+async function savePin(pin: { type: db.PinType; itemId: string }) {
+  db.insertPinnedItem(pin);
   try {
-    await api.pinItem(partialPin.itemId);
+    await api.pinItem(pin.itemId);
   } catch (e) {
     console.error('Failed to pin item', e);
     // rollback optimistic update
-    db.deletePinnedItem(partialPin);
+    db.deletePinnedItem(pin);
   }
 }
 

--- a/packages/shared/src/store/sync.test.ts
+++ b/packages/shared/src/store/sync.test.ts
@@ -296,9 +296,11 @@ test('syncs last posts', async () => {
   await syncLatestPosts();
   const chats = await db.getChats();
   const NUM_EMPTY_TEST_GROUPS = 6;
-  const chatsWithLatestPosts = chats.filter((c) => c.lastPost);
+  const chatsWithLatestPosts = chats.unpinned.filter((c) =>
+    c.type === 'channel' ? c.channel.lastPost : c.group.lastPost
+  );
   expect(chatsWithLatestPosts.length).toEqual(
-    chats.length - NUM_EMPTY_TEST_GROUPS
+    chats.unpinned.length - NUM_EMPTY_TEST_GROUPS
   );
 });
 

--- a/packages/ui/src/components/ChatList.tsx
+++ b/packages/ui/src/components/ChatList.tsx
@@ -1,7 +1,7 @@
 import { FlashList, ListRenderItem } from '@shopify/flash-list';
 import * as db from '@tloncorp/shared/db';
 import Fuse from 'fuse.js';
-import { debounce, get } from 'lodash';
+import { debounce } from 'lodash';
 import React, {
   useCallback,
   useEffect,

--- a/packages/ui/src/components/ChatList.tsx
+++ b/packages/ui/src/components/ChatList.tsx
@@ -1,9 +1,7 @@
 import { FlashList, ListRenderItem } from '@shopify/flash-list';
 import * as db from '@tloncorp/shared/db';
-import * as logic from '@tloncorp/shared/logic';
-import * as store from '@tloncorp/shared/store';
 import Fuse from 'fuse.js';
-import { debounce } from 'lodash';
+import { debounce, get } from 'lodash';
 import React, {
   useCallback,
   useEffect,
@@ -19,6 +17,7 @@ import Animated, {
 } from 'react-native-reanimated';
 import { Text, View, YStack, getTokenValue } from 'tamagui';
 
+import { useCalm } from '../contexts';
 import { interactionWithTiming } from '../utils/animation';
 import { TextInputWithIconAndButton } from './Form';
 import { ChatListItem, InteractableChatListItem } from './ListItem';
@@ -26,17 +25,15 @@ import Pressable from './Pressable';
 import { SectionListHeader } from './SectionList';
 import { Tabs } from './Tabs';
 
-export type Chat = db.Channel | db.Group;
-
 export type TabName = 'all' | 'groups' | 'messages';
 
 type SectionHeaderData = { type: 'sectionHeader'; title: string };
-type ChatListItemData = Chat | SectionHeaderData;
+type ChatListItemData = db.Chat | SectionHeaderData;
 
 export const ChatList = React.memo(function ChatListComponent({
   pinned,
   unpinned,
-  pendingChats,
+  pending,
   onLongPressItem,
   onPressItem,
   activeTab,
@@ -45,10 +42,9 @@ export const ChatList = React.memo(function ChatListComponent({
   searchQuery,
   onSearchQueryChange,
   onSearchToggle,
-}: store.CurrentChats & {
-  pendingChats: store.PendingChats;
-  onPressItem?: (chat: Chat) => void;
-  onLongPressItem?: (chat: Chat) => void;
+}: db.GroupedChats & {
+  onPressItem?: (chat: db.Chat) => void;
+  onLongPressItem?: (chat: db.Chat) => void;
   onSectionChange?: (title: string) => void;
   activeTab: TabName;
   setActiveTab: (tab: TabName) => void;
@@ -60,7 +56,7 @@ export const ChatList = React.memo(function ChatListComponent({
   const displayData = useFilteredChats({
     pinned,
     unpinned,
-    pending: pendingChats,
+    pending,
     searchQuery,
     activeTab,
   });
@@ -92,7 +88,7 @@ export const ChatList = React.memo(function ChatListComponent({
             <SectionListHeader.Text>{item.title}</SectionListHeader.Text>
           </SectionListHeader>
         );
-      } else if (logic.isChannel(item)) {
+      } else if (item.type === 'channel' || !item.isPending) {
         return (
           <InteractableChatListItem
             model={item}
@@ -156,17 +152,7 @@ export const ChatList = React.memo(function ChatListComponent({
 });
 
 function getItemType(item: ChatListItemData) {
-  return isSectionHeader(item)
-    ? 'sectionHeader'
-    : logic.isGroup(item)
-      ? 'group'
-      : logic.isChannel(item)
-        ? item.type === 'dm' ||
-          item.type === 'groupDm' ||
-          item.pin?.type === 'channel'
-          ? 'channel'
-          : 'groupAdapter'
-        : 'default';
+  return isSectionHeader(item) ? 'sectionHeader' : item.type;
 }
 
 function isSectionHeader(data: ChatListItemData): data is SectionHeaderData {
@@ -182,9 +168,6 @@ function getChatKey(chatItem: ChatListItemData) {
     return chatItem.title;
   }
 
-  if (logic.isGroup(chatItem)) {
-    return chatItem.id;
-  }
   return `${chatItem.id}-${chatItem.pin?.itemId ?? ''}`;
 }
 
@@ -290,13 +273,13 @@ function useFilteredChats({
   searchQuery,
   activeTab,
 }: {
-  pinned: Chat[];
-  unpinned: Chat[];
-  pending: Chat[];
+  pinned: db.Chat[];
+  unpinned: db.Chat[];
+  pending: db.Chat[];
   searchQuery: string;
   activeTab: TabName;
 }) {
-  const performSearch = useChatSearch({ pinned, unpinned });
+  const performSearch = useChatSearch({ pinned, unpinned, pending });
   const debouncedQuery = useDebouncedValue(searchQuery, 200);
   const searchResults = useMemo(
     () => performSearch(debouncedQuery),
@@ -331,42 +314,53 @@ function useFilteredChats({
   }, [activeTab, pending, searchQuery, searchResults, unpinned, pinned]);
 }
 
-function filterPendingChats(pending: Chat[], activeTab: TabName) {
+function filterPendingChats(pending: db.Chat[], activeTab: TabName) {
   if (activeTab === 'all') return pending;
   return pending.filter((chat) => {
-    const isGroupChannel = logic.isGroup(chat);
-    return activeTab === 'groups' ? isGroupChannel : !isGroupChannel;
+    const isGroup = chat.type === 'group';
+    return activeTab === 'groups' ? isGroup : !isGroup;
   });
 }
 
-function filterChats(chats: Chat[], activeTab: TabName) {
+function filterChats(chats: db.Chat[], activeTab: TabName) {
   if (activeTab === 'all') return chats;
   return chats.filter((chat) => {
-    const isGroupChannel = logic.isGroupChannelId(chat.id);
-    return activeTab === 'groups' ? isGroupChannel : !isGroupChannel;
+    const isGroup = chat.type === 'group';
+    return activeTab === 'groups' ? isGroup : !isGroup;
   });
 }
 
 function useChatSearch({
   pinned,
   unpinned,
+  pending,
 }: {
-  pinned: Chat[];
-  unpinned: Chat[];
+  pinned: db.Chat[];
+  unpinned: db.Chat[];
+  pending: db.Chat[];
 }) {
+  const { disableNicknames } = useCalm();
+
   const fuse = useMemo(() => {
-    const allData = [...pinned, ...unpinned];
+    const allData = [...pinned, ...unpinned, ...pending];
     return new Fuse(allData, {
       keys: [
-        'id',
-        'group.title',
-        'contact.nickname',
-        'members.contact.nickname',
-        'members.contact.id',
+        {
+          name: 'title',
+          getFn: (chat: db.Chat) => {
+            const title = getChatTitle(chat, disableNicknames);
+            return Array.isArray(title)
+              ? title.map(normalizeString)
+              : normalizeString(title);
+          },
+        },
       ],
-      threshold: 0.3,
     });
-  }, [pinned, unpinned]);
+  }, [pinned, unpinned, pending, disableNicknames]);
+
+  function normalizeString(str: string) {
+    return str.normalize('NFD').replace(/[\u0300-\u036f]/g, '');
+  }
 
   const performSearch = useCallback(
     (query: string) => {
@@ -379,6 +373,34 @@ function useChatSearch({
   );
 
   return performSearch;
+}
+
+function getChatTitle(
+  chat: db.Chat,
+  disableNicknames: boolean
+): string | string[] {
+  if (chat.type === 'channel') {
+    if (chat.channel.title) {
+      return chat.channel.title;
+    } else if (chat.channel.members) {
+      return chat.channel.members
+        .map((member) => {
+          const nickname = member.contact
+            ? (member.contact as db.Contact).nickname
+            : null;
+          return nickname && !disableNicknames ? nickname : member.contactId;
+        })
+        .join(', ');
+    } else {
+      return [];
+    }
+  } else {
+    if (chat.group.title) {
+      return chat.group.title;
+    } else {
+      return [];
+    }
+  }
 }
 
 function useDebouncedValue<T>(input: T, delay: number) {

--- a/packages/ui/src/components/ChatOptionsSheet.tsx
+++ b/packages/ui/src/components/ChatOptionsSheet.tsx
@@ -665,7 +665,7 @@ export function ChannelOptions({
               }
               channel.pin
                 ? store.unpinItem(channel.pin)
-                : store.pinItem(channel);
+                : store.pinChannel(channel);
             },
           },
         ],

--- a/packages/ui/src/components/ListItem/ChannelListItem.tsx
+++ b/packages/ui/src/components/ListItem/ChannelListItem.tsx
@@ -1,15 +1,12 @@
 import type * as db from '@tloncorp/shared/db';
 import * as logic from '@tloncorp/shared/logic';
 import { useMemo } from 'react';
-import { View } from 'tamagui';
-import { isWeb } from 'tamagui';
+import { View, isWeb } from 'tamagui';
 
-import useIsWindowNarrow from '../../hooks/useIsWindowNarrow';
 import * as utils from '../../utils';
 import { capitalize } from '../../utils';
 import { Badge } from '../Badge';
 import { Button } from '../Button';
-import { Chat } from '../ChatList';
 import { Icon } from '../Icon';
 import Pressable from '../Pressable';
 import { ListItem, type ListItemProps } from './ListItem';
@@ -27,7 +24,7 @@ export function ChannelListItem({
   useTypeIcon?: boolean;
   customSubtitle?: string;
   dimmed?: boolean;
-} & ListItemProps<Chat> & { model: db.Channel }) {
+} & ListItemProps<db.Channel>) {
   const unreadCount = model.unread?.count ?? 0;
   const title = utils.useChannelTitle(model);
   const firstMemberId = model.members?.[0]?.contactId ?? '';
@@ -82,7 +79,7 @@ export function ChannelListItem({
                 {subtitle}
               </ListItem.SubtitleWithIcon>
             )}
-            {model.lastPost && (
+            {model.lastPost && !model.isDmInvite && (
               <ListItem.PostPreview
                 post={model.lastPost}
                 showAuthor={model.type !== 'dm'}

--- a/packages/ui/src/components/ListItem/ChatListItem.tsx
+++ b/packages/ui/src/components/ListItem/ChatListItem.tsx
@@ -1,8 +1,7 @@
 import type * as db from '@tloncorp/shared/db';
 import * as logic from '@tloncorp/shared/logic';
-import React, { useMemo } from 'react';
+import React from 'react';
 
-import { Chat } from '../ChatList';
 import { ChannelListItem } from './ChannelListItem';
 import { GroupListItem } from './GroupListItem';
 import { ListItemProps } from './ListItem';
@@ -12,7 +11,7 @@ export const ChatListItem = React.memo(function ChatListItemComponent({
   onPress,
   onLongPress,
   ...props
-}: ListItemProps<Chat>) {
+}: ListItemProps<db.Chat>) {
   const handlePress = logic.useMutableCallback(() => {
     onPress?.(model);
   });
@@ -21,74 +20,23 @@ export const ChatListItem = React.memo(function ChatListItemComponent({
     onLongPress?.(model);
   });
 
-  // if the chat list item is a group, it's pending
-  if (logic.isGroup(model)) {
+  if (model.type === 'group') {
     return (
       <GroupListItem
         onPress={handlePress}
         onLongPress={handleLongPress}
-        model={model}
+        model={model.group}
+        {...props}
+      />
+    );
+  } else {
+    return (
+      <ChannelListItem
+        model={model.channel}
+        onPress={handlePress}
+        onLongPress={handleLongPress}
         {...props}
       />
     );
   }
-
-  if (logic.isChannel(model)) {
-    if (
-      model.type === 'dm' ||
-      model.type === 'groupDm' ||
-      model.pin?.type === 'channel'
-    ) {
-      return (
-        <ChannelListItem
-          model={model}
-          onPress={handlePress}
-          onLongPress={handleLongPress}
-          {...props}
-        />
-      );
-    } else if (model.group) {
-      return (
-        <GroupListItemAdapter
-          model={model}
-          groupModel={model.group}
-          onPress={handlePress}
-          onLongPress={handleLongPress}
-          {...props}
-        />
-      );
-    }
-  }
-
-  console.warn('unable to render chat list item', model.id, model);
-  return null;
 });
-
-function GroupListItemAdapter({
-  model,
-  groupModel,
-  onPress,
-  onLongPress,
-  ...props
-}: ListItemProps<Chat> & {
-  groupModel: db.Group;
-  onPress: () => void;
-  onLongPress: () => void;
-}) {
-  const resolvedModel = useMemo(() => {
-    return {
-      ...groupModel,
-      unreadCount: model.unread?.count,
-      lastPost: model.lastPost,
-      lastChannel: model.title,
-    };
-  }, [model, groupModel]);
-  return (
-    <GroupListItem
-      onPress={onPress}
-      onLongPress={onLongPress}
-      model={resolvedModel}
-      {...props}
-    />
-  );
-}

--- a/packages/ui/src/components/ListItem/GroupListItem.tsx
+++ b/packages/ui/src/components/ListItem/GroupListItem.tsx
@@ -43,11 +43,11 @@ export const GroupListItem = ({
             {customSubtitle && (
               <ListItem.Subtitle>{customSubtitle}</ListItem.Subtitle>
             )}
-            {model.lastPost && !customSubtitle && (
+            {model.lastPost && model.channels?.length && !customSubtitle && (
               <ListItem.SubtitleWithIcon
                 icon={getPostTypeIcon(model.lastPost.type)}
               >
-                {model.lastChannel}
+                {model.channels[0].title}
               </ListItem.SubtitleWithIcon>
             )}
             {!isPending && model.lastPost ? (

--- a/packages/ui/src/components/ListItem/InteractableChatListItem.tsx
+++ b/packages/ui/src/components/ListItem/InteractableChatListItem.tsx
@@ -20,7 +20,6 @@ import Animated, {
 import { ColorTokens, Stack, View, getTokenValue, isWeb } from 'tamagui';
 
 import * as utils from '../../utils';
-import { Chat } from '../ChatList';
 import { Icon, IconType } from '../Icon';
 import { ChatListItem } from './ChatListItem';
 import { ListItemProps } from './ListItem';
@@ -30,19 +29,14 @@ function BaseInteractableChatRow({
   model,
   onPress,
   onLongPress,
-}: ListItemProps<Chat> & { model: db.Channel }) {
+}: ListItemProps<db.Chat>) {
   const swipeableRef = useRef<SwipeableMethods>(null);
   const [currentSwipeDirection, setCurrentSwipeDirection] = useState<
     'left' | 'right' | null
   >(null);
 
   const isMuted = useMemo(() => {
-    if (model.group) {
-      return logic.isMuted(model.group.volumeSettings?.level, 'group');
-    } else if (model.type === 'dm' || model.type === 'groupDm') {
-      return logic.isMuted(model.volumeSettings?.level, 'channel');
-    }
-    return false;
+    return logic.isMuted(model.volumeSettings?.level, model.type);
   }, [model]);
 
   // prevent color flicker when unmuting
@@ -60,16 +54,16 @@ function BaseInteractableChatRow({
       utils.triggerHaptic('swipeAction');
       switch (actionId) {
         case 'pin':
-          model.pin ? store.unpinItem(model.pin) : store.pinItem(model);
+          model.pin ? store.unpinItem(model.pin) : store.pinChat(model);
           break;
         case 'mute':
           isMuted ? store.unmuteChat(model) : store.muteChat(model);
           break;
         case 'markRead':
-          if (model.group) {
+          if (model.type === 'group') {
             store.markGroupRead(model.group, true);
           } else {
-            store.markChannelRead(model);
+            store.markChannelRead(model.channel);
           }
           break;
         default:
@@ -89,9 +83,7 @@ function BaseInteractableChatRow({
 
   const renderLeftActions = useCallback(
     (progress: SharedValue<number>, drag: SharedValue<number>) => {
-      const hasUnread = model.group
-        ? (model.group.unread?.count ?? 0) > 0
-        : (model.unread?.count ?? 0) > 0;
+      const hasUnread = model.unreadCount > 0;
 
       if (currentSwipeDirection === 'right' || !hasUnread) {
         return <View />;
@@ -105,7 +97,7 @@ function BaseInteractableChatRow({
         />
       );
     },
-    [handleAction, model.group, model.unread?.count, currentSwipeDirection]
+    [model.unreadCount, currentSwipeDirection, handleAction]
   );
 
   const renderRightActions = useCallback(

--- a/packages/ui/src/contexts/chatOptions.tsx
+++ b/packages/ui/src/contexts/chatOptions.tsx
@@ -74,7 +74,7 @@ export const ChatOptionsProvider = ({
 
   const onTogglePinned = useCallback(() => {
     if (group && group.channels[0]) {
-      group.pin ? store.unpinItem(group.pin) : store.pinItem(group.channels[0]);
+      group.pin ? store.unpinItem(group.pin) : store.pinGroup(group);
     }
   }, [group]);
 


### PR DESCRIPTION
This PR refactors the `getChats` query to simplify rendering logic and add flexibility in querying. It sets up plumbing I'll need for the channel flattening work. 