### PR TITLE
electron: fix activity foreign key constraint issue

### DIFF
--- a/apps/tlon-desktop/electron-store-wrapper.cjs
+++ b/apps/tlon-desktop/electron-store-wrapper.cjs
@@ -83,13 +83,6 @@ module.exports = {
       const store = await initStore();
       if (!store) return null;
       const value = store.get(key);
-      if (key === 'encryptionKey' || key === 'encryptedAuthCookie') {
-        console.log(
-          `Reading ${key} from store: ${value ? 'exists' : 'missing'}`
-        );
-      } else {
-        console.log(`Reading ${key} from store:`, value);
-      }
       return value;
     } catch (error) {
       console.error(`Error getting ${key} from store:`, error);

--- a/apps/tlon-desktop/src/main/sqlite-service.ts
+++ b/apps/tlon-desktop/src/main/sqlite-service.ts
@@ -34,6 +34,7 @@ class SQLiteService {
       this.db.pragma('synchronous = NORMAL');
       this.db.pragma('temp_store = MEMORY');
       this.db.pragma('mmap_size = 268435456'); // 256MB mmap
+      this.db.pragma('foreign_keys = false'); // this matches the default behavior of SQLite (foreign keys are off in both the web and mobile implementations of SQLite that we're using)
 
       // Set up change notification function
       this.db.function('notifyChanges', (changeData: string) => {

--- a/packages/app/lib/electronDb.ts
+++ b/packages/app/lib/electronDb.ts
@@ -99,7 +99,7 @@ export class ElectronDb extends BaseDb {
           handleChange({
             table: changeData.table,
             operation: changeData.operation,
-            row: JSON.parse(changeData.data || '{}'),
+            row: changeData.data,
           });
         } catch (e) {
           logger.error('Failed to process change:', e);

--- a/packages/shared/src/db/changeListener.ts
+++ b/packages/shared/src/db/changeListener.ts
@@ -1,4 +1,7 @@
 import { queryClient } from '../api';
+import { createDevLogger } from '../debug';
+
+const logger = createDevLogger('db:changeListener', false);
 
 let postEvents: Record<string, string[]> = {};
 
@@ -29,6 +32,7 @@ export function handleChange({
    * keys (`id`, `channel_id`, 'group_id`, etc.) */
   row?: any;
 }) {
+  logger.log('handleChange, Received change', { table, operation, row });
   // If a post is updated, we need to refetch the post. If it's a new post, we
   // no-op because there's no query to invalidate.
   if (table === 'posts' && row && !row.parent_id && operation !== 'INSERT') {
@@ -44,6 +48,7 @@ export function handleChange({
   // We count updates to a post's reaction as post updates so that they trigger
   // channel refresh.
   if (table === 'post_reactions' && row) {
+    logger.log('handleChange, Received post reaction change:', row);
     queryClient.refetchQueries({
       queryKey: ['post', row.post_id],
     });


### PR DESCRIPTION
We were unable to insert rows into the `activity` table on desktop because better-sqlite3 enforces foreign key constraints by default (our other sqlite implementations don't) and we use a composite primary key in `activity` that we don't properly reference in `activity_events_contact_group_pins`.

Simplest solution here is just to match the other sqlite implementations (this is the default for sqlite in general) and disable the strict fk enforcement.

This PR also fixes an issue with changes not making it into the `handleChange` function on desktop (we were trying to parse a string that was actually already JSON into JSON) and removes some debug logging from the electron-store-wrapper that I had put in earlier.

More on the foreign keys: https://www.sqlite.org/pragma.html#pragma_foreign_keys