### PR TITLE
Enable lure flow logging in %grouper

### DIFF
--- a/desk/app/activity.hoon
+++ b/desk/app/activity.hoon
@@ -74,6 +74,7 @@
   |_  =bowl:gall
   +*  this  .
       def   ~(. (default-agent this %|) bowl)
+      log   ~(. logs [our.bowl /logs])
       cor   ~(. +> [bowl ~])
   ::
   ++  on-init
@@ -112,7 +113,7 @@
     |=  [=term =tang]
     ^-  (quip card _this)
     :_  this
-    [(log-fail:logs /logs our.bowl (fail-event:logs term tang))]~
+    [(fail:log term tang)]~
   --
 |_  [=bowl:gall cards=(list card)]
 ++  abet  [(flop cards) state]

--- a/desk/app/channels-server.hoon
+++ b/desk/app/channels-server.hoon
@@ -29,6 +29,7 @@
   |_  =bowl:gall
   +*  this  .
       def   ~(. (default-agent this %|) bowl)
+      log   ~(. logs [our.bowl /logs])
       cor   ~(. +> [bowl ~])
   ++  on-init
     ^-  (quip card _this)
@@ -64,7 +65,7 @@
     |=  [=term =tang]
     ^-  (quip card _this)
     :_  this
-    [(log-fail:logs /logs our.bowl (fail-event:logs term tang))]~
+    [(fail:log term tang)]~
   ::
   ++  on-agent
     |=  [=wire =sign:agent:gall]

--- a/desk/app/channels.hoon
+++ b/desk/app/channels.hoon
@@ -47,6 +47,7 @@
   |_  =bowl:gall
   +*  this  .
       def   ~(. (default-agent this %|) bowl)
+      log   ~(. logs [our.bowl /logs])
       cor   ~(. +> [bowl ~])
   ++  on-init
     ^-  (quip card _this)
@@ -82,7 +83,7 @@
     |=  [=term =tang]
     ^-  (quip card _this)
     :_  this
-    [(log-fail:logs /logs our.bowl (fail-event:logs term tang))]~
+    [(fail:log term tang)]~
   ::
   ++  on-agent
     |=  [=wire =sign:agent:gall]

--- a/desk/app/groups.hoon
+++ b/desk/app/groups.hoon
@@ -40,6 +40,7 @@
   |_  =bowl:gall
   +*  this  .
       def   ~(. (default-agent this %|) bowl)
+      log   ~(. logs [our.bowl /logs])
       cor   ~(. +> [bowl ~])
   ++  on-init
     ^-  (quip card _this)
@@ -73,7 +74,7 @@
     |=  [=term =tang]
     ^-  (quip card _this)
     :_  this
-    [(log-fail:logs /logs our.bowl (fail-event:logs term tang))]~
+    [(fail:log term tang)]~
   ::
   ++  on-agent
     |=  [=wire =sign:agent:gall]

--- a/desk/lib/logs.hoon
+++ b/desk/lib/logs.hoon
@@ -62,6 +62,8 @@
         %tell
       =-  ?>(?=(%o -.-) -)
       %-  pairs:enjs
+      ::
+      ::  insert tell id if present
       =-  ?~  id.e  -
           [id/s+u.id.e -]
       :~  type/s+event-type

--- a/desk/lib/logs.hoon
+++ b/desk/lib/logs.hoon
@@ -1,4 +1,26 @@
 /-  *logs
+=<
+  |_  [our=ship =wire]
+  ::
+  ++  fail
+    |=  [desc=term trace=tang]
+    ^-  card:agent:gall
+    =/  event=$>(%fail log-event)
+      [%fail desc trace]
+    (pass event)
+  ::
+  ++  tell
+    |=  [id=(unit @ta) vol=volume =echo]
+    ^-  card:agent:gall
+    =/  event=$>(%tell log-event)
+      [%tell id vol echo]
+    (pass event)
+  ::
+  ++  pass
+    |=  event=log-event
+    ^-  card:agent:gall
+    [%pass wire %agent [our %logs] %poke log-action+!>([%log event])]
+  --
 |%
 ::
 ++  fail-event
@@ -6,10 +28,10 @@
   ^-  $>(%fail log-event)
   [%fail term tang]
 ::
-++  log-fail
-  |=  [=wire our=ship event=$>(%fail log-event)]
-  ^-  card:agent:gall
-  [%pass wire %agent [our %logs] %poke log-action+!>([%log event])]
+++  tell-event
+  |=  [id=(unit @ta) vol=volume =echo]
+  ^-  $>(%tell log-event)
+  [%tell id vol echo]
 ::
 ++  enjs
   =,  format
@@ -34,7 +56,17 @@
       %-  pairs:enjs
       :~  type/s+event-type
           description/s+desc.e
-          stacktrace/(tang crash.e)
+          stacktrace/(tang trace.e)
+      ==
+    ::
+        %tell
+      =-  ?>(?=(%o -.-) -)
+      %-  pairs:enjs
+      =-  ?~  id.e  -
+          [id/s+u.id.e -]
+      :~  type/s+event-type
+          message/(tang echo.e)
+          volume/s+vol.e
       ==
     ==
   --

--- a/desk/sur/logs.hoon
+++ b/desk/sur/logs.hoon
@@ -1,15 +1,21 @@
 /+  mp=mop-extensions
 ::
 |%
+::  $echo: formatted message
++$  echo  (list tank)
+::  $volume: echo volume
++$  volume  ?(%info %warn %crit)
 ::  $log-event
 ::
 ::  %fail: agent failure
+::  %tell: agent message
 ::
 +$  log-event
-  $%  [%fail desc=term crash=tang]
+  $%  [%fail desc=term trace=tang]
+      [%tell id=(unit @ta) vol=volume =echo]
   ==
 ::
-::  $log-item: event with timestamp
+::  $log-item: an event with timestamp
 +$  log-item  [=time event=log-event]
 ::
 +$  a-log

--- a/desk/sur/logs.hoon
+++ b/desk/sur/logs.hoon
@@ -15,7 +15,7 @@
       [%tell id=(unit @ta) vol=volume =echo]
   ==
 ::
-::  $log-item: an event with timestamp
+::  $log-item: event with timestamp
 +$  log-item  [=time event=log-event]
 ::
 +$  a-log

--- a/desk/ted/posthog.hoon
+++ b/desk/ted/posthog.hoon
@@ -21,6 +21,10 @@
 =*  log-item  q.u.arg
 ;<  =bowl:strand  bind:m  get-bowl:io
 =/  log-event-json=$>(%o json)  (log-event:enjs:l event.log-item)
+::  retrieve desk hash
+::
+;<  hash=@uv  bind:m  (scry:io @uv %cz q.byk.bowl ~)
+::
 =/  props=json
   :-  %o
   %-  ~(uni by p.log-event-json)
@@ -28,6 +32,7 @@
   %-  my
   :~  'distinct_id'^s+(scot %p our.bowl)
       'origin'^s+(spat origin)
+      'hash'^s+(crip ((v-co:co 5) (end [0 25] hash)))
   ==
 =/  event=json
   %-  pairs:enjs:format


### PR DESCRIPTION
The Lure backend infrastructure comprises of three agents: %grouper, %reel and %bait. 
This PR augments %grouper with lure redemption tracing, as described in detail in TLON-3378.
(%logs agent functionality is also extended with a new event type, `%tell`, which carrier an `$echo` message with specified volume: `%info`, `%warn` or `%crit`.)