### PR TITLE
chat options menu: set explicit background on popover

### DIFF
--- a/packages/app/ui/components/ChatOptionsSheet.tsx
+++ b/packages/app/ui/components/ChatOptionsSheet.tsx
@@ -168,6 +168,7 @@ export function GroupOptionsSheetLoader({
           borderColor="$border"
           borderWidth={1}
           padding={1}
+          backgroundColor="$background"
         >
           {pane === 'notifications' ? (
             <NotificationsSheetContent


### PR DESCRIPTION
fixes tlon-3850

This one is super weird. It only shows up in the deployed app (can't repro when running in dev locally, or by building and serving locally), and it only started showing up recently. None of the relevant components have changed recently, afaict.

This *might* fix it, but I suspect something weirder is going on.