### PR TITLE
desktop (mostly): react perf optimization

### DIFF
--- a/apps/tlon-web-new/src/app.tsx
+++ b/apps/tlon-web-new/src/app.tsx
@@ -3,6 +3,7 @@ import {
   DarkTheme,
   DefaultTheme,
   NavigationContainer,
+  Route,
 } from '@react-navigation/native';
 import { ShipProvider } from '@tloncorp/app/contexts/ship';
 import { useConfigureUrbitClient } from '@tloncorp/app/hooks/useConfigureUrbitClient';
@@ -10,6 +11,7 @@ import { useCurrentUserId } from '@tloncorp/app/hooks/useCurrentUser';
 import useDesktopNotifications from '@tloncorp/app/hooks/useDesktopNotifications';
 import { useFindSuggestedContacts } from '@tloncorp/app/hooks/useFindSuggestedContacts';
 import { useIsDarkMode } from '@tloncorp/app/hooks/useIsDarkMode';
+import { useRenderCount } from '@tloncorp/app/hooks/useRenderCount';
 import { useTelemetry } from '@tloncorp/app/hooks/useTelemetry';
 import { BasePathNavigator } from '@tloncorp/app/navigation/BasePathNavigator';
 import {
@@ -25,7 +27,14 @@ import * as db from '@tloncorp/shared/db';
 import * as store from '@tloncorp/shared/store';
 import cookies from 'browser-cookies';
 import { usePostHog } from 'posthog-js/react';
-import React, { PropsWithChildren, useEffect, useState } from 'react';
+import React, {
+  PropsWithChildren,
+  useCallback,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+} from 'react';
 import { Helmet } from 'react-helmet';
 import { SafeAreaProvider } from 'react-native-safe-area-context';
 
@@ -76,48 +85,203 @@ function checkIfLoggedIn() {
   }
 }
 
+function getFriendlyName(routeName: string) {
+  const friendlyNames: Record<string, string> = {
+    ChatList: 'Home',
+    GroupSettings: 'Group Settings',
+    ChannelSearch: 'Search',
+    ChatDetails: 'Chat Details',
+    UserProfile: 'Profile',
+    AppSettings: 'Settings',
+    ManageAccount: 'Account',
+    BlockedUsers: 'Blocked Users',
+    FeatureFlags: 'Features',
+    PushNotificationSettings: 'Notifications',
+  };
+
+  return (
+    friendlyNames[routeName] || routeName.replace(/([A-Z])/g, ' $1').trim()
+  );
+}
+
+const extractNestedRouteMobile = (state: any) => {
+  if (!state) return null;
+  const route = state.routes[state.index];
+  return route.state?.routes[route.state?.index || 0] || null;
+};
+
+const extractNestedRouteDesktop = (state: any) => {
+  if (!state) return null;
+  const route = state.routes[state.index];
+  const nestedRoute = route.state?.routes[route.state?.index || 0];
+
+  if (
+    nestedRoute &&
+    (nestedRoute.name === 'Home' || nestedRoute.name === 'Messages')
+  ) {
+    return nestedRoute.state?.routes[nestedRoute.state?.index || 0] || null;
+  }
+  return null;
+};
+
 function AppRoutes() {
   const contactsQuery = store.useContacts();
-  const currentUserId = useCurrentUserId();
   const { needsUpdate, triggerUpdate } = useAppUpdates();
-  const [currentRoute, setCurrentRoute] = useState<any>(null);
+  const [currentRouteParams, setCurrentRouteParams] = useState<any>(null);
+  const currentRouteRef = useRef<any>(null);
+
+  const channelId = useMemo(
+    () => currentRouteParams?.channelId,
+    [currentRouteParams?.channelId]
+  );
+  const groupId = useMemo(
+    () => currentRouteParams?.groupId,
+    [currentRouteParams?.groupId]
+  );
 
   const { data: channelData } = store.useChannel({
-    id: currentRoute?.params?.channelId,
+    id: channelId,
   });
   const { data: groupData } = store.useGroup({
-    id: currentRoute?.params?.groupId,
+    id: groupId,
   });
+  const { data, refetch, isRefetching, isFetching } = contactsQuery;
 
   useEffect(() => {
-    const { data, refetch, isRefetching, isFetching } = contactsQuery;
-
     if (data?.length === 0 && !isRefetching && !isFetching) {
       refetch();
     }
-  }, [contactsQuery]);
+  }, [data?.length, isRefetching, isFetching, refetch]);
 
   const isMobile = useIsMobile();
   const isDarkMode = useIsDarkMode();
+  const theme = useMemo(() => {
+    if (isDarkMode) {
+      return DarkTheme;
+    }
+    return DefaultTheme;
+  }, [isDarkMode]);
 
