### PR TITLE
Refs: navigate directly to gallery or notebook posts from refs

### DIFF
--- a/packages/app/hooks/useChannelNavigation.ts
+++ b/packages/app/hooks/useChannelNavigation.ts
@@ -21,16 +21,20 @@ export const useChannelNavigation = ({ channelId }: { channelId: string }) => {
 
   const navigateToRef = useCallback(
     (channel: db.Channel, post: db.Post) => {
-      if (channel.id === channelId) {
-        navigation.navigate('Channel', {
-          channelId: channel.id,
-          selectedPostId: post.id,
-        });
+      if (channel.type === 'chat') {
+        if (channel.id === channelId) {
+          navigation.navigate('Channel', {
+            channelId: channel.id,
+            selectedPostId: post.id,
+          });
+        } else {
+          navigateToChannel(channel, post.id);
+        }
       } else {
-        navigateToChannel(channel, post.id);
+        navigateToPost(post);
       }
     },
-    [navigation, channelId, navigateToChannel]
+    [navigation, channelId, navigateToChannel, navigateToPost]
   );
 
   const navigateToImage = useCallback(


### PR DESCRIPTION
fixes TLON-3663 by sidestepping the weirdness we were seeing with post loading and scroller position by just navigating the user directly to the post rather than the channel containing the post (which is probably what the user wants anyway).