### PR TITLE
web: working telemetry

### DIFF
--- a/apps/tlon-mobile/src/hooks/useNotificationListener.ts
+++ b/apps/tlon-mobile/src/hooks/useNotificationListener.ts
@@ -118,8 +118,8 @@ export default function useNotificationListener() {
         // notification multiple times.
         const errorsFromExtension = data?.meta.errorsFromExtension;
         if (errorsFromExtension != null) {
-          posthog.trackError({
-            message: 'Notification service extension forwarded an error:',
+          logger.trackError(AnalyticsEvent.ErrorNotificationService, {
+            context: 'Notification service extension forwarded an error:',
             properties: { errors: errorsFromExtension },
           });
         }
@@ -128,8 +128,8 @@ export default function useNotificationListener() {
           // https://linear.app/tlon/issue/TLON-2551/multiple-notifications-that-lead-to-nowhere-crash-app
           // We're seeing cases where `data` is null here - not sure why this is happening.
           // Log the notification and don't try to navigate.
-          posthog.trackError({
-            message: 'Failed to get notification payload',
+          logger.trackError(AnalyticsEvent.ErrorNotificationService, {
+            context: 'Failed to get notification payload',
             properties: isTlonEmployee
               ? response.notification.request
               : undefined,

--- a/apps/tlon-mobile/src/screens/Onboarding/CheckOTPScreen.tsx
+++ b/apps/tlon-mobile/src/screens/Onboarding/CheckOTPScreen.tsx
@@ -3,19 +3,17 @@ import {
   useLureMetadata,
   useSignupParams,
 } from '@tloncorp/app/contexts/branch';
-import { useShip } from '@tloncorp/app/contexts/ship';
-import { trackOnboardingAction } from '@tloncorp/app/utils/posthog';
-import { getShipUrl } from '@tloncorp/app/utils/ship';
 import {
-  AnalyticsEvent,
-  HostedNodeStatus,
-  createDevLogger,
-} from '@tloncorp/shared';
+  ScreenHeader,
+  TlonText,
+  View,
+  YStack,
+  useStore,
+} from '@tloncorp/app/ui';
+import { trackOnboardingAction } from '@tloncorp/app/utils/posthog';
+import { createDevLogger } from '@tloncorp/shared';
 import { HostingError } from '@tloncorp/shared/api';
-import { getLandscapeAuthCookie } from '@tloncorp/shared/api';
 import { storage } from '@tloncorp/shared/db';
-import * as db from '@tloncorp/shared/db';
-import { ScreenHeader, TlonText, View, YStack, useStore } from '@tloncorp/app/ui';
 import { useCallback, useMemo, useState } from 'react';
 import { Platform } from 'react-native';
 

--- a/apps/tlon-mobile/src/screens/Onboarding/CheckVerifyScreen.tsx
+++ b/apps/tlon-mobile/src/screens/Onboarding/CheckVerifyScreen.tsx
@@ -1,5 +1,4 @@
 import type { NativeStackScreenProps } from '@react-navigation/native-stack';
-import { trackError, trackOnboardingAction } from '@tloncorp/app/utils/posthog';
 import {
   Field,
   ScreenHeader,
@@ -10,6 +9,8 @@ import {
   YStack,
   useStore,
 } from '@tloncorp/app/ui';
+import { trackOnboardingAction } from '@tloncorp/app/utils/posthog';
+import { createDevLogger } from '@tloncorp/shared';
 import { createRef, useCallback, useMemo, useState } from 'react';
 import type { TextInputKeyPressEventData } from 'react-native';
 import { TextInput as RNTextInput } from 'react-native';
@@ -21,6 +22,8 @@ import { useSignupContext } from '.././../lib/signupContext';
 type Props = NativeStackScreenProps<OnboardingStackParamList, 'CheckVerify'>;
 
 const PHONE_CODE_LENGTH = 6;
+
+const logger = createDevLogger('CheckVerifyScreen', true);
 
 export const CheckVerifyScreen = ({ navigation, route: { params } }: Props) => {
   const store = useStore();
@@ -51,7 +54,7 @@ export const CheckVerifyScreen = ({ navigation, route: { params } }: Props) => {
         console.error('Error submitting verification:', err);
         if (err instanceof Error) {
           setError(err.message);
-          trackError(err);
+          logger.trackError('Error submitting verifications', err);
         }
       }
 
@@ -83,7 +86,7 @@ export const CheckVerifyScreen = ({ navigation, route: { params } }: Props) => {
       console.error('Error resending verification code:', err);
       if (err instanceof Error) {
         setError(err.message);
-        trackError(err);
+        logger.trackError('Error resending verification code', err);
       }
     }
   };

--- a/apps/tlon-mobile/src/screens/Onboarding/InventoryCheckScreen.tsx
+++ b/apps/tlon-mobile/src/screens/Onboarding/InventoryCheckScreen.tsx
@@ -1,6 +1,5 @@
 import type { NativeStackScreenProps } from '@react-navigation/native-stack';
 import { useSignupParams } from '@tloncorp/app/contexts/branch';
-import { trackError } from '@tloncorp/app/utils/posthog';
 import {
   Icon,
   PrimaryButton,
@@ -11,6 +10,7 @@ import {
   XStack,
   YStack,
 } from '@tloncorp/app/ui';
+import { createDevLogger } from '@tloncorp/shared';
 import { useState } from 'react';
 import { Image } from 'react-native';
 
@@ -18,6 +18,8 @@ import { useOnboardingContext } from '../../lib/OnboardingContext';
 import type { OnboardingStackParamList } from '../../types';
 
 type Props = NativeStackScreenProps<OnboardingStackParamList, 'InventoryCheck'>;
+
+const logger = createDevLogger('InventoryCheckScreen', true);
 
 export const InventoryCheckScreen = ({ navigation }: Props) => {
   const signupParams = useSignupParams();
@@ -40,7 +42,7 @@ export const InventoryCheckScreen = ({ navigation }: Props) => {
     } catch (err) {
       console.error('Error checking hosting availability:', err);
       if (err instanceof Error) {
-        trackError(err);
+        logger.trackError('Error checking hosting availability', err);
       }
     }
 

--- a/apps/tlon-mobile/src/screens/Onboarding/JoinWaitListScreen.tsx
+++ b/apps/tlon-mobile/src/screens/Onboarding/JoinWaitListScreen.tsx
@@ -1,7 +1,5 @@
 import type { NativeStackScreenProps } from '@react-navigation/native-stack';
 import { EMAIL_REGEX } from '@tloncorp/app/constants';
-import { trackError, trackOnboardingAction } from '@tloncorp/app/utils/posthog';
-import { addUserToWaitlist } from '@tloncorp/shared/api';
 import {
   Field,
   ScreenHeader,
@@ -10,6 +8,9 @@ import {
   View,
   YStack,
 } from '@tloncorp/app/ui';
+import { trackOnboardingAction } from '@tloncorp/app/utils/posthog';
+import { createDevLogger } from '@tloncorp/shared';
+import { addUserToWaitlist } from '@tloncorp/shared/api';
 import { useState } from 'react';
 import { Controller, useForm } from 'react-hook-form';
 import { Alert } from 'react-native';
@@ -21,6 +22,8 @@ type Props = NativeStackScreenProps<OnboardingStackParamList, 'JoinWaitList'>;
 type FormData = {
   email: string;
 };
+
+const logger = createDevLogger('JoinWaitListScreen', true);
 
 export const JoinWaitListScreen = ({ navigation }: Props) => {
   const [remoteError, setRemoteError] = useState<string | undefined>();
@@ -47,7 +50,7 @@ export const JoinWaitListScreen = ({ navigation }: Props) => {
       Alert.alert('Failed', 'Unable to add you to the waitlist.');
       if (err instanceof Error) {
         setRemoteError(err.message);
-        trackError(err);
+        logger.trackError('Error joining waitlist', err);
       }
     }
   };

--- a/apps/tlon-mobile/src/screens/Onboarding/PasteInviteLinkScreen.tsx
+++ b/apps/tlon-mobile/src/screens/Onboarding/PasteInviteLinkScreen.tsx
@@ -6,12 +6,6 @@ import {
   DEFAULT_INVITE_LINK_URL,
 } from '@tloncorp/app/constants';
 import { useBranch, useLureMetadata } from '@tloncorp/app/contexts/branch';
-import { trackError, trackOnboardingAction } from '@tloncorp/app/utils/posthog';
-import {
-  createInviteLinkRegex,
-  extractNormalizedInviteLink,
-  getInviteLinkMeta,
-} from '@tloncorp/shared';
 import {
   Button,
   Field,
@@ -23,6 +17,13 @@ import {
   View,
   YStack,
 } from '@tloncorp/app/ui';
+import { trackOnboardingAction } from '@tloncorp/app/utils/posthog';
+import {
+  createDevLogger,
+  createInviteLinkRegex,
+  extractNormalizedInviteLink,
+  getInviteLinkMeta,
+} from '@tloncorp/shared';
 import { useCallback, useEffect, useState } from 'react';
 import { Controller, useForm } from 'react-hook-form';
 import { Keyboard } from 'react-native';
@@ -39,6 +40,8 @@ type Props = NativeStackScreenProps<
 type FormData = {
   inviteLink: string;
 };
+
+const logger = createDevLogger('PasteInviteLinkScreen', true);
 
 export const PasteInviteLinkScreen = ({ navigation }: Props) => {
   const lureMeta = useLureMetadata();
@@ -78,8 +81,8 @@ export const PasteInviteLinkScreen = ({ navigation }: Props) => {
             throw new Error('Failed to retrieve invite metadata');
           }
         } catch (e) {
-          trackError({
-            message: e.message,
+          logger.trackError('Error retrieving invite metadata', {
+            errorMessage: e.message,
             properties: {
               inviteLink: extractedLink,
               branchDomain: BRANCH_DOMAIN,

--- a/apps/tlon-mobile/src/screens/Onboarding/RequestPhoneVerifyScreen.tsx
+++ b/apps/tlon-mobile/src/screens/Onboarding/RequestPhoneVerifyScreen.tsx
@@ -1,6 +1,5 @@
 import type { NativeStackScreenProps } from '@react-navigation/native-stack';
 import { useIsDarkMode } from '@tloncorp/app/hooks/useIsDarkMode';
-import { trackError, trackOnboardingAction } from '@tloncorp/app/utils/posthog';
 import {
   Field,
   OnboardingTextBlock,
@@ -11,6 +10,8 @@ import {
   useStore,
   useTheme,
 } from '@tloncorp/app/ui';
+import { trackOnboardingAction } from '@tloncorp/app/utils/posthog';
+import { createDevLogger } from '@tloncorp/shared';
 import { isValidPhoneNumber } from 'libphonenumber-js';
 import { useRef, useState } from 'react';
 import { Controller, useForm } from 'react-hook-form';
@@ -27,6 +28,8 @@ type Props = NativeStackScreenProps<
 type FormData = {
   phoneNumber: string;
 };
+
+const logger = createDevLogger('RequestPhoneVerifyScreen', true);
 
 export const RequestPhoneVerifyScreen = ({
   navigation,
@@ -60,10 +63,10 @@ export const RequestPhoneVerifyScreen = ({
       console.error('Error verifiying phone number:', err);
       if (err instanceof SyntaxError) {
         setRemoteError('Invalid phone number, please contact support@tlon.io');
-        trackError({ message: 'Invalid phone number' });
+        logger.trackError('Invalid Phone Number', err);
       } else if (err instanceof Error) {
         setRemoteError(err.message);
-        trackError(err);
+        logger.trackError('Error Submitting Phone Verification', err);
       }
     }
 

--- a/apps/tlon-mobile/src/screens/Onboarding/ResetPasswordScreen.tsx
+++ b/apps/tlon-mobile/src/screens/Onboarding/ResetPasswordScreen.tsx
@@ -1,7 +1,5 @@
 import type { NativeStackScreenProps } from '@react-navigation/native-stack';
 import { EMAIL_REGEX } from '@tloncorp/app/constants';
-import { trackError } from '@tloncorp/app/utils/posthog';
-import { requestPasswordReset } from '@tloncorp/shared/api';
 import {
   Field,
   KeyboardAvoidingView,
@@ -11,6 +9,8 @@ import {
   View,
   YStack,
 } from '@tloncorp/app/ui';
+import { createDevLogger } from '@tloncorp/shared';
+import { requestPasswordReset } from '@tloncorp/shared/api';
 import { useState } from 'react';
 import { Controller, useForm } from 'react-hook-form';
 
@@ -21,6 +21,8 @@ type Props = NativeStackScreenProps<OnboardingStackParamList, 'ResetPassword'>;
 type FormData = {
   email: string;
 };
+
+const logger = createDevLogger('ResetPasswordScreen', true);
 
 export const ResetPasswordScreen = ({
   navigation,
@@ -55,7 +57,7 @@ export const ResetPasswordScreen = ({
           type: 'custom',
           message: err.message,
         });
-        trackError(err);
+        logger.trackError('Error resetting password', err);
       }
     }
 

--- a/apps/tlon-mobile/src/screens/Onboarding/SetNicknameScreen.tsx
+++ b/apps/tlon-mobile/src/screens/Onboarding/SetNicknameScreen.tsx
@@ -1,7 +1,6 @@
 import type { NativeStackScreenProps } from '@react-navigation/native-stack';
 import { DEFAULT_ONBOARDING_NICKNAME } from '@tloncorp/app/constants';
 import { requestNotificationToken } from '@tloncorp/app/lib/notifications';
-import { trackError } from '@tloncorp/app/utils/posthog';
 import {
   Field,
   Image,
@@ -13,6 +12,7 @@ import {
   YStack,
   useTheme,
 } from '@tloncorp/app/ui';
+import { createDevLogger } from '@tloncorp/shared';
 import { useEffect } from 'react';
 import { Controller, useForm } from 'react-hook-form';
 
@@ -25,6 +25,8 @@ type FormData = {
   nickname?: string;
   notificationToken?: string | undefined;
 };
+
+const logger = createDevLogger('SetNicknameScreen', true);
 
 export const SetNicknameScreen = ({ navigation }: Props) => {
   const theme = useTheme();
@@ -75,7 +77,7 @@ export const SetNicknameScreen = ({ navigation }: Props) => {
       } catch (err) {
         console.error('Error enabling notifications:', err);
         if (err instanceof Error) {
-          trackError(err);
+          logger.trackError('Error enabling notifications', err);
         }
       }
     }

--- a/apps/tlon-web-new/package.json
+++ b/apps/tlon-web-new/package.json
@@ -83,7 +83,7 @@
     "idb-keyval": "^6.2.0",
     "immer": "^9.0.12",
     "lodash": "^4.17.21",
-    "posthog-js": "^1.68.2",
+    "posthog-js": "^1.234.4",
     "prosemirror-commands": "~1.2.2",
     "prosemirror-history": "~1.2.0",
     "prosemirror-keymap": "~1.1.5",

--- a/apps/tlon-web-new/src/app.tsx
+++ b/apps/tlon-web-new/src/app.tsx
@@ -581,12 +581,6 @@ function RoutedApp() {
     }
   }, [isStandAlone, body]);
 
-  // useEffect(() => {
-  //   if (posthog && analyticsId !== '' && logActivity) {
-  //     posthog.identify(analyticsId, ANALYTICS_DEFAULT_PROPERTIES);
-  //   }
-  // }, [posthog, analyticsId, logActivity]);
-
   useEffect(() => {
     if (posthog) {
       if (showDevTools) {

--- a/apps/tlon-web-new/src/app.tsx
+++ b/apps/tlon-web-new/src/app.tsx
@@ -30,7 +30,6 @@ import { Helmet } from 'react-helmet';
 import { SafeAreaProvider } from 'react-native-safe-area-context';
 
 import EyrieMenu from '@/eyrie/EyrieMenu';
-// import { ANALYTICS_DEFAULT_PROPERTIES } from '@/logic/analytics';
 import useAppUpdates from '@/logic/useAppUpdates';
 import useErrorHandler from '@/logic/useErrorHandler';
 import useIsStandaloneMode from '@/logic/useIsStandaloneMode';

--- a/apps/tlon-web-new/src/app.tsx
+++ b/apps/tlon-web-new/src/app.tsx
@@ -10,6 +10,7 @@ import { useCurrentUserId } from '@tloncorp/app/hooks/useCurrentUser';
 import useDesktopNotifications from '@tloncorp/app/hooks/useDesktopNotifications';
 import { useFindSuggestedContacts } from '@tloncorp/app/hooks/useFindSuggestedContacts';
 import { useIsDarkMode } from '@tloncorp/app/hooks/useIsDarkMode';
+import { useTelemetry } from '@tloncorp/app/hooks/useTelemetry';
 import { BasePathNavigator } from '@tloncorp/app/navigation/BasePathNavigator';
 import {
   getDesktopLinkingConfig,
@@ -29,7 +30,7 @@ import { Helmet } from 'react-helmet';
 import { SafeAreaProvider } from 'react-native-safe-area-context';
 
 import EyrieMenu from '@/eyrie/EyrieMenu';
-import { ANALYTICS_DEFAULT_PROPERTIES } from '@/logic/analytics';
+// import { ANALYTICS_DEFAULT_PROPERTIES } from '@/logic/analytics';
 import useAppUpdates from '@/logic/useAppUpdates';
 import useErrorHandler from '@/logic/useErrorHandler';
 import useIsStandaloneMode from '@/logic/useIsStandaloneMode';
@@ -335,6 +336,7 @@ function ConnectedWebApp() {
   const configureClient = useConfigureUrbitClient();
   const session = store.useCurrentSession();
   const hasSyncedRef = React.useRef(false);
+  const telemetry = useTelemetry();
   useFindSuggestedContacts();
 
   useEffect(() => {
@@ -350,6 +352,7 @@ function ConnectedWebApp() {
         await db.headsSyncedAt.resetValue();
         sync.syncStart(false);
         hasSyncedRef.current = true;
+        telemetry.captureAppActive('web');
       }
 
       if (!session?.startTime) {
@@ -578,11 +581,11 @@ function RoutedApp() {
     }
   }, [isStandAlone, body]);
 
-  useEffect(() => {
-    if (posthog && analyticsId !== '' && logActivity) {
-      posthog.identify(analyticsId, ANALYTICS_DEFAULT_PROPERTIES);
-    }
-  }, [posthog, analyticsId, logActivity]);
+  // useEffect(() => {
+  //   if (posthog && analyticsId !== '' && logActivity) {
+  //     posthog.identify(analyticsId, ANALYTICS_DEFAULT_PROPERTIES);
+  //   }
+  // }, [posthog, analyticsId, logActivity]);
 
   useEffect(() => {
     if (posthog) {

--- a/apps/tlon-web-new/src/main.tsx
+++ b/apps/tlon-web-new/src/main.tsx
@@ -9,22 +9,28 @@
 // This was most likely caused by a recent dependency change.
 import regeneratorRuntime from '@babel/runtime/regenerator';
 import { EditorView } from '@tiptap/pm/view';
-import { ENABLED_LOGGERS } from '@tloncorp/app/constants';
+import { ENABLED_LOGGERS, POST_HOG_IN_DEV } from '@tloncorp/app/constants';
 import { loadConstants } from '@tloncorp/app/lib/constants';
-import { isElectron } from './electron-bridge';
-
-// Conditionally import the appropriate database implementation
-const { setupDb } = isElectron()
-  ? await import('@tloncorp/app/lib/electronDb')
-  : await import('@tloncorp/app/lib/webDb');
-import { addCustomEnabledLoggers } from '@tloncorp/shared';
+import {
+  AnalyticsEvent,
+  addCustomEnabledLoggers,
+  createDevLogger,
+} from '@tloncorp/shared';
 import { QueryClientProvider, queryClient } from '@tloncorp/shared/api';
 import { PostHogProvider } from 'posthog-js/react';
 import { createRoot } from 'react-dom/client';
 
 import App from './app';
+import { isElectron } from './electron-bridge';
 import { analyticsClient, captureError } from './logic/analytics';
 import './styles/index.css';
+
+const logger = createDevLogger('main.tsx', false);
+
+// Conditionally import the appropriate database implementation
+const { setupDb } = isElectron()
+  ? await import('@tloncorp/app/lib/electronDb')
+  : await import('@tloncorp/app/lib/webDb');
 
 loadConstants();
 addCustomEnabledLoggers(ENABLED_LOGGERS);
@@ -53,7 +59,11 @@ setupDb().then(() => {
   window.our = `~${window.ship}`;
 
   window.addEventListener('error', (e) => {
-    captureError('window', e.error);
+    logger.trackEvent(AnalyticsEvent.WebConsoleError, {
+      e: e.error,
+      stack: e.error?.stack,
+      errorMessage: e.error?.message,
+    });
   });
 
   const container = document.getElementById('app') as HTMLElement;

--- a/apps/tlon-web-new/tsconfig.json
+++ b/apps/tlon-web-new/tsconfig.json
@@ -16,7 +16,9 @@
     "composite": true,
     "paths": {
       "@/*": ["./apps/tlon-web-new/src/*"],
-      "sqlocal/drizzle": ["node_modules/sqlocal/dist/drizzle"]
+      "sqlocal/drizzle": ["node_modules/sqlocal/dist/drizzle"],
+      // needed to prevent TS mistakenly finding the old-web posthog-js version in root node_modules
+      "posthog-js": ["node_modules/posthog-js"]
     }
   },
   "include": [

--- a/packages/app/features/top/CreateChatSheet.tsx
+++ b/packages/app/features/top/CreateChatSheet.tsx
@@ -1,4 +1,5 @@
 import * as store from '@tloncorp/shared';
+import { createDevLogger } from '@tloncorp/shared';
 import {
   forwardRef,
   useCallback,
@@ -25,7 +26,6 @@ import {
   capitalize,
   useIsWindowNarrow,
 } from '../../ui';
-import { trackError } from '../../utils/posthog';
 
 type ChatType = 'dm' | 'group' | 'joinGroup';
 type Step = 'initial' | 'selectType' | `create${Capitalize<ChatType>}`;
@@ -38,6 +38,8 @@ export type CreateChatSheetMethods = {
   open: () => void;
   close: () => void;
 };
+
+const logger = createDevLogger('CreateChatSheet', true);
 
 function createTypeActions(onSelectType: (type: ChatType) => void): Action[] {
   return [
@@ -248,9 +250,7 @@ export const CreateChatSheet = forwardRef(function CreateChatSheet(
   useEffect(() => {
     if (createChatError) {
       Alert.alert('Error creating chat', createChatError);
-      trackError({
-        message: 'Error creating chat: ' + createChatError,
-      });
+      logger.trackError('Error creating chat', new Error(createChatError));
     }
   }, [createChatError]);
 
@@ -490,7 +490,7 @@ function useCreateChat() {
         }
         return true;
       } catch (e) {
-        trackError(e);
+        logger.trackError('createChat Failed', e);
         setCreateChatError(e.message);
         return false;
       } finally {

--- a/packages/app/hooks/usePosthog.ts
+++ b/packages/app/hooks/usePosthog.ts
@@ -9,15 +9,12 @@ export function usePosthog() {
     return {
       optedOut: posthog?.has_opted_out_capturing() ?? false,
       optIn: () => {
-        console.log('bl: Opting in to telemetry');
         posthog?.opt_in_capturing();
       },
       optOut: () => {
-        console.log('bl: Opting out of telemetry');
         posthog?.opt_out_capturing();
       },
       identify: (userId, properties) => {
-        console.log('bl: Identifying user', { userId, properties });
         posthog?.identify(userId, properties);
       },
       capture: (eventName, properties) =>

--- a/packages/app/hooks/usePosthog.ts
+++ b/packages/app/hooks/usePosthog.ts
@@ -8,9 +8,18 @@ export function usePosthog() {
   return useMemo((): PosthogClient => {
     return {
       optedOut: posthog?.has_opted_out_capturing() ?? false,
-      optIn: () => posthog?.opt_in_capturing(),
-      optOut: () => posthog?.opt_out_capturing(),
-      identify: (userId, properties) => posthog?.identify(userId, properties),
+      optIn: () => {
+        console.log('bl: Opting in to telemetry');
+        posthog?.opt_in_capturing();
+      },
+      optOut: () => {
+        console.log('bl: Opting out of telemetry');
+        posthog?.opt_out_capturing();
+      },
+      identify: (userId, properties) => {
+        console.log('bl: Identifying user', { userId, properties });
+        posthog?.identify(userId, properties);
+      },
       capture: (eventName, properties) =>
         posthog?.capture(eventName, properties),
       flush: async () => {

--- a/packages/app/lib/envVars.ts
+++ b/packages/app/lib/envVars.ts
@@ -6,6 +6,7 @@ const envVars = {
   notifyProvider: env.VITE_NOTIFY_PROVIDER,
   notifyService: env.VITE_NOTIFY_SERVICE,
   postHogApiKey: env.VITE_POST_HOG_API_KEY,
+  postHogInDev: env.VITE_POST_HOG_IN_DEV,
   apiUrl: env.VITE_API_URL,
   apiAuthUsername: env.VITE_API_AUTH_USERNAME,
   apiAuthPassword: env.VITE_API_AUTH_PASSWORD,
@@ -35,6 +36,7 @@ export const DEV_SHIP_URL = envVars.devShipUrl ?? '';
 export const NOTIFY_PROVIDER = envVars.notifyProvider ?? 'rivfur-livmet';
 export const NOTIFY_SERVICE = envVars.notifyService ?? 'groups-native';
 export const POST_HOG_API_KEY = envVars.postHogApiKey ?? '';
+export const POST_HOG_IN_DEV = Boolean(envVars.postHogInDev);
 export const API_URL = envVars.apiUrl ?? 'https://tlon.network';
 export const API_AUTH_USERNAME = envVars.apiAuthUsername;
 export const API_AUTH_PASSWORD = envVars.apiAuthPassword;
@@ -73,6 +75,7 @@ export const ENV_VARS = {
   NOTIFY_PROVIDER,
   NOTIFY_SERVICE,
   POST_HOG_API_KEY,
+  POST_HOG_IN_DEV,
   API_URL,
   API_AUTH_USERNAME,
   API_AUTH_PASSWORD,

--- a/packages/app/lib/notifications.ts
+++ b/packages/app/lib/notifications.ts
@@ -9,7 +9,6 @@ import { useCallback, useEffect, useState } from 'react';
 import { Linking, Platform } from 'react-native';
 
 import { AppStatus, useAppStatusChange } from '../hooks/useAppStatusChange';
-import { trackError } from '../utils/posthog';
 import { connectNotifyProvider } from './notificationsApi';
 
 const logger = createDevLogger('notifications', true);
@@ -146,7 +145,11 @@ export const connectNotifications = async () => {
   } catch (err) {
     console.error('Error requesting push notifications token:', err);
     if (err instanceof Error) {
-      trackError(err, 'notifications_request_error');
+      logger.trackError('Notifications Debug', {
+        contxt: 'Error requesting push notifications token',
+        errorMessage: err.message,
+        stack: err.stack,
+      });
     }
   }
 
@@ -160,7 +163,12 @@ export const connectNotifications = async () => {
   } catch (err) {
     console.error('Error connecting push notifications provider:', err);
     if (err instanceof Error) {
-      trackError(err, 'notifications_register_error');
+      logger.trackError('Notifications Debug', {
+        contxt: 'Error connecting push notifications provider',
+        errorMessage: err.message,
+        stack: err.stack,
+      });
+      logger;
     }
     return false;
   }

--- a/packages/app/package.json
+++ b/packages/app/package.json
@@ -18,7 +18,8 @@
     "react-native-email-link": "^1.16.1",
     "react-native-fetch-api": "^3.0.0",
     "react-native-polyfill-globals": "^3.1.0",
-    "sqlocal": "^0.11.1"
+    "sqlocal": "^0.11.1",
+    "posthog-js": "^1.234.4"
   },
   "devDependencies": {
     "@types/react": "^18.2.55",

--- a/packages/app/tsconfig.json
+++ b/packages/app/tsconfig.json
@@ -6,7 +6,9 @@
     "noEmit": true,
     "jsx": "react-jsx",
     "paths": {
-      "sqlocal/drizzle": ["node_modules/sqlocal/dist/drizzle"]
+      "sqlocal/drizzle": ["node_modules/sqlocal/dist/drizzle"],
+      // needed to prevent TS mistakenly finding the old-web posthog-js version in root node_modules
+      "posthog-js": ["node_modules/posthog-js"]
     }
   }
 }

--- a/packages/app/types/telemetry.ts
+++ b/packages/app/types/telemetry.ts
@@ -11,5 +11,5 @@ export interface TelemetryClient {
     eventId: string;
     properties?: Record<string, any>;
   }) => void;
-  captureAppActive: () => void;
+  captureAppActive: (platform?: 'web' | 'mobile' | 'electron') => void;
 }

--- a/packages/app/utils/posthog.web.ts
+++ b/packages/app/utils/posthog.web.ts
@@ -1,0 +1,64 @@
+import { useDebugStore } from '@tloncorp/shared';
+import * as db from '@tloncorp/shared/db';
+import posthog, { Properties } from 'posthog-js';
+
+import { POST_HOG_API_KEY, POST_HOG_IN_DEV } from '../constants';
+
+export const EVENT_PRIVACY_MASK: Properties = {
+  // The following default properties stop PostHog from auto-logging the URL,
+  // which can inadvertently reveal private info on Urbit
+  $current_url: null,
+  $pathname: null,
+  $set_once: null,
+  $host: null,
+  $referrer: null,
+  $initial_current_url: null,
+  $initial_referrer_url: null,
+  $referring_domain: null,
+  $initial_referring_domain: null,
+  $unset: [
+    'initial_referrer_url',
+    'initial_referring_domain',
+    'initial_current_url',
+    'current_url',
+    'pathname',
+    'host',
+    'referrer',
+    'referring_domain',
+  ],
+};
+
+// Configure PostHog with all auto-capturing settings disabled,
+// as we will only be tracking specific interactions.
+posthog.init(POST_HOG_API_KEY, {
+  api_host: 'https://data-bridge-v1.vercel.app/ingest',
+  ui_host: 'https://eu.posthog.com',
+  autocapture: false,
+  capture_pageview: false,
+  capture_pageleave: false,
+  disable_session_recording: true,
+  mask_all_text: true,
+  mask_all_element_attributes: true,
+});
+
+export const analyticsClient = posthog;
+
+const wrappedErrorLogger = {
+  capture: (event: string, data: Record<string, unknown>) => {
+    analyticsClient.capture(event, { ...data, ...EVENT_PRIVACY_MASK });
+  },
+};
+
+// hand off the instance to our dev loggers
+useDebugStore.getState().initializeErrorLogger(wrappedErrorLogger);
+
+export const identifyTlonEmployee = () => {
+  db.isTlonEmployee.setValue(true);
+  if (!posthog) {
+    console.debug('Identifying as Tlon employee before PostHog is initialized');
+    return;
+  }
+
+  const UUID = posthog.get_distinct_id();
+  posthog.identify(UUID, { isTlonEmployee: true });
+};

--- a/packages/shared/src/debug.ts
+++ b/packages/shared/src/debug.ts
@@ -266,6 +266,11 @@ export function createDevLogger(tag: string, enabled: boolean) {
                   ? `[${tag}] ${args[0]}`
                   : 'no message',
               breadcrumbs: useDebugStore.getState().getBreadcrumbs(),
+              errorMessage:
+                customProps instanceof Error ? customProps.message : undefined,
+              errorStack:
+                customProps instanceof Error ? customProps.stack : undefined,
+              logLevel: 'error',
             });
           getDebugInfo()
             .then(report)

--- a/packages/shared/src/domain/analytics.ts
+++ b/packages/shared/src/domain/analytics.ts
@@ -44,6 +44,8 @@ export enum AnalyticsEvent {
   NodeAuthSaved = 'Node Auth Saved',
   ErrorNodeResumePush = 'Node Resume Push Error',
   AnalyticsDigest = 'Usage Digest Report',
+  WebAppOpened = 'Web App Opened',
+  WebConsoleError = 'Web Console Error',
   ActionContactAdded = 'Contact Added',
   ActionContactRemoved = 'Contact Removed',
   ActionRemoveContactSuggestion = 'Removed Contact Suggestion',
@@ -115,6 +117,7 @@ export enum AnalyticsEvent {
   ErrorVerifyingPersonalInvite = 'Error Verifying DM Invite Link',
   ErrorAttestation = 'Attestation Error',
   ErrorNounParse = 'Error Parsing Noun',
+  ErrorNotificationService = 'Notification Service Error',
 }
 
 export interface AnalyticsDigest {

--- a/packages/shared/src/store/sync.ts
+++ b/packages/shared/src/store/sync.ts
@@ -237,7 +237,10 @@ export const syncUserAttestations = async (ctx?: SyncCtx) => {
     try {
       await db.insertCurrentUserAttestations({ attestations });
     } catch (e) {
-      logger.trackEvent('Error Inserting Lanyard Verifications', e);
+      console.log(`bl: error inserting lanyard verifications`, e);
+      logger.trackEvent('Error Inserting Lanyard Verifications', {
+        message: e.message,
+      });
     }
   } catch (e) {
     logger.trackError('Error Fetching Lanyard Verifications', e);

--- a/packages/shared/src/store/sync.ts
+++ b/packages/shared/src/store/sync.ts
@@ -237,7 +237,6 @@ export const syncUserAttestations = async (ctx?: SyncCtx) => {
     try {
       await db.insertCurrentUserAttestations({ attestations });
     } catch (e) {
-      console.log(`bl: error inserting lanyard verifications`, e);
       logger.trackEvent('Error Inserting Lanyard Verifications', {
         message: e.message,
       });

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1450,6 +1450,9 @@ importers:
       lodash:
         specifier: ^4.17.21
         version: 4.17.21
+      posthog-js:
+        specifier: ^1.234.4
+        version: 1.234.4
       react-native-device-info:
         specifier: ^10.8.0
         version: 10.12.0(react-native@0.74.5(@babel/core@7.25.2)(@babel/preset-env@7.26.0(@babel/core@7.25.2))(@types/react@18.2.55)(encoding@0.1.13)(react@18.2.0))

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1174,8 +1174,8 @@ importers:
         specifier: ^4.17.21
         version: 4.17.21
       posthog-js:
-        specifier: ^1.68.2
-        version: 1.68.2
+        specifier: ^1.234.4
+        version: 1.234.4
       prosemirror-commands:
         specifier: ~1.2.2
         version: 1.2.2
@@ -7939,6 +7939,9 @@ packages:
   core-js@3.24.1:
     resolution: {integrity: sha512-0QTBSYSUZ6Gq21utGzkfITDylE8jWC9Ne1D2MrhvlsZBI1x39OdDIVbzSqtgMndIy6BlHxBXpMGqzZmnztg2rg==}
 
+  core-js@3.41.0:
+    resolution: {integrity: sha512-SJ4/EHwS36QMJd6h/Rg+GyR4A5xE0FSI3eZ+iBVpfqf1x0eTSg1smWLHrA+2jQThZSh97fmSgFSU8B61nxosxA==}
+
   core-util-is@1.0.2:
     resolution: {integrity: sha512-3lqz5YjWTYnW6dlDa5TLaTCcShfar1e40rmcJVwCBJC6mWlFuj0eCHIElmG1g5kyuJ/GD+8Wn4FFCcz4gJPfaQ==}
 
@@ -11769,6 +11772,17 @@ packages:
     resolution: {integrity: sha512-u5U8qYpBCpN13BsiEB0CbR1Hhh4Gc0zLFuedrHJKMctHCHAGrMdG0PRM/KErzAL3CU6/eckEtmHNB3x6e3c0vA==}
     engines: {node: ^10 || ^12 || >=14}
 
+  posthog-js@1.234.4:
+    resolution: {integrity: sha512-IH7ISmm7SP+GYeCJ+RjlBnA9AtmbT6W/mZUW/ca/erHNb1EE1K3//IzDGyGYs7dT26b/HH9Z9kdO51h7PVSi6w==}
+    peerDependencies:
+      '@rrweb/types': 2.0.0-alpha.17
+      rrweb-snapshot: 2.0.0-alpha.17
+    peerDependenciesMeta:
+      '@rrweb/types':
+        optional: true
+      rrweb-snapshot:
+        optional: true
+
   posthog-js@1.68.2:
     resolution: {integrity: sha512-oh3MQonhbgVbBYNJ/cAx1L6fginAF5Msz3shexnXPhDNKj1DQGosepQC6TQpdeeUWp0H7R2cQG9eHJwmrEM1Lw==}
     deprecated: This version of posthog-js is deprecated, please update posthog-js, and do not use this version! Check out our JS docs at https://posthog.com/docs/libraries/js
@@ -11801,6 +11815,9 @@ packages:
         optional: true
       react-native-navigation:
         optional: true
+
+  preact@10.26.4:
+    resolution: {integrity: sha512-KJhO7LBFTjP71d83trW+Ilnjbo+ySsaAgCfXOXUlmGzJ4ygYPWmysm77yg4emwfmoz3b22yvH5IsVFHbhUaH5w==}
 
   prebuild-install@7.1.1:
     resolution: {integrity: sha512-jAXscXWMcCK8GgCoHOfIr0ODh5ai8mj63L2nWrjuAgXE6tDyYGnx4/8o/rCgU+B4JSyZBKbeZqzhtwtC3ovxjw==}
@@ -14285,6 +14302,9 @@ packages:
   web-streams-polyfill@3.3.3:
     resolution: {integrity: sha512-d2JWLCivmZYTSIoge9MsgFCZrt571BikcWGYkjC1khllbTeDlGqZ2D8vD8E/lJa8WGWbb7Plm8/XJYV7IJHZZw==}
     engines: {node: '>= 8'}
+
+  web-vitals@4.2.4:
+    resolution: {integrity: sha512-r4DIlprAGwJ7YM11VZp4R884m0Vmgr6EAKe3P+kO0PPj3Unqyvv59rczf6UiGcb9Z8QxZVcqKNwv/g0WNdWwsw==}
 
   webidl-conversions@3.0.1:
     resolution: {integrity: sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==}
@@ -24276,6 +24296,8 @@ snapshots:
 
   core-js@3.24.1: {}
 
+  core-js@3.41.0: {}
+
   core-util-is@1.0.2:
     optional: true
 
@@ -29055,6 +29077,13 @@ snapshots:
       picocolors: 1.0.0
       source-map-js: 1.0.2
 
+  posthog-js@1.234.4:
+    dependencies:
+      core-js: 3.41.0
+      fflate: 0.4.8
+      preact: 10.26.4
+      web-vitals: 4.2.4
+
   posthog-js@1.68.2:
     dependencies:
       fflate: 0.4.8
@@ -29068,6 +29097,8 @@ snapshots:
       expo-file-system: 17.0.1(expo@51.0.39(@babel/core@7.25.2)(@babel/preset-env@7.26.0(@babel/core@7.25.2))(encoding@0.1.13))
       expo-localization: 15.0.3(expo@51.0.39(@babel/core@7.25.2)(@babel/preset-env@7.26.0(@babel/core@7.25.2))(encoding@0.1.13))
       react-native-device-info: 10.12.0(react-native@0.74.5(@babel/core@7.25.2)(@babel/preset-env@7.26.0(@babel/core@7.25.2))(@types/react@18.2.55)(encoding@0.1.13)(react@18.2.0))
+
+  preact@10.26.4: {}
 
   prebuild-install@7.1.1:
     dependencies:
@@ -32151,6 +32182,8 @@ snapshots:
   web-namespaces@2.0.1: {}
 
   web-streams-polyfill@3.3.3: {}
+
+  web-vitals@4.2.4: {}
 
   webidl-conversions@3.0.1: {}
 


### PR DESCRIPTION
We weren't capturing app events in PostHog from new web, only a few particular events were making it through. 

Updates `posthog-js`, initializes it with our dev loggers, and uses our shared telemetry library for identification and mandatory events.

Also rips off the bandaid with old style `trackEvent` calls.