### PR TITLE
web telemetry: don't track console errors

### DIFF
--- a/apps/tlon-web-new/src/main.tsx
+++ b/apps/tlon-web-new/src/main.tsx
@@ -58,14 +58,6 @@ setupDb().then(() => {
 
   window.our = `~${window.ship}`;
 
-  window.addEventListener('error', (e) => {
-    logger.trackEvent(AnalyticsEvent.WebConsoleError, {
-      e: e.error,
-      stack: e.error?.stack,
-      errorMessage: e.error?.message,
-    });
-  });
-
   const container = document.getElementById('app') as HTMLElement;
   const root = createRoot(container);
   root.render(

--- a/packages/shared/src/api/urbit.ts
+++ b/packages/shared/src/api/urbit.ts
@@ -186,9 +186,6 @@ export function internalConfigureClient({
   });
 
   config.client.on('error', (error) => {
-    logger.trackError(AnalyticsEvent.NodeConnectionError, {
-      errorMessage: error.msg,
-    });
     logger.log('client error', error);
   });
 


### PR DESCRIPTION
This is too noisy to be useful right now. Until we're seeing these infrequently, I don't think it's worth capturing every single one.

Ditto for connection errors which happen consistently and provide no useful diagnostic info