### PR TITLE
profile: read contacts fields safely

### DIFF
--- a/desk/app/profile.hoon
+++ b/desk/app/profile.hoon
@@ -304,6 +304,11 @@
     :~  [%pass /contacts/ours %agent [our.bowl %contacts] %leave ~]
         [%pass /contacts/news %agent [our.bowl %contacts] %watch /news]
     ==
+  ::  ensure contacts subscription is in place
+  ::
+  =?  caz  &(!?=(%0 ver) !(~(has by wex.bowl) /contacts/news our.bowl %contacts))
+    %+  snoc  caz
+    [%pass /contacts/news %agent [our.bowl %contacts] %watch /news]
   [caz this]
   ::
   +$  versioned-state

--- a/desk/app/profile/widgets.hoon
+++ b/desk/app/profile/widgets.hoon
@@ -9,15 +9,15 @@
     ==
 ::NOTE  can't quite make a nice helper for this, wetness not wet enough...
 =/  nickname=(unit @t)  =+  a=(~(gut by contact) %nickname %text '')
-                        ?:(&(?=(%text -.a) !=('' +.a)) `+.a ~)
+                        ?:(&(?=([%text *] a) !=('' +.a)) `+.a ~)
 =/  bio=(unit @t)       =+  a=(~(gut by contact) %bio %text '')
-                        ?:(&(?=(%text -.a) !=('' +.a)) `+.a ~)
+                        ?:(&(?=([%text *] a) !=('' +.a)) `+.a ~)
 =/  color=@ux           =+  a=(~(gut by contact) %color %tint 0x0)
-                        ?:(?=(%tint -.a) +.a 0x0)
+                        ?:(?=([%tint *] a) +.a 0x0)
 =/  avatar=(unit @ta)   =+  a=(~(gut by contact) %avatar %look '')
-                        ?:(&(?=(%look -.a) !=('' +.a)) `+.a ~)
+                        ?:(&(?=([%look *] a) !=('' +.a)) `+.a ~)
 =/  cover=(unit @ta)    =+  a=(~(gut by contact) %cover %look '')
-                        ?:(&(?=(%look -.a) !=('' +.a)) `+.a ~)
+                        ?:(&(?=([%look *] a) !=('' +.a)) `+.a ~)
 |^  %-  ~(gas by *(map term [%0 @t %marl marl]))
     :~  [%profile %0 'Profile Header' %marl profile-widget]
         [%profile-bio %0 'Profile Bio' %marl profile-bio]


### PR DESCRIPTION
types. It checked for the tags on values found in the map. However, it's possible for values to be null, in which case trying to grab the head would crash at runtime.

Here, we update the typecheck to check on the full value as opposed to just the head.

Since this crashing code might have run in response to a contacts subscription update, killing the subscription, we add a bit of logic to +on-load to ensure that the contacts subscription gets set up again if needed.