### PR TITLE
settings: set theme on back-end, update across clients

### DIFF
--- a/apps/tlon-web/src/state/settings.ts
+++ b/apps/tlon-web/src/state/settings.ts
@@ -631,7 +631,7 @@ export function useTiles() {
 }
 
 export function useThemeMutation() {
-  const { status, mutate: oldMutate } = usePutEntryMutation({
+  const { status } = usePutEntryMutation({
     bucket: 'display',
     key: 'theme',
   });
@@ -640,15 +640,11 @@ export function useThemeMutation() {
 
   const mutate = async (theme: Theme) => {
     try {
-      // Update locally and in backend
       await updateTheme(theme);
-      
-      // Invalidate settings query to refresh UI
+      // Refresh UI by invalidating settings
       queryClient.invalidateQueries({ queryKey: ['settings'] });
     } catch (error) {
       console.error('Failed to update theme:', error);
-      // Fallback to old method if the new one fails
-      oldMutate({ val: theme });
     }
   };
 

--- a/apps/tlon-web/src/state/settings.ts
+++ b/apps/tlon-web/src/state/settings.ts
@@ -4,7 +4,7 @@ import { DelBucket, DelEntry, PutBucket, Value } from '@urbit/api';
 import cookies from 'browser-cookies';
 import produce from 'immer';
 import _ from 'lodash';
-import { useMemo, useEffect } from 'react';
+import { useMemo } from 'react';
 import { v4 as uuidv4 } from 'uuid';
 
 import api from '@/api';
@@ -17,8 +17,6 @@ import {
 } from '@/constants';
 import useReactQuerySubscription from '@/logic/useReactQuerySubscription';
 import { isHosted } from '@/logic/utils';
-import { updateTheme } from '@tloncorp/shared/store';
-import { subscribeToSettings, SettingsUpdate } from '@tloncorp/shared/api';
 
 interface ChannelSetting {
   flag: string;
@@ -628,30 +626,6 @@ export function useTiles() {
     }),
     [data, isLoading]
   );
-}
-
-export function useThemeMutation() {
-  const { status } = usePutEntryMutation({
-    bucket: 'display',
-    key: 'theme',
-  });
-  
-  const queryClient = useQueryClient();
-
-  const mutate = async (theme: Theme) => {
-    try {
-      await updateTheme(theme);
-      // Refresh UI by invalidating settings
-      queryClient.invalidateQueries({ queryKey: ['settings'] });
-    } catch (error) {
-      console.error('Failed to update theme:', error);
-    }
-  };
-
-  return {
-    mutate,
-    status,
-  };
 }
 
 export function createAnalyticsId() {

--- a/packages/app/features/settings/ThemeScreen.tsx
+++ b/packages/app/features/settings/ThemeScreen.tsx
@@ -3,13 +3,12 @@ import { useThemeSettings } from '@tloncorp/shared';
 import { subscribeToSettings } from '@tloncorp/shared/api';
 import { useContext, useEffect, useState } from 'react';
 import { ScrollView, YStack } from 'tamagui';
-import type { ThemeName } from 'tamagui';
 import { useTheme } from 'tamagui';
 
 import { useIsDarkMode } from '../../hooks/useIsDarkMode';
 import { RootStackParamList } from '../../navigation/types';
-import { normalizeTheme } from '../../provider';
 import { ThemeContext, clearTheme, setTheme } from '../../provider';
+import { AppTheme } from '../../types/theme';
 import {
   ListItem,
   ListItemInputOption,
@@ -19,6 +18,7 @@ import {
   ScreenHeader,
   View,
 } from '../../ui';
+import { normalizeTheme } from '../../ui/utils/themeUtils';
 
 type Props = NativeStackScreenProps<RootStackParamList, 'Theme'>;
 
@@ -27,14 +27,10 @@ export function ThemeScreen(props: Props) {
   const { data: storedTheme, isLoading } = useThemeSettings();
   const { setActiveTheme } = useContext(ThemeContext);
   const isDarkMode = useIsDarkMode();
-  const [selectedTheme, setSelectedTheme] = useState<ThemeName | 'auto'>(
-    'auto'
-  );
-  const [loadingTheme, setLoadingTheme] = useState<ThemeName | 'auto' | null>(
-    null
-  );
+  const [selectedTheme, setSelectedTheme] = useState<AppTheme>('auto');
+  const [loadingTheme, setLoadingTheme] = useState<AppTheme | null>(null);
 
-  const themes: ListItemInputOption<ThemeName | 'auto'>[] = [
+  const themes: ListItemInputOption<AppTheme>[] = [
     {
       title: 'Auto',
       value: 'auto',
@@ -51,7 +47,7 @@ export function ThemeScreen(props: Props) {
     { title: 'Solarized', value: 'solarized' },
   ];
 
-  const handleThemeChange = async (value: ThemeName | 'auto') => {
+  const handleThemeChange = async (value: AppTheme) => {
     if (value === selectedTheme || loadingTheme) return;
 
     setLoadingTheme(value);
@@ -79,7 +75,7 @@ export function ThemeScreen(props: Props) {
     subscribeToSettings((update) => {
       if (update.type === 'updateSetting' && 'theme' in update.setting) {
         const newTheme = update.setting.theme;
-        const themeValue = normalizeTheme(newTheme as any);
+        const themeValue = normalizeTheme(newTheme as AppTheme);
 
         setSelectedTheme(themeValue);
 

--- a/packages/app/provider/index.tsx
+++ b/packages/app/provider/index.tsx
@@ -53,18 +53,22 @@ export function Provider({
     // Set up subscription to settings changes
     subscribeToSettings((update) => {
       if (update.type === 'updateSetting' && 'theme' in update.setting) {
-        const newTheme = update.setting.theme as ThemeName | 'auto' | null;
+        const newTheme = update.setting.theme as ThemeName | 'auto' | null | '';
         console.log('Theme updated from backend:', newTheme);
 
-        // Update local storage
+        // Update local storage - treat empty string as null (auto theme)
+        const localTheme =
+          !newTheme || newTheme === 'auto' || (newTheme as any) === ''
+            ? null
+            : newTheme;
         themeSettings
-          .setValue(newTheme as ThemeName | null)
+          .setValue(localTheme)
           .catch((err) =>
             console.warn('Failed to update local theme setting:', err)
           );
 
         // Apply theme change to UI
-        if (newTheme === null || newTheme === 'auto') {
+        if (!newTheme || newTheme === 'auto' || (newTheme as any) === '') {
           // For auto theme, respect system setting
           setActiveTheme(isDarkMode ? 'dark' : 'light');
         } else {

--- a/packages/app/types/theme.ts
+++ b/packages/app/types/theme.ts
@@ -1,0 +1,3 @@
+import type { ThemeName } from 'tamagui';
+
+export type AppTheme = ThemeName | 'auto';

--- a/packages/app/ui/utils/index.ts
+++ b/packages/app/ui/utils/index.ts
@@ -3,6 +3,7 @@ export * from './groupUtils';
 export * from './colorUtils';
 export * from './user';
 export * from './animation';
+export * from './themeUtils';
 
 // WIP: Temporary export to avoid breaking imports.
 export * from '@tloncorp/ui';

--- a/packages/app/ui/utils/themeUtils.tsx
+++ b/packages/app/ui/utils/themeUtils.tsx
@@ -1,0 +1,36 @@
+import { ThemeName } from 'tamagui';
+
+import { AppTheme } from '../../types/theme';
+
+/**
+ * Normalizes a theme string to a valid AppTheme..
+ * Returns 'auto' if input is null or not a valid theme.
+ */
+export function normalizeTheme(theme: string | null): AppTheme {
+  if (!theme) return 'auto';
+  const t = String(theme).toLowerCase();
+  const validThemes: Record<string, ThemeName> = {
+    light: 'light',
+    dark: 'dark',
+    dracula: 'dracula',
+    greenscreen: 'greenscreen',
+    gruvbox: 'gruvbox',
+    monokai: 'monokai',
+    nord: 'nord',
+    peony: 'peony',
+    solarized: 'solarized',
+  };
+
+  return validThemes[t] || 'auto';
+}
+
+/**
+ * Converts a theme value to a display theme, handling 'auto' by using
+ * the system dark mode preference.
+ */
+export function getDisplayTheme(
+  theme: AppTheme,
+  isDarkMode: boolean
+): ThemeName {
+  return theme === 'auto' ? (isDarkMode ? 'dark' : 'light') : theme;
+}

--- a/packages/shared/src/api/settingsApi.ts
+++ b/packages/shared/src/api/settingsApi.ts
@@ -35,6 +35,8 @@ function getBucket(key: string): string {
     case 'disableSpellcheck':
     case 'showUnreadCounts':
       return 'calmEngine';
+    case 'theme':
+      return 'display';
     default:
       console.warn(
         `No explicit bucket defined for setting key: ${key}, defaulting to 'groups'`

--- a/packages/shared/src/domain/analytics.ts
+++ b/packages/shared/src/domain/analytics.ts
@@ -119,6 +119,7 @@ export enum AnalyticsEvent {
   ActionContactBookInviteShown = 'Contact Book Invite Shown',
   ActionContactBookInviteSent = 'Contact Book Invite Sent',
   ActionCalmSettingsUpdate = 'Calm Settings Updated',
+  ActionThemeUpdate = 'Theme Setting Updated',
   DebugSystemContacts = 'System Contacts Debug',
   GroupJoinComplete = 'Group Join Complete',
   PersonalInviteLinkReady = 'Personal Invite Link Ready',
@@ -138,6 +139,7 @@ export enum AnalyticsEvent {
   ErrorWayfinding = 'Wayfinding Error',
   ErrorSystemContacts = 'System Contacts Error',
   ErrorCalmSettingsUpdate = 'Error Updating Calm Settings',
+  ErrorThemeUpdate = 'Error Updating Theme Setting',
   ErrorApi = 'API Error',
 }
 

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -39,3 +39,4 @@ export * as utilHooks from './logic/utilHooks';
 export * from './debug';
 export * from './perf';
 export * from './electrtonAuth';
+export * from './store/dbHooks';

--- a/packages/shared/src/store/dbHooks.ts
+++ b/packages/shared/src/store/dbHooks.ts
@@ -603,12 +603,20 @@ export const useShowNotebookAddTooltip = (channelId: string) => {
   return isCorrectChan && !wayfindingProgress.tappedAddNote;
 };
 
-export const useSettings = () => {
-  const deps = useKeyFromQueryDeps(db.getSettings);
-  return useQuery({
-    queryKey: ['settings', deps],
-    queryFn: async () => {
-      return db.getSettings();
-    },
-  });
+export const useThemeSettings = () => {
+  try {
+    const deps = useKeyFromQueryDeps(db.getSettings);
+    return useQuery({
+      queryKey: ['themeSettings', deps],
+      queryFn: async () => {
+        const settings = await db.getSettings();
+        return settings?.theme || null;
+      },
+    });
+  } catch (e) {
+    if ((e as Error).message?.includes('No QueryClient set')) {
+      return { data: null, isLoading: false, error: null };
+    }
+    throw e;
+  }
 };

--- a/packages/shared/src/store/dbHooks.ts
+++ b/packages/shared/src/store/dbHooks.ts
@@ -604,19 +604,12 @@ export const useShowNotebookAddTooltip = (channelId: string) => {
 };
 
 export const useThemeSettings = () => {
-  try {
-    const deps = useKeyFromQueryDeps(db.getSettings);
-    return useQuery({
-      queryKey: ['themeSettings', deps],
-      queryFn: async () => {
-        const settings = await db.getSettings();
-        return settings?.theme || null;
-      },
-    });
-  } catch (e) {
-    if ((e as Error).message?.includes('No QueryClient set')) {
-      return { data: null, isLoading: false, error: null };
-    }
-    throw e;
-  }
+  const deps = useKeyFromQueryDeps(db.getSettings);
+  return useQuery({
+    queryKey: ['themeSettings', deps],
+    queryFn: async () => {
+      const settings = await db.getSettings();
+      return settings?.theme || null;
+    },
+  });
 };

--- a/packages/shared/src/store/dbHooks.ts
+++ b/packages/shared/src/store/dbHooks.ts
@@ -602,3 +602,13 @@ export const useShowNotebookAddTooltip = (channelId: string) => {
   }, [channelId]);
   return isCorrectChan && !wayfindingProgress.tappedAddNote;
 };
+
+export const useSettings = () => {
+  const deps = useKeyFromQueryDeps(db.getSettings);
+  return useQuery({
+    queryKey: ['settings', deps],
+    queryFn: async () => {
+      return db.getSettings();
+    },
+  });
+};

--- a/packages/shared/src/store/settingsActions.ts
+++ b/packages/shared/src/store/settingsActions.ts
@@ -1,3 +1,5 @@
+import { ThemeName } from 'tamagui';
+
 import { setSetting } from '../api';
 import * as db from '../db';
 import { createDevLogger } from '../debug';
@@ -5,7 +7,8 @@ import { AnalyticsEvent, AnalyticsSeverity } from '../domain';
 import * as logic from '../logic';
 import { withRetry } from '../logic';
 import { TalkSidebarFilter } from '../urbit';
-import { Theme } from '../urbit/settings';
+
+export type AppTheme = ThemeName | 'auto';
 
 const logger = createDevLogger('SettingsActions', false);
 
@@ -122,7 +125,7 @@ export async function markPotentialWayfindingChannelVisit(channelId: string) {
   }
 }
 
-export async function updateTheme(theme: Theme | 'auto') {
+export async function updateTheme(theme: AppTheme) {
   const existing = await db.getSettings();
   const oldTheme = existing?.theme;
 
@@ -131,7 +134,7 @@ export async function updateTheme(theme: Theme | 'auto') {
     await db.insertSettings({ theme: dbTheme });
     await setSetting('theme', theme === 'auto' ? '' : theme);
     logger.trackEvent(AnalyticsEvent.ActionThemeUpdate, {
-      theme: theme === 'auto' ? 'auto' : theme
+      theme: theme === 'auto' ? 'auto' : theme,
     });
   } catch (error) {
     logger.trackError(AnalyticsEvent.ErrorThemeUpdate, {

--- a/packages/shared/src/store/settingsActions.ts
+++ b/packages/shared/src/store/settingsActions.ts
@@ -134,9 +134,8 @@ export async function updateTheme(theme: Theme | 'auto') {
     // optimistic update for local database
     await db.insertSettings({ theme: dbTheme });
     
-    // update backend - send null for 'auto' theme to be consistent
-    // this ensures all clients understand this is "auto" mode
-    await setSetting('theme', dbTheme);
+    // update backend - send empty string for 'auto' theme
+    await setSetting('theme', theme === 'auto' ? '' : theme);
     
     logger.trackEvent(AnalyticsEvent.ActionThemeUpdate, {
       theme: theme === 'auto' ? 'auto' : theme

--- a/packages/shared/src/urbit/settings.ts
+++ b/packages/shared/src/urbit/settings.ts
@@ -1,6 +1,8 @@
+import { ThemeName } from 'tamagui';
+
 import { DisplayMode, SortMode } from './channel';
 
-export type Theme = 'light' | 'dark' | 'auto';
+export type AppTheme = ThemeName | 'auto';
 
 export type TalkSidebarFilter =
   | 'Direct Messages'
@@ -51,7 +53,7 @@ export type CalmEngineSettings = {
 };
 
 export type DisplaySettings = {
-  theme?: Theme;
+  theme?: AppTheme;
 };
 
 export type GroupsSettings = {


### PR DESCRIPTION
Fixes TLON-4118 by storing the theme on the back-end and syncing across clients.

- Adds proper settings bucket support for themes
- Syncs across devices by listening for changes to the theme setting
- Appropriately handles the "auto" (null) theme selection
- Adds logging for theme setting + errors

https://github.com/user-attachments/assets/47412726-be97-4db6-9e9c-5bcffc28d389


