### PR TITLE
Mobile: Invite UX Pass

### DIFF
--- a/packages/app/features/top/ChannelScreen.tsx
+++ b/packages/app/features/top/ChannelScreen.tsx
@@ -327,6 +327,15 @@ export default function ChannelScreen(props: Props) {
     }
   }, [group, props.navigation]);
 
+  const handleChatDetailsPressed = useCallback(() => {
+    if (group) {
+      props.navigation.navigate('ChatDetails', {
+        chatType: 'group',
+        chatId: group.id,
+      });
+    }
+  }, [group, props.navigation]);
+
   const handleChannelSelected = useCallback((channel: db.Channel) => {
     setCurrentChannelId(channel.id);
     setChannelNavOpen(false);
@@ -407,6 +416,7 @@ export default function ChannelScreen(props: Props) {
           goToPost={navigateToPost}
           goToImageViewer={navigateToImage}
           goToChannels={handleChannelNavButtonPressed}
+          goToChatDetails={handleChatDetailsPressed}
           goToSearch={navigateToSearch}
           goToDm={handleGoToDm}
           goToUserProfile={handleGoToUserProfile}

--- a/packages/app/features/top/ChannelScreen.tsx
+++ b/packages/app/features/top/ChannelScreen.tsx
@@ -105,8 +105,9 @@ export default function ChannelScreen(props: Props) {
   }, [channelIsPending, channelId]);
 
   const [channelNavOpen, setChannelNavOpen] = React.useState(false);
-  const [inviteSheetGroup, setInviteSheetGroup] =
-    React.useState<string | null>();
+  const [inviteSheetGroup, setInviteSheetGroup] = React.useState<
+    string | null
+  >();
 
   // for the unread channel divider, we care about the unread state when you enter but don't want it to update over
   // time
@@ -316,8 +317,15 @@ export default function ChannelScreen(props: Props) {
   );
 
   const handleChannelNavButtonPressed = useCallback(() => {
-    setChannelNavOpen(true);
-  }, []);
+    if ((group?.channels?.length ?? 1) > 1) {
+      setChannelNavOpen(true);
+    } else {
+      props.navigation.navigate('ChatDetails', {
+        chatType: 'group',
+        chatId: group!.id,
+      });
+    }
+  }, [group, props.navigation]);
 
   const handleChannelSelected = useCallback((channel: db.Channel) => {
     setCurrentChannelId(channel.id);

--- a/packages/app/features/top/ChannelScreen.tsx
+++ b/packages/app/features/top/ChannelScreen.tsx
@@ -317,15 +317,8 @@ export default function ChannelScreen(props: Props) {
   );
 
   const handleChannelNavButtonPressed = useCallback(() => {
-    if ((group?.channels?.length ?? 1) > 1) {
-      setChannelNavOpen(true);
-    } else {
-      props.navigation.navigate('ChatDetails', {
-        chatType: 'group',
-        chatId: group!.id,
-      });
-    }
-  }, [group, props.navigation]);
+    setChannelNavOpen(true);
+  }, []);
 
   const handleChatDetailsPressed = useCallback(() => {
     if (group) {

--- a/packages/app/features/top/ChatDetailsScreen.tsx
+++ b/packages/app/features/top/ChatDetailsScreen.tsx
@@ -415,14 +415,20 @@ function ChatMembersList({
               <View
                 width="$3xl"
                 height="$3xl"
-                backgroundColor={'$secondaryBackground'}
+                backgroundColor={'$blueSoft'}
                 borderRadius="$xs"
                 alignItems="center"
                 justifyContent="center"
               >
-                <Icon type="Add" customSize={[20, 20]} />
+                <Icon
+                  type="Add"
+                  color="$positiveActionText"
+                  customSize={[20, 20]}
+                />
               </View>
-              <TlonText.Text size="$label/l">Add members</TlonText.Text>
+              <TlonText.Text size="$label/l" color="$positiveActionText">
+                Invite People
+              </TlonText.Text>
             </XStack>
           </Pressable>
         ) : null}
@@ -483,7 +489,7 @@ function GroupQuickActions({ group }: { group: db.Group }) {
           action: togglePinned,
         },
         {
-          title: didCopyLink ? 'Copied' : 'Copy link',
+          title: didCopyLink ? 'Copied' : 'Reference',
           action: didCopyLink ? undefined : copyLink,
         }
       ),

--- a/packages/shared/src/domain/analytics.ts
+++ b/packages/shared/src/domain/analytics.ts
@@ -41,4 +41,5 @@ export enum AnalyticsEvent {
   NodeConnectionDebug = 'Node Connection Debug',
   NodeConnectionError = 'Node Connection Error',
   SyncDiscontinuity = 'Sync Discontinuity',
+  OnNetworkInvite = 'Sent On Network Group Invite',
 }

--- a/packages/shared/src/store/groupActions.ts
+++ b/packages/shared/src/store/groupActions.ts
@@ -4,6 +4,7 @@ import * as api from '../api';
 import * as db from '../db';
 import { GroupPrivacy } from '../db/schema';
 import { createDevLogger } from '../debug';
+import { AnalyticsEvent } from '../domain';
 import { getRandomId } from '../logic';
 import { createSectionId } from '../urbit';
 import { createChannel } from './channelActions';
@@ -143,6 +144,13 @@ export async function inviteGroupMembers({
     chatId: groupId,
     type: 'group',
     contactIds,
+  });
+
+  const groupType =
+    existingGroup.channels?.length > 1 ? 'multi-channel group' : 'groupchat';
+  logger.trackEvent(AnalyticsEvent.OnNetworkInvite, {
+    groupType,
+    numInvitesSent: contactIds.length,
   });
 
   try {

--- a/packages/ui/src/components/Channel/ChannelHeader.tsx
+++ b/packages/ui/src/components/Channel/ChannelHeader.tsx
@@ -83,7 +83,7 @@ export function ChannelHeader({
   goBack,
   goToSearch,
   goToEdit,
-  goToChannels,
+  goToChatDetails,
   showSpinner,
   showSearchButton = true,
   showMenuButton = false,
@@ -96,7 +96,8 @@ export function ChannelHeader({
   goBack?: () => void;
   goToSearch?: () => void;
   goToEdit?: () => void;
-  goToChannels?: () => void;
+  goToChannels?: () => void; // remove once we're confident we don't wanna open that as a pattern
+  goToChatDetails?: () => void;
   showSpinner?: boolean;
   showSearchButton?: boolean;
   showMenuButton?: boolean;
@@ -133,7 +134,7 @@ export function ChannelHeader({
     <>
       <ScreenHeader
         title={
-          <Pressable onPress={goToChannels}>
+          <Pressable onPress={goToChatDetails}>
             <ScreenHeader.Title>{title}</ScreenHeader.Title>
           </Pressable>
         }

--- a/packages/ui/src/components/Channel/ChannelHeader.tsx
+++ b/packages/ui/src/components/Channel/ChannelHeader.tsx
@@ -4,11 +4,13 @@ import {
   useCallback,
   useContext,
   useEffect,
+  useMemo,
   useState,
 } from 'react';
 
 import { useChatOptions } from '../../contexts';
 import useIsWindowNarrow from '../../hooks/useIsWindowNarrow';
+import { useGroupTitle } from '../../utils';
 import { ChatOptionsSheet } from '../ChatOptionsSheet';
 import Pressable from '../Pressable';
 import { ScreenHeader } from '../ScreenHeader';
@@ -156,11 +158,7 @@ export function ChannelHeader({
                   open={openChatOptions}
                   onOpenChange={setOpenChatOptions}
                   chat={{ type: 'channel', id: channel.id }}
-                  trigger={
-                    <ScreenHeader.IconButton
-                      type="Overflow"
-                    />
-                  }
+                  trigger={<ScreenHeader.IconButton type="Overflow" />}
                 />
               )
             ) : null}

--- a/packages/ui/src/components/Channel/index.tsx
+++ b/packages/ui/src/components/Channel/index.tsx
@@ -70,6 +70,7 @@ interface ChannelProps {
   group: db.Group | null;
   goBack: () => void;
   goToChannels: () => void;
+  goToChatDetails?: () => void;
   goToPost: (post: db.Post) => void;
   goToDm: (participants: string[]) => void;
   goToImageViewer: (post: db.Post, imageUri?: string) => void;
@@ -119,6 +120,7 @@ export const Channel = forwardRef<ChannelMethods, ChannelProps>(
       headerMode,
       goBack,
       goToChannels,
+      goToChatDetails,
       goToSearch,
       goToImageViewer,
       goToPost,
@@ -319,6 +321,7 @@ export const Channel = forwardRef<ChannelMethods, ChannelProps>(
                           showSearchButton={isChatChannel}
                           goToSearch={goToSearch}
                           goToChannels={goToChannels}
+                          goToChatDetails={goToChatDetails}
                           showSpinner={isLoadingPosts}
                           showMenuButton={true}
                         />

--- a/packages/ui/src/components/ChatOptionsSheet.tsx
+++ b/packages/ui/src/components/ChatOptionsSheet.tsx
@@ -139,6 +139,8 @@ export function GroupOptionsSheetLoader({
   }, [setPane]);
 
   const title = utils.useGroupTitle(group) ?? 'Loading...';
+  const currentUserId = useCurrentUserId();
+  const currentUserIsAdmin = utils.useIsAdmin(groupId, currentUserId);
   const { data: groupUnread, isFetched: groupUnreadIsFetched } =
     store.useGroupUnread({ groupId });
   const { data: groupData } = store.useGroup({ id: groupId });
@@ -186,6 +188,7 @@ export function GroupOptionsSheetLoader({
           ) : (
             <GroupOptionsSheetContent
               groupUnread={groupUnread ?? null}
+              currentUserIsAdmin={currentUserIsAdmin}
               onPressNotifications={handlePressNotifications}
               onPressSort={handlePressSort}
               chatTitle={title}
@@ -213,6 +216,7 @@ export function GroupOptionsSheetLoader({
       ) : (
         <GroupOptionsSheetContent
           groupUnread={groupUnread ?? null}
+          currentUserIsAdmin={currentUserIsAdmin}
           onPressNotifications={handlePressNotifications}
           onPressSort={handlePressSort}
           chatTitle={title}
@@ -228,6 +232,7 @@ function GroupOptionsSheetContent({
   chatTitle,
   group,
   groupUnread,
+  currentUserIsAdmin,
   onPressNotifications,
   onPressSort,
   onOpenChange,
@@ -235,13 +240,16 @@ function GroupOptionsSheetContent({
   group: db.Group;
   groupUnread: db.GroupUnread | null;
   chatTitle: string;
+  currentUserIsAdmin: boolean;
   onPressNotifications: () => void;
   onPressSort: () => void;
   onOpenChange: (open: boolean) => void;
 }) {
-  const { markGroupRead, onPressChatDetails, togglePinned } = useChatOptions();
+  const { markGroupRead, onPressChatDetails, togglePinned, onPressInvite } =
+    useChatOptions();
   const canMarkRead = !(group.unread?.count === 0 || groupUnread?.count === 0);
   const canSortChannels = (group.channels?.length ?? 0) > 1;
+  const canInvite = currentUserIsAdmin || group.privacy === 'public';
   const isPinned = group?.pin;
 
   const wrappedAction = useCallback(
@@ -283,6 +291,17 @@ function GroupOptionsSheetContent({
         ],
         [
           'neutral',
+          canInvite
+            ? {
+                title: 'Invite people',
+                action: wrappedAction.bind(null, onPressInvite),
+                endIcon: 'ChevronRight',
+              }
+            : {
+                accent: 'disabled',
+                title: 'Invites disabled',
+                description: 'Only admins may invite people to this group.',
+              },
           {
             title: 'Group info & settings',
             action: wrappedAction.bind(null, handlePressChatDetails),
@@ -291,11 +310,13 @@ function GroupOptionsSheetContent({
         ]
       ),
     [
+      canInvite,
       canMarkRead,
       canSortChannels,
       handlePressChatDetails,
       isPinned,
       markGroupRead,
+      onPressInvite,
       onPressNotifications,
       onPressSort,
       togglePinned,

--- a/packages/ui/src/components/InviteFriendsToTlonButton.tsx
+++ b/packages/ui/src/components/InviteFriendsToTlonButton.tsx
@@ -59,8 +59,7 @@ export function InviteFriendsToTlonButton({
 
       try {
         const result = await Share.share({
-          message: `Join ${title} on Tlon: ${shareUrl}`,
-          title: `Join ${title} on Tlon`,
+          message: shareUrl,
         });
 
         if (result.action === Share.sharedAction) {
@@ -122,7 +121,7 @@ export function InviteFriendsToTlonButton({
       ) : null}
       <Button.Text>
         {linkIsReady
-          ? 'Share invite link'
+          ? 'Share Invite Link'
           : linkIsDisabled
             ? 'Public invite links are disabled'
             : linkFailed

--- a/packages/ui/src/components/ListItem/GroupListItem.tsx
+++ b/packages/ui/src/components/ListItem/GroupListItem.tsx
@@ -115,22 +115,22 @@ export const GroupListItem = ({
               <Icon type="Overflow" />
             </Button>
           ) : (
-              <ChatOptionsSheet
-                open={open}
-                onOpenChange={setOpen}
-                chat={{ type: 'group', id: model.id }}
-                trigger={
-                  <Button
-                    backgroundColor="transparent"
-                    borderWidth="unset"
-                    paddingHorizontal={0}
-                    marginHorizontal="$-m"
-                    minimal
-                  >
-                    <Icon type="Overflow" />
-                  </Button>
-                }
-              />
+            <ChatOptionsSheet
+              open={open}
+              onOpenChange={setOpen}
+              chat={{ type: 'group', id: model.id }}
+              trigger={
+                <Button
+                  backgroundColor="transparent"
+                  borderWidth="unset"
+                  paddingHorizontal={0}
+                  marginHorizontal="$-m"
+                  minimal
+                >
+                  <Icon type="Overflow" />
+                </Button>
+              }
+            />
           )}
         </View>
       )}

--- a/packages/ui/src/components/PersonalInviteButton.tsx
+++ b/packages/ui/src/components/PersonalInviteButton.tsx
@@ -45,8 +45,7 @@ export function PersonalInviteButton() {
 
     try {
       const result = await Share.share({
-        message: `${userDisplayName} invited you to TM: ${inviteLink}`,
-        title: `${userDisplayName} invited you to TM`,
+        message: inviteLink,
       });
 
       if (result.action === Share.sharedAction) {
@@ -67,7 +66,7 @@ export function PersonalInviteButton() {
         <Icon type="Link" />
       </Button.Icon>
       <Text color="$background" size="$label/l">
-        Share invite link
+        Share Invite Link
       </Text>
     </Button>
   );


### PR DESCRIPTION
- Put invite option back in _GroupOptionsSheet_
- Make invite people CTA clearer in _ChatDetails_
- Open _ChatDetails_ primary action when clicking channel header (possibly controversial)
- Track an event for on network invites
- Nicer preview + just paste the link from native Share sheet

Fixes TLON-3583