### PR TITLE
groups: allow immediate cancel of private grp request

### DIFF
--- a/desk/app/groups.hoon
+++ b/desk/app/groups.hoon
@@ -2083,6 +2083,8 @@
     ga-core
   ++  ga-rescind
     ^+  ga-core
+    =.  cam.gang  ~
+    =.  cor  ga-give-update
     =.  cor  (emit rescind:ga-pass)
     ga-core
   ++  ga-watch
@@ -2163,8 +2165,6 @@
           =.  progress.u.cam.gang  %error
           %-  (slog leaf/"Rescind failed" u.p.sign)
           ga-core
-        =.  cam.gang  ~
-        =.  cor  ga-give-update
         ga-core
     ==
   ::


### PR DESCRIPTION
OTT we previously were forcing you to be able to communicate with host to be able to cancel a private group request. I think the behavior we want is to immediately clear the local state and send the command to the host, then not care whether command successfully goes through or not.