### PR TITLE
native: add periodic background sync

### DIFF
--- a/apps/tlon-mobile/ios/Podfile.lock
+++ b/apps/tlon-mobile/ios/Podfile.lock
@@ -95,6 +95,8 @@ PODS:
     - glog
     - RCT-Folly (= 2022.05.16.00)
     - React-Core
+  - ExpoBackgroundFetch (11.8.1):
+    - ExpoModulesCore
   - ExpoBattery (7.7.2):
     - ExpoModulesCore
   - ExpoBlur (12.9.2):
@@ -1399,7 +1401,7 @@ PODS:
     - glog
     - RCT-Folly (= 2022.05.16.00)
     - React-Core
-  - UMAppLoader (4.5.0)
+  - UMAppLoader (4.5.1)
   - Yoga (1.14.0)
 
 DEPENDENCIES:
@@ -1420,6 +1422,7 @@ DEPENDENCIES:
   - expo-dev-launcher (from `../../../node_modules/expo-dev-launcher`)
   - expo-dev-menu (from `../../../node_modules/expo-dev-menu`)
   - expo-dev-menu-interface (from `../../../node_modules/expo-dev-menu-interface/ios`)
+  - ExpoBackgroundFetch (from `../../../node_modules/expo-background-fetch/ios`)
   - ExpoBattery (from `../../../node_modules/expo-battery/ios`)
   - ExpoBlur (from `../../../node_modules/expo-blur/ios`)
   - ExpoClipboard (from `../../../node_modules/expo-clipboard/ios`)
@@ -1582,6 +1585,8 @@ EXTERNAL SOURCES:
     :path: "../../../node_modules/expo-dev-menu"
   expo-dev-menu-interface:
     :path: "../../../node_modules/expo-dev-menu-interface/ios"
+  ExpoBackgroundFetch:
+    :path: "../../../node_modules/expo-background-fetch/ios"
   ExpoBattery:
     :path: "../../../node_modules/expo-battery/ios"
   ExpoBlur:
@@ -1769,29 +1774,29 @@ SPEC CHECKSUMS:
   EXFont: 64e653a110eee050ad80dfcd676c4bada0a1ff92
   EXImageLoader: ba2506b443b9656e93167c104406a2c265924823
   EXJSONUtils: 5c42959e87be238b045ef37cc5268b16a6c0ad4a
