### PR TITLE
Desktop: fix crash on editing profile

### DIFF
--- a/packages/ui/src/components/FavoriteGroupsDisplay.tsx
+++ b/packages/ui/src/components/FavoriteGroupsDisplay.tsx
@@ -69,6 +69,7 @@ export function FavoriteGroupsDisplay(props: {
           <GroupListItem
             model={group}
             key={group.id}
+            disableOptions
             backgroundColor="unset"
             EndContent={
               <Pressable onPress={() => handleFavoriteGroupsChange(group)}>


### PR DESCRIPTION
fixes tlon-3578

We were rendering GroupListItem in FavoriteGroupsDisplay. GroupListItem renders ChatOptionsSheet if we don't pass the `disableOptions` prop. We weren't passing that prop, so we were rendering ChatOptionsSheet outside of the ChatOptionsProvider. If we try to render ChatOptionsSheet outside of the provider, the app will crash.

Solution: just pass `disableOptions` to GroupListItem.