### PR TITLE
prevent unnecessary full group syncs

### DIFF
--- a/packages/shared/src/db/migrations/0000_fluffy_cardiac.sql
+++ b/packages/shared/src/db/migrations/0000_fluffy_cardiac.sql
@@ -227,7 +227,8 @@ CREATE TABLE `groups` (
 	`join_status` text,
 	`last_post_id` text,
 	`last_post_at` integer,
-	`last_visited_channel_id` text
+	`last_visited_channel_id` text,
+	`synced_at` integer
 );
 --> statement-breakpoint
 CREATE TABLE `pins` (

--- a/packages/shared/src/db/migrations/meta/0000_snapshot.json
+++ b/packages/shared/src/db/migrations/meta/0000_snapshot.json
@@ -1,7 +1,7 @@
 {
   "version": "6",
   "dialect": "sqlite",
-  "id": "a317605a-b303-4b87-b2e9-0f210564fcce",
+  "id": "a81be202-e2ee-4117-8533-dd20783fad0d",
   "prevId": "00000000-0000-0000-0000-000000000000",
   "tables": {
     "activity_event_contact_group_pins": {
@@ -1524,6 +1524,13 @@
         "last_visited_channel_id": {
           "name": "last_visited_channel_id",
           "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "synced_at": {
+          "name": "synced_at",
+          "type": "integer",
           "primaryKey": false,
           "notNull": false,
           "autoincrement": false

--- a/packages/shared/src/db/migrations/meta/_journal.json
+++ b/packages/shared/src/db/migrations/meta/_journal.json
@@ -5,8 +5,8 @@
     {
       "idx": 0,
       "version": "6",
-      "when": 1737658544532,
-      "tag": "0000_unusual_christian_walker",
+      "when": 1738788275223,
+      "tag": "0000_fluffy_cardiac",
       "breakpoints": true
     }
   ]

--- a/packages/shared/src/db/migrations/migrations.js
+++ b/packages/shared/src/db/migrations/migrations.js
@@ -1,7 +1,7 @@
 // This file is required for Expo/React Native SQLite migrations - https://orm.drizzle.team/quick-sqlite/expo
 
 import journal from './meta/_journal.json';
-import m0000 from './0000_unusual_christian_walker.sql';
+import m0000 from './0000_fluffy_cardiac.sql';
 
   export default {
     journal,

--- a/packages/shared/src/db/schema.ts
+++ b/packages/shared/src/db/schema.ts
@@ -312,6 +312,7 @@ export const groups = sqliteTable('groups', {
   lastPostId: text('last_post_id'),
   lastPostAt: timestamp('last_post_at'),
   lastVisitedChannelId: text('last_visited_channel_id'),
+  syncedAt: timestamp('synced_at'),
 });
 
 export const groupsRelations = relations(groups, ({ one, many }) => ({

--- a/packages/shared/src/store/sync.ts
+++ b/packages/shared/src/store/sync.ts
@@ -16,7 +16,7 @@ import {
 import { addChannelToNavSection, moveChannel } from './groupActions';
 import { verifyUserInviteLink } from './inviteActions';
 import { useLureState } from './lure';
-import { updateSession } from './session';
+import { getSession, updateSession } from './session';
 import { SyncCtx, SyncPriority, syncQueue } from './syncQueue';
 import { addToChannelPosts, clearChannelPostsQueries } from './useChannelPosts';
 
@@ -353,11 +353,26 @@ export async function syncThreadPosts(
   });
 }
 
+const groupSyncsInProgress = new Set<string>();
+
 export async function syncGroup(id: string, ctx?: SyncCtx) {
+  if (groupSyncsInProgress.has(id)) {
+    return;
+  }
+  groupSyncsInProgress.add(id);
+  const group = await db.getGroup({ id });
+  const session = getSession();
+  if (group && session && (session.startTime ?? 0) < (group.syncedAt ?? 0)) {
+    return;
+  }
   const response = await syncQueue.add('syncGroup', ctx, () =>
     api.getGroup(id)
   );
-  await db.insertGroups({ groups: [response] });
+  await batchEffects('syncGroup', async (ctx) => {
+    await db.insertGroups({ groups: [response] }, ctx);
+    await db.updateGroup({ id, syncedAt: Date.now() }, ctx);
+  });
+  groupSyncsInProgress.delete(id);
 }
 
 export const syncStorageSettings = (ctx?: SyncCtx) => {


### PR DESCRIPTION
This PR ensures that we only perform a full group sync once per session -- if the session is intact, we should get all group updates through subscriptions.

Question: are there any changes that *don't* come through updates that we might miss?