### PR TITLE
ReserveShipScreen: remove unnecessary padding

### DIFF
--- a/apps/tlon-mobile/src/screens/Onboarding/ReserveShipScreen.tsx
+++ b/apps/tlon-mobile/src/screens/Onboarding/ReserveShipScreen.tsx
@@ -105,7 +105,7 @@ function BootStepDisplay(props: {
           props.bootPhase <= step.endInclusive;
         const hasCompleted = props.bootPhase > step.endInclusive;
         return (
-          <ListItem backgroundColor="unset" key={index} paddingVertical={0}>
+          <ListItem backgroundColor="unset" key={index}>
             <ListItem.SystemIcon color="$primaryText" icon={step.icon} />
             <ListItem.MainContent>
               <ListItem.Title>{step.description}</ListItem.Title>


### PR DESCRIPTION
Fixes vertical alignment of spinners / ListItem content on ReserveShipScreen.

Red borders for debugging/proof.

Old and bad:

<img width="540" alt="Screenshot 2024-12-16 at 6 41 14 PM" src="https://github.com/user-attachments/assets/baa5e603-b1bc-40af-b101-af3a991a064d" />

New and good:

<img width="541" alt="Screenshot 2024-12-16 at 6 40 38 PM" src="https://github.com/user-attachments/assets/32d54419-27e1-4e6c-b566-cab3d97f7414" />
