### PR TITLE
channel manager: fix issue with section creation

### DIFF
--- a/apps/tlon-mobile/package.json
+++ b/apps/tlon-mobile/package.json
@@ -64,7 +64,7 @@
     "@tloncorp/editor": "workspace:*",
     "@tloncorp/shared": "workspace:*",
     "@tloncorp/ui": "workspace:*",
-    "@urbit/aura": "^1.0.0",
+    "@urbit/aura": "^2.0.1",
     "@urbit/http-api": "3.2.0-dev",
     "@urbit/nockjs": "^1.4.0",
     "classnames": "^2.3.2",

--- a/apps/tlon-web-new/package.json
+++ b/apps/tlon-web-new/package.json
@@ -71,7 +71,7 @@
     "@tloncorp/shared": "workspace:*",
     "@tloncorp/ui": "workspace:*",
     "@urbit/api": "^2.2.0",
-    "@urbit/aura": "^1.0.0",
+    "@urbit/aura": "^2.0.1",
     "@urbit/http-api": "3.2.0-dev",
     "@urbit/sigil-js": "^2.2.0",
     "any-ascii": "^0.3.1",

--- a/apps/tlon-web-new/src/logic/utils.ts
+++ b/apps/tlon-web-new/src/logic/utils.ts
@@ -1214,10 +1214,3 @@ export function cacheIdFromString(str: string): CacheId {
     sent: parseInt(udToDec(sentStr), 10),
   };
 }
-
-export function getMessageKey(post: Post): MessageKey {
-  return {
-    id: `${post.essay.author}/${formatUd(unixToDa(post.essay.sent))}`,
-    time: formatUd(bigInt(post.seal.id)),
-  };
-}

--- a/packages/app/ui/components/ManageChannels/EditSectionNameSheet.tsx
+++ b/packages/app/ui/components/ManageChannels/EditSectionNameSheet.tsx
@@ -18,7 +18,7 @@ export function EditSectionNameSheet({
   onOpenChange: (open: boolean) => void;
   onSave?: (name: string) => void;
 }) {
-  const { control, handleSubmit } = useForm({
+  const { control, handleSubmit, reset } = useForm({
     defaultValues: {
       name: name ?? '',
     },
@@ -27,9 +27,10 @@ export function EditSectionNameSheet({
   const handlePressSave = useCallback(
     async (data: { name: string }) => {
       onSave?.(data.name);
+      reset();
       onOpenChange(false);
     },
-    [onSave, onOpenChange]
+    [onSave, onOpenChange, reset]
   );
 
   return (

--- a/packages/shared/src/urbit/utils.ts
+++ b/packages/shared/src/urbit/utils.ts
@@ -1,5 +1,4 @@
 import { formatUd, formatUv, isValidPatp, unixToDa } from '@urbit/aura';
-import bigInt from 'big-integer';
 import { useMemo } from 'react';
 
 import { ContentReference, PostContent } from '../api';
@@ -424,7 +423,7 @@ export function extractGroupPrivacy(
 }
 
 export function createSectionId() {
-  const idParts = formatUv(bigInt(Date.now()).toString()).split('.');
+  const idParts = formatUv(BigInt(Date.now())).split('.');
   const newSectionId = `z${idParts[idParts.length - 1]}`;
 
   return newSectionId;

--- a/packages/shared/src/urbit/utils.ts
+++ b/packages/shared/src/urbit/utils.ts
@@ -424,7 +424,7 @@ export function extractGroupPrivacy(
 }
 
 export function createSectionId() {
-  const idParts = formatUv(BigInt(Date.now())).split('.');
+  const idParts = formatUv(bigInt(Date.now()).toString()).split('.');
   const newSectionId = `z${idParts[idParts.length - 1]}`;
 
   return newSectionId;

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -184,8 +184,8 @@ importers:
         specifier: workspace:*
         version: link:../../packages/ui
       '@urbit/aura':
-        specifier: ^1.0.0
-        version: 1.0.0(big-integer@1.6.52)
+        specifier: ^2.0.1
+        version: 2.0.1
       '@urbit/http-api':
         specifier: 3.2.0-dev
         version: 3.2.0-dev
@@ -1101,8 +1101,8 @@ importers:
         specifier: 2.2.0
         version: 2.2.0
       '@urbit/aura':
-        specifier: ^1.0.0
-        version: 1.0.0(big-integer@1.6.52)
+        specifier: ^2.0.1
+        version: 2.0.1
       '@urbit/http-api':
         specifier: 3.2.0-dev
         version: 3.2.0-dev


### PR DESCRIPTION
This broke when we merged https://github.com/tloncorp/tlon-apps/pull/4408, because `formatUv` was not expecting the value produced by `BigInt`, apparently. ~Using the old `bigInt` and calling `.toString()` made it happy again.~ We needed to bump to the latest @urbit/aura in tlon-mobile and tlon-web-new.

I also noticed we weren't clearing the form on EditSectionNameSheet before closing it, so I added that in here, too.

fixes tlon-3714