### PR TITLE
invites: fix onboarding invite preview image size

### DIFF
--- a/packages/ui/src/components/Onboarding/OnboardingInvite.tsx
+++ b/packages/ui/src/components/Onboarding/OnboardingInvite.tsx
@@ -104,8 +104,6 @@ function GroupInvite({
         {...rest}
       >
         <ListItem.GroupIcon
-          width={100}
-          height={100}
           model={groupShim}
           backgroundColor={groupShim.iconImageColor ?? '$secondaryBorder'}
         />


### PR DESCRIPTION
Micro PR to reset onboarding invite images to normal size for now. A lot of times these Lure groups don't have images anyhow, in which case the first letter fallback is too dominating at 100px.

Fixes TLON-3405