### PR TITLE
nav: fix nav'ing from activity on desktop

### DIFF
--- a/apps/tlon-web-new/src/main.tsx
+++ b/apps/tlon-web-new/src/main.tsx
@@ -9,8 +9,10 @@
 // This was most likely caused by a recent dependency change.
 import regeneratorRuntime from '@babel/runtime/regenerator';
 import { EditorView } from '@tiptap/pm/view';
+import { ENABLED_LOGGERS } from '@tloncorp/app/constants';
 import { loadConstants } from '@tloncorp/app/lib/constants';
 import { setupDb } from '@tloncorp/app/lib/webDb';
+import { addCustomEnabledLoggers } from '@tloncorp/shared';
 import { QueryClientProvider, queryClient } from '@tloncorp/shared/api';
 import { PostHogProvider } from 'posthog-js/react';
 import { createRoot } from 'react-dom/client';
@@ -20,6 +22,7 @@ import { analyticsClient, captureError } from './logic/analytics';
 import './styles/index.css';
 
 loadConstants();
+addCustomEnabledLoggers(ENABLED_LOGGERS);
 
 window.regeneratorRuntime = regeneratorRuntime;
 

--- a/packages/ui/src/contexts/globalSearch.tsx
+++ b/packages/ui/src/contexts/globalSearch.tsx
@@ -3,8 +3,8 @@ import React, { createContext, useContext, useState } from 'react';
 interface GlobalSearchContextType {
   isOpen: boolean;
   setIsOpen: (open: boolean) => void;
-  lastOpenTab: string;
-  setLastOpenTab: (tab: string) => void;
+  lastOpenTab: 'Home' | 'Messages';
+  setLastOpenTab: (tab: 'Home' | 'Messages') => void;
 }
 
 const GlobalSearchContext = createContext<GlobalSearchContextType>({
@@ -20,7 +20,7 @@ export function GlobalSearchProvider({
   children: React.ReactNode;
 }) {
   const [isOpen, setIsOpen] = useState(false);
-  const [lastOpenTab, setLastOpenTab] = useState('Home');
+  const [lastOpenTab, setLastOpenTab] = useState<'Home' | 'Messages'>('Home');
 
   return (
     <GlobalSearchContext.Provider


### PR DESCRIPTION
Fixes TLON-3744. We weren't always taking into account `lastOpenTab` and also we weren't handling navigations from Activity very well. 