### PR TITLE
fix image viewer on mobile

### DIFF
--- a/packages/ui/src/components/ImageViewerScreenView.tsx
+++ b/packages/ui/src/components/ImageViewerScreenView.tsx
@@ -103,7 +103,7 @@ export function ImageViewerScreenView(props: {
         paddingTop={top}
         data-testid="image-viewer"
       >
-        <View>
+        <View flex={1}>
           {isWeb ? (
             <Zoomable
               ref={zoomableRef}


### PR DESCRIPTION
OTT, fixes tlon-3686

Apparently I removed a load bearing `flex={1}` the other day while working on the image viewer for web (the prop didn't do anything on web).