### PR TITLE
wayfinding: fix web splash modal display logic

### DIFF
--- a/packages/app/navigation/desktop/HomeSidebar.tsx
+++ b/packages/app/navigation/desktop/HomeSidebar.tsx
@@ -51,8 +51,6 @@ export const HomeSidebar = memo(
     const { setIsOpen } = useGlobalSearch();
     const showSplash = store.useShowWebSplashModal();
 
-    // const isFocused = useIsFocused();
-
     const { data: chats } = store.useCurrentChats();
     const { performGroupAction } = useGroupActions();
 

--- a/packages/app/ui/components/Wayfinding/SplashModal.tsx
+++ b/packages/app/ui/components/Wayfinding/SplashModal.tsx
@@ -1,5 +1,3 @@
-import { Dialog } from 'tamagui';
-
 import { ActionSheet } from '../ActionSheet';
 import { SplashSequence } from './SplashSequence';
 

--- a/packages/shared/src/domain/wayfinding.ts
+++ b/packages/shared/src/domain/wayfinding.ts
@@ -1,8 +1,8 @@
 export const PersonalGroupSlugs = {
-  slug: 'personal-group-placeholder',
-  chatSlug: 'personal-group-placeholder-chat',
-  collectionSlug: 'personal-group-placeholder-collection',
-  notebookSlug: 'personal-group-placeholder-notebook',
+  slug: 'tm-wayfinding-group',
+  chatSlug: 'tm-wayfinding-group-chat',
+  collectionSlug: 'tm-wayfinding-group-collection',
+  notebookSlug: 'tm-wayfinding-group-notebook',
 };
 
 export const PersonalGroupNames = {

--- a/packages/shared/src/store/dbHooks.ts
+++ b/packages/shared/src/store/dbHooks.ts
@@ -534,7 +534,7 @@ export const useWayfindingCompletion = () => {
 
 export const useShowWebSplashModal = () => {
   const { data: wayfinding, isLoading } = useWayfindingCompletion();
-  const personalGroup = usePersonalGroup();
+  const { data: personalGroup } = usePersonalGroup();
 
   return Boolean(
     personalGroup && !isLoading && !(wayfinding?.completedSplash ?? true)


### PR DESCRIPTION
The hook that controls if the splash modal is shown on web is supposed to short circuit if you don't have the new wayfinding group. There was a bug with detecting if you had said group — it was checking for a truthy value on a `useQuery` response object, rather than the `useQuery` data itself.

Also removes placeholder slug names.