### PR TITLE
Activity: make sure we render multiple gallery post previews when necessary

### DIFF
--- a/packages/ui/src/components/Activity/ActivitySourceContent.tsx
+++ b/packages/ui/src/components/Activity/ActivitySourceContent.tsx
@@ -153,6 +153,7 @@ function NotebookOrGalleryContentRenderer({
             post={post}
             onPress={pressHandler}
             width={128}
+            showAuthor={false}
           />
         )
       )}

--- a/packages/ui/src/components/Activity/ActivitySourceContent.tsx
+++ b/packages/ui/src/components/Activity/ActivitySourceContent.tsx
@@ -133,7 +133,7 @@ function NotebookOrGalleryContentRenderer({
     <ScrollView
       marginVertical="$m"
       horizontal
-      contentContainerStyle={{ gap: '$m', width: 128, height: 128 }}
+      contentContainerStyle={{ gap: '$m', height: 128 }}
       alwaysBounceHorizontal={false}
       showsHorizontalScrollIndicator={false}
     >
@@ -148,7 +148,12 @@ function NotebookOrGalleryContentRenderer({
             onPress={pressHandler}
           />
         ) : (
-          <GalleryPost key={post.id} post={post} onPress={pressHandler} />
+          <GalleryPost
+            key={post.id}
+            post={post}
+            onPress={pressHandler}
+            width={128}
+          />
         )
       )}
     </ScrollView>

--- a/packages/ui/src/components/GalleryPost/GalleryPost.tsx
+++ b/packages/ui/src/components/GalleryPost/GalleryPost.tsx
@@ -102,7 +102,7 @@ export function GalleryPost({
     <Pressable
       onPress={disableHandlePress ? undefined : handlePress}
       onLongPress={handleLongPress}
-      style={StyleSheet.absoluteFill}
+      flex={1}
     >
       <GalleryPostFrame {...props}>
         <GalleryContentRenderer


### PR DESCRIPTION
fixes tlon-3672

the issue was the fixed width on the scrollview (my mistake yesterday) and the StyleSheet.AbsoluteFill that had been added to the Pressable in GalleryPost (cc: @davidisaaclee will removing this and replacing it with flex={1} break something? looks fine afaict, but I'm not sure if there was some particular case you had in mind when you added it).

![Simulator Screenshot - iPhone 15 - 2025-02-11 at 13 27 04](https://github.com/user-attachments/assets/4fef74aa-0491-44cf-9254-f12e5481edfe)
