### PR TITLE
desktop: show message actions context menu for gallery and notebook posts

### DIFF
--- a/packages/ui/src/components/ChatMessage/ChatMessageActions/Component.tsx
+++ b/packages/ui/src/components/ChatMessage/ChatMessageActions/Component.tsx
@@ -35,7 +35,7 @@ export function ChatMessageActions({
   onViewReactions,
   onShowEmojiPicker,
   trigger,
-  onOpenChange
+  onOpenChange,
 }: ChatMessageActionsProps) {
   const insets = useSafeAreaInsets();
   const PADDING_THRESHOLD = 40;
@@ -154,13 +154,15 @@ export function ChatMessageActions({
           padding={1}
         >
           <YStack gap="$xs">
-            <XStack justifyContent="center">
-              <EmojiToolbar
-                post={post}
-                onDismiss={onDismiss}
-                openExternalSheet={onShowEmojiPicker}
-              />
-            </XStack>
+            {post.type === 'chat' && (
+              <XStack justifyContent="center">
+                <EmojiToolbar
+                  post={post}
+                  onDismiss={onDismiss}
+                  openExternalSheet={onShowEmojiPicker}
+                />
+              </XStack>
+            )}
             <MessageActions
               post={post}
               postActionIds={postActionIds}


### PR DESCRIPTION
Uses the same pattern we use for chat messages. fixes tlon-3688