### PR TITLE
desktop: prevent navigating to post on menu press in galleries

### DIFF
--- a/packages/app/ui/components/GalleryPost/GalleryPost.tsx
+++ b/packages/app/ui/components/GalleryPost/GalleryPost.tsx
@@ -116,7 +116,7 @@ export function GalleryPost({
 
   return (
     <Pressable
-      onPress={overFlowIsHovered ? undefined : handlePress}
+      onPress={overFlowIsHovered || isPopoverOpen ? undefined : handlePress}
       onLongPress={handleLongPress}
       onHoverIn={onHoverIn}
       onHoverOut={onHoverOut}


### PR DESCRIPTION
fixes tlon-3764
fixes tlon-3767

We weren't disabling the onPress for the Pressable when the popover was open. Any selection in the menu would cause the user to be navigated to the post detail view.