### PR TITLE
channels: fix +ca-recheck due to a invalid scry path

### DIFF
--- a/desk/app/channels.hoon
+++ b/desk/app/channels.hoon
@@ -2383,7 +2383,7 @@
     |=  sects=(set sect:g)
     =/  =flag:g  group.perm.perm.channel
     =/  exists-path
-      (scry-path %groups /exists/(scot %p p.flag)/[q.flag])
+      (scry-path %groups /exists/(scot %p p.flag)/[q.flag]/noun)
     =+  .^(exists=? %gx exists-path)
     ?.  exists  ca-core
     =/  =path


### PR DESCRIPTION
Apparently `+ca-recheck` was broken all this while, generating crashes due to invalid scry path. 

This is the first bug uncovered by the %logs agent.