### PR TITLE
filtered-chats: make section headers more clear in msgs tab

### DIFF
--- a/packages/app/hooks/useFilteredChats.ts
+++ b/packages/app/hooks/useFilteredChats.ts
@@ -15,6 +15,21 @@ export type SectionedChatData = {
   data: db.Chat[];
 }[];
 
+function getAllSectionHeader(
+  activeTab: TabName,
+  msgsFilter?: TalkSidebarFilter
+): string {
+  if (activeTab === 'talk') {
+    if (msgsFilter === 'Group Channels') {
+      return 'Chat Channels';
+    }
+
+    return msgsFilter ?? 'Direct Messages';
+  }
+
+  return 'All';
+}
+
 export function useFilteredChats({
   pinned,
   unpinned,
@@ -47,7 +62,7 @@ export function useFilteredChats({
         data: filterChats(pinned, activeTab, talkFilter),
       };
       const allSection = {
-        title: 'All',
+        title: getAllSectionHeader(activeTab, talkFilter),
         data: filterChats([...pending, ...unpinned], activeTab, talkFilter),
       };
       return pinnedSection.data.length


### PR DESCRIPTION
This is from feedback from Zach. idk if we want to make this change, but it makes sense to me.