### PR TITLE
ops: update artifact actions since deprecated

### DIFF
--- a/.github/workflows/deploy-canary.yml
+++ b/.github/workflows/deploy-canary.yml
@@ -33,7 +33,7 @@ jobs:
         run: pnpm build:all
       - working-directory: ./apps/tlon-web
         run: pnpm build
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v4
         with:
           name: "ui-dist"
           path: apps/tlon-web/dist
@@ -57,7 +57,7 @@ jobs:
         run: pnpm build:all
       - working-directory: ./apps/tlon-web-new
         run: pnpm build:alpha
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v4
         with:
           name: "ui-dist-new"
           path: apps/tlon-web-new/dist
@@ -70,7 +70,7 @@ jobs:
         with:
           ref: ${{ env.tag }}
           ssh-key: ${{ secrets.DEPLOY_KEY }}
-      - uses: actions/download-artifact@v3
+      - uses: actions/download-artifact@v4
         with:
           name: "ui-dist"
           path: apps/tlon-web/dist
@@ -104,7 +104,7 @@ jobs:
         with:
           ref: ${{ env.tag }}
           ssh-key: ${{ secrets.DEPLOY_KEY }}
-      - uses: actions/download-artifact@v3
+      - uses: actions/download-artifact@v4
         with:
           name: "ui-dist-new"
           path: apps/tlon-web-new/dist

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -37,7 +37,7 @@ jobs:
         run: pnpm build:all
       - working-directory: ./apps/tlon-web
         run: pnpm build
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v4
         with:
           name: "ui-dist"
           path: apps/tlon-web/dist
@@ -61,7 +61,7 @@ jobs:
         run: pnpm build:all
       - working-directory: ./apps/tlon-web-new
         run: pnpm build:alpha
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v4
         with:
           name: "ui-dist-new"
           path: apps/tlon-web-new/dist
@@ -74,7 +74,7 @@ jobs:
         with:
           ref: ${{ env.tag }}
           ssh-key: ${{ secrets.DEPLOY_KEY }}
-      - uses: actions/download-artifact@v3
+      - uses: actions/download-artifact@v4
         with:
           name: "ui-dist"
           path: apps/tlon-web/dist
@@ -108,7 +108,7 @@ jobs:
         with:
           ref: ${{ env.tag }}
           ssh-key: ${{ secrets.DEPLOY_KEY }}
-      - uses: actions/download-artifact@v3
+      - uses: actions/download-artifact@v4
         with:
           name: "ui-dist-new"
           path: apps/tlon-web-new/dist


### PR DESCRIPTION
Github deprecated the version we were using, should be same usage in our case https://github.blog/changelog/2024-04-16-deprecation-notice-v3-of-the-artifact-actions/