### PR TITLE
e2e: settings menu, profile editor

### DIFF
--- a/.maestro/00-start.yaml
+++ b/.maestro/00-start.yaml
@@ -6,3 +6,5 @@ appId: io.tlon.groups
     appId: io.tlon.groups
 - runFlow: 01-self-hosted-login.yaml
 - runFlow: 02-tlon-login.yaml
+- runFlow: 10-settings.yaml
+- runFlow: 20-profile.yaml

--- a/.maestro/10-settings.yaml
+++ b/.maestro/10-settings.yaml
@@ -1,0 +1,48 @@
+appId: io.tlon.groups
+---
+- clearState:
+    appId: io.tlon.groups
+- launchApp:
+    appId: io.tlon.groups
+- runFlow: subflows/tlon-login.yaml
+- assertVisible: 'Home'
+- tapOn:
+    id: "AvatarNavIcon"
+- assertVisible: "Contacts"
+- tapOn:
+    id: "ContactsSettingsButton"
+- assertVisible: "Settings"
+- tapOn: "Notification settings"
+- assertVisible: "Push Notifications"
+- tapOn: "All group activity"
+- tapOn:
+    id: "HeaderBackButton"
+- tapOn: "Blocked users"
+- assertVisible: "Blocked users"
+- tapOn:
+    id: "HeaderBackButton"
+- tapOn: "Theme"
+- assertVisible: "Theme"
+- tapOn:
+    id: "HeaderBackButton"
+- tapOn: "App info"
+- assertVisible: "App info"
+- tapOn:
+    id: "HeaderBackButton"
+- tapOn: "Report a bug"
+- assertVisible: "Report a bug"
+- tapOn: "What went wrong?"
+- "inputRandomText"
+- "hideKeyboard"
+- tapOn: "Send Report"
+- assertVisible: "Bug report sent"
+- tapOn: "OK"
+- assertVisible: "Settings"
+- tapOn: "Experimental features"
+- assertVisible: "Feature Previews"
+- tapOn:
+    id: "HeaderBackButton"  
+- tapOn: "Log out"
+- assertVisible: "Are you sure you want to log out?"
+- tapOn: "Log out now"
+- assertVisible: "Have an account? Log in"

--- a/.maestro/10-settings.yaml
+++ b/.maestro/10-settings.yaml
@@ -27,6 +27,8 @@ appId: io.tlon.groups
     id: "HeaderBackButton"
 - tapOn: "App info"
 - assertVisible: "App info"
+- tapOn: "OTA Update"
+- assertTrue: ${maestro.copiedText = "embedded"}
 - tapOn:
     id: "HeaderBackButton"
 - tapOn: "Report a bug"

--- a/.maestro/20-profile.yaml
+++ b/.maestro/20-profile.yaml
@@ -1,0 +1,74 @@
+appId: io.tlon.groups
+---
+- clearState:
+    appId: io.tlon.groups
+- launchApp:
+    appId: io.tlon.groups
+- runFlow: subflows/tlon-login.yaml
+- assertVisible: 'Home'
+# Set basic profile details
+- tapOn:
+    id: "AvatarNavIcon"
+- assertVisible: "Contacts"
+- tapOn: "You"
+- assertVisible: "Profile"
+- tapOn: "Edit"
+- assertVisible: "Edit Profile"
+- tapOn:
+    id: "ProfileNicknameInput"
+- "eraseText"
+- inputText: "Testing nickname"
+- "hideKeyboard"
+- runFlow:
+    when:
+      platform: ios
+    commands:
+      - tapOn: "Change avatar image"
+      - tapOn: "Photo Library"
+      - tapOn:
+          id: "PXGGridLayout-Info"
+          index: 0
+- tapOn: "Hanging out..."
+- "eraseText"
+- inputText: "Testing status"
+- "hideKeyboard"
+- tapOn: "About yourself"
+- "eraseText"
+- inputText: "Testing bio"
+- "hideKeyboard"
+- tapOn: "Done"
+# Assert profile details are visible on self-view
+- assertVisible: "Profile"
+- assertVisible: "Testing nickname"
+- assertVisible: "Testing status"
+- assertVisible: "Testing bio"
+- tapOn:
+    id: "HeaderBackButton"
+# Assert profile details are visible on Contacts list
+- assertVisible: "Testing nickname"
+- assertVisible: "Testing status"
+# Clear out profile details
+- tapOn: "You"
+- assertVisible: "Profile"
+- tapOn: "Edit"
+- assertVisible: "Edit Profile"
+- tapOn: "Testing nickname"
+- "eraseText"
+- "hideKeyboard"
+- tapOn: "Testing status"
+- "eraseText"
+- "hideKeyboard"
+- tapOn: "Testing bio"
+- "eraseText"
+- "hideKeyboard"
+- runFlow:
+    when:
+      platform: ios
+    commands:
+      - tapOn: "Change avatar image"
+      - tapOn: "Clear"
+      - swipe:
+          direction: 'DOWN'
+      - waitForAnimationToEnd:
+          timeout: 5000
+- tapOn: "Done"

