### PR TITLE
embeds: fix issue with opening embed links on web

### DIFF
--- a/packages/app/ui/components/Embed/EmbedWebView.web.tsx
+++ b/packages/app/ui/components/Embed/EmbedWebView.web.tsx
@@ -223,7 +223,7 @@ export const EmbedWebView = memo<EmbedWebViewProps>(
           onError={onIframeError}
           allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture"
           allowFullScreen
-          sandbox="allow-scripts allow-same-origin allow-popups allow-presentation"
+          sandbox="allow-scripts allow-same-origin allow-popups allow-presentation allow-popups-to-escape-sandbox"
         />
       </View>
     );


### PR DESCRIPTION
we need to add a directive that allows the iframe to open new tabs/windows outside of the iframe context (on web, obv).

https://issues.chromium.org/issues/40275209

h/t to jackson for finding this.