### PR TITLE
e2e: DMs

### DIFF
--- a/.maestro/52-DM.yaml
+++ b/.maestro/52-DM.yaml
@@ -129,6 +129,10 @@ appId: io.tlon.groups
       - tapOn: 'Delete message'
 - assertNotVisible: 'Delete this message '
 # Leave the DM from the Home screen
+# For some reason, this is not working with the first tap;
+# it works with the second tap.
+- tapOn:
+    id: 'HeaderBackButton'
 - tapOn:
     id: 'HeaderBackButton'
 - longPressOn: '~zod'
@@ -138,8 +142,9 @@ appId: io.tlon.groups
 - tapOn: 'Leave chat'
 - tapOn: 'Leave'
 - assertNotVisible: '~zod'
-# # Leave the DM from within the DM
-# # TODO: This is supposed to navigate you back to the Home screen
+# Leave the DM from within the DM
+# TODO: This is supposed to navigate you back to the Home screen,
+# but we have a bug that causes navigation to fail.
 # - tapOn:
 #     id: 'ChannelHeaderOverflowMenuButton'
 # - assertVisible: 'Leave chat'

--- a/.maestro/52-DM.yaml
+++ b/.maestro/52-DM.yaml
@@ -1,0 +1,147 @@
+appId: io.tlon.groups
+---
+- runFlow: subflows/launch.yaml
+- runFlow: subflows/tlon-login.yaml
+- assertVisible: 'Home'
+# Tap on the "+" button
+- tapOn:
+    id: 'CreateGroupButton'
+# Assert that the sheet pops
+- assertVisible: 'Create a new chat with one other person.'
+- tapOn: 'New direct message'
+# Assert that the contacts sheet pops
+- assertVisible: 'Select a contact to chat with'
+# Select a contact and start the DM
+- tapOn: 'Filter by nickname or id'
+- inputText: '~zod'
+- hideKeyboard
+- tapOn:
+    id: 'ContactRow'
+    index: 0
+- runFlow:
+    when:
+      visible: '~zod'
+    commands:
+      - assertVisible:
+          id: 'HeaderBackButton'
+# Insert some text into the DM and send it
+- tapOn: 'Message'
+- inputText: 'Hello, ~zod!'
+- 'hideKeyboard'
+- tapOn:
+    id: 'MessageInputSendButton'
+- runFlow:
+    when:
+      visible: '.*Hello, ~zod!.*'
+    commands:
+      - assertVisible: '.*Hello, ~zod!.*'
+# Navigate back to the Home screen and assert that the message preview is visible
+- tapOn:
+    id: 'HeaderBackButton'
+- runFlow:
+    when:
+      visible: 'Home'
+    commands:
+      - assertVisible: '.*Hello, ~zod!.*'
+# Navigate back into the DM
+- tapOn: '~zod'
+# Long-press the message and select "Start thread"
+- longPressOn: 'Hello, ~zod! '
+- tapOn: 'Start thread'
+- runFlow:
+    when:
+      visible: 'Thread:.*'
+    commands:
+      - assertVisible: '.*Hello, ~zod!.*'
+# Insert some text into the thread and send it
+- tapOn: 'Reply'
+- inputText: 'Thread reply'
+- 'hideKeyboard'
+- tapOn:
+    id: 'MessageInputSendButton'
+- runFlow:
+    when:
+      visible: '.*Thread reply.*'
+    commands:
+      - assertVisible: '.*Thread reply.*'
+# Navigate back into the channel and assert that the reply row is visible
+- tapOn:
+    id: 'HeaderBackButton'
+- assertVisible: '1 reply'
+# Long-press the message and react with a thumb emoji
+- longPressOn: 'Hello, ~zod! '
+- tapOn:
+    id: 'EmojiToolbarButton-thumb'
+- runFlow:
+    when:
+      visible: '.*👍.*'
+    commands:
+      - assertVisible: '.*👍.*'
+# Un-react to the message
+- tapOn:
+    id: 'ReactionDisplay'
+- assertNotVisible: '.*👍.*'
+# Quote-reply to a message using the simple reply
+- longPressOn: 'Hello, ~zod! '
+- tapOn: 'Reply'
+- assertVisible: '> Hello, ~zod!.*'
+- tapOn:
+    text: '> Hello, ~zod!.*'
+- pressKey: 'Enter'
+- inputText: 'Quote reply'
+- 'hideKeyboard'
+- tapOn:
+    id: 'MessageInputSendButton'
+- runFlow:
+    when:
+      visible:
+        text: '.*Quote reply.*'
+    commands:
+      - assertVisible:
+          text: '.*Quote reply.*'
+          below: '.*Hello, ~zod!.*'
+# Send a message and hide it
+- tapOn: 'Message'
+- inputText: 'Hide this message'
+- 'hideKeyboard'
+- tapOn:
+    id: 'MessageInputSendButton'
+- runFlow:
+    when:
+      visible: 'Hide this message '
+    commands:
+      - longPressOn:
+          text: 'Hide this message '
+      - tapOn: 'Hide message'
+- assertNotVisible: 'Hide this message '
+# Send a message and delete it
+- tapOn: 'Message'
+- inputText: 'Delete this message'
+- 'hideKeyboard'
+- tapOn:
+    id: 'MessageInputSendButton'
+- runFlow:
+    when:
+      visible: 'Delete this message '
+    commands:
+      - longPressOn:
+          text: 'Delete this message '
+      - tapOn: 'Delete message'
+- assertNotVisible: 'Delete this message '
+# Leave the DM from the Home screen
+- tapOn:
+    id: 'HeaderBackButton'
+- longPressOn: '~zod'
+- waitForAnimationToEnd:
+    timeout: 5000
+- assertVisible: 'Leave chat'
+- tapOn: 'Leave chat'
+- tapOn: 'Leave'
+- assertNotVisible: '~zod'
+# # Leave the DM from within the DM
+# # TODO: This is supposed to navigate you back to the Home screen
+# - tapOn:
+#     id: 'ChannelHeaderOverflowMenuButton'
+# - assertVisible: 'Leave chat'
+# - tapOn: 'Leave chat'
+# - tapOn: 'Leave'

