### PR TITLE
grouper: fix incorrect log message

### DIFF
--- a/desk/app/grouper.hoon
+++ b/desk/app/grouper.hoon
@@ -200,7 +200,7 @@
     =+  .^(=group:groups %gx :(weld prefix /groups gnat))
     ?+  -.cordon.group  ~
         %open
-      :-  %^  lure-log  %info  group-event
+      :-  %^  lure-log  %info  'Group Invite Sent'
           ~[leaf+"{<joiner.bite>} invited to public group {<p.flag>}/{(trip q.flag)}"]
       ~[[%pass /invite %agent [our.bowl %groups] %poke %group-invite !>(invite)]]
     ::


### PR DESCRIPTION
A wrong message was logged upon successful join to a public group. This did not generate alerts, but did generate a bunch of confusing group events in Posthog.

Fixes TLON-3667