### PR TITLE
fix desktop chatlist jank

### DIFF
--- a/packages/ui/src/components/ListItem/ListItem.tsx
+++ b/packages/ui/src/components/ListItem/ListItem.tsx
@@ -45,6 +45,7 @@ export const ListItemFrame = styled(XStack, {
   justifyContent: 'space-between',
   alignItems: 'stretch',
   backgroundColor: '$transparent',
+  height: '$6xl',
 });
 
 const ListItemIconContainer = styled(View, {


### PR DESCRIPTION
This PR fixes initial chatlist animation / rendering jank by more accurately estimating item sizes pre-render.

The jank is a known issue for `FlashList` on web, if it continues to crop up we could switch to `FlatList` on desktop instead.

Fixes TLON-3332