--- a/packages/app/ui/components/ContactBook.tsx
+++ b/packages/app/ui/components/ContactBook.tsx
@@ -116,7 +116,6 @@ export function ContactBook({
           selected={isSelected}
           onPress={handleSelect}
           pressStyle={{ backgroundColor: '$shadow' }}
-          testID="ContactRow"
         />
       );
     },

--- a/packages/app/ui/components/ContactRow.tsx
+++ b/packages/app/ui/components/ContactRow.tsx
@@ -42,6 +42,7 @@ function ContactRowItemRaw({
       pressStyle={pressStyle}
       borderRadius="$xl"
       onPress={handlePress(contact.id)}
+      testID="ContactRow"
     >
       <ListItem {...rest}>
         <ListItem.ContactIcon contactId={contact.id} />


### PR DESCRIPTION
Adds a Maestro test that:

- Taps on the "+" button
- Asserts that the new message sheet pops
- Selects starting a new DM
- Asserts that the contacts sheet pops
- Selects a contact and starts the DM
- Inserts some text into the DM and sends it
- Navigates back to the Home screen and asserts that the message preview is visible
- Navigates back into the DM
- Long-presses the message and selects "Start thread"
- Inserts some text into the thread and sends it
- Navigates back into the channel and asserts that the reply row is visible
- Long-presses the message and reacts with a thumb emoji
- Un-reacts to the message
- Quote-replies to a message using the simple reply
- Sends a message and hides it
- Sends a message and deletes it
- Leaves the DM from the Home screen

Note that we are supposed to be able to leave a DM from the DM itself using the "..." overflow menu, but we have a bug preventing that.