### PR TITLE
groups: make sure we can cancel an errored join

### DIFF
--- a/apps/tlon-mobile/ios/Podfile.lock
+++ b/apps/tlon-mobile/ios/Podfile.lock
@@ -1774,29 +1774,30 @@ SPEC CHECKSUMS:
   EXFont: 64e653a110eee050ad80dfcd676c4bada0a1ff92
   EXImageLoader: ba2506b443b9656e93167c104406a2c265924823
   EXJSONUtils: 5c42959e87be238b045ef37cc5268b16a6c0ad4a
-  EXManifests: 5e8c29f36c716af768a4ea47ec05e1b89ab93091
-  EXMediaLibrary: 70cf1fb7028fda2d682090c9fe57568674e4abab
-  EXNotifications: e254c0fa11337e15b30c200e91437b521f682bad
-  Expo: 7b9976a9b2be116a701b233d6655b229a3c9316e
-  expo-dev-client: f22fdebdb8760bc22f660b7c0cb1dd58d80005c0
-  expo-dev-launcher: 11c184a2dca65f9bd6dc575a73a554b7be589d1d
-  expo-dev-menu: 68ea53d923996e27b20ce02b51cc820fc2327a83
-  expo-dev-menu-interface: 7ba029c9d1a82ac22b9b584c00514860b060553e
-  ExpoBackgroundFetch: 80d41ec15c6cce0bafb5d2326b8e85f42152eba7
-  ExpoBattery: 60bf880aea8f769fe39f709a920442542c1bfd62
-  ExpoClipboard: b597982124f067ff9f5b89093eb3d97898d5d877
-  ExpoDevice: 97307196d8cab694e245752b8a7afacc35c14e03
-  ExpoFileSystem: 74cc0fae916f9f044248433971dcfc8c3befd057
-  ExpoHaptics: 28a771b630353cd6e8dcf1b1e3e693e38ad7c3c3
-  ExpoImage: 8cf2d51de3d03b7e984e9b0ba8f19c0c22057001
-  ExpoImageManipulator: c1d7cb865eacd620a35659f3da34c70531f10b59
-  ExpoImagePicker: 66970181d1c838f444e5e1f81b804ab2d5ff49bd
-  ExpoKeepAwake: 0f5cad99603a3268e50af9a6eb8b76d0d9ac956c
-  ExpoLinearGradient: 4ad1449a2408e0435ac959076562b3921f2e32a1
-  ExpoLocalization: f94759e55802e4a4f8b7d7cecb450de11b888721
-  ExpoModulesCore: 0f9e3c49657f681cd06219d97c77c3108a67ca00
-  ExpoSecureStore: c84ae37d1c36f38524d289c67c3a2e3fc56f1108
-  EXSplashScreen: 0fabdcf746d29e7f8b8969879cb09125cdd365d2
+  EXManifests: 429136cffa3ae82d1ba3b60b7243fb186615562e
+  EXMediaLibrary: d3bf5c458643f9821b96af328d399ef3f44de7db
+  EXNotifications: 9fd42ca3c5998ae93a2ac869ed9a47467c433219
+  Expo: 1b33cb8ab60cff9abf805ed6020af3d1846e457c
+  expo-dev-client: 775a683302570193a7ba71032d0b1b82f6ad1454
+  expo-dev-launcher: acd5b1e03e649e96675c85314a9d8745f23648d1
+  expo-dev-menu: 2b4ce6108396233849b71805906129de15aadfbc
+  expo-dev-menu-interface: 44e69ddff62bbc6c5418c200e657635720b5a480
+  ExpoBackgroundFetch: 466154f27b511cb3c369709dd4b3f152c785b26e
+  ExpoBattery: 6cdcb673b99f53b3e9955b03268fd571cff68f51
+  ExpoBlur: 3a9548a738624968836926f4aa1e18fa22155640
+  ExpoClipboard: 24cc2b881ab6ca2e5b431b1f6d9d4a302adbf9d0
+  ExpoDevice: fc21b9193d704f3759c1ede1b383fcdb0370b46a
+  ExpoFileSystem: df58e1eb2a4d6f1006a1ca70bddfbbf63e52fa4f
+  ExpoHaptics: c91902e436f3fb0e07aa19acc118018089fa90de
+  ExpoImage: a70db90f39a7af98930cef91c84e877b1131f3dd
+  ExpoImageManipulator: 0c2ada7a028619ea1cc0c670bfa90c8ebeaa4af4
+  ExpoImagePicker: d06822d74f1f0e7fe7cb070ece0fff6e678fa3eb
+  ExpoKeepAwake: 3b8cf8533b9212500565a1e41fb080fc5af29918
+  ExpoLinearGradient: 501f9bbd83f3ec1d0e0425862b9ef4693605fc1c
+  ExpoLocalization: 7423aa1abcc59209dc2ce2b9bb63776a18023a98
+  ExpoModulesCore: bc9f47045cd97b741444e335880d65c681d39007
+  ExpoSecureStore: 4cec57fd2c40dcff05ce2186c39afc1af39d213c
+  EXSplashScreen: 32c0a1ee2e9b416a5fb8ba41419bd040868e5dfe
   EXStructuredHeaders: 5b0f47259db047dc1fdfa84752e292c2bfa68ecd
   EXTaskManager: 8c5683c2fb543cf2baa77bab4ad130b7e3829c4a
   EXUpdates: 8cc7407328c3852e3ce890a381fe0022ae71902b
