### PR TITLE
Activity: Sync bell across clients

### DIFF
--- a/apps/tlon-mobile/ios/Podfile.lock
+++ b/apps/tlon-mobile/ios/Podfile.lock
@@ -1767,40 +1767,40 @@ SPEC CHECKSUMS:
   boost: d3f49c53809116a5d38da093a8aa78bf551aed09
   BranchSDK: cb046c2714b03e573484ce9e349e2ddbad7016e8
   DoubleConversion: fea03f2699887d960129cc54bba7e52542b6f953
-  EASClient: a42ee8bf36c93b3128352faf2ae49405ab4f80bd
-  EXApplication: 16bcea16789221bd566e64b5ea2608cf7756b005
-  EXAV: e4f6137431ddc4cb025895046bfefa9612025c35
-  EXConstants: a5f6276e565d98f9eb4280f81241fc342d641590
-  EXFont: f20669cb266ef48b004f1eb1f2b20db96cd1df9f
-  EXImageLoader: 55080616b2fe9da19ef8c7f706afd9814e279b6b
+  EASClient: 45d2459af3eb8a0283b50d3de38af7ac9930d747
+  EXApplication: d62cd534090692cbf538ea15f69f829b517a40b1
+  EXAV: e160fec51bf6bc41c3b6f7e4c72ea9fd36860cd6
+  EXConstants: c82ef9280044accc91fb6082047afdc9a408f61a
+  EXFont: 64e653a110eee050ad80dfcd676c4bada0a1ff92
+  EXImageLoader: ba2506b443b9656e93167c104406a2c265924823
   EXJSONUtils: 5c42959e87be238b045ef37cc5268b16a6c0ad4a
