### PR TITLE
fix: modal issues

### DIFF
--- a/packages/app/ui/components/ImageViewerScreenView.tsx
+++ b/packages/app/ui/components/ImageViewerScreenView.tsx
@@ -3,7 +3,7 @@ import { Icon } from '@tloncorp/ui';
 import { Image } from '@tloncorp/ui';
 import * as FileSystem from 'expo-file-system';
 import * as MediaLibrary from 'expo-media-library';
-import { ElementRef, useRef, useState } from 'react';
+import { ElementRef, PropsWithChildren, useRef, useState } from 'react';
 import { Alert, Dimensions, Modal, TouchableOpacity } from 'react-native';
 import {
   Directions,
@@ -96,7 +96,7 @@ export function ImageViewerScreenView(props: {
   };
 
   return (
-    <Modal animationType="none">
+    <ImageViewerContainer>
       <GestureDetector gesture={dismissGesture}>
         <ZStack
           flex={1}
@@ -144,7 +144,7 @@ export function ImageViewerScreenView(props: {
                 isDoubleTapEnabled
                 isSingleTapEnabled
                 isPanEnabled
-                width={Dimensions.get('window').width - 20}
+                width={Dimensions.get('window').width}
                 maxPanPointers={maxPanPointers}
                 minScale={0.1}
                 onPinchEnd={handlePinchEnd}
@@ -196,6 +196,15 @@ export function ImageViewerScreenView(props: {
           ) : null}
         </ZStack>
       </GestureDetector>
-    </Modal>
+    </ImageViewerContainer>
   );
+}
+
+function ImageViewerContainer(props: PropsWithChildren) {
+  // on web, we wrap in a mobile to escape the drawer navigators
+  if (isWeb) {
+    return <Modal animationType="none">{props.children}</Modal>;
+  }
+
+  return props.children;
 }

--- a/packages/app/ui/components/ImageViewerScreenView.tsx
+++ b/packages/app/ui/components/ImageViewerScreenView.tsx
@@ -201,7 +201,7 @@ export function ImageViewerScreenView(props: {
 }
 
 function ImageViewerContainer(props: PropsWithChildren) {
-  // on web, we wrap in a mobile to escape the drawer navigators
+  // on web, we wrap in a modal to escape the drawer navigators
   if (isWeb) {
     return <Modal animationType="none">{props.children}</Modal>;
   }


### PR DESCRIPTION
Fixes TLON-3870 by calling the correct close method. Also avoids open state thrashing by waiting to pop the sheet until reading the real storage value.

Fixes TLON-3875 by only rendering the `Modal` on web. More carefully managing the `Modal` state also worked, but since it's only present to escape the web drawer navigators, I think it's better to avoid using it here on mobile whatsoever.