### PR TITLE
edit-profile: fix mobile image input

### DIFF
--- a/packages/ui/src/components/Form/inputs.tsx
+++ b/packages/ui/src/components/Form/inputs.tsx
@@ -281,7 +281,6 @@ const ImageInputButtonText = styled(Text, {
 const ImageInputPreviewFrame = styled(View, {
   borderRadius: '$l',
   aspectRatio: 1,
-  // height: '100%',
   overflow: 'hidden',
   backgroundColor: '$border',
   alignItems: 'center',

--- a/packages/ui/src/components/Form/inputs.tsx
+++ b/packages/ui/src/components/Form/inputs.tsx
@@ -25,6 +25,7 @@ import {
   useAttachmentContext,
   useMappedImageAttachments,
 } from '../../contexts';
+import useIsWindowNarrow from '../../hooks/useIsWindowNarrow';
 import { VariantsFromValues } from '../../types';
 import AttachmentSheet from '../AttachmentSheet';
 import { Button } from '../Button';
@@ -187,6 +188,7 @@ export const ImageInput = XStack.styleable<{
     value ?? undefined
   );
   const { attachAssets, canUpload } = useAttachmentContext();
+  const isWindowNarrow = useIsWindowNarrow();
 
   useEffect(() => {
     if (assetUri !== value) {
@@ -231,7 +233,10 @@ export const ImageInput = XStack.styleable<{
         <ImageInputButtonFrame group onPress={handleSheetToggled}>
           <ImageInputButtonText>{buttonLabel}</ImageInputButtonText>
         </ImageInputButtonFrame>
-        <ImageInputPreviewFrame onPress={handleSheetToggled}>
+        <ImageInputPreviewFrame
+          height={isWindowNarrow ? undefined : '100%'}
+          onPress={handleSheetToggled}
+        >
           <Icon type="Camera" color="$tertiaryText" />
           {placeholderUri ? (
             <ImageInputPreviewImage source={{ uri: placeholderUri }} />
@@ -276,7 +281,7 @@ const ImageInputButtonText = styled(Text, {
 const ImageInputPreviewFrame = styled(View, {
   borderRadius: '$l',
   aspectRatio: 1,
-  height: '100%',
+  // height: '100%',
   overflow: 'hidden',
   backgroundColor: '$border',
   alignItems: 'center',


### PR DESCRIPTION
In my sidebar PR I tried fixing the avatar width on desktop, to do so web needed an explicit height set. Doing so however makes the image huge on mobile. So now we only set it on desktop.