### PR TITLE
Fix Drizzle Studio

### DIFF
--- a/packages/app/lib/devMenuItems.ts
+++ b/packages/app/lib/devMenuItems.ts
@@ -17,7 +17,7 @@ const simulatorOnlyMenuItems: ExpoDevMenuItem[] = [
   {
     name: 'Drizzle studio',
     callback: async () => {
-      const path = getDbPath() ?? '';
+      const path = (await getDbPath()) ?? '';
       sendBundlerRequest('open-sqlite', { path });
     },
   },
@@ -25,7 +25,7 @@ const simulatorOnlyMenuItems: ExpoDevMenuItem[] = [
     name: 'Dump SQLite',
     callback: async () => {
       const outputPath = process.env.SQLITE_DUMP_PATH ?? 'dump.sqlite3';
-      const databaseSourcePath = getDbPath() ?? '';
+      const databaseSourcePath = (await getDbPath()) ?? '';
 
       sendBundlerRequest('dump-sqlite', { databaseSourcePath, outputPath });
     },
@@ -34,7 +34,7 @@ const simulatorOnlyMenuItems: ExpoDevMenuItem[] = [
     name: 'Restore SQLite',
     callback: async () => {
       const sourcePath = process.env.SQLITE_RESTORE_PATH ?? 'restore.sqlite3';
-      const localDatabasePath = getDbPath();
+      const localDatabasePath = await getDbPath();
       if (localDatabasePath == null) {
         Alert.alert('Could not find database path');
         return;


### PR DESCRIPTION
Recent DB trigger changes updated the method to get the db path to be async. The raw promise was getting piped through to the dev tools, not the string we expected.

Just awaits those calls and Studio opens correctly.