### PR TITLE
web: switch to using sqlocal transaction method to ensure transaction isolation

### DIFF
--- a/packages/app/lib/webDb.ts
+++ b/packages/app/lib/webDb.ts
@@ -1,6 +1,11 @@
 import { createDevLogger } from '@tloncorp/shared';
 import type { Schema } from '@tloncorp/shared/db';
-import { handleChange, schema, setClient } from '@tloncorp/shared/db';
+import {
+  handleChange,
+  schema,
+  setClient,
+  setSqlocal,
+} from '@tloncorp/shared/db';
 import { migrations } from '@tloncorp/shared/db/migrations';
 import { sql } from 'drizzle-orm';
 import { integer, sqliteTable, text } from 'drizzle-orm/sqlite-core';
@@ -55,6 +60,7 @@ export async function setupDb() {
     logger.log('SQLite database opened:', dbInfo);
 
     setClient(client);
+    setSqlocal(sqlocal);
   } catch (e) {
     logger.error('Failed to setup SQLite db', e);
   }

--- a/packages/shared/src/db/client.ts
+++ b/packages/shared/src/db/client.ts
@@ -1,6 +1,7 @@
 import type { QueryResult } from '@op-engineering/op-sqlite';
 import { BaseSQLiteDatabase } from 'drizzle-orm/sqlite-core';
 import { SqliteRemoteResult } from 'drizzle-orm/sqlite-proxy';
+import { SQLocalDrizzle } from 'sqlocal/drizzle';
 
 import { Schema } from './types';
 
@@ -18,9 +19,14 @@ export type AnySqliteTransaction = Parameters<
 >[0];
 
 let clientInstance: AnySqliteDatabase | null = null;
+let sqlocalInstance: SQLocalDrizzle | null = null;
 
 export function setClient<T extends AnySqliteDatabase>(client: T) {
   clientInstance = client;
+}
+
+export function setSqlocal(sqlocal: SQLocalDrizzle) {
+  sqlocalInstance = sqlocal;
 }
 
 export const client = new Proxy(
@@ -34,3 +40,15 @@ export const client = new Proxy(
     },
   }
 ) as AnySqliteDatabase;
+
+export const sqlocal = new Proxy(
+  {},
+  {
+    get: function (target, prop, receiver) {
+      if (!sqlocalInstance) {
+        return undefined;
+      }
+      return Reflect.get(sqlocalInstance, prop, receiver);
+    },
+  }
+) as SQLocalDrizzle;

--- a/packages/shared/src/db/index.ts
+++ b/packages/shared/src/db/index.ts
@@ -4,7 +4,7 @@ export * from './types';
 export * from './fallback';
 export * from './modelBuilders';
 export * from './keyValue';
-export { setClient } from './client';
+export { setClient, setSqlocal } from './client';
 export type { AnySqliteDatabase } from './client';
 export * from './changeListener';
 export * from './domainTypes';

