### PR TITLE
PersonalInviteSheet cosmetics

### DIFF
--- a/packages/ui/src/components/Button.tsx
+++ b/packages/ui/src/components/Button.tsx
@@ -177,18 +177,16 @@ export const ButtonText = styled(Text, {
 });
 
 const ButtonIcon = (props: { color?: ColorTokens; children: any }) => {
-  const { size, color, hero, heroDestructive } = useContext(
-    ButtonContext.context
-  );
-  const smaller = getSize(size, {
-    shift: -1,
-  });
+  const context = useContext(ButtonContext.context);
+
+  const iconColor =
+    props.color ??
+    (context.hero || context.heroDestructive
+      ? '$background'
+      : context.color ?? '$primaryText');
+
   return cloneElement(props.children, {
-    size: smaller.val,
-    color:
-      props.color ??
-      color ??
-      (hero || heroDestructive ? '$white' : '$primaryText'),
+    color: iconColor,
   });
 };
 

--- a/packages/ui/src/components/PersonalInviteButton.tsx
+++ b/packages/ui/src/components/PersonalInviteButton.tsx
@@ -2,8 +2,9 @@ import { AnalyticsEvent, createDevLogger } from '@tloncorp/shared';
 import * as db from '@tloncorp/shared/db';
 import { useCallback, useMemo } from 'react';
 import { Share } from 'react-native';
-import { Text, View, XStack, isWeb } from 'tamagui';
+import { isWeb } from 'tamagui';
 
+import { TlonText } from '..';
 import { useContact, useCurrentUserId } from '../contexts';
 import { useCopy } from '../hooks/useCopy';
 import { getDisplayName } from '../utils';
@@ -61,22 +62,13 @@ export function PersonalInviteButton() {
   }, [doCopy, inviteLink, userDisplayName]);
 
   return (
-    <Button
-      hero
-      onPress={handleInviteButtonPress}
-      borderRadius="$xl"
-      width="100%"
-      justifyContent="space-between"
-    >
-      <XStack gap="$xl" paddingHorizontal="$m" alignItems="center">
-        <View>
-          <Icon type="Send" size="$l" color="$background" />
-        </View>
-        <Text flex={1} color="$background" fontSize="$l">
-          Invite Friends to Tlon
-        </Text>
-        <Icon type="ChevronRight" size="$l" color="$background" />
-      </XStack>
+    <Button hero onPress={handleInviteButtonPress}>
+      <Button.Icon>
+        <Icon type="Link" />
+      </Button.Icon>
+      <TlonText.Text color="$background" size="$label/l">
+        Share invite link
+      </TlonText.Text>
     </Button>
   );
 }

--- a/packages/ui/src/components/PersonalInviteSheet.tsx
+++ b/packages/ui/src/components/PersonalInviteSheet.tsx
@@ -18,29 +18,30 @@ export function PersonalInviteSheet({
 
   return (
     <ActionSheet open={open} onOpenChange={onOpenChange} snapPointsMode="fit">
-      <ActionSheet.Header>
-        <ListItem.Title>Invite Friends to TM</ListItem.Title>
-      </ActionSheet.Header>
-      <ActionSheet.Content>
-        <ActionSheet.ContentBlock>
-          <TlonText.Text size="$label/m" color="$secondaryText">
-            Anyone you invite will skip the waitlist and be added to your
-            contacts. You&apos;ll receive a DM when they join.
-          </TlonText.Text>
-        </ActionSheet.ContentBlock>
-        <ActionSheet.ContentBlock>
-          <View padding="$l" width="100%" display="flex" alignItems="center">
-            <QRCode
-              value={inviteLink}
-              size={200}
-              fgColor={theme.primaryText.val}
-              bgColor="transparent"
-            />
-          </View>
-        </ActionSheet.ContentBlock>
-        <ActionSheet.ContentBlock>
-          <PersonalInviteButton />
-        </ActionSheet.ContentBlock>
+      <ActionSheet.SimpleHeader title="Invite Friends to TM" />
+      <ActionSheet.Content paddingHorizontal={40}>
+        <TlonText.Text
+          size="$label/m"
+          color="$secondaryText"
+          marginBottom="$2xl"
+        >
+          Anyone you invite will skip the waitlist and be added to your
+          contacts. You&apos;ll receive a DM when they join.
+        </TlonText.Text>
+        <View
+          width="100%"
+          display="flex"
+          alignItems="center"
+          marginBottom="$3xl"
+        >
+          <QRCode
+            value={inviteLink}
+            size={200}
+            fgColor={theme.primaryText.val}
+            bgColor="transparent"
+          />
+        </View>
+        <PersonalInviteButton />
       </ActionSheet.Content>
     </ActionSheet>
   );


### PR DESCRIPTION
Another totally extra and non-blocking cosmetic PR. :)

- Fixes an issue with hero Buttons where we weren't properly setting icon colors (was returning a hex from button context, not a Tamagui token)
- Does away with the size computation for Button.Icon for simplicity's sake. The Button.Icon component was only used in one other place and it doesn't make a functional difference to have it be its natural size.
- Makes the PersonalInviteButton match InviteFriendsToTlonButton in appearance, but with a hero treatment
- Better aligns the content of PersonalInviteSheet

![](https://s3.rilfun-lidlen.startram.io/bucket/rilfun-lidlen/2024.12.17..19.30.32..1168.72b0.20c4.9ba5-image.png)
