### PR TITLE
Mark channel threads read in "Mark read" action

### DIFF
--- a/packages/app/ui/components/ChatOptionsSheet.tsx
+++ b/packages/app/ui/components/ChatOptionsSheet.tsx
@@ -646,7 +646,9 @@ function ChannelOptionsSheetContent({
           },
           canMarkRead && {
             title: 'Mark as read',
-            action: wrappedAction.bind(null, markChannelRead),
+            action: wrappedAction.bind(null, () =>
+              markChannelRead({ includeThreads: true })
+            ),
           },
         ],
         channel.type === 'groupDm' && [

--- a/packages/app/ui/contexts/chatOptions.tsx
+++ b/packages/app/ui/contexts/chatOptions.tsx
@@ -22,7 +22,7 @@ export type ChatOptionsContextValue = {
   group?: db.Group | null;
   channel?: db.Channel | null;
   markGroupRead: () => void;
-  markChannelRead: () => void;
+  markChannelRead: (options?: { includeThreads?: boolean }) => void;
   onPressGroupMeta: (fromBlankChannel?: boolean) => void;
   onPressGroupMembers: () => void;
   onPressManageChannels: () => void;
@@ -223,11 +223,18 @@ export const ChatOptionsProvider = ({
     closeSheet();
   }, [closeSheet, groupId]);
 
-  const markChannelRead = useCallback(() => {
-    if (channelId) {
-      store.markChannelRead({ id: channelId, groupId: groupId });
-    }
-  }, [channelId, groupId]);
+  const markChannelRead = useCallback(
+    ({ includeThreads }: { includeThreads?: boolean } = {}) => {
+      if (channelId) {
+        store.markChannelRead({
+          id: channelId,
+          groupId: groupId,
+          includeThreads,
+        });
+      }
+    },
+    [channelId, groupId]
+  );
 
   const setChannelSortPreference = useCallback(
     (sortBy: 'recency' | 'arranged') => {

--- a/packages/shared/src/api/activityApi.ts
+++ b/packages/shared/src/api/activityApi.ts
@@ -609,22 +609,30 @@ export const readGroup = async (group: db.Group, deep: boolean = false) => {
   });
 };
 
-export const readChannel = async (
-  channel: Pick<db.Channel, 'id' | 'groupId' | 'type'>
-) => {
+export const readChannel = async ({
+  channelId,
+  channelType,
+  groupId,
+  deep,
+}: {
+  channelId: string;
+  channelType: db.ChannelType;
+  groupId?: string | null;
+  deep?: boolean;
+}) => {
   let source: ub.Source;
-  if (channel.type === 'dm') {
-    source = { dm: { ship: channel.id } };
-  } else if (channel.type == 'groupDm') {
-    source = { dm: { club: channel.id } };
+  if (channelType === 'dm') {
+    source = { dm: { ship: channelId } };
+  } else if (channelType == 'groupDm') {
+    source = { dm: { club: channelId } };
   } else {
-    source = { channel: { nest: channel.id, group: channel.groupId! } };
+    source = { channel: { nest: channelId, group: groupId! } };
   }
 
   const action = activityAction({
-    read: { source, action: { all: { time: null, deep: false } } },
+    read: { source, action: { all: { time: null, deep: !!deep } } },
   });
-  logger.log(`reading channel ${channel.id}`, action);
+  logger.log(`reading channel ${channelId}`, action);
 
   // simple retry logic to avoid failed read leading to lingering unread state
   return backOff(() => poke(action), {

--- a/packages/shared/src/db/queries.ts
+++ b/packages/shared/src/db/queries.ts
@@ -3554,9 +3554,15 @@ export const insertThreadUnreads = createWriteQuery(
 
 export const getThreadUnreadsByChannel = createReadQuery(
   'getThreadUnreadsByChannel',
-  async ({ channelId }: { channelId: string }, ctx: QueryCtx) => {
+  async (
+    { channelId, excludeRead }: { channelId: string; excludeRead?: boolean },
+    ctx: QueryCtx
+  ): Promise<ThreadUnreadState[]> => {
     return ctx.db.query.threadUnreads.findMany({
-      where: eq($threadUnreads.channelId, channelId),
+      where: and(
+        eq($threadUnreads.channelId, channelId),
+        excludeRead ? not(eq($threadUnreads.count, 0)) : undefined
+      ),
     });
   },
   ['threadUnreads']
@@ -3577,6 +3583,17 @@ export const clearThreadUnread = createWriteQuery(
           eq($threadUnreads.threadId, threadId)
         )
       );
+  },
+  ['threadUnreads']
+);
+
+export const clearChannelThreadUnreads = createWriteQuery(
+  'clearChannelThreadUnreads',
+  async ({ channelId }: { channelId: string }, ctx: QueryCtx) => {
+    return ctx.db
+      .update($threadUnreads)
+      .set({ count: 0, firstUnreadPostId: null })
+      .where(eq($threadUnreads.channelId, channelId));
   },
   ['threadUnreads']
 );

--- a/packages/shared/src/store/channelActions.ts
+++ b/packages/shared/src/store/channelActions.ts
@@ -323,15 +323,26 @@ export async function markChannelVisited(channelId: string) {
 export async function markChannelRead({
   id,
   groupId,
+  includeThreads,
 }: {
   id: string;
   groupId?: string;
+  includeThreads?: boolean;
 }) {
-  logger.log(`marking channel as read`, id);
+  logger.log(`marking channel as read`, id, 'includeThreads', includeThreads);
   // optimistic update
   const existingUnread = await db.getChannelUnread({ channelId: id });
   if (existingUnread) {
     await db.clearChannelUnread(id);
+  }
+
+  let existingThreadUnreads: db.ThreadUnreadState[] = [];
+  if (includeThreads) {
+    existingThreadUnreads = await db.getThreadUnreadsByChannel({
+      channelId: id,
+      excludeRead: true,
+    });
+    await db.clearChannelThreadUnreads({ channelId: id });
   }
 
   const existingCount = existingUnread?.count ?? 0;
@@ -354,12 +365,20 @@ export async function markChannelRead({
   }
 
   try {
-    await api.readChannel(existingChannel);
+    await api.readChannel({
+      channelId: existingChannel.id,
+      channelType: existingChannel.type,
+      groupId: existingChannel.groupId,
+      deep: !!includeThreads,
+    });
   } catch (e) {
     logger.error('Failed to read channel', { id, groupId }, e);
     // rollback optimistic update
     if (existingUnread) {
       await db.insertChannelUnreads([existingUnread]);
+    }
+    if (existingThreadUnreads.length > 0) {
+      await db.insertThreadUnreads(existingThreadUnreads);
     }
   }
 }


### PR DESCRIPTION
Previously, marking a channel as read from the `ChatOptionsSheet` would not that channel's threads as read. Now it does.

Fixes TLON-3839