### PR TITLE
InlineRenderer: styling code blocks

### DIFF
--- a/packages/app/ui/components/PostContent/InlineRenderer.tsx
+++ b/packages/app/ui/components/PostContent/InlineRenderer.tsx
@@ -15,10 +15,6 @@ import {
   TextInlineData,
 } from './contentUtils';
 
-const StyleContext = React.createContext<{
-  parentStyle?: 'code' | 'bold' | 'italic' | 'strikethrough';
-}>({});
-
 export const CodeText = styled(Text, {
   name: 'CodeText',
   size: '$mono/m',
@@ -86,13 +82,11 @@ export function InlineStyle({
   }[inline.style];
 
   return (
-    <StyleContext.Provider value={{ parentStyle: inline.style }}>
-      <StyleComponent {...props}>
-        {inline.children.map((child, i) => (
-          <InlineRenderer inline={child} key={i} />
-        ))}
-      </StyleComponent>
-    </StyleContext.Provider>
+    <StyleComponent {...props}>
+      {inline.children.map((child, i) => (
+        <InlineRenderer inline={child} key={i} />
+      ))}
+    </StyleComponent>
   );
 }
 
@@ -103,12 +97,6 @@ export function InlineText({
   inline: TextInlineData;
   color?: ColorTokens;
 }) {
-  const { parentStyle } = useContext(StyleContext);
-
-  if (parentStyle === 'code') {
-    return <CodeText>{inline.text}</CodeText>;
-  }
-
   return <RawText color={color}>{inline.text}</RawText>;
 }
 

--- a/packages/app/ui/components/PostContent/InlineRenderer.tsx
+++ b/packages/app/ui/components/PostContent/InlineRenderer.tsx
@@ -15,6 +15,10 @@ import {
   TextInlineData,
 } from './contentUtils';
 
+const StyleContext = React.createContext<{
+  parentStyle?: 'code' | 'bold' | 'italic' | 'strikethrough';
+}>({});
+
 export const CodeText = styled(Text, {
   name: 'CodeText',
   size: '$mono/m',
@@ -80,12 +84,15 @@ export function InlineStyle({
     strikethrough: StrikethroughText,
     code: CodeText,
   }[inline.style];
+
   return (
-    <StyleComponent {...props}>
-      {inline.children.map((child, i) => (
-        <InlineRenderer inline={child} key={i} />
-      ))}
-    </StyleComponent>
+    <StyleContext.Provider value={{ parentStyle: inline.style }}>
+      <StyleComponent {...props}>
+        {inline.children.map((child, i) => (
+          <InlineRenderer inline={child} key={i} />
+        ))}
+      </StyleComponent>
+    </StyleContext.Provider>
   );
 }
 
@@ -96,6 +103,12 @@ export function InlineText({
   inline: TextInlineData;
   color?: ColorTokens;
 }) {
+  const { parentStyle } = useContext(StyleContext);
+
+  if (parentStyle === 'code') {
+    return <CodeText>{inline.text}</CodeText>;
+  }
+
   return <RawText color={color}>{inline.text}</RawText>;
 }
 

--- a/packages/app/ui/components/PostContent/InlineRenderer.tsx
+++ b/packages/app/ui/components/PostContent/InlineRenderer.tsx
@@ -97,7 +97,7 @@ export function InlineText({
   inline: TextInlineData;
   color?: ColorTokens;
 }) {
-  return <RawText color={color}>{inline.text}</RawText>;
+  return color ? <RawText color={color}>{inline.text}</RawText> : inline.text;
 }
 
 export function InlineLink({ inline: node }: { inline: LinkInlineData }) {

--- a/packages/ui/src/components/TextV2/Text.tsx
+++ b/packages/ui/src/components/TextV2/Text.tsx
@@ -21,7 +21,6 @@ export const RawText = styled(TamaguiText, {
   name: 'RawText',
   unstyled: true,
   color: 'unset',
-  fontFamily: 'inherit',
 });
 
 export const mobileTypeStyles = {

--- a/packages/ui/src/components/TextV2/Text.tsx
+++ b/packages/ui/src/components/TextV2/Text.tsx
@@ -21,6 +21,7 @@ export const RawText = styled(TamaguiText, {
   name: 'RawText',
   unstyled: true,
   color: 'unset',
+  fontFamily: 'inherit',
 });
 
 export const mobileTypeStyles = {


### PR DESCRIPTION
Fixes TLON-4184 by adding a context to `InlineRenderer` to track the parent style, then pass it to `InlineText` and conditionally render code blocks differently.

React Native styles don't automatically cascade to children, so recent changes to `InlineText` blew away the delicate balance of prop inheritance we had in place. 

We ended up with something to the effect of:

```
<CodeText> (monospace font)
  <RawText> (default font - overriding parent)
    "text content"
  </RawText>
</CodeText>
```

The RawText component was created with `unstyled: true`, making it ignore parent styling context altogether.

I had Copilot check to see if this plays nicely with #4752 and it seems to be fine; tagging @davidisaaclee in for good measure.