### PR TITLE
groups: correctly accumulate /epic %leave cards

### DIFF
--- a/desk/app/groups.hoon
+++ b/desk/app/groups.hoon
@@ -379,11 +379,11 @@
     %+  roll  ~(tap by wex.bowl)
     |=  [[[=wire =dock] *] =_cor]
     ?.  ?=([%epic ~] wire)  cor
-    =^  caz=(list card)  subs
+    =^  caz=(list card)  subs.cor
       (~(unsubscribe s [subs bowl]) wire dock)
-    =.  cor  (emil caz)
+    =.  cor  (emil:cor caz)
     ::  force leave
-    (emit [%pass wire %agent dock %leave ~])
+    (emit:cor [%pass wire %agent dock %leave ~])
   =?  cor  ?=(%4 -.old)
     (emit [%pass /load/active-channels %arvo %b %wait now.bowl])
   =?  old  ?=(%4 -.old)  (state-4-to-5 old)


### PR DESCRIPTION
Classic +roll mistake of accumulating the context core, but then pulling an arm from the context instead of the accumulator, which only ever pulls the arm in the context that exists when the gate gets _created_, not when it gets _called_.

Inspired by ames bug discussion in core blitz, I decided to sanity-check all the `+roll` calls in our codebase. This is the only problem I found.

(I must note for the record that I haven't tested this change in any way yet beyond compiling it, but I guarantee you, dear reviewer, that you'll "oh, yeah" when seeing the change.)

Since we don't really use `/epic` subscriptions anymore, and this code was intending to clean the mup, this isn't a huge deal. I do notice though that we no-op on all `/epic` `+on-agent` calls. Feels to me like, if we intend to force-leave `/epic` subscriptions anyway, we also want to issue a `%leave` whenever we still get some `+on-agent` call for it. Doing so would've automatically cleaned the stragglers from this up.

Not obvious to me what's up with the double-`%leave` this creates. This could probably be cleaned up further, and may need to come with a new migration that re-runs this, if we care about cleaning house enough. Up to you @mikolajpp.