### PR TITLE
Revert "chat input: fix issue with drafts not always clearing on send"

### DIFF
--- a/packages/shared/src/db/storageItem.ts
+++ b/packages/shared/src/db/storageItem.ts
@@ -42,7 +42,6 @@ export const createStorageItem = <T>(config: StorageItemConfig<T>) => {
   let updateLock = Promise.resolve();
 
   const getValue = async (): Promise<T> => {
-    await updateLock;
     const value = await storage.getItem(key);
 
     if (!value) {


### PR DESCRIPTION
This reverts commit 316be3a1700adcec1f44160ed32c9ca6fe9a933d.

was causing an issue with `setValue()` calls that passed an updater function.