-  const getFriendlyName = (routeName: string) => {
-    const friendlyNames: Record<string, string> = {
-      ChatList: 'Home',
-      GroupSettings: 'Group Settings',
-      ChannelSearch: 'Search',
-      ChatDetails: 'Chat Details',
-      UserProfile: 'Profile',
-      AppSettings: 'Settings',
-      ManageAccount: 'Account',
-      BlockedUsers: 'Blocked Users',
-      FeatureFlags: 'Features',
-      PushNotificationSettings: 'Notifications',
-    };
+  useRenderCount('AppRoutes');
 
-    return (
-      friendlyNames[routeName] || routeName.replace(/([A-Z])/g, ' $1').trim()
-    );
-  };
+  const handleStateChangeMobile = useCallback((state: any) => {
+    const nestedRoute = extractNestedRouteMobile(state);
+    if (nestedRoute) {
+      currentRouteRef.current = nestedRoute;
+      // Only update state if needed for specific param changes
+      if (
+        nestedRoute.params?.channelId !==
+          currentRouteRef.current?.params?.channelId ||
+        nestedRoute.params?.groupId !== currentRouteRef.current?.params?.groupId
+      ) {
+        setCurrentRouteParams(nestedRoute.params);
+      }
+    }
+  }, []);
+
+  const handleStateChangeDesktop = useCallback((state: any) => {
+    const nestedRoute = extractNestedRouteDesktop(state);
+    if (nestedRoute) {
+      currentRouteRef.current = nestedRoute;
+      // Only update state if needed for specific param changes
+      if (
+        nestedRoute.params?.channelId !==
+          currentRouteRef.current?.params?.channelId ||
+        nestedRoute.params?.groupId !== currentRouteRef.current?.params?.groupId
+      ) {
+        setCurrentRouteParams(nestedRoute.params);
+      }
+    }
+  }, []);
+
+  const documentTitleFormatterMobile = useCallback(
+    (_options: any, route: Route<string>) => {
+      if (!route?.name) return 'Tlon';
+
+      if (route.name === 'GroupChannels') {
+        if (groupData?.title) {
+          return `${groupData.title}`;
+        }
+        return 'Group Channels';
+      }
+
+      // For channel routes
+      if (route.name === 'Channel' || route.name === 'ChannelRoot') {
+        if (channelData?.title && groupData?.title) {
+          return `${channelData.title} - ${groupData.title}`;
+        }
+      }
+
+      // For DM routes
+      if (route.name === 'DM') {
+        const title =
+          channelData?.title ||
+          channelData?.contact?.peerNickname ||
+          channelData?.contact?.customNickname ||
+          channelData?.contactId ||
+          'Chat';
+        return `${title}`;
+      }
+
+      // For Group DM routes
+      if (route.name === 'GroupDM') {
+        return `${channelData?.title ?? 'Group DM'}`;
+      }
+
+      // For other routes
+      const screenName = getFriendlyName(route.name);
+      return `${screenName}`;
+    },
+    [
+      groupData?.title,
+      channelData?.title,
+      channelData?.contact?.peerNickname,
+      channelData?.contact?.customNickname,
+      channelData?.contactId,
+    ]
+  );
+
+  const documentTitleFormatterDesktop = useCallback(
+    (_options: any, route: Route<string>) => {
+      if (!route?.name) return 'Tlon';
+
+      // For channel routes
+      if (route.name === 'Channel' || route.name === 'ChannelRoot') {
+        if (groupData?.title && channelData?.title) {
+          return `${channelData.title} - ${groupData.title}`;
+        }
+
+        const title =
+          channelData?.title ||
+          channelData?.contact?.peerNickname ||
+          channelData?.contact?.customNickname ||
+          channelData?.contactId ||
+          'Chat';
+        return `${title}`;
+      }
+
+      // For other routes
+      const screenName = getFriendlyName(route.name);
+      return `${screenName}`;
+    },
+    [
+      groupData?.title,
+      channelData?.title,
+      channelData?.contact?.peerNickname,
+      channelData?.contact?.customNickname,
+      channelData?.contactId,
+    ]
+  );
+
+  const mobileLinkingConfig = useMemo(
+    () => getMobileLinkingConfig(import.meta.env.MODE),
+    []
+  );
+
+  const desktopLinkingConfig = useMemo(
+    () => getDesktopLinkingConfig(import.meta.env.MODE),
+    []
+  );
 
   return (
     <AppDataProvider
@@ -126,119 +290,27 @@ function AppRoutes() {
     >
       {isMobile ? (
         <NavigationContainer
-          linking={getMobileLinkingConfig(import.meta.env.MODE)}
-          theme={isDarkMode ? DarkTheme : DefaultTheme}
-          onStateChange={(state) => {
-            if (state) {
-              const route = state.routes[state.index];
-              const nestedRoute = route.state?.routes[route.state?.index || 0];
-              if (nestedRoute) {
-                setCurrentRoute(nestedRoute);
-              }
-            }
-          }}
+          linking={mobileLinkingConfig}
+          theme={theme}
+          onStateChange={handleStateChangeMobile}
           documentTitle={{
             enabled: true,
-            formatter: (options, route) => {
-              if (!route?.name) return 'Tlon';
-
-              if (route.name === 'GroupChannels') {
-                if (groupData) {
-                  return `${groupData.title}`;
-                }
-                return 'Group Channels';
-              }
-
-              // For channel routes
-              if (route.name === 'Channel' || route.name === 'ChannelRoot') {
-                if (channelData && groupData) {
-                  return `${channelData.title} - ${groupData.title}`;
-                }
-              }
-
-              // For DM routes
-              if (route.name === 'DM') {
-                if (channelData) {
-                  const title =
-                    channelData.title ||
-                    channelData.contact?.peerNickname ||
-                    channelData.contact?.customNickname ||
-                    channelData.contactId ||
-                    'Chat';
-                  return `${title}`;
-                }
-                return 'Chat';
-              }
-
-              // For Group DM routes
-              if (route.name === 'GroupDM') {
-                if (channelData) {
-                  return `${channelData.title !== '' ? channelData.title : 'Group DM'}`;
-                }
-                return 'Group DM';
-              }
-
-              // For other routes
-              const screenName = getFriendlyName(route.name);
-              return `${screenName}`;
-            },
+            formatter: documentTitleFormatterMobile,
           }}
         >
-          <BasePathNavigator isMobile={isMobile} />
+          <BasePathNavigator isMobile={true} />
         </NavigationContainer>
       ) : (
         <NavigationContainer
-          linking={getDesktopLinkingConfig(import.meta.env.MODE)}
-          theme={isDarkMode ? DarkTheme : DefaultTheme}
-          onStateChange={(state) => {
-            if (state) {
-              const route = state.routes[state.index];
-              const nestedRoute = route.state?.routes[route.state?.index || 0];
-              if (
-                nestedRoute &&
-                (nestedRoute.name === 'Home' || nestedRoute.name === 'Messages')
-              ) {
-                const nestedHomeRoute =
-                  nestedRoute.state?.routes[nestedRoute.state?.index || 0];
-                if (nestedHomeRoute) {
-                  setCurrentRoute(nestedHomeRoute);
-                }
-              }
-            }
-          }}
+          linking={desktopLinkingConfig}
+          theme={theme}
+          onStateChange={handleStateChangeDesktop}
           documentTitle={{
             enabled: true,
-            formatter: (options, route) => {
-              if (!route?.name) return 'Tlon';
-
-              // For channel routes
-              if (route.name === 'Channel' || route.name === 'ChannelRoot') {
-                if (channelData && groupData) {
-                  if (groupData?.title) {
-                    return `${channelData.title} - ${groupData.title}`;
-                  } else {
-                    return `${channelData.title}`;
-                  }
-                }
-                if (channelData) {
-                  const title =
-                    channelData.title ||
-                    channelData.contact?.peerNickname ||
-                    channelData.contact?.customNickname ||
-                    channelData.contactId ||
-                    'Chat';
-                  return `${title}`;
-                }
-                return 'Chat';
-              }
-
-              // For other routes
-              const screenName = getFriendlyName(route.name);
-              return `${screenName}`;
-            },
+            formatter: documentTitleFormatterDesktop,
           }}
         >
-          <BasePathNavigator isMobile={isMobile} />
+          <BasePathNavigator isMobile={false} />
         </NavigationContainer>
       )}
     </AppDataProvider>
@@ -382,7 +454,9 @@ function ConnectedWebApp() {
     };
 
     syncStart();
-  }, [dbIsLoaded, currentUserId, configureClient, session]);
+  }, [dbIsLoaded, currentUserId, configureClient, session?.startTime]);
+
+  useRenderCount('ConnectedWebApp');
 
   if (!dbIsLoaded) {
     return (

--- a/packages/app/features/chat-list/ChatList.tsx
+++ b/packages/app/features/chat-list/ChatList.tsx
@@ -1,10 +1,12 @@
 import { FlashList, ListRenderItem } from '@shopify/flash-list';
 import * as db from '@tloncorp/shared/db';
+import { isEqual } from 'lodash';
 import React, { useCallback, useMemo, useRef } from 'react';
 import { LayoutChangeEvent } from 'react-native';
 import { getTokenValue } from 'tamagui';
 
 import { SectionedChatData } from '../../hooks/useFilteredChats';
+import { useRenderCount } from '../../hooks/useRenderCount';
 import {
   ChatListItem,
   InteractableChatListItem,
@@ -33,14 +35,14 @@ export const ChatList = React.memo(function ChatListComponent({
     [data]
   );
 
-  const chatOptions = useChatOptions();
+  const { open } = useChatOptions();
   const handleLongPress = useCallback(
     (item: db.Chat) => {
       if (!item.isPending) {
-        chatOptions.open(item.id, item.type);
+        open(item.id, item.type);
       }
     },
-    [chatOptions]
+    [open]
   );
 
   // removed the use of useStyle here because it was causing FlashList to
@@ -117,6 +119,8 @@ export const ChatList = React.memo(function ChatListComponent({
     [handleHeaderLayout, onPressItem, handleLongPress, handleItemLayout]
   );
 
+  useRenderCount('ChatList');
+
   return (
     <FlashList
       data={listItems}
@@ -128,7 +132,7 @@ export const ChatList = React.memo(function ChatListComponent({
       overrideItemLayout={handleOverrideLayout}
     />
   );
-});
+}, isEqual);
 
 export function getItemType(item: ChatListItemData) {
   return isSectionHeader(item) ? 'sectionHeader' : item.type;

--- a/packages/app/features/chat-list/GlobalSearch/index.tsx
+++ b/packages/app/features/chat-list/GlobalSearch/index.tsx
@@ -10,6 +10,7 @@ import {
 import { getTokenValue } from 'tamagui';
 
 import { TabName, useFilteredChats } from '../../../hooks/useFilteredChats';
+import { useResolvedChats } from '../../../hooks/useResolvedChats';
 import {
   ChatListItem,
   LoadingSpinner,
@@ -53,17 +54,11 @@ export function GlobalSearch({
     enabled: isOpen,
   });
 
-  const resolvedChats = useMemo(() => {
-    return {
-      pinned: chats?.pinned ?? [],
-      unpinned: chats?.unpinned ?? [],
-    };
-  }, [chats]);
+  const resolvedChats = useResolvedChats(chats);
 
   const filteredChatsConfig = useMemo(
     () => ({
-      pinned: resolvedChats.pinned,
-      unpinned: resolvedChats.unpinned,
+      ...resolvedChats, // Use the resolved chats from the hook
       pending: [],
       searchQuery,
       activeTab: 'all' as TabName,

--- a/packages/app/features/top/ChannelScreen.tsx
+++ b/packages/app/features/top/ChannelScreen.tsx
@@ -399,6 +399,15 @@ export default function ChannelScreen(props: Props) {
   }, []);
 
   const channelRef = useRef<React.ElementRef<typeof Channel>>(null);
+  const handlePressInvite = useCallback((groupId: string) => {
+    setInviteSheetGroup(groupId);
+  }, []);
+
+  const handleConfigureChannel = useCallback(() => {
+    if (channelRef.current) {
+      channelRef.current.openChannelConfigurationBar();
+    }
+  }, [channelRef]);
 
   if (!channel) {
     return null;
@@ -411,10 +420,8 @@ export default function ChannelScreen(props: Props) {
         id: currentChannelId,
       }}
       useGroup={store.useGroup}
-      onPressInvite={(group) => {
-        setInviteSheetGroup(group);
-      }}
-      onPressConfigureChannel={channelRef.current?.openChannelConfigurationBar}
+      onPressInvite={handlePressInvite}
+      onPressConfigureChannel={handleConfigureChannel}
       {...chatOptionsNavProps}
     >
       <AttachmentProvider canUpload={canUpload} uploadAsset={store.uploadAsset}>
@@ -463,7 +470,7 @@ export default function ChannelScreen(props: Props) {
           onPressScrollToBottom={handleScrollToBottom}
         />
       </AttachmentProvider>
-      {group && (
+      {group && isChannelSwitcherEnabled && (
         <>
           <ChannelSwitcherSheet
             open={channelNavOpen}

--- a/packages/app/features/top/ChatListScreen.tsx
+++ b/packages/app/features/top/ChatListScreen.tsx
@@ -5,7 +5,6 @@ import {
 } from '@react-navigation/native';
 import type { NativeStackScreenProps } from '@react-navigation/native-stack';
 import { AnalyticsEvent, createDevLogger } from '@tloncorp/shared';
-import * as api from '@tloncorp/shared/api';
 import * as db from '@tloncorp/shared/db';
 import * as logic from '@tloncorp/shared/logic';
 import * as store from '@tloncorp/shared/store';
@@ -291,6 +290,10 @@ export function ChatListScreenView({
     activeTab,
   });
 
+  const handleInvitePress = useCallback(() => {
+    setInviteSheetGroup(selectedGroupId);
+  }, [selectedGroupId]);
+
   return (
     <RequestsProvider
       usePostReference={store.usePostReference}
@@ -301,9 +304,7 @@ export function ChatListScreenView({
     >
       <ChatOptionsProvider
         {...useChatSettingsNavigation()}
-        onPressInvite={(group) => {
-          setInviteSheetGroup(group);
-        }}
+        onPressInvite={handleInvitePress}
       >
         <NavigationProvider focusedChannelId={focusedChannelId}>
           <View userSelect="none" flex={1}>

--- a/packages/app/hooks/useFilteredChats.ts
+++ b/packages/app/hooks/useFilteredChats.ts
@@ -36,8 +36,11 @@ export function useFilteredChats({
   );
 
   const { data } = useMessagesFilter();
-  const talkFilter =
-    activeTab === 'talk' ? data ?? 'Direct Messages' : 'Direct Messages';
+  const talkFilter = useMemo(
+    () =>
+      activeTab === 'talk' ? data ?? 'Direct Messages' : 'Direct Messages',
+    [data, activeTab]
+  );
 
   return useMemo(() => {
     const isSearching = searchQuery && searchQuery.trim() !== '';

--- a/packages/app/hooks/useRenderCount.ts
+++ b/packages/app/hooks/useRenderCount.ts
@@ -1,0 +1,24 @@
+import { useRef, useEffect } from 'react';
+
+/**
+ * Hook to track and log component render counts
+ * 
+ * @param componentName Name of the component to include in the log message
+ * @param enabled Optional flag to enable/disable logging (defaults to true in development)
+ * @returns The current render count (useful for testing or conditional logic)
+ */
+export function useRenderCount(
+  componentName: string, 
+  enabled = process.env.NODE_ENV === 'development'
+): number {
+  const renderCount = useRef(0);
+  
+  useEffect(() => {
+    if (!enabled) return;
+    
+    renderCount.current += 1;
+    console.log(`${componentName} rendered:`, renderCount.current);
+  });
+  
+  return renderCount.current;
+}

--- a/packages/app/hooks/useResolvedChats.ts
+++ b/packages/app/hooks/useResolvedChats.ts
@@ -1,0 +1,56 @@
+import type * as db from '@tloncorp/shared/db';
+import type * as store from '@tloncorp/shared/store';
+import { useEffect, useMemo, useState } from 'react';
+
+type UseCurrentChatsResult = ReturnType<typeof store.useCurrentChats>['data'];
+
+/**
+ * Memoizes the chat list structure based on relevant changes
+ * (list lengths, unread counts) to prevent unnecessary recalculations
+ * in downstream hooks like useFilteredChats.
+ */
+export function useResolvedChats(chats: UseCurrentChatsResult): {
+  pinned: db.Chat[];
+  unpinned: db.Chat[];
+  pending: db.Chat[];
+} {
+  const [chatSignature, setChatSignature] = useState<string>('');
+
+  // Track previous values and update the signature when meaningful changes occur
+  useEffect(() => {
+    if (!chats) return;
+
+    const newSignature = JSON.stringify({
+      pinnedLength: chats.pinned.length,
+      unpinnedLength: chats.unpinned.length,
+      pendingLength: chats.pending.length,
+      pinnedUnreadCount: chats.pinned.reduce(
+        (acc, chat) => acc + (chat.unreadCount ?? 0),
+        0
+      ),
+      unpinnedUnreadCount: chats.unpinned.reduce(
+        (acc, chat) => acc + (chat.unreadCount ?? 0),
+        0
+      ),
+      pendingUnreadCount: chats.pending.reduce(
+        (acc, chat) => acc + (chat.unreadCount ?? 0),
+        0
+      ),
+    });
+
+    if (newSignature !== chatSignature) {
+      setChatSignature(newSignature);
+    }
+  }, [chats, chatSignature]);
+
+  // Only recalculate when the signature changes
+  const resolvedChats = useMemo(() => {
+    return {
+      pinned: chats?.pinned ?? [],
+      unpinned: chats?.unpinned ?? [],
+      pending: chats?.pending ?? [],
+    };
+  }, [chatSignature]);
+
+  return resolvedChats;
+}

--- a/packages/app/navigation/BasePathNavigator.tsx
+++ b/packages/app/navigation/BasePathNavigator.tsx
@@ -5,8 +5,9 @@ import {
 } from '@react-navigation/native';
 import { createNativeStackNavigator } from '@react-navigation/native-stack';
 import { storage } from '@tloncorp/shared/db';
-import { useEffect, useMemo, useRef } from 'react';
+import { memo, useEffect, useMemo, useRef } from 'react';
 
+import { useRenderCount } from '../hooks/useRenderCount';
 import { RootStack } from './RootStack';
 import { TopLevelDrawer } from './desktop/TopLevelDrawer';
 import {
@@ -33,27 +34,37 @@ const DesktopBasePathStackNavigator =
  * On web, this is necessary for navigation to work properly when the base URL
  * is something other than `/`, eg `/apps/groups/`
  */
-export function BasePathNavigator({ isMobile }: { isMobile: boolean }) {
+export const BasePathNavigator = memo(({ isMobile }: { isMobile: boolean }) => {
   const Navigator = isMobile
     ? MobileBasePathStackNavigator
     : DesktopBasePathStackNavigator;
 
-  const navState = useNavigationState((state) => state);
-  const currentRoute = navState?.routes[navState.index];
-  const rootState = currentRoute?.state;
+  const navStateIndex = useNavigationState((state) => state?.index);
+  const navStateRoutes = useNavigationState((state) => state?.routes);
+  const currentRoute = useMemo(
+    () =>
+      navStateIndex && navStateRoutes ? navStateRoutes[navStateIndex] : null,
+    [navStateIndex, navStateRoutes]
+  );
+  const rootState = useMemo(() => currentRoute?.state, [currentRoute]);
+  const rootStateIndex = useMemo(() => rootState?.index, [rootState]);
+  const rootStateRoutes = useMemo(() => rootState?.routes, [rootState]);
   const lastWasMobile = useRef(isMobile);
 
   const currentScreenAndParams = useMemo(() => {
+    console.log('BasePathNavigator, calculating current screen');
+    if (!rootStateIndex || !rootStateRoutes) {
+      return undefined;
+    }
     if (isMobile !== lastWasMobile.current) {
       return undefined;
     }
 
-    const isHome =
-      rootState?.index === 0 && rootState?.routes[0].name === 'Home';
+    const isHome = rootStateIndex === 0 && rootStateRoutes[0].name === 'Home';
     const isContacts =
-      rootState?.index === 2 && rootState?.routes[2].name === 'Contacts';
+      rootStateIndex === 2 && rootStateRoutes[2].name === 'Contacts';
     if (isHome) {
-      const homeState = rootState.routes[0].state;
+      const homeState = rootStateRoutes[0].state;
       if (!homeState || homeState.index === undefined) {
         return {
           name: 'Home',
@@ -69,7 +80,7 @@ export function BasePathNavigator({ isMobile }: { isMobile: boolean }) {
 
     if (isContacts) {
       // contacts tab is the third tab
-      const contactsState = rootState.routes[2].state;
+      const contactsState = rootStateRoutes[2].state;
       if (!contactsState || contactsState.index === undefined) {
         return {
           name: 'Contacts',
@@ -82,16 +93,12 @@ export function BasePathNavigator({ isMobile }: { isMobile: boolean }) {
       };
     }
 
-    if (rootState && rootState.routes && rootState.index !== undefined) {
-      const screen = rootState.routes[rootState.index];
-      return {
-        name: screen.name,
-        params: screen.params,
-      };
-    }
-
-    return undefined;
-  }, [isMobile, rootState]);
+    const screen = rootStateRoutes[rootStateIndex];
+    return {
+      name: screen.name,
+      params: screen.params,
+    };
+  }, [isMobile, rootStateIndex, rootStateRoutes]);
 
   const { resetToChannel } = useRootNavigation();
   const reset = useTypedReset();
@@ -129,23 +136,39 @@ export function BasePathNavigator({ isMobile }: { isMobile: boolean }) {
         });
       }, 1); // tiny delay to let navigator mount. otherwise it doesn't work.
     }
-  }, [isMobile, resetToChannel, rootState, reset]);
+  }, [isMobile, resetToChannel, reset]);
+
+  const prevScreenAndParamsRef = useRef<typeof currentScreenAndParams>();
 
   useEffect(() => {
     if (currentScreenAndParams && isMobile === lastWasMobile.current) {
-      storage.lastScreen.setValue(currentScreenAndParams);
+      if (
+        JSON.stringify(prevScreenAndParamsRef.current) !==
+        JSON.stringify(currentScreenAndParams)
+      ) {
+        prevScreenAndParamsRef.current = currentScreenAndParams;
+        storage.lastScreen.setValue(currentScreenAndParams);
+      }
     }
   }, [currentScreenAndParams, isMobile]);
 
+  const component = useMemo(() => {
+    if (isMobile) {
+      return RootStack;
+    }
+    return TopLevelDrawer;
+  }, [isMobile]);
+
+  useRenderCount('BasePathNavigator');
+
   return (
     <Navigator.Navigator screenOptions={{ headerShown: false }}>
-      <Navigator.Screen
-        name="Root"
-        component={isMobile ? RootStack : TopLevelDrawer}
-      />
+      <Navigator.Screen name="Root" component={component} />
     </Navigator.Navigator>
   );
-}
+});
+
+BasePathNavigator.displayName = 'BasePathNavigator';
 
 export const getLastScreen = storage.lastScreen
   .getValue as () => Promise<null | RouteProp<CombinedParamList, any>>;

--- a/packages/app/navigation/desktop/HomeNavigator.tsx
+++ b/packages/app/navigation/desktop/HomeNavigator.tsx
@@ -5,7 +5,8 @@ import {
 import type { NativeStackScreenProps } from '@react-navigation/native-stack';
 import { createNativeStackNavigator } from '@react-navigation/native-stack';
 import { NavigationState } from '@react-navigation/routers';
-import { useEffect } from 'react';
+import { isEqual } from 'lodash';
+import { memo, useEffect } from 'react';
 import { View, getVariableValue, useTheme } from 'tamagui';
 
 import { ChannelMembersScreen } from '../../features/channels/ChannelMembersScreen';
@@ -38,13 +39,9 @@ export const HomeNavigator = () => {
 
   return (
     <HomeDrawer.Navigator
-      drawerContent={DrawerContent}
+      drawerContent={(props) => <DrawerContent {...props} />}
       initialRouteName="ChatList"
-      screenOptions={({ navigation }) => {
-        const state = navigation.getState();
-        const routes = state.routes[state.index].state?.routes;
-        const currentScreen = routes?.[routes.length - 1];
-
+      screenOptions={() => {
         return {
           drawerType: 'permanent',
           headerShown: false,
@@ -67,7 +64,7 @@ export const HomeNavigator = () => {
   );
 };
 
-function DrawerContent(props: DrawerContentComponentProps) {
+const DrawerContent = memo((props: DrawerContentComponentProps) => {
   const state = props.state as NavigationState<HomeDrawerParamList>;
   const focusedRoute = state.routes[props.state.index];
   const focusedRouteParams = focusedRoute.params;
@@ -119,7 +116,9 @@ function DrawerContent(props: DrawerContentComponentProps) {
   } else {
     return <HomeSidebar />;
   }
-}
+}, isEqual);
+
+DrawerContent.displayName = 'HomeSidebarDrawerContent';
 
 const MainStackNavigator = createNativeStackNavigator();
 

--- a/packages/app/navigation/desktop/HomeSidebar.tsx
+++ b/packages/app/navigation/desktop/HomeSidebar.tsx
@@ -1,9 +1,8 @@
-import { useIsFocused } from '@react-navigation/native';
 import { createDevLogger } from '@tloncorp/shared';
 import * as db from '@tloncorp/shared/db';
 import * as store from '@tloncorp/shared/store';
 import { Text } from '@tloncorp/ui';
-import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import { memo, useCallback, useEffect, useMemo, useRef, useState } from 'react';
 
 import { TLON_EMPLOYEE_GROUP } from '../../constants';
 import { ChatList } from '../../features/chat-list/ChatList';
@@ -14,6 +13,8 @@ import {
 import { useChatSettingsNavigation } from '../../hooks/useChatSettingsNavigation';
 import { useFilteredChats } from '../../hooks/useFilteredChats';
 import { useGroupActions } from '../../hooks/useGroupActions';
+import { useRenderCount } from '../../hooks/useRenderCount';
+import { useResolvedChats } from '../../hooks/useResolvedChats';
 import {
   ChatOptionsProvider,
   GroupPreviewAction,
@@ -35,221 +36,223 @@ interface Props {
   focusedChannelId?: string;
 }
 
-export function HomeSidebar({ previewGroupId, focusedChannelId }: Props) {
-  const screenTitle = 'Home';
-  const [inviteSheetGroup, setInviteSheetGroup] = useState<string | null>();
+export const HomeSidebar = memo(
+  ({ previewGroupId, focusedChannelId }: Props) => {
+    const screenTitle = 'Home';
+    const [inviteSheetGroup, setInviteSheetGroup] = useState<string | null>();
 
-  const [selectedGroupId, setSelectedGroupId] = useState<string | null>(
-    previewGroupId ?? null
-  );
-  const { data: selectedGroup } = store.useGroup({ id: selectedGroupId ?? '' });
-  const { setIsOpen } = useGlobalSearch();
+    const [selectedGroupId, setSelectedGroupId] = useState<string | null>(
+      previewGroupId ?? null
+    );
+    const { data: selectedGroup } = store.useGroup({
+      id: selectedGroupId ?? '',
+    });
+    const { setIsOpen } = useGlobalSearch();
 
-  const isFocused = useIsFocused();
+    // const isFocused = useIsFocused();
 
-  const { data: chats } = store.useCurrentChats({
-    enabled: isFocused,
-  });
-  const { performGroupAction } = useGroupActions();
+    const { data: chats } = store.useCurrentChats();
+    const { performGroupAction } = useGroupActions();
 
-  const connStatus = store.useConnectionStatus();
-  const notReadyMessage: string | null = useMemo(() => {
-    // if not fully connected yet, show status
-    if (connStatus !== 'Connected') {
-      return `${connStatus}...`;
-    }
+    const connStatus = store.useConnectionStatus();
+    const notReadyMessage: string | null = useMemo(() => {
+      // if not fully connected yet, show status
+      if (connStatus !== 'Connected') {
+        return `${connStatus}...`;
+      }
 
-    // if still loading the screen data, show loading
-    if (!chats) {
-      return 'Loading...';
-    }
+      // if still loading the screen data, show loading
+      if (!chats) {
+        return 'Loading...';
+      }
 
-    return null;
-  }, [connStatus, chats]);
+      return null;
+    }, [connStatus, chats]);
 
-  const noChats = useMemo(
-    () =>
-      chats?.pinned.length === 0 &&
-      chats?.unpinned.length === 0 &&
-      chats?.pending.length === 0,
-    [chats]
-  );
+    const noChats = useMemo(
+      () =>
+        chats?.pinned.length === 0 &&
+        chats?.unpinned.length === 0 &&
+        chats?.pending.length === 0,
+      [chats]
+    );
 
-  /* Log an error if this screen takes more than 30 seconds to resolve to "Connected" */
-  const connectionTimeout = useRef<NodeJS.Timeout | null>(null);
-  const connectionAttempts = useRef(0);
+    /* Log an error if this screen takes more than 30 seconds to resolve to "Connected" */
+    const connectionTimeout = useRef<NodeJS.Timeout | null>(null);
+    const connectionAttempts = useRef(0);
 
-  useEffect(() => {
-    const checkConnection = () => {
-      if (connStatus === 'Connected') {
-        if (connectionTimeout.current) {
-          clearTimeout(connectionTimeout.current);
-        }
-        connectionAttempts.current = 0;
-      } else {
-        connectionAttempts.current += 1;
-        if (connectionAttempts.current >= 10) {
-          logger.error('Connection not established within 10 seconds');
+    useEffect(() => {
+      const checkConnection = () => {
+        if (connStatus === 'Connected') {
           if (connectionTimeout.current) {
             clearTimeout(connectionTimeout.current);
           }
+          connectionAttempts.current = 0;
         } else {
-          connectionTimeout.current = setTimeout(checkConnection, 1000);
+          connectionAttempts.current += 1;
+          if (connectionAttempts.current >= 10) {
+            logger.error('Connection not established within 10 seconds');
+            if (connectionTimeout.current) {
+              clearTimeout(connectionTimeout.current);
+            }
+          } else {
+            connectionTimeout.current = setTimeout(checkConnection, 1000);
+          }
         }
-      }
-    };
+      };
 
-    checkConnection();
+      checkConnection();
 
-    return () => {
-      if (connectionTimeout.current) {
-        clearTimeout(connectionTimeout.current);
-      }
-    };
-  }, [connStatus]);
+      return () => {
+        if (connectionTimeout.current) {
+          clearTimeout(connectionTimeout.current);
+        }
+      };
+    }, [connStatus]);
 
-  const resolvedChats = useMemo(() => {
-    return {
-      pinned: chats?.pinned ?? [],
-      unpinned: chats?.unpinned ?? [],
-      pending: chats?.pending ?? [],
-    };
-  }, [chats]);
+    const resolvedChats = useResolvedChats(chats);
+    const { navigateToGroup, navigateToChannel } = useRootNavigation();
 
-  const { navigateToGroup, navigateToChannel } = useRootNavigation();
-
-  const createChatSheetRef = useRef<CreateChatSheetMethods | null>(null);
-  const onPressChat = useCallback(
-    async (item: db.Chat) => {
-      if (item.type === 'group') {
-        if (item.isPending) {
-          setSelectedGroupId(item.id);
+    const createChatSheetRef = useRef<CreateChatSheetMethods | null>(null);
+    const onPressChat = useCallback(
+      async (item: db.Chat) => {
+        if (item.type === 'group') {
+          if (item.isPending) {
+            setSelectedGroupId(item.id);
+          } else {
+            navigateToGroup(item.group.id);
+          }
         } else {
-          navigateToGroup(item.group.id);
+          navigateToChannel(item.channel);
         }
-      } else {
-        navigateToChannel(item.channel);
-      }
-    },
-    [navigateToGroup, navigateToChannel]
-  );
-
-  const handlePressAddChat = useCallback(() => {
-    createChatSheetRef.current?.open();
-  }, []);
-
-  const handleGroupPreviewSheetOpenChange = useCallback((open: boolean) => {
-    if (!open) {
-      setSelectedGroupId(null);
-    }
-  }, []);
-
-  const handleInviteSheetOpenChange = useCallback((open: boolean) => {
-    if (!open) {
-      setInviteSheetGroup(null);
-    }
-  }, []);
-
-  const isTlonEmployee = useMemo(() => {
-    const allChats = [...resolvedChats.pinned, ...resolvedChats.unpinned];
-    return !!allChats.find(
-      (chat) => chat.type === 'group' && chat.group.id === TLON_EMPLOYEE_GROUP
+      },
+      [navigateToGroup, navigateToChannel]
     );
-  }, [resolvedChats]);
 
-  useEffect(() => {
-    if (isTlonEmployee && TLON_EMPLOYEE_GROUP !== '') {
-      identifyTlonEmployee();
-    }
-  }, [isTlonEmployee]);
+    const handlePressAddChat = useCallback(() => {
+      createChatSheetRef.current?.open();
+    }, []);
 
-  const handleGroupAction = useCallback(
-    (action: GroupPreviewAction, group: db.Group) => {
-      performGroupAction(action, group);
-      setSelectedGroupId(null);
-    },
-    [performGroupAction]
-  );
+    const handleGroupPreviewSheetOpenChange = useCallback((open: boolean) => {
+      if (!open) {
+        setSelectedGroupId(null);
+      }
+    }, []);
 
-  const handleSearch = useCallback(() => {
-    setIsOpen(true);
-  }, [setIsOpen]);
+    const handleInviteSheetOpenChange = useCallback((open: boolean) => {
+      if (!open) {
+        setInviteSheetGroup(null);
+      }
+    }, []);
 
-  const displayData = useFilteredChats({
-    ...resolvedChats,
-    searchQuery: '',
-    activeTab: 'home',
-  });
-  return (
-    <RequestsProvider
-      usePostReference={store.usePostReference}
-      useChannel={store.useChannelPreview}
-      usePost={store.usePostWithRelations}
-      useApp={db.appInfo.useValue}
-      useGroup={store.useGroupPreview}
-    >
-      <ChatOptionsProvider
-        {...useChatSettingsNavigation()}
-        onPressInvite={(group) => {
-          setInviteSheetGroup(group);
-        }}
+    const isTlonEmployee = useMemo(() => {
+      const allChats = [...resolvedChats.pinned, ...resolvedChats.unpinned];
+      return !!allChats.find(
+        (chat) => chat.type === 'group' && chat.group.id === TLON_EMPLOYEE_GROUP
+      );
+    }, [resolvedChats.pinned, resolvedChats.unpinned]);
+
+    useEffect(() => {
+      if (isTlonEmployee && TLON_EMPLOYEE_GROUP !== '') {
+        identifyTlonEmployee();
+      }
+    }, [isTlonEmployee]);
+
+    const handleGroupAction = useCallback(
+      (action: GroupPreviewAction, group: db.Group) => {
+        performGroupAction(action, group);
+        setSelectedGroupId(null);
+      },
+      [performGroupAction]
+    );
+
+    const handleSearch = useCallback(() => {
+      setIsOpen(true);
+    }, [setIsOpen]);
+
+    const handlePressInvite = useCallback((groupId: string) => {
+      setInviteSheetGroup(groupId);
+    }, []);
+
+    const displayData = useFilteredChats({
+      ...resolvedChats,
+      searchQuery: '',
+      activeTab: 'home',
+    });
+
+    useRenderCount('HomeSidebar');
+
+    return (
+      <RequestsProvider
+        usePostReference={store.usePostReference}
+        useChannel={store.useChannelPreview}
+        usePost={store.usePostWithRelations}
+        useApp={db.appInfo.useValue}
+        useGroup={store.useGroupPreview}
       >
-        <NavigationProvider focusedChannelId={focusedChannelId}>
-          <View userSelect="none" flex={1}>
-            <ScreenHeader
-              title={notReadyMessage ?? screenTitle}
-              rightControls={
-                <>
-                  <ScreenHeader.IconButton
-                    type="Search"
-                    onPress={handleSearch}
-                  />
-                  <CreateChatSheet
-                    ref={createChatSheetRef}
-                    trigger={<ScreenHeader.IconButton type="Add" />}
-                  />
-                </>
-              }
-            />
-            {chats && noChats ? (
-              <View
-                padding="$xl"
-                margin="$xl"
-                borderRadius="$m"
-                backgroundColor="$positiveBackground"
-                justifyContent="center"
-              >
-                <Text fontSize="$l">Welcome to Tlon</Text>
-                <Text fontSize="$s" marginTop="$m">
-                  This is Tlon, an app for messaging friends and constructing
-                  communities.
-                </Text>
-                <Text fontSize="$s" marginTop="$m">
-                  To get started, click the &quot;
-                  <Text fontWeight="$xl" fontSize="$l">
-                    +
+        <ChatOptionsProvider
+          {...useChatSettingsNavigation()}
+          onPressInvite={handlePressInvite}
+        >
+          <NavigationProvider focusedChannelId={focusedChannelId}>
+            <View userSelect="none" flex={1}>
+              <ScreenHeader
+                title={notReadyMessage ?? screenTitle}
+                rightControls={
+                  <>
+                    <ScreenHeader.IconButton
+                      type="Search"
+                      onPress={handleSearch}
+                    />
+                    <CreateChatSheet
+                      ref={createChatSheetRef}
+                      trigger={<ScreenHeader.IconButton type="Add" />}
+                    />
+                  </>
+                }
+              />
+              {chats && noChats ? (
+                <View
+                  padding="$xl"
+                  margin="$xl"
+                  borderRadius="$m"
+                  backgroundColor="$positiveBackground"
+                  justifyContent="center"
+                >
+                  <Text fontSize="$l">Welcome to Tlon</Text>
+                  <Text fontSize="$s" marginTop="$m">
+                    This is Tlon, an app for messaging friends and constructing
+                    communities.
                   </Text>
-                  &quot; button above to create a new chat.
-                </Text>
-              </View>
-            ) : (
-              <ChatList data={displayData} onPressItem={onPressChat} />
-            )}
-            <GroupPreviewSheet
-              open={!!selectedGroup}
-              onOpenChange={handleGroupPreviewSheetOpenChange}
-              group={selectedGroup ?? undefined}
-              onActionComplete={handleGroupAction}
-            />
-            <InviteUsersSheet
-              open={inviteSheetGroup !== null}
-              onOpenChange={handleInviteSheetOpenChange}
-              onInviteComplete={() => setInviteSheetGroup(null)}
-              groupId={inviteSheetGroup ?? undefined}
-            />
-          </View>
-        </NavigationProvider>
-      </ChatOptionsProvider>
-    </RequestsProvider>
-  );
-}
+                  <Text fontSize="$s" marginTop="$m">
+                    To get started, click the &quot;
+                    <Text fontWeight="$xl" fontSize="$l">
+                      +
+                    </Text>
+                    &quot; button above to create a new chat.
+                  </Text>
+                </View>
+              ) : (
+                <ChatList data={displayData} onPressItem={onPressChat} />
+              )}
+              <GroupPreviewSheet
+                open={!!selectedGroup}
+                onOpenChange={handleGroupPreviewSheetOpenChange}
+                group={selectedGroup ?? undefined}
+                onActionComplete={handleGroupAction}
+              />
+              <InviteUsersSheet
+                open={inviteSheetGroup !== null}
+                onOpenChange={handleInviteSheetOpenChange}
+                onInviteComplete={() => setInviteSheetGroup(null)}
+                groupId={inviteSheetGroup ?? undefined}
+              />
+            </View>
+          </NavigationProvider>
+        </ChatOptionsProvider>
+      </RequestsProvider>
+    );
+  }
+);
+
+HomeSidebar.displayName = 'HomeSidebar';

--- a/packages/app/navigation/desktop/MessagesNavigator.tsx
+++ b/packages/app/navigation/desktop/MessagesNavigator.tsx
@@ -5,7 +5,8 @@ import {
 import type { NativeStackScreenProps } from '@react-navigation/native-stack';
 import { createNativeStackNavigator } from '@react-navigation/native-stack';
 import { NavigationState } from '@react-navigation/routers';
-import { useEffect } from 'react';
+import { isEqual } from 'lodash';
+import { memo, useEffect } from 'react';
 import { View, getVariableValue, useTheme } from 'tamagui';
 
 import { ChannelMembersScreen } from '../../features/channels/ChannelMembersScreen';
@@ -37,13 +38,9 @@ export const MessagesNavigator = () => {
 
   return (
     <MessagesDrawer.Navigator
-      drawerContent={DrawerContent}
+      drawerContent={(props) => <DrawerContent {...props} />}
       initialRouteName="ChatList"
-      screenOptions={({ navigation }) => {
-        const state = navigation.getState();
-        const routes = state.routes[state.index].state?.routes;
-        const currentScreen = routes?.[routes.length - 1];
-
+      screenOptions={() => {
         return {
           drawerType: 'permanent',
           headerShown: false,
@@ -66,7 +63,7 @@ export const MessagesNavigator = () => {
   );
 };
 
-function DrawerContent(props: DrawerContentComponentProps) {
+const DrawerContent = memo((props: DrawerContentComponentProps) => {
   const state = props.state as NavigationState<HomeDrawerParamList>;
   const focusedRoute = state.routes[props.state.index];
   if (focusedRoute.params && 'channelId' in focusedRoute.params) {
@@ -74,7 +71,9 @@ function DrawerContent(props: DrawerContentComponentProps) {
   } else {
     return <MessagesSidebar />;
   }
-}
+}, isEqual);
+
+DrawerContent.displayName = 'MessagesSidebarDrawerContent';
 
 const MainStackNavigator = createNativeStackNavigator();
 

--- a/packages/app/navigation/desktop/MessagesSidebar.tsx
+++ b/packages/app/navigation/desktop/MessagesSidebar.tsx
@@ -1,8 +1,7 @@
-import { useIsFocused } from '@react-navigation/native';
 import { createDevLogger } from '@tloncorp/shared';
 import * as db from '@tloncorp/shared/db';
 import * as store from '@tloncorp/shared/store';
-import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import { memo, useCallback, useEffect, useMemo, useRef, useState } from 'react';
 
 import { TLON_EMPLOYEE_GROUP } from '../../constants';
 import { ChatList } from '../../features/chat-list/ChatList';
@@ -14,6 +13,8 @@ import { MessagesFilterMenu } from '../../features/top/MessagesFilterMenu';
 import { useChatSettingsNavigation } from '../../hooks/useChatSettingsNavigation';
 import { useFilteredChats } from '../../hooks/useFilteredChats';
 import { useGroupActions } from '../../hooks/useGroupActions';
+import { useRenderCount } from '../../hooks/useRenderCount';
+import { useResolvedChats } from '../../hooks/useResolvedChats';
 import {
   ChatOptionsProvider,
   GroupPreviewAction,
@@ -24,7 +25,6 @@ import {
   ScreenHeader,
   View,
   useGlobalSearch,
-  useIsWindowNarrow,
 } from '../../ui';
 import { identifyTlonEmployee } from '../../utils/posthog';
 import { useRootNavigation } from '../utils';
@@ -36,198 +36,196 @@ interface Props {
   focusedChannelId?: string;
 }
 
-export function MessagesSidebar({ previewGroupId, focusedChannelId }: Props) {
-  const screenTitle = 'Messages';
-  const [inviteSheetGroup, setInviteSheetGroup] = useState<string | null>();
-  const [selectedGroupId, setSelectedGroupId] = useState<string | null>(
-    previewGroupId ?? null
-  );
-  const { data: selectedGroup } = store.useGroup({ id: selectedGroupId ?? '' });
-  const { setIsOpen } = useGlobalSearch();
+export const MessagesSidebar = memo(
+  ({ previewGroupId, focusedChannelId }: Props) => {
+    const screenTitle = 'Messages';
+    const [inviteSheetGroup, setInviteSheetGroup] = useState<string | null>();
+    const [selectedGroupId, setSelectedGroupId] = useState<string | null>(
+      previewGroupId ?? null
+    );
+    const { data: selectedGroup } = store.useGroup({
+      id: selectedGroupId ?? '',
+    });
+    const { setIsOpen } = useGlobalSearch();
 
-  const isFocused = useIsFocused();
+    const { data: chats } = store.useCurrentChats();
+    const { performGroupAction } = useGroupActions();
 
-  const { data: chats } = store.useCurrentChats({
-    enabled: isFocused,
-  });
-  const { performGroupAction } = useGroupActions();
+    const connStatus = store.useConnectionStatus();
+    const notReadyMessage: string | null = useMemo(() => {
+      // if not fully connected yet, show status
+      if (connStatus !== 'Connected') {
+        return `${connStatus}...`;
+      }
 
-  const connStatus = store.useConnectionStatus();
-  const notReadyMessage: string | null = useMemo(() => {
-    // if not fully connected yet, show status
-    if (connStatus !== 'Connected') {
-      return `${connStatus}...`;
-    }
+      // if still loading the screen data, show loading
+      if (!chats || (!chats.unpinned.length && !chats.pinned.length)) {
+        return 'Loading...';
+      }
 
-    // if still loading the screen data, show loading
-    if (!chats || (!chats.unpinned.length && !chats.pinned.length)) {
-      return 'Loading...';
-    }
+      return null;
+    }, [connStatus, chats]);
 
-    return null;
-  }, [connStatus, chats]);
+    /* Log an error if this screen takes more than 30 seconds to resolve to "Connected" */
+    const connectionTimeout = useRef<NodeJS.Timeout | null>(null);
+    const connectionAttempts = useRef(0);
 
-  /* Log an error if this screen takes more than 30 seconds to resolve to "Connected" */
-  const connectionTimeout = useRef<NodeJS.Timeout | null>(null);
-  const connectionAttempts = useRef(0);
-
-  useEffect(() => {
-    const checkConnection = () => {
-      if (connStatus === 'Connected') {
-        if (connectionTimeout.current) {
-          clearTimeout(connectionTimeout.current);
-        }
-        connectionAttempts.current = 0;
-      } else {
-        connectionAttempts.current += 1;
-        if (connectionAttempts.current >= 10) {
-          logger.error('Connection not established within 10 seconds');
+    useEffect(() => {
+      const checkConnection = () => {
+        if (connStatus === 'Connected') {
           if (connectionTimeout.current) {
             clearTimeout(connectionTimeout.current);
           }
+          connectionAttempts.current = 0;
         } else {
-          connectionTimeout.current = setTimeout(checkConnection, 1000);
+          connectionAttempts.current += 1;
+          if (connectionAttempts.current >= 10) {
+            logger.error('Connection not established within 10 seconds');
+            if (connectionTimeout.current) {
+              clearTimeout(connectionTimeout.current);
+            }
+          } else {
+            connectionTimeout.current = setTimeout(checkConnection, 1000);
+          }
         }
-      }
-    };
+      };
 
-    checkConnection();
+      checkConnection();
 
-    return () => {
-      if (connectionTimeout.current) {
-        clearTimeout(connectionTimeout.current);
-      }
-    };
-  }, [connStatus]);
+      return () => {
+        if (connectionTimeout.current) {
+          clearTimeout(connectionTimeout.current);
+        }
+      };
+    }, [connStatus]);
 
-  const resolvedChats = useMemo(() => {
-    return {
-      pinned: chats?.pinned ?? [],
-      unpinned: chats?.unpinned ?? [],
-      pending: chats?.pending ?? [],
-    };
-  }, [chats]);
+    const resolvedChats = useResolvedChats(chats);
+    const { navigateToGroup, navigateToChannel } = useRootNavigation();
 
-  const { navigateToGroup, navigateToChannel } = useRootNavigation();
-
-  const createChatSheetRef = useRef<CreateChatSheetMethods | null>(null);
-  const onPressChat = useCallback(
-    async (item: db.Chat) => {
-      if (item.type === 'group') {
-        if (item.isPending) {
-          setSelectedGroupId(item.id);
+    const createChatSheetRef = useRef<CreateChatSheetMethods | null>(null);
+    const onPressChat = useCallback(
+      async (item: db.Chat) => {
+        if (item.type === 'group') {
+          if (item.isPending) {
+            setSelectedGroupId(item.id);
+          } else {
+            navigateToGroup(item.group.id);
+          }
         } else {
-          navigateToGroup(item.group.id);
+          navigateToChannel(item.channel);
         }
-      } else {
-        navigateToChannel(item.channel);
-      }
-    },
-    [navigateToGroup, navigateToChannel]
-  );
-
-  const handlePressAddChat = useCallback(() => {
-    createChatSheetRef.current?.open();
-  }, []);
-
-  const handleGroupPreviewSheetOpenChange = useCallback((open: boolean) => {
-    if (!open) {
-      setSelectedGroupId(null);
-    }
-  }, []);
-
-  const handleInviteSheetOpenChange = useCallback((open: boolean) => {
-    if (!open) {
-      setInviteSheetGroup(null);
-    }
-  }, []);
-
-  const isTlonEmployee = useMemo(() => {
-    const allChats = [...resolvedChats.pinned, ...resolvedChats.unpinned];
-    return !!allChats.find(
-      (chat) => chat.type === 'group' && chat.group.id === TLON_EMPLOYEE_GROUP
+      },
+      [navigateToGroup, navigateToChannel]
     );
-  }, [resolvedChats]);
 
-  useEffect(() => {
-    if (isTlonEmployee && TLON_EMPLOYEE_GROUP !== '') {
-      identifyTlonEmployee();
-    }
-  }, [isTlonEmployee]);
+    const handlePressAddChat = useCallback(() => {
+      createChatSheetRef.current?.open();
+    }, []);
 
-  const isWindowNarrow = useIsWindowNarrow();
+    const handleGroupPreviewSheetOpenChange = useCallback((open: boolean) => {
+      if (!open) {
+        setSelectedGroupId(null);
+      }
+    }, []);
 
-  const handleGroupAction = useCallback(
-    (action: GroupPreviewAction, group: db.Group) => {
-      performGroupAction(action, group);
-      setSelectedGroupId(null);
-    },
-    [performGroupAction]
-  );
+    const handleInviteSheetOpenChange = useCallback((open: boolean) => {
+      if (!open) {
+        setInviteSheetGroup(null);
+      }
+    }, []);
 
-  const handleSearch = useCallback(() => {
-    setIsOpen(true);
-  }, [setIsOpen]);
+    const isTlonEmployee = useMemo(() => {
+      const allChats = [...resolvedChats.pinned, ...resolvedChats.unpinned];
+      return !!allChats.find(
+        (chat) => chat.type === 'group' && chat.group.id === TLON_EMPLOYEE_GROUP
+      );
+    }, [resolvedChats.pinned, resolvedChats.unpinned]);
 
-  const displayData = useFilteredChats({
-    ...resolvedChats,
-    searchQuery: '',
-    activeTab: 'talk',
-  });
-  return (
-    <RequestsProvider
-      usePostReference={store.usePostReference}
-      useChannel={store.useChannelPreview}
-      usePost={store.usePostWithRelations}
-      useApp={db.appInfo.useValue}
-      useGroup={store.useGroupPreview}
-    >
-      <ChatOptionsProvider
-        {...useChatSettingsNavigation()}
-        onPressInvite={(group) => {
-          setInviteSheetGroup(group);
-        }}
+    useEffect(() => {
+      if (isTlonEmployee && TLON_EMPLOYEE_GROUP !== '') {
+        identifyTlonEmployee();
+      }
+    }, [isTlonEmployee]);
+
+    const handleGroupAction = useCallback(
+      (action: GroupPreviewAction, group: db.Group) => {
+        performGroupAction(action, group);
+        setSelectedGroupId(null);
+      },
+      [performGroupAction]
+    );
+
+    const handleSearch = useCallback(() => {
+      setIsOpen(true);
+    }, [setIsOpen]);
+
+    const displayData = useFilteredChats({
+      ...resolvedChats,
+      searchQuery: '',
+      activeTab: 'talk',
+    });
+
+    const handleInvite = useCallback((groupId: string) => {
+      setInviteSheetGroup(groupId);
+    }, []);
+
+    useRenderCount('MessagesSidebar');
+
+    return (
+      <RequestsProvider
+        usePostReference={store.usePostReference}
+        useChannel={store.useChannelPreview}
+        usePost={store.usePostWithRelations}
+        useApp={db.appInfo.useValue}
+        useGroup={store.useGroupPreview}
       >
-        <NavigationProvider focusedChannelId={focusedChannelId}>
-          <View userSelect="none" flex={1}>
-            <ScreenHeader
-              title={notReadyMessage ?? screenTitle}
-              leftControls={
-                <MessagesFilterMenu>
-                  <ScreenHeader.IconButton type="Filter" />
-                </MessagesFilterMenu>
-              }
-              rightControls={
-                <>
-                  <ScreenHeader.IconButton
-                    type="Search"
-                    onPress={handleSearch}
-                  />
-                  <CreateChatSheet
-                    ref={createChatSheetRef}
-                    trigger={<ScreenHeader.IconButton type="Add" />}
-                  />
-                </>
-              }
-            />
-            {chats && chats.unpinned.length ? (
-              <ChatList data={displayData} onPressItem={onPressChat} />
-            ) : null}
-            <GroupPreviewSheet
-              open={!!selectedGroup}
-              onOpenChange={handleGroupPreviewSheetOpenChange}
-              group={selectedGroup ?? undefined}
-              onActionComplete={handleGroupAction}
-            />
-            <InviteUsersSheet
-              open={inviteSheetGroup !== null}
-              onOpenChange={handleInviteSheetOpenChange}
-              onInviteComplete={() => setInviteSheetGroup(null)}
-              groupId={inviteSheetGroup ?? undefined}
-            />
-          </View>
-        </NavigationProvider>
-      </ChatOptionsProvider>
-    </RequestsProvider>
-  );
-}
+        <ChatOptionsProvider
+          {...useChatSettingsNavigation()}
+          onPressInvite={handleInvite}
+        >
+          <NavigationProvider focusedChannelId={focusedChannelId}>
+            <View userSelect="none" flex={1}>
+              <ScreenHeader
+                title={notReadyMessage ?? screenTitle}
+                leftControls={
+                  <MessagesFilterMenu>
+                    <ScreenHeader.IconButton type="Filter" />
+                  </MessagesFilterMenu>
+                }
+                rightControls={
+                  <>
+                    <ScreenHeader.IconButton
+                      type="Search"
+                      onPress={handleSearch}
+                    />
+                    <CreateChatSheet
+                      ref={createChatSheetRef}
+                      trigger={<ScreenHeader.IconButton type="Add" />}
+                    />
+                  </>
+                }
+              />
+              {chats && chats.unpinned.length ? (
+                <ChatList data={displayData} onPressItem={onPressChat} />
+              ) : null}
+              <GroupPreviewSheet
+                open={!!selectedGroup}
+                onOpenChange={handleGroupPreviewSheetOpenChange}
+                group={selectedGroup ?? undefined}
+                onActionComplete={handleGroupAction}
+              />
+              <InviteUsersSheet
+                open={inviteSheetGroup !== null}
+                onOpenChange={handleInviteSheetOpenChange}
+                onInviteComplete={() => setInviteSheetGroup(null)}
+                groupId={inviteSheetGroup ?? undefined}
+              />
+            </View>
+          </NavigationProvider>
+        </ChatOptionsProvider>
+      </RequestsProvider>
+    );
+  }
+);
+
+MessagesSidebar.displayName = 'MessagesSidebar';

--- a/packages/app/ui/components/ChatOptionsSheet.tsx
+++ b/packages/app/ui/components/ChatOptionsSheet.tsx
@@ -5,8 +5,10 @@ import * as ub from '@tloncorp/shared/urbit';
 import { useIsWindowNarrow } from '@tloncorp/ui';
 import { IconButton } from '@tloncorp/ui';
 import { ChevronLeft } from '@tloncorp/ui/assets/icons';
+import { isEqual } from 'lodash';
 import React, {
   ReactElement,
+  memo,
   useCallback,
   useEffect,
   useLayoutEffect,
@@ -44,8 +46,7 @@ export const ChatOptionsSheet = React.memo(function ChatOptionsSheet({
   onOpenChange: propOnOpenChange,
   trigger,
 }: ChatOptionsSheetProps) {
-  const context = useChatOptions();
-  const { group } = context;
+  const { open: contextOpen, setChat, group } = useChatOptions();
 
   // Use props for explicit control (popovers)
   // For sheets, this will be false and context.open will handle state
@@ -56,7 +57,7 @@ export const ChatOptionsSheet = React.memo(function ChatOptionsSheet({
     (open: boolean) => {
       if (open && chat) {
         // Set chat state for both popovers and sheets
-        context.open(chat.id, chat.type);
+        contextOpen(chat.id, chat.type);
       } else if (!open) {
         // Close both popover and sheet states
         if (propOnOpenChange) {
@@ -64,7 +65,7 @@ export const ChatOptionsSheet = React.memo(function ChatOptionsSheet({
         }
         // Clear chat state after a short delay to allow handlers to complete
         setTimeout(() => {
-          context.setChat(null);
+          setChat(null);
         }, 100);
       }
 
@@ -73,7 +74,7 @@ export const ChatOptionsSheet = React.memo(function ChatOptionsSheet({
         propOnOpenChange(open);
       }
     },
-    [chat, context, propOnOpenChange]
+    [chat, contextOpen, setChat, propOnOpenChange]
   );
 
   if (!chat || (!isOpen && !trigger)) {
@@ -108,7 +109,7 @@ export const ChatOptionsSheet = React.memo(function ChatOptionsSheet({
       trigger={trigger}
     />
   );
-});
+}, isEqual);
 
 export function GroupOptionsSheetLoader({
   groupId,
@@ -336,6 +337,8 @@ function GroupOptionsSheetContent({
       onPressSort,
       togglePinned,
       wrappedAction,
+      handleCancel,
+      isErrored,
     ]
   );
 
@@ -463,107 +466,117 @@ function EditGroupSheetContent({
 
 type ChannelPanes = 'initial' | 'notifications';
 
-export function ChannelOptionsSheetLoader({
-  channelId,
-  open,
-  onOpenChange,
-  trigger,
-  onPressConfigureChannel,
-}: {
-  channelId: string;
-  open: boolean;
-  onOpenChange: (open: boolean) => void;
-  trigger?: React.ReactNode;
-  onPressConfigureChannel?: () => void;
-}) {
-  const [pane, setPane] = useState<ChannelPanes>('initial');
-  const channelQuery = store.useChannel({
-    id: channelId,
-  });
+const ChannelOptionsSheetLoader = memo(
+  ({
+    channelId,
+    open,
+    onOpenChange,
+    trigger,
+    onPressConfigureChannel,
+  }: {
+    channelId: string;
+    open: boolean;
+    onOpenChange: (open: boolean) => void;
+    trigger?: React.ReactNode;
+    onPressConfigureChannel?: () => void;
+  }) => {
+    const [pane, setPane] = useState<ChannelPanes>('initial');
+    const channelQuery = store.useChannel({
+      id: channelId,
+    });
+    const groupId = useMemo(
+      () => channelQuery.data?.groupId ?? undefined,
+      [channelQuery.data?.groupId]
+    );
 
-  const { data: group } = store.useGroup({
-    id: channelQuery.data?.groupId ?? undefined,
-  });
-  const groupTitle = utils.useGroupTitle(group) ?? 'group';
-  const channelTitle =
-    utils.useChannelTitle(channelQuery.data ?? null) ?? 'channel';
-  const isSingleChannelGroup = group?.channels.length === 1;
-  const chatTitle = isSingleChannelGroup ? groupTitle : channelTitle;
-  const isWindowNarrow = useIsWindowNarrow();
+    const { data: group } = store.useGroup({
+      id: groupId,
+    });
+    const groupTitle = utils.useGroupTitle(group) ?? 'group';
+    const channelTitle =
+      utils.useChannelTitle(channelQuery.data ?? null) ?? 'channel';
+    const isSingleChannelGroup = group?.channels.length === 1;
+    const chatTitle = isSingleChannelGroup ? groupTitle : channelTitle;
+    const isWindowNarrow = useIsWindowNarrow();
 
-  const handlePressNotifications = useCallback(() => {
-    setPane('notifications');
-  }, [setPane]);
+    const handlePressNotifications = useCallback(() => {
+      setPane('notifications');
+    }, [setPane]);
 
-  const resetPane = useCallback(() => {
-    setPane('initial');
-  }, [setPane]);
+    const resetPane = useCallback(() => {
+      setPane('initial');
+    }, [setPane]);
 
-  useEffect(() => {
-    if (!open) {
-      resetPane();
+    useEffect(() => {
+      if (!open) {
+        resetPane();
+      }
+    }, [open, resetPane]);
+
+    if (!channelQuery.data) {
+      return null;
     }
-  }, [open, resetPane]);
 
-  if (!channelQuery.data) {
-    return null;
-  }
+    // Define channel variable before it's used in conditionals
+    const channel = channelQuery.data!;
 
-  if (isWeb && !isWindowNarrow) {
-    return (
-      <Popover
-        open={open}
-        onOpenChange={onOpenChange}
-        placement="top-end"
-        allowFlip
-        offset={-12}
-      >
-        <Popover.Trigger asChild>{trigger}</Popover.Trigger>
-        <Popover.Content
-          elevate
-          zIndex={1000000}
-          position="relative"
-          borderColor="$border"
-          borderWidth={1}
-          padding={1}
+    if (isWeb && !isWindowNarrow) {
+      return (
+        <Popover
+          open={open}
+          onOpenChange={onOpenChange}
+          placement="top-end"
+          allowFlip
+          offset={-12}
         >
-          {pane === 'notifications' ? (
-            <NotificationsSheetContent
-              chatTitle={chatTitle}
-              onPressBack={resetPane}
-            />
-          ) : (
-            <ChannelOptionsSheetContent
-              chatTitle={chatTitle}
-              channel={channelQuery.data}
-              onPressNotifications={handlePressNotifications}
-              onOpenChange={onOpenChange}
-            />
-          )}
-        </Popover.Content>
-      </Popover>
+          <Popover.Trigger asChild>{trigger}</Popover.Trigger>
+          <Popover.Content
+            elevate
+            zIndex={1000000}
+            position="relative"
+            borderColor="$border"
+            borderWidth={1}
+            padding={1}
+          >
+            {pane === 'notifications' ? (
+              <NotificationsSheetContent
+                chatTitle={chatTitle}
+                onPressBack={resetPane}
+              />
+            ) : (
+              <ChannelOptionsSheetContent
+                chatTitle={chatTitle}
+                channel={channel}
+                onPressNotifications={handlePressNotifications}
+                onOpenChange={onOpenChange}
+              />
+            )}
+          </Popover.Content>
+        </Popover>
+      );
+    }
+
+    return (
+      <ActionSheet open={open} onOpenChange={onOpenChange}>
+        {pane === 'notifications' ? (
+          <NotificationsSheetContent
+            chatTitle={chatTitle}
+            onPressBack={resetPane}
+          />
+        ) : (
+          <ChannelOptionsSheetContent
+            chatTitle={chatTitle}
+            channel={channel}
+            onPressNotifications={handlePressNotifications}
+            onOpenChange={onOpenChange}
+            onPressConfigureChannel={onPressConfigureChannel}
+          />
+        )}
+      </ActionSheet>
     );
   }
-
-  return (
-    <ActionSheet open={open} onOpenChange={onOpenChange}>
-      {pane === 'notifications' ? (
-        <NotificationsSheetContent
-          chatTitle={chatTitle}
-          onPressBack={resetPane}
-        />
-      ) : (
-        <ChannelOptionsSheetContent
-          chatTitle={chatTitle}
-          channel={channelQuery.data}
-          onPressNotifications={handlePressNotifications}
-          onOpenChange={onOpenChange}
-          onPressConfigureChannel={onPressConfigureChannel}
-        />
-      )}
-    </ActionSheet>
-  );
-}
+);
+ChannelOptionsSheetLoader.displayName = 'ChannelOptionsSheetLoader';
 
 function ChannelOptionsSheetContent({
   chatTitle,

--- a/packages/app/ui/components/GroupChannelsScreenView.tsx
+++ b/packages/app/ui/components/GroupChannelsScreenView.tsx
@@ -1,19 +1,34 @@
+import { FlashList, ListRenderItem } from '@shopify/flash-list';
 import * as db from '@tloncorp/shared/db';
 import { useIsWindowNarrow } from '@tloncorp/ui';
 import { LoadingSpinner } from '@tloncorp/ui';
 import { Text } from '@tloncorp/ui';
-import { useCallback, useState } from 'react';
+import React, { useCallback, useMemo, useRef, useState } from 'react';
+import { LayoutChangeEvent } from 'react-native';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
-import { ScrollView, View, YStack, getVariableValue, useTheme } from 'tamagui';
+import {
+  View,
+  YStack,
+  getTokenValue,
+  getVariableValue,
+  useTheme,
+} from 'tamagui';
 
+import { useRenderCount } from '../../hooks/useRenderCount';
 import { useChatOptions, useCurrentUserId } from '../contexts';
 import { useGroupTitle, useIsAdmin } from '../utils/channelUtils';
 import { Badge } from './Badge';
-import ChannelNavSections from './ChannelNavSections';
 import { ChatOptionsSheet } from './ChatOptionsSheet';
 import { ChannelListItem } from './ListItem/ChannelListItem';
 import { CreateChannelSheet } from './ManageChannels/CreateChannelSheet';
 import { ScreenHeader } from './ScreenHeader';
+
+type SectionHeaderData = { type: 'sectionHeader'; title: string; id: string };
+type ChannelListData = db.Channel | SectionHeaderData;
+
+function isSectionHeader(item: ChannelListData): item is SectionHeaderData {
+  return 'type' in item && item.type === 'sectionHeader';
+}
 
 type GroupChannelsScreenViewProps = {
   group: db.Group | null;
@@ -23,141 +38,276 @@ type GroupChannelsScreenViewProps = {
   onBackPressed: () => void;
 };
 
-export function GroupChannelsScreenView({
-  group,
-  unjoinedChannels = [],
-  onChannelPressed,
-  onJoinChannel,
-  onBackPressed,
-}: GroupChannelsScreenViewProps) {
-  const [showCreateChannel, setShowCreateChannel] = useState(false);
-  const [openChatOptions, setOpenChatOptions] = useState(false);
-  const sortBy = db.channelSortPreference.useValue();
-  const insets = useSafeAreaInsets();
-  const userId = useCurrentUserId();
-  const isGroupAdmin = useIsAdmin(group?.id ?? '', userId);
+export const GroupChannelsScreenView = React.memo(
+  function GroupChannelsScreenViewComponent({
+    group,
+    unjoinedChannels = [],
+    onChannelPressed,
+    onJoinChannel,
+    onBackPressed,
+  }: GroupChannelsScreenViewProps) {
+    useRenderCount('GroupChannelsScreenView');
+    const [showCreateChannel, setShowCreateChannel] = useState(false);
+    const [openChatOptions, setOpenChatOptions] = useState(false);
+    const sortBy = db.channelSortPreference.useValue();
+    const insets = useSafeAreaInsets();
+    const userId = useCurrentUserId();
+    const isGroupAdmin = useIsAdmin(group?.id ?? '', userId);
 
-  const chatOptions = useChatOptions();
-  const handlePressOverflowButton = useCallback(() => {
-    if (group) {
-      chatOptions.open(group.id, 'group');
-    }
-  }, [group, chatOptions]);
-
-  const handleOpenChannelOptions = useCallback(
-    (channel: db.Channel) => {
+    const chatOptions = useChatOptions();
+    const handlePressOverflowButton = useCallback(() => {
       if (group) {
-        chatOptions.open(channel.id, 'channel');
+        chatOptions.open(group.id, 'group');
       }
-    },
-    [group, chatOptions]
-  );
+    }, [group, chatOptions]);
 
-  const title = useGroupTitle(group);
-
-  const titleWidth = useCallback(() => {
-    if (isGroupAdmin) {
-      return 55;
-    } else {
-      return 75;
-    }
-  }, [isGroupAdmin]);
-
-  const listSectionTitleColor = getVariableValue(useTheme().secondaryText);
-  const isWindowNarrow = useIsWindowNarrow();
-
-  return (
-    <View flex={1}>
-      <ScreenHeader
-        // When we're fetching the group from the local database, this component
-        // will initially mount with group undefined, then very quickly load the
-        // group in. Keeping the key consistent as long as the ID is prevents a
-        // full re-render / animation triggering almost immediately after the
-        // component mounts.
-        key={group?.id}
-        title={title}
-        titleWidth={titleWidth()}
-        backAction={onBackPressed}
-        rightControls={
-          <>
-            {isGroupAdmin && (
-              <ScreenHeader.IconButton
-                type="Add"
-                onPress={() => setShowCreateChannel(true)}
-              />
-            )}
-            {!isWindowNarrow && group ? (
-              <ChatOptionsSheet
-                open={openChatOptions}
-                onOpenChange={setOpenChatOptions}
-                chat={{ type: 'group', id: group.id }}
-                trigger={<ScreenHeader.IconButton type="Overflow" />}
-              />
-            ) : (
-              <ScreenHeader.IconButton
-                type="Overflow"
-                onPress={handlePressOverflowButton}
-              />
-            )}
-          </>
+    const handleOpenChannelOptions = useCallback(
+      (channel: db.Channel) => {
+        if (group) {
+          chatOptions.open(channel.id, 'channel');
         }
-      />
-      {group && group.channels && group.channels.length ? (
-        <ScrollView
-          contentContainerStyle={{
-            gap: '$s',
-            paddingTop: '$l',
-            paddingHorizontal: '$l',
-            paddingBottom: insets.bottom,
-          }}
-        >
-          <ChannelNavSections
-            group={group}
-            channels={group.channels}
-            onSelect={onChannelPressed}
-            sortBy={sortBy || 'recency'}
-            onLongPress={handleOpenChannelOptions}
+      },
+      [group, chatOptions]
+    );
+
+    const title = useGroupTitle(group);
+
+    const titleWidth = useCallback(() => {
+      if (isGroupAdmin) {
+        return 55;
+      } else {
+        return 75;
+      }
+    }, [isGroupAdmin]);
+
+    const listSectionTitleColor = getVariableValue(useTheme().secondaryText);
+    const isWindowNarrow = useIsWindowNarrow();
+
+    const sizeRefs = useRef({
+      sectionHeader: 40,
+      channelItem: 70,
+    });
+
+    const handleHeaderLayout = useCallback((e: LayoutChangeEvent) => {
+      sizeRefs.current.sectionHeader = e.nativeEvent.layout.height;
+    }, []);
+
+    const handleItemLayout = useCallback((e: LayoutChangeEvent) => {
+      sizeRefs.current.channelItem = e.nativeEvent.layout.height;
+    }, []);
+
+    const listItems: ChannelListData[] = useMemo(() => {
+      if (!group || !group.channels || group.channels.length === 0) {
+        return [];
+      }
+
+      const result: ChannelListData[] = [];
+
+      // Add regular channels - either by section or by recency
+      if (sortBy === 'recency') {
+        // Sort channels by recency
+        const channelsSortedByRecency = [...group.channels].sort((a, b) => {
+          const aLastPostAt = a.lastPostAt || 0;
+          const bLastPostAt = b.lastPostAt || 0;
+          return bLastPostAt - aLastPostAt;
+        });
+
+        if (channelsSortedByRecency.length > 0) {
+          result.push({
+            type: 'sectionHeader',
+            title: 'Recent Channels',
+            id: 'recent-channels',
+          });
+          result.push(...channelsSortedByRecency);
+        }
+      } else {
+        // Add sections
+        group.navSections?.forEach((section) => {
+          const sectionChannels = group.channels?.filter((c) =>
+            section.channels?.some((sc) => sc.channelId === c.id)
+          );
+
+          if (sectionChannels && sectionChannels.length > 0) {
+            result.push({
+              type: 'sectionHeader',
+              title: section.title ?? '',
+              id: `section-${section.id}`,
+            });
+            // Sort section channels by their index within the section
+            const sortedSectionChannels = [...sectionChannels].sort((a, b) => {
+              const aIndex =
+                section.channels?.find((c) => c.channelId === a.id)
+                  ?.channelIndex ?? 0;
+              const bIndex =
+                section.channels?.find((c) => c.channelId === b.id)
+                  ?.channelIndex ?? 0;
+              return aIndex - bIndex;
+            });
+            result.push(...sortedSectionChannels);
+          }
+        });
+
+        // Add ungrouped channels
+        const unGroupedChannels = group.channels.filter(
+          (c) =>
+            !group.navSections?.some((s) =>
+              s.channels?.some((sc) => sc.channelId === c.id)
+            )
+        );
+
+        if (unGroupedChannels.length > 0) {
+          result.push({
+            type: 'sectionHeader',
+            title: 'All Channels',
+            id: 'all-channels',
+          });
+          result.push(...unGroupedChannels);
+        }
+      }
+
+      // Add unjoined channels section
+      if (unjoinedChannels.length > 0) {
+        result.push({
+          type: 'sectionHeader',
+          title: 'Available Channels',
+          id: 'available-channels',
+        });
+        result.push(...unjoinedChannels);
+      }
+
+      return result;
+    }, [group, unjoinedChannels, sortBy]);
+
+    const renderItem: ListRenderItem<ChannelListData> = useCallback(
+      ({ item }) => {
+        if (isSectionHeader(item)) {
+          return (
+            <Text
+              paddingHorizontal="$l"
+              paddingVertical="$xl"
+              fontSize="$s"
+              color={listSectionTitleColor}
+              onLayout={handleHeaderLayout}
+            >
+              {item.title}
+            </Text>
+          );
+        }
+
+        // Check if it's an unjoined channel
+        const isUnjoined = unjoinedChannels.some((c) => c.id === item.id);
+
+        return (
+          <ChannelListItem
+            key={item.id}
+            model={item}
+            onPress={isUnjoined ? onJoinChannel : onChannelPressed}
+            onLongPress={!isUnjoined ? handleOpenChannelOptions : undefined}
+            useTypeIcon={true}
+            dimmed={isUnjoined}
+            onLayout={handleItemLayout}
+            EndContent={
+              isUnjoined ? (
+                <View justifyContent="center">
+                  <Badge text="Join" />
+                </View>
+              ) : undefined
+            }
           />
+        );
+      },
+      [
+        unjoinedChannels,
+        onJoinChannel,
+        onChannelPressed,
+        handleOpenChannelOptions,
+        listSectionTitleColor,
+        handleHeaderLayout,
+        handleItemLayout,
+      ]
+    );
 
-          {unjoinedChannels.length > 0 && (
-            <YStack>
-              <Text
-                paddingHorizontal="$l"
-                paddingVertical="$xl"
-                fontSize="$s"
-                color={listSectionTitleColor}
-              >
-                Available Channels
-              </Text>
-              {unjoinedChannels.map((channel) => (
-                <ChannelListItem
-                  key={channel.id}
-                  model={channel}
-                  onPress={() => onJoinChannel(channel)}
-                  useTypeIcon={true}
-                  dimmed={true}
-                  EndContent={
-                    <View justifyContent="center">
-                      <Badge text="Join" />
-                    </View>
-                  }
+    const keyExtractor = useCallback((item: ChannelListData) => {
+      return isSectionHeader(item) ? item.id : item.id;
+    }, []);
+
+    const getItemType = useCallback((item: ChannelListData) => {
+      return isSectionHeader(item) ? 'sectionHeader' : 'channel';
+    }, []);
+
+    // Override layout function for FlashList
+    const handleOverrideLayout = useCallback(
+      (layout: { span?: number; size?: number }, item: ChannelListData) => {
+        layout.size = isSectionHeader(item)
+          ? sizeRefs.current.sectionHeader
+          : sizeRefs.current.channelItem;
+      },
+      []
+    );
+
+    return (
+      <View flex={1}>
+        <ScreenHeader
+          // When we're fetching the group from the local database, this component
+          // will initially mount with group undefined, then very quickly load the
+          // group in. Keeping the key consistent as long as the ID is prevents a
+          // full re-render / animation triggering almost immediately after the
+          // component mounts.
+          key={group?.id}
+          title={title}
+          titleWidth={titleWidth()}
+          backAction={onBackPressed}
+          rightControls={
+            <>
+              {isGroupAdmin && (
+                <ScreenHeader.IconButton
+                  type="Add"
+                  onPress={() => setShowCreateChannel(true)}
                 />
-              ))}
-            </YStack>
-          )}
-        </ScrollView>
-      ) : (
-        <YStack flex={1} justifyContent="center" alignItems="center">
-          <LoadingSpinner />
-        </YStack>
-      )}
-
-      {showCreateChannel && group && (
-        <CreateChannelSheet
-          onOpenChange={(open) => setShowCreateChannel(open)}
-          group={group}
+              )}
+              {!isWindowNarrow && group ? (
+                <ChatOptionsSheet
+                  open={openChatOptions}
+                  onOpenChange={setOpenChatOptions}
+                  chat={{ type: 'group', id: group.id }}
+                  trigger={<ScreenHeader.IconButton type="Overflow" />}
+                />
+              ) : (
+                <ScreenHeader.IconButton
+                  type="Overflow"
+                  onPress={handlePressOverflowButton}
+                />
+              )}
+            </>
+          }
         />
-      )}
-    </View>
-  );
-}
+        {group && group.channels && group.channels.length ? (
+          <FlashList
+            data={listItems}
+            renderItem={renderItem}
+            keyExtractor={keyExtractor}
+            getItemType={getItemType}
+            estimatedItemSize={sizeRefs.current.channelItem}
+            overrideItemLayout={handleOverrideLayout}
+            contentContainerStyle={{
+              paddingTop: getTokenValue('$l'),
+              paddingHorizontal: getTokenValue('$l'),
+              paddingBottom: insets.bottom,
+            }}
+          />
+        ) : (
+          <YStack flex={1} justifyContent="center" alignItems="center">
+            <LoadingSpinner />
+          </YStack>
+        )}
+
+        {showCreateChannel && group && (
+          <CreateChannelSheet
+            onOpenChange={(open) => setShowCreateChannel(open)}
+            group={group}
+          />
+        )}
+      </View>
+    );
+  }
+);

--- a/packages/app/ui/components/ListItem/ChannelListItem.tsx
+++ b/packages/app/ui/components/ListItem/ChannelListItem.tsx
@@ -4,7 +4,7 @@ import { useIsWindowNarrow } from '@tloncorp/ui';
 import { Button } from '@tloncorp/ui';
 import { Icon } from '@tloncorp/ui';
 import { Pressable } from '@tloncorp/ui';
-import { useMemo, useState } from 'react';
+import { useState, useMemo } from 'react';
 import { View, isWeb } from 'tamagui';
 
 import { useNavigation } from '../../contexts';
@@ -23,11 +23,13 @@ export function ChannelListItem({
   EndContent,
   dimmed,
   disableOptions = false,
+  onLayout,
   ...props
 }: {
   useTypeIcon?: boolean;
   customSubtitle?: string;
   dimmed?: boolean;
+  onLayout?: (e: any) => void;
 } & ListItemProps<db.Channel>) {
   const [open, setOpen] = useState(false);
   const unreadCount = model.unread?.count ?? 0;
@@ -36,6 +38,19 @@ export function ChannelListItem({
   const firstMemberId = model.members?.[0]?.contactId ?? '';
   const memberCount = model.members?.length ?? 0;
   const isWindowNarrow = useIsWindowNarrow();
+  
+  // Memoize the trigger button to prevent re-renders
+  const triggerButton = useMemo(() => (
+    <Button
+      backgroundColor="transparent"
+      borderWidth="unset"
+      paddingHorizontal={0}
+      marginHorizontal="$-m"
+      minimal
+    >
+      <Icon type="Overflow" />
+    </Button>
+  ), []);
 
   const handlePress = logic.useMutableCallback(() => {
     onPress?.(model);
@@ -75,7 +90,7 @@ export function ChannelListItem({
         backgroundColor={isFocused ? '$shadow' : undefined}
         hoverStyle={{ backgroundColor: '$secondaryBackground' }}
       >
-        <ListItem {...props}>
+        <ListItem onLayout={onLayout} {...props}>
           <ListItem.ChannelIcon
             model={model}
             useTypeIcon={useTypeIcon}
@@ -136,17 +151,7 @@ export function ChannelListItem({
               open={open}
               onOpenChange={setOpen}
               chat={{ type: 'channel', id: model.id }}
-              trigger={
-                <Button
-                  backgroundColor="transparent"
-                  borderWidth="unset"
-                  paddingHorizontal={0}
-                  marginHorizontal="$-m"
-                  minimal
-                >
-                  <Icon type="Overflow" />
-                </Button>
-              }
+              trigger={triggerButton}
             />
           )}
         </View>

--- a/packages/app/ui/components/ListItem/ChatListItem.tsx
+++ b/packages/app/ui/components/ListItem/ChatListItem.tsx
@@ -10,8 +10,9 @@ export const ChatListItem = React.memo(function ChatListItemComponent({
   model,
   onPress,
   onLongPress,
+  onLayout,
   ...props
-}: ListItemProps<db.Chat>) {
+}: ListItemProps<db.Chat> & { onLayout?: (e: any) => void }) {
   const handlePress = logic.useMutableCallback(() => {
     onPress?.(model);
   });
@@ -26,6 +27,7 @@ export const ChatListItem = React.memo(function ChatListItemComponent({
         onPress={handlePress}
         onLongPress={handleLongPress}
         model={model.group}
+        onLayout={onLayout}
         {...props}
       />
     );
@@ -35,6 +37,7 @@ export const ChatListItem = React.memo(function ChatListItemComponent({
         model={model.channel}
         onPress={handlePress}
         onLongPress={handleLongPress}
+        onLayout={onLayout}
         {...props}
       />
     );

--- a/packages/app/ui/components/ListItem/GroupListItem.tsx
+++ b/packages/app/ui/components/ListItem/GroupListItem.tsx
@@ -12,7 +12,7 @@ import { Pressable } from '@tloncorp/ui';
 import { ListItem, ListItemProps } from './ListItem';
 import { getGroupStatus, getPostTypeIcon } from './listItemUtils';
 import { ChatOptionsSheet } from '../ChatOptionsSheet';
-import { useState } from 'react';
+import { useState, useMemo } from 'react';
 import { useIsWindowNarrow } from '@tloncorp/ui';
 
 export const GroupListItem = ({
@@ -29,6 +29,19 @@ export const GroupListItem = ({
   const title = useGroupTitle(model);
   const { isPending, label: statusLabel, isErrored } = getGroupStatus(model);
   const isWindowNarrow = useIsWindowNarrow();
+  
+  // Memoize the trigger button to prevent re-renders
+  const triggerButton = useMemo(() => (
+    <Button
+      backgroundColor="transparent"
+      borderWidth="unset"
+      paddingHorizontal={0}
+      marginHorizontal="$-m"
+      minimal
+    >
+      <Icon type="Overflow" />
+    </Button>
+  ), []);
 
   const handlePress = logic.useMutableCallback(() => {
     onPress?.(model);
@@ -121,17 +134,7 @@ export const GroupListItem = ({
               open={open}
               onOpenChange={setOpen}
               chat={{ type: 'group', id: model.id }}
-              trigger={
-                <Button
-                  backgroundColor="transparent"
-                  borderWidth="unset"
-                  paddingHorizontal={0}
-                  marginHorizontal="$-m"
-                  minimal
-                >
-                  <Icon type="Overflow" />
-                </Button>
-              }
+              trigger={triggerButton}
             />
           )}
         </View>

--- a/packages/app/ui/components/ListItem/InteractableChatListItem.tsx
+++ b/packages/app/ui/components/ListItem/InteractableChatListItem.tsx
@@ -29,8 +29,9 @@ function BaseInteractableChatRow({
   model,
   onPress,
   onLongPress,
+  onLayout,
   ...props
-}: ListItemProps<db.Chat>) {
+}: ListItemProps<db.Chat> & { onLayout?: (e: any) => void }) {
   const swipeableRef = useRef<SwipeableMethods>(null);
   const [currentSwipeDirection, setCurrentSwipeDirection] = useState<
     'left' | 'right' | null
@@ -140,6 +141,7 @@ function BaseInteractableChatRow({
           model={model}
           onPress={onPress}
           onLongPress={onLongPress}
+          onLayout={onLayout}
           {...props}
         />
       </Swipeable>
@@ -150,6 +152,7 @@ function BaseInteractableChatRow({
         model={model}
         onPress={onPress}
         onLongPress={onLongPress}
+        onLayout={onLayout}
         {...props}
       />
     );

--- a/packages/shared/src/store/dbHooks.ts
+++ b/packages/shared/src/store/dbHooks.ts
@@ -313,7 +313,7 @@ export const useGroups = (options: db.GetGroupsOptions) => {
 export const useGroup = ({ id }: { id?: string }) => {
   return useQuery({
     enabled: !!id,
-    queryKey: [['group', { id }], useKeyFromQueryDeps(db.getGroup, { id })],
+    queryKey: [['group', id], useKeyFromQueryDeps(db.getGroup, id)],
     queryFn: () => {
       if (!id) {
         throw new Error('missing group id');
@@ -465,7 +465,7 @@ export const useChannel = (options: { id?: string }) => {
     queryKey: [
       'channelWithRelations',
       useKeyFromQueryDeps(db.getChannelWithRelations),
-      options,
+      options.id,
     ],
     queryFn: () => {
       if (!id) {
@@ -479,7 +479,7 @@ export const useChannel = (options: { id?: string }) => {
 export const usePostWithThreadUnreads = (options: { id: string }) => {
   const tableDeps = useKeyFromQueryDeps(db.getPostWithRelations);
   return useQuery({
-    queryKey: [['post', options], tableDeps],
+    queryKey: [['post', options.id], tableDeps],
     staleTime: Infinity,
     queryFn: () => db.getPostWithRelations(options),
   });

--- a/packages/ui/src/hooks/useIsWindowNarrow.ts
+++ b/packages/ui/src/hooks/useIsWindowNarrow.ts
@@ -1,6 +1,8 @@
+import { useMemo } from 'react';
 import { useWindowDimensions } from 'tamagui';
 
 export default function useIsWindowNarrow() {
   const { width } = useWindowDimensions();
-  return width < 768;
+  const isNarrow = useMemo(() => width < 768, [width]);
+  return isNarrow;
 }


### PR DESCRIPTION
fixes tlon-3892 (makes it much better anyway). 

We were seeing a lag when quickly switching between channels because of some render perf issues that were triggered by channel switching. HomeSidebar, MessagesSidebar, TopLevelDrawer, ChatList, GroupChannelsScreenView, ChannelOptionsSheetLoader, and some other components were re-rendering several times on every channel switch.

I went through and tried to find every place in the app that was unnecessarily re-rendering when we switched channels. If you run the profiler or the JS performance tool (most noticeable difference), you'll see that we cut the rendering time pretty dramatically by memoizing the crap out of everything.

There's still some noticeable hitching when we're waiting on multiple requests to finish when switching between several channels very quickly, but it's much better.