### PR TITLE
desktop: fix big input, and other desktop web issues

### DIFF
--- a/packages/ui/src/components/AuthorRow.tsx
+++ b/packages/ui/src/components/AuthorRow.tsx
@@ -160,7 +160,7 @@ export function ChatAuthorRow({
             </Text>
           ) : null}
         </XStack>
-        {deliveryStatus && deliveryStatus !== 'failed' ? (
+        {!!deliveryStatus && deliveryStatus !== 'failed' ? (
           <ChatMessageDeliveryStatus status={deliveryStatus} />
         ) : null}
       </XStack>

--- a/packages/ui/src/components/BigInput.tsx
+++ b/packages/ui/src/components/BigInput.tsx
@@ -1,11 +1,9 @@
 // import { EditorBridge } from '@10play/tentap-editor';
 import * as db from '@tloncorp/shared/db';
-import { useMemo, useRef, useState } from 'react';
-import { Dimensions, KeyboardAvoidingView, Platform } from 'react-native';
+import { useMemo, useState } from 'react';
 import { TouchableOpacity } from 'react-native-gesture-handler';
-import { useSafeAreaInsets } from 'react-native-safe-area-context';
 // TODO: replace input with our own input component
-import { Input, ScrollView, View, YStack, getTokenValue } from 'tamagui';
+import { Input, View, YStack, getTokenValue } from 'tamagui';
 
 import { ImageAttachment, useAttachmentContext } from '../contexts/attachment';
 import AttachmentSheet from './AttachmentSheet';
@@ -37,16 +35,8 @@ export function BigInput({
 } & MessageInputProps) {
   const [title, setTitle] = useState(editingPost?.title ?? '');
   const [showAttachmentSheet, setShowAttachmentSheet] = useState(false);
-  // const editorRef = useRef<{
-  // editor: TlonEditorBridge | null;
-  // setEditor: (editor: any) => void;
-  // }>(null);
-  const { top } = useSafeAreaInsets();
-  const { width } = Dimensions.get('screen');
   const titleInputHeight = getTokenValue('$4xl', 'size');
   const imageButtonHeight = getTokenValue('$4xl', 'size');
-  const keyboardVerticalOffset =
-    Platform.OS === 'ios' ? top + titleInputHeight : top;
 
   const { attachments, attachAssets } = useAttachmentContext();
   const imageAttachment = useMemo(() => {
@@ -90,11 +80,13 @@ export function BigInput({
           >
             {imageAttachment ? (
               <Image
-                source={{ uri: imageAttachment.file.uri }}
+                source={{
+                  uri: imageAttachment.file.uri,
+                }}
                 contentFit="cover"
+                height={imageButtonHeight}
                 style={{
                   width: '100%',
-                  height: '100%',
                   borderBottomLeftRadius: 16,
                   borderBottomRightRadius: 16,
                 }}
@@ -103,7 +95,7 @@ export function BigInput({
               <View
                 backgroundColor="$primaryText"
                 width="100%"
-                height="100%"
+                height={imageButtonHeight}
                 borderBottomLeftRadius="$xl"
                 borderBottomRightRadius="$xl"
                 padding="$2xl"
@@ -128,16 +120,10 @@ export function BigInput({
           </View>
         </View>
       )}
-      <ScrollView
-        scrollEventThrottle={16}
-        scrollToOverflowEnabled
-        overScrollMode="always"
-        contentContainerStyle={{
-          paddingTop:
-            channelType === 'notebook'
-              ? titleInputHeight + imageButtonHeight
-              : 0,
-        }}
+      <View
+        paddingTop={
+          channelType === 'notebook' ? titleInputHeight + imageButtonHeight : 0
+        }
       >
         <MessageInput
           shouldBlur={shouldBlur}
@@ -162,9 +148,10 @@ export function BigInput({
           placeholder={placeholder}
           bigInput
           channelType={channelType}
-          // ref={editorRef}
+          shouldAutoFocus
+          draftType={channelType === 'gallery' ? 'text' : undefined}
         />
-      </ScrollView>
+      </View>
       {/* channelType === 'notebook' &&
         editorRef.current &&
         editorRef.current.editor && (

--- a/packages/ui/src/components/Channel/index.tsx
+++ b/packages/ui/src/components/Channel/index.tsx
@@ -316,10 +316,7 @@ export function Channel({
                   initialAttachments={initialAttachments}
                   uploadAsset={uploadAsset}
                 >
-                  <View
-                    backgroundColor={backgroundColor}
-                    flex={1}
-                  >
+                  <View backgroundColor={backgroundColor} flex={1}>
                     <YStack
                       justifyContent="space-between"
                       width="100%"
@@ -332,7 +329,12 @@ export function Channel({
                             group={group}
                             mode={headerMode}
                             title={title ?? ''}
-                            goBack={isNarrow ? handleGoBack : undefined}
+                            goBack={
+                              isNarrow ||
+                              draftInputPresentationMode === 'fullscreen'
+                                ? handleGoBack
+                                : undefined
+                            }
                             showSearchButton={isChatChannel}
                             goToSearch={goToSearch}
                             showSpinner={isLoadingPosts}

--- a/packages/ui/src/components/ChatMessage/ChatMessage.tsx
+++ b/packages/ui/src/components/ChatMessage/ChatMessage.tsx
@@ -4,8 +4,8 @@ import { ComponentProps, memo, useCallback, useMemo, useState } from 'react';
 import { View, XStack, YStack, isWeb } from 'tamagui';
 
 import AuthorRow from '../AuthorRow';
-import { Button } from '../Button';
 import { Icon } from '../Icon';
+import { OverflowMenuButton } from '../OverflowMenuButton';
 import { createContentRenderer } from '../PostContent/ContentRenderer';
 import {
   usePostContent,
@@ -196,12 +196,13 @@ const ChatMessage = ({
           onPressDelete={handleDeletePressed}
         />
       </YStack>
-      {isWeb && !hideOverflowMenu && showOverflowOnHover && (
-        <View position="absolute" top={0} right={12} width={0} height={0}>
-          <Button onPress={handleLongPress} borderWidth="unset" size="$l">
-            <Icon type="Overflow" />
-          </Button>
-        </View>
+      {!hideOverflowMenu && showOverflowOnHover && (
+        <OverflowMenuButton
+          onPress={handleLongPress}
+          top={0}
+          right={12}
+          width={0}
+        />
       )}
     </Pressable>
   );

--- a/packages/ui/src/components/ChatMessage/ChatMessageActions/MessageContainer.tsx
+++ b/packages/ui/src/components/ChatMessage/ChatMessageActions/MessageContainer.tsx
@@ -26,7 +26,7 @@ export function MessageContainer({ post }: { post: db.Post }) {
         padding="$l"
         borderRadius="$l"
       >
-        <NotebookPost showAuthor={false} size="$xs" post={post} />
+        <NotebookPost showAuthor={false} size="$xs" post={post} hideOverflowMenu />
       </ScrollView>
     );
   }

--- a/packages/ui/src/components/Image.tsx
+++ b/packages/ui/src/components/Image.tsx
@@ -16,6 +16,8 @@ const WebImage = ({ source, style, alt, onLoad, ...props }: any) => {
     }
   };
 
+  const { contentFit  } = props;
+
   return (
     <img
       src={source.uri}
@@ -23,7 +25,8 @@ const WebImage = ({ source, style, alt, onLoad, ...props }: any) => {
       style={{
         ...StyleSheet.flatten(style),
         maxWidth: '100%',
-        height: 'auto',
+        height: props.height ? props.height : 'auto',
+        objectFit: contentFit ? contentFit : 'contain',
       }}
       onLoad={handleLoad}
       {...props}

--- a/packages/ui/src/components/Image.tsx
+++ b/packages/ui/src/components/Image.tsx
@@ -25,8 +25,8 @@ const WebImage = ({ source, style, alt, onLoad, ...props }: any) => {
       style={{
         ...StyleSheet.flatten(style),
         maxWidth: '100%',
-        height: props.height ? props.height : 'auto',
-        objectFit: contentFit ? contentFit : 'contain',
+        height: props.height ? props.height : '100%',
+        objectFit: contentFit ? contentFit : undefined,
       }}
       onLoad={handleLoad}
       {...props}

--- a/packages/ui/src/components/MessageInput/MessageInputBase.tsx
+++ b/packages/ui/src/components/MessageInput/MessageInputBase.tsx
@@ -132,6 +132,7 @@ export const MessageInputContainer = memo(
           gap="$l"
           alignItems="flex-end"
           justifyContent="space-between"
+          backgroundColor="$background"
         >
           {goBack ? (
             <View paddingBottom="$xs">

--- a/packages/ui/src/components/NotebookPost/NotebookPost.tsx
+++ b/packages/ui/src/components/NotebookPost/NotebookPost.tsx
@@ -8,8 +8,8 @@ import {
   YStack,
   createStyledContext,
   styled,
+  isWeb,
 } from 'tamagui';
-import { isWeb } from 'tamagui';
 
 import { DetailViewAuthorRow } from '../AuthorRow';
 import { Button } from '../Button';

--- a/packages/ui/src/components/NotebookPost/NotebookPost.tsx
+++ b/packages/ui/src/components/NotebookPost/NotebookPost.tsx
@@ -9,15 +9,19 @@ import {
   createStyledContext,
   styled,
 } from 'tamagui';
+import { isWeb } from 'tamagui';
 
 import { DetailViewAuthorRow } from '../AuthorRow';
+import { Button } from '../Button';
 import { ChatMessageReplySummary } from '../ChatMessage/ChatMessageReplySummary';
+import { Icon } from '../Icon';
 import { Image } from '../Image';
 import { createContentRenderer } from '../PostContent/ContentRenderer';
 import {
   usePostContent,
   usePostLastEditContent,
 } from '../PostContent/contentUtils';
+import Pressable from '../Pressable';
 import { SendPostRetrySheet } from '../SendPostRetrySheet';
 import { Text } from '../TextV2';
 
@@ -34,6 +38,7 @@ export function NotebookPost({
   showDate = false,
   viewMode,
   size = '$l',
+  hideOverflowMenu,
 }: {
   post: db.Post;
   onPress?: (post: db.Post) => void;
@@ -48,6 +53,7 @@ export function NotebookPost({
   viewMode?: 'activity';
   isHighlighted?: boolean;
   size?: '$l' | '$s' | '$xs';
+  hideOverflowMenu?: boolean;
 }) {
   const [showRetrySheet, setShowRetrySheet] = useState(false);
   const handleLongPress = useCallback(() => {
@@ -89,69 +95,77 @@ export function NotebookPost({
   const hasReplies = post.replyCount && post.replyTime && post.replyContactIds;
   return (
     <>
-      <NotebookPostFrame
-        size={size}
+      <Pressable
         onPress={handlePress}
         onLongPress={handleLongPress}
         pressStyle={{ backgroundColor: '$secondaryBackground' }}
-        disabled={viewMode === 'activity'}
+        borderRadius="$l"
       >
-        {post.hidden ? (
-          <XStack
-            gap="$s"
-            paddingVertical="$xl"
-            justifyContent="center"
-            alignItems="center"
-          >
-            <Text color="$tertiaryText" size="$body">
-              You have hidden this post.
-            </Text>
-          </XStack>
-        ) : (
-          <>
-            <NotebookPostHeader
-              post={post}
-              showDate={showDate}
-              showAuthor={showAuthor && viewMode !== 'activity'}
-              size={size}
-            />
-
-            {viewMode !== 'activity' && (
-              <Text
-                size="$body"
-                color="$secondaryText"
-                numberOfLines={3}
-                paddingBottom={showReplies && hasReplies ? 0 : '$m'}
-              >
-                {post.textContent}
+        <NotebookPostFrame size={size} disabled={viewMode === 'activity'}>
+          {post.hidden ? (
+            <XStack
+              gap="$s"
+              paddingVertical="$xl"
+              justifyContent="center"
+              alignItems="center"
+            >
+              <Text color="$tertiaryText" size="$body">
+                You have hidden this post.
               </Text>
-            )}
-
-            {showReplies && hasReplies ? (
-              <ChatMessageReplySummary
+            </XStack>
+          ) : (
+            <>
+              <NotebookPostHeader
                 post={post}
-                showTime={false}
-                textColor="$tertiaryText"
+                showDate={showDate}
+                showAuthor={showAuthor && viewMode !== 'activity'}
+                size={size}
               />
-            ) : null}
-          </>
-        )}
 
-        {post.deliveryStatus === 'failed' ? (
-          <XStack alignItems="center" justifyContent="flex-end">
-            <Text color="$negativeActionText" fontSize="$xs">
-              Message failed to send
-            </Text>
-          </XStack>
-        ) : null}
-      </NotebookPostFrame>
-      <SendPostRetrySheet
-        open={showRetrySheet}
-        post={post}
-        onOpenChange={setShowRetrySheet}
-        onPressRetry={handleRetryPressed}
-        onPressDelete={handleDeletePressed}
-      />
+              {viewMode !== 'activity' && (
+                <Text
+                  size="$body"
+                  color="$secondaryText"
+                  numberOfLines={3}
+                  paddingBottom={showReplies && hasReplies ? 0 : '$m'}
+                >
+                  {post.textContent}
+                </Text>
+              )}
+
+              {showReplies && hasReplies ? (
+                <ChatMessageReplySummary
+                  post={post}
+                  showTime={false}
+                  textColor="$tertiaryText"
+                />
+              ) : null}
+            </>
+          )}
+
+          {post.deliveryStatus === 'failed' ? (
+            <XStack alignItems="center" justifyContent="flex-end">
+              <Text color="$negativeActionText" fontSize="$xs">
+                Message failed to send
+              </Text>
+            </XStack>
+          ) : null}
+        </NotebookPostFrame>
+        <SendPostRetrySheet
+          open={showRetrySheet}
+          post={post}
+          onOpenChange={setShowRetrySheet}
+          onPressRetry={handleRetryPressed}
+          onPressDelete={handleDeletePressed}
+        />
+      </Pressable>
+      {isWeb && !hideOverflowMenu && (
+        <View position="absolute" top={8} right={24} width={8} height={0}>
+          <Button onPress={handleLongPress} borderWidth="unset" size="$l">
+            <Icon type="Overflow" />
+          </Button>
+        </View>
+      )}
     </>
   );
 }
@@ -174,7 +188,7 @@ function NotebookPostHeader({
 
   return (
     <NotebookPostHeaderFrame {...props}>
-      {post.image && size !== '$xs' && (
+      {!!post.image && size !== '$xs' && (
         <NotebookPostHeroImage
           source={{
             uri:

--- a/packages/ui/src/components/OverflowMenuButton.tsx
+++ b/packages/ui/src/components/OverflowMenuButton.tsx
@@ -1,0 +1,38 @@
+import { ComponentProps } from 'react';
+import { View, isWeb } from 'tamagui';
+
+import { Button } from './Button';
+import { Icon } from './Icon';
+
+export function OverflowMenuButton({
+  onPress,
+  backgroundColor,
+  ...viewProps
+}: {
+  onPress: () => void;
+  backgroundColor?: string;
+} & ComponentProps<typeof View>) {
+  if (!isWeb) {
+    return null;
+  }
+
+  return (
+    <View
+      position="absolute"
+      top={8}
+      right={24}
+      width={8}
+      height={0}
+      {...viewProps}
+    >
+      <Button
+        backgroundColor={backgroundColor}
+        onPress={onPress}
+        borderWidth="unset"
+        size="$l"
+      >
+        <Icon type="Overflow" />
+      </Button>
+    </View>
+  );
+}

--- a/packages/ui/src/components/PostScreenView.tsx
+++ b/packages/ui/src/components/PostScreenView.tsx
@@ -183,7 +183,6 @@ export function PostScreenView({
 
   const handleGoBack = useCallback(() => {
     if (isEditingParent) {
-      console.log('setEditingPost', undefined);
       setEditingPost?.(undefined);
       if (channel.type !== 'notebook') {
         goBack?.();


### PR DESCRIPTION
fixes TLON-3273 (making the BigInput actually usable on desktop) We weren't accounting for big input height.

Also fixes other issues:

Notebooks weren't wrapped in a Pressable. 

Some bad conditional checks were causing text strings to render outside of Text components/directly within Stack components.

Edits weren't working at all for notebook posts (we weren't filling in the draft content, we weren't passing along the title, and we weren't handling situations where the post had an image).

We were still unnecessarily using a ScrollView for the web version of the BigInput.

We had no way to allow the user to exit the big input editor if they wanted to abandon creating a post.

We were attempting to pass `contentFit` as a prop to `img` tags for web, which isn't a valid attribute, which made the image header in the notebook editor too large. I added a way to catch `contentFit` and pass it to the `img` as an `objectFit` property in the style prop. This also fixes an issue where image avatars weren't displaying correctly much of the time.

We had no overflow menu button on notebook posts, so there was no way to get to the message options on desktop.

General cleanup of the web MessageInput component.

Edit: now also adds an overflow button for gallery posts.