### PR TITLE
verifier: don't persist log details across events

### DIFF
--- a/desk/app/lanyard.hoon
+++ b/desk/app/lanyard.hoon
@@ -243,6 +243,7 @@
 ::
 ++  on-poke
   |=  [=mark =vase]
+  =-  -(log ^lo)  ::  reset any .log deets we might've set
   ^-  (quip card _this)
   ~|  [%on-poke mark=mark]
   ?+  mark  !!
@@ -403,6 +404,7 @@
 ::
 ++  on-agent
   |=  [=wire =sign:agent:gall]
+  =-  -(log ^lo)  ::  reset any .log deets we might've set
   ^-  (quip card _this)
   ~|  wire=wire
   ?+  wire  !!

--- a/desk/app/verifier.hoon
+++ b/desk/app/verifier.hoon
@@ -525,6 +525,7 @@
 ::
 ++  on-poke
   |=  [=mark =vase]
+  =-  -(log ^^l)  ::  reset any .log deets we might've set
   ^-  (quip card _this)
   ~|  [%on-poke mark=mark]
   ?+  mark  !!
@@ -896,6 +897,7 @@
 ::
 ++  on-arvo
   |=  [=wire sign=sign-arvo]
+  =-  -(log ^^l)  ::  reset any .log deets we might've set
   ^-  (quip card _this)
   ::NOTE  including this ~| means that, when logging traces, we might send
   ::      full identifiers over the wire...


### PR DESCRIPTION
Because the `.log` is in the agent core's context, it would get carried along across invocations, as would any changes we made to that core.

Because we set some of those door arguments for logging purposes and never _unset_ them, logs would _always_ have the optional values, just set to the most recent value, unless they changed them themselves.

This is the smallest viable fix. Arguably this is paying for cuteness by being even cuter. The logging pattern here remains really nice though, so it's a bit of a wash...