### PR TITLE
e2e: chat channels

### DIFF
--- a/.maestro/00-start.yaml
+++ b/.maestro/00-start.yaml
@@ -14,3 +14,4 @@ appId: io.tlon.groups
 - runFlow: 42-group-info-settings.yaml
 - runFlow: 43-roles.yaml
 - runFlow: 50-chat.yaml
+- runFlow: 51-threads.yaml

--- a/.maestro/00-start.yaml
+++ b/.maestro/00-start.yaml
@@ -13,3 +13,4 @@ appId: io.tlon.groups
 - runFlow: 41-customize-group.yaml
 - runFlow: 42-group-info-settings.yaml
 - runFlow: 43-roles.yaml
+- runFlow: 50-chat.yaml

--- a/.maestro/40-create-group.yaml
+++ b/.maestro/40-create-group.yaml
@@ -28,27 +28,7 @@ appId: io.tlon.groups
       - assertVisible: 'Untitled group'
       - tapOn: 'Untitled group'
       - assertVisible: 'General'
-# Insert some text into the General channel and send it
-- tapOn: 'Message'
-- inputText: 'Hello, world!'
-- 'hideKeyboard'
-- tapOn:
-    id: 'MessageInputSendButton'
-- runFlow:
-    when:
-      visible: '.*Hello, world!.*'
-    commands:
-      - assertVisible: '.*Hello, world!.*'
-# Navigate back to the Home screen and assert that the message preview is visible
-- tapOn:
-    id: 'HeaderBackButton'
-- runFlow:
-    when:
-      visible: 'Home'
-    commands:
-      - assertVisible: '.*Hello, world!.*'
 # Open the overflow menu from the channel header and delete the group
-- tapOn: 'Untitled group'
 - tapOn:
     id: 'ChannelHeaderOverflowMenuButton'
 - assertVisible: 'Secret group with 1 member'

--- a/.maestro/50-chat.yaml
+++ b/.maestro/50-chat.yaml
@@ -1,0 +1,134 @@
+appId: io.tlon.groups
+---
+- runFlow: subflows/launch.yaml
+- runFlow: subflows/tlon-login.yaml
+- assertVisible: 'Home'
+# Tap on the "+" button
+- tapOn:
+    id: 'CreateGroupButton'
+# Assert that the sheet pops
+- assertVisible: 'Create customizable group chat'
+- tapOn: 'New group'
+# Assert that the contacts sheet pops
+- assertVisible: 'Select contacts to invite'
+# Create the group
+- tapOn: 'Create group'
+- runFlow:
+    when:
+      visible: 'General'
+    commands:
+      - assertVisible: 'Welcome to your group!'
+# Navigate back to Home and assert that the group is created
+- tapOn:
+    id: 'HeaderBackButton'
+- runFlow:
+    when:
+      visible: 'Home'
+    commands:
+      - assertVisible: 'Untitled group'
+      - tapOn: 'Untitled group'
+      - assertVisible: 'General'
+# Insert some text into the General channel and send it
+- tapOn: 'Message'
+- inputText: 'Hello, world!'
+- 'hideKeyboard'
+- tapOn:
+    id: 'MessageInputSendButton'
+- runFlow:
+    when:
+      visible: '.*Hello, world!.*'
+    commands:
+      - assertVisible: '.*Hello, world!.*'
+# Navigate back to the Home screen and assert that the message preview is visible
+- tapOn:
+    id: 'HeaderBackButton'
+- runFlow:
+    when:
+      visible: 'Home'
+    commands:
+      - assertVisible: '.*Hello, world!.*'
+# Navigate back into the group
+- tapOn: 'Untitled group'
+# Long-press the message and select "Start thread"
+- longPressOn: 'Hello, world! '
+- tapOn: 'Start thread'
+- runFlow:
+    when:
+      visible: 'Thread: General'
+    commands:
+      - assertVisible: '.*Hello, world!.*'
+# Insert some text into the thread and send it
+- tapOn: 'Reply'
+- inputText: 'Thread reply'
+- 'hideKeyboard'
+- tapOn:
+    id: 'MessageInputSendButton'
+- runFlow:
+    when:
+      visible: '.*Thread reply.*'
+    commands:
+      - assertVisible: '.*Thread reply.*'
+# Navigate back into the channel and assert that the reply row is visible
+- tapOn:
+    id: 'HeaderBackButton'
+- assertVisible: '1 reply'
+# Long-press the message and react with a thumb emoji
+- longPressOn: 'Hello, world! '
+- tapOn:
+    id: 'EmojiToolbarButton-thumb'
+- runFlow:
+    when:
+      visible: '.*👍.*'
+    commands:
+      - assertVisible: '.*👍.*'
+# Un-react to the message
+- tapOn:
+    id: 'ReactionDisplay'
+- assertNotVisible: '.*👍.*'
+# Quote-reply to the message
+- longPressOn: 'Hello, world! '
+- tapOn: 'Reply'
+- assertVisible: 'Chat Post'
+- assertVisible:
+    text: '.*Hello, world!.*'
+    index: 1
+- tapOn: 'Message'
+- inputText: 'Quote reply'
+- 'hideKeyboard'
+- tapOn:
+    id: 'MessageInputSendButton'
+- runFlow:
+    when:
+      visible: '.*Quote reply.*'
+    commands:
+      - assertVisible: '.*Quote reply.*'
+# Open the overflow menu from the channel header and delete the group
+- tapOn:
+    id: 'ChannelHeaderOverflowMenuButton'
+- assertVisible: 'Secret group with 1 member'
+- tapOn: 'Group info & settings'
+- assertVisible: 'Group info'
+- scrollUntilVisible:
+    direction: DOWN
+    element:
+      text: 'Delete group'
+- tapOn: 'Delete group'
+- runFlow:
+    when:
+      visible: 'This action cannot be undone.'
+    commands:
+      - assertVisible: 'This action cannot be undone.'
+      - tapOn: 'Delete group'
+- runFlow:
+    when:
+      visible: 'Home'
+    commands:
+      - assertVisible: 'Home'
+      - assertNotVisible: 'Untitled group'
+# Log out
+- tapOn:
+    id: 'AvatarNavIcon'
+- tapOn:
+    id: 'ContactsSettingsButton'
+- tapOn: 'Log out'
+- tapOn: 'Log out now'

