### PR TITLE
DMs: add reply action

### DIFF
--- a/packages/shared/src/types/ChannelActions.ts
+++ b/packages/shared/src/types/ChannelActions.ts
@@ -52,6 +52,7 @@ export function channelActionIdsFor({
     case 'dm':
     case 'groupDm':
       return [
+        'quote',
         'startThread',
         'muteThread',
         'viewReactions',

--- a/packages/ui/src/components/BareChatInput/helpers.ts
+++ b/packages/ui/src/components/BareChatInput/helpers.ts
@@ -79,6 +79,15 @@ const processLine = (line: string, mentions: Mention[]): JSONContent => {
   let isItalicizing = false;
   let isCoding = false;
   let isEndOfFormatting = false;
+
+  if (line.startsWith('> ')) {
+    const quotedContent = processLine(line.slice(2), mentions);
+    return {
+      type: 'blockquote',
+      content: [quotedContent]
+    };
+  }
+
   line.split(' ').forEach((word) => {
     const marks = [];
     const mention = mentions.find((mention) => mention.display === word);
@@ -382,6 +391,24 @@ export function contentToTextAndMentions(jsonContent: JSONContent): {
       text.push('```\n');
       text.push(node.content[0].text);
       text.push('\n```\n');
+    } else if (node.type === 'blockquote') {
+      if (!node.content) {
+        return;
+      }
+      text.push('> ');
+      node.content.forEach((child, index) => {
+        if (child.type === 'paragraph' && child.content) {
+          child.content.forEach(content => {
+            if (content.type === 'text' && content.text) {
+              text.push(content.text);
+            }
+          });
+          if (index < node.content!.length - 1) {
+            text.push('\n> ');
+          }
+        }
+      });
+      text.push('\n');
     }
   });
 

--- a/packages/ui/src/components/BareChatInput/index.tsx
+++ b/packages/ui/src/components/BareChatInput/index.tsx
@@ -33,6 +33,7 @@ import { View } from 'tamagui';
 
 import {
   Attachment,
+  TextAttachment,
   UploadedImageAttachment,
   useAttachmentContext,
 } from '../../contexts';
@@ -211,6 +212,7 @@ export default function BareChatInput({
     addAttachment,
     clearAttachments,
     resetAttachments,
+    removeAttachment,
     waitForAttachmentUploads,
   } = useAttachmentContext();
   const [controlledText, setControlledText] = useState('');
@@ -267,44 +269,47 @@ export default function BareChatInput({
 
   const lastProcessedRef = useRef('');
 
-  const handleTextChange = (newText: string) => {
-    const oldText = controlledText;
+  const handleTextChange = useCallback(
+    (newText: string) => {
+      const oldText = controlledText;
 
-    bareChatInputLogger.log('text change', newText);
+      bareChatInputLogger.log('text change', newText);
 
-    // Only process references if the text contains a reference and hasn't been processed before.
-    // This check prevents infinite loops on native platforms where we manually update
-    // the input's text value using setNativeProps after processing references.
-    // Without this guard, each manual text update would trigger another onChangeText,
-    // creating an endless cycle.
-    if (REF_REGEX.test(newText) && lastProcessedRef.current !== newText) {
-      lastProcessedRef.current = newText;
-      const textWithoutRefs = processReferences(newText);
-      setControlledText(textWithoutRefs);
-      handleMention(oldText, textWithoutRefs);
+      // Only process references if the text contains a reference and hasn't been processed before.
+      // This check prevents infinite loops on native platforms where we manually update
+      // the input's text value using setNativeProps after processing references.
+      // Without this guard, each manual text update would trigger another onChangeText,
+      // creating an endless cycle.
+      if (REF_REGEX.test(newText) && lastProcessedRef.current !== newText) {
+        lastProcessedRef.current = newText;
+        const textWithoutRefs = processReferences(newText);
+        setControlledText(textWithoutRefs);
+        handleMention(oldText, textWithoutRefs);
 
-      const jsonContent = textAndMentionsToContent(textWithoutRefs, mentions);
-      bareChatInputLogger.log('setting draft', jsonContent);
-      storeDraft(jsonContent);
+        const jsonContent = textAndMentionsToContent(textWithoutRefs, mentions);
+        bareChatInputLogger.log('setting draft', jsonContent);
+        storeDraft(jsonContent);
 
-      // force update the native input's text.
-      // we must set the text to an empty string because sending any text via
-      // setNativeProps is actually *additive* to the existing text and not a replacement.
-      // calling setNativeProps is still necessary because it forces the input to update
-      // and display the new text value.
-      if (!isWeb) {
-        inputRef.current?.setNativeProps({ text: '' });
+        // force update the native input's text.
+        // we must set the text to an empty string because sending any text via
+        // setNativeProps is actually *additive* to the existing text and not a replacement.
+        // calling setNativeProps is still necessary because it forces the input to update
+        // and display the new text value.
+        if (!isWeb) {
+          inputRef.current?.setNativeProps({ text: '' });
+        }
+      } else if (!REF_REGEX.test(newText)) {
+        // if there's no reference to process, just update normally
+        setControlledText(newText);
+        handleMention(oldText, newText);
+
+        const jsonContent = textAndMentionsToContent(newText, mentions);
+        bareChatInputLogger.log('setting draft', jsonContent);
+        storeDraft(jsonContent);
       }
-    } else if (!REF_REGEX.test(newText)) {
-      // if there's no reference to process, just update normally
-      setControlledText(newText);
-      handleMention(oldText, newText);
-
-      const jsonContent = textAndMentionsToContent(newText, mentions);
-      bareChatInputLogger.log('setting draft', jsonContent);
-      storeDraft(jsonContent);
-    }
-  };
+    },
+    [controlledText, processReferences, storeDraft, handleMention, mentions]
+  );
 
   const onMentionSelect = useCallback(
     (contact: db.Contact) => {
@@ -322,6 +327,22 @@ export default function BareChatInput({
     [handleSelectMention, controlledText]
   );
 
+  // Handle text attachments by inserting them into the input
+  useEffect(() => {
+    const textAttachment = attachments.find(
+      (a): a is TextAttachment => a.type === 'text'
+    );
+    if (textAttachment) {
+      if (controlledText === '') {
+        handleTextChange(`${textAttachment.text}`);
+      } else {
+        handleTextChange(`${textAttachment.text}${controlledText}`);
+      }
+      // Remove the text attachment since we've handled it
+      removeAttachment(textAttachment);
+    }
+  }, [attachments, handleTextChange, removeAttachment, controlledText]);
+
   const sendMessage = useCallback(
     async (isEdit?: boolean) => {
       const jsonContent = textAndMentionsToContent(controlledText, mentions);
@@ -330,48 +351,50 @@ export default function BareChatInput({
 
       const finalAttachments = await waitForAttachmentUploads();
 
-      const blocks = finalAttachments.flatMap((attachment): Block[] => {
-        if (attachment.type === 'reference') {
-          const cite = pathToCite(attachment.path);
-          return cite ? [{ cite }] : [];
-        }
-        if (
-          attachment.type === 'image' &&
-          (!image || attachment.file.uri !== image?.uri)
-        ) {
-          return [
-            {
-              image: {
-                src: attachment.uploadState.remoteUri,
-                height: attachment.file.height,
-                width: attachment.file.width,
-                alt: 'image',
+      const blocks = finalAttachments
+        .filter((attachment) => attachment.type !== 'text')
+        .flatMap((attachment): Block[] => {
+          if (attachment.type === 'reference') {
+            const cite = pathToCite(attachment.path);
+            return cite ? [{ cite }] : [];
+          }
+          if (
+            attachment.type === 'image' &&
+            (!image || attachment.file.uri !== image?.uri)
+          ) {
+            return [
+              {
+                image: {
+                  src: attachment.uploadState.remoteUri,
+                  height: attachment.file.height,
+                  width: attachment.file.width,
+                  alt: 'image',
+                },
               },
-            },
-          ];
-        }
+            ];
+          }
 
-        if (
-          image &&
-          attachment.type === 'image' &&
-          attachment.file.uri === image?.uri &&
-          isEdit &&
-          channelType === 'gallery'
-        ) {
-          return [
-            {
-              image: {
-                src: image.uri,
-                height: image.height,
-                width: image.width,
-                alt: 'image',
+          if (
+            image &&
+            attachment.type === 'image' &&
+            attachment.file.uri === image?.uri &&
+            isEdit &&
+            channelType === 'gallery'
+          ) {
+            return [
+              {
+                image: {
+                  src: image.uri,
+                  height: image.height,
+                  width: image.width,
+                  alt: 'image',
+                },
               },
-            },
-          ];
-        }
+            ];
+          }
 
-        return [];
-      });
+          return [];
+        });
 
       if (blocks && blocks.length > 0) {
         if (channelType === 'chat') {

--- a/packages/ui/src/components/ChatMessage/ChatMessageActions/MessageActions.tsx
+++ b/packages/ui/src/components/ChatMessage/ChatMessageActions/MessageActions.tsx
@@ -209,7 +209,13 @@ export async function handleAction({
       onViewReactions?.(post);
       break;
     case 'quote':
-      addAttachment({ type: 'reference', reference, path });
+      if (channel.type === 'dm' && post.textContent) {
+        // For DMs, insert text as markdown quote
+        addAttachment({ type: 'text', text: `> ${post.textContent}\n` });
+      } else {
+        // For other channel types, use reference attachment
+        addAttachment({ type: 'reference', reference, path });
+      }
       break;
     case 'edit':
       onEdit?.();
@@ -286,7 +292,7 @@ export function useDisplaySpecForChannelActionId(
         return { label: isMuted ? 'Unmute thread' : 'Mute thread' };
 
       case 'quote':
-        return { label: 'Quote' };
+        return { label: 'Reply' };
 
       case 'report':
         return {

--- a/packages/ui/src/components/MessageInput/AttachmentPreviewList.tsx
+++ b/packages/ui/src/components/MessageInput/AttachmentPreviewList.tsx
@@ -22,15 +22,17 @@ export const AttachmentPreviewList = () => {
       overScrollMode="always"
       horizontal={true}
     >
-      {attachments.map((attachment, i) => {
-        return (
-          <AttachmentPreview
-            key={i}
-            attachment={attachment}
-            uploading={false}
-          />
-        );
-      })}
+      {attachments
+        .filter((a) => a.type !== 'text')
+        .map((attachment, i) => {
+          return (
+            <AttachmentPreview
+              key={i}
+              attachment={attachment}
+              uploading={false}
+            />
+          );
+        })}
     </ScrollView>
   ) : null;
 };
@@ -62,7 +64,7 @@ export function AttachmentPreview({
             uri: attachment.file.uri,
           }}
         />
-      ) : (
+      ) : attachment.type === 'reference' ? (
         <ContentReferenceLoader
           position="absolute"
           contentSize="$s"
@@ -73,7 +75,7 @@ export function AttachmentPreview({
           reference={attachment.reference}
           actionIcon={null}
         />
-      )}
+      ) : null}
 
       <RemoveAttachmentButton attachment={attachment} />
 

--- a/packages/ui/src/contexts/attachment.tsx
+++ b/packages/ui/src/contexts/attachment.tsx
@@ -37,8 +37,13 @@ export type UploadedImageAttachment = {
   };
 };
 
-export type Attachment = ReferenceAttachment | ImageAttachment;
-export type FinalizedAttachment = ReferenceAttachment | UploadedImageAttachment;
+export type TextAttachment = {
+  type: 'text';
+  text: string;
+};
+
+export type Attachment = ReferenceAttachment | ImageAttachment | TextAttachment;
+export type FinalizedAttachment = ReferenceAttachment | UploadedImageAttachment | TextAttachment;
 
 export type AttachmentState = {
   attachments: Attachment[];


### PR DESCRIPTION
Adds a simple "Reply" action to DMs, just inserts a `> [quoted text]` string (with a carriage return) into the chat input.

Also renames the "Quote" message action to "Reply".

I don't expect we'll keep it like this, this is just a stopgap until we get a *real* reply feature into DMs.

Fixes TLON-3515