### PR TITLE
Telemetry: Fix model capture & log chatlist taps

### DIFF
--- a/packages/app/features/top/ChannelScreen.tsx
+++ b/packages/app/features/top/ChannelScreen.tsx
@@ -69,11 +69,9 @@ export default function ChannelScreen(props: Props) {
   useFocusEffect(
     useCallback(() => {
       // Mark the channel as visited when we unfocus/leave this screen
-      () => {
-        if (!channelIsPending) {
-          store.markChannelVisited(channelId);
-        }
-      };
+      if (!channelIsPending) {
+        store.markChannelVisited(channelId);
+      }
     }, [channelId, channelIsPending])
   );
 

--- a/packages/app/features/top/ChatListScreen.tsx
+++ b/packages/app/features/top/ChatListScreen.tsx
@@ -7,6 +7,7 @@ import type { NativeStackScreenProps } from '@react-navigation/native-stack';
 import { AnalyticsEvent, createDevLogger } from '@tloncorp/shared';
 import * as api from '@tloncorp/shared/api';
 import * as db from '@tloncorp/shared/db';
+import * as logic from '@tloncorp/shared/logic';
 import * as store from '@tloncorp/shared/store';
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { Keyboard } from 'react-native';
@@ -159,9 +160,17 @@ export function ChatListScreenView({
         if (item.isPending) {
           setSelectedGroupId(item.id);
         } else {
+          logger.trackEvent(
+            AnalyticsEvent.ActionTappedChat,
+            logic.getModelAnalytics({ group: item.group })
+          );
           navigateToGroup(item.group.id);
         }
       } else {
+        logger.trackEvent(
+          AnalyticsEvent.ActionTappedChat,
+          logic.getModelAnalytics({ channel: item.channel })
+        );
         navigateToChannel(item.channel);
       }
     },

--- a/packages/app/features/top/GroupChannelsScreen.tsx
+++ b/packages/app/features/top/GroupChannelsScreen.tsx
@@ -1,6 +1,8 @@
 import { useIsFocused } from '@react-navigation/native';
 import type { NativeStackScreenProps } from '@react-navigation/native-stack';
+import { AnalyticsEvent, createDevLogger } from '@tloncorp/shared';
 import * as db from '@tloncorp/shared/db';
+import * as logic from '@tloncorp/shared/logic';
 import * as store from '@tloncorp/shared/store';
 import { useCallback, useState } from 'react';
 
@@ -17,6 +19,8 @@ import {
 } from '../../ui';
 
 type Props = NativeStackScreenProps<RootStackParamList, 'GroupChannels'>;
+
+const logger = createDevLogger('GroupChannelsScreen', false);
 
 export function GroupChannelsScreen({ route }: Props) {
   return <GroupChannelsScreenContent groupId={route.params.groupId} />;
@@ -40,6 +44,10 @@ export function GroupChannelsScreenContent({
 
   const handleChannelSelected = useCallback(
     (channel: db.Channel) => {
+      logger.trackEvent(
+        AnalyticsEvent.ActionGroupChannelSelected,
+        logic.getModelAnalytics({ channel })
+      );
       navigateToChannel(channel);
     },
     [navigateToChannel]

--- a/packages/shared/src/domain/analytics.ts
+++ b/packages/shared/src/domain/analytics.ts
@@ -93,6 +93,7 @@ export enum AnalyticsEvent {
   ActionViewProfileGroup = 'Viewed Pinned Profile Group',
   ActionSelectActivityEvent = 'Tapped Activity Event',
   ActionsNotifPermsChecked = 'Checked Notification Permissions',
+  ActionGroupChannelSelected = 'Tapped group channel',
   ActionTappedPushNotif = 'Tapped Push Notification',
   GroupJoinComplete = 'Group Join Complete',
   PersonalInviteLinkReady = 'Personal Invite Link Ready',

--- a/packages/shared/src/domain/analytics.ts
+++ b/packages/shared/src/domain/analytics.ts
@@ -88,6 +88,7 @@ export enum AnalyticsEvent {
   ActionPinChat = 'Pinned Chat',
   ActionUnpinChat = 'Unpinned Chat',
   ActionVisitedChannel = 'Viewed Channel',
+  ActionTappedChat = 'Tapped Chatlist Item',
   ActionJoinChannel = 'Joined Channel',
   ActionUpdateChannelWriters = 'Updated Channel Writers',
   ActionViewProfileGroup = 'Viewed Pinned Profile Group',

--- a/packages/shared/src/logic/utils.ts
+++ b/packages/shared/src/logic/utils.ts
@@ -544,9 +544,9 @@ export function getModelAnalytics({
   group,
   channel,
 }: {
-  post?: Partial<db.Post>;
-  group?: Partial<db.Group>;
-  channel?: Partial<db.Channel>;
+  post?: Partial<db.Post> | null;
+  group?: Partial<db.Group> | null;
+  channel?: Partial<db.Channel> | null;
 }) {
   const details: Record<string, string | null> = {};
 

--- a/packages/shared/src/store/channelActions.ts
+++ b/packages/shared/src/store/channelActions.ts
@@ -307,10 +307,14 @@ export async function unpinItem(pin: db.Pin) {
 
 export async function markChannelVisited(channelId: string) {
   const channel = await db.getChannel({ id: channelId });
+  let group = null;
+  if (channel && channel.groupId) {
+    group = await db.getGroup({ id: channel.groupId });
+  }
   if (channel) {
     logger.trackEvent(
       AnalyticsEvent.ActionVisitedChannel,
-      logic.getModelAnalytics({ channel })
+      logic.getModelAnalytics({ channel, group })
     );
   }
   await db.updateChannel({ id: channelId, lastViewedAt: Date.now() });

--- a/packages/shared/src/store/groupActions.ts
+++ b/packages/shared/src/store/groupActions.ts
@@ -231,11 +231,6 @@ export async function markGroupNew(group: db.Group) {
 }
 
 export async function markGroupVisited(groupId: string) {
-  logger.log('marking new group as visited', groupId);
-  logger.trackEvent(
-    AnalyticsEvent.ActionVisitedGroup,
-    logic.getModelAnalytics({ group: { id: groupId } })
-  );
   await db.updateGroup({ id: groupId, isNew: false });
 }
 

--- a/packages/shared/src/store/postActions.ts
+++ b/packages/shared/src/store/postActions.ts
@@ -56,9 +56,13 @@ export async function sendPost({
     metadata,
   });
 
+  let group: null | db.Group = null;
+  if (channel.groupId) {
+    group = await db.getGroup({ id: channel.groupId });
+  }
   logger.trackEvent(
     AnalyticsEvent.ActionSendPost,
-    logic.getModelAnalytics({ post: cachePost, channel })
+    logic.getModelAnalytics({ post: cachePost, channel, group })
   );
 
   logger.crumb('insert channel posts');
@@ -239,9 +243,14 @@ export async function sendReply({
     replyTime: cachePost.sentAt,
   });
 
+  let group = null;
+  if (channel.groupId) {
+    group = await db.getGroup({ id: channel.groupId });
+  }
+
   logger.trackEvent(
     AnalyticsEvent.ActionSendReply,
-    logic.getModelAnalytics({ post: cachePost, channel })
+    logic.getModelAnalytics({ post: cachePost, channel, group })
   );
 
   try {

--- a/packages/shared/src/store/postActions.ts
+++ b/packages/shared/src/store/postActions.ts
@@ -371,9 +371,15 @@ export async function addPostReaction(
   shortCode: string,
   currentUserId: string
 ) {
+  const channel = await db.getChannel({ id: post.channelId });
+  let group = null;
+  if (channel && channel.groupId) {
+    group = await db.getGroup({ id: channel.groupId });
+  }
+
   logger.trackEvent(
     AnalyticsEvent.ActionReact,
-    logic.getModelAnalytics({ post })
+    logic.getModelAnalytics({ post, channel, group })
   );
   const formattedShortcode = shortCode.replace(/^(?!:)(.*)$(?<!:)/, ':$1:');
 


### PR DESCRIPTION
OTT

Fixes a few limitations that cropped up while analyzing remote telemetry. Also fixes a bug where we were never calling an intended `ChannelScreen` focus effect.