### PR TITLE
CreateChatSheet: clear selection on group creation

### DIFF
--- a/packages/app/features/top/CreateChatSheet.tsx
+++ b/packages/app/features/top/CreateChatSheet.tsx
@@ -322,6 +322,7 @@ export function CreateChatInviteSheet({
 
   const handlePressCreateGroup = useCallback(async () => {
     onSubmit({ type: 'group', contactIds: selectedContactIds });
+    setSelectedContactIds([]);
   }, [onSubmit, selectedContactIds]);
 
   return (


### PR DESCRIPTION
One-liner that fixes TLON-3713, which @Fang- keeps hitting during his end-to-end testing.

We weren't clearing out the selection between group creation button presses, so adds a simple state-clearing in the handler.

I didn't add a useEffect to clear when the user closes the screen without creating a group, figuring they probably want to retain their selection unless they explicitly clear it.