### PR TITLE
embeds: webview rerender jihad

### DIFF
--- a/packages/app/ui/components/Embed/EmbedWebView.tsx
+++ b/packages/app/ui/components/Embed/EmbedWebView.tsx
@@ -1,5 +1,12 @@
 import { LoadingSpinner } from '@tloncorp/ui';
-import { memo, useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import {
+  memo,
+  useCallback,
+  useEffect,
+  useMemo,
+  useReducer,
+  useRef,
+} from 'react';
 import {
   Dimensions,
   LayoutChangeEvent,
@@ -32,15 +39,63 @@ interface WebViewMessageData {
   loaded?: boolean;
 }
 
+type WebViewState = {
+  isLoading: boolean;
+  hideTweetMedia: boolean;
+  webViewHeight: number;
+};
+
+type WebViewAction =
+  | { type: 'HIDE_MEDIA' }
+  | { type: 'SET_HEIGHT'; height: number }
+  | { type: 'LOADING_COMPLETE' }
+  | { type: 'HIDE_MEDIA_AND_UPDATE_HEIGHT'; height: number }
+  | { type: 'UPDATE_HEIGHT_AND_COMPLETE'; height: number };
+
+function webViewReducer(
+  state: WebViewState,
+  action: WebViewAction
+): WebViewState {
+  switch (action.type) {
+    case 'HIDE_MEDIA':
+      return { ...state, hideTweetMedia: true };
+    case 'SET_HEIGHT':
+      return { ...state, webViewHeight: action.height };
+    case 'LOADING_COMPLETE':
+      return { ...state, isLoading: false };
+    case 'HIDE_MEDIA_AND_UPDATE_HEIGHT':
+      return {
+        ...state,
+        hideTweetMedia: true,
+        webViewHeight: action.height,
+      };
+    case 'UPDATE_HEIGHT_AND_COMPLETE':
+      return {
+        ...state,
+        isLoading: false,
+        webViewHeight: action.height,
+      };
+    default:
+      return state;
+  }
+}
+
 export const EmbedWebView = memo<EmbedWebViewProps>(
   ({ url, provider, embedHtml, onError }) => {
-    const primaryBackground = useTheme().background.val;
-    const [isLoading, setIsLoading] = useState(true);
-    const [hideTweetMedia, setHideTweetMedia] = useState(false);
-    const [webViewHeight, setWebViewHeight] = useState(provider.defaultHeight);
+    const theme = useTheme();
+    const primaryBackground = useMemo(() => theme.background.val, [theme]);
+
+    const initialState: WebViewState = {
+      isLoading: true,
+      hideTweetMedia: false,
+      webViewHeight: provider.defaultHeight,
+    };
+
+    const [state, dispatch] = useReducer(webViewReducer, initialState);
+    const { isLoading, hideTweetMedia, webViewHeight } = state;
+
     const webViewRef = useRef<WebView>(null);
     const lastHeightRef = useRef(provider.defaultHeight);
-    const heightUpdateTimerRef = useRef<NodeJS.Timeout | null>(null);
     const isDark = useIsDarkTheme();
     const borderRadiusVal = getTokenValue('$s');
 
@@ -51,47 +106,20 @@ export const EmbedWebView = memo<EmbedWebViewProps>(
       return Math.max(maxHeight, provider.defaultHeight);
     }, [provider.defaultHeight]);
 
-    const setDebouncedWebViewHeight = useCallback(
-      (height: number) => {
-        if (heightUpdateTimerRef.current) {
-          clearTimeout(heightUpdateTimerRef.current);
-        }
-
-        heightUpdateTimerRef.current = setTimeout(() => {
-          const heightDiff = Math.abs(height - webViewHeight);
-          if (heightDiff > 25) {
-            setWebViewHeight(height);
-          }
-        }, 100);
-      },
-      [webViewHeight]
-    );
-
-    useEffect(() => {
-      return () => {
-        if (heightUpdateTimerRef.current) {
-          clearTimeout(heightUpdateTimerRef.current);
-        }
-      };
-    }, []);
+    const baseHtml = useMemo(() => {
+      if (!embedHtml || !url) return '';
+      return provider.generateHtml(url, embedHtml, isDark, hideTweetMedia);
+    }, [url, embedHtml, isDark, provider, hideTweetMedia]);
 
     const html = useMemo(() => {
-      if (!embedHtml || !url) {
-        return '';
-      }
-      const baseHtml = provider.generateHtml(
-        url,
-        embedHtml,
-        isDark,
-        hideTweetMedia
-      );
+      if (!baseHtml) return '';
       return baseHtml.replace(
         '<style>',
         `<style>
         :root { background-color: ${primaryBackground} !important; }
         html, body { background-color: ${primaryBackground} !important; }`
       );
-    }, [url, embedHtml, isDark, primaryBackground, provider, hideTweetMedia]);
+    }, [baseHtml, primaryBackground]);
 
     const containerStyle = useMemo(
       () => (IS_ANDROID ? [{ minHeight: provider.defaultHeight }] : []),
@@ -108,68 +136,80 @@ export const EmbedWebView = memo<EmbedWebViewProps>(
       }),
       [isLoading, primaryBackground, borderRadiusVal]
     );
