### PR TITLE
discipline: enforce mark sanity

### DIFF
--- a/desk/lib/discipline.hoon
+++ b/desk/lib/discipline.hoon
@@ -43,7 +43,7 @@
 ::
 /%  m-noun  %noun
 ::
-|=  $:  marks=(list [=mark =type])
+|=  $:  marks=(list [=mark strict=? =type])
         facts=(list [=path marks=(list mark)])  ::  first matching is used, ~ for any
         scries=(list [=path =mark])
     ==
@@ -51,7 +51,7 @@
 ::
 =.  marks
   =-  (weld - marks)
-  :~  [%noun -:!>(*vale:m-noun)]
+  :~  [%noun & -:!>(*vale:m-noun)]
   ==
 =.  facts
   %+  weld
@@ -77,6 +77,11 @@
   (aor i.a i.b)
 =.  facts   (sort facts por)
 =.  scries  (sort scries por)
+::
+=/  mark-map=(map mark [strict=? =type])
+  (~(gas by *(map mark [? type])) marks)
+=/  mark-types=(map mark type)
+  (~(run by mark-map) tail)
 ::
 |=  inner=agent:gall
 |^  agent
@@ -190,16 +195,17 @@
   ::    produces the marks that aren't equivalent
   ::
   ++  check-marks
-    |=  [ole=(map mark type) neu=(map mark type)]
+    |=  [ole=(map mark type) neu=(map mark [strict=? =type])]
     ^-  (list mark)
     %+  murn  ~(tap by ole)
     |=  old=[=mark =type]
     ^-  (unit mark)
     ?~  new=(~(get by neu) mark.old)  ~
