### PR TITLE
groups: fix broken private group initiated invite flow

### DIFF
--- a/desk/app/groups.hoon
+++ b/desk/app/groups.hoon
@@ -2062,7 +2062,9 @@
     ::  already in the group
     ?:  (~(has by groups) flag)  ga-core
     ::  already valid join in progress
-    ?:  &(?=(^ cam.gang) !=(%error progress.u.cam.gang))
+    ?:  ?&  ?=(^ cam.gang)
+            !?=(?(%knocking %error) progress.u.cam.gang)
+        ==
       ga-core
     =.  cam.gang  `[join-all %adding]
     =.  cor  (emit add-self:ga-pass)


### PR DESCRIPTION
A condition added in https://github.com/tloncorp/tlon-apps/commit/6a172f0eb464123c92bbb18a0df80b58d556d572 to prevent double group joins had broken the private group invite flow. 

The following scenario would result in a group invite being permanently stuck
1.  Alice hosts a private group
2. Bob initiates a join request to the group, creating an entry in gangs that is at `%knocking` progress.
3. A group invite send by Alice would now be mistakenly dropped by Bob.