### PR TITLE
Onboarding: Handle legacy invites

### DIFF
--- a/apps/tlon-mobile/src/fixtures/Onboarding.fixture.tsx
+++ b/apps/tlon-mobile/src/fixtures/Onboarding.fixture.tsx
@@ -2,8 +2,8 @@ import { NavigationContainer } from '@react-navigation/native';
 import { Context as BranchContext } from '@tloncorp/app/contexts/branch';
 import { exampleContacts } from '@tloncorp/app/fixtures/contentHelpers';
 import { group } from '@tloncorp/app/fixtures/fakeData';
-import { AppInvite, QueryClientProvider, queryClient } from '@tloncorp/shared';
 import { Theme } from '@tloncorp/app/ui';
+import { AppInvite, QueryClientProvider, queryClient } from '@tloncorp/shared';
 import { PropsWithChildren, useState } from 'react';
 import { useFixtureSelect } from 'react-cosmos/client';
 
@@ -45,7 +45,6 @@ function OnboardingFixture({
     hasGroupInvite
       ? {
           id: group.id,
-          shouldAutoJoin: true,
           inviterUserId: exampleContacts.ed.id,
           inviterNickname: exampleContacts.ed.nickname,
           invitedGroupId: group.id,

--- a/apps/tlon-mobile/src/hooks/useDeepLinkListener.ts
+++ b/apps/tlon-mobile/src/hooks/useDeepLinkListener.ts
@@ -27,7 +27,7 @@ export const useDeepLinkListener = () => {
           lure: lure.id,
         });
         try {
-          if (lure.shouldAutoJoin || !ship) {
+          if (!ship) {
             // if the lure was clicked prior to authenticating, no-op for now.
             // Hosting will handle once the user signs up.
           } else {

--- a/apps/tlon-mobile/src/screens/Onboarding/PasteInviteLinkScreen.tsx
+++ b/apps/tlon-mobile/src/screens/Onboarding/PasteInviteLinkScreen.tsx
@@ -6,16 +6,8 @@ import {
   DEFAULT_INVITE_LINK_URL,
 } from '@tloncorp/app/constants';
 import { useBranch, useLureMetadata } from '@tloncorp/app/contexts/branch';
-import { trackError, trackOnboardingAction } from '@tloncorp/app/utils/posthog';
 import {
-  createInviteLinkRegex,
-  extractNormalizedInviteLink,
-  getInviteLinkMeta,
-} from '@tloncorp/shared';
-import {
-  Button,
   Field,
-  OnboardingButton,
   Pressable,
   ScreenHeader,
   TextInput,
@@ -23,13 +15,19 @@ import {
   View,
   YStack,
 } from '@tloncorp/app/ui';
+import { trackError, trackOnboardingAction } from '@tloncorp/app/utils/posthog';
+import {
+  createInviteLinkRegex,
+  extractNormalizedInviteLink,
+  getInviteLinkMeta,
+} from '@tloncorp/shared';
 import { useCallback, useEffect, useState } from 'react';
 import { Controller, useForm } from 'react-hook-form';
 import { Keyboard } from 'react-native';
 
 import type { OnboardingStackParamList } from '../../types';
 
-const INVITE_LINK_REGEX = createInviteLinkRegex(BRANCH_DOMAIN);
+const INVITE_LINK_REGEX = createInviteLinkRegex();
 
 type Props = NativeStackScreenProps<
   OnboardingStackParamList,
@@ -68,8 +66,6 @@ export const PasteInviteLinkScreen = ({ navigation }: Props) => {
         try {
           const appInvite = await getInviteLinkMeta({
             inviteLink: extractedLink,
-            branchDomain: BRANCH_DOMAIN,
-            branchKey: BRANCH_KEY,
           });
           if (appInvite) {
             setLure(appInvite);

--- a/packages/app/hooks/useBootSequence.ts
+++ b/packages/app/hooks/useBootSequence.ts
@@ -8,7 +8,6 @@ import { useLureMetadata } from '../contexts/branch';
 import { useShip } from '../contexts/ship';
 import { BootPhaseNames, NodeBootPhase } from '../lib/bootHelpers';
 import BootHelpers from '../lib/bootHelpers';
-import { getShipFromCookie } from '../utils/ship';
 import { useConfigureUrbitClient } from './useConfigureUrbitClient';
 import { usePosthog } from './usePosthog';
 
@@ -160,7 +159,9 @@ export function useBootSequence() {
       });
 
       const requiredInvites =
-        lureMeta?.inviteType === 'user' ? invitedDm : invitedGroup && invitedDm;
+        lureMeta?.inviteType === 'user'
+          ? invitedDm
+          : invitedGroup && (lureMeta?.isLegacy ? true : invitedDm); // old style lures will not receive a DM invite
 
       if (requiredInvites) {
         logger.trackEvent(AnalyticsEvent.InviteDebug, {
@@ -241,7 +242,9 @@ export function useBootSequence() {
         updatedGroup.channels.length > 0;
 
       const hadSuccess =
-        lureMeta?.inviteType === 'user' ? dmIsGood : groupIsGood && dmIsGood;
+        lureMeta?.inviteType === 'user'
+          ? dmIsGood
+          : groupIsGood && (lureMeta?.isLegacy ? true : dmIsGood); // old style lures will not receive a DM invite
 
       if (hadSuccess) {
         logger.crumb('successfully accepted invites');

--- a/packages/app/ui/components/Onboarding/OnboardingInvite.tsx
+++ b/packages/app/ui/components/Onboarding/OnboardingInvite.tsx
@@ -1,4 +1,4 @@
-import { DeepLinkMetadata } from '@tloncorp/shared';
+import { AppInvite } from '@tloncorp/shared';
 import * as db from '@tloncorp/shared/db';
 import React, { ComponentProps } from 'react';
 
@@ -16,7 +16,7 @@ interface GroupShim {
 export const OnboardingInviteBlock = React.memo(function OnboardingInviteBlock({
   metadata,
   ...rest
-}: { metadata: DeepLinkMetadata } & ComponentProps<typeof ListItem>) {
+}: { metadata: AppInvite } & ComponentProps<typeof ListItem>) {
   const {
     inviterUserId,
     invitedGroupId,

--- a/packages/shared/src/logic/branch.ts
+++ b/packages/shared/src/logic/branch.ts
@@ -34,13 +34,11 @@ export const getDeepLink = async (
   return url;
 };
 
-export const getBranchLinkMeta = async (
-  branchUrl: string,
-  branchKey: string
-) => {
+export const getBranchLinkMeta = async (branchUrl: string) => {
+  const env = getConstants();
   const params = new URLSearchParams();
   params.set('url', branchUrl);
-  params.set('branch_key', branchKey);
+  params.set('branch_key', env.BRANCH_KEY);
   const response = await fetchBranchApi(`/v1/url?${params}`);
   if (!response.ok) {
     const badRequestInfo = await response.json();
@@ -86,7 +84,7 @@ export interface DeepLinkMetadata {
 
 export interface AppInvite extends DeepLinkMetadata {
   id: string;
-  shouldAutoJoin: boolean;
+  isLegacy?: boolean;
 }
 
 export type Lure = {
@@ -101,12 +99,13 @@ export interface DeepLinkData extends DeepLinkMetadata {
   lure?: string;
 }
 
-export function extractLureMetadata(branchParams: any) {
+export function extractLureMetadata(branchParams: any): AppInvite | null {
   if (!branchParams || typeof branchParams !== 'object') {
-    return {};
+    return null;
   }
 
-  const extracted = {
+  const extracted: AppInvite = {
+    id: branchParams.lure,
     inviterUserId: branchParams.inviterUserId || branchParams.inviter,
     inviterNickname: branchParams.inviterNickname,
     inviterAvatarImage: branchParams.inviterAvatarImage,
@@ -131,6 +130,7 @@ export function extractLureMetadata(branchParams: any) {
     if (isValidPatp(ship)) {
       extracted.inviterUserId = ship;
       extracted.invitedGroupId = branchParams.lure;
+      extracted.isLegacy = true;
     }
   }
 

--- a/packages/shared/src/logic/deeplinks.ts
+++ b/packages/shared/src/logic/deeplinks.ts
@@ -131,17 +131,27 @@ export async function getInviteLinkMeta({
   return null;
 }
 
-export function createInviteLinkRegex() {
+// new style invite links
+export function createTokenInviteLinkRegex() {
   const env = getConstants();
   return new RegExp(
     `^(https?://)?(${env.BRANCH_DOMAIN}/|tlon\\.network/lure/)0v[^/]+$`
   );
 }
 
+// old style invite links
 export function createLegacyInviteLinkRegex() {
   const env = getConstants();
   return new RegExp(
     `^(https?://)?(${env.BRANCH_DOMAIN}/|tlon\\.network/lure/)~[a-zA-Z0-9-]+/[a-zA-Z0-9-]+$`
+  );
+}
+
+// either new or old style invite links
+export function createInviteLinkRegex() {
+  const env = getConstants();
+  return new RegExp(
+    `^(https?://)?(${env.BRANCH_DOMAIN}/|tlon\\.network/lure/)(0v[^/]+|~[a-zA-Z0-9-]+/[a-zA-Z0-9-]+)$`
   );
 }
 

--- a/packages/shared/src/store/inviteActions.ts
+++ b/packages/shared/src/store/inviteActions.ts
@@ -11,8 +11,8 @@ import { AnalyticsEvent } from '../domain';
 import {
   checkInviteServiceLinkExists,
   createDeepLink,
+  extractInviteIdFromInviteLink,
   extractNormalizedInviteLink,
-  extractTokenFromInviteLink,
   getFlagParts,
   withRetry,
 } from '../logic';
@@ -36,7 +36,7 @@ export async function verifyUserInviteLink() {
       logger.trackEvent('Created personal invite link');
     } else {
       // otherwise, make sure we have the corresponding link on the invite service
-      const inviteId = extractTokenFromInviteLink(inviteLink);
+      const inviteId = extractInviteIdFromInviteLink(inviteLink);
       if (!inviteId) {
         throw new Error(`Provider returned invalid link ${inviteLink}`);
       }


### PR DESCRIPTION
Adds handling for non-branch wrapped legacy invites (e.g. join.tlon.io/~latter-bolden/garden). Will detect them when clicked or pasted on _PasteInviteLink_ screen.

This fixes client side handling, but as of right now it looks like we need backend changes to fully support. This should not be merged until we know we handle these invites correctly e2e.

Fixes TLON-3757