### PR TITLE
desktop: fix context menu issues in gallery and notebook

### DIFF
--- a/packages/app/ui/components/GalleryPost/GalleryPost.tsx
+++ b/packages/app/ui/components/GalleryPost/GalleryPost.tsx
@@ -48,6 +48,7 @@ const GalleryPostFrame = styled(View, {
 export function GalleryPost({
   post,
   onPress,
+  onPressEdit,
   onLongPress,
   onPressRetry,
   onPressDelete,
@@ -183,6 +184,7 @@ export function GalleryPost({
               onDismiss={() => setIsPopoverOpen(false)}
               onOpenChange={setIsPopoverOpen}
               onReply={handlePress}
+              onEdit={onPressEdit}
               trigger={
                 <Button
                   backgroundColor="transparent"

--- a/packages/app/ui/components/NotebookPost/NotebookPost.tsx
+++ b/packages/app/ui/components/NotebookPost/NotebookPost.tsx
@@ -16,6 +16,7 @@ import {
 } from 'tamagui';
 
 import { useChannelContext } from '../../contexts';
+import { MinimalRenderItemProps } from '../../contexts/componentsKits';
 import { DetailViewAuthorRow } from '../AuthorRow';
 import { ChatMessageActions } from '../ChatMessage/ChatMessageActions/Component';
 import { ChatMessageReplySummary } from '../ChatMessage/ChatMessageReplySummary';
@@ -31,6 +32,7 @@ const IMAGE_HEIGHT = 268;
 export function NotebookPost({
   post,
   onPress,
+  onPressEdit,
   onLongPress,
   onPressRetry,
   onPressDelete,
@@ -40,19 +42,10 @@ export function NotebookPost({
   viewMode,
   size = '$l',
   hideOverflowMenu,
-}: {
-  post: db.Post;
-  onPress?: (post: db.Post) => void;
-  onLongPress?: (post: db.Post) => void;
-  onPressImage?: (post: db.Post, imageUri?: string) => void;
-  onPressRetry?: (post: db.Post) => Promise<void>;
-  onPressDelete?: (post: db.Post) => void;
+}: MinimalRenderItemProps & {
   detailView?: boolean;
-  showReplies?: boolean;
-  showAuthor?: boolean;
   showDate?: boolean;
   viewMode?: 'activity';
-  isHighlighted?: boolean;
   size?: '$l' | '$s' | '$xs';
   hideOverflowMenu?: boolean;
 }) {
@@ -121,7 +114,7 @@ export function NotebookPost({
   const hasReplies = post.replyCount && post.replyTime && post.replyContactIds;
   return (
     <Pressable
-      onPress={overFlowIsHovered ? undefined : handlePress}
+      onPress={overFlowIsHovered || isPopoverOpen ? undefined : handlePress}
       onHoverIn={onHoverIn}
       onHoverOut={onHoverOut}
       onLongPress={handleLongPress}
@@ -187,6 +180,7 @@ export function NotebookPost({
               postActionIds={postActionIds}
               onDismiss={() => setIsPopoverOpen(false)}
               onOpenChange={setIsPopoverOpen}
+              onEdit={onPressEdit}
               onReply={handlePress}
               trigger={
                 <Button

--- a/packages/app/ui/contexts/componentsKits.tsx
+++ b/packages/app/ui/contexts/componentsKits.tsx
@@ -68,6 +68,7 @@ export type MinimalRenderItemProps = {
   showAuthor?: boolean;
   showReplies?: boolean;
   onPress?: (post: db.Post) => void;
+  onPressEdit?: () => void;
   onPressReplies?: (post: db.Post) => void;
   onPressImage?: (post: db.Post, imageUri?: string) => void;
   onLongPress?: (post: db.Post) => void;


### PR DESCRIPTION
fixes tlon-3836

Fixes the original issue by making sure we pass `onPressEdit` to the `onEditProp` in ChatMessageActions in GalleryPost.

Also does the same thing for notebooks.

While working on this, I noticed that pressing any menu item in the popover for a notebook post in a notebook channel would redirect the user to the detail view for the post. We weren't disabling the onPress on the Pressable in NotebookPost when the popover was open. This also fixes that.

Also cleans up the props on NotebookPost.