-  EXManifests: 429136cffa3ae82d1ba3b60b7243fb186615562e
-  EXMediaLibrary: d3bf5c458643f9821b96af328d399ef3f44de7db
-  EXNotifications: 9fd42ca3c5998ae93a2ac869ed9a47467c433219
-  Expo: 1b33cb8ab60cff9abf805ed6020af3d1846e457c
-  expo-dev-client: 775a683302570193a7ba71032d0b1b82f6ad1454
-  expo-dev-launcher: acd5b1e03e649e96675c85314a9d8745f23648d1
-  expo-dev-menu: 2b4ce6108396233849b71805906129de15aadfbc
-  expo-dev-menu-interface: 44e69ddff62bbc6c5418c200e657635720b5a480
-  ExpoBattery: 6cdcb673b99f53b3e9955b03268fd571cff68f51
-  ExpoBlur: 3a9548a738624968836926f4aa1e18fa22155640
-  ExpoClipboard: 24cc2b881ab6ca2e5b431b1f6d9d4a302adbf9d0
-  ExpoDevice: fc21b9193d704f3759c1ede1b383fcdb0370b46a
-  ExpoFileSystem: df58e1eb2a4d6f1006a1ca70bddfbbf63e52fa4f
-  ExpoHaptics: c91902e436f3fb0e07aa19acc118018089fa90de
-  ExpoImage: a70db90f39a7af98930cef91c84e877b1131f3dd
-  ExpoImageManipulator: 0c2ada7a028619ea1cc0c670bfa90c8ebeaa4af4
-  ExpoImagePicker: d06822d74f1f0e7fe7cb070ece0fff6e678fa3eb
-  ExpoKeepAwake: 3b8cf8533b9212500565a1e41fb080fc5af29918
-  ExpoLinearGradient: 501f9bbd83f3ec1d0e0425862b9ef4693605fc1c
-  ExpoLocalization: 7423aa1abcc59209dc2ce2b9bb63776a18023a98
-  ExpoModulesCore: bc9f47045cd97b741444e335880d65c681d39007
-  ExpoSecureStore: 4cec57fd2c40dcff05ce2186c39afc1af39d213c
-  EXSplashScreen: 32c0a1ee2e9b416a5fb8ba41419bd040868e5dfe
+  EXManifests: 5e8c29f36c716af768a4ea47ec05e1b89ab93091
+  EXMediaLibrary: 70cf1fb7028fda2d682090c9fe57568674e4abab
+  EXNotifications: e254c0fa11337e15b30c200e91437b521f682bad
+  Expo: 7b9976a9b2be116a701b233d6655b229a3c9316e
+  expo-dev-client: f22fdebdb8760bc22f660b7c0cb1dd58d80005c0
+  expo-dev-launcher: 11c184a2dca65f9bd6dc575a73a554b7be589d1d
+  expo-dev-menu: 68ea53d923996e27b20ce02b51cc820fc2327a83
+  expo-dev-menu-interface: 7ba029c9d1a82ac22b9b584c00514860b060553e
+  ExpoBackgroundFetch: 80d41ec15c6cce0bafb5d2326b8e85f42152eba7
+  ExpoBattery: 60bf880aea8f769fe39f709a920442542c1bfd62
+  ExpoClipboard: b597982124f067ff9f5b89093eb3d97898d5d877
+  ExpoDevice: 97307196d8cab694e245752b8a7afacc35c14e03
+  ExpoFileSystem: 74cc0fae916f9f044248433971dcfc8c3befd057
+  ExpoHaptics: 28a771b630353cd6e8dcf1b1e3e693e38ad7c3c3
+  ExpoImage: 8cf2d51de3d03b7e984e9b0ba8f19c0c22057001
+  ExpoImageManipulator: c1d7cb865eacd620a35659f3da34c70531f10b59
+  ExpoImagePicker: 66970181d1c838f444e5e1f81b804ab2d5ff49bd
+  ExpoKeepAwake: 0f5cad99603a3268e50af9a6eb8b76d0d9ac956c
+  ExpoLinearGradient: 4ad1449a2408e0435ac959076562b3921f2e32a1
+  ExpoLocalization: f94759e55802e4a4f8b7d7cecb450de11b888721
+  ExpoModulesCore: 0f9e3c49657f681cd06219d97c77c3108a67ca00
+  ExpoSecureStore: c84ae37d1c36f38524d289c67c3a2e3fc56f1108
+  EXSplashScreen: 0fabdcf746d29e7f8b8969879cb09125cdd365d2
   EXStructuredHeaders: 5b0f47259db047dc1fdfa84752e292c2bfa68ecd
   EXTaskManager: 8c5683c2fb543cf2baa77bab4ad130b7e3829c4a
   EXUpdates: 8cc7407328c3852e3ce890a381fe0022ae71902b
@@ -1893,9 +1898,9 @@ SPEC CHECKSUMS:
   SDWebImageWebPCoder: af09429398d99d524cae2fe00f6f0f6e491ed102
   SocketRocket: f32cd54efbe0f095c4d7594881e52619cfe80b17
   sqlite3: f163dbbb7aa3339ad8fc622782c2d9d7b72f7e9c
-  tentap: 2a4256b6641a27d72d2b5fe2eb94cd1a203e4975
-  UMAppLoader: 5df85360d65cabaef544be5424ac64672e648482
-  Yoga: fb61b2337c7688c81a137e5560b3cbb515289f91
+  tentap: 2cf2e387dd284bf867010eb7d0f91618fb35b673
+  UMAppLoader: 79d3ee6aa2447a1fe2e8b0d07acf2de106e55b58
+  Yoga: 4dbfeceb9bb0f62899d0a53d37a1ddd58898d3f2
 
 PODFILE CHECKSUM: 0cb7a78e5777e69c86c1bf4bb5135fd660376dbe
 

--- a/apps/tlon-mobile/package.json
+++ b/apps/tlon-mobile/package.json
@@ -73,6 +73,7 @@
     "expo-application": "~5.8.4",
     "expo-asset": "~9.0.2",
     "expo-av": "~13.10.5",