--- a/.maestro/50-chat.yaml
+++ b/.maestro/50-chat.yaml
@@ -144,6 +144,28 @@ appId: io.tlon.groups
           text: 'Delete this message '
       - tapOn: 'Delete message'
 - assertNotVisible: 'Delete this message '
+# Send a message and edit it
+- tapOn: 'Message'
+- inputText: 'Edit this message'
+- 'hideKeyboard'
+- tapOn:
+    id: 'MessageInputSendButton'
+- runFlow:
+    when:
+      visible: 'Edit this message '
+    commands:
+      - longPressOn:
+          text: 'Edit this message '
+      - tapOn: 'Edit message'
+      - tapOn:
+          text: 'Edit this message '
+          index: 1
+      - 'eraseText'
+      - inputText: 'Edited message'
+      - 'hideKeyboard'
+      - tapOn:
+          id: 'MessageInputSendButton'
+- assertVisible: 'Edited message '
 # Open the overflow menu from the channel header and delete the group
 - tapOn:
     id: 'ChannelHeaderOverflowMenuButton'

--- a/.maestro/50-chat.yaml
+++ b/.maestro/50-chat.yaml
@@ -102,6 +102,48 @@ appId: io.tlon.groups
       visible: '.*Quote reply.*'
     commands:
       - assertVisible: '.*Quote reply.*'
+# Send a message and hide it
+- tapOn: 'Message'
+- inputText: 'Hide this message'
+- 'hideKeyboard'
+- tapOn:
+    id: 'MessageInputSendButton'
+- runFlow:
+    when:
+      visible: 'Hide this message '
+    commands:
+      - longPressOn:
+          text: 'Hide this message '
+      - tapOn: 'Hide message'
+- assertNotVisible: 'Hide this message '
+# Send a message and report it
+- tapOn: 'Message'
+- inputText: 'Report this message'
+- 'hideKeyboard'
+- tapOn:
+    id: 'MessageInputSendButton'
+- runFlow:
+    when:
+      visible: 'Report this message '
+    commands:
+      - longPressOn:
+          text: 'Report this message '
+      - tapOn: 'Report message'
+- assertNotVisible: 'Report this message '
+# Send a message and delete it
+- tapOn: 'Message'
+- inputText: 'Delete this message'
+- 'hideKeyboard'
+- tapOn:
+    id: 'MessageInputSendButton'
+- runFlow:
+    when:
+      visible: 'Delete this message '
+    commands:
+      - longPressOn:
+          text: 'Delete this message '
+      - tapOn: 'Delete message'
+- assertNotVisible: 'Delete this message '
 # Open the overflow menu from the channel header and delete the group
 - tapOn:
     id: 'ChannelHeaderOverflowMenuButton'

