### PR TITLE
desktop: show user profile in ActivityNavigator

### DIFF
--- a/packages/app/features/settings/EditProfileScreen.tsx
+++ b/packages/app/features/settings/EditProfileScreen.tsx
@@ -22,20 +22,12 @@ export function EditProfileScreen({ route, navigation }: Props) {
     [navigation]
   );
 
-  const handleGoBack = useCallback(() => {
-    // We'll always go back to the profile screen of the user being edited
-    // navigation.goBack() was sometimes not working as expected (particularly in the Activity tab)
-    navigation.navigate('UserProfile', {
-      userId: route.params.userId,
-    });
-  }, [navigation, route.params.userId]);
-
   return (
     <GroupsProvider groups={groups ?? []}>
       <AttachmentProvider canUpload={canUpload} uploadAsset={store.uploadAsset}>
         <EditProfileScreenView
           userId={route.params.userId}
-          onGoBack={handleGoBack}
+          onGoBack={navigation.goBack}
           onGoToAttestation={handleGoToAttestation}
         />
       </AttachmentProvider>

--- a/packages/app/features/settings/EditProfileScreen.tsx
+++ b/packages/app/features/settings/EditProfileScreen.tsx
@@ -22,12 +22,20 @@ export function EditProfileScreen({ route, navigation }: Props) {
     [navigation]
   );
 
+  const handleGoBack = useCallback(() => {
+    // We'll always go back to the profile screen of the user being edited
+    // navigation.goBack() was sometimes not working as expected (particularly in the Activity tab)
+    navigation.navigate('UserProfile', {
+      userId: route.params.userId,
+    });
+  }, [navigation, route.params.userId]);
+
   return (
     <GroupsProvider groups={groups ?? []}>
       <AttachmentProvider canUpload={canUpload} uploadAsset={store.uploadAsset}>
         <EditProfileScreenView
           userId={route.params.userId}
-          onGoBack={() => navigation.goBack()}
+          onGoBack={handleGoBack}
           onGoToAttestation={handleGoToAttestation}
         />
       </AttachmentProvider>

--- a/packages/app/features/top/UserProfileScreen.tsx
+++ b/packages/app/features/top/UserProfileScreen.tsx
@@ -94,7 +94,7 @@ export function UserProfileScreen({ route, navigation }: Props) {
     const isContactsTabRoot = navHistory?.length === 1;
     // @ts-expect-error - key is a valid property
     const isActivityTab = navHistory?.[0]?.key.includes('ActivityEmpty');
-    return !((isWebDesktop && isContactsTabRoot) || isActivityTab);
+    return !(isWebDesktop && (isContactsTabRoot || isActivityTab));
   }, [isWindowNarrow, navigation]);
 
   return (

--- a/packages/app/features/top/UserProfileScreen.tsx
+++ b/packages/app/features/top/UserProfileScreen.tsx
@@ -90,8 +90,11 @@ export function UserProfileScreen({ route, navigation }: Props) {
 
   const shouldShowBackButton = useMemo(() => {
     const isWebDesktop = isWeb && !isWindowNarrow;
-    const isContactsTabRoot = navigation.getState().history?.length === 1;
-    return !(isWebDesktop && isContactsTabRoot);
+    const navHistory = navigation.getState().history;
+    const isContactsTabRoot = navHistory?.length === 1;
+    // @ts-expect-error - key is a valid property
+    const isActivityTab = navHistory?.[0]?.key.includes('ActivityEmpty');
+    return !((isWebDesktop && isContactsTabRoot) || isActivityTab);
   }, [isWindowNarrow, navigation]);
 
   return (

--- a/packages/app/navigation/desktop/ActivityNavigator.tsx
+++ b/packages/app/navigation/desktop/ActivityNavigator.tsx
@@ -90,6 +90,7 @@ export const ActivityNavigator = () => {
     <ActivityDrawer.Navigator
       initialRouteName="ActivityEmpty"
       drawerContent={DrawerContent}
+      backBehavior='history'
       screenOptions={{
         headerShown: false,
         drawerType: 'permanent',

--- a/packages/app/navigation/desktop/ActivityNavigator.tsx
+++ b/packages/app/navigation/desktop/ActivityNavigator.tsx
@@ -8,6 +8,8 @@ import * as db from '@tloncorp/shared/db';
 import * as store from '@tloncorp/shared/store';
 import { useCallback, useMemo } from 'react';
 
+import { EditProfileScreen } from '../../features/settings/EditProfileScreen';
+import { UserProfileScreen } from '../../features/top/UserProfileScreen';
 import { useGroupActions } from '../../hooks/useGroupActions';
 import { ActivityScreenView, DESKTOP_SIDEBAR_WIDTH } from '../../ui';
 import { useRootNavigation } from '../utils';
@@ -86,7 +88,7 @@ function DrawerContent(props: DrawerContentComponentProps) {
 export const ActivityNavigator = () => {
   return (
     <ActivityDrawer.Navigator
-      initialRouteName="UserProfile"
+      initialRouteName="ActivityEmpty"
       drawerContent={DrawerContent}
       screenOptions={{
         headerShown: false,
@@ -102,6 +104,8 @@ export const ActivityNavigator = () => {
         name="ActivityEmpty"
         component={EmptyActivityScreen}
       />
+      <ActivityDrawer.Screen name="UserProfile" component={UserProfileScreen} />
+      <ActivityDrawer.Screen name="EditProfile" component={EditProfileScreen} />
     </ActivityDrawer.Navigator>
   );
 };


### PR DESCRIPTION
fixes tlon-4074

There was no way to get to user profiles from the Activity tab on desktop, so clicking on a status update (or avatar change) activity item would do nothing.

EditProfileScreen comes along for the ride too so that users can edit nicknames/avatars for their contacts.