### PR TITLE
notebooks: fix issue with notebook editor interactivity on Android

### DIFF
--- a/packages/app/ui/components/MessageInput/MessageInputBase.tsx
+++ b/packages/app/ui/components/MessageInput/MessageInputBase.tsx
@@ -232,9 +232,11 @@ export const MessageInputContainer = memo(
             )}
           </XStack>
         ) : (
-          <YStack width="100%" backgroundColor="$background">
+          // Note: This **must** be an XStack (not a YStack, View, or Stack), otherwise the WebView in MessageInput will not
+          // be interactive on Android.
+          <XStack width="100%" backgroundColor="$background">
             {children}
-          </YStack>
+          </XStack>
         )}
       </YStack>
     );


### PR DESCRIPTION
fixes tlon-4075

This is super weird. It turns out this was caused (somehow, I have no idea how. chalk it up to Tamagui weirdness) by using a YStack as the parent container for the MessageInput component within MessageInputBase.

If we use an XStack instead (*not* a View or Stack), it's fine.

That's it, that's the change.