### PR TITLE
GalleryPostDetailView: image tap navigation to lightbox

### DIFF
--- a/packages/app/ui/components/GalleryPost/GalleryPost.tsx
+++ b/packages/app/ui/components/GalleryPost/GalleryPost.tsx
@@ -1,6 +1,9 @@
+import { useNavigation } from '@react-navigation/native';
+import { NativeStackNavigationProp } from '@react-navigation/native-stack';
 import {
   ChannelAction,
   JSONValue,
+  createDevLogger,
   makePrettyShortDate,
 } from '@tloncorp/shared';
 import * as db from '@tloncorp/shared/db';
@@ -18,6 +21,7 @@ import {
 } from 'react';
 import { View, XStack, styled } from 'tamagui';
 
+import { RootStackParamList } from '../../../navigation/types';
 import { useChannelContext } from '../../contexts';
 import { MinimalRenderItemProps } from '../../contexts/componentsKits';
 import { DetailViewAuthorRow } from '../AuthorRow';
@@ -205,19 +209,36 @@ export function GalleryPostDetailView({
   post: db.Post;
   onPressImage?: (post: db.Post, uri?: string) => void;
 }) {
+  const logger = createDevLogger('GalleryPostDetailView', true);
+  const navigation =
+    useNavigation<NativeStackNavigationProp<RootStackParamList>>();
   const formattedDate = useMemo(() => {
     return makePrettyShortDate(new Date(post.receivedAt));
   }, [post.receivedAt]);
   const content = usePostContent(post);
-  const isImagePost = useMemo(
-    () => content.some((block) => block.type === 'image'),
-    [content]
-  );
+
+  const firstImage = useMemo(() => {
+    const img = content.find((block) => block.type === 'image');
+    logger.log('First image found in GalleryPostDetailView:', img);
+    return img;
+  }, [content, logger]);
+
+  const isImagePost = useMemo(() => !!firstImage, [firstImage]);
+
   const handlePressImage = useCallback(
     (src: string) => {
-      onPressImage?.(post, src);
+      logger.log('Detail view: Image pressed, navigating to', src);
+      try {
+        navigation.navigate('ImageViewer', { uri: src });
+      } catch (error) {
+        logger.log('Navigation error:', error);
+        // Try the fallback if direct navigation fails
+        if (onPressImage && firstImage && firstImage.type === 'image') {
+          onPressImage(post, firstImage.src);
+        }
+      }
     },
-    [onPressImage, post]
+    [navigation, logger, onPressImage, post, firstImage]
   );
 
   return (

--- a/packages/app/ui/components/PostScreenView.tsx
+++ b/packages/app/ui/components/PostScreenView.tsx
@@ -94,6 +94,7 @@ export function PostScreenView({
   onGroupAction: (action: GroupPreviewAction, group: db.Group) => void;
   goToDm: (participants: string[]) => void;
 } & ChannelContext) {
+  const isWindowNarrow = utils.useIsWindowNarrow();
   const currentUserId = useCurrentUserId();
   const currentUserIsAdmin = utils.useIsAdmin(
     channel.groupId ?? '',
@@ -107,6 +108,10 @@ export function PostScreenView({
   const [focusedPost, setFocusedPost] = useState<db.Post | null>(parentPost);
 
   const mode: 'single' | 'carousel' = useMemo(() => {
+    if (!isWindowNarrow) {
+      return 'single';
+    }
+
     // If someone taps a ref to a reply, they drill into the specific reply as
     // a full-screen post. In this case, we always want to show the reply as a
     // `single` post.
@@ -114,7 +119,7 @@ export function PostScreenView({
       return 'single';
     }
     return ['gallery'].includes(channel?.type) ? 'carousel' : 'single';
-  }, [channel, parentPost]);
+  }, [channel, parentPost, isWindowNarrow]);
 
   const showEdit = useMemo(() => {
     // This logic assumes this screen only shows a single post - if we're


### PR DESCRIPTION
Fixes TLON-3791 by adding tap-to-lightbox functionality in the Gallery detail view.

- First and foremost, adds navigation to ImageViewer when an image is pressed
- Memoizes image detection so we can be sure to have the src in hand at all times
- Add fallback image press handling if the navigation fails
- Plenty of logging

In action, with swiping:

https://github.com/user-attachments/assets/4d98e1b1-da3c-4f11-ba4d-4dc50c48b538