-  EXManifests: 5e8c29f36c716af768a4ea47ec05e1b89ab93091
-  EXMediaLibrary: 70cf1fb7028fda2d682090c9fe57568674e4abab
-  EXNotifications: e254c0fa11337e15b30c200e91437b521f682bad
-  Expo: 7b9976a9b2be116a701b233d6655b229a3c9316e
-  expo-dev-client: f22fdebdb8760bc22f660b7c0cb1dd58d80005c0
-  expo-dev-launcher: 11c184a2dca65f9bd6dc575a73a554b7be589d1d
-  expo-dev-menu: 68ea53d923996e27b20ce02b51cc820fc2327a83
-  expo-dev-menu-interface: 7ba029c9d1a82ac22b9b584c00514860b060553e
-  ExpoBackgroundFetch: 80d41ec15c6cce0bafb5d2326b8e85f42152eba7
-  ExpoBattery: 60bf880aea8f769fe39f709a920442542c1bfd62
-  ExpoBlur: e832d874bd94afc0645daddbd3162ec1ce172080
-  ExpoClipboard: b597982124f067ff9f5b89093eb3d97898d5d877
-  ExpoDevice: 97307196d8cab694e245752b8a7afacc35c14e03
-  ExpoFileSystem: 74cc0fae916f9f044248433971dcfc8c3befd057
-  ExpoHaptics: 28a771b630353cd6e8dcf1b1e3e693e38ad7c3c3
-  ExpoImage: 8cf2d51de3d03b7e984e9b0ba8f19c0c22057001
-  ExpoImageManipulator: c1d7cb865eacd620a35659f3da34c70531f10b59
-  ExpoImagePicker: 66970181d1c838f444e5e1f81b804ab2d5ff49bd
-  ExpoKeepAwake: 0f5cad99603a3268e50af9a6eb8b76d0d9ac956c
-  ExpoLinearGradient: 4ad1449a2408e0435ac959076562b3921f2e32a1
-  ExpoLocalization: f94759e55802e4a4f8b7d7cecb450de11b888721
-  ExpoModulesCore: 0f9e3c49657f681cd06219d97c77c3108a67ca00
-  ExpoSecureStore: c84ae37d1c36f38524d289c67c3a2e3fc56f1108
-  EXSplashScreen: 0fabdcf746d29e7f8b8969879cb09125cdd365d2
+  EXManifests: 429136cffa3ae82d1ba3b60b7243fb186615562e
+  EXMediaLibrary: d3bf5c458643f9821b96af328d399ef3f44de7db
+  EXNotifications: 9fd42ca3c5998ae93a2ac869ed9a47467c433219
+  Expo: 1b33cb8ab60cff9abf805ed6020af3d1846e457c
+  expo-dev-client: 775a683302570193a7ba71032d0b1b82f6ad1454
+  expo-dev-launcher: acd5b1e03e649e96675c85314a9d8745f23648d1
+  expo-dev-menu: 2b4ce6108396233849b71805906129de15aadfbc
+  expo-dev-menu-interface: 44e69ddff62bbc6c5418c200e657635720b5a480
+  ExpoBackgroundFetch: 466154f27b511cb3c369709dd4b3f152c785b26e
+  ExpoBattery: 6cdcb673b99f53b3e9955b03268fd571cff68f51
+  ExpoBlur: 3a9548a738624968836926f4aa1e18fa22155640
+  ExpoClipboard: 24cc2b881ab6ca2e5b431b1f6d9d4a302adbf9d0
+  ExpoDevice: fc21b9193d704f3759c1ede1b383fcdb0370b46a
+  ExpoFileSystem: df58e1eb2a4d6f1006a1ca70bddfbbf63e52fa4f
+  ExpoHaptics: c91902e436f3fb0e07aa19acc118018089fa90de
+  ExpoImage: a70db90f39a7af98930cef91c84e877b1131f3dd
+  ExpoImageManipulator: 0c2ada7a028619ea1cc0c670bfa90c8ebeaa4af4
+  ExpoImagePicker: d06822d74f1f0e7fe7cb070ece0fff6e678fa3eb
+  ExpoKeepAwake: 3b8cf8533b9212500565a1e41fb080fc5af29918
+  ExpoLinearGradient: 501f9bbd83f3ec1d0e0425862b9ef4693605fc1c
+  ExpoLocalization: 7423aa1abcc59209dc2ce2b9bb63776a18023a98
+  ExpoModulesCore: bc9f47045cd97b741444e335880d65c681d39007
+  ExpoSecureStore: 4cec57fd2c40dcff05ce2186c39afc1af39d213c
+  EXSplashScreen: 32c0a1ee2e9b416a5fb8ba41419bd040868e5dfe
   EXStructuredHeaders: 5b0f47259db047dc1fdfa84752e292c2bfa68ecd
-  EXTaskManager: 07d427a5213dd275c13b6b6c07bba35a672e6698
-  EXUpdates: 40e069f2987861a6d39101c4496e816561f3e167
+  EXTaskManager: 8c5683c2fb543cf2baa77bab4ad130b7e3829c4a
+  EXUpdates: 8cc7407328c3852e3ce890a381fe0022ae71902b
   EXUpdatesInterface: 3e444e2093e25b7ca0999a7d8c16e8392dee70c3
   FBLazyVector: 98c189b92292d4bfeac13ffa8df3ce3d84e2fc5b
   FBReactNativeSpec: f40d89f4be3e854b08cf9b66cba9e9d6c68d863d
@@ -1827,82 +1827,82 @@ SPEC CHECKSUMS:
   libvmaf: 27f523f1e63c694d14d534cd0fddd2fab0ae8711
   libwebp: 1786c9f4ff8a279e4dac1e8f385004d5fc253009
   nanopb: 438bc412db1928dac798aa6fd75726007be04262
-  op-sqlite: 1aa4e1b456cff23410a28be65820d0c8bc74fb04
+  op-sqlite: 556313532c972dd2e5452f44efabffd9641b0e26
   PromisesObjC: f5707f49cb48b9636751c5b2e7d227e43fba9f47
   PromisesSwift: 9d77319bbe72ebf6d872900551f7eeba9bce2851