+    ?.  strict.u.new  ~
     =;  match=?
       ?:(match ~ `mark.old)
-    ?&  (~(nest ut type.old) | u.new)
-        (~(nest ut u.new) | type.old)
+    ?&  (~(nest ut type.old) | type.u.new)
+        (~(nest ut type.u.new) | type.old)
     ==
   --
 ::
@@ -220,7 +226,7 @@
   ::
   ++  on-init
     ^-  (quip card _this)
-    =.  last-marks  (~(gas by *(map mark type)) marks)
+    =.  last-marks  mark-types
     =^  cards  inner  on-init:og  !:
     =.  cards  (check-cards:help ~ cards)
     [cards this]
@@ -230,16 +236,16 @@
     |=  ole=vase
     ^-  (quip card _this)
     ?.  ?=([[%discipline *] *] q.ole)
-      =.  last-marks  (~(gas by *(map mark type)) marks)
+      =.  last-marks  mark-types
       =^  cards  inner  (on-load:og ole)  !:
       =.  cards  (check-cards:help ~ cards)
       [cards this]
     =+  !<([%discipline old=state-0] (slot 2 ole))
     =.  state  old
-    ?^  bad=(check-marks:help last-marks (~(gas by *(map mark type)) marks))
+    ?^  bad=(check-marks:help last-marks mark-map)
       ~|  [%discipline %mark-types-changed marks=bad]
       !!  ::REVIEW  possibly annoying during development?
-    =.  last-marks  (~(gas by *(map mark type)) marks)
+    =.  last-marks  mark-types
     =^  cards  inner  (on-load:og (slot 3 ole))  !:
     =.  cards  (check-cards:help ~ cards)
     [cards this]

--- a/desk/lib/discipline.hoon
+++ b/desk/lib/discipline.hoon
@@ -2,8 +2,9 @@
 ::
 ::    guards the inner agent's egress against mark shenanigans.
 ::    set it up by wrapping it around an agent, providing known marks and
-::    their types, and specifying which subscription and scry paths are
-::    allowed to produce which marks.
+::    their types (and whether to hard-prevent changing their types),
+::    and specifying which subscription and scry paths are allowed to produce
+::    which marks.
 ::    on agent reload, will check to ensure mark types have not changed.
 ::    whenever the agent emits facts, or gets scried into, will check that
 ::    the output lines up with what was specified, and if we know the relevant
@@ -26,7 +27,7 @@
 ::      %-  %-  discipline
 ::          :+  ::  marks
 ::              ::
-::              :~  [%my-mark -:!>(*vale:m-my-mark)]
+::              :~  [%my-mark strict=& -:!>(*vale:m-my-mark)]
 ::              ==
 ::            ::  facts
 ::            ::

--- a/desk/lib/discipline.hoon
+++ b/desk/lib/discipline.hoon
@@ -174,7 +174,7 @@
     ^-  ?
     ?.  ?=([~ ~ *] result)  &
     ?~  want=(expected-scry-mark path)
-      ~&  [%discipline %unknown-scry-path path=path]
+      ~&  [%discipline %unknown-scry-path path=path mark=p.u.u.result]
       &
     ?:  =(%$ u.want)
       ::NOTE  easy-out

--- a/desk/lib/discipline.hoon
+++ b/desk/lib/discipline.hoon
@@ -245,7 +245,7 @@
     =.  state  old
     ?^  bad=(check-marks:help last-marks mark-map)
       ~|  [%discipline dap=dap.bowl %mark-types-changed marks=;;((list mark) bad)]
-      !!  ::REVIEW  possibly annoying during development?
+      !!
     =.  last-marks  mark-types
     =^  cards  inner  (on-load:og (slot 3 ole))  !:
     =.  cards  (check-cards:help ~ cards)

--- a/desk/lib/discipline.hoon
+++ b/desk/lib/discipline.hoon
@@ -144,19 +144,19 @@
     :-  card
     ?.  ?=([%give %fact *] card)  ~
     =?  paths.p.card  ?=(~ paths.p.card)
-      ~?  >>  ?=(~ watch-path)  [%discipline %initial-fact-but-no-watch-path]
+      ~?  >>  ?=(~ watch-path)  [%discipline dap=dap.bowl %initial-fact-but-no-watch-path]
       (drop watch-path)
     %+  murn  paths.p.card
     |=  =path
     ^-  (unit ^card)
     ?~  ex-marks=(expected-fact-marks path)
-      ~&  >>  [%discipline %unknown-path path=path]
+      ~&  >>  [%discipline dap=dap.bowl %unknown-path path=path]
       `(tell:log %warn ~['discipline: unknown path' >path<] ~)
     ?.  ?|  =(~ u.ex-marks)  ::  empty list allows any mark
             ?=(^ (find ~[p.cage.p.card] u.ex-marks))
         ==
       =+  n=[path=path mark=p.cage.p.card allowed=u.ex-marks]
-      ~&  >>>  [%discipline %bad-fact-mark n]
+      ~&  >>>  [%discipline dap=dap.bowl %bad-fact-mark n]
       `(tell:log %crit ~['discipline: bad fact mark' >n<] ~)
     ?~  type=(~(get by marks) p.cage.p.card)
       ::NOTE  if we don't have a type for this mark,
@@ -165,7 +165,7 @@
     ?:  (~(nest ut u.type) | p.q.cage.p.card)
       ~
     =+  n=[on-path=path with-mark=p.cage.p.card %nest-fail]
-    ~&  >>>  [%discipline %bad-fact-data n]
+    ~&  >>>  [%discipline dap=dap.bowl %bad-fact-data n]
     `(tell:log %crit ~['discipline: bad fact data' >n<] ~)
   ::  +check-scry: validate result against known marks
   ::
@@ -174,13 +174,13 @@
     ^-  ?
     ?.  ?=([~ ~ *] result)  &
     ?~  want=(expected-scry-mark path)
-      ~&  [%discipline %unknown-scry-path path=path mark=p.u.u.result]
+      ~&  [%discipline dap=dap.bowl %unknown-scry-path path=path mark=p.u.u.result]
       &
     ?:  =(%$ u.want)
       ::NOTE  easy-out
       &
     ?.  =(p.u.u.result u.want)
-      ~&  >>>  [%discipline %bad-scry-mark path=path want=want got=p.u.u.result]
+      ~&  >>>  [%discipline dap=dap.bowl %bad-scry-mark path=path want=want got=p.u.u.result]
       |
     ?~  type=(~(get by marks) p.u.u.result)
       ::NOTE  if we don't have a type for this mark,
@@ -188,7 +188,7 @@
       &
     ?:  (~(nest ut u.type) | p.q.u.u.result)
       &
-    ~&  >>>  [%discipline %bad-scry-data on-path=path with-mark=p.u.u.result %nest-fail]
+    ~&  >>>  [%discipline dap=dap.bowl %bad-scry-data on-path=path with-mark=p.u.u.result %nest-fail]
     |
   ::  +check-marks: for marks where we know both sides, check equivalence
   ::
@@ -243,7 +243,7 @@
     =+  !<([%discipline old=state-0] (slot 2 ole))
     =.  state  old
     ?^  bad=(check-marks:help last-marks mark-map)
-      ~|  [%discipline %mark-types-changed marks=bad]
+      ~|  [%discipline dap=dap.bowl %mark-types-changed marks=;;((list mark) bad)]
       !!  ::REVIEW  possibly annoying during development?
     =.  last-marks  mark-types
     =^  cards  inner  (on-load:og (slot 3 ole))  !:
@@ -284,7 +284,7 @@
     ^-  (quip card _this)
     ?:  ?=([%~.~ %discipline *] wire)
       ?:  ?=([%logs ~] t.t.wire)  [~ this]
-      ~&  [%discipline bad-wire=wire]
+      ~&  [%discipline dap=dap.bowl bad-wire=wire]
       [~ this]
     =^  cards  inner  (on-agent:og wire sign)
     =.  cards  (check-cards:help ~ cards)

--- a/desk/lib/discipline.hoon
+++ b/desk/lib/discipline.hoon
@@ -1,0 +1,281 @@
+::  discipline: enforce mark sanity
+::
+::    guards the inner agent's egress against mark shenanigans.
+::    set it up by wrapping it around an agent, providing known marks and
+::    their types, and specifying which subscription and scry paths are
+::    allowed to produce which marks.
+::    on agent reload, will check to ensure mark types have not changed.
+::    whenever the agent emits facts, or gets scried into, will check that
+::    the output lines up with what was specified, and if we know the relevant
+::    mark types, that the data actually fits in those.
+::
+::    watch and scry paths may use the empty path element to indicate
+::    "wildcard" spots where any value is matched. the first matching prefix
+::    is used.
+::REVIEW  or do we want to enforce "longest matching prefix"?
+::    for subscription paths, specify any number of marks. zero marks means
+::    anything goes. for scry paths, specify the mark that should be produced.
+::    the empty string mark means anything goes, but is mostly intended for
+::    stubbing out recognition of dev tooling scries.
+::
+::    mismatches are reported as priority debug prints and, when possible,
+::    logged to posthog as criticals.
+::
+::    usage example:
+::      /%  m-my-mark  %my-mark
+::      %-  %-  discipline
+::          :+  ::  marks
+::              ::
+::              :~  [%my-mark -:!>(*vale:m-my-mark)]
+::              ==
+::            ::  facts
+::            ::
+::            :~  [/some/path/$/details %my-mark ~]
+::                [/some/more/things %my-mark %noun ~]
+::            ==
+::          ::  scries
+::          ::
+::          :~  [/x/stuff %my-mark]
+::          ==
+::      rest-of-the-agent
+::
+/+  logs
+::
+/%  m-noun  %noun
+::
+|=  $:  marks=(list [=mark =type])
+        facts=(list [=path marks=(list mark)])  ::  first matching is used, ~ for any
+        scries=(list [=path =mark])
+    ==
+::  take care of common marks, libraries
+::
+=.  marks
+  =-  (weld - marks)
+  :~  [%noun -:!>(*vale:m-noun)]
+  ==
+=.  facts
+  %+  weld  facts
+  ^-  (list [path (list mark)])
+  :~  [/verb ~]
+  ==
+|=  inner=agent:gall
+|^  agent
+::
++$  card  card:agent:gall
+::  +match-path: is .test a template-prefix of .real?
+::
+++  match-path
+  |=  [test=path real=path]
+  ^-  ?
+  ?|  ?=(~ test)
+  ?&  ?=(^ real)
+      |(=(%$ i.test) =(i.test i.real))
+      $(test t.test, real t.real)
+  ==  ==
+::  +expected-fact-marks: marks from the first path in .facts matching .path
+::
+++  expected-fact-marks
+  |=  =path
+  ^-  (unit (list mark))
+  ?~  facts  ~
+  ?:  (match-path path.i.facts path)
+    `marks.i.facts
+  $(facts t.facts)
+::
+::  +expected-scry-mark: marks from the first path in .scries matching .path
+::
+++  expected-scry-mark
+  |=  =path
+  ^-  (unit mark)
+  ?~  scries  ~
+  ?:  (match-path path.i.scries path)
+    `mark.i.scries
+  $(scries t.scries)
+::
+++  helper
+  |_  [=bowl:gall marks=(map mark type)]
+  ++  log  ~(. logs our.bowl /~/discipline/logs)
+  ::  +inner-bowl: bowl without /~/discipline subs
+  ::
+  ++  inner-bowl
+    %_  bowl
+        wex
+      %-  ~(gas by *boat:gall)
+      %+  skip  ~(tap by wex.bowl)
+      |=  [[=wire *] *]
+      ?=([%~.~ %discipline *] wire)
+    ==
+  ::  +check-cards: check facts among cards
+  ::
+  ++  check-cards
+    |=  [watch-path=(unit path) cards=(list card)]
+    ^+  cards
+    (zing (turn cards (cury check-card watch-path)))
+  ::  +check-card: check facts for mismatching marks, log if so
+  ::
+  ++  check-card
+    |=  [watch-path=(unit path) =card]
+    ^-  (list ^card)
+    :-  card
+    ?.  ?=([%give %fact *] card)  ~
+    =?  paths.p.card  ?=(~ paths.p.card)
+      ~?  >>  ?=(~ watch-path)  [%discipline %initial-fact-but-no-watch-path]
+      (drop watch-path)
+    %+  murn  paths.p.card
+    |=  =path
+    ^-  (unit ^card)
+    ?~  ex-marks=(expected-fact-marks path)
+      ~&  >>  [%discipline %unknown-path path=path]
+      `(tell:log %warn ~['discipline: unknown path' >path<] ~)
+    ?.  ?|  =(~ u.ex-marks)  ::  empty list allows any mark
+            ?=(^ (find ~[p.cage.p.card] u.ex-marks))
+        ==
+      =+  n=[path=path mark=p.cage.p.card allowed=u.ex-marks]
+      ~&  >>>  [%discipline %bad-fact-mark n]
+      `(tell:log %crit ~['discipline: bad fact mark' >n<] ~)
+    ?~  type=(~(get by marks) p.cage.p.card)
+      ::NOTE  if we don't have a type for this mark,
+      ::      ignore it, since we can't test it
+      ~
+    ?:  (~(nest ut u.type) | p.q.cage.p.card)
+      ~
+    =+  n=[on-path=path with-mark=p.cage.p.card %nest-fail]
+    ~&  >>>  [%discipline %bad-fact-data n]
+    `(tell:log %crit ~['discipline: bad fact data' >n<] ~)
+  ::  +check-scry: validate result against known marks
+  ::
+  ++  check-scry
+    |=  [=path result=(unit (unit cage))]
+    ^-  ?
+    ?.  ?=([~ ~ *] result)  &
+    ?~  want=(expected-scry-mark path)
+      ~&  [%discipline %unknown-scry-path path=path]
+      &
+    ?:  =(%$ u.want)
+      ::NOTE  easy-out
+      &
+    ?.  =(p.u.u.result u.want)
+      ~&  >>>  [%discipline %bad-scry-mark path=path want=want got=p.u.u.result]
+      |
+    ?~  type=(~(get by marks) p.u.u.result)
+      ::NOTE  if we don't have a type for this mark,
+      ::      ignore it, since we can't test it
+      &
+    ?:  (~(nest ut u.type) | p.q.u.u.result)
+      &
+    ~&  >>>  [%discipline %bad-scry-data on-path=path with-mark=p.u.u.result %nest-fail]
+    |
+  ::  +check-marks: for marks where we know both sides, check equivalence
+  ::
+  ::    produces the marks that aren't equivalent
+  ::
+  ++  check-marks
+    |=  [ole=(map mark type) neu=(map mark type)]
+    ^-  (list mark)
+    %+  murn  ~(tap by ole)
+    |=  old=[=mark =type]
+    ^-  (unit mark)
+    ?~  new=(~(get by neu) mark.old)  ~
+    =;  match=?
+      ?:(match ~ `mark.old)
+    ?&  (~(nest ut type.old) | u.new)
+        (~(nest ut u.new) | type.old)
+    ==
+  --
+::
++$  state-0
+  $:  %0
+      last-marks=(map mark type)
+  ==
+::
+++  agent
+  =|  state-0
+  =*  state  -
+  ^-  agent:gall
+  !.  ::  we hide all the "straight into the inner agent" paths from traces
+  |_  =bowl:gall
+  +*  this    .
+      help    ~(. helper bowl last-marks)
+      og      ~(. inner inner-bowl:help)
+  ::
+  ++  on-init
+    ^-  (quip card _this)
+    =.  last-marks  (~(gas by *(map mark type)) marks)
+    =^  cards  inner  on-init:og  !:
+    =.  cards  (check-cards:help ~ cards)
+    [cards this]
+  ::
+  ++  on-save  (slop !>([%discipline state]) on-save:og)
+  ++  on-load
+    |=  ole=vase
+    ^-  (quip card _this)
+    ?.  ?=([[%discipline *] *] q.ole)
+      =.  last-marks  (~(gas by *(map mark type)) marks)
+      =^  cards  inner  (on-load:og ole)  !:
+      =.  cards  (check-cards:help ~ cards)
+      [cards this]
+    =+  !<([%discipline old=state-0] (slot 2 ole))
+    =.  state  old
+    ?^  bad=(check-marks:help last-marks (~(gas by *(map mark type)) marks))
+      ~|  [%discipline %mark-types-changed marks=bad]
+      !!  ::REVIEW  possibly annoying during development?
+    =.  last-marks  (~(gas by *(map mark type)) marks)
+    =^  cards  inner  (on-load:og (slot 3 ole))  !:
+    =.  cards  (check-cards:help ~ cards)
+    [cards this]
+  ::
+  ++  on-watch
+    |=  =path
+    ^-  (quip card _this)
+    =^  cards  inner  (on-watch:og path)
+    =.  cards  (check-cards:help `path cards)
+    [cards this]
+  ::
+  ++  on-peek
+    |=  =path
+    ^-  (unit (unit cage))
+    =/  res=(unit (unit cage))
+      (on-peek:og path)
+    =+  (check-scry:help path res)
+    res
+  ::
+  ++  on-poke
+    |=  =cage
+    ^-  (quip card _this)
+    =^  cards  inner  (on-poke:og cage)
+    =.  cards  (check-cards:help ~ cards)
+    [cards this]
+  ::
+  ++  on-leave
+    |=  =path
+    ^-  (quip card _this)
+    =^  cards  inner  (on-leave:og path)
+    =.  cards  (check-cards:help ~ cards)
+    [cards this]
+  ::
+  ++  on-agent
+    |=  [=wire =sign:agent:gall]
+    ^-  (quip card _this)
+    ?:  ?=([%~.~ %discipline *] wire)
+      ?:  ?=([%logs ~] t.t.wire)  [~ this]
+      ~&  [%discipline bad-wire=wire]
+      [~ this]
+    =^  cards  inner  (on-agent:og wire sign)
+    =.  cards  (check-cards:help ~ cards)
+    [cards this]
+  ::
+  ++  on-arvo
+    |=  [=wire sign=sign-arvo]
+    ^-  (quip card _this)
+    =^  cards  inner  (on-arvo:og wire sign)
+    =.  cards  (check-cards:help ~ cards)
+    [cards this]
+  ::
+  ++  on-fail
+    |=  [=term =tang]
+    ^-  (quip card _this)
+    =^  cards  inner  (on-fail:og term tang)
+    =.  cards  (check-cards:help ~ cards)
+    [cards this]
+  --
+--

--- a/desk/lib/discipline.hoon
+++ b/desk/lib/discipline.hoon
@@ -54,10 +54,30 @@
   :~  [%noun -:!>(*vale:m-noun)]
   ==
 =.  facts
-  %+  weld  facts
-  ^-  (list [path (list mark)])
-  :~  [/verb ~]
+  %+  weld
+    ^-  (list [path (list mark)])
+    :~  [/verb ~]
+    ==
+  facts
+=.  scries
+  %+  weld  scries
+  ^-  (list [path mark])
+  :~  [/u %loob]
+      [/x/~/negotiate %$]
   ==
+::  sort arguments such that we always encounter/test the most specific ones first
+::
+=/  por
+  |=  [[a=path *] [b=path *]]
+  ?~  a  |
+  ?~  b  &
+  ?:  =(i.a i.b)  $(a t.a, b t.b)
+  ?:  =(%$ i.a)  |
+  ?:  =(%$ i.b)  &
+  (aor i.a i.b)
+=.  facts   (sort facts por)
+=.  scries  (sort scries por)
+::
 |=  inner=agent:gall
 |^  agent
 ::


### PR DESCRIPTION
Implements a wrapper agent style library that checks mark sanity on the inner agent.

This means the developer must give the library:
1. a list of marks and their types,
2. a list of subscription paths (path prefixes) and their marks,
3. and a list of scry paths (path prefixes) and their marks.

The library will then:
1. on reload, enforce that mark types haven't changed,
2. for each fact, check if the mark is expected, and type-check the data against it,
3. and for each scry, check if the mark is expected, and type-check the data against it.

Subscription and scry paths support empty string for wildcards. As written, they will simply use the first found matching path. Mismatches are printed to the terminal as priority debug prints and logged to posthog as criticals where possible.

Draft because I've only tested this on a dummy agent. I want to throw this onto channels agents and see how it behaves during the protocol upgrade scenario. Should already be good for initial developer review.