### PR TITLE
groups: avoid %kick-ing empty list of paths

### DIFF
--- a/desk/app/groups.hoon
+++ b/desk/app/groups.hoon
@@ -1025,10 +1025,13 @@
       ~
     `path
   ?+    -.sign  cor
-      %kick  (give %kick matching ~)
+      %kick
+    ?~  matching  cor
+    (give %kick matching ~)
   ::
       %watch-ack
     ?~  p.sign  cor
+    ?~  matching  cor
     (give %kick matching ~)
   ::
       %fact
@@ -1037,6 +1040,7 @@
       cor
     =+  !<(=dude:gall q.cage.sign)
     =.  shoal  (~(put by shoal) gra dude)
+    ?~  matching  cor
     =.  cor  (give %fact matching cage.sign)
     (give %kick matching ~)
   ==


### PR DESCRIPTION
Kicking empty list of paths means "kick subscription that triggered this event". This does mean that when constructing a path list of unknown size, you have to catch the empty list case to avoid falling into that specialized behavior.

Here, we check for the empty list, and avoid emitting kicks (or facts) in that case.

(In practice, this resulted in the kick going into clay during an update reload, which failed without providing a clear trace or legible failure reason. Notably, clay's error handling only handles errors on the `/drip` wire, crashing in other cases. Potentially not the right approach...)