### PR TITLE
chat: show author row with edited tag when a post has been edited

### DIFF
--- a/packages/app/ui/components/ChatMessage/ChatMessage.tsx
+++ b/packages/app/ui/components/ChatMessage/ChatMessage.tsx
@@ -175,7 +175,7 @@ const ChatMessage = ({
         backgroundColor={isHighlighted ? '$secondaryBackground' : undefined}
         key={post.id}
       >
-        {showAuthor ? (
+        {showAuthor || post.isEdited ? (
           <AuthorRow
             padding="$l"
             paddingBottom="$2xs"

--- a/packages/app/ui/components/ChatMessage/ChatMessage.tsx
+++ b/packages/app/ui/components/ChatMessage/ChatMessage.tsx
@@ -175,7 +175,7 @@ const ChatMessage = ({
         backgroundColor={isHighlighted ? '$secondaryBackground' : undefined}
         key={post.id}
       >
-        {showAuthor || post.isEdited ? (
+        {showAuthor ? (
           <AuthorRow
             padding="$l"
             paddingBottom="$2xs"
@@ -206,6 +206,19 @@ const ChatMessage = ({
             zIndex={199}
           >
             <ChatMessageDeliveryStatus status={post.deliveryStatus} />
+          </View>
+        ) : null}
+
+        {!showAuthor && post.isEdited ? (
+          <View
+            position="absolute"
+            right={12}
+            top={8}
+            zIndex={199}
+          >
+            <Text size="$label/s" color="$tertiaryText">
+              Edited
+            </Text>
           </View>
         ) : null}
 


### PR DESCRIPTION
fixes tlon-3972

This isn't really a desktop issue, it's just that nobody noticed it until we rolled out the desktop web app. We had no way of showing if a post had been edited in chat if the message didn't show the author row. This change just ensures that we always show the author row if the post has been edited (just so we can show the edited tag).