### PR TITLE
native: fix onboarding nickname

### DIFF
--- a/apps/tlon-mobile/src/screens/Onboarding/ReserveShipScreen.tsx
+++ b/apps/tlon-mobile/src/screens/Onboarding/ReserveShipScreen.tsx
@@ -1,6 +1,5 @@
 import type { NativeStackScreenProps } from '@react-navigation/native-stack';
 import { useLureMetadata } from '@tloncorp/app/contexts/branch';
-import { useSignupContext } from '.././../lib/signupContext';
 import { NodeBootPhase } from '@tloncorp/app/lib/bootHelpers';
 import {
   ArvosDiscussing,
@@ -14,6 +13,7 @@ import {
 } from '@tloncorp/ui';
 import { useEffect, useMemo } from 'react';
 
+import { useSignupContext } from '../../lib/signupContext';
 import type { OnboardingStackParamList } from '../../types';
 
 type Props = NativeStackScreenProps<OnboardingStackParamList, 'ReserveShip'>;
@@ -36,7 +36,7 @@ export const ReserveShipScreen = ({ navigation }: Props) => {
       signupContext.setOnboardingValues({ didCompleteOnboarding: true });
     }
     signupContext.kickOffBootSequence();
-  }, []);
+  }, [signupContext]);
 
   return (
     <View flex={1} backgroundColor="$secondaryBackground">

--- a/apps/tlon-mobile/src/screens/Onboarding/SetNicknameScreen.tsx
+++ b/apps/tlon-mobile/src/screens/Onboarding/SetNicknameScreen.tsx
@@ -16,8 +16,8 @@ import {
 import { useEffect } from 'react';
 import { Controller, useForm } from 'react-hook-form';
 
+import { useSignupContext } from '../../lib/signupContext';
 import type { OnboardingStackParamList } from '../../types';
-import { useSignupContext } from '.././../lib/signupContext';
 
 type Props = NativeStackScreenProps<OnboardingStackParamList, 'SetNickname'>;
 


### PR DESCRIPTION
Looks like this was a bug in our key value logic. When relying on the `current` prop in `setValue(current: value) => nextValue`, there was a race condition if you called it rapidly causing stale `current` reads and thus overwrites of any previous pending updates. 

Just adds a basic lock around kv writes, but let me know if you guys can think of a cleaner way to do this?

Fixes TLON-3363