### PR TITLE
BareChatInput: reliably autofocus on web

### DIFF
--- a/packages/app/ui/components/BareChatInput/index.tsx
+++ b/packages/app/ui/components/BareChatInput/index.tsx
@@ -225,7 +225,6 @@ export default function BareChatInput({
   const [sendError, setSendError] = useState(false);
   const [hasSetInitialContent, setHasSetInitialContent] = useState(false);
   const [editorIsEmpty, setEditorIsEmpty] = useState(attachments.length === 0);
-  const [hasAutoFocused, setHasAutoFocused] = useState(false);
   const [needsHeightAdjustmentAfterLoad, setNeedsHeightAdjustmentAfterLoad] =
     useState(false);
   const {
@@ -516,11 +515,12 @@ export default function BareChatInput({
 
   // Handle autofocus
   useEffect(() => {
-    if (!shouldBlur && shouldAutoFocus && !hasAutoFocused) {
-      inputRef.current?.focus();
-      setHasAutoFocused(true);
+    if (!shouldBlur && shouldAutoFocus && inputRef.current) {
+      if (!inputRef.current.isFocused()) {
+        inputRef.current.focus();
+      }
     }
-  }, [shouldBlur, shouldAutoFocus, hasAutoFocused]);
+  }, [shouldBlur, shouldAutoFocus]);
 
   // Blur input when needed
   useEffect(() => {

--- a/packages/app/ui/components/BareChatInput/index.tsx
+++ b/packages/app/ui/components/BareChatInput/index.tsx
@@ -225,6 +225,7 @@ export default function BareChatInput({
   const [sendError, setSendError] = useState(false);
   const [hasSetInitialContent, setHasSetInitialContent] = useState(false);
   const [editorIsEmpty, setEditorIsEmpty] = useState(attachments.length === 0);
+  const [hasAutoFocused, setHasAutoFocused] = useState(false);
   const [needsHeightAdjustmentAfterLoad, setNeedsHeightAdjustmentAfterLoad] =
     useState(false);
   const {
@@ -513,14 +514,21 @@ export default function BareChatInput({
     runSendMessage(true);
   }, [runSendMessage, editingPost]);
 
-  // Handle autofocus
   useEffect(() => {
-    if (!shouldBlur && shouldAutoFocus && inputRef.current) {
+    if (shouldAutoFocus && !hasAutoFocused && !shouldBlur && inputRef.current) {
+      // Check if the input is not already focused (extra precaution)
       if (!inputRef.current.isFocused()) {
         inputRef.current.focus();
       }
+      // Mark as focused for this channel context
+      setHasAutoFocused(true);
     }
-  }, [shouldBlur, shouldAutoFocus]);
+  }, [shouldAutoFocus, hasAutoFocused, shouldBlur]);
+
+  // Reset when the channel context changes
+  useEffect(() => {
+    setHasAutoFocused(false);
+  }, [channelId]);
 
   // Blur input when needed
   useEffect(() => {


### PR DESCRIPTION
Fixes TLON-3959 where the chat input doesn't autofocus, especially when the window loses and then regains focus.

BareChatInput had a useEffect to trigger the autofocus based on shouldAutoFocus, which was passed down from ChatInput. However, hasAutoFocused was set to true the first time the input was focused and would therefore never actually autofocus again. When the user navigated away and came back, the hook saw that hasAutoFocused was true, then skipped the focus() call.

To fix, I removed hasAutoFocused from the useEffect dependencies because we don't ever want to _prevent_ autofocusing. This seems to reliably keep the cursor active in the chat input field between channel / group navigations, browser tab switches, virtual desktop changes, etc.