### PR TITLE
channels: don't strictly need to initiate:negotiate

### DIFF
--- a/desk/app/channels.hoon
+++ b/desk/app/channels.hoon
@@ -390,9 +390,6 @@
     (~(unsubscribe s [subs bowl]) wire dock)
   (emil caz)
 ++  inflate-io
-  ::  initiate version negotiation with our own channels-server
-  ::
-  =.  cor  (emit (initiate:neg our.bowl server))
   ::  leave all subscriptions we don't recognize
   ::
   =.  cor


### PR DESCRIPTION
As of 34014ad the library will let pokes through (without crashing) even if the target's version is unknown. We previously had to explicitly +initiate:negotiate to make sure that pokes wouldn't crash, but that is no longer necessary.