### PR TITLE
verifier: include revocation reason in logs

### DIFF
--- a/desk/app/verifier.hoon
+++ b/desk/app/verifier.hoon
@@ -332,7 +332,7 @@
   ^-  (quip card _state)
   =.  rec  ?^(rec rec (~(get by records) id))
   ?~  rec  [~ state]
-  %-  (~(tell l our.bowl `for.u.rec `-.id) %info ['registration revoked']~)
+  %-  (~(tell l our.bowl `for.u.rec `-.id) %info ~['registration revoked' why])
   :-  [(give-status for.u.rec id why %gone ~)]~
   =?  attested  ?=(%done -.status.u.rec)
     %.  sig.full.status.u.rec


### PR DESCRIPTION
We have it, might as well put it in for better insight.