### PR TITLE
Invite Fixes

### DIFF
--- a/apps/tlon-mobile/src/hooks/useOnboardingHelpers.ts
+++ b/apps/tlon-mobile/src/hooks/useOnboardingHelpers.ts
@@ -87,6 +87,12 @@ export function useOnboardingHelpers() {
       // clear native managed cookie since we set manually
       await clearHostingNativeCookie();
 
+      logger.trackEvent(AnalyticsEvent.UserLoggedIn, {
+        email: params.email,
+        phoneNumber: params.phoneNumber,
+        client: 'tlon-mobile',
+      });
+
       if (maybeAccountIssue) {
         switch (maybeAccountIssue) {
           // If the account has no assigned ship, treat it as a signup

--- a/packages/app/contexts/branch.tsx
+++ b/packages/app/contexts/branch.tsx
@@ -161,7 +161,7 @@ export const BranchProvider = ({ children }: { children: ReactNode }) => {
       console.debug('[branch] Unsubscribing from Branch listener');
       unsubscribe();
     };
-  }, [isAuthenticated]);
+  }, [goToChannel, isAuthenticated]);
 
   const setLure = useCallback(
     (invite: AppInvite) => {

--- a/packages/app/contexts/branch.tsx
+++ b/packages/app/contexts/branch.tsx
@@ -1,4 +1,4 @@
-import { createDevLogger } from '@tloncorp/shared';
+import { AnalyticsEvent, createDevLogger } from '@tloncorp/shared';
 import { storage } from '@tloncorp/shared/db';
 import { AppInvite, Lure, extractLureMetadata } from '@tloncorp/shared/logic';
 import {
@@ -111,26 +111,36 @@ export const BranchProvider = ({ children }: { children: ReactNode }) => {
 
         // Handle Branch link click
         if (params?.['+clicked_branch_link']) {
-          logger.log('detected Branch link click');
+          logger.trackEvent('Detected Branch Link Click', {
+            inviteId: params.lure,
+          });
 
           if (params.lure) {
             // Link had a lure field embedded
             logger.log('detected lure link:', params.lure);
-            const nextLure: Lure = {
-              lure: {
-                ...extractLureMetadata(params),
-                id: params.lure as string,
-                // if not already authenticated, we should run Lure's invite auto-join capability after signing in
-                shouldAutoJoin: !isAuthenticated,
-              },
-              priorityToken: params.token as string | undefined,
-            };
-            console.log(`setting deeplink lure`, nextLure);
-            setState({
-              ...nextLure,
-              deepLinkPath: undefined,
-            });
-            storage.invitation.setValue(nextLure);
+            try {
+              const nextLure: Lure = {
+                lure: {
+                  ...extractLureMetadata(params),
+                  id: params.lure as string,
+                  // if not already authenticated, we should run Lure's invite auto-join capability after signing in
+                  shouldAutoJoin: !isAuthenticated,
+                },
+                priorityToken: params.token as string | undefined,
+              };
+              console.log(`setting deeplink lure`, nextLure);
+              setState({
+                ...nextLure,
+                deepLinkPath: undefined,
+              });
+              storage.invitation.setValue(nextLure);
+            } catch (e) {
+              logger.trackError(AnalyticsEvent.InviteError, {
+                context: 'Failed to extract lure metadata',
+                inviteId: params.lure,
+                errorMessage: e?.message,
+              });
+            }
           } else if (params.wer) {
             // Link had a wer (deep link) field embedded
             const deepLinkPath = getPathFromWer(params.wer as string);

--- a/packages/app/contexts/ship.tsx
+++ b/packages/app/contexts/ship.tsx
@@ -1,4 +1,5 @@
 import crashlytics from '@react-native-firebase/crashlytics';
+import { AnalyticsEvent, createDevLogger } from '@tloncorp/shared';
 import { ShipInfo, storage } from '@tloncorp/shared/db';
 import { preSig } from '@urbit/aura';
 import type { ReactNode } from 'react';
@@ -12,6 +13,8 @@ import {
 import { NativeModules } from 'react-native';
 
 import { transformShipURL } from '../utils/string';
+
+const logger = createDevLogger('useShip', false);
 
 const { UrbitModule } = NativeModules;
 
@@ -111,6 +114,7 @@ export const ShipProvider = ({ children }: { children: ReactNode }) => {
         })();
       }
 
+      logger.trackEvent(AnalyticsEvent.NodeAuthSaved);
       setIsLoading(false);
     },
     []

--- a/packages/shared/src/domain/analytics.ts
+++ b/packages/shared/src/domain/analytics.ts
@@ -41,4 +41,6 @@ export enum AnalyticsEvent {
   NodeConnectionDebug = 'Node Connection Debug',
   NodeConnectionError = 'Node Connection Error',
   SyncDiscontinuity = 'Sync Discontinuity',
+  UserLoggedIn = 'User Logged In',
+  NodeAuthSaved = 'Node Auth Saved',
 }

--- a/packages/shared/src/logic/branch.ts
+++ b/packages/shared/src/logic/branch.ts
@@ -79,6 +79,7 @@ export interface DeepLinkMetadata {
   invitedGroupIconImageUrl?: string;
   invitedGroupiconImageColor?: string;
   inviteType?: 'user' | 'group';
+  group?: string; // legacy identifier for invitedGroupId
 }
 
 export interface AppInvite extends DeepLinkMetadata {

--- a/packages/shared/src/logic/branch.ts
+++ b/packages/shared/src/logic/branch.ts
@@ -80,6 +80,8 @@ export interface DeepLinkMetadata {
   invitedGroupiconImageColor?: string;
   inviteType?: 'user' | 'group';
   group?: string; // legacy identifier for invitedGroupId
+  inviter?: string; // legacy identifier for inviterUserId
+  image?: string; // legacy identifier for invitedGroupIconImageUrl
 }
 
 export interface AppInvite extends DeepLinkMetadata {
@@ -104,18 +106,39 @@ export function extractLureMetadata(branchParams: any) {
     return {};
   }
 
-  return {
-    inviterUserId: branchParams.inviterUserId,
+  const extracted = {
+    inviterUserId: branchParams.inviterUserId || branchParams.inviter,
     inviterNickname: branchParams.inviterNickname,
     inviterAvatarImage: branchParams.inviterAvatarImage,
     inviterColor: branchParams.inviterColor,
-    invitedGroupId: branchParams.invitedGroupId,
-    invitedGroupTitle: branchParams.invitedGroupTitle,
+    invitedGroupId: branchParams.invitedGroupId ?? branchParams.group, // only fallback to key if invitedGroupId missing, not empty
+    invitedGroupTitle: branchParams.invitedGroupTitle || branchParams.title,
     invitedGroupDescription: branchParams.invitedGroupDescription,
-    invitedGroupIconImageUrl: branchParams.invitedGroupIconImageUrl,
+    invitedGroupIconImageUrl:
+      branchParams.invitedGroupIconImageUrl || branchParams.image,
     invitedGroupiconImageColor: branchParams.invitedGroupiconImageColor,
     inviteType: branchParams.inviteType,
   };
+
+  if (
+    !extracted.inviterUserId &&
+    !extracted.invitedGroupId &&
+    branchParams.lure &&
+    branchParams.lure.includes('/')
+  ) {
+    // fall back to v1 style lures where the id is a flag
+    const [ship, _] = branchParams.lure.split('/');
+    if (isValidPatp(ship)) {
+      extracted.inviterUserId = ship;
+      extracted.invitedGroupId = branchParams.lure;
+    }
+  }
+
+  if (!extracted.inviterUserId && !extracted.invitedGroupId) {
+    throw new Error('Failed to extract valid lure metadata');
+  }
+
+  return extracted;
 }
 
 export function isLureMeta(input: unknown): input is DeepLinkMetadata {

--- a/packages/shared/src/store/hostingActions.ts
+++ b/packages/shared/src/store/hostingActions.ts
@@ -5,6 +5,7 @@ import * as domain from '../domain';
 import { AnalyticsEvent } from '../domain';
 import * as logic from '../logic';
 import { withRetry } from '../logic';
+import { syncGroupPreviews } from './sync';
 
 const logger = createDevLogger('hostingActions', true);
 
@@ -269,4 +270,54 @@ export async function authenticateWithReadyNode(): Promise<db.ShipInfo | null> {
     authCookie,
     authType: 'hosted',
   };
+}
+
+export async function redeemInviteIfNeeded(invite: logic.AppInvite) {
+  const currentUserId = api.getCurrentUserId();
+  if (invite.inviteType && invite.inviteType === 'user') {
+    return;
+  }
+
+  const groupId = invite.invitedGroupId || invite.group;
+  if (!groupId) {
+    logger.trackEvent(AnalyticsEvent.InviteError, {
+      context: 'Invite missing group identifier',
+      inviteId: invite.id,
+    });
+    return;
+  }
+
+  const group = await db.getGroup({ id: groupId });
+
+  if (!group) {
+    syncGroupPreviews([groupId]);
+  }
+
+  const isJoined = group && group.currentUserIsMember;
+  const haveInvite = group && group.haveInvite;
+  const shouldRedeem = !isJoined && !haveInvite;
+
+  if (shouldRedeem) {
+    try {
+      await api.inviteShipWithLure({ ship: currentUserId, lure: invite.id });
+      logger.trackEvent(AnalyticsEvent.InviteDebug, {
+        context: 'Success, bit invite deeplink lure while logged in',
+        lure: invite.id,
+      });
+    } catch (err) {
+      logger.trackEvent(AnalyticsEvent.InviteError, {
+        context: 'Failed to bite lure on invite deeplink while logged in',
+        lure: invite.id,
+        errorMessage: err.message,
+      });
+    }
+  } else {
+    logger.trackEvent(AnalyticsEvent.InviteDebug, {
+      context: 'Invite redemption not needed, skipping',
+      inviteId: invite.id,
+      isJoined,
+      haveInvite,
+      shouldRedeem,
+    });
+  }
 }

--- a/packages/ui/src/components/Onboarding/OnboardingInvite.tsx
+++ b/packages/ui/src/components/Onboarding/OnboardingInvite.tsx
@@ -37,7 +37,7 @@ export const OnboardingInviteBlock = React.memo(function OnboardingInviteBlock({
   }
 
   const inviter = {
-    id: inviterUserId!,
+    id: inviterUserId,
     nickname: inviterNickname,
     avatarImage: inviterAvatarImage,
     color: inviterColor || undefined,
@@ -107,10 +107,10 @@ function GroupInvite({
         />
         <ListItem.MainContent>
           <ListItem.Title>
-            Join {groupShim.title ?? groupShim.id}
+            {groupShim.title ? `Join ${groupShim.title}` : `Join a Groupchat`}
           </ListItem.Title>
           <ListItem.Subtitle>
-            Invited by {inviter.nickname ?? inviter.id}
+            Invited by {getDisplayName(inviter)}
           </ListItem.Subtitle>
         </ListItem.MainContent>
       </ListItem>


### PR DESCRIPTION
Fixes TLON-3575  by biting the lure if we're not already a member or invited.
Fixes TLON-3577 by adding better lure metadata extraction fallbacks and being more careful about how the invite preview card displays info.