### PR TITLE
group-options: don't close sheet on sort click

### DIFF
--- a/packages/ui/src/components/ChatOptionsSheet.tsx
+++ b/packages/ui/src/components/ChatOptionsSheet.tsx
@@ -138,7 +138,6 @@ export function GroupOptionsSheetLoader({
     setPane('initial');
   }, [setPane]);
 
-  console.log('current pane', pane);
   const title = utils.useGroupTitle(group) ?? 'Loading...';
   const currentUserId = useCurrentUserId();
   const currentUserIsAdmin = utils.useIsAdmin(groupId, currentUserId);

--- a/packages/ui/src/components/ChatOptionsSheet.tsx
+++ b/packages/ui/src/components/ChatOptionsSheet.tsx
@@ -131,7 +131,6 @@ export function GroupOptionsSheetLoader({
   }, [setPane]);
 
   const handlePressSort = useCallback(() => {
-    console.log('setting pane to sort');
     setPane('sort');
   }, [setPane]);
 

--- a/packages/ui/src/components/ChatOptionsSheet.tsx
+++ b/packages/ui/src/components/ChatOptionsSheet.tsx
@@ -131,6 +131,7 @@ export function GroupOptionsSheetLoader({
   }, [setPane]);
 
   const handlePressSort = useCallback(() => {
+    console.log('setting pane to sort');
     setPane('sort');
   }, [setPane]);
 
@@ -138,6 +139,7 @@ export function GroupOptionsSheetLoader({
     setPane('initial');
   }, [setPane]);
 
+  console.log('current pane', pane);
   const title = utils.useGroupTitle(group) ?? 'Loading...';
   const currentUserId = useCurrentUserId();
   const currentUserIsAdmin = utils.useIsAdmin(groupId, currentUserId);
@@ -286,7 +288,7 @@ function GroupOptionsSheetContent({
           canSortChannels && {
             title: 'Sort channels',
             endIcon: 'ChevronRight',
-            action: wrappedAction.bind(null, onPressSort),
+            action: onPressSort,
           },
         ],
         [


### PR DESCRIPTION
Fixes TLON-3657, recent changes accidentally included the sort channels function wrapped with the sheet close when it needs to stay open to advance to the next pane.