### PR TITLE
ChannelListItem, channelUtils: fix bare patp display in ChatList

### DIFF
--- a/packages/ui/src/components/ListItem/ChannelListItem.tsx
+++ b/packages/ui/src/components/ListItem/ChannelListItem.tsx
@@ -78,11 +78,12 @@ export function ChannelListItem({
             <ListItem.Title dimmed={dimmed}>{title}</ListItem.Title>
             {customSubtitle ? (
               <ListItem.Subtitle>{customSubtitle}</ListItem.Subtitle>
-            ) : (
+            ) : (model.type === 'dm' || model.type === 'groupDm') &&
+              utils.hasNickname(model.members?.[0]?.contact) ? (
               <ListItem.SubtitleWithIcon icon={subtitleIcon}>
                 {subtitle}
               </ListItem.SubtitleWithIcon>
-            )}
+            ) : null}
             {model.lastPost && !model.isDmInvite && (
               <ListItem.PostPreview
                 post={model.lastPost}

--- a/packages/ui/src/utils/channelUtils.tsx
+++ b/packages/ui/src/utils/channelUtils.tsx
@@ -13,7 +13,7 @@ export function getChannelMemberName(
   if (disableNicknames) {
     return member.contactId;
   }
-  return member.contact?.nickname ?? member.contactId;
+  return member.contact?.nickname || member.contactId;
 }
 
 export function useChannelMemberName(member: db.ChatMember) {
@@ -110,4 +110,8 @@ export function getChannelTypeIcon(type: db.Channel['type']): IconType {
     default:
       return 'ChannelTalk';
   }
+}
+
+export function hasNickname(contact: db.Contact | null | undefined): boolean {
+  return 'nickname' in (contact ?? {}) && (contact?.nickname?.length ?? 0) > 0;
 }


### PR DESCRIPTION
Corrects the nullish check pattern in channelUtils / getChannelMemberName. Tries to get the nickname from the contact, but if that's not available, it falls back to using the contactId (patp).

Also implements a "hasNickname" channelUtil to hide the duplicitous patp subtitle in ChannelListItems.

Here's a DM with someone who has a nickname set:
<img width="375" alt="Screenshot 2024-12-09 at 7 21 31 PM" src="https://github.com/user-attachments/assets/94552fdf-3b45-4f53-b84f-4ff6105421ce">

And without:
<img width="385" alt="image" src="https://github.com/user-attachments/assets/26719bb6-b102-4e1f-9763-35c7b33b79d9">
