### PR TITLE
embeds: fix issue with rendering embeds inline

### DIFF
--- a/packages/app/ui/components/Embed/EmbedContent.tsx
+++ b/packages/app/ui/components/Embed/EmbedContent.tsx
@@ -9,7 +9,7 @@ import { Embed } from './Embed';
 import { EmbedWebView } from './EmbedWebView';
 import { getProviderConfig } from './providers';
 
-const trustedProviders = [
+export const trustedProviders = [
   {
     name: 'YouTube',
     regex: /^https:\/\/(?:www\.)?youtube\.com\/watch\?v=|youtu\.be\//,

--- a/packages/app/ui/components/Embed/EmbedWebView.tsx
+++ b/packages/app/ui/components/Embed/EmbedWebView.tsx
@@ -1,6 +1,12 @@
 import { LoadingSpinner } from '@tloncorp/ui';
-import { memo, useCallback, useMemo, useRef, useState } from 'react';
-import { LayoutChangeEvent, Linking, Platform, ViewStyle } from 'react-native';
+import { memo, useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import {
+  Dimensions,
+  LayoutChangeEvent,
+  Linking,
+  Platform,
+  ViewStyle,
+} from 'react-native';
 import WebView from 'react-native-webview';
 import { View, getTokenValue, useTheme } from 'tamagui';
 
@@ -11,6 +17,7 @@ const IS_ANDROID = Platform.OS === 'android';
 const ANDROID_LAYER_TYPE = IS_ANDROID ? 'hardware' : undefined;
 const ANDROID_OVERSCROLL_MODE = IS_ANDROID ? 'never' : undefined;
 const SCROLL_ENABLED = IS_ANDROID;
+const MAX_HEIGHT_PERCENT = 0.6;
 
 interface EmbedWebViewProps {
   url: string;
@@ -29,24 +36,62 @@ export const EmbedWebView = memo<EmbedWebViewProps>(
   ({ url, provider, embedHtml, onError }) => {
     const primaryBackground = useTheme().background.val;
     const [isLoading, setIsLoading] = useState(true);
+    const [hideTweetMedia, setHideTweetMedia] = useState(false);
     const [webViewHeight, setWebViewHeight] = useState(provider.defaultHeight);
     const webViewRef = useRef<WebView>(null);
     const lastHeightRef = useRef(provider.defaultHeight);
+    const heightUpdateTimerRef = useRef<NodeJS.Timeout | null>(null);
     const isDark = useIsDarkTheme();
     const borderRadiusVal = getTokenValue('$s');
+
+    const maxAllowedHeight = useMemo(() => {
+      const { height: screenHeight } = Dimensions.get('window');
+      const maxHeight = screenHeight * MAX_HEIGHT_PERCENT;
+
+      return Math.max(maxHeight, provider.defaultHeight);
+    }, [provider.defaultHeight]);
+
+    const setDebouncedWebViewHeight = useCallback(
+      (height: number) => {
+        if (heightUpdateTimerRef.current) {
+          clearTimeout(heightUpdateTimerRef.current);
+        }
+
+        heightUpdateTimerRef.current = setTimeout(() => {
+          const heightDiff = Math.abs(height - webViewHeight);
+          if (heightDiff > 25) {
+            setWebViewHeight(height);
+          }
+        }, 100);
+      },
+      [webViewHeight]
+    );
+
+    useEffect(() => {
+      return () => {
+        if (heightUpdateTimerRef.current) {
+          clearTimeout(heightUpdateTimerRef.current);
+        }
+      };
+    }, []);
 
     const html = useMemo(() => {
       if (!embedHtml || !url) {
         return '';
       }
-      const baseHtml = provider.generateHtml(url, embedHtml, isDark);
+      const baseHtml = provider.generateHtml(
+        url,
+        embedHtml,
+        isDark,
+        hideTweetMedia
+      );
       return baseHtml.replace(
         '<style>',
         `<style>
         :root { background-color: ${primaryBackground} !important; }
         html, body { background-color: ${primaryBackground} !important; }`
       );
-    }, [url, embedHtml, isDark, primaryBackground, provider]);
+    }, [url, embedHtml, isDark, primaryBackground, provider, hideTweetMedia]);
 
     const containerStyle = useMemo(
       () => (IS_ANDROID ? [{ minHeight: provider.defaultHeight }] : []),
@@ -82,24 +127,36 @@ export const EmbedWebView = memo<EmbedWebViewProps>(
         try {
           const data = JSON.parse(event.nativeEvent.data) as WebViewMessageData;
           if (data.height) {
-            const heightDiff = Math.abs(data.height - lastHeightRef.current);
             if (provider.name === 'Twitter') {
-              // Always process the loaded flag regardless of height
               if (data.loaded) {
-                // Only mark as loaded if we have a valid height
                 if (data.height > 0) {
+                  if (data.height > maxAllowedHeight) {
+                    setHideTweetMedia(true);
+                  }
                   lastHeightRef.current = data.height;
-                  setWebViewHeight(data.height);
+                  setDebouncedWebViewHeight(data.height);
                   setIsLoading(false);
                 }
               }
-              // Update height only if it's a significant change and non-zero
-              else if (heightDiff > 5 && data.height > 0) {
-                lastHeightRef.current = data.height;
-                setWebViewHeight(data.height);
+              // For height updates, use more conservative approach to avoid loops
+              else {
+                const heightDiff = Math.abs(
+                  data.height - lastHeightRef.current
+                );
+                // Only update height if it's a significant change, non-zero,
+                // and different from the last reported height
+                if (
+                  heightDiff > 25 &&
+                  data.height > 0 &&
+                  data.height !== lastHeightRef.current
+                ) {
+                  lastHeightRef.current = data.height;
+                  setDebouncedWebViewHeight(data.height);
+                }
               }
             } else {
-              setWebViewHeight(data.height);
+              // For other providers, use the simple approach
+              setDebouncedWebViewHeight(data.height);
               setIsLoading(false);
             }
           }
@@ -107,7 +164,7 @@ export const EmbedWebView = memo<EmbedWebViewProps>(
           console.warn('Failed to parse WebView message:', e);
         }
       },
-      [provider.name]
+      [provider.name, setDebouncedWebViewHeight, maxAllowedHeight]
     );
 
     const onErrorHandler = useCallback(
@@ -158,6 +215,7 @@ export const EmbedWebView = memo<EmbedWebViewProps>(
           </View>
         )}
         <View
+          key={`webview-${webViewHeight}`}
           width={provider.defaultWidth}
           height={webViewHeight}
           backgroundColor={primaryBackground}
@@ -166,7 +224,6 @@ export const EmbedWebView = memo<EmbedWebViewProps>(
           onLayout={onLayoutHandler}
         >
           <WebView
-            key={`webview-${webViewHeight}`}
             style={webViewStyle}
             source={{ html }}
             androidLayerType={ANDROID_LAYER_TYPE}

--- a/packages/app/ui/components/PostContent/BlockRenderer.tsx
+++ b/packages/app/ui/components/PostContent/BlockRenderer.tsx
@@ -25,6 +25,7 @@ import {
 
 import { ContentReferenceLoader, Reference } from '../ContentReference';
 import { VideoEmbed } from '../Embed';
+import EmbedContent from '../Embed/EmbedContent';
 import { HighlightedCode } from '../HighlightedCode';
 import { InlineRenderer } from './InlineRenderer';
 import * as cn from './contentUtils';
@@ -360,8 +361,19 @@ export const HeaderText = styled(Text, {
   } as const,
 });
 
-export function EmbedBlock() {
-  return null;
+export function EmbedBlock({
+  block,
+  ...props
+}: { block: cn.EmbedBlockData } & ComponentProps<typeof View>) {
+  if (!block.url) {
+    return null;
+  }
+
+  return (
+    <View width="100%" {...props}>
+      <EmbedContent url={block.url} content={block.content} />
+    </View>
+  );
 }
 
 export type BlockRenderer<T extends cn.BlockData> = (props: {

--- a/packages/app/ui/components/PostContent/InlineRenderer.tsx
+++ b/packages/app/ui/components/PostContent/InlineRenderer.tsx
@@ -1,10 +1,10 @@
 import { RawText, Text } from '@tloncorp/ui';
 import React, { PropsWithChildren, useCallback, useContext } from 'react';
+import { Linking, Platform } from 'react-native';
 import { ColorTokens, styled } from 'tamagui';
 
 import { useNavigation } from '../../contexts';
 import { useContactName } from '../ContactNameV2';
-import { EmbedContent } from '../Embed';
 import {
   InlineData,
   InlineFromType,
@@ -99,17 +99,19 @@ export function InlineText({
 }
 
 export function InlineLink({ inline: node }: { inline: LinkInlineData }) {
-  return <EmbedContent url={node.href} content={node.text || node.href} />;
-  // For now, we pass all links to the EmbedContent component.
-  // In the future, we'll create a new block type for embed content and we'll render links directly again.
-  // const handlePress = useCallback(() => {
-  //   Linking.openURL(node.href);
-  // }, [node.href]);
-  // return (
-  //   <Text cursor="pointer" textDecorationLine="underline" onPress={handlePress}>
-  //     {node.text || node.href}
-  //   </Text>
-  // );
+  const handlePress = useCallback(() => {
+    if (Platform.OS === 'web') {
+      window.open(node.href, '_blank', 'noopener,noreferrer');
+    } else {
+      Linking.openURL(node.href);
+    }
+  }, [node.href]);
+
+  return (
+    <Text cursor="pointer" textDecorationLine="underline" onPress={handlePress}>
+      {node.text || node.href}
+    </Text>
+  );
 }
 
 export type InlineRenderer<T extends InlineData> = React.ComponentType<{


### PR DESCRIPTION
The actual issue didn't end up being the height of the twitter embeds, the issue was that if you posted a link to some embeddable content *on the same line* as some other text, then the webview would render within the Text component and it would either a) break out of that container on iOS or b) push the height of that container tall enough to fit the embed webview on Android (which also looked bizarre).

To fix this, embeds are now extracted as standalone block elements, separate from text. Links from trusted providers are now converted to block-level embeds.

Also:

I hardened are height change detection and fixed an issue that was causing crashes on iOS (changing the key on Webview based on the webViewHeight was causing crashes in some instances, moving the key to the parent View ensures that we still force an adjustment when necessary and prevents the crash, the WebView will just expand to fill the parent).

I created a maxAllowedHeight value that will be calculated based on the viewport height. If a tweet is too big, we'll hide the media in the tweet (video, pictures, external links) to constrain the height a bit.


https://github.com/user-attachments/assets/df8f3f78-f589-4335-9964-7018f3a88483

