### PR TITLE
chat options menu: remove animation prop from popover

### DIFF
--- a/packages/app/ui/components/ChatOptionsSheet.tsx
+++ b/packages/app/ui/components/ChatOptionsSheet.tsx
@@ -162,7 +162,6 @@ export function GroupOptionsSheetLoader({
         <Popover.Trigger asChild>{trigger}</Popover.Trigger>
         <Popover.Content
           elevate
-          animation="quick"
           zIndex={1000000}
           position="relative"
           borderColor="$border"


### PR DESCRIPTION
fixes tlon-3850 (maybe)

I noticed that we see an error from react-native-reanimated in the console on production when we pop the menu open. We see the same error when running the prod build locally, but we don't see the weird transparent background/inability to interact issue.

If we remove the animation prop from the popover, that reanimated error no longer shows in the console when opening the menu. 

Let's try this and see if it gets us anywhere in production.