### PR TITLE
input: disable optimization to prevent dark mode issues

### DIFF
--- a/packages/app/ui/components/MessageInput/MessageInputBase.tsx
+++ b/packages/app/ui/components/MessageInput/MessageInputBase.tsx
@@ -7,7 +7,7 @@ import { Icon } from '@tloncorp/ui';
 import { ImagePickerAsset } from 'expo-image-picker';
 import { memo } from 'react';
 import { PropsWithChildren } from 'react';
-import { SpaceTokens, getTokenValue, styled, useThemeName } from 'tamagui';
+import { SpaceTokens, styled } from 'tamagui';
 import {
   ThemeTokens,
   View,

--- a/packages/app/ui/components/MessageInput/MessageInputBase.tsx
+++ b/packages/app/ui/components/MessageInput/MessageInputBase.tsx
@@ -7,7 +7,7 @@ import { Icon } from '@tloncorp/ui';
 import { ImagePickerAsset } from 'expo-image-picker';
 import { memo } from 'react';
 import { PropsWithChildren } from 'react';
-import { SpaceTokens, styled } from 'tamagui';
+import { SpaceTokens, getTokenValue, styled, useThemeName } from 'tamagui';
 import {
   ThemeTokens,
   View,
@@ -121,10 +121,10 @@ export const MessageInputContainer = memo(
     frameless?: boolean;
   }>) => {
     const { canUpload } = useAttachmentContext();
-
-    const defaultBackgroundColor = getVariableValue(useTheme().background);
+    const theme = useTheme();
+    const defaultBackgroundColor = getVariableValue(theme.background);
     const secondaryBackgroundColor = getVariableValue(
-      useTheme().secondaryBackground
+      theme.secondaryBackground
     );
 
     return (
@@ -150,6 +150,7 @@ export const MessageInputContainer = memo(
             alignItems="flex-end"
             justifyContent="space-between"
             backgroundColor="$background"
+            disableOptimization
           >
             {goBack ? (
               <View paddingBottom="$xs">


### PR DESCRIPTION
Fixes TLON-3887, something about the way that Tamagui optimizes this breaks the background from switching correctly when themes change.