### PR TITLE
useChannelPosts: clear `newPosts` state when switching channels

### DIFF
--- a/packages/shared/src/store/useChannelPosts.ts
+++ b/packages/shared/src/store/useChannelPosts.ts
@@ -174,6 +174,7 @@ export const useChannelPosts = (options: UseChannelPostsParams) => {
     db.getUnconfirmedPosts({ channelId: options.channelId }).then(
       setUnconfirmedPosts
     );
+    setNewPosts([]);
   }, [options.channelId]);
   const rawPosts = useMemo<db.Post[] | null>(() => {
     const rawPostsWithoutUnconfirmeds = (() => {


### PR DESCRIPTION
fixes tlon-3663

The issue stems from our `newPosts` state sticking around after we switch channels. Not clear to me why this never cropped up in the past. Clearing `newPosts` when the channelId changes definitely fixes the issue though.

To test: go to some channel, copy a ref link. Go to another channel, post that ref as a message. Press the ref, taking you back to the first channel. The posts in the first channel should look normal, without any of the posts from the second channel "sticking" around.