### PR TITLE
images: provide default fallback for errored images

### DIFF
--- a/packages/ui/src/components/Image.tsx
+++ b/packages/ui/src/components/Image.tsx
@@ -1,9 +1,38 @@
 import { Image as BaseImage, ImageErrorEventData } from 'expo-image';
 import { ReactElement, useCallback, useState } from 'react';
 import { Platform, StyleSheet } from 'react-native';
-import { styled } from 'tamagui';
+import { SizableText, View, styled } from 'tamagui';
 
-const WebImage = ({ source, style, alt, onLoad, ...props }: any) => {
+import { Icon } from './Icon';
+
+const DefaultImageFallback = () => (
+  <View flex={1} alignItems="center" justifyContent="center">
+    <Icon type="Placeholder" color="$tertiaryText" />
+    <SizableText color="$tertiaryText">Unable to load image</SizableText>
+  </View>
+);
+
+const WebImage = ({
+  source,
+  style,
+  alt,
+  onLoad,
+  onError,
+  fallback,
+  ...props
+}: any) => {
+  const [hasError, setHasError] = useState(false);
+
+  const handleError = (e: React.SyntheticEvent<HTMLImageElement>) => {
+    setHasError(true);
+    if (onError) {
+      onError({
+        error: new Error('Image loading failed'),
+        target: e.currentTarget,
+      });
+    }
+  };
+
   const handleLoad = (e: React.SyntheticEvent<HTMLImageElement>) => {
     if (onLoad) {
       // Mimic expo-image's onLoad event structure
@@ -16,7 +45,15 @@ const WebImage = ({ source, style, alt, onLoad, ...props }: any) => {
     }
   };
 
-  const { contentFit  } = props;
+  const { contentFit } = props;
+
+  if (hasError && fallback) {
+    return fallback;
+  }
+
+  if (hasError) {
+    return <DefaultImageFallback />;
+  }
 
   return (
     <img
@@ -29,6 +66,7 @@ const WebImage = ({ source, style, alt, onLoad, ...props }: any) => {
         objectFit: contentFit ? contentFit : undefined,
       }}
       onLoad={handleLoad}
+      onError={handleError}
       {...props}
     />
   );
@@ -51,11 +89,15 @@ export const ImageWithFallback = StyledBaseImage.styleable<{
       [onError]
     );
 
-    return hasErrored ? (
-      fallback
-    ) : (
-      <StyledBaseImage ref={ref} {...props} onError={handleError} />
-    );
+    if (hasErrored && fallback) {
+      return fallback;
+    }
+
+    if (hasErrored) {
+      return <DefaultImageFallback />;
+    }
+
+    return <StyledBaseImage ref={ref} {...props} onError={handleError} />;
   },
   {
     staticConfig: {


### PR DESCRIPTION
fixes TLON-3323

The fact that we didn't provide a default fallback for errored images was most noticeable on web because:

a) the browsers shows a broken image icon
b) we just weren't accounting for broken images at all, no fallback was ever returned there.

This PR adds a new default image fallback that will be returned if an image fails to load. That fallback can be overridden by the `fallback` prop on Image.