### PR TITLE
ChannelHeader: reflect connection state

### DIFF
--- a/packages/app/ui/components/Channel/BaubleHeader.tsx
+++ b/packages/app/ui/components/Channel/BaubleHeader.tsx
@@ -1,10 +1,11 @@
 import { LinearGradient } from '@tamagui/linear-gradient';
+import { useConnectionStatus } from '@tloncorp/shared';
 import * as db from '@tloncorp/shared/db';
 import { Icon } from '@tloncorp/ui';
 import { Image } from '@tloncorp/ui';
 import { Pressable } from '@tloncorp/ui';
 import { BlurView } from 'expo-blur';
-import { useCallback } from 'react';
+import { useCallback, useMemo } from 'react';
 import { OpaqueColorValue } from 'react-native';
 import Animated, {
   Easing,
@@ -42,6 +43,7 @@ export function BaubleHeader({
   const insets = useSafeAreaInsets();
   const frame = useSafeAreaFrame();
   const groupTitle = useGroupTitle(group);
+  const connectionStatus = useConnectionStatus();
 
   const easedValue = useDerivedValue(
     () => Easing.ease(scrollValue.value),
@@ -73,6 +75,11 @@ export function BaubleHeader({
     }
   }, [channel.id, group, chatOptions]);
 
+  const connectionOpacity = useMemo(
+    () => (connectionStatus === 'Connected' ? 1 : 0.5),
+    [connectionStatus]
+  );
+
   return (
     <View
       height={insets.top}
@@ -88,7 +95,7 @@ export function BaubleHeader({
         <Animated.View
           style={[
             {
-              opacity: 1,
+              opacity: connectionOpacity,
               position: 'absolute',
               top: insets.top,
               left: frame.width / 2 - 24,
@@ -102,6 +109,7 @@ export function BaubleHeader({
             borderRadius="$l"
             overflow="hidden"
             onPress={handlePress}
+            opacity={connectionOpacity}
           >
             <BlurView intensity={32}>
               {showSpinner ? (

--- a/packages/app/ui/components/Channel/ChannelHeader.tsx
+++ b/packages/app/ui/components/Channel/ChannelHeader.tsx
@@ -1,3 +1,4 @@
+import { useConnectionStatus } from '@tloncorp/shared';
 import * as db from '@tloncorp/shared/db';
 import { useIsWindowNarrow } from '@tloncorp/ui';
 import { Pressable } from '@tloncorp/ui';
@@ -106,6 +107,7 @@ export function ChannelHeader({
 }) {
   const chatOptions = useChatOptions();
   const [openChatOptions, setOpenChatOptions] = useState(false);
+  const connectionStatus = useConnectionStatus();
 
   const handlePressOverflowMenu = useCallback(() => {
     chatOptions.open(channel.id, 'channel');
@@ -114,8 +116,33 @@ export function ChannelHeader({
   const contextItems = useContext(ChannelHeaderItemsContext)?.items ?? [];
   const isWindowNarrow = useIsWindowNarrow();
 
+  const displayTitle = useMemo(() => {
+    if (connectionStatus === 'Connected') {
+      return title;
+    }
+
+    const statusText =
+      connectionStatus === 'Connecting' || connectionStatus === 'Reconnecting'
+        ? 'Connecting...'
+        : connectionStatus === 'Idle'
+          ? 'Initializing...'
+          : 'Disconnected';
+
+    return statusText;
+  }, [title, connectionStatus]);
+
   if (mode === 'next') {
-    return <BaubleHeader channel={channel} group={group} />;
+    return (
+      <BaubleHeader
+        channel={channel}
+        group={group}
+        showSpinner={
+          showSpinner ||
+          connectionStatus === 'Connecting' ||
+          connectionStatus === 'Reconnecting'
+        }
+      />
+    );
   }
 
   const titleWidth = () => {
@@ -135,7 +162,7 @@ export function ChannelHeader({
       <ScreenHeader
         title={
           <Pressable onPress={goToChatDetails}>
-            <ScreenHeader.Title>{title}</ScreenHeader.Title>
+            <ScreenHeader.Title>{displayTitle}</ScreenHeader.Title>
           </Pressable>
         }
         titleWidth={titleWidth()}


### PR DESCRIPTION
When the user in a channel and their long-press actions are disabled, it's not clear what's going on. Since the channel header looks black, things seem fine. When they navigate to the home screen, I can see that the app is 'Connecting…'.

This surfaces the connecting / init / disconnected state in the channel header. If the state is fully connected, we show the channel title and/or the "Loading..." indicator.

Fixes TLON-3662