### PR TITLE
AttachmentButton.native, others: use Icon component

### DIFF
--- a/packages/app/ui/components/Channel/ChannelFooter.tsx
+++ b/packages/app/ui/components/Channel/ChannelFooter.tsx
@@ -1,7 +1,6 @@
 import { Button } from '@tloncorp/ui';
 import { Icon } from '@tloncorp/ui';
 import { IconButton } from '@tloncorp/ui';
-import { ChevronLeft, Search } from '@tloncorp/ui/assets/icons';
 import Animated, {
   Easing,
   interpolate,

--- a/packages/app/ui/components/Channel/ChannelFooter.tsx
+++ b/packages/app/ui/components/Channel/ChannelFooter.tsx
@@ -79,7 +79,7 @@ export function ChannelFooter({
           flex={1}
         >
           <IconButton onPress={goBack} color={'$secondaryText'}>
-            <ChevronLeft />
+            <Icon type="ChevronLeft" />
           </IconButton>
           {showSpinner && <Spinner />}
           {showPickerButton && (
@@ -109,7 +109,7 @@ export function ChannelFooter({
           )}
           {showSearchButton && (
             <IconButton onPress={goToSearch} color={'$secondaryText'}>
-              <Search />
+              <Icon type="Search" />
             </IconButton>
           )}
         </XStack>

--- a/packages/app/ui/components/ChatOptionsSheet.tsx
+++ b/packages/app/ui/components/ChatOptionsSheet.tsx
@@ -2,9 +2,8 @@ import { featureFlags } from '@tloncorp/shared';
 import * as db from '@tloncorp/shared/db';
 import * as store from '@tloncorp/shared/store';
 import * as ub from '@tloncorp/shared/urbit';
-import { useIsWindowNarrow } from '@tloncorp/ui';
+import { Icon, useIsWindowNarrow } from '@tloncorp/ui';
 import { IconButton } from '@tloncorp/ui';
-import { ChevronLeft } from '@tloncorp/ui/assets/icons';
 import React, {
   ReactElement,
   useCallback,
@@ -841,7 +840,7 @@ function NotificationsSheetContent({
 function SheetBackButton({ onPress }: { onPress: () => void }) {
   return (
     <IconButton width="$4xl" onPress={onPress}>
-      <ChevronLeft />
+      <Icon type="ChevronLeft" />
     </IconButton>
   );
 }

--- a/packages/app/ui/components/MessageInput/AttachmentButton.native.tsx
+++ b/packages/app/ui/components/MessageInput/AttachmentButton.native.tsx
@@ -1,5 +1,4 @@
-import { IconButton } from '@tloncorp/ui';
-import { Add } from '@tloncorp/ui/assets/icons';
+import { Icon, IconButton } from '@tloncorp/ui';
 import { useEffect, useState } from 'react';
 
 import AttachmentSheet from '../AttachmentSheet';
@@ -23,7 +22,7 @@ export default function AttachmentButton({
         backgroundColor="unset"
         onPress={() => setShowInputSelector(true)}
       >
-        <Add />
+        <Icon type="Add" color="$primaryText" />
       </IconButton>
       <AttachmentSheet
         isOpen={showInputSelector}


### PR DESCRIPTION
Switches the bare "Add" SVG to use the Icon UI component; makes it reappear on mobile.

Fixes TLON-3938

Also makes the same change in ChatOptionsSheet and ChannelFooter to avoid regressions there.