### PR TITLE
fixes for image upload issues

### DIFF
--- a/packages/app/ui/components/AttachmentSheet.tsx
+++ b/packages/app/ui/components/AttachmentSheet.tsx
@@ -28,7 +28,8 @@ export default function AttachmentSheet({
   const [cameraPermissionStatus, requestCameraPermission] =
     ImagePicker.useCameraPermissions();
 
-  const { attachAssets, clearAttachments } = useAttachmentContext();
+  const { attachAssets, clearAttachments, removeAttachment } =
+    useAttachmentContext();
 
   const placeholderAsset: ImagePicker.ImagePickerAsset = useMemo(
     () => ({
@@ -45,6 +46,15 @@ export default function AttachmentSheet({
     }),
     []
   );
+
+  const removePlaceholderAttachment = useCallback(() => {
+    const placeholderToRemove = {
+      type: 'image' as const,
+      file: { uri: 'placeholder-image-uri' } as ImagePicker.ImagePickerAsset,
+    };
+
+    removeAttachment(placeholderToRemove);
+  }, [removeAttachment]);
 
   const takePicture = useCallback(() => {
     // Close the sheet immediately
@@ -77,7 +87,7 @@ export default function AttachmentSheet({
           // Replace the placeholder with the real image data
           const realAsset = result.assets[0];
 
-          clearAttachments();
+          removePlaceholderAttachment();
           attachAssets([realAsset]);
           onAttach?.(result.assets);
         } else {
@@ -99,6 +109,7 @@ export default function AttachmentSheet({
     cameraPermissionStatus,
     requestCameraPermission,
     placeholderAsset,
+    removePlaceholderAttachment,
   ]);
 
   const pickImage = useCallback(() => {
@@ -132,7 +143,7 @@ export default function AttachmentSheet({
           // Replace the placeholder with the real image data
           const realAsset = result.assets[0];
 
-          clearAttachments();
+          removePlaceholderAttachment();
           attachAssets([realAsset]);
           onAttach?.(result.assets);
         } else {
@@ -155,6 +166,7 @@ export default function AttachmentSheet({
     mediaLibraryPermissionStatus,
     requestMediaLibraryPermission,
     placeholderAsset,
+    removePlaceholderAttachment,
   ]);
 
   const actionGroups: ActionGroup[] = useMemo(

--- a/packages/app/ui/components/BareChatInput/index.tsx
+++ b/packages/app/ui/components/BareChatInput/index.tsx
@@ -228,6 +228,7 @@ export default function BareChatInput({
   const [hasAutoFocused, setHasAutoFocused] = useState(false);
   const [needsHeightAdjustmentAfterLoad, setNeedsHeightAdjustmentAfterLoad] =
     useState(false);
+  const [isSending, setIsSending] = useState(false);
   const {
     handleMention,
     handleSelectMention,
@@ -488,16 +489,19 @@ export default function BareChatInput({
   const runSendMessage = useCallback(
     async (isEdit: boolean) => {
       try {
+        setIsSending(true);
         await sendMessage(isEdit);
       } catch (e) {
         bareChatInputLogger.trackError('failed to send', e);
         setSendError(true);
+      } finally {
+        setIsSending(false);
+        setTimeout(() => {
+          // allow some time for send errors to be displayed
+          // before clearing the error state
+          setSendError(false);
+        }, 2000);
       }
-      setTimeout(() => {
-        // allow some time for send errors to be displayed
-        // before clearing the error state
-        setSendError(false);
-      }, 2000);
     },
     [sendMessage]
   );
@@ -781,7 +785,8 @@ export default function BareChatInput({
       onPressSend={handleSend}
       setShouldBlur={setShouldBlur}
       containerHeight={48}
-      disableSend={editorIsEmpty}
+      disableSend={editorIsEmpty || isSending}
+      isSending={isSending}
       sendError={sendError}
       isMentionModeActive={isMentionModeActive}
       showWayfindingTooltip={showWayfindingTooltip}

--- a/packages/app/ui/components/MessageInput/MessageInputBase.tsx
+++ b/packages/app/ui/components/MessageInput/MessageInputBase.tsx
@@ -2,7 +2,7 @@ import type { BridgeState, EditorBridge } from '@10play/tentap-editor';
 import * as db from '@tloncorp/shared/db';
 import * as logic from '@tloncorp/shared/logic';
 import { JSONContent, Story } from '@tloncorp/shared/urbit';
-import { Button } from '@tloncorp/ui';
+import { Button, LoadingSpinner } from '@tloncorp/ui';
 import { FloatingActionButton, Text } from '@tloncorp/ui';
 import { Icon } from '@tloncorp/ui';
 import { ImagePickerAsset } from 'expo-image-picker';
@@ -96,6 +96,7 @@ export const MessageInputContainer = memo(
     floatingActionButton = false,
     showWayfindingTooltip = false,
     disableSend = false,
+    isSending = false,
     mentionText,
     groupMembers,
     onSelectMention,
@@ -116,6 +117,7 @@ export const MessageInputContainer = memo(
     floatingActionButton?: boolean;
     showWayfindingTooltip?: boolean;
     disableSend?: boolean;
+    isSending?: boolean;
     mentionText?: string;
     groupMembers: db.ChatMember[];
     onSelectMention: (contact: db.Contact) => void;
@@ -220,6 +222,8 @@ export const MessageInputContainer = memo(
                 >
                   {isEditing ? (
                     <Icon size="$m" type="Checkmark" />
+                  ) : isSending ? (
+                    <LoadingSpinner />
                   ) : (
                     <Icon
                       color={sendError ? '$negativeActionText' : undefined}

--- a/packages/app/ui/components/MessageInput/index.tsx
+++ b/packages/app/ui/components/MessageInput/index.tsx
@@ -164,6 +164,7 @@ export const MessageInput = forwardRef<MessageInputHandle, MessageInputProps>(
     const [hasAutoFocused, setHasAutoFocused] = useState(false);
     const [editorCrashed, setEditorCrashed] = useState<string | undefined>();
     const [containerHeight, setContainerHeight] = useState(initialHeight);
+    const [isSending, setIsSending] = useState(false);
     const { bottom, top } = useSafeAreaInsets();
     const { height } = useWindowDimensions();
     const headerHeight = 48;
@@ -750,12 +751,15 @@ export const MessageInput = forwardRef<MessageInputHandle, MessageInputProps>(
     const runSendMessage = useCallback(
       async (isEdit: boolean) => {
         try {
+          setIsSending(true);
           await sendMessage(isEdit);
         } catch (e) {
           console.error('failed to send', e);
           setSendError(true);
+        } finally {
+          setIsSending(false);
+          setSendError(false);
         }
-        setSendError(false);
       },
       [sendMessage]
     );
@@ -989,7 +993,9 @@ export const MessageInput = forwardRef<MessageInputHandle, MessageInputProps>(
         showAttachmentButton={showAttachmentButton}
         floatingActionButton={floatingActionButton}
         disableSend={
-          editorIsEmpty || (channelType === 'notebook' && titleIsEmpty)
+          editorIsEmpty ||
+          (channelType === 'notebook' && titleIsEmpty) ||
+          isSending
         }
         goBack={goBack}
         frameless={frameless}


### PR DESCRIPTION
fixes tlon-4113 (I think? I can't repro what's in the description, I can repro what was mentioned in the meeting that I think was supposed to be in the description) by only clearing the placeholder attachment, not all attachments, upon adding a new attachment.

fixes tlon-4094 by disabling the send button while we're sending (!).

Also, adds a loading spinner in place of the up arrow so users know something is happening before the message appears in the scroller. Thoughts?


https://github.com/user-attachments/assets/7e1e16a7-01c5-4180-94f8-b17a92a64b2e

