### PR TITLE
chat: prevent on fail loop

### DIFF
--- a/desk/app/chat.hoon
+++ b/desk/app/chat.hoon
@@ -641,6 +641,7 @@
   ?+    pole  ~|(bad-agent-wire/pole !!)
       ~  cor
   ::
+      [%logs *]  cor
       [%epic ~]  cor
       [%hook *]  cor
   ::


### PR DESCRIPTION
OTT, the new on-fail logging was getting triggered by blocked ships trying to DM the blocker. Because we didn't handle `/logs` in the `agent` arm, it would crash and produce another poke to `/logs` creating a loop. This just no-ops the ack handling of that poke. I checked all other agents in this desk and they are either handling that already or have a different `on-agent` setup that prevents this from happening.