### PR TITLE
native: revert double migration gate possibly causing skipped migration

### DIFF
--- a/packages/app/lib/nativeDb.ts
+++ b/packages/app/lib/nativeDb.ts
@@ -17,7 +17,6 @@ export class NativeDb extends BaseDb {
   private connection: SQLiteConnection | null = null;
   private isProcessingChanges: boolean = false;
   private changesPending: boolean = false;
-  private didMigrate: boolean = false;
 
   async setupDb() {
     if (this.connection || this.client) {
@@ -88,10 +87,6 @@ export class NativeDb extends BaseDb {
   }
 
   async runMigrations() {
-    if (this.didMigrate) {
-      return;
-    }
-
     if (!this.client || !this.connection) {
       logger.warn('runMigrations called before setupDb, ignoring');
       return;
@@ -100,7 +95,6 @@ export class NativeDb extends BaseDb {
     try {
       await this.connection?.migrateClient(this.client!);
       await this.connection?.execute(TRIGGER_SETUP);
-      this.didMigrate = true;
       return;
     } catch (e) {
       logger.log('migrations failed, purging db and retrying', e);
@@ -108,7 +102,6 @@ export class NativeDb extends BaseDb {
     await this.purgeDb();
     await this.connection?.migrateClient(this.client!);
     logger.log("migrations succeeded after purge, shouldn't happen often");
-    this.didMigrate = true;
   }
 }
 


### PR DESCRIPTION
We're seeing error logs that look like migrations were not run on a client. Reverting this change in case it caused an incorrect migration skip. https://eu.posthog.com/project/7233/persons/e5b20d75-5d6a-5736-bd8f-3e6d3e0554a6