### PR TITLE
ops: always default to prod branch env

### DIFF
--- a/apps/tlon-mobile/app.config.ts
+++ b/apps/tlon-mobile/app.config.ts
@@ -45,12 +45,8 @@ export default ({ config }: ConfigContext): ExpoConfig => ({
     enabledLoggers: process.env.ENABLED_LOGGERS,
     ignoreCosmos: process.env.IGNORE_COSMOS,
     TlonEmployeeGroup: process.env.TLON_EMPLOYEE_GROUP,
-    branchKey: isPreview
-      ? process.env.BRANCH_KEY_TEST
-      : process.env.BRANCH_KEY_PROD,
-    branchDomain: isPreview
-      ? process.env.BRANCH_DOMAIN_TEST
-      : process.env.BRANCH_DOMAIN_PROD,
+    branchKey: process.env.BRANCH_KEY_PROD,
+    branchDomain: process.env.BRANCH_DOMAIN_PROD,
     inviteServiceEndpoint: process.env.INVITE_SERVICE_ENDPOINT,
     inviteServiceIsDev: process.env.INVITE_SERVICE_IS_DEV,
   },


### PR DESCRIPTION
We don't much use the test branch environment anymore. Changing these env vars to make sure preview builds (black app) will work with and produce normal invite links.