### PR TITLE
threads: use day and time if no title

### DIFF
--- a/packages/app/ui/components/PostScreenView.tsx
+++ b/packages/app/ui/components/PostScreenView.tsx
@@ -1,5 +1,7 @@
 import {
   isChatChannel as getIsChatChannel,
+  makePrettyDayAndTime,
+  makePrettyTime,
   useDebouncedValue,
 } from '@tloncorp/shared';
 import * as db from '@tloncorp/shared/db';
@@ -287,8 +289,11 @@ function ConnectedHeader({
 
   const { focusedPost: parentPost } = useContext(FocusedPostContext);
 
+  const prettyTime = parentPost
+    ? makePrettyDayAndTime(new Date(parentPost.receivedAt)).asString
+    : '';
   const headerTitle = isChatChannel
-    ? `Thread: ${channel?.title ?? null}`
+    ? `Thread: ${channel?.title || prettyTime}`
     : parentPost?.title && parentPost.title !== ''
       ? parentPost.title
       : 'Post';


### PR DESCRIPTION
Something that's bothered me since we did the new client is that if you're in a thread in a DM you just see "Thread:" which just looked broken. Trying just "Thread" with no colon also felt weird. Not sure if this is what we want to go with, but seemed reasonable:

<img width="872" alt="image" src="https://github.com/user-attachments/assets/ebce0ba0-39f7-48c7-a264-95db9bf1f4a3" />
