### PR TITLE
keyVal: handle migration from legacy storage library

### DIFF
--- a/packages/shared/src/db/storageItem.ts
+++ b/packages/shared/src/db/storageItem.ts
@@ -43,7 +43,22 @@ export const createStorageItem = <T>(config: StorageItemConfig<T>) => {
 
   const getValue = async (): Promise<T> => {
     const value = await storage.getItem(key);
-    return value ? deserialize(value) : defaultValue;
+
+    if (!value) {
+      return defaultValue;
+    }
+
+    const deserializedValue = deserialize(value);
+
+    // Check to handle migration from a previous storage library
+    // that prefixed all keys
+    if (
+      typeof deserializedValue === 'object' &&
+      'rawData' in deserializedValue
+    ) {
+      return deserializedValue.rawData;
+    }
+    return deserializedValue;
   };
 
   const resetValue = async (): Promise<T> => {


### PR DESCRIPTION
We figured out the old library was prefixing values with the key `rawData` whereas the new one stores them without prefix. This caused migrated values to get deserialized incorrectly. Notably, authentication details which would cause a logout on app update.

To address, we wrap the `getValue` logic to handle this situation. Next time `setValue` is called, it will be stored without the prefix.

Should confirm we no longer get logged out on TestFlight after merging.

Fixes TLON-3446