### PR TITLE
activity: fix navigating to threads

### DIFF
--- a/packages/app/features/top/PostScreen.tsx
+++ b/packages/app/features/top/PostScreen.tsx
@@ -1,7 +1,7 @@
 import type { NativeStackScreenProps } from '@react-navigation/native-stack';
 import * as db from '@tloncorp/shared/db';
 import * as store from '@tloncorp/shared/store';
-import { useCallback } from 'react';
+import { useCallback, useEffect } from 'react';
 
 import { useChannelNavigation } from '../../hooks/useChannelNavigation';
 import { useChatSettingsNavigation } from '../../hooks/useChatSettingsNavigation';
@@ -24,9 +24,16 @@ export default function PostScreen(props: Props) {
   const { postId, channelId, authorId } = props.route.params;
   const chatOptionsNavProps = useChatSettingsNavigation();
   const canUpload = store.useCanUpload();
-  const { data: post } = store.usePostWithThreadUnreads({
+  const { data: post, isLoading } = store.usePostWithThreadUnreads({
     id: postId,
   });
+
+  useEffect(() => {
+    // if we don't already have the post in the DB, make sure we sync it
+    if (!post && !isLoading) {
+      store.syncThreadPosts({ postId, authorId, channelId });
+    }
+  }, [post, isLoading, postId, authorId, channelId]);
 
   return (
     <ChatOptionsProvider

--- a/packages/shared/src/store/useThreadPosts.ts
+++ b/packages/shared/src/store/useThreadPosts.ts
@@ -21,7 +21,7 @@ export const useThreadPosts = ({
       authorId,
       channelId,
     });
-  }, []);
+  }, [authorId, channelId, postId]);
 
   return useQuery({
     queryKey: [


### PR DESCRIPTION
It looks like the issue here is actually just that we don't have the activity posts already loaded into the DB. If the post does already exist, it works as you'd expect. 

What tipped me off was that it wasn't working on mobile either. My guess is this broke after we refactored screen params to only accept primitive types. Previously activity would scaffold a full post and pass that along.

The post-navigation URL having unserialized objects in the query param seems to have been a red herring. We probably do want to avoid those somehow? But it seems that's not actually what's breaking things here.

Fixes TLON-3927