### PR TITLE
Signup: track debug events during invite acceptance loop

### DIFF
--- a/packages/app/hooks/useBootSequence.ts
+++ b/packages/app/hooks/useBootSequence.ts
@@ -150,8 +150,14 @@ export function useBootSequence() {
         store.addContact(lureMeta?.inviterUserId);
       }
 
-      const { invitedDm, invitedGroup } =
+      const { invitedDm, invitedGroup, tlonTeamDM } =
         await BootHelpers.getInvitedGroupAndDm(lureMeta);
+      logger.trackEvent(AnalyticsEvent.InviteDebug, {
+        context: 'invites to look for',
+        invitedDm,
+        invitedGroup,
+        tlonTeamDM,
+      });
 
       const requiredInvites =
         lureMeta?.inviteType === 'user' ? invitedDm : invitedGroup && invitedDm;

--- a/packages/app/hooks/useBootSequence.ts
+++ b/packages/app/hooks/useBootSequence.ts
@@ -1,4 +1,4 @@
-import { createDevLogger } from '@tloncorp/shared';
+import { AnalyticsEvent, createDevLogger } from '@tloncorp/shared';
 import * as db from '@tloncorp/shared/db';
 import * as store from '@tloncorp/shared/store';
 import { preSig } from '@tloncorp/shared/urbit';
@@ -157,11 +157,15 @@ export function useBootSequence() {
         lureMeta?.inviteType === 'user' ? invitedDm : invitedGroup && invitedDm;
 
       if (requiredInvites) {
-        logger.crumb('confirmed node has the invites');
+        logger.trackEvent(AnalyticsEvent.InviteDebug, {
+          context: 'confirmed node has the invites',
+        });
         return NodeBootPhase.ACCEPTING_INVITES;
       }
 
-      logger.crumb('checked node for invites, not yet found');
+      logger.trackEvent(AnalyticsEvent.InviteDebug, {
+        context: 'checked node for invites, not yet found',
+      });
       return NodeBootPhase.CHECKING_FOR_INVITE;
     }
 
@@ -174,12 +178,16 @@ export function useBootSequence() {
 
       // if we have invites, accept them
       if (tlonTeamDM && tlonTeamDM.isDmInvite) {
-        logger.crumb(`accepting dm invitation`);
+        logger.trackEvent(AnalyticsEvent.InviteDebug, {
+          context: `have tlon team dm invite, accepting`,
+        });
         await store.respondToDMInvite({ channel: tlonTeamDM, accept: true });
       }
 
       if (invitedDm && invitedDm.isDmInvite) {
-        logger.crumb(`accepting dm invitation`);
+        logger.trackEvent(AnalyticsEvent.InviteDebug, {
+          context: `have dm invite from inviter, accepting`,
+        });
         await store.respondToDMInvite({ channel: invitedDm, accept: true });
       }
 
@@ -188,7 +196,9 @@ export function useBootSequence() {
         !invitedGroup.currentUserIsMember &&
         invitedGroup.haveInvite
       ) {
-        logger.crumb('accepting group invitation');
+        logger.trackEvent(AnalyticsEvent.InviteDebug, {
+          context: `have group invite, joining`,
+        });
         await store.joinGroup(invitedGroup);
       }
 
@@ -235,12 +245,12 @@ export function useBootSequence() {
         return NodeBootPhase.READY;
       }
 
-      logger.crumb(
-        'still waiting on invites to be accepted',
-        `dm is ready: ${dmIsGood}`,
-        `group is ready: ${groupIsGood}`,
-        `tlonTeam is ready: ${tlonTeamIsGood}`
-      );
+      logger.trackEvent(AnalyticsEvent.InviteDebug, {
+        context: `not all invites are confirmed accepted`,
+        dmReady: dmIsGood,
+        groupReady: groupIsGood,
+        tlonTeamReady: tlonTeamIsGood,
+      });
       return NodeBootPhase.ACCEPTING_INVITES;
     }
 


### PR DESCRIPTION
We've seen a few accept invite aborts where the backend logs indicate the invites were in fact sent.

This just adds some debug logging for PostHog to help us understand the invite state for cases where we should be able to join, but didn't.