### PR TITLE
contact suggestions: fix trigger

### DIFF
--- a/apps/tlon-mobile/src/components/AuthenticatedApp.tsx
+++ b/apps/tlon-mobile/src/components/AuthenticatedApp.tsx
@@ -2,6 +2,7 @@ import { useShip } from '@tloncorp/app/contexts/ship';
 import { useAppStatusChange } from '@tloncorp/app/hooks/useAppStatusChange';
 import { useConfigureUrbitClient } from '@tloncorp/app/hooks/useConfigureUrbitClient';
 import { useCurrentUserId } from '@tloncorp/app/hooks/useCurrentUser';
+import { useFindSuggestedContacts } from '@tloncorp/app/hooks/useFindSuggestedContacts';
 import { useNavigationLogging } from '@tloncorp/app/hooks/useNavigationLogger';
 import { useNetworkLogger } from '@tloncorp/app/hooks/useNetworkLogger';
 import { useTelemetry } from '@tloncorp/app/hooks/useTelemetry';
@@ -29,6 +30,7 @@ function AuthenticatedApp() {
   useNavigationLogging();
   useNetworkLogger();
   useCheckAppUpdated();
+  useFindSuggestedContacts();
 
   useEffect(() => {
     configureClient();

--- a/apps/tlon-web-new/src/app.tsx
+++ b/apps/tlon-web-new/src/app.tsx
@@ -6,6 +6,7 @@ import {
 } from '@react-navigation/native';
 import { useConfigureUrbitClient } from '@tloncorp/app/hooks/useConfigureUrbitClient';
 import { useCurrentUserId } from '@tloncorp/app/hooks/useCurrentUser';
+import { useFindSuggestedContacts } from '@tloncorp/app/hooks/useFindSuggestedContacts';
 import { useIsDarkMode } from '@tloncorp/app/hooks/useIsDarkMode';
 import { checkDb, useMigrations } from '@tloncorp/app/lib/webDb';
 import { BasePathNavigator } from '@tloncorp/app/navigation/BasePathNavigator';
@@ -135,6 +136,7 @@ const App = React.memo(function AppComponent() {
   const [dbIsLoaded, setDbIsLoaded] = useState(false);
   const [startedSync, setStartedSync] = useState(false);
   const configureClient = useConfigureUrbitClient();
+  useFindSuggestedContacts();
 
   useEffect(() => {
     handleError(() => {

--- a/packages/app/hooks/useFindSuggestedContacts.ts
+++ b/packages/app/hooks/useFindSuggestedContacts.ts
@@ -1,0 +1,10 @@
+import * as store from '@tloncorp/shared/store';
+import { useEffect } from 'react';
+
+export function useFindSuggestedContacts() {
+  const { data: joinedGroupCount } = store.useJoinedGroupsCount();
+
+  useEffect(() => {
+    store.findContactSuggestions();
+  }, [joinedGroupCount]);
+}

--- a/packages/shared/src/db/keyValue.ts
+++ b/packages/shared/src/db/keyValue.ts
@@ -290,6 +290,11 @@ export const groupsUsedForSuggestions = createStorageItem<string[]>({
   defaultValue: [],
 });
 
+export const lastAddedSuggestionsAt = createStorageItem<number>({
+  key: 'lastAddedSuggestionsAt',
+  defaultValue: 0,
+});
+
 export const postDraft = (opts: {
   key: string;
   type: 'caption' | 'text' | undefined; // matches GalleryDraftType

--- a/packages/shared/src/db/queries.ts
+++ b/packages/shared/src/db/queries.ts
@@ -153,6 +153,19 @@ export const getGroupPreviews = createReadQuery(
   ['groups']
 );
 
+export const getJoinedGroupsCount = createReadQuery(
+  'getJoinedGroupCount',
+  async (ctx: QueryCtx) => {
+    const result = await ctx.db
+      .select({ count: count() })
+      .from($groups)
+      .where(eq($groups.currentUserIsMember, true));
+
+    return result[0]?.count ?? 0;
+  },
+  ['groups']
+);
+
 // TODO: inefficient, should optimize
 export const getGroupsWithMemberThreshold = createReadQuery(
   'getGroupsWithMemberThreshold',

--- a/packages/shared/src/store/dbHooks.ts
+++ b/packages/shared/src/store/dbHooks.ts
@@ -325,6 +325,14 @@ export const useGroup = ({ id }: { id?: string }) => {
   });
 };
 
+export const useJoinedGroupsCount = () => {
+  const deps = useKeyFromQueryDeps(db.getJoinedGroupsCount);
+  return useQuery({
+    queryKey: ['joinedGroupsCount', deps],
+    queryFn: () => db.getJoinedGroupsCount(),
+  });
+};
+
 export const useGroupByChannel = (channelId: string) => {
   return useQuery({
     queryKey: [['group', channelId]],

--- a/packages/shared/src/store/sync.ts
+++ b/packages/shared/src/store/sync.ts
@@ -12,7 +12,6 @@ import {
   INFINITE_ACTIVITY_QUERY_KEY,
   resetActivityFetchers,
 } from '../store/useActivityFetchers';
-import { findContactSuggestions } from './contactActions';
 import { useLureState } from './lure';
 import { getSyncing, updateIsSyncing, updateSession } from './session';
 import { SyncCtx, SyncPriority, syncQueue } from './syncQueue';
@@ -1175,10 +1174,6 @@ export const syncStart = async (alreadySubscribed?: boolean) => {
     });
 
   updateIsSyncing(false);
-
-  // finding contacts is a bit of an outlier here, but it's work we need to do
-  // that can roughly be batched whenever we sync
-  findContactSuggestions();
 };
 
 export const setupHighPrioritySubscriptions = async (ctx?: SyncCtx) => {


### PR DESCRIPTION
With the last batch of edits, this was failing to run properly for new signups. Changes a few things:
- moves logic back to joined group count based trigger rather than `syncStart`
  - mounted on both native and desktop
- only sets _groups last used_ short-circuit after having found some suggestions
- will only give you new suggestions once per day
  - previously if you were joined to under 4 groups, it would keep adding new suggestions continuously until you'd dismissed ever single person with a profile set