### PR TITLE
ImageViewerScreenView: image saving errors

### DIFF
--- a/packages/app/ui/components/ImageViewerScreenView.tsx
+++ b/packages/app/ui/components/ImageViewerScreenView.tsx
@@ -143,7 +143,7 @@ export function ImageViewerScreenView(props: {
             );
             return;
           }
-        case MediaLibrary.PermissionStatus.UNDETERMINED:
+        case MediaLibrary.PermissionStatus.UNDETERMINED: {
           const result = await MediaLibrary.requestPermissionsAsync();
           permissionStatus = result.status;
           if (permissionStatus !== MediaLibrary.PermissionStatus.GRANTED) {
@@ -158,6 +158,7 @@ export function ImageViewerScreenView(props: {
             return;
           }
           break;
+        }
       }
 
       if (!props.uri) {

--- a/packages/app/ui/components/ImageViewerScreenView.tsx
+++ b/packages/app/ui/components/ImageViewerScreenView.tsx
@@ -24,7 +24,7 @@ import { Stack, View, XStack, YStack, ZStack, isWeb } from 'tamagui';
 
 import { triggerHaptic } from '../utils';
 
-const logger = createDevLogger('imageViewer', true);
+const logger = createDevLogger('imageViewer', false);
 
 export function ImageViewerScreenView(props: {
   uri?: string;

--- a/packages/app/ui/components/ImageViewerScreenView.tsx
+++ b/packages/app/ui/components/ImageViewerScreenView.tsx
@@ -1,10 +1,18 @@
 import { ImageZoom, Zoomable } from '@likashefqet/react-native-image-zoom';
+import { createDevLogger } from '@tloncorp/shared';
 import { Icon } from '@tloncorp/ui';
 import { Image } from '@tloncorp/ui';
 import * as FileSystem from 'expo-file-system';
 import * as MediaLibrary from 'expo-media-library';
 import { ElementRef, PropsWithChildren, useRef, useState } from 'react';
-import { Alert, Dimensions, Modal, TouchableOpacity } from 'react-native';
+import {
+  Alert,
+  Dimensions,
+  Linking,
+  Modal,
+  Platform,
+  TouchableOpacity,
+} from 'react-native';
 import {
   Directions,
   Gesture,
@@ -15,6 +23,8 @@ import { useSafeAreaInsets } from 'react-native-safe-area-context';
 import { Stack, View, XStack, YStack, ZStack, isWeb } from 'tamagui';
 
 import { triggerHaptic } from '../utils';
+
+const logger = createDevLogger('imageViewer', true);
 
 export function ImageViewerScreenView(props: {
   uri?: string;
@@ -67,31 +77,160 @@ export function ImageViewerScreenView(props: {
 
   const handleDownloadImage = async () => {
     try {
-      const { status } = await MediaLibrary.requestPermissionsAsync();
-      if (status !== 'granted') {
-        Alert.alert(
-          'Permission needed',
-          'Please grant Tlon permission to save images'
-        );
+      const { status, canAskAgain } =
+        await MediaLibrary.requestPermissionsAsync();
+
+      switch (status) {
+        case MediaLibrary.PermissionStatus.GRANTED:
+          break;
+        case MediaLibrary.PermissionStatus.DENIED:
+          if (canAskAgain) {
+            logger.trackError('Photo library permission denied (temporary)', {
+              canAskAgain: true,
+            });
+            Alert.alert(
+              'Permission needed',
+              'Tlon needs permission to save images to your photo library. Would you like to grant permission now?',
+              [
+                {
+                  text: 'Cancel',
+                  style: 'cancel',
+                },
+                {
+                  text: 'Grant Permission',
+                  onPress: async () => {
+                    const { status: newStatus } =
+                      await MediaLibrary.requestPermissionsAsync();
+                    if (newStatus !== MediaLibrary.PermissionStatus.GRANTED) {
+                      logger.trackError(
+                        'Photo library permission denied after retry',
+                        { canAskAgain: true }
+                      );
+                      Alert.alert(
+                        'Permission denied',
+                        'To save images, please enable photo library access in your device settings.'
+                      );
+                    }
+                  },
+                },
+              ]
+            );
+            return;
+          } else {
+            logger.trackError('Photo library permission denied (permanent)', {
+              canAskAgain: false,
+            });
+            Alert.alert(
+              'Permission required',
+              'To save images, please enable photo library access in your device settings.',
+              [
+                {
+                  text: 'Cancel',
+                  style: 'cancel',
+                },
+                {
+                  text: 'Open Settings',
+                  onPress: () => {
+                    if (Platform.OS === 'ios') {
+                      Linking.openURL('app-settings:');
+                    } else {
+                      Linking.openSettings();
+                    }
+                  },
+                },
+              ]
+            );
+            return;
+          }
+        case MediaLibrary.PermissionStatus.UNDETERMINED:
+          const { status: newStatus } =
+            await MediaLibrary.requestPermissionsAsync();
+          if (newStatus !== MediaLibrary.PermissionStatus.GRANTED) {
+            logger.trackError(
+              'Photo library permission denied on first request',
+              { canAskAgain: true }
+            );
+            Alert.alert(
+              'Permission needed',
+              'Tlon needs permission to save images to your photo library. Please grant permission in the next prompt.'
+            );
+            return;
+          }
+          break;
+      }
+
+      if (!props.uri) {
+        logger.trackError('Attempted to save image with no URI', {
+          hasUri: false,
+        });
+        Alert.alert('Error', 'No image URL provided');
         return;
       }
 
-      const filename = props.uri?.split('/').pop() || 'downloaded-image.jpg';
+      const filename = props.uri.split('/').pop() || 'downloaded-image.jpg';
       const localUri = `${FileSystem.documentDirectory}${filename}`;
-      const downloadResult = await FileSystem.downloadAsync(
-        props.uri!,
-        localUri
-      );
 
-      if (downloadResult.status === 200) {
-        await MediaLibrary.saveToLibraryAsync(localUri);
-        await FileSystem.deleteAsync(localUri);
+      try {
+        const downloadResult = await FileSystem.downloadAsync(
+          props.uri,
+          localUri
+        );
 
-        Alert.alert('Success', 'Image saved to your photos!');
+        if (downloadResult.status !== 200) {
+          logger.trackError('Failed to download image', {
+            status: downloadResult.status,
+            uri: props.uri,
+          });
+          throw new Error(
+            `Download failed with status ${downloadResult.status}`
+          );
+        }
+
+        try {
+          await MediaLibrary.saveToLibraryAsync(localUri);
+          Alert.alert('Success', 'Image saved to your photos!');
+        } catch (saveError) {
+          logger.trackError('Failed to save image to library', {
+            error: saveError.message,
+            uri: props.uri,
+          });
+          Alert.alert(
+            'Error',
+            'Failed to save image to photos. Please check your device storage and try again.'
+          );
+          console.error('Save error:', saveError);
+        } finally {
+          try {
+            await FileSystem.deleteAsync(localUri);
+          } catch (deleteError) {
+            logger.trackError('Failed to delete temporary image file', {
+              error: deleteError.message,
+              uri: localUri,
+            });
+            console.error('Failed to delete temporary file:', deleteError);
+          }
+        }
+      } catch (downloadError) {
+        logger.trackError('Failed to download image', {
+          error: downloadError.message,
+          uri: props.uri,
+        });
+        Alert.alert(
+          'Error',
+          'Failed to download image. Please check your internet connection and try again.'
+        );
+        console.error('Download error:', downloadError);
       }
     } catch (error) {
-      Alert.alert('Error', 'Failed to save image');
-      console.error('Download error:', error);
+      logger.trackError('Unexpected error saving image', {
+        error: error.message,
+        uri: props.uri,
+      });
+      Alert.alert(
+        'Error',
+        'An unexpected error occurred while saving the image. Please try again.'
+      );
+      console.error('Unexpected error:', error);
     }
   };
 

--- a/packages/app/ui/components/ImageViewerScreenView.tsx
+++ b/packages/app/ui/components/ImageViewerScreenView.tsx
@@ -79,6 +79,7 @@ export function ImageViewerScreenView(props: {
     try {
       const { status, canAskAgain } =
         await MediaLibrary.requestPermissionsAsync();
+      let permissionStatus;
 
       switch (status) {
         case MediaLibrary.PermissionStatus.GRANTED:
@@ -99,9 +100,9 @@ export function ImageViewerScreenView(props: {
                 {
                   text: 'Grant Permission',
                   onPress: async () => {
-                    const { status: newStatus } =
+                    const { status: retryStatus } =
                       await MediaLibrary.requestPermissionsAsync();
-                    if (newStatus !== MediaLibrary.PermissionStatus.GRANTED) {
+                    if (retryStatus !== MediaLibrary.PermissionStatus.GRANTED) {
                       logger.trackError(
                         'Photo library permission denied after retry',
                         { canAskAgain: true }
@@ -143,9 +144,9 @@ export function ImageViewerScreenView(props: {
             return;
           }
         case MediaLibrary.PermissionStatus.UNDETERMINED:
-          const { status: newStatus } =
-            await MediaLibrary.requestPermissionsAsync();
-          if (newStatus !== MediaLibrary.PermissionStatus.GRANTED) {
+          const result = await MediaLibrary.requestPermissionsAsync();
+          permissionStatus = result.status;
+          if (permissionStatus !== MediaLibrary.PermissionStatus.GRANTED) {
             logger.trackError(
               'Photo library permission denied on first request',
               { canAskAgain: true }

--- a/packages/app/ui/components/InviteFriendsToTlonButton.tsx
+++ b/packages/app/ui/components/InviteFriendsToTlonButton.tsx
@@ -39,7 +39,7 @@ export function InviteFriendsToTlonButton({
 
   useEffect(() => {
     logger.trackEvent('Invite Button Shown', { group: group?.id });
-  }, []);
+  }, [group?.id]);
 
   const handleInviteButtonPress = useCallback(async () => {
     if (shareUrl && status === 'ready' && group) {


### PR DESCRIPTION
Fixes TLON-4052 by getting Very Serious about the save image prompt. Makes the following changes:

- Adds comprehensive error tracking w/ PostHog
- Adds proper permission state handling
- Cleans up the temporarily-downloaded file
- Adds a bunch of validation checks and handles the errors appropriately

This also prompts the user to visit their app settings to grant permission if they haven't (copied this from where we handle notification prompts)

<img width="607" alt="image" src="https://github.com/user-attachments/assets/7ec435d8-a49a-4aaa-8d83-9a5d16bdc365" />
