### PR TITLE
logs: fix broken Posthog API key

### DIFF
--- a/desk/ted/posthog.hoon
+++ b/desk/ted/posthog.hoon
@@ -3,7 +3,7 @@
 /-  spider
 /+  io=strandio, l=logs
 ::
-=+  posthog-key='phx_5Cee2IQzFw5XapO8xiXZj9VvQEAcJY2NRaEGly9ZKXbb9sf'
+=+  posthog-key='phc_GyI5iD7kM6RRbb1hIU0fiGmTCh4ha44hthJYJ7a89td'
 =+  posthog-url='https://eu.i.posthog.com/capture/'
 =+  posthog-retry=3
 =+  posthog-retry-delay=~s5


### PR DESCRIPTION
It turns out a personal API key can't be used to capture events into Posthog. This PR sadly restores the previous API key, as it seems to be only way to capture events. 