### PR TITLE
key value: add option to keep or clear storage items after logout

### DIFF
--- a/packages/app/hooks/useHandleLogout.native.ts
+++ b/packages/app/hooks/useHandleLogout.native.ts
@@ -1,6 +1,6 @@
 import { createDevLogger } from '@tloncorp/shared';
 import * as api from '@tloncorp/shared/api';
-import { finishingSelfHostedLogin } from '@tloncorp/shared/db';
+import { clearNonPersistentStorageItems } from '@tloncorp/shared/db';
 import * as store from '@tloncorp/shared/store';
 import { useCallback } from 'react';
 
@@ -28,7 +28,7 @@ export function useHandleLogout({ resetDb }: { resetDb: () => void }) {
     clearDeepLink();
     clearSplashDismissed();
     clearTelemetry();
-    finishingSelfHostedLogin.resetValue();
+    clearNonPersistentStorageItems();
     if (!resetDb) {
       logger.trackError('could not reset db on logout');
       return;

--- a/packages/app/hooks/useHandleLogout.ts
+++ b/packages/app/hooks/useHandleLogout.ts
@@ -4,6 +4,7 @@
 // which isn't made for web.
 import { createDevLogger } from '@tloncorp/shared';
 import * as api from '@tloncorp/shared/api';
+import { clearNonPersistentStorageItems } from '@tloncorp/shared/db';
 import * as store from '@tloncorp/shared/store';
 import { useCallback } from 'react';
 
@@ -33,7 +34,7 @@ export function useHandleLogout({ resetDb }: { resetDb?: () => void }) {
     removeHostingUserId();
     removeHostingAuthTracking();
     clearSplashDismissed();
-    // signupContext.clear();
+    clearNonPersistentStorageItems();
     if (!resetDb) {
       logger.trackError('could not reset db on logout');
       return;


### PR DESCRIPTION
Today I got bit by a key value item not getting cleared after logout. Thus far we've been ad hoc adding reset calls to `useHandleLogout`, but I realized this should probably just be a property of `createStorageItem` itself.

Can now pass a `persistAfterLogout` flag in the config, defaults to false.