--- a/.maestro/51-threads.yaml
+++ b/.maestro/51-threads.yaml
@@ -1,0 +1,200 @@
+appId: io.tlon.groups
+---
+- runFlow: subflows/launch.yaml
+- runFlow: subflows/tlon-login.yaml
+- assertVisible: 'Home'
+# Tap on the "+" button
+- tapOn:
+    id: 'CreateGroupButton'
+# Assert that the sheet pops
+- assertVisible: 'Create customizable group chat'
+- tapOn: 'New group'
+# Assert that the contacts sheet pops
+- assertVisible: 'Select contacts to invite'
+# Create the group
+- tapOn: 'Create group'
+- runFlow:
+    when:
+      visible: 'General'
+    commands:
+      - assertVisible: 'Welcome to your group!'
+# Navigate back to Home and assert that the group is created
+- tapOn:
+    id: 'HeaderBackButton'
+- runFlow:
+    when:
+      visible: 'Home'
+    commands:
+      - assertVisible: 'Untitled group'
+      - tapOn: 'Untitled group'
+      - assertVisible: 'General'
+# Insert some text into the General channel and send it
+- tapOn: 'Message'
+- inputText: 'Hello, world!'
+- 'hideKeyboard'
+- tapOn:
+    id: 'MessageInputSendButton'
+- runFlow:
+    when:
+      visible: '.*Hello, world!.*'
+    commands:
+      - assertVisible: '.*Hello, world!.*'
+# Navigate back to the Home screen and assert that the message preview is visible
+- tapOn:
+    id: 'HeaderBackButton'
+- runFlow:
+    when:
+      visible: 'Home'
+    commands:
+      - assertVisible: '.*Hello, world!.*'
+# Navigate back into the group
+- tapOn: 'Untitled group'
+# Long-press the message and select "Start thread"
+- longPressOn: 'Hello, world! '
+- tapOn: 'Start thread'
+- runFlow:
+    when:
+      visible: 'Thread: General'
+    commands:
+      - assertVisible: '.*Hello, world!.*'
+# Insert some text into the thread and send it
+- tapOn: 'Reply'
+- inputText: 'Thread reply'
+- 'hideKeyboard'
+- tapOn:
+    id: 'MessageInputSendButton'
+- runFlow:
+    when:
+      visible: '.*Thread reply.*'
+    commands:
+      - assertVisible: '.*Thread reply.*'
+# Long-press the message and react with a thumb emoji
+- longPressOn: 'Thread reply '
+- tapOn:
+    id: 'EmojiToolbarButton-thumb'
+- runFlow:
+    when:
+      visible: '.*👍.*'
+    commands:
+      - assertVisible: '.*👍.*'
+# Un-react to the message
+- tapOn:
+    id: 'ReactionDisplay'
+    optional: true
+- assertNotVisible:
+    text: '.*👍.*'
+    optional: true
+# Quote-reply to the message
+- longPressOn: 'Thread reply '
+- tapOn: 'Reply'
+- assertVisible: 'Chat Post'
+- assertVisible:
+    text: '.*Thread reply.*'
+    index: 1
+- tapOn: 'Reply'
+- inputText: 'Quote reply'
+- 'hideKeyboard'
+- tapOn:
+    id: 'MessageInputSendButton'
+- runFlow:
+    when:
+      visible: '.*Quote reply.*'
+    commands:
+      - assertVisible: '.*Quote reply.*'
+# Send a message and hide it
+- tapOn: 'Reply'
+- inputText: 'Hide this reply'
+- 'hideKeyboard'
+- tapOn:
+    id: 'MessageInputSendButton'
+- runFlow:
+    when:
+      visible: 'Hide this reply '
+    commands:
+      - longPressOn:
+          text: 'Hide this reply '
+      - tapOn: 'Hide message'
+- assertNotVisible: 'Hide this reply '
+# Send a message and report it
+- tapOn: 'Reply'
+- inputText: 'Report this reply'
+- 'hideKeyboard'
+- tapOn:
+    id: 'MessageInputSendButton'
+- runFlow:
+    when:
+      visible: 'Report this reply '
+    commands:
+      - longPressOn:
+          text: 'Report this reply '
+      - tapOn: 'Report message'
+- assertNotVisible: 'Report this reply '
+# Send a message and delete it
+- tapOn: 'Reply'
+- inputText: 'Delete this reply'
+- 'hideKeyboard'
+- tapOn:
+    id: 'MessageInputSendButton'
+- runFlow:
+    when:
+      visible: 'Delete this reply '
+    commands:
+      - longPressOn:
+          text: 'Delete this reply '
+      - tapOn: 'Delete message'
+- assertNotVisible: 'Delete this reply '
+# Send a message and edit it
+- tapOn: 'Reply'
+- inputText: 'Edit this reply'
+- 'hideKeyboard'
+- tapOn:
+    id: 'MessageInputSendButton'
+- runFlow:
+    when:
+      visible: 'Edit this reply '
+    commands:
+      - longPressOn:
+          text: 'Edit this reply '
+      - tapOn: 'Edit message'
+      - tapOn:
+          text: 'Edit this reply '
+          index: 1
+      - 'eraseText'
+      - inputText: 'Edited reply'
+      - 'hideKeyboard'
+      - tapOn:
+          id: 'MessageInputSendButton'
+- assertVisible: 'Edited reply '
+# Navigate back into the main channel
+- tapOn:
+    id: 'HeaderBackButton'
+# Open the overflow menu from the channel header and delete the group
+- tapOn:
+    id: 'ChannelHeaderOverflowMenuButton'
+- assertVisible: 'Secret group with 1 member'
+- tapOn: 'Group info & settings'
+- assertVisible: 'Group info'
+- scrollUntilVisible:
+    direction: DOWN
+    element:
+      text: 'Delete group'
+- tapOn: 'Delete group'
+- runFlow:
+    when:
+      visible: 'This action cannot be undone.'
+    commands:
+      - assertVisible: 'This action cannot be undone.'
+      - tapOn: 'Delete group'
+- runFlow:
+    when:
+      visible: 'Home'
+    commands:
+      - assertVisible: 'Home'
+      - assertNotVisible: 'Untitled group'
+# Log out
+- tapOn:
+    id: 'AvatarNavIcon'
+- tapOn:
+    id: 'ContactsSettingsButton'
+- tapOn: 'Log out'
+- tapOn: 'Log out now'

