### PR TITLE
references: update copy for unavailable references

### DIFF
--- a/packages/app/ui/components/ContentReference/Reference.tsx
+++ b/packages/app/ui/components/ContentReference/Reference.tsx
@@ -77,14 +77,14 @@ const ReferenceComponent = ReferenceFrame.styleable<{
           />
         ) : isError ? (
           <ReferenceSkeleton
-            message={errorMessage || 'Error loading content'}
+            message="Content not available"
             messageType="error"
             {...props}
           />
         ) : !hasData ? (
           <ReferenceSkeleton
             messageType="not-found"
-            message="This content could not be found"
+            message="Content not available"
             {...props}
           />
         ) : null}


### PR DESCRIPTION
fixes tlon-4149

Both errored refs and "not found" refs now just say "Content not available".