### PR TITLE
web: double press on home icon in nav to reset navigation state (return home)

### DIFF
--- a/packages/app/navigation/desktop/TopLevelDrawer.tsx
+++ b/packages/app/navigation/desktop/TopLevelDrawer.tsx
@@ -54,20 +54,27 @@ const DrawerContent = (props: DrawerContentComponentProps) => {
     }
   }, [props.state, isRouteActive]);
 
+  const resetNavigationState = useCallback(() => {
+    props.navigation.reset({
+      index: 0,
+      routes: [{ name: 'Home' }],
+    });
+  }, [props.navigation]);
+
   const restoreHomeState = useCallback(() => {
     try {
       if (lastHomeStateRef.current) {
         props.navigation.reset(lastHomeStateRef.current);
       } else {
         // Default state if no saved state exists
-        props.navigation.reset({ index: 0, routes: [{ name: 'Home' }] });
+        resetNavigationState();
       }
     } catch (error) {
       console.error('Error restoring Home navigation state:', error);
       // Fallback to default state if restoration fails
-      props.navigation.reset({ index: 0, routes: [{ name: 'Home' }] });
+      resetNavigationState();
     }
-  }, [props.navigation]);
+  }, [props.navigation, resetNavigationState]);
 
   return (
     <YStack flex={1} paddingVertical="$l">
@@ -80,6 +87,7 @@ const DrawerContent = (props: DrawerContentComponentProps) => {
           // intentionally leave undotted for now
           shouldShowUnreads={false}
           onPress={restoreHomeState}
+          onDoublePress={resetNavigationState}
         />
         <NavIcon
           type="Messages"

--- a/packages/app/ui/components/NavBar/NavIcon.tsx
+++ b/packages/app/ui/components/NavBar/NavIcon.tsx
@@ -11,11 +11,13 @@ export function AvatarNavIcon({
   id,
   focused,
   onPress,
+  onDoublePress,
   onLongPress,
 }: {
   id: string;
   focused: boolean;
   onPress?: () => void;
+  onDoublePress?: () => void;
   onLongPress?: () => void;
 }) {
   const props: Omit<ComponentProps<typeof Pressable>, 'children'> = isWeb
@@ -36,6 +38,7 @@ export function AvatarNavIcon({
       testID="AvatarNavIcon"
       flex={1}
       onPress={onPress}
+      onDoublePress={onDoublePress}
       onLongPress={onLongPress}
       alignItems="center"
       borderRadius="$s"
@@ -58,6 +61,7 @@ export default function NavIcon({
   isActive,
   hasUnreads = false,
   onPress,
+  onDoublePress,
   backgroundColor,
   shouldShowUnreads = true,
 }: {
@@ -66,6 +70,7 @@ export default function NavIcon({
   isActive: boolean;
   hasUnreads?: boolean;
   onPress?: () => void;
+  onDoublePress?: () => void;
   backgroundColor?: ColorTokens;
   shouldShowUnreads?: boolean;
 }) {
@@ -83,6 +88,7 @@ export default function NavIcon({
       alignItems="center"
       flex={1}
       onPress={onPress}
+      onDoublePress={onDoublePress}
       borderRadius="$s"
       backgroundColor={backgroundColor}
       {...props}

--- a/packages/ui/src/components/Pressable.tsx
+++ b/packages/ui/src/components/Pressable.tsx
@@ -5,7 +5,7 @@ import { Stack, StackProps, isWeb } from 'tamagui';
 
 import { useDoublePress } from '../hooks/useDoublePress';
 
-type PressHandler = ((event: GestureResponderEvent) => void) | undefined;
+type PressHandler = ((event: GestureResponderEvent) => void) | undefined | null;
 
 type PressableProps = Omit<StackProps, 'onPress' | 'onLongPress'> & {
   onLongPress?: PressHandler;
@@ -61,8 +61,8 @@ export default function Pressable({
   ...stackProps
 }: PressableProps) {
   const handlePress = useDoublePress(
-    onPress,
-    onDoublePress,
+    onPress ?? (() => {}),
+    onDoublePress ?? (() => {}),
     300 // Adjust the delay as needed
   );
   const longPressHandler = isWeb ? undefined : onLongPress;

--- a/packages/ui/src/components/Pressable.tsx
+++ b/packages/ui/src/components/Pressable.tsx
@@ -3,11 +3,14 @@ import { To } from '@react-navigation/native/lib/typescript/src/useLinkTo';
 import { GestureResponderEvent } from 'react-native';
 import { Stack, StackProps, isWeb } from 'tamagui';
 
-type PressHandler = ((event: GestureResponderEvent) => void) | undefined | null;
+import { useDoublePress } from '../hooks/useDoublePress';
+
+type PressHandler = ((event: GestureResponderEvent) => void) | undefined;
 
 type PressableProps = Omit<StackProps, 'onPress' | 'onLongPress'> & {
   onLongPress?: PressHandler;
   onPress?: PressHandler;
+  onDoublePress?: PressHandler;
   to?: To;
   action?: NavigationAction;
   children: React.ReactNode;
@@ -50,12 +53,18 @@ const StackComponent = ({
 
 export default function Pressable({
   onPress,
+  onDoublePress,
   onLongPress,
   to,
   action,
   children,
   ...stackProps
 }: PressableProps) {
+  const handlePress = useDoublePress(
+    onPress,
+    onDoublePress,
+    300 // Adjust the delay as needed
+  );
   const longPressHandler = isWeb ? undefined : onLongPress;
   const { onPress: onPressLink, ...linkProps } = useLinkProps({
     to: to ?? '',
@@ -77,7 +86,7 @@ export default function Pressable({
         {...stackProps}
         {...linkProps}
         group
-        onPress={onPressLink ?? onPress}
+        onPress={onPressLink ?? handlePress}
         onLongPress={longPressHandler}
         cursor="pointer"
         // Pressable always blocks touches from bubbling to ancestors, even if
@@ -94,7 +103,7 @@ export default function Pressable({
   return (
     <StackComponent
       {...stackProps}
-      onPress={onPress}
+      onPress={handlePress}
       onLongPress={longPressHandler}
       disabled={!hasInteractionHandler}
       cursor="pointer"

--- a/packages/ui/src/hooks/useDoublePress.ts
+++ b/packages/ui/src/hooks/useDoublePress.ts
@@ -1,0 +1,30 @@
+import { useRef, useState } from 'react';
+import { GestureResponderEvent } from 'react-native';
+
+export const useDoublePress = (
+  onSinglePress?: (event?: GestureResponderEvent) => void,
+  onDoublePress?: (event?: GestureResponderEvent) => void,
+  delay = 300
+) => {
+  const [lastPressTime, setLastPressTime] = useState(0);
+  const singlePressTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  return () => {
+    const currentTime = Date.now();
+    const timeBetweenPresses = currentTime - lastPressTime;
+
+    if (singlePressTimer.current !== null) {
+      clearTimeout(singlePressTimer.current);
+    }
+
+    if (timeBetweenPresses < delay && timeBetweenPresses > 10) {
+      onDoublePress && onDoublePress();
+      setLastPressTime(0);
+    } else {
+      singlePressTimer.current = setTimeout(() => {
+        onSinglePress && onSinglePress();
+      }, delay);
+      setLastPressTime(currentTime);
+    }
+  };
+};


### PR DESCRIPTION
fixes tlon-4122

If you're already navigated to some screen in the HomeNavigator and you press the Home Icon, nothing happens because you're already in the "home" tab. With this, if you double press, you'll be taken back to the root home screen/chat list.