### PR TITLE
groups: dont loop on section moves

### DIFF
--- a/packages/shared/src/domain/analytics.ts
+++ b/packages/shared/src/domain/analytics.ts
@@ -98,6 +98,7 @@ export enum AnalyticsEvent {
   ActionVisitedChannel = 'Viewed Channel',
   ActionTappedChat = 'Tapped Chatlist Item',
   ActionJoinChannel = 'Joined Channel',
+  ActionMoveChannel = 'Moved Channel',
   ActionUpdateChannelWriters = 'Updated Channel Writers',
   ActionViewProfileGroup = 'Viewed Pinned Profile Group',
   ActionSelectActivityEvent = 'Tapped Activity Event',

--- a/packages/shared/src/store/sync.ts
+++ b/packages/shared/src/store/sync.ts
@@ -837,17 +837,9 @@ async function handleGroupUpdate(update: api.GroupUpdate, ctx: QueryCtx) {
       break;
     case 'moveChannel':
       logger.log('moving channel', update);
-      // eslint-disable-next-line
-      const existingGroup = await db.getGroup({ id: update.groupId });
-      if (!existingGroup) {
-        logger.error('Group not found');
-        return;
-      }
       await updateChannelSections({
-        channelId: update.channelId,
-        group: existingGroup,
+        ...update,
         navSectionId: update.sectionId,
-        index: update.index,
       });
       break;
     case 'addChannelToNavSection':


### PR DESCRIPTION
Fixes TLON-4187. We were accidentally calling the API here when hearing a fact to update our local DB, but sending this to the API created a new fact which then triggered the same flow over and over. This switches that handling to only modify local DB.