### PR TITLE
embeds: fix issue with embeds losing interactability on mobile

### DIFF
--- a/packages/app/ui/components/Embed/EmbedWebView.tsx
+++ b/packages/app/ui/components/Embed/EmbedWebView.tsx
@@ -157,6 +157,17 @@ export const EmbedWebView = memo<EmbedWebViewProps>(
       currentHeightRef.current = webViewHeight;
     }, [webViewHeight]);
 
+    useEffect(() => {
+      const webView = webViewRef.current;
+      return () => {
+        if (webView) {
+          webView.stopLoading();
+          webView.clearHistory?.();
+          webView.clearCache?.(true);
+        }
+      };
+    }, []);
+
     const onLayoutHandler = useCallback((event: LayoutChangeEvent) => {
       if (!IS_ANDROID) return;
       const { height } = event.nativeEvent.layout;
@@ -246,7 +257,11 @@ export const EmbedWebView = memo<EmbedWebViewProps>(
       (navState: { url: string }) => {
         if (navState.url !== 'about:blank') {
           webViewRef.current?.stopLoading();
-          Linking.openURL(navState.url);
+          setTimeout(() => {
+            Linking.openURL(navState.url).catch((err) =>
+              logger.crumb('Failed to open URL:', err)
+            );
+          }, 50);
           return false;
         }
         return true;


### PR DESCRIPTION
fixes tlon-4038

This is difficult to repro, but my hypothesis is that this has to do with either a race condition in onNavigationChangeHandler or the fact that we don't cleanup the webview on dismount. This PR attempts to address both of those issues and also adds a catch with a logger.crumb call to get some more observability on why/how frequently we're failing to open embed links in the wild.