### PR TITLE
fix "untitled group" issue

### DIFF
--- a/desk/app/groups.hoon
+++ b/desk/app/groups.hoon
@@ -837,8 +837,8 @@
   =.  fleet.group
     =/  our-vessel=vessel:fleet:g  (~(gut by fleet.group) our.bowl *vessel:fleet:g)
     =/  fleet-size=@ud  ~(wyt by fleet.group)
-    ?:  (lte fleet-size 3)
-      fleet.group  :: keep all members if 3 or fewer
+    ?:  (lte fleet-size 15)
+      fleet.group  :: keep all members if 15 or fewer
     =/  other-ships=(list [ship vessel:fleet:g])
       %+  sort
         ~(tap by (~(del by fleet.group) our.bowl))
@@ -846,7 +846,7 @@
       (aor (scot %p a) (scot %p b)) :: alphabetical order by ship name
     =/  keep-ships=(list [ship vessel:fleet:g])
       :-  [our.bowl our-vessel]
-      (scag 2 other-ships)  :: take first 2 other ships
+      (scag 14 other-ships)  :: take first 14 other ships
     (~(gas by *fleet:g) keep-ships)
   group
 ::

--- a/desk/app/groups.hoon
+++ b/desk/app/groups.hoon
@@ -835,9 +835,22 @@
   |=  =group:g
   ^-  group:g
   =.  fleet.group
-    %+  ~(put by *fleet:g)
-      our.bowl
-    (~(gut by fleet.group) our.bowl *vessel:fleet:g)
+    =/  our-vessel=vessel:fleet:g  (~(gut by fleet.group) our.bowl *vessel:fleet:g)
+    =/  fleet-size=@ud  ~(wyt by fleet.group)
+    ?:  (lte fleet-size 3)
+      fleet.group  :: keep all members if 3 or fewer
+    =/  other-ships=(list [ship vessel:fleet:g])
+      %+  sort
+        %+  skip
+          ~(tap by fleet.group)
+        |=([=ship *] =(ship our.bowl))
+      |=  [[a=ship *] [b=ship *]]
+      (aor a b)  :: alphabetical order by ship name
+    =/  keep-ships=(list [ship vessel:fleet:g])
+      %+  weld
+        ~[[our.bowl our-vessel]]
+      (scag 2 other-ships)  :: take first 2 other ships
+    (~(gas by *fleet:g) keep-ships)
   group
 ::
 ++  to-claim-2

--- a/desk/app/groups.hoon
+++ b/desk/app/groups.hoon
@@ -841,14 +841,11 @@
       fleet.group  :: keep all members if 3 or fewer
     =/  other-ships=(list [ship vessel:fleet:g])
       %+  sort
-        %+  skip
-          ~(tap by fleet.group)
-        |=([=ship *] =(ship our.bowl))
+        ~(tap by (~(del by fleet.group) our.bowl))
       |=  [[a=ship *] [b=ship *]]
-      (aor a b)  :: alphabetical order by ship name
+      (aor (scot %p a) (scot %p b)) :: alphabetical order by ship name
     =/  keep-ships=(list [ship vessel:fleet:g])
-      %+  weld
-        ~[[our.bowl our-vessel]]
+      :-  [our.bowl our-vessel]
       (scag 2 other-ships)  :: take first 2 other ships
     (~(gas by *fleet:g) keep-ships)
   group

--- a/packages/app/hooks/useResolvedChats.ts
+++ b/packages/app/hooks/useResolvedChats.ts
@@ -66,6 +66,21 @@ export function useResolvedChats(chats: UseCurrentChatsResult): {
           ),
         0
       ),
