### PR TITLE
android: post / dm handoff from push

### DIFF
--- a/apps/tlon-mobile/android/app/src/main/java/io/tlon/landscape/api/TalkApi.java
+++ b/apps/tlon-mobile/android/app/src/main/java/io/tlon/landscape/api/TalkApi.java
@@ -173,6 +173,10 @@ public class TalkApi {
         fetchObject("/~/scry/contacts/all", callback);
     }
 
+    public void fetchActivityEvent(String uid, TalkObjectCallback callback) {
+        fetchObject("/apps/groups/~/notify/note/" + uid + "/activity-event", callback);
+    }
+
     public void fetchContact(String id, TalkObjectCallback callback) {
         fetchContacts(new TalkObjectCallback() {
             @Override

--- a/apps/tlon-mobile/android/app/src/main/java/io/tlon/landscape/notifications/TalkNotificationManager.java
+++ b/apps/tlon-mobile/android/app/src/main/java/io/tlon/landscape/notifications/TalkNotificationManager.java
@@ -19,10 +19,8 @@ import org.json.JSONException;
 import org.json.JSONObject;
 
 import java.util.Date;
-import java.util.Iterator;
 
 import io.invertase.firebase.crashlytics.ReactNativeFirebaseCrashlyticsNativeHelper;
-import io.tlon.landscape.AppLifecycleManager;
 import io.tlon.landscape.MainActivity;
 import io.tlon.landscape.R;
 import io.tlon.landscape.api.TalkApi;
@@ -83,7 +81,7 @@ public class TalkNotificationManager {
                 }
 
                 Log.d("TalkNotificationManager", "fetching contact: " + yarn.senderId);
-                TalkObjectCallback fetchContactCallback = createFetchContactCallback(context, id, yarn);
+                TalkObjectCallback fetchContactCallback = createFetchContactCallback(context, id, yarn, uid);
                 api.fetchContact(yarn.senderId, fetchContactCallback);
             }
 
@@ -99,7 +97,7 @@ public class TalkNotificationManager {
         api.fetchYarn(uid, fetchYarnCallback);
     }
 
-    private static TalkObjectCallback createFetchContactCallback(Context context, int id, Yarn yarn) {
+    private static TalkObjectCallback createFetchContactCallback(Context context, int id, Yarn yarn, String uid) {
         final TalkApi api = new TalkApi(context);
 
         return new TalkObjectCallback() {
@@ -109,24 +107,84 @@ public class TalkNotificationManager {
                 final String channelId = yarn.channelId.orElse("");
                 Log.d("TalkNotificationManager", "handleNotification, contact: " + contact.toString());
                 createNotificationTitle(api, yarn, contact, title -> {
-                    Bundle data = new Bundle();
-                    data.putString("wer", yarn.wer);
-                    data.putString("channelId", channelId);
-                    data.putInt("notificationId", id);
-                    sendNotification(
+                    api.fetchActivityEvent(uid, createFetchActivityEventCallback(
                             context,
-                            id,
-                            contact.person,
                             title,
-                            yarn.contentText,
-                            yarn.isGroup || yarn.isClub,
-                            data);
+                            id,
+                            yarn,
+                            contact
+                    ));
                 });
             }
 
             @Override
             public void onError(VolleyError error) {
                 ReactNativeFirebaseCrashlyticsNativeHelper.recordNativeException(new Exception("notifications_fetch_contacts", error));
+            }
+        };
+    }
+
+    private static TalkObjectCallback createFetchActivityEventCallback(
+            Context context,
+            String notificationTitle,
+            int id,
+            Yarn yarn,
+            Contact sender
+    ) {
+        return new TalkObjectCallback() {
+            @Override
+            public void onComplete(JSONObject response) {
+                Log.d("TalkNotificationManager", "activity event recv" + response.toString());
+
+                Bundle data = new Bundle();
+                data.putString("wer", yarn.wer);
+                final String channelId = yarn.channelId.orElse("");
+                data.putString("channelId", channelId);
+                data.putInt("notificationId", id);
+
+                JSONObject jsonEvent = response.optJSONObject("event");
+                if (jsonEvent != null) {
+                    JSONObject jsonPost = jsonEvent.optJSONObject("post");
+                    if (jsonPost != null) {
+                        // Why use a JSON string instead of putting the JSON object into the
+                        // notification data?
+                        // - We need to access this notification data in JS via expo-notifications,
+                        //   which doesn't expect us to manipulate notifications in this way.
+                        // - expo-notifications uses this code to convert the `extras` `Bundle` into a JS-compatible payload:
+                        //   https://github.com/expo/expo/blob/24be063c1d4a091a7ef081e282ff788b2c94e674/packages/expo-notifications/android/src/main/java/expo/modules/notifications/service/delegates/ExpoPresentationDelegate.kt#L207
+                        //   which relies on `JSONObject.wrap()` to convert the `Bundle` entry into
+                        //   a JSON-compatible value; if that returns null (i.e. fails),
+                        //   expo-notifications omits the value from the payload.
+                        // - We are limited in how we can represent a JSON object in a `Bundle` and
+                        //   decode that object correctly through the expo-notifications code
+                        // - I don't think `Bundle` can hold a `JSONObject` as a value
+                        // - `Bundle` can hold a `Serializable` `Map`, which is handled well by
+                        //   `JSONObject.wrap()` - but somewhere in deeper expo-notifications JS
+                        //   conversion, a null value inside a `Map` causes a crash; and we have
+                        //   nulls in our post content schema.
+                        data.putString("postJsonString", jsonPost.toString());
+                    }
+                    JSONObject jsonDm = jsonEvent.optJSONObject("dm-post");
+                    if (jsonDm != null) {
+                        data.putString("dmPostJsonString", jsonDm.toString());
+                    }
+                }
+
+                sendNotification(
+                        context,
+                        id,
+                        sender.person,
+                        notificationTitle,
+                        yarn.contentText,
+                        yarn.isGroup || yarn.isClub,
+                        data);
+            }
+
+            @Override
+            public void onError(VolleyError error) {
+                ReactNativeFirebaseCrashlyticsNativeHelper.recordNativeException(
+                        new Exception("notifications_fetch_activity_event", error)
+                );
             }
         };
     }
@@ -224,6 +282,7 @@ public class TalkNotificationManager {
                 .setSmallIcon(R.drawable.notification_icon)
                 .setContentTitle(title)
                 .setContentText(text)
+                .addExtras(data)
                 .setStyle(new NotificationCompat.MessagingStyle(user)
                         .setGroupConversation(isGroupConversation)
                         .setConversationTitle(isGroupConversation ? title : null)

--- a/apps/tlon-mobile/src/hooks/useNotificationListener.ts
+++ b/apps/tlon-mobile/src/hooks/useNotificationListener.ts
@@ -57,7 +57,9 @@ function payloadFromNotification(
   // `trigger`.
   // Detect and use whatever payload is available.
   const payload =
-    notification.request.trigger.type === 'push'
+    // `NotificationRequest.trigger` is marked as non-null in
+    // expo-notifications' types, but is null on Android - so we need the `?`
+    notification.request.trigger?.type === 'push'
       ? notification.request.trigger.payload
       : notification.request.content.data;
 

--- a/apps/tlon-mobile/src/hooks/useNotificationListener.ts
+++ b/apps/tlon-mobile/src/hooks/useNotificationListener.ts
@@ -81,6 +81,17 @@ function payloadFromNotification(
       if (post != null) {
         return db.postFromPostActivityEvent(post);
       }
+
+      // Android can't seem to send a dictionary in notification data, so we send a string.
+      const dmPostJson = payload.dmPostJsonString as string | undefined;
+      if (dmPostJson != null) {
+        return db.postFromDmPostActivityEvent(JSON.parse(dmPostJson));
+      }
+      const postJson = payload.postJsonString as string | undefined;
+      if (postJson != null) {
+        return db.postFromDmPostActivityEvent(JSON.parse(postJson));
+      }
+
       return undefined;
     })();
     return {

--- a/packages/app/lib/notifications.ts
+++ b/packages/app/lib/notifications.ts
@@ -76,12 +76,18 @@ export const connectNotifications = async () => {
 };
 
 const channelIdFromNotification = (notif: Notifications.Notification) => {
-  if (notif.request.trigger.type !== 'push') {
-    return null;
+  let out: string | null = null;
+  if (
+    notif.request.trigger?.type === 'push' &&
+    typeof notif.request.trigger.payload?.channelId === 'string'
+  ) {
+    out = notif.request.trigger.payload.channelId;
   }
-  const out = notif.request.trigger.payload?.channelId;
-  if (typeof out !== 'string') {
-    return null;
+  if (
+    out == null &&
+    typeof notif.request.content.data?.channelId === 'string'
+  ) {
+    out = notif.request.content.data.channelId;
   }
   return out;
 };


### PR DESCRIPTION
extends #4280 to Android

This work was complicated by our custom Android notification handling code. Notably, we are intercepting notifications before expo-notifications has a chance to handle them, which I think means that we can't rely on expo-notifications' guarantees when receiving events or accessing notifications via JS (this is backed up by missing fields in the expo-notifications JS payloads, as if expo-notifications didn't have a chance to add the expected `trigger` data before JS could consume it).

<details>

<summary>more details about how we're breaking expo-notification's guarantees</summary>

I'm new to Android notifications, but here's my understanding:
- We set up a service that responds to FCM events https://github.com/tloncorp/tlon-apps/blob/686ba3a98abf9008754c23ce350e7df168f7aa30/apps/tlon-mobile/android/app/src/main/AndroidManifest.xml#L23-L27 which subclasses `FirebaseMessagingService` https://github.com/tloncorp/tlon-apps/blob/686ba3a98abf9008754c23ce350e7df168f7aa30/apps/tlon-mobile/android/app/src/main/java/io/tlon/landscape/TalkMessagingService.java#L14
- expo-notifications expects to be the ingestion point for notifications – i.e. we'd subclass their `FirebaseMessagingService` class and call `super` on each event, then append our behavior after they did their work
- not that easy – expo-notifications moved away from `FirebaseMessagingService` a couple of years ago https://github.com/expo/expo/pull/10558 so we'd need to change to use this kind of service (?) to ingest notifications. I gave this a shot, but I had trouble moving our Android code to this kind of service. I think it'd still be possible and what we should do.

</details>

### Summary
- [Unroll async pyramid](https://github.com/tloncorp/tlon-apps/pull/4395/commits/d7ab84f4a0887ed60c92b415d3f7ced37b267015) is simple code movement – excluding it from the diff might make review easier.
- I could not figure out how to match the `post`/`dmPost` notification payloads that iOS adds (added inline comments about complications), so I put this data as JSON strings in the notification payload on Android
- I found that the app was hitting hard errors when indexing into `NotificationRequest.trigger` on Android – expo-notifications' types says this `trigger` should never be null, but it is null on Android. This could either be an issue within expo-notifications (I didn't find anything in their issues in a quick search), or it could be due to how we manipulate notifications, which goes against expo-notifications' recommendation. To quickfix, I added cases to handle a null `trigger` to avoid crash.
- [Only clear channel notifications when have an active session](https://github.com/tloncorp/tlon-apps/commit/686ba3a98abf9008754c23ce350e7df168f7aa30) – this felt like a necessary fix, as message notifications were being cleared before the user was able to read them in-app:
  1. User gets some notifications for new messages
  2. User opens app
  3. Code removes notifications for any channel which has an unread count of 0: if the channel with the new messages previously had no unreads, the code would immediately clear the notifications for the new messages before we had a chance to receive the message over sync
  To fix, hold off on clearing notifications unless we have an active session.

### How did I test?
1. Sent 2 messages to a user on an Android client while Android app was backgrounded
2. Checked that Android client received pushes
3. Opened Android client, navigated to channel with new messages
4. Saw the 2 new messages load instantly, and the rest of the channel loaded subsequently
5. Sent some more messages in this channel while app was open – new messages acted as expected