### PR TITLE
Activity screen: fix width issue with gallery post items

### DIFF
--- a/packages/ui/src/components/Activity/ActivitySourceContent.tsx
+++ b/packages/ui/src/components/Activity/ActivitySourceContent.tsx
@@ -133,8 +133,7 @@ function NotebookOrGalleryContentRenderer({
     <ScrollView
       marginVertical="$m"
       horizontal
-      height={128}
-      contentContainerStyle={{ gap: '$m' }}
+      contentContainerStyle={{ gap: '$m', width: 128, height: 128 }}
       alwaysBounceHorizontal={false}
       showsHorizontalScrollIndicator={false}
     >


### PR DESCRIPTION
OTT, fixes tlon-3659. Afaict this should have never worked before, since we had zero width. 
![Simulator Screenshot - iPhone 15 - 2025-02-10 at 16 04 08](https://github.com/user-attachments/assets/a1b5fab4-62aa-4a54-92eb-d0c515477351)
