### PR TITLE
desktop: fix issue with stale data breaking the app on first load

### DIFF
--- a/apps/tlon-web-new/src/logic/useAppUpdates.ts
+++ b/apps/tlon-web-new/src/logic/useAppUpdates.ts
@@ -1,3 +1,4 @@
+import { queryClient } from '@tloncorp/shared';
 import { createContext, useCallback, useEffect, useState } from 'react';
 import { useRegisterSW } from 'virtual:pwa-register/react';
 
@@ -78,6 +79,7 @@ export default function useAppUpdates() {
         : `${window.location.href}?updatedAt=${Date.now()}`;
 
       if (needRefresh) {
+        queryClient.clear();
         try {
           await updateServiceWorker(false);
         } catch (e) {

--- a/apps/tlon-web-new/src/main.tsx
+++ b/apps/tlon-web-new/src/main.tsx
@@ -57,8 +57,8 @@ setupDb().then(() => {
     <PersistQueryClientProvider
       client={queryClient}
       persistOptions={{
-        persister: indexedDBPersistor(`${window.our}-landscape`),
-        buster: `${window.our}-landscape-4.0.1`,
+        persister: indexedDBPersistor(`${window.our}-tlon`),
+        buster: `${window.our}-tlon-buster-0`,
       }}
     >
       <PostHogProvider client={analyticsClient}>


### PR DESCRIPTION
This morning, a change to the return type of useCurrentChats caused the web app to crash on initial load. This appears to have been happening because the `isFocused` flag defaults to false on first load, which means we disabled the fetch on the useCurrentChats query, which caused us to try to hydrate the ChatListScreenView component with data that doesn't match the return type expected by the component.

In order to prevent this sort of thing in the future, we now clear the cache before updating the service worker when the user presses the update button in the TopLevelDrawer.

This also changes the cache buster string so we can fix the situation with users who are currently synced to wannec (who have already attempted to update). Not totally sure that'll work, if not those users will have to manually update their service worker. This is probably just devs and a few other people at tlon (reid, eleanor, maybe galen).

It also changes the persister string so we don't collide with the old app's persister (not clear that this caused an issue, but it seems like it could).

fixes TLON-3288