### PR TITLE
api: OpenAPI scaffolding for TM backend API specification and documentation

### DIFF
--- a/api/README.md
+++ b/api/README.md
@@ -1,0 +1,23 @@
+# TM API
+
+All TM components offer an API accessible over HTTP.
+The API specification follows the OpenAPI standard.
+
+# Directory
+
+/openapi.yaml: root spec file
+
+/components: contains specs grouped by TM component.
+There is usually a file per agent, or per structure file.
+
+/components/common.yaml: specs corresponding to general Hoon types
+
+/paths: contains endpoint specs grouped by agent.
+
+# Generating documentation
+
+We use open-source edition of [Redocly](https://redocly.com).
+To generate documentation, [install Redocly CLI](https://redocly.com/docs/cli/installation) and then run
+```
+> redocly preview-docs api/openapi.yaml
+```

--- a/api/components/common.yaml
+++ b/api/components/common.yaml
@@ -1,0 +1,22 @@
+# JSON schemas for common Hoon types
+#
+# $ship
+ship:
+  type: string
+  description: network ID
+  pattern: '~[\D-]+'
+  example: ~sampel-palnet
+# $rank
+rank:
+  type: string
+  description: network ID rank
+  enum:
+    - "czar"
+    - "king"
+    - "duke"
+    - "earl"
+    - "pawn"
+# $time
+time:
+  type: number
+  description: time of event

--- a/api/components/groups.yaml
+++ b/api/components/groups.yaml
@@ -1,0 +1,314 @@
+#
+# headers
+#
+common:
+  $ref: "common.yaml"
+meta:
+  $ref: "meta.yaml"
+# %groups structures
+#
+# $flag:g
+flag:
+  type: string
+  description: group ID
+  pattern: '~[\D-]+\/\w+'
+  example: '~sampel-palnet/gardening'
+# $nest:g
+nest:
+  type: string
+  description: channel ID, {app}/{ship}/{name}
+# $sect:g
+sect:
+  type: string
+  description: group role
+#
+# groups v6
+#
+gang-v6:
+  type: object
+  properties:
+    claim:
+      nullable: true
+      $ref: "#/claim-v5"
+    preview:
+      nullable: true
+      $ref: "#/preview-v5"
+    invite:
+      nullable: true
+      $ref: "#/invite"
+    error:
+      nullable: true
+      $ref: "#/access-error"
+#
+# $access-error:g
+access-error:
+  type: string
+  enum:
+    - missing
+    - forbidden
+#
+#
+# groups v5
+#
+# $gang:v5:g
+gang-v5:
+  type: object
+  properties:
+    claim:
+      nullable: true
+      $ref: "#/claim-v5"
+    preview:
+      nullable: true
+      $ref: "#/preview-v5"
+    invite:
+      nullable: true
+      $ref: "#/invite"
+#
+# $claim:v5:g
+claim-v5:
+  type: object
+  properties:
+    join-all:
+      type: boolean
+    progress:
+      $ref: "#/progress-v5"
+#
+# $progress:v5:g
+progress-v5:
+  type: string
+  enum:
+    - knocking
+    - adding
+    - watching
+    - error
+#
+# $preview:v5:g
+preview-v5:
+  type: object
+  properties:
+    flag:
+      $ref: "#/flag"
+    meta:
+      $ref: "meta.yaml#/data"
+    cordon:
+      $ref: "#/cordon"
+    time:
+      type: number
+    secret:
+      type: boolean
+    count:
+      type: number
+#
+# groups v2
+#
+# $gang:v2:g
+gang-v2:
+  type: object
+  properties:
+    claim:
+      nullable: true
+      $ref: "#/claim-v2"
+    preview:
+      nullable: true
+      $ref: "#/preview-v2"
+    invite:
+      nullable: true
+      $ref: "#/invite"
+
+# $claim:v2:g
+claim-v2:
+  type: object
+  properties:
+    join-all:
+      type: boolean
+    progress:
+      $ref: "#/progress-v2"
+# $progress:v2:g
+progress-v2:
+  type: string
+  enum:
+    - knocking
+    - adding
+    - watching
+    - error
+# $invite:g
+invite:
+  type: object
+  properties:
+    flag:
+      $ref: "#/flag"
+    ship:
+      $ref: "#/common/ship"
+# $preview:v2:g
+preview-v2:
+  type: object
+  properties:
+    flag:
+      $ref: "#/flag"
+    meta:
+      $ref: "meta.yaml#/data"
+    time:
+      type: number
+    secret:
+      type: boolean
+#
+# $cordon:g
+cordon:
+  oneOf:
+    - $ref: "#/cordon-open"
+    - $ref: "#/cordon-shut"
+cordon-open:
+  type: object
+  properties:
+    open:
+      type: object
+      description: open cordon
+      properties:
+        ships:
+          type: array
+          items:
+            $ref: "#/common/ship"
+        ranks:
+          type: array
+          items:
+            $ref: "#/common/rank"
+cordon-shut:
+  type: object
+  properties:
+    shut:
+      type: object
+      description: shut cordon
+      properties:
+        pending:
+          type: array
+          items:
+            $ref: "#/common/ship"
+        ask:
+          type: array
+          items:
+            $ref: "#/common/ship"
+# $group:v2:g
+group-v2:
+  type: object
+  description: collection of people and communication channels
+  properties:
+    fleet:
+      $ref: "#/fleet"
+    cabals:
+      type: object
+      description: group cabals
+      additionalProperties:
+        $ref: "#/cabal"
+    zones:
+      type: object
+      description: group zones
+      additionalProperties:
+        $ref: "#/realm"
+    zone-ord:
+      type: array
+      items:
+        type: string
+        description: zone index
+    bloc:
+      type: array
+      description: set of superuser sects
+      items:
+        $ref: "#/sect"
+    channels:
+      type: object
+      propertyNames:
+        description: channel nest
+        example: "chat/~sampel-palnet/web"
+      additionalProperties:
+        $ref: "#/channel"
+    active-channels:
+      type: array
+      items:
+        $ref: "#/nest"
+    cordon:
+      $ref: "#/cordon"
+    secret:
+      type: boolean
+    meta:
+      $ref: "meta.yaml#/data"
+    flagged-content:
+      $ref: "#/flagged-content"
+# $fleet:g
+fleet:
+  type: object
+  additionalProperties:
+    $ref: "#/vessel"
+# $vessel:g
+vessel:
+  type: object
+  properties:
+    sects:
+      type: array
+      description: set of sects
+      items:
+        $ref: "#/sect"
+    joined:
+      $ref: "#/common/time"
+# $cabal:g
+cabal:
+  type: object
+  properties:
+    meta:
+      $ref: "#/meta/data"
+# $realm:g
+realm:
+  type: object
+  properties:
+    meta:
+      $ref: "#/meta/data"
+    idx:
+      type: array
+      description: realm index
+      items:
+        type: string
+# $channel:g
+channel:
+  type: object
+  properties:
+    meta:
+      $ref: "#/meta/data"
+    added:
+      $ref: "#/common/time"
+    readers:
+      type: array
+      items:
+        $ref: "#/common/ship"
+    zone:
+      type: string
+    join:
+      type: boolean
+# $flagged-content:g
+flagged-content:
+  type: object
+  propertyNames:
+    description: channel nest
+  additionalProperties:
+    type: object
+    propertyNames:
+      description: post timestamp
+    additionalProperties:
+      $ref: "#/flagged-data"
+# flagged-data
+flagged-data:
+  type: object
+  properties:
+    flagged:
+      type: boolean
+    flaggers:
+      type: array
+      items:
+        $ref: "#/common/ship"
+    replies:
+      type: object
+      propertyNames:
+        description: post reply timestamp
+      additionalProperties:
+        type: array
+        items:
+          $ref: "#/common/ship"
+

--- a/api/components/meta.yaml
+++ b/api/components/meta.yaml
@@ -1,0 +1,14 @@
+
+data:
+  type: object
+  description: generic metadata
+  properties:
+    title:
+      type: string
+    description:
+      type: string
+    image:
+      type: string
+    cover:
+      type: string
+

--- a/api/openapi.yaml
+++ b/api/openapi.yaml
@@ -1,0 +1,43 @@
+openapi: 3.1.0
+info:
+  version: 6.10.0
+  title: "Tlon Messenger API"
+  description: >
+    # Tlon Messenger
+
+    TM is a unique messenger that is under your control down to the very last bit.
+    Your personal TM node, apart from serving as a locus of communication,
+    is also a general-purpose computer, capable of running any computation.
+    TM API allows access to any TM component running on your node.
+
+
+    TM platform consists of the following distinct services, each with their
+    own API.
+
+
+    1. groups: channel aggregation, group entry and member permissions
+
+    2. channels: content posting
+
+    3. chat: direct messaging
+
+    4. contacts: social graph
+
+    5. activity: notifications
+
+    6. profile: personal webpage
+
+    7. expose: content publishing
+
+paths:
+  # %groups
+  #
+  /groups/gangs.json:
+    $ref: "paths/groups.yaml#/gangs"
+  /groups/v1/gangs.json:
+    $ref: "paths/groups.yaml#/v1-gangs"
+  /groups/v2/gangs.json:
+    $ref: "paths/groups.yaml#/v2-gangs"
+  #
+  /groups/groups/light.json:
+    $ref: "paths/groups.yaml#/groups-light"

--- a/api/paths/groups.yaml
+++ b/api/paths/groups.yaml
@@ -1,0 +1,75 @@
+gangs:
+  get:
+    summary: "Get group gangs"
+    description: >
+      Retrieves a collection of gangs, keyed by
+      the group `$flag`. A `$gang` is an invitation to a group.
+    operationId: getGroupsGangs
+    tags:
+      - "Groups"
+    responses:
+      "200":
+        description: "OK"
+        content:
+          application/json:
+            schema:
+              type: object
+              additionalProperties:
+                $ref: "../components/groups.yaml#/gang-v2"
+v1-gangs:
+  get:
+    summary: "(v1) Get group gangs"
+    description: >
+      Retrieves a collection of gangs, keyed by
+      the group `$flag`. A `$gang` is an invitation to a group.
+    operationId: getGroupsGangs-v1
+    tags:
+      - "Groups"
+    responses:
+      "200":
+        description: "OK"
+        content:
+          application/json:
+            schema:
+              type: object
+              additionalProperties:
+                $ref: "../components/groups.yaml#/gang-v5"
+v2-gangs:
+  get:
+    summary: "(v2) Get group gangs"
+    description: >
+      Retrieves a collection of gangs, keyed by
+      the group `$flag`. A `$gang` is an invitation to a group.
+    operationId: getGroupsGangs-v2
+    tags:
+      - "Groups"
+    responses:
+      "200":
+        description: "OK"
+        content:
+          application/json:
+            schema:
+              type: object
+              additionalProperties:
+                $ref: "../components/groups.yaml#/gang-v6"
+
+groups-light:
+  get:
+    summary: "Get groups lightweight"
+    description: >
+      Returns a collection of groups, keyed by the group $flag.
+      The fleet, which is a collection of group members and can be
+      quite big, is removed from each group, with only the host
+      remaining.
+    operationId: getGroupsLight
+    tags:
+      - "Groups"
+    responses:
+      "200":
+        description: "OK"
+        content:
+          application/json:
+            schema:
+              type: object
+              additionalProperties:
+                $ref: "../components/groups.yaml#/group-v2"

--- a/api/paths/groups.yaml
+++ b/api/paths/groups.yaml
@@ -21,7 +21,7 @@ v1-gangs:
     summary: "(v1) Get group gangs"
     description: >
       Retrieves a collection of gangs, keyed by
-      the group `$flag`. A `$gang` is an invitation to a group.
+      the group `$flag`. A `$gang` is a preview or invitation to a group.
     operationId: getGroupsGangs-v1
     tags:
       - "Groups"

--- a/api/paths/groups.yaml
+++ b/api/paths/groups.yaml
@@ -59,7 +59,7 @@ groups-light:
     description: >
       Returns a collection of groups, keyed by the group $flag.
       The fleet, which is a collection of group members and can be
-      quite big, is removed from each group, with only the host
+      quite big, is removed from each group, with only your self
       remaining.
     operationId: getGroupsLight
     tags:


### PR DESCRIPTION
This PR lays the foundation of TM API documentation. We use OpenAPI to define the specification of existing backend endpoints. Subsequently, the documentation can be generated with [Redocly](https://redocly.com).

The API coverage so far is minimal and includes only a handful of endpoints of the %groups agent. This was enough to establish a general structure. The specification can now be expanded in the areas we consider most useful. 

I have made an attempt at generating the spec using static code analysis of our Hoon codebase, but for this approach to be practical the code analyser would have to be made more powerful – other things take priority for now.

Fixes TLON-3571