### PR TITLE
scroller: move AuthorRow when deleting first message in sequence

### DIFF
--- a/packages/app/ui/components/Channel/Scroller.tsx
+++ b/packages/app/ui/components/Channel/Scroller.tsx
@@ -266,6 +266,7 @@ const Scroller = forwardRef(
         const showAuthor =
           post.type === 'note' ||
           post.type === 'block' ||
+          !previousItem ||
           previousItem?.authorId !== post.authorId ||
           previousItem?.type === 'notice' ||
           isFirstPostOfDay;
@@ -308,6 +309,7 @@ const Scroller = forwardRef(
             itemAspectRatio={collectionLayout.itemAspectRatio ?? undefined}
             itemWidth={itemWidth}
             columnCount={columns}
+            previousPost={previousItem}
             {...anchorScrollLockScrollerItemProps}
           />
         );
@@ -612,6 +614,7 @@ const BaseScrollerItem = ({
   itemAspectRatio,
   itemWidth,
   columnCount,
+  previousPost,
 }: {
   showUnreadDivider: boolean;
   showAuthor: boolean;
@@ -639,8 +642,18 @@ const BaseScrollerItem = ({
   itemAspectRatio?: number;
   itemWidth?: number;
   columnCount: number;
+  previousPost?: db.Post | null;
 }) => {
   const post = useLivePost(item);
+  const previousPostLive = previousPost ? useLivePost(previousPost) : null;
+  const isPrevDeleted = previousPostLive?.isDeleted === true;
+
+  const showAuthorLive = useMemo(() => {
+    if (isPrevDeleted) {
+      return true;
+    }
+    return showAuthor;
+  }, [isPrevDeleted, showAuthor]);
 
   const handleLayout = useCallback(
     (e: LayoutChangeEvent) => {
@@ -712,7 +725,7 @@ const BaseScrollerItem = ({
           isHighlighted={isSelected}
           post={post}
           setViewReactionsPost={setViewReactionsPost}
-          showAuthor={showAuthor}
+          showAuthor={showAuthorLive}
           showReplies={showReplies}
           onPressReplies={post.isDeleted ? undefined : onPressReplies}
           onPressImage={post.isDeleted ? undefined : onPressImage}

--- a/packages/app/ui/components/Channel/Scroller.tsx
+++ b/packages/app/ui/components/Channel/Scroller.tsx
@@ -645,9 +645,7 @@ const BaseScrollerItem = ({
   previousPost?: db.Post | null;
 }) => {
   const post = useLivePost(item);
-  const previousPostLive = previousPost ? useLivePost(previousPost) : null;
-  const isPrevDeleted = previousPostLive?.isDeleted === true;
-
+  const isPrevDeleted = previousPost?.isDeleted === true;
   const showAuthorLive = useMemo(() => {
     if (isPrevDeleted) {
       return true;


### PR DESCRIPTION
Fixes TLON-3132 where deleting the first message in a sequence wouldn't move the AuthorRow to the second one, making it appear as though the person above you sent your second message. showAuthor was mostly just checking to see if the previous message was sent by the same author and wasn't taking the live state of the previous post into account (i.e. deleting).

- Adjusts the showAuthor logic to account for deleted posts preceding the current one.
- Uses useLivePost inside BaseScrollerItem to get the current state of the previous post and looks for the isDeleted flag.
- Tracks if the live version of the previous post exists and if it's deleted. If so, forces showAuthor to true.
- If the previous message was simply edited and not deleted, we fall back to the original showAuthor logic.

<img width="1339" alt="image" src="https://github.com/user-attachments/assets/5f9c427f-e960-47fe-9b98-3d338b95735c" />

I don't actually know if this affects performance in the FlatList at all, since I know we've done a lot of work there and things are fairly torqued-down. @dnbrwstr would love your opinion here.