### PR TITLE
telemetry: separate property for userId

### DIFF
--- a/packages/app/hooks/useTelemetry.ts
+++ b/packages/app/hooks/useTelemetry.ts
@@ -46,9 +46,10 @@ export function useTelemetry(): TelemetryClient {
         posthog?.optOut();
       } else {
         posthog?.optIn();
-        if (isHosted) {
-          posthog?.identify(currentUserId, { isHostedUser: true });
-        }
+        posthog?.identify(currentUserId, {
+          isHostedUser: isHosted,
+          userId: currentUserId,
+        });
         posthog?.capture('Telemetry enabled', {
           isHostedUser: isHostedUser(isHosted),
         });
@@ -127,14 +128,10 @@ export function useTelemetry(): TelemetryClient {
         posthog?.capture('Initializing telemetry');
       }
 
-      if (isHosted) {
-        posthog?.identify(currentUserId, { isHostedUser: true });
-      } else {
-        captureMandatoryEvent({
-          eventId: '$set',
-          properties: { $set: { isHostedUser: false } },
-        });
-      }
+      posthog?.identify(currentUserId, {
+        isHostedUser: true,
+        userId: currentUserId,
+      });
       setDisabled(posthog.getIsOptedOut());
       telemetryInitialized.setValue(true);
     }


### PR DESCRIPTION
Right now we only append the user identity as the distinct ID but this can't be used as an event filter when charting insights. By additionally tacking it on as a user property, we can effectively filter on it.

Also correlates actual user ID unconditionally if _share usage statistics_ is on (which remains the primary privacy control mechanim) 