### PR TITLE
desktop: make sure we only run syncStart once

### DIFF
--- a/apps/tlon-web-new/src/app.tsx
+++ b/apps/tlon-web-new/src/app.tsx
@@ -264,9 +264,9 @@ const App = React.memo(function AppComponent() {
   const isDarkMode = useIsDark();
   const currentUserId = useCurrentUserId();
   const [dbIsLoaded, setDbIsLoaded] = useState(false);
-  const [startedSync, setStartedSync] = useState(false);
   const configureClient = useConfigureUrbitClient();
   useFindSuggestedContacts();
+  const hasSyncedRef = React.useRef(false);
 
   useEffect(() => {
     handleError(() => {
@@ -280,11 +280,14 @@ const App = React.memo(function AppComponent() {
       shipUrl: '',
     });
     const syncStart = async () => {
-      // Web doesn't persist database, so headsSyncedAt is misleading
-      await db.headsSyncedAt.resetValue();
+      // Only call sync.syncStart once during the app's lifecycle
+      if (!hasSyncedRef.current) {
+        // Web doesn't persist database, so headsSyncedAt is misleading
+        await db.headsSyncedAt.resetValue();
 
-      await sync.syncStart(startedSync);
-      setStartedSync(true);
+        await sync.syncStart(false);
+        hasSyncedRef.current = true;
+      }
 
       // we need to check the size of the database here to see if it's not zero
       // if it's not zero, set the dbIsLoaded to true
@@ -310,7 +313,7 @@ const App = React.memo(function AppComponent() {
     };
 
     syncStart();
-  }, [dbIsLoaded, currentUserId, startedSync]);
+  }, [dbIsLoaded, currentUserId]);
 
   return (
     <div className="flex h-full w-full flex-col">

--- a/packages/shared/src/logic/branch.ts
+++ b/packages/shared/src/logic/branch.ts
@@ -4,7 +4,7 @@ import { getPostInfoFromWer } from '../api/harkApi';
 import { createDevLogger } from '../debug';
 import { getConstants } from '../domain';
 
-const logger = createDevLogger('branch', true);
+const logger = createDevLogger('branch', false);
 
 const fetchBranchApi = async (path: string, init?: RequestInit) =>
   fetch(`https://api2.branch.io${path}`, init);

--- a/packages/shared/src/store/inviteActions.ts
+++ b/packages/shared/src/store/inviteActions.ts
@@ -17,7 +17,7 @@ import {
   withRetry,
 } from '../logic';
 
-const logger = createDevLogger('inviteActions', true);
+const logger = createDevLogger('inviteActions', false);
 
 export async function verifyUserInviteLink() {
   try {


### PR DESCRIPTION
fixes tlon-3743

We were running `sync.syncStart` multiple times because we were using `useState` and re-running the useEffect after we'd already started a sync, which would then call `sync.syncStart` again with `alreadySubscribed` set to `true` for no reason.

Replacing the useState-based tracking of our sync with a ref ensures we only run it one time, and we should always run `sync.syncStart` with `false` here since we're not in a discontinuity situation.

I also turned off a few loggers that had been left on in other spots.