### PR TITLE
mentions: allow spaces

### DIFF
--- a/packages/app/ui/components/PostContent/InlineRenderer.tsx
+++ b/packages/app/ui/components/PostContent/InlineRenderer.tsx
@@ -96,7 +96,7 @@ export function InlineText({
   inline: TextInlineData;
   color?: ColorTokens;
 }) {
-  return color ? <RawText color={color}>{inline.text}</RawText> : inline.text;
+  return <RawText color={color}>{inline.text}</RawText>;
 }
 
 export function InlineLink({ inline: node }: { inline: LinkInlineData }) {

--- a/packages/app/ui/components/PostContent/contentUtils.tsx
+++ b/packages/app/ui/components/PostContent/contentUtils.tsx
@@ -291,7 +291,7 @@ function extractEmbedsFromInlines(inlines: ub.Inline[]): BlockData[] {
 
   function flushSegment() {
     if (currentSegment.length > 0) {
-      // Check if segment only contains whitespace]
+      // Check if segment only contains whitespace
       const isOnlyWhitespace = currentSegment.every(
         (item) => typeof item === 'string' && item.trim() === ''
       );

--- a/packages/app/ui/components/PostContent/contentUtils.tsx
+++ b/packages/app/ui/components/PostContent/contentUtils.tsx
@@ -291,7 +291,7 @@ function extractEmbedsFromInlines(inlines: ub.Inline[]): BlockData[] {
 
   function flushSegment() {
     if (currentSegment.length > 0) {
-      // Check if segment only contains whitespace
+      // Check if segment only contains whitespace]
       const isOnlyWhitespace = currentSegment.every(
         (item) => typeof item === 'string' && item.trim() === ''
       );
@@ -299,16 +299,10 @@ function extractEmbedsFromInlines(inlines: ub.Inline[]): BlockData[] {
       // Only create a paragraph if there's actual content
       if (!isOnlyWhitespace) {
         const convertedInlines = convertInlineContent(currentSegment);
-
-        // Filter out empty text nodes or text nodes with only whitespace
-        const filteredInlines = convertedInlines.filter(
-          (inline) => !(inline.type === 'text' && inline.text.trim() === '')
-        );
-
-        if (filteredInlines.length) {
+        if (convertedInlines.length) {
           blocks.push({
             type: 'paragraph',
-            content: filteredInlines,
+            content: convertedInlines,
           });
         }
       }

--- a/packages/shared/src/http-api/Urbit.ts
+++ b/packages/shared/src/http-api/Urbit.ts
@@ -393,7 +393,9 @@ export class Urbit {
           if (event.data && JSON.parse(event.data)) {
             const data: any = JSON.parse(event.data);
 
-            console.log(`received data`, data);
+            if (this.verbose) {
+              console.log(`received data`, data);
+            }
 
             if (
               data.response === 'poke' &&


### PR DESCRIPTION
Allows us to show nicknames in text input when selecting mentions. When doing this noticed that we accidentally we're removing text nodes with just spaces when they were in between distinct non-text nodes. This should fix the issue we have where special formatted nodes get slammed together.