### PR TITLE
Personal Invite Link Fix

### DIFF
--- a/packages/app/lib/bootHelpers.ts
+++ b/packages/app/lib/bootHelpers.ts
@@ -129,9 +129,10 @@ async function getInvitedGroupAndDm(lureMeta: AppInvite | null): Promise<{
   if (!lureMeta) {
     throw new Error('no stored invite found, cannot check');
   }
-  const { invitedGroupId, inviterUserId } = lureMeta;
+  const { invitedGroupId, inviterUserId, inviteType } = lureMeta;
   const tlonTeam = `~wittyr-witbes`;
-  if (!invitedGroupId || !inviterUserId) {
+  const isPersonalInvite = inviteType === 'user';
+  if (!inviterUserId || (!isPersonalInvite && !invitedGroupId)) {
     throw new Error(
       `invalid invite metadata: group[${invitedGroupId}] inviter[${inviterUserId}]`
     );
@@ -139,7 +140,9 @@ async function getInvitedGroupAndDm(lureMeta: AppInvite | null): Promise<{
   // use api client to see if you have pending DM and group invite
   const invitedDm = await db.getChannel({ id: inviterUserId });
   const tlonTeamDM = await db.getChannel({ id: tlonTeam });
-  const invitedGroup = await db.getGroup({ id: invitedGroupId });
+  const invitedGroup = isPersonalInvite
+    ? null
+    : await db.getGroup({ id: invitedGroupId! });
 
   return { invitedDm, invitedGroup, tlonTeamDM };
 }

--- a/packages/shared/src/logic/branch.ts
+++ b/packages/shared/src/logic/branch.ts
@@ -221,3 +221,18 @@ async function getLinkFromInviteService({
 
   return inviteLink;
 }
+
+export async function checkInviteServiceLinkExists(inviteId: string) {
+  const env = getConstants();
+  // hack to avoid shuffling env vars around
+  const serverlessInfraUrl = env.INVITE_SERVICE_ENDPOINT.substring(
+    0,
+    env.INVITE_SERVICE_ENDPOINT.lastIndexOf('/')
+  );
+  const response = await fetch(`${serverlessInfraUrl}/checkLink`, {
+    method: 'POST',
+    body: JSON.stringify({ inviteId }),
+  });
+
+  return response.status === 200;
+}

--- a/packages/shared/src/logic/branch.ts
+++ b/packages/shared/src/logic/branch.ts
@@ -231,6 +231,9 @@ export async function checkInviteServiceLinkExists(inviteId: string) {
   );
   const response = await fetch(`${serverlessInfraUrl}/checkLink`, {
     method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+    },
     body: JSON.stringify({ inviteId }),
   });
 

--- a/packages/shared/src/logic/deeplinks.ts
+++ b/packages/shared/src/logic/deeplinks.ts
@@ -123,10 +123,13 @@ export function createInviteLinkRegex(branchDomain: string) {
 
 export function extractTokenFromInviteLink(
   url: string,
-  branchDomain: string
+  branchDomain?: string
 ): string | null {
+  const env = getConstants();
   if (!url) return null;
-  const INVITE_LINK_REGEX = createInviteLinkRegex(branchDomain);
+  const INVITE_LINK_REGEX = createInviteLinkRegex(
+    branchDomain ?? env.BRANCH_DOMAIN
+  );
   const match = url.trim().match(INVITE_LINK_REGEX);
 
   if (match) {

--- a/packages/shared/src/store/inviteActions.ts
+++ b/packages/shared/src/store/inviteActions.ts
@@ -42,7 +42,7 @@ export async function verifyUserInviteLink() {
     }
 
     if (finalInviteLink) {
-      await db.personalInviteLink.setValue(inviteLink);
+      await db.personalInviteLink.setValue(finalInviteLink);
     }
   } catch (e) {
     logger.trackError('Failed to verify personal invite link', {

--- a/packages/shared/src/store/inviteActions.ts
+++ b/packages/shared/src/store/inviteActions.ts
@@ -3,8 +3,10 @@ import * as api from '../api';
 import * as db from '../db';
 import { createDevLogger } from '../debug';
 import {
+  checkInviteServiceLinkExists,
   createDeepLink,
   extractNormalizedInviteLink,
+  extractTokenFromInviteLink,
   withRetry,
 } from '../logic';
 
@@ -18,15 +20,28 @@ export async function verifyUserInviteLink() {
       return;
     }
 
-    let inviteLink = await api.checkExistingUserInviteLink();
+    let finalInviteLink = '';
+    const inviteLink = await api.checkExistingUserInviteLink();
+
     if (!inviteLink) {
-      inviteLink = await withRetry(() => createUserInviteLink());
+      // if we don't have one on the provider, create it
+      finalInviteLink = await withRetry(() => createUserInviteLink());
       logger.trackEvent('Created personal invite link');
     } else {
-      inviteLink = extractNormalizedInviteLink(inviteLink);
+      // otherwise, make sure we have the corresponding link on the invite service
+      const inviteId = extractTokenFromInviteLink(inviteLink);
+      if (!inviteId) {
+        throw new Error(`Provider returned invalid link ${inviteLink}`);
+      }
+      const serviceInviteLinkExists =
+        await checkInviteServiceLinkExists(inviteId);
+      if (!serviceInviteLinkExists) {
+        await withRetry(() => createPersonalInviteLinkOnService(inviteLink!));
+      }
+      finalInviteLink = extractNormalizedInviteLink(inviteLink) ?? '';
     }
 
-    if (inviteLink) {
+    if (finalInviteLink) {
       await db.personalInviteLink.setValue(inviteLink);
     }
   } catch (e) {
@@ -42,6 +57,20 @@ export async function createUserInviteLink(): Promise<string> {
   const user = await db.getContact({ id: currentUserId });
 
   const tlonNetworkUrl = await api.createPersonalInviteLink(user);
+  const inviteLink = await createPersonalInviteLinkOnService(tlonNetworkUrl);
+  return inviteLink;
+}
+
+export async function createPersonalInviteLinkOnService(
+  tlonNetworkUrl: string
+) {
+  const currentUserId = getCurrentUserId();
+  const user = await db.getContact({ id: currentUserId });
+  if (!tlonNetworkUrl) {
+    throw new Error(
+      'upsertExistingPersonalInviteDeeplink: Failed to get invite link from reel'
+    );
+  }
 
   // create on branch
   const inviteLink = await createDeepLink({
@@ -59,7 +88,9 @@ export async function createUserInviteLink(): Promise<string> {
   });
 
   if (!inviteLink) {
-    throw new Error('Failed to wrap self invite deep link');
+    throw new Error(
+      'upsertExistingPersonalInviteDeeplink: Failed to wrap self invite deep link'
+    );
   }
 
   return inviteLink;

--- a/packages/ui/src/components/Onboarding/OnboardingInvite.tsx
+++ b/packages/ui/src/components/Onboarding/OnboardingInvite.tsx
@@ -72,8 +72,6 @@ function UserInvite({
         {...rest}
       >
         <ListItem.ContactIcon
-          width={100}
-          height={100}
           contactId={inviter.id}
           contactOverride={inviter}
         />


### PR DESCRIPTION
If something went wrong creating your link on the invite service/branch, but it went through on the provider, the initial attempt to verify your link would fail but subsequent attempts would succeed. We should never show the invite link unless we positively have it in both places.

This adds extra handling to enforce that invariant.