### PR TITLE
mobile: Fix images in chat

### DIFF
--- a/packages/ui/src/components/ChatMessage/ChatMessage.tsx
+++ b/packages/ui/src/components/ChatMessage/ChatMessage.tsx
@@ -6,6 +6,7 @@ import { View, XStack, YStack, isWeb } from 'tamagui';
 import AuthorRow from '../AuthorRow';
 import { Icon } from '../Icon';
 import { OverflowMenuButton } from '../OverflowMenuButton';
+import { DefaultRendererProps } from '../PostContent/BlockRenderer';
 import { createContentRenderer } from '../PostContent/ContentRenderer';
 import {
   usePostContent,
@@ -233,6 +234,17 @@ const ChatMessage = ({
   );
 };
 
+const WebChatImageRenderer: DefaultRendererProps['image'] = {
+  alignItems: 'flex-start',
+  imageProps: {
+    maxWidth: 600,
+    maxHeight: 600,
+    height: 'auto',
+    width: 'auto',
+    objectFit: 'contain',
+  },
+};
+
 const ChatContentRenderer = createContentRenderer({
   blockSettings: {
     blockWrapper: {
@@ -241,16 +253,7 @@ const ChatContentRenderer = createContentRenderer({
     reference: {
       contentSize: '$l',
     },
-    image: {
-      alignItems: 'flex-start',
-      imageProps: {
-        maxWidth: 600,
-        maxHeight: 600,
-        height: 'auto',
-        width: 'auto',
-        objectFit: 'contain',
-      },
-    },
+    image: isWeb ? WebChatImageRenderer : undefined,
   },
 });
 


### PR DESCRIPTION
The new image config we passed to `ChatContentRenderer` to fix sizing on web breaks mobile (the `auto` height/width collapses them). 

This PR just moves that config to be conditionally passed on Web. This seemed simplest, but if we wanted to avoid switching on platform, we could work on a composite image config that works for both.

Fixes TLON-3502