-  RCT-Folly: 7169b2b1c44399c76a47b5deaaba715eeeb476c0
+  RCT-Folly: cd21f1661364f975ae76b3308167ad66b09f53f5
   RCTRequired: d362a61864a64315aee00faea8dee6cf5b3f4aad
   RCTTypeSafety: 09baf60faeab02492dc8bf04ce5af1dda645b86d
   ReachabilitySwift: 7f151ff156cea1481a8411701195ac6a984f4979
   React: b87c7c7c12f8232bd7cfdc4a00bf687144c17e30
   React-callinvoker: 67de0bc05ecb7e690345a53a1661cea9b24670b0
-  React-Codegen: dd60c11cfeb20cdd8b5a787603346d4e04f95499
-  React-Core: 4c87a1873c6d11c6d3843582fbc266ba9ea304ce
-  React-CoreModules: 29ad1cbe757a70575913457bb7c646b7f4d4edf0
-  React-cxxreact: 08ffaf2def6fe1ec8ef7f16e208587c96a87978e
+  React-Codegen: e81f008b53f3db74336a4324ea2b1ca15d7fe2da
+  React-Core: 4cb660fe310d6ee6d1e87308c2bec1541e1a40b4
+  React-CoreModules: 12f9b33b8e1c67324be550e3c2ef1a03fa1aa473
+  React-cxxreact: 4abb46b2ce1fa4eabe1105be8df331fc2dca9706
   React-debug: 30d97e8abfec9b6ba0ad111b92ac749d3ace2dd5
-  React-Fabric: 8da8e4c0ed603fbed5208f5045cd1582a96ffa3d
-  React-FabricImage: f0cf2b8a823e98dae20013910bbdd0889bc719c2
-  React-graphics: 6dc8dba8a095a962204dd8bd4ca8264a1ed718db
-  React-hermes: fdaab14cc289d8d9cd45ffd9a3f8aa11157d4c7e
-  React-ImageManager: 4a39d60f9163fce83474c2b79acec8336742983d
-  React-jserrorhandler: 81e19a227a75741456c8f7b1240fc8926fb48c7e
-  React-jsi: 2253621cb2fb5d43a78fec4db8989cf9711039df
-  React-jsiexecutor: 5e4620a87fbc4ab174d75220f06ba8b53ae8317b
+  React-Fabric: 93d15dfd53ea0a8ece4d4bc399924571c1ab2d1c
+  React-FabricImage: 3e7fa7e5bd260008741e60f7ca4f8d5417b5fa7f
+  React-graphics: fe19a38958a23f951ef36613a34a6e867a6ef8f9
+  React-hermes: 1f47d1f8b218565fd980eb00121d40e0ba2edcea
+  React-ImageManager: 941a294408b8a35cf929cf38d74deb83522c4556
+  React-jserrorhandler: c06aabbbcd49aad9ddaa360b1fedaa7a4a0e820e
+  React-jsi: 0422dc0b680234b3eabee952c20e23ca63e10b3d
+  React-jsiexecutor: a61443a46b9616f17142d8f63d2e788f9b634be6
   React-jsinspector: aee04d04ef553d5e30e52a4de2af958cb060069f
