### PR TITLE
attachments: don't show upload error for fake image uri, no-op instead

### DIFF
--- a/packages/shared/src/store/storage/storageActions.ts
+++ b/packages/shared/src/store/storage/storageActions.ts
@@ -20,6 +20,10 @@ import {
 const logger = createDevLogger('storageActions', false);
 
 export const uploadAsset = async (asset: ImagePickerAsset, isWeb = false) => {
+  if (asset.uri === 'placeholder-image-uri') {
+    logger.log('placeholder image, skipping upload');
+    return;
+  }
   logger.crumb(
     'uploading asset',
     asset.mimeType,


### PR DESCRIPTION
OTT, fixes tlon-4087.

You should now see the loading spinner on the attachment preview rather than the failure message.