### PR TITLE
e2e: initial iOS test flows w/ Maestro

### DIFF
--- a/apps/tlon-mobile/tests/00-start.yaml
+++ b/apps/tlon-mobile/tests/00-start.yaml
@@ -1,0 +1,9 @@
+appId: io.tlon.groups
+---
+- clearState:
+    appId: io.tlon.groups
+- launchApp:
+    appId: io.tlon.groups
+- runFlow: 01-self-hosted-login.yaml
+- runFlow: 02-home-tab.yaml
+- runFlow: 03-create-group.yaml

--- a/apps/tlon-mobile/tests/01-self-hosted-login.yaml
+++ b/apps/tlon-mobile/tests/01-self-hosted-login.yaml
@@ -1,0 +1,36 @@
+appId: io.tlon.groups
+---
+- assertVisible: 'Welcome to TM'
+- swipe:
+    direction: 'DOWN'
+- waitForAnimationToEnd:
+    timeout: 5000
+- tapOn: 'Have an account? Log in'
+- tapOn: 'Or configure self hosted'
+# Open EULA
+- tapOn:
+    point: '73%,55%'
+- waitForAnimationToEnd:
+    timeout: 5000
+- assertVisible: 'EULA'
+- tapOn:
+    point: '9%,7%'
+- waitForAnimationToEnd:
+    timeout: 5000
+# Log in
+- tapOn:
+    id: 'textInput shipUrl'
+- inputText: ${URL}
+- tapOn:
+    id: 'textInput accessCode'
+- inputText: ${CODE}
+- tapOn: 'Connect'
+# Dismiss password save prompt
+- tapOn: 'Not now'
+- tapOn: 'Next'
+- assertVisible: 'Welcome to TM'
+- swipe:
+    direction: 'DOWN'
+- waitForAnimationToEnd:
+    timeout: 5000
+- assertVisible: 'Home'

--- a/apps/tlon-mobile/tests/02-home-tab.yaml
+++ b/apps/tlon-mobile/tests/02-home-tab.yaml
@@ -1,0 +1,50 @@
+appId: io.tlon.groups
+---
+# Open Fashion group and confirm the 'S/S 2025' channel is visible;
+# navigate back to home tab
+- scrollUntilVisible:
+    element: 'Fashion'
+    direction: 'DOWN'
+    speed: 75
+- waitForAnimationToEnd:
+    timeout: 5000
+- tapOn: 'Fashion'
+- assertVisible: 'S/S 2025'
+- tapOn:
+    point: '9%,7%'
+- scrollUntilVisible:
+    element: 'Pinned'
+    direction: 'UP'
+    speed: 100
+# Tap on each filtering tab and confirm the correct groups/DMs are visible
+- tapOn: 'All'
+- assertVisible: 'Tlon Local'
+- tapOn: 'Groups'
+- assertVisible: 'Tlon Local'
+- tapOn: 'Messages'
+- assertVisible: 'galen'
+- tapOn: 'All'
+# Open the filtering input and look for Tlon Local in each tab
+- tapOn:
+    point: '79%,7%'
+- tapOn: 'Find by name'
+- inputText: 'Tlon'
+- assertVisible: 'Tlon Local'
+- tapOn: 'Groups'
+- assertVisible: 'Tlon Local'
+- tapOn: 'Messages'
+- assertNotVisible: 'Tlon Local'
+- tapOn: 'Clear'
+- tapOn: 'Close'
+# Open the filtering input and look for 'galen' in each tab
+- tapOn:
+    point: '79%,7%'
+- tapOn: 'Find by name'
+- inputText: 'gal'
+- assertVisible: 'galen'
+- tapOn: 'Groups'
+- assertNotVisible: 'galen'
+- tapOn: 'All'
+- assertVisible: 'galen'
+- tapOn: 'Clear'
+- tapOn: 'Close'

--- a/apps/tlon-mobile/tests/03-create-group.yaml
+++ b/apps/tlon-mobile/tests/03-create-group.yaml
@@ -1,0 +1,43 @@
+appId: io.tlon.groups
+---
+# Create an empty group from the home screen
+- tapOn:
+    point: '91%,7%'
+- waitForAnimationToEnd:
+    timeout: 5000
+- assertVisible: 'Start a chat'
+- tapOn: 'Create group'
+- tapOn: 'Skip'
+- tapOn: 'Group name'
+- inputText: 'Automated Test Group'
+- tapOn:
+    point: '50%,33%'
+- waitForAnimationToEnd:
+    timeout: 5000
+- assertVisible: 'Welcome'
+- assertVisible:
+    'This is your group’s default welcome channel. Feel free to rename it or
+    create additional channels.'
+## Verify that channel properties sheet opens and all options are visible
+- tapOn:
+    point: '91%,7%'
+- waitForAnimationToEnd:
+    timeout: 5000
+- assertVisible: 'Channel in Automated Test Group'
+- tapOn: 'Notifications'
+- assertVisible: 'Only mentions and replies'
+- tapOn:
+    point: '17%,42%'
+- tapOn: 'Manage channels'
+- assertVisible: 'Create a channel'
+- tapOn:
+    point: '9%,7%'
+- tapOn: 'Welcome'
+- tapOn:
+    point: '91%,7%'
+- tapOn: 'Invite people'
+- assertVisible: 'Select people to invite'
+- swipe:
+    direction: 'DOWN'
+- tapOn:
+    point: '9%,7%'


### PR DESCRIPTION
Draft PR for observation/comments on Maestro end-to-end tests for the mobile app. These tests assume you're joined to both Tlon Local and ~rilfun-lidlen/fashion, and have a DM with ~ravmel-ropdyl (and have nicknames turned on).

I'll make these parameters configurable in another pass.

- Created initial test suite to clear state and launch the app.
- Implemented self-hosted login flow in 01-self-hosted-login.yaml, including EULA acceptance and login assertions.
- Developed home tab navigation tests in 02-home-tab.yaml, verifying visibility of groups and messages.
- Added group creation test in 03-create-group.yaml, ensuring proper channel setup and visibility.

To run these tests locally:

1. Install [openjdk21](https://formulae.brew.sh/formula/openjdk@21) if you don't have it on your system already.
2. Install [Maestro](https://maestro.mobile.dev/getting-started/installing-maestro).
3. Build the iOS app for release (`pnpm build:mobile-release` from project root).
4. Open an iPhone SE (3rd generation) simulator running iOS 18.1.
5. Run `npm run ios:release` from `/apps/tlon-mobile`.
6. Wait until the app has booted in the simulator.
7. Run `maestro test` from `/apps/tlon-mobile/tests` with the following arguments:

```
maestro test -e URL=http://localhost:8080 -e CODE=lidlut-tabwed-pillex-ridrup 00-start.yaml
```