### PR TITLE
chat-list: don't show options on invites

### DIFF
--- a/packages/app/features/chat-list/ChatList.tsx
+++ b/packages/app/features/chat-list/ChatList.tsx
@@ -81,7 +81,7 @@ export const ChatList = React.memo(function ChatListComponent({
             <SectionListHeader.Text>{item.title}</SectionListHeader.Text>
           </SectionListHeader>
         );
-      } else if (item.type === 'channel' || !item.isPending) {
+      } else if (item.type === 'channel' && !item.isPending) {
         return (
           <InteractableChatListItem
             model={item}
@@ -97,6 +97,7 @@ export const ChatList = React.memo(function ChatListComponent({
             onPress={onPressItem}
             onLongPress={handleLongPress}
             onLayout={handleItemLayout}
+            disableOptions={item.isPending}
           />
         );
       }


### PR DESCRIPTION
The triple dot icon was overlapping the invite bubble and really didn't make sense to have in the first place. This disables options on pending items.