### PR TITLE
channelUtils: return actual userID from getChannelMemberName

### DIFF
--- a/packages/app/ui/utils/channelUtils.tsx
+++ b/packages/app/ui/utils/channelUtils.tsx
@@ -12,7 +12,7 @@ export function getChannelMemberName(
   disableNicknames: boolean
 ) {
   if (disableNicknames) {
-    return formatUserId(member.contactId);
+    return formatUserId(member.contactId)?.display;
   }
   return member.contact?.nickname
     ? member.contact.nickname


### PR DESCRIPTION
Fixes TLON-3799 by returning display name from getChannelMemberName in cases where the user has disabled user-set nicknames, rather than the entire object.

End result:

<img width="448" alt="Screenshot 2025-03-12 at 12 12 44 PM" src="https://github.com/user-attachments/assets/1de6e9f8-069f-4d51-b8c9-9f8a6747bb17" />
<img width="457" alt="Screenshot 2025-03-12 at 12 12 48 PM" src="https://github.com/user-attachments/assets/aa735550-715a-4c28-b207-977381b35db7" />
