### PR TITLE
native: parse cite block correctly in convertContent

### DIFF
--- a/packages/app/ui/components/PostContent/contentUtils.tsx
+++ b/packages/app/ui/components/PostContent/contentUtils.tsx
@@ -3,6 +3,7 @@ import { trustedProviders } from '@tloncorp/shared';
 import * as api from '@tloncorp/shared/api';
 import { Post } from '@tloncorp/shared/db';
 import * as ub from '@tloncorp/shared/urbit';
+import { assertNever } from '@tloncorp/shared/utils';
 import { useContext, useMemo } from 'react';
 import { createStyledContext } from 'tamagui';
 
@@ -345,45 +346,56 @@ function extractEmbedsFromInlines(inlines: ub.Inline[]): BlockData[] {
 }
 
 function convertBlock(block: ub.Block): BlockData {
-  if (ub.isImage(block)) {
-    if (utils.VIDEO_REGEX.test(block.image.src)) {
+  const is = ub.Block.is;
+  switch (true) {
+    case is(block, 'image'): {
+      if (utils.VIDEO_REGEX.test(block.image.src)) {
+        return {
+          type: 'video',
+          ...block.image,
+        };
+      } else {
+        return {
+          type: 'image',
+          ...block.image,
+        };
+      }
+    }
+
+    case is(block, 'listing'): {
       return {
-        type: 'video',
-        ...block.image,
-      };
-    } else {
-      return {
-        type: 'image',
-        ...block.image,
+        type: 'list',
+        list: convertListing(block.listing),
       };
     }
-  } else if (ub.isListing(block)) {
-    return {
-      type: 'list',
-      list: convertListing(block.listing),
-    };
-  } else if (ub.isHeader(block)) {
-    return {
-      type: 'header',
-      level: block.header.tag,
-      children: convertInlineContent(block.header.content),
-    };
-  } else if (ub.isCode(block)) {
-    return {
-      type: 'code',
-      content: block.code.code,
-      lang: block.code.lang,
-    };
-  } else if ('rule' in block) {
-    return {
-      type: 'rule',
-    };
-  } else {
-    console.warn('Unhandled block type:', { block });
-    return {
-      type: 'paragraph',
-      content: [{ type: 'text', text: 'Unknown content type' }],
-    };
+    case is(block, 'header'): {
+      return {
+        type: 'header',
+        level: block.header.tag,
+        children: convertInlineContent(block.header.content),
+      };
+    }
+    case is(block, 'code'): {
+      return {
+        type: 'code',
+        content: block.code.code,
+        lang: block.code.lang,
+      };
+    }
+    case is(block, 'rule'): {
+      return {
+        type: 'rule',
+      };
+    }
+    default: {
+      assertNever(block);
+
+      console.warn('Unhandled block type:', { block });
+      return {
+        type: 'paragraph',
+        content: [{ type: 'text', text: 'Unknown content type' }],
+      };
+    }
   }
 }
 

--- a/packages/app/ui/components/PostContent/contentUtils.tsx
+++ b/packages/app/ui/components/PostContent/contentUtils.tsx
@@ -347,6 +347,11 @@ function extractEmbedsFromInlines(inlines: ub.Inline[]): BlockData[] {
 
 function convertBlock(block: ub.Block): BlockData {
   const is = ub.Block.is;
+  const errorMessage = (text: string): BlockData => ({
+    type: 'paragraph',
+    content: [{ type: 'text', text }],
+  });
+
   switch (true) {
     case is(block, 'image'): {
       if (utils.VIDEO_REGEX.test(block.image.src)) {
@@ -387,14 +392,16 @@ function convertBlock(block: ub.Block): BlockData {
         type: 'rule',
       };
     }
+    case is(block, 'cite'): {
+      return (
+        api.toContentReference(block.cite) ?? errorMessage('Failed to parse')
+      );
+    }
     default: {
       assertNever(block);
 
       console.warn('Unhandled block type:', { block });
-      return {
-        type: 'paragraph',
-        content: [{ type: 'text', text: 'Unknown content type' }],
-      };
+      return errorMessage('Unknown content type');
     }
   }
 }

--- a/packages/shared/src/urbit/activity.ts
+++ b/packages/shared/src/urbit/activity.ts
@@ -4,6 +4,7 @@ import _ from 'lodash';
 import { Kind, Story } from './channel';
 import { ContactBookProfile } from './contact';
 import { nestToFlag, whomIsDm, whomIsFlag, whomIsMultiDm } from './utils';
+import type { UnionToIntersection } from '../utils';
 
 export type Whom = { ship: string } | { club: string };
 
@@ -877,10 +878,6 @@ export function getRelevancy(
   );
   return 'involvedThread';
 }
-
-type UnionToIntersection<T> = {
-  [E in T as keyof E]: E[keyof E];
-};
 
 // eslint-disable-next-line @typescript-eslint/no-namespace
 export namespace ActivityIncomingEvent {

--- a/packages/shared/src/urbit/channel.ts
+++ b/packages/shared/src/urbit/channel.ts
@@ -3,6 +3,7 @@ import bigInt, { BigInteger } from 'big-integer';
 import _ from 'lodash';
 import BTree from 'sorted-btree';
 
+import { UnionToIntersection } from '../utils';
 import { Inline } from './content';
 import { GroupMeta } from './groups';
 import { Flag } from './hark';
@@ -141,6 +142,17 @@ export type Block =
   | Header
   | Rule
   | Code;
+
+// eslint-disable-next-line @typescript-eslint/no-namespace
+export namespace Block {
+  export function is<K extends keyof UnionToIntersection<Block>>(
+    poly: Block,
+    type: K
+  ): // @ts-expect-error - hey, I'm asserting here!
+  poly is Pick<UnionToIntersection<Block>, K> {
+    return type in poly;
+  }
+}
 
 export interface VerseBlock {
   block: Block;

--- a/packages/shared/src/utils/assertNever.ts
+++ b/packages/shared/src/utils/assertNever.ts
@@ -1,0 +1,16 @@
+/**
+ * Assert that the argument is typed as `never`. Use to assert exhaustiveness
+ * in cases that Typescript can't handle.
+ *
+ * ```ts
+ * const x: string | number = 1;
+ * switch (true) {
+ *   case typeof x === 'string': return x;
+ *   case typeof x === 'number': return 'number';
+ *   default: return assertNever(x);
+ * }
+ * ```
+ */
+export function assertNever<T>(x: never): T {
+  throw new Error(`Unexpected case: ${x}`);
+}

--- a/packages/shared/src/utils/index.ts
+++ b/packages/shared/src/utils/index.ts
@@ -2,5 +2,6 @@
  * `shared/utils` should contain code that has no other dependencies - just some
  * really really good typescript.
  */
+export * from './assertNever';
 export * from './object';
 export type * from './utilityTypes';

--- a/packages/shared/src/utils/utilityTypes.d.ts
+++ b/packages/shared/src/utils/utilityTypes.d.ts
@@ -1,1 +1,8 @@
 export type ValuesOf<T> = T[keyof T];
+
+/**
+ * UnionToIntersection<A | B | C> = A & B & C
+ */
+export type UnionToIntersection<T> = {
+  [E in T as keyof E]: E[keyof E];
+};


### PR DESCRIPTION
fixes TLON-4222

`convertContent` did not have a branch for `cite` blocks. To avoid this kind of bug happening in the future, I moved the conditional to use a new helper, and added an `assertNever` to raise a type error if we miss a case (e.g. if another block type is added).

I checked that a `cite` (created by "copy link to message" -> paste in message input) rendered correctly in:
- iOS notification body (should be the same for Android, just didn't check)
- latest message preview in chat list
- actual post view in chat scroll