### PR TITLE
android: group notifications by conversation

### DIFF
--- a/apps/tlon-mobile/android/app/src/main/java/io/tlon/landscape/notifications/ActivityEvent.kt
+++ b/apps/tlon-mobile/android/app/src/main/java/io/tlon/landscape/notifications/ActivityEvent.kt
@@ -22,6 +22,7 @@ data class ActivityEventPreviewMessage(
 data class ActivityEventPreview(
     val title: String?,
     val body: String?,
+    val groupingKey: String?,
 
     // present when event represents a user-to-user message
     val messagingMetadata: ActivityEventPreviewMessage?,
@@ -57,6 +58,7 @@ suspend fun renderPreview(context: Context, activityEventJson: String): Activity
                     val preview = ActivityEventPreview(
                         title = parsed.notification.title?.let { x -> renderer.render(x) },
                         body = renderer.render(parsed.notification.body),
+                        groupingKey = parsed.notification.groupingKey?.let { x -> renderer.render(x) },
                         messagingMetadata = parsed.message?.let { m ->
                             contact?.let { contact ->
                                 ActivityEventPreviewMessage(

--- a/apps/tlon-mobile/android/app/src/main/java/io/tlon/landscape/notifications/NotificationManager.kt
+++ b/apps/tlon-mobile/android/app/src/main/java/io/tlon/landscape/notifications/NotificationManager.kt
@@ -26,6 +26,7 @@ import kotlin.coroutines.resume
 import kotlin.coroutines.resumeWithException
 import kotlin.coroutines.suspendCoroutine
 
+const val MAX_CACHED_CONVERSATION_LENGTH = 15
 val notificationMessagesCache = HashMap<String, Array<NotificationCompat.MessagingStyle.Message>>();
 
 suspend fun processNotification(context: Context, uid: String) {
@@ -111,7 +112,10 @@ suspend fun processNotification(context: Context, uid: String) {
             for (message in previousMessages) {
                 notifStyle.addMessage(message)
             }
-            notificationMessagesCache[preview.groupingKey] = previousMessages.plus(incomingMessage)
+
+            var nextCachedList = previousMessages.plus(incomingMessage)
+            nextCachedList = nextCachedList.takeLast(MAX_CACHED_CONVERSATION_LENGTH - 1).toTypedArray()
+            notificationMessagesCache[preview.groupingKey] = nextCachedList
         }
         notifStyle.addMessage(incomingMessage)
         builder.setStyle(notifStyle)

--- a/apps/tlon-mobile/android/app/src/main/java/io/tlon/landscape/notifications/NotificationManager.kt
+++ b/apps/tlon-mobile/android/app/src/main/java/io/tlon/landscape/notifications/NotificationManager.kt
@@ -45,36 +45,20 @@ suspend fun processNotification(context: Context, uid: String) {
     val extras = Bundle()
     extras.putString("activityEventJsonString", activityEvent.toString())
 
-    sendNotification(
-        context,
-        UvParser.getIntCompatibleFromUv(uid),
-        preview.messagingMetadata?.sender?.person,
-        preview.title,
-        preview.body,
-        preview.messagingMetadata?.isGroupConversation ?: false,
-        extras
-    )
-}
+    val id = UvParser.getIntCompatibleFromUv(uid)
+    val person = preview.messagingMetadata?.sender?.person
+    val title = preview.title
+    val text = preview.body
+    val isGroupConversation = preview.messagingMetadata?.isGroupConversation ?: false
 
-fun processNotificationBlocking(context: Context, uid: String) =
-    runBlocking { processNotification(context, uid) }
-
-fun sendNotification(
-    context: Context,
-    id: Int,
-    person: Person?,
-    title: String?,
-    text: String?,
-    isGroupConversation: Boolean,
-    data: Bundle?
-) {
     Log.d(
-        "TalkNotificationManager",
+        "NotificationManager",
         "sendNotification: $id $title $text $isGroupConversation"
     )
+
     val tapIntent = Intent(context, MainActivity::class.java)
     tapIntent.setFlags(Intent.FLAG_ACTIVITY_NEW_TASK or Intent.FLAG_ACTIVITY_CLEAR_TASK)
-    tapIntent.replaceExtras(data)
+    tapIntent.replaceExtras(extras)
     val tapPendingIntent =
         PendingIntent.getActivity(context, id, tapIntent, PendingIntent.FLAG_IMMUTABLE)
 
@@ -83,7 +67,7 @@ fun sendNotification(
         TalkBroadcastReceiver::class.java
     )
     markAsReadIntent.setAction(TalkBroadcastReceiver.MARK_AS_READ_ACTION)
-    markAsReadIntent.replaceExtras(data)
+    markAsReadIntent.replaceExtras(extras)
     val markAsReadPendingIntent =
         PendingIntent.getBroadcast(
             context,
@@ -99,7 +83,7 @@ fun sendNotification(
             .setSmallIcon(R.drawable.notification_icon)
             .setContentTitle(title)
             .setContentText(text)
-            .addExtras(data)
+            .addExtras(extras)
             .setPriority(NotificationCompat.PRIORITY_DEFAULT)
             .setContentIntent(tapPendingIntent)
             .addAction(
@@ -135,3 +119,6 @@ fun sendNotification(
     }
     NotificationManagerCompat.from(context).notify(id, builder.build())
 }
+
+fun processNotificationBlocking(context: Context, uid: String) =
+    runBlocking { processNotification(context, uid) }

--- a/apps/tlon-mobile/android/app/src/main/java/io/tlon/landscape/notifications/NotificationManager.kt
+++ b/apps/tlon-mobile/android/app/src/main/java/io/tlon/landscape/notifications/NotificationManager.kt
@@ -1,10 +1,13 @@
 package io.tlon.landscape.notifications
 
+import android.Manifest
 import android.app.PendingIntent
 import android.content.Context
 import android.content.Intent
+import android.content.pm.PackageManager
 import android.os.Bundle
 import android.util.Log
+import androidx.core.app.ActivityCompat
 import androidx.core.app.NotificationCompat
 import androidx.core.app.NotificationManagerCompat
 import androidx.core.app.Person
@@ -116,5 +119,19 @@ fun sendNotification(
             )
     }
 
+    if (ActivityCompat.checkSelfPermission(
+            context,
+            Manifest.permission.POST_NOTIFICATIONS
+        ) != PackageManager.PERMISSION_GRANTED
+    ) {
+        // TODO: Consider calling
+        //    ActivityCompat#requestPermissions
+        // here to request the missing permissions, and then overriding
+        //   public void onRequestPermissionsResult(int requestCode, String[] permissions,
+        //                                          int[] grantResults)
+        // to handle the case where the user grants the permission. See the documentation
+        // for ActivityCompat#requestPermissions for more details.
+        return
+    }
     NotificationManagerCompat.from(context).notify(id, builder.build())
 }

--- a/apps/tlon-mobile/android/app/src/main/java/io/tlon/landscape/notifications/NotificationManager.kt
+++ b/apps/tlon-mobile/android/app/src/main/java/io/tlon/landscape/notifications/NotificationManager.kt
@@ -92,6 +92,7 @@ suspend fun processNotification(context: Context, uid: String) {
                 markAsReadPendingIntent
             )
             .setAutoCancel(true)
+            .setGroup(preview.groupingKey)
 
     if (person != null) {
         builder

--- a/apps/tlon-mobile/android/app/src/main/java/io/tlon/landscape/notifications/NotificationManager.kt
+++ b/apps/tlon-mobile/android/app/src/main/java/io/tlon/landscape/notifications/NotificationManager.kt
@@ -1,13 +1,23 @@
 package io.tlon.landscape.notifications
 
+import android.app.PendingIntent
 import android.content.Context
+import android.content.Intent
 import android.os.Bundle
+import android.util.Log
+import androidx.core.app.NotificationCompat
+import androidx.core.app.NotificationManagerCompat
+import androidx.core.app.Person
 import com.android.volley.VolleyError
+import io.tlon.landscape.MainActivity
 import io.tlon.landscape.api.TalkApi
 import io.tlon.landscape.api.TalkObjectCallback
+import io.tlon.landscape.R
+import io.tlon.landscape.storage.SecureStorage
 import io.tlon.landscape.utils.UvParser
 import kotlinx.coroutines.runBlocking
 import org.json.JSONObject
+import java.util.Date
 import kotlin.coroutines.resume
 import kotlin.coroutines.resumeWithException
 import kotlin.coroutines.suspendCoroutine
@@ -32,7 +42,7 @@ suspend fun processNotification(context: Context, uid: String) {
     val extras = Bundle()
     extras.putString("activityEventJsonString", activityEvent.toString())
 
-    TalkNotificationManager.sendNotification(
+    sendNotification(
         context,
         UvParser.getIntCompatibleFromUv(uid),
         preview.messagingMetadata?.sender?.person,
@@ -45,3 +55,66 @@ suspend fun processNotification(context: Context, uid: String) {
 
 fun processNotificationBlocking(context: Context, uid: String) =
     runBlocking { processNotification(context, uid) }
+
+fun sendNotification(
+    context: Context,
+    id: Int,
+    person: Person?,
+    title: String?,
+    text: String?,
+    isGroupConversation: Boolean,
+    data: Bundle?
+) {
+    Log.d(
+        "TalkNotificationManager",
+        "sendNotification: $id $title $text $isGroupConversation"
+    )
+    val tapIntent = Intent(context, MainActivity::class.java)
+    tapIntent.setFlags(Intent.FLAG_ACTIVITY_NEW_TASK or Intent.FLAG_ACTIVITY_CLEAR_TASK)
+    tapIntent.replaceExtras(data)
+    val tapPendingIntent =
+        PendingIntent.getActivity(context, id, tapIntent, PendingIntent.FLAG_IMMUTABLE)
+
+    val markAsReadIntent = Intent(
+        context,
+        TalkBroadcastReceiver::class.java
+    )
+    markAsReadIntent.setAction(TalkBroadcastReceiver.MARK_AS_READ_ACTION)
+    markAsReadIntent.replaceExtras(data)
+    val markAsReadPendingIntent =
+        PendingIntent.getBroadcast(
+            context,
+            id,
+            markAsReadIntent,
+            PendingIntent.FLAG_IMMUTABLE or PendingIntent.FLAG_UPDATE_CURRENT
+        )
+
+    val user =
+        Person.Builder().setName(SecureStorage.getString(SecureStorage.SHIP_NAME_KEY)).build()
+    val builder: NotificationCompat.Builder =
+        NotificationCompat.Builder(context, TalkNotificationManager.CHANNEL_ID)
+            .setSmallIcon(R.drawable.notification_icon)
+            .setContentTitle(title)
+            .setContentText(text)
+            .addExtras(data)
+            .setPriority(NotificationCompat.PRIORITY_DEFAULT)
+            .setContentIntent(tapPendingIntent)
+            .addAction(
+                R.drawable.ic_mark_as_read,
+                context.getString(R.string.landscape_notification_mark_as_read),
+                markAsReadPendingIntent
+            )
+            .setAutoCancel(true)
+
+    if (person != null) {
+        builder
+            .setStyle(
+                NotificationCompat.MessagingStyle(user)
+                    .setGroupConversation(isGroupConversation)
+                    .setConversationTitle(if (isGroupConversation) title else null)
+                    .addMessage(text, Date().time, person)
+            )
+    }
+
+    NotificationManagerCompat.from(context).notify(id, builder.build())
+}

--- a/apps/tlon-mobile/android/app/src/main/java/io/tlon/landscape/notifications/TalkNotificationManager.java
+++ b/apps/tlon-mobile/android/app/src/main/java/io/tlon/landscape/notifications/TalkNotificationManager.java
@@ -2,38 +2,13 @@ package io.tlon.landscape.notifications;
 
 import android.app.NotificationChannel;
 import android.app.NotificationManager;
-import android.app.PendingIntent;
 import android.content.Context;
-import android.content.Intent;
-import android.os.Bundle;
-
-import androidx.core.app.NotificationCompat;
 import androidx.core.app.NotificationManagerCompat;
-import androidx.core.app.Person;
-
-import com.android.volley.TimeoutError;
-import com.android.volley.VolleyError;
-import android.util.Log;
-
-import org.json.JSONException;
-import org.json.JSONObject;
-
-import java.util.Date;
-
-import io.invertase.firebase.crashlytics.ReactNativeFirebaseCrashlyticsNativeHelper;
-import io.tlon.landscape.MainActivity;
 import io.tlon.landscape.R;
-import io.tlon.landscape.api.TalkApi;
-import io.tlon.landscape.api.TalkObjectCallback;
-import io.tlon.landscape.models.Club;
-import io.tlon.landscape.models.Contact;
-import io.tlon.landscape.models.Yarn;
-import io.tlon.landscape.storage.SecureStorage;
-import io.tlon.landscape.utils.UvParser;
 
 public class TalkNotificationManager {
 
-    private static final String CHANNEL_ID = "tlon";
+    static final String CHANNEL_ID = "tlon";
 
     public static void createNotificationChannel(Context context) {
         CharSequence name = context.getString(R.string.landscape_notification_channel_name);
@@ -45,44 +20,6 @@ public class TalkNotificationManager {
         // or other notification behaviors after this
         NotificationManager notificationManager = context.getSystemService(NotificationManager.class);
         notificationManager.createNotificationChannel(channel);
-    }
-
-    static void sendNotification(Context context, int id, Person person, String title, String text, Boolean isGroupConversation, Bundle data) {
-        Log.d("TalkNotificationManager", "sendNotification: " + id + " " + title + " " + text + " " + isGroupConversation);
-        Intent tapIntent = new Intent(context, MainActivity.class);
-        tapIntent.setFlags(Intent.FLAG_ACTIVITY_NEW_TASK | Intent.FLAG_ACTIVITY_CLEAR_TASK);
-        tapIntent.replaceExtras(data);
-        PendingIntent tapPendingIntent =
-                PendingIntent.getActivity(context, id, tapIntent, PendingIntent.FLAG_IMMUTABLE);
-
-        Intent markAsReadIntent = new Intent(context, TalkBroadcastReceiver.class);
-        markAsReadIntent.setAction(TalkBroadcastReceiver.MARK_AS_READ_ACTION);
-        markAsReadIntent.replaceExtras(data);
-        PendingIntent markAsReadPendingIntent =
-                PendingIntent.getBroadcast(context, id, markAsReadIntent, PendingIntent.FLAG_IMMUTABLE | PendingIntent.FLAG_UPDATE_CURRENT);
-
-        Person user = new Person.Builder().setName(SecureStorage.getString(SecureStorage.SHIP_NAME_KEY)).build();
-        NotificationCompat.Builder builder = new NotificationCompat.Builder(context, CHANNEL_ID)
-                .setSmallIcon(R.drawable.notification_icon)
-                .setContentTitle(title)
-                .setContentText(text)
-                .addExtras(data)
-                .setPriority(NotificationCompat.PRIORITY_DEFAULT)
-                .setContentIntent(tapPendingIntent)
-                .addAction(R.drawable.ic_mark_as_read, context.getString(R.string.landscape_notification_mark_as_read), markAsReadPendingIntent)
-                .setAutoCancel(true);
-
-        if (person != null) {
-            builder
-                    .setStyle(
-                            new NotificationCompat.MessagingStyle(user)
-                                    .setGroupConversation(isGroupConversation)
-                                    .setConversationTitle(isGroupConversation ? title : null)
-                                    .addMessage(text, new Date().getTime(), person)
-                    );
-        }
-
-        NotificationManagerCompat.from(context).notify(id, builder.build());
     }
 
     public static void dismissNotification(Context context, int notificationId) {


### PR DESCRIPTION
_currently pointed at #4665_

I'd recommend reviewing the first commit a8a16cbbb8cf0c0e57dd69bcfd5fb699656727ba separately – that commit just translates old Java code into Kotlin (using an automatic IDE-provided translation), and messes with the diff.

---

| Expanded | Collapsed |
| --- | --- |
| ![Screenshot 2025-04-29 at 11 11 30 AM](https://github.com/user-attachments/assets/4efe94c2-075c-47d9-a940-a7ac561bf633) | These notifications auto-collapse when new notifications come in: ![Screenshot 2025-04-29 at 11 11 49 AM](https://github.com/user-attachments/assets/ebd26d7a-3092-463c-8a2b-f390d8774270) |

Groups subsequent notifications from the same channel or thread into "conversations" in the Android notification drawer.

iOS accumulates notifications posted to the same `threadIdentifier` automatically, but Android is different: it requires the service to (1) build the entire conversation history for each notification, and (2) replace the existing notification with the updated one.

(1) means that we need to hold onto older messages so we can prepend them when receiving new message notifications. I did this with a simple in-memory store: https://github.com/tloncorp/tlon-apps/blob/f9a6147c61ed8912273be274b8e0ea26fea2293c/apps/tlon-mobile/android/app/src/main/java/io/tlon/landscape/notifications/NotificationManager.kt#L29 https://github.com/tloncorp/tlon-apps/blob/f9a6147c61ed8912273be274b8e0ea26fea2293c/apps/tlon-mobile/android/app/src/main/java/io/tlon/landscape/notifications/NotificationManager.kt#L106-L116

This is not a perfect solution: if the service is killed (or crashes), we lose this store. **Once the store is lost, a subsequent new-message notif in a channel will lose the conversation history (and overwrite any existing notification), effectively making the older notifications disappear.** I don't know how bad this is in practice – tested that this is the actual behavior by triggering a crash in the service.

<details>

<summary>Some better solutions:</summary>

1. Generate a salt for each service launch, and use it with the thread ID when replacing any previous notification. This means that during a service's lifetime, a conversation's messages will be grouped (e.g. `conversation1` is grouped into `msg1, msg2, msg3`); and after getting killed, the next service's launch will again group messages, but separately from the previous batch (so you'd have the older batch `msg1, msg2, msg3` and a separate Android conversation `msg4, msg5`).
2. Persist pending messages between service launches (either using main SQLite or separate persistence)

</details>