-  React-logger: 87a4232dd55485435edfa6803ff0de0b5c9eea1a
-  React-Mapbuffer: 94db5977cd64330f9e715c19026c9a267d8358a5
-  react-native-branch: 021b9c261f732d0950e9a304284779d48bf81109
-  react-native-context-menu-view: dcec18eb8882e20596dbb75802e7d19cb87dac02
-  react-native-cookies: f54fcded06bb0cda05c11d86788020b43528a26c
-  react-native-get-random-values: 21325b2244dfa6b58878f51f9aa42821e7ba3d06
-  react-native-netinfo: 3aa5637c18834966e0c932de8ae1ae56fea20a97
-  react-native-safe-area-context: b97eb6f9e3b7f437806c2ce5983f479f8eb5de4b
-  react-native-webview: ad868affda04ff2b204de83546193bc0325a8280
+  React-logger: ef76a6d8e04672f19be9b3a49f6ecc4c7141399b
+  React-Mapbuffer: 30deaceab523707646f5f35efad961133e4e1f25
+  react-native-branch: 5d4ecda7bae040542f6c9f651a05d3df23d8b35a
+  react-native-context-menu-view: c7477ad2a9b5005eb45dd168c2dcdd64526dba77
+  react-native-cookies: d648ab7025833b977c0b19e142503034f5f29411
+  react-native-get-random-values: d16467cf726c618e9c7a8c3c39c31faa2244bbba
+  react-native-netinfo: 5364263f903da576bdef9c84a76fe243ab06812c
+  react-native-safe-area-context: 435f4c13ac75ceed6135382ee77d57d1a5b5b2d6
+  react-native-webview: dc76301066fed23a66b1198f990056d2f8c67d20
   React-nativeconfig: 44cd3076b158c39cb6758f238cd3e65953e989c0
-  React-NativeModulesApple: af58ca346cf42c3bb4dab9173b6edd0c83c2a21c
+  React-NativeModulesApple: d8f0d34218e897ff56525e4446ba4d5e8f74f9c8
   React-perflogger: c93b6a895eca3f9196656bb20ce0e15ad597a4e9
   React-RCTActionSheet: 258842f426709dccbc2af31ca42b0a1807d76ad7
-  React-RCTAnimation: 78c40269e35864f541b7486d17bd82a353c99fbc
-  React-RCTAppDelegate: d98ec2cdfb161d7a8496990e9649f94018025922
-  React-RCTBlob: 593a5dbc58c45e3cccc37ad4498b10766ace26e6
-  React-RCTFabric: c589babe0224cb137f64bfa4770e92d752c18012
-  React-RCTImage: a0cdbb81db012ebc42c7dbaabdcb15f488c7c391
-  React-RCTLinking: 82b6b0a5b2d5c8d3a28997e70bda46bac4be4c6e
-  React-RCTNetwork: 45e30079bcb987724028c9a93c0110b6d82e4a1f
-  React-RCTSettings: e67cbe694fe45b080b96b1394d4e45dff1b3ae04
-  React-RCTText: 14a54686a1fa0b51b76660c7700980fdec6c3093
-  React-RCTVibration: 00561f3d12dca44ed55af9060752bf8cf3fb0bfc
-  React-rendererdebug: 9e62f84756f080d88ed01b8063355c3a042934ed
+  React-RCTAnimation: e173f27b6e20108354df11ee0ae5a9f7fe09930f
+  React-RCTAppDelegate: 8c1e725f4be6d5fb55e7ea62b76c929eddcb859e
+  React-RCTBlob: 2135cb24f3fa9f4617d7cae03aee10724d5122bb
+  React-RCTFabric: 51dbbcfa09f76183d2fe9d305eedf0f4f7343333
+  React-RCTImage: 345d59868e372e90a40f30f9775c8f34c50b5ebb
+  React-RCTLinking: d9623fb24075a5a7b9d5f263297135c5128ea37c
+  React-RCTNetwork: 4dfc12857609eae588c212268656bf0ff3ebe1f3
+  React-RCTSettings: 5fa0803b17f29d87dc8d4649a1e5a32d4d081237
+  React-RCTText: f23cca90ce571720460ee8e3525ff7e5f1af5ad0
+  React-RCTVibration: efd2a82f8ecac6e7b363689322215735d1cbcf9e
+  React-rendererdebug: ea0f77385485b5251a0e61133e3b5f709ef02e9b
   React-rncore: e7f10bc6dbd75fa137583bd3b2bc4880203dbc1d
   React-runtimeexecutor: bf98e8973ed4c45139fbbaf2c34af44053acc9a9
