### PR TITLE
Notebook editor: fix text color on alternative themes

### DIFF
--- a/packages/editor/src/MessageInputEditor.tsx
+++ b/packages/editor/src/MessageInputEditor.tsx
@@ -22,7 +22,6 @@ import { EditorContent } from '@tiptap/react';
 import { useCallback } from 'react';
 
 import { CodeBlockBridge, MentionsBridge, ShortcutsBridge } from './bridges';
-import { useIsDark } from './useMedia';
 
 export const MessageInputEditor = () => {
   const handlePaste = useCallback(
@@ -77,7 +76,6 @@ export const MessageInputEditor = () => {
         height: 'auto',
         fontSize: 16,
         overflowY: 'auto',
-        color: useIsDark() ? 'white' : 'black',
         fontFamily:
           "System, -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Ubuntu, 'Helvetica Neue', sans-serif",
       }}

--- a/packages/ui/src/components/MessageInput/index.native.tsx
+++ b/packages/ui/src/components/MessageInput/index.native.tsx
@@ -46,10 +46,10 @@ import {
   useRef,
   useState,
 } from 'react';
-import { Keyboard } from 'react-native';
+import { Keyboard, Platform } from 'react-native';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
 import type { WebViewMessageEvent } from 'react-native-webview';
-import { YStack, getTokenValue, useWindowDimensions } from 'tamagui';
+import { YStack, getTokenValue, useTheme, useWindowDimensions } from 'tamagui';
 import { XStack } from 'tamagui';
 
 import { useBranchDomain, useBranchKey } from '../../contexts';
@@ -928,6 +928,13 @@ export const MessageInput = forwardRef<MessageInputHandle, MessageInputProps>(
       clearAttachments();
     }, [setEditingPost, editor, clearDraft, clearAttachments, draftType]);
 
+    const primaryTextColor = useTheme().primaryText.val;
+    const backgroundColorValue = useTheme().background.val;
+    const injectThemeColors = `
+      document.body.style.backgroundColor = '${backgroundColorValue}';
+      document.body.style.color = '${primaryTextColor}';
+    `;
+
     return (
       <MessageInputContainer
         setShouldBlur={setShouldBlur}
@@ -995,6 +1002,7 @@ export const MessageInput = forwardRef<MessageInputHandle, MessageInputProps>(
               renderLoading={() => <></>}
               injectedJavaScript={`
               ${tentapInjectedJs}
+              ${injectThemeColors}
 
               window.onerror = function(message, source, lineno, colno, error) {
                 window.ReactNativeWebView.postMessage(JSON.stringify({ type: 'content-error', payload: message }));

--- a/packages/ui/src/components/MessageInput/index.tsx
+++ b/packages/ui/src/components/MessageInput/index.tsx
@@ -35,7 +35,13 @@ import {
 import { useCallback, useEffect, useMemo, useState } from 'react';
 import { Keyboard } from 'react-native';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
-import { View, YStack, getTokenValue, useWindowDimensions } from 'tamagui';
+import {
+  View,
+  YStack,
+  getTokenValue,
+  useTheme,
+  useWindowDimensions,
+} from 'tamagui';
 
 import {
   Attachment,
@@ -584,6 +590,7 @@ export function MessageInput({
   }, [runSendMessage, editingPost]);
 
   const titleIsEmpty = useMemo(() => !title || title.length === 0, [title]);
+  const primaryTextColor = useTheme().primaryText.val;
 
   return (
     <MessageInputContainer
@@ -615,12 +622,16 @@ export function MessageInput({
         borderRadius="$xl"
       >
         {showInlineAttachments && <AttachmentPreviewList />}
-        <View height={bigInput ? bigInputHeightBasic : initialHeight} width="80%">
+        <View
+          height={bigInput ? bigInputHeightBasic : initialHeight}
+          width="80%"
+        >
           <EditorContent
             style={{
               width: '100%',
               height: '100%',
               padding: 12,
+              color: primaryTextColor,
             }}
             editor={editor}
           />


### PR DESCRIPTION
This change ensures that we pass the theme value for the text color (and the background) into the webview so that the colors will match the theme (and removes the use of useIsDark in the editor react app). Also updates the web version of the editor to use the appropriate colors.

Fixes tlon-3536
![Simulator Screenshot - iPhone 15 - 2025-02-04 at 15 38 17](https://github.com/user-attachments/assets/f7db6564-5a6d-4d58-975f-31ef32b8a308)
![Screenshot_1738705415](https://github.com/user-attachments/assets/571992f3-495d-43af-ad5e-76712185efba)
![Apps Groups iPhone 14 Pro Max](https://github.com/user-attachments/assets/1ae48c1e-9e1f-4a91-9902-f661384493ba)
