### PR TITLE
ContactsScreen, ProfileNavigator: immediately add suggested contact

### DIFF
--- a/packages/app/features/top/ContactsScreen.tsx
+++ b/packages/app/features/top/ContactsScreen.tsx
@@ -34,14 +34,14 @@ export default function ContactsScreen(props: Props) {
 
   const onContactPress = useCallback(
     (contact: db.Contact) => {
-      if (contact.isContactSuggestion) {
-        store.addContact(contact.id);
-      } else {
-        navigate('UserProfile', { userId: contact.id });
-      }
+      navigate('UserProfile', { userId: contact.id });
     },
     [navigate]
   );
+
+  const onAddContact = useCallback((contact: db.Contact) => {
+    store.addContact(contact.id);
+  }, []);
 
   const onContactLongPress = useCallback((contact: db.Contact) => {
     if (!isWeb && contact.isContactSuggestion) {
@@ -99,6 +99,7 @@ export default function ContactsScreen(props: Props) {
             contacts={userContacts ?? []}
             suggestions={suggestions ?? []}
             onContactPress={onContactPress}
+            onAddContact={onAddContact}
             onContactLongPress={onContactLongPress}
           />
           <NavBarView

--- a/packages/app/features/top/ContactsScreen.tsx
+++ b/packages/app/features/top/ContactsScreen.tsx
@@ -34,7 +34,11 @@ export default function ContactsScreen(props: Props) {
 
   const onContactPress = useCallback(
     (contact: db.Contact) => {
-      navigate('UserProfile', { userId: contact.id });
+      if (contact.isContactSuggestion) {
+        store.addContact(contact.id);
+      } else {
+        navigate('UserProfile', { userId: contact.id });
+      }
     },
     [navigate]
   );

--- a/packages/app/navigation/desktop/ProfileNavigator.tsx
+++ b/packages/app/navigation/desktop/ProfileNavigator.tsx
@@ -34,7 +34,11 @@ function DrawerContent(props: DrawerContentComponentProps) {
 
   const onContactPress = useCallback(
     (contact: db.Contact) => {
-      navigate('UserProfile', { userId: contact.id });
+      if (contact.isContactSuggestion) {
+        store.addContact(contact.id);
+      } else {
+        navigate('UserProfile', { userId: contact.id });
+      }
     },
     [navigate]
   );

--- a/packages/app/navigation/desktop/ProfileNavigator.tsx
+++ b/packages/app/navigation/desktop/ProfileNavigator.tsx
@@ -34,14 +34,14 @@ function DrawerContent(props: DrawerContentComponentProps) {
 
   const onContactPress = useCallback(
     (contact: db.Contact) => {
-      if (contact.isContactSuggestion) {
-        store.addContact(contact.id);
-      } else {
-        navigate('UserProfile', { userId: contact.id });
-      }
+      navigate('UserProfile', { userId: contact.id });
     },
     [navigate]
   );
+
+  const onAddContact = useCallback((contact: db.Contact) => {
+    store.addContact(contact.id);
+  }, []);
 
   const onContactLongPress = useCallback((contact: db.Contact) => {
     if (!isWeb && contact.isContactSuggestion) {
@@ -84,6 +84,7 @@ function DrawerContent(props: DrawerContentComponentProps) {
         suggestions={suggestions ?? []}
         focusedContactId={focusedRoute.params?.userId}
         onContactPress={onContactPress}
+        onAddContact={onAddContact}
         onContactLongPress={onContactLongPress}
       />
     </View>

--- a/packages/app/ui/components/Badge.tsx
+++ b/packages/app/ui/components/Badge.tsx
@@ -1,3 +1,4 @@
+import { Pressable } from '@tloncorp/ui';
 import { ComponentProps } from 'react';
 import { ColorTokens, SizableText, View } from 'tamagui';
 
@@ -18,16 +19,20 @@ const badgeText: Record<BadgeType, ColorTokens> = {
 export function Badge({
   text,
   type = 'positive',
+  onPress,
+  ...props
 }: {
   text: string;
   type?: BadgeType;
+  onPress?: (e: React.MouseEvent | React.TouchEvent) => void;
 } & ComponentProps<typeof View>) {
-  return (
+  const content = (
     <View
       backgroundColor={badgeBackground[type]}
       paddingVertical="$xs"
       paddingHorizontal="$l"
       borderRadius="$xl"
+      {...props}
     >
       <SizableText
         size="$s"
@@ -39,4 +44,19 @@ export function Badge({
       </SizableText>
     </View>
   );
+
+  if (onPress) {
+    return (
+      <Pressable
+        onPress={(e) => {
+          e.stopPropagation();
+          onPress(e);
+        }}
+      >
+        {content}
+      </Pressable>
+    );
+  }
+
+  return content;
 }

--- a/packages/app/ui/components/ContactsScreenView.tsx
+++ b/packages/app/ui/components/ContactsScreenView.tsx
@@ -15,6 +15,7 @@ interface Props {
   suggestions: db.Contact[];
   focusedContactId?: string;
   onContactPress: (contact: db.Contact) => void;
+  onAddContact: (contact: db.Contact) => void;
   onContactLongPress: (contact: db.Contact) => void;
 }
 
@@ -69,7 +70,14 @@ export function ContactsScreenView(props: Props) {
           showEndContent
           endContent={
             item.isContactSuggestion && !isSelf ? (
-              <Badge text="Add" type="positive" />
+              <Badge
+                text="Add"
+                type="positive"
+                onPress={(e) => {
+                  e.stopPropagation();
+                  props.onAddContact(item);
+                }}
+              />
             ) : isSelf ? (
               <XStack gap="$xs" alignItems="center">
                 <Badge


### PR DESCRIPTION
Fixes TLON-3935, a common complaint with suggested contacts. This changes the click/tap handlers for suggested contact rows to immediately add the suggested contact to the user's contacts, rather than navigating them to their profile.