### PR TITLE
Fix missing latest posts

### DIFF
--- a/packages/app/lib/nativeDb.ts
+++ b/packages/app/lib/nativeDb.ts
@@ -1,5 +1,6 @@
 import { open } from '@op-engineering/op-sqlite';
 import { escapeLog } from '@tloncorp/shared';
+import * as kv from '@tloncorp/shared/db';
 import { schema, setClient } from '@tloncorp/shared/db';
 
 import {
@@ -73,6 +74,10 @@ export class NativeDb extends BaseDb {
     this.connection.delete();
     this.connection = null;
     this.client = null;
+
+    // reset values related to tracking db sync state
+    await kv.headsSyncedAt.resetValue();
+
     logger.log('purged sqlite database, recreating');
     await this.setupDb();
   }

--- a/packages/shared/src/db/keyValue.ts
+++ b/packages/shared/src/db/keyValue.ts
@@ -10,11 +10,6 @@ import * as ub from '../urbit';
 import { NodeBootPhase, SignupParams } from './domainTypes';
 import { createStorageItem } from './storageItem';
 
-export const activitySeenMarker = createStorageItem<number>({
-  key: 'activitySeenMarker',
-  defaultValue: 1,
-});
-
 export const pushNotificationSettings =
   createStorageItem<ub.PushNotificationsSetting>({
     key: 'settings:pushNotifications',


### PR DESCRIPTION
The prod build last night included a DB migration to save the new activity read marker setting. This uncovered a bug with our latest posts logic — when the migration wipes all SQL data, the keyval store keeps its existing `headsSyncedAt` timestamp. This means `syncLatestPost` thinks it already has messages that it doesn't.

To fix, we'll now clear out that key anytime we purge the DB. I tried upgrading from an older version to confirm it works, but wanted to double check with y'all if purge is always called in these migration scenarios?

Another thought I had: if we have more of these sync optimization flags, it might be worth considering an optional `persistAfterMigration` storage item flag (analogous to `persistAfterLogout`).