@@ -1898,9 +1899,9 @@ SPEC CHECKSUMS:
   SDWebImageWebPCoder: af09429398d99d524cae2fe00f6f0f6e491ed102
   SocketRocket: f32cd54efbe0f095c4d7594881e52619cfe80b17
   sqlite3: f163dbbb7aa3339ad8fc622782c2d9d7b72f7e9c
-  tentap: 2cf2e387dd284bf867010eb7d0f91618fb35b673
+  tentap: 2a4256b6641a27d72d2b5fe2eb94cd1a203e4975
   UMAppLoader: 79d3ee6aa2447a1fe2e8b0d07acf2de106e55b58
-  Yoga: 4dbfeceb9bb0f62899d0a53d37a1ddd58898d3f2
+  Yoga: fb61b2337c7688c81a137e5560b3cbb515289f91
 
 PODFILE CHECKSUM: 0cb7a78e5777e69c86c1bf4bb5135fd660376dbe
 

--- a/packages/app/ui/components/ChatOptionsSheet.tsx
+++ b/packages/app/ui/components/ChatOptionsSheet.tsx
@@ -251,6 +251,7 @@ function GroupOptionsSheetContent({
   const canSortChannels = (group.channels?.length ?? 0) > 1;
   const canInvite = currentUserIsAdmin || group.privacy === 'public';
   const isPinned = group?.pin;
+  const isErrored = group?.joinStatus === 'errored';
 
   const wrappedAction = useCallback(
     (action: () => void) => {
@@ -263,6 +264,11 @@ function GroupOptionsSheetContent({
   const handlePressChatDetails = useCallback(() => {
     onPressChatDetails({ type: 'group', id: group.id });
   }, [group.id, onPressChatDetails]);
+
+  const handleCancel = useCallback(async () => {
+    await store.cancelGroupJoin(group);
+    store.leaveGroup(group.id);
+  }, [group]);
 
   const actionGroups = useMemo(
     () =>
@@ -306,6 +312,15 @@ function GroupOptionsSheetContent({
             title: 'Group info & settings',
             action: wrappedAction.bind(null, handlePressChatDetails),
             endIcon: 'ChevronRight',
+          },
+        ],
+        // this is CYA in case the group somehow looks joined but isn't
+        isErrored && [
+          'negative',
+          {
+            title: 'Cancel join',
+            description: 'Group joining failed or timed out',
+            action: wrappedAction.bind(null, handleCancel),
           },
         ]
       ),


### PR DESCRIPTION
Fixes TLON-3179 for cases where the join in progress actually errors (stuck private requests were fixed with tloncorp/tlon-apps#4472). I was tempted to refactor the way we track status here because we're juggling a lot of booleans, but decided to push it off for a little longer, although I still think we should change it sooner than later.