-
-    const onLayoutHandler = useCallback(
-      (event: LayoutChangeEvent) => {
-        if (!IS_ANDROID) return;
-        const { height } = event.nativeEvent.layout;
-        if (height !== webViewHeight) {
-          requestAnimationFrame(() => {
-            setWebViewHeight(height);
-          });
-        }
-      },
-      [webViewHeight]
+    const webViewProps = useMemo(
+      () => ({
+        style: webViewStyle,
+        source: { html },
+        automaticallyAdjustContentInsets: false,
+        scrollEnabled: SCROLL_ENABLED,
+        javaScriptEnabled: true,
+        domStorageEnabled: true,
+      }),
+      [webViewStyle, html]
     );
+
+    const currentHeightRef = useRef(webViewHeight);
+
+    useEffect(() => {
+      currentHeightRef.current = webViewHeight;
+    }, [webViewHeight]);
+
+    const onLayoutHandler = useCallback((event: LayoutChangeEvent) => {
+      if (!IS_ANDROID) return;
+      const { height } = event.nativeEvent.layout;
+      if (height !== currentHeightRef.current) {
+        requestAnimationFrame(() => {
+          dispatch({ type: 'SET_HEIGHT', height });
+        });
+      }
+    }, []);
 
     const onMessageHandler = useCallback(
       (event: any) => {
         try {
           const data = JSON.parse(event.nativeEvent.data) as WebViewMessageData;
-          if (data.height) {
-            if (provider.name === 'Twitter') {
-              if (data.loaded) {
-                if (data.height > 0) {
-                  if (data.height > maxAllowedHeight) {
-                    setHideTweetMedia(true);
-                  }
-                  lastHeightRef.current = data.height;
-                  setDebouncedWebViewHeight(data.height);
-                  setIsLoading(false);
-                }
+          if (data.height && data.height > 0) {
+            // For Twitter's initial load
+            if (provider.name === 'Twitter' && data.loaded) {
+              // For tall tweets that need media hiding
+              if (data.height > maxAllowedHeight) {
+                // Just set the flag, don't update height yet
+                dispatch({ type: 'HIDE_MEDIA' });
+              } else {
+                // For normal sized tweets, update height and complete loading in one action
+                lastHeightRef.current = data.height;
+                dispatch({
+                  type: 'UPDATE_HEIGHT_AND_COMPLETE',
+                  height: data.height,
+                });
               }
-              // For height updates, use more conservative approach to avoid loops
-              else {
-                const heightDiff = Math.abs(
-                  data.height - lastHeightRef.current
-                );
-                // Only update height if it's a significant change, non-zero,
-                // and different from the last reported height
-                if (
-                  heightDiff > 25 &&
-                  data.height > 0 &&
-                  data.height !== lastHeightRef.current
-                ) {
-                  lastHeightRef.current = data.height;
-                  setDebouncedWebViewHeight(data.height);
-                }
+            }
+            // For height updates from Twitter after media hiding
+            else if (provider.name === 'Twitter' && !data.loaded) {
+              const heightDiff = Math.abs(data.height - lastHeightRef.current);
+              if (heightDiff > 25 && data.height !== lastHeightRef.current) {
+                lastHeightRef.current = data.height;
+                dispatch({ type: 'SET_HEIGHT', height: data.height });
               }
-            } else {
-              // For other providers, use the simple approach
-              setDebouncedWebViewHeight(data.height);
-              setIsLoading(false);
+            }
+            // For other providers
+            else {
+              dispatch({
+                type: 'UPDATE_HEIGHT_AND_COMPLETE',
+                height: data.height,
+              });
             }
           }
         } catch (e) {
           console.warn('Failed to parse WebView message:', e);
         }
       },
-      [provider.name, setDebouncedWebViewHeight, maxAllowedHeight]
+      [provider.name, maxAllowedHeight]
     );
 
     const onErrorHandler = useCallback(
       (event: any) => {
-        setIsLoading(false);
+        dispatch({ type: 'LOADING_COMPLETE' });
         const { nativeEvent } = event;
         console.warn('WebView error: ', nativeEvent);
         onError?.(nativeEvent);
@@ -223,15 +263,10 @@ export const EmbedWebView = memo<EmbedWebViewProps>(
           onLayout={onLayoutHandler}
         >
           <WebView
-            style={webViewStyle}
-            source={{ html }}
+            {...webViewProps}
             androidLayerType={ANDROID_LAYER_TYPE}
             overScrollMode={ANDROID_OVERSCROLL_MODE}
             onMessage={onMessageHandler}
-            automaticallyAdjustContentInsets={false}
-            scrollEnabled={SCROLL_ENABLED}
-            javaScriptEnabled={true}
-            domStorageEnabled={true}
             mixedContentMode="always"
             onError={onErrorHandler}
             onHttpError={onHttpErrorHandler}


### PR DESCRIPTION
fixes tlon-3778 by:

- replacing multiple useState hooks with one useReducer for atomic state updates
- eliminating the unnecessary debounced height setter, replaced with direct dispatch calls
- reducing handler dependencies by using refs
- making onLayoutHandler dependency free via refs
- memoizing everything

This should fix the cascading state updates that were causing the re-renders/visual flicker we were seeing in threads (and when loading a chat channel where a tweet was near the bottom of a chat, or the gallery details view).