### PR TITLE
gallery: fix issue with scrolling to selected post

### DIFF
--- a/packages/app/ui/components/Channel/Scroller.tsx
+++ b/packages/app/ui/components/Channel/Scroller.tsx
@@ -225,6 +225,8 @@ const Scroller = forwardRef(
       shouldMaintainVisibleContentPosition:
         collectionLayout.shouldMaintainVisibleContentPosition,
       isScrollingToBottom: hasPressedGoToBottom,
+      collectionLayoutType,
+      columnsCount: columns,
     });
 
     const theme = useTheme();


### PR DESCRIPTION
fixes tlon-3632

The issue was that FlatList treats each row in the grid as one logical "item" in the list, and our galleries always have at least two items per row. If we have an item we need to scroll to we can't use the real index of that item because it doesn't correspond to the logical "item" in the FlatList.

For instance, if we have 18 real items and each row has three items, then FlatList will only see six "items" (index 0 to 5), and if we try to scroll to real item 14 it will always be out of range. But, if we use Math.floor(index/columnCount), we adjust the index to 4 (fifth out of 0 to 5) and FlatList scrolls to the fifth row.