### PR TITLE
web/privacy: prevent telemetry toggle from showing true when we don't know

### DIFF
--- a/packages/app/hooks/usePosthog.ts
+++ b/packages/app/hooks/usePosthog.ts
@@ -7,7 +7,7 @@ export function usePosthog() {
   const posthog = useWebPosthog();
   return useMemo((): PosthogClient => {
     return {
-      getIsOptedOut: () => posthog?.has_opted_out_capturing() ?? false,
+      getIsOptedOut: () => posthog?.has_opted_out_capturing() ?? true,
       optIn: () => {
         posthog?.opt_in_capturing();
       },

--- a/packages/app/hooks/usePosthog.ts
+++ b/packages/app/hooks/usePosthog.ts
@@ -7,6 +7,7 @@ export function usePosthog() {
   const posthog = useWebPosthog();
   return useMemo((): PosthogClient => {
     return {
+      // since the function returns undefined if posthog is blocked or not available, we default to true
       getIsOptedOut: () => posthog?.has_opted_out_capturing() ?? true,
       optIn: () => {
         posthog?.opt_in_capturing();


### PR DESCRIPTION
fixes tlon-4119.

I think these users have posthog blocked, which is causing `posthog.has_opted_out_capturing()` to be undefined, so they were getting the default value of `false` for `getIsOptedOut` when it should have been `true`.

What are the other implications for this change, though?