### PR TITLE
gallery: fix item size issues on desktop

### DIFF
--- a/packages/ui/src/components/Channel/Scroller.tsx
+++ b/packages/ui/src/components/Channel/Scroller.tsx
@@ -32,7 +32,7 @@ import {
 } from 'react-native';
 import Animated from 'react-native-reanimated';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
-import { View, styled, useStyle, useTheme } from 'tamagui';
+import { View, getTokenValue, styled, useStyle, useTheme } from 'tamagui';
 
 import { RenderItemType } from '../../contexts/componentsKits';
 import { useLivePost } from '../../contexts/requests';
@@ -201,13 +201,16 @@ const Scroller = forwardRef(
 
     const theme = useTheme();
 
-    // Used to hide the scroller until we've found the anchor post.
     const style = useMemo(() => {
       return {
         backgroundColor: theme.background.val,
+        // Used to hide the scroller until we've found the anchor post.
         opacity: readyToDisplayPosts ? 1 : 0,
+        // Necessary to prevent content from flowing off the right side of the
+        // screen when the scroller is in two-column mode.
+        paddingRight: collectionLayoutType === 'grid' ? getTokenValue('$l') : 0,
       };
-    }, [readyToDisplayPosts, theme.background.val]);
+    }, [readyToDisplayPosts, theme.background.val, collectionLayoutType]);
 
     const postsWithNeighbors: PostWithNeighbors[] | undefined = useMemo(
       () =>
@@ -268,6 +271,7 @@ const Scroller = forwardRef(
             messageRef={activeMessageRefs.current[post.id]}
             dividersEnabled={collectionLayout.dividersEnabled}
             itemAspectRatio={collectionLayout.itemAspectRatio ?? undefined}
+            columnCount={collectionLayout.columnCount}
             {...anchorScrollLockScrollerItemProps}
           />
         );
@@ -580,6 +584,7 @@ const BaseScrollerItem = ({
   isLastPostOfBlock,
   dividersEnabled,
   itemAspectRatio,
+  columnCount,
 }: {
   showUnreadDivider: boolean;
   showAuthor: boolean;
@@ -603,6 +608,7 @@ const BaseScrollerItem = ({
   isLastPostOfBlock: boolean;
   dividersEnabled: boolean;
   itemAspectRatio?: number;
+  columnCount: number;
 }) => {
   const post = useLivePost(item);
 
@@ -652,7 +658,11 @@ const BaseScrollerItem = ({
   }, [dividerType, post, unreadCount, showDayDivider]);
 
   return (
-    <View onLayout={handleLayout} flex={1} aspectRatio={itemAspectRatio}>
+    <View
+      onLayout={handleLayout}
+      width={columnCount === 2 ? '50%' : '100%'}
+      aspectRatio={itemAspectRatio}
+    >
       {divider}
       <PressableMessage
         ref={messageRef}

--- a/packages/ui/src/components/Channel/Scroller.tsx
+++ b/packages/ui/src/components/Channel/Scroller.tsx
@@ -206,11 +206,8 @@ const Scroller = forwardRef(
         backgroundColor: theme.background.val,
         // Used to hide the scroller until we've found the anchor post.
         opacity: readyToDisplayPosts ? 1 : 0,
-        // Necessary to prevent content from flowing off the right side of the
-        // screen when the scroller is in two-column mode.
-        paddingRight: collectionLayoutType === 'grid' ? getTokenValue('$l') : 0,
       };
-    }, [readyToDisplayPosts, theme.background.val, collectionLayoutType]);
+    }, [readyToDisplayPosts, theme.background.val]);
 
     const postsWithNeighbors: PostWithNeighbors[] | undefined = useMemo(
       () =>
@@ -294,6 +291,7 @@ const Scroller = forwardRef(
         showDividers,
         collectionLayout.dividersEnabled,
         collectionLayout.itemAspectRatio,
+        collectionLayout.columnCount,
       ]
     );
 
@@ -339,6 +337,9 @@ const Scroller = forwardRef(
         : {
             gap: '$l',
             width: '100%',
+            // Necessary to prevent content from flowing off the right side of the
+            // screen when the scroller is in two-column mode.
+            paddingRight: '$l',
           }
     ) as StyleProp<ViewStyle>;
 


### PR DESCRIPTION
fixes tlon-3316

This makes grid items size correctly by setting their width based on the number of columns (50% for 2 columns, 100% for 1 column) while using aspectRatio to maintain the desired shape.

This was necessary because without an explicit width constraint, the grid items were sizing themselves based on their content's intrinsic dimensions (the full-size images), and even though we had aspectRatio set to create square shapes, the items were becoming too large and creating layout issues. By explicitly setting the width to a percentage of the container and letting aspectRatio determine the height, we make sure that grid items maintain the right proportions while fitting into the grid layout.

Setting the width of the items to 50% in two column mode also requires adding some right padding to the scroller container itself while in that mode, because otherwise the items on the right would be partially cut off (50% on the item itself doesn't account for padding/gap).