### PR TITLE
ops: set new web action env vars

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -181,3 +181,10 @@ jobs:
           SSH_SEC_KEY: ${{ secrets.GCP_SSH_SEC_KEY }}
           SSH_PUB_KEY: ${{ secrets.GCP_SSH_PUB_KEY }}
           URBIT_REPO_TAG: ${{ vars.URBIT_REPO_TAG }}
+          VITE_BRANCH_DOMAIN_PROD: ${{ secrets.VITE_BRANCH_DOMAIN_PROD}}
+          VITE_BRANCH_DOMAIN_TEST: ${{ secrets.VITE_BRANCH_DOMAIN_TEST}}
+          VITE_BRANCH_KEY_PROD: ${{ secrets.VITE_BRANCH_KEY_PROD}}
+          VITE_BRANCH_KEY_TEST: ${{ secrets.VITE_BRANCH_KEY_TEST}}
+          VITE_INVITE_SERVICE_ENDPOINT:
+            ${{ secrets.VITE_INVITE_SERVICE_ENDPOINT}}
+          VITE_POST_HOG_API_KEY: ${{ secrets.VITE_POST_HOG_API_KEY}}

--- a/apps/tlon-web-new/.env
+++ b/apps/tlon-web-new/.env
@@ -1,6 +1,3 @@
 # Change manually to clear local storage once
 VITE_LAST_WIPE=2022-05-13
 VITE_ENABLE_WDYR=false
-VITE_POST_HOG_API_KEY=phc_o25oAii2Hz9tIDe2SXyr0fvnL73qXxoP21NCOLfs40O
-VITE_BRANCH_KEY=key_live_hubypwhuxR6vkwKfdozyRoamErouusXi
-VITE_BRANCH_DOMAIN=join.tlon.io


### PR DESCRIPTION
I'm trying to configure the env vars that are rolled into the compiled glob in our deploy action. I want to avoid having to check in values explicitly.

I set them up as secrets in GH and am attempting to reference them in the action.

Going to merge without review, we can revert in the morning if needed.