### PR TITLE
threads: use correct authorId

### DIFF
--- a/packages/app/ui/components/PostScreenView.tsx
+++ b/packages/app/ui/components/PostScreenView.tsx
@@ -393,7 +393,7 @@ function SinglePostView({
 
   const { data: threadPosts } = store.useThreadPosts({
     postId: parentPost.id,
-    authorId: parentPost.id,
+    authorId: parentPost.authorId,
     channelId: channel.id,
   });
 

--- a/packages/shared/src/api/postsApi.ts
+++ b/packages/shared/src/api/postsApi.ts
@@ -705,6 +705,7 @@ export const getPostWithReplies = async ({
   channelId: string;
   authorId: string;
 }) => {
+  logger.log('fetching post with replies', { postId, channelId, authorId });
   if (
     !authorId &&
     (isDmChannelId(channelId) || isGroupDmChannelId(channelId))

--- a/packages/shared/src/store/sync.ts
+++ b/packages/shared/src/store/sync.ts
@@ -367,6 +367,7 @@ export async function syncThreadPosts(
       channelId,
     })
   );
+  logger.log('got thread posts from api', response);
   await db.insertChannelPosts({
     channelId,
     posts: [response, ...(response.replies ?? [])],


### PR DESCRIPTION
Fixes TLON-3842, we were using the wrong ID for author here.