### PR TITLE
mobile: fix invite button in chat option sheet

### DIFF
--- a/packages/app/features/top/ChatListScreen.tsx
+++ b/packages/app/features/top/ChatListScreen.tsx
@@ -263,10 +263,6 @@ export function ChatListScreenView({
     activeTab,
   });
 
-  useEffect(() => {
-    console.log(`slected group change`, selectedGroupId);
-  }, [selectedGroupId]);
-
   return (
     <RequestsProvider
       usePostReference={store.usePostReference}

--- a/packages/app/features/top/ChatListScreen.tsx
+++ b/packages/app/features/top/ChatListScreen.tsx
@@ -24,7 +24,6 @@ import {
   ChatOptionsProvider,
   GroupPreviewAction,
   GroupPreviewSheet,
-  InviteUsersSheet,
   NavBarView,
   NavigationProvider,
   PersonalInviteSheet,
@@ -61,7 +60,6 @@ export function ChatListScreenView({
   const navigation = useNavigation<NavigationProp<RootStackParamList>>();
   const [personalInviteOpen, setPersonalInviteOpen] = useState(false);
   const [screenTitle, setScreenTitle] = useState('Home');
-  const [inviteSheetGroup, setInviteSheetGroup] = useState<string | null>();
   const personalInvite = db.personalInviteLink.useValue();
   const viewedPersonalInvite = db.hasViewedPersonalInvite.useValue();
   const { isOpen, setIsOpen } = useGlobalSearch();
@@ -194,12 +192,6 @@ export function ChatListScreenView({
     }
   }, []);
 
-  const handleInviteSheetOpenChange = useCallback((open: boolean) => {
-    if (!open) {
-      setInviteSheetGroup(null);
-    }
-  }, []);
-
   const isTlonEmployee = useMemo(() => {
     const allChats = [...resolvedChats.pinned, ...resolvedChats.unpinned];
     return !!allChats.find(
@@ -212,15 +204,6 @@ export function ChatListScreenView({
       identifyTlonEmployee();
     }
   }, [isTlonEmployee]);
-
-  const handleSectionChange = useCallback(
-    (title: string) => {
-      if (activeTab === 'home') {
-        setScreenTitle(title);
-      }
-    },
-    [activeTab]
-  );
 
   useEffect(() => {
     if (activeTab === 'home') {
@@ -280,8 +263,8 @@ export function ChatListScreenView({
     activeTab,
   });
 
-  const handleInvitePress = useCallback(() => {
-    setInviteSheetGroup(selectedGroupId);
+  useEffect(() => {
+    console.log(`slected group change`, selectedGroupId);
   }, [selectedGroupId]);
 
   return (
@@ -292,10 +275,7 @@ export function ChatListScreenView({
       useApp={db.appInfo.useValue}
       useGroup={store.useGroupPreview}
     >
-      <ChatOptionsProvider
-        {...useChatSettingsNavigation()}
-        onPressInvite={handleInvitePress}
-      >
+      <ChatOptionsProvider {...useChatSettingsNavigation()}>
         <NavigationProvider focusedChannelId={focusedChannelId}>
           <View userSelect="none" flex={1}>
             <ScreenHeader
@@ -356,12 +336,6 @@ export function ChatListScreenView({
               onOpenChange={handleGroupPreviewSheetOpenChange}
               group={selectedGroup ?? undefined}
               onActionComplete={handleGroupAction}
-            />
-            <InviteUsersSheet
-              open={inviteSheetGroup !== null}
-              onOpenChange={handleInviteSheetOpenChange}
-              onInviteComplete={() => setInviteSheetGroup(null)}
-              groupId={inviteSheetGroup ?? undefined}
             />
           </View>
         </NavigationProvider>

--- a/packages/app/ui/components/ChatOptionsSheet.tsx
+++ b/packages/app/ui/components/ChatOptionsSheet.tsx
@@ -53,7 +53,7 @@ export const ChatOptionsSheet = React.memo(function ChatOptionsSheet({
 
   // Handle open state changes
   const handleOpenChange = useCallback(
-    (open: boolean) => {
+    (open: boolean, clearChat = true) => {
       if (open && chat) {
         // Set chat state for both popovers and sheets
         contextOpen(chat.id, chat.type);
@@ -63,9 +63,11 @@ export const ChatOptionsSheet = React.memo(function ChatOptionsSheet({
           propOnOpenChange(false);
         }
         // Clear chat state after a short delay to allow handlers to complete
-        setTimeout(() => {
-          setChat(null);
-        }, 100);
+        if (clearChat) {
+          setTimeout(() => {
+            setChat(null);
+          }, 100);
+        }
       }
 
       // Call provided handler for popovers
@@ -243,7 +245,7 @@ function GroupOptionsSheetContent({
   currentUserIsAdmin: boolean;
   onPressNotifications: () => void;
   onPressSort: () => void;
-  onOpenChange: (open: boolean) => void;
+  onOpenChange: (open: boolean, clearChat?: boolean) => void;
 }) {
   const { markGroupRead, onPressChatDetails, togglePinned, onPressInvite } =
     useChatOptions();
@@ -254,9 +256,9 @@ function GroupOptionsSheetContent({
   const isErrored = group?.joinStatus === 'errored';
 
   const wrappedAction = useCallback(
-    (action: () => void) => {
+    (action: () => void, clearChat = true) => {
       action();
-      onOpenChange(false);
+      onOpenChange(false, clearChat);
     },
     [onOpenChange]
   );
@@ -300,7 +302,7 @@ function GroupOptionsSheetContent({
           canInvite
             ? {
                 title: 'Invite people',
-                action: wrappedAction.bind(null, onPressInvite),
+                action: wrappedAction.bind(null, onPressInvite, false),
                 endIcon: 'ChevronRight',
               }
             : {


### PR DESCRIPTION
In a recent refactor, we moved the rendering of the ChatOptionsSheet into the `chatOptions` provider itself when on mobile. This broke the invite button because which chat is active for the options sheet is now handled internally rather than at the ChatList level (where the previous invite sheet behavior lived). 

To solve this while matching that new pattern, I pulled the invite sheet into `chatOptions` as well. If the context is not passed an `onInvitePressed` handler, it will display its own internal invite sheet.


The chat options logic is getting quite complicated imo (state is too intermingled between the context hooks and actual components with expected behavior differing by use case and platform). We should try to pull these apart, but that would be outside the scope of this fix.

Fixes TLON-4086 