### PR TITLE
http-api: fix thread abort signal

### DIFF
--- a/packages/shared/src/api/urbit.ts
+++ b/packages/shared/src/api/urbit.ts
@@ -197,15 +197,6 @@ export function internalConfigureClient({
     });
     logger.log('client channel-reaped');
   });
-
-  setTimeout(() => {
-    async function run() {
-      console.log('bl: initiating connection close');
-      await config.client?.delete();
-      console.log('bl: completed connection close');
-    }
-    run();
-  }, 10000);
 }
 
 export function internalRemoveClient() {

--- a/packages/shared/src/domain/analytics.ts
+++ b/packages/shared/src/domain/analytics.ts
@@ -32,6 +32,7 @@ export enum AnalyticsEvent {
   Poke = 'Poke',
   TrackedPoke = 'TrackedPoke',
   ErrorTrackedPokeTimeout = 'Error Tracked Poke Timeout',
+  ErrorThread = 'Thread Error',
   ErrorSubscribeOnceTimeout = 'Error Subscribe Once Timeout',
   InitDataFetched = 'Init Data Fetched',
   InitDataWritten = 'Init Data Written',

--- a/packages/shared/src/http-api/Urbit.ts
+++ b/packages/shared/src/http-api/Urbit.ts
@@ -945,18 +945,6 @@ export class Urbit {
         }
       }, timeout);
     });
-
-    // const res = await this.fetchFn(
-    //   `${this.url}/spider/${desk}/${inputMark}/${threadName}/${outputMark}`,
-    //   {
-    //     ...this.fetchOptions,
-    //     signal: undefined,
-    //     method: 'POST',
-    //     body: JSON.stringify(body),
-    //   }
-    // );
-
-    // return res;
   }
 
   /**

--- a/packages/shared/src/http-api/events.ts
+++ b/packages/shared/src/http-api/events.ts
@@ -8,6 +8,10 @@ export type ChannelStatus =
 
 export interface StatusUpdateEvent {
   status: ChannelStatus;
+  context?: {
+    message?: string;
+    requestStatus?: string;
+  };
 }
 
 export interface FactEvent {

--- a/packages/shared/src/http-api/fetch-event-source/fetch.ts
+++ b/packages/shared/src/http-api/fetch-event-source/fetch.ts
@@ -139,7 +139,6 @@ export function fetchEventSource(
             'Invalid server response',
             response.status
           );
-          // throw new Error(`Invalid server response: ${response.status}`);
         }
 
         await onopen(response, isReconnect);

--- a/packages/shared/src/http-api/fetch-event-source/fetch.ts
+++ b/packages/shared/src/http-api/fetch-event-source/fetch.ts
@@ -1,4 +1,9 @@
-import { FatalError, ReapError, SSEBadResponseError } from '../types';
+import {
+  FatalError,
+  ReapError,
+  SSEBadResponseError,
+  SSETimeoutError,
+} from '../types';
 import { EventSourceMessage, getBytes, getLines, getMessages } from './parse';
 
 export const EventStreamContentType = 'text/event-stream';
@@ -121,7 +126,7 @@ export function fetchEventSource(
           }),
           new Promise((_, reject) => {
             setTimeout(
-              () => reject(new Error('fetch timed out')),
+              () => reject(new SSETimeoutError('Request timed out')),
               responseTimeout
             );
           }),

--- a/packages/shared/src/http-api/fetch-event-source/fetch.ts
+++ b/packages/shared/src/http-api/fetch-event-source/fetch.ts
@@ -1,4 +1,4 @@
-import { FatalError, ReapError } from '../types';
+import { FatalError, ReapError, SSEBadResponseError } from '../types';
 import { EventSourceMessage, getBytes, getLines, getMessages } from './parse';
 
 export const EventStreamContentType = 'text/event-stream';
@@ -135,7 +135,11 @@ export function fetchEventSource(
         }
 
         if (response.status < 200 || response.status >= 300) {
-          throw new Error(`Invalid server response: ${response.status}`);
+          throw new SSEBadResponseError(
+            'Invalid server response',
+            response.status
+          );
+          // throw new Error(`Invalid server response: ${response.status}`);
         }
 
         await onopen(response, isReconnect);

--- a/packages/shared/src/http-api/types.ts
+++ b/packages/shared/src/http-api/types.ts
@@ -143,6 +143,8 @@ export interface Thread<Action> {
    * Data of the input vase
    */
   body: Action;
+
+  timeout?: number;
 }
 
 export type Action = 'poke' | 'subscribe' | 'ack' | 'unsubscribe' | 'delete';
@@ -236,3 +238,15 @@ export class FatalError extends Error {}
 export class ReapError extends Error {}
 
 export class AuthError extends Error {}
+
+export class SSETimeoutError extends Error {}
+
+export class SSEBadResponseError extends Error {
+  public status: number;
+  public text?: string;
+  constructor(message: string, status: number, text?: string) {
+    super(message);
+    this.status = status;
+    this.text = text;
+  }
+}


### PR DESCRIPTION
OTT

Thread `POST`s will no longer fail due to SSE disruption. Also adds more telemetry for thread failures and channel reconnects.