### PR TITLE
channel-options: use channel volume in channel options

### DIFF
--- a/packages/ui/src/components/ChatOptionsSheet.tsx
+++ b/packages/ui/src/components/ChatOptionsSheet.tsx
@@ -573,10 +573,17 @@ function NotificationsSheetContent({
   chatTitle?: string | null;
   onPressBack: () => void;
 }) {
-  const { updateVolume, group } = useChatOptions();
-  const { data: currentVolumeLevel } = store.useGroupVolumeLevel(
+  const { updateVolume, group, channel } = useChatOptions();
+  const { data: currentChannelVolume } = store.useChannelVolumeLevel(
+    channel?.id ?? ''
+  );
+  const { data: currentGroupVolume } = store.useGroupVolumeLevel(
     group?.id ?? ''
   );
+  const currentVolumeLevel = channel?.id
+    ? currentChannelVolume
+    : currentGroupVolume;
+
   const notificationActions = useMemo(
     () =>
       createActionGroups([


### PR DESCRIPTION
OTT, found this today while QA'ing, we weren't using the channel volume when we're in a channel

PR Checklist
- [ ] Includes changes to desk files
- [ ] Describes how you tested the PR locally (test ship vs livenet)
- [ ] If a new feature, includes automated tests
- [ ] Comments added anywhere logic may be confusing without context