### PR TITLE
db: make cache ids unique, remove unsupported extra conflict resolver

### DIFF
--- a/packages/shared/src/db/migrations/0000_curious_squirrel_girl.sql
+++ b/packages/shared/src/db/migrations/0000_curious_squirrel_girl.sql
@@ -330,8 +330,7 @@ CREATE TABLE `posts` (
 	`backend_time` text
 );
 --> statement-breakpoint
-CREATE UNIQUE INDEX `posts_sent_at_unique` ON `posts` (`sent_at`);--> statement-breakpoint
-CREATE UNIQUE INDEX `cache_id` ON `posts` (`author_id`,`sent_at`);--> statement-breakpoint
+CREATE UNIQUE INDEX `cache_id` ON `posts` (`channel_id`,`author_id`,`sent_at`);--> statement-breakpoint
 CREATE INDEX `posts_channel_id` ON `posts` (`channel_id`,`id`);--> statement-breakpoint
 CREATE INDEX `posts_group_id` ON `posts` (`group_id`,`id`);--> statement-breakpoint
 CREATE TABLE `settings` (

--- a/packages/shared/src/db/migrations/meta/0000_snapshot.json
+++ b/packages/shared/src/db/migrations/meta/0000_snapshot.json
@@ -1,7 +1,7 @@
 {
   "version": "6",
   "dialect": "sqlite",
-  "id": "2b508d13-46c8-4794-a6ea-aef69c58a417",
+  "id": "609dcd27-71cb-4bb7-a343-8a18cc1249dc",
   "prevId": "00000000-0000-0000-0000-000000000000",
   "tables": {
     "activity_event_contact_group_pins": {
@@ -2179,16 +2179,10 @@
         }
       },
       "indexes": {
-        "posts_sent_at_unique": {
-          "name": "posts_sent_at_unique",
-          "columns": [
-            "sent_at"
-          ],
-          "isUnique": true
-        },
         "cache_id": {
           "name": "cache_id",
           "columns": [
+            "channel_id",
             "author_id",
             "sent_at"
           ],

--- a/packages/shared/src/db/migrations/meta/_journal.json
+++ b/packages/shared/src/db/migrations/meta/_journal.json
@@ -5,8 +5,8 @@
     {
       "idx": 0,
       "version": "6",
-      "when": 1743372652894,
-      "tag": "0000_strong_jasper_sitwell",
+      "when": 1744231960681,
+      "tag": "0000_curious_squirrel_girl",
       "breakpoints": true
     }
   ]

--- a/packages/shared/src/db/migrations/migrations.js
+++ b/packages/shared/src/db/migrations/migrations.js
@@ -1,7 +1,7 @@
 // This file is required for Expo/React Native SQLite migrations - https://orm.drizzle.team/quick-sqlite/expo
 
 import journal from './meta/_journal.json';
-import m0000 from './0000_strong_jasper_sitwell.sql';
+import m0000 from './0000_curious_squirrel_girl.sql';
 
   export default {
     journal,

--- a/packages/shared/src/db/queries.test.ts
+++ b/packages/shared/src/db/queries.test.ts
@@ -223,7 +223,7 @@ function insertPostsForWindow(
         channelId: window.channelId,
         authorId: 'test',
         receivedAt: 0,
-        sentAt: 0,
+        sentAt: 1,
         syncedAt: 0,
       },
     ],

--- a/packages/shared/src/db/queries.test.ts
+++ b/packages/shared/src/db/queries.test.ts
@@ -200,9 +200,12 @@ const testCases: {
   },
 ];
 
+let sentTime = Date.now();
+
 function insertPostsForWindow(
   window: PostWindow & { older?: string; newer?: string }
 ) {
+  console.log(`Inserting posts for window: ${JSON.stringify(window)}`);
   return queries.insertChannelPosts({
     channelId: window.channelId,
     older: window.older,
@@ -214,7 +217,7 @@ function insertPostsForWindow(
         channelId: window.channelId,
         authorId: 'test',
         receivedAt: 0,
-        sentAt: 0,
+        sentAt: sentTime++,
         syncedAt: 0,
       },
       {
@@ -223,7 +226,7 @@ function insertPostsForWindow(
         channelId: window.channelId,
         authorId: 'test',
         receivedAt: 0,
-        sentAt: 1,
+        sentAt: sentTime++,
         syncedAt: 0,
       },
     ],

--- a/packages/shared/src/db/schema.ts
+++ b/packages/shared/src/db/schema.ts
@@ -887,7 +887,7 @@ export const posts = sqliteTable(
     image: text('image'),
     content: text('content', { mode: 'json' }),
     receivedAt: timestamp('received_at').notNull(),
-    sentAt: timestamp('sent_at').unique().notNull(),
+    sentAt: timestamp('sent_at').notNull(),
     // client-side time
     replyCount: integer('reply_count'),
     replyTime: timestamp('reply_time'),
@@ -919,7 +919,11 @@ export const posts = sqliteTable(
     backendTime: text('backend_time'),
   },
   (table) => ({
-    cacheId: uniqueIndex('cache_id').on(table.authorId, table.sentAt),
+    cacheId: uniqueIndex('cache_id').on(
+      table.channelId,
+      table.authorId,
+      table.sentAt
+    ),
     channelId: index('posts_channel_id').on(table.channelId, table.id),
     groupId: index('posts_group_id').on(table.groupId, table.id),
   })

--- a/packages/shared/src/store/sync.ts
+++ b/packages/shared/src/store/sync.ts
@@ -1052,6 +1052,7 @@ export async function handleAddPost(
   // it, we need to add it to the parent post
   if (post.parentId) {
     const cachedReply = await db.getPostByCacheId({
+      channelId: post.channelId,
       sentAt: post.sentAt,
       authorId: post.authorId,
     });


### PR DESCRIPTION
What present as the web app breaking and the mobile client not showing contact data, was actually an issue with inserting latest posts. We had multiple `onConflictDoUpdate` clauses which is unsupported in the current drizzle version we're using. On top of this we had a restrictive constraint for `cacheId` which wasn't accurate. Additionally we had a unique constraint on `sentAt` time which doesn't map with the backend. Finally we were bailing if we ended up trying to insert the exact same post window, so now we just no-op since it's already there (the key is the row).

In other words, most of this is just resolving discrepancies between client and backend.
- Post IDs are only unique across a single channel (not addressed in this PR, but looming issue, although it should almost never happen)
- Sent At is not unique globally, you could very easily have two posts with the same sent time
- Posts are not unique simply by their author and sent time, only by channel + author + sent

Does not address the fact that if sync bails on web, we just spin forever. Will follow up with another PR.