### PR TITLE
ListItem: opaque on non-hover, transparent on hover

### DIFF
--- a/packages/app/ui/components/ListItem/ChannelListItem.tsx
+++ b/packages/app/ui/components/ListItem/ChannelListItem.tsx
@@ -57,7 +57,8 @@ export function ChannelListItem({
       <Button
         backgroundColor="transparent"
         borderWidth="unset"
-        paddingHorizontal={0}
+        paddingLeft={0}
+        paddingRight="$s"
         marginHorizontal="$-m"
         minimal
         onPress={(e) => {
@@ -175,6 +176,7 @@ export function ChannelListItem({
                 <Badge text="Invite" />
               ) : (
                 <ListItem.Count
+                  opacity={isHovered ? 0 : 1}
                   notified={notified}
                   count={unreadCount}
                   muted={logic.isMuted(model.volumeSettings?.level, 'channel')}

--- a/packages/app/ui/components/ListItem/GroupListItem.tsx
+++ b/packages/app/ui/components/ListItem/GroupListItem.tsx
@@ -49,7 +49,8 @@ export const GroupListItem = ({
       <Button
         backgroundColor="transparent"
         borderWidth="unset"
-        paddingHorizontal={0}
+        paddingLeft={0}
+        paddingRight="$s"
         marginHorizontal="$-m"
         minimal
         onPress={(e) => {
@@ -176,6 +177,7 @@ export const GroupListItem = ({
                 <>
                   <ListItem.Time time={model.lastPostAt} />
                   <ListItem.Count
+                    opacity={isHovered ? 0 : 1}
                     notified={notified}
                     count={unreadCount}
                     muted={logic.isMuted(model.volumeSettings?.level, 'group')}

--- a/packages/app/ui/components/ListItem/ListItem.tsx
+++ b/packages/app/ui/components/ListItem/ListItem.tsx
@@ -176,10 +176,14 @@ const ListItemCount = ({
   notified,
   muted,
   count,
+  opacity = 1,
   ...rest
-}: { notified: boolean; muted?: boolean; count: number } & ComponentProps<
-  typeof Stack
->) => {
+}: {
+  notified: boolean;
+  muted?: boolean;
+  count: number;
+  opacity?: number;
+} & ComponentProps<typeof Stack>) => {
   const theme = useTheme();
   const foregroundColor = getVariableValue(
     notified ? theme.positiveActionText : theme.secondaryText
@@ -189,6 +193,7 @@ const ListItemCount = ({
   );
   return (
     <Stack
+      opacity={opacity}
       paddingHorizontal={'$m'}
       backgroundColor={count < 1 ? undefined : backgroundColor}
       borderRadius="$l"


### PR DESCRIPTION
Eliminates unread count badge and options menu occlusion on hover in sidebar items.

Fixes TLON-4212


https://github.com/user-attachments/assets/3ca4ce7e-c5ad-4656-b340-27e2fba35400

