### PR TITLE
groups agent: remove sort w/alphabetical ordering from drop-fleet

### DIFF
--- a/desk/app/groups.hoon
+++ b/desk/app/groups.hoon
@@ -855,10 +855,7 @@
     ?:  (lte fleet-size 15)
       fleet.group  :: keep all members if 15 or fewer
     =/  other-ships=(list [ship vessel:fleet:g])
-      %+  sort
-        ~(tap by (~(del by fleet.group) our.bowl))
-      |=  [[a=ship *] [b=ship *]]
-      (aor (scot %p a) (scot %p b)) :: alphabetical order by ship name
+      ~(tap by (~(del by fleet.group) our.bowl))
     =/  keep-ships=(list [ship vessel:fleet:g])
       :-  [our.bowl our-vessel]
       (scag 14 other-ships)  :: take first 14 other ships

--- a/packages/app/ui/utils/channelUtils.tsx
+++ b/packages/app/ui/utils/channelUtils.tsx
@@ -95,6 +95,7 @@ export function getGroupTitle(
     return (
       group.members
         ?.map((member) => getChannelMemberName(member, disableNicknames))
+        .sort((a, b) => (a && b ? a.localeCompare(b) : 0))
         .join(', ') ?? 'No title'
     );
   } else if (isPending) {


### PR DESCRIPTION
fixes tlon-4142

we just sort alphabetically on the frontend instead.