### PR TITLE
ChatMessage: conditionally render reactions display

### DIFF
--- a/packages/app/ui/components/ChatMessage/ChatMessage.tsx
+++ b/packages/app/ui/components/ChatMessage/ChatMessage.tsx
@@ -235,12 +235,14 @@ const ChatMessage = ({
           />
         </View>
 
-        <View paddingBottom="$l" paddingLeft="$4xl">
-          <ReactionsDisplay
-            post={post}
-            onViewPostReactions={setViewReactionsPost}
-          />
-        </View>
+        {post.reactions && post.reactions.length > 0 && (
+          <View paddingBottom="$l" paddingLeft="$4xl">
+            <ReactionsDisplay
+              post={post}
+              onViewPostReactions={setViewReactionsPost}
+            />
+          </View>
+        )}
 
         {shouldRenderReplies ? (
           <XStack paddingLeft={'$4xl'} paddingRight="$l" paddingBottom="$l">


### PR DESCRIPTION
Does what it says on the tin. Fixes TLON-3878 and eliminates extra padding between ChatMessages.