### PR TITLE
remove duplicate read only notice from channel view

### DIFF
--- a/packages/app/ui/components/Channel/index.tsx
+++ b/packages/app/ui/components/Channel/index.tsx
@@ -462,8 +462,6 @@ export const Channel = forwardRef<ChannelMethods, ChannelProps>(
                             />
                           )}
 
-                          {!canWrite && <ReadOnlyNotice type="read-only" />}
-
                           {channel.isDmInvite && (
                             <DmInviteOptions
                               channel={channel}


### PR DESCRIPTION
just something I noticed, there's no issue for it.

we were rendering the read only notice twice.