### PR TITLE
chat options menu: remove animation prop from popover (again)

### DIFF
--- a/packages/app/ui/components/ChatOptionsSheet.tsx
+++ b/packages/app/ui/components/ChatOptionsSheet.tsx
@@ -521,7 +521,6 @@ export function ChannelOptionsSheetLoader({
         <Popover.Trigger asChild>{trigger}</Popover.Trigger>
         <Popover.Content
           elevate
-          animation="quick"
           zIndex={1000000}
           position="relative"
           borderColor="$border"


### PR DESCRIPTION
fixes tlon-3850 (finally)

missed a spot when removing the animation props earlier