### PR TITLE
sync: remove clientside reconnect heartbeat

### DIFF
--- a/packages/shared/src/store/sync.ts
+++ b/packages/shared/src/store/sync.ts
@@ -1385,16 +1385,6 @@ export const handleDiscontinuity = async () => {
 };
 
 export const handleChannelStatusChange = async (status: ChannelStatus) => {
-  // Since Eyre doesn't send a response body when opening an event
-  // source request, the reconnect request won't resolve until we get a new fact
-  // or a heartbeat. We call this method to manually trigger a fact -- anything
-  // that does so would work.
-  //
-  // Eyre issue is fixed in this PR, https://github.com/urbit/urbit/pull/7080,
-  // we should remove this hack once 410 is rolled out.
-  if (status === 'reconnecting') {
-    api.checkExistingUserInviteLink();
-  }
   updateSession({ channelStatus: status });
 
   // Trigger verification for posts marked as 'needs_verification' when connection becomes active


### PR DESCRIPTION
410 is out and widely deployed. It automatically sends some initial bytes to warm the connection, so we no longer need a "heartbeat" request from the client.