### PR TITLE
clean up warnings

### DIFF
--- a/packages/app/hooks/useConfigureUrbitClient.ts
+++ b/packages/app/hooks/useConfigureUrbitClient.ts
@@ -49,11 +49,12 @@ const apiFetch: typeof fetch = (input, { ...init } = {}) => {
 export function useConfigureUrbitClient() {
   const shipInfo = useShip();
   const { ship, shipUrl, authType } = shipInfo;
+  const runResetDb = useCallback(() => {
+    clientLogger.log('Resetting db on logout');
+    resetDb();
+  }, []);
   const logout = useHandleLogout({
-    resetDb: () => {
-      clientLogger.log('Resetting db on logout');
-      resetDb();
-    },
+    resetDb: runResetDb,
   });
 
   return useCallback(

--- a/packages/app/hooks/usePosthog.base.tsx
+++ b/packages/app/hooks/usePosthog.base.tsx
@@ -1,0 +1,9 @@
+export interface PosthogClient {
+  optedOut: boolean;
+  optIn: () => void;
+  optOut: () => void;
+  identify: (userId: string, properties: Record<string, any>) => void;
+  capture: (eventName: string, properties?: Record<string, any>) => void;
+  flush: () => Promise<void>;
+  reset: () => void;
+}

--- a/packages/app/hooks/usePosthog.native.ts
+++ b/packages/app/hooks/usePosthog.native.ts
@@ -1,50 +1,18 @@
 import { usePostHog as useNativePosthog } from 'posthog-react-native';
-import { useCallback, useMemo } from 'react';
+import { useMemo } from 'react';
 
 export function usePosthog() {
   const posthog = useNativePosthog();
 
-  const optedOut = useMemo(() => {
-    return posthog?.optedOut ?? false;
+  return useMemo(() => {
+    return {
+      optedOut: posthog?.optedOut ?? false,
+      optIn: posthog?.optIn,
+      optOut: posthog?.optOut,
+      identify: posthog?.identify,
+      capture: posthog?.capture,
+      flush: posthog?.flush,
+      reset: posthog?.reset,
+    };
   }, [posthog]);
-
-  const optIn = useCallback(() => {
-    return posthog?.optIn();
-  }, [posthog]);
-
-  const optOut = useCallback(() => {
-    return posthog?.optOut();
-  }, [posthog]);
-
-  const identify = useCallback(
-    (userId: string, properties: Record<string, any>) => {
-      return posthog?.identify(userId, properties);
-    },
-    [posthog]
-  );
-
-  const capture = useCallback(
-    (eventName: string, properties?: Record<string, any>) => {
-      return posthog?.capture(eventName, properties);
-    },
-    [posthog]
-  );
-
-  const flush = useCallback(async () => {
-    // TODO: how to send await all pending events sent?
-  }, []);
-
-  const reset = useCallback(() => {
-    return posthog?.reset();
-  }, [posthog]);
-
-  return {
-    optedOut,
-    optIn,
-    optOut,
-    identify,
-    capture,
-    flush,
-    reset,
-  };
 }

--- a/packages/app/hooks/usePosthog.native.ts
+++ b/packages/app/hooks/usePosthog.native.ts
@@ -1,18 +1,21 @@
 import { usePostHog as useNativePosthog } from 'posthog-react-native';
 import { useMemo } from 'react';
 
+import { PosthogClient } from './usePosthog.base';
+
 export function usePosthog() {
   const posthog = useNativePosthog();
 
-  return useMemo(() => {
+  return useMemo((): PosthogClient => {
     return {
       optedOut: posthog?.optedOut ?? false,
-      optIn: posthog?.optIn,
-      optOut: posthog?.optOut,
-      identify: posthog?.identify,
-      capture: posthog?.capture,
-      flush: posthog?.flush,
-      reset: posthog?.reset,
+      optIn: () => posthog?.optIn(),
+      optOut: () => posthog?.optOut(),
+      identify: (userId, properties) => posthog?.identify(userId, properties),
+      capture: (eventName, properties) =>
+        posthog?.capture(eventName, properties),
+      flush: async () => posthog?.flush(),
+      reset: () => posthog?.reset(),
     };
   }, [posthog]);
 }

--- a/packages/app/hooks/usePosthog.ts
+++ b/packages/app/hooks/usePosthog.ts
@@ -1,18 +1,22 @@
 import { usePostHog as useWebPosthog } from 'posthog-js/react';
 import { useMemo } from 'react';
 
+import { PosthogClient } from './usePosthog.base';
+
 export function usePosthog() {
   const posthog = useWebPosthog();
-  return useMemo(() => {
+  return useMemo((): PosthogClient => {
     return {
       optedOut: posthog?.has_opted_out_capturing() ?? false,
-      optIn: posthog?.opt_in_capturing,
-      identify: posthog?.identify,
-      capture: posthog?.capture,
-      flush: () => {
+      optIn: () => posthog?.opt_in_capturing(),
+      optOut: () => posthog?.opt_out_capturing(),
+      identify: (userId, properties) => posthog?.identify(userId, properties),
+      capture: (eventName, properties) =>
+        posthog?.capture(eventName, properties),
+      flush: async () => {
         // TODO: how to send await all pending events sent?
       },
-      reset: posthog?.reset,
+      reset: () => posthog?.reset(),
     };
   }, [posthog]);
 }

--- a/packages/app/hooks/usePosthog.ts
+++ b/packages/app/hooks/usePosthog.ts
@@ -1,50 +1,18 @@
 import { usePostHog as useWebPosthog } from 'posthog-js/react';
-import { useCallback, useMemo } from 'react';
+import { useMemo } from 'react';
 
 export function usePosthog() {
   const posthog = useWebPosthog();
-
-  const optedOut = useMemo(() => {
-    return posthog?.has_opted_in_capturing() ?? false;
+  return useMemo(() => {
+    return {
+      optedOut: posthog?.has_opted_out_capturing() ?? false,
+      optIn: posthog?.opt_in_capturing,
+      identify: posthog?.identify,
+      capture: posthog?.capture,
+      flush: () => {
+        // TODO: how to send await all pending events sent?
+      },
+      reset: posthog?.reset,
+    };
   }, [posthog]);
-
-  const optIn = useCallback(() => {
-    return posthog?.opt_in_capturing();
-  }, [posthog]);
-
-  const optOut = useCallback(() => {
-    return posthog?.opt_out_capturing();
-  }, [posthog]);
-
-  const identify = useCallback(
-    (userId: string, properties?: Record<string, any>) => {
-      return posthog?.identify(userId, properties);
-    },
-    [posthog]
-  );
-
-  const capture = useCallback(
-    (eventName: string, properties?: Record<string, any>) => {
-      return posthog?.capture(eventName, properties);
-    },
-    [posthog]
-  );
-
-  const flush = useCallback(async () => {
-    // TODO: how to send await all pending events sent?
-  }, []);
-
-  const reset = useCallback(() => {
-    return posthog?.reset();
-  }, [posthog]);
-
-  return {
-    optedOut,
-    optIn,
-    optOut,
-    identify,
-    capture,
-    flush,
-    reset,
-  };
 }

--- a/packages/shared/src/api/urbit.ts
+++ b/packages/shared/src/api/urbit.ts
@@ -73,7 +73,7 @@ export const client = new Proxy(
   {
     get: function (target, prop, receiver) {
       if (!config.client) {
-        throw new Error('Database not set.');
+        throw new Error('Urbit client not set.');
       }
       return Reflect.get(config.client, prop, receiver);
     },

--- a/packages/ui/src/components/ChatOptionsSheet.tsx
+++ b/packages/ui/src/components/ChatOptionsSheet.tsx
@@ -11,7 +11,8 @@ import React, {
 } from 'react';
 
 import { ChevronLeft } from '../assets/icons';
-import { useChatOptions, useCurrentUserId } from '../contexts';
+import { useCurrentUserId } from '../contexts/appDataContext';
+import { useChatOptions } from '../contexts/chatOptions';
 import * as utils from '../utils';
 import { useIsAdmin } from '../utils';
 import {

--- a/packages/ui/src/components/EditProfileScreenView.tsx
+++ b/packages/ui/src/components/EditProfileScreenView.tsx
@@ -1,12 +1,11 @@
 import * as db from '@tloncorp/shared/db';
-import { useStore } from '@tloncorp/ui';
 import { useCallback, useMemo, useState } from 'react';
 import { useForm } from 'react-hook-form';
 import { Alert } from 'react-native';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
 import { ScrollView, View, XStack } from 'tamagui';
 
-import { useContact, useCurrentUserId } from '../contexts';
+import { useContact, useCurrentUserId, useStore } from '../contexts';
 import { SigilAvatar } from './Avatar';
 import { FavoriteGroupsDisplay } from './FavoriteGroupsDisplay';
 import {

--- a/packages/ui/src/components/PersonalInviteButton.tsx
+++ b/packages/ui/src/components/PersonalInviteButton.tsx
@@ -4,12 +4,12 @@ import { useCallback, useMemo } from 'react';
 import { Share } from 'react-native';
 import { isWeb } from 'tamagui';
 
-import { TlonText } from '..';
 import { useContact, useCurrentUserId } from '../contexts';
 import { useCopy } from '../hooks/useCopy';
 import { getDisplayName } from '../utils';
 import { Button } from './Button';
 import { Icon } from './Icon';
+import { Text } from './TextV2';
 
 const logger = createDevLogger('PersonalInviteButton', true);
 
@@ -66,9 +66,9 @@ export function PersonalInviteButton() {
       <Button.Icon>
         <Icon type="Link" />
       </Button.Icon>
-      <TlonText.Text color="$background" size="$label/l">
+      <Text color="$background" size="$label/l">
         Share invite link
-      </TlonText.Text>
+      </Text>
     </Button>
   );
 }

--- a/packages/ui/src/components/PersonalInviteSheet.tsx
+++ b/packages/ui/src/components/PersonalInviteSheet.tsx
@@ -1,10 +1,10 @@
 import * as db from '@tloncorp/shared/db';
 import QRCode from 'react-qr-code';
+import { View, useTheme } from 'tamagui';
 
-import { TlonText, View } from '..';
-import { useTheme } from '../';
 import { ActionSheet } from './ActionSheet';
 import { PersonalInviteButton } from './PersonalInviteButton';
+import { Text } from './TextV2';
 
 export function PersonalInviteSheet({
   open,
@@ -20,14 +20,10 @@ export function PersonalInviteSheet({
     <ActionSheet open={open} onOpenChange={onOpenChange} snapPointsMode="fit">
       <ActionSheet.SimpleHeader title="Invite Friends to TM" />
       <ActionSheet.Content paddingHorizontal={40}>
-        <TlonText.Text
-          size="$label/m"
-          color="$secondaryText"
-          marginBottom="$2xl"
-        >
+        <Text size="$label/m" color="$secondaryText" marginBottom="$2xl">
           Anyone you invite will skip the waitlist and be added to your
           contacts. You&apos;ll receive a DM when they join.
-        </TlonText.Text>
+        </Text>
         <View
           width="100%"
           display="flex"

--- a/packages/ui/src/components/PersonalInviteSheet.tsx
+++ b/packages/ui/src/components/PersonalInviteSheet.tsx
@@ -1,7 +1,7 @@
 import * as db from '@tloncorp/shared/db';
 import QRCode from 'react-qr-code';
 
-import { ListItem, TlonText, View } from '..';
+import { TlonText, View } from '..';
 import { useTheme } from '../';
 import { ActionSheet } from './ActionSheet';
 import { PersonalInviteButton } from './PersonalInviteButton';
@@ -13,7 +13,7 @@ export function PersonalInviteSheet({
   open: boolean;
   onOpenChange: (open: boolean) => void;
 }) {
-  const inviteLink = db.personalInviteLink.useValue() as string;
+  const inviteLink = db.personalInviteLink.useValue();
   const theme = useTheme();
 
   return (
@@ -34,12 +34,14 @@ export function PersonalInviteSheet({
           alignItems="center"
           marginBottom="$3xl"
         >
-          <QRCode
-            value={inviteLink}
-            size={200}
-            fgColor={theme.primaryText.val}
-            bgColor="transparent"
-          />
+          {inviteLink && (
+            <QRCode
+              value={inviteLink}
+              size={200}
+              fgColor={theme.primaryText.val}
+              bgColor="transparent"
+            />
+          )}
         </View>
         <PersonalInviteButton />
       </ActionSheet.Content>


### PR DESCRIPTION
This pr cleans up a few existing warnings:

- QRCode prop warning: happened because cached invite link was null before being loaded, which the QR component doesn't like. Fixed by waiting to render until we have a valid invite link.
- ` useFindSuggestedContacts` warning: happened because this hook would sometimes run before the urbit client was ready. Fixed by moving client initialization logic to an outer component (also had to do some deps cleanup as part of this, including memoizing the `usePosthog` result
- Fixed a few of the easier circular import errors.