+    "expo-background-fetch": "~11.8.1",
     "expo-battery": "^7.7.2",
     "expo-clipboard": "~5.0.1",
     "expo-constants": "~15.4.6",

--- a/apps/tlon-mobile/src/App.main.tsx
+++ b/apps/tlon-mobile/src/App.main.tsx
@@ -13,6 +13,7 @@ import ErrorBoundary from '@tloncorp/app/ErrorBoundary';
 import { BranchProvider } from '@tloncorp/app/contexts/branch';
 import { ShipProvider, useShip } from '@tloncorp/app/contexts/ship';
 import { useIsDarkMode } from '@tloncorp/app/hooks/useIsDarkMode';
+import { registerBackgroundSyncTask } from '@tloncorp/app/lib/backgroundSync';
 import { useMigrations } from '@tloncorp/app/lib/nativeDb';
 import { Provider as TamaguiProvider } from '@tloncorp/app/provider';
 import { FeatureFlagConnectedInstrumentationProvider } from '@tloncorp/app/utils/perf';
@@ -37,6 +38,8 @@ import { SafeAreaProvider } from 'react-native-safe-area-context';
 import { OnboardingStack } from './OnboardingStack';
 import AuthenticatedApp from './components/AuthenticatedApp';
 import { SignupProvider, useSignupContext } from './lib/signupContext';
