### PR TITLE
desktop: messages filter should stay consistent until changed

### DIFF
--- a/packages/shared/src/db/queries.ts
+++ b/packages/shared/src/db/queries.ts
@@ -134,13 +134,10 @@ export interface GetGroupsOptions {
 export const insertSettings = createWriteQuery(
   'insertSettings',
   async (settings: Settings, ctx: QueryCtx) => {
-    return ctx.db
-      .insert($settings)
-      .values(settings)
-      .onConflictDoUpdate({
-        target: $settings.userId,
-        set: conflictUpdateSetAll($settings),
-      });
+    return ctx.db.insert($settings).values(settings).onConflictDoUpdate({
+      target: $settings.userId,
+      set: settings,
+    });
   },
   ['settings']
 );


### PR DESCRIPTION
This fixes TLON-3823 by making sure inserting settings doesn't override other values when giving a partial set.