### PR TITLE
Mobile: bundle of fixes

### DIFF
--- a/apps/tlon-mobile/eas.json
+++ b/apps/tlon-mobile/eas.json
@@ -23,7 +23,8 @@
         "gradleCommand": ":app:bundlePreviewRelease"
       },
       "ios": {
-        "scheme": "Landscape-preview"
+        "scheme": "Landscape-preview",
+        "image": "macos-sonoma-14.6-xcode-16.0"
       }
     },
     "production": {
@@ -39,7 +40,8 @@
         "gradleCommand": ":app:bundleProductionRelease"
       },
       "ios": {
-        "scheme": "Landscape"
+        "scheme": "Landscape",
+        "image": "macos-sonoma-14.6-xcode-16.0"
       }
     },
     "demo": {
@@ -59,7 +61,7 @@
       },
       "ios": {
         "scheme": "Landscape-preview",
-        "image": "latest"
+        "image": "macos-sonoma-14.6-xcode-16.0"
       }
     },
     "local-testing": {

--- a/apps/tlon-mobile/src/screens/Onboarding/SignupScreen.tsx
+++ b/apps/tlon-mobile/src/screens/Onboarding/SignupScreen.tsx
@@ -8,9 +8,6 @@ import {
   useLureMetadata,
   useSignupParams,
 } from '@tloncorp/app/contexts/branch';
-import { trackOnboardingAction } from '@tloncorp/app/utils/posthog';
-import { AnalyticsEvent, createDevLogger } from '@tloncorp/shared';
-import { HostingError } from '@tloncorp/shared/api';
 import {
   Field,
   KeyboardAvoidingView,
@@ -23,6 +20,9 @@ import {
   View,
   YStack,
 } from '@tloncorp/app/ui';
+import { trackOnboardingAction } from '@tloncorp/app/utils/posthog';
+import { AnalyticsEvent, createDevLogger } from '@tloncorp/shared';
+import { HostingError } from '@tloncorp/shared/api';
 import { useCallback, useState } from 'react';
 import { Controller, useForm } from 'react-hook-form';
 import { Platform } from 'react-native';
@@ -230,9 +230,15 @@ export const SignupScreen = ({ navigation }: Props) => {
                       keyboardType="email-address"
                       autoCapitalize="none"
                       autoCorrect={false}
-                      returnKeyType={emailForm.formState.isValid ? "next" : "default"}
-                      enablesReturnKeyAutomatically={emailForm.formState.isValid}
-                      onSubmitEditing={emailForm.formState.isValid ? onSubmit : undefined}
+                      returnKeyType={
+                        emailForm.formState.isValid ? 'next' : 'default'
+                      }
+                      enablesReturnKeyAutomatically={
+                        emailForm.formState.isValid
+                      }
+                      onSubmitEditing={
+                        emailForm.formState.isValid ? onSubmit : undefined
+                      }
                       autoFocus
                     />
                   </Field>
@@ -246,7 +252,6 @@ export const SignupScreen = ({ navigation }: Props) => {
               loading={isSubmitting}
               disabled={
                 isSubmitting ||
-                remoteError !== undefined ||
                 (otpMethod === 'phone'
                   ? !phoneForm.formState.isValid
                   : !emailForm.formState.isValid)

--- a/packages/app/ui/components/AttestationPane.tsx
+++ b/packages/app/ui/components/AttestationPane.tsx
@@ -255,10 +255,10 @@ function AttestationValueDisplay({
   }
 
   if (attestation.type === 'phone') {
-    if (attestation.contactId === currentUserId) {
+    if (attestation.contactId === currentUserId && attestation.value) {
       return (
         <Text size="$label/xl" fontWeight="600">
-          {attestation.value ? attestation.value : 'X Account'}
+          {domain.displayablePhoneNumber(attestation.value)}
         </Text>
       );
     } else {

--- a/packages/app/ui/components/EditProfile/EditAttestationsDisplay.tsx
+++ b/packages/app/ui/components/EditProfile/EditAttestationsDisplay.tsx
@@ -1,4 +1,5 @@
 import * as db from '@tloncorp/shared/db';
+import * as domain from '@tloncorp/shared/domain';
 import { Pressable } from '@tloncorp/ui';
 
 import { Field } from '../Form';
@@ -53,7 +54,8 @@ export function EditAttestationsDisplay(props: {
               <ListItem.Title>Phone</ListItem.Title>
               {phoneAttestation && (
                 <ListItem.Subtitle>
-                  {phoneAttestation.value}
+                  {phoneAttestation.value &&
+                    domain.displayablePhoneNumber(phoneAttestation.value)}
                   {'    '}
                   <ListItem.Subtitle
                     color={

--- a/packages/shared/src/domain/attestations.ts
+++ b/packages/shared/src/domain/attestations.ts
@@ -1,3 +1,5 @@
+import * as LibPhone from 'libphonenumber-js';
+
 export function parseForTwitterPostId(text: string): string | null {
   // If input is already just a numeric ID
   if (/^\d+$/.test(text)) {
@@ -31,4 +33,17 @@ export function twitterHandleDisplay(text: string): string {
   }
 
   return `@${text}`;
+}
+
+export function displayablePhoneNumber(phoneNumber: string): string {
+  if (!phoneNumber) {
+    console.error('Cannot make displayable phone number, none passed in');
+  }
+
+  const parsed = LibPhone.parsePhoneNumberFromString(phoneNumber, 'US');
+  if (!parsed) {
+    return phoneNumber;
+  }
+
+  return parsed.format('INTERNATIONAL');
 }


### PR DESCRIPTION
- Fix the issue where phone number can not be submitted multiple times during signup
- Ensure client always sends `E.164` encoded phone numbers to lanyard (cc @Fang- ) and in turn, runs pretty display processing before displaying values read from lanyard
- Explicitly sets `eas` build image for iOS to fix the warning email. 
  - Note: this should get resolved automatically before the deadline by the Expo Team, but configuring manually for now should remove the warning