### PR TITLE
channel: fix mark read on desktop

### DIFF
--- a/packages/app/ui/components/Channel/Scroller.tsx
+++ b/packages/app/ui/components/Channel/Scroller.tsx
@@ -169,8 +169,6 @@ const Scroller = forwardRef(
       return Math.floor((availableSpace - totalGap) / columns);
     }, [availableSpace, columns]);
 
-    console.log({ availableSpace, columns, itemWidth });
-
     const [hasPressedGoToBottom, setHasPressedGoToBottom] = useState(false);
     const [viewReactionsPost, setViewReactionsPost] = useState<null | db.Post>(
       null

--- a/packages/app/ui/components/Channel/index.tsx
+++ b/packages/app/ui/components/Channel/index.tsx
@@ -1,3 +1,4 @@
+import { useIsFocused } from '@react-navigation/native';
 import {
   DraftInputId,
   isChatChannel as getIsChatChannel,
@@ -177,12 +178,13 @@ export const Channel = forwardRef<ChannelMethods, ChannelProps>(
     );
     const { attachAssets } = useAttachmentContext();
 
+    const inView = useIsFocused();
     const hasLoaded = !!(posts && channel);
     useEffect(() => {
-      if (hasLoaded) {
+      if (hasLoaded && inView) {
         markRead();
       }
-    }, [hasLoaded, markRead]);
+    }, [hasLoaded, inView, markRead]);
 
     const handleRefPress = useCallback(
       (refChannel: db.Channel, post: db.Post) => {


### PR DESCRIPTION
We weren't accounting for the fact that we're rendering in a stack which means if we load a channel once and then navigate to a different one, that original channel render is still in memory. When we come back to it, the `hasLoaded` flag is still true, so we don't actually mark read. This adds a flag for `isFocused` so we know if this channel comes to focus and can mark read appropriately.