### PR TITLE
ops: only deploy/test last commit

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -16,6 +16,9 @@ on:
       - "develop"
 env:
   tag: ${{ github.event.inputs.tag || 'develop' }}
+concurrency:
+  group: ${{ github.ref }}
+  cancel-in-progress: true
 jobs:
   build-frontend:
     runs-on: ubuntu-latest

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -17,7 +17,7 @@ on:
 env:
   tag: ${{ github.event.inputs.tag || 'develop' }}
 concurrency:
-  group: ${{ github.ref }}
+  group: ${{ format('{0}-{1}', github.ref, 'testing') }}
   cancel-in-progress: true
 jobs:
   build-frontend:

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -17,7 +17,7 @@ on:
 env:
   tag: ${{ github.event.inputs.tag || 'develop' }}
 concurrency:
-  group: ${{ format('{0}-{1}', github.ref, 'testing') }}
+  group: ${{ format('{0}-{1}', github.ref, 'deploy') }}
   cancel-in-progress: true
 jobs:
   build-frontend:

--- a/.github/workflows/mobile-testing.yml
+++ b/.github/workflows/mobile-testing.yml
@@ -3,6 +3,9 @@ on:
   push:
     branches: [develop]
   workflow_dispatch:
+concurrency:
+  group: ${{ github.ref }}
+  cancel-in-progress: true
 jobs:
   build:
     runs-on: ubuntu-latest

--- a/.github/workflows/mobile-testing.yml
+++ b/.github/workflows/mobile-testing.yml
@@ -4,7 +4,7 @@ on:
     branches: [develop]
   workflow_dispatch:
 concurrency:
-  group: ${{ github.ref }}
+  group: ${{ format('{0}-{1}', github.ref, 'testing') }}
   cancel-in-progress: true
 jobs:
   build:


### PR DESCRIPTION
The rapid fire PR commits kinda lock our ships down, so I think this should help with that. It basically will cancel any action currently running that matches the same group.