### PR TITLE
mentions: revert change to show nicknames in input box

### DIFF
--- a/packages/app/ui/components/BareChatInput/useMentions.tsx
+++ b/packages/app/ui/components/BareChatInput/useMentions.tsx
@@ -128,7 +128,7 @@ export const useMentions = () => {
   const handleSelectMention = (contact: db.Contact, text: string) => {
     if (mentionStartIndex === null) return;
 
-    const mentionDisplay = contact.nickname || contact.id;
+    const mentionDisplay = contact.id;
     const beforeMention = text.slice(0, mentionStartIndex);
     const afterMention = text.slice(
       mentionStartIndex + (mentionSearchText?.length || 0) + 1


### PR DESCRIPTION
Because of the way we break text up to convert it back to our backend data type, mentions break if you have spaces in your nickname. This just reverts that change and places the id in the input.