### PR TITLE
desktop: fix routing/crash issues in settings, add contacts, add themes

### DIFF
--- a/packages/app/features/settings/AppInfoScreen.tsx
+++ b/packages/app/features/settings/AppInfoScreen.tsx
@@ -1,6 +1,5 @@
 import { NativeStackScreenProps } from '@react-navigation/native-stack';
 import { useDebugStore } from '@tloncorp/shared';
-import { getCurrentUserId } from '@tloncorp/shared/api';
 import * as store from '@tloncorp/shared/store';
 import {
   AppSetting,
@@ -23,6 +22,7 @@ import { getEmailClients, openComposer } from 'react-native-email-link';
 import { ScrollView } from 'react-native-gesture-handler';
 
 import { NOTIFY_PROVIDER, NOTIFY_SERVICE } from '../../constants';
+import { useCurrentUserId } from '../../hooks/useCurrentUser';
 import { useTelemetry } from '../../hooks/useTelemetry';
 import { setDebug } from '../../lib/debug';
 import { getEasUpdateDisplay } from '../../lib/platformHelpers';
@@ -32,13 +32,17 @@ const BUILD_VERSION = `${Platform.OS === 'ios' ? 'iOS' : 'Android'} ${Applicatio
 
 type Props = NativeStackScreenProps<RootStackParamList, 'AppInfo'>;
 
-function makeDebugEmail(appInfo: any, platformInfo: any) {
+function makeDebugEmail(
+  appInfo: any,
+  platformInfo: any,
+  currentUserId: string
+) {
   return `
 ----------------------------------------------
 Insert description of problem here.
 ----------------------------------------------
 
-Tlon ID: ${getCurrentUserId()}
+Tlon ID: ${currentUserId}
 
 Platform Information:
 ${JSON.stringify(platformInfo)}
@@ -54,6 +58,7 @@ export function AppInfoScreen(props: Props) {
   const easUpdateDisplay = useMemo(() => getEasUpdateDisplay(Updates), []);
   const [hasClients, setHasClients] = useState(true);
   const telemetry = useTelemetry();
+  const currentUserId = useCurrentUserId();
   const [telemetryDisabled, setTelemetryDisabled] = useState(
     telemetry.optedOut
   );
@@ -105,10 +110,10 @@ export function AppInfoScreen(props: Props) {
 
     openComposer({
       to: 'support@tlon.io',
-      subject: `${getCurrentUserId()} uploaded logs ${id}`,
-      body: makeDebugEmail(appInfo, platformInfo),
+      subject: `${currentUserId} uploaded logs ${id}`,
+      body: makeDebugEmail(appInfo, platformInfo, currentUserId),
     });
-  }, [hasClients]);
+  }, [hasClients, currentUserId]);
 
   return (
     <View flex={1} backgroundColor="$background">

--- a/packages/app/features/settings/ThemeScreen.tsx
+++ b/packages/app/features/settings/ThemeScreen.tsx
@@ -71,7 +71,7 @@ export function ThemeScreen(props: Props) {
   }, []);
 
   return (
-    <>
+    <View backgroundColor="$background" flex={1}>
       <ScreenHeader
         title="Theme"
         backAction={() => props.navigation.goBack()}
@@ -106,6 +106,6 @@ export function ThemeScreen(props: Props) {
           ))}
         </YStack>
       </ScrollView>
-    </>
+    </View>
   );
 }

