### PR TITLE
mobile: handle deferred deep links

### DIFF
--- a/apps/tlon-mobile/ios/Landscape/AppDelegate.mm
+++ b/apps/tlon-mobile/ios/Landscape/AppDelegate.mm
@@ -24,6 +24,7 @@
    [RNBranch useTestInstance];
 #endif
 
+  [RNBranch.branch checkPasteboardOnInstall];
   [RNBranch initSessionWithLaunchOptions:launchOptions isReferrable:YES];
 
   // Listen to changes in app-specific cookie storage, and push those to the app group shared

--- a/apps/tlon-mobile/ios/Landscape/Info.plist
+++ b/apps/tlon-mobile/ios/Landscape/Info.plist
@@ -92,6 +92,7 @@
 	<key>branch_universal_link_domains</key>
 	<array>
 		<string>join.tlon.io</string>
+		<string>sa96e.app.link</string>
 		<string>sa96e-alternate.app.link</string>
 	</array>
 </dict>

--- a/packages/app/contexts/branch.tsx
+++ b/packages/app/contexts/branch.tsx
@@ -118,6 +118,16 @@ export const BranchProvider = ({ children }: { children: ReactNode }) => {
           if (params.lure) {
             // Link had a lure field embedded
             logger.log('detected lure link:', params.lure);
+            if (
+              params?.['+match_guaranteed'] &&
+              params?.['+is_first_session']
+            ) {
+              logger.trackEvent(AnalyticsEvent.ActionDeferredDeepLink, {
+                inviteId: params.lure,
+                inviterUserId: params?.inviterUserId,
+              });
+            }
+
             try {
               const nextLure: Lure = {
                 lure: {

--- a/packages/shared/src/domain/analytics.ts
+++ b/packages/shared/src/domain/analytics.ts
@@ -107,6 +107,7 @@ export enum AnalyticsEvent {
   ActionConfirmPhoneAttest = 'Confirmed Phone Attestation',
   ActionGroupChannelSelected = 'Tapped group channel',
   ActionTappedPushNotif = 'Tapped Push Notification',
+  ActionDeferredDeepLink = 'Installed with Deferred Deeplink Invite',
   GroupJoinComplete = 'Group Join Complete',
   PersonalInviteLinkReady = 'Personal Invite Link Ready',
   ErrorSendPost = 'Error Sending Post',


### PR DESCRIPTION
Updates our branch configuration to work with deferred deeplinking on iOS + telemetry when it's triggered.

Fixes TLON-4017