### PR TITLE
desktop: fix link formatting in notebooks

### DIFF
--- a/packages/app/ui/components/MessageInput/InputToolbar.tsx
+++ b/packages/app/ui/components/MessageInput/InputToolbar.tsx
@@ -192,7 +192,16 @@ const InputToolbar = memo(
         const linkBarProps: any = {
           theme: editor.theme,
           initialLink: editorState.activeLink,
-          onBlur: () => setToolbarContext(ToolbarContext.Main),
+          onBlur: () => {
+            if (Platform.OS === 'web') {
+              // Delay blur handling slightly to allow button press to register
+              setTimeout(() => {
+                setToolbarContext(ToolbarContext.Main);
+              }, 150); // 150 seems to be a good delay. 100 was too short.
+            } else {
+              setToolbarContext(ToolbarContext.Main);
+            }
+          },
           onLinkIconClick: () => {
             setToolbarContext(ToolbarContext.Main);
             editor.focus();


### PR DESCRIPTION
fixes tlon-4035

This was a bear to track down. The issue is that the `onBlur` from the input was firing before we could register the press to the "Insert" button in the EditLinkBar, so the formatting was just never applied.