### PR TITLE
web-new: themed scrollbars, app loader

### DIFF
--- a/apps/tlon-web-new/src/app.tsx
+++ b/apps/tlon-web-new/src/app.tsx
@@ -19,7 +19,7 @@ import { AppDataProvider } from '@tloncorp/app/provider/AppDataProvider';
 import { sync } from '@tloncorp/shared';
 import * as db from '@tloncorp/shared/db';
 import * as store from '@tloncorp/shared/store';
-import { LoadingSpinner, StoreProvider, View } from '@tloncorp/ui';
+import { LoadingSpinner, StoreProvider, Text, View } from '@tloncorp/ui';
 import cookies from 'browser-cookies';
 import { usePostHog } from 'posthog-js/react';
 import React, { PropsWithChildren, useEffect, useState } from 'react';
@@ -197,8 +197,23 @@ const App = React.memo(function AppComponent() {
                   width="100%"
                   justifyContent="center"
                   alignItems="center"
+                  backgroundColor="$secondaryBackground"
                 >
-                  <LoadingSpinner />
+                  <View
+                    backgroundColor="$background"
+                    padding="$xl"
+                    borderRadius="$l"
+                    aspectRatio={1}
+                    alignItems="center"
+                    justifyContent="center"
+                    borderWidth={1}
+                    borderColor="$border"
+                  >
+                    <LoadingSpinner color="$primaryText" />
+                    <Text color="$primaryText" marginTop="$xl" fontSize="$s">
+                      Starting up&hellip;
+                    </Text>
+                  </View>
                 </View>
               )}
             </StoreProvider>

--- a/apps/tlon-web-new/src/styles/base.css
+++ b/apps/tlon-web-new/src/styles/base.css
@@ -1,7 +1,26 @@
 * {
-  /* Scrollbar resizing for Firefox */
   scrollbar-width: thin;
-  scrollbar-color: rgb(var(--colors-gray-200)) transparent;
+  scrollbar-color: var(--primaryText) transparent;
+  color-scheme: light dark;
+}
+
+@supports selector(::-webkit-scrollbar) {
+  ::-webkit-scrollbar {
+    width: 8px;
+    height: 8px;
+  }
+
+  ::-webkit-scrollbar-track {
+    background: transparent;
+  }
+
+  ::-webkit-scrollbar-thumb {
+    background: var(--primaryText);
+    border-radius: 4px;
+  }
+}
+
+* {
   /* Hide gray box when tapping a link on iOS */
   -webkit-tap-highlight-color: transparent;
   /* Disable double-tap to zoom, removes click delay */
@@ -12,23 +31,6 @@
   -webkit-font-smoothing: subpixel-antialiased;
 }
 
-/* Scrollbar resizing for Chrome, Edge, and Safari */
-*::-webkit-scrollbar {
-  width: 10px;
-}
-
-*::-webkit-scrollbar-track {
-  background: transparent;
-  border: solid 2px transparent;
-}
-
-*::-webkit-scrollbar-thumb {
-  background: rgb(var(--colors-gray-200));
-  border: solid 2px transparent;
-  border-radius: 20px;
-  background-clip: content-box;
-}
-
 html,
 body,
 #app {
@@ -36,7 +38,6 @@ body,
   @apply h-full min-h-screen w-full;
   min-height: -webkit-fill-available;
   font-variant-ligatures: contextual;
-  /* Prevents undesirable scroll capture / locking on iOS */
   overflow: clip;
 }
 


### PR DESCRIPTION
I use Safari daily and I was getting annoyed with the default non-matching scrollbar appearance (even in dark mode). Adds a "color-scheme" property so Safari 17+ knows how to style its own chrome. As a nice side-quest, I made the scrollbars respect the user's currently selected theme (looks quite nice in the more colorful themes).

Also makes a very basic visual change to the app's loading screen. I didn't do anything too fancy; just want to communicate that something (anything) is happening.

