### PR TITLE
web: fix stretched images in image viewer

### DIFF
--- a/packages/ui/src/components/ImageViewerScreenView.tsx
+++ b/packages/ui/src/components/ImageViewerScreenView.tsx
@@ -103,7 +103,7 @@ export function ImageViewerScreenView(props: {
         paddingTop={top}
         data-testid="image-viewer"
       >
-        <View flex={1}>
+        <View flex={isWeb ? 0 : 1}>
           {isWeb ? (
             <Zoomable
               ref={zoomableRef}


### PR DESCRIPTION
earlier fix for mobile brought back the stretched images issue on web, now we only apply `flex={1}` if we're not on web.