### PR TITLE
channels: add %link $block element

### DIFF
--- a/desk/app/chat.hoon
+++ b/desk/app/chat.hoon
@@ -401,7 +401,7 @@
   ::
   ++  story-4-to-5
     |=  [=ship old=content:two]
-    ^-  story:d
+    ^-  story:v7:old:d
     ?-    -.old
         %notice  ~[%inline pfix.p.old ship+ship sfix.p.old]~
         %story
@@ -677,7 +677,7 @@
   ::
   ++  new-story
     |=  [=ship old=content:old-2]
-    ^-  story:d
+    ^-  story:v7:old:d
     ?-    -.old
         %notice  ~[%inline pfix.p.old ship+ship sfix.p.old]~
         %story

--- a/desk/lib/channel-json.hoon
+++ b/desk/lib/channel-json.hoon
@@ -500,6 +500,11 @@
       :~  code+s+code.b
           lang+s+lang.b
       ==
+        %link
+      %-  pairs
+      :~  url+s+url.b
+          meta+o+(~(run by meta.b) (lead %s))
+      ==
     ==
   ::
   ++  listing
@@ -1202,10 +1207,46 @@
           sent/di
       ==
     ::
+    ++  story  (ar verse)
+    ++  verse
+      ^-  $-(json verse:v7:old:c)
+      %-  of
+      :~  block+block
+          inline+(ar inline)
+      ==
+    ::
+    ++  block
+      ^-  $-(json block:v7:old:c)
+      %-  of
+      :~  rule/ul
+          cite/dejs:cite
+          listing/listing
+      ::
+        :-  %code
+        %-  ot
+        :~  code/so
+            lang/(se %tas)
+        ==
+      ::
+        :-  %header
+        %-  ot
+        :~  tag/(su (perk %h1 %h2 %h3 %h4 %h5 %h6 ~))
+            content/(ar inline)
+        ==
+      ::
+        :-  %image
+        %-  ot
+        :~  src/so
+            height/ni
+            width/ni
+            alt/so
+        ==
+      ==
+    ::
     ++  essay
       ^-  $-(json essay:v7:old:c)
       %+  cu
-        |=  [=story:c =ship:z =time:z =kind-data:c]
+        |=  [=story:v7:old:c =ship:z =time:z =kind-data:c]
         `essay:v7:old:c`[[story ship time] kind-data]
       %-  ot
       :~  content/story
@@ -1313,6 +1354,12 @@
           height/ni
           width/ni
           alt/so
+      ==
+    ::
+      :-  %link
+      %-  ot
+      :~  url+so
+          meta+(om so)
       ==
     ==
   ::

--- a/desk/lib/channel-utils.hoon
+++ b/desk/lib/channel-utils.hoon
@@ -443,7 +443,17 @@
 ++  memo-1
   |=  =memo:c
   ^-  memo:v7:old:c
-  memo(author (author-1 author.memo))
+  %=  memo
+    author   (author-1 author.memo)
+    content  (turn content.memo verse-1)
+  ==
+::
+++  verse-1
+  |=  =verse:c
+  ^-  verse:v7:old:c
+  ?.  ?=([%block %link *] verse)
+    verse
+  [%inline [%link [. .]:url.p.verse] ~]  ::REVIEW
 ::
 ++  essay-1
   |=  =essay:c
@@ -1073,6 +1083,13 @@
       ;+
       ;pre
         ;code:"{(trip code.block)}"
+      ==
+    ::
+        %link
+      ::TODO  render w/ preview data
+      ;*  :~
+        (inline %link url.block url.block)
+        ;br;
       ==
     ==
   ::

--- a/desk/sur/channels.hoon
+++ b/desk/sur/channels.hoon
@@ -167,6 +167,7 @@
 ::    %header: a traditional HTML heading, h1-h6
 ::    %listing: a traditional HTML list, ul and ol
 ::    %code: a block of code
+::    %link: a link, with metadata for rendering a preview card
 ::
 +$  block  $+  channel-block
   $%  [%image src=cord height=@ud width=@ud alt=cord]
@@ -175,7 +176,12 @@
       [%listing p=listing]
       [%rule ~]
       [%code code=cord lang=cord]
+      [%link url=@t meta=(map ?(link-meta-key @t) @t)]
   ==
+::  $link-meta-key: known-good %link $block meta keys
+::
++$  link-meta-key
+  ?(%title %description %image %site-name %site-icon)
 ::  $inline: post content that flows within a paragraph
 ::
 ::    @t: plain text
@@ -622,6 +628,14 @@
           sent=time
       ==
     +$  essay  [memo =kind-data]
+    +$  story  (list verse)
+    +$  verse
+      $%  [%block p=block]
+          [%inline p=(list inline)]
+      ==
+    +$  block
+      $~  [%rule ~]
+      $<(%link ^block)
     +$  v-replies     ((mop id-reply (unit v-reply)) lte)
     +$  channels  (map nest channel)
     ++  channel


### PR DESCRIPTION
For links that should be rendered as a preview card block element. Contains arbitrary metadata for use in that rendering, but we specify well-known meta keys for clarity.

Haven't tested this end-to-end yet, @latter-bolden's client integration work with `m/link-preview-fetching` is still pending.

Would be good to sneak this content AST change in along with the other protocol changes. This PR has all the changes needed to make our agents and helper libraries compile and makes sure to include the new addition in the json parser. That _should_ cover things, shouldn't it?

Closes TLON-3910.