### PR TITLE
mobile: fix issue with channel header truncation

### DIFF
--- a/packages/app/ui/components/Channel/ChannelHeader.tsx
+++ b/packages/app/ui/components/Channel/ChannelHeader.tsx
@@ -161,7 +161,7 @@ export function ChannelHeader({
     <>
       <ScreenHeader
         title={
-          <Pressable onPress={goToChatDetails}>
+          <Pressable flex={1} onPress={goToChatDetails}>
             <ScreenHeader.Title>{displayTitle}</ScreenHeader.Title>
           </Pressable>
         }


### PR DESCRIPTION
fixes tlon-3671, which was actually an issue with the ChannelHeader generally. The `<Pressable />` container that is wrapping `<ScreenHeader.Title />` didn't have a definite width, so the `numberOfLines` prop on `<ScreenHeader.Title />` was just being ingored.