### PR TITLE
Onboarding Fixes

### DIFF
--- a/apps/tlon-mobile/ios/Podfile.lock
+++ b/apps/tlon-mobile/ios/Podfile.lock
@@ -1824,7 +1824,7 @@ SPEC CHECKSUMS:
   op-sqlite: b0c2f06e0660235bc3dca10714b0498fdbb811bb
   PromisesObjC: f5707f49cb48b9636751c5b2e7d227e43fba9f47
   PromisesSwift: 9d77319bbe72ebf6d872900551f7eeba9bce2851
-  RCT-Folly: 7169b2b1c44399c76a47b5deaaba715eeeb476c0
+  RCT-Folly: cd21f1661364f975ae76b3308167ad66b09f53f5
   RCTRequired: d362a61864a64315aee00faea8dee6cf5b3f4aad
   RCTTypeSafety: 09baf60faeab02492dc8bf04ce5af1dda645b86d
   ReachabilitySwift: 7f151ff156cea1481a8411701195ac6a984f4979
@@ -1848,6 +1848,7 @@ SPEC CHECKSUMS:
   React-Mapbuffer: 30deaceab523707646f5f35efad961133e4e1f25
   react-native-branch: 5d4ecda7bae040542f6c9f651a05d3df23d8b35a
   react-native-context-menu-view: c7477ad2a9b5005eb45dd168c2dcdd64526dba77
+  react-native-cookies: d648ab7025833b977c0b19e142503034f5f29411
   react-native-get-random-values: d16467cf726c618e9c7a8c3c39c31faa2244bbba
   react-native-netinfo: 5364263f903da576bdef9c84a76fe243ab06812c
   react-native-safe-area-context: 435f4c13ac75ceed6135382ee77d57d1a5b5b2d6

--- a/apps/tlon-mobile/package.json
+++ b/apps/tlon-mobile/package.json
@@ -92,6 +92,7 @@
     "expo-task-manager": "~11.7.2",
     "expo-updates": "~0.24.10",
     "immer": "^9.0.12",
+    "libphonenumber-js": "^1.11.18",
     "lodash": "^4.17.21",
     "posthog-react-native": "^2.7.1",
     "react": "^18.2.0",

--- a/apps/tlon-mobile/src/components/OnboardingInputs.tsx
+++ b/apps/tlon-mobile/src/components/OnboardingInputs.tsx
@@ -1,5 +1,6 @@
 import { useIsDarkMode } from '@tloncorp/app/hooks/useIsDarkMode';
 import { Field, TextInput, XStack, useTheme } from '@tloncorp/ui';
