### PR TITLE
Add ability to join group by flag

### DIFF
--- a/apps/tlon-mobile/ios/Podfile.lock
+++ b/apps/tlon-mobile/ios/Podfile.lock
@@ -2168,7 +2168,7 @@ EXTERNAL SOURCES:
 SPEC CHECKSUMS:
   boost: d3f49c53809116a5d38da093a8aa78bf551aed09
   BranchSDK: cb046c2714b03e573484ce9e349e2ddbad7016e8
-  DoubleConversion: 76ab83afb40bddeeee456813d9c04f67f78771b5
+  DoubleConversion: fea03f2699887d960129cc54bba7e52542b6f953
   EASClient: 1509a9a6b48b932ec61667644634daf2562983b8
   EXApplication: c08200c34daca7af7fd76ac4b9d606077410e8ad
   EXAV: afa491e598334bbbb92a92a2f4dd33d7149ad37f
@@ -2219,7 +2219,7 @@ SPEC CHECKSUMS:
   FirebaseSessions: dbd14adac65ce996228652c1fc3a3f576bdf3ecc
   FirebaseSharedSwift: 20530f495084b8d840f78a100d8c5ee613375f6e
   fmt: 4c2741a687cc09f0634a2e2c72a838b99f1ff120
-  glog: fdfdfe5479092de0c4bdbebedd9056951f092c4f
+  glog: c5d68082e772fa1c511173d6b30a9de2c05a69a2
   GoogleDataTransport: 6c09b596d841063d76d4288cc2d2f42cc36e1e2a
   GoogleUtilities: ea963c370a38a8069cc5f7ba4ca849a60b6d7d15
   hermes-engine: 8c1577f3fdb849cbe7729c2e7b5abc4b845e88f8

