### PR TITLE
Channel manager: reflect channel name changes immediately

### DIFF
--- a/packages/ui/src/components/ManageChannels/ManageChannelsScreenView.tsx
+++ b/packages/ui/src/components/ManageChannels/ManageChannelsScreenView.tsx
@@ -341,7 +341,26 @@ export function ManageChannelsScreenView({
     // Only update local state if the total number of sections have changed
     // OR if a newly created channel has been added to the default section
     // OR if a channel has been deleted
+    // OR if a channel name has changed
     if (newNavSections.length === sections.length) {
+      // Check if any channel names have changed
+      const hasChannelNameChanged = newNavSections.some((newSection) => {
+        const currentSection = sections.find((s) => s.id === newSection.id);
+        if (!currentSection) return false;
+
+        return newSection.channels.some((newChannel) => {
+          const currentChannel = currentSection.channels.find(
+            (c) => c.id === newChannel.id
+          );
+          return currentChannel && currentChannel.title !== newChannel.title;
+        });
+      });
+
+      if (hasChannelNameChanged) {
+        setSections(newNavSections);
+        return;
+      }
+
       if (newTotalChannels !== currentTotalChannels) {
         // Check if a new channel has been added to the default section
         if (
@@ -353,11 +372,12 @@ export function ManageChannelsScreenView({
           )
         ) {
           setSections(newNavSections);
+          return;
         }
         // Check if a channel has been deleted
         if (newTotalChannels < currentTotalChannels) {
-          console.log('Channel deleted');
           setSections(newNavSections);
+          return;
         }
       }
 


### PR DESCRIPTION
fixes TLON-3585

In the channel manager we use a `useEffect` to selectively update the `sections` local state var with the groupNavSectionsWithChannel data from the sqlite db in certain cases in order to enable an optimistic UI for the channel/section movement without unnecessary re-renders (we don't want the whole thing to re-render when a user is just moving channels/sections around).

Channel name changes weren't being reflected because we weren't checking for them in this useEffect. This just adds a check for them.