### PR TITLE
groups: ignore %kicks for deleted groups

### DIFF
--- a/desk/app/groups.hoon
+++ b/desk/app/groups.hoon
@@ -943,6 +943,10 @@
   ::
       [%groups ship=@ name=@ rest=*]
     =/  =ship  (slav %p ship.pole)
+    ?:  ?&  ?=(%kick -.sign)
+            !(~(has by groups) ship name.pole)
+        ==
+      cor
     go-abet:(go-agent:(go-abed:group-core ship name.pole) rest.pole sign)
   ::
       [%gangs %index ship=@ ~]


### PR DESCRIPTION
A %kick on a subscription to a group that had been deleted would crash. This caused a problem in conjunction with the use of lib-negotiate: during first load, the library sends a %kick on every subscription in order to force protocol negotiation. If a subscription was not properly cleaned-up by the agent, the %kick will trigger a crash, interrupting the update.