### PR TITLE
verifier: log twitter api responses

### DIFF
--- a/desk/app/verifier.hoon
+++ b/desk/app/verifier.hoon
@@ -1082,6 +1082,12 @@
     ::
     =/  result
       (parse-post:twitter [handle nonce.u.pre.status] +.res)
+    %-  %+  tell:l  %info
+        :~  (cat 3 'twitter api response: %' ?@(result result -.result))
+            (cat 3 'status code: ' (crip (a-co:co status-code.response-header.res)))
+            ?~  full-file.res  'no body'
+            q.data.u.full-file.res
+        ==
     ::
     =*  abort
       %-  (tell:l %warn (cat 3 'twitter verification aborted with result %' result) ~)


### PR DESCRIPTION
For investigating supposed twitter api flakiness, we'll want to know the kinds of responses we get back. Include the status code and response body in the logs.

Already pushed this onto the service, but PRing for persistence.