### PR TITLE
web: telemetry fix

### DIFF
--- a/packages/app/features/settings/AppInfoScreen.tsx
+++ b/packages/app/features/settings/AppInfoScreen.tsx
@@ -65,7 +65,7 @@ export function AppInfoScreen(props: Props) {
   const telemetry = useTelemetry();
   const currentUserId = useCurrentUserId();
   const [telemetryDisabled, setTelemetryDisabled] = useState(
-    telemetry.optedOut
+    telemetry.getIsOptedOut()
   );
 
   const toggleSetTelemetry = useCallback(() => {

--- a/packages/app/hooks/usePosthog.base.tsx
+++ b/packages/app/hooks/usePosthog.base.tsx
@@ -1,5 +1,5 @@
 export interface PosthogClient {
-  optedOut: boolean;
+  getIsOptedOut: () => boolean;
   optIn: () => void;
   optOut: () => void;
   identify: (userId: string, properties: Record<string, any>) => void;

--- a/packages/app/hooks/usePosthog.native.ts
+++ b/packages/app/hooks/usePosthog.native.ts
@@ -8,7 +8,7 @@ export function usePosthog() {
 
   return useMemo((): PosthogClient => {
     return {
-      optedOut: posthog?.optedOut ?? false,
+      getIsOptedOut: () => posthog?.optedOut ?? false,
       optIn: () => posthog?.optIn(),
       optOut: () => posthog?.optOut(),
       identify: (userId, properties) => posthog?.identify(userId, properties),

--- a/packages/app/hooks/usePosthog.ts
+++ b/packages/app/hooks/usePosthog.ts
@@ -7,7 +7,7 @@ export function usePosthog() {
   const posthog = useWebPosthog();
   return useMemo((): PosthogClient => {
     return {
-      optedOut: posthog?.has_opted_out_capturing() ?? false,
+      getIsOptedOut: () => posthog?.has_opted_out_capturing() ?? false,
       optIn: () => {
         posthog?.opt_in_capturing();
       },

--- a/packages/app/navigation/utils.ts
+++ b/packages/app/navigation/utils.ts
@@ -196,7 +196,7 @@ export function useNavigateToPost() {
         groupId: post.groupId ?? undefined,
       });
     },
-    [navigation, isWindowNarrow, currentScreenIsActivity]
+    [isWindowNarrow, currentScreenIsActivity, navigation, lastOpenTab]
   );
 }
 

--- a/packages/app/types/telemetry.ts
+++ b/packages/app/types/telemetry.ts
@@ -1,5 +1,5 @@
 export interface TelemetryClient {
-  optedOut: boolean;
+  getIsOptedOut: () => boolean;
   optIn: () => void;
   optOut: () => void;
   identify: (userId: string, properties?: Record<string, any>) => void;

--- a/packages/shared/src/db/keyValue.ts
+++ b/packages/shared/src/db/keyValue.ts
@@ -127,6 +127,11 @@ export const didInitializeTelemetry = createStorageItem<boolean>({
   defaultValue: false,
 });
 
+export const hasClearedLegacyWebTelemetry = createStorageItem<boolean>({
+  key: 'hasClearedLegacyWebTelemetry',
+  defaultValue: false,
+});
+
 export const lastAnonymousAppOpenAt = createStorageItem<number | null>({
   key: 'lastAnonymousAppOpenAt',
   defaultValue: null,


### PR DESCRIPTION
On new web, we're seeing hosted users initialized with Telemetry disabled. I think this is because previous iterations of the web build were hardcoded to unconditionally disable telemetry (PostHog opt out) and we were cueing off that setting when identifying.

This adds a one time forced telemetry reset for new web. Continues to only enable it by default for hosted users.