### PR TITLE
add ability to cancel requests using AbortController

### DIFF
--- a/packages/app/features/top/ChannelScreen.tsx
+++ b/packages/app/features/top/ChannelScreen.tsx
@@ -102,10 +102,19 @@ export default function ChannelScreen(props: Props) {
     }, [groupId, channelId])
   );
 
+  const channelThreadAbortController = useRef<AbortController | null>(
+    new AbortController()
+  );
+
   useEffect(() => {
     if (!channelIsPending) {
+      if (channelThreadAbortController.current) {
+        channelThreadAbortController.current.abort();
+      }
+      channelThreadAbortController.current = new AbortController();
       store.syncChannelThreadUnreads(channelId, {
         priority: store.SyncPriority.High,
+        abortSignal: channelThreadAbortController.current?.signal,
       });
     }
   }, [channelIsPending, channelId]);

--- a/packages/ui/src/components/ParentAgnosticKeyboardAvoidingView.tsx
+++ b/packages/ui/src/components/ParentAgnosticKeyboardAvoidingView.tsx
@@ -77,9 +77,12 @@ export function ParentAgnosticKeyboardAvoidingView({
   }, [adjustmentPaddingBottom]);
 
   const combinedStyle = React.useMemo(() => {
-    return StyleSheet.compose(contentContainerStyle, {
-      paddingBottom: adjustmentPaddingBottom,
-    });
+    return [
+      contentContainerStyle,
+      {
+        paddingBottom: adjustmentPaddingBottom,
+      },
+    ];
   }, [contentContainerStyle, adjustmentPaddingBottom]);
 
   return (


### PR DESCRIPTION
Fixes TLON-4032

Adds ability to cancel requests using an `AbortController` signal. We should look for more places to apply this, and may want to abstract some usage patterns as they become clearer.