+      pinnedTitles: chats.pinned
+        .map((chat) =>
+          chat.type === 'group' ? chat.group.title : chat.channel.title
+        )
+        .join('|'),
+      unpinnedTitles: chats.unpinned
+        .map((chat) =>
+          chat.type === 'group' ? chat.group.title : chat.channel.title
+        )
+        .join('|'),
+      pendingTitles: chats.pending
+        .map((chat) =>
+          chat.type === 'group' ? chat.group.title : chat.channel.title
+        )
+        .join('|'),
     });
 
     if (newSignature !== chatSignature) {

--- a/packages/app/ui/components/ListItem/GroupListItem.tsx
+++ b/packages/app/ui/components/ListItem/GroupListItem.tsx
@@ -12,7 +12,7 @@ import { ListItem, ListItemProps } from './ListItem';
 import { getGroupStatus, getPostTypeIcon } from './listItemUtils';
 import { ChatOptionsSheet } from '../ChatOptionsSheet';
 import { useState, useRef, useEffect, useCallback, useMemo } from 'react';
-import { useChatOptions } from '../../contexts';
+import { useChatOptions, useContact } from '../../contexts';
 
 export const GroupListItem = ({
   model,
@@ -28,8 +28,9 @@ export const GroupListItem = ({
   const containerRef = useRef<HTMLDivElement>(null);
   const unreadCount = model.unread?.count ?? 0;
   const notified = model.unread?.notify ?? false;
-  const title = useGroupTitle(model);
   const { isPending, label: statusLabel, isErrored } = getGroupStatus(model);
+  const hostContact = useContact(model.hostUserId);
+  const title = useGroupTitle(model, hostContact);
 
   const handleHoverIn = useCallback(() => {
     if (isWeb) {
@@ -148,7 +149,8 @@ export const GroupListItem = ({
                   Group invitation
                 </ListItem.SubtitleWithIcon>
                 <ListItem.Subtitle>
-                  Hosted by <ContactName contactId={model.hostUserId} />
+                  Hosted by{' '}
+                  <ContactName contactId={model.hostUserId} numberOfLines={1} />
                 </ListItem.Subtitle>
               </>
             ) : null}

--- a/packages/shared/src/db/queries.ts
+++ b/packages/shared/src/db/queries.ts
@@ -756,10 +756,17 @@ export const insertGroups = createWriteQuery(
         }
         if (group.members?.length) {
           logger.log('insertGroups: inserting members', group.members);
+          // Delete existing members for this group before inserting the new ones
+          // This ensures all member data including membershipType is properly updated
+          await txCtx.db
+            .delete($chatMembers)
+            .where(eq($chatMembers.chatId, group.id));
+          
+          // Insert the new members
           await txCtx.db
             .insert($chatMembers)
-            .values(group.members)
-            .onConflictDoNothing();
+            .values(group.members);
+            
           const validRoleNames = group.roles?.map((r) => r.id);
           const memberRoles = group.members.flatMap((m) => {
             return (m.roles ?? []).flatMap((r) => {

--- a/packages/shared/src/db/queries.ts
+++ b/packages/shared/src/db/queries.ts
@@ -756,17 +756,14 @@ export const insertGroups = createWriteQuery(
         }
         if (group.members?.length) {
           logger.log('insertGroups: inserting members', group.members);
-          // Delete existing members for this group before inserting the new ones
-          // This ensures all member data including membershipType is properly updated
-          await txCtx.db
-            .delete($chatMembers)
-            .where(eq($chatMembers.chatId, group.id));
-          
-          // Insert the new members
           await txCtx.db
             .insert($chatMembers)
-            .values(group.members);
-            
+            .values(group.members)
+            .onConflictDoUpdate({
+              target: [$chatMembers.chatId, $chatMembers.contactId],
+              set: conflictUpdateSetAll($chatMembers),
+            });
+
           const validRoleNames = group.roles?.map((r) => r.id);
           const memberRoles = group.members.flatMap((m) => {
             return (m.roles ?? []).flatMap((r) => {


### PR DESCRIPTION
fixes tlon-4022

There were a few issues causing this.

1) We never know the group members when we're invited to a group, and if a title wasn't set we would just show the user "Untitled Group".
2) We weren't getting a full fleet list from the groups-ui init api response because we were purposefully dropping the fleet (with `drop-fleet` in the groups agent) and replacing it with just our own ship to speed the request up. This meant that when the app was initialized (which happens on every refresh on web), every group without a title would just appear as "Untitled Group".
3) After entering the group and triggering `syncGroup`, we grab the specific data for that group from the api and insert it into the db. This *should* have updated the group member list permanently in the db, but it wasn't because of an `onConflictDoNothing()` call. 

Fixes:
For 1): I changed it so we now show "New group by {host}" when the group doesn't have a title.
For 2): I updated the `drop-fleet` arm in `groups.hoon` to actually return at least 3 members of the fleet if we can.
For 3): I replaced that `onConflictDoNothing()` with ~a hard overwrite of the group members in insertGroups~ `onConflictDoUpdate()`.

Also, for good measure, I updated useResolvedChats to make sure that it updates when a group/chat title changes.

