### PR TITLE
profile: click-to-copy feedback

### DIFF
--- a/packages/app/ui/components/UserProfileScreenView.tsx
+++ b/packages/app/ui/components/UserProfileScreenView.tsx
@@ -364,42 +364,44 @@ function UserInfoRow(props: { userId: string; hasNickname: boolean }) {
     triggerHaptic('success');
   }, [doCopy]);
 
+  const primaryNameProps = props.hasNickname
+    ? { mode: 'nickname' as const, color: '$primaryText' }
+    : { mode: 'contactId' as const };
+
   return (
     <Pressable width="100%" onPress={handleCopy}>
       <XStack alignItems="center" padding="$l" gap="$xl" width={'100%'}>
         <ContactAvatar contactId={props.userId} size="$5xl" />
         <YStack flex={1} justifyContent="center">
-          {props.hasNickname ? (
-            <>
-              <ContactName
-                contactId={props.userId}
-                color="$primaryText"
-                mode="nickname"
-                fontSize={24}
-                lineHeight={24}
-                maxWidth="100%"
-                numberOfLines={1}
-              />
-              <XStack alignItems="center">
-                <Text color="$secondaryText">
-                  <ContactName contactId={props.userId} mode="contactId" />
-                </Text>
-                {didCopy ? (
+          <ContactName
+            contactId={props.userId}
+            fontSize={24}
+            lineHeight={32}
+            maxWidth="100%"
+            numberOfLines={1}
+            {...primaryNameProps}
+          />
+          {(props.hasNickname || didCopy) && (
+            <XStack alignItems="center">
+              {didCopy ? (
+                <>
                   <Icon
                     type="Checkmark"
                     customSize={[14, 14]}
                     position="relative"
                     top={1}
+                    color="$secondaryText"
                   />
-                ) : null}
-              </XStack>
-            </>
-          ) : (
-            <ContactName
-              fontSize={24}
-              lineHeight={24}
-              contactId={props.userId}
-            />
+                  <Text color="$secondaryText">Copied!</Text>
+                </>
+              ) : (
+                props.hasNickname && (
+                  <Text color="$secondaryText">
+                    <ContactName contactId={props.userId} mode="contactId" />
+                  </Text>
+                )
+              )}
+            </XStack>
           )}
         </YStack>
       </XStack>


### PR DESCRIPTION
Fixes TLON-4049 by making the click-to-copy ID function in profiles very obvious.

I simplified the ContactName component to handle either the nickname or the patp as the "primary name" for the profile. The secondary line shows the patp normally when a nickname is present and is now responsible for showing the copied indicator. This secondary line is only shown when props.hasNickname is true or if didCopy flips to true.

Quick demo for nickname vs non:

![copy](https://github.com/user-attachments/assets/86821b0e-de58-4100-bc52-b3d67c503f29)
![copy_nonick](https://github.com/user-attachments/assets/4e5a81fa-976b-44dd-9e2b-f9dbb59edf82)

