### PR TITLE
verifier: logging & maintenance details

### DIFF
--- a/desk/app/verifier.hoon
+++ b/desk/app/verifier.hoon
@@ -740,6 +740,7 @@
     ==
   ::
       %verifier-user-query
+    =.  for.log  `src.bowl
     =+  !<(qer=user-query vase)
     =;  [res=result:query-result nu=_state]
       =.  state  nu

--- a/desk/sur/verifier.hoon
+++ b/desk/sur/verifier.hoon
@@ -18,7 +18,7 @@
       lookups=(map @ identifier)
       reverse=(jug identifier @)
     ::
-      limits=[solo=(map @p allowance) pool=_allowance:pool:rates]
+      limits=[solo=(map @p allowance) pool=$~(allowance:pool:rates allowance)]
     ::
       ::NOTE  basic auth only needed for staging api key
       phone-api=[base=@t key=@t basic=(unit [user=@t pass=@t])]


### PR DESCRIPTION
Two small fixes.

We weren't including the `src.bowl` in the logs for user queries, leading to "rate limited" info logs without the affected ship being legible.

Shared pool rate limiting allowance was being set through `$_`'s implicit bunt, but this interferes with the `;;` we do for dbug safety purposes, so we switch to doing a proper `$~` instead. (Same change as 3429eda.)