### PR TITLE
chat: fix reply in chat actions for group dms

### DIFF
--- a/packages/ui/src/components/ChatMessage/ChatMessageActions/MessageActions.tsx
+++ b/packages/ui/src/components/ChatMessage/ChatMessageActions/MessageActions.tsx
@@ -212,7 +212,10 @@ export async function handleAction({
       onViewReactions?.(post);
       break;
     case 'quote':
-      if (channel.type === 'dm' && post.textContent) {
+      if (
+        (channel.type === 'dm' || channel.type === 'groupDm') &&
+        post.textContent
+      ) {
         // For DMs, insert text as markdown quote
         addAttachment({ type: 'text', text: `> ${post.textContent}\n` });
       } else {


### PR DESCRIPTION
fixes tlon-3601

we weren't using the `addAttachment` method to add the quote reply for groupDMs before, just DMs. Now we use it for both.