### PR TITLE
contact-sorters: change exact match addition

### DIFF
--- a/packages/app/ui/hooks/contactSorters.ts
+++ b/packages/app/ui/hooks/contactSorters.ts
@@ -106,7 +106,11 @@ export function useSortedContacts({
       const exactMatchCheck = preSig(query.trim().toLocaleLowerCase());
       if (isValidPatp(exactMatchCheck)) {
         const exactMatch = db.getFallbackContact(exactMatchCheck);
-        filtered.filter((c) => c.id !== exactMatchCheck).push(exactMatch);
+        if (filtered.find((c) => c.id === exactMatchCheck)) {
+          return filtered;
+        }
+
+        filtered.push(exactMatch);
       }
       return filtered;
     }


### PR DESCRIPTION
Fixes TLON-3980, when @latter-bolden added this check I didn't catch it when reviewing, but basically we were pushing the exact match to a new array that was never assigned to anything since `.filter` doesn't mutate. This meant that the exact match never made it into the array. Also if the match is already in the array, we want to use that contact since it has all the contact data instead of the fallback contact.