### PR TITLE
fix message action height issue

### DIFF
--- a/packages/ui/src/components/ChatMessage/ChatMessageActions/MessageActions.tsx
+++ b/packages/ui/src/components/ChatMessage/ChatMessageActions/MessageActions.tsx
@@ -120,6 +120,7 @@ function ConnectedAction({
   return (
     <ActionList.Action
       disabled={action.isNetworkDependent && connectionStatus !== 'Connected'}
+      height="auto"
       onPress={() =>
         handleAction({
           id: actionId,
@@ -151,7 +152,7 @@ function CopyJsonAction({ post }: { post: db.Post }) {
   }, [post.content]);
   const { doCopy, didCopy } = useCopy(jsonString);
   return (
-    <ActionList.Action onPress={doCopy} last>
+    <ActionList.Action height="auto" onPress={doCopy} last>
       {!didCopy ? 'Copy post JSON' : 'Copied'}
     </ActionList.Action>
   );


### PR DESCRIPTION
fixes tlon-3375

Our fixes for getting rid of the FlashList jank involved setting a definite height on ListItem of `$6xl`. This worked fine for most use cases, but not for our message actions. We just need to override the height in this case with `'auto'`.