--- a/packages/app/features/settings/UserBugReportScreen.tsx
+++ b/packages/app/features/settings/UserBugReportScreen.tsx
@@ -43,7 +43,7 @@ export function UserBugReportScreen({ navigation }: Props) {
   );
 
   return (
-    <View backgroundColor="$background">
+    <View backgroundColor="$background" flex={1}>
       <ScreenHeader
         title="Report a bug"
         backAction={() => navigation.goBack()}

--- a/packages/app/features/top/ContactsScreen.tsx
+++ b/packages/app/features/top/ContactsScreen.tsx
@@ -63,7 +63,7 @@ export default function ContactsScreen(props: Props) {
 
   return (
     <AppDataContextProvider contacts={contacts} currentUserId={currentUser}>
-      <View flex={1}>
+      <View backgroundColor="$background" flex={1}>
         <ScreenHeader
           title="Contacts"
           rightControls={

--- a/packages/app/hooks/useTelemetry.ts
+++ b/packages/app/hooks/useTelemetry.ts
@@ -7,7 +7,7 @@ import { useCallback, useEffect, useMemo } from 'react';
 
 import { useShip } from '../contexts/ship';
 import { TelemetryClient } from '../types/telemetry';
-import { useCurrentUserId } from './useCurrentUser.native';
+import { useCurrentUserId } from './useCurrentUser';
 import { usePosthog } from './usePosthog';
 
 export function useClearTelemetryConfig() {

--- a/packages/app/navigation/desktop/HomeNavigator.tsx
+++ b/packages/app/navigation/desktop/HomeNavigator.tsx
@@ -5,6 +5,7 @@ import {
 import type { NativeStackScreenProps } from '@react-navigation/native-stack';
 import { createNativeStackNavigator } from '@react-navigation/native-stack';
 import { NavigationState } from '@react-navigation/routers';
+import { View, getVariableValue, useTheme } from 'tamagui';
 
 import { ChannelMembersScreen } from '../../features/channels/ChannelMembersScreen';
 import { ChannelMetaScreen } from '../../features/channels/ChannelMetaScreen';
@@ -34,6 +35,7 @@ export const HomeNavigator = () => {
         headerShown: false,
         drawerStyle: {
           width: 340,
+          backgroundColor: getVariableValue(useTheme().background),
         },
       }}
     >
@@ -68,9 +70,9 @@ function MainStack() {
       screenOptions={{
         headerShown: false,
       }}
-      initialRouteName="ChatList"
+      initialRouteName="Home"
     >
-      <MainStackNavigator.Screen name="ChatList" component={Empty} />
+      <MainStackNavigator.Screen name="Home" component={Empty} />
       <MainStackNavigator.Screen
         name="CreateGroup"
         component={CreateGroupScreen}
@@ -141,5 +143,5 @@ function ChannelStack(
 }
 
 function Empty() {
-  return null;
+  return <View backgroundColor="$secondaryBackground" flex={1} />;
 }

--- a/packages/app/navigation/desktop/ProfileScreenNavigator.tsx
+++ b/packages/app/navigation/desktop/ProfileScreenNavigator.tsx
@@ -7,7 +7,9 @@ import { FeatureFlagScreen } from '../../features/settings/FeatureFlagScreen';
 import { ManageAccountScreen } from '../../features/settings/ManageAccountScreen';
 import ProfileScreen from '../../features/settings/ProfileScreen';
 import { PushNotificationSettingsScreen } from '../../features/settings/PushNotificationSettingsScreen';
+import { ThemeScreen } from '../../features/settings/ThemeScreen';
 import { UserBugReportScreen } from '../../features/settings/UserBugReportScreen';
+import ContactsScreen from '../../features/top/ContactsScreen';
 import { UserProfileScreen } from '../../features/top/UserProfileScreen';
 
 const ProfileScreenStack = createNativeStackNavigator();
@@ -15,13 +17,14 @@ const ProfileScreenStack = createNativeStackNavigator();
 export const ProfileScreenNavigator = () => {
   return (
     <ProfileScreenStack.Navigator
-      initialRouteName="ProfileScreen"
+      initialRouteName="Contacts"
       screenOptions={{
         headerShown: false,
       }}
     >
+      <ProfileScreenStack.Screen name="Contacts" component={ContactsScreen} />
       <ProfileScreenStack.Screen
-        name="ProfileScreen"
+        name="Profile"
         component={ProfileScreen}
       />
       <ProfileScreenStack.Screen name="AppInfo" component={AppInfoScreen} />
@@ -53,6 +56,7 @@ export const ProfileScreenNavigator = () => {
         name="EditProfile"
         component={EditProfileScreen}
       />
+      <ProfileScreenStack.Screen name="Theme" component={ThemeScreen} />
     </ProfileScreenStack.Navigator>
   );
 };

--- a/packages/app/navigation/desktop/TopLevelDrawer.tsx
+++ b/packages/app/navigation/desktop/TopLevelDrawer.tsx
@@ -4,6 +4,7 @@ import {
 } from '@react-navigation/drawer';
 import * as store from '@tloncorp/shared/store';
 import { AvatarNavIcon, NavIcon, YStack, useWebAppUpdate } from '@tloncorp/ui';
+import { getVariableValue, useTheme } from 'tamagui';
 
 import { ActivityScreen } from '../../features/top/ActivityScreen';
 import { useCurrentUserId } from '../../hooks/useCurrentUser';
@@ -72,6 +73,8 @@ export const TopLevelDrawer = () => {
         headerShown: false,
         drawerStyle: {
           width: 48,
+          backgroundColor: getVariableValue(useTheme().background),
+          borderRightColor: getVariableValue(useTheme().border),
         },
       }}
     >


### PR DESCRIPTION
fixes TLON-3280
fixes TLON-3283
fixes TLON-3284

The crash in the AppInfoScreen was caused by the use of `getCurrentUser` in that screen and the import of the native version of useCurrentUser in the useTelemetry hook.

Updated desktop to now point to the Contacts screen when pressing the profile avatar in the nav, and the settings are now behind the cog like they are on mobile.

I also made desktop work with our themes (and made sure we could navigate to the ThemeScreen on desktop), including adding `backgroundColor` to a few places where we needed it.