### PR TITLE
desktop: Create DM/Group modal fixes

### DIFF
--- a/packages/app/features/top/CreateChatSheet.tsx
+++ b/packages/app/features/top/CreateChatSheet.tsx
@@ -2,6 +2,7 @@ import * as store from '@tloncorp/shared';
 import { createDevLogger } from '@tloncorp/shared';
 import * as db from '@tloncorp/shared/db';
 import {
+  ComponentProps,
   forwardRef,
   useCallback,
   useEffect,
@@ -9,7 +10,7 @@ import {
   useMemo,
   useState,
 } from 'react';
-import { Alert } from 'react-native';
+import { Alert, Modal } from 'react-native';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
 import { Popover, View, YStack } from 'tamagui';
 
@@ -87,7 +88,8 @@ const CHAT_TYPE_CONFIG = {
 
 interface ActionButtonsProps {
   actions: Action[];
-  paddingBottom?: number;
+  buttonProps?: ComponentProps<typeof Button>;
+  containerProps?: ComponentProps<typeof YStack>;
 }
 
 interface CreateChatFormContentProps {
@@ -99,14 +101,19 @@ interface CreateChatFormContentProps {
   onScrollChange?: (scrolling: boolean) => void;
 }
 
-const ActionButtons = ({ actions, paddingBottom }: ActionButtonsProps) => (
-  <YStack gap="$s" paddingBottom={paddingBottom}>
+const ActionButtons = ({
+  actions,
+  containerProps,
+  buttonProps,
+}: ActionButtonsProps) => (
+  <YStack gap="$s" {...containerProps}>
     {actions.map((action, i) => (
       <Button
         key={i}
         onPress={action.action}
         width="100%"
         justifyContent="flex-start"
+        {...buttonProps}
       >
         <YStack>
           <Button.Text size="$s">{action.title}</Button.Text>
@@ -366,20 +373,39 @@ export const CreateChatSheet = forwardRef(function CreateChatSheet(
         padding="$m"
       >
         {step === 'selectType' ? (
-          <ActionButtons actions={actions} paddingBottom={insets.bottom} />
+          <ActionButtons
+            actions={actions}
+            buttonProps={{ paddingBottom: insets.bottom }}
+          />
         ) : step === 'createJoinGroup' ? (
           <JoinGroupFormContent
             chatType={chatType}
             close={() => setStep('initial')}
           />
         ) : (
-          <CreateChatFormContent
-            chatType={chatType}
-            isCreating={isCreatingChat}
-            onSelectDmContact={handleSelectDmContact}
-            onSelectedChange={setSelectedContactIds}
-            onCreateGroup={handlePressCreateGroup}
-          />
+          <ActionSheet
+            open={step === 'createDm' || step === 'createGroup'}
+            onOpenChange={() => setStep('initial')}
+            mode="dialog"
+            closeButton
+            dialogContentProps={{ height: '80%', maxHeight: 1200, width: 600 }}
+          >
+            <ActionSheet.MainContent
+              paddingHorizontal="$3xl"
+              paddingBottom="$3xl"
+              flex={1}
+            >
+              <View flex={1}>
+                <CreateChatFormContent
+                  chatType={chatType}
+                  isCreating={isCreatingChat}
+                  onSelectDmContact={handleSelectDmContact}
+                  onSelectedChange={setSelectedContactIds}
+                  onCreateGroup={handlePressCreateGroup}
+                />
+              </View>
+            </ActionSheet.MainContent>
+          </ActionSheet>
         )}
       </Popover.Content>
     </Popover>

--- a/packages/app/ui/components/ActionSheet.tsx
+++ b/packages/app/ui/components/ActionSheet.tsx
@@ -1,4 +1,4 @@
-import { useCopy } from '@tloncorp/ui';
+import { IconButton, useCopy } from '@tloncorp/ui';
 import { useIsWindowNarrow } from '@tloncorp/ui';
 import { Icon, IconType } from '@tloncorp/ui';
 import { Sheet } from '@tloncorp/ui';
@@ -13,15 +13,17 @@ import {
   useMemo,
   useRef,
 } from 'react';
-import { Modal, useWindowDimensions } from 'react-native';
+import { Modal, TouchableOpacity, useWindowDimensions } from 'react-native';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
 import {
+  Circle,
   Dialog,
   Popover,
   ScrollView,
   SheetProps,
   View,
   VisuallyHidden,
+  XStack,
   YStack,
   createStyledContext,
   getTokenValue,
@@ -102,6 +104,8 @@ type ActionSheetProps = {
   title?: string;
   trigger?: ReactNode;
   mode?: AdaptiveMode;
+  dialogContentProps?: ComponentProps<typeof Dialog.Content>;
+  closeButton?: boolean;
 };
 
 const useAdaptiveMode = (mode?: AdaptiveMode) => {
@@ -125,6 +129,8 @@ const ActionSheetComponent = ({
   trigger,
   mode: forcedMode,
   children,
+  dialogContentProps,
+  closeButton,
   ...props
 }: PropsWithChildren<ActionSheetProps & SheetProps>) => {
   const mode = useAdaptiveMode(forcedMode);
@@ -181,8 +187,32 @@ const ActionSheetComponent = ({
             // prevent the modal from going off screen
             maxHeight={maxHeight}
             marginVertical="$2xl"
+            {...dialogContentProps}
           >
-            <ScrollView id="ActionSheetDialogScrollView">{children}</ScrollView>
+            {closeButton && (
+              <XStack
+                width="100%"
+                justifyContent="flex-end"
+                paddingTop="$l"
+                paddingRight="$l"
+              >
+                <Dialog.Close>
+                  <IconButton
+                    backgroundColor="$border"
+                    height={24}
+                    width={24}
+                    borderRadius="$m"
+                  >
+                    <Icon
+                      type="Close"
+                      customSize={[14, 14]}
+                      color="$secondaryText"
+                    />
+                  </IconButton>
+                </Dialog.Close>
+              </XStack>
+            )}
+            {children}
           </Dialog.Content>
         </Dialog.Portal>
 

--- a/packages/app/ui/components/ActionSheet.tsx
+++ b/packages/app/ui/components/ActionSheet.tsx
@@ -13,13 +13,11 @@ import {
   useMemo,
   useRef,
 } from 'react';
-import { Modal, TouchableOpacity, useWindowDimensions } from 'react-native';
+import { Modal, useWindowDimensions } from 'react-native';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
 import {
-  Circle,
   Dialog,
   Popover,
-  ScrollView,
   SheetProps,
   View,
   VisuallyHidden,

--- a/packages/app/ui/components/ContactBook.tsx
+++ b/packages/app/ui/components/ContactBook.tsx
@@ -12,7 +12,7 @@ import {
   ViewStyle,
 } from 'react-native';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
-import { View, XStack, useStyle } from 'tamagui';
+import { View, XStack, getTokenValue, useStyle } from 'tamagui';
 
 import { useContactIndex, useContacts } from '../contexts';
 import {
@@ -158,6 +158,7 @@ export function ContactBook({
     if (!isWindowNarrow) {
       return {
         flex: 1,
+        paddingTop: getTokenValue('$l'),
         overflow: 'scroll' as const,
       };
     }
@@ -189,6 +190,7 @@ export function ContactBook({
               spellCheck: false,
               autoCapitalize: 'none',
               autoComplete: 'off',
+              flex: 1,
             }}
           />
         </XStack>

--- a/packages/app/ui/components/SearchBar.tsx
+++ b/packages/app/ui/components/SearchBar.tsx
@@ -49,6 +49,8 @@ export function SearchBar({
   return (
     <YStack flexGrow={1} justifyContent="center" alignItems="center" {...rest}>
       <TextInput
+        // frameStyle={{ flex: 1 }}
+        frameStyle={{ width: '100%' }}
         icon="Search"
         value={value}
         onChangeText={onTextChange}

--- a/packages/app/ui/components/SearchBar.tsx
+++ b/packages/app/ui/components/SearchBar.tsx
@@ -49,7 +49,6 @@ export function SearchBar({
   return (
     <YStack flexGrow={1} justifyContent="center" alignItems="center" {...rest}>
       <TextInput
-        // frameStyle={{ flex: 1 }}
         frameStyle={{ width: '100%' }}
         icon="Search"
         value={value}

--- a/packages/app/ui/hooks/contactSorters.ts
+++ b/packages/app/ui/hooks/contactSorters.ts
@@ -106,7 +106,7 @@ export function useSortedContacts({
       const exactMatchCheck = preSig(query.trim().toLocaleLowerCase());
       if (isValidPatp(exactMatchCheck)) {
         const exactMatch = db.getFallbackContact(exactMatchCheck);
-        filtered.push(exactMatch);
+        filtered.filter((c) => c.id !== exactMatchCheck).push(exactMatch);
       }
       return filtered;
     }


### PR DESCRIPTION
OTT

Moves the main interaction into a centered modal with a close button. Height stays fixed even as search results change.

<img width="1449" alt="Screenshot 2025-04-02 at 3 28 52 PM" src="https://github.com/user-attachments/assets/79c0572f-4630-4da8-b44c-5c5884540fb8" />

After:
<img width="1710" alt="Screenshot 2025-04-02 at 3 40 47 PM" src="https://github.com/user-attachments/assets/d7bde970-6c19-497d-9ec0-b1917279d383" />

I did remove the built in `Scroller` wrapper for `ActionSheet mode=dialog` because it was collapsing the main content height. Tried to make sure there were no regressions, but let me know if y'all have concerns.
