### PR TITLE
initial sync tweaks

### DIFF
--- a/packages/shared/src/store/session.ts
+++ b/packages/shared/src/store/session.ts
@@ -39,31 +39,6 @@ export function useCurrentSession() {
   return useSyncExternalStore(subscribeToSession, getSession);
 }
 
-// Syncing — whether our initial fetching logic is currently running
-let isSyncing: boolean = false;
-type SyncListener = (syncing: boolean) => void;
-const syncListeners: SyncListener[] = [];
-
-export function getSyncing() {
-  return isSyncing;
-}
-
-export function updateIsSyncing(newValue: boolean) {
-  isSyncing = newValue;
-  syncListeners.forEach((listener) => listener(newValue));
-}
-
-function subscribeToIsSyncing(listener: SyncListener) {
-  syncListeners.push(listener);
-  return () => {
-    syncListeners.splice(syncListeners.indexOf(listener), 1);
-  };
-}
-
-export function useSyncing() {
-  return useSyncExternalStore(subscribeToIsSyncing, getSyncing);
-}
-
 // Initialized Client — whether the client has been initialized
 let initializedClient: boolean = false;
 type InitializedClientListener = (initialized: boolean) => void;
@@ -97,7 +72,6 @@ export function useInitializedClient() {
 
 export function useConnectionStatus() {
   const currentSession = useCurrentSession();
-  const syncing = useSyncing();
   const initializedClient = useInitializedClient();
 
   if (!initializedClient) {
@@ -110,10 +84,6 @@ export function useConnectionStatus() {
 
   if (currentSession.channelStatus === 'reconnecting') {
     return 'Reconnecting';
-  }
-
-  if (syncing) {
-    return 'Syncing';
   }
 
   if (['active', 'reconnected'].includes(currentSession.channelStatus ?? '')) {

--- a/packages/shared/src/store/sync.ts
+++ b/packages/shared/src/store/sync.ts
@@ -1120,7 +1120,7 @@ export const syncStart = async (alreadySubscribed?: boolean) => {
   updateIsSyncing(true);
   logger.crumb(`sync start running${alreadySubscribed ? ' (recovery)' : ''}`);
 
-  batchEffects('sync start (high)', async (ctx) => {
+  await batchEffects('sync start (high)', async (ctx) => {
     // this allows us to run the api calls first in parallel but handle
     // writing the data in a specific order
     const yieldWriter = true;
@@ -1178,6 +1178,8 @@ export const syncStart = async (alreadySubscribed?: boolean) => {
     updateSession({ startTime: Date.now() });
   });
 
+  updateIsSyncing(false);
+
   const lowPriorityPromises = [
     alreadySubscribed
       ? Promise.resolve()
@@ -1214,8 +1216,6 @@ export const syncStart = async (alreadySubscribed?: boolean) => {
     .catch((e) => {
       logger.trackError(e);
     });
-
-  updateIsSyncing(false);
 
   // post sync initialization work
   verifyUserInviteLink();

--- a/packages/shared/src/store/sync.ts
+++ b/packages/shared/src/store/sync.ts
@@ -16,7 +16,7 @@ import {
 import { addChannelToNavSection, moveChannel } from './groupActions';
 import { verifyUserInviteLink } from './inviteActions';
 import { useLureState } from './lure';
-import { getSyncing, updateIsSyncing, updateSession } from './session';
+import { updateSession } from './session';
 import { SyncCtx, SyncPriority, syncQueue } from './syncQueue';
 import { addToChannelPosts, clearChannelPostsQueries } from './useChannelPosts';
 
@@ -1090,7 +1090,7 @@ export const clearSyncQueue = () => {
 */
 export const handleDiscontinuity = async () => {
   logger.trackEvent(AnalyticsEvent.SyncDiscontinuity);
-  if (getSyncing()) {
+  if (isSyncing) {
     // we probably don't want to do this while we're already syncing
     return;
   }
@@ -1110,14 +1110,16 @@ export const handleChannelStatusChange = async (status: ChannelStatus) => {
   updateSession({ channelStatus: status });
 };
 
+let isSyncing = false;
+
 export const syncStart = async (alreadySubscribed?: boolean) => {
-  if (getSyncing()) {
+  if (isSyncing) {
     // we probably don't want multiple sync starts
     return;
   }
-  const startTime = Date.now();
+  isSyncing = true;
 
-  updateIsSyncing(true);
+  const startTime = Date.now();
   logger.crumb(`sync start running${alreadySubscribed ? ' (recovery)' : ''}`);
 
   await batchEffects('sync start (high)', async (ctx) => {
@@ -1178,8 +1180,6 @@ export const syncStart = async (alreadySubscribed?: boolean) => {
     updateSession({ startTime: Date.now() });
   });
 
-  updateIsSyncing(false);
-
   const lowPriorityPromises = [
     alreadySubscribed
       ? Promise.resolve()
@@ -1218,7 +1218,9 @@ export const syncStart = async (alreadySubscribed?: boolean) => {
     });
 
   // post sync initialization work
-  verifyUserInviteLink();
+  await verifyUserInviteLink();
+
+  isSyncing = false;
 };
 
 export const setupHighPrioritySubscriptions = async (ctx?: SyncCtx) => {


### PR DESCRIPTION
Tweaks to initial sync to improve apparent+actual performance:

- Ensure high priority tasks finish before kicking off lower priority
- Ignore syncing status when deciding what header message to show
- Simplify syncing tracking a bit