### PR TITLE
ops: make sure we have env vars

### DIFF
--- a/.github/workflows/deploy-canary.yml
+++ b/.github/workflows/deploy-canary.yml
@@ -61,6 +61,13 @@ jobs:
         with:
           name: "ui-dist-new"
           path: apps/tlon-web-new/dist
+    env:
+      VITE_BRANCH_DOMAIN_PROD: ${{ secrets.VITE_BRANCH_DOMAIN_PROD}}
+      VITE_BRANCH_DOMAIN_TEST: ${{ secrets.VITE_BRANCH_DOMAIN_TEST}}
+      VITE_BRANCH_KEY_PROD: ${{ secrets.VITE_BRANCH_KEY_PROD}}
+      VITE_BRANCH_KEY_TEST: ${{ secrets.VITE_BRANCH_KEY_TEST}}
+      VITE_INVITE_SERVICE_ENDPOINT: ${{ secrets.VITE_INVITE_SERVICE_ENDPOINT}}
+      VITE_POST_HOG_API_KEY: ${{ secrets.VITE_POST_HOG_API_KEY}}
   glob:
     runs-on: ubuntu-latest
     name: "Make a glob"

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -72,6 +72,13 @@ jobs:
         with:
           name: "ui-dist-new"
           path: apps/tlon-web-new/dist
+    env:
+      VITE_BRANCH_DOMAIN_PROD: ${{ secrets.VITE_BRANCH_DOMAIN_PROD}}
+      VITE_BRANCH_DOMAIN_TEST: ${{ secrets.VITE_BRANCH_DOMAIN_TEST}}
+      VITE_BRANCH_KEY_PROD: ${{ secrets.VITE_BRANCH_KEY_PROD}}
+      VITE_BRANCH_KEY_TEST: ${{ secrets.VITE_BRANCH_KEY_TEST}}
+      VITE_INVITE_SERVICE_ENDPOINT: ${{ secrets.VITE_INVITE_SERVICE_ENDPOINT}}
+      VITE_POST_HOG_API_KEY: ${{ secrets.VITE_POST_HOG_API_KEY}}
   glob:
     runs-on: ubuntu-latest
     name: "Make a glob"


### PR DESCRIPTION
I noticed new desktop never resolved generating an invite link even though we get a response from reel. Turns out we didn't have the env vars, so I added those in here.