### PR TITLE
mobile: small fixes

### DIFF
--- a/apps/tlon-mobile/src/hooks/useDeepLinkListener.ts
+++ b/apps/tlon-mobile/src/hooks/useDeepLinkListener.ts
@@ -26,7 +26,24 @@ export const useDeepLinkListener = () => {
           if (lure.shouldAutoJoin) {
             // no-op for now, hosting will handle
           } else {
-            // otherwise, treat it as a deeplink and navigate to the group
+            // otherwise, treat it as a deeplink and navigate
+            if (lure.inviteType === 'user') {
+              const inviter = lure.inviterUserId;
+              if (inviter) {
+                logger.log(`handling deep link to user`, inviter);
+                reset([
+                  {
+                    name: 'Contacts',
+                  },
+                  {
+                    name: 'UserProfile',
+                    params: { userId: inviter },
+                  },
+                ]);
+              }
+              return;
+            }
+
             if (lure.invitedGroupId) {
               logger.log(
                 `handling deep link to invited group`,

--- a/packages/ui/src/components/Onboarding/OnboardingInvite.tsx
+++ b/packages/ui/src/components/Onboarding/OnboardingInvite.tsx
@@ -40,7 +40,7 @@ export const OnboardingInviteBlock = React.memo(function OnboardingInviteBlock({
     id: inviterUserId!,
     nickname: inviterNickname,
     avatarImage: inviterAvatarImage,
-    color: inviterColor,
+    color: inviterColor || undefined,
   } as db.Contact;
 
   const groupShim = {

--- a/packages/ui/src/utils/colorUtils.tsx
+++ b/packages/ui/src/utils/colorUtils.tsx
@@ -5,7 +5,7 @@ import { ThemeName, useThemeName } from 'tamagui';
 export const useSigilColors = (accentColor: string | null = '#000000') => {
   const theme = useThemeName();
   const backgroundColor = useMemo(
-    () => adjustColorContrastForTheme(accentColor ?? '#000000', theme),
+    () => adjustColorContrastForTheme(accentColor || '#000000', theme),
     [accentColor, theme]
   );
   const foregroundColor = useMemo(


### PR DESCRIPTION
Addresses some issues that cropped up:

- Avoid crashing on empty string colors in Invite metadata
- If personal invite link clicked while logged in, route to their  _UserProfile_ 

Fixes TLON-3504