### PR TITLE
fix android build

### DIFF
--- a/apps/tlon-mobile/metro.config.js
+++ b/apps/tlon-mobile/metro.config.js
@@ -113,6 +113,9 @@ module.exports = mergeConfig(config, {
 
     // Enables importing alternative package exports, e.g. `react-tweet/api`
     unstable_enablePackageExports: true,
+    // Removes import, which causes issues for zustand
+    // This is the default setting in newer versions of react-native
+    unstable_conditionNames: ['require'],
   },
 });
 


### PR DESCRIPTION
This PR fixes an issue introduced in #4309 by modifying metro package import settings. Before this change, importing `zustand/middleware` would grab files which contain `import.meta` references, which apparently is invalid in the react native environment.

Android builds will probably fail until this is merged.