### PR TITLE
Noun enabled client and initial verifier integration

### DIFF
--- a/apps/tlon-mobile/package.json
+++ b/apps/tlon-mobile/package.json
@@ -66,6 +66,7 @@
     "@tloncorp/ui": "workspace:*",
     "@urbit/aura": "^1.0.0",
     "@urbit/http-api": "3.2.0-dev",
+    "@urbit/nockjs": "^1.4.0",
     "classnames": "^2.3.2",
     "dotenv-expand": "^11.0.6",
     "expo": "~50.0.20",

--- a/packages/app/features/top/ChatListScreen.tsx
+++ b/packages/app/features/top/ChatListScreen.tsx
@@ -5,6 +5,7 @@ import {
 } from '@react-navigation/native';
 import type { NativeStackScreenProps } from '@react-navigation/native-stack';
 import { AnalyticsEvent, createDevLogger } from '@tloncorp/shared';
+import * as api from '@tloncorp/shared/api';
 import * as db from '@tloncorp/shared/db';
 import * as store from '@tloncorp/shared/store';
 import {

--- a/packages/app/hooks/useConfigureUrbitClient.ts
+++ b/packages/app/hooks/useConfigureUrbitClient.ts
@@ -30,14 +30,14 @@ const apiFetch: typeof fetch = (input, { ...init } = {}) => {
     };
   }
 
-  const headers = new Headers(init.headers);
+  const headers: any = { ...init.headers };
   // The urbit client is inconsistent about sending cookies, sometimes causing
   // the server to send back a new, anonymous, cookie, which is sent on all
   // subsequent requests and screws everything up. This ensures that explicit
   // cookie headers are never set, delegating all cookie handling to the
   // native http client.
