### PR TITLE
Onboarding: fix more onboarding errors

### DIFF
--- a/apps/tlon-mobile/src/screens/Onboarding/CheckOTPScreen.tsx
+++ b/apps/tlon-mobile/src/screens/Onboarding/CheckOTPScreen.tsx
@@ -137,7 +137,14 @@ export const CheckOTPScreen = ({ navigation, route: { params } }: Props) => {
           await handleLogin({ otp: code, ...accountCreds });
         }
       } catch (e) {
-        if (e instanceof HostingError && e.details.status === 401) {
+        const SIGNUP_OTP_INCORRECT_STATUS = 400;
+        const LOGIN_OTP_INCORRECT_STATUS = 401;
+        if (
+          e instanceof HostingError &&
+          [SIGNUP_OTP_INCORRECT_STATUS, LOGIN_OTP_INCORRECT_STATUS].includes(
+            e.details.status ?? 0
+          )
+        ) {
           setError('Confirmation code is incorrect or expired.');
         } else {
           setError(e.message);

--- a/apps/tlon-mobile/src/screens/Onboarding/TlonLogin.tsx
+++ b/apps/tlon-mobile/src/screens/Onboarding/TlonLogin.tsx
@@ -98,10 +98,19 @@ export const TlonLoginScreen = ({ navigation, route }: Props) => {
               platform: Platform.OS,
             });
           } catch (err) {
-            if (err instanceof HostingError && err.details.status === 429) {
-              // Rate limited, must have received one recently so proceed
+            if (err instanceof HostingError) {
+              if (err.details.status === 429) {
+                // Rate limited, must have received one recently so proceed
+              }
+              if (err.details.status === 404) {
+                setRemoteError('This phone number is ineligible for login.');
+                return;
+              }
             }
+            setRemoteError('Something went wrong. Please try again.');
+            return;
           }
+
           logger.trackEvent('Initiated login', { type: 'phone', phoneNumber });
           navigation.navigate('CheckOTP', {
             mode: 'login',
@@ -118,9 +127,17 @@ export const TlonLoginScreen = ({ navigation, route }: Props) => {
               platform: Platform.OS,
             });
           } catch (err) {
-            if (err instanceof HostingError && err.details.status === 429) {
-              // Rate limited, must have received one recently so proceed
+            if (err instanceof HostingError) {
+              if (err.details.status === 429) {
+                // Rate limited, must have received one recently so proceed
+              }
+              if (err.details.status === 404) {
+                setRemoteError('This email number is ineligible for login.');
+                return;
+              }
             }
+            setRemoteError('Something went wrong. Please try again.');
+            return;
           }
           logger.trackEvent('Initiated login', { type: 'email', email });
           navigation.navigate('CheckOTP', {


### PR DESCRIPTION
- The fix from this morning for wrong/expired OTP did not catch cases during signup (apparently we pass a `400` there instead of `401` as with login)
- Were erroneously handling bad email/phone errors on the login screen. Now surfaces a nicely formatted message and doesn't progress.

Fixes TLON-3530