### PR TITLE
getChannelPosts: prioritize the request of active channels in the syncQueue, deprioritize inactive channels

### DIFF
--- a/packages/app/features/top/ChannelScreen.tsx
+++ b/packages/app/features/top/ChannelScreen.tsx
@@ -7,6 +7,7 @@ import {
 } from '@tloncorp/shared';
 import * as db from '@tloncorp/shared/db';
 import * as store from '@tloncorp/shared/store';
+import { useActiveChannel } from '@tloncorp/shared/store';
 import {
   useCanUpload,
   useChannelPreview,
@@ -43,10 +44,18 @@ export default function ChannelScreen(props: Props) {
     startDraft: false,
   };
   const [currentChannelId, setCurrentChannelId] = React.useState(channelId);
+  const { setActiveChannel } = useActiveChannel();
 
   useEffect(() => {
     setCurrentChannelId(channelId);
-  }, [channelId]);
+    setActiveChannel(channelId);
+
+    return () => {
+      if (useActiveChannel.getState().activeChannelId === channelId) {
+        setActiveChannel(null);
+      }
+    };
+  }, [channelId, setActiveChannel]);
 
   const [isChannelSwitcherEnabled] = useFeatureFlag('channelSwitcher');
   const {

--- a/packages/shared/src/store/activeChannel.ts
+++ b/packages/shared/src/store/activeChannel.ts
@@ -1,0 +1,17 @@
+import create from 'zustand';
+
+import { syncQueue } from './syncQueue';
+
+type ActiveChannelState = {
+  activeChannelId: string | null;
+  setActiveChannel: (channelId: string | null) => void;
+  isActiveChannel: (channelId: string) => boolean;
+};
+
+export const useActiveChannel = create<ActiveChannelState>((set, get) => ({
+  activeChannelId: null,
+  setActiveChannel: (channelId) => {
+    set({ activeChannelId: channelId });
+  },
+  isActiveChannel: (channelId) => get().activeChannelId === channelId,
+}));

--- a/packages/shared/src/store/index.ts
+++ b/packages/shared/src/store/index.ts
@@ -23,4 +23,5 @@ export * from './inviteActions';
 export * from './hostingActions';
 export * from './lanyardActions';
 export * from './settingsActions';
+export * from './activeChannel';
 export { useChannelContext } from './useChannelContext';

--- a/packages/shared/src/store/sync.ts
+++ b/packages/shared/src/store/sync.ts
@@ -1047,8 +1047,11 @@ export async function syncPosts(
     'syncing posts',
     `${options.channelId}/${options.cursor}/${options.mode}`
   );
-  const response = await syncQueue.add('channelPosts', ctx, () =>
-    api.getChannelPosts(options)
+  const response = await syncQueue.add(
+    'channelPosts',
+    ctx,
+    () => api.getChannelPosts(options),
+    options.channelId
   );
   if (response.posts.length) {
     await db.insertChannelPosts({


### PR DESCRIPTION
OTT, fixes tlon-3892.

Didn't end up going with the abort signal route because:
a) it's not necessary imo, this reprioritization method works fine and it's simpler
b) it would require a more fundamental rewrite of Urbit.ts to work appropriately than I had originally thought

Zustand seemed like the simplest method for state management here, lmk if you feel differently.

To test: refresh the web app and click through channels very rapidly. Don't allow them to fully load before switching to another channel. The UI should still function smoothly and you won't see it locking up as the requests pile up.