+
+registerBackgroundSyncTask();
 
 // Android notification tap handler passes initial params here
 const App = () => {

--- a/packages/app/hooks/useConfigureUrbitClient.ts
+++ b/packages/app/hooks/useConfigureUrbitClient.ts
@@ -51,6 +51,68 @@ const apiFetch: typeof fetch = (input, { ...init } = {}) => {
     : fetch(input, newInit);
 };
 
+export function configureUrbitClient({
+  ship,
+  shipUrl,
+  authType,
+  onAuthFailure,
+}: {
+  ship: string;
+  shipUrl: string;
+  authType: 'self' | 'hosted';
+  onAuthFailure?: () => void;
+}) {
+  configureClient({
+    shipName: ship,
+    shipUrl: shipUrl,
+    verbose: ENABLED_LOGGERS.includes('urbit'),
+    fetchFn: apiFetch,
+    onQuitOrReset: sync.handleDiscontinuity,
+    onChannelStatusChange: sync.handleChannelStatusChange,
+    getCode: async () => {
+      clientLogger.log('Cliet getting access code');
+      // use stored access code to reauth if we have it
+      const accessCode = await db.nodeAccessCode.getValue();
+      if (accessCode) {
+        clientLogger.trackEvent('Recovered Auth Code from Storage');
+        return accessCode;
+      }
+
+      // if missing and they're hosted, try to fetch it
+      if (authType === 'self') {
+        const message = 'Self hosted user has no stored access code';
+        clientLogger.trackEvent(AnalyticsEvent.AuthFailedToGetCode, {
+          authType,
+          context: message,
+        });
+        throw new Error(message);
+      }
+
+      if (!ship) {
+        const message = 'Cannot get access code, no ship set';
+        clientLogger.trackEvent(AnalyticsEvent.AuthFailedToGetCode, {
+          authType,
+          context: message,
+        });
+        throw new Error(message);
+      }
+      const { code } = await getShipAccessCode(ship);
+      if (!code) {
+        const message = 'Failed to fetch access code';
+        clientLogger.trackEvent(AnalyticsEvent.AuthFailedToGetCode, {
+          authType,
+          context: message,
+        });
+        throw new Error(message);
+      } else {
+        clientLogger.trackEvent('Recovered Auth Code from Hosting');
+      }
+      return code;
+    },
+    handleAuthFailure: onAuthFailure,
+  });
+}
+
 export function useConfigureUrbitClient() {
   const shipInfo = useShip();
   const { ship, shipUrl, authType } = shipInfo;
@@ -64,54 +126,11 @@ export function useConfigureUrbitClient() {
 
   return useCallback(
     (params?: Partial<ClientParams>) => {
-      configureClient({
-        shipName: params?.shipName ?? ship ?? '',
+      configureUrbitClient({
+        ship: params?.shipName ?? ship ?? '',
         shipUrl: params?.shipUrl ?? shipUrl ?? '',
-        verbose: ENABLED_LOGGERS.includes('urbit'),
-        fetchFn: apiFetch,
-        onQuitOrReset: sync.handleDiscontinuity,
-        onChannelStatusChange: sync.handleChannelStatusChange,
-        getCode: async () => {
-          clientLogger.log('Cliet getting access code');
-          // use stored access code to reauth if we have it
-          const accessCode = await db.nodeAccessCode.getValue();
-          if (accessCode) {
-            clientLogger.trackEvent('Recovered Auth Code from Storage');
-            return accessCode;
-          }
-
-          // if missing and they're hosted, try to fetch it
-          if (authType === 'self') {
-            const message = 'Self hosted user has no stored access code';
-            clientLogger.trackEvent(AnalyticsEvent.AuthFailedToGetCode, {
-              authType,
-              context: message,
-            });
-            throw new Error(message);
-          }
-
-          if (!ship) {
-            const message = 'Cannot get access code, no ship set';
-            clientLogger.trackEvent(AnalyticsEvent.AuthFailedToGetCode, {
-              authType,
-              context: message,
-            });
-            throw new Error(message);
-          }
-          const { code } = await getShipAccessCode(ship);
-          if (!code) {
-            const message = 'Failed to fetch access code';
-            clientLogger.trackEvent(AnalyticsEvent.AuthFailedToGetCode, {
-              authType,
-              context: message,
-            });
-            throw new Error(message);
-          } else {
-            clientLogger.trackEvent('Recovered Auth Code from Hosting');
-          }
-          return code;
-        },
-        handleAuthFailure: async () => {
+        authType,
+        onAuthFailure: async () => {
           clientLogger.log('Cliet handling auth failure');
           if (authType === 'self') {
             // there's nothing we can do to recover, must log out

--- a/packages/app/lib/backgroundSync.ts
+++ b/packages/app/lib/backgroundSync.ts
@@ -1,0 +1,95 @@
+import { createDevLogger, syncStart } from '@tloncorp/shared';
+import { storage } from '@tloncorp/shared/db';
+import * as db from '@tloncorp/shared/db';
+import * as BackgroundFetch from 'expo-background-fetch';
+import * as Notifications from 'expo-notifications';
+import * as TaskManager from 'expo-task-manager';
+
+import { configureUrbitClient } from '../hooks/useConfigureUrbitClient';
+
+const logger = createDevLogger('backgroundSync', false);
+
+function summarizePost(post: db.Post) {
+  return {
+    channel: post.channelId,
+    content: post.content,
+    syncedAt: post.syncedAt,
+  };
+}
+
+async function performSync() {
+  const shipInfo = await storage.shipInfo.getValue();
+  if (shipInfo == null) {
+    logger.info('No ship info found, skipping sync');
+    return;
+  }
+
+  if (
+    shipInfo.ship == null ||
+    shipInfo.shipUrl == null ||
+    shipInfo.authType == null
+  ) {
+    logger.info('Ship info missing necessary fields');
+    return;
+  }
+
+  logger.log('Configuring urbit client...');
+  configureUrbitClient({
+    ship: shipInfo.ship,
+    shipUrl: shipInfo.shipUrl,
+    authType: shipInfo.authType,
+  });
+  logger.log('Configured urbit client.');
+
+  logger.log('Starting background sync...');
+  await syncStart(
+    // we pass alreadySubscribed=true to avoid making subscriptions
+    true
+  );
+  logger.log('Completed background sync.');
+}
+
+const TASK_ID = 'backgroundSync';
+export function registerBackgroundSyncTask() {
+  TaskManager.defineTask<Record<string, unknown>>(
+    TASK_ID,
+    async ({ error }) => {
+      logger.log(`Running background sync background task`);
+      if (error) {
+        logger.error(`Failed background sync background task`, error.message);
+        return;
+      }
+
+      try {
+        await performSync();
+      } catch (err) {
+        logger.error(
+          'Failed background sync',
+          err instanceof Error ? err.message : err
+        );
+      }
+    }
+  );
+
+  logger.log('Registered background sync task');
+  (async () => {
+    try {
+      await Notifications.registerTaskAsync(TASK_ID);
+      logger.log('Registered notification task');
+      await BackgroundFetch.registerTaskAsync(TASK_ID, {
+        // Uses expo-notification default - at time of writing, 10 minutes on
+        // Android, system minimum on iOS (10-15 minutes)
+        minimumInterval: undefined,
+
+        // Android-only
+        // We could flip these to be more aggressive; let's start with lower
+        // usage to avoid slamming battery.
+        stopOnTerminate: true,
+        startOnBoot: false,
+      });
+      logger.log('Registered background fetch');
+    } catch (err) {
+      logger.error('Failed to register background sync task', err);
+    }
+  })();
+}

--- a/packages/app/lib/backgroundSync.ts
+++ b/packages/app/lib/backgroundSync.ts
@@ -53,20 +53,24 @@ const TASK_ID = 'backgroundSync';
 export function registerBackgroundSyncTask() {
   TaskManager.defineTask<Record<string, unknown>>(
     TASK_ID,
-    async ({ error }) => {
+    async ({ error }): Promise<BackgroundFetch.BackgroundFetchResult> => {
       logger.log(`Running background sync background task`);
       if (error) {
         logger.error(`Failed background sync background task`, error.message);
-        return;
+        return BackgroundFetch.BackgroundFetchResult.Failed;
       }
 
       try {
         await performSync();
+        // We always return NewData because we don't have a way to know whether
+        // there actually was new data.
+        return BackgroundFetch.BackgroundFetchResult.NewData;
       } catch (err) {
         logger.error(
           'Failed background sync',
           err instanceof Error ? err.message : err
         );
+        return BackgroundFetch.BackgroundFetchResult.Failed;
       }
     }
   );

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -210,6 +210,9 @@ importers:
       expo-av:
         specifier: ~13.10.5
         version: 13.10.6(expo@50.0.21(@babel/core@7.25.2)(@react-native/babel-preset@0.73.21(@babel/core@7.25.2)(@babel/preset-env@7.23.7(@babel/core@7.25.2)))(encoding@0.1.13))
+      expo-background-fetch:
+        specifier: ~11.8.1
+        version: 11.8.1(expo@50.0.21(@babel/core@7.25.2)(@react-native/babel-preset@0.73.21(@babel/core@7.25.2)(@babel/preset-env@7.23.7(@babel/core@7.25.2)))(encoding@0.1.13))
       expo-battery:
         specifier: ^7.7.2
         version: 7.7.2(expo@50.0.21(@babel/core@7.25.2)(@react-native/babel-preset@0.73.21(@babel/core@7.25.2)(@babel/preset-env@7.23.7(@babel/core@7.25.2)))(encoding@0.1.13))
@@ -8786,6 +8789,11 @@ packages:
     peerDependencies:
       expo: '*'
 
+  expo-background-fetch@11.8.1:
+    resolution: {integrity: sha512-WkWgj1RZsBjIt/J2HvYhfNi+8WEM6vEptuUj6r/vW9w+kXzDo5z/+pkr7YnPgQIhc4P7Z/j7TlM43azUpIEFZA==}
+    peerDependencies:
+      expo: '*'
+
   expo-battery@7.7.2:
     resolution: {integrity: sha512-Bo4X10m04oPS1B7g78EWO2KHIMaO9ZHNEgoD0C/8YpjkdJmbDkfVwO2i/uVtzV74zpV3M6TlAnWRPNsKMUMxZQ==}
     peerDependencies:
@@ -13392,8 +13400,8 @@ packages:
     resolution: {integrity: sha512-6t3foTQI9qne+OZoVQB/8x8rk2k1eVy1gRXhV3oFQ5T6R1dqQ1xtin3XqSlx3+ATBkliTaR/hHyJBm+LVPNM8w==}
     engines: {node: '>=4'}
 
-  unimodules-app-loader@4.5.0:
-    resolution: {integrity: sha512-q/Xug4K6/20876Xac+tjOLOOAeHEu2zF66LNN/5c8EV4WPEe/+RYZEljN/woQt17KPIB2eyel9dc+d6qUMjUOg==}
+  unimodules-app-loader@4.5.1:
+    resolution: {integrity: sha512-yQAsoL0jsCjld1C/iWS4tB5a6LZTb8+enZ9mpt9t9zHYw7YZgeInmW7yz5QZAgVE93ZMPN3SudZHWiXGuD4Wfg==}
 
   unique-filename@1.1.1:
     resolution: {integrity: sha512-Vmp0jIp2ln35UTXuryvjzkjGdRyf9b2lTXuSYUiPmzRcl3FDtYqAwOnTJkAngD9SWhnoJzDbTKwaOrZ+STtxNQ==}
@@ -25204,6 +25212,11 @@ snapshots:
     dependencies:
       expo: 50.0.21(@babel/core@7.25.2)(@react-native/babel-preset@0.73.21(@babel/core@7.25.2)(@babel/preset-env@7.26.0(@babel/core@7.25.2)))(encoding@0.1.13)
 
+  expo-background-fetch@11.8.1(expo@50.0.21(@babel/core@7.25.2)(@react-native/babel-preset@0.73.21(@babel/core@7.25.2)(@babel/preset-env@7.23.7(@babel/core@7.25.2)))(encoding@0.1.13)):
+    dependencies:
+      expo: 50.0.21(@babel/core@7.25.2)(@react-native/babel-preset@0.73.21(@babel/core@7.25.2)(@babel/preset-env@7.23.7(@babel/core@7.25.2)))(encoding@0.1.13)
+      expo-task-manager: 11.7.3(expo@50.0.21(@babel/core@7.25.2)(@react-native/babel-preset@0.73.21(@babel/core@7.25.2)(@babel/preset-env@7.23.7(@babel/core@7.25.2)))(encoding@0.1.13))
+
   expo-battery@7.7.2(expo@50.0.21(@babel/core@7.25.2)(@react-native/babel-preset@0.73.21(@babel/core@7.25.2)(@babel/preset-env@7.23.7(@babel/core@7.25.2)))(encoding@0.1.13)):
     dependencies:
       expo: 50.0.21(@babel/core@7.25.2)(@react-native/babel-preset@0.73.21(@babel/core@7.25.2)(@babel/preset-env@7.23.7(@babel/core@7.25.2)))(encoding@0.1.13)
@@ -25428,7 +25441,7 @@ snapshots:
   expo-task-manager@11.7.3(expo@50.0.21(@babel/core@7.25.2)(@react-native/babel-preset@0.73.21(@babel/core@7.25.2)(@babel/preset-env@7.23.7(@babel/core@7.25.2)))(encoding@0.1.13)):
     dependencies:
       expo: 50.0.21(@babel/core@7.25.2)(@react-native/babel-preset@0.73.21(@babel/core@7.25.2)(@babel/preset-env@7.23.7(@babel/core@7.25.2)))(encoding@0.1.13)
-      unimodules-app-loader: 4.5.0
+      unimodules-app-loader: 4.5.1
 
   expo-updates-interface@0.15.3(expo@50.0.21(@babel/core@7.25.2)(@react-native/babel-preset@0.73.21(@babel/core@7.25.2)(@babel/preset-env@7.23.7(@babel/core@7.25.2)))(encoding@0.1.13)):
     dependencies:
@@ -31223,7 +31236,7 @@ snapshots:
 
   unicode-property-aliases-ecmascript@2.1.0: {}
 
-  unimodules-app-loader@4.5.0: {}
+  unimodules-app-loader@4.5.1: {}
 
   unique-filename@1.1.1:
     dependencies:


### PR DESCRIPTION
Fixes TLON-3628

Adds a background task which periodically performs an initial sync (i.e. `startSync(true)`).

- When does this task run?
  - Android: Runs every 10 minutes; does not run if app has been force-quit or if the app hasn't been opened since last system boot
  - iOS: Runs as often as possible, subject to OS's fuzzy scheduling – supposedly every 10-15 minutes. Does not run if app has been force-quit.
- What gets synced?
  - Everything we sync on initial sync – which might be too much, but for me, this sync was very fast. On iOS, if sync takes more than 30 seconds, the background task will be killed (and will likely be invoked less often in the future).
- Is this hard on the battery?
  - This is hard to tell – I tried checking expo-battery's `Battery.getBatteryLevelAsync` before and after the task was run on a real iOS device, but there was not enough resolution to give a difference (i.e. diff = 0).
  - iOS seems pretty conservative about not running the task if it'll be a battery drain, based on docs.
- What effect does this have on returning to app?
  - iOS
    - When app is still active but backgrounded (i.e. user swiped out of app recently), the background sync makes newer messages appear immediately on return to app.
    - When app is inactive (i.e. user swiped out of app and has used many apps since): I don't know how to test this. I think we'll probably hit [this issue](https://linear.app/tlon/issue/TLON-3628/fetch-latest-conversations-from-background#comment-f92d6612) where we need to wait for a session to be established before showing posts.
  - Android: Hard to tell since I've only gotten the background task to work on a dev build, so returning to the app causes a JS reload; but it seems like the new messages are immediately shown in the channel, then the rest of the channel loads.

### How did I test?

#### iOS

> `Debug > Simulate background fetch` only works on a release build, and has only worked on simulator for me.

Xcode has an option at `Debug > Simulate background fetch`, which backgrounds the app and triggers the `application:performFetchWithCompletionHandler:` app delegate method. I swapped out the `logger` in `backgroundSync.ts` with a special logger that prints its logs to local notification banners, and checked that (1) background sync was completing, (2) the channel contents before sync did not have message received while backgrounded, and (3) channel had new messages after performing background sync.

I also installed onto a real device with debug logs enabled, and saw that it did background sync as expected after waiting.

<details>

<summary>

`Debug > Simulate background fetch` appears to only work on release builds: I think makes sense because`expo-task-manager` probably needs to load the static JS without hitting the server.

</summary>

`expo-task-manager` executes background tasks by:
1. receive request to perform task
2. load JS app in headless mode (using [`UMAppLoader`](https://github.com/expo/expo/tree/main/packages/unimodules-app-loader))
3. JS app registers tasks synchronously on app launch (this is why `registerBackgroundSyncTask` is called at global scope)
4. after headless app execution, expo-task-manager collects all the registered tasks matching the request and executes them.
My thinking is that it can't do step 2 in the background via dev server – no real data to back this up. [relevant code](https://github.com/expo/expo/blob/a2fda19a5aba854cdee8c0c82240efc5c0b1a2e9/packages/expo-task-manager/ios/EXTaskManager/EXTaskService.m#L534)

</details>

#### Android
Set `minimumInterval: 60` when calling [`BackgroundFetch.registerTaskAsync`](https://github.com/tloncorp/tlon-apps/blob/f153338131bb229ff8a5401c15d9deaaffd89bda/packages/app/lib/backgroundSync.ts#L83); do `pnpm run --filter tlon-mobile android` onto an emulator; then do similar checks as listed above (waiting a minute after backgrounding app to have background fetch automatically triggered).

### Future work
**This PR does not run background sync when receiving a notification.** expo-notifications has a `registerTaskAsync` hook to register running a `expo-task-manager` task when receiving a data-only notification (`content-available: 1`), but that doesn't appear to work for our use case: our notifications (which have `content-available: 1` *and* `mutable-content: 1`) do not (reliably?) trigger the required app delegate callback (`application:didReceiveRemoteNotification:fetchCompletionHandler:`).

Some solutions to trigger background sync on our user-facing notifications:
- Update backend to send separate silent, data-only notifications to trigger background sync. (These would use the same mechanism as our old pushes, and Apple technically says to only send 3 / hour.)
- Find a way to call an `expo-task-manager` task from the notifications native code.
  - iOS: The notif extension is a separate bundle from the host app – we'd need to find a way to access the JS bundle. This seems doable (and opens more options for extensions in the future, e.g. lockscreen widgets), but off the beaten path.
  - Android: I don't know whether we can access the JS bundle from the notification intent, but I think it'd be similar to iOS once we have access to the JS bundle.
- Re-implement background sync in native code. (This would be a lot of work, and require maintenance to keep in lockstep with JS.)