### PR TITLE
Web: Fix hosted uploads

### DIFF
--- a/packages/app/lib/envVars.native.ts
+++ b/packages/app/lib/envVars.native.ts
@@ -6,6 +6,7 @@ const envVars = (Constants.expoConfig?.extra ?? {}) as Record<
   string | undefined
 >;
 
+export const DEV_SHIP_URL = '';
 export const NOTIFY_PROVIDER = envVars.notifyProvider ?? 'rivfur-livmet';
 export const NOTIFY_SERVICE = envVars.notifyService ?? 'groups-native';
 export const POST_HOG_API_KEY = envVars.postHogApiKey ?? '';
@@ -46,6 +47,7 @@ export const INVITE_SERVICE_IS_DEV =
   envVars.inviteServiceIsDev === 'true' ? true : undefined;
 
 export const ENV_VARS = {
+  DEV_SHIP_URL,
   NOTIFY_PROVIDER,
   NOTIFY_SERVICE,
   POST_HOG_API_KEY,

--- a/packages/app/lib/envVars.ts
+++ b/packages/app/lib/envVars.ts
@@ -2,6 +2,7 @@
 // @ts-ignore – only valid on web
 const env = import.meta.env;
 const envVars = {
+  devShipUrl: env.VITE_SHIP_URL,
   notifyProvider: env.VITE_NOTIFY_PROVIDER,
   notifyService: env.VITE_NOTIFY_SERVICE,
   postHogApiKey: env.VITE_POST_HOG_API_KEY,
@@ -30,6 +31,7 @@ const envVars = {
   inviteServiceIsDev: env.VITE_INVITE_SERVICE_IS_DEV,
 } as Record<string, string | undefined>;
 
+export const DEV_SHIP_URL = envVars.devShipUrl ?? '';
 export const NOTIFY_PROVIDER = envVars.notifyProvider ?? 'rivfur-livmet';
 export const NOTIFY_SERVICE = envVars.notifyService ?? 'groups-native';
 export const POST_HOG_API_KEY = envVars.postHogApiKey ?? '';
@@ -67,6 +69,7 @@ export const INVITE_SERVICE_IS_DEV =
   envVars.inviteServiceIsDev === 'true' ? true : undefined;
 
 export const ENV_VARS = {
+  DEV_SHIP_URL,
   NOTIFY_PROVIDER,
   NOTIFY_SERVICE,
   POST_HOG_API_KEY,

--- a/packages/shared/src/api/urbit.ts
+++ b/packages/shared/src/api/urbit.ts
@@ -132,7 +132,6 @@ export function internalConfigureClient({
   onQuitOrReset,
   onChannelStatusChange,
 }: ClientParams) {
-  console.log('bl: internally configuring client', { shipName, shipUrl });
   config.client = config.client || new Urbit(shipUrl, '', '', fetchFn);
   config.client.verbose = verbose;
   config.client.nodeId = preSig(shipName);

--- a/packages/shared/src/api/urbit.ts
+++ b/packages/shared/src/api/urbit.ts
@@ -109,7 +109,7 @@ export const getCurrentUserIsHosted = () => {
 
   // prefer referencing client URL if available
   if (client.url) {
-    return client.url.endsWith('tlon.network');
+    return Hosting.nodeUrlIsHosted(client.url);
   }
 
   /*

--- a/packages/shared/src/domain/constants.ts
+++ b/packages/shared/src/domain/constants.ts
@@ -1,6 +1,7 @@
 const TLON_NAMESPACE = 'tlonEnv';
 
 interface Constants {
+  DEV_SHIP_URL: string;
   NOTIFY_PROVIDER: string;
   NOTIFY_SERVICE: string;
   POST_HOG_API_KEY: string;

--- a/packages/shared/src/domain/hosting.ts
+++ b/packages/shared/src/domain/hosting.ts
@@ -50,3 +50,7 @@ export enum HostedNodeStatus {
   UnderMaintenance = 'UnderMaintenance',
   Unknown = 'Unknown',
 }
+
+export function nodeUrlIsHosted(url: string) {
+  return url.endsWith('tlon.network') || url.endsWith('.test.tlon.systems');
+}


### PR DESCRIPTION
When checking hosted upload eligibility, we confirm the ship's URL is Tlon controlled. This check was failing on web because the http client's url property is not explicitly set. This updates the method to fall back to window location or env configuration during development.

Fixes TLON-3246