### PR TITLE
notebooks: fix issue with pasting formatted text

### DIFF
--- a/packages/app/ui/components/MessageInput/index.tsx
+++ b/packages/app/ui/components/MessageInput/index.tsx
@@ -879,6 +879,17 @@ export const MessageInput = forwardRef<MessageInputHandle, MessageInputProps>(
 
         if (type === 'content-error') {
           messageInputLogger.log('[webview] Content error', payload);
+          if (
+            payload &&
+            typeof payload === 'string' &&
+            // @ts-expect-error - this is a string
+            payload.includes("(reading 'nodeSize')")
+          ) {
+            // We know this error is related to handlePaste within the editor in the webview,
+            // it's incidental to the way we're using the editor, and it doesn't affect the
+            // functionality of the editor. We can safely ignore it.
+            return;
+          }
           if (!editorCrashed) {
             setEditorCrashed(payload);
           }


### PR DESCRIPTION
fixes tlon-3951

Prosemirror is expecting the `handlePaste` function that we're passing to it (in `packages/editor/src/MessageInputEditor.tsx`) to return `true`.

If we don't return `true` and the user pastes some formatted text into the editor, the editor will send a `content-error` message (concerning `nodeSize` being undefined) back up to the RN MessageEditor component, and that component will assume this error is fatal and refresh the editor webview. 

If we return `true` then we'll no longer get that error message and the editor won't restart, but we'll also never get the content into the editor after paste (because prosemirror will assume we're handling the formatting/insertion externally). We don't want to handle that externally, we want prosemirror to do it for us, otherwise we'll have to add a bunch of complicated logic in the `handlePaste` function in the RN MessageEditor component.

I wasn't sure that this `nodeSize` error was actually fatal (fairly certain I remembered this happening before), so I tested what might happen if we no-op when we hear about this sort of error.

Result: seems fine if we no-op. User can paste in formatted content without issue. Everything continues working as expected.

So, I think we just no-op in this case and move on with our lives.