### PR TITLE
gallery: fix issue with shorter gallery posts in index

### DIFF
--- a/packages/app/ui/components/Channel/Scroller.tsx
+++ b/packages/app/ui/components/Channel/Scroller.tsx
@@ -261,6 +261,7 @@ const Scroller = forwardRef(
         );
         const isLastPostOfBlock =
           post.type !== 'notice' &&
+          (post.type === 'chat' || post.type === 'reply') &&
           ((nextItem && nextItem.authorId !== post.authorId) || !isSameDay);
         const showAuthor =
           post.type === 'note' ||


### PR DESCRIPTION
fixes tlon-3779

we were inserting `<PostBlockSeparator/>` unnecessarily after gallery posts, which shoves an empty View of a defined height after a post or set of posts. Inserting that component makes sense in chat, but not in galleries or notebooks.