### PR TITLE
storage: fix legacy prefix check

### DIFF
--- a/packages/shared/src/db/storageItem.ts
+++ b/packages/shared/src/db/storageItem.ts
@@ -53,6 +53,7 @@ export const createStorageItem = <T>(config: StorageItemConfig<T>) => {
     // Check to handle migration from a previous storage library
     // that prefixed all keys
     if (
+      deserializedValue &&
       typeof deserializedValue === 'object' &&
       'rawData' in deserializedValue
     ) {


### PR DESCRIPTION
Was getting errors from this if the value isn't there. Gotta love JS for making `null` an object...