### PR TITLE
http-api: rely on included timeout signal

### DIFF
--- a/packages/shared/src/utils/index.ts
+++ b/packages/shared/src/utils/index.ts
@@ -5,3 +5,4 @@
 export * from './assertNever';
 export * from './object';
 export type * from './utilityTypes';
+export * from './timeoutSignal';

--- a/packages/shared/src/utils/timeoutSignal.ts
+++ b/packages/shared/src/utils/timeoutSignal.ts
@@ -1,0 +1,27 @@
+interface ManualAbortSignal extends AbortSignal {
+  cleanup: () => void;
+}
+
+export function createTimeoutSignal(ms: number): ManualAbortSignal {
+  const controller = new AbortController();
+  const signal = controller.signal;
+
+  const timeout = setTimeout(() => {
+    controller.abort();
+  }, ms);
+
+  // Clean up the timeout if signal is aborted from elsewhere
+  signal.addEventListener(
+    'abort',
+    () => {
+      clearTimeout(timeout);
+    },
+    { once: true }
+  );
+
+  (signal as ManualAbortSignal).cleanup = () => {
+    clearTimeout(timeout);
+  };
+
+  return signal as ManualAbortSignal;
+}


### PR DESCRIPTION
Instead of relying on `PostHog` to ad-hoc polyfill this for us, implements a basic timeout-based abort signal for use with `fetch`.