### PR TITLE
ProfileStatusSheet: add send button

### DIFF
--- a/packages/ui/src/components/ProfileStatusSheet.tsx
+++ b/packages/ui/src/components/ProfileStatusSheet.tsx
@@ -86,7 +86,7 @@ export default function ProfileStatusSheet({
               hero
               onPress={handleSave}
               disabled={!isValid}
-              padding={11.5}
+              paddingHorizontal="$l"
             >
               <Icon type="Send" color="$background" />
             </Button>

--- a/packages/ui/src/components/ProfileStatusSheet.tsx
+++ b/packages/ui/src/components/ProfileStatusSheet.tsx
@@ -1,11 +1,13 @@
 import { useCallback, useRef } from 'react';
 import { useForm } from 'react-hook-form';
 import { Keyboard } from 'react-native';
-import { YStack } from 'tamagui';
+import { XStack, YStack } from 'tamagui';
 
 import { useContact, useCurrentUserId } from '../contexts';
 import { ActionSheet } from './ActionSheet';
+import { Button } from './Button';
 import { ControlledTextField } from './Form';
+import { Icon } from './Icon';
 
 export default function ProfileStatusSheet({
   open,
@@ -57,27 +59,38 @@ export default function ProfileStatusSheet({
       snapPoints={[60]}
     >
       <ActionSheet.Content flex={1} paddingBottom={0}>
-        <YStack flex={1} marginHorizontal="$2xl">
-          <ControlledTextField
-            name="status"
-            label="Update your status"
-            control={control}
-            inputProps={{
-              placeholder: 'Hanging out...',
-              autoFocus: true,
-              returnKeyType: isValid ? 'send' : 'done',
-              onSubmitEditing: handleSave,
-              blurOnSubmit: true,
-              multiline: true,
-              maxLength: 50,
-            }}
-            rules={{
-              maxLength: {
-                value: 50,
-                message: 'Your status is limited to 50 characters',
-              },
-            }}
-          />
+        <YStack flex={1} marginHorizontal="$2xl" gap="$l">
+          <XStack gap="$m" alignItems="flex-end" width="100%">
+            <ControlledTextField
+              name="status"
+              label="Update your status"
+              control={control}
+              inputProps={{
+                placeholder: 'Hanging out...',
+                autoFocus: true,
+                returnKeyType: isValid ? 'send' : 'done',
+                onSubmitEditing: handleSave,
+                blurOnSubmit: true,
+                multiline: false,
+                maxLength: 50,
+              }}
+              flex={1}
+              rules={{
+                maxLength: {
+                  value: 50,
+                  message: 'Your status is limited to 50 characters',
+                },
+              }}
+            />
+            <Button
+              hero
+              onPress={handleSave}
+              disabled={!isValid}
+              padding={11.5}
+            >
+              <Icon type="Send" color="$background" />
+            </Button>
+          </XStack>
         </YStack>
       </ActionSheet.Content>
     </ActionSheet>


### PR DESCRIPTION
Adds a send button to the ProfileStatusSheet and makes the input a single line.

<img width="558" alt="Screenshot 2024-12-02 at 3 07 03 PM" src="https://github.com/user-attachments/assets/1bf1e76c-cfd1-4bfb-b4be-a8063e68a0d1">