--- a/packages/shared/src/db/queries.ts
+++ b/packages/shared/src/db/queries.ts
@@ -2326,8 +2326,10 @@ async function updatePostWindows(
   const { oldestId, newestId } = (
     await ctx.db
       .select({
-        oldestId: min($postWindows.oldestPostId),
-        newestId: max($postWindows.newestPostId),
+        // Explicit aliases required for aggregation functions when using SQLocal transaction proxy.
+        // The proxy's result transformation requires these to map SQL results back to the expected field names.
+        oldestId: min($postWindows.oldestPostId).as('oldestId'),
+        newestId: max($postWindows.newestPostId).as('newestId'),
       })
       .from($postWindows)
       .where(overlapsWindow(referenceWindow))


### PR DESCRIPTION
fixes tlon-3302

Adds a transaction proxy system that's called within `withTransactionCtx` that allows the Drizzle ORM to work with SQLocal's SQLite transactions in the browser, which allows us to pass drizzle queries to the `handler` param and have them processed using the SQLocal transaction function.

In order to access the transaction method I added a new SQLocal client instance that's exported from the client module that we then pass to `queryFn` in `withCtxOrDefault`.

If we don't have the `sqlocal.transaction` method (as we wouldn't on native), we fall back to our manual transaction building process.

Copilot description:
This pull request introduces support for SQLocal transactions and improves the handling of SQLite database operations. The most important changes include adding a new `setSqlocal` function, modifying transaction handling to support SQLocal, and updating query functions to work with SQLocal proxies.

### SQLocal Integration:

* [`packages/app/lib/webDb.ts`](diffhunk://#diff-451eef8eb10d3442b648755b6e83e40cc65f4fab175c3311245d9137f6659e51L3-R8): Added `setSqlocal` function to initialize SQLocal instance and updated `setupDb` function to call `setSqlocal`. [[1]](diffhunk://#diff-451eef8eb10d3442b648755b6e83e40cc65f4fab175c3311245d9137f6659e51L3-R8) [[2]](diffhunk://#diff-451eef8eb10d3442b648755b6e83e40cc65f4fab175c3311245d9137f6659e51R63)
* [`packages/shared/src/db/client.ts`](diffhunk://#diff-7cab2f063a8d893ad3e68ef041deed09c96c48804e127d43ab06c52835a0917dR4): Introduced `SQLocalDrizzle` import, added `sqlocalInstance` variable, and created `setSqlocal` function. [[1]](diffhunk://#diff-7cab2f063a8d893ad3e68ef041deed09c96c48804e127d43ab06c52835a0917dR4) [[2]](diffhunk://#diff-7cab2f063a8d893ad3e68ef041deed09c96c48804e127d43ab06c52835a0917dR22-R31)
* [`packages/shared/src/db/client.ts`](diffhunk://#diff-7cab2f063a8d893ad3e68ef041deed09c96c48804e127d43ab06c52835a0917dR43-R54): Added `sqlocal` proxy to handle SQLocal transactions.
* [`packages/shared/src/db/index.ts`](diffhunk://#diff-4713f0974a6e8d92d6f075f046e4b96a7dc7ec7fce46da16eb72c77b12684facL7-R7): Exported `setSqlocal` function.

### Query and Transaction Handling:

* [`packages/shared/src/db/query.ts`](diffhunk://#diff-f05190eab3abeb8dd58b15f56c4b12767a9f1daa9174c900448ef13297e96223R36): Updated query context to include optional `sqlocal` property and modified `withCtxOrDefault` function to pass `sqlocal` to query functions. [[1]](diffhunk://#diff-f05190eab3abeb8dd58b15f56c4b12767a9f1daa9174c900448ef13297e96223R36) [[2]](diffhunk://#diff-f05190eab3abeb8dd58b15f56c4b12767a9f1daa9174c900448ef13297e96223L174-R181)
* [`packages/shared/src/db/query.ts`](diffhunk://#diff-f05190eab3abeb8dd58b15f56c4b12767a9f1daa9174c900448ef13297e96223R230-R377): Added `createTransactionProxyDb` function to create a proxy for handling SQLocal transactions.
* [`packages/shared/src/db/query.ts`](diffhunk://#diff-f05190eab3abeb8dd58b15f56c4b12767a9f1daa9174c900448ef13297e96223R391-R421): Enhanced `withTransactionCtx` function to support SQLocal transaction API and handle SQLocal-specific transaction logic. [[1]](diffhunk://#diff-f05190eab3abeb8dd58b15f56c4b12767a9f1daa9174c900448ef13297e96223R391-R421) [[2]](diffhunk://#diff-f05190eab3abeb8dd58b15f56c4b12767a9f1daa9174c900448ef13297e96223R432-R441)

These changes ensure that the database operations can utilize SQLocal transactions, providing more flexibility and improved transaction handling capabilities.