### PR TITLE
desktop: harden navigation between home/non-home screens and nested screens

### DIFF
--- a/apps/tlon-mobile/src/hooks/useNotificationListener.ts
+++ b/apps/tlon-mobile/src/hooks/useNotificationListener.ts
@@ -157,6 +157,7 @@ export default function useNotificationListener() {
         const routeStack: RouteStack = [{ name: 'ChatList' }];
         if (channel.groupId) {
           const mainGroupRoute = await getMainGroupRoute(channel.groupId);
+          // @ts-expect-error - we know we're on mobile and we can't get a "Home" route
           routeStack.push(mainGroupRoute);
         }
         // Only push the channel if it wasn't already handled by the main group stack

--- a/packages/app/features/top/ActivityScreen.tsx
+++ b/packages/app/features/top/ActivityScreen.tsx
@@ -10,7 +10,7 @@ import { useCurrentUserId } from '../../hooks/useCurrentUser';
 import { useGroupActions } from '../../hooks/useGroupActions';
 import { useFeatureFlag } from '../../lib/featureFlags';
 import { RootStackParamList } from '../../navigation/types';
-import { screenNameFromChannelId } from '../../navigation/utils';
+import { useNavigateToChannel, useNavigateToPost } from '../../navigation/utils';
 
 type Props = NativeStackScreenProps<RootStackParamList, 'Activity'>;
 
@@ -19,6 +19,7 @@ export function ActivityScreen(props: Props) {
   const currentUserId = useCurrentUserId();
   const [contactsTabEnabled] = useFeatureFlag('contactsTab');
   const { performGroupAction } = useGroupActions();
+  const navigateToChannel = useNavigateToChannel();
 
   const allFetcher = store.useInfiniteBucketedActivity('all');
   const mentionsFetcher = store.useInfiniteBucketedActivity('mentions');
@@ -37,27 +38,20 @@ export function ActivityScreen(props: Props) {
 
   const handleGoToChannel = useCallback(
     (channel: db.Channel, selectedPostId?: string) => {
-      const screenName = screenNameFromChannelId(channel.id);
-      props.navigation.navigate(screenName, {
-        channelId: channel.id,
-        selectedPostId,
-      });
+      navigateToChannel(channel, selectedPostId);
     },
-    [props.navigation]
+    [navigateToChannel]
   );
 
+  const navigateToPost = useNavigateToPost();
   // TODO: if diary or gallery, figure out a way to pop open the comment
   // sheet
   const handleGoToThread = useCallback(
     (post: db.Post) => {
       // TODO: we have no way to route to specific thread message rn
-      props.navigation.navigate('Post', {
-        postId: post.id,
-        authorId: post.authorId,
-        channelId: post.channelId,
-      });
+      navigateToPost(post);
     },
-    [props.navigation]
+    [navigateToPost]
   );
 
   const handleGoToGroup = useCallback(

--- a/packages/app/features/top/ChatListScreen.tsx
+++ b/packages/app/features/top/ChatListScreen.tsx
@@ -29,7 +29,7 @@ import { useCurrentUserId } from '../../hooks/useCurrentUser';
 import { useGroupActions } from '../../hooks/useGroupActions';
 import type { RootStackParamList } from '../../navigation/types';
 import {
-  screenNameFromChannelId,
+  useNavigateToChannel,
   useNavigateToGroup,
 } from '../../navigation/utils';
 import { identifyTlonEmployee } from '../../utils/posthog';
@@ -158,6 +158,7 @@ export function ChatListScreenView({
   }, []);
 
   const navigateToGroup = useNavigateToGroup();
+  const navigateToChannel = useNavigateToChannel();
 
   const onPressChat = useCallback(
     async (item: db.Chat) => {
@@ -168,13 +169,10 @@ export function ChatListScreenView({
           navigateToGroup(item.group.id);
         }
       } else {
-        const screenName = screenNameFromChannelId(item.id);
-        navigation.navigate(screenName, {
-          channelId: item.id,
-        });
+        navigateToChannel(item.channel);
       }
     },
-    [navigateToGroup, navigation]
+    [navigateToGroup, navigateToChannel]
   );
 
   const handleGroupPreviewSheetOpenChange = useCallback((open: boolean) => {

--- a/packages/app/features/top/CreateGroupScreen.tsx
+++ b/packages/app/features/top/CreateGroupScreen.tsx
@@ -4,21 +4,17 @@ import { CreateGroupView } from '@tloncorp/ui';
 import { useCallback } from 'react';
 
 import type { RootStackParamList } from '../../navigation/types';
+import { useNavigateToChannel } from '../../navigation/utils';
 
 type Props = NativeStackScreenProps<RootStackParamList, 'ChatList'>;
 
 export function CreateGroupScreen(props: Props) {
+  const navigateToChannel = useNavigateToChannel();
   const handleGoToChannel = useCallback(
     (channel: db.Channel) => {
-      props.navigation.reset({
-        index: 1,
-        routes: [
-          { name: 'ChatList' },
-          { name: 'Channel', params: { channelId: channel.id } },
-        ],
-      });
+      navigateToChannel(channel);
     },
-    [props.navigation]
+    [navigateToChannel]
   );
 
   return (

--- a/packages/app/features/top/GroupChannelsScreen.tsx
+++ b/packages/app/features/top/GroupChannelsScreen.tsx
@@ -1,8 +1,4 @@
-import {
-  NavigationProp,
-  useIsFocused,
-  useNavigation,
-} from '@react-navigation/native';
+import { useIsFocused } from '@react-navigation/native';
 import type { NativeStackScreenProps } from '@react-navigation/native-stack';
 import * as db from '@tloncorp/shared/db';
 import * as store from '@tloncorp/shared/store';
@@ -11,6 +7,7 @@ import {
   GroupChannelsScreenView,
   InviteUsersSheet,
   NavigationProvider,
+  useIsWindowNarrow,
 } from '@tloncorp/ui';
 import { useCallback, useState } from 'react';
 
@@ -18,6 +15,7 @@ import { useChatSettingsNavigation } from '../../hooks/useChatSettingsNavigation
 import { useGroupContext } from '../../hooks/useGroupContext';
 import { useFeatureFlag } from '../../lib/featureFlags';
 import type { RootStackParamList } from '../../navigation/types';
+import { useNavigateToChannel, useNavigation } from '../../navigation/utils';
 
 type Props = NativeStackScreenProps<RootStackParamList, 'GroupChannels'>;
 
@@ -32,7 +30,7 @@ export function GroupChannelsScreenContent({
   groupId: string;
   focusedChannelId?: string;
 }) {
-  const navigation = useNavigation<NavigationProp<RootStackParamList>>();
+  const navigation = useNavigation();
   const isFocused = useIsFocused();
   const [inviteSheetGroup, setInviteSheetGroup] = useState<db.Group | null>(
     null
@@ -41,20 +39,27 @@ export function GroupChannelsScreenContent({
   const { data: unjoinedChannels } = store.useUnjoinedGroupChannels(
     group?.id ?? ''
   );
+  const navigateToChannel = useNavigateToChannel();
+  const isWindowNarrow = useIsWindowNarrow();
 
   const handleChannelSelected = useCallback(
     (channel: db.Channel) => {
-      navigation.navigate('Channel', {
-        channelId: channel.id,
-        groupId: channel.groupId ?? undefined,
-      });
+      navigateToChannel(channel);
     },
-    [navigation]
+    [navigateToChannel]
   );
 
   const handleGoBackPressed = useCallback(() => {
-    navigation.navigate('ChatList');
-  }, [navigation]);
+    if (isWindowNarrow) {
+      navigation.navigate('ChatList');
+    } else {
+      // Reset is necessary on desktop to ensure that the ChannelStack is cleared
+      navigation.reset({
+        index: 0,
+        routes: [{ name: 'Home' }],
+      });
+    }
+  }, [navigation, isWindowNarrow]);
 
   const [enableCustomChannels] = useFeatureFlag('customChannelCreation');
 

--- a/packages/app/features/top/PostScreen.tsx
+++ b/packages/app/features/top/PostScreen.tsx
@@ -15,6 +15,7 @@ import { useChatSettingsNavigation } from '../../hooks/useChatSettingsNavigation
 import { useGroupActions } from '../../hooks/useGroupActions';
 import { useFeatureFlag } from '../../lib/featureFlags';
 import type { RootStackParamList } from '../../navigation/types';
+import { useNavigateToChannel } from '../../navigation/utils';
 
 type Props = NativeStackScreenProps<RootStackParamList, 'Post'>;
 
@@ -139,6 +140,16 @@ export default function PostScreen(props: Props) {
     [props.navigation]
   );
 
+  const navigateToChannel = useNavigateToChannel();
+  const handleGoBack = useCallback(() => {
+    if (!channel) {
+      props.navigation.goBack();
+      return;
+    }
+    // This allows us to navigate to and highlight the message in the scroller
+    navigateToChannel(channel, postId);
+  }, [channel, navigateToChannel, postId, props.navigation]);
+
   const chatOptionsNavProps = useChatSettingsNavigation();
 
   return currentUserId && channel && post ? (
@@ -151,7 +162,7 @@ export default function PostScreen(props: Props) {
         isLoadingPosts={isLoadingPosts}
         channel={channel}
         initialThreadUnread={initialThreadUnread}
-        goBack={props.navigation.goBack}
+        goBack={handleGoBack}
         sendReply={sendReply}
         groupMembers={group?.members ?? []}
         uploadAsset={store.uploadAsset}

--- a/packages/app/hooks/useChannelNavigation.ts
+++ b/packages/app/hooks/useChannelNavigation.ts
@@ -5,6 +5,7 @@ import * as store from '@tloncorp/shared/store';
 import { useCallback } from 'react';
 
 import { RootStackParamList } from '../navigation/types';
+import { useNavigateToChannel, useNavigateToPost } from '../navigation/utils';
 
 export const useChannelNavigation = ({ channelId }: { channelId: string }) => {
   const channelQuery = store.useChannel({
@@ -16,16 +17,8 @@ export const useChannelNavigation = ({ channelId }: { channelId: string }) => {
       NativeStackNavigationProp<RootStackParamList, 'Channel' | 'Post'>
     >();
 
-  const navigateToPost = useCallback(
-    (post: db.Post) => {
-      navigation.push('Post', {
-        postId: post.id,
-        channelId,
-        authorId: post.authorId,
-      });
-    },
-    [channelId, navigation]
-  );
+  const navigateToPost = useNavigateToPost();
+  const navigateToChannel = useNavigateToChannel();
 
   const navigateToRef = useCallback(
     (channel: db.Channel, post: db.Post) => {
@@ -35,13 +28,10 @@ export const useChannelNavigation = ({ channelId }: { channelId: string }) => {
           selectedPostId: post.id,
         });
       } else {
-        navigation.replace('Channel', {
-          channelId: channel.id,
-          selectedPostId: post.id,
-        });
+        navigateToChannel(channel, post.id);
       }
     },
-    [navigation, channelId]
+    [navigation, channelId, navigateToChannel]
   );
 
   const navigateToImage = useCallback(

--- a/packages/app/navigation/types.ts
+++ b/packages/app/navigation/types.ts
@@ -41,6 +41,7 @@ export type RootStackParamList = {
     postId: string;
     channelId: string;
     authorId: string;
+    groupId?: string;
   };
   ImageViewer: {
     uri?: string;
@@ -75,11 +76,32 @@ export type RootDrawerParamList = {
   Home: NavigatorScreenParams<HomeDrawerParamList>;
 } & Pick<RootStackParamList, 'Activity' | 'Contacts'>;
 
+export type CombinedParamList = RootStackParamList & RootDrawerParamList;
+
 export type HomeDrawerParamList = Pick<
   RootStackParamList,
-  'ChatList' | 'GroupChannels' | 'Channel' | 'DM' | 'GroupDM'
+  'ChatList' | 'GroupChannels'
 > & {
   MainContent: undefined;
+  Channel:
+    | NavigatorScreenParams<ChannelStackParamList>
+    | RootStackParamList['Channel'];
+  DM: NavigatorScreenParams<ChannelStackParamList> | RootStackParamList['DM'];
+  GroupDM:
+    | NavigatorScreenParams<ChannelStackParamList>
+    | RootStackParamList['GroupDM'];
+};
+
+export type ChannelStackParamList = {
+  ChannelRoot: RootStackParamList['Channel'];
+  GroupSettings: RootStackParamList['GroupSettings'];
+  ChannelSearch: RootStackParamList['ChannelSearch'];
+  Post: RootStackParamList['Post'];
+  ImageViewer: RootStackParamList['ImageViewer'];
+  UserProfile: RootStackParamList['UserProfile'];
+  EditProfile: RootStackParamList['EditProfile'];
+  ChannelMembers: RootStackParamList['ChannelMembers'];
+  ChannelMeta: RootStackParamList['ChannelMeta'];
 };
 
 export type DesktopChannelStackParamList = Pick<


### PR DESCRIPTION
fixes tlon-3306

This adds some new hooks to our navigation utils, `useNavigateToChannel` and `useNavigateToPost`, that allow us to navigate from the ActivityScreen on desktop into the relevant nested screens within the HomeNavigator.

It also updates our navigation types to account for the fact that Channel in HomeNavigator is a Stack and not just a route, and updates Screen components where appropriate to use the new hooks.

This gets us a bit closer to the abstraction layer for navigation that we've been talking about.