-  React-runtimescheduler: 7a4ccc1854c5918dee508536fad93172b4c49629
-  React-utils: 59bbef368c9ba8b6e27416b46933cd03a35f2841
-  ReactCommon: 656e520d76937c8d781ef82a7186a4af7160d814
-  recaptcha-enterprise-react-native: 7d63c5bdde3b48996b984a86ac2b536a1d8f5f16
+  React-runtimescheduler: e6288bce4309ba16280ce54690b4d7109091ff43
+  React-utils: 28bc17e3e21dc06646b45a003718e0fe6034c66f
+  ReactCommon: e7f772a7660fc683a6ba0a0e0bebd45f4977ee57
+  recaptcha-enterprise-react-native: 82f186a0ab29c91c4d4bd08f7758f849e91b4558
   RecaptchaEnterprise: dc302910b77963a0cc6f6908407e30b35268a755
   RecaptchaInterop: 7d1a4a01a6b2cb1610a47ef3f85f0c411434cb21
-  RNCAsyncStorage: 618d03a5f52fbccb3d7010076bc54712844c18ef
-  RNCClipboard: 090462274cc05b02628bd158baf6d73c3abe8441
-  RNDeviceInfo: db5c64a060e66e5db3102d041ebe3ef307a85120
-  RNFBApp: 91311b27bc9a33e23b76a62825afd1635501018a
-  RNFBCrashlytics: c3219ef7a0c779f2428236215781c38e7892f6f9
-  RNFBPerf: 2c926ff255c704a644dd53572008cba47c67ada0
-  RNFlashList: 4b4b6b093afc0df60ae08f9cbf6ccd4c836c667a
-  RNGestureHandler: 79c035e2243d3b7f4f353e7eb32869eace6b596c
-  RNReanimated: 4b1bce37b188450e3a2d03c925edd5fb11d4bb2d
-  RNScreens: a4d9ce8f68f833f4e42410140eafd88e38bba163
-  RNSVG: 3f65a03e0c61a8495dee92bf82545ed9041cbf3b
+  RNCAsyncStorage: a03b770a50541a761447cea9c24536047832124d
+  RNCClipboard: c20b93d3a1b47ce86dcffa5c0af5dd59938e47e1
+  RNDeviceInfo: addb9b427c2822a2d8e94c87a136a224e0af738c
+  RNFBApp: e905ce948d9290555d9ab1303449827eb5119b5c
+  RNFBCrashlytics: e9459c8656ccbbb53d12afe47b4a96194c858745
+  RNFBPerf: ae6cfdac3e06eab3d4d092944e979e95a69b0179
+  RNFlashList: 1076a3fb7c4608a8cdf265f0783592b8fc41b6a7
+  RNGestureHandler: 9852b7617e28551f5d339309c73ebf221ba1013d
+  RNReanimated: 1b07d2def747e4e5510ecd8460b2862029ee3df2
+  RNScreens: 1174f55dd2f72abe45a4e48bf20e552feb051600
+  RNSVG: a9e095acf2e207f2ef491870523ed455636cf3b8
   SDWebImage: 750adf017a315a280c60fde706ab1e552a3ae4e9
   SDWebImageAVIFCoder: 8348fef6d0ec69e129c66c9fe4d74fbfbf366112
   SDWebImageSVGCoder: 15a300a97ec1c8ac958f009c02220ac0402e936c
   SDWebImageWebPCoder: af09429398d99d524cae2fe00f6f0f6e491ed102
   SocketRocket: f32cd54efbe0f095c4d7594881e52619cfe80b17
   sqlite3: f163dbbb7aa3339ad8fc622782c2d9d7b72f7e9c
-  tentap: 2cf2e387dd284bf867010eb7d0f91618fb35b673
+  tentap: 2a4256b6641a27d72d2b5fe2eb94cd1a203e4975
   UMAppLoader: 79d3ee6aa2447a1fe2e8b0d07acf2de106e55b58
-  Yoga: 4dbfeceb9bb0f62899d0a53d37a1ddd58898d3f2
+  Yoga: fb61b2337c7688c81a137e5560b3cbb515289f91
 
 PODFILE CHECKSUM: 0cb7a78e5777e69c86c1bf4bb5135fd660376dbe
 