--- a/.maestro/20-profile.yaml
+++ b/.maestro/20-profile.yaml
@@ -36,12 +36,22 @@ appId: io.tlon.groups
 - "eraseText"
 - inputText: "Testing bio"
 - "hideKeyboard"
+# Set favorite group
+- tapOn: "Add a group"
+- scrollUntilVisible:
+    element: "Tlon Studio"
+- tapOn: "Tlon Studio"
+- swipe:
+    direction: 'DOWN'
+- waitForAnimationToEnd:
+    timeout: 5000
 - tapOn: "Done"
 # Assert profile details are visible on self-view
 - assertVisible: "Profile"
 - assertVisible: "Testing nickname"
 - assertVisible: "Testing status"
 - assertVisible: "Testing bio"
+- assertVisible: "Tlon Studio"
 - tapOn:
     id: "HeaderBackButton"
 # Assert profile details are visible on Contacts list
@@ -71,4 +81,6 @@ appId: io.tlon.groups
           direction: 'DOWN'
       - waitForAnimationToEnd:
           timeout: 5000
+- tapOn:
+    id: "ProfilePinnedGroupRemove"
 - tapOn: "Done"

--- a/packages/app/features/top/ContactsScreen.tsx
+++ b/packages/app/features/top/ContactsScreen.tsx
@@ -78,6 +78,7 @@ export default function ContactsScreen(props: Props) {
             rightControls={
               <ScreenHeader.IconButton
                 type="Settings"
+                testID="ContactsSettingsButton"
                 onPress={() => {
                   navigate('Profile');
                 }}

--- a/packages/ui/src/components/EditProfileScreenView.tsx
+++ b/packages/ui/src/components/EditProfileScreenView.tsx
@@ -196,7 +196,7 @@ export function EditProfileScreenView(props: Props) {
                         }
                       : undefined
                   }
-                  inputProps={{ placeholder: nicknamePlaceholder }}
+                  inputProps={{ placeholder: nicknamePlaceholder, testID: 'ProfileNicknameInput' }}
                   rules={{
                     maxLength: {
                       value: 30,

--- a/packages/ui/src/components/FavoriteGroupsDisplay.tsx
+++ b/packages/ui/src/components/FavoriteGroupsDisplay.tsx
@@ -74,6 +74,7 @@ export function FavoriteGroupsDisplay(props: {
               <Pressable onPress={() => handleFavoriteGroupsChange(group)}>
                 <ListItem.SystemIcon
                   icon="Close"
+                  testID='ProfilePinnedGroupRemove'
                   onPress={() => handleFavoriteGroupsChange(group)}
                   backgroundColor={'transparent'}
                   color={'$tertiaryText'}

--- a/packages/ui/src/components/NavBar/NavIcon.tsx
+++ b/packages/ui/src/components/NavBar/NavIcon.tsx
@@ -19,6 +19,7 @@ export function AvatarNavIcon({
 }) {
   return (
     <Pressable
+      testID="AvatarNavIcon"
       flex={1}
       onPress={onPress}
       onLongPress={onLongPress}

--- a/packages/ui/src/components/ProfileScreenView.tsx
+++ b/packages/ui/src/components/ProfileScreenView.tsx
@@ -27,13 +27,13 @@ interface Props {
 export function ProfileScreenView(props: Props) {
   // TODO: Add logout back in when we figure out TLON-2098.
   const handleLogoutPressed = () => {
-    Alert.alert('Log out', 'Are you sure you want to log out?', [
+    Alert.alert('Log out from Tlon', 'Are you sure you want to log out?', [
       {
         text: 'Cancel',
         style: 'cancel',
       },
       {
-        text: 'Log out',
+        text: 'Log out now',
         style: 'destructive',
         onPress: props.onLogoutPressed,
       },

--- a/packages/ui/src/components/ScreenHeader.tsx
+++ b/packages/ui/src/components/ScreenHeader.tsx
@@ -99,7 +99,7 @@ const HeaderTextButton = styled(Text, {
 const HeaderBackButton = ({ onPress }: { onPress?: () => void }) => {
   return (
     <HeaderIconButton
-      testID="Top Back Button"
+      testID="HeaderBackButton"
       type="ChevronLeft"
       onPress={onPress}
     />


### PR DESCRIPTION
Introduces end-to-end tests for basic profile updates and settings menu navigation.

- Uses the hosted Tlon login sub-flow
- Taps on the lower-right sigil menu
- Taps on the gear icon
- Navigates through all Settings menus and verifies that navigation works
- Edits the profile with a test nickname, status, bio, and avatar (avatar is only on iOS; I'm not sure how the camera roll interaction works on Android and if they share identifiers for Maestro's purposes)
- Sets Tlon Local as a pinned group
- Verifies that the changed profile details display both on the self-view and the top of the Contacts list
- Resets the profile

Makes a few changes to verbiage in system dialogs to avoid two elements with the same text on the screen in cases where we can't use an ID. Also adds a few test ID hooks where string-matching wouldn't work (icon buttons, mostly).

Fixes TLON-3655