### PR TITLE
verifier, lanyard: compat with 410 jael vile scry

### DIFF
--- a/desk/app/lanyard.hoon
+++ b/desk/app/lanyard.hoon
@@ -60,8 +60,14 @@
 ++  sign
   |*  [[our=@p now=@da] dat=*]
   ^-  (signed _dat)
-  =+  =>  [our=our now=now ..lull]  ~+
-      ;;(=seed:jael (cue .^(@ %j /(scot %p our)/vile/(scot %da now))))
+  =+  =>  [our=our now=now feed=feed ..lull]  ~+
+      ;;(=feed (cue .^(@ %j /(scot %p our)/vile/(scot %da now))))
+  =/  seed=[who=@p lyf=life key=ring]
+    ?-  feed
+      [@ *]       [who.feed lyf.feed key.feed]
+      [[%1 *] *]  [who.feed (rear kyz.feed)]
+      [[%2 *] *]  [who.feed (rear kyz.feed)]
+    ==
   ?>  =(who.seed our)
   =/  sig=@ux  (sigh:as:(nol:nu:crub:crypto key.seed) (jam dat))
   [our lyf.seed dat sig]

--- a/desk/app/verifier.hoon
+++ b/desk/app/verifier.hoon
@@ -368,8 +368,14 @@
 ++  sign
   |*  [[our=@p now=@da] dat=*]
   ^-  (signed _dat)
-  =+  =>  [our=our now=now ..lull]  ~+
-      ;;(=seed:jael (cue .^(@ %j /(scot %p our)/vile/(scot %da now))))
+  =+  =>  [our=our now=now feed=feed ..lull]  ~+
+      ;;(=feed (cue .^(@ %j /(scot %p our)/vile/(scot %da now))))
+  =/  seed=[who=@p lyf=life key=ring]
+    ?-  feed
+      [@ *]       [who.feed lyf.feed key.feed]
+      [[%1 *] *]  [who.feed (rear kyz.feed)]
+      [[%2 *] *]  [who.feed (rear kyz.feed)]
+    ==
   ?>  =(who.seed our)
   =/  sig=@ux  (sigh:as:(nol:nu:crub:crypto key.seed) (jam dat))
   [our lyf.seed dat sig]

--- a/desk/sur/verifier.hoon
+++ b/desk/sur/verifier.hoon
@@ -77,6 +77,13 @@
       [%urbit sig=payload:urbit]
   ==
 ::
+::TMP  410 jael vile scry type for cross-compat
++$  feed
+  $^  $%  [[%1 ~] who=ship kyz=(list [lyf=life key=ring])]
+          [[%2 ~] who=ship ryf=rift kyz=(list [lyf=life key=ring])]
+      ==
+  seed:jael
+::
 ++  signed
   |$  dat
   $:  who=@p


### PR DESCRIPTION
Copies over the 410 $feed:jael type into our sur file, because we scry for it in (due to operational weakness) environments in either 411 _or_ 410. This types hould be compatible with both.

We pluck suss out the $seed from the result we receive and operate on it as normal.

We should do a proper 410-only patch here once the situation around that scry endpoint in 410 solidifies.