### PR TITLE
Settings Table Refactor

### DIFF
--- a/packages/app/features/settings/BlockedUsersScreen.tsx
+++ b/packages/app/features/settings/BlockedUsersScreen.tsx
@@ -11,8 +11,7 @@ import { BlockedContactsWidget, ScreenHeader, View } from '../../ui';
 type Props = NativeStackScreenProps<RootStackParamList, 'BlockedUsers'>;
 
 export function BlockedUsersScreen(props: Props) {
-  const currentUserId = useCurrentUserId();
-  const { data: calm } = store.useCalmSettings({ userId: currentUserId });
+  const { data: calm } = store.useCalmSettings();
   const { data: blockedContacts } = store.useBlockedContacts();
 
   const onBlockedContactPress = useCallback(

--- a/packages/app/features/top/ContactsScreen.tsx
+++ b/packages/app/features/top/ContactsScreen.tsx
@@ -30,7 +30,7 @@ export default function ContactsScreen(props: Props) {
   const { data: userContacts } = store.useUserContacts();
   const { data: contacts } = store.useContacts();
   const { data: suggestions } = store.useSuggestedContacts();
-  const { data: calmSettings } = store.useCalmSettings({ userId: currentUser });
+  const { data: calmSettings } = store.useCalmSettings();
 
   const onContactPress = useCallback(
     (contact: db.Contact) => {

--- a/packages/app/features/top/MessagesFilterMenu.tsx
+++ b/packages/app/features/top/MessagesFilterMenu.tsx
@@ -2,18 +2,16 @@ import * as store from '@tloncorp/shared/store';
 import { TalkSidebarFilter } from '@tloncorp/shared/urbit';
 import { PropsWithChildren, useCallback, useMemo, useState } from 'react';
 
-import { useCurrentUserId } from '../../hooks/useCurrentUser';
 import { ActionSheet, createActionGroups } from '../../ui';
 
 export function MessagesFilterMenu({ children }: PropsWithChildren) {
   const [isOpen, setIsOpen] = useState(false);
-  const currentUserId = useCurrentUserId();
-  const { data } = store.useMessagesFilter({ userId: currentUserId });
+  const { data } = store.useMessagesFilter();
   const talkFilter = data ?? 'Direct Messages';
 
   const handleAction = useCallback((value: TalkSidebarFilter) => {
     return () => {
-      store.changeMessageFilter(value, currentUserId);
+      store.changeMessageFilter(value);
       setIsOpen(false);
     };
   }, []);

--- a/packages/app/features/top/UserProfileScreen.tsx
+++ b/packages/app/features/top/UserProfileScreen.tsx
@@ -33,9 +33,7 @@ export function UserProfileScreen({ route, navigation }: Props) {
   const userId = params?.userId || currentUserId;
   const { data: contacts } = store.useContacts();
   const connectionStatus = useConnectionStatus(userId);
-  const { data: calmSettings } = store.useCalmSettings({
-    userId: currentUserId,
-  });
+  const { data: calmSettings } = store.useCalmSettings();
   const [selectedGroup, setSelectedGroup] = useState<db.Group | null>(null);
   const { resetToDm } = useRootNavigation();
 

--- a/packages/app/hooks/useCalmSettings.ts
+++ b/packages/app/hooks/useCalmSettings.ts
@@ -1,11 +1,6 @@
 import * as store from '@tloncorp/shared/store';
 
-import { useCurrentUserId } from '../hooks/useCurrentUser';
-
 export const useCalmSettings = () => {
-  const currentUserId = useCurrentUserId();
-  const calmSettingsQuery = store.useCalmSettings({
-    userId: currentUserId,
-  });
+  const calmSettingsQuery = store.useCalmSettings();
   return { calmSettings: calmSettingsQuery.data ?? null } as const;
 };

--- a/packages/app/hooks/useFilteredChats.ts
+++ b/packages/app/hooks/useFilteredChats.ts
@@ -7,7 +7,6 @@ import { useCallback, useLayoutEffect, useMemo, useState } from 'react';
 
 import { useCalm } from '../ui';
 import { getChannelTitle, getGroupTitle } from '../ui';
-import { useCurrentUserId } from './useCurrentUser';
 
 export type TabName = 'all' | 'home' | 'groups' | 'messages' | 'talk';
 
@@ -29,7 +28,6 @@ export function useFilteredChats({
   searchQuery: string;
   activeTab: TabName;
 }): SectionedChatData {
-  const userId = useCurrentUserId();
   const performSearch = useChatSearch({ pinned, unpinned, pending });
   const debouncedQuery = useDebouncedValue(searchQuery, 200);
   const searchResults = useMemo(
@@ -37,7 +35,7 @@ export function useFilteredChats({
     [debouncedQuery, performSearch]
   );
 
-  const { data } = useMessagesFilter({ userId });
+  const { data } = useMessagesFilter();
   const talkFilter =
     activeTab === 'talk' ? data ?? 'Direct Messages' : 'Direct Messages';
 

--- a/packages/app/provider/AppDataProvider.tsx
+++ b/packages/app/provider/AppDataProvider.tsx
@@ -21,7 +21,7 @@ export function AppDataProvider({
   const currentUserId = useCurrentUserId();
   const session = store.useCurrentSession();
   const contactsQuery = store.useContacts();
-  const calmSettingsQuery = store.useCalmSettings({ userId: currentUserId });
+  const calmSettingsQuery = store.useCalmSettings();
   return (
     <AppDataContextProvider
       currentUserId={currentUserId}

--- a/packages/shared/src/api/settingsApi.ts
+++ b/packages/shared/src/api/settingsApi.ts
@@ -1,4 +1,5 @@
 import * as db from '../db';
+import { SETTINGS_SINGLETON_KEY } from '../db/schema';
 import * as ub from '../urbit';
 import { getCurrentUserId, poke, scry, subscribe } from './urbit';
 
@@ -74,7 +75,6 @@ export const toClientSettings = (
   settings: ub.GroupsDeskSettings
 ): db.Settings => {
   return {
-    userId: getCurrentUserId(),
     theme: settings.desk.display?.theme,
     disableAppTileUnreads: settings.desk.calmEngine?.disableAppTileUnreads,
     disableAvatars: settings.desk.calmEngine?.disableAvatars,

--- a/packages/shared/src/db/queries.ts
+++ b/packages/shared/src/db/queries.ts
@@ -75,6 +75,7 @@ import {
   threadUnreads as $threadUnreads,
   verifications as $verifications,
   volumeSettings as $volumeSettings,
+  SETTINGS_SINGLETON_KEY,
   channels,
 } from './schema';
 import {
@@ -133,21 +134,24 @@ export interface GetGroupsOptions {
 
 export const insertSettings = createWriteQuery(
   'insertSettings',
-  async (settings: Settings, ctx: QueryCtx) => {
-    return ctx.db.insert($settings).values(settings).onConflictDoUpdate({
-      target: $settings.userId,
-      set: settings,
-    });
+  async (settings: Partial<Settings>, ctx: QueryCtx) => {
+    return ctx.db
+      .insert($settings)
+      .values({ ...settings, id: SETTINGS_SINGLETON_KEY })
+      .onConflictDoUpdate({
+        target: $settings.id,
+        set: settings,
+      });
   },
   ['settings']
 );
 
 export const getSettings = createReadQuery(
   'getSettings',
-  async (userId: string, ctx: QueryCtx) => {
+  async (ctx: QueryCtx) => {
     return ctx.db.query.settings.findFirst({
       where(fields) {
-        return eq(fields.userId, userId);
+        return eq(fields.id, SETTINGS_SINGLETON_KEY);
       },
     });
   },

--- a/packages/shared/src/db/schema.ts
+++ b/packages/shared/src/db/schema.ts
@@ -28,8 +28,9 @@ const metaFields = {
   description: text('description'),
 };
 
+export const SETTINGS_SINGLETON_KEY = 'settings';
 export const settings = sqliteTable('settings', {
-  userId: text('user_id').primaryKey(),
+  id: text('id').primaryKey().default(SETTINGS_SINGLETON_KEY),
   theme: text('theme'),
   disableAppTileUnreads: boolean('disable_app_tile_unreads'),
   disableAvatars: boolean('disable_avatars'),

--- a/packages/shared/src/store/activityActions.ts
+++ b/packages/shared/src/store/activityActions.ts
@@ -133,13 +133,11 @@ export async function setDefaultNotificationLevel(
 }
 
 export async function advanceActivitySeenMarker(timestamp: number) {
-  const currentUserId = api.getCurrentUserId();
-  const settings = await db.getSettings(currentUserId);
+  const settings = await db.getSettings();
   const existingMarker = settings?.activitySeenTimestamp ?? 1;
   if (timestamp > existingMarker) {
     // optimistic update
     db.insertSettings({
-      userId: currentUserId,
       activitySeenTimestamp: timestamp,
     });
 

--- a/packages/shared/src/store/dbHooks.ts
+++ b/packages/shared/src/store/dbHooks.ts
@@ -72,11 +72,11 @@ export const usePins = (
   });
 };
 
-export const useCalmSettings = (options: { userId: string }) => {
+export const useCalmSettings = () => {
   return useQuery({
     queryKey: ['calmSettings'],
     queryFn: () =>
-      db.getSettings(options.userId).then((r) => ({
+      db.getSettings().then((r) => ({
         disableAvatars: r?.disableAvatars ?? false,
         disableNicknames: r?.disableNicknames ?? false,
         disableRemoteContent: r?.disableRemoteContent ?? false,
@@ -84,24 +84,23 @@ export const useCalmSettings = (options: { userId: string }) => {
   });
 };
 
-export const useMessagesFilter = (options: { userId: string }) => {
+export const useMessagesFilter = () => {
   const deps = useKeyFromQueryDeps(db.getSettings);
   return useQuery({
     queryKey: ['messagesFilter', deps],
     queryFn: async () => {
-      const settings = await db.getSettings(options.userId);
+      const settings = await db.getSettings();
       return getMessagesFilter(settings?.messagesFilter);
     },
   });
 };
 
 export const useActivitySeenMarker = () => {
-  const userId = api.getCurrentUserId();
   const deps = useKeyFromQueryDeps(db.getSettings);
   return useQuery({
     queryKey: ['activitySeenMarker', deps],
     queryFn: async () => {
-      const settings = await db.getSettings(userId);
+      const settings = await db.getSettings();
       return settings?.activitySeenTimestamp ?? 1;
     },
   });

--- a/packages/shared/src/store/settingsActions.ts
+++ b/packages/shared/src/store/settingsActions.ts
@@ -2,18 +2,15 @@ import { setSetting } from '../api';
 import * as db from '../db';
 import { TalkSidebarFilter } from '../urbit';
 
-export async function changeMessageFilter(
-  filter: TalkSidebarFilter,
-  userId: string
-) {
-  const existing = await db.getSettings(userId);
+export async function changeMessageFilter(filter: TalkSidebarFilter) {
+  const existing = await db.getSettings();
   const oldFilter = existing?.messagesFilter;
   try {
     // optimistic update
-    await db.insertSettings({ userId, messagesFilter: filter });
+    await db.insertSettings({ messagesFilter: filter });
     return setSetting('messagesFilter', filter);
   } catch (e) {
     console.error('Failed to change message filter', e);
-    await db.insertSettings({ userId, messagesFilter: oldFilter });
+    await db.insertSettings({ messagesFilter: oldFilter });
   }
 }

--- a/packages/shared/src/store/sync.ts
+++ b/packages/shared/src/store/sync.ts
@@ -6,6 +6,7 @@ import * as api from '../api';
 import { GetChangedPostsOptions } from '../api';
 import * as db from '../db';
 import { QueryCtx, batchEffects } from '../db/query';
+import { SETTINGS_SINGLETON_KEY } from '../db/schema';
 import { createDevLogger, runIfDev } from '../debug';
 import { AnalyticsEvent } from '../domain';
 import { extractClientVolumes } from '../logic/activity';
@@ -853,11 +854,10 @@ export const handleStorageUpdate = async (update: api.StorageUpdate) => {
 };
 
 export const handleSettingsUpdate = async (update: api.SettingsUpdate) => {
-  const userId = api.getCurrentUserId();
   switch (update.type) {
     case 'updateSetting':
       await db.insertSettings({
-        userId,
+        id: SETTINGS_SINGLETON_KEY,
         ...update.setting,
       });
       break;


### PR DESCRIPTION
The release candidate is crashing on logout. The issue is a race condition with clearing the current user ID before all listeners for the settings table are unmounted.  Current user ID is the primary key for the settings table, but we don't actually store other user's settings (table only ever has the singleton row).

To fix this I changed the primary key for the settings table to a static string. I also updated the query methods to assume you always want to read/write that singleton without needing to manually pass in a row ID.

Fixes TLON-3832