### PR TITLE
input: clear controlled text before awaiting send

### DIFF
--- a/packages/ui/src/components/BareChatInput/index.tsx
+++ b/packages/ui/src/components/BareChatInput/index.tsx
@@ -418,6 +418,7 @@ export default function BareChatInput({
       }
 
       try {
+        setControlledText('');
         bareChatInputLogger.log('clearing attachments');
         clearAttachments();
         bareChatInputLogger.log('resetting input height');
@@ -447,7 +448,6 @@ export default function BareChatInput({
         bareChatInputLogger.log('clearing draft');
         await clearDraft();
         bareChatInputLogger.log('setting initial content');
-        setControlledText('');
         setHasSetInitialContent(false);
       }
     },


### PR DESCRIPTION
I caused this in my context menus PR by moving `setControlledText` to the finally block in BareChatInput, which was unnecessary.