+import { isValidPhoneNumber } from 'libphonenumber-js';
 import {
   createRef,
   useCallback,
@@ -131,6 +132,7 @@ export function PhoneNumberInput({
         control={form.control}
         rules={{
           required: 'Please enter a valid phone number.',
+          validate: (value) => isValidPhoneNumber(value),
         }}
         render={({ field: { onChange } }) => (
           <Field

--- a/apps/tlon-mobile/src/screens/Onboarding/CheckVerifyScreen.tsx
+++ b/apps/tlon-mobile/src/screens/Onboarding/CheckVerifyScreen.tsx
@@ -188,6 +188,11 @@ function CodeInput({
             paddingVertical="$xl"
             width="$4xl"
             textContentType={!isEmail ? 'oneTimeCode' : undefined}
+            frameStyle={{
+              width: '$4xl',
+              paddingLeft: 0,
+              paddingRight: 0,
+            }}
           />
         ))}
       </XStack>

--- a/apps/tlon-mobile/src/screens/Onboarding/GettingNodeReadyScreen.tsx
+++ b/apps/tlon-mobile/src/screens/Onboarding/GettingNodeReadyScreen.tsx
@@ -19,7 +19,7 @@ import {
   View,
   YStack,
 } from '@tloncorp/ui';
-import { useCallback, useEffect, useState } from 'react';
+import { useCallback, useEffect, useRef, useState } from 'react';
 
 import { OnboardingStackParamList } from '../../types';
 
@@ -35,12 +35,13 @@ export function GettingNodeReadyScreen({
   route: { params },
 }: Props) {
   const isFocused = useIsFocused();
+  const lastWasFocused = useRef(true);
   const { setShip } = useShip();
   const resetDb = useResetDb();
   const handleLogout = useHandleLogout({ resetDb });
   const [loggingOut, setLoggingOut] = useState(false);
 
-  const { phase, shipInfo } = useStoppedNodeSequence({
+  const { phase, shipInfo, resetSequence } = useStoppedNodeSequence({
     waitType: params.waitType,
     enabled: isFocused,
   });
@@ -55,6 +56,14 @@ export function GettingNodeReadyScreen({
       }, 1000);
     }
   }, [navigation, phase, setShip, shipInfo]);
+
+  useEffect(() => {
+    if (isFocused && !lastWasFocused.current) {
+      // if we came back to this screen, make sure the sequence starts over
+      resetSequence();
+    }
+    lastWasFocused.current = isFocused;
+  }, [isFocused, resetSequence]);
 
   const onLogout = useCallback(async () => {
     setLoggingOut(true);

--- a/apps/tlon-mobile/src/screens/Onboarding/RequestPhoneVerifyScreen.tsx
+++ b/apps/tlon-mobile/src/screens/Onboarding/RequestPhoneVerifyScreen.tsx
@@ -11,6 +11,7 @@ import {
   useStore,
   useTheme,
 } from '@tloncorp/ui';
+import { isValidPhoneNumber } from 'libphonenumber-js';
 import { useRef, useState } from 'react';
 import { Controller, useForm } from 'react-hook-form';
 import { CountryPicker } from 'react-native-country-codes-picker';
@@ -108,6 +109,7 @@ export const RequestPhoneVerifyScreen = ({
             control={control}
             rules={{
               required: 'Please enter a valid phone number.',
+              validate: (value) => isValidPhoneNumber(value),
             }}
             render={({ field: { onChange } }) => (
               <Field

--- a/packages/app/hooks/useStoppedNodeSequence.ts
+++ b/packages/app/hooks/useStoppedNodeSequence.ts
@@ -56,7 +56,7 @@ export function useStoppedNodeSequence(params: {
       });
       return NodeResumeState.WaitingForRunning;
     }
-  }, [store]);
+  }, [bootStepCounter, store]);
 
   const authenticateWithNode = useCallback(async () => {
     try {
@@ -101,6 +101,13 @@ export function useStoppedNodeSequence(params: {
     },
     [checkNodeRunning, authenticateWithNode]
   );
+
+  const resetSequence = useCallback(() => {
+    setPhase(NodeResumeState.WaitingForRunning);
+    setShipInfo(null);
+    sequenceStartTimeRef.current = 0;
+    setBootedAt(0);
+  }, []);
 
   useEffect(() => {
     async function runSequence() {
@@ -156,5 +163,6 @@ export function useStoppedNodeSequence(params: {
   return {
     phase,
     shipInfo,
+    resetSequence,
   };
 }

--- a/packages/app/lib/bootHelpers.ts
+++ b/packages/app/lib/bootHelpers.ts
@@ -63,6 +63,7 @@ export async function reserveNode(
 
   // if the hosting user already has a ship tied to their account, use that
   if (user.ships?.length) {
+    await db.hostedUserNodeId.setValue(user.ships[0]);
     return user.ships[0];
   }
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -270,6 +270,9 @@ importers:
       immer:
         specifier: ^9.0.12
         version: 9.0.21
+      libphonenumber-js:
+        specifier: ^1.11.18
+        version: 1.11.18
       lodash:
         specifier: ^4.17.21
         version: 4.17.21
@@ -10280,6 +10283,9 @@ packages:
   levn@0.4.1:
     resolution: {integrity: sha512-+bT2uH4E5LGE7h/n3evcS/sQlJXCpIp6ym8OWJ5eV6+67Dsql/LaaT7qJBAt2rzfoa/5QBGBhxDix1dMt2kQKQ==}
     engines: {node: '>= 0.8.0'}
+
+  libphonenumber-js@1.11.18:
+    resolution: {integrity: sha512-okMm/MCoFrm1vByeVFLBdkFIXLSHy/AIK2AEGgY3eoicfWZeOZqv3GfhtQgICkzs/tqorAMm3a4GBg5qNCrqzg==}
 
   lighthouse-logger@1.4.2:
     resolution: {integrity: sha512-gPWxznF6TKmUHrOQjlVo2UbaL2EJ71mb2CCeRs/2qBpi4L/g4LUVc9+3lKQ6DTUZwJswfM7ainGrLO1+fOqa2g==}
@@ -27151,6 +27157,8 @@ snapshots:
     dependencies:
       prelude-ls: 1.2.1
       type-check: 0.4.0
+
+  libphonenumber-js@1.11.18: {}
 
   lighthouse-logger@1.4.2:
     dependencies:


### PR DESCRIPTION
Fixes TLON-3513, OTP display issue needed to be carried over to another component.
Fixes TLON-3522, Phone form was never being marked invalid
Fixes TLON-3521, prevent stopped ship sequence from locking up if navigated back while still mounted


Also fixes a recovery issue I noticed where `hostedNodeId` wasn't getting set if we found an existing ship attached to an account.