### PR TITLE
store last visited group channel in keyval storage

### DIFF
--- a/packages/app/features/top/ChannelScreen.tsx
+++ b/packages/app/features/top/ChannelScreen.tsx
@@ -94,10 +94,7 @@ export default function ChannelScreen(props: Props) {
       if (groupId) {
         // Update the last visited channel in the group so we can return to it
         // when we come back to the group
-        db.updateGroup({
-          id: groupId,
-          lastVisitedChannelId: channelId,
-        });
+        db.lastVisitedChannelId(groupId).setValue(channelId);
       }
     }, [groupId, channelId])
   );

--- a/packages/app/navigation/utils.ts
+++ b/packages/app/navigation/utils.ts
@@ -424,6 +424,9 @@ export async function getMainGroupRoute(
   isWindowNarrow: boolean
 ) {
   const group = await db.getGroup({ id: groupId });
+  const lastVisitedChannelId = await db
+    .lastVisitedChannelId(groupId)
+    .getValue();
   const channelSwitcherEnabled =
     useFeatureFlagStore.getState().flags.channelSwitcher;
   if (
@@ -431,12 +434,8 @@ export async function getMainGroupRoute(
     group.channels &&
     (group.channels.length === 1 || channelSwitcherEnabled || !isWindowNarrow)
   ) {
-    if (!isWindowNarrow && group.lastVisitedChannelId) {
-      return getDesktopChannelRoute(
-        'Home',
-        group.lastVisitedChannelId,
-        groupId
-      );
+    if (!isWindowNarrow && lastVisitedChannelId) {
+      return getDesktopChannelRoute('Home', lastVisitedChannelId, groupId);
     }
 
     if (!isWindowNarrow) {

--- a/packages/shared/src/db/keyValue.ts
+++ b/packages/shared/src/db/keyValue.ts
@@ -172,6 +172,13 @@ export const postDraft = (opts: {
   });
 };
 
+export const lastVisitedChannelId = (groupId: string) => {
+  return createStorageItem<string | null>({
+    key: `lastVisitedChannelId-${groupId}`,
+    defaultValue: null,
+  });
+};
+
 export const themeSettings = createStorageItem<ThemeName | null>({
   key: '@user_theme',
   defaultValue: null,

--- a/packages/shared/src/db/migrations/0000_shiny_bloodstorm.sql
+++ b/packages/shared/src/db/migrations/0000_shiny_bloodstorm.sql
@@ -258,7 +258,6 @@ CREATE TABLE `groups` (
 	`join_status` text,
 	`last_post_id` text,
 	`last_post_at` integer,
-	`last_visited_channel_id` text,
 	`synced_at` integer
 );
 --> statement-breakpoint

--- a/packages/shared/src/db/migrations/meta/0000_snapshot.json
+++ b/packages/shared/src/db/migrations/meta/0000_snapshot.json
@@ -1,7 +1,7 @@
 {
   "version": "6",
   "dialect": "sqlite",
-  "id": "609dcd27-71cb-4bb7-a343-8a18cc1249dc",
+  "id": "2d0cb632-02eb-4190-8b44-0e7765f3a701",
   "prevId": "00000000-0000-0000-0000-000000000000",
   "tables": {
     "activity_event_contact_group_pins": {
@@ -1716,13 +1716,6 @@
         "last_post_at": {
           "name": "last_post_at",
           "type": "integer",
-          "primaryKey": false,
-          "notNull": false,
-          "autoincrement": false
-        },
-        "last_visited_channel_id": {
-          "name": "last_visited_channel_id",
-          "type": "text",
           "primaryKey": false,
           "notNull": false,
           "autoincrement": false

--- a/packages/shared/src/db/migrations/meta/_journal.json
+++ b/packages/shared/src/db/migrations/meta/_journal.json
@@ -5,8 +5,8 @@
     {
       "idx": 0,
       "version": "6",
-      "when": 1744231960681,
-      "tag": "0000_curious_squirrel_girl",
+      "when": 1744745700906,
+      "tag": "0000_shiny_bloodstorm",
       "breakpoints": true
     }
   ]

--- a/packages/shared/src/db/migrations/migrations.js
+++ b/packages/shared/src/db/migrations/migrations.js
@@ -1,7 +1,7 @@
 // This file is required for Expo/React Native SQLite migrations - https://orm.drizzle.team/quick-sqlite/expo
 
 import journal from './meta/_journal.json';
-import m0000 from './0000_curious_squirrel_girl.sql';
+import m0000 from './0000_shiny_bloodstorm.sql';
 
   export default {
     journal,

--- a/packages/shared/src/db/schema.ts
+++ b/packages/shared/src/db/schema.ts
@@ -383,7 +383,6 @@ export const groups = sqliteTable('groups', {
   joinStatus: text('join_status').$type<GroupJoinStatus>(),
   lastPostId: text('last_post_id'),
   lastPostAt: timestamp('last_post_at'),
-  lastVisitedChannelId: text('last_visited_channel_id'),
   syncedAt: timestamp('synced_at'),
 });
 


### PR DESCRIPTION
Fixes TLON-4026 by moving `lastVisitedChannelId` out of SQLite and into keyval storage.