### PR TITLE
latest posts: always do a full sync when the app is freshly opened

### DIFF
--- a/apps/tlon-mobile/src/components/AuthenticatedApp.tsx
+++ b/apps/tlon-mobile/src/components/AuthenticatedApp.tsx
@@ -42,8 +42,9 @@ function AuthenticatedApp() {
 
       // app opened
       if (status === 'opened') {
-        db.headsSyncedAt.resetValue();
-        sync.syncLatestPosts({ priority: sync.SyncPriority.High });
+        db.headsSyncedAt.resetValue().then(() => {
+          sync.syncLatestPosts({ priority: sync.SyncPriority.High });
+        });
       }
 
       // app opened or returned from background

--- a/apps/tlon-mobile/src/components/AuthenticatedApp.tsx
+++ b/apps/tlon-mobile/src/components/AuthenticatedApp.tsx
@@ -10,9 +10,9 @@ import { useTelemetry } from '@tloncorp/app/hooks/useTelemetry';
 import { useUpdatePresentedNotifications } from '@tloncorp/app/lib/notifications';
 import { RootStack } from '@tloncorp/app/navigation/RootStack';
 import { AppDataProvider } from '@tloncorp/app/provider/AppDataProvider';
+import { PortalProvider, ZStack } from '@tloncorp/app/ui';
 import { sync } from '@tloncorp/shared';
 import * as db from '@tloncorp/shared/db';
-import { PortalProvider, ZStack } from '@tloncorp/app/ui';
 import { useCallback, useEffect, useState } from 'react';
 
 import { checkAnalyticsDigest, useCheckAppUpdated } from '../hooks/analytics';
@@ -38,6 +38,12 @@ function AuthenticatedApp() {
       if (status === 'active') {
         sync.syncUnreads({ priority: sync.SyncPriority.High });
         sync.syncPinnedItems({ priority: sync.SyncPriority.High });
+      }
+
+      // app opened
+      if (status === 'opened') {
+        db.headsSyncedAt.resetValue();
+        sync.syncLatestPosts({ priority: sync.SyncPriority.High });
       }
 
       // app opened or returned from background


### PR DESCRIPTION
We added a performance optimization to `syncLatestPosts` that tries to only grab new ones you don't already have. This can be an issue when the DB resets since the `headsSyncedAt` marker is stored separately.

To account for this scenario, we manually reset the marker anytime the DB is purged. However it seems this doesn't cover all cases since we're getting reports of missing posts after app updates where that logic should have been triggered.

Let's make sure this can never happen by always doing a full `syncLatestPosts` whenever the app is first opened (not returning from background). This should make sure we never get partial results after app update or force close while continuing to use the lighter optimized sync most of the time. 

Perf wise, until recently we were _always_ doing a full `syncLatestPosts` so incurring that cost infrequently should be tolerable.