### PR TITLE
ReactionsDisplay: don't show react button on chat, fix issue with unconstrained list height in EmojiPickerSheet

### DIFF
--- a/packages/app/ui/components/ChatMessage/ReactionsDisplay.tsx
+++ b/packages/app/ui/components/ChatMessage/ReactionsDisplay.tsx
@@ -181,27 +181,31 @@ export function ReactionsDisplay({
         </XStack>
       </Pressable>
 
-      <Pressable onPress={() => setSheetOpen(true)}>
-        <View
-          justifyContent="center"
-          alignItems="center"
-          backgroundColor="$secondaryBackground"
-          padding="$xs"
-          paddingHorizontal="$s"
-          marginLeft={reactionDetails.list.length > 0 ? '$s' : 0}
-          height="$3xl"
-          borderRadius="$m"
-          borderColor="$border"
-          disableOptimization // height is wrong if optimized
-        >
-          <Icon type="React" />
-        </View>
-      </Pressable>
-      <EmojiPickerSheet
-        open={sheetOpen}
-        onOpenChange={() => setSheetOpen(false)}
-        onEmojiSelect={handleSelectEmoji}
-      />
+      {post.type !== 'chat' && post.type !== 'reply' ? (
+        <>
+          <Pressable onPress={() => setSheetOpen(true)}>
+            <View
+              justifyContent="center"
+              alignItems="center"
+              backgroundColor="$secondaryBackground"
+              padding="$xs"
+              paddingHorizontal="$s"
+              marginLeft={reactionDetails.list.length > 0 ? '$s' : 0}
+              height="$3xl"
+              borderRadius="$m"
+              borderColor="$border"
+              disableOptimization // height is wrong if optimized
+            >
+              <Icon type="React" />
+            </View>
+          </Pressable>
+          <EmojiPickerSheet
+            open={sheetOpen}
+            onOpenChange={() => setSheetOpen(false)}
+            onEmojiSelect={handleSelectEmoji}
+          />
+        </>
+      ) : null}
     </XStack>
   );
 }

--- a/packages/app/ui/components/Emoji/EmojiPickerSheet.tsx
+++ b/packages/app/ui/components/Emoji/EmojiPickerSheet.tsx
@@ -1,3 +1,4 @@
+import { FlashList } from '@shopify/flash-list';
 import { useIsWindowNarrow } from '@tloncorp/ui';
 import { Button } from '@tloncorp/ui';
 import { KeyboardAvoidingView } from '@tloncorp/ui';
@@ -130,7 +131,8 @@ export function EmojiPickerSheet(
             borderWidth={1}
             borderColor="$border"
             padding="$m"
-            minWidth={300}
+            height={600}
+            width={350}
             key="content"
           >
             <VisuallyHidden>
@@ -144,10 +146,7 @@ export function EmojiPickerSheet(
                 inputProps={{ spellCheck: false, autoComplete: 'off' }}
               />
             </View>
-            <FlatList
-              style={{ width: '100%', height: 400 }}
-              horizontal={false}
-              // contentContainerStyle={{ flexGrow: 1 }}
+            <FlashList
               onScroll={handleScroll}
               onTouchStart={onTouchStart}
               onTouchEnd={onTouchEnd}


### PR DESCRIPTION
Don't show the button on chat messages or replies.

FlatList was rendering differently when <EmojiPickerSheet /> was being rendered within <ReactionsDisplay />. Looking at the element inspector, the FlatList itself was not adding an intermediate (internal) parent component that constrained the height of the list. Tried fighting this for a while with various CSS props to no satisfaction (closest I could get to "good" was adding an `overflow="scroll"` prop to the parent of the FlatList, but the FlatList itself was still rendering the *entire* list every time, it was just hidden.)

Decided to try switching out FlatList with FlashList and it Just Worked™️.

I also considered rewriting EmojiPickerSheet to use our new(ish) adaptive sheets, but decided it's probably not worth the effort at the moment (and may have no effect on the FlatList weirdness anyway).