### PR TITLE
groups: handle http requests, if we ever get bound

### DIFF
--- a/desk/app/groups.hoon
+++ b/desk/app/groups.hoon
@@ -250,6 +250,20 @@
       [~ %| *]  ~&  [dap.bowl %overwriting-pending-import]
                 cor(pimp `|+egg-any)
     ==
+  ::
+      %handle-http-request
+    ::  we may (in some Tlon hosting circumstances) have been bound to serve
+    ::  on the root path, making us act as a catch-all for http requests.
+    ::  handle all requests that hit us by redirecting back into the web app.
+    ::
+    =+  !<([id=@ta inbound-request:eyre] vase)
+    =/  pax=path                 /http-response/[id]
+    =/  pay=simple-payload:http  [[307 ['location' '/apps/groups/']~] ~]
+    %-  emil
+    :~  [%give %fact ~[pax] %http-response-header !>(response-header.pay)]
+        [%give %fact ~[pax] %http-response-data !>(data.pay)]
+        [%give %kick ~[pax] ~]
+    ==
   ==
 ::
 ++  run-import
@@ -481,6 +495,7 @@
   ^+  cor
   ~|  watch-path=`path`pole
   ?+  pole  ~|(%bad-watch-path !!)
+    [%http-response *]    cor
     [%init ~]             (give %kick ~ ~)
     [%groups ~]           cor
     [%groups %ui ~]       cor


### PR DESCRIPTION
We may in some (hosting) circumstances want to bind the `/` catch-all binding to something we control, so that we can redirect root (and other unhandled pages) back into the groups web app.

Here we make the groups agent handle http requests by redirecting to `/apps/groups/`, setting us up for `|pass [%e %connect [~ /] %groups]` or some equivalent.

This goes into `release-410` because the same is true for tloncorp/landscape#313, which this soft-depends on. The kelvin is a nice boundary for solidifying that relation.

Someone sign off on the trailing `/` on the redirect path for me please.