### PR TITLE
Telemetry: Explicit errors for sync start failure and displaying DM invite link

### DIFF
--- a/packages/shared/src/domain/analytics.ts
+++ b/packages/shared/src/domain/analytics.ts
@@ -95,12 +95,16 @@ export enum AnalyticsEvent {
   ActionsNotifPermsChecked = 'Checked Notification Permissions',
   ActionTappedPushNotif = 'Tapped Push Notification',
   GroupJoinComplete = 'Group Join Complete',
+  PersonalInviteLinkReady = 'Personal Invite Link Ready',
   ErrorSendPost = 'Error Sending Post',
   ErrorSendReply = 'Error Sending Thread Reply',
   ErrorReact = 'Error Reacting to Post',
   ErrorUnreact = 'Error Removing Reaction from Post',
   ErrorPushNotifNavigate = 'Error Navigating to Push Channel',
   ErrorDigestFailed = 'Error Preparing Usage Digest',
+  ErrorSyncStartHighPriority = 'Error Start Sync: High Priority',
+  ErrorSyncStartLowPriority = 'Error Start Sync: Low Priority',
+  ErrorVerifyingPersonalInvite = 'Error Verifying DM Invite Link',
 }
 
 export interface AnalyticsDigest {

--- a/packages/shared/src/store/inviteActions.ts
+++ b/packages/shared/src/store/inviteActions.ts
@@ -50,6 +50,9 @@ export async function verifyUserInviteLink() {
 
     if (finalInviteLink) {
       await db.personalInviteLink.setValue(finalInviteLink);
+      logger.trackEvent(AnalyticsEvent.PersonalInviteLinkReady);
+    } else {
+      throw new Error('finalInviteLink is falsy');
     }
   } catch (e) {
     logger.trackError('Failed to verify personal invite link', {

--- a/packages/shared/src/store/sync.ts
+++ b/packages/shared/src/store/sync.ts
@@ -1190,63 +1190,69 @@ export const syncStart = async (alreadySubscribed?: boolean) => {
   const startTime = Date.now();
   logger.crumb(`sync start running${alreadySubscribed ? ' (recovery)' : ''}`);
 
-  await batchEffects('sync start (high)', async (ctx) => {
-    // this allows us to run the api calls first in parallel but handle
-    // writing the data in a specific order
-    const yieldWriter = true;
+  try {
+    await batchEffects('sync start (high)', async (ctx) => {
+      // this allows us to run the api calls first in parallel but handle
+      // writing the data in a specific order
+      const yieldWriter = true;
 
-    // first kickoff the fetching
-    const syncInitPromise = syncInitData(
-      { priority: SyncPriority.High, retry: true },
-      ctx,
-      yieldWriter
-    );
-    const syncLatestPostsPromise = syncLatestPosts(
-      {
-        priority: SyncPriority.High,
-        retry: true,
-      },
-      ctx,
-      yieldWriter
-    );
-    const subsPromise = alreadySubscribed
-      ? Promise.resolve()
-      : setupHighPrioritySubscriptions({
-          priority: SyncPriority.High - 1,
-        }).then(() => logger.crumb('subscribed high priority'));
+      // first kickoff the fetching
+      const syncInitPromise = syncInitData(
+        { priority: SyncPriority.High, retry: true },
+        ctx,
+        yieldWriter
+      );
+      const syncLatestPostsPromise = syncLatestPosts(
+        {
+          priority: SyncPriority.High,
+          retry: true,
+        },
+        ctx,
+        yieldWriter
+      );
+      const subsPromise = alreadySubscribed
+        ? Promise.resolve()
+        : setupHighPrioritySubscriptions({
+            priority: SyncPriority.High - 1,
+          }).then(() => logger.crumb('subscribed high priority'));
 
-    const trackStep = (function () {
-      let last = Date.now();
-      return (event: AnalyticsEvent) => {
-        const now = Date.now();
-        logger.trackEvent(event, { duration: now - last });
-        last = now;
-      };
-    })();
+      const trackStep = (function () {
+        let last = Date.now();
+        return (event: AnalyticsEvent) => {
+          const now = Date.now();
+          logger.trackEvent(event, { duration: now - last });
+          last = now;
+        };
+      })();
 
-    // then enforce the ordering of writes to avoid race conditions
-    const initWriter = await syncInitPromise;
-    trackStep(AnalyticsEvent.InitDataFetched);
-    await initWriter();
-    trackStep(AnalyticsEvent.InitDataWritten);
-    logger.crumb('finished writing init data');
+      // then enforce the ordering of writes to avoid race conditions
+      const initWriter = await syncInitPromise;
+      trackStep(AnalyticsEvent.InitDataFetched);
+      await initWriter();
+      trackStep(AnalyticsEvent.InitDataWritten);
+      logger.crumb('finished writing init data');
 
-    const latestPostsWriter = await syncLatestPostsPromise;
-    trackStep(AnalyticsEvent.LatestPostsFetched);
-    await latestPostsWriter();
-    trackStep(AnalyticsEvent.LatestPostsWritten);
-    logger.crumb('finished writing latest posts');
+      const latestPostsWriter = await syncLatestPostsPromise;
+      trackStep(AnalyticsEvent.LatestPostsFetched);
+      await latestPostsWriter();
+      trackStep(AnalyticsEvent.LatestPostsWritten);
+      logger.crumb('finished writing latest posts');
 
-    await subsPromise;
-    trackStep(AnalyticsEvent.SubscriptionsEstablished);
-    logger.crumb('finished initializing high priority subs');
+      await subsPromise;
+      trackStep(AnalyticsEvent.SubscriptionsEstablished);
+      logger.crumb('finished initializing high priority subs');
 
-    logger.crumb(`finished high priority init sync`);
-    logger.trackEvent(AnalyticsEvent.SessionInitialized, {
-      duration: Date.now() - startTime,
+      logger.crumb(`finished high priority init sync`);
+      logger.trackEvent(AnalyticsEvent.SessionInitialized, {
+        duration: Date.now() - startTime,
+      });
+      updateSession({ startTime: Date.now() });
     });
-    updateSession({ startTime: Date.now() });
-  });
+  } catch (err) {
+    logger.trackError(AnalyticsEvent.ErrorSyncStartHighPriority, {
+      errorMessage: err.message,
+    });
+  }
 
   const lowPriorityPromises = [
     alreadySubscribed
@@ -1282,7 +1288,9 @@ export const syncStart = async (alreadySubscribed?: boolean) => {
       logger.crumb(`finished low priority sync`);
     })
     .catch((e) => {
-      logger.trackError(e);
+      logger.trackError(AnalyticsEvent.ErrorSyncStartLowPriority, {
+        errorMessage: e.message,
+      });
     });
 
   // post sync initialization work


### PR DESCRIPTION
OTT

Adds messages for high/low priority start sync failures and an error + success event for displaying the Personal Invite paper airplane. Will dashboard appropriately once live.