### PR TITLE
attachments: improve UX while image is being resized and uploaded

### DIFF
--- a/packages/app/fixtures/ActionSheet/AttachmentSheet.fixture.tsx
+++ b/packages/app/fixtures/ActionSheet/AttachmentSheet.fixture.tsx
@@ -3,10 +3,6 @@ import AttachmentSheet from '../../ui/components/AttachmentSheet';
 
 export default (
   <AppDataContextProvider contacts={[]}>
-    <AttachmentSheet
-      onAttachmentsSet={() => {}}
-      onOpenChange={() => {}}
-      isOpen={true}
-    />
+    <AttachmentSheet onOpenChange={() => {}} isOpen={true} />
   </AppDataContextProvider>
 );

--- a/packages/app/ui/components/AddGalleryPost.tsx
+++ b/packages/app/ui/components/AddGalleryPost.tsx
@@ -1,7 +1,6 @@
 import { ImagePickerAsset } from 'expo-image-picker';
 import { useCallback, useState } from 'react';
 
-import { useAttachmentContext } from '../contexts/attachment';
 import { SimpleActionSheet } from './ActionSheet';
 import AttachmentSheet from './AttachmentSheet';
 
@@ -16,7 +15,6 @@ export default function AddGalleryPost({
   setShowGalleryInput: (show: boolean) => void;
   onSetImage: (assets: ImagePickerAsset[]) => void;
 }) {
-  const { attachAssets } = useAttachmentContext();
   const [showAttachmentSheet, setShowAttachmentSheet] = useState(false);
 
   const actions = [
@@ -38,10 +36,9 @@ export default function AddGalleryPost({
 
   const handleImageSet = useCallback(
     (assets: ImagePickerAsset[]) => {
-      attachAssets(assets);
       onSetImage(assets);
     },
-    [attachAssets, onSetImage]
+    [onSetImage]
   );
 
   return (
@@ -54,7 +51,7 @@ export default function AddGalleryPost({
       <AttachmentSheet
         isOpen={showAttachmentSheet}
         onOpenChange={setShowAttachmentSheet}
-        onAttachmentsSet={handleImageSet}
+        onAttach={handleImageSet}
       />
     </>
   );

--- a/packages/app/ui/components/BigInput.native.tsx
+++ b/packages/app/ui/components/BigInput.native.tsx
@@ -45,7 +45,7 @@ export function BigInput({
   const keyboardVerticalOffset =
     Platform.OS === 'ios' ? top + titleInputHeight : top;
 
-  const { attachments, attachAssets } = useAttachmentContext();
+  const { attachments } = useAttachmentContext();
   const imageAttachment = useMemo(() => {
     if (attachments.length > 0) {
       return attachments.find(
@@ -178,7 +178,6 @@ export function BigInput({
         <AttachmentSheet
           isOpen={showAttachmentSheet}
           onOpenChange={setShowAttachmentSheet}
-          onAttachmentsSet={attachAssets}
         />
       )}
     </YStack>

--- a/packages/app/ui/components/BigInput.tsx
+++ b/packages/app/ui/components/BigInput.tsx
@@ -38,7 +38,7 @@ export function BigInput({
   const titleInputHeight = getTokenValue('$4xl', 'size');
   const imageButtonHeight = getTokenValue('$4xl', 'size');
 
-  const { attachments, attachAssets } = useAttachmentContext();
+  const { attachments } = useAttachmentContext();
   const imageAttachment = useMemo(() => {
     if (attachments.length > 0) {
       return attachments.find(
@@ -172,7 +172,6 @@ export function BigInput({
         <AttachmentSheet
           isOpen={showAttachmentSheet}
           onOpenChange={setShowAttachmentSheet}
-          onAttachmentsSet={attachAssets}
         />
       )}
     </YStack>

--- a/packages/app/ui/components/EditableProfileImages.tsx
+++ b/packages/app/ui/components/EditableProfileImages.tsx
@@ -57,7 +57,7 @@ export function EditablePofileImages({
       props.channel?.coverImage ??
       ''
   );
-  const { attachAssets, canUpload } = useAttachmentContext();
+  const { canUpload } = useAttachmentContext();
   const { coverAttachment, iconAttachment } = useMappedImageAttachments({
     coverAttachment: localCoverUrl,
     iconAttachment: localIconUrl,
@@ -104,14 +104,12 @@ export function EditablePofileImages({
   const handleAssetsSelected = useCallback(
     (assets: ImagePickerAsset[]) => {
       if (attachingTo === 'cover') {
-        attachAssets([assets[0]]);
         setLocalCoverUrl(assets[0].uri);
       } else if (attachingTo === 'icon') {
-        attachAssets([assets[0]]);
         setLocalIconUrl(assets[0].uri);
       }
     },
-    [attachingTo, attachAssets]
+    [attachingTo]
   );
 
   const handleAttachmentCleared = useCallback(() => {
@@ -218,7 +216,7 @@ export function EditablePofileImages({
       <AttachmentSheet
         isOpen={showAttachmentSheet}
         onOpenChange={setShowAttachmentSheet}
-        onAttachmentsSet={handleAssetsSelected}
+        onAttach={handleAssetsSelected}
         showClearOption={
           (attachingTo === 'cover' && localCoverUrl !== '') ||
           (attachingTo === 'icon' && localIconUrl !== '')

--- a/packages/app/ui/components/Form/inputs.tsx
+++ b/packages/app/ui/components/Form/inputs.tsx
@@ -186,7 +186,7 @@ export const ImageInput = XStack.styleable<{
   const [assetUri, setAssetUri] = useState<string | undefined>(
     value ?? undefined
   );
-  const { attachAssets, canUpload } = useAttachmentContext();
+  const { canUpload } = useAttachmentContext();
   const isWindowNarrow = useIsWindowNarrow();
 
   useEffect(() => {
@@ -197,13 +197,9 @@ export const ImageInput = XStack.styleable<{
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [assetUri]);
 
-  const handleImageSelected = useCallback(
-    (assets: ImagePickerAsset[]) => {
-      attachAssets([assets[0]]);
-      setAssetUri(assets[0].uri);
-    },
-    [attachAssets]
-  );
+  const handleImageSelected = useCallback((assets: ImagePickerAsset[]) => {
+    setAssetUri(assets[0].uri);
+  }, []);
 
   const handleSheetToggled = useCallback(() => {
     if (!canUpload) {
@@ -253,7 +249,7 @@ export const ImageInput = XStack.styleable<{
       <AttachmentSheet
         isOpen={sheetOpen}
         onOpenChange={setSheetOpen}
-        onAttachmentsSet={handleImageSelected}
+        onAttach={handleImageSelected}
         showClearOption={showClear && !!value}
         onClearAttachments={handleImageRemoved}
       />

--- a/packages/app/ui/components/MessageInput/AttachmentButton.native.tsx
+++ b/packages/app/ui/components/MessageInput/AttachmentButton.native.tsx
@@ -2,7 +2,6 @@ import { IconButton } from '@tloncorp/ui';
 import { Add } from '@tloncorp/ui/assets/icons';
 import { useEffect, useState } from 'react';
 
-import { useAttachmentContext } from '../../contexts/attachment';
 import AttachmentSheet from '../AttachmentSheet';
 
 export default function AttachmentButton({
@@ -18,8 +17,6 @@ export default function AttachmentButton({
     }
   }, [showInputSelector, setShouldBlur]);
 
-  const { attachAssets } = useAttachmentContext();
-
   return (
     <>
       <IconButton
@@ -31,7 +28,6 @@ export default function AttachmentButton({
       <AttachmentSheet
         isOpen={showInputSelector}
         onOpenChange={setShowInputSelector}
-        onAttachmentsSet={attachAssets}
       />
     </>
   );

--- a/packages/app/ui/components/MessageInput/AttachmentButton.tsx
+++ b/packages/app/ui/components/MessageInput/AttachmentButton.tsx
@@ -2,7 +2,6 @@ import { Button } from '@tloncorp/ui';
 import { Icon } from '@tloncorp/ui';
 import { useEffect, useState } from 'react';
 
-import { useAttachmentContext } from '../../contexts/attachment';
 import AttachmentSheet from '../AttachmentSheet';
 
 export default function AttachmentButton({
@@ -18,8 +17,6 @@ export default function AttachmentButton({
     }
   }, [showInputSelector, setShouldBlur]);
 
-  const { attachAssets } = useAttachmentContext();
-
   return (
     <>
       <Button
@@ -32,7 +29,6 @@ export default function AttachmentButton({
       <AttachmentSheet
         isOpen={showInputSelector}
         onOpenChange={setShowInputSelector}
-        onAttachmentsSet={attachAssets}
       />
     </>
   );

--- a/packages/app/ui/components/MessageInput/AttachmentPreviewList.tsx
+++ b/packages/app/ui/components/MessageInput/AttachmentPreviewList.tsx
@@ -45,8 +45,11 @@ export function AttachmentPreview({
   uploading?: boolean;
 }) {
   const [aspect, setAspect] = useState(1);
+  const [isLoading, setIsLoading] = useState(true);
+
   const handleLoad = useCallback((e: ImageLoadEventData) => {
     setAspect(e.source.width / e.source.height);
+    setIsLoading(false);
   }, []);
 
   return (
@@ -60,6 +63,7 @@ export function AttachmentPreview({
           left={0}
           bottom={0}
           onLoad={handleLoad}
+          onLoadStart={() => setIsLoading(true)}
           source={{
             uri: attachment.file.uri,
           }}
@@ -79,7 +83,7 @@ export function AttachmentPreview({
 
       <RemoveAttachmentButton attachment={attachment} />
 
-      {uploading && (
+      {(uploading || (attachment.type === 'image' && isLoading)) && (
         <View
           position="absolute"
           top={0}


### PR DESCRIPTION
fixes tlon-3664 by eagerly showing a loading indicator and closing the attachment sheet as soon as the image picker or camera are launched. The hang that users were experiencing had to do with:

1) the sheet staying open until the launcher method returned a promise
2) the attachment preview list not showing any loading indicator (user only saw a gray box when we had the actual attachment ready, and that was just until the image rendered in).

Also, cleans up our use of the `attachAssets` method throughout the app. Rather than passing it in as a prop to AttachmentSheet, we just pull it out of the context there. Components that need to process the attached images can use the `onAttach` prop.