### PR TITLE
desktop: fix crash on adding pinned group

### DIFF
--- a/packages/app/ui/components/GroupSelector.tsx
+++ b/packages/app/ui/components/GroupSelector.tsx
@@ -85,6 +85,7 @@ function SelectableGroupItemComponent(props: {
       model={props.group}
       backgroundColor="unset"
       onPress={handlePress}
+      disableOptions
       EndContent={
         props.selectable ? (
           <ListItem.EndContent>


### PR DESCRIPTION
OTT, we were crashing because we were attempting to render the chat options in GroupListItem. Just needed to pass `disableOptions`.

fixes tlon-3727