### PR TITLE
privacy settings: fix phone discoverability toggle

### DIFF
--- a/packages/app/features/settings/PrivacyScreen.tsx
+++ b/packages/app/features/settings/PrivacyScreen.tsx
@@ -49,6 +49,15 @@ export function PrivacySettingsScreen(props: Props) {
     }
   }, [calmSettings]);
 
+  useEffect(() => {
+    if (phoneAttest) {
+      setState((prev) => ({
+        ...prev,
+        phoneDiscoverable: parsePhoneDiscoverability(phoneAttest),
+      }));
+    }
+  }, [phoneAttest]);
+
   const togglePhoneDiscoverable = useCallback(async () => {
     if (!phoneAttest) {
       return;


### PR DESCRIPTION
There's a race condition with the toggle not showing to the proper value if the attestation hasn't loaded by the time the component state is initialized. 

This adds an effect to update the toggle state to match the attestation in the DB. We'll still optimistically update it on press in addition to listening for DB updates.