### PR TITLE
channel: display read-only notice if canWrite is false

### DIFF
--- a/packages/app/ui/components/Channel/ReadOnlyNotice.tsx
+++ b/packages/app/ui/components/Channel/ReadOnlyNotice.tsx
@@ -1,0 +1,25 @@
+import { Icon } from '@tloncorp/ui';
+import { SafeAreaView } from 'react-native-safe-area-context';
+import { SizableText, View, YStack } from 'tamagui';
+
+export function ReadOnlyNotice() {
+  return (
+    <SafeAreaView edges={['right', 'left', 'bottom']}>
+      <YStack
+        padding="$l"
+        alignItems="center"
+        justifyContent="center"
+        backgroundColor="$background"
+        borderTopWidth={1}
+        borderTopColor="$border"
+      >
+        <View flexDirection="row" alignItems="center" gap="$m">
+          <Icon type="Info" size="$s" color="$tertiaryText" />
+          <SizableText size="$s" color="$tertiaryText">
+            This channel is read-only for you.
+          </SizableText>
+        </View>
+      </YStack>
+    </SafeAreaView>
+  );
+}

--- a/packages/app/ui/components/Channel/index.tsx
+++ b/packages/app/ui/components/Channel/index.tsx
@@ -56,6 +56,7 @@ import { ChannelHeader, ChannelHeaderItemsProvider } from './ChannelHeader';
 import { DmInviteOptions } from './DmInviteOptions';
 import { DraftInputView } from './DraftInputView';
 import { PostView } from './PostView';
+import { ReadOnlyNotice } from './ReadOnlyNotice';
 
 export { INITIAL_POSTS_PER_PAGE } from './Scroller';
 
@@ -417,6 +418,8 @@ export const Channel = forwardRef<ChannelMethods, ChannelProps>(
                                 }
                               />
                             ))}
+
+                          {!canWrite && <ReadOnlyNotice />}
 
                           {channel.isDmInvite && (
                             <DmInviteOptions


### PR DESCRIPTION
Does what it says on the tin. Displays a notice in the root of channels that you can't write to.

<img width="560" alt="Screenshot 2025-03-25 at 2 34 29 PM" src="https://github.com/user-attachments/assets/b15805fb-1c84-40c9-8577-f9357d2e5940" />
<img width="560" alt="Screenshot 2025-03-25 at 2 34 25 PM" src="https://github.com/user-attachments/assets/fe421b20-7a35-4f67-8aa5-ef86282fcdce" />
<img width="560" alt="Screenshot 2025-03-25 at 2 34 19 PM" src="https://github.com/user-attachments/assets/b0a9448e-0c73-49f7-9bf5-10169cad46d3" />
