### PR TITLE
gallery: render all text on text posts

### DIFF
--- a/cosmos.imports.ts
+++ b/cosmos.imports.ts
@@ -67,7 +67,7 @@ import * as decorator0 from './packages/app/fixtures/cosmos.decorator';
 import * as decorator1 from './apps/tlon-mobile/src/fixtures/cosmos.decorator';
 
 export const rendererConfig: RendererConfig = {
-  "playgroundUrl": "http://localhost:5002",
+  "playgroundUrl": "http://localhost:5001",
   "rendererUrl": null
 };
 

--- a/packages/app/fixtures/contentHelpers.tsx
+++ b/packages/app/fixtures/contentHelpers.tsx
@@ -199,7 +199,7 @@ export const exampleContacts = {
 
 export const postWithImage = makePost(
   exampleContacts.eleanor,
-  [block.randomImage(317 * 2, 251 * 2)],
+  [block.randomImage(317 * 2, 251 * 2), verse.inline('Check out this image!')],
   {
     replyCount: 56,
     reactions: createFakeReactions({ count: 5, minTotal: 1, maxTotal: 5 }),
@@ -530,6 +530,7 @@ export const postWithVideo = makePost(exampleContacts.emotive, [
     src: 'https://storage.googleapis.com/tlon-prod-memex-assets/solfer-magfed/solfer-magfed/2024.8.28..21.6.48..978d.4fdf.3b64.05a1-Screen-Recording-2024-08-02-at-9.13.37 AM.mov',
     height: 1660,
   }),
+  verse.inline('Check out this video!'),
 ]);
 
 export const postWithDeleted = makePost(exampleContacts.eleanor, [], {

--- a/packages/app/fixtures/contentHelpers.tsx
+++ b/packages/app/fixtures/contentHelpers.tsx
@@ -260,6 +260,9 @@ p.kyz
   { replyCount: 0 }
 );
 export const postWithList = makePost(exampleContacts.hooncell, [
+  verse.inline(
+    'This is a list. It has a few items, and some of them are long.'
+  ),
   block.list(
     'ordered',
     ['helo my list!'],

--- a/packages/app/ui/components/GalleryPost/GalleryPost.tsx
+++ b/packages/app/ui/components/GalleryPost/GalleryPost.tsx
@@ -393,14 +393,25 @@ function LargePreview({
   ComponentProps<typeof PreviewFrame>,
   'content'
 >) {
-  const containsImage = useMemo(() => {
-    return content.some((block) => block.type === 'image');
+  const containsPreviewableContent = useMemo(() => {
+    return (
+      (content.some(
+        (block) =>
+          block.type === 'image' ||
+          block.type === 'video' ||
+          block.type === 'reference'
+      ) &&
+        content.length > 1 &&
+        content[0].type === 'image') ||
+      content[0].type === 'video' ||
+      content[0].type === 'reference'
+    );
   }, [content]);
 
   return (
     <PreviewFrame {...props} previewType={content[0]?.type ?? 'unsupported'}>
       <LargeContentRenderer
-        content={containsImage ? content.slice(0, 1) : content}
+        content={containsPreviewableContent ? content.slice(0, 1) : content}
         onPressImage={onPressImage}
       />
     </PreviewFrame>
@@ -415,8 +426,19 @@ function SmallPreview({
   'content'
 >) {
   const link = useBlockLink(content);
-  const containsImage = useMemo(() => {
-    return content.some((block) => block.type === 'image');
+  const containsPreviewableContent = useMemo(() => {
+    return (
+      (content.some(
+        (block) =>
+          block.type === 'image' ||
+          block.type === 'video' ||
+          block.type === 'reference'
+      ) &&
+        content.length > 1 &&
+        content[0].type === 'image') ||
+      content[0].type === 'video' ||
+      content[0].type === 'reference'
+    );
   }, [content]);
 
   return link ? (
@@ -426,7 +448,7 @@ function SmallPreview({
   ) : (
     <PreviewFrame {...props} previewType={content[0]?.type ?? 'unsupported'}>
       <SmallContentRenderer
-        content={containsImage ? content.slice(0, 1) : content}
+        content={containsPreviewableContent ? content.slice(0, 1) : content}
       />
     </PreviewFrame>
   );

--- a/packages/app/ui/components/GalleryPost/GalleryPost.tsx
+++ b/packages/app/ui/components/GalleryPost/GalleryPost.tsx
@@ -393,10 +393,14 @@ function LargePreview({
   ComponentProps<typeof PreviewFrame>,
   'content'
 >) {
+  const containsImage = useMemo(() => {
+    return content.some((block) => block.type === 'image');
+  }, [content]);
+
   return (
     <PreviewFrame {...props} previewType={content[0]?.type ?? 'unsupported'}>
       <LargeContentRenderer
-        content={content.slice(0, 1)}
+        content={containsImage ? content.slice(0, 1) : content}
         onPressImage={onPressImage}
       />
     </PreviewFrame>
@@ -411,6 +415,9 @@ function SmallPreview({
   'content'
 >) {
   const link = useBlockLink(content);
+  const containsImage = useMemo(() => {
+    return content.some((block) => block.type === 'image');
+  }, [content]);
 
   return link ? (
     <PreviewFrame {...props} previewType="link">
@@ -418,7 +425,9 @@ function SmallPreview({
     </PreviewFrame>
   ) : (
     <PreviewFrame {...props} previewType={content[0]?.type ?? 'unsupported'}>
-      <SmallContentRenderer height={'100%'} content={content.slice(0, 1)} />
+      <SmallContentRenderer
+        content={containsImage ? content.slice(0, 1) : content}
+      />
     </PreviewFrame>
   );
 }


### PR DESCRIPTION
fixes tlon-4124

if a list appeared as the second item in the `content` array it never rendered because we were slicing to grab just the first item from the array (which makes sense on image posts, we want the image and we don't want the caption, doesn't make sense for text-only posts).

Also updates the gallery post fixture so that we render a `postWithList` that has both an inline *and* a list after the inline, which is the case that was failing here.