### PR TITLE
heap/diary: removing unnecessary operations on deprecated agents

### DIFF
--- a/desk/app/diary.hoon
+++ b/desk/app/diary.hoon
@@ -95,23 +95,7 @@
     ::
       %2
     =.  state  old
-    =.  cor  restore-missing-subs
-    =.  cor  (emit %pass / %agent [our.bowl dap.bowl] %poke %recheck-all-perms !>(0))
-    =.  cor  (emit %pass / %agent [our.bowl dap.bowl] %poke %leave-old-channels !>(0))
-    =.  cor
-      (emil (drop load:epos))
-    =/  diaries  ~(tap in ~(key by shelf))
-    =.  cor
-      %+  roll
-        ~(tap in (~(gas in *(set ship)) (turn diaries head)))
-      |=  [=ship cr=_cor]
-      ?:  =(ship our.bowl)  cr
-      (watch-epic:cr ship &)
-    |-
-    ?~  diaries
-      cor
-    =.  cor  di-abet:di-upgrade:(di-abed:di-core i.diaries)
-    $(diaries t.diaries)
+    cor
   ==
   ::
   +$  versioned-state  $%(current-state state-1)

--- a/desk/app/heap.hoon
+++ b/desk/app/heap.hoon
@@ -217,24 +217,7 @@
     ::
       %1
     =.  state  old
-    =.  cor  restore-missing-subs
-    =.  cor  (emit %pass / %agent [our.bowl dap.bowl] %poke %recheck-all-perms !>(0))
-    =.  cor  (emit %pass / %agent [our.bowl dap.bowl] %poke %leave-old-channels !>(0))
-    =.  cor
-      %+  roll  ~(tap in `(set @p)`(~(run in ~(key by stash)) head))
-      |=  [=ship cr=_cor]
-      ?:  =(ship our.bowl)  cr
-      (watch-epic:cr ship &)
-    ?:  =(okay:h cool)  cor
-    ::  speak the good news
-    =.  cor  (emil (drop load:epos))
-    =/  heaps  ~(tap in ~(key by stash))
-    |-
-    ?~  heaps
-      cor
-    =.  cor
-      he-abet:he-upgrade:(he-abed:he-core i.heaps)
-    $(heaps t.heaps)
+    cor
   ==
   ::
   +$  versioned-state  $%(current-state state-0)


### PR DESCRIPTION
OTT, while were debugging found that these are doing a lot of things that simply aren't necessary anymore. This just removes those and no-ops.