### PR TITLE
mention: oddities omnibus

### DIFF
--- a/packages/app/ui/components/BareChatInput/useMentions.tsx
+++ b/packages/app/ui/components/BareChatInput/useMentions.tsx
@@ -77,7 +77,13 @@ export const useMentions = () => {
       const textBetweenTriggerAndCursor = beforeCursor.slice(
         lastTriggerIndex + 1
       );
-      const hasSpace = textBetweenTriggerAndCursor.includes(' ');
+      const textBeforeTrigger = beforeCursor.slice(
+        lastTriggerIndex - 1,
+        lastTriggerIndex
+      );
+      const spaceBeforeOrFirst =
+        lastTriggerIndex === 0 || textBeforeTrigger === ' ';
+      const spaceAfter = textBetweenTriggerAndCursor.includes(' ');
 
       // Only show popup if:
       // 1. We're right after the trigger or actively searching
@@ -86,7 +92,8 @@ export const useMentions = () => {
       const isDismissedTrigger =
         wasDismissedByEscape && lastTriggerIndex === lastDismissedTriggerIndex;
       if (
-        !hasSpace &&
+        spaceBeforeOrFirst &&
+        !spaceAfter &&
         !isDismissedTrigger &&
         (cursorPosition === lastTriggerIndex + 1 ||
           (cursorPosition > lastTriggerIndex && !afterCursor.includes(' ')))

--- a/packages/app/ui/components/ListItem/ContactListItem.tsx
+++ b/packages/app/ui/components/ListItem/ContactListItem.tsx
@@ -14,7 +14,7 @@ export const ContactListItem = ({
   onLongPress,
   showNickname = false,
   showUserId = false,
-  full = false,
+  full = true,
   showIcon = true,
   showEndContent = false,
   endContent,
@@ -59,7 +59,7 @@ export const ContactListItem = ({
           </ListItem.Title>
           {showUserId && showNickname ? (
             <ListItem.Subtitle>
-              {formatUserId(contactId)?.display}
+              {formatUserId(contactId, true)?.display}
             </ListItem.Subtitle>
           ) : null}
           {subtitle && <ListItem.Subtitle>{subtitle}</ListItem.Subtitle>}

--- a/packages/app/ui/components/MentionPopup.tsx
+++ b/packages/app/ui/components/MentionPopup.tsx
@@ -57,10 +57,8 @@ function MentionPopupInternal(
   const subsetSize = useMemo(() => subSet.length, [subSet]);
 
   useEffect(() => {
-    if (matchText) {
-      setHasMentionCandidates?.(subsetSize > 0);
-    }
-  }, [matchText, subsetSize, setHasMentionCandidates]);
+    setHasMentionCandidates?.(subsetSize > 0);
+  }, [subsetSize, setHasMentionCandidates]);
 
   const [selectedIndex, setSelectedIndex] = useState(0);
 

--- a/packages/app/ui/components/MentionPopup.tsx
+++ b/packages/app/ui/components/MentionPopup.tsx
@@ -1,5 +1,6 @@
 import * as db from '@tloncorp/shared/db';
 import { desig } from '@tloncorp/shared/urbit';
+import _ from 'lodash';
 import {
   PropsWithRef,
   useEffect,
@@ -10,6 +11,7 @@ import {
 import React from 'react';
 import { Platform } from 'react-native';
 
+import { emptyContact } from '../../fixtures/fakeData';
 import { ContactList } from './ContactList';
 
 export interface MentionController {
@@ -33,26 +35,23 @@ function MentionPopupInternal(
     handleMentionKey(key: 'ArrowUp' | 'ArrowDown' | 'Enter'): void;
   }>
 ) {
-  const subSet = useMemo(
-    () =>
-      groupMembers
-        .map((member) => member.contact)
-        .filter((contact) => {
-          if (contact === null || contact === undefined) {
-            return false;
-          }
-          if (!matchText) {
-            return true;
-          }
+  const subSet = useMemo(() => {
+    const pattern = matchText
+      ? new RegExp(_.escapeRegExp(matchText), 'i')
+      : null;
+    return groupMembers
+      .map(
+        (member) => member.contact || { ...emptyContact, id: member.contactId }
+      )
+      .filter((contact) => {
+        if (!pattern) {
+          return true;
+        }
 
-          return (
-            contact.id.match(new RegExp(matchText, 'i')) ||
-            contact.nickname?.match(new RegExp(matchText, 'i'))
-          );
-        })
-        .slice(0, 7),
-    [groupMembers, matchText]
-  );
+        return contact.id.match(pattern) || contact.nickname?.match(pattern);
+      })
+      .slice(0, 7);
+  }, [groupMembers, matchText]);
 
   const subsetSize = useMemo(() => subSet.length, [subSet]);
 

--- a/packages/app/ui/components/UserProfileScreenView.tsx
+++ b/packages/app/ui/components/UserProfileScreenView.tsx
@@ -397,7 +397,11 @@ function UserInfoRow(props: { userId: string; hasNickname: boolean }) {
               ) : (
                 props.hasNickname && (
                   <Text color="$secondaryText">
-                    <ContactName contactId={props.userId} mode="contactId" />
+                    <ContactName
+                      contactId={props.userId}
+                      mode="contactId"
+                      expandLongIds
+                    />
                   </Text>
                 )
               )}


### PR DESCRIPTION
Fixes TLON-4130 where trying to search a mention with regex chars would break the app, and a few other things I found when working with mentions:

- we didn't allow you to select a mention if you only typed the trigger character and didn't search
- we were triggering mentions if you put a mention trigger character in the middle of the word. I think its fine to make it require whitespace before it (or be first character) 
- when mentioning the mention in the input would only be the patp not the nickname
- we tend to not show the full ID which in most cases won't matter for normal users, but for power users who have moons this made it impossible to know which moon it was
- if someone had never modified their profile and was in the group with you and never posted, they would be missing from the mentions list because they wouldn't have a `contact` field, we just yield the empty contact instead