### PR TITLE
notebook: fix some formatting issues

### DIFF
--- a/packages/app/ui/components/MessageInput/index.tsx
+++ b/packages/app/ui/components/MessageInput/index.tsx
@@ -265,24 +265,6 @@ export const MessageInput = forwardRef<MessageInputHandle, MessageInputProps>(
                 'Not editing and we have draft content',
                 draft
               );
-              // const inlines = tiptap.JSONToInlines(draft);
-              // const newInlines = inlines
-              //   .map((inline) => {
-              //     if (typeof inline === 'string') {
-              //       if (inline.match(REF_REGEX)) {
-              //         return null;
-              //       }
-              //       return inline;
-              //     }
-              //     return inline;
-              //   })
-              //   .filter((inline) => inline !== null) as Inline[];
-              // const newStory = constructStory(newInlines);
-              // const tiptapContent = tiptap.diaryMixedToJSON(newStory);
-              // messageInputLogger.log(
-              //   'Setting content with draft',
-              //   tiptapContent
-              // );
               // @ts-expect-error setContent does accept JSONContent
               editor.setContent(draft);
               setEditorIsEmpty(false);
@@ -791,38 +773,10 @@ export const MessageInput = forwardRef<MessageInputHandle, MessageInputProps>(
       runSendMessage(true);
     }, [runSendMessage, editingPost]);
 