--- a/packages/app/features/top/CreateChatSheet.tsx
+++ b/packages/app/features/top/CreateChatSheet.tsx
@@ -329,7 +329,6 @@ export const CreateChatSheet = forwardRef(function CreateChatSheet(
       <Popover.Trigger asChild>{trigger}</Popover.Trigger>
       <Popover.Content
         elevate
-        animation="quick"
         zIndex={1000000}
         position="relative"
         borderColor="$border"

--- a/packages/app/hooks/useGroupSearch.ts
+++ b/packages/app/hooks/useGroupSearch.ts
@@ -1,0 +1,116 @@
+import * as store from '@tloncorp/shared';
+import * as db from '@tloncorp/shared/db';
+import { useCallback, useEffect, useMemo, useState } from 'react';
+
+import { GroupPreviewAction } from '../ui';
+import { useGroupActions } from './useGroupActions';
+
+export default function useGroupSearch(groupCode: string) {
+  const [isSearching, setIsSearching] = useState(false);
+  const [foundGroup, setFoundGroup] = useState<db.Group | null>(null);
+  const [isCodeValid, setIsCodeValid] = useState(false);
+
+  useEffect(() => {
+    if (groupCode !== '') {
+      const isValidGroupId = store.isGroupId(groupCode);
+      if (!isValidGroupId) {
+        // Check if it's a group reference format
+        const parts = groupCode.split('/');
+        const potentialGroupCode = [parts[3], parts[4]].join('/');
+        const isValidRef = store.isGroupId(potentialGroupCode);
+        setIsCodeValid(isValidRef);
+      } else {
+        setIsCodeValid(true);
+      }
+    } else {
+      setIsCodeValid(false);
+    }
+  }, [groupCode]);
+
+  const normalizedCode = useMemo(() => {
+    if (!groupCode) return '';
+
+    if (store.isGroupId(groupCode)) {
+      return groupCode;
+    }
+
+    // Handle reference format
+    const parts = groupCode.split('/');
+    if (parts.length >= 5) {
+      const potentialCode = [parts[3], parts[4]].join('/');
+      if (store.isGroupId(potentialCode)) {
+        return potentialCode;
+      }
+    }
+
+    return groupCode;
+  }, [groupCode]);
+
+  const {
+    data: groupsHostedBy,
+    isLoading,
+    isError,
+    error: errorHostedBy,
+  } = store.useGroupsHostedBy(normalizedCode.split('/')[0], !isCodeValid);
+
+  useEffect(() => {
+    if (groupsHostedBy && !isLoading && !isError && isSearching) {
+      const groupInHostedBy = groupsHostedBy.find(
+        (g) => g.id === normalizedCode
+      );
+      if (groupInHostedBy) {
+        setFoundGroup(groupInHostedBy);
+      }
+    }
+
+    if (isError) {
+      setFoundGroup(null);
+      console.error('Error fetching group', errorHostedBy);
+    }
+  }, [
+    isLoading,
+    isError,
+    groupsHostedBy,
+    normalizedCode,
+    errorHostedBy,
+    isSearching,
+  ]);
+
+  const { performGroupAction } = useGroupActions();
+
+  const handleGroupAction = useCallback(
+    (action: GroupPreviewAction, updatedGroup: db.Group) => {
+      performGroupAction(action, updatedGroup);
+      setIsSearching(false);
+      setFoundGroup(null);
+    },
+    [performGroupAction]
+  );
+
+  const startSearch = useCallback(() => {
+    if (isCodeValid) {
+      setIsSearching(true);
+    }
+  }, [isCodeValid]);
+
+  const resetSearch = useCallback(() => {
+    setIsSearching(false);
+    setFoundGroup(null);
+  }, []);
+
+  return {
+    isCodeValid,
+    normalizedCode,
+    state: {
+      isSearching,
+      isLoading,
+      isError,
+      group: foundGroup,
+    },
+    actions: {
+      startSearch,
+      resetSearch,
+      handleGroupAction,
+    },
+  };
+}

--- a/packages/app/hooks/useGroupSearch.ts
+++ b/packages/app/hooks/useGroupSearch.ts
@@ -1,5 +1,6 @@
-import * as store from '@tloncorp/shared';
 import * as db from '@tloncorp/shared/db';
+import * as store from '@tloncorp/shared/store';
+import { whomIsFlag } from '@tloncorp/shared/urbit';
 import { useCallback, useEffect, useMemo, useState } from 'react';
 
 import { GroupPreviewAction } from '../ui';
@@ -12,12 +13,12 @@ export default function useGroupSearch(groupCode: string) {
 
   useEffect(() => {
     if (groupCode !== '') {
-      const isValidGroupId = store.isGroupId(groupCode);
+      const isValidGroupId = whomIsFlag(groupCode);
       if (!isValidGroupId) {
         // Check if it's a group reference format
         const parts = groupCode.split('/');
         const potentialGroupCode = [parts[3], parts[4]].join('/');
-        const isValidRef = store.isGroupId(potentialGroupCode);
+        const isValidRef = whomIsFlag(potentialGroupCode);
         setIsCodeValid(isValidRef);
       } else {
         setIsCodeValid(true);
@@ -30,7 +31,7 @@ export default function useGroupSearch(groupCode: string) {
   const normalizedCode = useMemo(() => {
     if (!groupCode) return '';
 
-    if (store.isGroupId(groupCode)) {
+    if (whomIsFlag(groupCode)) {
       return groupCode;
     }
 
@@ -38,7 +39,7 @@ export default function useGroupSearch(groupCode: string) {
     const parts = groupCode.split('/');
     if (parts.length >= 5) {
       const potentialCode = [parts[3], parts[4]].join('/');
-      if (store.isGroupId(potentialCode)) {
+      if (whomIsFlag(potentialCode)) {
         return potentialCode;
       }
     }

--- a/packages/app/ui/components/ChatMessage/ChatMessageActions/Component.tsx
+++ b/packages/app/ui/components/ChatMessage/ChatMessageActions/Component.tsx
@@ -146,7 +146,6 @@ export function ChatMessageActions({
         <Popover.Trigger asChild>{trigger}</Popover.Trigger>
         <Popover.Content
           elevate
-          animation="quick"
           zIndex={1000000}
           position="relative"
           borderColor="$border"

--- a/packages/app/ui/components/GroupPreviewSheet.tsx
+++ b/packages/app/ui/components/GroupPreviewSheet.tsx
@@ -4,6 +4,7 @@ import * as logic from '@tloncorp/shared/logic';
 import * as store from '@tloncorp/shared/store';
 import { LoadingSpinner } from '@tloncorp/ui';
 import React, { useCallback, useEffect, useMemo, useState } from 'react';
+import { YStack } from 'tamagui';
 
 import { triggerHaptic, useGroupTitle } from '../utils';
 import {
@@ -62,7 +63,9 @@ function GroupPreviewSheetComponent({
   return (
     <ActionSheet open={open} onOpenChange={onOpenChange}>
       {group ? (
-        <GroupPreviewPane group={group} onActionComplete={actionHandler} />
+        <ActionSheet.Content>
+          <GroupPreviewPane group={group} onActionComplete={actionHandler} />
+        </ActionSheet.Content>
       ) : (
         <LoadingSpinner />
       )}
@@ -170,7 +173,7 @@ export function GroupPreviewPane({
         subtitle={group.description ?? undefined}
         icon={<ListItem.GroupIcon model={group} />}
       />
-      <ActionSheet.Content>
+      <YStack>
         <ActionSheet.SimpleActionGroupList
           actionGroups={getActionGroups(status, {
             respondToInvite,
@@ -181,7 +184,7 @@ export function GroupPreviewPane({
             cancelJoin,
           })}
         />
-      </ActionSheet.Content>
+      </YStack>
     </>
   );
 }

--- a/packages/shared/src/api/apiUtils.ts
+++ b/packages/shared/src/api/apiUtils.ts
@@ -1,6 +1,7 @@
 import {
   formatUd as baseFormatUd,
   daToUnix,
+  isValidPatp,
   parseUd,
   unixToDa,
 } from '@urbit/aura';
@@ -80,6 +81,14 @@ export function isGroupChannelId(channelId: string) {
     channelId.startsWith('diary') ||
     channelId.startsWith('heap')
   );
+}
+
+export function isGroupId(groupId: string) {
+  const parts = groupId.split('/');
+  const host = parts[0];
+  const length = parts.length;
+  const hostIsPatp = isValidPatp(host);
+  return hostIsPatp && length === 2;
 }
 
 export function parseGroupChannelId(channelId: string) {

--- a/packages/shared/src/api/apiUtils.ts
+++ b/packages/shared/src/api/apiUtils.ts
@@ -83,14 +83,6 @@ export function isGroupChannelId(channelId: string) {
   );
 }
 
-export function isGroupId(groupId: string) {
-  const parts = groupId.split('/');
-  const host = parts[0];
-  const length = parts.length;
-  const hostIsPatp = isValidPatp(host);
-  return hostIsPatp && length === 2;
-}
-
 export function parseGroupChannelId(channelId: string) {
   const parts = channelId.split('/');
   return {

--- a/packages/shared/src/logic/utils.ts
+++ b/packages/shared/src/logic/utils.ts
@@ -10,11 +10,12 @@ import {
   isDmChannelId,
   isGroupChannelId,
   isGroupDmChannelId,
+  isGroupId,
 } from '../api/apiUtils';
 import * as db from '../db';
 import * as ub from '../urbit';
 
-export { isDmChannelId, isGroupChannelId, isGroupDmChannelId };
+export { isDmChannelId, isGroupChannelId, isGroupDmChannelId, isGroupId };
 
 export const IMAGE_REGEX =
   /(\.jpg|\.img|\.png|\.gif|\.tiff|\.jpeg|\.webp|\.svg)(?:\?.*)?$/i;

--- a/packages/shared/src/logic/utils.ts
+++ b/packages/shared/src/logic/utils.ts
@@ -10,12 +10,11 @@ import {
   isDmChannelId,
   isGroupChannelId,
   isGroupDmChannelId,
-  isGroupId,
 } from '../api/apiUtils';
 import * as db from '../db';
 import * as ub from '../urbit';
 
-export { isDmChannelId, isGroupChannelId, isGroupDmChannelId, isGroupId };
+export { isDmChannelId, isGroupChannelId, isGroupDmChannelId };
 
 export const IMAGE_REGEX =
   /(\.jpg|\.img|\.png|\.gif|\.tiff|\.jpeg|\.webp|\.svg)(?:\?.*)?$/i;

--- a/packages/shared/src/store/dbHooks.ts
+++ b/packages/shared/src/store/dbHooks.ts
@@ -428,7 +428,7 @@ export const usePostReference = ({
   return postQuery;
 };
 
-export const useGroupsHostedBy = (userId: string) => {
+export const useGroupsHostedBy = (userId: string, disabled?: boolean) => {
   return useQuery({
     queryKey: ['groupsHostedBy', userId],
     queryFn: async () => {
@@ -444,6 +444,7 @@ export const useGroupsHostedBy = (userId: string) => {
     // this query's data rarely changes and is never invalidated elsewhere,
     // so we set stale time manually
     staleTime: 1000 * 60 * 30,
+    enabled: !disabled,
   });
 };
 


### PR DESCRIPTION
fixes tlon-3849

Adds a new option to the CreateChatSheet that allows the user to "Join a group by code" (thoughts on copy here?). The user can paste either a reference string (`/1/group/~zod/some-group`) or a flag (`~zod/some-group`). If it's valid, they can press "Go" on the text input and we'll fetch the group details and display the GroupPreviewPane (where they can join/request to join the group).

Works on both desktop and mobile. 

I created a new hook called `useGroupSearch` in case we want to add this functionality elsewhere, later on down the line.