### PR TITLE
desktop: proper shades for active/hover states in sidebars

### DIFF
--- a/packages/app/features/chat-list/ChatList.tsx
+++ b/packages/app/features/chat-list/ChatList.tsx
@@ -88,7 +88,7 @@ export const ChatList = React.memo(function ChatListComponent({
             onPress={onPressItem}
             onLongPress={handleLongPress}
             onLayout={handleItemLayout}
-            hoverStyle={{ backgroundColor: '$border' }}
+            hoverStyle={{ backgroundColor: '$secondaryBackground' }}
           />
         );
       } else if (item.type === 'group' && !item.isPending) {
@@ -98,7 +98,7 @@ export const ChatList = React.memo(function ChatListComponent({
             onPress={onPressItem}
             onLongPress={handleLongPress}
             onLayout={handleItemLayout}
-            hoverStyle={{ backgroundColor: '$border' }}
+            hoverStyle={{ backgroundColor: '$secondaryBackground' }}
           />
         );
       } else {
@@ -109,7 +109,7 @@ export const ChatList = React.memo(function ChatListComponent({
             onLongPress={handleLongPress}
             onLayout={handleItemLayout}
             disableOptions={item.isPending}
-            hoverStyle={{ backgroundColor: '$border' }}
+            hoverStyle={{ backgroundColor: '$secondaryBackground' }}
           />
         );
       }

--- a/packages/app/ui/components/ContactsScreenView.tsx
+++ b/packages/app/ui/components/ContactsScreenView.tsx
@@ -86,9 +86,9 @@ export function ContactsScreenView(props: Props) {
           subtitle={item.status ? item.status : undefined}
           onPress={() => props.onContactPress(item)}
           onLongPress={() => props.onContactLongPress(item)}
-          backgroundColor={isFocused ? '$secondaryBackground' : 'unset'}
+          backgroundColor={isFocused ? '$shadow' : 'unset'}
           borderColor="$border"
-          hoverStyle={{ backgroundColor: '$border' }}
+          hoverStyle={{ backgroundColor: '$secondaryBackground' }}
         />
       );
     },

--- a/packages/app/ui/components/ListItem/ChannelListItem.tsx
+++ b/packages/app/ui/components/ListItem/ChannelListItem.tsx
@@ -72,8 +72,8 @@ export function ChannelListItem({
         borderRadius="$xl"
         onPress={handlePress}
         onLongPress={isWeb ? undefined : handleLongPress}
-        backgroundColor={isFocused ? '$secondaryBackground' : undefined}
-        hoverStyle={{ backgroundColor: '$border' }}
+        backgroundColor={isFocused ? '$shadow' : undefined}
+        hoverStyle={{ backgroundColor: '$secondaryBackground' }}
       >
         <ListItem {...props}>
           <ListItem.ChannelIcon


### PR DESCRIPTION
Does what it says on the tin. Darker shade for selected, slightly lighter shade for hover.