### PR TITLE
ChatOptions: navigate home when leaving a DM from within

### DIFF
--- a/packages/app/ui/contexts/chatOptions.tsx
+++ b/packages/app/ui/contexts/chatOptions.tsx
@@ -187,11 +187,12 @@ export const ChatOptionsProvider = ({
         channel,
         accept: false,
       });
+      navigateOnLeave?.();
     } else {
       store.leaveGroupChannel(channel.id);
     }
     closeSheet();
-  }, [channel, closeSheet]);
+  }, [channel, closeSheet, navigateOnLeave]);
 
   const leaveChannel = useCallback(() => {
     if (isWeb) {
@@ -250,12 +251,15 @@ export const ChatOptionsProvider = ({
     }
   }, [channelId, closeSheet, onPressChannelMeta]);
 
-  const handlePressGroupMeta = useCallback((fromBlankChannel?: boolean) => {
-    if (groupId) {
-      onPressGroupMeta?.(groupId, fromBlankChannel);
-      closeSheet();
-    }
-  }, [closeSheet, groupId, onPressGroupMeta]);
+  const handlePressGroupMeta = useCallback(
+    (fromBlankChannel?: boolean) => {
+      if (groupId) {
+        onPressGroupMeta?.(groupId, fromBlankChannel);
+        closeSheet();
+      }
+    },
+    [closeSheet, groupId, onPressGroupMeta]
+  );
 
   const handlePressManageChannels = useCallback(() => {
     if (groupId) {


### PR DESCRIPTION
The leave operation for DMs was properly unsubscribing from the channel but not navigating away from the screen, leaving the user on a blank, inescapable screen that required a force-quit. This adds the same navigation for when a user leaves a group, thereby fixes TLON-3752.