### PR TITLE
native: fix navigating to tapped notification

### DIFF
--- a/apps/tlon-mobile/src/hooks/useNotificationListener.ts
+++ b/apps/tlon-mobile/src/hooks/useNotificationListener.ts
@@ -16,6 +16,7 @@ import * as api from '@tloncorp/shared/api';
 import * as db from '@tloncorp/shared/db';
 import * as store from '@tloncorp/shared/store';
 import { whomIsDm, whomIsMultiDm } from '@tloncorp/shared/urbit';
+import { useIsWindowNarrow } from '@tloncorp/ui';
 import {
   Notification,
   addNotificationResponseReceivedListener,
@@ -144,6 +145,8 @@ export default function useNotificationListener() {
     };
   }, [navigation, isTlonEmployee]);
 
+  const isDesktop = useIsWindowNarrow();
+
   // If notification tapped, push channel on stack
   useEffect(() => {
     if (notifToProcess && notifToProcess.channelId) {
@@ -156,7 +159,10 @@ export default function useNotificationListener() {
 
         const routeStack: RouteStack = [{ name: 'ChatList' }];
         if (channel.groupId) {
-          const mainGroupRoute = await getMainGroupRoute(channel.groupId);
+          const mainGroupRoute = await getMainGroupRoute(
+            channel.groupId,
+            isDesktop
+          );
           // @ts-expect-error - we know we're on mobile and we can't get a "Home" route
           routeStack.push(mainGroupRoute);
         }

--- a/packages/app/navigation/utils.ts
+++ b/packages/app/navigation/utils.ts
@@ -103,7 +103,7 @@ function useResetToGroup() {
 
   return async function resetToGroup(groupId: string) {
     if (isWindowNarrow) {
-      reset([{ name: 'ChatList' }, await getMainGroupRoute(groupId)]);
+      reset([{ name: 'ChatList' }, await getMainGroupRoute(groupId, true)]);
     } else {
       reset([
         {
@@ -241,7 +241,7 @@ export function getDesktopChannelRoute(
 
 export async function getMainGroupRoute(
   groupId: string,
-  isWindowNarrow?: boolean
+  isWindowNarrow: boolean
 ) {
   const group = await db.getGroup({ id: groupId });
   const channelSwitcherEnabled =


### PR DESCRIPTION
fixes TLON-3384

Bug was caused by not passing "is desktop" to `getMainGroupRoute` – so we were trying to navigate to a desktop-only route on mobile, which failed. Fixed this by making that argument required, so everyone needs to pass it.

While here, I noticed we're using the `useIsWindowNarrow` for this "is desktop" check – I think `useIsWindowNarrow` makes sense for doing responsive layout, but not for checking which sets of routes the built app is using (e.g. someone could be using desktop with a narrow viewport, then everything will break). Fixed this by adding a context-based `useAppPlatform` hook – replaced all of the navigation-based switches on `useIsWindowNarrow` that I could see.