### PR TITLE
chat input: fix issue with drafts not always clearing on send (again)

### DIFF
--- a/packages/shared/src/db/storageItem.ts
+++ b/packages/shared/src/db/storageItem.ts
@@ -45,7 +45,6 @@ export const createStorageItem = <T>(config: StorageItemConfig<T>) => {
     if (waitForLock) {
       await updateLock;
     }
-    await updateLock;
     const value = await storage.getItem(key);
 
     if (!value) {

--- a/packages/shared/src/store/usePostDraftCallbacks.ts
+++ b/packages/shared/src/store/usePostDraftCallbacks.ts
@@ -37,7 +37,7 @@ export function usePostDraftCallbacks(
         try {
           return await kv
             .postDraft({ key: draftKey, type: draftType })
-            .getValue();
+            .getValue(true);
         } catch (e) {
           return null;
         }


### PR DESCRIPTION
fixes tlon-4055

adds an optional `waitForLock` param to `getValue`, we'll pass `true` when we know we wanna wait for the updateLock to resolve before performing the operation.