### PR TITLE
desktop: fix issue with weird avatar render in profile editing

### DIFF
--- a/packages/ui/src/components/Avatar.tsx
+++ b/packages/ui/src/components/Avatar.tsx
@@ -6,6 +6,7 @@ import {
   Text,
   View,
   getTokenValue,
+  isWeb,
   styled,
   useStyle,
 } from 'tamagui';
@@ -327,9 +328,21 @@ export const SigilAvatar = React.memo(function SigilAvatarComponent({
     if (size && size !== 'custom') {
       return getTokenValue(size);
     } else {
+      if (isWeb && (props.width || props.height)) {
+        // Sigil size must be a number
+        if (
+          typeof props.width === 'string' ||
+          typeof props.height === 'string'
+        ) {
+          return 20;
+        }
+
+        return props.width ?? props.height ?? 20;
+      }
+
       return styles.width ?? styles.height ?? 20;
     }
-  }, [size, styles.width, styles.height]);
+  }, [size, styles.width, styles.height, props.width, props.height]);
 
   return (
     <AvatarFrame

--- a/packages/ui/src/components/Avatar.tsx
+++ b/packages/ui/src/components/Avatar.tsx
@@ -329,7 +329,10 @@ export const SigilAvatar = React.memo(function SigilAvatarComponent({
       return getTokenValue(size);
     } else {
       if (isWeb && (props.width || props.height)) {
-        // Sigil size must be a number
+        // Sigil size must be a number (because we need to multiply by it). 
+        // On web, `useStyle` will return a string.
+        // We'll use the height or width prop if it's not a string, otherwise
+        // default to 20.
         if (
           typeof props.width === 'string' ||
           typeof props.height === 'string'


### PR DESCRIPTION
fixes tlon-3377

it turns out the `useStyles` on web transforms numeric height/width values into strings (e.g., `56` becomes `'56px`). This breaks the calculation for the `size` prop that gets passed into UrbitSigil, which expects a number.

Tested on iOS and Android as well to make sure this doesn't break anything over there, it's fine.