### PR TITLE
http-api: fix order of disposes so we aren't aborting new valid requests

### DIFF
--- a/packages/shared/src/http-api/fetch-event-source/fetch.ts
+++ b/packages/shared/src/http-api/fetch-event-source/fetch.ts
@@ -128,8 +128,8 @@ export function fetchEventSource(
         ])) as Response;
 
         if (response.status === 404) {
-          onerror?.(new ReapError('Channel reaped'));
           dispose();
+          onerror?.(new ReapError('Channel reaped'));
           resolve();
           return;
         }
@@ -175,9 +175,9 @@ export function fetchEventSource(
           try {
             isReconnect = true;
             // check if we need to retry:
+            curRequestController.abort();
             const interval: any = onerror?.(err) ?? retryInterval;
             clearTimeout(retryTimer);
-            curRequestController.abort();
             retryTimer = setTimeout(create, interval);
           } catch (innerErr) {
             // we should not retry anymore:


### PR DESCRIPTION
OTT, @pkova and I found this when trying to investigate why we were getting stuck in a "Connecting..." state. Basically we were aborting after initiating a bunch of new requests to resubscribe to things. Aborts trigger an error on the fetch which we don't handle, so we were never hitting the code path where the event source gets reinitiated.