### PR TITLE
Desktop: fix channel screen nav crashes

### DIFF
--- a/packages/app/features/top/ChannelScreen.tsx
+++ b/packages/app/features/top/ChannelScreen.tsx
@@ -33,7 +33,11 @@ const logger = createDevLogger('ChannelScreen', false);
 type Props = NativeStackScreenProps<RootStackParamList, 'Channel'>;
 
 export default function ChannelScreen(props: Props) {
-  const { channelId, selectedPostId, startDraft } = props.route.params;
+  const { channelId, selectedPostId, startDraft } = props.route.params ?? {
+    channelId: '',
+    selectedPostId: '',
+    startDraft: false,
+  };
   const [currentChannelId, setCurrentChannelId] = React.useState(channelId);
 
   useEffect(() => {

--- a/packages/app/navigation/desktop/HomeNavigator.tsx
+++ b/packages/app/navigation/desktop/HomeNavigator.tsx
@@ -108,10 +108,14 @@ function ChannelStack(
   props: NativeStackScreenProps<HomeDrawerParamList, 'Channel'>
 ) {
   const navKey = () => {
-    if ('channelId' in props.route.params) {
+    if (props.route.params && 'channelId' in props.route.params) {
       return props.route.params.channelId;
     }
-    if (props.route.params.params && 'channelId' in props.route.params.params) {
+    if (
+      props.route.params &&
+      props.route.params.params &&
+      'channelId' in props.route.params.params
+    ) {
       return props.route.params.params.channelId;
     }
 


### PR DESCRIPTION
fixes tlon-3594

Fixing the crashes is easy (make sure we're never checking for a property on an `undefined` value, basically), but forcing the app to always go back to where you expect it to go when using the browser back button is not, especially in the case of going back to another channel from a different channel. I spent most of my time trying to get that functionality to work, but came up short.

The browser back button seems to work fine when moving from a detail screen back to a channel screen, but switching between screens using the back button doesn't work. You'll always get sent back to the "Home" (ChatList with empty main pane) screen.

I think this has to do with our using `navigation.navigate` rather than `push` (which is necessary since we're in a drawer navigator). I tried using `reset` as a workaround, didn't work. I looked into keeping track of paths the user has navigated to and manually intervening when the user presses the back button (via a listener in app.tsx), but that just seems messy and fraught. I do think we need to fix this behavior, but for now I think we should fix the crash and investigate a solution for the back button behavior later.