### PR TITLE
nav: specify screen to ensure proper nav

### DIFF
--- a/apps/tlon-mobile/src/components/AuthenticatedApp.tsx
+++ b/apps/tlon-mobile/src/components/AuthenticatedApp.tsx
@@ -30,7 +30,6 @@ function AuthenticatedApp() {
   useNotificationListener();
   useUpdatePresentedNotifications();
   useDeepLinkListener();
-  useNavigationLogging();
   useNetworkLogger();
   useCheckAppUpdated();
   useFindSuggestedContacts();
@@ -87,8 +86,8 @@ export default function ConnectedAuthenticatedApp() {
 
   return (
     <AppDataProvider>
-      {/* 
-        This portal provider overrides the root portal provider 
+      {/*
+        This portal provider overrides the root portal provider
         to ensure that sheets have access to `AppDataContext`
       */}
       <PortalProvider>{clientReady && <AuthenticatedApp />}</PortalProvider>

--- a/packages/app/hooks/useNavigationLogger.ts
+++ b/packages/app/hooks/useNavigationLogger.ts
@@ -25,6 +25,11 @@ export function useNavigationLogging() {
       ) {
         logger.crumb(`to: ${currentRouteName}, from: ${previousRouteName}`);
       }
+      logger.log(
+        `to: ${currentRouteName}, from: ${previousRouteName}`,
+        'current state:',
+        state
+      );
 
       // Update the route name ref
       routeNameRef.current = currentRouteName;

--- a/packages/app/navigation/BasePathNavigator.tsx
+++ b/packages/app/navigation/BasePathNavigator.tsx
@@ -7,6 +7,7 @@ import { createNativeStackNavigator } from '@react-navigation/native-stack';
 import { storage } from '@tloncorp/shared/db';
 import { memo, useEffect, useMemo, useRef } from 'react';
 
+import { useNavigationLogging } from '../hooks/useNavigationLogger';
 import { useRenderCount } from '../hooks/useRenderCount';
 import { RootStack } from './RootStack';
 import { TopLevelDrawer } from './desktop/TopLevelDrawer';
@@ -39,6 +40,7 @@ export const BasePathNavigator = memo(({ isMobile }: { isMobile: boolean }) => {
     ? MobileBasePathStackNavigator
     : DesktopBasePathStackNavigator;
 
+  useNavigationLogging();
   const navStateIndex = useNavigationState((state) => state?.index);
   const navStateRoutes = useNavigationState((state) => state?.routes);
   const currentRoute = useMemo(

--- a/packages/app/navigation/utils.ts
+++ b/packages/app/navigation/utils.ts
@@ -154,6 +154,13 @@ function useNavigateToChannel() {
           channel.groupId ?? undefined,
           selectedPostId
         );
+        logger.log('navigateToChannel', {
+          channelRoute,
+          tab,
+          channelId: channel.id,
+          groupId: channel.groupId,
+          selectedPostId,
+        });
         navigation.navigate(channelRoute);
       }
     },
@@ -173,17 +180,22 @@ export function useNavigateToPost() {
 
   return useCallback(
     (post: db.Post) => {
+      const postParams = {
+        postId: post.id,
+        authorId: post.authorId,
+        channelId: post.channelId,
+        groupId: post.groupId ?? undefined,
+      };
+
       if (!isWindowNarrow && currentScreenIsActivity) {
-        navigation.navigate(getTab(navigation, lastOpenTab), {
+        const tab = getTab(navigation, lastOpenTab);
+        logger.log('navigateToPost', tab, postParams);
+
+        navigation.navigate(tab, {
           screen: 'Channel',
           params: {
             screen: 'Post',
-            params: {
-              postId: post.id,
-              authorId: post.authorId,
-              channelId: post.channelId,
-              groupId: post.groupId ?? undefined,
-            },
+            params: postParams,
           },
         });
         return;
@@ -266,7 +278,7 @@ function getTab(
       ? parent
       : navigation.getState();
 
-  logger.log(parent, navigation.getState());
+  logger.log('looking for drawer', parent, navigation.getState());
   if (state.type !== 'drawer' || state.routes[state.index]?.name === 'Root') {
     console.warn(
       'Top-level navigator is not a drawer navigator, using lastOpenTab'
@@ -409,11 +421,13 @@ export function getDesktopChannelRoute(
     name: tab,
     params: {
       screen: screenName,
-      initial: true,
       params: {
-        channelId,
-        selectedPostId,
-        ...(groupId ? { groupId } : {}),
+        screen: 'ChannelRoot',
+        params: {
+          channelId,
+          selectedPostId,
+          ...(groupId ? { groupId } : {}),
+        },
       },
     },
   } as const;


### PR DESCRIPTION
Fixes TLON-3982, there's some weird behavior in react navigation where any navigate call that doesn't specify `initial: false` will make itself the "initial" route for a particular stack. This caused problems because if you navigated from activity to a thread/post, the initial route for the channel stack would be "Post". So later when we tried to nav with `initial: true` we'd get "Post" instead of "ChannelRoot". I just tried to avoid this implicit behavior by just being specific about what screen we actually wanted.

Also added some more logging.