### PR TITLE
Onboarding: reset boot sequence after completing signup

### DIFF
--- a/apps/tlon-mobile/src/lib/signupContext.tsx
+++ b/apps/tlon-mobile/src/lib/signupContext.tsx
@@ -44,7 +44,8 @@ export const SignupProvider = ({ children }: { children: React.ReactNode }) => {
     setValue: setValues,
     resetValue: resetValues,
   } = signupData.useStorageItem();
-  const { bootPhase, bootReport, kickOffBootSequence } = useBootSequence();
+  const { bootPhase, bootReport, kickOffBootSequence, resetBootSequence } =
+    useBootSequence();
   const postHog = usePostHog();
 
   const setOnboardingValues = useCallback(
@@ -88,7 +89,15 @@ export const SignupProvider = ({ children }: { children: React.ReactNode }) => {
         errorStack: e.stack,
       });
     } finally {
-      setTimeout(() => clear(), 2000);
+      // this is when the UI will transition to authenticated app
+      setTimeout(() => {
+        clear();
+        setTimeout(() => {
+          // delay resetting the boot sequence to avoid race conditions
+          // with displaying the checkmarks before transitioning
+          resetBootSequence();
+        }, 1000);
+      }, 2000);
     }
   }, [
     values.nickname,
@@ -98,6 +107,7 @@ export const SignupProvider = ({ children }: { children: React.ReactNode }) => {
     postHog,
     bootReport,
     clear,
+    resetBootSequence,
   ]);
 
   useEffect(() => {

--- a/packages/app/hooks/useBootSequence.ts
+++ b/packages/app/hooks/useBootSequence.ts
@@ -312,6 +312,17 @@ export function useBootSequence() {
     }
   }, [runBootPhase, setBootPhase, bootPhase, bootStepCounter, lureMeta?.id]);
 
+  const resetBootSequence = useCallback(() => {
+    setBootPhase(NodeBootPhase.IDLE);
+    setReport(null);
+    setReservedNodeId(null);
+    isRunningRef.current = false;
+    lastRunPhaseRef.current = NodeBootPhase.IDLE;
+    lastRunErrored.current = false;
+
+    sequenceStartTimeRef.current = 0;
+  }, []);
+
   // once finished, set the report
   useEffect(() => {
     if (bootPhase === NodeBootPhase.READY && report === null) {
@@ -325,6 +336,7 @@ export function useBootSequence() {
   return {
     bootPhase,
     kickOffBootSequence,
+    resetBootSequence,
     bootReport: report,
   };
 }


### PR DESCRIPTION
Not resetting this was causing issues if you tried to signup multiple times in a row. Edge case in the wild, but is a confounding variable during testing.