### PR TITLE
chat details: fix navigation issues

### DIFF
--- a/packages/app/features/groups/GroupMetaScreen.tsx
+++ b/packages/app/features/groups/GroupMetaScreen.tsx
@@ -4,15 +4,11 @@ import * as store from '@tloncorp/shared/store';
 import { uploadAsset, useCanUpload } from '@tloncorp/shared/store';
 import { useCallback, useState } from 'react';
 
-import {
-  INVITE_SERVICE_ENDPOINT,
-  INVITE_SERVICE_IS_DEV,
-} from '../../constants';
+import { useChatSettingsNavigation } from '../../hooks/useChatSettingsNavigation';
 import { useGroupContext } from '../../hooks/useGroupContext';
 import { GroupSettingsStackParamList } from '../../navigation/types';
 import {
   AttachmentProvider,
-  Button,
   DeleteSheet,
   MetaEditorScreenView,
   YStack,
@@ -31,16 +27,17 @@ export function GroupMetaScreen(props: Props) {
   const { group, setGroupMetadata, deleteGroup } = useGroupContext({
     groupId,
   });
+  const { onPressChatDetails } = useChatSettingsNavigation();
   const canUpload = useCanUpload();
   const [showDeleteSheet, setShowDeleteSheet] = useState(false);
 
   const handleSubmit = useCallback(
     (data: db.ClientMeta) => {
       setGroupMetadata(data);
-      props.navigation.goBack();
+      onPressChatDetails({ type: 'group', id: groupId });
       store.createGroupInviteLink(groupId);
     },
-    [setGroupMetadata, props.navigation, groupId]
+    [setGroupMetadata, groupId, onPressChatDetails]
   );
 
   const handlePressDelete = useCallback(() => {

--- a/packages/app/features/top/ChatDetailsScreen.tsx
+++ b/packages/app/features/top/ChatDetailsScreen.tsx
@@ -36,6 +36,7 @@ import {
   useCurrentUserId,
   useGroupTitle,
   useIsAdmin,
+  useIsWindowNarrow,
 } from '../../ui';
 
 type Props = NativeStackScreenProps<RootStackParamList, 'ChatDetails'>;
@@ -84,7 +85,8 @@ export function ChatDetailsScreenView() {
     onPressGroupMeta: navigateToGroupMeta,
     onPressChannelMeta: navigateToChannelMeta,
   } = useChatSettingsNavigation();
-  const { navigateBack } = useRootNavigation();
+  const { navigateToGroup, navigateBack } = useRootNavigation();
+  const isWindowNarrow = useIsWindowNarrow();
 
   const currentUser = useCurrentUserId();
   const currentUserIsAdmin = useIsAdmin(group?.id ?? '', currentUser);
@@ -97,10 +99,18 @@ export function ChatDetailsScreenView() {
     }
   }, [channel, chatType, group, navigateToChannelMeta, navigateToGroupMeta]);
 
+  const handlePressBack = useCallback(() => {
+    if (chatType === 'group' && group && !isWindowNarrow) {
+      navigateToGroup(group.id);
+    } else {
+      navigateBack();
+    }
+  }, [chatType, group, navigateToGroup, navigateBack, isWindowNarrow]);
+
   return (
     <View flex={1} backgroundColor="$secondaryBackground">
       <ScreenHeader
-        backAction={navigateBack}
+        backAction={handlePressBack}
         title={chatType === 'group' ? 'Group info' : 'Channel info'}
         rightControls={
           currentUserIsAdmin ? (

--- a/packages/app/navigation/desktop/HomeNavigator.tsx
+++ b/packages/app/navigation/desktop/HomeNavigator.tsx
@@ -104,6 +104,17 @@ function DrawerContent(props: DrawerContentComponentProps) {
     return (
       <GroupChannelsScreenContent groupId={nestedFocusedRouteParams.groupId} />
     );
+  } else if (
+    focusedRouteParams &&
+    focusedRoute.name === 'ChatDetails' &&
+    'chatId' in focusedRouteParams &&
+    'chatType' in focusedRouteParams
+  ) {
+    if (focusedRouteParams.chatType === 'channel') {
+      return <HomeSidebar focusedChannelId={focusedRouteParams.chatId} />;
+    } else if (focusedRouteParams.chatType === 'group') {
+      return <GroupChannelsScreenContent groupId={focusedRouteParams.chatId} />;
+    }
   } else if (focusedRoute.params && 'channelId' in focusedRoute.params) {
     return <HomeSidebar focusedChannelId={focusedRoute.params.channelId} />;
   } else {


### PR DESCRIPTION
fixes tlon-3769

Now:

- If we navigate to `ChatDetails` (group settings) on desktop we'll also render the group channels list in the sidebar.

- If we press the back button (on desktop) while we're in ChatDetails, and we're in the details for a group, we'll just navigate to the group.

- If we edit the group meta and press save, we'll be navigated back to ChatDetails rather than back to the group.