### PR TITLE
Web: optimize startup time

### DIFF
--- a/apps/tlon-web-new/src/app.tsx
+++ b/apps/tlon-web-new/src/app.tsx
@@ -352,7 +352,6 @@ function ConnectedWebApp() {
         hasSyncedRef.current = true;
       }
 
-      console.log(`bl: session`, session);
       if (!session?.startTime) {
         return;
       }

--- a/apps/tlon-web-new/src/app.tsx
+++ b/apps/tlon-web-new/src/app.tsx
@@ -7,6 +7,7 @@ import {
 import { ShipProvider } from '@tloncorp/app/contexts/ship';
 import { useConfigureUrbitClient } from '@tloncorp/app/hooks/useConfigureUrbitClient';
 import { useCurrentUserId } from '@tloncorp/app/hooks/useCurrentUser';
+import useDesktopNotifications from '@tloncorp/app/hooks/useDesktopNotifications';
 import { useFindSuggestedContacts } from '@tloncorp/app/hooks/useFindSuggestedContacts';
 import { useIsDarkMode } from '@tloncorp/app/hooks/useIsDarkMode';
 import { BasePathNavigator } from '@tloncorp/app/navigation/BasePathNavigator';
@@ -36,7 +37,6 @@ import { useIsDark, useIsMobile } from '@/logic/useMedia';
 import { preSig } from '@/logic/utils';
 import { toggleDevTools, useLocalState, useShowDevTools } from '@/state/local';
 import { useAnalyticsId, useLogActivity, useTheme } from '@/state/settings';
-import useDesktopNotifications from '@tloncorp/app/hooks/useDesktopNotifications';
 
 import { DesktopLoginScreen } from './components/DesktopLoginScreen';
 import { isElectron } from './electron-bridge';
@@ -270,7 +270,7 @@ function ConnectedDesktopApp({
   const hasSyncedRef = React.useRef(false);
   useFindSuggestedContacts();
   useDesktopNotifications(clientReady);
-  
+
   useEffect(() => {
     window.ship = ship;
     window.our = ship;
@@ -333,6 +333,7 @@ function ConnectedWebApp() {
   const currentUserId = useCurrentUserId();
   const [dbIsLoaded, setDbIsLoaded] = useState(false);
   const configureClient = useConfigureUrbitClient();
+  const session = store.useCurrentSession();
   const hasSyncedRef = React.useRef(false);
   useFindSuggestedContacts();
 
@@ -347,8 +348,13 @@ function ConnectedWebApp() {
       if (!hasSyncedRef.current) {
         // Web doesn't persist database, so headsSyncedAt is misleading
         await db.headsSyncedAt.resetValue();
-        await sync.syncStart(false);
+        sync.syncStart(false);
         hasSyncedRef.current = true;
+      }
+
+      console.log(`bl: session`, session);
+      if (!session?.startTime) {
+        return;
       }
 
       // we need to check the size of the database here to see if it's not zero
@@ -375,7 +381,7 @@ function ConnectedWebApp() {
     };
 
     syncStart();
-  }, [dbIsLoaded, currentUserId, configureClient]);
+  }, [dbIsLoaded, currentUserId, configureClient, session]);
 
   if (!dbIsLoaded) {
     return (

--- a/packages/shared/src/store/cachedData.ts
+++ b/packages/shared/src/store/cachedData.ts
@@ -1,0 +1,12 @@
+// No-op on Native. Response cacheing is only valuable in
+// ephemeral environments like web where the app is regularly
+// loaded from scratch.
+import * as db from '../db';
+
+export function cacheContacts(contacts: db.Contact[]) {
+  return;
+}
+
+export async function loadCachedContacts(): Promise<boolean> {
+  return false;
+}

--- a/packages/shared/src/store/cachedData.web.ts
+++ b/packages/shared/src/store/cachedData.web.ts
@@ -1,0 +1,40 @@
+import * as db from '../db';
+
+const CacheKeys = {
+  contacts: 'tlon:cache:contacts',
+  contactsLastUpdated: 'tlon:cache:contacts:lastUpdated',
+};
+
+const TWO_DAYS = 2 * 24 * 60 * 60 * 1000;
+
+export function cacheContacts(contacts: db.Contact[]) {
+  const value = JSON.stringify(contacts);
+  localStorage.setItem(CacheKeys.contacts, value);
+  localStorage.setItem(CacheKeys.contactsLastUpdated, Date.now().toString());
+}
+
+export async function loadCachedContacts(): Promise<boolean> {
+  try {
+    const contactsValue = localStorage.getItem(CacheKeys.contacts);
+    const lastUpdatedValue = localStorage.getItem(
+      CacheKeys.contactsLastUpdated
+    );
+
+    if (!contactsValue || !lastUpdatedValue) {
+      return false;
+    }
+
+    const contacts = JSON.parse(contactsValue);
+    const lastUpdated = new Date(lastUpdatedValue).getTime();
+
+    if (Date.now() - lastUpdated > TWO_DAYS) {
+      return false;
+    }
+
+    await db.insertContacts(contacts);
+    return true;
+  } catch (e) {
+    console.error('Failed to load cached contacts', e);
+    return false;
+  }
+}

--- a/packages/shared/src/store/sync.ts
+++ b/packages/shared/src/store/sync.ts
@@ -24,7 +24,7 @@ import { addToChannelPosts, clearChannelPostsQueries } from './useChannelPosts';
 
 export { SyncPriority, syncQueue } from './syncQueue';
 
-const logger = createDevLogger('sync', true);
+const logger = createDevLogger('sync', false);
 
 // Used to track latest post we've seen for each channel.
 // Updated when:


### PR DESCRIPTION
It seems the main driver of laggy startup time is waiting for all of `syncStart` to complete. Limiting the UI blocking to high priority sync seemed to alleviate a decent portion of the wait.

The one low priority request we have right now that's required to display the root ChatList view is `syncContacts`. Bumping it up to high priority still nets most of the savings without initially flashing empty contact info in the list.

Going a step further, it also occurred to me that `syncContacts` results are more cacheable than `syncInit` and `syncLatestPosts` — generally you won't have new contacts or contacts with updated avatars/nicknames between webapp opens. I added a basic mechanism to store contacts outside the DB on sync and try loading them from cache during `syncStart`. On web, if we get a cache hit we'll defer syncing to low priority and paint the UI before refreshing them.

Kind of on the fence as to whether it's worthwhile to add that complexity. Let me know what y'all think, I'm also fine simply bumping it up to high priority unconditionally.