### PR TITLE
contacts: quick fixes

### DIFF
--- a/packages/shared/src/api/contactsApi.ts
+++ b/packages/shared/src/api/contactsApi.ts
@@ -247,6 +247,7 @@ export const v0PeerToClientProfile = (
     isContactSuggestion?: boolean;
   }
 ): db.Contact => {
+  const currentUserId = getCurrentUserId();
   return {
     id,
     peerNickname: contact?.nickname ?? null,
@@ -262,7 +263,7 @@ export const v0PeerToClientProfile = (
       })) ?? [],
 
     isContact: false,
-    isContactSuggestion: config?.isContactSuggestion,
+    isContactSuggestion: config?.isContactSuggestion && id !== currentUserId,
   };
 };
 
@@ -287,6 +288,7 @@ export const v1PeerToClientProfile = (
     isContactSuggestion?: boolean;
   }
 ): db.Contact => {
+  const currentUserId = getCurrentUserId();
   return {
     id,
     peerNickname: contact.nickname?.value ?? null,
@@ -301,7 +303,8 @@ export const v1PeerToClientProfile = (
         contactId: id,
       })) ?? [],
     isContact: config?.isContact,
-    isContactSuggestion: config?.isContactSuggestion && !config?.isContact,
+    isContactSuggestion:
+      config?.isContactSuggestion && !config?.isContact && id !== currentUserId,
   };
 };
 

--- a/packages/shared/src/db/queries.ts
+++ b/packages/shared/src/db/queries.ts
@@ -2811,10 +2811,12 @@ export const getUserContacts = createReadQuery(
 export const getSuggestedContacts = createReadQuery(
   'getSuggestedContacts',
   async (ctx: QueryCtx) => {
+    const currentUserId = getCurrentUserId();
     return ctx.db.query.contacts.findMany({
       where: and(
         eq($contacts.isContact, false),
-        eq($contacts.isContactSuggestion, true)
+        eq($contacts.isContactSuggestion, true),
+        not(eq($contacts.id, currentUserId))
       ),
       with: {
         pinnedGroups: {

--- a/packages/ui/src/components/ContactsScreenView.tsx
+++ b/packages/ui/src/components/ContactsScreenView.tsx
@@ -54,7 +54,7 @@ export function ContactsScreenView(props: Props) {
 
     if (trimmedSuggested.length > 0) {
       result.push({
-        title: 'Suggested by Pals and DMs',
+        title: 'Suggested from %pals and DMs',
         data: trimmedSuggested,
       });
     }
@@ -72,7 +72,7 @@ export function ContactsScreenView(props: Props) {
           showNickname
           showEndContent
           endContent={
-            item.isContactSuggestion ? (
+            item.isContactSuggestion && !isSelf ? (
               <Badge text="Add" type="positive" />
             ) : isSelf ? (
               <XStack gap="$xs" alignItems="center">


### PR DESCRIPTION
Omits the current user from the suggested contacts query. Turns out, if you DM with yourself, you're eligible as a contact!

Furthermore, our condition for showing "You" vs "Add" vs just a caret in the ContactListItem endContent was a little shaky. Made that a little more explicit.

Things are looking better now IMO:
<img width="505" alt="image" src="https://github.com/user-attachments/assets/a8f8240a-cf2d-4db0-ad80-f0c2818d0721">
