### PR TITLE
debounce update hook

### DIFF
--- a/packages/app/lib/nativeDb.ts
+++ b/packages/app/lib/nativeDb.ts
@@ -58,6 +58,7 @@ export class NativeDb extends BaseDb {
     await this.processChanges();
     this.isProcessingChanges = false;
     if (this.changesPending) {
+      this.changesPending = false;
       this.handleUpdate();
     }
   }

--- a/packages/app/lib/nativeDb.ts
+++ b/packages/app/lib/nativeDb.ts
@@ -14,6 +14,8 @@ import { TRIGGER_SETUP } from './triggers';
 
 export class NativeDb extends BaseDb {
   private connection: SQLiteConnection | null = null;
+  private isProcessingChanges: boolean = false;
+  private changesPending: boolean = false;
 
   async setupDb() {
     if (this.connection || this.client) {
@@ -31,9 +33,7 @@ export class NativeDb extends BaseDb {
     this.connection.execute('PRAGMA journal_mode=MEMORY');
     this.connection.execute('PRAGMA synchronous=OFF');
 
-    this.connection.updateHook(() => {
-      this.processChanges();
-    });
+    this.connection.updateHook(() => this.handleUpdate());
 
     this.client = this.connection.createClient({
       schema,
@@ -47,6 +47,19 @@ export class NativeDb extends BaseDb {
     });
     setClient(this.client);
     logger.log('SQLite database opened at', this.connection.getDbPath());
+  }
+
+  async handleUpdate() {
+    if (this.isProcessingChanges) {
+      this.changesPending = true;
+      return;
+    }
+    this.isProcessingChanges = true;
+    await this.processChanges();
+    this.isProcessingChanges = false;
+    if (this.changesPending) {
+      this.handleUpdate();
+    }
   }
 
   async purgeDb() {


### PR DESCRIPTION
Previously, when a large number of changes was made at once, the update hook would trigger for each row all at once, meaning that all of the updates would attempt to read changes before any of the changes were actually cleared, leading to an exponential change handler explosion. This update ensures that previous changes are cleared before the next change handler attempts to read them. 

Fixes TLON-3430.