### PR TITLE
members-list: only show join requests and banned members for admins

### DIFF
--- a/packages/ui/src/components/GroupMembersScreenView.tsx
+++ b/packages/ui/src/components/GroupMembersScreenView.tsx
@@ -112,7 +112,7 @@ export function GroupMembersScreenView({
           data: membersByRole[role],
         }))
         .concat(
-          joinRequestData.length > 0
+          joinRequestData.length > 0 && currentUserIsAdmin
             ? [
                 {
                   title: 'Join Requests',
@@ -122,7 +122,7 @@ export function GroupMembersScreenView({
             : []
         )
         .concat(
-          bannedUserData.length > 0
+          bannedUserData.length > 0 && currentUserIsAdmin
             ? [
                 {
                   title: 'Banned Users',


### PR DESCRIPTION
Does what it says on the tin. Avoids showing join requests and banned ships to rank and file members; keeps these sections visible only to group administrators.