### PR TITLE
embeds: remove key on parent view that was causing re-renders

### DIFF
--- a/packages/app/ui/components/Embed/EmbedWebView.tsx
+++ b/packages/app/ui/components/Embed/EmbedWebView.tsx
@@ -215,7 +215,6 @@ export const EmbedWebView = memo<EmbedWebViewProps>(
           </View>
         )}
         <View
-          key={`webview-${webViewHeight}`}
           width={provider.defaultWidth}
           height={webViewHeight}
           backgroundColor={primaryBackground}


### PR DESCRIPTION
This wasn't causing an issue on every tweet, and it didn't seem to cause an issue at all on iOS, but it was causing an issue where many tweet embeds would reload continuously on Android. I initially added it in the first iteration of embeds to force the component to remount when we got a height update (and originally it was a key on the WebView itself), but in my testing today it looks like it's unnecessary and just giving us trouble.