### PR TITLE
expose: update for latest channels content types

### DIFF
--- a/desk/app/expose.hoon
+++ b/desk/app/expose.hoon
@@ -236,7 +236,7 @@
     ::
         %fact
       ?.  =(%channel-response-1 p.cage.sign)  [~ this]
-      =+  !<(r-channels:d q.cage.sign)
+      =+  !<(r-channels:v7:old:d q.cage.sign)
       ::REVIEW  should this handle %posts also?
       ?+  -.r-channel  [~ this]
           %post

--- a/desk/app/expose.hoon
+++ b/desk/app/expose.hoon
@@ -235,7 +235,7 @@
       [~ this]
     ::
         %fact
-      ?.  =(%channel-response-1 p.cage.sign)  [~ this]
+      ?.  =(%channel-response-2 p.cage.sign)  [~ this]
       =+  !<(r-channels:v7:old:d q.cage.sign)
       ::REVIEW  should this handle %posts also?
       ?+  -.r-channel  [~ this]

--- a/desk/app/expose.hoon
+++ b/desk/app/expose.hoon
@@ -224,6 +224,12 @@
   |=  [=wire =sign:agent:gall]
   ^-  (quip card _this)
   ?+  wire  ~&([dap.bowl strange-wire=wire] [~ this])
+      [%profile %widget *]
+    ?>  ?=(%poke-ack -.sign)
+    ~?  ?=(^ p.sign)
+      [dap.bowl %nacked-by-profile]
+    [~ this]
+  ::
       [%channels ~]
     ?-  -.sign
       %poke-ack  !!

--- a/desk/app/expose/page.hoon
+++ b/desk/app/expose/page.hoon
@@ -11,8 +11,7 @@
   |=  [=bowl:gall =nest:g:c msg=post:d]
   ^-  (unit manx)
   =/  author=@p
-    ?@  author.msg  author.msg
-    ship.author.msg
+    (get-author-ship:u author.msg)
   =/  aco=(unit contact-0:co)
     (get-author-contact:r bowl author.msg)
   ::

--- a/desk/app/expose/page.hoon
+++ b/desk/app/expose/page.hoon
@@ -10,12 +10,15 @@
 ++  render
   |=  [=bowl:gall =nest:g:c msg=post:d]
   ^-  (unit manx)
+  =/  author=@p
+    ?@  author.msg  author.msg
+    ship.author.msg
   =/  aco=(unit contact-0:co)
