### PR TITLE
activity: prevent base volume from being reset

### DIFF
--- a/desk/app/activity.hoon
+++ b/desk/app/activity.hoon
@@ -155,7 +155,7 @@
     (~(gut by volume-settings.state) [%base ~] *volume-map:a)
   =.  volume-settings.state
     %+  ~(put by volume-settings.state)  [%base ~]
-    (~(uni by base-volume) *volume-map:a)
+    (~(uni by *volume-map:a) base-volume)
   =.  allowed  %all
   (emit %pass /fix-init-unreads %agent [our.bowl dap.bowl] %poke noun+!>(%fix-init-unreads))
   +$  versioned-state


### PR DESCRIPTION
Fixes TLON-3574, we were erroneously putting the old volume on the side that gets overridden if there already exists a key so we were just always set back to defaults any time activity reloads.