### PR TITLE
embeds: use ContentRenderer to render fallback links in EmbedContent

### DIFF
--- a/packages/app/ui/components/Embed/EmbedContent.tsx
+++ b/packages/app/ui/components/Embed/EmbedContent.tsx
@@ -1,10 +1,12 @@
 import { useEmbed, utils, validOembedCheck } from '@tloncorp/shared';
+import { Text } from '@tloncorp/ui';
 import { memo, useCallback, useMemo } from 'react';
 import { Linking, Platform } from 'react-native';
-import { Text } from 'tamagui';
 
 import { useCalm } from '../../contexts';
 import { AudioEmbed } from '../Embed';
+import { createContentRenderer } from '../PostContent';
+import { InlineLink } from '../PostContent/InlineRenderer';
 import { Embed } from './Embed';
 import { EmbedWebView } from './EmbedWebView';
 import { getProviderConfig } from './providers';
@@ -27,6 +29,12 @@ export const trustedProviders = [
     regex: /^https:\/\/www\.tiktok\.com\//,
   },
 ];
+
+const ContentRenderer = createContentRenderer({
+  inlineRenderers: {
+    link: InlineLink,
+  },
+});
 
 interface GenericEmbedProps {
   provider: string;
@@ -157,21 +165,29 @@ const EmbedContent = memo(function EmbedContent({
       }
 
       return (
-        <Text
-          onPress={openLink}
-          textDecorationLine="underline"
-          cursor="pointer"
-        >
-          {content || url}
-        </Text>
+        <ContentRenderer
+          padding={0}
+          margin="$-l"
+          content={[
+            {
+              type: 'paragraph',
+              content: [{ type: 'link', text: content ?? '', href: url }],
+            },
+          ]}
+        />
       );
     }
   }
 
   return (
-    <Text textDecorationLine="underline" cursor="pointer" onPress={openLink}>
-      {content || url}
-    </Text>
+    <ContentRenderer
+      content={[
+        {
+          type: 'paragraph',
+          content: [{ type: 'link', text: content ?? '', href: url }],
+        },
+      ]}
+    />
   );
 });
 


### PR DESCRIPTION
Our fallback links were rendering with tiny text. This didn't matter when twitter was working, but now we're seeing twitter return failing SSL certs (they seem to be having trouble), so we're seeing the fallback links a lot.