### PR TITLE
native: omit param instead of passing `undefined`

### DIFF
--- a/packages/app/lib/backgroundSync.ts
+++ b/packages/app/lib/backgroundSync.ts
@@ -83,7 +83,7 @@ export function registerBackgroundSyncTask() {
       await BackgroundFetch.registerTaskAsync(TASK_ID, {
         // Uses expo-notification default - at time of writing, 10 minutes on
         // Android, system minimum on iOS (10-15 minutes)
-        minimumInterval: undefined,
+        // minimumInterval: undefined,
 
         // Android-only
         // We could flip these to be more aggressive; let's start with lower


### PR DESCRIPTION
We want to use the default value for `minimumInterval`; and since this is such an important parameter for UX, I want to make sure our usage is explicit, so I set `minimumInterval: undefined` to call out that we're using the default value. 

Instead of omitting an `undefined` entry when converting to native code, expo-background-fetch converts this to `"<null>"`, which breaks the native module.

(This change was made in my previous local branch but not included in the final set of commits – double-checked my stash, I didn't see any other omissions.)

context: /1/chan/chat/~bitpyx-dildus/interface/msg/170141184507263636203902727312912678912