### PR TITLE
group-members: crashes on desktop, shows incorrectly on mobile

### DIFF
--- a/packages/app/ui/components/GroupMembersScreenView.tsx
+++ b/packages/app/ui/components/GroupMembersScreenView.tsx
@@ -51,6 +51,7 @@ export function GroupMembersScreenView({
 }) {
   const { bottom } = useSafeAreaInsets();
   const [selectedContact, setSelectedContact] = useState<string | null>(null);
+  const currentUserIsAdmin = useIsAdmin(groupId, currentUserId);
   const contacts = useMemo(
     () =>
       members
@@ -141,7 +142,13 @@ export function GroupMembersScreenView({
               ]
             : []
         ),
-    [membersByRole, joinRequestData, bannedUserData, membersWithoutRoles]
+    [
+      membersByRole,
+      joinRequestData,
+      bannedUserData,
+      membersWithoutRoles,
+      currentUserIsAdmin,
+    ]
   );
 
   const keyExtractor = useCallback((item: db.ChatMember) => item.contactId, []);
@@ -169,8 +176,6 @@ export function GroupMembersScreenView({
     ),
     [roles]
   );
-
-  const currentUserIsAdmin = useIsAdmin(groupId, currentUserId);
 
   const selectedUserRoles = useMemo(
     () =>


### PR DESCRIPTION
On desktop navigating to the group members screen crashes the app completely. Meanwhile on mobile it somehow doesn't crash, but doesn't show anything that was gated by `currentUserIsAdmin` because it defaults it to false? (I guess idk). Fixes issue about banning failure reported on spreadsheet.