### PR TITLE
mentions: allow mentioning everyone in channel or specific roles

### DIFF
--- a/desk/app/activity.hoon
+++ b/desk/app/activity.hoon
@@ -278,6 +278,11 @@
   %+  welp
   /(scot %p our.bowl)/[dude]/(scot %da now.bowl)
   path
+++  get-vessel
+  |=  [=flag:g =ship]
+  =/  =path
+    /groups/(scot %p p.flag)/[q.flag]/fleet/(scot %p ship)/vessel/noun
+  .^(vessel:fleet:g %gx (scry-path %groups path))
 ++  poke
   |=  [=mark =vase]
   ^+  cor
@@ -1255,8 +1260,9 @@
     =/  key=message-key:a
       :_  time
       [(get-author-ship:ch-utils author.u.post) time]
+    =/  =vessel:fleet:g  (get-vessel group our.bowl)
     =/  mention
-      (was-mentioned:ch-utils content.u.post our.bowl)
+      (was-mentioned:ch-utils content.u.post our.bowl `vessel)
     `[time %post key nest group content.u.post mention]
   =/  replies=(list [time incoming-event:a])
     %-  zing
@@ -1280,8 +1286,9 @@
     =/  parent=message-key:a
       :_  id-post
       [(get-author-ship:ch-utils author.u.u.post) id-post]
+    =/  =vessel:fleet:g  (get-vessel group our.bowl)
     =/  mention
-      (was-mentioned:ch-utils content.u.reply our.bowl)
+      (was-mentioned:ch-utils content.u.reply our.bowl `vessel)
     [time %reply key parent nest group content.u.reply mention]
   =/  init-time
     ?:  &(=(posts ~) =(replies ~))  recency.unread
@@ -1320,7 +1327,7 @@
     |=  [=time =writ:ch]
     =/  key=message-key:a  [id.writ time]
     =/  mention
-      (was-mentioned:ch-utils content.writ our.bowl)
+      (was-mentioned:ch-utils content.writ our.bowl ~)
     `[time %dm-post key whom content.writ mention]
   =/  replies=(list [time incoming-event:a])
     %-  zing
@@ -1335,7 +1342,7 @@
       (tab:on:replies:ch replies.u.writ `(sub time.key 1) count)
     |=  [=time =reply:ch]
     =/  mention
-      (was-mentioned:ch-utils content.reply our.bowl)
+      (was-mentioned:ch-utils content.reply our.bowl ~)
     [time %dm-reply key parent whom content.reply mention]
   =/  init-time
     ?:  &(=(writs ~) =(replies ~))  recency.unread

--- a/desk/app/channels.hoon
+++ b/desk/app/channels.hoon
@@ -963,7 +963,6 @@
   (welp /(scot %p our.bowl)/[agent]/(scot %da now.bowl) path)
 ++  get-vessel
   |=  [=flag:g =ship]
-  ~&  ['scrying for vessel' flag ship]
   =/  =path
     /groups/(scot %p p.flag)/[q.flag]/fleet/(scot %p ship)/vessel/noun
   .^(vessel:fleet:g %gx (scry-path %groups path))
@@ -1008,9 +1007,7 @@
         =/  =source  [%channel nest group.perm.perm.channel]
         (send [%read source [%all `now.bowl |]] ~)
       =/  =vessel:fleet:g  (get-vessel group.perm.perm.channel our.bowl)
