### PR TITLE
native: remove badging for now

### DIFF
--- a/apps/tlon-mobile/ios/Shared/Notifications/PushNotificationManager.swift
+++ b/apps/tlon-mobile/ios/Shared/Notifications/PushNotificationManager.swift
@@ -138,11 +138,11 @@ enum NotificationCategory: String {
         content.threadIdentifier = yarn.rope.thread
         content.title = await yarn.getTitle()
         content.body = yarn.body
-        content.badge = await withUnsafeContinuation { cnt in
-            UNUserNotificationCenter.current().getDeliveredNotifications { notifs in
-                cnt.resume(returning: NSNumber(value: notifs.count + 1))
-            }
-        }
+        // content.badge = await withUnsafeContinuation { cnt in
+        //     UNUserNotificationCenter.current().getDeliveredNotifications { notifs in
+        //         cnt.resume(returning: NSNumber(value: notifs.count + 1))
+        //     }
+        // }
         content.categoryIdentifier = yarn.category.rawValue
         content.userInfo = yarn.userInfo
         content.sound = UNNotificationSound.default

--- a/packages/app/lib/notifications.ts
+++ b/packages/app/lib/notifications.ts
@@ -117,9 +117,10 @@ async function updatePresentedNotifications(badgeCount?: number) {
     })
   );
 
-  const count =
-    badgeCount ?? (await Notifications.getPresentedNotificationsAsync()).length;
-  await Notifications.setBadgeCountAsync(count);
+  // NOTE: removing badging for now
+  // const count =
+  //   badgeCount ?? (await Notifications.getPresentedNotificationsAsync()).length;
+  // await Notifications.setBadgeCountAsync(count);
 }
 
 export function useUpdatePresentedNotifications() {


### PR DESCRIPTION
Getting badge counts dialed is going to take a little longer. Let's leave the notification dismissal logic in place, but omit those for now.