-  headers.delete('Cookie');
-  headers.delete('cookie');
+  delete headers['Cookie'];
+  delete headers['cookie'];
   const newInit: RequestInit = {
     ...init,
     headers,
@@ -45,7 +45,10 @@ const apiFetch: typeof fetch = (input, { ...init } = {}) => {
     credentials: undefined,
     signal: abortController.signal,
   };
-  return platformFetch(input, newInit);
+  const containsEventStream = headers['accept'] === 'text/event-stream';
+  return containsEventStream
+    ? platformFetch(input, newInit)
+    : fetch(input, newInit);
 };
 
 export function useConfigureUrbitClient() {

--- a/packages/app/navigation/types.ts
+++ b/packages/app/navigation/types.ts
@@ -5,6 +5,7 @@ import type {
 } from '@react-navigation/native';
 
 export type RootStackParamList = {
+  VerifierStub: undefined;
   Contacts: undefined;
   Empty: undefined;
   ChatList: { previewGroupId: string } | undefined;

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -50,7 +50,8 @@
   },
   "dependencies": {
     "@react-native-async-storage/async-storage": "1.21.0",
-    "@urbit/aura": "^1.0.0",
+    "@urbit/aura": "^2.0.1",
+    "@urbit/nockjs": "^1.4.0",
     "any-ascii": "^0.3.1",
     "big-integer": "^1.6.52",
     "browser-or-node": "^3.0.0",

--- a/packages/shared/src/api/channelsApi.ts
+++ b/packages/shared/src/api/channelsApi.ts
@@ -372,7 +372,7 @@ export const searchChannel = async (params: {
     response = await scry<ub.ChannelScam>({
       app: 'channels',
       path: `/${params.channelId}/search/bounded/text/${
-        params.cursor ? formatUd(bigInt(params.cursor ?? 0)) : ''
+        params.cursor ? formatUd(BigInt(params.cursor ?? 0)) : ''
       }/${SINGLE_PAGE_SEARCH_DEPTH}/${encodedQuery}`,
     });
   } else {
@@ -381,7 +381,7 @@ export const searchChannel = async (params: {
     response = await scry<ub.ChatScam>({
       app: 'chat',
       path: `/${type}/${params.channelId}/search/bounded/text/${
-        params.cursor ? formatUd(bigInt(params.cursor ?? 0)) : ''
+        params.cursor ? formatUd(BigInt(params.cursor ?? 0)) : ''
       }/${SINGLE_PAGE_SEARCH_DEPTH}/${encodedQuery}`,
     });
   }

--- a/packages/shared/src/api/contactsApi.test.ts
+++ b/packages/shared/src/api/contactsApi.test.ts
@@ -17,6 +17,9 @@ const inputContact: [string, any] = [
       '~nibset-napwyn/tlon',
       '~ravmel-ropdyl/crate',
     ],
+    verifiedPhoneAt: null,
+    verifiedPhoneSignature: null,
+    hasVerifiedPhone: false,
   },
 ];
 
@@ -36,6 +39,9 @@ const outputContact = {
   ],
   isContact: false,
   isContactSuggestion: undefined,
+  verifiedPhoneAt: null,
+  verifiedPhoneSignature: null,
+  hasVerifiedPhone: false,
 };
 
 test('converts a contact from server to client format', () => {

--- a/packages/shared/src/api/index.ts
+++ b/packages/shared/src/api/index.ts
@@ -17,6 +17,7 @@ export * from './activityApi';
 export * from './harkApi';
 export * from './storageApi';
 export * from './vitalsApi';
+export * from './lanyardApi';
 export * from './inviteApi';
 export * from './hostingApi';
 export * from './apiUtils';

--- a/packages/shared/src/api/lanyardApi.ts
+++ b/packages/shared/src/api/lanyardApi.ts
@@ -1,0 +1,73 @@
+import { Cell, Noun, dwim, enjs } from '@urbit/nockjs';
+
+import * as db from '../db';
+import { getFrondValue, getPatp } from '../logic';
+import { pokeNoun, scryNoun } from './urbit';
+
+function getRecords(noun: Noun): db.Verification[] {
+  return enjs.tree((n: Noun) => {
+    if (!(n instanceof Cell)) {
+      throw new Error('malformed map');
+    }
+
+    if (!(n.head instanceof Cell)) {
+      throw new Error('malformed record key');
+    }
+
+    const provider = getPatp(n.head.head) as string;
+
+    if (!(n.head.tail instanceof Cell)) {
+      throw new Error('malformed record key identifier');
+    }
+
+    const type = enjs.cord(n.head.tail.head);
+    const value = getFrondValue([
+      { tag: 'dummy', get: enjs.cord },
+      { tag: 'phone', get: enjs.cord },
+      { tag: 'urbit', get: getPatp },
+    ])(n.head.tail) as string;
+
+    if (!(n.tail instanceof Cell)) {
+      throw new Error('malformed record value');
+    }
+
+    const config = enjs.cord(n.tail.head) as db.VerificationVisibility;
+    const status = getFrondValue([
+      { tag: 'want', get: () => 'pending' },
+      { tag: 'wait', get: () => 'waiting' },
+      { tag: 'done', get: () => 'verified' },
+    ])(n.tail.tail) as db.VerificationStatus;
+
+    return {
+      provider,
+      type,
+      value,
+      initiatedAt: null,
+      visibility: config,
+      status,
+    };
+  })(noun) as unknown as db.Verification[];
+}
+
+export async function fetchVerifications(): Promise<db.Verification[]> {
+  const result = await scryNoun({
+    app: 'lanyard',
+    path: '/records',
+  });
+  console.log(`bl: scry result`, result);
+  const records = getRecords(result);
+  console.log(`bl: records`, records);
+
+  return records;
+}
+
+export async function initiatePhoneVerify(phoneNumber: string) {
+  const payload = [null, ['start', ['phone', phoneNumber]]];
+  const noun = dwim(payload);
+  await pokeNoun({ app: 'lanyard', mark: 'lanyard-command', noun });
+  return;
+}
+
+export function confirmPhoneVerify(phoneNumber: string, otp: string) {
+  // TODO
+}

--- a/packages/shared/src/api/urbit.ts
+++ b/packages/shared/src/api/urbit.ts
@@ -1,12 +1,19 @@
+import { Noun } from '@urbit/nockjs';
 import _ from 'lodash';
 
 import { createDevLogger, escapeLog, runIfDev } from '../debug';
 import { AnalyticsEvent } from '../domain';
-import { AuthError, ChannelStatus, PokeInterface, Urbit } from '../http-api';
-import { preSig } from '../urbit';
+import {
+  AuthError,
+  ChannelStatus,
+  NounPokeInterface,
+  PokeInterface,
+  Urbit,
+} from '../http-api';
+import { desig, preSig } from '../urbit';
 import { getLandscapeAuthCookie } from './landscapeApi';
 
-const logger = createDevLogger('urbit', false);
+const logger = createDevLogger('urbit', true);
 
 interface Config
   extends Pick<
@@ -32,6 +39,12 @@ export type PokeParams = {
   app: string;
   mark: string;
   json: any;
+};
+
+export type NounPokeParams = {
+  app: string;
+  mark: string;
+  noun: Noun;
 };
 
 export class BadResponseError extends Error {
@@ -304,6 +317,48 @@ export async function unsubscribe(id: number) {
   }
 }
 
+export async function pokeNoun<T>({ app, mark, noun }: NounPokeParams) {
+  const doPoke = async (params?: Partial<NounPokeInterface>) => {
+    if (!config.client) {
+      throw new Error('Client not initialized');
+    }
+    if (config.pendingAuth) {
+      await config.pendingAuth;
+    }
+    logger.log('noun poke', { app, mark });
+    return config.client.pokeNoun({
+      ...params,
+      app,
+      mark,
+      noun,
+      onSuccess: () => {
+        console.log(`poke success`);
+      },
+      onError: (err) => {
+        console.log(`poke error`, err);
+      },
+    });
+  };
+  const retry = async (err: any) => {
+    logger.trackError(`NOUN POKE: bad poke to ${app} with mark ${mark}`, {
+      stack: err,
+      noun: noun,
+    });
+    if (!(err instanceof AuthError)) {
+      throw err;
+    }
+
+    await reauth();
+    return doPoke();
+  };
+
+  try {
+    return doPoke({ onError: retry });
+  } catch (err) {
+    retry(err);
+  }
+}
+
 export async function poke({ app, mark, json }: PokeParams) {
   logger.log('poke', app, mark, json);
   const trackDuration = createDurationTracker(AnalyticsEvent.Poke, {
@@ -417,6 +472,28 @@ export async function scry<T>({ app, path }: { app: string; path: string }) {
       return result;
     }
     trackDuration('error');
+    const body = await res.text();
+    throw new BadResponseError(res.status, body);
+  }
+}
+
+export async function scryNoun({ app, path }: { app: string; path: string }) {
+  if (!config.client) {
+    throw new Error('Client not initialized');
+  }
+  if (config.pendingAuth) {
+    await config.pendingAuth;
+  }
+  logger.log('scry noun', app, path);
+  try {
+    return await config.client.scryNoun({ app, path });
+  } catch (res) {
+    logger.log('bad scry', app, path, res.status);
+    if (res.status === 403) {
+      logger.log('scry failed with 403, authing to try again');
+      await reauth();
+      return config.client.scryNoun({ app, path });
+    }
     const body = await res.text();
     throw new BadResponseError(res.status, body);
   }

--- a/packages/shared/src/db/migrations/0000_outgoing_valkyrie.sql
+++ b/packages/shared/src/db/migrations/0000_outgoing_valkyrie.sql
@@ -120,7 +120,10 @@ CREATE TABLE `contacts` (
 	`coverImage` text,
 	`blocked` integer,
 	`isContact` integer,
-	`isContactSuggestion` integer
+	`isContactSuggestion` integer,
+	`hasVerifiedPhone` integer,
+	`verifiedPhoneSignature` text,
+	`verifiedPhoneAt` integer
 );
 --> statement-breakpoint
 CREATE TABLE `group_flagged_posts` (
@@ -335,6 +338,16 @@ CREATE TABLE `thread_unreads` (
 	`first_unread_post_id` text,
 	`first_unread_post_received_at` integer,
 	PRIMARY KEY(`channel_id`, `thread_id`)
+);
+--> statement-breakpoint
+CREATE TABLE `verifications` (
+	`provider` text NOT NULL,
+	`type` text NOT NULL,
+	`value` text NOT NULL,
+	`initiated_at` integer,
+	`visibility` text NOT NULL,
+	`status` text NOT NULL,
+	PRIMARY KEY(`provider`, `type`, `value`)
 );
 --> statement-breakpoint
 CREATE TABLE `volume_settings` (

--- a/packages/shared/src/db/migrations/meta/0000_snapshot.json
+++ b/packages/shared/src/db/migrations/meta/0000_snapshot.json
@@ -1,7 +1,7 @@
 {
   "version": "6",
   "dialect": "sqlite",
-  "id": "a81be202-e2ee-4117-8533-dd20783fad0d",
+  "id": "6dc0c522-044d-4399-9e6d-6c46177eeac3",
   "prevId": "00000000-0000-0000-0000-000000000000",
   "tables": {
     "activity_event_contact_group_pins": {
@@ -815,6 +815,27 @@
         },
         "isContactSuggestion": {
           "name": "isContactSuggestion",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "hasVerifiedPhone": {
+          "name": "hasVerifiedPhone",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "verifiedPhoneSignature": {
+          "name": "verifiedPhoneSignature",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "verifiedPhoneAt": {
+          "name": "verifiedPhoneAt",
           "type": "integer",
           "primaryKey": false,
           "notNull": false,
@@ -2229,6 +2250,67 @@
             "thread_id"
           ],
           "name": "thread_unreads_channel_id_thread_id_pk"
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "verifications": {
+      "name": "verifications",
+      "columns": {
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "initiated_at": {
+          "name": "initiated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "visibility": {
+          "name": "visibility",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "verifications_provider_type_value_pk": {
+          "columns": [
+            "provider",
+            "type",
+            "value"
+          ],
+          "name": "verifications_provider_type_value_pk"
         }
       },
       "uniqueConstraints": {},

--- a/packages/shared/src/db/migrations/meta/_journal.json
+++ b/packages/shared/src/db/migrations/meta/_journal.json
@@ -5,8 +5,8 @@
     {
       "idx": 0,
       "version": "6",
-      "when": 1738788275223,
-      "tag": "0000_fluffy_cardiac",
+      "when": 1739215059171,
+      "tag": "0000_outgoing_valkyrie",
       "breakpoints": true
     }
   ]

--- a/packages/shared/src/db/migrations/migrations.js
+++ b/packages/shared/src/db/migrations/migrations.js
@@ -1,7 +1,7 @@
 // This file is required for Expo/React Native SQLite migrations - https://orm.drizzle.team/quick-sqlite/expo
 
 import journal from './meta/_journal.json';
-import m0000 from './0000_fluffy_cardiac.sql';
+import m0000 from './0000_outgoing_valkyrie.sql';
 
   export default {
     journal,

--- a/packages/shared/src/db/queries.ts
+++ b/packages/shared/src/db/queries.ts
@@ -72,6 +72,7 @@ import {
   posts as $posts,
   settings as $settings,
   threadUnreads as $threadUnreads,
+  verifications as $verifications,
   volumeSettings as $volumeSettings,
 } from './schema';
 import {
@@ -95,6 +96,7 @@ import {
   Settings,
   TableName,
   ThreadUnreadState,
+  Verification,
   VolumeSettings,
 } from './types';
 
@@ -304,6 +306,88 @@ export const getUnjoinedGroupChannels = createReadQuery(
     });
   },
   ['channels', 'groups']
+);
+
+export const insertVerifications = createWriteQuery(
+  'insertVerifications',
+  async (
+    { verifications }: { verifications: Verification[] },
+    ctx: QueryCtx
+  ) => {
+    if (verifications.length === 0) {
+      await ctx.db
+        .delete($verifications)
+        .where(isNotNull($verifications.value));
+      return;
+    } else {
+      const values = verifications.map((v) => v.value);
+      await ctx.db
+        .delete($verifications)
+        .where(not(inArray($verifications.value, values)));
+    }
+
+    return ctx.db
+      .insert($verifications)
+      .values(verifications)
+      .onConflictDoUpdate({
+        target: [
+          $verifications.type,
+          $verifications.value,
+          $verifications.provider,
+        ],
+        set: conflictUpdateSetAll($verifications),
+      });
+  },
+  ['verifications']
+);
+
+export const updateVerification = createWriteQuery(
+  'updateVerification',
+  async (
+    {
+      verification,
+    }: {
+      verification: Partial<Verification> & {
+        type: Verification['type'];
+        value: string;
+      };
+    },
+    ctx: QueryCtx
+  ) => {
+    return ctx.db
+      .update($verifications)
+      .set(verification)
+      .where(
+        and(
+          eq($verifications.type, verification.type),
+          eq($verifications.value, verification.value)
+        )
+      );
+  },
+  ['verifications']
+);
+
+export const deleteVerification = createWriteQuery(
+  'deleteVerifications',
+  async (
+    { type, value }: { type: Verification['type']; value: string },
+    ctx: QueryCtx
+  ) => {
+    return ctx.db
+      .delete($verifications)
+      .where(
+        and(eq($verifications.type, type), eq($verifications.value, value))
+      );
+  },
+  ['verifications']
+);
+
+export const getVerifications = createReadQuery(
+  'getVerifications',
+  async (ctx: QueryCtx) => {
+    return ctx.db.query.verifications.findMany();
+  },
+  ['verifications']
 );
 
 export const getPins = createReadQuery(

--- a/packages/shared/src/db/schema.ts
+++ b/packages/shared/src/db/schema.ts
@@ -79,6 +79,9 @@ export const contacts = sqliteTable('contacts', {
   isBlocked: boolean('blocked'),
   isContact: boolean('isContact'),
   isContactSuggestion: boolean('isContactSuggestion'),
+  hasVerifiedPhone: boolean('hasVerifiedPhone'),
+  verifiedPhoneSignature: text('verifiedPhoneSignature'),
+  verifiedPhoneAt: timestamp('verifiedPhoneAt'),
 });
 
 export const contactsRelations = relations(contacts, ({ many }) => ({
@@ -401,6 +404,26 @@ export const groupFlaggedPosts = sqliteTable(
       pk: primaryKey({
         columns: [table.groupId, table.postId],
       }),
+    };
+  }
+);
+
+export type VerificationType = 'phone' | 'node';
+export type VerificationVisibility = 'public' | 'discoverable' | 'hidden';
+export type VerificationStatus = 'waiting' | 'pending' | 'verified';
+export const verifications = sqliteTable(
+  'verifications',
+  {
+    provider: text('provider').notNull(),
+    type: text('type').$type<VerificationType>().notNull(),
+    value: text('value').notNull(),
+    initiatedAt: timestamp('initiated_at'),
+    visibility: text('visibility').$type<VerificationVisibility>().notNull(),
+    status: text('status').$type<VerificationStatus>().notNull(),
+  },
+  (table) => {
+    return {
+      pk: primaryKey({ columns: [table.provider, table.type, table.value] }),
     };
   }
 );

--- a/packages/shared/src/db/types.ts
+++ b/packages/shared/src/db/types.ts
@@ -95,6 +95,9 @@ export type PinType = schema.PinType;
 export type Settings = BaseModel<'settings'>;
 export type PostWindow = BaseModel<'postWindows'>;
 export type VolumeSettings = BaseModel<'volumeSettings'>;
+export type Verification = BaseModel<'verifications'>;
+export type VerificationStatus = schema.VerificationStatus;
+export type VerificationVisibility = schema.VerificationVisibility;
 
 export type Chat = {
   id: string;

--- a/packages/shared/src/http-api/Urbit.ts
+++ b/packages/shared/src/http-api/Urbit.ts
@@ -1,3 +1,5 @@
+import { formatUw, patp2bn, patp2dec } from '@urbit/aura';
+import { Atom, Cell, Noun, dejs, enjs, jam } from '@urbit/nockjs';
 import { isBrowser } from 'browser-or-node';
 
 import { desig } from '../urbit';
@@ -9,6 +11,8 @@ import {
   AuthenticationInterface,
   FatalError,
   Message,
+  NounPoke,
+  NounPokeInterface,
   PokeHandlers,
   PokeInterface,
   ReapError,
@@ -18,7 +22,12 @@ import {
   Thread,
   headers,
 } from './types';
-import EventEmitter, { hexString } from './utils';
+import EventEmitter, { hexString, unpackJamBytes } from './utils';
+
+//TODO  move into nockjs utils
+function isNoun(a: any): a is Noun {
+  return a instanceof Atom || a instanceof Cell;
+}
 
 /**
  * A class for interacting with an urbit ship, given its URL and code
@@ -118,6 +127,40 @@ export class Urbit {
 
     return {
       credentials: isBrowser ? 'include' : undefined,
+      accept: '*',
+      headers,
+      signal: this.abort.signal,
+    };
+  }
+
+  private fetchOptionsNoun(
+    method: 'PUT' | 'GET' = 'PUT',
+    mode: 'noun' | 'json' = 'noun'
+  ): any {
+    let type;
+    switch (mode) {
+      case 'noun':
+        type = 'application/x-urb-jam';
+        break;
+      case 'json':
+        type = 'application/json';
+        break;
+    }
+    const headers: Record<string, string | undefined> = {};
+    switch (method) {
+      case 'PUT':
+        headers['Content-Type'] = type;
+        headers['Accept'] = type;
+        break;
+      case 'GET':
+        headers['X-Channel-Format'] = type;
+        break;
+    }
+    if (!isBrowser) {
+      headers.Cookie = this.cookie;
+    }
+    return {
+      credentials: 'include',
       accept: '*',
       headers,
       signal: this.abort.signal,
@@ -350,6 +393,8 @@ export class Urbit {
           if (event.data && JSON.parse(event.data)) {
             const data: any = JSON.parse(event.data);
 
+            console.log(`received data`, data);
+
             if (
               data.response === 'poke' &&
               this.outstandingPokes.has(data.id)
@@ -508,6 +553,34 @@ export class Urbit {
     return eventId;
   }
 
+  //NOTE  every arg is interpreted (through nockjs.dwim) as a noun, which
+  //      should result in a noun nesting inside of the xx $eyre-command type
+  private async sendNounsToChannel(...args: (Noun | any)[]): Promise<void> {
+    const options = this.fetchOptionsNoun('PUT', 'noun');
+    const body = formatUw(jam(dejs.list(args)).number.toString());
+    const response = await this.fetchFn(this.channelUrl, {
+      ...options,
+      method: 'PUT',
+      body,
+    });
+    if (!response.ok) {
+      console.log(response.status, response.statusText, await response.text());
+      throw new Error('Failed to PUT channel command(s)');
+    }
+    if (!this.sseClientInitialized) {
+      if (this.verbose) {
+        console.log('initializing event source');
+      }
+      await Promise.all([this.getOurName(), this.getShipName()]);
+
+      if (this.our !== this.nodeId) {
+        throw new AuthError('invalid session');
+      }
+
+      await this.eventSource();
+    }
+  }
+
   private async sendJSONtoChannel(...json: (Message | Ack)[]): Promise<void> {
     const response = await this.fetchFn(this.channelUrl, {
       ...this.fetchOptions,
@@ -586,6 +659,31 @@ export class Urbit {
         }
       });
     });
+  }
+
+  async pokeNoun(params: NounPokeInterface): Promise<number> {
+    params.onSuccess = params.onSuccess || (() => {});
+    params.onError = params.onError || (() => {});
+    const { app, mark, noun, ship } = {
+      ship: this.nodeId?.replace('~', '') || '',
+      ...params,
+    };
+
+    if (this.lastEventId === 0) {
+      this.emit('status-update', { status: 'opening' });
+    }
+
+    const eventId = this.getEventId();
+    this.outstandingPokes.set(eventId, params);
+
+    if (isNoun(noun)) {
+      const shipAtom = new Atom(BigInt(patp2bn(`~${ship}`).toString()));
+      const non = ['poke', eventId, shipAtom, app, mark, noun];
+      await this.sendNounsToChannel(non);
+    } else {
+      throw new Error('pokeNoun requires a noun');
+    }
+    return eventId;
   }
 
   /**
@@ -751,6 +849,34 @@ export class Urbit {
     }
 
     return await response.json();
+  }
+
+  async scryNoun(params: Scry): Promise<Noun> {
+    const { app, path } = params;
+
+    try {
+      const response = await this.fetchFn(
+        `${this.url}/~/scry/${app}${path}.noun`,
+        this.fetchOptionsNoun('GET', 'noun')
+      );
+      const responseBlob = await response.blob();
+      const buffer: ArrayBuffer = await new Promise((resolve, reject) => {
+        const reader = new FileReader();
+        reader.onload = () => resolve(reader.result as ArrayBuffer);
+        reader.readAsArrayBuffer(responseBlob);
+      });
+
+      try {
+        const unpacked = await unpackJamBytes(buffer);
+        return unpacked;
+      } catch (e) {
+        console.error('Unpack failed', e);
+        throw e;
+      }
+    } catch (e) {
+      console.error(e);
+      throw e;
+    }
   }
 
   /**

--- a/packages/shared/src/http-api/index.ts
+++ b/packages/shared/src/http-api/index.ts
@@ -1,4 +1,6 @@
+import { Urbit } from './Urbit';
+
 export * from './types';
 export * from './events';
-import { Urbit } from './Urbit';
+
 export { Urbit as default, Urbit };

--- a/packages/shared/src/http-api/types.ts
+++ b/packages/shared/src/http-api/types.ts
@@ -1,3 +1,5 @@
+import { Noun } from '@urbit/nockjs';
+
 /**
  * An urbit style path, rendered as a Javascript string
  * @example
@@ -77,6 +79,29 @@ export interface Poke<Action> {
   json: Action;
 }
 
+export interface NounPoke {
+  /**
+   * Ship to poke. If left empty, the api lib will populate it with the ship that it is connected to.
+   *
+   * @remarks
+   *
+   * This should always be the ship that you are connected to
+   *
+   */
+  ship?: PatpNoSig;
+  /**
+   */
+  app: GallAgent;
+  /**
+   * Mark of the cage to be poked
+   *
+   */
+  mark: Mark;
+
+  noun: Noun;
+  onError?: (e: Noun) => void;
+}
+
 /**
  * Description of a scry request
  */
@@ -128,6 +153,7 @@ export interface PokeHandlers {
 }
 
 export type PokeInterface<T> = PokeHandlers & Poke<T>;
+export type NounPokeInterface = PokeHandlers & NounPoke;
 
 export interface AuthenticationInterface {
   ship: string;

--- a/packages/shared/src/http-api/utils.ts
+++ b/packages/shared/src/http-api/utils.ts
@@ -1,3 +1,5 @@
+import { Atom, Noun, cue, jam } from '@urbit/nockjs';
+
 export function camelize(str: string) {
   return str
     .replace(/\s(.)/g, function ($1: string) {
@@ -15,6 +17,18 @@ export function uncamelize(str: string, separator = '-') {
     return separator + letter.toLowerCase();
   });
   return str.replace(new RegExp('^' + separator), '');
+}
+
+export async function unpackJamBytes(buf: ArrayBuffer): Promise<Noun> {
+  const hex = [...new Uint8Array(buf)]
+    .reverse() //  endianness shenanigans
+    .map((x) => x.toString(16).padStart(2, '0'))
+    .join('');
+  return cue(Atom.fromString(hex, 16));
+}
+
+export function packJamBytes(non: Noun): BodyInit {
+  return new Uint8Array(jam(non).bytes());
 }
 
 /**

--- a/packages/shared/src/logic/index.ts
+++ b/packages/shared/src/logic/index.ts
@@ -9,3 +9,4 @@ export * from './deeplinks';
 export * as featureFlags from './featureFlags';
 export * from './tiptap';
 export * from './hosting';
+export * from './noun';

--- a/packages/shared/src/logic/noun.ts
+++ b/packages/shared/src/logic/noun.ts
@@ -1,0 +1,83 @@
+import { daToUnix, formatUv, patp } from '@urbit/aura';
+import { Atom, Cell, EnjsFunction, Noun, enjs } from '@urbit/nockjs';
+
+type Json = ReturnType<EnjsFunction>;
+
+export const giveNull: EnjsFunction = () => null;
+export const maybe =
+  (fn: EnjsFunction): EnjsFunction =>
+  (noun: Noun) => {
+    if (noun instanceof Atom) {
+      return null;
+    }
+
+    return fn(noun.tail);
+  };
+
+export const getPatp: EnjsFunction = (noun: Noun) => {
+  if (noun instanceof Cell) {
+    throw new Error(`malformed patp ${noun.toString()}`);
+  }
+
+  return patp(noun.number);
+};
+
+export const getUv: EnjsFunction = runIfAtom((a) => formatUv(a.number));
+
+export const time: EnjsFunction = runIfAtom((a) => daToUnix(a.number));
+
+export function getMapAsObject<T>(
+  noun: Noun,
+  key: EnjsFunction,
+  value: EnjsFunction
+): Record<string, T> {
+  return Object.fromEntries(
+    enjs.tree((n: Noun) => {
+      if (!(n instanceof Cell)) {
+        throw new Error('malformed map');
+      }
+
+      return [key(n.head), value(n.tail)];
+    })(noun) as [string, T][]
+  );
+}
+
+export function runIfAtom(fn: (atom: Atom) => Json): EnjsFunction {
+  return (noun: Noun) => {
+    if (noun instanceof Cell) {
+      throw new Error('malformed atom');
+    }
+
+    return fn(noun);
+  };
+}
+
+export const logNoun =
+  (fn: EnjsFunction, str: string): EnjsFunction =>
+  (noun: Noun) => {
+    console.log(str, noun.toString());
+    return fn(noun);
+  };
+
+interface frondOpt {
+  tag: string;
+  get: EnjsFunction;
+}
+
+export function getFrondValue(opts: frondOpt[]): EnjsFunction {
+  return (noun: Noun) => {
+    if (!(noun instanceof Cell)) {
+      throw new Error('malformed frond');
+    }
+
+    const tag = enjs.cord(noun.head);
+
+    const opt = opts.find((o) => o.tag === tag);
+
+    if (!opt) {
+      throw new Error('unknown frond tag');
+    }
+
+    return opt.get(noun.tail);
+  };
+}

--- a/packages/shared/src/store/dbHooks.ts
+++ b/packages/shared/src/store/dbHooks.ts
@@ -462,3 +462,11 @@ export const usePostWithRelations = (
     queryFn: () => db.getPostWithRelations(options),
   });
 };
+
+export const useVerifications = () => {
+  const deps = useKeyFromQueryDeps(db.getVerifications);
+  return useQuery({
+    queryKey: ['verifications', deps],
+    queryFn: () => db.getVerifications(),
+  });
+};

--- a/packages/shared/src/store/sync.ts
+++ b/packages/shared/src/store/sync.ts
@@ -216,6 +216,20 @@ export const syncContacts = async (ctx?: SyncCtx) => {
   }
 };
 
+export const syncVerifications = async (ctx?: SyncCtx) => {
+  logger.log('syncing verifications');
+  const verifications = await syncQueue.add('verifications', ctx, () =>
+    api.fetchVerifications()
+  );
+  try {
+    await db.insertVerifications({ verifications });
+  } catch (e) {
+    logger.error('error inserting verifications', e);
+  }
+
+  logger.log('inserted verifications from api', verifications);
+};
+
 export const syncPinnedItems = async (ctx?: SyncCtx) => {
   logger.log('syncing pinned items');
   const pinnedItems = await syncQueue.add('pinnedItems', ctx, () =>

--- a/packages/shared/src/store/useChannelSearch.ts
+++ b/packages/shared/src/store/useChannelSearch.ts
@@ -1,10 +1,8 @@
 import { useInfiniteQuery } from '@tanstack/react-query';
 import { daToUnix } from '@urbit/aura';
-import bigInt from 'big-integer';
 import { useEffect, useMemo } from 'react';
 
 import { searchChannel } from '../api/channelsApi';
-import * as db from '../db';
 import { createDevLogger } from '../debug';
 import { useAttachAuthorToPosts } from './useAttachAuthorToPosts';
 
@@ -80,7 +78,7 @@ export function useInfiniteChannelSearch(channelId: string, query: string) {
     const lastValidCursor = params.findLast(
       (page) => page.cursor !== null
     )?.cursor;
-    return lastValidCursor ? new Date(daToUnix(bigInt(lastValidCursor))) : null;
+    return lastValidCursor ? new Date(daToUnix(BigInt(lastValidCursor))) : null;
   }, [data]);
 
   return {

--- a/packages/shared/src/urbit/channel.ts
+++ b/packages/shared/src/urbit/channel.ts
@@ -1,5 +1,5 @@
 import { parseUd } from '@urbit/aura';
-import { BigInteger } from 'big-integer';
+import bigInt, { BigInteger } from 'big-integer';
 import _ from 'lodash';
 import BTree from 'sorted-btree';
 
@@ -663,7 +663,7 @@ export function newPostTupleArray(
     data.pages
       .map((page) => {
         const pagePosts = Object.entries(page.posts).map(
-          ([k, v]) => [parseUd(k), v] as PostTuple
+          ([k, v]) => [bigInt(parseUd(k)), v] as PostTuple
         );
 
         return pagePosts;

--- a/packages/shared/src/urbit/contact.ts
+++ b/packages/shared/src/urbit/contact.ts
@@ -8,6 +8,9 @@ export interface Contact {
   avatar: string | null;
   cover: string | null;
   groups: string[];
+  ['lanyard-tmp-urbits']?: VerifiedShipsField;
+  ['lanyard-tmp-phone-since']?: PhoneVerifySign;
+  ['lanyard-tmp-phone-sign']?: PhoneVerifiedAt;
 }
 
 export interface ContactAddGroup {
@@ -69,6 +72,21 @@ export interface ContactFieldGroups {
   value: { type: 'flag'; value: string }[];
 }
 
+export interface VerifiedShipsField {
+  type: 'set';
+  value: { type: 'ship'; value: string }[];
+}
+
+export interface PhoneVerifySign {
+  type: 'text';
+  value: string;
+}
+
+export interface PhoneVerifiedAt {
+  type: 'date';
+  value: string;
+}
+
 export interface ContactBookProfile {
   nickname?: ContactFieldText;
   bio?: ContactFieldText;
@@ -77,6 +95,9 @@ export interface ContactBookProfile {
   color?: ContactFieldColor;
   groups?: ContactFieldGroups;
   status?: ContactFieldText;
+  ['lanyard-tmp-urbits']?: VerifiedShipsField;
+  ['lanyard-tmp-phone-since']?: PhoneVerifySign;
+  ['lanyard-tmp-phone-sign']?: PhoneVerifiedAt;
 }
 
 export interface ContactBookProfileEdit {

--- a/packages/shared/src/urbit/dms.ts
+++ b/packages/shared/src/urbit/dms.ts
@@ -1,5 +1,5 @@
 import { parseUd } from '@urbit/aura';
-import { BigInteger } from 'big-integer';
+import bigInt, { BigInteger } from 'big-integer';
 import _ from 'lodash';
 import BTree from 'sorted-btree';
 
@@ -196,7 +196,7 @@ export function newWritTupleArray(
     data?.pages
       ?.map((page) => {
         const writPages = Object.entries(page.writs).map(
-          ([k, v]) => [parseUd(k), v] as WritTuple
+          ([k, v]) => [bigInt(parseUd(k)), v] as WritTuple
         );
         return writPages;
       })

--- a/packages/shared/src/urbit/utils.ts
+++ b/packages/shared/src/urbit/utils.ts
@@ -424,7 +424,7 @@ export function extractGroupPrivacy(
 }
 
 export function createSectionId() {
-  const idParts = formatUv(bigInt(Date.now())).split('.');
+  const idParts = formatUv(BigInt(Date.now())).split('.');
   const newSectionId = `z${idParts[idParts.length - 1]}`;
 
   return newSectionId;

--- a/packages/ui/src/components/UserProfileScreenView.tsx
+++ b/packages/ui/src/components/UserProfileScreenView.tsx
@@ -11,6 +11,7 @@ import {
 import { LayoutChangeEvent } from 'react-native';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
 import {
+  Circle,
   ScrollView,
   View,
   XStack,

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -98,7 +98,7 @@ importers:
         version: 8.0.1(@swc/core@1.7.26(@swc/helpers@0.5.13))(postcss@8.4.35)(typescript@5.4.5)
       vitest:
         specifier: ^1.2.2
-        version: 1.2.2(@types/node@20.17.6)(jsdom@23.2.0)(terser@5.36.0)
+        version: 1.2.2(@types/node@20.17.6)(jsdom@23.2.0)(lightningcss@1.19.0)(terser@5.36.0)
 
   apps/tlon-mobile:
     dependencies:
@@ -155,7 +155,7 @@ importers:
         version: 6.5.12(@react-navigation/native@6.1.10(react-native@0.73.9(@babel/core@7.25.2)(@babel/preset-env@7.23.7(@babel/core@7.25.2))(encoding@0.1.13)(react@18.2.0))(react@18.2.0))(react-native-safe-area-context@4.9.0(react-native@0.73.9(@babel/core@7.25.2)(@babel/preset-env@7.23.7(@babel/core@7.25.2))(encoding@0.1.13)(react@18.2.0))(react@18.2.0))(react-native-screens@3.29.0(react-native@0.73.9(@babel/core@7.25.2)(@babel/preset-env@7.23.7(@babel/core@7.25.2))(encoding@0.1.13)(react@18.2.0))(react@18.2.0))(react-native@0.73.9(@babel/core@7.25.2)(@babel/preset-env@7.23.7(@babel/core@7.25.2))(encoding@0.1.13)(react@18.2.0))(react@18.2.0)
       '@react-navigation/drawer':
         specifier: ^6.7.2
-        version: 6.7.2(patch_hash=rib4hjvzksqzwv3bbw4vfi5a5i)(a53mioyydbpzjdyawnhlozkhyy)
+        version: 6.7.2(patch_hash=rib4hjvzksqzwv3bbw4vfi5a5i)(@react-navigation/native@6.1.10(react-native@0.73.9(@babel/core@7.25.2)(@babel/preset-env@7.23.7(@babel/core@7.25.2))(encoding@0.1.13)(react@18.2.0))(react@18.2.0))(react-native-gesture-handler@2.20.0(react-native@0.73.9(@babel/core@7.25.2)(@babel/preset-env@7.23.7(@babel/core@7.25.2))(encoding@0.1.13)(react@18.2.0))(react@18.2.0))(react-native-reanimated@3.8.1(patch_hash=iololnqcieadxwydikuxdlowf4)(@babel/core@7.25.2)(react-native@0.73.9(@babel/core@7.25.2)(@babel/preset-env@7.23.7(@babel/core@7.25.2))(encoding@0.1.13)(react@18.2.0))(react@18.2.0))(react-native-safe-area-context@4.9.0(react-native@0.73.9(@babel/core@7.25.2)(@babel/preset-env@7.23.7(@babel/core@7.25.2))(encoding@0.1.13)(react@18.2.0))(react@18.2.0))(react-native-screens@3.29.0(react-native@0.73.9(@babel/core@7.25.2)(@babel/preset-env@7.23.7(@babel/core@7.25.2))(encoding@0.1.13)(react@18.2.0))(react@18.2.0))(react-native@0.73.9(@babel/core@7.25.2)(@babel/preset-env@7.23.7(@babel/core@7.25.2))(encoding@0.1.13)(react@18.2.0))(react@18.2.0)
       '@react-navigation/native':
         specifier: ^6.1.7
         version: 6.1.10(react-native@0.73.9(@babel/core@7.25.2)(@babel/preset-env@7.23.7(@babel/core@7.25.2))(encoding@0.1.13)(react@18.2.0))(react@18.2.0)
@@ -189,6 +189,9 @@ importers:
       '@urbit/http-api':
         specifier: 3.2.0-dev
         version: 3.2.0-dev
+      '@urbit/nockjs':
+        specifier: ^1.4.0
+        version: 1.4.0
       classnames:
         specifier: ^2.3.2
         version: 2.5.1
@@ -278,7 +281,7 @@ importers:
         version: 4.17.21
       posthog-react-native:
         specifier: ^2.7.1
-        version: 2.11.3(5da2lqyaedbkzrvmxe6zbne2yu)
+        version: 2.11.3(@react-native-async-storage/async-storage@1.21.0(react-native@0.73.9(@babel/core@7.25.2)(@babel/preset-env@7.23.7(@babel/core@7.25.2))(encoding@0.1.13)(react@18.2.0)))(@react-navigation/native@6.1.10(react-native@0.73.9(@babel/core@7.25.2)(@babel/preset-env@7.23.7(@babel/core@7.25.2))(encoding@0.1.13)(react@18.2.0))(react@18.2.0))(expo-application@5.8.4(expo@50.0.21(@babel/core@7.25.2)(@react-native/babel-preset@0.73.21(@babel/core@7.25.2)(@babel/preset-env@7.23.7(@babel/core@7.25.2)))(encoding@0.1.13)))(expo-device@5.9.4(expo@50.0.21(@babel/core@7.25.2)(@react-native/babel-preset@0.73.21(@babel/core@7.25.2)(@babel/preset-env@7.23.7(@babel/core@7.25.2)))(encoding@0.1.13)))(expo-file-system@16.0.9(expo@50.0.21(@babel/core@7.25.2)(@react-native/babel-preset@0.73.21(@babel/core@7.25.2)(@babel/preset-env@7.23.7(@babel/core@7.25.2)))(encoding@0.1.13)))(expo-localization@14.8.4(expo@50.0.21(@babel/core@7.25.2)(@react-native/babel-preset@0.73.21(@babel/core@7.25.2)(@babel/preset-env@7.23.7(@babel/core@7.25.2)))(encoding@0.1.13)))(react-native-device-info@10.12.0(react-native@0.73.9(@babel/core@7.25.2)(@babel/preset-env@7.23.7(@babel/core@7.25.2))(encoding@0.1.13)(react@18.2.0)))
       react:
         specifier: ^18.2.0
         version: 18.2.0
@@ -360,7 +363,7 @@ importers:
         version: 29.7.0
       '@react-native/metro-config':
         specifier: ^0.73.5
-        version: 0.73.5(@babel/core@7.25.2)(@babel/preset-env@7.23.7(@babel/core@7.25.2))
+        version: 0.73.5(@babel/core@7.25.2)(@babel/preset-env@7.23.7(@babel/core@7.25.2))(encoding@0.1.13)
       '@tamagui/babel-plugin':
         specifier: ~1.112.12
         version: 1.112.12(@swc/helpers@0.5.13)(encoding@0.1.13)(react@18.2.0)
@@ -441,7 +444,7 @@ importers:
         version: 3.4.1
       vitest:
         specifier: ^1.0.4
-        version: 1.2.2(@types/node@20.14.10)(jsdom@23.2.0)(terser@5.36.0)
+        version: 1.2.2(@types/node@20.14.10)(jsdom@23.2.0)(lightningcss@1.19.0)(terser@5.36.0)
 
   apps/tlon-web:
     dependencies:
@@ -813,7 +816,7 @@ importers:
         version: 0.16.0(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
       vite-plugin-svgr:
         specifier: ^4.2.0
-        version: 4.2.0(rollup@2.79.2)(typescript@5.4.5)(vite@5.1.6(@types/node@20.10.8)(terser@5.36.0))
+        version: 4.2.0(rollup@4.13.0)(typescript@5.4.5)(vite@5.1.6(@types/node@20.10.8)(lightningcss@1.19.0)(terser@5.36.0))
       workbox-precaching:
         specifier: ^6.5.4
         version: 6.6.0
@@ -904,10 +907,10 @@ importers:
         version: 2.0.1
       '@vitejs/plugin-basic-ssl':
         specifier: ^1.1.0
-        version: 1.1.0(vite@5.1.6(@types/node@20.10.8)(terser@5.36.0))
+        version: 1.1.0(vite@5.1.6(@types/node@20.10.8)(lightningcss@1.19.0)(terser@5.36.0))
       '@vitejs/plugin-react':
         specifier: ^4.2.1
-        version: 4.2.1(vite@5.1.6(@types/node@20.10.8)(terser@5.36.0))
+        version: 4.2.1(vite@5.1.6(@types/node@20.10.8)(lightningcss@1.19.0)(terser@5.36.0))
       '@welldone-software/why-did-you-render':
         specifier: ^7.0.1
         version: 7.0.1(react@18.2.0)
@@ -952,7 +955,7 @@ importers:
         version: 4.0.0
       rollup-plugin-visualizer:
         specifier: ^5.6.0
-        version: 5.12.0(rollup@2.79.2)
+        version: 5.12.0(rollup@4.13.0)
       tailwindcss:
         specifier: ^3.2.7
         version: 3.4.1
@@ -967,13 +970,13 @@ importers:
         version: 1.1.4(typescript@5.4.5)
       vite:
         specifier: ^5.1.6
-        version: 5.1.6(@types/node@20.10.8)(terser@5.36.0)
+        version: 5.1.6(@types/node@20.10.8)(lightningcss@1.19.0)(terser@5.36.0)
       vite-plugin-pwa:
         specifier: ^0.17.5
-        version: 0.17.5(vite@5.1.6(@types/node@20.10.8)(terser@5.36.0))(workbox-build@7.0.0(@types/babel__core@7.20.5))(workbox-window@7.0.0)
+        version: 0.17.5(vite@5.1.6(@types/node@20.10.8)(lightningcss@1.19.0)(terser@5.36.0))(workbox-build@7.0.0(@types/babel__core@7.20.5))(workbox-window@7.0.0)
       vitest:
         specifier: ^0.34.1
-        version: 0.34.6(jsdom@23.2.0)(terser@5.36.0)
+        version: 0.34.6(jsdom@23.2.0)(lightningcss@1.19.0)(terser@5.36.0)
       workbox-window:
         specifier: ^7.0.0
         version: 7.0.0
@@ -991,7 +994,7 @@ importers:
         version: 7.25.9
       '@react-navigation/drawer':
         specifier: ^6.7.2
-        version: 6.7.2(patch_hash=rib4hjvzksqzwv3bbw4vfi5a5i)(iit2e4i3acs4vllzhs45ckztzu)
+        version: 6.7.2(patch_hash=rib4hjvzksqzwv3bbw4vfi5a5i)(@react-navigation/native@6.1.10(react-native@0.73.9(@babel/core@7.25.2)(@babel/preset-env@7.26.0(@babel/core@7.25.2))(encoding@0.1.13)(react@18.2.0))(react@18.2.0))(react-native-gesture-handler@2.20.0(react-native@0.73.9(@babel/core@7.25.2)(@babel/preset-env@7.26.0(@babel/core@7.25.2))(encoding@0.1.13)(react@18.2.0))(react@18.2.0))(react-native-reanimated@3.8.1(patch_hash=iololnqcieadxwydikuxdlowf4)(@babel/core@7.25.2)(react-native@0.73.9(@babel/core@7.25.2)(@babel/preset-env@7.26.0(@babel/core@7.25.2))(encoding@0.1.13)(react@18.2.0))(react@18.2.0))(react-native-safe-area-context@4.9.0(react-native@0.73.9(@babel/core@7.25.2)(@babel/preset-env@7.26.0(@babel/core@7.25.2))(encoding@0.1.13)(react@18.2.0))(react@18.2.0))(react-native-screens@3.29.0(react-native@0.73.9(@babel/core@7.25.2)(@babel/preset-env@7.26.0(@babel/core@7.25.2))(encoding@0.1.13)(react@18.2.0))(react@18.2.0))(react-native@0.73.9(@babel/core@7.25.2)(@babel/preset-env@7.26.0(@babel/core@7.25.2))(encoding@0.1.13)(react@18.2.0))(react@18.2.0)
       '@react-navigation/native':
         specifier: ^6.1.7
         version: 6.1.10(react-native@0.73.9(@babel/core@7.25.2)(@babel/preset-env@7.26.0(@babel/core@7.25.2))(encoding@0.1.13)(react@18.2.0))(react@18.2.0)
@@ -1204,7 +1207,7 @@ importers:
         version: 13.7.0
       vite-plugin-svgr:
         specifier: ^4.2.0
-        version: 4.2.0(rollup@4.13.0)(typescript@5.4.5)(vite@5.1.6(@types/node@20.14.10)(terser@5.36.0))
+        version: 4.2.0(rollup@4.13.0)(typescript@5.4.5)(vite@5.1.6(@types/node@20.14.10)(lightningcss@1.19.0)(terser@5.36.0))
       workbox-precaching:
         specifier: ^6.5.4
         version: 6.6.0
@@ -1298,10 +1301,10 @@ importers:
         version: 2.0.1
       '@vitejs/plugin-basic-ssl':
         specifier: ^1.1.0
-        version: 1.1.0(vite@5.1.6(@types/node@20.14.10)(terser@5.36.0))
+        version: 1.1.0(vite@5.1.6(@types/node@20.14.10)(lightningcss@1.19.0)(terser@5.36.0))
       '@vitejs/plugin-react':
         specifier: ^4.2.1
-        version: 4.2.1(vite@5.1.6(@types/node@20.14.10)(terser@5.36.0))
+        version: 4.2.1(vite@5.1.6(@types/node@20.14.10)(lightningcss@1.19.0)(terser@5.36.0))
       '@welldone-software/why-did-you-render':
         specifier: ^7.0.1
         version: 7.0.1(react@18.2.0)
@@ -1343,7 +1346,7 @@ importers:
         version: 3.2.5
       react-cosmos-plugin-vite:
         specifier: 6.1.1
-        version: 6.1.1(vite@5.1.6(@types/node@20.14.10)(terser@5.36.0))
+        version: 6.1.1(vite@5.1.6(@types/node@20.14.10)(lightningcss@1.19.0)(terser@5.36.0))
       react-test-renderer:
         specifier: ^18.2.0
         version: 18.2.0(react@18.2.0)
@@ -1367,13 +1370,13 @@ importers:
         version: 1.1.4(typescript@5.4.5)
       vite:
         specifier: ^5.1.6
-        version: 5.1.6(@types/node@20.14.10)(terser@5.36.0)
+        version: 5.1.6(@types/node@20.14.10)(lightningcss@1.19.0)(terser@5.36.0)
       vite-plugin-pwa:
         specifier: ^0.17.5
-        version: 0.17.5(vite@5.1.6(@types/node@20.14.10)(terser@5.36.0))(workbox-build@7.0.0(@types/babel__core@7.20.5))(workbox-window@7.0.0)
+        version: 0.17.5(vite@5.1.6(@types/node@20.14.10)(lightningcss@1.19.0)(terser@5.36.0))(workbox-build@7.0.0(@types/babel__core@7.20.5))(workbox-window@7.0.0)
       vitest:
         specifier: ^0.34.1
-        version: 0.34.6(jsdom@23.2.0)(terser@5.36.0)
+        version: 0.34.6(jsdom@23.2.0)(lightningcss@1.19.0)(terser@5.36.0)
       workbox-window:
         specifier: ^7.0.0
         version: 7.0.0
@@ -1425,7 +1428,7 @@ importers:
     dependencies:
       '@10play/tentap-editor':
         specifier: 0.5.21
-        version: 0.5.21(@tiptap/core@2.6.6(@tiptap/pm@2.6.6))(react-native-webview@13.6.4(react-native@0.73.9(@babel/core@7.25.2)(@babel/preset-env@7.26.0(@babel/core@7.25.2))(encoding@0.1.13)(react@18.2.0))(react@18.2.0))(react-native@0.73.9(@babel/core@7.25.2)(@babel/preset-env@7.26.0(@babel/core@7.25.2))(encoding@0.1.13)(react@18.2.0))(react@18.2.0)
+        version: 0.5.21(@tiptap/core@2.6.6(@tiptap/pm@2.6.6))(react-native-webview@13.6.4(react-native@0.73.9(@babel/core@7.23.7)(@babel/preset-env@7.26.0(@babel/core@7.23.7))(encoding@0.1.13)(react@18.2.0))(react@18.2.0))(react-native@0.73.9(@babel/core@7.23.7)(@babel/preset-env@7.26.0(@babel/core@7.23.7))(encoding@0.1.13)(react@18.2.0))(react@18.2.0)
       '@tiptap/core':
         specifier: ^2.6.6
         version: 2.6.6(@tiptap/pm@2.6.6)
@@ -1450,7 +1453,7 @@ importers:
         version: 6.21.0(eslint@8.56.0)(typescript@5.4.5)
       '@vitejs/plugin-react':
         specifier: ^4.2.1
-        version: 4.2.1(vite@5.1.6(@types/node@20.17.6)(terser@5.36.0))
+        version: 4.2.1(vite@5.1.6(@types/node@20.17.6)(lightningcss@1.19.0)(terser@5.36.0))
       eslint:
         specifier: ^8.50.0
         version: 8.56.0
@@ -1462,13 +1465,13 @@ importers:
         version: 5.4.5
       vite:
         specifier: ^5.1.6
-        version: 5.1.6(@types/node@20.17.6)(terser@5.36.0)
+        version: 5.1.6(@types/node@20.17.6)(lightningcss@1.19.0)(terser@5.36.0)
       vite-plugin-singlefile:
         specifier: ^2.0.1
-        version: 2.0.1(rollup@4.13.0)(vite@5.1.6(@types/node@20.17.6)(terser@5.36.0))
+        version: 2.0.1(rollup@4.13.0)(vite@5.1.6(@types/node@20.17.6)(lightningcss@1.19.0)(terser@5.36.0))
       vitest:
         specifier: ^1.0.4
-        version: 1.5.0(@types/node@20.17.6)(jsdom@23.2.0)(terser@5.36.0)
+        version: 1.5.0(@types/node@20.17.6)(jsdom@23.2.0)(lightningcss@1.19.0)(terser@5.36.0)
 
   packages/shared:
     dependencies:
@@ -1491,8 +1494,11 @@ importers:
         specifier: 2.6.0
         version: 2.6.0(@tiptap/core@2.6.6(@tiptap/pm@2.6.6))(@tiptap/pm@2.6.6)
       '@urbit/aura':
-        specifier: ^1.0.0
-        version: 1.0.0(big-integer@1.6.52)
+        specifier: ^2.0.1
+        version: 2.0.1
+      '@urbit/nockjs':
+        specifier: ^1.4.0
+        version: 1.4.0
       any-ascii:
         specifier: ^0.3.1
         version: 0.3.2(patch_hash=5ofxtlxe6za2xqrbq5pqbz7wb4)
@@ -1535,7 +1541,7 @@ importers:
         version: 5.4.5
       vitest:
         specifier: ^1.4.0
-        version: 1.5.0(@types/node@20.17.6)(jsdom@23.2.0)(terser@5.36.0)
+        version: 1.5.0(@types/node@20.17.6)(jsdom@23.2.0)(lightningcss@1.19.0)(terser@5.36.0)
 
   packages/ui:
     dependencies:
@@ -6936,8 +6942,15 @@ packages:
     peerDependencies:
       big-integer: ^1.6.51
 
+  '@urbit/aura@2.0.1':
+    resolution: {integrity: sha512-B1ZTwsEVqi/iybxjHlY3gBz7r4Xd7n9pwi9NY6V+7r4DksqBYBpfzdqWGUXgZ0x67IW8AOGjC73tkTOclNMhUg==}
+    engines: {node: '>=16', npm: '>=8'}
+
   '@urbit/http-api@3.2.0-dev':
     resolution: {integrity: sha512-phG35u7Uhlg4ZIRt/7mVum9KuR0j7XrxMnYsRUlRk3XgsXgDDNOgT7tvKeY6+L2PTblUOBqcVqNWNtzAOsy3hQ==}
+
+  '@urbit/nockjs@1.4.0':
+    resolution: {integrity: sha512-jC0miyeJgydPn9b9UER5nvLR6/6YG4fHKyKoTPrYFi6x7PsXfDavcEWHWjQOc4T+GFP9RgLz63XbNFAxPzFklA==}
 
   '@urbit/sigil-js@2.2.0':
     resolution: {integrity: sha512-UNtRJ0K4CAXe+IP4wARNRMjuI5GTF2MNj9FL5l4RSMddCPJqSWSpkrYcREBI4AOB+80AEyN1kK/jtzhlm5WW+w==}
@@ -14128,6 +14141,43 @@ packages:
 
 snapshots:
 
+  '@10play/tentap-editor@0.5.21(@tiptap/core@2.6.6(@tiptap/pm@2.6.6))(react-native-webview@13.6.4(react-native@0.73.9(@babel/core@7.23.7)(@babel/preset-env@7.26.0(@babel/core@7.23.7))(encoding@0.1.13)(react@18.2.0))(react@18.2.0))(react-native@0.73.9(@babel/core@7.23.7)(@babel/preset-env@7.26.0(@babel/core@7.23.7))(encoding@0.1.13)(react@18.2.0))(react@18.2.0)':
+    dependencies:
+      '@tiptap/extension-blockquote': 2.6.6(@tiptap/core@2.6.6(@tiptap/pm@2.6.6))
+      '@tiptap/extension-bold': 2.6.6(@tiptap/core@2.6.6(@tiptap/pm@2.6.6))
+      '@tiptap/extension-bullet-list': 2.6.6(@tiptap/core@2.6.6(@tiptap/pm@2.6.6))
+      '@tiptap/extension-code': 2.6.6(@tiptap/core@2.6.6(@tiptap/pm@2.6.6))
+      '@tiptap/extension-code-block': 2.6.6(@tiptap/core@2.6.6(@tiptap/pm@2.6.6))(@tiptap/pm@2.6.6)
+      '@tiptap/extension-color': 2.3.0(@tiptap/core@2.6.6(@tiptap/pm@2.6.6))(@tiptap/extension-text-style@2.3.0(@tiptap/core@2.6.6(@tiptap/pm@2.6.6)))
+      '@tiptap/extension-document': 2.6.6(@tiptap/core@2.6.6(@tiptap/pm@2.6.6))
+      '@tiptap/extension-dropcursor': 2.3.0(@tiptap/core@2.6.6(@tiptap/pm@2.6.6))(@tiptap/pm@2.6.6)
+      '@tiptap/extension-hard-break': 2.6.0(@tiptap/core@2.6.6(@tiptap/pm@2.6.6))
+      '@tiptap/extension-heading': 2.6.6(@tiptap/core@2.6.6(@tiptap/pm@2.6.6))
+      '@tiptap/extension-highlight': 2.3.0(@tiptap/core@2.6.6(@tiptap/pm@2.6.6))
+      '@tiptap/extension-history': 2.6.6(@tiptap/core@2.6.6(@tiptap/pm@2.6.6))(@tiptap/pm@2.6.6)
+      '@tiptap/extension-horizontal-rule': 2.6.6(@tiptap/core@2.6.6(@tiptap/pm@2.6.6))(@tiptap/pm@2.6.6)
+      '@tiptap/extension-image': 2.3.0(@tiptap/core@2.6.6(@tiptap/pm@2.6.6))
+      '@tiptap/extension-italic': 2.6.6(@tiptap/core@2.6.6(@tiptap/pm@2.6.6))
+      '@tiptap/extension-link': 2.6.6(@tiptap/core@2.6.6(@tiptap/pm@2.6.6))(@tiptap/pm@2.6.6)
+      '@tiptap/extension-list-item': 2.6.6(@tiptap/core@2.6.6(@tiptap/pm@2.6.6))
+      '@tiptap/extension-ordered-list': 2.6.6(@tiptap/core@2.6.6(@tiptap/pm@2.6.6))
+      '@tiptap/extension-placeholder': 2.6.6(@tiptap/core@2.6.6(@tiptap/pm@2.6.6))(@tiptap/pm@2.6.6)
+      '@tiptap/extension-strike': 2.6.6(@tiptap/core@2.6.6(@tiptap/pm@2.6.6))
+      '@tiptap/extension-task-item': 2.6.6(@tiptap/core@2.6.6(@tiptap/pm@2.6.6))(@tiptap/pm@2.6.6)
+      '@tiptap/extension-task-list': 2.6.6(@tiptap/core@2.6.6(@tiptap/pm@2.6.6))
+      '@tiptap/extension-text-style': 2.3.0(@tiptap/core@2.6.6(@tiptap/pm@2.6.6))
+      '@tiptap/extension-underline': 2.3.0(@tiptap/core@2.6.6(@tiptap/pm@2.6.6))
+      '@tiptap/pm': 2.6.6
+      '@tiptap/react': 2.6.6(@tiptap/core@2.6.6(@tiptap/pm@2.6.6))(@tiptap/pm@2.6.6)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
+      '@tiptap/starter-kit': 2.3.0(@tiptap/pm@2.6.6)
+      lodash: 4.17.21
+      react: 18.2.0
+      react-dom: 18.2.0(react@18.2.0)
+      react-native: 0.73.9(@babel/core@7.23.7)(@babel/preset-env@7.26.0(@babel/core@7.23.7))(encoding@0.1.13)(react@18.2.0)
+      react-native-webview: 13.6.4(react-native@0.73.9(@babel/core@7.23.7)(@babel/preset-env@7.26.0(@babel/core@7.23.7))(encoding@0.1.13)(react@18.2.0))(react@18.2.0)
+    transitivePeerDependencies:
+      - '@tiptap/core'
+
   '@10play/tentap-editor@0.5.21(@tiptap/core@2.6.6(@tiptap/pm@2.6.6))(react-native-webview@13.6.4(react-native@0.73.9(@babel/core@7.25.2)(@babel/preset-env@7.23.7(@babel/core@7.25.2))(encoding@0.1.13)(react@18.2.0))(react@18.2.0))(react-native@0.73.9(@babel/core@7.25.2)(@babel/preset-env@7.23.7(@babel/core@7.25.2))(encoding@0.1.13)(react@18.2.0))(react@18.2.0)':
     dependencies:
       '@tiptap/extension-blockquote': 2.6.6(@tiptap/core@2.6.6(@tiptap/pm@2.6.6))
@@ -15098,6 +15148,19 @@ snapshots:
       lru-cache: 5.1.1
       semver: 6.3.1
 
+  '@babel/helper-create-class-features-plugin@7.23.10(@babel/core@7.23.7)':
+    dependencies:
+      '@babel/core': 7.23.7
+      '@babel/helper-annotate-as-pure': 7.22.5
+      '@babel/helper-environment-visitor': 7.22.20
+      '@babel/helper-function-name': 7.23.0
+      '@babel/helper-member-expression-to-functions': 7.23.0
+      '@babel/helper-optimise-call-expression': 7.22.5
+      '@babel/helper-replace-supers': 7.22.20(@babel/core@7.23.7)
+      '@babel/helper-skip-transparent-expression-wrappers': 7.22.5
+      '@babel/helper-split-export-declaration': 7.22.6
+      semver: 6.3.1
+
   '@babel/helper-create-class-features-plugin@7.23.10(@babel/core@7.25.2)':
     dependencies:
       '@babel/core': 7.25.2
@@ -15110,6 +15173,19 @@ snapshots:
       '@babel/helper-skip-transparent-expression-wrappers': 7.22.5
       '@babel/helper-split-export-declaration': 7.22.6
       semver: 6.3.1
+
+  '@babel/helper-create-class-features-plugin@7.25.9(@babel/core@7.23.7)':
+    dependencies:
+      '@babel/core': 7.23.7
+      '@babel/helper-annotate-as-pure': 7.25.9
+      '@babel/helper-member-expression-to-functions': 7.25.9
+      '@babel/helper-optimise-call-expression': 7.25.9
+      '@babel/helper-replace-supers': 7.25.9(@babel/core@7.23.7)
+      '@babel/helper-skip-transparent-expression-wrappers': 7.25.9
+      '@babel/traverse': 7.25.9
+      semver: 6.3.1
+    transitivePeerDependencies:
+      - supports-color
 
   '@babel/helper-create-class-features-plugin@7.25.9(@babel/core@7.25.2)':
     dependencies:
@@ -15124,11 +15200,25 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  '@babel/helper-create-regexp-features-plugin@7.22.15(@babel/core@7.23.7)':
+    dependencies:
+      '@babel/core': 7.23.7
+      '@babel/helper-annotate-as-pure': 7.24.7
+      regexpu-core: 5.3.2
+      semver: 6.3.1
+
   '@babel/helper-create-regexp-features-plugin@7.22.15(@babel/core@7.25.2)':
     dependencies:
       '@babel/core': 7.25.2
       '@babel/helper-annotate-as-pure': 7.24.7
       regexpu-core: 5.3.2
+      semver: 6.3.1
+
+  '@babel/helper-create-regexp-features-plugin@7.25.9(@babel/core@7.23.7)':
+    dependencies:
+      '@babel/core': 7.23.7
+      '@babel/helper-annotate-as-pure': 7.25.9
+      regexpu-core: 6.1.1
       semver: 6.3.1
 
   '@babel/helper-create-regexp-features-plugin@7.25.9(@babel/core@7.25.2)':
@@ -15149,11 +15239,33 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  '@babel/helper-define-polyfill-provider@0.5.0(@babel/core@7.23.7)':
+    dependencies:
+      '@babel/core': 7.23.7
+      '@babel/helper-compilation-targets': 7.25.2
+      '@babel/helper-plugin-utils': 7.24.8
+      debug: 4.3.7
+      lodash.debounce: 4.0.8
+      resolve: 1.22.8
+    transitivePeerDependencies:
+      - supports-color
+
   '@babel/helper-define-polyfill-provider@0.5.0(@babel/core@7.25.2)':
     dependencies:
       '@babel/core': 7.25.2
       '@babel/helper-compilation-targets': 7.25.2
       '@babel/helper-plugin-utils': 7.24.8
+      debug: 4.3.7
+      lodash.debounce: 4.0.8
+      resolve: 1.22.8
+    transitivePeerDependencies:
+      - supports-color
+
+  '@babel/helper-define-polyfill-provider@0.6.2(@babel/core@7.23.7)':
+    dependencies:
+      '@babel/core': 7.23.7
+      '@babel/helper-compilation-targets': 7.25.9
+      '@babel/helper-plugin-utils': 7.25.9
       debug: 4.3.7
       lodash.debounce: 4.0.8
       resolve: 1.22.8
@@ -15220,6 +15332,16 @@ snapshots:
       '@babel/helper-split-export-declaration': 7.22.6
       '@babel/helper-validator-identifier': 7.24.7
 
+  '@babel/helper-module-transforms@7.25.2(@babel/core@7.23.7)':
+    dependencies:
+      '@babel/core': 7.23.7
+      '@babel/helper-module-imports': 7.24.7
+      '@babel/helper-simple-access': 7.24.7
+      '@babel/helper-validator-identifier': 7.24.7
+      '@babel/traverse': 7.25.6
+    transitivePeerDependencies:
+      - supports-color
+
   '@babel/helper-module-transforms@7.25.2(@babel/core@7.25.2)':
     dependencies:
       '@babel/core': 7.25.2
@@ -15227,6 +15349,15 @@ snapshots:
       '@babel/helper-simple-access': 7.24.7
       '@babel/helper-validator-identifier': 7.24.7
       '@babel/traverse': 7.25.6
+    transitivePeerDependencies:
+      - supports-color
+
+  '@babel/helper-module-transforms@7.26.0(@babel/core@7.23.7)':
+    dependencies:
+      '@babel/core': 7.23.7
+      '@babel/helper-module-imports': 7.25.9
+      '@babel/helper-validator-identifier': 7.25.9
+      '@babel/traverse': 7.25.9
     transitivePeerDependencies:
       - supports-color
 
@@ -15253,12 +15384,28 @@ snapshots:
 
   '@babel/helper-plugin-utils@7.25.9': {}
 
+  '@babel/helper-remap-async-to-generator@7.22.20(@babel/core@7.23.7)':
+    dependencies:
+      '@babel/core': 7.23.7
+      '@babel/helper-annotate-as-pure': 7.24.7
+      '@babel/helper-environment-visitor': 7.22.20
+      '@babel/helper-wrap-function': 7.22.20
+
   '@babel/helper-remap-async-to-generator@7.22.20(@babel/core@7.25.2)':
     dependencies:
       '@babel/core': 7.25.2
       '@babel/helper-annotate-as-pure': 7.24.7
       '@babel/helper-environment-visitor': 7.22.20
       '@babel/helper-wrap-function': 7.22.20
+
+  '@babel/helper-remap-async-to-generator@7.25.9(@babel/core@7.23.7)':
+    dependencies:
+      '@babel/core': 7.23.7
+      '@babel/helper-annotate-as-pure': 7.25.9
+      '@babel/helper-wrap-function': 7.25.9
+      '@babel/traverse': 7.25.9
+    transitivePeerDependencies:
+      - supports-color
 
   '@babel/helper-remap-async-to-generator@7.25.9(@babel/core@7.25.2)':
     dependencies:
@@ -15269,12 +15416,28 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  '@babel/helper-replace-supers@7.22.20(@babel/core@7.23.7)':
+    dependencies:
+      '@babel/core': 7.23.7
+      '@babel/helper-environment-visitor': 7.22.20
+      '@babel/helper-member-expression-to-functions': 7.23.0
+      '@babel/helper-optimise-call-expression': 7.22.5
+
   '@babel/helper-replace-supers@7.22.20(@babel/core@7.25.2)':
     dependencies:
       '@babel/core': 7.25.2
       '@babel/helper-environment-visitor': 7.22.20
       '@babel/helper-member-expression-to-functions': 7.23.0
       '@babel/helper-optimise-call-expression': 7.22.5
+
+  '@babel/helper-replace-supers@7.25.9(@babel/core@7.23.7)':
+    dependencies:
+      '@babel/core': 7.23.7
+      '@babel/helper-member-expression-to-functions': 7.25.9
+      '@babel/helper-optimise-call-expression': 7.25.9
+      '@babel/traverse': 7.25.9
+    transitivePeerDependencies:
+      - supports-color
 
   '@babel/helper-replace-supers@7.25.9(@babel/core@7.25.2)':
     dependencies:
@@ -15388,6 +15551,14 @@ snapshots:
     dependencies:
       '@babel/types': 7.26.0
 
+  '@babel/plugin-bugfix-firefox-class-in-computed-class-key@7.25.9(@babel/core@7.23.7)':
+    dependencies:
+      '@babel/core': 7.23.7
+      '@babel/helper-plugin-utils': 7.25.9
+      '@babel/traverse': 7.25.9
+    transitivePeerDependencies:
+      - supports-color
+
   '@babel/plugin-bugfix-firefox-class-in-computed-class-key@7.25.9(@babel/core@7.25.2)':
     dependencies:
       '@babel/core': 7.25.2
@@ -15395,6 +15566,11 @@ snapshots:
       '@babel/traverse': 7.25.9
     transitivePeerDependencies:
       - supports-color
+
+  '@babel/plugin-bugfix-safari-class-field-initializer-scope@7.25.9(@babel/core@7.23.7)':
+    dependencies:
+      '@babel/core': 7.23.7
+      '@babel/helper-plugin-utils': 7.25.9
 
   '@babel/plugin-bugfix-safari-class-field-initializer-scope@7.25.9(@babel/core@7.25.2)':
     dependencies:
@@ -15405,6 +15581,11 @@ snapshots:
     dependencies:
       '@babel/core': 7.25.2
       '@babel/helper-plugin-utils': 7.24.8
+
+  '@babel/plugin-bugfix-safari-id-destructuring-collision-in-function-expression@7.25.9(@babel/core@7.23.7)':
+    dependencies:
+      '@babel/core': 7.23.7
+      '@babel/helper-plugin-utils': 7.25.9
 
   '@babel/plugin-bugfix-safari-id-destructuring-collision-in-function-expression@7.25.9(@babel/core@7.25.2)':
     dependencies:
@@ -15417,6 +15598,15 @@ snapshots:
       '@babel/helper-plugin-utils': 7.24.8
       '@babel/helper-skip-transparent-expression-wrappers': 7.22.5
       '@babel/plugin-transform-optional-chaining': 7.23.4(@babel/core@7.25.2)
+
+  '@babel/plugin-bugfix-v8-spread-parameters-in-optional-chaining@7.25.9(@babel/core@7.23.7)':
+    dependencies:
+      '@babel/core': 7.23.7
+      '@babel/helper-plugin-utils': 7.25.9
+      '@babel/helper-skip-transparent-expression-wrappers': 7.25.9
+      '@babel/plugin-transform-optional-chaining': 7.25.9(@babel/core@7.23.7)
+    transitivePeerDependencies:
+      - supports-color
 
   '@babel/plugin-bugfix-v8-spread-parameters-in-optional-chaining@7.25.9(@babel/core@7.25.2)':
     dependencies:
@@ -15433,6 +15623,14 @@ snapshots:
       '@babel/helper-environment-visitor': 7.22.20
       '@babel/helper-plugin-utils': 7.24.8
 
+  '@babel/plugin-bugfix-v8-static-class-fields-redefine-readonly@7.25.9(@babel/core@7.23.7)':
+    dependencies:
+      '@babel/core': 7.23.7
+      '@babel/helper-plugin-utils': 7.25.9
+      '@babel/traverse': 7.25.9
+    transitivePeerDependencies:
+      - supports-color
+
   '@babel/plugin-bugfix-v8-static-class-fields-redefine-readonly@7.25.9(@babel/core@7.25.2)':
     dependencies:
       '@babel/core': 7.25.2
@@ -15441,6 +15639,14 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  '@babel/plugin-proposal-async-generator-functions@7.20.7(@babel/core@7.23.7)':
+    dependencies:
+      '@babel/core': 7.23.7
+      '@babel/helper-environment-visitor': 7.22.20
+      '@babel/helper-plugin-utils': 7.24.8
+      '@babel/helper-remap-async-to-generator': 7.22.20(@babel/core@7.23.7)
+      '@babel/plugin-syntax-async-generators': 7.8.4(@babel/core@7.23.7)
+
   '@babel/plugin-proposal-async-generator-functions@7.20.7(@babel/core@7.25.2)':
     dependencies:
       '@babel/core': 7.25.2
@@ -15448,6 +15654,12 @@ snapshots:
       '@babel/helper-plugin-utils': 7.24.8
       '@babel/helper-remap-async-to-generator': 7.22.20(@babel/core@7.25.2)
       '@babel/plugin-syntax-async-generators': 7.8.4(@babel/core@7.25.2)
+
+  '@babel/plugin-proposal-class-properties@7.18.6(@babel/core@7.23.7)':
+    dependencies:
+      '@babel/core': 7.23.7
+      '@babel/helper-create-class-features-plugin': 7.23.10(@babel/core@7.23.7)
+      '@babel/helper-plugin-utils': 7.24.8
 
   '@babel/plugin-proposal-class-properties@7.18.6(@babel/core@7.25.2)':
     dependencies:
@@ -15462,6 +15674,12 @@ snapshots:
       '@babel/helper-plugin-utils': 7.22.5
       '@babel/plugin-syntax-decorators': 7.23.3(@babel/core@7.25.2)
 
+  '@babel/plugin-proposal-export-default-from@7.23.3(@babel/core@7.23.7)':
+    dependencies:
+      '@babel/core': 7.23.7
+      '@babel/helper-plugin-utils': 7.24.8
+      '@babel/plugin-syntax-export-default-from': 7.23.3(@babel/core@7.23.7)
+
   '@babel/plugin-proposal-export-default-from@7.23.3(@babel/core@7.25.2)':
     dependencies:
       '@babel/core': 7.25.2
@@ -15474,17 +15692,38 @@ snapshots:
       '@babel/helper-plugin-utils': 7.22.5
       '@babel/plugin-syntax-export-namespace-from': 7.8.3(@babel/core@7.25.2)
 
+  '@babel/plugin-proposal-nullish-coalescing-operator@7.18.6(@babel/core@7.23.7)':
+    dependencies:
+      '@babel/core': 7.23.7
+      '@babel/helper-plugin-utils': 7.24.8
+      '@babel/plugin-syntax-nullish-coalescing-operator': 7.8.3(@babel/core@7.23.7)
+
   '@babel/plugin-proposal-nullish-coalescing-operator@7.18.6(@babel/core@7.25.2)':
     dependencies:
       '@babel/core': 7.25.2
       '@babel/helper-plugin-utils': 7.24.8
       '@babel/plugin-syntax-nullish-coalescing-operator': 7.8.3(@babel/core@7.25.2)
 
+  '@babel/plugin-proposal-numeric-separator@7.18.6(@babel/core@7.23.7)':
+    dependencies:
+      '@babel/core': 7.23.7
+      '@babel/helper-plugin-utils': 7.24.8
+      '@babel/plugin-syntax-numeric-separator': 7.10.4(@babel/core@7.23.7)
+
   '@babel/plugin-proposal-numeric-separator@7.18.6(@babel/core@7.25.2)':
     dependencies:
       '@babel/core': 7.25.2
       '@babel/helper-plugin-utils': 7.24.8
       '@babel/plugin-syntax-numeric-separator': 7.10.4(@babel/core@7.25.2)
+
+  '@babel/plugin-proposal-object-rest-spread@7.20.7(@babel/core@7.23.7)':
+    dependencies:
+      '@babel/compat-data': 7.25.2
+      '@babel/core': 7.23.7
+      '@babel/helper-compilation-targets': 7.25.2
+      '@babel/helper-plugin-utils': 7.24.8
+      '@babel/plugin-syntax-object-rest-spread': 7.8.3(@babel/core@7.23.7)
+      '@babel/plugin-transform-parameters': 7.23.3(@babel/core@7.23.7)
 
   '@babel/plugin-proposal-object-rest-spread@7.20.7(@babel/core@7.25.2)':
     dependencies:
@@ -15495,11 +15734,24 @@ snapshots:
       '@babel/plugin-syntax-object-rest-spread': 7.8.3(@babel/core@7.25.2)
       '@babel/plugin-transform-parameters': 7.23.3(@babel/core@7.25.2)
 
+  '@babel/plugin-proposal-optional-catch-binding@7.18.6(@babel/core@7.23.7)':
+    dependencies:
+      '@babel/core': 7.23.7
+      '@babel/helper-plugin-utils': 7.24.8
+      '@babel/plugin-syntax-optional-catch-binding': 7.8.3(@babel/core@7.23.7)
+
   '@babel/plugin-proposal-optional-catch-binding@7.18.6(@babel/core@7.25.2)':
     dependencies:
       '@babel/core': 7.25.2
       '@babel/helper-plugin-utils': 7.24.8
       '@babel/plugin-syntax-optional-catch-binding': 7.8.3(@babel/core@7.25.2)
+
+  '@babel/plugin-proposal-optional-chaining@7.21.0(@babel/core@7.23.7)':
+    dependencies:
+      '@babel/core': 7.23.7
+      '@babel/helper-plugin-utils': 7.24.8
+      '@babel/helper-skip-transparent-expression-wrappers': 7.22.5
+      '@babel/plugin-syntax-optional-chaining': 7.8.3(@babel/core@7.23.7)
 
   '@babel/plugin-proposal-optional-chaining@7.21.0(@babel/core@7.25.2)':
     dependencies:
@@ -15508,9 +15760,18 @@ snapshots:
       '@babel/helper-skip-transparent-expression-wrappers': 7.22.5
       '@babel/plugin-syntax-optional-chaining': 7.8.3(@babel/core@7.25.2)
 
+  '@babel/plugin-proposal-private-property-in-object@7.21.0-placeholder-for-preset-env.2(@babel/core@7.23.7)':
+    dependencies:
+      '@babel/core': 7.23.7
+
   '@babel/plugin-proposal-private-property-in-object@7.21.0-placeholder-for-preset-env.2(@babel/core@7.25.2)':
     dependencies:
       '@babel/core': 7.25.2
+
+  '@babel/plugin-syntax-async-generators@7.8.4(@babel/core@7.23.7)':
+    dependencies:
+      '@babel/core': 7.23.7
+      '@babel/helper-plugin-utils': 7.24.8
 
   '@babel/plugin-syntax-async-generators@7.8.4(@babel/core@7.25.2)':
     dependencies:
@@ -15537,9 +15798,19 @@ snapshots:
       '@babel/core': 7.25.2
       '@babel/helper-plugin-utils': 7.24.8
 
+  '@babel/plugin-syntax-dynamic-import@7.8.3(@babel/core@7.23.7)':
+    dependencies:
+      '@babel/core': 7.23.7
+      '@babel/helper-plugin-utils': 7.24.8
+
   '@babel/plugin-syntax-dynamic-import@7.8.3(@babel/core@7.25.2)':
     dependencies:
       '@babel/core': 7.25.2
+      '@babel/helper-plugin-utils': 7.24.8
+
+  '@babel/plugin-syntax-export-default-from@7.23.3(@babel/core@7.23.7)':
+    dependencies:
+      '@babel/core': 7.23.7
       '@babel/helper-plugin-utils': 7.24.8
 
   '@babel/plugin-syntax-export-default-from@7.23.3(@babel/core@7.25.2)':
@@ -15552,6 +15823,11 @@ snapshots:
       '@babel/core': 7.25.2
       '@babel/helper-plugin-utils': 7.22.5
 
+  '@babel/plugin-syntax-flow@7.23.3(@babel/core@7.23.7)':
+    dependencies:
+      '@babel/core': 7.23.7
+      '@babel/helper-plugin-utils': 7.24.8
+
   '@babel/plugin-syntax-flow@7.23.3(@babel/core@7.25.2)':
     dependencies:
       '@babel/core': 7.25.2
@@ -15562,6 +15838,11 @@ snapshots:
       '@babel/core': 7.25.2
       '@babel/helper-plugin-utils': 7.24.8
 
+  '@babel/plugin-syntax-import-assertions@7.26.0(@babel/core@7.23.7)':
+    dependencies:
+      '@babel/core': 7.23.7
+      '@babel/helper-plugin-utils': 7.25.9
+
   '@babel/plugin-syntax-import-assertions@7.26.0(@babel/core@7.25.2)':
     dependencies:
       '@babel/core': 7.25.2
@@ -15571,6 +15852,11 @@ snapshots:
     dependencies:
       '@babel/core': 7.25.2
       '@babel/helper-plugin-utils': 7.24.8
+
+  '@babel/plugin-syntax-import-attributes@7.26.0(@babel/core@7.23.7)':
+    dependencies:
+      '@babel/core': 7.23.7
+      '@babel/helper-plugin-utils': 7.25.9
 
   '@babel/plugin-syntax-import-attributes@7.26.0(@babel/core@7.25.2)':
     dependencies:
@@ -15592,6 +15878,11 @@ snapshots:
       '@babel/core': 7.25.2
       '@babel/helper-plugin-utils': 7.22.5
 
+  '@babel/plugin-syntax-jsx@7.24.7(@babel/core@7.23.7)':
+    dependencies:
+      '@babel/core': 7.23.7
+      '@babel/helper-plugin-utils': 7.24.8
+
   '@babel/plugin-syntax-jsx@7.24.7(@babel/core@7.25.2)':
     dependencies:
       '@babel/core': 7.25.2
@@ -15602,14 +15893,29 @@ snapshots:
       '@babel/core': 7.25.2
       '@babel/helper-plugin-utils': 7.24.8
 
+  '@babel/plugin-syntax-nullish-coalescing-operator@7.8.3(@babel/core@7.23.7)':
+    dependencies:
+      '@babel/core': 7.23.7
+      '@babel/helper-plugin-utils': 7.22.5
+
   '@babel/plugin-syntax-nullish-coalescing-operator@7.8.3(@babel/core@7.25.2)':
     dependencies:
       '@babel/core': 7.25.2
       '@babel/helper-plugin-utils': 7.22.5
 
+  '@babel/plugin-syntax-numeric-separator@7.10.4(@babel/core@7.23.7)':
+    dependencies:
+      '@babel/core': 7.23.7
+      '@babel/helper-plugin-utils': 7.24.8
+
   '@babel/plugin-syntax-numeric-separator@7.10.4(@babel/core@7.25.2)':
     dependencies:
       '@babel/core': 7.25.2
+      '@babel/helper-plugin-utils': 7.24.8
+
+  '@babel/plugin-syntax-object-rest-spread@7.8.3(@babel/core@7.23.7)':
+    dependencies:
+      '@babel/core': 7.23.7
       '@babel/helper-plugin-utils': 7.24.8
 
   '@babel/plugin-syntax-object-rest-spread@7.8.3(@babel/core@7.25.2)':
@@ -15617,15 +15923,30 @@ snapshots:
       '@babel/core': 7.25.2
       '@babel/helper-plugin-utils': 7.24.8
 
+  '@babel/plugin-syntax-optional-catch-binding@7.8.3(@babel/core@7.23.7)':
+    dependencies:
+      '@babel/core': 7.23.7
+      '@babel/helper-plugin-utils': 7.24.8
+
   '@babel/plugin-syntax-optional-catch-binding@7.8.3(@babel/core@7.25.2)':
     dependencies:
       '@babel/core': 7.25.2
       '@babel/helper-plugin-utils': 7.24.8
 
+  '@babel/plugin-syntax-optional-chaining@7.8.3(@babel/core@7.23.7)':
+    dependencies:
+      '@babel/core': 7.23.7
+      '@babel/helper-plugin-utils': 7.22.5
+
   '@babel/plugin-syntax-optional-chaining@7.8.3(@babel/core@7.25.2)':
     dependencies:
       '@babel/core': 7.25.2
       '@babel/helper-plugin-utils': 7.22.5
+
+  '@babel/plugin-syntax-private-property-in-object@7.14.5(@babel/core@7.23.7)':
+    dependencies:
+      '@babel/core': 7.23.7
+      '@babel/helper-plugin-utils': 7.24.8
 
   '@babel/plugin-syntax-private-property-in-object@7.14.5(@babel/core@7.25.2)':
     dependencies:
@@ -15637,9 +15958,20 @@ snapshots:
       '@babel/core': 7.25.2
       '@babel/helper-plugin-utils': 7.24.8
 
+  '@babel/plugin-syntax-typescript@7.23.3(@babel/core@7.23.7)':
+    dependencies:
+      '@babel/core': 7.23.7
+      '@babel/helper-plugin-utils': 7.24.8
+
   '@babel/plugin-syntax-typescript@7.23.3(@babel/core@7.25.2)':
     dependencies:
       '@babel/core': 7.25.2
+      '@babel/helper-plugin-utils': 7.24.8
+
+  '@babel/plugin-syntax-unicode-sets-regex@7.18.6(@babel/core@7.23.7)':
+    dependencies:
+      '@babel/core': 7.23.7
+      '@babel/helper-create-regexp-features-plugin': 7.22.15(@babel/core@7.23.7)
       '@babel/helper-plugin-utils': 7.24.8
 
   '@babel/plugin-syntax-unicode-sets-regex@7.18.6(@babel/core@7.25.2)':
@@ -15648,10 +15980,20 @@ snapshots:
       '@babel/helper-create-regexp-features-plugin': 7.22.15(@babel/core@7.25.2)
       '@babel/helper-plugin-utils': 7.24.8
 
+  '@babel/plugin-transform-arrow-functions@7.23.3(@babel/core@7.23.7)':
+    dependencies:
+      '@babel/core': 7.23.7
+      '@babel/helper-plugin-utils': 7.22.5
+
   '@babel/plugin-transform-arrow-functions@7.23.3(@babel/core@7.25.2)':
     dependencies:
       '@babel/core': 7.25.2
       '@babel/helper-plugin-utils': 7.22.5
+
+  '@babel/plugin-transform-arrow-functions@7.25.9(@babel/core@7.23.7)':
+    dependencies:
+      '@babel/core': 7.23.7
+      '@babel/helper-plugin-utils': 7.25.9
 
   '@babel/plugin-transform-arrow-functions@7.25.9(@babel/core@7.25.2)':
     dependencies:
@@ -15666,6 +16008,15 @@ snapshots:
       '@babel/helper-remap-async-to-generator': 7.22.20(@babel/core@7.25.2)
       '@babel/plugin-syntax-async-generators': 7.8.4(@babel/core@7.25.2)
 
+  '@babel/plugin-transform-async-generator-functions@7.25.9(@babel/core@7.23.7)':
+    dependencies:
+      '@babel/core': 7.23.7
+      '@babel/helper-plugin-utils': 7.25.9
+      '@babel/helper-remap-async-to-generator': 7.25.9(@babel/core@7.23.7)
+      '@babel/traverse': 7.25.9
+    transitivePeerDependencies:
+      - supports-color
+
   '@babel/plugin-transform-async-generator-functions@7.25.9(@babel/core@7.25.2)':
     dependencies:
       '@babel/core': 7.25.2
@@ -15675,12 +16026,30 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  '@babel/plugin-transform-async-to-generator@7.23.3(@babel/core@7.23.7)':
+    dependencies:
+      '@babel/core': 7.23.7
+      '@babel/helper-module-imports': 7.24.7
+      '@babel/helper-plugin-utils': 7.24.8
+      '@babel/helper-remap-async-to-generator': 7.22.20(@babel/core@7.23.7)
+    transitivePeerDependencies:
+      - supports-color
+
   '@babel/plugin-transform-async-to-generator@7.23.3(@babel/core@7.25.2)':
     dependencies:
       '@babel/core': 7.25.2
       '@babel/helper-module-imports': 7.24.7
       '@babel/helper-plugin-utils': 7.24.8
       '@babel/helper-remap-async-to-generator': 7.22.20(@babel/core@7.25.2)
+    transitivePeerDependencies:
+      - supports-color
+
+  '@babel/plugin-transform-async-to-generator@7.25.9(@babel/core@7.23.7)':
+    dependencies:
+      '@babel/core': 7.23.7
+      '@babel/helper-module-imports': 7.25.9
+      '@babel/helper-plugin-utils': 7.25.9
+      '@babel/helper-remap-async-to-generator': 7.25.9(@babel/core@7.23.7)
     transitivePeerDependencies:
       - supports-color
 
@@ -15698,15 +16067,30 @@ snapshots:
       '@babel/core': 7.25.2
       '@babel/helper-plugin-utils': 7.24.8
 
+  '@babel/plugin-transform-block-scoped-functions@7.25.9(@babel/core@7.23.7)':
+    dependencies:
+      '@babel/core': 7.23.7
+      '@babel/helper-plugin-utils': 7.25.9
+
   '@babel/plugin-transform-block-scoped-functions@7.25.9(@babel/core@7.25.2)':
     dependencies:
       '@babel/core': 7.25.2
       '@babel/helper-plugin-utils': 7.25.9
 
+  '@babel/plugin-transform-block-scoping@7.23.4(@babel/core@7.23.7)':
+    dependencies:
+      '@babel/core': 7.23.7
+      '@babel/helper-plugin-utils': 7.24.8
+
   '@babel/plugin-transform-block-scoping@7.23.4(@babel/core@7.25.2)':
     dependencies:
       '@babel/core': 7.25.2
       '@babel/helper-plugin-utils': 7.24.8
+
+  '@babel/plugin-transform-block-scoping@7.25.9(@babel/core@7.23.7)':
+    dependencies:
+      '@babel/core': 7.23.7
+      '@babel/helper-plugin-utils': 7.25.9
 
   '@babel/plugin-transform-block-scoping@7.25.9(@babel/core@7.25.2)':
     dependencies:
@@ -15718,6 +16102,14 @@ snapshots:
       '@babel/core': 7.25.2
       '@babel/helper-create-class-features-plugin': 7.23.10(@babel/core@7.25.2)
       '@babel/helper-plugin-utils': 7.24.8
+
+  '@babel/plugin-transform-class-properties@7.25.9(@babel/core@7.23.7)':
+    dependencies:
+      '@babel/core': 7.23.7
+      '@babel/helper-create-class-features-plugin': 7.25.9(@babel/core@7.23.7)
+      '@babel/helper-plugin-utils': 7.25.9
+    transitivePeerDependencies:
+      - supports-color
 
   '@babel/plugin-transform-class-properties@7.25.9(@babel/core@7.25.2)':
     dependencies:
@@ -15734,6 +16126,14 @@ snapshots:
       '@babel/helper-plugin-utils': 7.24.8
       '@babel/plugin-syntax-class-static-block': 7.14.5(@babel/core@7.25.2)
 
+  '@babel/plugin-transform-class-static-block@7.26.0(@babel/core@7.23.7)':
+    dependencies:
+      '@babel/core': 7.23.7
+      '@babel/helper-create-class-features-plugin': 7.25.9(@babel/core@7.23.7)
+      '@babel/helper-plugin-utils': 7.25.9
+    transitivePeerDependencies:
+      - supports-color
+
   '@babel/plugin-transform-class-static-block@7.26.0(@babel/core@7.25.2)':
     dependencies:
       '@babel/core': 7.25.2
@@ -15741,6 +16141,18 @@ snapshots:
       '@babel/helper-plugin-utils': 7.25.9
     transitivePeerDependencies:
       - supports-color
+
+  '@babel/plugin-transform-classes@7.23.8(@babel/core@7.23.7)':
+    dependencies:
+      '@babel/core': 7.23.7
+      '@babel/helper-annotate-as-pure': 7.22.5
+      '@babel/helper-compilation-targets': 7.25.2
+      '@babel/helper-environment-visitor': 7.22.20
+      '@babel/helper-function-name': 7.23.0
+      '@babel/helper-plugin-utils': 7.24.8
+      '@babel/helper-replace-supers': 7.22.20(@babel/core@7.23.7)
+      '@babel/helper-split-export-declaration': 7.22.6
+      globals: 11.12.0
 
   '@babel/plugin-transform-classes@7.23.8(@babel/core@7.25.2)':
     dependencies:
@@ -15754,6 +16166,18 @@ snapshots:
       '@babel/helper-split-export-declaration': 7.22.6
       globals: 11.12.0
 
+  '@babel/plugin-transform-classes@7.25.9(@babel/core@7.23.7)':
+    dependencies:
+      '@babel/core': 7.23.7
+      '@babel/helper-annotate-as-pure': 7.25.9
+      '@babel/helper-compilation-targets': 7.25.9
+      '@babel/helper-plugin-utils': 7.25.9
+      '@babel/helper-replace-supers': 7.25.9(@babel/core@7.23.7)
+      '@babel/traverse': 7.25.9
+      globals: 11.12.0
+    transitivePeerDependencies:
+      - supports-color
+
   '@babel/plugin-transform-classes@7.25.9(@babel/core@7.25.2)':
     dependencies:
       '@babel/core': 7.25.2
@@ -15766,11 +16190,23 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  '@babel/plugin-transform-computed-properties@7.23.3(@babel/core@7.23.7)':
+    dependencies:
+      '@babel/core': 7.23.7
+      '@babel/helper-plugin-utils': 7.24.8
+      '@babel/template': 7.25.0
+
   '@babel/plugin-transform-computed-properties@7.23.3(@babel/core@7.25.2)':
     dependencies:
       '@babel/core': 7.25.2
       '@babel/helper-plugin-utils': 7.24.8
       '@babel/template': 7.25.0
+
+  '@babel/plugin-transform-computed-properties@7.25.9(@babel/core@7.23.7)':
+    dependencies:
+      '@babel/core': 7.23.7
+      '@babel/helper-plugin-utils': 7.25.9
+      '@babel/template': 7.25.9
 
   '@babel/plugin-transform-computed-properties@7.25.9(@babel/core@7.25.2)':
     dependencies:
@@ -15778,10 +16214,20 @@ snapshots:
       '@babel/helper-plugin-utils': 7.25.9
       '@babel/template': 7.25.9
 
+  '@babel/plugin-transform-destructuring@7.23.3(@babel/core@7.23.7)':
+    dependencies:
+      '@babel/core': 7.23.7
+      '@babel/helper-plugin-utils': 7.24.8
+
   '@babel/plugin-transform-destructuring@7.23.3(@babel/core@7.25.2)':
     dependencies:
       '@babel/core': 7.25.2
       '@babel/helper-plugin-utils': 7.24.8
+
+  '@babel/plugin-transform-destructuring@7.25.9(@babel/core@7.23.7)':
+    dependencies:
+      '@babel/core': 7.23.7
+      '@babel/helper-plugin-utils': 7.25.9
 
   '@babel/plugin-transform-destructuring@7.25.9(@babel/core@7.25.2)':
     dependencies:
@@ -15794,6 +16240,12 @@ snapshots:
       '@babel/helper-create-regexp-features-plugin': 7.22.15(@babel/core@7.25.2)
       '@babel/helper-plugin-utils': 7.24.8
 
+  '@babel/plugin-transform-dotall-regex@7.25.9(@babel/core@7.23.7)':
+    dependencies:
+      '@babel/core': 7.23.7
+      '@babel/helper-create-regexp-features-plugin': 7.25.9(@babel/core@7.23.7)
+      '@babel/helper-plugin-utils': 7.25.9
+
   '@babel/plugin-transform-dotall-regex@7.25.9(@babel/core@7.25.2)':
     dependencies:
       '@babel/core': 7.25.2
@@ -15805,9 +16257,20 @@ snapshots:
       '@babel/core': 7.25.2
       '@babel/helper-plugin-utils': 7.24.8
 
+  '@babel/plugin-transform-duplicate-keys@7.25.9(@babel/core@7.23.7)':
+    dependencies:
+      '@babel/core': 7.23.7
+      '@babel/helper-plugin-utils': 7.25.9
+
   '@babel/plugin-transform-duplicate-keys@7.25.9(@babel/core@7.25.2)':
     dependencies:
       '@babel/core': 7.25.2
+      '@babel/helper-plugin-utils': 7.25.9
+
+  '@babel/plugin-transform-duplicate-named-capturing-groups-regex@7.25.9(@babel/core@7.23.7)':
+    dependencies:
+      '@babel/core': 7.23.7
+      '@babel/helper-create-regexp-features-plugin': 7.25.9(@babel/core@7.23.7)
       '@babel/helper-plugin-utils': 7.25.9
 
   '@babel/plugin-transform-duplicate-named-capturing-groups-regex@7.25.9(@babel/core@7.25.2)':
@@ -15822,6 +16285,11 @@ snapshots:
       '@babel/helper-plugin-utils': 7.24.8
       '@babel/plugin-syntax-dynamic-import': 7.8.3(@babel/core@7.25.2)
 
+  '@babel/plugin-transform-dynamic-import@7.25.9(@babel/core@7.23.7)':
+    dependencies:
+      '@babel/core': 7.23.7
+      '@babel/helper-plugin-utils': 7.25.9
+
   '@babel/plugin-transform-dynamic-import@7.25.9(@babel/core@7.25.2)':
     dependencies:
       '@babel/core': 7.25.2
@@ -15832,6 +16300,14 @@ snapshots:
       '@babel/core': 7.25.2
       '@babel/helper-builder-binary-assignment-operator-visitor': 7.22.15
       '@babel/helper-plugin-utils': 7.24.8
+
+  '@babel/plugin-transform-exponentiation-operator@7.25.9(@babel/core@7.23.7)':
+    dependencies:
+      '@babel/core': 7.23.7
+      '@babel/helper-builder-binary-assignment-operator-visitor': 7.25.9
+      '@babel/helper-plugin-utils': 7.25.9
+    transitivePeerDependencies:
+      - supports-color
 
   '@babel/plugin-transform-exponentiation-operator@7.25.9(@babel/core@7.25.2)':
     dependencies:
@@ -15847,10 +16323,21 @@ snapshots:
       '@babel/helper-plugin-utils': 7.22.5
       '@babel/plugin-syntax-export-namespace-from': 7.8.3(@babel/core@7.25.2)
 
+  '@babel/plugin-transform-export-namespace-from@7.25.9(@babel/core@7.23.7)':
+    dependencies:
+      '@babel/core': 7.23.7
+      '@babel/helper-plugin-utils': 7.25.9
+
   '@babel/plugin-transform-export-namespace-from@7.25.9(@babel/core@7.25.2)':
     dependencies:
       '@babel/core': 7.25.2
       '@babel/helper-plugin-utils': 7.25.9
+
+  '@babel/plugin-transform-flow-strip-types@7.23.3(@babel/core@7.23.7)':
+    dependencies:
+      '@babel/core': 7.23.7
+      '@babel/helper-plugin-utils': 7.24.8
+      '@babel/plugin-syntax-flow': 7.23.3(@babel/core@7.23.7)
 
   '@babel/plugin-transform-flow-strip-types@7.23.3(@babel/core@7.25.2)':
     dependencies:
@@ -15864,6 +16351,14 @@ snapshots:
       '@babel/helper-plugin-utils': 7.24.8
       '@babel/helper-skip-transparent-expression-wrappers': 7.22.5
 
+  '@babel/plugin-transform-for-of@7.25.9(@babel/core@7.23.7)':
+    dependencies:
+      '@babel/core': 7.23.7
+      '@babel/helper-plugin-utils': 7.25.9
+      '@babel/helper-skip-transparent-expression-wrappers': 7.25.9
+    transitivePeerDependencies:
+      - supports-color
+
   '@babel/plugin-transform-for-of@7.25.9(@babel/core@7.25.2)':
     dependencies:
       '@babel/core': 7.25.2
@@ -15872,12 +16367,28 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  '@babel/plugin-transform-function-name@7.23.3(@babel/core@7.23.7)':
+    dependencies:
+      '@babel/core': 7.23.7
+      '@babel/helper-compilation-targets': 7.25.2
+      '@babel/helper-function-name': 7.23.0
+      '@babel/helper-plugin-utils': 7.24.8
+
   '@babel/plugin-transform-function-name@7.23.3(@babel/core@7.25.2)':
     dependencies:
       '@babel/core': 7.25.2
       '@babel/helper-compilation-targets': 7.25.2
       '@babel/helper-function-name': 7.23.0
       '@babel/helper-plugin-utils': 7.24.8
+
+  '@babel/plugin-transform-function-name@7.25.9(@babel/core@7.23.7)':
+    dependencies:
+      '@babel/core': 7.23.7
+      '@babel/helper-compilation-targets': 7.25.9
+      '@babel/helper-plugin-utils': 7.25.9
+      '@babel/traverse': 7.25.9
+    transitivePeerDependencies:
+      - supports-color
 
   '@babel/plugin-transform-function-name@7.25.9(@babel/core@7.25.2)':
     dependencies:
@@ -15894,15 +16405,30 @@ snapshots:
       '@babel/helper-plugin-utils': 7.24.8
       '@babel/plugin-syntax-json-strings': 7.8.3(@babel/core@7.25.2)
 
+  '@babel/plugin-transform-json-strings@7.25.9(@babel/core@7.23.7)':
+    dependencies:
+      '@babel/core': 7.23.7
+      '@babel/helper-plugin-utils': 7.25.9
+
   '@babel/plugin-transform-json-strings@7.25.9(@babel/core@7.25.2)':
     dependencies:
       '@babel/core': 7.25.2
       '@babel/helper-plugin-utils': 7.25.9
 
+  '@babel/plugin-transform-literals@7.23.3(@babel/core@7.23.7)':
+    dependencies:
+      '@babel/core': 7.23.7
+      '@babel/helper-plugin-utils': 7.24.8
+
   '@babel/plugin-transform-literals@7.23.3(@babel/core@7.25.2)':
     dependencies:
       '@babel/core': 7.25.2
       '@babel/helper-plugin-utils': 7.24.8
+
+  '@babel/plugin-transform-literals@7.25.9(@babel/core@7.23.7)':
+    dependencies:
+      '@babel/core': 7.23.7
+      '@babel/helper-plugin-utils': 7.25.9
 
   '@babel/plugin-transform-literals@7.25.9(@babel/core@7.25.2)':
     dependencies:
@@ -15915,6 +16441,11 @@ snapshots:
       '@babel/helper-plugin-utils': 7.24.8
       '@babel/plugin-syntax-logical-assignment-operators': 7.10.4(@babel/core@7.25.2)
 
+  '@babel/plugin-transform-logical-assignment-operators@7.25.9(@babel/core@7.23.7)':
+    dependencies:
+      '@babel/core': 7.23.7
+      '@babel/helper-plugin-utils': 7.25.9
+
   '@babel/plugin-transform-logical-assignment-operators@7.25.9(@babel/core@7.25.2)':
     dependencies:
       '@babel/core': 7.25.2
@@ -15924,6 +16455,11 @@ snapshots:
     dependencies:
       '@babel/core': 7.25.2
       '@babel/helper-plugin-utils': 7.24.8
+
+  '@babel/plugin-transform-member-expression-literals@7.25.9(@babel/core@7.23.7)':
+    dependencies:
+      '@babel/core': 7.23.7
+      '@babel/helper-plugin-utils': 7.25.9
 
   '@babel/plugin-transform-member-expression-literals@7.25.9(@babel/core@7.25.2)':
     dependencies:
@@ -15938,11 +16474,28 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  '@babel/plugin-transform-modules-amd@7.25.9(@babel/core@7.23.7)':
+    dependencies:
+      '@babel/core': 7.23.7
+      '@babel/helper-module-transforms': 7.26.0(@babel/core@7.23.7)
+      '@babel/helper-plugin-utils': 7.25.9
+    transitivePeerDependencies:
+      - supports-color
+
   '@babel/plugin-transform-modules-amd@7.25.9(@babel/core@7.25.2)':
     dependencies:
       '@babel/core': 7.25.2
       '@babel/helper-module-transforms': 7.26.0(@babel/core@7.25.2)
       '@babel/helper-plugin-utils': 7.25.9
+    transitivePeerDependencies:
+      - supports-color
+
+  '@babel/plugin-transform-modules-commonjs@7.23.3(@babel/core@7.23.7)':
+    dependencies:
+      '@babel/core': 7.23.7
+      '@babel/helper-module-transforms': 7.25.2(@babel/core@7.23.7)
+      '@babel/helper-plugin-utils': 7.24.8
+      '@babel/helper-simple-access': 7.22.5
     transitivePeerDependencies:
       - supports-color
 
@@ -15952,6 +16505,15 @@ snapshots:
       '@babel/helper-module-transforms': 7.25.2(@babel/core@7.25.2)
       '@babel/helper-plugin-utils': 7.24.8
       '@babel/helper-simple-access': 7.22.5
+    transitivePeerDependencies:
+      - supports-color
+
+  '@babel/plugin-transform-modules-commonjs@7.25.9(@babel/core@7.23.7)':
+    dependencies:
+      '@babel/core': 7.23.7
+      '@babel/helper-module-transforms': 7.26.0(@babel/core@7.23.7)
+      '@babel/helper-plugin-utils': 7.25.9
+      '@babel/helper-simple-access': 7.25.9
     transitivePeerDependencies:
       - supports-color
 
@@ -15974,6 +16536,16 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  '@babel/plugin-transform-modules-systemjs@7.25.9(@babel/core@7.23.7)':
+    dependencies:
+      '@babel/core': 7.23.7
+      '@babel/helper-module-transforms': 7.26.0(@babel/core@7.23.7)
+      '@babel/helper-plugin-utils': 7.25.9
+      '@babel/helper-validator-identifier': 7.25.9
+      '@babel/traverse': 7.25.9
+    transitivePeerDependencies:
+      - supports-color
+
   '@babel/plugin-transform-modules-systemjs@7.25.9(@babel/core@7.25.2)':
     dependencies:
       '@babel/core': 7.25.2
@@ -15992,6 +16564,14 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  '@babel/plugin-transform-modules-umd@7.25.9(@babel/core@7.23.7)':
+    dependencies:
+      '@babel/core': 7.23.7
+      '@babel/helper-module-transforms': 7.26.0(@babel/core@7.23.7)
+      '@babel/helper-plugin-utils': 7.25.9
+    transitivePeerDependencies:
+      - supports-color
+
   '@babel/plugin-transform-modules-umd@7.25.9(@babel/core@7.25.2)':
     dependencies:
       '@babel/core': 7.25.2
@@ -16000,11 +16580,23 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  '@babel/plugin-transform-named-capturing-groups-regex@7.22.5(@babel/core@7.23.7)':
+    dependencies:
+      '@babel/core': 7.23.7
+      '@babel/helper-create-regexp-features-plugin': 7.22.15(@babel/core@7.23.7)
+      '@babel/helper-plugin-utils': 7.24.8
+
   '@babel/plugin-transform-named-capturing-groups-regex@7.22.5(@babel/core@7.25.2)':
     dependencies:
       '@babel/core': 7.25.2
       '@babel/helper-create-regexp-features-plugin': 7.22.15(@babel/core@7.25.2)
       '@babel/helper-plugin-utils': 7.24.8
+
+  '@babel/plugin-transform-named-capturing-groups-regex@7.25.9(@babel/core@7.23.7)':
+    dependencies:
+      '@babel/core': 7.23.7
+      '@babel/helper-create-regexp-features-plugin': 7.25.9(@babel/core@7.23.7)
+      '@babel/helper-plugin-utils': 7.25.9
 
   '@babel/plugin-transform-named-capturing-groups-regex@7.25.9(@babel/core@7.25.2)':
     dependencies:
@@ -16017,6 +16609,11 @@ snapshots:
       '@babel/core': 7.25.2
       '@babel/helper-plugin-utils': 7.24.8
 
+  '@babel/plugin-transform-new-target@7.25.9(@babel/core@7.23.7)':
+    dependencies:
+      '@babel/core': 7.23.7
+      '@babel/helper-plugin-utils': 7.25.9
+
   '@babel/plugin-transform-new-target@7.25.9(@babel/core@7.25.2)':
     dependencies:
       '@babel/core': 7.25.2
@@ -16028,6 +16625,11 @@ snapshots:
       '@babel/helper-plugin-utils': 7.22.5
       '@babel/plugin-syntax-nullish-coalescing-operator': 7.8.3(@babel/core@7.25.2)
 
+  '@babel/plugin-transform-nullish-coalescing-operator@7.25.9(@babel/core@7.23.7)':
+    dependencies:
+      '@babel/core': 7.23.7
+      '@babel/helper-plugin-utils': 7.25.9
+
   '@babel/plugin-transform-nullish-coalescing-operator@7.25.9(@babel/core@7.25.2)':
     dependencies:
       '@babel/core': 7.25.2
@@ -16038,6 +16640,11 @@ snapshots:
       '@babel/core': 7.25.2
       '@babel/helper-plugin-utils': 7.24.8
       '@babel/plugin-syntax-numeric-separator': 7.10.4(@babel/core@7.25.2)
+
+  '@babel/plugin-transform-numeric-separator@7.25.9(@babel/core@7.23.7)':
+    dependencies:
+      '@babel/core': 7.23.7
+      '@babel/helper-plugin-utils': 7.25.9
 
   '@babel/plugin-transform-numeric-separator@7.25.9(@babel/core@7.25.2)':
     dependencies:
@@ -16053,6 +16660,13 @@ snapshots:
       '@babel/plugin-syntax-object-rest-spread': 7.8.3(@babel/core@7.25.2)
       '@babel/plugin-transform-parameters': 7.23.3(@babel/core@7.25.2)
 
+  '@babel/plugin-transform-object-rest-spread@7.25.9(@babel/core@7.23.7)':
+    dependencies:
+      '@babel/core': 7.23.7
+      '@babel/helper-compilation-targets': 7.25.9
+      '@babel/helper-plugin-utils': 7.25.9
+      '@babel/plugin-transform-parameters': 7.25.9(@babel/core@7.23.7)
+
   '@babel/plugin-transform-object-rest-spread@7.25.9(@babel/core@7.25.2)':
     dependencies:
       '@babel/core': 7.25.2
@@ -16065,6 +16679,14 @@ snapshots:
       '@babel/core': 7.25.2
       '@babel/helper-plugin-utils': 7.24.8
       '@babel/helper-replace-supers': 7.22.20(@babel/core@7.25.2)
+
+  '@babel/plugin-transform-object-super@7.25.9(@babel/core@7.23.7)':
+    dependencies:
+      '@babel/core': 7.23.7
+      '@babel/helper-plugin-utils': 7.25.9
+      '@babel/helper-replace-supers': 7.25.9(@babel/core@7.23.7)
+    transitivePeerDependencies:
+      - supports-color
 
   '@babel/plugin-transform-object-super@7.25.9(@babel/core@7.25.2)':
     dependencies:
@@ -16080,6 +16702,11 @@ snapshots:
       '@babel/helper-plugin-utils': 7.24.8
       '@babel/plugin-syntax-optional-catch-binding': 7.8.3(@babel/core@7.25.2)
 
+  '@babel/plugin-transform-optional-catch-binding@7.25.9(@babel/core@7.23.7)':
+    dependencies:
+      '@babel/core': 7.23.7
+      '@babel/helper-plugin-utils': 7.25.9
+
   '@babel/plugin-transform-optional-catch-binding@7.25.9(@babel/core@7.25.2)':
     dependencies:
       '@babel/core': 7.25.2
@@ -16092,6 +16719,14 @@ snapshots:
       '@babel/helper-skip-transparent-expression-wrappers': 7.22.5
       '@babel/plugin-syntax-optional-chaining': 7.8.3(@babel/core@7.25.2)
 
+  '@babel/plugin-transform-optional-chaining@7.25.9(@babel/core@7.23.7)':
+    dependencies:
+      '@babel/core': 7.23.7
+      '@babel/helper-plugin-utils': 7.25.9
+      '@babel/helper-skip-transparent-expression-wrappers': 7.25.9
+    transitivePeerDependencies:
+      - supports-color
+
   '@babel/plugin-transform-optional-chaining@7.25.9(@babel/core@7.25.2)':
     dependencies:
       '@babel/core': 7.25.2
@@ -16100,21 +16735,45 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  '@babel/plugin-transform-parameters@7.23.3(@babel/core@7.23.7)':
+    dependencies:
+      '@babel/core': 7.23.7
+      '@babel/helper-plugin-utils': 7.22.5
+
   '@babel/plugin-transform-parameters@7.23.3(@babel/core@7.25.2)':
     dependencies:
       '@babel/core': 7.25.2
       '@babel/helper-plugin-utils': 7.22.5
+
+  '@babel/plugin-transform-parameters@7.25.9(@babel/core@7.23.7)':
+    dependencies:
+      '@babel/core': 7.23.7
+      '@babel/helper-plugin-utils': 7.25.9
 
   '@babel/plugin-transform-parameters@7.25.9(@babel/core@7.25.2)':
     dependencies:
       '@babel/core': 7.25.2
       '@babel/helper-plugin-utils': 7.25.9
 
+  '@babel/plugin-transform-private-methods@7.23.3(@babel/core@7.23.7)':
+    dependencies:
+      '@babel/core': 7.23.7
+      '@babel/helper-create-class-features-plugin': 7.23.10(@babel/core@7.23.7)
+      '@babel/helper-plugin-utils': 7.24.8
+
   '@babel/plugin-transform-private-methods@7.23.3(@babel/core@7.25.2)':
     dependencies:
       '@babel/core': 7.25.2
       '@babel/helper-create-class-features-plugin': 7.23.10(@babel/core@7.25.2)
       '@babel/helper-plugin-utils': 7.24.8
+
+  '@babel/plugin-transform-private-methods@7.25.9(@babel/core@7.23.7)':
+    dependencies:
+      '@babel/core': 7.23.7
+      '@babel/helper-create-class-features-plugin': 7.25.9(@babel/core@7.23.7)
+      '@babel/helper-plugin-utils': 7.25.9
+    transitivePeerDependencies:
+      - supports-color
 
   '@babel/plugin-transform-private-methods@7.25.9(@babel/core@7.25.2)':
     dependencies:
@@ -16124,6 +16783,14 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  '@babel/plugin-transform-private-property-in-object@7.23.4(@babel/core@7.23.7)':
+    dependencies:
+      '@babel/core': 7.23.7
+      '@babel/helper-annotate-as-pure': 7.22.5
+      '@babel/helper-create-class-features-plugin': 7.23.10(@babel/core@7.23.7)
+      '@babel/helper-plugin-utils': 7.24.8
+      '@babel/plugin-syntax-private-property-in-object': 7.14.5(@babel/core@7.23.7)
+
   '@babel/plugin-transform-private-property-in-object@7.23.4(@babel/core@7.25.2)':
     dependencies:
       '@babel/core': 7.25.2
@@ -16131,6 +16798,15 @@ snapshots:
       '@babel/helper-create-class-features-plugin': 7.23.10(@babel/core@7.25.2)
       '@babel/helper-plugin-utils': 7.24.8
       '@babel/plugin-syntax-private-property-in-object': 7.14.5(@babel/core@7.25.2)
+
+  '@babel/plugin-transform-private-property-in-object@7.25.9(@babel/core@7.23.7)':
+    dependencies:
+      '@babel/core': 7.23.7
+      '@babel/helper-annotate-as-pure': 7.25.9
+      '@babel/helper-create-class-features-plugin': 7.25.9(@babel/core@7.23.7)
+      '@babel/helper-plugin-utils': 7.25.9
+    transitivePeerDependencies:
+      - supports-color
 
   '@babel/plugin-transform-private-property-in-object@7.25.9(@babel/core@7.25.2)':
     dependencies:
@@ -16146,10 +16822,20 @@ snapshots:
       '@babel/core': 7.25.2
       '@babel/helper-plugin-utils': 7.24.8
 
+  '@babel/plugin-transform-property-literals@7.25.9(@babel/core@7.23.7)':
+    dependencies:
+      '@babel/core': 7.23.7
+      '@babel/helper-plugin-utils': 7.25.9
+
   '@babel/plugin-transform-property-literals@7.25.9(@babel/core@7.25.2)':
     dependencies:
       '@babel/core': 7.25.2
       '@babel/helper-plugin-utils': 7.25.9
+
+  '@babel/plugin-transform-react-display-name@7.23.3(@babel/core@7.23.7)':
+    dependencies:
+      '@babel/core': 7.23.7
+      '@babel/helper-plugin-utils': 7.24.8
 
   '@babel/plugin-transform-react-display-name@7.23.3(@babel/core@7.25.2)':
     dependencies:
@@ -16192,6 +16878,17 @@ snapshots:
       '@babel/plugin-syntax-jsx': 7.23.3(@babel/core@7.25.2)
       '@babel/types': 7.25.6
 
+  '@babel/plugin-transform-react-jsx@7.25.2(@babel/core@7.23.7)':
+    dependencies:
+      '@babel/core': 7.23.7
+      '@babel/helper-annotate-as-pure': 7.24.7
+      '@babel/helper-module-imports': 7.24.7
+      '@babel/helper-plugin-utils': 7.24.8
+      '@babel/plugin-syntax-jsx': 7.24.7(@babel/core@7.23.7)
+      '@babel/types': 7.25.9
+    transitivePeerDependencies:
+      - supports-color
+
   '@babel/plugin-transform-react-jsx@7.25.2(@babel/core@7.25.2)':
     dependencies:
       '@babel/core': 7.25.2
@@ -16215,11 +16912,23 @@ snapshots:
       '@babel/helper-plugin-utils': 7.24.8
       regenerator-transform: 0.15.2
 
+  '@babel/plugin-transform-regenerator@7.25.9(@babel/core@7.23.7)':
+    dependencies:
+      '@babel/core': 7.23.7
+      '@babel/helper-plugin-utils': 7.25.9
+      regenerator-transform: 0.15.2
+
   '@babel/plugin-transform-regenerator@7.25.9(@babel/core@7.25.2)':
     dependencies:
       '@babel/core': 7.25.2
       '@babel/helper-plugin-utils': 7.25.9
       regenerator-transform: 0.15.2
+
+  '@babel/plugin-transform-regexp-modifiers@7.26.0(@babel/core@7.23.7)':
+    dependencies:
+      '@babel/core': 7.23.7
+      '@babel/helper-create-regexp-features-plugin': 7.25.9(@babel/core@7.23.7)
+      '@babel/helper-plugin-utils': 7.25.9
 
   '@babel/plugin-transform-regexp-modifiers@7.26.0(@babel/core@7.25.2)':
     dependencies:
@@ -16232,10 +16941,27 @@ snapshots:
       '@babel/core': 7.25.2
       '@babel/helper-plugin-utils': 7.24.8
 
+  '@babel/plugin-transform-reserved-words@7.25.9(@babel/core@7.23.7)':
+    dependencies:
+      '@babel/core': 7.23.7
+      '@babel/helper-plugin-utils': 7.25.9
+
   '@babel/plugin-transform-reserved-words@7.25.9(@babel/core@7.25.2)':
     dependencies:
       '@babel/core': 7.25.2
       '@babel/helper-plugin-utils': 7.25.9
+
+  '@babel/plugin-transform-runtime@7.23.9(@babel/core@7.23.7)':
+    dependencies:
+      '@babel/core': 7.23.7
+      '@babel/helper-module-imports': 7.24.7
+      '@babel/helper-plugin-utils': 7.24.8
+      babel-plugin-polyfill-corejs2: 0.4.8(@babel/core@7.23.7)
+      babel-plugin-polyfill-corejs3: 0.9.0(@babel/core@7.23.7)
+      babel-plugin-polyfill-regenerator: 0.5.5(@babel/core@7.23.7)
+      semver: 6.3.1
+    transitivePeerDependencies:
+      - supports-color
 
   '@babel/plugin-transform-runtime@7.23.9(@babel/core@7.25.2)':
     dependencies:
@@ -16249,21 +16975,45 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  '@babel/plugin-transform-shorthand-properties@7.23.3(@babel/core@7.23.7)':
+    dependencies:
+      '@babel/core': 7.23.7
+      '@babel/helper-plugin-utils': 7.22.5
+
   '@babel/plugin-transform-shorthand-properties@7.23.3(@babel/core@7.25.2)':
     dependencies:
       '@babel/core': 7.25.2
       '@babel/helper-plugin-utils': 7.22.5
+
+  '@babel/plugin-transform-shorthand-properties@7.25.9(@babel/core@7.23.7)':
+    dependencies:
+      '@babel/core': 7.23.7
+      '@babel/helper-plugin-utils': 7.25.9
 
   '@babel/plugin-transform-shorthand-properties@7.25.9(@babel/core@7.25.2)':
     dependencies:
       '@babel/core': 7.25.2
       '@babel/helper-plugin-utils': 7.25.9
 
+  '@babel/plugin-transform-spread@7.23.3(@babel/core@7.23.7)':
+    dependencies:
+      '@babel/core': 7.23.7
+      '@babel/helper-plugin-utils': 7.24.8
+      '@babel/helper-skip-transparent-expression-wrappers': 7.22.5
+
   '@babel/plugin-transform-spread@7.23.3(@babel/core@7.25.2)':
     dependencies:
       '@babel/core': 7.25.2
       '@babel/helper-plugin-utils': 7.24.8
       '@babel/helper-skip-transparent-expression-wrappers': 7.22.5
+
+  '@babel/plugin-transform-spread@7.25.9(@babel/core@7.23.7)':
+    dependencies:
+      '@babel/core': 7.23.7
+      '@babel/helper-plugin-utils': 7.25.9
+      '@babel/helper-skip-transparent-expression-wrappers': 7.25.9
+    transitivePeerDependencies:
+      - supports-color
 
   '@babel/plugin-transform-spread@7.25.9(@babel/core@7.25.2)':
     dependencies:
@@ -16273,10 +17023,20 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  '@babel/plugin-transform-sticky-regex@7.23.3(@babel/core@7.23.7)':
+    dependencies:
+      '@babel/core': 7.23.7
+      '@babel/helper-plugin-utils': 7.24.8
+
   '@babel/plugin-transform-sticky-regex@7.23.3(@babel/core@7.25.2)':
     dependencies:
       '@babel/core': 7.25.2
       '@babel/helper-plugin-utils': 7.24.8
+
+  '@babel/plugin-transform-sticky-regex@7.25.9(@babel/core@7.23.7)':
+    dependencies:
+      '@babel/core': 7.23.7
+      '@babel/helper-plugin-utils': 7.25.9
 
   '@babel/plugin-transform-sticky-regex@7.25.9(@babel/core@7.25.2)':
     dependencies:
@@ -16288,6 +17048,11 @@ snapshots:
       '@babel/core': 7.25.2
       '@babel/helper-plugin-utils': 7.22.5
 
+  '@babel/plugin-transform-template-literals@7.25.9(@babel/core@7.23.7)':
+    dependencies:
+      '@babel/core': 7.23.7
+      '@babel/helper-plugin-utils': 7.25.9
+
   '@babel/plugin-transform-template-literals@7.25.9(@babel/core@7.25.2)':
     dependencies:
       '@babel/core': 7.25.2
@@ -16298,10 +17063,23 @@ snapshots:
       '@babel/core': 7.25.2
       '@babel/helper-plugin-utils': 7.24.8
 
+  '@babel/plugin-transform-typeof-symbol@7.25.9(@babel/core@7.23.7)':
+    dependencies:
+      '@babel/core': 7.23.7
+      '@babel/helper-plugin-utils': 7.25.9
+
   '@babel/plugin-transform-typeof-symbol@7.25.9(@babel/core@7.25.2)':
     dependencies:
       '@babel/core': 7.25.2
       '@babel/helper-plugin-utils': 7.25.9
+
+  '@babel/plugin-transform-typescript@7.23.6(@babel/core@7.23.7)':
+    dependencies:
+      '@babel/core': 7.23.7
+      '@babel/helper-annotate-as-pure': 7.22.5
+      '@babel/helper-create-class-features-plugin': 7.23.10(@babel/core@7.23.7)
+      '@babel/helper-plugin-utils': 7.22.5
+      '@babel/plugin-syntax-typescript': 7.23.3(@babel/core@7.23.7)
 
   '@babel/plugin-transform-typescript@7.23.6(@babel/core@7.25.2)':
     dependencies:
@@ -16316,6 +17094,11 @@ snapshots:
       '@babel/core': 7.25.2
       '@babel/helper-plugin-utils': 7.24.8
 
+  '@babel/plugin-transform-unicode-escapes@7.25.9(@babel/core@7.23.7)':
+    dependencies:
+      '@babel/core': 7.23.7
+      '@babel/helper-plugin-utils': 7.25.9
+
   '@babel/plugin-transform-unicode-escapes@7.25.9(@babel/core@7.25.2)':
     dependencies:
       '@babel/core': 7.25.2
@@ -16327,17 +17110,35 @@ snapshots:
       '@babel/helper-create-regexp-features-plugin': 7.22.15(@babel/core@7.25.2)
       '@babel/helper-plugin-utils': 7.24.8
 
+  '@babel/plugin-transform-unicode-property-regex@7.25.9(@babel/core@7.23.7)':
+    dependencies:
+      '@babel/core': 7.23.7
+      '@babel/helper-create-regexp-features-plugin': 7.25.9(@babel/core@7.23.7)
+      '@babel/helper-plugin-utils': 7.25.9
+
   '@babel/plugin-transform-unicode-property-regex@7.25.9(@babel/core@7.25.2)':
     dependencies:
       '@babel/core': 7.25.2
       '@babel/helper-create-regexp-features-plugin': 7.25.9(@babel/core@7.25.2)
       '@babel/helper-plugin-utils': 7.25.9
 
+  '@babel/plugin-transform-unicode-regex@7.23.3(@babel/core@7.23.7)':
+    dependencies:
+      '@babel/core': 7.23.7
+      '@babel/helper-create-regexp-features-plugin': 7.22.15(@babel/core@7.23.7)
+      '@babel/helper-plugin-utils': 7.24.8
+
   '@babel/plugin-transform-unicode-regex@7.23.3(@babel/core@7.25.2)':
     dependencies:
       '@babel/core': 7.25.2
       '@babel/helper-create-regexp-features-plugin': 7.22.15(@babel/core@7.25.2)
       '@babel/helper-plugin-utils': 7.24.8
+
+  '@babel/plugin-transform-unicode-regex@7.25.9(@babel/core@7.23.7)':
+    dependencies:
+      '@babel/core': 7.23.7
+      '@babel/helper-create-regexp-features-plugin': 7.25.9(@babel/core@7.23.7)
+      '@babel/helper-plugin-utils': 7.25.9
 
   '@babel/plugin-transform-unicode-regex@7.25.9(@babel/core@7.25.2)':
     dependencies:
@@ -16350,6 +17151,12 @@ snapshots:
       '@babel/core': 7.25.2
       '@babel/helper-create-regexp-features-plugin': 7.22.15(@babel/core@7.25.2)
       '@babel/helper-plugin-utils': 7.24.8
+
+  '@babel/plugin-transform-unicode-sets-regex@7.25.9(@babel/core@7.23.7)':
+    dependencies:
+      '@babel/core': 7.23.7
+      '@babel/helper-create-regexp-features-plugin': 7.25.9(@babel/core@7.23.7)
+      '@babel/helper-plugin-utils': 7.25.9
 
   '@babel/plugin-transform-unicode-sets-regex@7.25.9(@babel/core@7.25.2)':
     dependencies:
@@ -16443,6 +17250,81 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  '@babel/preset-env@7.26.0(@babel/core@7.23.7)':
+    dependencies:
+      '@babel/compat-data': 7.26.2
+      '@babel/core': 7.23.7
+      '@babel/helper-compilation-targets': 7.25.9
+      '@babel/helper-plugin-utils': 7.25.9
+      '@babel/helper-validator-option': 7.25.9
+      '@babel/plugin-bugfix-firefox-class-in-computed-class-key': 7.25.9(@babel/core@7.23.7)
+      '@babel/plugin-bugfix-safari-class-field-initializer-scope': 7.25.9(@babel/core@7.23.7)
+      '@babel/plugin-bugfix-safari-id-destructuring-collision-in-function-expression': 7.25.9(@babel/core@7.23.7)
+      '@babel/plugin-bugfix-v8-spread-parameters-in-optional-chaining': 7.25.9(@babel/core@7.23.7)
+      '@babel/plugin-bugfix-v8-static-class-fields-redefine-readonly': 7.25.9(@babel/core@7.23.7)
+      '@babel/plugin-proposal-private-property-in-object': 7.21.0-placeholder-for-preset-env.2(@babel/core@7.23.7)
+      '@babel/plugin-syntax-import-assertions': 7.26.0(@babel/core@7.23.7)
+      '@babel/plugin-syntax-import-attributes': 7.26.0(@babel/core@7.23.7)
+      '@babel/plugin-syntax-unicode-sets-regex': 7.18.6(@babel/core@7.23.7)
+      '@babel/plugin-transform-arrow-functions': 7.25.9(@babel/core@7.23.7)
+      '@babel/plugin-transform-async-generator-functions': 7.25.9(@babel/core@7.23.7)
+      '@babel/plugin-transform-async-to-generator': 7.25.9(@babel/core@7.23.7)
+      '@babel/plugin-transform-block-scoped-functions': 7.25.9(@babel/core@7.23.7)
+      '@babel/plugin-transform-block-scoping': 7.25.9(@babel/core@7.23.7)
+      '@babel/plugin-transform-class-properties': 7.25.9(@babel/core@7.23.7)
+      '@babel/plugin-transform-class-static-block': 7.26.0(@babel/core@7.23.7)
+      '@babel/plugin-transform-classes': 7.25.9(@babel/core@7.23.7)
+      '@babel/plugin-transform-computed-properties': 7.25.9(@babel/core@7.23.7)
+      '@babel/plugin-transform-destructuring': 7.25.9(@babel/core@7.23.7)
+      '@babel/plugin-transform-dotall-regex': 7.25.9(@babel/core@7.23.7)
+      '@babel/plugin-transform-duplicate-keys': 7.25.9(@babel/core@7.23.7)
+      '@babel/plugin-transform-duplicate-named-capturing-groups-regex': 7.25.9(@babel/core@7.23.7)
+      '@babel/plugin-transform-dynamic-import': 7.25.9(@babel/core@7.23.7)
+      '@babel/plugin-transform-exponentiation-operator': 7.25.9(@babel/core@7.23.7)
+      '@babel/plugin-transform-export-namespace-from': 7.25.9(@babel/core@7.23.7)
+      '@babel/plugin-transform-for-of': 7.25.9(@babel/core@7.23.7)
+      '@babel/plugin-transform-function-name': 7.25.9(@babel/core@7.23.7)
+      '@babel/plugin-transform-json-strings': 7.25.9(@babel/core@7.23.7)
+      '@babel/plugin-transform-literals': 7.25.9(@babel/core@7.23.7)
+      '@babel/plugin-transform-logical-assignment-operators': 7.25.9(@babel/core@7.23.7)
+      '@babel/plugin-transform-member-expression-literals': 7.25.9(@babel/core@7.23.7)
+      '@babel/plugin-transform-modules-amd': 7.25.9(@babel/core@7.23.7)
+      '@babel/plugin-transform-modules-commonjs': 7.25.9(@babel/core@7.23.7)
+      '@babel/plugin-transform-modules-systemjs': 7.25.9(@babel/core@7.23.7)
+      '@babel/plugin-transform-modules-umd': 7.25.9(@babel/core@7.23.7)
+      '@babel/plugin-transform-named-capturing-groups-regex': 7.25.9(@babel/core@7.23.7)
+      '@babel/plugin-transform-new-target': 7.25.9(@babel/core@7.23.7)
+      '@babel/plugin-transform-nullish-coalescing-operator': 7.25.9(@babel/core@7.23.7)
+      '@babel/plugin-transform-numeric-separator': 7.25.9(@babel/core@7.23.7)
+      '@babel/plugin-transform-object-rest-spread': 7.25.9(@babel/core@7.23.7)
+      '@babel/plugin-transform-object-super': 7.25.9(@babel/core@7.23.7)
+      '@babel/plugin-transform-optional-catch-binding': 7.25.9(@babel/core@7.23.7)
+      '@babel/plugin-transform-optional-chaining': 7.25.9(@babel/core@7.23.7)
+      '@babel/plugin-transform-parameters': 7.25.9(@babel/core@7.23.7)
+      '@babel/plugin-transform-private-methods': 7.25.9(@babel/core@7.23.7)
+      '@babel/plugin-transform-private-property-in-object': 7.25.9(@babel/core@7.23.7)
+      '@babel/plugin-transform-property-literals': 7.25.9(@babel/core@7.23.7)
+      '@babel/plugin-transform-regenerator': 7.25.9(@babel/core@7.23.7)
+      '@babel/plugin-transform-regexp-modifiers': 7.26.0(@babel/core@7.23.7)
+      '@babel/plugin-transform-reserved-words': 7.25.9(@babel/core@7.23.7)
+      '@babel/plugin-transform-shorthand-properties': 7.25.9(@babel/core@7.23.7)
+      '@babel/plugin-transform-spread': 7.25.9(@babel/core@7.23.7)
+      '@babel/plugin-transform-sticky-regex': 7.25.9(@babel/core@7.23.7)
+      '@babel/plugin-transform-template-literals': 7.25.9(@babel/core@7.23.7)
+      '@babel/plugin-transform-typeof-symbol': 7.25.9(@babel/core@7.23.7)
+      '@babel/plugin-transform-unicode-escapes': 7.25.9(@babel/core@7.23.7)
+      '@babel/plugin-transform-unicode-property-regex': 7.25.9(@babel/core@7.23.7)
+      '@babel/plugin-transform-unicode-regex': 7.25.9(@babel/core@7.23.7)
+      '@babel/plugin-transform-unicode-sets-regex': 7.25.9(@babel/core@7.23.7)
+      '@babel/preset-modules': 0.1.6-no-external-plugins(@babel/core@7.23.7)
+      babel-plugin-polyfill-corejs2: 0.4.11(@babel/core@7.23.7)
+      babel-plugin-polyfill-corejs3: 0.10.6(@babel/core@7.23.7)
+      babel-plugin-polyfill-regenerator: 0.6.2(@babel/core@7.23.7)
+      core-js-compat: 3.39.0
+      semver: 6.3.1
+    transitivePeerDependencies:
+      - supports-color
+
   '@babel/preset-env@7.26.0(@babel/core@7.25.2)':
     dependencies:
       '@babel/compat-data': 7.26.2
@@ -16524,6 +17406,13 @@ snapshots:
       '@babel/helper-plugin-utils': 7.24.8
       '@babel/helper-validator-option': 7.24.8
       '@babel/plugin-transform-flow-strip-types': 7.23.3(@babel/core@7.25.2)
+
+  '@babel/preset-modules@0.1.6-no-external-plugins(@babel/core@7.23.7)':
+    dependencies:
+      '@babel/core': 7.23.7
+      '@babel/helper-plugin-utils': 7.24.8
+      '@babel/types': 7.25.6
+      esutils: 2.0.3
 
   '@babel/preset-modules@0.1.6-no-external-plugins(@babel/core@7.25.2)':
     dependencies:
@@ -19166,9 +20055,64 @@ snapshots:
       - '@babel/preset-env'
       - supports-color
 
+  '@react-native/babel-plugin-codegen@0.73.4(@babel/preset-env@7.26.0(@babel/core@7.23.7))':
+    dependencies:
+      '@react-native/codegen': 0.73.3(@babel/preset-env@7.26.0(@babel/core@7.23.7))
+    transitivePeerDependencies:
+      - '@babel/preset-env'
+      - supports-color
+
   '@react-native/babel-plugin-codegen@0.73.4(@babel/preset-env@7.26.0(@babel/core@7.25.2))':
     dependencies:
       '@react-native/codegen': 0.73.3(@babel/preset-env@7.26.0(@babel/core@7.25.2))
+    transitivePeerDependencies:
+      - '@babel/preset-env'
+      - supports-color
+
+  '@react-native/babel-preset@0.73.21(@babel/core@7.23.7)(@babel/preset-env@7.26.0(@babel/core@7.23.7))':
+    dependencies:
+      '@babel/core': 7.23.7
+      '@babel/plugin-proposal-async-generator-functions': 7.20.7(@babel/core@7.23.7)
+      '@babel/plugin-proposal-class-properties': 7.18.6(@babel/core@7.23.7)
+      '@babel/plugin-proposal-export-default-from': 7.23.3(@babel/core@7.23.7)
+      '@babel/plugin-proposal-nullish-coalescing-operator': 7.18.6(@babel/core@7.23.7)
+      '@babel/plugin-proposal-numeric-separator': 7.18.6(@babel/core@7.23.7)
+      '@babel/plugin-proposal-object-rest-spread': 7.20.7(@babel/core@7.23.7)
+      '@babel/plugin-proposal-optional-catch-binding': 7.18.6(@babel/core@7.23.7)
+      '@babel/plugin-proposal-optional-chaining': 7.21.0(@babel/core@7.23.7)
+      '@babel/plugin-syntax-dynamic-import': 7.8.3(@babel/core@7.23.7)
+      '@babel/plugin-syntax-export-default-from': 7.23.3(@babel/core@7.23.7)
+      '@babel/plugin-syntax-flow': 7.23.3(@babel/core@7.23.7)
+      '@babel/plugin-syntax-nullish-coalescing-operator': 7.8.3(@babel/core@7.23.7)
+      '@babel/plugin-syntax-optional-chaining': 7.8.3(@babel/core@7.23.7)
+      '@babel/plugin-transform-arrow-functions': 7.23.3(@babel/core@7.23.7)
+      '@babel/plugin-transform-async-to-generator': 7.23.3(@babel/core@7.23.7)
+      '@babel/plugin-transform-block-scoping': 7.23.4(@babel/core@7.23.7)
+      '@babel/plugin-transform-classes': 7.23.8(@babel/core@7.23.7)
+      '@babel/plugin-transform-computed-properties': 7.23.3(@babel/core@7.23.7)
+      '@babel/plugin-transform-destructuring': 7.23.3(@babel/core@7.23.7)
+      '@babel/plugin-transform-flow-strip-types': 7.23.3(@babel/core@7.23.7)
+      '@babel/plugin-transform-function-name': 7.23.3(@babel/core@7.23.7)
+      '@babel/plugin-transform-literals': 7.23.3(@babel/core@7.23.7)
+      '@babel/plugin-transform-modules-commonjs': 7.23.3(@babel/core@7.23.7)
+      '@babel/plugin-transform-named-capturing-groups-regex': 7.22.5(@babel/core@7.23.7)
+      '@babel/plugin-transform-parameters': 7.23.3(@babel/core@7.23.7)
+      '@babel/plugin-transform-private-methods': 7.23.3(@babel/core@7.23.7)
+      '@babel/plugin-transform-private-property-in-object': 7.23.4(@babel/core@7.23.7)
+      '@babel/plugin-transform-react-display-name': 7.23.3(@babel/core@7.23.7)
+      '@babel/plugin-transform-react-jsx': 7.25.2(@babel/core@7.23.7)
+      '@babel/plugin-transform-react-jsx-self': 7.23.3(@babel/core@7.23.7)
+      '@babel/plugin-transform-react-jsx-source': 7.23.3(@babel/core@7.23.7)
+      '@babel/plugin-transform-runtime': 7.23.9(@babel/core@7.23.7)
+      '@babel/plugin-transform-shorthand-properties': 7.23.3(@babel/core@7.23.7)
+      '@babel/plugin-transform-spread': 7.23.3(@babel/core@7.23.7)
+      '@babel/plugin-transform-sticky-regex': 7.23.3(@babel/core@7.23.7)
+      '@babel/plugin-transform-typescript': 7.23.6(@babel/core@7.23.7)
+      '@babel/plugin-transform-unicode-regex': 7.23.3(@babel/core@7.23.7)
+      '@babel/template': 7.25.0
+      '@react-native/babel-plugin-codegen': 0.73.4(@babel/preset-env@7.26.0(@babel/core@7.23.7))
+      babel-plugin-transform-flow-enums: 0.0.2(@babel/core@7.23.7)
+      react-refresh: 0.14.0
     transitivePeerDependencies:
       - '@babel/preset-env'
       - supports-color
@@ -19282,6 +20226,19 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  '@react-native/codegen@0.73.3(@babel/preset-env@7.26.0(@babel/core@7.23.7))':
+    dependencies:
+      '@babel/parser': 7.25.3
+      '@babel/preset-env': 7.26.0(@babel/core@7.23.7)
+      flow-parser: 0.206.0
+      glob: 7.2.3
+      invariant: 2.2.4
+      jscodeshift: 0.14.0(@babel/preset-env@7.26.0(@babel/core@7.23.7))
+      mkdirp: 0.5.6
+      nullthrows: 1.1.1
+    transitivePeerDependencies:
+      - supports-color
+
   '@react-native/codegen@0.73.3(@babel/preset-env@7.26.0(@babel/core@7.25.2))':
     dependencies:
       '@babel/parser': 7.25.3
@@ -19328,6 +20285,27 @@ snapshots:
       metro-config: 0.80.12
       metro-core: 0.80.12
       node-fetch: 2.7.0(encoding@0.1.13)
+      readline: 1.3.0
+    transitivePeerDependencies:
+      - '@babel/core'
+      - '@babel/preset-env'
+      - bufferutil
+      - encoding
+      - supports-color
+      - utf-8-validate
+
+  '@react-native/community-cli-plugin@0.73.18(@babel/core@7.23.7)(@babel/preset-env@7.26.0(@babel/core@7.23.7))(encoding@0.1.13)':
+    dependencies:
+      '@react-native-community/cli-server-api': 12.3.7(encoding@0.1.13)
+      '@react-native-community/cli-tools': 12.3.7(encoding@0.1.13)
+      '@react-native/dev-middleware': 0.73.8(encoding@0.1.13)
+      '@react-native/metro-babel-transformer': 0.73.15(@babel/core@7.23.7)(@babel/preset-env@7.26.0(@babel/core@7.23.7))
+      chalk: 4.1.2
+      execa: 5.1.1
+      metro: 0.80.5(encoding@0.1.13)
+      metro-config: 0.80.5(encoding@0.1.13)
+      metro-core: 0.80.5
+      node-fetch: 2.6.12(encoding@0.1.13)
       readline: 1.3.0
     transitivePeerDependencies:
       - '@babel/core'
@@ -19404,6 +20382,16 @@ snapshots:
 
   '@react-native/js-polyfills@0.73.1': {}
 
+  '@react-native/metro-babel-transformer@0.73.15(@babel/core@7.23.7)(@babel/preset-env@7.26.0(@babel/core@7.23.7))':
+    dependencies:
+      '@babel/core': 7.23.7
+      '@react-native/babel-preset': 0.73.21(@babel/core@7.23.7)(@babel/preset-env@7.26.0(@babel/core@7.23.7))
+      hermes-parser: 0.15.0
+      nullthrows: 1.1.1
+    transitivePeerDependencies:
+      - '@babel/preset-env'
+      - supports-color
+
   '@react-native/metro-babel-transformer@0.73.15(@babel/core@7.25.2)(@babel/preset-env@7.23.7(@babel/core@7.25.2))':
     dependencies:
       '@babel/core': 7.25.2
@@ -19424,7 +20412,7 @@ snapshots:
       - '@babel/preset-env'
       - supports-color
 
-  '@react-native/metro-config@0.73.5(@babel/core@7.25.2)(@babel/preset-env@7.23.7(@babel/core@7.25.2))':
+  '@react-native/metro-config@0.73.5(@babel/core@7.25.2)(@babel/preset-env@7.23.7(@babel/core@7.25.2))(encoding@0.1.13)':
     dependencies:
       '@react-native/js-polyfills': 0.73.1
       '@react-native/metro-babel-transformer': 0.73.15(@babel/core@7.25.2)(@babel/preset-env@7.23.7(@babel/core@7.25.2))
@@ -19433,13 +20421,22 @@ snapshots:
     transitivePeerDependencies:
       - '@babel/core'
       - '@babel/preset-env'
+      - bufferutil
+      - encoding
       - supports-color
+      - utf-8-validate
 
   '@react-native/normalize-color@2.1.0': {}
 
   '@react-native/normalize-colors@0.73.2': {}
 
   '@react-native/normalize-colors@0.74.88': {}
+
+  '@react-native/virtualized-lists@0.73.4(react-native@0.73.9(@babel/core@7.23.7)(@babel/preset-env@7.26.0(@babel/core@7.23.7))(encoding@0.1.13)(react@18.2.0))':
+    dependencies:
+      invariant: 2.2.4
+      nullthrows: 1.1.1
+      react-native: 0.73.9(@babel/core@7.23.7)(@babel/preset-env@7.26.0(@babel/core@7.23.7))(encoding@0.1.13)(react@18.2.0)
 
   '@react-native/virtualized-lists@0.73.4(react-native@0.73.9(@babel/core@7.25.2)(@babel/preset-env@7.23.7(@babel/core@7.25.2))(encoding@0.1.13)(react@18.2.0))':
     dependencies:
@@ -19481,8 +20478,8 @@ snapshots:
       react: 18.2.0
       stacktrace-parser: 0.1.10
 
-  '@react-navigation/drawer@6.7.2(patch_hash=rib4hjvzksqzwv3bbw4vfi5a5i)(a53mioyydbpzjdyawnhlozkhyy)':
-    dependencies:
+  ? '@react-navigation/drawer@6.7.2(patch_hash=rib4hjvzksqzwv3bbw4vfi5a5i)(@react-navigation/native@6.1.10(react-native@0.73.9(@babel/core@7.25.2)(@babel/preset-env@7.23.7(@babel/core@7.25.2))(encoding@0.1.13)(react@18.2.0))(react@18.2.0))(react-native-gesture-handler@2.20.0(react-native@0.73.9(@babel/core@7.25.2)(@babel/preset-env@7.23.7(@babel/core@7.25.2))(encoding@0.1.13)(react@18.2.0))(react@18.2.0))(react-native-reanimated@3.8.1(patch_hash=iololnqcieadxwydikuxdlowf4)(@babel/core@7.25.2)(react-native@0.73.9(@babel/core@7.25.2)(@babel/preset-env@7.23.7(@babel/core@7.25.2))(encoding@0.1.13)(react@18.2.0))(react@18.2.0))(react-native-safe-area-context@4.9.0(react-native@0.73.9(@babel/core@7.25.2)(@babel/preset-env@7.23.7(@babel/core@7.25.2))(encoding@0.1.13)(react@18.2.0))(react@18.2.0))(react-native-screens@3.29.0(react-native@0.73.9(@babel/core@7.25.2)(@babel/preset-env@7.23.7(@babel/core@7.25.2))(encoding@0.1.13)(react@18.2.0))(react@18.2.0))(react-native@0.73.9(@babel/core@7.25.2)(@babel/preset-env@7.23.7(@babel/core@7.25.2))(encoding@0.1.13)(react@18.2.0))(react@18.2.0)'
+  : dependencies:
       '@react-navigation/elements': 1.3.31(@react-navigation/native@6.1.10(react-native@0.73.9(@babel/core@7.25.2)(@babel/preset-env@7.23.7(@babel/core@7.25.2))(encoding@0.1.13)(react@18.2.0))(react@18.2.0))(react-native-safe-area-context@4.9.0(react-native@0.73.9(@babel/core@7.25.2)(@babel/preset-env@7.23.7(@babel/core@7.25.2))(encoding@0.1.13)(react@18.2.0))(react@18.2.0))(react-native@0.73.9(@babel/core@7.25.2)(@babel/preset-env@7.23.7(@babel/core@7.25.2))(encoding@0.1.13)(react@18.2.0))(react@18.2.0)
       '@react-navigation/native': 6.1.10(react-native@0.73.9(@babel/core@7.25.2)(@babel/preset-env@7.23.7(@babel/core@7.25.2))(encoding@0.1.13)(react@18.2.0))(react@18.2.0)
       color: 4.2.3
@@ -19494,8 +20491,8 @@ snapshots:
       react-native-screens: 3.29.0(react-native@0.73.9(@babel/core@7.25.2)(@babel/preset-env@7.23.7(@babel/core@7.25.2))(encoding@0.1.13)(react@18.2.0))(react@18.2.0)
       warn-once: 0.1.1
 
-  '@react-navigation/drawer@6.7.2(patch_hash=rib4hjvzksqzwv3bbw4vfi5a5i)(iit2e4i3acs4vllzhs45ckztzu)':
-    dependencies:
+  ? '@react-navigation/drawer@6.7.2(patch_hash=rib4hjvzksqzwv3bbw4vfi5a5i)(@react-navigation/native@6.1.10(react-native@0.73.9(@babel/core@7.25.2)(@babel/preset-env@7.26.0(@babel/core@7.25.2))(encoding@0.1.13)(react@18.2.0))(react@18.2.0))(react-native-gesture-handler@2.20.0(react-native@0.73.9(@babel/core@7.25.2)(@babel/preset-env@7.26.0(@babel/core@7.25.2))(encoding@0.1.13)(react@18.2.0))(react@18.2.0))(react-native-reanimated@3.8.1(patch_hash=iololnqcieadxwydikuxdlowf4)(@babel/core@7.25.2)(react-native@0.73.9(@babel/core@7.25.2)(@babel/preset-env@7.26.0(@babel/core@7.25.2))(encoding@0.1.13)(react@18.2.0))(react@18.2.0))(react-native-safe-area-context@4.9.0(react-native@0.73.9(@babel/core@7.25.2)(@babel/preset-env@7.26.0(@babel/core@7.25.2))(encoding@0.1.13)(react@18.2.0))(react@18.2.0))(react-native-screens@3.29.0(react-native@0.73.9(@babel/core@7.25.2)(@babel/preset-env@7.26.0(@babel/core@7.25.2))(encoding@0.1.13)(react@18.2.0))(react@18.2.0))(react-native@0.73.9(@babel/core@7.25.2)(@babel/preset-env@7.26.0(@babel/core@7.25.2))(encoding@0.1.13)(react@18.2.0))(react@18.2.0)'
+  : dependencies:
       '@react-navigation/elements': 1.3.31(@react-navigation/native@6.1.10(react-native@0.73.9(@babel/core@7.25.2)(@babel/preset-env@7.26.0(@babel/core@7.25.2))(encoding@0.1.13)(react@18.2.0))(react@18.2.0))(react-native-safe-area-context@4.9.0(react-native@0.73.9(@babel/core@7.25.2)(@babel/preset-env@7.26.0(@babel/core@7.25.2))(encoding@0.1.13)(react@18.2.0))(react@18.2.0))(react-native@0.73.9(@babel/core@7.25.2)(@babel/preset-env@7.26.0(@babel/core@7.25.2))(encoding@0.1.13)(react@18.2.0))(react@18.2.0)
       '@react-navigation/native': 6.1.10(react-native@0.73.9(@babel/core@7.25.2)(@babel/preset-env@7.26.0(@babel/core@7.25.2))(encoding@0.1.13)(react@18.2.0))(react@18.2.0)
       color: 4.2.3
@@ -19596,14 +20593,6 @@ snapshots:
       '@types/estree': 0.0.39
       estree-walker: 1.0.1
       picomatch: 2.3.1
-      rollup: 2.79.2
-
-  '@rollup/pluginutils@5.1.0(rollup@2.79.2)':
-    dependencies:
-      '@types/estree': 1.0.5
-      estree-walker: 2.0.2
-      picomatch: 2.3.1
-    optionalDependencies:
       rollup: 2.79.2
 
   '@rollup/pluginutils@5.1.0(rollup@4.13.0)':
@@ -21803,12 +22792,16 @@ snapshots:
     dependencies:
       big-integer: 1.6.52
 
+  '@urbit/aura@2.0.1': {}
+
   '@urbit/http-api@3.2.0-dev':
     dependencies:
       '@babel/runtime': 7.25.9
       '@types/node': 20.14.10
       browser-or-node: 1.3.0
       core-js: 3.24.1
+
+  '@urbit/nockjs@1.4.0': {}
 
   '@urbit/sigil-js@2.2.0':
     dependencies:
@@ -21829,44 +22822,44 @@ snapshots:
       graphql: 15.8.0
       wonka: 4.0.15
 
-  '@vitejs/plugin-basic-ssl@1.1.0(vite@5.1.6(@types/node@20.10.8)(terser@5.36.0))':
+  '@vitejs/plugin-basic-ssl@1.1.0(vite@5.1.6(@types/node@20.10.8)(lightningcss@1.19.0)(terser@5.36.0))':
     dependencies:
-      vite: 5.1.6(@types/node@20.10.8)(terser@5.36.0)
+      vite: 5.1.6(@types/node@20.10.8)(lightningcss@1.19.0)(terser@5.36.0)
 
-  '@vitejs/plugin-basic-ssl@1.1.0(vite@5.1.6(@types/node@20.14.10)(terser@5.36.0))':
+  '@vitejs/plugin-basic-ssl@1.1.0(vite@5.1.6(@types/node@20.14.10)(lightningcss@1.19.0)(terser@5.36.0))':
     dependencies:
-      vite: 5.1.6(@types/node@20.14.10)(terser@5.36.0)
+      vite: 5.1.6(@types/node@20.14.10)(lightningcss@1.19.0)(terser@5.36.0)
 
-  '@vitejs/plugin-react@4.2.1(vite@5.1.6(@types/node@20.10.8)(terser@5.36.0))':
+  '@vitejs/plugin-react@4.2.1(vite@5.1.6(@types/node@20.10.8)(lightningcss@1.19.0)(terser@5.36.0))':
     dependencies:
       '@babel/core': 7.23.7
       '@babel/plugin-transform-react-jsx-self': 7.23.3(@babel/core@7.23.7)
       '@babel/plugin-transform-react-jsx-source': 7.23.3(@babel/core@7.23.7)
       '@types/babel__core': 7.20.5
       react-refresh: 0.14.0
-      vite: 5.1.6(@types/node@20.10.8)(terser@5.36.0)
+      vite: 5.1.6(@types/node@20.10.8)(lightningcss@1.19.0)(terser@5.36.0)
     transitivePeerDependencies:
       - supports-color
 
-  '@vitejs/plugin-react@4.2.1(vite@5.1.6(@types/node@20.14.10)(terser@5.36.0))':
+  '@vitejs/plugin-react@4.2.1(vite@5.1.6(@types/node@20.14.10)(lightningcss@1.19.0)(terser@5.36.0))':
     dependencies:
       '@babel/core': 7.23.7
       '@babel/plugin-transform-react-jsx-self': 7.23.3(@babel/core@7.23.7)
       '@babel/plugin-transform-react-jsx-source': 7.23.3(@babel/core@7.23.7)
       '@types/babel__core': 7.20.5
       react-refresh: 0.14.0
-      vite: 5.1.6(@types/node@20.14.10)(terser@5.36.0)
+      vite: 5.1.6(@types/node@20.14.10)(lightningcss@1.19.0)(terser@5.36.0)
     transitivePeerDependencies:
       - supports-color
 
-  '@vitejs/plugin-react@4.2.1(vite@5.1.6(@types/node@20.17.6)(terser@5.36.0))':
+  '@vitejs/plugin-react@4.2.1(vite@5.1.6(@types/node@20.17.6)(lightningcss@1.19.0)(terser@5.36.0))':
     dependencies:
       '@babel/core': 7.23.7
       '@babel/plugin-transform-react-jsx-self': 7.23.3(@babel/core@7.23.7)
       '@babel/plugin-transform-react-jsx-source': 7.23.3(@babel/core@7.23.7)
       '@types/babel__core': 7.20.5
       react-refresh: 0.14.0
-      vite: 5.1.6(@types/node@20.17.6)(terser@5.36.0)
+      vite: 5.1.6(@types/node@20.17.6)(lightningcss@1.19.0)(terser@5.36.0)
     transitivePeerDependencies:
       - supports-color
 
@@ -22333,11 +23326,29 @@ snapshots:
       cosmiconfig: 7.1.0
       resolve: 1.22.8
 
+  babel-plugin-polyfill-corejs2@0.4.11(@babel/core@7.23.7):
+    dependencies:
+      '@babel/compat-data': 7.26.2
+      '@babel/core': 7.23.7
+      '@babel/helper-define-polyfill-provider': 0.6.2(@babel/core@7.23.7)
+      semver: 6.3.1
+    transitivePeerDependencies:
+      - supports-color
+
   babel-plugin-polyfill-corejs2@0.4.11(@babel/core@7.25.2):
     dependencies:
       '@babel/compat-data': 7.26.2
       '@babel/core': 7.25.2
       '@babel/helper-define-polyfill-provider': 0.6.2(@babel/core@7.25.2)
+      semver: 6.3.1
+    transitivePeerDependencies:
+      - supports-color
+
+  babel-plugin-polyfill-corejs2@0.4.8(@babel/core@7.23.7):
+    dependencies:
+      '@babel/compat-data': 7.25.2
+      '@babel/core': 7.23.7
+      '@babel/helper-define-polyfill-provider': 0.5.0(@babel/core@7.23.7)
       semver: 6.3.1
     transitivePeerDependencies:
       - supports-color
@@ -22348,6 +23359,14 @@ snapshots:
       '@babel/core': 7.25.2
       '@babel/helper-define-polyfill-provider': 0.5.0(@babel/core@7.25.2)
       semver: 6.3.1
+    transitivePeerDependencies:
+      - supports-color
+
+  babel-plugin-polyfill-corejs3@0.10.6(@babel/core@7.23.7):
+    dependencies:
+      '@babel/core': 7.23.7
+      '@babel/helper-define-polyfill-provider': 0.6.2(@babel/core@7.23.7)
+      core-js-compat: 3.39.0
     transitivePeerDependencies:
       - supports-color
 
@@ -22367,6 +23386,14 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  babel-plugin-polyfill-corejs3@0.9.0(@babel/core@7.23.7):
+    dependencies:
+      '@babel/core': 7.23.7
+      '@babel/helper-define-polyfill-provider': 0.5.0(@babel/core@7.23.7)
+      core-js-compat: 3.35.1
+    transitivePeerDependencies:
+      - supports-color
+
   babel-plugin-polyfill-corejs3@0.9.0(@babel/core@7.25.2):
     dependencies:
       '@babel/core': 7.25.2
@@ -22375,10 +23402,24 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  babel-plugin-polyfill-regenerator@0.5.5(@babel/core@7.23.7):
+    dependencies:
+      '@babel/core': 7.23.7
+      '@babel/helper-define-polyfill-provider': 0.5.0(@babel/core@7.23.7)
+    transitivePeerDependencies:
+      - supports-color
+
   babel-plugin-polyfill-regenerator@0.5.5(@babel/core@7.25.2):
     dependencies:
       '@babel/core': 7.25.2
       '@babel/helper-define-polyfill-provider': 0.5.0(@babel/core@7.25.2)
+    transitivePeerDependencies:
+      - supports-color
+
+  babel-plugin-polyfill-regenerator@0.6.2(@babel/core@7.23.7):
+    dependencies:
+      '@babel/core': 7.23.7
+      '@babel/helper-define-polyfill-provider': 0.6.2(@babel/core@7.23.7)
     transitivePeerDependencies:
       - supports-color
 
@@ -22392,6 +23433,12 @@ snapshots:
   babel-plugin-react-native-web@0.18.12: {}
 
   babel-plugin-syntax-trailing-function-commas@7.0.0-beta.0: {}
+
+  babel-plugin-transform-flow-enums@0.0.2(@babel/core@7.23.7):
+    dependencies:
+      '@babel/plugin-syntax-flow': 7.23.3(@babel/core@7.23.7)
+    transitivePeerDependencies:
+      - '@babel/core'
 
   babel-plugin-transform-flow-enums@0.0.2(@babel/core@7.25.2):
     dependencies:
@@ -25993,6 +27040,31 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  jscodeshift@0.14.0(@babel/preset-env@7.26.0(@babel/core@7.23.7)):
+    dependencies:
+      '@babel/core': 7.25.2
+      '@babel/parser': 7.25.6
+      '@babel/plugin-proposal-class-properties': 7.18.6(@babel/core@7.25.2)
+      '@babel/plugin-proposal-nullish-coalescing-operator': 7.18.6(@babel/core@7.25.2)
+      '@babel/plugin-proposal-optional-chaining': 7.21.0(@babel/core@7.25.2)
+      '@babel/plugin-transform-modules-commonjs': 7.23.3(@babel/core@7.25.2)
+      '@babel/preset-env': 7.26.0(@babel/core@7.23.7)
+      '@babel/preset-flow': 7.23.3(@babel/core@7.25.2)
+      '@babel/preset-typescript': 7.23.3(@babel/core@7.25.2)
+      '@babel/register': 7.23.7(@babel/core@7.25.2)
+      babel-core: 7.0.0-bridge.0(@babel/core@7.25.2)
+      chalk: 4.1.2
+      flow-parser: 0.206.0
+      graceful-fs: 4.2.10
+      micromatch: 4.0.8
+      neo-async: 2.6.2
+      node-dir: 0.1.17
+      recast: 0.21.5
+      temp: 0.8.4
+      write-file-atomic: 2.4.3
+    transitivePeerDependencies:
+      - supports-color
+
   jscodeshift@0.14.0(@babel/preset-env@7.26.0(@babel/core@7.25.2)):
     dependencies:
       '@babel/core': 7.25.2
@@ -27488,8 +28560,8 @@ snapshots:
     dependencies:
       fflate: 0.4.8
 
-  posthog-react-native@2.11.3(5da2lqyaedbkzrvmxe6zbne2yu):
-    optionalDependencies:
+  ? posthog-react-native@2.11.3(@react-native-async-storage/async-storage@1.21.0(react-native@0.73.9(@babel/core@7.25.2)(@babel/preset-env@7.23.7(@babel/core@7.25.2))(encoding@0.1.13)(react@18.2.0)))(@react-navigation/native@6.1.10(react-native@0.73.9(@babel/core@7.25.2)(@babel/preset-env@7.23.7(@babel/core@7.25.2))(encoding@0.1.13)(react@18.2.0))(react@18.2.0))(expo-application@5.8.4(expo@50.0.21(@babel/core@7.25.2)(@react-native/babel-preset@0.73.21(@babel/core@7.25.2)(@babel/preset-env@7.23.7(@babel/core@7.25.2)))(encoding@0.1.13)))(expo-device@5.9.4(expo@50.0.21(@babel/core@7.25.2)(@react-native/babel-preset@0.73.21(@babel/core@7.25.2)(@babel/preset-env@7.23.7(@babel/core@7.25.2)))(encoding@0.1.13)))(expo-file-system@16.0.9(expo@50.0.21(@babel/core@7.25.2)(@react-native/babel-preset@0.73.21(@babel/core@7.25.2)(@babel/preset-env@7.23.7(@babel/core@7.25.2)))(encoding@0.1.13)))(expo-localization@14.8.4(expo@50.0.21(@babel/core@7.25.2)(@react-native/babel-preset@0.73.21(@babel/core@7.25.2)(@babel/preset-env@7.23.7(@babel/core@7.25.2)))(encoding@0.1.13)))(react-native-device-info@10.12.0(react-native@0.73.9(@babel/core@7.25.2)(@babel/preset-env@7.23.7(@babel/core@7.25.2))(encoding@0.1.13)(react@18.2.0)))
+  : optionalDependencies:
       '@react-native-async-storage/async-storage': 1.21.0(react-native@0.73.9(@babel/core@7.25.2)(@babel/preset-env@7.23.7(@babel/core@7.25.2))(encoding@0.1.13)(react@18.2.0))
       '@react-navigation/native': 6.1.10(react-native@0.73.9(@babel/core@7.25.2)(@babel/preset-env@7.23.7(@babel/core@7.25.2))(encoding@0.1.13)(react@18.2.0))(react@18.2.0)
       expo-application: 5.8.4(expo@50.0.21(@babel/core@7.25.2)(@react-native/babel-preset@0.73.21(@babel/core@7.25.2)(@babel/preset-env@7.23.7(@babel/core@7.25.2)))(encoding@0.1.13))
@@ -27843,11 +28915,11 @@ snapshots:
       react-cosmos-core: 6.1.1
       react-cosmos-renderer: 6.1.1
 
-  react-cosmos-plugin-vite@6.1.1(vite@5.1.6(@types/node@20.14.10)(terser@5.36.0)):
+  react-cosmos-plugin-vite@6.1.1(vite@5.1.6(@types/node@20.14.10)(lightningcss@1.19.0)(terser@5.36.0)):
     dependencies:
       react-cosmos-core: 6.2.0
       react-cosmos-dom: 6.2.0
-      vite: 5.1.6(@types/node@20.14.10)(terser@5.36.0)
+      vite: 5.1.6(@types/node@20.14.10)(lightningcss@1.19.0)(terser@5.36.0)
 
   react-cosmos-renderer@6.1.1:
     dependencies:
@@ -28304,6 +29376,13 @@ snapshots:
     transitivePeerDependencies:
       - encoding
 
+  react-native-webview@13.6.4(react-native@0.73.9(@babel/core@7.23.7)(@babel/preset-env@7.26.0(@babel/core@7.23.7))(encoding@0.1.13)(react@18.2.0))(react@18.2.0):
+    dependencies:
+      escape-string-regexp: 2.0.0
+      invariant: 2.2.4
+      react: 18.2.0
+      react-native: 0.73.9(@babel/core@7.23.7)(@babel/preset-env@7.26.0(@babel/core@7.23.7))(encoding@0.1.13)(react@18.2.0)
+
   react-native-webview@13.6.4(react-native@0.73.9(@babel/core@7.25.2)(@babel/preset-env@7.23.7(@babel/core@7.25.2))(encoding@0.1.13)(react@18.2.0))(react@18.2.0):
     dependencies:
       escape-string-regexp: 2.0.0
@@ -28421,6 +29500,55 @@ snapshots:
       - '@babel/core'
       - '@babel/preset-env'
       - applicationinsights-native-metrics
+      - bufferutil
+      - encoding
+      - supports-color
+      - utf-8-validate
+
+  react-native@0.73.9(@babel/core@7.23.7)(@babel/preset-env@7.26.0(@babel/core@7.23.7))(encoding@0.1.13)(react@18.2.0):
+    dependencies:
+      '@jest/create-cache-key-function': 29.7.0
+      '@react-native-community/cli': 12.3.7(encoding@0.1.13)
+      '@react-native-community/cli-platform-android': 12.3.7(encoding@0.1.13)
+      '@react-native-community/cli-platform-ios': 12.3.7(encoding@0.1.13)
+      '@react-native/assets-registry': 0.73.1
+      '@react-native/codegen': 0.73.3(@babel/preset-env@7.26.0(@babel/core@7.23.7))
+      '@react-native/community-cli-plugin': 0.73.18(@babel/core@7.23.7)(@babel/preset-env@7.26.0(@babel/core@7.23.7))(encoding@0.1.13)
+      '@react-native/gradle-plugin': 0.73.4
+      '@react-native/js-polyfills': 0.73.1
+      '@react-native/normalize-colors': 0.73.2
+      '@react-native/virtualized-lists': 0.73.4(react-native@0.73.9(@babel/core@7.23.7)(@babel/preset-env@7.26.0(@babel/core@7.23.7))(encoding@0.1.13)(react@18.2.0))
+      abort-controller: 3.0.0
+      anser: 1.4.10
+      ansi-regex: 5.0.1
+      base64-js: 1.5.1
+      chalk: 4.1.2
+      deprecated-react-native-prop-types: 5.0.0
+      event-target-shim: 5.0.1
+      flow-enums-runtime: 0.0.6
+      invariant: 2.2.4
+      jest-environment-node: 29.7.0
+      jsc-android: 250231.0.0
+      memoize-one: 5.2.1
+      metro-runtime: 0.80.5
+      metro-source-map: 0.80.5
+      mkdirp: 0.5.6
+      nullthrows: 1.1.1
+      pretty-format: 26.6.2
+      promise: 8.3.0
+      react: 18.2.0
+      react-devtools-core: 4.28.5
+      react-refresh: 0.14.0
+      react-shallow-renderer: 16.15.0(react@18.2.0)
+      regenerator-runtime: 0.13.11
+      scheduler: 0.24.0-canary-efb381bbf-20230505
+      stacktrace-parser: 0.1.10
+      whatwg-fetch: 3.6.20
+      ws: 6.2.2
+      yargs: 17.7.2
+    transitivePeerDependencies:
+      - '@babel/core'
+      - '@babel/preset-env'
       - bufferutil
       - encoding
       - supports-color
@@ -28915,15 +30043,6 @@ snapshots:
       rollup: 2.79.2
       serialize-javascript: 4.0.0
       terser: 5.36.0
-
-  rollup-plugin-visualizer@5.12.0(rollup@2.79.2):
-    dependencies:
-      open: 8.4.2
-      picomatch: 2.3.1
-      source-map: 0.7.4
-      yargs: 17.7.2
-    optionalDependencies:
-      rollup: 2.79.2
 
   rollup-plugin-visualizer@5.12.0(rollup@4.13.0):
     dependencies:
@@ -30275,14 +31394,14 @@ snapshots:
       react-dom: 18.2.0(react@18.2.0)
       redux: 4.2.0
 
-  vite-node@0.34.6(@types/node@20.10.8)(terser@5.36.0):
+  vite-node@0.34.6(@types/node@20.10.8)(lightningcss@1.19.0)(terser@5.36.0):
     dependencies:
       cac: 6.7.14
       debug: 4.3.4
       mlly: 1.5.0
       pathe: 1.1.2
       picocolors: 1.0.0
-      vite: 5.1.6(@types/node@20.10.8)(terser@5.36.0)
+      vite: 5.1.6(@types/node@20.10.8)(lightningcss@1.19.0)(terser@5.36.0)
     transitivePeerDependencies:
       - '@types/node'
       - less
@@ -30293,13 +31412,13 @@ snapshots:
       - supports-color
       - terser
 
-  vite-node@1.2.2(@types/node@20.14.10)(terser@5.36.0):
+  vite-node@1.2.2(@types/node@20.14.10)(lightningcss@1.19.0)(terser@5.36.0):
     dependencies:
       cac: 6.7.14
       debug: 4.3.4
       pathe: 1.1.2
       picocolors: 1.0.0
-      vite: 5.1.6(@types/node@20.14.10)(terser@5.36.0)
+      vite: 5.1.6(@types/node@20.14.10)(lightningcss@1.19.0)(terser@5.36.0)
     transitivePeerDependencies:
       - '@types/node'
       - less
@@ -30310,13 +31429,13 @@ snapshots:
       - supports-color
       - terser
 
-  vite-node@1.2.2(@types/node@20.17.6)(terser@5.36.0):
+  vite-node@1.2.2(@types/node@20.17.6)(lightningcss@1.19.0)(terser@5.36.0):
     dependencies:
       cac: 6.7.14
       debug: 4.3.4
       pathe: 1.1.2
       picocolors: 1.0.0
-      vite: 5.1.6(@types/node@20.17.6)(terser@5.36.0)
+      vite: 5.1.6(@types/node@20.17.6)(lightningcss@1.19.0)(terser@5.36.0)
     transitivePeerDependencies:
       - '@types/node'
       - less
@@ -30327,13 +31446,13 @@ snapshots:
       - supports-color
       - terser
 
-  vite-node@1.5.0(@types/node@20.17.6)(terser@5.36.0):
+  vite-node@1.5.0(@types/node@20.17.6)(lightningcss@1.19.0)(terser@5.36.0):
     dependencies:
       cac: 6.7.14
       debug: 4.3.4
       pathe: 1.1.2
       picocolors: 1.0.1
-      vite: 5.1.6(@types/node@20.17.6)(terser@5.36.0)
+      vite: 5.1.6(@types/node@20.17.6)(lightningcss@1.19.0)(terser@5.36.0)
     transitivePeerDependencies:
       - '@types/node'
       - less
@@ -30344,57 +31463,57 @@ snapshots:
       - supports-color
       - terser
 
-  vite-plugin-pwa@0.17.5(vite@5.1.6(@types/node@20.10.8)(terser@5.36.0))(workbox-build@7.0.0(@types/babel__core@7.20.5))(workbox-window@7.0.0):
+  vite-plugin-pwa@0.17.5(vite@5.1.6(@types/node@20.10.8)(lightningcss@1.19.0)(terser@5.36.0))(workbox-build@7.0.0(@types/babel__core@7.20.5))(workbox-window@7.0.0):
     dependencies:
       debug: 4.3.4
       fast-glob: 3.3.2
       pretty-bytes: 6.1.1
-      vite: 5.1.6(@types/node@20.10.8)(terser@5.36.0)
+      vite: 5.1.6(@types/node@20.10.8)(lightningcss@1.19.0)(terser@5.36.0)
       workbox-build: 7.0.0(@types/babel__core@7.20.5)
       workbox-window: 7.0.0
     transitivePeerDependencies:
       - supports-color
 
-  vite-plugin-pwa@0.17.5(vite@5.1.6(@types/node@20.14.10)(terser@5.36.0))(workbox-build@7.0.0(@types/babel__core@7.20.5))(workbox-window@7.0.0):
+  vite-plugin-pwa@0.17.5(vite@5.1.6(@types/node@20.14.10)(lightningcss@1.19.0)(terser@5.36.0))(workbox-build@7.0.0(@types/babel__core@7.20.5))(workbox-window@7.0.0):
     dependencies:
       debug: 4.3.4
       fast-glob: 3.3.2
       pretty-bytes: 6.1.1
-      vite: 5.1.6(@types/node@20.14.10)(terser@5.36.0)
+      vite: 5.1.6(@types/node@20.14.10)(lightningcss@1.19.0)(terser@5.36.0)
       workbox-build: 7.0.0(@types/babel__core@7.20.5)
       workbox-window: 7.0.0
     transitivePeerDependencies:
       - supports-color
 
-  vite-plugin-singlefile@2.0.1(rollup@4.13.0)(vite@5.1.6(@types/node@20.17.6)(terser@5.36.0)):
+  vite-plugin-singlefile@2.0.1(rollup@4.13.0)(vite@5.1.6(@types/node@20.17.6)(lightningcss@1.19.0)(terser@5.36.0)):
     dependencies:
       micromatch: 4.0.5
       rollup: 4.13.0
-      vite: 5.1.6(@types/node@20.17.6)(terser@5.36.0)
+      vite: 5.1.6(@types/node@20.17.6)(lightningcss@1.19.0)(terser@5.36.0)
 
-  vite-plugin-svgr@4.2.0(rollup@2.79.2)(typescript@5.4.5)(vite@5.1.6(@types/node@20.10.8)(terser@5.36.0)):
-    dependencies:
-      '@rollup/pluginutils': 5.1.0(rollup@2.79.2)
-      '@svgr/core': 8.1.0(typescript@5.4.5)
-      '@svgr/plugin-jsx': 8.1.0(@svgr/core@8.1.0(typescript@5.4.5))
-      vite: 5.1.6(@types/node@20.10.8)(terser@5.36.0)
-    transitivePeerDependencies:
-      - rollup
-      - supports-color
-      - typescript
-
-  vite-plugin-svgr@4.2.0(rollup@4.13.0)(typescript@5.4.5)(vite@5.1.6(@types/node@20.14.10)(terser@5.36.0)):
+  vite-plugin-svgr@4.2.0(rollup@4.13.0)(typescript@5.4.5)(vite@5.1.6(@types/node@20.10.8)(lightningcss@1.19.0)(terser@5.36.0)):
     dependencies:
       '@rollup/pluginutils': 5.1.0(rollup@4.13.0)
       '@svgr/core': 8.1.0(typescript@5.4.5)
       '@svgr/plugin-jsx': 8.1.0(@svgr/core@8.1.0(typescript@5.4.5))
-      vite: 5.1.6(@types/node@20.14.10)(terser@5.36.0)
+      vite: 5.1.6(@types/node@20.10.8)(lightningcss@1.19.0)(terser@5.36.0)
     transitivePeerDependencies:
       - rollup
       - supports-color
       - typescript
 
-  vite@5.1.6(@types/node@20.10.8)(terser@5.36.0):
+  vite-plugin-svgr@4.2.0(rollup@4.13.0)(typescript@5.4.5)(vite@5.1.6(@types/node@20.14.10)(lightningcss@1.19.0)(terser@5.36.0)):
+    dependencies:
+      '@rollup/pluginutils': 5.1.0(rollup@4.13.0)
+      '@svgr/core': 8.1.0(typescript@5.4.5)
+      '@svgr/plugin-jsx': 8.1.0(@svgr/core@8.1.0(typescript@5.4.5))
+      vite: 5.1.6(@types/node@20.14.10)(lightningcss@1.19.0)(terser@5.36.0)
+    transitivePeerDependencies:
+      - rollup
+      - supports-color
+      - typescript
+
+  vite@5.1.6(@types/node@20.10.8)(lightningcss@1.19.0)(terser@5.36.0):
     dependencies:
       esbuild: 0.19.12
       postcss: 8.4.35
@@ -30402,9 +31521,10 @@ snapshots:
     optionalDependencies:
       '@types/node': 20.10.8
       fsevents: 2.3.3
+      lightningcss: 1.19.0
       terser: 5.36.0
 
-  vite@5.1.6(@types/node@20.14.10)(terser@5.36.0):
+  vite@5.1.6(@types/node@20.14.10)(lightningcss@1.19.0)(terser@5.36.0):
     dependencies:
       esbuild: 0.19.12
       postcss: 8.4.35
@@ -30412,9 +31532,10 @@ snapshots:
     optionalDependencies:
       '@types/node': 20.14.10
       fsevents: 2.3.3
+      lightningcss: 1.19.0
       terser: 5.36.0
 
-  vite@5.1.6(@types/node@20.17.6)(terser@5.36.0):
+  vite@5.1.6(@types/node@20.17.6)(lightningcss@1.19.0)(terser@5.36.0):
     dependencies:
       esbuild: 0.19.12
       postcss: 8.4.35
@@ -30422,9 +31543,10 @@ snapshots:
     optionalDependencies:
       '@types/node': 20.17.6
       fsevents: 2.3.3
+      lightningcss: 1.19.0
       terser: 5.36.0
 
-  vitest@0.34.6(jsdom@23.2.0)(terser@5.36.0):
+  vitest@0.34.6(jsdom@23.2.0)(lightningcss@1.19.0)(terser@5.36.0):
     dependencies:
       '@types/chai': 4.3.11
       '@types/chai-subset': 1.3.5
@@ -30447,8 +31569,8 @@ snapshots:
       strip-literal: 1.3.0
       tinybench: 2.6.0
       tinypool: 0.7.0
-      vite: 5.1.6(@types/node@20.10.8)(terser@5.36.0)
-      vite-node: 0.34.6(@types/node@20.10.8)(terser@5.36.0)
+      vite: 5.1.6(@types/node@20.10.8)(lightningcss@1.19.0)(terser@5.36.0)
+      vite-node: 0.34.6(@types/node@20.10.8)(lightningcss@1.19.0)(terser@5.36.0)
       why-is-node-running: 2.2.2
     optionalDependencies:
       jsdom: 23.2.0
@@ -30461,7 +31583,7 @@ snapshots:
       - supports-color
       - terser
 
-  vitest@1.2.2(@types/node@20.14.10)(jsdom@23.2.0)(terser@5.36.0):
+  vitest@1.2.2(@types/node@20.14.10)(jsdom@23.2.0)(lightningcss@1.19.0)(terser@5.36.0):
     dependencies:
       '@vitest/expect': 1.2.2
       '@vitest/runner': 1.2.2
@@ -30481,8 +31603,8 @@ snapshots:
       strip-literal: 1.3.0
       tinybench: 2.6.0
       tinypool: 0.8.2
-      vite: 5.1.6(@types/node@20.14.10)(terser@5.36.0)
-      vite-node: 1.2.2(@types/node@20.14.10)(terser@5.36.0)
+      vite: 5.1.6(@types/node@20.14.10)(lightningcss@1.19.0)(terser@5.36.0)
+      vite-node: 1.2.2(@types/node@20.14.10)(lightningcss@1.19.0)(terser@5.36.0)
       why-is-node-running: 2.2.2
     optionalDependencies:
       '@types/node': 20.14.10
@@ -30496,7 +31618,7 @@ snapshots:
       - supports-color
       - terser
 
-  vitest@1.2.2(@types/node@20.17.6)(jsdom@23.2.0)(terser@5.36.0):
+  vitest@1.2.2(@types/node@20.17.6)(jsdom@23.2.0)(lightningcss@1.19.0)(terser@5.36.0):
     dependencies:
       '@vitest/expect': 1.2.2
       '@vitest/runner': 1.2.2
@@ -30516,8 +31638,8 @@ snapshots:
       strip-literal: 1.3.0
       tinybench: 2.6.0
       tinypool: 0.8.2
-      vite: 5.1.6(@types/node@20.17.6)(terser@5.36.0)
-      vite-node: 1.2.2(@types/node@20.17.6)(terser@5.36.0)
+      vite: 5.1.6(@types/node@20.17.6)(lightningcss@1.19.0)(terser@5.36.0)
+      vite-node: 1.2.2(@types/node@20.17.6)(lightningcss@1.19.0)(terser@5.36.0)
       why-is-node-running: 2.2.2
     optionalDependencies:
       '@types/node': 20.17.6
@@ -30531,7 +31653,7 @@ snapshots:
       - supports-color
       - terser
 
-  vitest@1.5.0(@types/node@20.17.6)(jsdom@23.2.0)(terser@5.36.0):
+  vitest@1.5.0(@types/node@20.17.6)(jsdom@23.2.0)(lightningcss@1.19.0)(terser@5.36.0):
     dependencies:
       '@vitest/expect': 1.5.0
       '@vitest/runner': 1.5.0
@@ -30550,8 +31672,8 @@ snapshots:
       strip-literal: 2.1.0
       tinybench: 2.6.0
       tinypool: 0.8.4
-      vite: 5.1.6(@types/node@20.17.6)(terser@5.36.0)
-      vite-node: 1.5.0(@types/node@20.17.6)(terser@5.36.0)
+      vite: 5.1.6(@types/node@20.17.6)(lightningcss@1.19.0)(terser@5.36.0)
+      vite-node: 1.5.0(@types/node@20.17.6)(lightningcss@1.19.0)(terser@5.36.0)
       why-is-node-running: 2.2.2
     optionalDependencies:
       '@types/node': 20.17.6


### PR DESCRIPTION
For our verifier integration, we've been working off a branch that diverged in November. I want to stop battling conflicts, so this branch represents the minimal amount of changes I think will be safe to merge into `develop`:

- Adds noun scries and pokes to the http-api client and our wrapper for it
- Pulls in `@urbit/nock-js` dependency and our new helper methods
- Removes all `/desk` changes from `m/verification-and-discovery`
- Removes all partial UI implementations for Verifier functionality
- Leaves the `lanyardApi`, DB model, queries, and DB hooks

The last item is still a work in progress, but should be safe to incorporate since there are no remaining codepaths that call into it.

With this in we should avoid needless repeated conflicts and can limit future changes to actual backend verifier code and working UI components.