### PR TITLE
channels: properly handle mismatches for dms and newer channels

### DIFF
--- a/packages/app/ui/components/Channel/ReadOnlyNotice.tsx
+++ b/packages/app/ui/components/Channel/ReadOnlyNotice.tsx
@@ -2,7 +2,21 @@ import { Icon } from '@tloncorp/ui';
 import { SafeAreaView } from 'react-native-safe-area-context';
 import { SizableText, View, YStack } from 'tamagui';
 
-export function ReadOnlyNotice() {
+export function ReadOnlyNotice({
+  type,
+}: {
+  type: 'read-only' | 'dm-mismatch' | 'channel-mismatch';
+}) {
+  const Message =
+    type === 'read-only' ? (
+      <>'This channel is read-only for you.'</>
+    ) : (
+      <>
+        Your node&apos;s version of the Tlon app doesn&apos;t match the{' '}
+        {type === 'dm-mismatch' ? 'other node.' : 'channel host.'}
+      </>
+    );
+
   return (
     <SafeAreaView edges={['right', 'left', 'bottom']}>
       <YStack
@@ -16,7 +30,7 @@ export function ReadOnlyNotice() {
         <View flexDirection="row" alignItems="center" gap="$m">
           <Icon type="Info" size="$s" color="$tertiaryText" />
           <SizableText size="$s" color="$tertiaryText">
-            This channel is read-only for you.
+            {Message}
           </SizableText>
         </View>
       </YStack>

--- a/packages/app/ui/components/Channel/index.tsx
+++ b/packages/app/ui/components/Channel/index.tsx
@@ -7,7 +7,10 @@ import {
   usePostReference as usePostReferenceHook,
   usePostWithRelations,
 } from '@tloncorp/shared';
-import { ChannelContentConfiguration } from '@tloncorp/shared/api';
+import {
+  ChannelContentConfiguration,
+  isDmChannelId,
+} from '@tloncorp/shared/api';
 import * as db from '@tloncorp/shared/db';
 import { JSONContent, Story } from '@tloncorp/shared/urbit';
 import { useIsWindowNarrow } from '@tloncorp/ui';
@@ -24,7 +27,6 @@ import {
 import { SafeAreaView } from 'react-native-safe-area-context';
 import {
   AnimatePresence,
-  SizableText,
   View,
   YStack,
   getVariableValue,
@@ -166,6 +168,7 @@ export const Channel = forwardRef<ChannelMethods, ChannelProps>(
     const collectionRef = useRef<PostCollectionHandle>(null);
 
     const isChatChannel = channel ? getIsChatChannel(channel) : true;
+    const isDM = isDmChannelId(channel.id);
 
     const onPressGroupRef = useCallback((group: db.Group) => {
       setGroupPreview(group);
@@ -415,50 +418,51 @@ export const Channel = forwardRef<ChannelMethods, ChannelProps>(
                             )}
                           </AnimatePresence>
 
-                          {canWrite &&
-                            (channel.contentConfiguration == null ? (
-                              <>
-                                {isChatChannel &&
-                                  !channel.isDmInvite &&
-                                  (negotiationMatch ? (
-                                    <DraftInputView
-                                      draftInputContext={draftInputContext}
-                                      type={DraftInputId.chat}
-                                    />
-                                  ) : (
-                                    <SafeAreaView
-                                      edges={['right', 'left', 'bottom']}
-                                    >
-                                      <NegotionMismatchNotice />
-                                    </SafeAreaView>
-                                  ))}
+                          {!canWrite || !negotiationMatch ? (
+                            <ReadOnlyNotice
+                              type={
+                                !canWrite
+                                  ? 'read-only'
+                                  : isDM
+                                    ? 'dm-mismatch'
+                                    : 'channel-mismatch'
+                              }
+                            />
+                          ) : channel.contentConfiguration == null ? (
+                            <>
+                              {isChatChannel && !channel.isDmInvite && (
+                                <DraftInputView
+                                  draftInputContext={draftInputContext}
+                                  type={DraftInputId.chat}
+                                />
+                              )}
 
-                                {channel.type === 'gallery' && (
-                                  <DraftInputView
-                                    draftInputContext={draftInputContext}
-                                    type={DraftInputId.gallery}
-                                  />
-                                )}
+                              {channel.type === 'gallery' && (
+                                <DraftInputView
+                                  draftInputContext={draftInputContext}
+                                  type={DraftInputId.gallery}
+                                />
+                              )}
 
-                                {channel.type === 'notebook' && (
-                                  <DraftInputView
-                                    draftInputContext={draftInputContext}
-                                    type={DraftInputId.notebook}
-                                  />
-                                )}
-                              </>
-                            ) : (
-                              <DraftInputView
-                                draftInputContext={draftInputContext}
-                                type={
-                                  ChannelContentConfiguration.draftInput(
-                                    channel.contentConfiguration
-                                  ).id
-                                }
-                              />
-                            ))}
+                              {channel.type === 'notebook' && (
+                                <DraftInputView
+                                  draftInputContext={draftInputContext}
+                                  type={DraftInputId.notebook}
+                                />
+                              )}
+                            </>
+                          ) : (
+                            <DraftInputView
+                              draftInputContext={draftInputContext}
+                              type={
+                                ChannelContentConfiguration.draftInput(
+                                  channel.contentConfiguration
+                                ).id
+                              }
+                            />
+                          )}
 
-                          {!canWrite && <ReadOnlyNotice />}
+                          {!canWrite && <ReadOnlyNotice type="read-only" />}
 
                           {channel.isDmInvite && (
                             <DmInviteOptions
@@ -500,21 +504,3 @@ export const Channel = forwardRef<ChannelMethods, ChannelProps>(
     );
   }
 );
-
-function NegotionMismatchNotice() {
-  return (
-    <View alignItems="center" justifyContent="center" padding="$l">
-      <View
-        backgroundColor="$secondaryBackground"
-        borderRadius="$l"
-        paddingHorizontal="$l"
-        paddingVertical="$xl"
-      >
-        <SizableText size="$s">
-          Your ship&apos;s version of the Tlon app doesn&apos;t match the
-          channel host.
-        </SizableText>
-      </View>
-    </View>
-  );
-}

--- a/packages/shared/src/store/useChannelContext.ts
+++ b/packages/shared/src/store/useChannelContext.ts
@@ -1,6 +1,7 @@
 import { useCallback, useEffect, useMemo, useState } from 'react';
 
 import type { Post, PostMetadata } from '../db';
+import { isDmChannelId } from '../logic';
 import type { Story } from '../urbit';
 import * as dbHooks from './dbHooks';
 import * as postActions from './postActions';
@@ -61,12 +62,16 @@ export const useChannelContext = ({
   );
 
   // Version negotiation
-  const channelHost = useMemo(() => channelId.split('/')[1], [channelId]);
+  const isDM = isDmChannelId(channelId);
+  const channelHost = useMemo(
+    () => (isDM ? channelId : channelId.split('/')[1]),
+    [channelId, isDM]
+  );
 
   const negotiationStatus = useNegotiate(
     channelHost,
-    'channels',
-    'channels-server'
+    isDM ? 'chat' : 'channels',
+    isDM ? 'chat' : 'channels-server'
   );
 
   // Draft

--- a/packages/shared/src/store/useNegotiation.ts
+++ b/packages/shared/src/store/useNegotiation.ts
@@ -4,7 +4,10 @@ import { useCallback, useEffect, useMemo, useRef } from 'react';
 
 import * as api from '../api';
 import { queryClient } from '../api';
+import { createDevLogger } from '../debug';
 import { MatchingEvent, MatchingResponse } from '../urbit/negotiation';
+
+const logger = createDevLogger('useNegotiation', true);
 
 function negotiationUpdater(
   event: MatchingEvent | null,
@@ -85,14 +88,22 @@ export function useNegotiate(ship: string, app: string, agent: string) {
   }
 
   const isInData = `${ship}/${agent}` in data;
+  const status = data[`${ship}/${agent}`];
+  const matchedOrPending =
+    data[`${ship}/${agent}`] === 'match' ||
+    data[`${ship}/${agent}`] === 'await';
 
+  logger.log(
+    'Negotiation data:',
+    status,
+    matchedOrPending,
+    JSON.stringify(data)
+  );
   if (isInData) {
     return {
       ...rest,
-      status: data[`${ship}/${agent}`],
-      matchedOrPending:
-        data[`${ship}/${agent}`] === 'match' ||
-        data[`${ship}/${agent}`] === 'await',
+      status,
+      matchedOrPending,
     };
   }
 


### PR DESCRIPTION
Fixes TLON-3777. There were a few issues here. One was that we weren't actually showing mismatches for newer channels which use the channel configuration mechanism. Another was that for older notebooks/galleries we just weren't showing a version mismatch. Finally DMs were not being compat checked so I added that as well. I left out group DMs since I'm not sure what the proper behavior would be.