### PR TITLE
embeds: text formatted as a link shouldn't render an embed

### DIFF
--- a/packages/app/ui/components/PostContent/contentUtils.tsx
+++ b/packages/app/ui/components/PostContent/contentUtils.tsx
@@ -322,8 +322,9 @@ function extractEmbedsFromInlines(inlines: ub.Inline[]): BlockData[] {
       const isTrustedEmbed = trustedProviders.some((provider) =>
         provider.regex.test(inline.link.href)
       );
+      const isNotFormattedText = inline.link.href === inline.link.content;
 
-      if (isTrustedEmbed) {
+      if (isTrustedEmbed && isNotFormattedText) {
         // Flush the current segment before adding the embed
         flushSegment();
 


### PR DESCRIPTION
fixes tlon-4003

if the href and the content of the link don't match, we know the user has formatted some content as a link and we should just render the content that way.