### PR TITLE
ops: bump node engine

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
     "vitest": "^1.2.2"
   },
   "engines": {
-    "node": ">=18.18.0"
+    "node": ">=20.11.0"
   },
   "packageManager": "pnpm@9.0.5+sha256.61bd66913b52012107ec25a6ee4d6a161021ab99e04f6acee3aa50d0e34b4af9",
   "pnpm": {


### PR DESCRIPTION
Seems like Expo builds are failing because some of the new Electron deps expect Node 20+. 

After bumping the `package.json` engine, re-installing and building locally still works fine.