### PR TITLE
lure: continue refetching if lure is invalid

### DIFF
--- a/packages/app/ui/components/InviteFriendsToTlonButton.tsx
+++ b/packages/app/ui/components/InviteFriendsToTlonButton.tsx
@@ -73,16 +73,23 @@ export function InviteFriendsToTlonButton({
 
   useEffect(() => {
     const enableLinks = async () => {
-      if (!group) return;
-      await enableGroupLinks(group.id);
+      if (!group?.id) return;
+      try {
+        await enableGroupLinks(group.id);
+        logger.trackEvent(AnalyticsEvent.InviteDebug, {
+          group: group?.id,
+          context: 'enabled group on %grouper',
+        });
+      } catch (e) {
+        logger.trackEvent(AnalyticsEvent.InviteError, {
+          context: 'failed to enable group link',
+          groupId: group.id,
+          error: e,
+        });
+      }
     };
-
-    logger.trackEvent(AnalyticsEvent.InviteDebug, {
-      group: group?.id,
-      context: 'invite button: disabled and isAdmin, enabling',
-    });
     enableLinks();
-  }, [group]);
+  }, [group?.id]);
 
   if (
     (group?.privacy === 'private' || group?.privacy === 'secret') &&

--- a/packages/shared/src/store/lure.ts
+++ b/packages/shared/src/store/lure.ts
@@ -188,8 +188,7 @@ export function useLure({
 
   const canCheckForUpdate = useMemo(() => {
     const uninitialized = Boolean(
-      !lure.fetched &&
-        (!lure.url || !checkLureToken(lure.url) || !lure.deepLinkUrl)
+      !lure.url || !checkLureToken(lure.url) || !lure.deepLinkUrl
     );
     return Boolean(bait && !disableLoading && uninitialized);
   }, [bait, lure, disableLoading]);
@@ -230,7 +229,7 @@ export function useLure({
     }
 
     return 'ready';
-  }, [bait, fetched, url, deepLinkUrl, flag]);
+  }, [bait, fetched, url, deepLinkUrl]);
 
   // prevent over zealous logging
   const statusKey = useMemo(() => {


### PR DESCRIPTION
In our client side Lure logic, if `fetchLure` returns results that are invalid, it's designed to refetch on an interval. However, that refetching is gated on `canCheckForUpdate` being set. If the lure is marked `fetched`, this will make `canCheckForUpdate` falsy and short circuit the polling.

This just updates that conditional to continue refetching so long as the lure `status = 'ready'` conditions are not met. This should prevent the hook from ever locking up in a `stale` state.