--- a/.maestro/51-threads.yaml
+++ b/.maestro/51-threads.yaml
@@ -78,6 +78,8 @@ appId: io.tlon.groups
     commands:
       - assertVisible: '.*👍.*'
 # Un-react to the message
+# This is optional because the interaction is flaky; works fine
+# for reactions on others' thread replies, but not on own replies
 - tapOn:
     id: 'ReactionDisplay'
     optional: true

--- a/packages/app/ui/components/ChatMessage/ChatMessageActions/EmojiToolbar.tsx
+++ b/packages/app/ui/components/ChatMessage/ChatMessageActions/EmojiToolbar.tsx
@@ -57,21 +57,25 @@ export function EmojiToolbar({
           details={details}
           shortCode="+1"
           handlePress={handlePress}
+          testID="EmojiToolbarButton-thumb"
         />
         <EmojiToolbarButton
           details={details}
           shortCode="heart"
           handlePress={handlePress}
+          testID="EmojiToolbarButton-heart"
         />
         <EmojiToolbarButton
           details={details}
           shortCode="laughing"
           handlePress={handlePress}
+          testID="EmojiToolbarButton-laughing"
         />
         <EmojiToolbarButton
           details={details}
           shortCode={lastShortCode}
           handlePress={handlePress}
+          testID="EmojiToolbarButton-last"
         />
         <Button padding="$xs" borderWidth={0} onPress={handleSheetOpen}>
           <Icon type="ChevronDown" size="$l" />
@@ -90,10 +94,12 @@ function EmojiToolbarButton({
   shortCode,
   details,
   handlePress,
+  testID,
 }: {
   shortCode: string;
   details: ReactionDetails;
   handlePress: (shortCode: string) => void;
+  testID: string;
 }) {
   return (
     <Button
@@ -105,6 +111,7 @@ function EmojiToolbarButton({
           : undefined
       }
       onPress={() => handlePress(shortCode)}
+      testID={testID}
     >
       <SizableEmoji shortCode={shortCode} fontSize={32} />
     </Button>

--- a/packages/app/ui/components/ChatMessage/ReactionsDisplay.tsx
+++ b/packages/app/ui/components/ChatMessage/ReactionsDisplay.tsx
@@ -60,6 +60,7 @@ export function ReactionsDisplay({
             borderRadius="$s"
             onPress={() => handleModifyYourReaction(reaction.value)}
             onLongPress={() => handleOpenReactions(post)}
+            testID={`ReactionDisplay`}
           >
             <Tooltip placement="top" delay={0} restMs={25}>
               <Tooltip.Trigger>


### PR DESCRIPTION
Introduces a new test that:

- Creates a new group
- Inserts some text into the General channel and sends it
- Navigates back to the Home screen and asserts that the message preview is visible
- Navigates back into the group
- Long-presses the message and starts a thread
- Sends a message in the thread
- Navigates back to the channel root and asserts that the UI shows 1 reply
- Long-presses the message and reacts with a thumbs-up
- Asserts that a thumbs-up reaction appears below the message
- Taps on the reaction and asserts that it is removed
- Long-presses the message and starts a quote-reply with a reference
- Asserts that the quote-reply is sent
- Sends a message, long-presses on it, hides the message, and asserts that the message is hidden
- Sends a message, long-presses on it, reports the message, and asserts that the message is hidden
- Sends a message, long-presses on it, deletes the message, and asserts that the message is deleted
- Sends a message, long-presses on it, edits the message, sends the edit, and asserts that the edit appears in the chat log

Does the same for chat threads as well.

Also deletes the group and logs the user out as part of cleanup.