-COCOAPODS: 1.15.2
+COCOAPODS: 1.16.2

--- a/packages/app/ui/components/Activity/ActivityScreenView.tsx
+++ b/packages/app/ui/components/Activity/ActivityScreenView.tsx
@@ -7,7 +7,7 @@ import React, { useCallback, useEffect, useMemo, useState } from 'react';
 import { FlatList, RefreshControl, StyleProp, ViewStyle } from 'react-native';
 import { View, useStyle } from 'tamagui';
 
-import { NavigationProvider } from '../../contexts';
+import { NavigationProvider, useStore } from '../../contexts';
 import { GroupPreviewAction, GroupPreviewSheet } from '../GroupPreviewSheet';
 import { ActivityHeader } from './ActivityHeader';
 import { ActivityListItem } from './ActivityListItem';
@@ -33,7 +33,9 @@ export function ActivityScreenView({
   bucketFetchers: store.BucketFetchers;
   refresh: () => Promise<void>;
 }) {
-  const activitySeenMarker = db.activitySeenMarker.useValue();
+  const store = useStore();
+  // const activitySeenMarker = db.activitySeenMarker.useValue();
+  const { data: activitySeenMarker } = store.useActivitySeenMarker();
   const [activeTab, setActiveTab] = useState<db.ActivityBucket>('all');
   const currentFetcher = bucketFetchers[activeTab];
 
@@ -49,7 +51,7 @@ export function ActivityScreenView({
     setTimeout(() => {
       store.advanceActivitySeenMarker(newestTimestamp);
     }, 1000);
-  }, [newestTimestamp]);
+  }, [newestTimestamp, store]);
 
   useEffect(() => {
     if (

--- a/packages/app/ui/components/Activity/ActivityScreenView.tsx
+++ b/packages/app/ui/components/Activity/ActivityScreenView.tsx
@@ -34,7 +34,6 @@ export function ActivityScreenView({
   refresh: () => Promise<void>;
 }) {
   const store = useStore();
-  // const activitySeenMarker = db.activitySeenMarker.useValue();
   const { data: activitySeenMarker } = store.useActivitySeenMarker();
   const [activeTab, setActiveTab] = useState<db.ActivityBucket>('all');
   const currentFetcher = bucketFetchers[activeTab];

--- a/packages/shared/src/api/settingsApi.ts
+++ b/packages/shared/src/api/settingsApi.ts
@@ -23,6 +23,8 @@ function getBucket(key: string): string {
   switch (key) {
     case 'messagesFilter':
       return 'talk';
+    case 'activitySeenTimestamp':
+      return 'groups';
     default:
       throw new Error(`Invalid setting key: ${key}`);
   }
@@ -92,6 +94,7 @@ export const toClientSettings = (
     messagesFilter: settings.desk.talk?.messagesFilter,
     gallerySettings: settings.desk.heaps?.heapSettings,
     notebookSettings: JSON.stringify(settings.desk.diary),
+    activitySeenTimestamp: settings.desk.groups?.activitySeenTimestamp,
   };
 };
 

--- a/packages/shared/src/db/migrations/0000_sour_wonder_man.sql
+++ b/packages/shared/src/db/migrations/0000_sour_wonder_man.sql
@@ -95,7 +95,8 @@ CREATE TABLE `group_members` (
 	`contact_id` text NOT NULL,
 	`joined_at` integer,
 	`status` text,
-	PRIMARY KEY(`chat_id`, `contact_id`)
+	PRIMARY KEY(`chat_id`, `contact_id`),
+	FOREIGN KEY (`chat_id`) REFERENCES `channels`(`id`) ON UPDATE no action ON DELETE cascade
 );
 --> statement-breakpoint
 CREATE TABLE `contact_group_pins` (
@@ -299,7 +300,8 @@ CREATE TABLE `posts` (
 	`last_edit_title` text,
 	`last_edit_image` text,
 	`synced_at` integer,
-	`backend_time` text
+	`backend_time` text,
+	FOREIGN KEY (`channel_id`) REFERENCES `channels`(`id`) ON UPDATE no action ON DELETE cascade
 );
 --> statement-breakpoint
 CREATE UNIQUE INDEX `posts_sent_at_unique` ON `posts` (`sent_at`);--> statement-breakpoint
@@ -326,7 +328,8 @@ CREATE TABLE `settings` (
 	`messages_nav_state` text,
 	`messages_filter` text,
 	`gallery_settings` text,
-	`notebook_settings` text
+	`notebook_settings` text,
+	`activity_seen_timestamp` integer
 );
 --> statement-breakpoint
 CREATE TABLE `thread_unreads` (

--- a/packages/shared/src/db/migrations/0000_sour_wonder_man.sql
+++ b/packages/shared/src/db/migrations/0000_sour_wonder_man.sql
@@ -95,8 +95,7 @@ CREATE TABLE `group_members` (
 	`contact_id` text NOT NULL,
 	`joined_at` integer,
 	`status` text,
-	PRIMARY KEY(`chat_id`, `contact_id`),
-	FOREIGN KEY (`chat_id`) REFERENCES `channels`(`id`) ON UPDATE no action ON DELETE cascade
+	PRIMARY KEY(`chat_id`, `contact_id`)
 );
 --> statement-breakpoint
 CREATE TABLE `contact_group_pins` (
@@ -300,8 +299,7 @@ CREATE TABLE `posts` (
 	`last_edit_title` text,
 	`last_edit_image` text,
 	`synced_at` integer,
-	`backend_time` text,
-	FOREIGN KEY (`channel_id`) REFERENCES `channels`(`id`) ON UPDATE no action ON DELETE cascade
+	`backend_time` text
 );
 --> statement-breakpoint
 CREATE UNIQUE INDEX `posts_sent_at_unique` ON `posts` (`sent_at`);--> statement-breakpoint

--- a/packages/shared/src/db/migrations/meta/0000_snapshot.json
+++ b/packages/shared/src/db/migrations/meta/0000_snapshot.json
@@ -1,7 +1,7 @@
 {
   "version": "6",
   "dialect": "sqlite",
-  "id": "6dc0c522-044d-4399-9e6d-6c46177eeac3",
+  "id": "fa25c16a-e15a-45be-9783-6405cc7a2e14",
   "prevId": "00000000-0000-0000-0000-000000000000",
   "tables": {
     "activity_event_contact_group_pins": {
@@ -639,7 +639,21 @@
         }
       },
       "indexes": {},
-      "foreignKeys": {},
+      "foreignKeys": {
+        "group_members_chat_id_channels_id_fk": {
+          "name": "group_members_chat_id_channels_id_fk",
+          "tableFrom": "group_members",
+          "tableTo": "channels",
+          "columnsFrom": [
+            "chat_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
       "compositePrimaryKeys": {
         "group_members_chat_id_contact_id_pk": {
           "columns": [
@@ -2033,7 +2047,21 @@
           "isUnique": false
         }
       },
-      "foreignKeys": {},
+      "foreignKeys": {
+        "posts_channel_id_channels_id_fk": {
+          "name": "posts_channel_id_channels_id_fk",
+          "tableFrom": "posts",
+          "tableTo": "channels",
+          "columnsFrom": [
+            "channel_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
       "compositePrimaryKeys": {},
       "uniqueConstraints": {},
       "checkConstraints": {}
@@ -2177,6 +2205,13 @@
         "notebook_settings": {
           "name": "notebook_settings",
           "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "activity_seen_timestamp": {
+          "name": "activity_seen_timestamp",
+          "type": "integer",
           "primaryKey": false,
           "notNull": false,
           "autoincrement": false

--- a/packages/shared/src/db/migrations/meta/_journal.json
+++ b/packages/shared/src/db/migrations/meta/_journal.json
@@ -5,8 +5,8 @@
     {
       "idx": 0,
       "version": "6",
-      "when": 1739215059171,
-      "tag": "0000_outgoing_valkyrie",
+      "when": 1742234785697,
+      "tag": "0000_sour_wonder_man",
       "breakpoints": true
     }
   ]

--- a/packages/shared/src/db/migrations/migrations.js
+++ b/packages/shared/src/db/migrations/migrations.js
@@ -1,7 +1,7 @@
 // This file is required for Expo/React Native SQLite migrations - https://orm.drizzle.team/quick-sqlite/expo
 
 import journal from './meta/_journal.json';
-import m0000 from './0000_outgoing_valkyrie.sql';
+import m0000 from './0000_sour_wonder_man.sql';
 
   export default {
     journal,

--- a/packages/shared/src/db/schema.ts
+++ b/packages/shared/src/db/schema.ts
@@ -51,6 +51,7 @@ export const settings = sqliteTable('settings', {
   messagesFilter: text('messages_filter'),
   gallerySettings: text('gallery_settings'),
   notebookSettings: text('notebook_settings', { mode: 'json' }),
+  activitySeenTimestamp: timestamp('activity_seen_timestamp'),
 });
 
 export const contacts = sqliteTable('contacts', {

--- a/packages/shared/src/store/activityActions.ts
+++ b/packages/shared/src/store/activityActions.ts
@@ -133,9 +133,17 @@ export async function setDefaultNotificationLevel(
 }
 
 export async function advanceActivitySeenMarker(timestamp: number) {
-  const existingMarker = await db.activitySeenMarker.getValue();
+  const currentUserId = api.getCurrentUserId();
+  const settings = await db.getSettings(currentUserId);
+  const existingMarker = settings?.activitySeenTimestamp ?? 1;
   if (timestamp > existingMarker) {
-    db.activitySeenMarker.setValue(timestamp);
+    // optimistic update
+    db.insertSettings({
+      userId: currentUserId,
+      activitySeenTimestamp: timestamp,
+    });
+
+    await api.setSetting('activitySeenTimestamp', timestamp);
   }
 }
 

--- a/packages/shared/src/store/dbHooks.ts
+++ b/packages/shared/src/store/dbHooks.ts
@@ -95,6 +95,18 @@ export const useMessagesFilter = (options: { userId: string }) => {
   });
 };
 
+export const useActivitySeenMarker = () => {
+  const userId = api.getCurrentUserId();
+  const deps = useKeyFromQueryDeps(db.getSettings);
+  return useQuery({
+    queryKey: ['activitySeenMarker', deps],
+    queryFn: async () => {
+      const settings = await db.getSettings(userId);
+      return settings?.activitySeenTimestamp ?? 1;
+    },
+  });
+};
+
 export const useCanUpload = () => {
   return (
     useQuery({
@@ -189,7 +201,7 @@ export const useBaseVolumeLevel = (): ub.NotificationLevel => {
 
 export const useHaveUnreadUnseenActivity = () => {
   const depsKey = useKeyFromQueryDeps(db.getUnreadUnseenActivityEvents);
-  const seenMarker = db.activitySeenMarker.useValue();
+  const { data: seenMarker } = useActivitySeenMarker();
   const { data: meaningfulUnseenActivity } = useQuery({
     queryKey: ['unseenUnreadActivity', depsKey, seenMarker],
     queryFn: () =>

--- a/packages/shared/src/urbit/settings.ts
+++ b/packages/shared/src/urbit/settings.ts
@@ -66,6 +66,7 @@ export type GroupsSettings = {
   newGroupFlags: string[];
   groupsNavState?: string;
   messagesNavState?: string;
+  activitySeenTimestamp?: number;
 };
 
 export type TalkSettings = {


### PR DESCRIPTION
OTT

Uses settings store to persist your Activity seen marker. Clients pull this down instead of storing a local one.

To test, try running new web and mobile simulator locally. Try navigating to activity on one and see the bell clear on the other.

Fixes TLON-3687