### PR TITLE
e2e: use photo ID from iOS simulator for avatar selection

### DIFF
--- a/.maestro/20-profile.yaml
+++ b/.maestro/20-profile.yaml
@@ -22,9 +22,7 @@ appId: io.tlon.groups
     commands:
       - tapOn: 'Change avatar image'
       - tapOn: 'Photo Library'
-      - tapOn:
-          id: 'PXGGridLayout-Info'
-          index: 0
+      - tapOn: 'Photo, March 30, 2018, 3:14 PM'
 - tapOn: 'Hanging out...'
 - 'eraseText'
 - inputText: 'Testing status'

--- a/.maestro/30-contacts.yaml
+++ b/.maestro/30-contacts.yaml
@@ -32,9 +32,7 @@ appId: io.tlon.groups
     commands:
       - tapOn: 'Change avatar image'
       - tapOn: 'Photo Library'
-      - tapOn:
-          id: 'PXGGridLayout-Info'
-          index: 0
+      - tapOn: 'Photo, March 30, 2018, 3:14 PM'
 - tapOn: 'Done'
 - assertVisible: 'Profile'
 - assertVisible: 'Testing pet name'


### PR DESCRIPTION
Selects a specific photo from the iOS Camera Roll grid to use in the profile and contacts end-to-end tests when the user chooses an overlay avatar. If this proves to be problematic, I can always switch to a coordinate-based tap action, but I'd rather not if we can get away with it.