### PR TITLE
chat: don't disable the send button while we're sending

### DIFF
--- a/packages/app/ui/components/BareChatInput/index.tsx
+++ b/packages/app/ui/components/BareChatInput/index.tsx
@@ -218,7 +218,6 @@ export default function BareChatInput({
   } = useAttachmentContext();
   const [controlledText, setControlledText] = useState('');
   const [inputHeight, setInputHeight] = useState(initialHeight);
-  const [isSending, setIsSending] = useState(false);
   const [sendError, setSendError] = useState(false);
   const [hasSetInitialContent, setHasSetInitialContent] = useState(false);
   const [editorIsEmpty, setEditorIsEmpty] = useState(attachments.length === 0);
@@ -475,14 +474,12 @@ export default function BareChatInput({
 
   const runSendMessage = useCallback(
     async (isEdit: boolean) => {
-      setIsSending(true);
       try {
         await sendMessage(isEdit);
       } catch (e) {
         bareChatInputLogger.trackError('failed to send', e);
         setSendError(true);
       }
-      setIsSending(false);
       setSendError(false);
     },
     [sendMessage]
@@ -715,7 +712,6 @@ export default function BareChatInput({
       showAttachmentButton={showAttachmentButton}
       groupMembers={groupMembers}
       onSelectMention={onMentionSelect}
-      isSending={isSending}
       isEditing={!!editingPost}
       cancelEditing={handleCancelEditing}
       onPressEdit={handleEdit}

--- a/packages/app/ui/components/MessageInput/MessageInputBase.tsx
+++ b/packages/app/ui/components/MessageInput/MessageInputBase.tsx
@@ -95,7 +95,6 @@ export const MessageInputContainer = memo(
     mentionText,
     groupMembers,
     onSelectMention,
-    isSending,
     isEditing = false,
     cancelEditing,
     onPressEdit,
@@ -115,7 +114,6 @@ export const MessageInputContainer = memo(
     groupMembers: db.ChatMember[];
     onSelectMention: (contact: db.Contact) => void;
     isEditing?: boolean;
-    isSending?: boolean;
     cancelEditing?: () => void;
     onPressEdit?: () => void;
     goBack?: () => void;
@@ -203,7 +201,7 @@ export const MessageInputContainer = memo(
             ) : (
               <View marginBottom="$xs">
                 <Button
-                  disabled={disableSend || isSending}
+                  disabled={disableSend}
                   onPress={isEditing ? onPressEdit : onPressSend}
                   backgroundColor="unset"
                   borderColor="transparent"

--- a/packages/app/ui/components/MessageInput/index.tsx
+++ b/packages/app/ui/components/MessageInput/index.tsx
@@ -154,7 +154,6 @@ export const MessageInput = forwardRef<MessageInputHandle, MessageInputProps>(
   ) => {
     const branchDomain = useBranchDomain();
     const branchKey = useBranchKey();
-    const [isSending, setIsSending] = useState(false);
     const [sendError, setSendError] = useState(false);
     const [hasSetInitialContent, setHasSetInitialContent] = useState(false);
     useEffect(() => {
@@ -767,14 +766,12 @@ export const MessageInput = forwardRef<MessageInputHandle, MessageInputProps>(
 
     const runSendMessage = useCallback(
       async (isEdit: boolean) => {
-        setIsSending(true);
         try {
           await sendMessage(isEdit);
         } catch (e) {
           console.error('failed to send', e);
           setSendError(true);
         }
-        setIsSending(false);
         setSendError(false);
       },
       [sendMessage]
@@ -1021,7 +1018,6 @@ export const MessageInput = forwardRef<MessageInputHandle, MessageInputProps>(
         onSelectMention={onSelectMention}
         showMentionPopup={showMentionPopup && !bigInput}
         isEditing={!!editingPost}
-        isSending={isSending}
         cancelEditing={handleCancelEditing}
         showAttachmentButton={showAttachmentButton}
         floatingActionButton={floatingActionButton}


### PR DESCRIPTION
fixes tlon-3942

I suspect we were just being overly cautious by disabling the send button while we're currently sending? Maybe it was a way to prevent accidental double posts (we clear the message input on send anyway, though)?

Anyway, we were definitely disabling the send button while we were in the `isSending` state. Not sure why we didn't notice this earlier. I guess we didn't notice because messages were getting delivered quickly?