### PR TITLE
Onboarding: Custom message for incorrect OTP code

### DIFF
--- a/apps/tlon-mobile/src/screens/Onboarding/CheckOTPScreen.tsx
+++ b/apps/tlon-mobile/src/screens/Onboarding/CheckOTPScreen.tsx
@@ -137,14 +137,19 @@ export const CheckOTPScreen = ({ navigation, route: { params } }: Props) => {
           await handleLogin({ otp: code, ...accountCreds });
         }
       } catch (e) {
-        setError(e.message);
-        logger.trackError(
-          `Error ${mode === 'signup' ? 'Signing Up' : 'Logging In'}`,
-          {
-            errorMessage: e.message,
-            errorStack: e.stack,
-          }
-        );
+        if (e instanceof HostingError && e.details.status === 401) {
+          setError('Confirmation code is incorrect or expired.');
+        } else {
+          setError(e.message);
+          logger.trackError(
+            `Error ${mode === 'signup' ? 'Signing Up' : 'Logging In'}`,
+            {
+              errorMessage: e.message,
+              errorStack: e.stack,
+              details: e.details,
+            }
+          );
+        }
       } finally {
         setIsSubmitting(false);
       }

--- a/apps/tlon-mobile/src/screens/Onboarding/TlonLoginLegacy.tsx
+++ b/apps/tlon-mobile/src/screens/Onboarding/TlonLoginLegacy.tsx
@@ -7,7 +7,11 @@ import {
 import { useShip } from '@tloncorp/app/contexts/ship';
 import { getShipUrl } from '@tloncorp/app/utils/ship';
 import { AnalyticsEvent, createDevLogger } from '@tloncorp/shared';
-import { getShipAccessCode, requestPhoneVerify } from '@tloncorp/shared/api';
+import {
+  HostingError,
+  getShipAccessCode,
+  requestPhoneVerify,
+} from '@tloncorp/shared/api';
 import { getLandscapeAuthCookie } from '@tloncorp/shared/api';
 import { storage } from '@tloncorp/shared/db';
 import {
@@ -79,7 +83,16 @@ export const TlonLoginLegacy = ({ navigation }: Props) => {
         errorMessage: err.message,
         errorStack: err.stack,
       });
-      setRemoteError(err.message);
+      if (err instanceof HostingError && err.details.status === 401) {
+        setRemoteError('Incorrect email or password.');
+      } else {
+        logger.trackError(`Error Logging In`, {
+          errorMessage: err.message,
+          errorStack: err.stack,
+          details: err.details,
+        });
+        setRemoteError(err.message);
+      }
     } finally {
       setIsSubmitting(false);
     }

--- a/packages/shared/src/api/hostingApi.ts
+++ b/packages/shared/src/api/hostingApi.ts
@@ -225,10 +225,6 @@ export const signUpHostingUser = async (params: {
       method: 'POST',
       path: '/v1/sign-up',
     });
-    logger.trackEvent(AnalyticsEvent.UnexpectedHostingError, {
-      details: hostingErr.details,
-      context: hostingErr.message,
-    });
     throw hostingErr;
   }
 
@@ -263,8 +259,9 @@ export const logInHostingUser = async (params: {
 
   const result = (await response.json()) as HostingError | User;
   if (!response.ok) {
-    throw new Error(
-      'message' in result ? result.message : 'An unknown error has occurred.'
+    throw new HostingError(
+      'message' in result ? result.message : 'An unknown error has occurred.',
+      { status: response.status, method: 'POST', path: '/v1/login' }
     );
   }
 


### PR DESCRIPTION
Instead of displaying raw JSON/hosting error, present a custom message for `401` responses (incorrect/expired code).

Fixes TLON-3524