### PR TITLE
groups: Add support for blank channel group metadata navigation

### DIFF
--- a/packages/app/features/groups/GroupMetaScreen.tsx
+++ b/packages/app/features/groups/GroupMetaScreen.tsx
@@ -23,7 +23,7 @@ type Props = NativeStackScreenProps<
 };
 
 export function GroupMetaScreen(props: Props) {
-  const { groupId } = props.route.params;
+  const { groupId, fromBlankChannel } = props.route.params;
   const { group, setGroupMetadata, deleteGroup } = useGroupContext({
     groupId,
   });
@@ -34,10 +34,18 @@ export function GroupMetaScreen(props: Props) {
   const handleSubmit = useCallback(
     (data: db.ClientMeta) => {
       setGroupMetadata(data);
-      onPressChatDetails({ type: 'group', id: groupId });
+      
+      // If coming from a blank channel, go back instead of navigating to chat details
+      if (fromBlankChannel) {
+        props.navigation.goBack();
+      } else {
+        // Default behavior - navigate to chat details
+        onPressChatDetails({ type: 'group', id: groupId });
+      }
+      
       store.createGroupInviteLink(groupId);
     },
-    [setGroupMetadata, groupId, onPressChatDetails]
+    [setGroupMetadata, groupId, onPressChatDetails, fromBlankChannel, props.navigation]
   );
 
   const handlePressDelete = useCallback(() => {

--- a/packages/app/hooks/useChatSettingsNavigation.ts
+++ b/packages/app/hooks/useChatSettingsNavigation.ts
@@ -43,8 +43,8 @@ export const useChatSettingsNavigation = () => {
   );
 
   const onPressGroupMeta = useCallback(
-    (groupId: string) => {
-      navigateToGroupSettings('GroupMeta', { groupId });
+    (groupId: string, fromBlankChannel?: boolean) => {
+      navigateToGroupSettings('GroupMeta', { groupId, fromBlankChannel });
     },
     [navigateToGroupSettings]
   );

--- a/packages/app/navigation/types.ts
+++ b/packages/app/navigation/types.ts
@@ -165,6 +165,7 @@ export type GroupSettingsStackParamList = {
   };
   GroupMeta: {
     groupId: string;
+    fromBlankChannel?: boolean;
   };
   GroupMembers: {
     groupId: string;

--- a/packages/app/ui/components/Channel/EmptyChannelNotice.tsx
+++ b/packages/app/ui/components/Channel/EmptyChannelNotice.tsx
@@ -36,7 +36,7 @@ export function EmptyChannelNotice({
         aspectRatio={911 / 755}
       />
       <YStack gap="$m" width={'100%'}>
-        <Button secondary onPress={onPressGroupMeta}>
+        <Button secondary onPress={() => onPressGroupMeta(true)}>
           <Icon type="Settings" size="$m" color="$secondaryText" />
           <Button.Text>Customize</Button.Text>
         </Button>

--- a/packages/app/ui/contexts/chatOptions.tsx
+++ b/packages/app/ui/contexts/chatOptions.tsx
@@ -23,7 +23,7 @@ export type ChatOptionsContextValue = {
   channel?: db.Channel | null;
   markGroupRead: () => void;
   markChannelRead: () => void;
-  onPressGroupMeta: () => void;
+  onPressGroupMeta: (fromBlankChannel?: boolean) => void;
   onPressGroupMembers: () => void;
   onPressManageChannels: () => void;
   onPressInvite?: () => void;
@@ -56,7 +56,7 @@ type ChatOptionsProviderProps = {
   children: ReactNode;
   useChannel?: typeof store.useChannel;
   useGroup?: typeof store.useGroup;
-  onPressGroupMeta: (groupId: string) => void;
+  onPressGroupMeta: (groupId: string, fromBlankChannel?: boolean) => void;
   onPressGroupMembers: (groupId: string) => void;
   onPressManageChannels: (groupId: string) => void;
   onPressInvite?: (groupId: string) => void;
@@ -250,9 +250,9 @@ export const ChatOptionsProvider = ({
     }
   }, [channelId, closeSheet, onPressChannelMeta]);
 
-  const handlePressGroupMeta = useCallback(() => {
+  const handlePressGroupMeta = useCallback((fromBlankChannel?: boolean) => {
     if (groupId) {
-      onPressGroupMeta?.(groupId);
+      onPressGroupMeta?.(groupId, fromBlankChannel);
       closeSheet();
     }
   }, [closeSheet, groupId, onPressGroupMeta]);


### PR DESCRIPTION
Fixes TLON-3794. Updates the GroupSettingsStackParamList type to include an optional fromBlankChannel parameter in the GroupMeta route. GroupMetaScreen now checks for this parameter and handles the navigation differently.

Also updates the useChatSettingsNavigation and ChatOptionsContext to accept the fromBlankChannel parameter. Finally, changes EmptyChannelNotice to pass true when the user taps the Customize button.

Therefore, when a user taps the "Customize" button in a new, blank channel:

1. We'll pass fromBlankChannel=true through the navigation stack
2. When they press "Save", the GroupMetaScreen will detect that fromBlankChannel is true
3. It will go back to the previous screen (the blank channel) instead of navigating to the group settings screen

Desktop behavior is unchanged.