### PR TITLE
Desktop: show group channels screen content in drawer when navigating directly to a post (from activity)

### DIFF
--- a/packages/app/navigation/desktop/HomeNavigator.tsx
+++ b/packages/app/navigation/desktop/HomeNavigator.tsx
@@ -78,6 +78,30 @@ function DrawerContent(props: DrawerContentComponentProps) {
       );
     }
     return <GroupChannelsScreenContent groupId={focusedRoute.params.groupId} />;
+  } else if (
+    focusedRoute.params &&
+    // @ts-expect-error - nested params is not in the type
+    focusedRoute.params.params &&
+    // @ts-expect-error - nested params is not in the type
+    'groupId' in focusedRoute.params.params
+  ) {
+    // @ts-expect-error - nested params is not in the type
+    if ('channelId' in focusedRoute.params.params) {
+      return (
+        <GroupChannelsScreenContent
+          // @ts-expect-error - nested params is not in the type
+          groupId={focusedRoute.params.params.groupId}
+          // @ts-expect-error - nested params is not in the type
+          focusedChannelId={focusedRoute.params.params.channelId}
+        />
+      );
+    }
+    return (
+      <GroupChannelsScreenContent
+        // @ts-expect-error - nested params is not in the type
+        groupId={focusedRoute.params.params.groupId}
+      />
+    );
   } else if (focusedRoute.params && 'channelId' in focusedRoute.params) {
     return (
       <ChatListScreenView focusedChannelId={focusedRoute.params.channelId} />


### PR DESCRIPTION
We weren't accounting for the nested params that we can have in our nested nav structure.

the nested params aren't in the type, torturing the nav types to get them in there is probably possible but I'm not sure it's totally necessary at this point.

fixes tlon-3617