-    const handleAddNewLine = useCallback(() => {
-      if (editorState.isCodeBlockActive) {
-        editor.newLineInCode();
-        return;
-      }
-
-      if (editorState.isBulletListActive || editorState.isOrderedListActive) {
-        editor.splitListItem('listItem');
-        return;
-      }
-
-      if (editorState.isTaskListActive) {
-        editor.splitListItem('taskItem');
-        return;
-      }
-
-      editor.splitBlock();
-    }, [editor, editorState]);
-
     const handleMessage = useCallback(
       async (event: WebViewMessageEvent) => {
         const { data } = event.nativeEvent;
         messageInputLogger.log('[webview] Message from editor', data);
-        if (data === 'enter') {
-          handleAddNewLine();
-          return;
-        }
-
-        if (data === 'shift-enter') {
-          handleAddNewLine();
-          return;
-        }
 
         const { type, payload } =
           typeof data === 'object'
@@ -908,7 +862,6 @@ export const MessageInput = forwardRef<MessageInputHandle, MessageInputProps>(
       },
       [
         editor,
-        handleAddNewLine,
         handlePaste,
         setHeight,
         webviewRef,

--- a/packages/app/ui/components/MessageInput/index.tsx
+++ b/packages/app/ui/components/MessageInput/index.tsx
@@ -70,7 +70,7 @@ import { processReferenceAndUpdateEditor } from './helpers';
 
 export const DEFAULT_MESSAGE_INPUT_HEIGHT = Platform.OS === 'web' ? 38 : 44;
 
-const messageInputLogger = createDevLogger('MessageInput', false);
+const messageInputLogger = createDevLogger('MessageInput', true);
 
 type MessageEditorMessage = {
   type: 'contentHeight';
@@ -265,26 +265,26 @@ export const MessageInput = forwardRef<MessageInputHandle, MessageInputProps>(
                 'Not editing and we have draft content',
                 draft
               );
-              const inlines = tiptap.JSONToInlines(draft);
-              const newInlines = inlines
-                .map((inline) => {
-                  if (typeof inline === 'string') {
-                    if (inline.match(REF_REGEX)) {
-                      return null;
-                    }
-                    return inline;
-                  }
-                  return inline;
-                })
-                .filter((inline) => inline !== null) as Inline[];
-              const newStory = constructStory(newInlines);
-              const tiptapContent = tiptap.diaryMixedToJSON(newStory);
-              messageInputLogger.log(
-                'Setting content with draft',
-                tiptapContent
-              );
+              // const inlines = tiptap.JSONToInlines(draft);
+              // const newInlines = inlines
+              //   .map((inline) => {
+              //     if (typeof inline === 'string') {
+              //       if (inline.match(REF_REGEX)) {
+              //         return null;
+              //       }
+              //       return inline;
+              //     }
+              //     return inline;
+              //   })
+              //   .filter((inline) => inline !== null) as Inline[];
+              // const newStory = constructStory(newInlines);
+              // const tiptapContent = tiptap.diaryMixedToJSON(newStory);
+              // messageInputLogger.log(
+              //   'Setting content with draft',
+              //   tiptapContent
+              // );
               // @ts-expect-error setContent does accept JSONContent
-              editor.setContent(tiptapContent);
+              editor.setContent(draft);
               setEditorIsEmpty(false);
               messageInputLogger.log(
                 'set has set initial content, not editing'
@@ -480,6 +480,7 @@ export const MessageInput = forwardRef<MessageInputHandle, MessageInputProps>(
         clearDraft(draftType);
       }
 
+      messageInputLogger.log('Storing draft', json);
       storeDraft(json, draftType);
     };
 

--- a/packages/app/ui/components/MessageInput/index.tsx
+++ b/packages/app/ui/components/MessageInput/index.tsx
@@ -70,7 +70,7 @@ import { processReferenceAndUpdateEditor } from './helpers';
 
 export const DEFAULT_MESSAGE_INPUT_HEIGHT = Platform.OS === 'web' ? 38 : 44;
 
-const messageInputLogger = createDevLogger('MessageInput', true);
+const messageInputLogger = createDevLogger('MessageInput', false);
 
 type MessageEditorMessage = {
   type: 'contentHeight';
@@ -275,7 +275,7 @@ export const MessageInput = forwardRef<MessageInputHandle, MessageInputProps>(
             }
 
             if (editingPost && editingPost.content) {
-              messageInputLogger.log('Editing post', editingPost);
+              messageInputLogger.log('Editing post', editingPost.content);
               const {
                 story,
                 references: postReferences,

--- a/packages/editor/src/MessageInputEditor.tsx
+++ b/packages/editor/src/MessageInputEditor.tsx
@@ -21,7 +21,7 @@ import { EditorView } from '@tiptap/pm/view';
 import { EditorContent } from '@tiptap/react';
 import { useCallback } from 'react';
 
-import { CodeBlockBridge, MentionsBridge, ShortcutsBridge } from './bridges';
+import { CodeBlockBridge, MentionsBridge } from './bridges';
 
 export const MessageInputEditor = () => {
   const handlePaste = useCallback(
@@ -47,7 +47,6 @@ export const MessageInputEditor = () => {
       TaskListBridge,
       ImageBridge,
       StrikeBridge,
-      ShortcutsBridge,
       BlockquoteBridge,
       HistoryBridge.configureExtension({
         newGroupDelay: 100,

--- a/packages/shared/src/logic/tiptap.ts
+++ b/packages/shared/src/logic/tiptap.ts
@@ -636,6 +636,20 @@ export const inlineToContent = (
     const inlineValue = inline[key as keyof Inline];
     const newContext: JSONContent = ctx ? Object.assign(ctx) : {};
     newContext.marks = [makeMarks(key), ...(newContext?.marks ?? [])];
+    if (key === 'code') {
+      // this is a special case for inline code. `code` is always actually a code block,
+      // meanwhile `inline-code` is a span of text.
+      return {
+        type: 'codeBlock',
+        content: [
+          {
+            type: 'text',
+            text: inline[key as keyof Inline] as string,
+          },
+        ],
+      };
+    }
+
     // if Array, it's a nestable tag (bold, italics, strike); otherwise it's
     // an un-nestable tag such as inline-code or code
     return inlineToContent(


### PR DESCRIPTION
fixes tlon-3985

We no longer need to override the `enter` or `shift-enter` keys in our tentap editor because `enter` will never send a message in notebooks or galleries (it would in chat, when we used it there), so we can remove the shortcuts bridge. The shortcuts bridge was causing the issue where the user was unable to add a new line within a code block (it would just split the editor, taking the user out of the code block and adding a new paragraph node).

Also, our draft logic was overly complex, which led to issues with restoring drafts. It's already stored in prosemirror AST, we don't need to convert it to a Story and then back to the prosemirror AST.

The last thing I noticed here is that `diaryMixedToJSON` didn't account for the fact that we treat `code` nodes within an `inline` in our AST as if they are code blocks (inline code is always `inline-code` after some changes we made last year), so when editing an existing post with code blocks those code blocks would get turned into inline code. By adding a special case for handling `code` inlines and returning them as `codeBlocks` in the prosemirror AST, we can ensure that the post is formatted correctly in the editor when editing an existing post.