### PR TITLE
calm: disable avatars should not turn off group icons

### DIFF
--- a/packages/app/features/top/ContactsScreen.tsx
+++ b/packages/app/features/top/ContactsScreen.tsx
@@ -30,6 +30,7 @@ export default function ContactsScreen(props: Props) {
   const { data: userContacts } = store.useUserContacts();
   const { data: contacts } = store.useContacts();
   const { data: suggestions } = store.useSuggestedContacts();
+  const { data: calmSettings } = store.useCalmSettings({ userId: currentUser });
 
   const onContactPress = useCallback(
     (contact: db.Contact) => {
@@ -64,7 +65,11 @@ export default function ContactsScreen(props: Props) {
   }, []);
 
   return (
-    <AppDataContextProvider contacts={contacts} currentUserId={currentUser}>
+    <AppDataContextProvider
+      contacts={contacts}
+      currentUserId={currentUser}
+      calmSettings={calmSettings}
+    >
       <View backgroundColor={theme?.background?.val} flex={1} height="100%">
         <View flex={1} width="100%" maxWidth={600} marginHorizontal="auto">
           <ScreenHeader

--- a/packages/app/features/top/UserProfileScreen.tsx
+++ b/packages/app/features/top/UserProfileScreen.tsx
@@ -33,6 +33,9 @@ export function UserProfileScreen({ route, navigation }: Props) {
   const userId = params?.userId || currentUserId;
   const { data: contacts } = store.useContacts();
   const connectionStatus = useConnectionStatus(userId);
+  const { data: calmSettings } = store.useCalmSettings({
+    userId: currentUserId,
+  });
   const [selectedGroup, setSelectedGroup] = useState<db.Group | null>(null);
   const { resetToDm } = useRootNavigation();
 
@@ -81,6 +84,7 @@ export function UserProfileScreen({ route, navigation }: Props) {
     <AppDataContextProvider
       currentUserId={currentUserId}
       contacts={contacts ?? []}
+      calmSettings={calmSettings}
     >
       <NavigationProvider onPressGoToDm={handleGoToDm}>
         <AttachmentProvider

--- a/packages/app/ui/components/Avatar.tsx
+++ b/packages/app/ui/components/Avatar.tsx
@@ -73,22 +73,26 @@ const AvatarFrame = styled(View, {
 
 export type AvatarProps = ComponentProps<typeof AvatarFrame> & {
   ignoreCalm?: boolean;
+  isGroupIcon?: boolean;
 };
 
-export const ContactAvatar = React.memo(function ContactAvatComponent({
+export const ContactAvatar = React.memo(function ContactAvatarComponent({
   contactId,
   contactOverride,
   overrideUrl,
   innerSigilSize,
+  ignoreCalm = false,
   ...props
 }: {
   contactId: string;
   contactOverride?: db.Contact;
   overrideUrl?: string;
   innerSigilSize?: number;
-} & AvatarProps) {
+  ignoreCalm?: boolean;
+} & Omit<AvatarProps, 'ignoreCalm'>) {
   const dbContact = useContact(contactId);
   const contact = contactOverride ?? dbContact;
+
   return (
     <ImageAvatar
       imageUrl={overrideUrl ?? contact?.avatarImage ?? undefined}
@@ -100,6 +104,7 @@ export const ContactAvatar = React.memo(function ContactAvatComponent({
           {...props}
         />
       }
+      ignoreCalm={ignoreCalm}
       {...props}
     />
   );
@@ -132,6 +137,7 @@ export const GroupAvatar = React.memo(function GroupAvatarComponent({
     <ImageAvatar
       imageUrl={model.iconImage ?? undefined}
       fallback={fallback}
+      isGroupIcon={true}
       {...props}
     />
   );
@@ -178,6 +184,7 @@ export const ChannelAvatar = React.memo(function ChannelAvatarComponent({
       <ImageAvatar
         imageUrl={model.iconImage ?? model.group?.iconImage ?? undefined}
         fallback={fallback}
+        isGroupIcon={true}
         {...props}
       />
     );
@@ -230,11 +237,15 @@ export const SystemIconAvatar = React.memo(function SystemIconAvatarComponent({
 export const ImageAvatar = function ImageAvatarComponent({
   imageUrl,
   fallback,
+  isGroupIcon = false,
+  ignoreCalm = false,
   ...props
 }: {
   imageUrl?: string;
   fallback?: React.ReactNode;
-} & AvatarProps) {
+  isGroupIcon?: boolean;
+  ignoreCalm?: boolean;
+} & Omit<AvatarProps, 'ignoreCalm'>) {
   const calmSettings = useCalm();
   const [loadFailed, setLoadFailed] = useState(false);
   const [isLoading, setIsLoading] = useState(true);
@@ -245,10 +256,13 @@ export const ImageAvatar = function ImageAvatarComponent({
   // TODO: figure out how to sanitize svgs so we can support svg avatars
   const isSVG = imageUrl?.endsWith('.svg');
 
+  const shouldShowImage =
+    isGroupIcon || ignoreCalm || !calmSettings.disableAvatars;
+
   return imageUrl &&
     imageUrl !== '' &&
     !isSVG &&
-    (props.ignoreCalm || !calmSettings.disableAvatars) &&
+    shouldShowImage &&
     !loadFailed ? (
     <AvatarFrame
       key={imageUrl}


### PR DESCRIPTION
Fixes TLON-3792 by explicitly always showing image avatars for group icons. This way, the user can turn off user avatars and still see group icons. Adds an optional prop so we can explicitly ignore calm settings for other icons in the future, should we need it.

Furthermore, I noticed that contact and profile avatars were not affected by calm settings, so I made sure the AppDataContextProvider had the user's calm settings injected.

Tested on iOS simulator and web-new development.