### PR TITLE
grouper: don't send a group invite for personal lure bites

### DIFF
--- a/desk/app/grouper.hoon
+++ b/desk/app/grouper.hoon
@@ -171,6 +171,11 @@
                ~[leaf+"{<joiner.bite>} invited to DM"]
       (snoc [dez caz] [%pass wir %agent dock %poke cage])
     ::
+    =+  invite-type=(~(get by fields.metadata.bite) 'inviteType')
+    ::
+    ::  don't send group invite if this is a personal bite
+    ?:  &(?=(^ invite-type) =('user' u.invite-type))  ~
+    ::
     =*  group-event  'Group Invite Fail'
     ?~  group=(~(get by fields.metadata.bite) 'group')
       :_  ~
@@ -215,7 +220,7 @@
   |=  [=term =tang]
   ^-  (quip card _this)
   :_  this
-  [(fail:log term tang ~)]~
+  [(fail:log term tang)]~
 ::
 ++  on-leave
   |=  =path


### PR DESCRIPTION
Personal lure link generate an error, since presently %grouper attempts to send a group invite in all cases. This PR adds a check on the `inviteType` field in bite metadata. If it is present and set to `user`, we don't attempt to send group invite and don't generate a failure.