### PR TITLE
chat input: fix issue with drafts not always clearing on send

### DIFF
--- a/packages/shared/src/db/storageItem.ts
+++ b/packages/shared/src/db/storageItem.ts
@@ -42,6 +42,7 @@ export const createStorageItem = <T>(config: StorageItemConfig<T>) => {
   let updateLock = Promise.resolve();
 
   const getValue = async (): Promise<T> => {
+    await updateLock;
     const value = await storage.getItem(key);
 
     if (!value) {


### PR DESCRIPTION
fixes tlon-4055

The root cause was a race condition in `storageItem.ts`. The getValue function could read from storage before a pending setValue or resetValue operation (triggered by clearDraft) had completed writing, due to not awaiting the internal updateLock.

This change modifies getValue to await updateLock before reading, ensuring that reads only occur after any pending writes for the same key are finished. This should eliminate the race condition and ensure that drafts are reliably cleared.