### PR TITLE
Mobile: Prevent groups getting stuck in "requested invite" state

### DIFF
--- a/packages/app/lib/devMenuItems.ts
+++ b/packages/app/lib/devMenuItems.ts
@@ -17,7 +17,7 @@ const simulatorOnlyMenuItems: ExpoDevMenuItem[] = [
   {
     name: 'Drizzle studio',
     callback: async () => {
-      const path = getDbPath() ?? '';
+      const path = (await getDbPath()) ?? '';
       sendBundlerRequest('open-sqlite', { path });
     },
   },
@@ -25,7 +25,7 @@ const simulatorOnlyMenuItems: ExpoDevMenuItem[] = [
     name: 'Dump SQLite',
     callback: async () => {
       const outputPath = process.env.SQLITE_DUMP_PATH ?? 'dump.sqlite3';
-      const databaseSourcePath = getDbPath() ?? '';
+      const databaseSourcePath = (await getDbPath()) ?? '';
 
       sendBundlerRequest('dump-sqlite', { databaseSourcePath, outputPath });
     },
@@ -34,7 +34,7 @@ const simulatorOnlyMenuItems: ExpoDevMenuItem[] = [
     name: 'Restore SQLite',
     callback: async () => {
       const sourcePath = process.env.SQLITE_RESTORE_PATH ?? 'restore.sqlite3';
-      const localDatabasePath = getDbPath();
+      const localDatabasePath = await getDbPath();
       if (localDatabasePath == null) {
         Alert.alert('Could not find database path');
         return;

--- a/packages/shared/src/api/groupsApi.ts
+++ b/packages/shared/src/api/groupsApi.ts
@@ -1487,7 +1487,7 @@ export function toClientGroup(
     roles,
     privacy: extractGroupPrivacy(group),
     ...toClientGroupMeta(group.meta),
-    haveInvite: false,
+    haveInvite: isJoined ? false : undefined,
     haveRequestedInvite: isJoined ? false : undefined,
     currentUserIsMember: isJoined,
     currentUserIsHost: hostUserId === currentUserId,

--- a/packages/shared/src/api/groupsApi.ts
+++ b/packages/shared/src/api/groupsApi.ts
@@ -1488,6 +1488,7 @@ export function toClientGroup(
     privacy: extractGroupPrivacy(group),
     ...toClientGroupMeta(group.meta),
     haveInvite: false,
+    haveRequestedInvite: isJoined ? false : undefined,
     currentUserIsMember: isJoined,
     currentUserIsHost: hostUserId === currentUserId,
     joinStatus: groupIsSyncing(group) ? 'joining' : undefined,

--- a/packages/shared/src/db/queries.ts
+++ b/packages/shared/src/db/queries.ts
@@ -593,7 +593,8 @@ export const insertGroups = createWriteQuery(
                 $groups.privacy,
                 $groups.joinStatus,
                 $groups.currentUserIsMember,
-                $groups.haveInvite
+                $groups.haveInvite,
+                $groups.haveRequestedInvite
               ),
             });
         } else {


### PR DESCRIPTION
The issue here was keeping `haveRequestedInvite` in sync on the group model. 

If that flag is set, we'll display the group as an unjoined preview at the top of your list (overrides `currentUserIsMember`). The groups serializer was never modifying that column.  If you 1) had requested an invite and 2) accepted that invite on another client, the field would get "stuck" and would continue to seem unjoined.

Updates the serializer to properly set `haveRequestedInvite` and the insert query to allow overwriting it.

Fixes TLON-3707