### PR TITLE
e2e: contacts CRUD

### DIFF
--- a/.maestro/30-contacts.yaml
+++ b/.maestro/30-contacts.yaml
@@ -1,0 +1,54 @@
+appId: io.tlon.groups
+---
+- clearState:
+    appId: io.tlon.groups
+- launchApp:
+    appId: io.tlon.groups
+- runFlow: subflows/tlon-login.yaml
+- assertVisible: 'Home'
+- tapOn:
+    id: "AvatarNavIcon"
+- assertVisible: "Contacts"
+- tapOn:
+    id: "ContactsAddButton"
+- tapOn: "Filter by nickname, @p"
+- inputText: "zod"
+- "hideKeyboard"
+- tapOn:
+    id: "ContactRow"
+- runFlow:
+    when:
+      visible: 'Add 1 contact'
+    commands:
+      - tapOn: 'Add 1 contact'
+- assertVisible: "Contacts"
+- tapOn: "~zod"
+- assertVisible: "Remove Contact"
+- tapOn: "Edit"
+- assertVisible: "Edit Profile"
+- tapOn: "~zod"
+- inputText: "Testing pet name"
+- "hideKeyboard"
+- runFlow:
+    when:
+      platform: ios
+    commands:
+    - tapOn: "Change avatar image"
+    - tapOn: "Photo Library"
+    - tapOn:
+        id: "PXGGridLayout-Info"
+        index: 0
+- tapOn: "Done"
+- assertVisible: "Profile"
+- assertVisible: "Testing pet name"
+- tapOn:
+    id: "HeaderBackButton"
+- assertVisible: "Contacts"
+- assertVisible: "Testing pet name"
+- tapOn: "Testing pet name"
+- tapOn: "Remove Contact"
+- assertVisible: "zod"
+- tapOn: "Message"
+- assertVisible: "Message"
+- tapOn:
+    id: "HeaderBackButton"

--- a/packages/app/features/top/ContactsScreen.tsx
+++ b/packages/app/features/top/ContactsScreen.tsx
@@ -72,6 +72,7 @@ export default function ContactsScreen(props: Props) {
             leftControls={
               <ScreenHeader.IconButton
                 type="Add"
+                testID='ContactsAddButton'
                 onPress={() => navigate('AddContacts')}
               />
             }

--- a/packages/ui/src/components/ContactBook.tsx
+++ b/packages/ui/src/components/ContactBook.tsx
@@ -116,6 +116,7 @@ export function ContactBook({
           selected={isSelected}
           onPress={handleSelect}
           pressStyle={{ backgroundColor: '$shadow' }}
+          testID='ContactRow'
         />
       );
     },


### PR DESCRIPTION
Adds an end-to-end test that:

- Logs in via the Tlon Hosted sub-flow
- Navigates to the Contacts screen
- Adds ~zod to contacts
- Adds a nickname and overrides the avatar
- Confirms the nickname is set
- Removes the contact
- Confirms removing the contact unsets the nickname
- Confirms you can start a DM from a profile