### PR TITLE
refine manage channels screen

### DIFF
--- a/packages/app/hooks/useGroupContext.ts
+++ b/packages/app/hooks/useGroupContext.ts
@@ -175,7 +175,7 @@ export const useGroupContext = ({
     async (channelId: string, navSectionId: string, index: number) => {
       if (group) {
         await store.moveChannel({
-          group,
+          groupId: group.id,
           channelId,
           navSectionId,
           index,
@@ -202,7 +202,7 @@ export const useGroupContext = ({
       // Use addChannelToNavSection which handles both adding to new section
       // and removing from the previous section
       await store.addChannelToNavSection({
-        group,
+        groupId: group.id,
         channelId,
         navSectionId,
       });

--- a/packages/shared/src/api/groupsApi.ts
+++ b/packages/shared/src/api/groupsApi.ts
@@ -743,6 +743,7 @@ export type GroupChannelDelete = {
 export type GroupChannelNavSectionAdd = {
   type: 'addChannelToNavSection';
   channelId: string;
+  groupId: string;
   navSectionId: string;
   sectionId: string;
 };
@@ -778,6 +779,7 @@ export type GroupnavSectionMoveChannel = {
   type: 'moveChannel';
   navSectionId: string;
   sectionId: string;
+  groupId: string;
   channelId: string;
   index: number;
 };
@@ -1205,6 +1207,7 @@ export const toGroupUpdate = (
         type: 'moveChannel',
         navSectionId,
         sectionId,
+        groupId,
         channelId: zoneDelta['mov-nest'].nest,
         index: zoneDelta['mov-nest'].idx,
       };
@@ -1262,6 +1265,7 @@ export const toGroupUpdate = (
       return {
         type: 'addChannelToNavSection',
         channelId,
+        groupId,
         navSectionId: `${groupId}-${zoneId}`,
         sectionId: zoneId,
       };

--- a/packages/shared/src/db/queries.ts
+++ b/packages/shared/src/db/queries.ts
@@ -1604,7 +1604,7 @@ export const addNavSectionToGroup = createWriteQuery(
         set: conflictUpdateSetAll($groupNavSections),
       });
   },
-  ['groupNavSections']
+  ['groups','groupNavSections', 'groupNavSectionChannels']
 );
 
 export const updateNavSectionChannel = createWriteQuery(

--- a/packages/shared/src/db/queries.ts
+++ b/packages/shared/src/db/queries.ts
@@ -673,7 +673,7 @@ export const updateGroup = createWriteQuery(
   async (group: Partial<Group> & { id: string }, ctx: QueryCtx) => {
     return ctx.db.update($groups).set(group).where(eq($groups.id, group.id));
   },
-  ['groups']
+  ['groups', 'channels', 'groupNavSections', 'groupNavSectionChannels']
 );
 
 export const deleteGroup = createWriteQuery(
@@ -1607,6 +1607,33 @@ export const addNavSectionToGroup = createWriteQuery(
   ['groupNavSections']
 );
 
+export const updateNavSectionChannel = createWriteQuery(
+  'updateNavSectionChannel',
+  async (
+    {
+      channelId,
+      groupNavSectionId,
+      channelIndex,
+    }: {
+      channelId: string;
+      groupNavSectionId: string;
+      channelIndex: number;
+    },
+    ctx: QueryCtx
+  ) => {
+    return ctx.db
+      .update($groupNavSectionChannels)
+      .set({ channelIndex })
+      .where(
+        and(
+          eq($groupNavSectionChannels.channelId, channelId),
+          eq($groupNavSectionChannels.groupNavSectionId, groupNavSectionId)
+        )
+      );
+  },
+  ['groupNavSectionChannels']
+);
+
 export const updateNavSection = createWriteQuery(
   'updateNavSection',
   async (
@@ -1656,7 +1683,7 @@ export const addChannelToNavSection = createWriteQuery(
       })
       .onConflictDoNothing();
   },
-  ['groupNavSectionChannels']
+  ['groupNavSectionChannels', 'groups']
 );
 
 export const deleteChannelFromNavSection = createWriteQuery(
@@ -2765,6 +2792,7 @@ export const getGroup = createReadQuery(
     'channels',
     'groupJoinRequests',
     'groupMemberBans',
+    'groupNavSectionChannels'
   ]
 );
 

--- a/packages/shared/src/store/sync.ts
+++ b/packages/shared/src/store/sync.ts
@@ -13,6 +13,7 @@ import {
   INFINITE_ACTIVITY_QUERY_KEY,
   resetActivityFetchers,
 } from '../store/useActivityFetchers';
+import { addChannelToNavSection, moveChannel } from './groupActions';
 import { verifyUserInviteLink } from './inviteActions';
 import { useLureState } from './lure';
 import { getSyncing, updateIsSyncing, updateSession } from './session';
@@ -620,18 +621,20 @@ async function handleGroupUpdate(update: api.GroupUpdate) {
       break;
     case 'moveChannel':
       logger.log('moving channel', update);
-      await db.addChannelToNavSection({
+      await moveChannel({
         channelId: update.channelId,
-        groupNavSectionId: update.navSectionId,
+        groupId: update.groupId,
+        navSectionId: update.sectionId,
         index: update.index,
       });
       break;
     case 'addChannelToNavSection':
       logger.log('adding channel to nav section', update);
-      await db.addChannelToNavSection({
+
+      await addChannelToNavSection({
         channelId: update.channelId,
-        groupNavSectionId: update.navSectionId,
-        index: 0,
+        groupId: update.groupId,
+        navSectionId: update.sectionId,
       });
       break;
     case 'setUnjoinedGroups':

--- a/packages/ui/src/components/ChannelNavSection.tsx
+++ b/packages/ui/src/components/ChannelNavSection.tsx
@@ -18,9 +18,18 @@ export default function ChannelNavSection({
   const sectionChannels = useMemo(
     () =>
       section.channels
-        ? section.channels.filter(
-            (item) => !!channels.find((c) => c.id === item.channelId)
-          )
+        ? section.channels
+            .filter((item) => !!channels.find((c) => c.id === item.channelId))
+            .sort((a, b) => {
+              const aChannelIndex =
+                section.channels?.find((c) => c.channelId === a.channelId)
+                  ?.channelIndex ?? 0;
+              const bChannelIndex =
+                section.channels?.find((c) => c.channelId === b.channelId)
+                  ?.channelIndex ?? 0;
+
+              return aChannelIndex - bChannelIndex;
+            })
         : [],
     [section, channels]
   );

--- a/packages/ui/src/components/GroupChannelsScreenView.tsx
+++ b/packages/ui/src/components/GroupChannelsScreenView.tsx
@@ -1,5 +1,5 @@
 import * as db from '@tloncorp/shared/db';
-import { useCallback, useEffect, useState } from 'react';
+import { useCallback, useState } from 'react';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
 import { ScrollView, View, YStack, getVariableValue, useTheme } from 'tamagui';
 

--- a/packages/ui/src/components/ManageChannels/ManageChannelsScreenView.tsx
+++ b/packages/ui/src/components/ManageChannels/ManageChannelsScreenView.tsx
@@ -674,16 +674,15 @@ export function ManageChannelsScreenView({
         <YStack
           backgroundColor="$background"
           gap="$2xl"
-          // padding="$xl"
           alignItems="center"
           flex={1}
         >
           <ScrollView
             style={{ zIndex: 1, elevation: 1, width: '100%' }}
             gap="$2xl"
-            paddingBottom={bottom}
             contentContainerStyle={{
               alignItems: 'center',
+              paddingBottom: bottom,
             }}
           >
             {renderSectionsAndChannels}

--- a/packages/ui/src/components/ManageChannels/ManageChannelsScreenView.tsx
+++ b/packages/ui/src/components/ManageChannels/ManageChannelsScreenView.tsx
@@ -1,14 +1,13 @@
 import * as db from '@tloncorp/shared/db';
 import { omit } from 'lodash';
-import { useCallback, useEffect, useMemo, useState } from 'react';
-import { LayoutRectangle } from 'react-native';
-import Animated, { useSharedValue } from 'react-native-reanimated';
+import { useCallback, useMemo, useState } from 'react';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
-import { Text, View, XStack, YStack } from 'tamagui';
+import { ScrollView, Text, View, XStack, YStack } from 'tamagui';
 
+import { capitalize } from '../../utils';
 import { Button } from '../Button';
-import { DraggableItem } from '../DraggableItem';
 import { Icon } from '../Icon';
+import { ListItem } from '../ListItem';
 import Pressable from '../Pressable';
 import { ScreenHeader } from '../ScreenHeader';
 import { CreateChannelSheet } from './CreateChannelSheet';
@@ -22,91 +21,138 @@ export type Section = {
 
 type Channel = {
   id: string;
+  type: db.ChannelType;
   title?: string | null;
+  index?: number;
 };
 
-type DraggedItem = {
-  type: 'section' | 'channel';
-  channelId?: string;
-  sectionId: string;
-  layout: LayoutRectangle;
-};
-
-function EmptySection({
-  deleteSection,
-  isDefault,
-}: {
-  deleteSection: () => Promise<void>;
-  isDefault: boolean;
-}) {
+function EmptySection() {
   return (
-    <YStack width="100%">
-      <Text padding="$l" fontSize="$m" color="$secondaryText">
-        No channels
+    <YStack alignItems="center" width="100%">
+      <Text padding="$l" fontSize="$s" color="$secondaryText">
+        No channels in this section
       </Text>
-      {!isDefault && (
-        <Button heroDestructive onPress={deleteSection}>
-          <Button.Text>Delete section</Button.Text>
-        </Button>
-      )}
     </YStack>
   );
 }
 
-function DraggableChannel({
+function ChannelItem({
   channel,
   onEdit,
-  onDrag,
-  onDragStart,
-  onDragEnd,
-  isDragging = false,
+  moveChannelWithinNavSection,
+  moveChannelToNavSection,
+  index,
+  sectionIndex,
+  isLast,
+  isFirst,
+  isLastSection,
+  isFirstSection,
 }: {
   channel: Channel;
   onEdit: () => void;
-  onDrag: (translateY: number) => void;
-  onDragStart: (layout: LayoutRectangle) => void;
-  onDragEnd: (translateY: number) => void;
-  isDragging?: boolean;
+  moveChannelWithinNavSection: (newIndex: number) => void;
+  moveChannelToNavSection: (newSectionIndex: number) => void;
+  index: number;
+  sectionIndex: number;
+  isLast: boolean;
+  isFirst: boolean;
+  isLastSection: boolean;
+  isFirstSection: boolean;
 }) {
+  const handleMoveUp = useCallback(() => {
+    if (isFirst) {
+      if (isFirstSection) {
+        console.error(
+          `Channel "${channel.title}" is already at the top of the first section`
+        );
+        return;
+      } else {
+        moveChannelToNavSection(sectionIndex - 1);
+      }
+      return;
+    }
+    moveChannelWithinNavSection(index - 1);
+  }, [
+    moveChannelWithinNavSection,
+    index,
+    sectionIndex,
+    isFirst,
+    isFirstSection,
+    moveChannelToNavSection,
+    channel.title,
+  ]);
+
+  const handleMoveDown = useCallback(() => {
+    if (isLast) {
+      if (isLastSection) {
+        console.error(
+          `Channel "${channel.title}" is already at the bottom of the last section`
+        );
+        return;
+      } else {
+        moveChannelToNavSection(sectionIndex + 1);
+      }
+      return;
+    }
+    moveChannelWithinNavSection(index + 1);
+  }, [
+    moveChannelWithinNavSection,
+    index,
+    sectionIndex,
+    isLast,
+    isLastSection,
+    moveChannelToNavSection,
+    channel.title,
+  ]);
+
   return (
-    <DraggableItem
-      onDrag={onDrag}
-      onDragEnd={onDragEnd}
-      onDragStart={onDragStart}
+    <XStack
+      paddingLeft="$l"
+      width="100%"
+      height="$6xl"
+      borderRadius="$xl"
+      alignItems="center"
+      justifyContent="space-between"
+      backgroundColor="$background"
     >
-      <XStack
-        paddingHorizontal="$l"
-        paddingLeft="$l"
-        paddingRight="$2xl"
-        width="100%"
-        borderColor="$border"
-        height="$6xl"
-        gap="$2xl"
-        borderWidth={1}
-        borderRadius="$xl"
-        alignItems="center"
-        justifyContent="space-between"
-        backgroundColor="$background"
-      >
-        {!isDragging && (
-          <>
-            <XStack alignItems="center" gap="$l">
-              <Pressable onPress={() => console.log('edit')}>
-                <Icon color="$secondaryText" type="Dragger" />
-              </Pressable>
-              <Text fontSize="$l" paddingVertical="$s">
-                {channel?.title}
-              </Text>
-            </XStack>
-            <Pressable onPress={onEdit}>
-              <View paddingVertical="$xs">
-                <Icon color="$secondaryText" type="Overflow" size="$m" />
-              </View>
-            </Pressable>
-          </>
-        )}
+      <XStack alignItems="center" gap="$l">
+        <ListItem.ChannelIcon
+          // @ts-expect-error - we don't need the whole channel object
+          model={{ type: channel.type }}
+          useTypeIcon
+        />
+        <YStack gap="$2xs">
+          <Text fontSize="$l" paddingVertical="$s">
+            {channel?.title}
+          </Text>
+          <Text fontSize="$s" color="$secondaryText">
+            {capitalize(channel.type)}
+          </Text>
+        </YStack>
       </XStack>
-    </DraggableItem>
+
+      <XStack gap="$2xs">
+        <Pressable onPress={handleMoveUp} disabled={isFirst && isFirstSection}>
+          <Icon
+            color={
+              isFirst && isFirstSection ? '$secondaryText' : '$primaryText'
+            }
+            type="ChevronUp"
+          />
+        </Pressable>
+        <Pressable onPress={handleMoveDown} disabled={isLast && isLastSection}>
+          <Icon
+            color={isLast && isLastSection ? '$secondaryText' : '$primaryText'}
+            type="ChevronDown"
+          />
+        </Pressable>
+        <Pressable onPress={onEdit}>
+          <View paddingVertical="$xs">
+            <Icon color="$secondaryText" type="Overflow" size="$m" />
+          </View>
+        </Pressable>
+      </XStack>
+    </XStack>
   );
 }
 
@@ -117,6 +163,11 @@ function NavSection({
   onMoveUp,
   onMoveDown,
   editSection,
+  deleteSection,
+  setShowCreateChannel,
+  setShowAddSection,
+  isEmpty,
+  isDefault,
   children,
 }: {
   section: Section;
@@ -125,45 +176,87 @@ function NavSection({
   onMoveUp: (sectionId: string) => void;
   onMoveDown: (sectionId: string) => void;
   editSection: (section: Section) => void;
+  deleteSection: (sectionId: string) => void;
+  setShowCreateChannel: (show: boolean) => void;
+  setShowAddSection: (show: boolean) => void;
+  isEmpty: boolean;
+  isDefault: boolean;
   children: React.ReactNode;
 }) {
-  console.log('section, index', section.title, index);
+  const borderTopWidth = useMemo(() => (index === 0 ? 'unset' : 1), [index]);
+  const borderColor = useMemo(
+    () => (index === 0 ? 'transparent' : '$border'),
+    [index]
+  );
+  const paddingTop = useMemo(() => (index === 0 ? '$l' : '$xl'), [index]);
+
   return (
     <YStack
-      padding="$xl"
-      borderWidth={1}
-      borderRadius="$xl"
-      borderColor="$border"
       width="100%"
       gap="$2xl"
       backgroundColor="$background"
+      borderTopWidth={borderTopWidth}
+      borderColor={borderColor}
+      paddingTop={paddingTop}
+      paddingHorizontal="$l"
     >
-      <XStack
-        width="100%"
-        justifyContent="space-between"
-        alignItems="center"
-        gap="$l"
-      >
-        <XStack paddingLeft="$s" alignItems="center" gap="$l">
-          <Text fontSize="$l">{section.title}</Text>
+      <XStack width="100%" justifyContent="space-between" alignItems="center">
+        <Text paddingLeft="$l" fontSize="$s" color="$secondaryText">
+          {section.title}
+        </Text>
+        <XStack gap="$s">
+          {!isDefault ? (
+            <>
+              <Button minimal size="$s" onPress={() => editSection(section)}>
+                <Button.Text size="$s" color="$positiveActionText">
+                  Edit
+                </Button.Text>
+              </Button>
+              {isEmpty && (
+                <Button
+                  minimal
+                  size="$s"
+                  onPress={() => deleteSection(section.id)}
+                >
+                  <Button.Text size="$s" color="$negativeActionText">
+                    Delete
+                  </Button.Text>
+                </Button>
+              )}
+            </>
+          ) : (
+            <>
+              <Button
+                minimal
+                size="$s"
+                onPress={() => setShowCreateChannel(true)}
+              >
+                <Button.Text size="$s" color="$positiveActionText">
+                  New Channel
+                </Button.Text>
+              </Button>
+              <Button minimal size="$s" onPress={() => setShowAddSection(true)}>
+                <Button.Text size="$s" color="$positiveActionText">
+                  New Section
+                </Button.Text>
+              </Button>
+            </>
+          )}
         </XStack>
-        <XStack alignItems="center" gap="$s">
+        {/* TODO: Implement these actions after we get design feedback
+        <XStack alignItems="center" gap="$xs">
           {index !== 0 && (
             <Pressable onPress={() => onMoveUp(section.id)}>
-              <Icon color="$primaryText" type="ArrowUp" size="$m" />
+              <Icon color="$primaryText" type="ChevronUp" size="$m" />
             </Pressable>
           )}
           {index !== totalSections - 1 && (
             <Pressable onPress={() => onMoveDown(section.id)}>
-              <Icon color="$primaryText" type="ArrowDown" size="$m" />
-            </Pressable>
-          )}
-          {section.id !== 'default' && (
-            <Pressable onPress={() => editSection(section)}>
-              <Icon color="$primaryText" type="Draw" size="$m" />
+              <Icon color="$primaryText" type="ChevronDown" size="$m" />
             </Pressable>
           )}
         </XStack>
+        */}
       </XStack>
       {children}
     </YStack>
@@ -209,160 +302,20 @@ export function ManageChannelsScreenView({
   enableCustomChannels = false,
 }: ManageChannelsScreenViewProps) {
   const [sections, setSections] = useState<Section[]>(() => {
-    console.log('componentDidMount', groupNavSectionsWithChannels);
     return groupNavSectionsWithChannels.map((s) => ({
       id: s.sectionId,
       title: s.title ?? 'Untitled Section',
       channels: s.channels.map((c) => ({
         id: c.id,
         title: c.title ?? 'Untitled Channel',
+        type: c.type,
       })),
     }));
   });
 
-  useEffect(() => {
-    console.log('componentDidUpdate', groupNavSectionsWithChannels);
-    setSections(
-      groupNavSectionsWithChannels.map((s) => ({
-        id: s.sectionId,
-        title: s.title ?? 'Untitled Section',
-        channels: s.channels.map((c) => ({
-          id: c.id,
-          title: c.title ?? 'Untitled Channel',
-        })),
-      }))
-    );
-  }, [groupNavSectionsWithChannels]);
-
   const [editSection, setEditSection] = useState<Section | null>(null);
   const [showAddSection, setShowAddSection] = useState(false);
   const [showCreateChannel, setShowCreateChannel] = useState(false);
-
-  const [draggedItem, setDraggedItem] = useState<DraggedItem | null>(null);
-  const draggedItemY = useSharedValue(0);
-
-  // const handleSectionDragEnd = useCallback(
-  // async (index: number, translateY: number) => {
-  // const newIndex = Math.min(
-  // Math.max(0, Math.round(index + translateY / 40)),
-  // sections.length - 1
-  // );
-
-  // setSections((prevSections) => {
-  // const newSections = [...prevSections];
-  // const [movedSection] = newSections.splice(index, 1);
-  // newSections.splice(newIndex, 0, movedSection);
-
-  // return newSections;
-  // });
-  // setDraggedItem(null);
-  // draggedItemY.value = 0;
-  // await moveNavSection(sections[index].id, newIndex);
-  // },
-  // [draggedItemY, moveNavSection, sections]
-  // );
-
-  const handleChannelDragEnd = useCallback(
-    async (sectionId: string, channelIndex: number, translateY: number) => {
-      let newSections: Section[] = [];
-      let newChannelIndex;
-      let targetSectionIndex;
-      setSections((prevSections) => {
-        newSections = [...prevSections];
-        const currentSectionIndex = newSections.findIndex(
-          (s) => s.id === sectionId
-        );
-        const currentSection = newSections[currentSectionIndex];
-        const [movedChannel] = currentSection.channels.splice(channelIndex, 1);
-
-        // Calculate the target section index
-        targetSectionIndex = currentSectionIndex;
-        const sectionHeight = 150; // Approximate height of a section
-        const direction = Math.sign(translateY);
-        const sectionsMoved = Math.floor(Math.abs(translateY) / sectionHeight);
-
-        if (direction > 0) {
-          // Moving down
-          targetSectionIndex = Math.min(
-            currentSectionIndex + sectionsMoved,
-            newSections.length - 1
-          );
-        } else if (direction < 0) {
-          // Moving up
-          targetSectionIndex = Math.max(currentSectionIndex - sectionsMoved, 0);
-        }
-
-        // Calculate new index within the target section
-        const targetSection = newSections[targetSectionIndex];
-        const channelHeight = 72; // Approximate height of a channel
-        if (targetSectionIndex === currentSectionIndex) {
-          newChannelIndex = Math.min(
-            Math.max(0, Math.round(channelIndex + translateY / channelHeight)),
-            targetSection.channels.length
-          );
-        } else {
-          newChannelIndex = direction > 0 ? 0 : targetSection.channels.length;
-        }
-
-        // Insert the channel at its new position
-        targetSection.channels.splice(newChannelIndex, 0, movedChannel);
-
-        return newSections;
-      });
-
-      setDraggedItem(null);
-      draggedItemY.value = 0;
-
-      if (
-        newChannelIndex !== undefined &&
-        targetSectionIndex !== undefined &&
-        newSections.length > 0
-      ) {
-        if (sections[targetSectionIndex].id !== sectionId) {
-          await moveChannelToNavSection(
-            newSections[targetSectionIndex].channels[newChannelIndex].id,
-            newSections[targetSectionIndex].id
-          );
-        } else {
-          await moveChannelWithinNavSection(
-            newSections[targetSectionIndex].channels[newChannelIndex].id,
-            newSections[targetSectionIndex].id,
-            newChannelIndex
-          );
-        }
-      }
-    },
-    [
-      draggedItemY,
-      moveChannelWithinNavSection,
-      sections,
-      moveChannelToNavSection,
-    ]
-  );
-
-  const handleDragStart = useCallback(
-    (
-      type: 'section' | 'channel',
-      layout: LayoutRectangle,
-      sectionId: string,
-      channelId?: string
-    ) => {
-      draggedItemY.value = layout.y;
-      setDraggedItem({ type, sectionId, channelId, layout });
-    },
-    [draggedItemY]
-  );
-
-  const handleDrag = useCallback(
-    (translateY: number) => {
-      if (!draggedItem) {
-        return;
-      }
-
-      draggedItemY.value = translateY + draggedItem.layout.y;
-    },
-    [draggedItemY, draggedItem]
-  );
 
   const handleUpdateSection = useCallback(
     async (sectionId: string, title: string) => {
@@ -371,19 +324,30 @@ export function ManageChannelsScreenView({
       );
 
       if (!navSection) {
+        console.error(`Section not found: ${sectionId} (for update operation)`);
         return;
       }
 
-      await updateNavSection({
-        ...omit(navSection, 'channels'),
-        title,
-      });
+      // Store original state for rollback
+      const originalSections = [...sections];
 
+      // Update local state first for optimistic UI
       setSections((prevSections) =>
         prevSections.map((s) => (s.id === sectionId ? { ...s, title } : s))
       );
+
+      try {
+        await updateNavSection({
+          ...omit(navSection, 'channels'),
+          title,
+        });
+      } catch (e) {
+        // Restore original state on error
+        setSections(originalSections);
+        console.error('Failed to update section:', e);
+      }
     },
-    [groupNavSectionsWithChannels, updateNavSection]
+    [groupNavSectionsWithChannels, updateNavSection, sections]
   );
 
   const handleDeleteSection = useCallback(
@@ -393,129 +357,295 @@ export function ManageChannelsScreenView({
       );
 
       if (!navSection) {
+        console.error(`Section not found: ${sectionId} (for deletion)`);
         return;
       }
-      await deleteNavSection(navSection.id);
+
+      // Store original state for rollback
+      const originalSections = [...sections];
+
+      // Update local state first for optimistic UI
+      setSections((prevSections) =>
+        prevSections.filter((s) => s.id !== sectionId)
+      );
+
+      try {
+        await deleteNavSection(navSection.id);
+      } catch (e) {
+        // Restore original state on error
+        setSections(originalSections);
+        console.error('Failed to delete section:', e);
+      }
     },
-    [deleteNavSection, groupNavSectionsWithChannels]
+    [deleteNavSection, groupNavSectionsWithChannels, sections]
   );
 
   const handleMoveSectionUp = useCallback(
     async (sectionId: string) => {
-      console.log('move up', sectionId);
       const index = sections.findIndex((s) => s.id === sectionId);
       if (index === 0) {
+        console.error(
+          `Section "${sections[index].title}" is already at the top`
+        );
         return;
       }
+
+      // Store original state for rollback
+      const originalSections = [...sections];
+
+      // Update local state first for optimistic UI
       setSections((prevSections) => {
         const newSections = [...prevSections];
         const [movedSection] = newSections.splice(index, 1);
         newSections.splice(index - 1, 0, movedSection);
-
         return newSections;
       });
-      await moveNavSection(sectionId, index - 1);
+
+      try {
+        await moveNavSection(sectionId, index - 1);
+      } catch (e) {
+        // Restore original state on error
+        setSections(originalSections);
+        console.error('Failed to move section up:', e);
+      }
     },
     [sections, moveNavSection]
   );
 
   const handleMoveSectionDown = useCallback(
     async (sectionId: string) => {
-      console.log('move down', sectionId);
       const index = sections.findIndex((s) => s.id === sectionId);
       if (index === sections.length - 1) {
+        console.error(
+          `Section "${sections[index].title}" is already at the bottom`
+        );
         return;
       }
+
+      // Store original state for rollback
+      const originalSections = [...sections];
+
+      // Update local state first for optimistic UI
       setSections((prevSections) => {
         const newSections = [...prevSections];
         const [movedSection] = newSections.splice(index, 1);
         newSections.splice(index + 1, 0, movedSection);
+        return newSections;
+      });
+
+      try {
+        await moveNavSection(sectionId, index + 1);
+      } catch (e) {
+        // Restore original state on error
+        setSections(originalSections);
+        console.error('Failed to move section down:', e);
+      }
+    },
+    [sections, moveNavSection]
+  );
+
+  const handleMoveChannelWithinNavSection = useCallback(
+    async (channelId: string, sectionId: string, newIndex: number) => {
+      const sectionIndex = sections.findIndex((s) => s.id === sectionId);
+      if (sectionIndex === -1) {
+        console.error('Invalid section ID:', sectionId);
+        return;
+      }
+
+      const channelIndex = sections[sectionIndex].channels.findIndex(
+        (c) => c.id === channelId
+      );
+      if (channelIndex === -1) {
+        console.error(
+          `Channel not found: ${channelId} (expected in section ${sectionId})`
+        );
+        return;
+      }
+
+      // Validate newIndex is within bounds
+      if (newIndex < 0 || newIndex >= sections[sectionIndex].channels.length) {
+        console.error(
+          'Invalid new index:',
+          newIndex,
+          'for section with',
+          sections[sectionIndex].channels.length,
+          'channels'
+        );
+        return;
+      }
+
+      // Store the original state for rollback
+      const originalSections = [...sections];
+
+      // Update local state first for optimistic UI
+      setSections((prevSections) => {
+        const newSections = [...prevSections];
+        const newChannels = [...newSections[sectionIndex].channels];
+        const [movedChannel] = newChannels.splice(channelIndex, 1);
+        newChannels.splice(newIndex, 0, movedChannel);
+        newSections[sectionIndex] = {
+          ...newSections[sectionIndex],
+          channels: newChannels,
+        };
+        return newSections;
+      });
+
+      try {
+        await moveChannelWithinNavSection(channelId, sectionId, newIndex);
+      } catch (e) {
+        // Restore original state on error
+        setSections(originalSections);
+        console.error('Failed to move channel within section:', e);
+      }
+    },
+    [sections, moveChannelWithinNavSection]
+  );
+
+  const handleMoveChannelToNavSection = useCallback(
+    async (
+      channelId: string,
+      newSectionId: string,
+      previousSectionId: string
+    ) => {
+      const previousSectionIndex = sections.findIndex(
+        (s) => s.id === previousSectionId
+      );
+
+      if (previousSectionIndex === -1) {
+        console.error('Invalid previous section ID:', previousSectionId);
+        return;
+      }
+
+      // Prevent moving to the same section
+      if (newSectionId === previousSectionId) {
+        console.error(
+          `Cannot move channel to section "${sections[previousSectionIndex].title}" as it is already there`
+        );
+        return;
+      }
+
+      const channel = sections[previousSectionIndex].channels.find(
+        (c) => c.id === channelId
+      );
+
+      if (!channel) {
+        console.error(
+          `Channel not found: ${channelId} (expected in section ${previousSectionId})`
+        );
+        return;
+      }
+
+      const sectionIndex = sections.findIndex((s) => s.id === newSectionId);
+      if (sectionIndex === -1) {
+        console.error('Invalid new section ID:', newSectionId);
+        return;
+      }
+
+      // Store the original state for rollback
+      const originalSections = [...sections];
+
+      // Update local state first for optimistic UI
+      setSections((prevSections) => {
+        const newSections = [...prevSections];
+        const newChannels = [...newSections[sectionIndex].channels];
+
+        // The %groups agent only supports adding new channels to the start of a section.
+        newChannels.unshift({
+          id: channelId,
+          title: channel.title,
+          index: 0,
+          type: channel.type,
+        });
+
+        newSections[sectionIndex] = {
+          ...newSections[sectionIndex],
+          channels: newChannels,
+        };
+
+        // Remove from the previous section
+        const newPreviousChannels = newSections[
+          previousSectionIndex
+        ].channels.filter((c) => c.id !== channelId);
+
+        newSections[previousSectionIndex] = {
+          ...newSections[previousSectionIndex],
+          channels: newPreviousChannels,
+        };
 
         return newSections;
       });
-      await moveNavSection(sectionId, index + 1);
+
+      try {
+        await moveChannelToNavSection(channelId, newSectionId);
+      } catch (e) {
+        // Restore original state on error
+        setSections(originalSections);
+        console.error('Failed to move channel to new section:', e);
+      }
     },
-    [sections, moveNavSection]
+    [sections, moveChannelToNavSection]
   );
 
   const { bottom } = useSafeAreaInsets();
 
   const renderSectionsAndChannels = useMemo(() => {
-    return sections.map((section, index) => (
+    return sections.map((section, sectionIndex) => (
       <NavSection
         key={section.id}
-        index={index}
+        index={sectionIndex}
         totalSections={sections.length}
         section={section}
         onMoveUp={handleMoveSectionUp}
         onMoveDown={handleMoveSectionDown}
         editSection={setEditSection}
+        deleteSection={handleDeleteSection}
+        setShowAddSection={setShowAddSection}
+        setShowCreateChannel={setShowCreateChannel}
+        isEmpty={section.id !== 'default' && section.channels.length === 0}
+        isDefault={section.id === 'default'}
       >
-        {section.channels.length === 0 && (
-          <EmptySection
-            isDefault={section.id === 'default'}
-            deleteSection={() => handleDeleteSection(section.id)}
-          />
-        )}
-        {section.channels.map((channel, index) => (
-          <DraggableChannel
+        {section.channels.length === 0 && <EmptySection />}
+        {section.channels.map((channel, channelIndex) => (
+          <ChannelItem
             key={channel.id}
             channel={channel}
+            moveChannelWithinNavSection={(newIndex) => {
+              handleMoveChannelWithinNavSection(
+                channel.id,
+                section.id,
+                newIndex
+              );
+            }}
+            moveChannelToNavSection={(newSectionIndex) => {
+              handleMoveChannelToNavSection(
+                channel.id,
+                sections[newSectionIndex].id,
+                section.id
+              );
+            }}
+            index={channelIndex}
+            sectionIndex={sectionIndex}
+            isLast={channelIndex === section.channels.length - 1}
+            isFirst={channelIndex === 0}
+            isFirstSection={sectionIndex === 0}
+            isLastSection={sectionIndex === sections.length - 1}
             onEdit={() => goToEditChannel(channel.id)}
-            onDrag={handleDrag}
-            onDragStart={(layout) =>
-              handleDragStart('channel', layout, section.id, channel.id)
-            }
-            onDragEnd={(translateY) =>
-              handleChannelDragEnd(section.id, index, translateY)
-            }
-            isDragging={
-              draggedItem?.type === 'channel' &&
-              draggedItem.channelId === channel.id
-            }
           />
         ))}
       </NavSection>
     ));
   }, [
     sections,
-    draggedItem,
-    handleChannelDragEnd,
-    handleDragStart,
-    handleDrag,
     handleDeleteSection,
     goToEditChannel,
     handleMoveSectionDown,
     handleMoveSectionUp,
+    handleMoveChannelWithinNavSection,
+    handleMoveChannelToNavSection,
   ]);
 
   return (
     <View backgroundColor="$background" flex={1}>
-      {draggedItem && (
-        <Animated.View
-          style={{
-            position: 'absolute',
-            top: draggedItemY ?? draggedItem.layout.y,
-            left: draggedItem.layout.x,
-            width: draggedItem.layout.width,
-            height: draggedItem.layout.height,
-            zIndex: 2000,
-            elevation: 2000,
-          }}
-        >
-          <DraggableChannel
-            channel={
-              sections
-                .find((s) => s.id === draggedItem.sectionId)!
-                .channels.find((c) => c.id === draggedItem.channelId)!
-            }
-            onEdit={() => {}}
-            onDrag={() => {}}
-            onDragStart={() => {}}
-            onDragEnd={() => {}}
-          />
-        </Animated.View>
-      )}
       <YStack
         backgroundColor="$background"
         justifyContent="space-between"
@@ -525,35 +655,20 @@ export function ManageChannelsScreenView({
         <YStack
           backgroundColor="$background"
           gap="$2xl"
-          padding="$xl"
+          // padding="$xl"
           alignItems="center"
           flex={1}
         >
-          <Animated.ScrollView
-            // 114.7 is the height of the buttons at the bottom
-            contentContainerStyle={{ paddingBottom: bottom + 114.7 }}
-            style={{ zIndex: 1, elevation: 1 }}
+          <ScrollView
+            style={{ zIndex: 1, elevation: 1, width: '100%' }}
+            gap="$2xl"
+            paddingBottom={bottom}
+            contentContainerStyle={{
+              alignItems: 'center',
+            }}
           >
-            <YStack gap="$2xl" alignItems="center">
-              {renderSectionsAndChannels}
-            </YStack>
-          </Animated.ScrollView>
-          <YStack
-            position="absolute"
-            backgroundColor="$background"
-            bottom={bottom}
-            gap="$l"
-            width="100%"
-            alignItems="center"
-            zIndex={5}
-          >
-            <Button hero onPress={() => setShowCreateChannel(true)}>
-              <Button.Text>Create a channel</Button.Text>
-            </Button>
-            <Button secondary onPress={() => setShowAddSection(true)}>
-              <Button.Text>Add a section</Button.Text>
-            </Button>
-          </YStack>
+            {renderSectionsAndChannels}
+          </ScrollView>
         </YStack>
       </YStack>
       {showCreateChannel && group && (
@@ -567,11 +682,18 @@ export function ManageChannelsScreenView({
         open={showAddSection}
         mode="add"
         onOpenChange={(open) => setShowAddSection(open)}
-        onSave={async (title) =>
-          createNavSection({
-            title,
-          })
-        }
+        onSave={async (title) => {
+          try {
+            await createNavSection({
+              title,
+            });
+          } catch (e) {
+            console.error('Failed to create section:', e);
+            // Note: We don't need state rollback here since the section
+            // hasn't been added to local state yet - the UI will update
+            // via the useEffect when groupNavSectionsWithChannels changes
+          }
+        }}
       />
       <EditSectionNameSheet
         open={!!editSection}

--- a/packages/ui/src/components/ManageChannels/ManageChannelsScreenView.tsx
+++ b/packages/ui/src/components/ManageChannels/ManageChannelsScreenView.tsx
@@ -1,6 +1,6 @@
 import * as db from '@tloncorp/shared/db';
 import { omit } from 'lodash';
-import { useCallback, useMemo, useState } from 'react';
+import { useCallback, useEffect, useMemo, useState } from 'react';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
 import { ScrollView, Text, View, XStack, YStack } from 'tamagui';
 
@@ -22,7 +22,7 @@ export type Section = {
 type Channel = {
   id: string;
   type: db.ChannelType;
-  title?: string | null;
+  title: string;
   index?: number;
 };
 
@@ -316,6 +316,25 @@ export function ManageChannelsScreenView({
   const [editSection, setEditSection] = useState<Section | null>(null);
   const [showAddSection, setShowAddSection] = useState(false);
   const [showCreateChannel, setShowCreateChannel] = useState(false);
+
+  useEffect(() => {
+    const newNavSections = groupNavSectionsWithChannels.map((s) => ({
+      id: s.sectionId,
+      title: s.title ?? 'Untitled Section',
+      channels: s.channels.map((c) => ({
+        id: c.id,
+        title: c.title ?? 'Untitled Channel',
+        type: c.type,
+      })),
+    }));
+
+    // Only update if the total number of sections have changed
+    if (newNavSections.length === sections.length) {
+      return;
+    }
+
+    setSections(newNavSections);
+  }, [groupNavSectionsWithChannels, sections]);
 
   const handleUpdateSection = useCallback(
     async (sectionId: string, title: string) => {

--- a/packages/ui/src/components/ManageChannels/ManageChannelsScreenView.tsx
+++ b/packages/ui/src/components/ManageChannels/ManageChannelsScreenView.tsx
@@ -1,3 +1,4 @@
+import { createDevLogger } from '@tloncorp/shared';
 import * as db from '@tloncorp/shared/db';
 import { omit } from 'lodash';
 import { useCallback, useEffect, useMemo, useState } from 'react';
@@ -12,6 +13,8 @@ import Pressable from '../Pressable';
 import { ScreenHeader } from '../ScreenHeader';
 import { CreateChannelSheet } from './CreateChannelSheet';
 import { EditSectionNameSheet } from './EditSectionNameSheet';
+
+const logger = createDevLogger('ManageChannelsScreenView', false);
 
 export type Section = {
   id: string;
@@ -62,7 +65,7 @@ function ChannelItem({
   const handleMoveUp = useCallback(() => {
     if (isFirst) {
       if (isFirstSection) {
-        console.error(
+        logger.error(
           `Channel "${channel.title}" is already at the top of the first section`
         );
         return;
@@ -85,7 +88,7 @@ function ChannelItem({
   const handleMoveDown = useCallback(() => {
     if (isLast) {
       if (isLastSection) {
-        console.error(
+        logger.error(
           `Channel "${channel.title}" is already at the bottom of the last section`
         );
         return;
@@ -343,7 +346,7 @@ export function ManageChannelsScreenView({
       );
 
       if (!navSection) {
-        console.error(`Section not found: ${sectionId} (for update operation)`);
+        logger.error(`Section not found: ${sectionId} (for update operation)`);
         return;
       }
 
@@ -363,7 +366,7 @@ export function ManageChannelsScreenView({
       } catch (e) {
         // Restore original state on error
         setSections(originalSections);
-        console.error('Failed to update section:', e);
+        logger.error('Failed to update section:', e);
       }
     },
     [groupNavSectionsWithChannels, updateNavSection, sections]
@@ -376,7 +379,7 @@ export function ManageChannelsScreenView({
       );
 
       if (!navSection) {
-        console.error(`Section not found: ${sectionId} (for deletion)`);
+        logger.error(`Section not found: ${sectionId} (for deletion)`);
         return;
       }
 
@@ -393,7 +396,7 @@ export function ManageChannelsScreenView({
       } catch (e) {
         // Restore original state on error
         setSections(originalSections);
-        console.error('Failed to delete section:', e);
+        logger.error('Failed to delete section:', e);
       }
     },
     [deleteNavSection, groupNavSectionsWithChannels, sections]
@@ -403,7 +406,7 @@ export function ManageChannelsScreenView({
     async (sectionId: string) => {
       const index = sections.findIndex((s) => s.id === sectionId);
       if (index === 0) {
-        console.error(
+        logger.error(
           `Section "${sections[index].title}" is already at the top`
         );
         return;
@@ -425,7 +428,7 @@ export function ManageChannelsScreenView({
       } catch (e) {
         // Restore original state on error
         setSections(originalSections);
-        console.error('Failed to move section up:', e);
+        logger.error('Failed to move section up:', e);
       }
     },
     [sections, moveNavSection]
@@ -435,7 +438,7 @@ export function ManageChannelsScreenView({
     async (sectionId: string) => {
       const index = sections.findIndex((s) => s.id === sectionId);
       if (index === sections.length - 1) {
-        console.error(
+        logger.error(
           `Section "${sections[index].title}" is already at the bottom`
         );
         return;
@@ -457,7 +460,7 @@ export function ManageChannelsScreenView({
       } catch (e) {
         // Restore original state on error
         setSections(originalSections);
-        console.error('Failed to move section down:', e);
+        logger.error('Failed to move section down:', e);
       }
     },
     [sections, moveNavSection]
@@ -467,7 +470,7 @@ export function ManageChannelsScreenView({
     async (channelId: string, sectionId: string, newIndex: number) => {
       const sectionIndex = sections.findIndex((s) => s.id === sectionId);
       if (sectionIndex === -1) {
-        console.error('Invalid section ID:', sectionId);
+        logger.error('Invalid section ID:', sectionId);
         return;
       }
 
@@ -475,7 +478,7 @@ export function ManageChannelsScreenView({
         (c) => c.id === channelId
       );
       if (channelIndex === -1) {
-        console.error(
+        logger.error(
           `Channel not found: ${channelId} (expected in section ${sectionId})`
         );
         return;
@@ -483,7 +486,7 @@ export function ManageChannelsScreenView({
 
       // Validate newIndex is within bounds
       if (newIndex < 0 || newIndex >= sections[sectionIndex].channels.length) {
-        console.error(
+        logger.error(
           'Invalid new index:',
           newIndex,
           'for section with',
@@ -514,7 +517,7 @@ export function ManageChannelsScreenView({
       } catch (e) {
         // Restore original state on error
         setSections(originalSections);
-        console.error('Failed to move channel within section:', e);
+        logger.error('Failed to move channel within section:', e);
       }
     },
     [sections, moveChannelWithinNavSection]
@@ -531,13 +534,13 @@ export function ManageChannelsScreenView({
       );
 
       if (previousSectionIndex === -1) {
-        console.error('Invalid previous section ID:', previousSectionId);
+        logger.error('Invalid previous section ID:', previousSectionId);
         return;
       }
 
       // Prevent moving to the same section
       if (newSectionId === previousSectionId) {
-        console.error(
+        logger.error(
           `Cannot move channel to section "${sections[previousSectionIndex].title}" as it is already there`
         );
         return;
@@ -548,7 +551,7 @@ export function ManageChannelsScreenView({
       );
 
       if (!channel) {
-        console.error(
+        logger.error(
           `Channel not found: ${channelId} (expected in section ${previousSectionId})`
         );
         return;
@@ -556,7 +559,7 @@ export function ManageChannelsScreenView({
 
       const sectionIndex = sections.findIndex((s) => s.id === newSectionId);
       if (sectionIndex === -1) {
-        console.error('Invalid new section ID:', newSectionId);
+        logger.error('Invalid new section ID:', newSectionId);
         return;
       }
 
@@ -599,7 +602,7 @@ export function ManageChannelsScreenView({
       } catch (e) {
         // Restore original state on error
         setSections(originalSections);
-        console.error('Failed to move channel to new section:', e);
+        logger.error('Failed to move channel to new section:', e);
       }
     },
     [sections, moveChannelToNavSection]
@@ -706,7 +709,7 @@ export function ManageChannelsScreenView({
               title,
             });
           } catch (e) {
-            console.error('Failed to create section:', e);
+            logger.error('Failed to create section:', e);
             // Note: We don't need state rollback here since the section
             // hasn't been added to local state yet - the UI will update
             // via the useEffect when groupNavSectionsWithChannels changes


### PR DESCRIPTION
fixes tlon-3340

This refines the manage channels screen to:

- use arrows rather than drag and drop
- match (as closely as we can for now) the new ochre design
- look less weird on desktop
- work reliably

It also:
- hardens the associated `groupActions`
- hardens sync updates
- adds a missing db query
- fixes some deps issues on other queries
- and fixes some UI bugs having to do with actually rendering the channels in the right order (according to the index we have on the backend)

Note:

- For now we've disabled the section moving arrows (I added "Edit" and "Delete" buttons on the section title row, though)
- The "default" section (which we currently call "Sectionless") appears at the bottom of the list since this is actually where it appears in the GroupChannelsScreen. If we wanna change that in both places to match the ochre design showing it at the top, with the "Default section" title, that's fine by me.

Looks like this on desktop:
![image](https://github.com/user-attachments/assets/a005eb5b-e4aa-4733-8cfc-9da7dd2a1491)

Looks like this on mobile:

https://github.com/user-attachments/assets/bc4479ce-20c0-4e33-b953-8794276fdfe8



