### PR TITLE
profile: fix crash on edit screen

### DIFF
--- a/packages/app/ui/components/ListItem/ChannelListItem.tsx
+++ b/packages/app/ui/components/ListItem/ChannelListItem.tsx
@@ -29,7 +29,7 @@ export function ChannelListItem({
   onLayout?: (e: any) => void;
 } & ListItemProps<db.Channel>) {
   const [open, setOpen] = useState(false);
-  const { setChat } = useChatOptions();
+  const { setChat } = useChatOptions(disableOptions);
   const [isHovered, setIsHovered] = useState(false);
   const containerRef = useRef<HTMLDivElement>(null);
   const unreadCount = model.unread?.count ?? 0;

--- a/packages/app/ui/components/ListItem/GroupListItem.tsx
+++ b/packages/app/ui/components/ListItem/GroupListItem.tsx
@@ -23,7 +23,7 @@ export const GroupListItem = ({
   ...props
 }: { customSubtitle?: string } & ListItemProps<db.Group>) => {
   const [open, setOpen] = useState(false);
-  const { setChat } = useChatOptions();
+  const { setChat } = useChatOptions(disableOptions);
   const [isHovered, setIsHovered] = useState(false);
   const containerRef = useRef<HTMLDivElement>(null);
   const unreadCount = model.unread?.count ?? 0;

--- a/packages/app/ui/contexts/chatOptions.tsx
+++ b/packages/app/ui/contexts/chatOptions.tsx
@@ -42,10 +42,38 @@ export type ChatOptionsContextValue = {
   setChat: (chat: { id: string; type: 'group' | 'channel' } | null) => void;
 } | null;
 
+const defaultValue: ChatOptionsContextValue = {
+  useGroup: store.useGroup,
+  group: null,
+  channel: null,
+  markGroupRead: () => {},
+  markChannelRead: () => {},
+  onPressGroupMeta: () => {},
+  onPressGroupMembers: () => {},
+  onPressManageChannels: () => {},
+  onPressInvite: () => {},
+  onPressGroupPrivacy: () => {},
+  onPressRoles: () => {},
+  onPressChannelMembers: () => {},
+  onPressChannelMeta: () => {},
+  onPressChannelTemplate: () => {},
+  onPressChatDetails: () => {},
+  togglePinned: () => {},
+  leaveGroup: async () => {}, 
+  leaveChannel: () => {},
+  updateVolume: () => {},
+  setChannelSortPreference: () => {},
+  open: () => {},
+  setChat: () => {},
+};
+
 const ChatOptionsContext = createContext<ChatOptionsContextValue>(null);
 
-export const useChatOptions = () => {
+export const useChatOptions = (disabled = false) => {
   const value = useContext(ChatOptionsContext);
+  if (disabled) {
+    return defaultValue;
+  }
   if (!value) {
     throw new Error('useChatOptions used outside of ChatOptions context');
   }


### PR DESCRIPTION
fixes tlon-4056

I introduced a change recently (for the context menus) where we call `setChat` from `useChatOptions` in GroupListItem. We also happen to use GroupListItem in the FavoriteGroupsDisplay via the GroupSelectorSheet, where we pass `disableOptions` to the component.

`useChatOptions` will throw an error if it's called outside of a ChatOptions context.

Since we know there are cases where a component might use `useChatOptions` but also allow for the options to be disabled, we need to pass a `disabled` parameter to `useChatOptions` to prevent it from throwing an error when it's called outside of a ChatOptions context.

update: now fixes tlon-4059