-    (get-contact:co bowl author.msg)
+    (get-author-contact:r bowl author.msg)
   ::
   ::TODO  if we render replies then we can "unroll" whole chat threads too (:
-  |^  ?-  -.kind-data.msg
-          %chat
+  |^  ?+  kind.msg  ~
+          [%chat ~]
         =/  title=tape
           (trip (rap 3 (turn (first-inline:u content.msg) flatten-inline:u)))
         %-  some
@@ -25,24 +28,26 @@
           (story:en-manx:u content.msg)
         ==
       ::
-          %diary
-        =*  kd  kind-data.msg
-        =/  title=tape  (trip title.kd)
+          [%diary ~]
+        =/  [title=@t image=@t]
+          ?~  meta.msg  ['' '']
+          [title image]:u.meta.msg
+        =+  title=(trip title)
         %-  some
         %:  build  "diary"
-          (heads title ?:(=('' image.kd) ~ `image.kd))
+          (heads title ?:(=('' image) ~ `image))
         ::
-          ?:  =('' image.kd)  (prelude `title)
-          :-  ;img.cover@"{(trip image.kd)}"(alt "Cover image");
+          ?:  =('' image)  (prelude `title)
+          :-  ;img.cover@"{(trip image)}"(alt "Cover image");
           (prelude `title)
         ::
           (story:en-manx:u content.msg)
         ==
       ::
-          %heap
+          [%heap ~]
         =/  title=tape
-          ?:  &(?=(^ title.kind-data.msg) !=('' u.title.kind-data.msg))
-            (trip u.title.kind-data.msg)
+          ?^  meta.msg
+            (trip title.u.meta.msg)
           ::NOTE  could flatten the first-inline, but we don't. showing that
           ::      as both h1 and content is strange
           ""
@@ -92,7 +97,7 @@
       ;meta(property "twitter:title", content title);
       ;meta(property "og:site_name", content "Tlon");
       ;meta(property "og:type", content "article");
-      ;meta(property "og:article:author:username", content (scow %p author.msg));
+      ;meta(property "og:article:author:username", content (scow %p author));
     ::
       ;*  ?~  img
           :_  ~
@@ -124,8 +129,8 @@
     =/  main=manx
       ;div.author-row
         ;+  =;  link=(unit @t)
-              (%*(. author:r link link) bowl author.msg)
-            ?.  =(our.bowl author.msg)  ~
+              (%*(. author:r link link) bowl author)
+            ?.  =(our.bowl author)  ~
             ?.  .^(? %gu /(scot %p our.bowl)/profile/(scot %da now.bowl)/$)  ~
             `'/profile'
         ;+  (datetime:r sent.msg)

--- a/desk/app/expose/page.hoon
+++ b/desk/app/expose/page.hoon
@@ -17,7 +17,7 @@
   ::
   ::TODO  if we render replies then we can "unroll" whole chat threads too (:
   |^  ?+  kind.msg  ~
-          [%chat ~]
+          [%chat *]
         =/  title=tape
           (trip (rap 3 (turn (first-inline:u content.msg) flatten-inline:u)))
         %-  some
@@ -27,7 +27,7 @@
           (story:en-manx:u content.msg)
         ==
       ::
-          [%diary ~]
+          [%diary *]
         =/  [title=@t image=@t]
           ?~  meta.msg  ['' '']
           [title image]:u.meta.msg
@@ -43,7 +43,7 @@
           (story:en-manx:u content.msg)
         ==
       ::
-          [%heap ~]
+          [%heap *]
         =/  title=tape
           ?^  meta.msg
             (trip title.u.meta.msg)

--- a/desk/app/expose/render.hoon
+++ b/desk/app/expose/render.hoon
@@ -1,15 +1,40 @@
 ::  expose render: rendering utilities for pages & the widget
 ::
-/-  co=contacts-0
+/-  c=channels, co=contacts-0
 /+  sigil
 ::
 |%
+::  +author-contact: turn a post author into a contact profile
+::
+::    if the author is a bot, replaces nickname and avatar fields,
+::    when those are specified.
+::
+++  get-author-contact
+  |=  [=bowl:gall =author:c]
+  ^-  (unit contact-0:co)
+  =/  aco=(unit contact-0:co)
+    (get-contact:co bowl ?@(author author ship.author))
+  ?@  author  aco
+  %-  some
+  ?~  aco
+    %*  .  *contact-0:co
+      nickname  (fall nickname.author '')
+      avatar    avatar.author
+    ==
+  %_  u.aco
+    nickname  (fall nickname.author nickname.u.aco)
+    avatar    (hunt |=(* &) avatar.author avatar.u.aco)
+  ==
+::
 ++  author
   =/  link=(unit @t)  ~
-  |=  [=bowl:gall author=ship]
+  |=  [=bowl:gall post-author=author:c]
   ^-  manx
+  =/  author=@p
+    ?@  post-author  post-author
+    ship.post-author
   =/  aco=(unit contact-0:co)
-    (get-contact:co bowl author)
+    (get-author-contact bowl post-author)
   |^  ::TODO  we should just have a bunch of manx construction helpers
       ::      for stuff like this
       ?~  link

--- a/desk/app/expose/render.hoon
+++ b/desk/app/expose/render.hoon
@@ -1,7 +1,7 @@
 ::  expose render: rendering utilities for pages & the widget
 ::
 /-  c=channels, co=contacts-0
-/+  sigil
+/+  u=channel-utils, sigil
 ::
 |%
 ::  +author-contact: turn a post author into a contact profile
@@ -13,7 +13,7 @@
   |=  [=bowl:gall =author:c]
   ^-  (unit contact-0:co)
   =/  aco=(unit contact-0:co)
-    (get-contact:co bowl ?@(author author ship.author))
+    (get-contact:co bowl (get-author-ship:u author))
   ?@  author  aco
   %-  some
   ?~  aco
@@ -31,8 +31,7 @@
   |=  [=bowl:gall post-author=author:c]
   ^-  manx
   =/  author=@p
-    ?@  post-author  post-author
-    ship.post-author
+    (get-author-ship:u post-author)
   =/  aco=(unit contact-0:co)
     (get-author-contact bowl post-author)
   |^  ::TODO  we should just have a bunch of manx construction helpers

--- a/desk/app/expose/widget.hoon
+++ b/desk/app/expose/widget.hoon
@@ -39,7 +39,7 @@
     (spud (print:c ref))
   =,  post.u.pon
   ?+  kind.post.u.pon  ;div.exposed.fail:"kind lost: {(spud kind.post.u.pon)}"
-      [%chat ~]
+      [%chat *]
     ;div.exposed
       ;div.content
         ;a.chat/"/expose{link}"
@@ -53,7 +53,7 @@
       ==
     ==
   ::
-      [%diary ~]
+      [%diary *]
     =/  [title=@t image=@t]
       ?~  meta.post.u.pon  ['' '']
       [title image]:u.meta.post.u.pon
@@ -72,7 +72,7 @@
       ==
     ==
   ::
-      [%heap ~]
+      [%heap *]
     ::TODO  for the kinds of children the div.content gets for heap posts,
     ::      having an %a (grand)parent breaks the html rendering,
     ::      putting the inner divs outside/after the a.exposed

--- a/desk/app/expose/widget.hoon
+++ b/desk/app/expose/widget.hoon
@@ -38,8 +38,8 @@
   =/  link=tape
     (spud (print:c ref))
   =,  post.u.pon
-  ?-  -.kind-data.post.u.pon
-      %chat
+  ?+  kind.post.u.pon  ;div.exposed.fail:"kind lost: {(spud kind.post.u.pon)}"
+      [%chat ~]
     ;div.exposed
       ;div.content
         ;a.chat/"/expose{link}"
@@ -53,15 +53,18 @@
       ==
     ==
   ::
-      %diary
+      [%diary ~]
+    =/  [title=@t image=@t]
+      ?~  meta.post.u.pon  ['' '']
+      [title image]:u.meta.post.u.pon
     ;div.exposed
-      ;*  ?:  =('' image.kind-data)  ~
+      ;*  ?:  =('' image)  ~
           :_  ~
           ;a.diary/"/expose{link}"
-            ;img@"{(trip image.kind-data)}";
+            ;img@"{(trip image)}";
           ==
       ;a.diary/"/expose{link}"
-        ;h3:"{(trip title.kind-data)}"
+        ;h3:"{(trip title)}"
       ==
       ;div.author-row
         ;+  (author:r bowl author)
@@ -69,7 +72,7 @@
       ==
     ==
   ::
-      %heap
+      [%heap ~]
     ::TODO  for the kinds of children the div.content gets for heap posts,
     ::      having an %a (grand)parent breaks the html rendering,
     ::      putting the inner divs outside/after the a.exposed

--- a/desk/lib/channel-utils.hoon
+++ b/desk/lib/channel-utils.hoon
@@ -900,12 +900,12 @@
     =/  base=path
       %+  weld
         /(scot %p our.bowl)/channels/(scot %da now.bowl)
-      /v2/[p.nest]/(scot %p p.q.nest)/[q.q.nest]
+      /v3/[p.nest]/(scot %p p.q.nest)/[q.q.nest]
     ?.  .^(? %gu base)  ~
     :+  ~  nest
     .^  post:c  %gx
       %+  weld  base
-      /posts/post/(scot %ud (rash i.t.wer dum:ag))/channel-post-2
+      /posts/post/(scot %ud (rash i.t.wer dum:ag))/channel-post-3
     ==
   ::
   ++  from-post


### PR DESCRIPTION
Minimal viable change, to make sure `/app/expose` doesn't crash and burn. It was failing to compile, which would've prevented the upgrade on ships that had it enabled.

Most significantly, `kind-data` was replaced by a `kind=path`, and `author` might have a "bot profile" included. The former we handle by reading the path instead of the tag, the latter by overlaying the bot profile on top of whatever the underlying ship's contact profile is.