### PR TITLE
notifications: use channel ID to group iOS notifications when available

### DIFF
--- a/apps/tlon-mobile/ios/Shared/Notifications/PushNotificationManager.swift
+++ b/apps/tlon-mobile/ios/Shared/Notifications/PushNotificationManager.swift
@@ -88,7 +88,7 @@ protocol UNNotificationRenderable {
 extension Yarn: UNNotificationRenderable {
   func render(to content: UNMutableNotificationContent) async -> (UNNotificationContent, INSendMessageIntent?) {
     content.interruptionLevel = .active
-    content.threadIdentifier = self.rope.thread
+    content.threadIdentifier = self.channelID ?? self.rope.thread
     content.title = await self.getTitle()
     content.body = self.body
     // content.badge = await withUnsafeContinuation { cnt in


### PR DESCRIPTION
fixes TLON-3932

Detailed context about problem and solution is in Linear ticket + comments.

This approach creates some small bugs:
- All posts in a channel will be in the same notification group: this includes replies inside threads. A notification group may consist of `top-level-post1`, `top-level-post2`, `some-reply-to-top-level-post1`, `top-level-post3`.
- This is true for any channel – not just chats. If you have notifications enabled for a gallery, each new gallery post will get slotted into a single notification grouping.

We'll have more resolution to better group notifications when we are sourcing from activity events, but this should be a significant improvement in the short term.