-      ~&  ['got vessel' vessel]
       =/  mention=?  (was-mentioned:utils content our.bowl `vessel)
-      ~&  ['was mentioned' mention]
       =/  action
         [%add %post [[author-ship id] id] nest group.perm.perm.channel content mention]
       (send ~[action])
@@ -1371,7 +1368,6 @@
   ++  ca-take-update
     |=  =sign:agent:gall
     ^+  ca-core
-    ~&  ['taking fact' sign]
     ?+    -.sign  ca-core
         %kick       (ca-safe-sub &)
         %watch-ack
@@ -1494,7 +1490,6 @@
   ::
   ++  ca-apply-logs
     |=  =log:c
-    ~&  ['processing' (wyt:log-on:c log) 'logs']
     ^+  ca-core
     %+  roll  (tap:log-on:c log)
     |=  [[=time =u-channel:c] ca=_ca-core]
@@ -1508,7 +1503,6 @@
   ::
   ++  ca-u-channels
     |=  [=time =u-channel:c]
-    ~&  ['processing update' u-channel]
     ?>  ca-from-host
     ^+  ca-core
     =?  last-updated.channel  ?=(%post -.u-channel)
@@ -1562,7 +1556,6 @@
   ++  ca-u-post
     |=  [=id-post:c =u-post:c]
     ^+  ca-core
-    ~&  ['processing post' u-post]
     =/  post  (get:on-v-posts:c posts.channel id-post)
     ?:  ?=([~ ~] post)  ca-core
     ?:  ?=(%set -.u-post)
@@ -1571,16 +1564,13 @@
       =?  ca-core  ?&  ?=(^ post.u-post)
                        ?=(~ post)
                    ==
-        ~&  'activity processing'
         ::  we don't send an activity event for edits or deletes
         (on-post:ca-activity u.post.u-post)
       ?~  post
-        ~&  'new post'
         =/  post=(unit post:c)  (bind post.u-post uv-post-2:utils)
         =?  ca-core  ?=(^ post.u-post)
           (ca-heed ~[author.u.post.u-post])
         =?  ca-core  ?=(^ post.u-post)
-          ~&  'hark processing'
           ::TODO  what about the "mention was added during edit" case?
           (on-post:ca-hark id-post u.post.u-post)
         =.  posts.channel  (put:on-v-posts:c posts.channel id-post post.u-post)

--- a/desk/app/channels.hoon
+++ b/desk/app/channels.hoon
@@ -2603,6 +2603,10 @@
         ?(%bold %italics %strike %blockquote)  ^$(p.verse p.inline)
         ?(%code %inline-code)                  $(inline p.inline)
       ::
+          %sect
+        ?~  p.inline  $(inline '@all@everyone@channel')
+        $(inline p.inline)
+      ::
           %link
         ?|  $(inline p.inline)
         ?&  !=(p.inline q.inline)

--- a/desk/app/chat.hoon
+++ b/desk/app/chat.hoon
@@ -1886,6 +1886,7 @@
     ^-  (unit inline:old-2)
     ?@  i    `i
     ?+  -.i  `i
+      %sect        ~
       %task        ~
       %italics     `[-.i ^$(p.v p.i)]
       %bold        `[-.i ^$(p.v p.i)]

--- a/desk/app/chat.hoon
+++ b/desk/app/chat.hoon
@@ -1628,14 +1628,14 @@
         =.  recency.remark.club  now.bowl
         =.  cor  (give-unread club/id cu-unread)
         =/  concern  [%post p.diff.delta now.bowl]
-        =/  mention  (was-mentioned:utils content.essay our.bowl)
+        =/  mention  (was-mentioned:utils content.essay our.bowl ~)
         =.  cu-core  (cu-activity concern content.essay mention)
         (cu-give-writs-diff diff.delta)
       ::
           %del
         =?  cu-core  ?=(^ had)
           =*  content  content.writ.u.had
-          =/  mention  (was-mentioned:utils content our.bowl)
+          =/  mention  (was-mentioned:utils content our.bowl ~)
           (cu-activity [%delete-post [id time]:writ.u.had] content mention)
         (cu-give-writs-diff diff.delta)
       ::
@@ -1650,7 +1650,7 @@
             %del
           =?  cu-core  &(?=(^ entry) ?=(^ reply))
             =*  content  content.reply.u.reply
-            =/  mention  (was-mentioned:utils content our.bowl)
+            =/  mention  (was-mentioned:utils content our.bowl ~)
             =/  concern
               [%delete-reply [id time]:reply.u.reply [id time]:writ.u.entry]
             (cu-activity concern content mention)
@@ -1668,7 +1668,7 @@
           =*  op  writ.u.entry
           =/  top-con  [id time]:op
           =/  concern  [%reply [id.q.diff.delta now.bowl] top-con]
-          =/  mention  (was-mentioned:utils content.memo our.bowl)
+          =/  mention  (was-mentioned:utils content.memo our.bowl ~)
           =.  cu-core  (cu-activity concern content.memo mention)
           (cu-give-writs-diff diff.delta)
         ==
@@ -2024,14 +2024,14 @@
       =?  cor  &(!=(old-unread di-unread) !=(net.dm %invited))
         (give-unread ship/ship di-unread)
       =/  concern  [%post p.diff now.bowl]
-      =/  mention  (was-mentioned:utils content.essay our.bowl)
+      =/  mention  (was-mentioned:utils content.essay our.bowl ~)
       =.  di-core  (di-activity concern content.essay mention)
       (di-give-writs-diff diff)
     ::
         %del
       =?  di-core  ?=(^ had)
         =*  content  content.writ.u.had
-        =/  mention  (was-mentioned:utils content our.bowl)
+        =/  mention  (was-mentioned:utils content our.bowl ~)
         (di-activity [%delete-post [id time]:writ.u.had] content mention)
       (di-give-writs-diff diff)
     ::
@@ -2045,7 +2045,7 @@
           %del
         =?  di-core  &(?=(^ entry) ?=(^ reply))
           =*  content  content.reply.u.reply
-          =/  mention  (was-mentioned:utils content our.bowl)
+          =/  mention  (was-mentioned:utils content our.bowl ~)
           =/  concern
             [%delete-reply [id time]:reply.u.reply [id time]:writ.u.entry]
           (di-activity concern content mention)
@@ -2063,7 +2063,7 @@
         ?~  entry  (di-give-writs-diff diff)
         =/  top-con  [id.writ.u.entry time.writ.u.entry]
         =/  concern  [%reply [id.q.diff now.bowl] top-con]
-        =/  mention  (was-mentioned:utils content.memo our.bowl)
+        =/  mention  (was-mentioned:utils content.memo our.bowl ~)
         =.  di-core  (di-activity concern content.memo mention)
         (di-give-writs-diff diff)
       ==

--- a/desk/lib/channel-json.hoon
+++ b/desk/lib/channel-json.hoon
@@ -532,6 +532,8 @@
     ::
         %ship  s/(scot %p p.i)
     ::
+        %sect  ?~(p.i ~ s+p.i)
+    ::
         ?(%code %tag %inline-code)
       s+p.i
     ::

--- a/desk/lib/channel-json.hoon
+++ b/desk/lib/channel-json.hoon
@@ -1392,6 +1392,7 @@
         strike/(ar inline)
         blockquote/(ar inline)
         ship/ship
+        sect/(maybe (se %tas))
         inline-code/so
         code/so
         tag/so
@@ -1427,5 +1428,9 @@
     :~  hide/(se %ud)
         show/(se %ud)
     ==
+  ++  maybe
+    |*  wit=fist
+    |=  jon=json
+    ?~(jon ~ (wit jon))
   --
 --

--- a/desk/lib/channel-utils.hoon
+++ b/desk/lib/channel-utils.hoon
@@ -713,19 +713,15 @@
   %+  lien  story
   |=  =verse:c
   ?:  ?=(%block -.verse)  |
-  ~&  ['checking inlines' p.verse]
   %+  lien  p.verse
   |=  =inline:c
   ?@  inline  |
-  ~&  ['checking inline' inline]
   ?+  -.inline  |
     %ship  =(who p.inline)
   ::
       %sect
-    ~&  ['checking sect' inline]
     ?~  p.inline  &
     ?~  vessel  |
-    ~&  ['checking vessel' sects.u.vessel p.inline]
     (~(has in sects.u.vessel) p.inline)
   ==
 ::

--- a/desk/lib/channel-utils.hoon
+++ b/desk/lib/channel-utils.hoon
@@ -739,8 +739,13 @@
         ?(%code %inline-code)  ''
         %ship                  (scot %p p.c)
         %task                  (flatten [%inline q.c]~)
+    ::
         ?(%italics %bold %strike %blockquote)
       (flatten [%inline p.c]~)
+    ::
+        %sect
+      ?~  p.c  '@all'
+      (cat 3 '@' (scot %tas p.c))
     ==
   ==
 ::
@@ -938,6 +943,7 @@
     ?(%italics %bold %strike %blockquote)  (rap 3 (turn p.i flatten-inline))
     ?(%inline-code %code %tag)  p.i
     %ship   (scot %p p.i)
+    %sect  ?~(p.i '@all' (cat 3 '@' p.i))
     %block  q.i
     %link   q.i
     %task   (rap 3 (turn q.i flatten-inline))
@@ -1129,6 +1135,10 @@
     ::
         %ship
       ;span.ship:"{(scow %p p.inline)}"
+    ::
+        %sect
+      ?~  p.inline  ;span.sect:"@all"
+      ;span.sect:"@{<p.inline>}"
     ::
         %block
       ;span.block:"[block xx]"

--- a/desk/lib/channel-utils.hoon
+++ b/desk/lib/channel-utils.hoon
@@ -708,13 +708,26 @@
   scam(scan (scan-1 scan.scam))
 ::
 ++  was-mentioned
-  |=  [=story:c who=ship]
+  |=  [=story:c who=ship vessel=(unit vessel:fleet:g)]
   ^-  ?
   %+  lien  story
   |=  =verse:c
   ?:  ?=(%block -.verse)  |
+  ~&  ['checking inlines' p.verse]
   %+  lien  p.verse
-  (cury test [%ship who])
+  |=  =inline:c
+  ?@  inline  |
+  ~&  ['checking inline' inline]
+  ?+  -.inline  |
+    %ship  =(who p.inline)
+  ::
+      %sect
+    ~&  ['checking sect' inline]
+    ?~  p.inline  &
+    ?~  vessel  |
+    ~&  ['checking vessel' sects.u.vessel p.inline]
+    (~(has in sects.u.vessel) p.inline)
+  ==
 ::
 ++  flatten
   |=  content=(list verse:c)

--- a/desk/sur/channels.hoon
+++ b/desk/sur/channels.hoon
@@ -191,6 +191,8 @@
 ::    %inline-code: code formatting for small snippets
 ::    %blockquote: blockquote surrounded content
 ::    %block: link/reference to blocks
+::    %ship: mention/reference to a ship
+::    %sect: mention/reference to a sect of users, ~ signifies everyone
 ::    %code: code formatting for large snippets
 ::    %tag: tag gets special signifier
 ::    %link: link to a URL with a face
@@ -205,6 +207,7 @@
       [%inline-code p=cord]
       [%code p=cord]
       [%ship p=ship]
+      [%sect p=?(~ sect:g)]
       [%block p=@ud q=cord]
       [%tag p=cord]
       [%link p=cord q=cord]

--- a/packages/app/features/top/ChannelScreen.tsx
+++ b/packages/app/features/top/ChannelScreen.tsx
@@ -360,6 +360,15 @@ export default function ChannelScreen(props: Props) {
     [props.navigation]
   );
 
+  const handleGoToGroupSettings = useCallback(() => {
+    if (group) {
+      props.navigation.navigate('GroupSettings', {
+        screen: 'GroupMembers',
+        params: { groupId: group.id },
+      });
+    }
+  }, [group, props.navigation]);
+
   const handleInviteSheetOpenChange = useCallback((open: boolean) => {
     if (!open) {
       setInviteSheetGroup(null);
@@ -416,6 +425,7 @@ export default function ChannelScreen(props: Props) {
           goToSearch={navigateToSearch}
           goToDm={handleGoToDm}
           goToUserProfile={handleGoToUserProfile}
+          goToGroupSettings={handleGoToGroupSettings}
           onScrollEndReached={loadOlder}
           onScrollStartReached={loadNewer}
           onPressRef={navigateToRef}

--- a/packages/app/features/top/PostScreen.tsx
+++ b/packages/app/features/top/PostScreen.tsx
@@ -147,7 +147,7 @@ function PostScreenContent({
       parentPost={post}
       channel={channel}
       goBack={handleGoBack}
-      groupMembers={group?.members ?? []}
+      group={group}
       handleGoToImage={navigateToImage}
       onPressDelete={handleDeletePost}
       onPressRetry={handleRetrySend}

--- a/packages/app/fixtures/PostScreen.fixture.tsx
+++ b/packages/app/fixtures/PostScreen.fixture.tsx
@@ -75,7 +75,7 @@ export default {
           setEditingPost={() => {}}
           parentPost={null}
           channel={tlonLocalBulletinBoard}
-          groupMembers={group.members ?? []}
+          group={group}
           headerMode="default"
           onGroupAction={() => {}}
           goToDm={() => {}}
@@ -175,7 +175,6 @@ export default {
               fetchOlderPage,
               channelContext: {
                 group: data.channel.group,
-                groupMembers: data.channel.group?.members ?? [],
                 editingPost: undefined,
                 setEditingPost: undefined,
                 editPost: noop,

--- a/packages/app/ui/components/BareChatInput/index.tsx
+++ b/packages/app/ui/components/BareChatInput/index.tsx
@@ -49,7 +49,11 @@ import {
   MessageInputProps,
 } from '../MessageInput/MessageInputBase';
 import { contentToTextAndMentions, textAndMentionsToContent } from './helpers';
-import { useMentions } from './useMentions';
+import {
+  MentionOption,
+  createMentionOptions,
+  useMentions,
+} from './useMentions';
 
 const bareChatInputLogger = createDevLogger('bareChatInput', false);
 
@@ -185,6 +189,7 @@ export default function BareChatInput({
   send,
   channelId,
   groupMembers,
+  groupRoles,
   storeDraft,
   clearDraft,
   getDraft,
@@ -228,17 +233,22 @@ export default function BareChatInput({
   const [hasAutoFocused, setHasAutoFocused] = useState(false);
   const [needsHeightAdjustmentAfterLoad, setNeedsHeightAdjustmentAfterLoad] =
     useState(false);
+  const options = useMemo(() => {
+    return createMentionOptions(groupMembers, groupRoles);
+  }, [groupMembers, groupRoles]);
+  console.log({ groupMembers, groupRoles, options });
+
   const {
+    mentions,
+    validOptions,
+    mentionSearchText,
+    isMentionModeActive,
+    hasMentionCandidates,
+    setMentions,
     handleMention,
     handleSelectMention,
-    mentionSearchText,
-    mentions,
-    setMentions,
-    isMentionModeActive,
     handleMentionEscape,
-    hasMentionCandidates,
-    setHasMentionCandidates,
-  } = useMentions();
+  } = useMentions({ options });
   const maxInputHeight = useKeyboardHeight(maxInputHeightBasic);
   const inputRef = useRef<TextInput>(null);
 
@@ -322,8 +332,8 @@ export default function BareChatInput({
   );
 
   const onMentionSelect = useCallback(
-    (contact: db.Contact) => {
-      const newText = handleSelectMention(contact, controlledText);
+    (option: MentionOption) => {
+      const newText = handleSelectMention(option, controlledText);
 
       if (!newText) {
         return;
@@ -756,6 +766,12 @@ export default function BareChatInput({
 
       if (keyEvent.key === 'Enter' && !keyEvent.shiftKey) {
         e.preventDefault();
+        console.log({
+          isMentionModeActive,
+          hasMentionCandidates,
+          mentions,
+          mentionSearchText,
+        });
         if (isMentionModeActive && hasMentionCandidates) {
           mentionRef.current?.handleMentionKey('Enter');
         } else if (editingPost) {
@@ -783,14 +799,13 @@ export default function BareChatInput({
       containerHeight={48}
       disableSend={editorIsEmpty}
       sendError={sendError}
-      isMentionModeActive={isMentionModeActive}
       showWayfindingTooltip={showWayfindingTooltip}
+      isMentionModeActive={isMentionModeActive}
       mentionText={mentionSearchText}
+      mentionOptions={validOptions}
       mentionRef={mentionRef}
-      setHasMentionCandidates={setHasMentionCandidates}
-      showAttachmentButton={showAttachmentButton}
-      groupMembers={groupMembers}
       onSelectMention={onMentionSelect}
+      showAttachmentButton={showAttachmentButton}
       isEditing={!!editingPost}
       cancelEditing={handleCancelEditing}
       onPressEdit={handleEdit}

--- a/packages/app/ui/components/BareChatInput/useMentions.tsx
+++ b/packages/app/ui/components/BareChatInput/useMentions.tsx
@@ -1,5 +1,10 @@
+import { escapeRegExp, isValidPatp } from '@tloncorp/shared';
+import { getCurrentUserId } from '@tloncorp/shared/api';
 import * as db from '@tloncorp/shared/db';
-import { useState } from 'react';
+import { useMemo, useState } from 'react';
+
+import { emptyContact } from '../../../fixtures/fakeData';
+import { formatUserId } from '../../utils';
 
 export interface Mention {
   id: string;
@@ -8,9 +13,67 @@ export interface Mention {
   end: number;
 }
 
-export const useMentions = () => {
+export interface MentionOption {
+  id: string;
+  type: 'contact' | 'group';
+  title?: string | null;
+  subtitle?: string | null;
+  priority: number;
+}
+
+export function getMentionPriority(member: db.ChatMember): number {
+  const { contact } = member;
+  if (!contact) {
+    return 1;
+  }
+
+  if (contact.isContact) {
+    return 3;
+  }
+
+  if (contact.isContactSuggestion) {
+    return 2;
+  }
+
+  return 1;
+}
+
+export function createMentionOptions(
+  groupMembers: db.ChatMember[],
+  groupRoles: db.GroupRole[]
+): MentionOption[] {
+  const currentUserId = getCurrentUserId();
+  const members = groupMembers
+    .filter((member) => member.contactId !== currentUserId)
+    .map<MentionOption>((member) => ({
+      id: member.contactId,
+      title: member.contact?.nickname || member.contactId,
+      subtitle: formatUserId(member.contactId, true)?.display,
+      type: 'contact',
+      priority: getMentionPriority(member),
+      contact: member.contact || emptyContact,
+    }));
+
+  const roles = groupRoles.map<MentionOption>((role) => ({
+    id: role.id,
+    title: role.title || role.id,
+    subtitle: role.description,
+    type: 'group',
+    priority: 4,
+  }));
+
+  const all: MentionOption = {
+    id: 'all',
+    title: 'All',
+    subtitle: 'All members in this channel',
+    type: 'group',
+    priority: 5,
+  };
+  return [all, ...members, ...roles].sort((a, b) => a.priority - b.priority);
+}
+
+export const useMentions = ({ options }: { options: MentionOption[] }) => {
   const [isMentionModeActive, setIsMentionModeActive] = useState(false);
-  const [hasMentionCandidates, setHasMentionCandidates] = useState(false);
   const [mentionStartIndex, setMentionStartIndex] = useState<number | null>(
     null
   );
@@ -20,6 +83,18 @@ export const useMentions = () => {
   const [lastDismissedTriggerIndex, setLastDismissedTriggerIndex] = useState<
     number | null
   >(null);
+
+  const validOptions = useMemo(() => {
+    return options.filter((option) => {
+      const pattern = new RegExp(escapeRegExp(mentionSearchText), 'i');
+
+      return option.title?.match(pattern) || option.subtitle?.match(pattern);
+    });
+  }, [options, mentionSearchText]);
+
+  const hasMentionCandidates = useMemo(() => {
+    return validOptions.length > 0;
+  }, [validOptions]);
 
   const handleMention = (oldText: string, newText: string) => {
     // Find cursor position by comparing old and new text
@@ -118,10 +193,11 @@ export const useMentions = () => {
     }
   };
 
-  const handleSelectMention = (contact: db.Contact, text: string) => {
+  const handleSelectMention = (option: MentionOption, text: string) => {
     if (mentionStartIndex === null) return;
 
-    const mentionDisplay = `${contact.id}`;
+    const display = option.title || option.id;
+    const mentionDisplay = isValidPatp(display) ? display : `@${display}`;
     const beforeMention = text.slice(0, mentionStartIndex);
     const afterMention = text.slice(
       mentionStartIndex + (mentionSearchText?.length || 0) + 1
@@ -129,7 +205,7 @@ export const useMentions = () => {
 
     const newText = beforeMention + mentionDisplay + ' ' + afterMention;
     const newMention: Mention = {
-      id: contact.id,
+      id: option.id,
       display: mentionDisplay,
       start: mentionStartIndex,
       end: mentionStartIndex + mentionDisplay.length,
@@ -153,6 +229,7 @@ export const useMentions = () => {
 
   return {
     mentions,
+    validOptions,
     setMentions,
     mentionSearchText,
     setMentionSearchText,
@@ -162,6 +239,5 @@ export const useMentions = () => {
     setIsMentionModeActive,
     handleMentionEscape,
     hasMentionCandidates,
-    setHasMentionCandidates,
   };
 };

--- a/packages/app/ui/components/Channel/index.tsx
+++ b/packages/app/ui/components/Channel/index.tsx
@@ -78,6 +78,7 @@ interface ChannelProps {
   goToChatDetails?: () => void;
   goToPost: (post: db.Post) => void;
   goToDm: (participants: string[]) => void;
+  goToGroupSettings: () => void;
   goToImageViewer: (post: db.Post, imageUri?: string) => void;
   goToSearch: () => void;
   goToUserProfile: (userId: string) => void;
@@ -131,6 +132,7 @@ export const Channel = forwardRef<ChannelMethods, ChannelProps>(
       goToPost,
       goToDm,
       goToUserProfile,
+      goToGroupSettings,
       messageSender,
       onScrollEndReached,
       onScrollStartReached,
@@ -342,6 +344,7 @@ export const Channel = forwardRef<ChannelMethods, ChannelProps>(
                 onPressGroupRef={onPressGroupRef}
                 onPressGoToDm={goToDm}
                 onGoToUserProfile={goToUserProfile}
+                onGoToGroupSettings={goToGroupSettings}
               >
                 <View backgroundColor={backgroundColor} flex={1}>
                   <FileDrop

--- a/packages/app/ui/components/MentionPopup.tsx
+++ b/packages/app/ui/components/MentionPopup.tsx
@@ -22,12 +22,10 @@ function MentionPopupInternal(
     groupMembers,
     onPress,
     matchText,
-    setHasMentionCandidates,
   }: PropsWithRef<{
     groupMembers: db.ChatMember[];
     onPress: (contact: db.Contact) => void;
     matchText?: string;
-    setHasMentionCandidates?: (has: boolean) => void;
   }>,
   ref: React.Ref<{
     handleMentionKey(key: 'ArrowUp' | 'ArrowDown' | 'Enter'): void;
@@ -55,12 +53,6 @@ function MentionPopupInternal(
   );
 
   const subsetSize = useMemo(() => subSet.length, [subSet]);
-
-  useEffect(() => {
-    if (matchText) {
-      setHasMentionCandidates?.(subsetSize > 0);
-    }
-  }, [matchText, subsetSize, setHasMentionCandidates]);
 
   const [selectedIndex, setSelectedIndex] = useState(0);
 

--- a/packages/app/ui/components/MentionPopup.tsx
+++ b/packages/app/ui/components/MentionPopup.tsx
@@ -1,5 +1,6 @@
 import * as db from '@tloncorp/shared/db';
 import { desig } from '@tloncorp/shared/urbit';
+import { Pressable } from '@tloncorp/ui';
 import {
   PropsWithRef,
   useEffect,
@@ -10,55 +11,91 @@ import {
 import React from 'react';
 import { Platform } from 'react-native';
 
+import { MentionOption } from './BareChatInput/useMentions';
 import { ContactList } from './ContactList';
+import ContactName from './ContactName';
+import { ListItem } from './ListItem/ListItem';
+import { useBoundHandler } from './ListItem/listItemUtils';
 
 export interface MentionController {
   handleMentionKey(key: 'ArrowUp' | 'ArrowDown' | 'Enter'): void;
 }
 export type MentionPopupRef = React.RefObject<MentionController>;
 
+function MentionOptionItem({
+  selected,
+  matchText,
+  option,
+  onPress,
+}: {
+  selected: boolean;
+  matchText?: string;
+  option: MentionOption;
+  onPress: (option: MentionOption) => void;
+}) {
+  const handlePress = useBoundHandler(option, onPress);
+  const isContact = option.type === 'contact';
+  const size = '$4xl';
+  return (
+    <Pressable borderRadius="$xl" onPress={handlePress}>
+      <ListItem
+        alignItems="center"
+        justifyContent="flex-start"
+        // setting the width to the screen width - 40 so that we can use
+        // ellipsizeMode="tail" to truncate the text
+        // width={Dimensions.get('window').width - 40}
+        // this is a hack to make the text not overflow the container
+        paddingRight="$3xl"
+        padding="$s"
+        backgroundColor={selected ? '$positiveBackground' : 'unset'}
+      >
+        {isContact ? (
+          <ListItem.ContactIcon size={size} contactId={option.id} />
+        ) : (
+          <ListItem.SystemIcon icon="Face" size={size} />
+        )}
+        <ListItem.MainContent>
+          <ListItem.Title>
+            {isContact ? (
+              <ContactName
+                matchText={matchText}
+                showNickname
+                userId={option.id}
+              />
+            ) : (
+              option.title || option.id
+            )}
+          </ListItem.Title>
+          {option.subtitle ? (
+            <ListItem.Subtitle>{option.subtitle}</ListItem.Subtitle>
+          ) : null}
+        </ListItem.MainContent>
+      </ListItem>
+    </Pressable>
+  );
+}
+
 function MentionPopupInternal(
   {
-    groupMembers,
+    options,
     onPress,
     matchText,
   }: PropsWithRef<{
-    groupMembers: db.ChatMember[];
-    onPress: (contact: db.Contact) => void;
+    options: MentionOption[];
+    onPress: (option: MentionOption) => void;
     matchText?: string;
   }>,
   ref: React.Ref<{
     handleMentionKey(key: 'ArrowUp' | 'ArrowDown' | 'Enter'): void;
   }>
 ) {
-  const subSet = useMemo(
-    () =>
-      groupMembers
-        .map((member) => member.contact)
-        .filter((contact) => {
-          if (contact === null || contact === undefined) {
-            return false;
-          }
-          if (!matchText) {
-            return true;
-          }
-
-          return (
-            contact.id.match(new RegExp(matchText, 'i')) ||
-            contact.nickname?.match(new RegExp(matchText, 'i'))
-          );
-        })
-        .slice(0, 7),
-    [groupMembers, matchText]
-  );
-
-  const subsetSize = useMemo(() => subSet.length, [subSet]);
+  const subSet = useMemo(() => options.slice(0, 7), [options]);
 
   const [selectedIndex, setSelectedIndex] = useState(0);
 
   useEffect(() => {
     setSelectedIndex(0);
-  }, [subsetSize]);
+  }, [subSet.length]);
 
   useImperativeHandle(ref, () => ({
     handleMentionKey(key) {
@@ -70,7 +107,7 @@ function MentionPopupInternal(
           break;
         case 'ArrowDown':
           setSelectedIndex((prevIndex) =>
-            prevIndex < subsetSize - 1 ? prevIndex + 1 : prevIndex
+            prevIndex < subSet.length - 1 ? prevIndex + 1 : prevIndex
           );
           break;
         case 'Enter':
@@ -88,31 +125,17 @@ function MentionPopupInternal(
 
   return (
     <ContactList>
-      {subSet.map((contact, index) =>
-        contact ? (
-          <ContactList.Item
-            alignItems="center"
-            justifyContent="flex-start"
-            onPress={() => onPress(contact)}
-            // setting the width to the screen width - 40 so that we can use
-            // ellipsizeMode="tail" to truncate the text
-            // width={Dimensions.get('window').width - 40}
-            // this is a hack to make the text not overflow the container
-            paddingRight="$3xl"
-            padding="$s"
-            key={contact.id}
-            contactId={contact.id}
-            matchText={matchText ? desig(matchText) : undefined}
-            showNickname
-            showUserId
-            backgroundColor={
-              Platform.OS === 'web' && index === selectedIndex
-                ? '$positiveBackground'
-                : 'unset'
-            }
+      {subSet.map((option, index) => {
+        return (
+          <MentionOptionItem
+            key={`${option.id}-${option.type}`}
+            selected={index === selectedIndex && Platform.OS === 'web'}
+            option={option}
+            matchText={matchText}
+            onPress={onPress}
           />
-        ) : null
-      )}
+        );
+      })}
     </ContactList>
   );
 }

--- a/packages/app/ui/components/MessageInput/InputMentionPopup.tsx
+++ b/packages/app/ui/components/MessageInput/InputMentionPopup.tsx
@@ -1,8 +1,9 @@
 import * as db from '@tloncorp/shared/db';
-import { PropsWithRef, useEffect } from 'react';
+import { PropsWithRef } from 'react';
 import React from 'react';
 import { View, YStack } from 'tamagui';
 
+import { MentionOption } from '../BareChatInput/useMentions';
 import { useIsWindowNarrow } from '../Emoji';
 import MentionPopup, { MentionPopupRef } from '../MentionPopup';
 
@@ -11,16 +12,14 @@ function InputMentionPopupInternal(
     containerHeight,
     isMentionModeActive,
     mentionText,
-    groupMembers,
+    options,
     onSelectMention,
-    setHasMentionCandidates,
   }: PropsWithRef<{
     containerHeight: number;
     isMentionModeActive: boolean;
     mentionText?: string;
-    groupMembers: db.ChatMember[];
-    onSelectMention: (contact: db.Contact) => void;
-    setHasMentionCandidates?: (has: boolean) => void;
+    options: MentionOption[];
+    onSelectMention: (option: MentionOption) => void;
   }>,
   ref: MentionPopupRef
 ) {
@@ -39,8 +38,7 @@ function InputMentionPopupInternal(
         <MentionPopup
           onPress={onSelectMention}
           matchText={mentionText}
-          groupMembers={groupMembers}
-          setHasMentionCandidates={setHasMentionCandidates}
+          options={options}
           ref={ref}
         />
       </View>

--- a/packages/app/ui/components/MessageInput/MessageInputBase.tsx
+++ b/packages/app/ui/components/MessageInput/MessageInputBase.tsx
@@ -1,14 +1,13 @@
 import type { BridgeState, EditorBridge } from '@10play/tentap-editor';
 import * as db from '@tloncorp/shared/db';
-import * as logic from '@tloncorp/shared/logic';
 import { JSONContent, Story } from '@tloncorp/shared/urbit';
 import { Button } from '@tloncorp/ui';
-import { FloatingActionButton, Text } from '@tloncorp/ui';
+import { FloatingActionButton } from '@tloncorp/ui';
 import { Icon } from '@tloncorp/ui';
 import { ImagePickerAsset } from 'expo-image-picker';
 import { memo } from 'react';
 import { PropsWithChildren } from 'react';
-import { Circle, SpaceTokens, styled } from 'tamagui';
+import { SpaceTokens, styled } from 'tamagui';
 import {
   ThemeTokens,
   View,
@@ -19,6 +18,7 @@ import {
 } from 'tamagui';
 
 import { useAttachmentContext } from '../../contexts/attachment';
+import { MentionOption } from '../BareChatInput/useMentions';
 import { MentionPopupRef } from '../MentionPopup';
 import Notices from '../Wayfinding/Notices';
 import { GalleryDraftType } from '../draftInputs/shared';
@@ -35,6 +35,7 @@ export interface MessageInputProps {
   ) => Promise<void>;
   channelId: string;
   groupMembers: db.ChatMember[];
+  groupRoles: db.GroupRole[];
   storeDraft: (
     draft: JSONContent,
     draftType?: GalleryDraftType
@@ -97,7 +98,7 @@ export const MessageInputContainer = memo(
     showWayfindingTooltip = false,
     disableSend = false,
     mentionText,
-    groupMembers,
+    mentionOptions,
     onSelectMention,
     isEditing = false,
     cancelEditing,
@@ -105,7 +106,6 @@ export const MessageInputContainer = memo(
     goBack,
     mentionRef,
     frameless = false,
-    setHasMentionCandidates,
   }: PropsWithChildren<{
     setShouldBlur: (shouldBlur: boolean) => void;
     onPressSend: () => void;
@@ -117,15 +117,14 @@ export const MessageInputContainer = memo(
     showWayfindingTooltip?: boolean;
     disableSend?: boolean;
     mentionText?: string;
-    groupMembers: db.ChatMember[];
-    onSelectMention: (contact: db.Contact) => void;
+    mentionOptions: MentionOption[];
+    onSelectMention: (option: MentionOption) => void;
     isEditing?: boolean;
     cancelEditing?: () => void;
     onPressEdit?: () => void;
     goBack?: () => void;
     mentionRef?: MentionPopupRef;
     frameless?: boolean;
-    setHasMentionCandidates?: (has: boolean) => void;
   }>) => {
     const { canUpload } = useAttachmentContext();
     const theme = useTheme();
@@ -145,10 +144,9 @@ export const MessageInputContainer = memo(
           containerHeight={containerHeight}
           isMentionModeActive={isMentionModeActive}
           mentionText={mentionText}
-          groupMembers={groupMembers}
+          options={mentionOptions}
           onSelectMention={onSelectMention}
           ref={mentionRef}
-          setHasMentionCandidates={setHasMentionCandidates}
         />
         {!frameless ? (
           <XStack

--- a/packages/app/ui/components/MessageInput/index.tsx
+++ b/packages/app/ui/components/MessageInput/index.tsx
@@ -64,6 +64,10 @@ import {
   UploadedImageAttachment,
   useAttachmentContext,
 } from '../../contexts/attachment';
+import {
+  createMentionOptions,
+  useMentions,
+} from '../BareChatInput/useMentions';
 import { AttachmentPreviewList } from './AttachmentPreviewList';
 import { MessageInputContainer, MessageInputProps } from './MessageInputBase';
 import { processReferenceAndUpdateEditor } from './helpers';
@@ -122,6 +126,7 @@ export const MessageInput = forwardRef<MessageInputHandle, MessageInputProps>(
       send,
       channelId,
       groupMembers,
+      groupRoles,
       storeDraft,
       clearDraft,
       getDraft,
@@ -189,8 +194,6 @@ export const MessageInput = forwardRef<MessageInputHandle, MessageInputProps>(
     ]);
     const [bigInputHeight, setBigInputHeight] = useState(bigInputHeightBasic);
     const [maxInputHeight, setMaxInputHeight] = useState(maxInputHeightBasic);
-    const [mentionText, setMentionText] = useState<string>();
-    const [showMentionPopup, setShowMentionPopup] = useState(false);
 
     const {
       attachments,
@@ -426,31 +429,31 @@ export const MessageInput = forwardRef<MessageInputHandle, MessageInputProps>(
       );
 
       const json = (await editor.getJSON()) as JSONContent;
-      const inlines = (
-        tiptap
-          .JSONToInlines(json)
-          .filter(
-            (c) =>
-              typeof c === 'string' || (typeof c === 'object' && isInline(c))
-          ) as Inline[]
-      ).filter((inline) => inline !== null) as Inline[];
-      // find the first mention in the inlines without refs
-      const mentionInline = inlines.find(
-        (inline) => typeof inline === 'string' && inline.match(/\B[~@]/)
-      ) as string | undefined;
-      // extract the mention text from the mention inline
-      const mentionTextFromInline = mentionInline
-        ? mentionInline.slice((mentionInline.match(/\B[~@]/)?.index ?? -1) + 1)
-        : null;
-      if (mentionTextFromInline !== null) {
-        messageInputLogger.log('Mention text', mentionTextFromInline);
-        // if we have a mention text, we show the mention popup
-        setShowMentionPopup(true);
-        setMentionText(mentionTextFromInline);
-      } else {
-        setShowMentionPopup(false);
-        setMentionText('');
-      }
+      // const inlines = (
+      //   tiptap
+      //     .JSONToInlines(json)
+      //     .filter(
+      //       (c) =>
+      //         typeof c === 'string' || (typeof c === 'object' && isInline(c))
+      //     ) as Inline[]
+      // ).filter((inline) => inline !== null) as Inline[];
+      // // find the first mention in the inlines without refs
+      // const mentionInline = inlines.find(
+      //   (inline) => typeof inline === 'string' && inline.match(/\B[~@]/)
+      // ) as string | undefined;
+      // // extract the mention text from the mention inline
+      // const mentionTextFromInline = mentionInline
+      //   ? mentionInline.slice((mentionInline.match(/\B[~@]/)?.index ?? -1) + 1)
+      //   : null;
+      // if (mentionTextFromInline !== null) {
+      //   messageInputLogger.log('Mention text', mentionTextFromInline);
+      //   // if we have a mention text, we show the mention popup
+      //   setShowMentionPopup(true);
+      //   setMentionText(mentionTextFromInline);
+      // } else {
+      //   setShowMentionPopup(false);
+      //   setMentionText('');
+      // }
 
       messageInputLogger.log('Storing draft', json);
 
@@ -624,8 +627,8 @@ export const MessageInput = forwardRef<MessageInputHandle, MessageInputProps>(
         // @ts-expect-error setContent does accept JSONContent
         editor.setContent(newJson);
         storeDraft(newJson, draftType);
-        setMentionText('');
-        setShowMentionPopup(false);
+        // setMentionText('');
+        // setShowMentionPopup(false);
       },
       [editor, storeDraft, draftType]
     );
@@ -981,9 +984,8 @@ export const MessageInput = forwardRef<MessageInputHandle, MessageInputProps>(
         onPressEdit={handleEdit}
         containerHeight={containerHeight}
         sendError={sendError}
-        mentionText={mentionText}
-        groupMembers={groupMembers}
-        onSelectMention={onSelectMention}
+        mentionOptions={[]}
+        onSelectMention={() => {}}
         isEditing={!!editingPost}
         cancelEditing={handleCancelEditing}
         showAttachmentButton={showAttachmentButton}

--- a/packages/app/ui/components/PostContent/contentUtils.tsx
+++ b/packages/app/ui/components/PostContent/contentUtils.tsx
@@ -38,6 +38,11 @@ export type MentionInlineData = {
   contactId: string;
 };
 
+export type GroupMentionInlineData = {
+  type: 'groupMention';
+  group: 'all' | string;
+};
+
 export type LineBreakInlineData = {
   type: 'lineBreak';
 };
@@ -58,6 +63,7 @@ export type InlineData =
   | StyleInlineData
   | TextInlineData
   | MentionInlineData
+  | GroupMentionInlineData
   | LineBreakInlineData
   | LinkInlineData
   | TaskInlineData;
@@ -456,6 +462,11 @@ function convertInlineContent(inlines: ub.Inline[]): InlineData[] {
       nodes.push({
         type: 'mention',
         contactId: inline.ship,
+      });
+    } else if (ub.isSect(inline)) {
+      nodes.push({
+        type: 'groupMention',
+        group: !inline.sect ? 'all' : inline.sect,
       });
     } else if (ub.isTask(inline)) {
       nodes.push({

--- a/packages/app/ui/components/PostScreenView.tsx
+++ b/packages/app/ui/components/PostScreenView.tsx
@@ -57,8 +57,7 @@ const FocusedPostContext = createContext<{
 );
 
 interface ChannelContext {
-  group?: db.Group | null;
-  groupMembers: db.ChatMember[];
+  group: db.Group | null;
   editingPost?: db.Post;
   setEditingPost?: (post: db.Post | undefined) => void;
   editPost: (
@@ -75,9 +74,9 @@ interface ChannelContext {
 
 export function PostScreenView({
   channel,
+  group,
   parentPost,
   goBack,
-  groupMembers,
   handleGoToImage,
   handleGoToUserProfile,
   editingPost,
@@ -98,6 +97,8 @@ export function PostScreenView({
   onGroupAction: (action: GroupPreviewAction, group: db.Group) => void;
   goToDm: (participants: string[]) => void;
 } & ChannelContext) {
+  const groupMembers = group?.members ?? [];
+  const groupRoles = group?.roles ?? [];
   const isWindowNarrow = utils.useIsWindowNarrow();
   const currentUserId = useCurrentUserId();
   const currentUserIsAdmin = utils.useIsAdmin(
@@ -235,7 +236,7 @@ export function PostScreenView({
                           editPost,
                           editingPost,
                           goBack,
-                          groupMembers,
+                          group,
                           handleGoToImage,
                           headerMode,
                           negotiationMatch,
@@ -254,7 +255,7 @@ export function PostScreenView({
                         channelContext={{
                           editPost,
                           editingPost,
-                          groupMembers,
+                          group,
                           headerMode,
                           negotiationMatch,
                           onPressDelete,
@@ -350,10 +351,10 @@ function useMarkThreadAsReadEffect(
 
 function SinglePostView({
   channel,
+  group,
   editPost,
   editingPost,
   goBack,
-  groupMembers,
   handleGoToImage,
   headerMode,
   negotiationMatch,
@@ -371,8 +372,7 @@ function SinglePostView({
   ) => Promise<void>;
   editingPost?: db.Post;
   goBack?: () => void;
-  group?: db.Group | null;
-  groupMembers: db.ChatMember[];
+  group: db.Group | null;
   handleGoToImage?: (post: db.Post, uri?: string) => void;
   headerMode: 'default' | 'next';
   negotiationMatch: boolean;
@@ -381,6 +381,8 @@ function SinglePostView({
   parentPost: db.Post;
   setEditingPost?: (post: db.Post | undefined) => void;
 }) {
+  const groupMembers = group?.members ?? [];
+  const groupRoles = group?.roles ?? [];
   const store = useStore();
   const { focusedPost } = useContext(FocusedPostContext);
   const isFocusedPost = focusedPost?.id === parentPost.id;
@@ -518,6 +520,7 @@ function SinglePostView({
               send={sendReply}
               channelId={channel.id}
               groupMembers={groupMembers}
+              groupRoles={groupRoles}
               {...bareInputDraftProps}
               editingPost={editingPost}
               setEditingPost={setEditingPost}
@@ -573,6 +576,7 @@ function SinglePostView({
             storeDraft={storeDraft}
             clearDraft={clearDraft}
             groupMembers={groupMembers}
+            groupRoles={groupRoles}
           />
         </View>
       ) : null}

--- a/packages/app/ui/components/draftInputs/ChatInput.tsx
+++ b/packages/app/ui/components/draftInputs/ChatInput.tsx
@@ -39,6 +39,7 @@ export function ChatInput({
           send={send}
           channelId={channel.id}
           groupMembers={group?.members ?? []}
+          groupRoles={group?.roles ?? []}
           storeDraft={storeDraft}
           clearDraft={clearDraft}
           getDraft={getDraft}

--- a/packages/app/ui/components/draftInputs/DraftInputConnectedBigInput.tsx
+++ b/packages/app/ui/components/draftInputs/DraftInputConnectedBigInput.tsx
@@ -50,6 +50,7 @@ export function DraftInputConnectedBigInput({
         }
         channelId={channel.id}
         groupMembers={group?.members ?? []}
+        groupRoles={group?.roles ?? []}
         shouldBlur={shouldBlur}
         setShouldBlur={setShouldBlur}
         send={send}

--- a/packages/app/ui/contexts/navigation.tsx
+++ b/packages/app/ui/contexts/navigation.tsx
@@ -6,6 +6,7 @@ type State = {
   onPressGroupRef?: (group: db.Group) => void;
   onPressGoToDm?: (participants: string[]) => void;
   onGoToUserProfile?: (userId: string) => void;
+  onGoToGroupSettings?: () => void;
   focusedChannelId?: string;
 };
 
@@ -23,6 +24,9 @@ const Context = createContext<ContextValue>({
   },
   onGoToUserProfile: () => {
     console.log(`onGoToUserProfile called, but missing from context`);
+  },
+  onGoToGroupSettings: () => {
+    console.log(`onGoToGroupSettings called, but missing from context`);
   },
 });
 
@@ -42,6 +46,7 @@ export const NavigationProvider = ({
   onPressGroupRef,
   onPressGoToDm,
   onGoToUserProfile,
+  onGoToGroupSettings,
   focusedChannelId,
 }: {
   children: React.ReactNode;
@@ -49,6 +54,7 @@ export const NavigationProvider = ({
   onPressGroupRef?: (group: db.Group) => void;
   onPressGoToDm?: (participants: string[]) => void;
   onGoToUserProfile?: (userId: string) => void;
+  onGoToGroupSettings?: () => void;
   focusedChannelId?: string;
 }) => {
   const value = useMemo(
@@ -57,6 +63,7 @@ export const NavigationProvider = ({
       onPressGroupRef,
       onPressGoToDm,
       onGoToUserProfile,
+      onGoToGroupSettings,
       focusedChannelId,
     }),
     [
@@ -64,6 +71,7 @@ export const NavigationProvider = ({
       onPressGroupRef,
       onPressGoToDm,
       onGoToUserProfile,
+      onGoToGroupSettings,
       focusedChannelId,
     ]
   );

--- a/packages/shared/src/db/migrations/0000_wet_maximus.sql
+++ b/packages/shared/src/db/migrations/0000_wet_maximus.sql
@@ -220,7 +220,7 @@ CREATE TABLE `group_rank_bans` (
 );
 --> statement-breakpoint
 CREATE TABLE `group_roles` (
-	`id` text,
+	`id` text NOT NULL,
 	`group_id` text,
 	`icon_image` text,
 	`icon_image_color` text,

--- a/packages/shared/src/db/migrations/meta/0000_snapshot.json
+++ b/packages/shared/src/db/migrations/meta/0000_snapshot.json
@@ -1,7 +1,7 @@
 {
   "version": "6",
   "dialect": "sqlite",
-  "id": "3303be3f-f219-4db0-b80f-dc73fc170656",
+  "id": "f55661be-e63e-4b35-bacc-957ceba9465c",
   "prevId": "00000000-0000-0000-0000-000000000000",
   "tables": {
     "activity_event_contact_group_pins": {
@@ -1472,7 +1472,7 @@
           "name": "id",
           "type": "text",
           "primaryKey": false,
-          "notNull": false,
+          "notNull": true,
           "autoincrement": false
         },
         "group_id": {

--- a/packages/shared/src/db/migrations/meta/_journal.json
+++ b/packages/shared/src/db/migrations/meta/_journal.json
@@ -5,8 +5,8 @@
     {
       "idx": 0,
       "version": "6",
-      "when": 1744755759885,
-      "tag": "0000_short_phil_sheldon",
+      "when": 1745876924073,
+      "tag": "0000_wet_maximus",
       "breakpoints": true
     }
   ]

--- a/packages/shared/src/db/migrations/migrations.js
+++ b/packages/shared/src/db/migrations/migrations.js
@@ -1,7 +1,7 @@
 // This file is required for Expo/React Native SQLite migrations - https://orm.drizzle.team/quick-sqlite/expo
 
 import journal from './meta/_journal.json';
-import m0000 from './0000_short_phil_sheldon.sql';
+import m0000 from './0000_wet_maximus.sql';
 
   export default {
     journal,

--- a/packages/shared/src/db/schema.ts
+++ b/packages/shared/src/db/schema.ts
@@ -415,7 +415,7 @@ export const groupsRelations = relations(groups, ({ one, many }) => ({
 export const groupRoles = sqliteTable(
   'group_roles',
   {
-    id: text('id'),
+    id: text('id').notNull(),
     groupId: text('group_id').references(() => groups.id, {
       onDelete: 'cascade',
     }),

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -39,3 +39,4 @@ export * as utilHooks from './logic/utilHooks';
 export * from './debug';
 export * from './perf';
 export * from './electrtonAuth';
+export * from '@urbit/aura';

--- a/packages/shared/src/logic/tiptap.ts
+++ b/packages/shared/src/logic/tiptap.ts
@@ -5,7 +5,7 @@ import {
   PasteRule,
 } from '@tiptap/core';
 import { JSONContent } from '@tiptap/react';
-import { deSig } from '@urbit/aura';
+import { deSig, isValidPatp } from '@urbit/aura';
 import { isEqual, reduce } from 'lodash';
 
 import { Block, Cite, HeaderLevel, Listing, Story } from '../urbit/channel';
@@ -452,9 +452,15 @@ export function JSONToInlines(
     }
     case 'mention':
     case 'at-mention': {
+      const id = json.attrs?.id;
+      const ship = preSig(id);
+      if (isValidPatp(ship)) {
+        return [{ ship }];
+      }
+
       return [
         {
-          ship: preSig(json.attrs?.id),
+          sect: id === 'all' ? null : id,
         },
       ];
     }
@@ -509,9 +515,9 @@ const makeLink = (link: Link['link']) => ({
   marks: [{ type: 'link', attrs: { href: link.href } }],
   text: link.content,
 });
-export const makeMention = (ship: string) => ({
+export const makeMention = (id: string) => ({
   type: 'mention',
-  attrs: { id: deSig(ship) },
+  attrs: { id },
 });
 export const makeParagraph = (content?: JSONContent[]): JSONContent => {
   const p = { type: 'paragraph' };
@@ -620,7 +626,11 @@ export const inlineToContent = (
   }
 
   if ('ship' in inline) {
-    return makeMention(inline.ship);
+    return makeMention(deSig(inline.ship));
+  }
+
+  if ('sect' in inline) {
+    return makeMention(inline.sect || 'all');
   }
 
   if ('link' in inline) {

--- a/packages/shared/src/logic/utils.ts
+++ b/packages/shared/src/logic/utils.ts
@@ -614,3 +614,7 @@ export function getModelAnalytics({
 
   return details;
 }
+
+export function escapeRegExp(text: string): string {
+  return text.replace(/[-[\]{}()*+?.,\\^$|#\s]/g, '\\$&');
+}

--- a/packages/shared/src/urbit/content.ts
+++ b/packages/shared/src/urbit/content.ts
@@ -27,6 +27,10 @@ export interface Ship {
   ship: string;
 }
 
+export interface Sect {
+  sect: string | null;
+}
+
 export interface Italics {
   italics: Inline[];
 }
@@ -89,6 +93,7 @@ export type Inline =
   | Italics
   | Strikethrough
   | Ship
+  | Sect
   | Break
   | InlineCode
   | BlockCode
@@ -108,7 +113,10 @@ export type InlineKey =
   | 'code'
   | 'tag'
   | 'link'
-  | 'break';
+  | 'break'
+  | 'ship'
+  | 'task'
+  | 'sect';
 
 export function isBlock(verse: Verse): verse is VerseBlock {
   return 'block' in verse;
@@ -148,6 +156,10 @@ export function isBreak(item: unknown): item is Break {
 
 export function isShip(item: unknown): item is Ship {
   return typeof item === 'object' && item !== null && 'ship' in item;
+}
+
+export function isSect(item: unknown): item is Sect {
+  return typeof item === 'object' && item !== null && 'sect' in item;
 }
 
 export function isHeader(block: Block): block is Header {

--- a/packages/shared/src/urbit/utils.ts
+++ b/packages/shared/src/urbit/utils.ts
@@ -288,6 +288,8 @@ export function getInlineContent(inline: ubc.Inline): string {
     return '';
   } else if (ubc.isShip(inline)) {
     return inline.ship;
+  } else if (ubc.isSect(inline)) {
+    return `@${inline.sect || 'all'}`;
   } else if (ubc.isTag(inline)) {
     return inline.tag;
   } else if (ubc.isBlockReference(inline)) {


### PR DESCRIPTION
Fixes TLON-4080. This introduces a new inline type `sect` which allows for mentioning either the entire channel or a specific role. I took an opportunity to lightly refactor how mention popup works and sources options.