### PR TITLE
chat details: fix missing navigation on leaving a group

### DIFF
--- a/packages/app/features/top/ChatDetailsScreen.tsx
+++ b/packages/app/features/top/ChatDetailsScreen.tsx
@@ -215,7 +215,7 @@ function ChatDetailsScreenContent({
 }
 
 function GroupLeaveActions({ group }: { group: db.Group }) {
-  const { navigateOnLeave } = useChatSettingsNavigation();
+  const { onLeaveGroup } = useChatSettingsNavigation();
   const [showDeleteSheet, setShowDeleteSheet] = useState(false);
   const canLeave = !group.currentUserIsHost;
   const canDelete = group.currentUserIsHost;
@@ -241,8 +241,8 @@ function GroupLeaveActions({ group }: { group: db.Group }) {
 
   const handleDeleteGroup = useCallback(() => {
     deleteGroup();
-    navigateOnLeave();
-  }, [deleteGroup, navigateOnLeave]);
+    onLeaveGroup();
+  }, [deleteGroup, onLeaveGroup]);
 
   return (
     <>

--- a/packages/app/hooks/useChatSettingsNavigation.ts
+++ b/packages/app/hooks/useChatSettingsNavigation.ts
@@ -98,7 +98,7 @@ export const useChatSettingsNavigation = () => {
     [navigationRef]
   );
 
-  const navigateOnLeave = useCallback(() => {
+  const onLeaveGroup = useCallback(() => {
     navigationRef.current.navigate('ChatList');
   }, [navigationRef]);
 
@@ -113,6 +113,6 @@ export const useChatSettingsNavigation = () => {
     onPressChatDetails: navigateToChatDetails,
     onPressChatVolume: navigateToChatVolume,
     onPressRoles,
-    navigateOnLeave,
+    onLeaveGroup,
   };
 };


### PR DESCRIPTION
OTT
fixes tlon-3582

we're expecting this method to be named `onLeaveGroup`, not `navigateOnLeave`.