### PR TITLE
refs: render smaller images in refs

### DIFF
--- a/packages/app/ui/components/ContentReference/ContentReference.tsx
+++ b/packages/app/ui/components/ContentReference/ContentReference.tsx
@@ -4,8 +4,8 @@ import * as db from '@tloncorp/shared/db';
 import { getChannelType } from '@tloncorp/shared/urbit';
 import { IconType } from '@tloncorp/ui';
 import { Text } from '@tloncorp/ui';
-import React from 'react';
-import { ComponentProps, useCallback } from 'react';
+import React, { createContext } from 'react';
+import { ComponentProps, useCallback, useContext } from 'react';
 import { View, XStack, styled } from 'tamagui';
 
 import { useNavigation } from '../../contexts';
@@ -24,6 +24,9 @@ import {
   ReferenceSkeleton,
   useReferenceContext,
 } from './Reference';
+
+export const IsInsideReferenceContext = createContext(false);
+export const useIsInsideReference = () => useContext(IsInsideReferenceContext);
 
 // Any reference
 
@@ -117,13 +120,15 @@ export const PostReference = ({
   return (
     <Reference {...props} hasData={!!post}>
       <ContentReferenceHeader type={channelType} />
-      {post?.type === 'block' ? (
-        <BlockReferenceContent post={post} />
-      ) : post?.type === 'note' ? (
-        <NoteReferenceContent post={post} />
-      ) : post ? (
-        <ChatReferenceContent post={post} />
-      ) : null}
+      <IsInsideReferenceContext.Provider value={true}>
+        {post?.type === 'block' ? (
+          <BlockReferenceContent post={post} />
+        ) : post?.type === 'note' ? (
+          <NoteReferenceContent post={post} />
+        ) : post ? (
+          <ChatReferenceContent post={post} />
+        ) : null}
+      </IsInsideReferenceContext.Provider>
     </Reference>
   );
 };
@@ -203,7 +208,7 @@ function ChatReferenceContent({ post }: { post: db.Post }) {
           {post.textContent}
         </Text>
       ) : (
-        <PostContentRenderer renderReferences={false} post={post} />
+        <PostContentRenderer post={post} />
       )}
     </Reference.Body>
   );

--- a/packages/app/ui/components/PostContent/BlockRenderer.tsx
+++ b/packages/app/ui/components/PostContent/BlockRenderer.tsx
@@ -23,7 +23,11 @@ import {
   styled,
 } from 'tamagui';
 
-import { ContentReferenceLoader, Reference } from '../ContentReference';
+import {
+  ContentReferenceLoader,
+  IsInsideReferenceContext,
+  Reference,
+} from '../ContentReference';
 import { VideoEmbed } from '../Embed';
 import EmbedContent from '../Embed/EmbedContent';
 import { HighlightedCode } from '../HighlightedCode';
@@ -195,6 +199,12 @@ export function ReferenceBlock({
   ComponentProps<typeof ContentReferenceLoader>,
   'reference'
 >) {
+  const isInsideReference = useContext(IsInsideReferenceContext);
+
+  if (isInsideReference) {
+    return null;
+  }
+
   return <ContentReferenceLoader reference={block} {...props} />;
 }
 
@@ -236,6 +246,8 @@ export function ImageBlock({
     aspect: block.width && block.height ? block.width / block.height : null,
   });
 
+  const isInsideReference = useContext(IsInsideReferenceContext);
+
   const handlePress = useCallback(() => {
     onPressImage?.(block.src);
   }, [block.src, onPressImage]);
@@ -250,6 +262,34 @@ export function ImageBlock({
   }, []);
 
   const shouldUseAspectRatio = imageProps?.aspectRatio !== 'unset';
+
+  if (isInsideReference) {
+    return (
+      <Pressable
+        overflow="hidden"
+        onPress={handlePress}
+        onLongPress={onLongPress}
+        {...props}
+      >
+        <ContentImage
+          source={{ uri: block.src }}
+          style={{
+            width: '100%',
+            maxHeight: 250,
+            resizeMode: 'contain',
+            ...(shouldUseAspectRatio
+              ? { aspectRatio: dimensions.aspect || 1 }
+              : {}),
+          }}
+          contentFit="contain"
+          borderRadius="$s"
+          alt={block.alt}
+          onLoad={handleImageLoaded}
+          {...imageProps}
+        />
+      </Pressable>
+    );
+  }
 
   return (
     <Pressable

--- a/packages/app/ui/components/PostContent/ContentRenderer.tsx
+++ b/packages/app/ui/components/PostContent/ContentRenderer.tsx
@@ -31,12 +31,10 @@ type ContentRendererProps = ContentContextProps &
 
 type PostContentRendererProps = ContentRendererProps & {
   post: Post;
-  renderReferences?: boolean;
 };
 
 export function PostContentRenderer({
   post,
-  renderReferences = true,
   ...props
 }: PostContentRendererProps) {
   const content = useMemo(() => {
@@ -45,11 +43,8 @@ export function PostContentRenderer({
       return [];
     }
     const content = convertContent(post.content);
-    // We don't want to render nested references
-    return !renderReferences
-      ? content.filter((b) => b.type !== 'reference')
-      : content;
-  }, [post.content, renderReferences]);
+    return content;
+  }, [post.content]);
 
   return (
     <BlockRendererProvider>


### PR DESCRIPTION
fixes tlon-3872

This adds a new, simple context: `IsInsideReferenceContext`. We can use this context to conditionally change the way we render some content in refs. For now, we just show smaller images in refs and we return null for refs-in-refs.

Removes the need for the `renderReferences?` prop in PostContentRenderer.
