### PR TITLE
fix pending group display

### DIFF
--- a/packages/shared/src/db/queries.test.ts
+++ b/packages/shared/src/db/queries.test.ts
@@ -56,6 +56,12 @@ test('uses init data to get chat list', async () => {
     '~hansel-ribbur',
     '~pondus-watbel',
   ]);
+
+  expect(result.pending.map((r) => r.id)).toEqual([
+    '~fabled-faster/new-york',
+    '~barmyl-sigted/network-being',
+    '~salfer-biswed/gamers',
+  ]);
 });
 
 const refDate = Date.now();

--- a/packages/shared/src/db/queries.ts
+++ b/packages/shared/src/db/queries.ts
@@ -311,6 +311,8 @@ export const getChats = createReadQuery(
       where: or(
         eq($groups.currentUserIsMember, true),
         eq($groups.isNew, true),
+        eq($groups.haveInvite, true),
+        eq($groups.haveRequestedInvite, true),
         isNotNull($groups.joinStatus)
       ),
       with: {

--- a/packages/shared/src/test/init.json
+++ b/packages/shared/src/test/init.json
@@ -11600,7 +11600,10 @@
     "~fabled-faster/new-york": {
       "preview": null,
       "invite": null,
-      "claim": null
+      "claim": {
+        "progress": "knocking",
+        "join-all": false
+      }
     },
     "~barmyl-sigted/network-being": {
       "preview": {
@@ -11615,7 +11618,10 @@
           "description": "A group to discuss Heidegger, cybernetics, and the phenomenology of being online. "
         }
       },
-      "invite": null,
+      "invite": {
+        "flag": "~dacler-ricwyt/new-new-new-york",
+        "ship": "~solfer-magfed"
+      },
       "claim": null
     },
     "~salfer-biswed/gamers": {
@@ -11632,7 +11638,10 @@
         }
       },
       "invite": null,
-      "claim": null
+      "claim": {
+        "progress": "adding",
+        "join-all": true
+      }
     },
     "~dacler-ricwyt/new-new-new-york": {
       "preview": {

--- a/packages/ui/src/components/ListItem/listItemUtils.tsx
+++ b/packages/ui/src/components/ListItem/listItemUtils.tsx
@@ -28,14 +28,14 @@ export function getGroupStatus(group: db.Group) {
 
   const state = isNew
     ? 'new'
-    : isRequested
-      ? 'requested'
-      : isInvite
-        ? 'invited'
-        : isErrored
-          ? 'errored'
-          : isJoining
-            ? 'joining'
+    : isErrored
+      ? 'errored'
+      : isJoining
+        ? 'joining'
+        : isRequested
+          ? 'requested'
+          : isInvite
+            ? 'invited'
             : 'joined';
 
   const labels = {


### PR DESCRIPTION
Ensure that group invitations + requests are show in chat list. Also modifies labelling logic so that joining / error statuses take precedence over invite status. 

Fixes TLON-3362