### PR TITLE
image: set max dimensions for chat and align to start, fix other usages

### DIFF
--- a/packages/ui/src/components/ChatMessage/ChatMessage.tsx
+++ b/packages/ui/src/components/ChatMessage/ChatMessage.tsx
@@ -241,6 +241,16 @@ const ChatContentRenderer = createContentRenderer({
     reference: {
       contentSize: '$l',
     },
+    image: {
+      alignItems: 'flex-start',
+      imageProps: {
+        maxWidth: 600,
+        maxHeight: 600,
+        height: 'auto',
+        width: 'auto',
+        objectFit: 'contain',
+      },
+    },
   },
 });
 

--- a/packages/ui/src/components/Image.tsx
+++ b/packages/ui/src/components/Image.tsx
@@ -60,10 +60,10 @@ const WebImage = ({
       src={source.uri}
       alt={alt}
       style={{
-        ...StyleSheet.flatten(style),
         maxWidth: '100%',
         height: props.height ? props.height : '100%',
         objectFit: contentFit ? contentFit : undefined,
+        ...StyleSheet.flatten(style),
       }}
       onLoad={handleLoad}
       onError={handleError}

--- a/packages/ui/src/components/NotebookPost/NotebookPost.tsx
+++ b/packages/ui/src/components/NotebookPost/NotebookPost.tsx
@@ -312,6 +312,7 @@ export const NotebookPostHeroImage = styled(Image, {
   width: '100%',
   height: IMAGE_HEIGHT,
   borderRadius: '$s',
+  objectFit: 'cover',
   variants: {
     size: {
       $s: {

--- a/packages/ui/src/components/PostContent/BlockRenderer.tsx
+++ b/packages/ui/src/components/PostContent/BlockRenderer.tsx
@@ -250,7 +250,6 @@ export function ImageBlock({
 
   return (
     <Pressable
-      borderRadius="$s"
       overflow="hidden"
       onPress={handlePress}
       onLongPress={onLongPress}
@@ -265,6 +264,7 @@ export function ImageBlock({
             ? { aspectRatio: dimensions.aspect || undefined }
             : {}),
         }}
+        borderRadius="$s"
         alt={block.alt}
         onLoad={handleImageLoaded}
         {...imageProps}


### PR DESCRIPTION
Fixes TLON-3327, chat images will now have maximum height/width, but will keep their aspect ratio. Smaller images are not stretched and will stay at natural size. Notebook post preview images are now the original intended slim size with "cover" as the fit. Small adjustments had to be made to keep gallery posts the same.

<img width="1228" alt="image" src="https://github.com/user-attachments/assets/626e9c5d-5f87-4c43-a786-c88ba46aeff7" />

<img width="1230" alt="Screenshot 2025-01-14 at 10 44 46 AM" src="https://github.com/user-attachments/assets/b1bc1fa3-d522-428e-b991-5252e61eec40" />

<img width="1225" alt="image" src="https://github.com/user-attachments/assets/d3d6b2cd-c7cb-4c23-914a-5b92e62b4d66" />


PR Checklist
- [ ] Includes changes to desk files
- [ ] Describes how you tested the PR locally (test ship vs livenet)
- [ ] If a new feature, includes automated tests
- [ ] Comments added anywhere logic may be confusing without context