### PR TITLE
Revert "api/store: update reaction handlers"

### DIFF
--- a/packages/shared/src/api/channelsApi.ts
+++ b/packages/shared/src/api/channelsApi.ts
@@ -267,17 +267,10 @@ export const toChannelsUpdate = (
 
           logger.log('delete post event');
           return { type: 'deletePost', postId, channelId };
-        } else if ('reacts' in postResponse) {
-          logger.log('update reactions event', postResponse);
-          if (postResponse.reacts !== null) {
-            const updatedReacts = toReactionsData(postResponse.reacts, postId);
-            logger.log('reaction data processed:', updatedReacts);
-            return {
-              type: 'updateReactions',
-              postId,
-              reactions: updatedReacts,
-            };
-          }
+        } else if ('reacts' in postResponse && postResponse.reacts !== null) {
+          const updatedReacts = toReactionsData(postResponse.reacts, postId);
+          logger.log('update reactions event');
+          return { type: 'updateReactions', postId, reactions: updatedReacts };
         }
       }
 

--- a/packages/shared/src/store/sync.ts
+++ b/packages/shared/src/store/sync.ts
@@ -925,16 +925,6 @@ export const handleChannelsUpdate = async (update: api.ChannelsUpdate) => {
         postId: update.postId,
         reactions: update.reactions,
       });
-      await db.updatePost({
-        id: update.postId,
-        syncedAt: Date.now(),
-      });
-
-      logger.log(
-        'Updated reactions for post',
-        update.postId,
-        update.reactions.length
-      );
       break;
     case 'markPostSent':
       await db.updatePost({ id: update.cacheId, deliveryStatus: 'sent' });
@@ -976,8 +966,7 @@ export const handleChatUpdate = async (update: api.ChatEvent) => {
       await db.deletePosts({ ids: [update.postId] });
       break;
     case 'addReaction':
-      // First insert the reaction
-      await db.insertPostReactions({
+      db.insertPostReactions({
         reactions: [
           {
             postId: update.postId,
@@ -986,29 +975,12 @@ export const handleChatUpdate = async (update: api.ChatEvent) => {
           },
         ],
       });
-
-      // Then update the post's syncedAt to force UI updates
-      await db.updatePost({
-        id: update.postId,
-        syncedAt: Date.now(),
-      });
-
-      logger.log('Added reaction to post', update.postId, update.react);
       break;
     case 'deleteReaction':
-      // Delete the reaction
-      await db.deletePostReaction({
+      db.deletePostReaction({
         postId: update.postId,
         contactId: update.userId,
       });
-
-      // Then update the post's syncedAt to force UI updates
-      await db.updatePost({
-        id: update.postId,
-        syncedAt: Date.now(),
-      });
-
-      logger.log('Removed reaction from post', update.postId, update.userId);
       break;
     case 'addDmInvites':
       db.insertChannels(update.channels);


### PR DESCRIPTION
This reverts commit b15b1ab0fd1b3f3b987a25b2f18359cdb9b6757f introduced in #4581. This broke live-updating reactions in chat and gallery channels.