### PR TITLE
desktop: clean up console spam

### DIFF
--- a/apps/tlon-mobile/package.json
+++ b/apps/tlon-mobile/package.json
@@ -131,7 +131,7 @@
     "@faker-js/faker": "^8.4.1",
     "@jest/globals": "^29.7.0",
     "@react-native/metro-config": "^0.73.5",
-    "@tamagui/babel-plugin": "~1.112.12",
+    "@tamagui/babel-plugin": "~1.126.12",
     "@testing-library/react-native": "^12.5.2",
     "@trivago/prettier-plugin-sort-imports": "^4.2.0",
     "@types/react": "18.2.55",

--- a/apps/tlon-web/package.json
+++ b/apps/tlon-web/package.json
@@ -39,7 +39,7 @@
     "@babel/runtime": "^7.25.9",
     "@react-navigation/drawer": "^6.7.2",
     "@react-navigation/native": "^6.1.7",
-    "@tamagui/vite-plugin": "~1.112.12",
+    "@tamagui/vite-plugin": "~1.126.12",
     "@tanstack/react-query": "^5.32.1",
     "@tanstack/react-query-devtools": "^5.32.1",
     "@tiptap/core": "^2.6.6",

--- a/apps/tlon-web/src/app.tsx
+++ b/apps/tlon-web/src/app.tsx
@@ -25,7 +25,6 @@ import {
   ForwardPostSheetProvider,
   LoadingSpinner,
   StoreProvider,
-  Text,
   View,
 } from '@tloncorp/app/ui';
 import {
@@ -37,6 +36,7 @@ import { sync } from '@tloncorp/shared';
 import * as db from '@tloncorp/shared/db';
 import * as logic from '@tloncorp/shared/logic';
 import * as store from '@tloncorp/shared/store';
+import { Text } from '@tloncorp/ui';
 import cookies from 'browser-cookies';
 import { usePostHog } from 'posthog-js/react';
 import React, {
@@ -408,7 +408,7 @@ function ConnectedDesktopApp({
           borderColor="$border"
         >
           <LoadingSpinner color="$primaryText" />
-          <Text color="$primaryText" marginTop="$xl" fontSize="$s">
+          <Text color="$primaryText" marginTop="$xl" size="$label/m">
             Starting up&hellip;
           </Text>
         </View>
@@ -545,7 +545,7 @@ function ConnectedWebApp() {
           borderColor="$border"
         >
           <LoadingSpinner color="$primaryText" />
-          <Text color="$primaryText" marginTop="$xl" fontSize="$s">
+          <Text color="$primaryText" marginTop="$xl" size="$label/m">
             Starting up&hellip;
           </Text>
         </View>

--- a/packages/app/package.json
+++ b/packages/app/package.json
@@ -34,7 +34,7 @@
     "expo-notifications": "~0.27.6",
     "lodash": "^4.17.21",
     "react-native-device-info": "^10.8.0",
-    "tamagui": "~1.112.12",
+    "tamagui": "~1.126.12",
     "zustand": "^3.7.2"
   }
 }

--- a/packages/app/ui/components/ContentReference/ContentReference.tsx
+++ b/packages/app/ui/components/ContentReference/ContentReference.tsx
@@ -228,7 +228,6 @@ const PostReferenceAuthor = ({
 };
 
 const PostReferenceAuthorFrame = styled(XStack, {
-  context: ReferenceContext,
   name: 'PostReferenceAuthorFrame',
   gap: '$m',
   alignItems: 'center',
@@ -244,7 +243,6 @@ const PostReferenceAuthorFrame = styled(XStack, {
 
 const PostReferenceAuthorName = styled(Text, {
   name: 'PostReferenceAuthorName',
-  context: ReferenceContext,
   color: '$tertiaryText',
   size: '$label/m',
   variants: {

--- a/packages/app/ui/components/ContentReference/Reference.tsx
+++ b/packages/app/ui/components/ContentReference/Reference.tsx
@@ -65,8 +65,10 @@ const ReferenceComponent = ReferenceFrame.styleable<{
   hasData?: boolean;
 }>(
   ({ children, isLoading, isError, hasData, errorMessage, ...props }, ref) => {
+    // We cannot pass `contentSize` to the styled component, so we need to extract it
+    const { contentSize, ...rest } = props;
     return (
-      <ReferenceFrame {...props} pressable={!!props.onPress} ref={ref}>
+      <ReferenceFrame {...rest} pressable={!!props.onPress} ref={ref}>
         {children}
         {isLoading ? (
           <ReferenceSkeleton
@@ -183,8 +185,9 @@ export function ReferenceSkeleton({
   message?: string;
   messageType?: 'loading' | 'error' | 'not-found';
 } & ComponentProps<typeof ReferenceFrame>) {
+  const { contentSize, ...rest } = props;
   return (
-    <ReferenceFrame {...props}>
+    <ReferenceFrame {...rest}>
       <ReferenceBody padding="$l" justifyContent="center" alignItems="center">
         <YStack gap="$l" alignItems="center">
           {messageType === 'error' ? (
@@ -195,7 +198,7 @@ export function ReferenceSkeleton({
             />
           ) : null}
           <Text
-            size={props.contentSize === '$s' ? '$label/s' : '$label/m'}
+            size={contentSize === '$s' ? '$label/s' : '$label/m'}
             color="$tertiaryText"
             flex={1}
           >

--- a/packages/app/ui/components/ContentReference/Reference.tsx
+++ b/packages/app/ui/components/ContentReference/Reference.tsx
@@ -36,7 +36,6 @@ export const useReferenceContext = () => {
 };
 
 const ReferenceFrame = styled(YStack, {
-  context: ReferenceContext,
   name: 'ReferenceFrame',
   borderRadius: '$s',
   padding: 0,
@@ -99,7 +98,6 @@ const ReferenceComponent = ReferenceFrame.styleable<{
 );
 
 const ReferenceHeader = styled(XStack, {
-  context: ReferenceContext,
   name: 'ReferenceHeader',
   paddingLeft: '$l',
   paddingRight: '$l',
@@ -131,7 +129,6 @@ const ReferenceTitleIcon = styled(
 
 const ReferenceTitleText = styled(Text, {
   name: 'ReferenceTitleText',
-  context: ReferenceContext,
   size: '$label/m',
   color: '$tertiaryText',
   variants: {
@@ -163,7 +160,6 @@ const ReferenceActionIcon = ({
 };
 
 const ReferenceBody = styled(View, {
-  context: ReferenceContext,
   name: 'ReferenceBody',
   pointerEvents: 'none',
   flex: 1,

--- a/packages/app/ui/components/Embed/EmbedContent.tsx
+++ b/packages/app/ui/components/Embed/EmbedContent.tsx
@@ -77,7 +77,10 @@ const EmbedContent = memo(function EmbedContent({
   url,
   content,
 }: EmbedContentProps) {
-  const { embed } = useEmbed(url);
+  const { embed } = useEmbed(
+    url,
+    Platform.OS === 'android' || Platform.OS === 'ios'
+  );
   const isValidWithHtml = validOembedCheck(embed, url);
   const isValidWithoutHtml = embed && embed.title && embed.author_name;
   const calm = useCalm();

--- a/packages/app/ui/components/GroupChannelsScreenView.tsx
+++ b/packages/app/ui/components/GroupChannelsScreenView.tsx
@@ -1,9 +1,8 @@
 import { FlashList, ListRenderItem } from '@shopify/flash-list';
 import * as db from '@tloncorp/shared/db';
 import * as logic from '@tloncorp/shared/logic';
-import { useIsWindowNarrow } from '@tloncorp/ui';
+import { SectionListHeader, useIsWindowNarrow } from '@tloncorp/ui';
 import { LoadingSpinner } from '@tloncorp/ui';
-import { Text } from '@tloncorp/ui';
 import React, { useCallback, useMemo, useRef, useState } from 'react';
 import { LayoutChangeEvent } from 'react-native';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
@@ -90,8 +89,8 @@ export const GroupChannelsScreenView = React.memo(
     const isWindowNarrow = useIsWindowNarrow();
 
     const sizeRefs = useRef({
-      sectionHeader: 44,
-      channelItem: 64,
+      sectionHeader: isWindowNarrow ? 28 : 24.55,
+      channelItem: isWindowNarrow ? 72 : 64,
     });
 
     const handleHeaderLayout = useCallback((e: LayoutChangeEvent) => {
@@ -188,15 +187,11 @@ export const GroupChannelsScreenView = React.memo(
       ({ item }) => {
         if (isSectionHeader(item)) {
           return (
-            <Text
-              paddingHorizontal="$l"
-              paddingVertical="$xl"
-              fontSize="$s"
-              color={listSectionTitleColor}
-              onLayout={handleHeaderLayout}
-            >
-              {item.title}
-            </Text>
+            <SectionListHeader onLayout={handleHeaderLayout}>
+              <SectionListHeader.Text color={listSectionTitleColor}>
+                {item.title}
+              </SectionListHeader.Text>
+            </SectionListHeader>
           );
         }
 

--- a/packages/app/ui/components/PostContent/contentUtils.tsx
+++ b/packages/app/ui/components/PostContent/contentUtils.tsx
@@ -13,11 +13,7 @@ export interface ContentContextProps {
   onLongPress?: () => void;
 }
 
-export const ContentContext = createStyledContext<ContentContextProps>({
-  // Inclusion of this property seems to be causing the errors in the console
-  // about `isNotice` not being a valid prop. I'm not sure why this is happening
-  isNotice: false,
-});
+export const ContentContext = createStyledContext<ContentContextProps>();
 
 export const useContentContext = () => useContext(ContentContext);
 

--- a/packages/shared/src/logic/embed.ts
+++ b/packages/shared/src/logic/embed.ts
@@ -66,7 +66,7 @@ export async function fetchEmbed(inputUrl: string, isMobile?: boolean) {
     return jsonFetch(`https://www.tiktok.com/oembed?url=${url}`);
   }
 
-  if (isTwitter) {
+  if (isTwitter && isMobile) {
     return jsonFetch(`https://publish.twitter.com/oembed?url=${url}`);
   }
 

--- a/packages/shared/src/logic/utils.ts
+++ b/packages/shared/src/logic/utils.ts
@@ -72,7 +72,8 @@ export async function jsonFetch<T>(
 ): Promise<T> {
   const res = await fetch(info, init);
   if (!res.ok) {
-    throw new Error('Bad Fetch Response');
+    console.log('Could not fetch', res.status, res.statusText);
+    return {} as T;
   }
   const data = await res.json();
   return data as T;

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -32,9 +32,9 @@
     "@emoji-mart/data": "^1.1.2",
     "@likashefqet/react-native-image-zoom": "^4.2.0",
     "@react-native-clipboard/clipboard": "^1.14.0",
-    "@tamagui/animations-moti": "~1.112.12",
-    "@tamagui/get-token": "~1.112.12",
-    "@tamagui/image": "~1.112.12",
+    "@tamagui/animations-moti": "~1.126.12",
+    "@tamagui/get-token": "~1.126.12",
+    "@tamagui/image": "~1.126.12",
     "@tloncorp/editor": "workspace:*",
     "@tloncorp/shared": "workspace:*",
     "@uidotdev/usehooks": "^2.4.1",
@@ -53,7 +53,7 @@
     "react-native-svg": "^15.0.0",
     "react-qr-code": "^2.0.12",
     "react-tweet": "^3.0.4",
-    "tamagui": "~1.112.12",
+    "tamagui": "~1.126.12",
     "urbit-ob": "^5.0.1"
   },
   "peerDependencies": {
@@ -68,6 +68,6 @@
     "react-native-svg": "*"
   },
   "devDependencies": {
-    "@tamagui/build": "~1.112.12"
+    "@tamagui/build": "~1.126.12"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -423,8 +423,8 @@ importers:
         specifier: ^0.73.5
         version: 0.73.5(@babel/core@7.25.2)(@babel/preset-env@7.26.0(@babel/core@7.25.2))(encoding@0.1.13)
       '@tamagui/babel-plugin':
-        specifier: ~1.112.12
-        version: 1.112.12(@swc/helpers@0.5.13)(encoding@0.1.13)(react@18.2.0)
+        specifier: ~1.126.12
+        version: 1.126.12(@swc/helpers@0.5.13)(encoding@0.1.13)(react-dom@18.2.0(react@18.2.0))(react-native@0.74.5(@babel/core@7.25.2)(@babel/preset-env@7.26.0(@babel/core@7.25.2))(@types/react@18.2.55)(encoding@0.1.13)(react@18.2.0))(react@18.2.0)
       '@testing-library/react-native':
         specifier: ^12.5.2
         version: 12.5.3(jest@29.7.0(@types/node@20.17.6)(babel-plugin-macros@3.1.0))(react-native@0.74.5(@babel/core@7.25.2)(@babel/preset-env@7.26.0(@babel/core@7.25.2))(@types/react@18.2.55)(encoding@0.1.13)(react@18.2.0))(react-test-renderer@18.2.0(react@18.2.0))(react@18.2.0)
@@ -534,8 +534,8 @@ importers:
         specifier: ^6.1.7
         version: 6.1.10(react-native@0.74.5(@babel/core@7.25.2)(@babel/preset-env@7.26.0(@babel/core@7.25.2))(@types/react@18.2.55)(encoding@0.1.13)(react@18.2.0))(react@18.2.0)
       '@tamagui/vite-plugin':
-        specifier: ~1.112.12
-        version: 1.112.12(@swc/helpers@0.5.13)(encoding@0.1.13)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
+        specifier: ~1.126.12
+        version: 1.126.12(@swc/helpers@0.5.13)(encoding@0.1.13)(react-dom@18.2.0(react@18.2.0))(react-native@0.74.5(@babel/core@7.25.2)(@babel/preset-env@7.26.0(@babel/core@7.25.2))(@types/react@18.2.55)(encoding@0.1.13)(react@18.2.0))(react@18.2.0)(vite@5.1.6(@types/node@20.14.10)(lightningcss@1.19.0)(terser@5.36.0))
       '@tanstack/react-query':
         specifier: ^5.32.1
         version: 5.32.1(react@18.2.0)
@@ -973,8 +973,8 @@ importers:
         specifier: ^0.11.1
         version: 0.11.1(drizzle-orm@0.39.3(patch_hash=fgfowqwijxaynyk2usehnwtmvm)(@op-engineering/op-sqlite@11.4.2(react-native@0.74.5(@babel/core@7.25.2)(@babel/preset-env@7.26.0(@babel/core@7.25.2))(@types/react@18.2.55)(encoding@0.1.13)(react@18.2.0))(react@18.2.0))(@opentelemetry/api@1.9.0)(@types/better-sqlite3@7.6.9)(better-sqlite3@11.8.1))
       tamagui:
-        specifier: ~1.112.12
-        version: 1.112.12(@types/react@18.2.55)(react-dom@18.2.0(react@18.2.0))(react-native@0.74.5(@babel/core@7.25.2)(@babel/preset-env@7.26.0(@babel/core@7.25.2))(@types/react@18.2.55)(encoding@0.1.13)(react@18.2.0))(react@18.2.0)
+        specifier: ~1.126.12
+        version: 1.126.12(@types/react@18.2.55)(react-dom@18.2.0(react@18.2.0))(react-native@0.74.5(@babel/core@7.25.2)(@babel/preset-env@7.26.0(@babel/core@7.25.2))(@types/react@18.2.55)(encoding@0.1.13)(react@18.2.0))(react@18.2.0)
       zustand:
         specifier: ^3.7.2
         version: 3.7.2(react@18.2.0)
@@ -1139,14 +1139,14 @@ importers:
         specifier: ^1.14.0
         version: 1.14.0(react-native-macos@0.73.24(@babel/core@7.25.2)(@babel/preset-env@7.26.0(@babel/core@7.25.2))(encoding@0.1.13)(react-native@0.74.5(@babel/core@7.25.2)(@babel/preset-env@7.26.0(@babel/core@7.25.2))(@types/react@18.2.55)(encoding@0.1.13)(react@18.2.0))(react@18.2.0))(react-native-windows@0.73.11(@babel/core@7.25.2)(@babel/preset-env@7.26.0(@babel/core@7.25.2))(encoding@0.1.13)(react-native@0.74.5(@babel/core@7.25.2)(@babel/preset-env@7.26.0(@babel/core@7.25.2))(@types/react@18.2.55)(encoding@0.1.13)(react@18.2.0))(react@18.2.0))(react-native@0.74.5(@babel/core@7.25.2)(@babel/preset-env@7.26.0(@babel/core@7.25.2))(@types/react@18.2.55)(encoding@0.1.13)(react@18.2.0))(react@18.2.0)
       '@tamagui/animations-moti':
-        specifier: ~1.112.12
-        version: 1.112.12(moti@0.28.1(react-dom@18.2.0(react@18.2.0))(react-native-reanimated@3.8.1(patch_hash=iololnqcieadxwydikuxdlowf4)(@babel/core@7.25.2)(react-native@0.74.5(@babel/core@7.25.2)(@babel/preset-env@7.26.0(@babel/core@7.25.2))(@types/react@18.2.55)(encoding@0.1.13)(react@18.2.0))(react@18.2.0))(react@18.2.0))(react@18.2.0)
+        specifier: ~1.126.12
+        version: 1.126.12(react-dom@18.2.0(react@18.2.0))(react-native-reanimated@3.8.1(patch_hash=iololnqcieadxwydikuxdlowf4)(@babel/core@7.25.2)(react-native@0.74.5(@babel/core@7.25.2)(@babel/preset-env@7.26.0(@babel/core@7.25.2))(@types/react@18.2.55)(encoding@0.1.13)(react@18.2.0))(react@18.2.0))(react@18.2.0)
       '@tamagui/get-token':
-        specifier: ~1.112.12
-        version: 1.112.12(react@18.2.0)
+        specifier: ~1.126.12
+        version: 1.126.12(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
       '@tamagui/image':
-        specifier: ~1.112.12
-        version: 1.112.12(react@18.2.0)
+        specifier: ~1.126.12
+        version: 1.126.12(react-dom@18.2.0(react@18.2.0))(react-native@0.74.5(@babel/core@7.25.2)(@babel/preset-env@7.26.0(@babel/core@7.25.2))(@types/react@18.2.55)(encoding@0.1.13)(react@18.2.0))(react@18.2.0)
       '@tloncorp/editor':
         specifier: workspace:*
         version: link:../editor
@@ -1223,15 +1223,15 @@ importers:
         specifier: ^3.0.4
         version: 3.1.1(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
       tamagui:
-        specifier: ~1.112.12
-        version: 1.112.12(@types/react@18.2.55)(react-dom@18.2.0(react@18.2.0))(react-native@0.74.5(@babel/core@7.25.2)(@babel/preset-env@7.26.0(@babel/core@7.25.2))(@types/react@18.2.55)(encoding@0.1.13)(react@18.2.0))(react@18.2.0)
+        specifier: ~1.126.12
+        version: 1.126.12(@types/react@18.2.55)(react-dom@18.2.0(react@18.2.0))(react-native@0.74.5(@babel/core@7.25.2)(@babel/preset-env@7.26.0(@babel/core@7.25.2))(@types/react@18.2.55)(encoding@0.1.13)(react@18.2.0))(react@18.2.0)
       urbit-ob:
         specifier: ^5.0.1
         version: 5.0.1
     devDependencies:
       '@tamagui/build':
-        specifier: ~1.112.12
-        version: 1.112.12(@swc/helpers@0.5.13)
+        specifier: ~1.126.12
+        version: 1.126.12(@swc/helpers@0.5.13)
 
 packages:
 
@@ -1697,20 +1697,12 @@ packages:
     resolution: {integrity: sha512-3LEEcj3PVW8pW2R1SR1M89g/qrYk/m/mB/tLqn7dn4sbBUQyTqnlod+II2U4dqiGtUmkcnAmkMDralTFZttRiw==}
     engines: {node: '>=6.9.0'}
 
-  '@babel/generator@7.25.6':
-    resolution: {integrity: sha512-VPC82gr1seXOpkjAAKoLhP50vx4vGNlF4msF64dSFq1P8RfB+QAuJWGHPXXPc8QyfVWwwB/TNNU4+ayZmHNbZw==}
-    engines: {node: '>=6.9.0'}
-
   '@babel/generator@7.26.2':
     resolution: {integrity: sha512-zevQbhbau95nkoxSq3f/DC/SC+EEOUZd3DYqfSkMhY2/wfSeaHV1Ew4vk8e+x8lja31IbyuUa2uQ3JONqKbysw==}
     engines: {node: '>=6.9.0'}
 
   '@babel/helper-annotate-as-pure@7.22.5':
     resolution: {integrity: sha512-LvBTxu8bQSQkcyKOU+a1btnNFQ1dMAd0R6PyW3arXes06F6QLWLIrd681bxRPIXlrMGR3XYnW9JyML7dP3qgxg==}
-    engines: {node: '>=6.9.0'}
-
-  '@babel/helper-annotate-as-pure@7.24.7':
-    resolution: {integrity: sha512-BaDeOonYvhdKw+JoMVkAixAAJzG2jVPIwWoKBPdYuY9b452e2rPuI9QPYh3KpofZ3pW2akOmwZLOiOsHMiqRAg==}
     engines: {node: '>=6.9.0'}
 
   '@babel/helper-annotate-as-pure@7.25.9':
@@ -1771,22 +1763,12 @@ packages:
     resolution: {integrity: sha512-0pYVBnDKZO2fnSPCrgM/6WMc7eS20Fbok+0r88fp+YtWVLZrp4CkafFGIp+W0VKw4a22sgebPT99y+FDNMdP4w==}
     engines: {node: '>=6.9.0'}
 
-  '@babel/helper-module-imports@7.24.7':
-    resolution: {integrity: sha512-8AyH3C+74cgCVVXow/myrynrAGv+nTVg5vKu2nZph9x7RcRwzmh0VFallJuFTZ9mx6u4eSdXZfcOzSqTUm0HCA==}
-    engines: {node: '>=6.9.0'}
-
   '@babel/helper-module-imports@7.25.9':
     resolution: {integrity: sha512-tnUA4RsrmflIM6W6RFTLFSXITtl0wKjgpnLgXyowocVPrbYrLUXSBXDgTs8BlbmIzIdlBySRQjINYs2BAkiLtw==}
     engines: {node: '>=6.9.0'}
 
   '@babel/helper-module-transforms@7.23.3':
     resolution: {integrity: sha512-7bBs4ED9OmswdfDzpz4MpWgSrV7FXlc3zIagvLFjS5H+Mk7Snr21vQ6QwrsoCGMfNC4e4LQPdoULEt4ykz0SRQ==}
-    engines: {node: '>=6.9.0'}
-    peerDependencies:
-      '@babel/core': ^7.0.0
-
-  '@babel/helper-module-transforms@7.25.2':
-    resolution: {integrity: sha512-BjyRAbix6j/wv83ftcVJmBt72QtHI56C7JXZoG2xATiLpmoC7dpd8WnkikExHDVPpi/3qCmO6WY1EaXOluiecQ==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0
@@ -1803,10 +1785,6 @@ packages:
 
   '@babel/helper-plugin-utils@7.22.5':
     resolution: {integrity: sha512-uLls06UVKgFG9QD4OeFYLEGteMIAa5kpTPcFL28yuCIIzsf6ZyKZMllKVOCZFhiZ5ptnwX4mtKdWCBE/uT4amg==}
-    engines: {node: '>=6.9.0'}
-
-  '@babel/helper-plugin-utils@7.24.8':
-    resolution: {integrity: sha512-FFWx5142D8h2Mgr/iPVGH5G7w6jDn4jUSpZTyDnQO0Yn7Ks2Kuz6Pci8H6MPCoUJegd/UZQ3tAvfLCxQSnWWwg==}
     engines: {node: '>=6.9.0'}
 
   '@babel/helper-plugin-utils@7.25.9':
@@ -1827,10 +1805,6 @@ packages:
 
   '@babel/helper-simple-access@7.22.5':
     resolution: {integrity: sha512-n0H99E/K+Bika3++WNL17POvo4rKWZ7lZEp1Q+fStVbUi8nxPQEBOlTmCOxW/0JsS56SKKQ+ojAe2pHKJHN35w==}
-    engines: {node: '>=6.9.0'}
-
-  '@babel/helper-simple-access@7.24.7':
-    resolution: {integrity: sha512-zBAIvbCMh5Ts+b86r/CjU+4XGYIs+R1j951gxI3KmmxBMhCg4oQMsv6ZXQ64XOm/cvzfU1FmoCyt6+owc5QMYg==}
     engines: {node: '>=6.9.0'}
 
   '@babel/helper-simple-access@7.25.9':
@@ -1891,16 +1865,6 @@ packages:
 
   '@babel/parser@7.23.6':
     resolution: {integrity: sha512-Z2uID7YJ7oNvAI20O9X0bblw7Qqs8Q2hFy0R9tAfnfLkp5MW0UH9eUvnDSnFwKZ0AvgS1ucqR4KzvVHgnke1VQ==}
-    engines: {node: '>=6.0.0'}
-    hasBin: true
-
-  '@babel/parser@7.25.3':
-    resolution: {integrity: sha512-iLTJKDbJ4hMvFPgQwwsVoxtHyWpKKPBrxkANrSYewDPaPpT5py5yeVkgPIJ7XYXhndxJpaA3PyALSXQ7u8e/Dw==}
-    engines: {node: '>=6.0.0'}
-    hasBin: true
-
-  '@babel/parser@7.25.6':
-    resolution: {integrity: sha512-trGdfBdbD0l1ZPmcJ83eNxB9rbEax4ALFTF7fN386TMYbeCQbyme5cOEXQhbGXKebwGaB/J52w1mrklMcbgy6Q==}
     engines: {node: '>=6.0.0'}
     hasBin: true
 
@@ -2566,24 +2530,12 @@ packages:
     resolution: {integrity: sha512-FDSOghenHTiToteC/QRlv2q3DhPZ/oOXTBoirfWNx1Cx3TMVcGWQtMMmQcSvb/JjpNeGzx8Pq/b4fKEJuWm1sw==}
     engines: {node: '>=6.9.0'}
 
-  '@babel/template@7.25.0':
-    resolution: {integrity: sha512-aOOgh1/5XzKvg1jvVz7AVrx2piJ2XBi227DHmbY6y+bM9H2FlN+IfecYu4Xl0cNiiVejlsCri89LUsbj8vJD9Q==}
-    engines: {node: '>=6.9.0'}
-
   '@babel/template@7.25.9':
     resolution: {integrity: sha512-9DGttpmPvIxBb/2uwpVo3dqJ+O6RooAFOS+lB+xDqoE2PVCE8nfoHMdZLpfCQRLwvohzXISPZcgxt80xLfsuwg==}
     engines: {node: '>=6.9.0'}
 
   '@babel/traverse@7.23.2':
     resolution: {integrity: sha512-azpe59SQ48qG6nu2CzcMLbxUudtN+dOM9kDbUqGq3HXUJRlo7i8fvPoxQUzYgLZ4cMVmuZgm8vvBpNeRhd6XSw==}
-    engines: {node: '>=6.9.0'}
-
-  '@babel/traverse@7.25.3':
-    resolution: {integrity: sha512-HefgyP1x754oGCsKmV5reSmtV7IXj/kpaE1XYY+D9G5PvKKoFfSbiS4M77MdjuwlZKDIKFCffq9rPU+H/s3ZdQ==}
-    engines: {node: '>=6.9.0'}
-
-  '@babel/traverse@7.25.6':
-    resolution: {integrity: sha512-9Vrcx5ZW6UwK5tvqsj0nGpp/XzqthkT0dqIc9g1AdtygFToNtTF67XzYS//dm+SAK9cp3B9R4ZO/46p63SCjlQ==}
     engines: {node: '>=6.9.0'}
 
   '@babel/traverse@7.25.9':
@@ -2708,12 +2660,6 @@ packages:
     cpu: [ppc64]
     os: [aix]
 
-  '@esbuild/aix-ppc64@0.24.0':
-    resolution: {integrity: sha512-WtKdFM7ls47zkKHFVzMz8opM7LkcsIp9amDUBIAWirg70RM71WRSjdILPsY5Uv1D42ZpUfaPILDlfactHgsRkw==}
-    engines: {node: '>=18'}
-    cpu: [ppc64]
-    os: [aix]
-
   '@esbuild/aix-ppc64@0.25.2':
     resolution: {integrity: sha512-wCIboOL2yXZym2cgm6mlA742s9QeJ8DjGVaL39dLN4rRwrOgOyYSnOaFPhKZGLb2ngj4EyfAFjsNJwPXZvseag==}
     engines: {node: '>=18'}
@@ -2729,12 +2675,6 @@ packages:
   '@esbuild/android-arm64@0.19.12':
     resolution: {integrity: sha512-P0UVNGIienjZv3f5zq0DP3Nt2IE/3plFzuaS96vihvD0Hd6H/q4WXUGpCxD/E8YrSXfNyRPbpTq+T8ZQioSuPA==}
     engines: {node: '>=12'}
-    cpu: [arm64]
-    os: [android]
-
-  '@esbuild/android-arm64@0.24.0':
-    resolution: {integrity: sha512-Vsm497xFM7tTIPYK9bNTYJyF/lsP590Qc1WxJdlB6ljCbdZKU9SY8i7+Iin4kyhV/KV5J2rOKsBQbB77Ab7L/w==}
-    engines: {node: '>=18'}
     cpu: [arm64]
     os: [android]
 
@@ -2756,12 +2696,6 @@ packages:
     cpu: [arm]
     os: [android]
 
-  '@esbuild/android-arm@0.24.0':
-    resolution: {integrity: sha512-arAtTPo76fJ/ICkXWetLCc9EwEHKaeya4vMrReVlEIUCAUncH7M4bhMQ+M9Vf+FFOZJdTNMXNBrWwW+OXWpSew==}
-    engines: {node: '>=18'}
-    cpu: [arm]
-    os: [android]
-
   '@esbuild/android-arm@0.25.2':
     resolution: {integrity: sha512-NQhH7jFstVY5x8CKbcfa166GoV0EFkaPkCKBQkdPJFvo5u+nGXLEH/ooniLb3QI8Fk58YAx7nsPLozUWfCBOJA==}
     engines: {node: '>=18'}
@@ -2777,12 +2711,6 @@ packages:
   '@esbuild/android-x64@0.19.12':
     resolution: {integrity: sha512-3k7ZoUW6Q6YqhdhIaq/WZ7HwBpnFBlW905Fa4s4qWJyiNOgT1dOqDiVAQFwBH7gBRZr17gLrlFCRzF6jFh7Kew==}
     engines: {node: '>=12'}
-    cpu: [x64]
-    os: [android]
-
-  '@esbuild/android-x64@0.24.0':
-    resolution: {integrity: sha512-t8GrvnFkiIY7pa7mMgJd7p8p8qqYIz1NYiAoKc75Zyv73L3DZW++oYMSHPRarcotTKuSs6m3hTOa5CKHaS02TQ==}
-    engines: {node: '>=18'}
     cpu: [x64]
     os: [android]
 
@@ -2804,12 +2732,6 @@ packages:
     cpu: [arm64]
     os: [darwin]
 
-  '@esbuild/darwin-arm64@0.24.0':
-    resolution: {integrity: sha512-CKyDpRbK1hXwv79soeTJNHb5EiG6ct3efd/FTPdzOWdbZZfGhpbcqIpiD0+vwmpu0wTIL97ZRPZu8vUt46nBSw==}
-    engines: {node: '>=18'}
-    cpu: [arm64]
-    os: [darwin]
-
   '@esbuild/darwin-arm64@0.25.2':
     resolution: {integrity: sha512-MpM6LUVTXAzOvN4KbjzU/q5smzryuoNjlriAIx+06RpecwCkL9JpenNzpKd2YMzLJFOdPqBpuub6eVRP5IgiSA==}
     engines: {node: '>=18'}
@@ -2825,12 +2747,6 @@ packages:
   '@esbuild/darwin-x64@0.19.12':
     resolution: {integrity: sha512-hKoVkKzFiToTgn+41qGhsUJXFlIjxI/jSYeZf3ugemDYZldIXIxhvwN6erJGlX4t5h417iFuheZ7l+YVn05N3A==}
     engines: {node: '>=12'}
-    cpu: [x64]
-    os: [darwin]
-
-  '@esbuild/darwin-x64@0.24.0':
-    resolution: {integrity: sha512-rgtz6flkVkh58od4PwTRqxbKH9cOjaXCMZgWD905JOzjFKW+7EiUObfd/Kav+A6Gyud6WZk9w+xu6QLytdi2OA==}
-    engines: {node: '>=18'}
     cpu: [x64]
     os: [darwin]
 
@@ -2852,12 +2768,6 @@ packages:
     cpu: [arm64]
     os: [freebsd]
 
-  '@esbuild/freebsd-arm64@0.24.0':
-    resolution: {integrity: sha512-6Mtdq5nHggwfDNLAHkPlyLBpE5L6hwsuXZX8XNmHno9JuL2+bg2BX5tRkwjyfn6sKbxZTq68suOjgWqCicvPXA==}
-    engines: {node: '>=18'}
-    cpu: [arm64]
-    os: [freebsd]
-
   '@esbuild/freebsd-arm64@0.25.2':
     resolution: {integrity: sha512-mLwm4vXKiQ2UTSX4+ImyiPdiHjiZhIaE9QvC7sw0tZ6HoNMjYAqQpGyui5VRIi5sGd+uWq940gdCbY3VLvsO1w==}
     engines: {node: '>=18'}
@@ -2873,12 +2783,6 @@ packages:
   '@esbuild/freebsd-x64@0.19.12':
     resolution: {integrity: sha512-EYoXZ4d8xtBoVN7CEwWY2IN4ho76xjYXqSXMNccFSx2lgqOG/1TBPW0yPx1bJZk94qu3tX0fycJeeQsKovA8gg==}
     engines: {node: '>=12'}
-    cpu: [x64]
-    os: [freebsd]
-
-  '@esbuild/freebsd-x64@0.24.0':
-    resolution: {integrity: sha512-D3H+xh3/zphoX8ck4S2RxKR6gHlHDXXzOf6f/9dbFt/NRBDIE33+cVa49Kil4WUjxMGW0ZIYBYtaGCa2+OsQwQ==}
-    engines: {node: '>=18'}
     cpu: [x64]
     os: [freebsd]
 
@@ -2900,12 +2804,6 @@ packages:
     cpu: [arm64]
     os: [linux]
 
-  '@esbuild/linux-arm64@0.24.0':
-    resolution: {integrity: sha512-TDijPXTOeE3eaMkRYpcy3LarIg13dS9wWHRdwYRnzlwlA370rNdZqbcp0WTyyV/k2zSxfko52+C7jU5F9Tfj1g==}
-    engines: {node: '>=18'}
-    cpu: [arm64]
-    os: [linux]
-
   '@esbuild/linux-arm64@0.25.2':
     resolution: {integrity: sha512-gq/sjLsOyMT19I8obBISvhoYiZIAaGF8JpeXu1u8yPv8BE5HlWYobmlsfijFIZ9hIVGYkbdFhEqC0NvM4kNO0g==}
     engines: {node: '>=18'}
@@ -2921,12 +2819,6 @@ packages:
   '@esbuild/linux-arm@0.19.12':
     resolution: {integrity: sha512-J5jPms//KhSNv+LO1S1TX1UWp1ucM6N6XuL6ITdKWElCu8wXP72l9MM0zDTzzeikVyqFE6U8YAV9/tFyj0ti+w==}
     engines: {node: '>=12'}
-    cpu: [arm]
-    os: [linux]
-
-  '@esbuild/linux-arm@0.24.0':
-    resolution: {integrity: sha512-gJKIi2IjRo5G6Glxb8d3DzYXlxdEj2NlkixPsqePSZMhLudqPhtZ4BUrpIuTjJYXxvF9njql+vRjB2oaC9XpBw==}
-    engines: {node: '>=18'}
     cpu: [arm]
     os: [linux]
 
@@ -2948,12 +2840,6 @@ packages:
     cpu: [ia32]
     os: [linux]
 
-  '@esbuild/linux-ia32@0.24.0':
-    resolution: {integrity: sha512-K40ip1LAcA0byL05TbCQ4yJ4swvnbzHscRmUilrmP9Am7//0UjPreh4lpYzvThT2Quw66MhjG//20mrufm40mA==}
-    engines: {node: '>=18'}
-    cpu: [ia32]
-    os: [linux]
-
   '@esbuild/linux-ia32@0.25.2':
     resolution: {integrity: sha512-bBYCv9obgW2cBP+2ZWfjYTU+f5cxRoGGQ5SeDbYdFCAZpYWrfjjfYwvUpP8MlKbP0nwZ5gyOU/0aUzZ5HWPuvQ==}
     engines: {node: '>=18'}
@@ -2969,12 +2855,6 @@ packages:
   '@esbuild/linux-loong64@0.19.12':
     resolution: {integrity: sha512-LiXdXA0s3IqRRjm6rV6XaWATScKAXjI4R4LoDlvO7+yQqFdlr1Bax62sRwkVvRIrwXxvtYEHHI4dm50jAXkuAA==}
     engines: {node: '>=12'}
-    cpu: [loong64]
-    os: [linux]
-
-  '@esbuild/linux-loong64@0.24.0':
-    resolution: {integrity: sha512-0mswrYP/9ai+CU0BzBfPMZ8RVm3RGAN/lmOMgW4aFUSOQBjA31UP8Mr6DDhWSuMwj7jaWOT0p0WoZ6jeHhrD7g==}
-    engines: {node: '>=18'}
     cpu: [loong64]
     os: [linux]
 
@@ -2996,12 +2876,6 @@ packages:
     cpu: [mips64el]
     os: [linux]
 
-  '@esbuild/linux-mips64el@0.24.0':
-    resolution: {integrity: sha512-hIKvXm0/3w/5+RDtCJeXqMZGkI2s4oMUGj3/jM0QzhgIASWrGO5/RlzAzm5nNh/awHE0A19h/CvHQe6FaBNrRA==}
-    engines: {node: '>=18'}
-    cpu: [mips64el]
-    os: [linux]
-
   '@esbuild/linux-mips64el@0.25.2':
     resolution: {integrity: sha512-hDDRlzE6rPeoj+5fsADqdUZl1OzqDYow4TB4Y/3PlKBD0ph1e6uPHzIQcv2Z65u2K0kpeByIyAjCmjn1hJgG0Q==}
     engines: {node: '>=18'}
@@ -3017,12 +2891,6 @@ packages:
   '@esbuild/linux-ppc64@0.19.12':
     resolution: {integrity: sha512-nYJA2/QPimDQOh1rKWedNOe3Gfc8PabU7HT3iXWtNUbRzXS9+vgB0Fjaqr//XNbd82mCxHzik2qotuI89cfixg==}
     engines: {node: '>=12'}
-    cpu: [ppc64]
-    os: [linux]
-
-  '@esbuild/linux-ppc64@0.24.0':
-    resolution: {integrity: sha512-HcZh5BNq0aC52UoocJxaKORfFODWXZxtBaaZNuN3PUX3MoDsChsZqopzi5UupRhPHSEHotoiptqikjN/B77mYQ==}
-    engines: {node: '>=18'}
     cpu: [ppc64]
     os: [linux]
 
@@ -3044,12 +2912,6 @@ packages:
     cpu: [riscv64]
     os: [linux]
 
-  '@esbuild/linux-riscv64@0.24.0':
-    resolution: {integrity: sha512-bEh7dMn/h3QxeR2KTy1DUszQjUrIHPZKyO6aN1X4BCnhfYhuQqedHaa5MxSQA/06j3GpiIlFGSsy1c7Gf9padw==}
-    engines: {node: '>=18'}
-    cpu: [riscv64]
-    os: [linux]
-
   '@esbuild/linux-riscv64@0.25.2':
     resolution: {integrity: sha512-k4LtpgV7NJQOml/10uPU0s4SAXGnowi5qBSjaLWMojNCUICNu7TshqHLAEbkBdAszL5TabfvQ48kK84hyFzjnw==}
     engines: {node: '>=18'}
@@ -3068,12 +2930,6 @@ packages:
     cpu: [s390x]
     os: [linux]
 
-  '@esbuild/linux-s390x@0.24.0':
-    resolution: {integrity: sha512-ZcQ6+qRkw1UcZGPyrCiHHkmBaj9SiCD8Oqd556HldP+QlpUIe2Wgn3ehQGVoPOvZvtHm8HPx+bH20c9pvbkX3g==}
-    engines: {node: '>=18'}
-    cpu: [s390x]
-    os: [linux]
-
   '@esbuild/linux-s390x@0.25.2':
     resolution: {integrity: sha512-GRa4IshOdvKY7M/rDpRR3gkiTNp34M0eLTaC1a08gNrh4u488aPhuZOCpkF6+2wl3zAN7L7XIpOFBhnaE3/Q8Q==}
     engines: {node: '>=18'}
@@ -3089,12 +2945,6 @@ packages:
   '@esbuild/linux-x64@0.19.12':
     resolution: {integrity: sha512-B71g1QpxfwBvNrfyJdVDexenDIt1CiDN1TIXLbhOw0KhJzE78KIFGX6OJ9MrtC0oOqMWf+0xop4qEU8JrJTwCg==}
     engines: {node: '>=12'}
-    cpu: [x64]
-    os: [linux]
-
-  '@esbuild/linux-x64@0.24.0':
-    resolution: {integrity: sha512-vbutsFqQ+foy3wSSbmjBXXIJ6PL3scghJoM8zCL142cGaZKAdCZHyf+Bpu/MmX9zT9Q0zFBVKb36Ma5Fzfa8xA==}
-    engines: {node: '>=18'}
     cpu: [x64]
     os: [linux]
 
@@ -3122,23 +2972,11 @@ packages:
     cpu: [x64]
     os: [netbsd]
 
-  '@esbuild/netbsd-x64@0.24.0':
-    resolution: {integrity: sha512-hjQ0R/ulkO8fCYFsG0FZoH+pWgTTDreqpqY7UnQntnaKv95uP5iW3+dChxnx7C3trQQU40S+OgWhUVwCjVFLvg==}
-    engines: {node: '>=18'}
-    cpu: [x64]
-    os: [netbsd]
-
   '@esbuild/netbsd-x64@0.25.2':
     resolution: {integrity: sha512-voZT9Z+tpOxrvfKFyfDYPc4DO4rk06qamv1a/fkuzHpiVBMOhpjK+vBmWM8J1eiB3OLSMFYNaOaBNLXGChf5tg==}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [netbsd]
-
-  '@esbuild/openbsd-arm64@0.24.0':
-    resolution: {integrity: sha512-MD9uzzkPQbYehwcN583yx3Tu5M8EIoTD+tUgKF982WYL9Pf5rKy9ltgD0eUgs8pvKnmizxjXZyLt0z6DC3rRXg==}
-    engines: {node: '>=18'}
-    cpu: [arm64]
-    os: [openbsd]
 
   '@esbuild/openbsd-arm64@0.25.2':
     resolution: {integrity: sha512-dcXYOC6NXOqcykeDlwId9kB6OkPUxOEqU+rkrYVqJbK2hagWOMrsTGsMr8+rW02M+d5Op5NNlgMmjzecaRf7Tg==}
@@ -3155,12 +2993,6 @@ packages:
   '@esbuild/openbsd-x64@0.19.12':
     resolution: {integrity: sha512-RbrfTB9SWsr0kWmb9srfF+L933uMDdu9BIzdA7os2t0TXhCRjrQyCeOt6wVxr79CKD4c+p+YhCj31HBkYcXebw==}
     engines: {node: '>=12'}
-    cpu: [x64]
-    os: [openbsd]
-
-  '@esbuild/openbsd-x64@0.24.0':
-    resolution: {integrity: sha512-4ir0aY1NGUhIC1hdoCzr1+5b43mw99uNwVzhIq1OY3QcEwPDO3B7WNXBzaKY5Nsf1+N11i1eOfFcq+D/gOS15Q==}
-    engines: {node: '>=18'}
     cpu: [x64]
     os: [openbsd]
 
@@ -3182,12 +3014,6 @@ packages:
     cpu: [x64]
     os: [sunos]
 
-  '@esbuild/sunos-x64@0.24.0':
-    resolution: {integrity: sha512-jVzdzsbM5xrotH+W5f1s+JtUy1UWgjU0Cf4wMvffTB8m6wP5/kx0KiaLHlbJO+dMgtxKV8RQ/JvtlFcdZ1zCPA==}
-    engines: {node: '>=18'}
-    cpu: [x64]
-    os: [sunos]
-
   '@esbuild/sunos-x64@0.25.2':
     resolution: {integrity: sha512-cfZH1co2+imVdWCjd+D1gf9NjkchVhhdpgb1q5y6Hcv9TP6Zi9ZG/beI3ig8TvwT9lH9dlxLq5MQBBgwuj4xvA==}
     engines: {node: '>=18'}
@@ -3203,12 +3029,6 @@ packages:
   '@esbuild/win32-arm64@0.19.12':
     resolution: {integrity: sha512-URgtR1dJnmGvX864pn1B2YUYNzjmXkuJOIqG2HdU62MVS4EHpU2946OZoTMnRUHklGtJdJZ33QfzdjGACXhn1A==}
     engines: {node: '>=12'}
-    cpu: [arm64]
-    os: [win32]
-
-  '@esbuild/win32-arm64@0.24.0':
-    resolution: {integrity: sha512-iKc8GAslzRpBytO2/aN3d2yb2z8XTVfNV0PjGlCxKo5SgWmNXx82I/Q3aG1tFfS+A2igVCY97TJ8tnYwpUWLCA==}
-    engines: {node: '>=18'}
     cpu: [arm64]
     os: [win32]
 
@@ -3230,12 +3050,6 @@ packages:
     cpu: [ia32]
     os: [win32]
 
-  '@esbuild/win32-ia32@0.24.0':
-    resolution: {integrity: sha512-vQW36KZolfIudCcTnaTpmLQ24Ha1RjygBo39/aLkM2kmjkWmZGEJ5Gn9l5/7tzXA42QGIoWbICfg6KLLkIw6yw==}
-    engines: {node: '>=18'}
-    cpu: [ia32]
-    os: [win32]
-
   '@esbuild/win32-ia32@0.25.2':
     resolution: {integrity: sha512-WRJgsz9un0nqZJ4MfhabxaD9Ft8KioqU3JMinOTvobbX6MOSUigSBlogP8QB3uxpJDsFS6yN+3FDBdqE5lg9kg==}
     engines: {node: '>=18'}
@@ -3251,12 +3065,6 @@ packages:
   '@esbuild/win32-x64@0.19.12':
     resolution: {integrity: sha512-T1QyPSDCyMXaO3pzBkF96E8xMkiRYbUEZADd29SyPGabqxMViNoii+NcK7eWJAEoU6RZyEm5lVSIjTmcdoB9HA==}
     engines: {node: '>=12'}
-    cpu: [x64]
-    os: [win32]
-
-  '@esbuild/win32-x64@0.24.0':
-    resolution: {integrity: sha512-7IAFPrjSQIJrGsK6flwg7NFmwBoSTyF3rl7If0hNUFQU4ilTsEPL6GuMuU9BfIWVVGuRnuIidkSMC+c0Otu8IA==}
-    engines: {node: '>=18'}
     cpu: [x64]
     os: [win32]
 
@@ -3399,20 +3207,23 @@ packages:
       react: '>=16.8.0'
       react-dom: '>=16.8.0'
 
-  '@floating-ui/react-native@0.10.6':
-    resolution: {integrity: sha512-/9tXRdwhPFUQhReb4XLWMClVDIi1620+pHDxfqPXXkRrH2cTIb9AJu3Cg7XszbXNArPdrPsB7OILrq92TOVVNg==}
+  '@floating-ui/react-native@0.10.7':
+    resolution: {integrity: sha512-deSecLPrdfl8RL1yyNJlbgqDDZFPuhBtJhY2aTnOZOoJWaal2vVOad9EBVIa0QV/YordgTyFPgDI8oLfyLZuZA==}
     peerDependencies:
       react: '>=16.8.0'
       react-native: '>=0.64.0'
 
-  '@floating-ui/react@0.26.24':
-    resolution: {integrity: sha512-2ly0pCkZIGEQUq5H8bBK0XJmc1xIK/RM3tvVzY3GBER7IOD1UgmC2Y2tjj4AuS+TC+vTE1KJv2053290jua0Sw==}
+  '@floating-ui/react@0.27.8':
+    resolution: {integrity: sha512-EQJ4Th328y2wyHR3KzOUOoTW2UKjFk53fmyahfwExnFQ8vnsMYqKc+fFPOkeYtj5tcp1DUMiNJ7BFhed7e9ONw==}
     peerDependencies:
-      react: '>=16.8.0'
-      react-dom: '>=16.8.0'
+      react: '>=17.0.0'
+      react-dom: '>=17.0.0'
 
   '@floating-ui/utils@0.2.8':
     resolution: {integrity: sha512-kym7SodPp8/wloecOpcmSnWJsK7M0E5Wg8UcFA+uO4B9s5d0ywXOEro/8HM9x0rW+TljRzul/14UYz3TleT3ig==}
+
+  '@floating-ui/utils@0.2.9':
+    resolution: {integrity: sha512-MDWhGtE+eHw5JW7lq4qhc5yRLS11ERl1c7Z6Xd0a58DozHES6EnNNwUWbMiG4J9Cgj053Bhk8zvlhFYKVhULwg==}
 
   '@gar/promisify@1.1.3':
     resolution: {integrity: sha512-k2Ty1JcVojjJFwrg/ThKi2ujJ7XNLYaFGNB/bWT9wGR+oSMJHMa5w+CUq6p/pVrKeNNgA7pCqEcjSnHVoqJQFw==}
@@ -3729,6 +3540,46 @@ packages:
   '@opentelemetry/semantic-conventions@1.27.0':
     resolution: {integrity: sha512-sAay1RrB+ONOem0OZanAR1ZI/k7yDpnOQSQmTMuGImUQb2y8EbSaCJ94FQluM74xoU03vlb2d2U90hZluL6nQg==}
     engines: {node: '>=14'}
+
+  '@oxc-transform/binding-darwin-arm64@0.47.1':
+    resolution: {integrity: sha512-GT56Wkk/M1Eo1HCFfj8PxNn/ssBfxFVIrS3A5lJ6GE2k3gbVRORNzVA1znHtB3Tj4hIvWPNzqh+EQ2bhaFypNQ==}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@oxc-transform/binding-darwin-x64@0.47.1':
+    resolution: {integrity: sha512-2lwBMYHouI8Q0wubDCRuK4lMosiA0acsk2ZZzvTzYkn2xNKXtug2+D5UsOxpRLzW1vtIiTEdE5kPaafGPIIcqw==}
+    cpu: [x64]
+    os: [darwin]
+
+  '@oxc-transform/binding-linux-arm64-gnu@0.47.1':
+    resolution: {integrity: sha512-AvAhryJTpOF0pJdroI0167cmRHDGv2aBBbTjEeNYW5b5KHNvmfeFF1eKT5e8pwj9ygR6DhwXQMIfYOsR2GBzrw==}
+    cpu: [arm64]
+    os: [linux]
+
+  '@oxc-transform/binding-linux-arm64-musl@0.47.1':
+    resolution: {integrity: sha512-b3KDPQeC3yTZXF3vroOD9Mq6QfODxVt8OOeWkufytgOvNyM0NrHhXiiRLBvbNQyf7GfKd82B0l7is6hKuGELwg==}
+    cpu: [arm64]
+    os: [linux]
+
+  '@oxc-transform/binding-linux-x64-gnu@0.47.1':
+    resolution: {integrity: sha512-bvdPbWnAtfWhQ+hRLtZCeI+mHivHBR4oJL1Zk8HZdo61LEr32XrfTjAOjzoaRqcANKaZv5o9Skyotp71Pf+Xfg==}
+    cpu: [x64]
+    os: [linux]
+
+  '@oxc-transform/binding-linux-x64-musl@0.47.1':
+    resolution: {integrity: sha512-E549H+YqzkkvX72QxJechLEAAIseHndrrSWW5lacfCpatZjpTEBoHaMfTf7L3B4Ha/hg/JRZrn/rudYOMJ7ztA==}
+    cpu: [x64]
+    os: [linux]
+
+  '@oxc-transform/binding-win32-arm64-msvc@0.47.1':
+    resolution: {integrity: sha512-GGbQBBKjIJ3CZ+lnOyPdKdyy1cbazZxTAJWN+EShfXJz+T1gY3BF6U3yhiRAvDefZ2SYLvALi2n4Wz//4vUz6A==}
+    cpu: [arm64]
+    os: [win32]
+
+  '@oxc-transform/binding-win32-x64-msvc@0.47.1':
+    resolution: {integrity: sha512-IVdLjLWknwrhWsWj0f0WTWd3Mfu3a/kjEWwTy0X65udWNxfzpIOVSnauHL7E0lWiatAKmpjS4GacVDPtMdw3GQ==}
+    cpu: [x64]
+    os: [win32]
 
   '@pkgjs/parseargs@0.11.0':
     resolution: {integrity: sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg==}
@@ -4721,96 +4572,91 @@ packages:
     peerDependencies:
       tailwindcss: '>=3.0.0 || insiders'
 
-  '@tamagui/accordion@1.112.12':
-    resolution: {integrity: sha512-bJsPm3GcyLL9HSnt6023s0o1nSZ/pR5DnqHrKff50nGQv87azsEd+N7UfrGlKZAfjRgb6YZAJj4O6EgcCBrX/w==}
+  '@tamagui/accordion@1.126.12':
+    resolution: {integrity: sha512-Hv2ORxwR3Ypf6gpvM27EsXAjkZaQf1Ks1DWc2TQh5JHKB44/aCNOx5D7epXaKfZ0OKiMxFjVMZ7ip/HZSN5PRg==}
     peerDependencies:
       react: '*'
 
-  '@tamagui/adapt@1.112.12':
-    resolution: {integrity: sha512-kwMsduoBRF8CgzdSV48gga6UEs8swY4tZnIA3npoK5IbQkCHuE9FqX7g0mka8EjPMhF9WTg2La5/z68CgWBduw==}
+  '@tamagui/adapt@1.126.12':
+    resolution: {integrity: sha512-QZDF6cXtcEQVj6YYs/zJQ1/cHwC5cF0k1HjfA/DsyZ96xF5roWZDTBAAWAweyx1KgNlhfIOZqmcS8Cna0s3x+Q==}
 
-  '@tamagui/alert-dialog@1.112.12':
-    resolution: {integrity: sha512-7GloAZ5S3iEzKVN++PkTzzYvcWRpI/gGlQhw9AuyGm+GKCt9Ff97+0YAC9NQI2O1epafzXjn9/hdmTk1hEoQ1Q==}
+  '@tamagui/alert-dialog@1.126.12':
+    resolution: {integrity: sha512-fJMuZSU1aK247kcuf32WJDQ0gumKQMwqHHquPxkdXZqxhSqZXFAf3jULMzTI/sOzjQa1lEBL920vWMWDTLzuvw==}
     peerDependencies:
       react: '*'
 
-  '@tamagui/animate-presence@1.112.12':
-    resolution: {integrity: sha512-f5Vf4HXiCDb4fbbutQhUYKrIDuDaQM6fnqoQVJm+NbBnpVsj54aBLP+GXGzMPcWjSNB6DCH2Rez2ztyL7j01UA==}
+  '@tamagui/animate-presence@1.126.12':
+    resolution: {integrity: sha512-NG3aCUUUCLjCAxSzFhc/i9JfwT0iozdmvLXAhDNrIXI6sRYkKOY61o/8wSKn9feaPuAQU9YmbIzFzflAAqj4Fw==}
 
-  '@tamagui/animate@1.112.12':
-    resolution: {integrity: sha512-9FAGebvmukqOnhRO3Nd5PyUuLVCJmvM9M+g7XwwVRh38E2HNsk2eTyxt2BwsvvYV6CGN25wmWmR1pQtJ8rbl3w==}
+  '@tamagui/animate@1.126.12':
+    resolution: {integrity: sha512-KBPUvUh5p7f0Dyt0Bxffj1CN++UL1YjgmcGmZQDLUNvSegC2bw7XXDiN2GQwm2uLI9FJJ0W/onjRCcC7TF5UWg==}
 
-  '@tamagui/animations-css@1.112.12':
-    resolution: {integrity: sha512-0mAZbo2ZjpmK3394CwHfNA8bmBJXac32Ao5XmzOXWUJdJmibTFfgdsSyeo99zxj4UK6wKhailLz56P4nJelWhg==}
+  '@tamagui/animations-css@1.126.12':
+    resolution: {integrity: sha512-A/8RBt09hTcvHHeRUJ8QDXY3ZddZrCE1YFOy4ZPuhTUsv3XpokI30TRxox80CK9hFvOW5jzIEv01vKviyRbUvQ==}
+    peerDependencies:
+      react: '*'
+      react-dom: '*'
+
+  '@tamagui/animations-moti@1.126.12':
+    resolution: {integrity: sha512-jNVvuw46sqd7ANCOw0rvTcFvER9ktGddqod8xFIdvAoCkjxfFBXpwGlW8u6CXTfrGQd+BMgrybjP2vrDp2H8LA==}
     peerDependencies:
       react: '*'
 
-  '@tamagui/animations-moti@1.112.12':
-    resolution: {integrity: sha512-CTZww/9iruyZNYC/t8moYfcaNB/y6KcS/lP8uEZu4bUZ9mer2LrPqyvvkKnbe7r4aJCkV3oeLZQ58m9POM+l6g==}
-    peerDependencies:
-      moti: '*'
-      react: '*'
-
-  '@tamagui/animations-react-native@1.112.12':
-    resolution: {integrity: sha512-AMM+8kXAbkAyXpCDuLNQBMD1cvLzSEgE5Keo4AHAkGE1qBZJzhXJB4aHMtpYD1IoaXnu/Uua+AuTq1Rh0GARAw==}
+  '@tamagui/animations-react-native@1.126.12':
+    resolution: {integrity: sha512-41JAU9j7/ad3i9l4AfppOidsEdUHHqiO4g0B6zpV4x5Y8EmphBqSM6DhuM4kKE5ywRkjSwSJYa/P54wR4L5p0A==}
     peerDependencies:
       react: '*'
 
-  '@tamagui/aria-hidden@1.112.12':
-    resolution: {integrity: sha512-YpB2UgmqEfRYl2YWmsm9LZN29pgUtZV1AHECgu6f1+XCn25ufPIqI9ZtyIJbJ/I3n0CMkyv6Q9y34Ax1Bp2/jA==}
+  '@tamagui/aria-hidden@1.126.12':
+    resolution: {integrity: sha512-6elQuZazsVFPGI2X/04qE+Eg6UQv+imacCcu9hqnwpu3gJGt1I+3oqW9zE4FlzLhfRC/ZFwJOapd4PYW+uNdQw==}
     peerDependencies:
       react: '*'
 
-  '@tamagui/avatar@1.112.12':
-    resolution: {integrity: sha512-xDdePJB4aykJViRlhckdmOW9Zi2zLtoEUkoaeGJPL4aqBkfSh8kzuuwH8M7DO4vJ4mNUZNQnB/uvgnF8TyHOQA==}
+  '@tamagui/avatar@1.126.12':
+    resolution: {integrity: sha512-ib+p/vGKDV8xganZb0wRURZHpzaYQIbRVljliU1OnrTyDvyxHU6oN+a0nzXnJlfT67FZhNjOdgrnO4hzjE0PEA==}
     peerDependencies:
       react: '*'
 
-  '@tamagui/babel-plugin-fully-specified@1.112.12':
-    resolution: {integrity: sha512-IeWEDDYcX0WR1FTCMfMLkpKSxWTy7UtOfNJLtiYdhYGS99ttYxU7VCBDEEkp1qY8TwD0wi4GVvqRY4t6o5GUZw==}
+  '@tamagui/babel-plugin-fully-specified@1.126.12':
+    resolution: {integrity: sha512-PoPlrJz0NLCsJLWh/mi9Ebu/vxyP43BQ8KHumbLRFm2wywMZH7BkFRC9U86c5spfG1iELhqZSxQgl626Aqwnew==}
 
-  '@tamagui/babel-plugin@1.112.12':
-    resolution: {integrity: sha512-ZbJenBHgCb3Av3BA9HMYTx79+6xg/E4OzWXCZ71kD+ong2IKwkN6/U4P/DHnrq1lvUUkOGPfCFdhdEdLbvlozA==}
+  '@tamagui/babel-plugin@1.126.12':
+    resolution: {integrity: sha512-C2xbOzHGBbtUO4tfVzUSJj6xJE5AqwvffBQMPRXZlR6XT6aBTNRzf1mEqFel0yKYbkspaqjwfPGu7wFK+cDPfA==}
 
-  '@tamagui/build@1.112.12':
-    resolution: {integrity: sha512-gVuZJl0rCGWzy0JLrdn5Niw4jqZk96bRAINVMOpmPNKCBXWKe/PmMxvB2dzOfM9rduxfNOlF/J/ggxhMMr5e+Q==}
+  '@tamagui/build@1.126.12':
+    resolution: {integrity: sha512-liCBwOf/a35k9mkApWLYLOgnxy9oEalTGbleUAECTBB8JY0eoq5GB81mqUlJSpyIYgqk3QO1+9fNn4DweTHJBg==}
     hasBin: true
 
-  '@tamagui/button@1.112.12':
-    resolution: {integrity: sha512-dK7g3O1+KfPgkiIoRdxR7W+hJNS41Pjt8RWi5l/u30MRqbcVrZZifWpgRguU9Lr0d2PQGNIK767HG3EEeOduzw==}
+  '@tamagui/button@1.126.12':
+    resolution: {integrity: sha512-6R8e5FRqrDQAx9Bu52yjRrQPasDrIlHXE4B4IvPu8M8Nn4GdEup4bV20wq3abg5PyHTGAUa6vJX1ElW44H+r5A==}
     peerDependencies:
       react: '*'
 
-  '@tamagui/card@1.112.12':
-    resolution: {integrity: sha512-PIfKvCfu3cqyidYytSQeKWBetHG0kCEbiQ7bxtFcyKQcwnIzrRub1CFCrohy5sETzGnm0xosTI7wi/plKjKHxg==}
+  '@tamagui/card@1.126.12':
+    resolution: {integrity: sha512-iQ3JOHa/vTgC+lR/cQQs8zaS89lW5ynCgu+S5KOEwFzQ0UuBlCfRU5xN56f6qiaYTnudanEgnCZfIMJhq9jOcA==}
     peerDependencies:
       react: '*'
 
-  '@tamagui/checkbox-headless@1.112.12':
-    resolution: {integrity: sha512-hs1ZOxGVzHqmUK+EwFqehrCjZfeI6yYcNOvd8O9uDr0SLpABZCBbn32BF+SwhgOMZotbK0ae0pA2x+Tb3ueIDg==}
+  '@tamagui/checkbox-headless@1.126.12':
+    resolution: {integrity: sha512-PIgnHkVeZ1iGwl4smqO+v2kvZr4Bia3d1ssUDo2ZoGNeL8qy86IdGjEoX11kH1dCuw2JkiPsG8b4wMQ3kcpDHQ==}
     peerDependencies:
       react: '*'
 
-  '@tamagui/checkbox@1.112.12':
-    resolution: {integrity: sha512-2W2xhquVqdV73J4d3ea6tkHs8Kg/z5hF7FI47t9t0xUVS6cLnGyGHqrY5c/kXHQM0T3Hgf+CAx5d2OnK5t1Kqg==}
+  '@tamagui/checkbox@1.126.12':
+    resolution: {integrity: sha512-9zHUeZXHfm3AdEqlrzUG0RFNRnbhUk84J3R9uDuskJxEn5TE8aktrpd/RObWQcjIFpbAe/p/g3use0KcKzMuTw==}
     peerDependencies:
       react: '*'
 
-  '@tamagui/cli-color@1.112.12':
-    resolution: {integrity: sha512-wTOUE9n6xKEJyWfj0asri0KGrYk9Yj2agbZhjG57KcR8RIbM02hoZ84Ljn3M43F8J8LxNRIti8s6aW6SnSJ1QA==}
+  '@tamagui/cli-color@1.126.12':
+    resolution: {integrity: sha512-eCo1ixMjlxEtCIUiUQYjI4dEYxkVHL5KBqm1/oCQ/RNlOthPm/tXokEnYgUtJG2Khv94qRw5hEBiCQzllvN/vg==}
 
-  '@tamagui/collapsible@1.112.12':
-    resolution: {integrity: sha512-nZFlnILNM0eo1EZ2tPywnPcLNcU/vq72+5dV9y8CdxRd/HUnO9JoU1+CyZ2ZEkky7k8eXivLdD7DuudSSr9qRg==}
+  '@tamagui/collapsible@1.126.12':
+    resolution: {integrity: sha512-qtxxLaRWYRamGQZDKVIgnNC/qOKOGBNlRe3rubQa3VVVUfriWZO7hhzQquUVdIVhkCWj0+xZ1Fz3aoGzhso7yg==}
     peerDependencies:
       react: '*'
 
-  '@tamagui/collection@1.112.12':
-    resolution: {integrity: sha512-DCBwPiDMEOZLlTLiHAjavD6O6RXUz+3S3M+5yUFs5ANUVIcNjyIzIMbD+QLVoCGHKjjuCSyTqh9kuj+zGC7Vtg==}
-    peerDependencies:
-      react: '*'
-
-  '@tamagui/compose-refs@1.112.12':
-    resolution: {integrity: sha512-xwijG1j+IAn5RmhQ+8KoiJ9HtQQyKjsOLWGLBvQ5MdN9NHH9hTt83W4FbY4tTdWOgwQ9KywP9doMvzK69SgBMg==}
+  '@tamagui/collection@1.126.12':
+    resolution: {integrity: sha512-ZyR7vklkLiPZdK6LdR2g45L9yLJyZM0g9KJ1R9VtqzOHANIKvUBv8BGj9KL82HPYgx6MU5KzVs73BiJndKEbPg==}
     peerDependencies:
       react: '*'
 
@@ -4819,339 +4665,337 @@ packages:
     peerDependencies:
       react: '*'
 
-  '@tamagui/config-default@1.112.12':
-    resolution: {integrity: sha512-j/wpsBsBF4hj9r778Kq7ANsgPh50bUVa7VLzWLe48FrV35J+MjafBGjwSPThLkFcPM8TRnHBFRPuKL4GAX4MuQ==}
-
-  '@tamagui/constants@1.112.12':
-    resolution: {integrity: sha512-GkcqeF0m0ZHThPcAeDx9Z4qYGt7Cm1J72P8NQ7ax2WpilLlheGILRhrN9TUbKb0DXCz789GOjk+HnbksG1ihZw==}
+  '@tamagui/compose-refs@1.126.12':
+    resolution: {integrity: sha512-CLdmRHvZWGnb6dUDmYLA/ua0H2G54iKc5Hy7aktHOZf003J2T+peImD/bGjfjOW0CoyRuTAdbtcAciMNmwJegA==}
     peerDependencies:
       react: '*'
+
+  '@tamagui/config-default@1.126.12':
+    resolution: {integrity: sha512-EZ9NR6baoJ/moYhYd4Ky2YOVHyqjb5NBGYoYtSqiePot4Obnby8tlmb+rmdi6euRK+Lcq3tpjHk7YwaWv/e/pA==}
 
   '@tamagui/constants@1.116.12':
     resolution: {integrity: sha512-Cxms04IdoDa0mbSjOkbw8/NbRc0PPr06AqoNoxK0bLn1mNsMJJCErI0iImL50ZVLuqq+/8i4lpWVSs/RkOskqw==}
     peerDependencies:
       react: '*'
 
-  '@tamagui/core@1.112.12':
-    resolution: {integrity: sha512-s6GbHi0c2HgaFm/LOVuMIalb2ntXmSk9C+tsKFgwK6tg6k6w2qhWvrR05Gfm3IUN19Yb9X2VBqnXOzICwjaf+w==}
-
-  '@tamagui/create-context@1.112.12':
-    resolution: {integrity: sha512-OkWlIKLOudQ93r4vM1yXUeEUU2lJ+steJvsrEatTfxnaMW4flpTaFxK6UrG8rrfGrPKMWJecSzSwPD5RctCftg==}
+  '@tamagui/constants@1.126.12':
+    resolution: {integrity: sha512-Fy5TtNYzZ+DacqxzEXGIDW/Wej0ftYOb7ffRsVD3pHfqWssVdqMOuqPX4ZXhBq5F3ztHhK4H26DMm8E+ROpxwg==}
     peerDependencies:
       react: '*'
 
-  '@tamagui/create-theme@1.112.12':
-    resolution: {integrity: sha512-EVsV2UfihuGS8ThIQtUNAkft1+7nfABE8hHMiIm4djx2p/OOvJPy8u8oB0rUacygtFHQqTQ5uoVHuCxz8yPMfA==}
+  '@tamagui/core@1.126.12':
+    resolution: {integrity: sha512-3HGjHIrX92UdMCMFZK3fTClpRy8UJ23uwx5cwvSOgxGk72lq7fssRJI7p5xvBY1H+841HWPBjfsYx0aMrGWNTg==}
 
-  '@tamagui/cubic-bezier-animator@1.112.12':
-    resolution: {integrity: sha512-7M8iyfd5hFjwB4IlCjjuqP4rj6a61reLjaFuWLOCkEF+qOtlAhGPE8IJQgmlz8//RN/DrxsICXXvXuk9O5dmPg==}
-
-  '@tamagui/dialog@1.112.12':
-    resolution: {integrity: sha512-/bIiV9ntGrYOKSwTNzFM2wBijYHUsd6xdy5c4NWLc/HWDWVERi+zCSbS2abT0I6kllvsOsVNz0eDEnh7UymM+g==}
+  '@tamagui/create-context@1.126.12':
+    resolution: {integrity: sha512-Z4lxdN7tUw0G538pJjI2YFhErUu75q0omdppUPhNb4XChat+b1bZBT+Y4jOrjEhtfSkZeHQ4J664K5/pU6BMpQ==}
     peerDependencies:
       react: '*'
 
-  '@tamagui/dismissable@1.112.12':
-    resolution: {integrity: sha512-DdKWky75Vu0HUfBcjKLo+KAI/oL0gfE8656Q/s4UX3gIx5DYZ2MrYKR72RUC2AsexnibP2yn1PWOMLLoOdDb2w==}
+  '@tamagui/create-theme@1.126.12':
+    resolution: {integrity: sha512-looo2G/9WDBFg+lydbu930lmKu2aZ0GmB6eHi2mkgrsRqB4uIcIYagP9SFhktG6+CXUW5iLd+KW8A/Kfp93ZkQ==}
+
+  '@tamagui/cubic-bezier-animator@1.126.12':
+    resolution: {integrity: sha512-loElyQGGWIV/G7RUxekv8nFL8WeHUrd2FB8/w7GnVd7dZIO2px6Hw5fgOhHldZe4Pi51RJxJo5WJguf0qpZHJw==}
+
+  '@tamagui/dialog@1.126.12':
+    resolution: {integrity: sha512-1t1eLICxK+TWzWzQwSP/jWRrRszyhEBmwLGdAutINAwVgLjsoeBp6xs9k+OtxB+cFQkGsxeqNBVEdOXVludhew==}
     peerDependencies:
       react: '*'
 
-  '@tamagui/elements@1.112.12':
-    resolution: {integrity: sha512-DULrW10o0KlP8dHN3O0oflGeswdTBWH3tQ9FW3sY2KCqjwVs3vwJM/2VS9eiMPSxeOv/UDS+trrcD3bIXFZfaQ==}
+  '@tamagui/dismissable@1.126.12':
+    resolution: {integrity: sha512-m8Cb1qOjkP7ycK5aZDvOJhp8heEnv4NyFe0NegGRQ22+pXDM0LpYMnwA6LCGcH4FQa0fOOzYUzzwtnjFatZwsQ==}
     peerDependencies:
       react: '*'
 
-  '@tamagui/fake-react-native@1.112.12':
-    resolution: {integrity: sha512-ZsGGq6w74VgdBzgQ0m7YyBibDXPdxJK1I3Z28HoO7mtRhSMRXl/u0jE+r/KAkquMz78n5JP+ZLDa/jaKfKqbhA==}
-
-  '@tamagui/floating@1.112.12':
-    resolution: {integrity: sha512-dOi6vXUMKJRyxePq/JEglTM432HyxqwFVWCUV3GDEfsWNaWG1ntuYQs+uISKyVpfpAn7/ruQ8b+sqLqzY+URow==}
+  '@tamagui/elements@1.126.12':
+    resolution: {integrity: sha512-KAmoyCdlb0BL23JhcfFbcu4qOEuZyH54xSYV7m1apnQ/fnD76xA7GRhzinrk9Cmm0i14pV+Q1/3ngZivgaUCEQ==}
     peerDependencies:
       react: '*'
 
-  '@tamagui/focus-scope@1.112.12':
-    resolution: {integrity: sha512-MvRp3CP0mIUx5beiMtjZmMepWY3c/t86AgCR+tpzCFJJeY29nOaAofQpU7ZEgGM34+OlvJcNllEiigQsN8vWbA==}
+  '@tamagui/fake-react-native@1.126.12':
+    resolution: {integrity: sha512-A1VOuXnKag9/QELZHjcroSJYh6VXudDlqW2TwDzerXZFaJELgiDhlbcbdQpBnB0WHFel31oluCryf5QwDrlksQ==}
+
+  '@tamagui/floating@1.126.12':
+    resolution: {integrity: sha512-TNhugL6ju7QhBfHJPPWBkT0Rc+gI2Z4oT7jGiX6G200LSMWRZQ0OoYnFSvNRSEk1E0nV+RpxtISr5+Tb2SORuw==}
     peerDependencies:
       react: '*'
 
-  '@tamagui/focusable@1.112.12':
-    resolution: {integrity: sha512-rr1xZQstxgvB0/71cqsV4awG5ZZ+A9krmbCkIwPYDQl8CJiX+5kCokqZyrVkeVrg2GRkmCnBJQtC+kcZt6D5mA==}
+  '@tamagui/focus-scope@1.126.12':
+    resolution: {integrity: sha512-6/uLGB5PFqG294LCsVltVdKBbFhrlxMesns/fSbrsnEbjZvrK9SXp3sIaJYxBtzepMvV2MHFv+aZ1LzVCdQLCA==}
     peerDependencies:
       react: '*'
 
-  '@tamagui/font-size@1.112.12':
-    resolution: {integrity: sha512-/Y5K9ZobR69dzcBOMm+EIZfKaLlaEYqicZ0Zostr/2vfjf7oW1xE2b7KZiSo2gz8POUwKYY8ybbg4Z3bcknYkg==}
+  '@tamagui/focusable@1.126.12':
+    resolution: {integrity: sha512-e+878wj3WyG3+C9jtWcgUBikvBJ87BtJTLTtAHU/yDzBEdAQjYHDbRbJGKeM85MPDDHQ35DpnGy9dyxXfas7pQ==}
     peerDependencies:
       react: '*'
 
-  '@tamagui/form@1.112.12':
-    resolution: {integrity: sha512-GFKqpqbxR2talj70E4hUNng4uT3kqiQ53mNso8S8UGdv3jb9jHByMNzsMNUqRvp8t+Gi97gvN4PlhdXcb2/5BA==}
+  '@tamagui/font-size@1.126.12':
+    resolution: {integrity: sha512-5jsh7ixgYSi3OvjqnXcMEZmZ/VOwTexHKONLRP7EUXrgxLiJWoihgu2k/9WW2eqdJUMOegnOXvSyCnAfM7RtIA==}
     peerDependencies:
       react: '*'
 
-  '@tamagui/generate-themes@1.112.12':
-    resolution: {integrity: sha512-hSVjTGQ9fq5HOwnMB1NAhvEnVgrigQiQstlxxRWmHf9bfPioTcvxkhKbfD6xQIg7BzbhGxf567aNr5wT9adkSg==}
-
-  '@tamagui/get-button-sized@1.112.12':
-    resolution: {integrity: sha512-gIdHe65Wa05sef5zt9KY9jJ9nO22ZMivAauoyGS80HVRYacGoFFhJ+rEeQQmXdIdRa+Q+m9+4yjVyPgHDpXyhg==}
+  '@tamagui/form@1.126.12':
+    resolution: {integrity: sha512-JDMH+OiBXqWN6yD+xiCGeUz1qyrYXDJlt2tLOoHZbcdTZFuexnuyEo8OztzJ2FxveVCN7QAQX2NaHJxZVmq69w==}
     peerDependencies:
       react: '*'
 
-  '@tamagui/get-font-sized@1.112.12':
-    resolution: {integrity: sha512-zqNRrIKj9l5kbqGdXU4kuLNLIc/o4l8olusxbv7wRdt30HwIDit7hbVBcjgxx0qkzrEzzdAIo731mH9lxNOQCQ==}
+  '@tamagui/generate-themes@1.126.12':
+    resolution: {integrity: sha512-L01JjqcuUGq2eQUzjVPXeZE3zuTk98felfFYmuE0Qbtppbz0PIMGAiWnfseq7x0wbaT4szjVcca5J1fpJhI/tA==}
+
+  '@tamagui/get-button-sized@1.126.12':
+    resolution: {integrity: sha512-rvZ1Fy1sajLiGxTxx87VfuDbHRaf8BOi3Yi2EvDlOrclffNj8dh9a1QZARitFT0dWdRb400wClnmHaYow4yeTw==}
     peerDependencies:
       react: '*'
 
-  '@tamagui/get-token@1.112.12':
-    resolution: {integrity: sha512-9y4JjQYoBbN8cV7TQ6T+YyH0RLLmVwNMUdTGfE2Orrs+MnpwIpVRhE2KTjIK60fZSIWDlKOYGshEm+wrZp79UA==}
+  '@tamagui/get-font-sized@1.126.12':
+    resolution: {integrity: sha512-1qrp/aAxol3VJI6SThs+83UenXSQMyeSRgq2/x4T3wgMz+IBmsX5CY4qMmZ3YrR5CTAgR/LKWkkIZsb//Bmm/A==}
     peerDependencies:
       react: '*'
 
-  '@tamagui/group@1.112.12':
-    resolution: {integrity: sha512-7OlX1x9MB/M8dz/54m4ChG6qz8YlR5gWZIIBvVHmgBxhhLwj5D71oHeOXLLiE3918/QHeyG19SMnvcWWX8RzBg==}
+  '@tamagui/get-token@1.126.12':
+    resolution: {integrity: sha512-EoRIWz2daLYCOLPuLOSPJ79EeW9slQcRBJZUnoE8KPfYpoz2Da3jetBQqMymzFcxZia0UJjxJvw6X9IZLzuq6w==}
     peerDependencies:
       react: '*'
 
-  '@tamagui/helpers-node@1.112.12':
-    resolution: {integrity: sha512-EABUdvWOe3LLnZKd++FrtNZy058GrTNhhs2GilswRIjwA2HLPDbcqGmdJwq5FWo7tBbvi5CW98fcVKINrI1uUg==}
-
-  '@tamagui/helpers-tamagui@1.112.12':
-    resolution: {integrity: sha512-oXePJyQV5I6wC7ZUsJdDFacC7Cfeqgt+rwvpBwxtN0UXBY6H4J7G6CcGezJaA7ZOGgv9aMkTrDBlrPTF9PZF9w==}
+  '@tamagui/group@1.126.12':
+    resolution: {integrity: sha512-7gY30KAeDPO2PXVnHOhCWfbF4Sc/8rmYHCl0Mot0YImU0dVYrLCzO1IIbuWQCb7QJ8zFPcALTCbAKFLApY9Xxw==}
     peerDependencies:
       react: '*'
 
-  '@tamagui/helpers@1.112.12':
-    resolution: {integrity: sha512-OxnUIiaY27DPyZ0/N3RB4gqFGNr0yf3EUehjDLtTH9Hcpt1Z8ZVDXRrngdGd7p+jrktaXts5BWDelN3sXJiRWA==}
+  '@tamagui/helpers-node@1.126.12':
+    resolution: {integrity: sha512-h/yASD/RdIJDkBBSGb5mF5R35X4u/WauuVAGH/UPULP/c1qrtoXFlY85GL39B7dq9bOVOBV3j6CLJPrzyqAa+w==}
+
+  '@tamagui/helpers-tamagui@1.126.12':
+    resolution: {integrity: sha512-8reniSIuZ4fQ/PMmYWT/9k/+apq6a8lLP7fxyMrMceH/m2f6IwzvNQi+3Sex6yCtzUB3BMaM8ppWrsWBUJcYAg==}
+    peerDependencies:
+      react: '*'
 
   '@tamagui/helpers@1.116.12':
     resolution: {integrity: sha512-rYeZ4+4xZo01V1KF1f4U7Psnkl+XoD28Hc49BG0xKZPp9YMzsPKtZT/cKe7kLJtZOgwOAi5TmwFLxXQWyZULTQ==}
 
-  '@tamagui/image@1.112.12':
-    resolution: {integrity: sha512-3O00UE6yaA8ZocD+VzWHVn9oLsJ/IsfAY8TS2IMZjL+rFrdzRfRCJOUMJJLV7ZvidUlgnWAWGY7INBUrq2XdsQ==}
+  '@tamagui/helpers@1.126.12':
+    resolution: {integrity: sha512-ZChjCFGRRbTGf0CuqOG86miv0sQ7Bly3BNkgzWqNdxvK/TNywMKulVrmVDGz39X5Mcr1dcamj6o/4C3VrGr06A==}
+
+  '@tamagui/image@1.126.12':
+    resolution: {integrity: sha512-gy5cXHJe1CWi8gibgKm8j4UJrN6gReyT0p10kKoUFKLP4v4AOoPKfv6FcmD9wqtDvKfoHihPweKFuvjsc7KFPg==}
     peerDependencies:
       react: '*'
 
-  '@tamagui/label@1.112.12':
-    resolution: {integrity: sha512-dyAB5DZhxq36ynvYnxwjA/ntLD7hyIP9/NAkip4dJLvheX+FNJKn28tCs/vEEvNCJ02FQ8Hy8/x6r3zd9rdDMw==}
+  '@tamagui/label@1.126.12':
+    resolution: {integrity: sha512-IO05udUcKZmGHXFZ9JpC72+3Sp7vwaR0soJxEtxU56+lRrRYjQBgT77OsuriUXEn39E0RQKmSKR7w7ncWouxwA==}
     peerDependencies:
       react: '*'
       react-native: '*'
 
-  '@tamagui/linear-gradient@1.112.12':
-    resolution: {integrity: sha512-0UWaPTrQJZUHvga5qBJ3zJPlObi8ULcHU196l+WRmFhln8SJ3I7HVe9rp5a0SWNVIJ7dA2KrcS0AyA15K6uA+w==}
+  '@tamagui/linear-gradient@1.126.12':
+    resolution: {integrity: sha512-GNzwNocld+6HWMgSRnvmFYlpKqg9cMkvXdIX2F2iMGZ/EdVX9QMI9G/KUHJD0oC7sipij56FCUq5HDSGumEasA==}
     peerDependencies:
       react: '*'
 
-  '@tamagui/list-item@1.112.12':
-    resolution: {integrity: sha512-LZ8sB08sfn+mJ06Y59He+e8aAIwVd9vxLsBYOyN2EOANTDNJomkrfCzrPG+4HrtbxooIlZ3uBKmAryeb+UA7hQ==}
+  '@tamagui/list-item@1.126.12':
+    resolution: {integrity: sha512-d5X4WkCaKFZoA8nD/fpxAc6b/ihBFN5PdPL8cs3tigrtfCgyB5o/Wyl8eMWvmtP3Eiis1cCUUux/SWIuMi3sCg==}
     peerDependencies:
       react: '*'
-
-  '@tamagui/normalize-css-color@1.112.12':
-    resolution: {integrity: sha512-r8KU0h0bmad5i0fWx9pVwYLXLnYQ0OJp7C70KmJtP751cp/6y8BK2OZTGeJUq5DjyQhIf8M4foLvsM6ZarBe+g==}
 
   '@tamagui/normalize-css-color@1.116.12':
     resolution: {integrity: sha512-KPIeHuGvsCByXYp3dwcxZ5tfIb5PRzI3DawRjM79+jrqKp1q535gDbDkBa2zqE7DHVQuAO4f+p5aFaDYNyCyJQ==}
 
-  '@tamagui/polyfill-dev@1.112.12':
-    resolution: {integrity: sha512-puZRQoEQsBVUAnkFIhEWcjhCJeIazqOGxTKt5zSHG1DF6LRrZiY3qrrriaqTEFaZogW0lVLiFH21+3CLPg3kkQ==}
+  '@tamagui/normalize-css-color@1.126.12':
+    resolution: {integrity: sha512-gaFrZtioA2fXZeJwwOY6p9DmOFzMCIzW5kJ3qg3fCEzoQogDCUY5/fhbbutQjIf7DlPWEf7U9LvysRFO/IZH8A==}
 
-  '@tamagui/popover@1.112.12':
-    resolution: {integrity: sha512-h4+1uFf4h/zFU2fG6fv5yJUNzqiQrkgPXiwsrd2QAAUccj96gdrafx/WRynr12RRFk2ANXCuKXr3atDlRVh//A==}
+  '@tamagui/polyfill-dev@1.126.12':
+    resolution: {integrity: sha512-P6KH5jbnt8KoJXj/jRYdpyZBOu6YBbnKTqhuBH80fHfCvYDkYBsAxb3XGCj7LZtFEJ4MZoP6N925MZ1Q4Dsznw==}
+
+  '@tamagui/popover@1.126.12':
+    resolution: {integrity: sha512-kpVYviuqkLWU2ofe0g6wFIR6AnwEn9xLewZE3Mxr9Wxqbz0wVTohElAK+NpX2qAjISJIYpPk9recfoHSQ6FLlQ==}
     peerDependencies:
       react: '*'
 
-  '@tamagui/popper@1.112.12':
-    resolution: {integrity: sha512-cb3y1SkqUBxx8kHqiU9N+zP5fSiMbGP8adof0dQS7yObH8Rprx4NWD8RzNMvKROOLsXpwK/Yn5dqLf4QiA6OUQ==}
+  '@tamagui/popper@1.126.12':
+    resolution: {integrity: sha512-wJHWUCsDOvG1eilMv755dFWkR3/T/o4cBw7JTJysWgp3aHdDEw7ZZQaxsNcfp8yhVncC9TY/csfH0dXsJLrTyQ==}
     peerDependencies:
       react: '*'
 
-  '@tamagui/portal@1.112.12':
-    resolution: {integrity: sha512-CkJ5hN0wofeXMGqMhG41NGB/O447t2GE61qPoQJ3bxvjq7dtnpmTcMbznbWcMwKwFnTIu38guo/k39xOocWtqg==}
+  '@tamagui/portal@1.126.12':
+    resolution: {integrity: sha512-ZEusqYWFTEl8/RnFhwTlWsqub5TcH+WedYr2Pr19Zrhjt0JAdWoEg27DLncPmnt3Zj9mKvTtf2YrscQLeGeCvQ==}
+
+  '@tamagui/progress@1.126.12':
+    resolution: {integrity: sha512-m+AKhdJAWUGyGxdh49d96d84pQgavZrp642SR87jhQOI2Lx3V62De/AtSuYKbx4HWchGC5f3fW3BclLj4DXTuA==}
     peerDependencies:
       react: '*'
 
-  '@tamagui/progress@1.112.12':
-    resolution: {integrity: sha512-dNjUhSgKZpeudUAuzIg+BsmGLAZAeVTy9ZLT2yYbCsf31TRTPhbi8G3iv8djCSf2Gjzy/aBWhj43IXRddcuvZw==}
+  '@tamagui/proxy-worm@1.126.12':
+    resolution: {integrity: sha512-Q0A6cfzTHqsgklLU4VbcN6Lf+sJ8vWf7MAvec5Hvb8VJYGqtTRDXjTdgPwj1Xf4GbtewoyYffu+Dum54GebQ6g==}
+
+  '@tamagui/radio-group@1.126.12':
+    resolution: {integrity: sha512-tLvkcp6dOtbFoTt0LbMJSWhYN8q/bnC22ZMRyBkDBkmkqPOpBvQzuW5NPQcJjm0IjnDSdMLVFdXmsdGe3XJdJg==}
     peerDependencies:
       react: '*'
 
-  '@tamagui/proxy-worm@1.112.12':
-    resolution: {integrity: sha512-+uCBd4OraEmdS2wnYzc3XzZyBnuf8ewKplgXEHF3vpj8jGbRgPybFMTuFcdgZ5rLltYpnJg9JKAJ3ZPizQX5OA==}
-
-  '@tamagui/radio-group@1.112.12':
-    resolution: {integrity: sha512-eA1RnvbxKFgEwpU7W6fXGvnP9z8BvfeTf7PyfV65pAhtLI6EQMMju/kkt2KbNk51IcfmYJIb47wPtRAWqhh7jw==}
+  '@tamagui/radio-headless@1.126.12':
+    resolution: {integrity: sha512-ss8LIPSlfOA60U807MsHrU86R4Q5l0jiPYb0J+/RDUC3i3zl3v6AGd5HuYN+qpIlhqY6wBz0nXUUZlHlfNp9Mw==}
     peerDependencies:
       react: '*'
-
-  '@tamagui/radio-headless@1.112.12':
-    resolution: {integrity: sha512-qXFfUdNCALesu4Irs6APq5ve4Be+MHd7kEiX4HCU7WjjtFJFiEx8kHtkBHiMi4XAnXV1kR1VOHmgo1QsYiBEqg==}
-    peerDependencies:
-      react: '*'
-
-  '@tamagui/react-native-media-driver@1.112.12':
-    resolution: {integrity: sha512-mmJOahjLg43krV+y7wnDDWaJQQIQ1GW3jV4JbsKNJQEDlwXKMTcA/UO8L2MsVdWP8OtxX5Sg6p79OFUAnUNMpQ==}
-    peerDependencies:
-      react-native: '*'
 
   '@tamagui/react-native-media-driver@1.116.12':
     resolution: {integrity: sha512-EdzlsDu4xaqVKWCzZxGrK/ITO0X7aNymfcBTVxYeA18lDzGR12o3LtDZhsDTcEFVNYse8kD8cc7Jd5fDciAj4w==}
     peerDependencies:
       react-native: '*'
 
-  '@tamagui/react-native-svg@1.112.12':
-    resolution: {integrity: sha512-ZLVdySFRrqwj4nqkxUSCC5IPCIVxRb9+JyZXdiVw444+bZ8ssfh5tu8iaPaltFkl2A41Xq69Y/217gi5Juw1sA==}
+  '@tamagui/react-native-media-driver@1.126.12':
+    resolution: {integrity: sha512-yXi618Zjt7AVHFXFZKakHw+AfDAhgxDGkA/nNvk2vhBLHqn3SrLOI+s/B3WJx5Ts6Uz6SvyHJP2etY5TBtWE2g==}
+    peerDependencies:
+      react-native: '*'
 
-  '@tamagui/react-native-use-pressable@1.112.12':
-    resolution: {integrity: sha512-JodPKfCanZR3hyn694rN22ExzPdINRJim63vZ5eKVnXnyTJ7ml/6JvzxlBgkozt3RBJjzUHm4Xha0JNwmG+law==}
+  '@tamagui/react-native-svg@1.126.12':
+    resolution: {integrity: sha512-N/A9HPgMkAlSh0bmi/GuG0O1SFlhU5AJg9WNShDHEXU+GlcfbY1+YAfahP3OmdNyj2UPiDVyLNNDA3yWyPeGjA==}
+
+  '@tamagui/react-native-use-pressable@1.126.12':
+    resolution: {integrity: sha512-CReoZVVpp0C9OggKIqMQx3pum9Myw+GpRr9YdJSk3EAq4xLGvMvY4vLLV7mW+syH9JVbqiX7whCEk3MPNXxkjA==}
     peerDependencies:
       react: '*'
 
-  '@tamagui/react-native-use-responder-events@1.112.12':
-    resolution: {integrity: sha512-vI4ORRAgfuiXTtSuEIbfcwsES9dy4Jqs9zdnD+vLII+5cdkjV9njM9AWS2kXnz+zvPdblXcIvaaH3hDOX14YeA==}
+  '@tamagui/react-native-use-responder-events@1.126.12':
+    resolution: {integrity: sha512-CMuX3jV6KVnzaKjbqNYQZtN8qPMutQSQkBoUJHTCbUcj8nElYpjjXYIP3l+S6GkntGArVlx7qxlPl1gMU3tVeA==}
     peerDependencies:
       react: '*'
 
-  '@tamagui/react-native-web-internals@1.112.12':
-    resolution: {integrity: sha512-+dOHO6NkNx7hW01alv4bgWc8D6nOQjdGDiowghsO4zvfZr27ABzsw7f+hzCwtFJBh0psOrMxJb1rcoYZYzUtNA==}
+  '@tamagui/react-native-web-internals@1.126.12':
+    resolution: {integrity: sha512-0CNknaFHCIt6nz6B3fSq9uTSv44b6iN2vqcpNR2++x7twXwLNZAaMfxmPyy/rL166gtcRFmJ944BiXQdrEzz5w==}
 
-  '@tamagui/react-native-web-lite@1.112.12':
-    resolution: {integrity: sha512-Bx5Yb7obxHqhm6G4bqCKSKHgPbqwWOvVFgjth+XP6m7UStu0i/TxKKmoGQeHhlVs6Y27p/JspD4nEKenkLJAGw==}
+  '@tamagui/react-native-web-lite@1.126.12':
+    resolution: {integrity: sha512-xb9ag/XJMEmJynGcnLkay8AuoONr0brtUdar+MwhtQG31qRa4YyR7gMq7qtVuCHSFGVF2nwiHyTGb20ui4dxhg==}
     peerDependencies:
       react: '*'
 
-  '@tamagui/remove-scroll@1.112.12':
-    resolution: {integrity: sha512-YHtr/fZWz70c08U7yHXHJxWWspM4+OftHjyWufBniVgg+VJ6ymTt+UGGYOxkCLNm6SMecpQd0i1IobOLK6ehJg==}
+  '@tamagui/remove-scroll@1.126.12':
+    resolution: {integrity: sha512-xzmXRwStYLIT1XHbAYCrnizDB1sOYAnM5hR4kEU8zMNPz3nyFYIn+jj1lTma5Px26hCWyhZkFjIUAfXDf1ue6A==}
     peerDependencies:
       react: '*'
 
-  '@tamagui/roving-focus@1.112.12':
-    resolution: {integrity: sha512-WynoBCzXNSpkJzwmqVqffnshom5euDjzaZjGvcuM6icZMi2N71JhdauTkzGpn9mqsj14VijH2t+50rTnjqTV/g==}
+  '@tamagui/roving-focus@1.126.12':
+    resolution: {integrity: sha512-pmgRD+VIKDBrv+crn/hIuNr88XEVx8Cw0aSfJ9Fz5tswq8dx6VJXcDEGw2gPF3aftyivkxzBbqDOz4toKQJ/hw==}
     peerDependencies:
       react: '*'
 
-  '@tamagui/scroll-view@1.112.12':
-    resolution: {integrity: sha512-YqLAWmE87YL+GmWEXTo3nPCEtbOM2BqF+NA/NctVFdjqzxy1nwjtPU4KQsOp6qLPk+dlS2CcyXaeT9iGdsYPlQ==}
+  '@tamagui/scroll-view@1.126.12':
+    resolution: {integrity: sha512-fpz3N708nXxAe7D/3xABukg7VTuNG0qtUAK9aFAZ8cn35j7yZuCI6tU3GDSO30UZhFo9eWSHTCeOrvIqsLJoGA==}
     peerDependencies:
       react: '*'
 
-  '@tamagui/select@1.112.12':
-    resolution: {integrity: sha512-4QKrQBf50fNbsFBOfqDt51A2MFQRpatmEPrb7D/KEwPr/GgJSaojw27A8BFrcSsgDHOce9bpAmxr0xKqMQI8VA==}
+  '@tamagui/select@1.126.12':
+    resolution: {integrity: sha512-mD5c+3kBf5aSyFz6oKOlDqpU9VFo4VZ8Lzw4/22QgLTvgdS3iwUAJa2GfwAqAaPufsN5Pvafpnb/EParQRIZQg==}
     peerDependencies:
       react: '*'
 
-  '@tamagui/separator@1.112.12':
-    resolution: {integrity: sha512-C1y0liH9hoEptGaE+4PocFisaocYUrLXQl81TGzxCYDz1/minEoTfOAoG/Q0kIHlTZozNa64X3I9x5maLdVtHg==}
+  '@tamagui/separator@1.126.12':
+    resolution: {integrity: sha512-uywZSKQD5P+6I7S0+UMgWsteYeGioocaYxR/6rZ06wFvfLuerF5YwV5tGz2IVxEd+yJKH12LbpjYkwTert9H1Q==}
     peerDependencies:
       react: '*'
 
-  '@tamagui/shapes@1.112.12':
-    resolution: {integrity: sha512-b585zMob96/vZZ0A+snH5WqTpDxDonzUNbEgVs01mNbtMA6ab1iI/oeJHGZzIGxNlj5rGztPLKmjx+wuh/ofTQ==}
+  '@tamagui/shapes@1.126.12':
+    resolution: {integrity: sha512-kxAIoUoUZSaoBB0kFmFkgDynOVjAj0U57cdCanhajFt+PtoIeAxc6TlAWzMCBk18mP4xM+YJhbB1ACCli1koLA==}
     peerDependencies:
       react: '*'
 
-  '@tamagui/sheet@1.112.12':
-    resolution: {integrity: sha512-xfD7KeJ7BXxGoKIblFscNStmXkgq4CgrVn63sZrO/ar0Xg3km2B9O9P/xHlFNYHbaSwNXJxxkAm/xnGYn4Z4mQ==}
+  '@tamagui/sheet@1.126.12':
+    resolution: {integrity: sha512-pAlR3uh7XEowfGvCBQuQiG4z1XZKTz1N93VOAY8t1+K66sWpgssXmafMQ+6guTejLMr+YZPpVXGeU5SxcOg/cQ==}
     peerDependencies:
       react: '*'
 
-  '@tamagui/shorthands@1.112.12':
-    resolution: {integrity: sha512-ei9uWmnszNFzi+9CBKx+v9pDe3XQuyweBQNolZxgAzRE/pLBkKMCfPZfK4xEaU8BgIwZBleg2iIf2LExH1IrTA==}
-
-  '@tamagui/simple-hash@1.112.12':
-    resolution: {integrity: sha512-G860Qc76HaxhPShNlcyifeMGJOqVD0brTQIQniv/+/8Zj12tSZezLvUVzt4XEWaGGt46VM8G4asM1ns0TEq3fg==}
+  '@tamagui/shorthands@1.126.12':
+    resolution: {integrity: sha512-N8H4mq+mb44PzOxW3W6C/NEDg6yyFjeeXAbCjoUVsABQsGThjea9nZrLxk1rFfgKRkObHkOKNqK1QV/fkmdZAg==}
 
   '@tamagui/simple-hash@1.116.12':
     resolution: {integrity: sha512-xx93KTDourP1x3euncQJE5r8mlHJJWILvmqDEPNPXxWeHN21idVkdzdRwC/oxpPbGFCTREPgxlQBoJp2kp5spw==}
 
-  '@tamagui/slider@1.112.12':
-    resolution: {integrity: sha512-L7iW9ck2rep3sQQ8ads6v5iR3ocmmFX72zHxUmPtpEatPmBYcpzyPe8VPCf4NEH08wnNmi6k+F+Lfbsn+bgahg==}
+  '@tamagui/simple-hash@1.126.12':
+    resolution: {integrity: sha512-+JGmNo5SAoLTDZIfkH6EfzDS1aXw9NiTJBnOuMNLPiJCE+1zPs0HezD9Iv6hroIU0WaiUfw5E103Phlp9wlNeQ==}
+
+  '@tamagui/slider@1.126.12':
+    resolution: {integrity: sha512-IiURazRgvYBW+kCqPk82CL4+EtobPw5T8LbJG21BGseLLlU74peiCDQKVwoi+vbjcuSly61Aao8tZN37UzTVNw==}
     peerDependencies:
       react: '*'
 
-  '@tamagui/stacks@1.112.12':
-    resolution: {integrity: sha512-dWag6I49tfjCbfMcFvQ7NsGMYGmvAy+++4HxoNFZU90DcJncjX2Ikz/5hFy9+Fe+Td8/JEVbxw5vYjD4W83Zig==}
+  '@tamagui/stacks@1.126.12':
+    resolution: {integrity: sha512-HoLDrbghaDLPPvZS98DtOfFOOIYIBKnUNwJ/YdCpGsbLvQtkwvQUuToBrwo0BSYT+lYumkbFiaootzS7sA8yEg==}
     peerDependencies:
       react: '*'
 
-  '@tamagui/start-transition@1.112.12':
-    resolution: {integrity: sha512-idb/Rm9Oex/7JorjHVh6MT299ipqz0G1Gvgek5n8keX+VamaRPqmCSK4MakHIDIUV4h6+sHFbhfKTJ85WvlN0w==}
+  '@tamagui/start-transition@1.126.12':
+    resolution: {integrity: sha512-iBf+eXd8yH/AvQFaXHOFyFHtHdFVYW+hB+mCKywjc4PnK4ZZW8AwBSuXVB8Z/BPtTjm6DSNhTg1Y50aBVoYusg==}
 
-  '@tamagui/static@1.112.12':
-    resolution: {integrity: sha512-Vt8TV7CWbDypV3JklQ3TFacKkCIz7aOPq0A/nSs++4KM2/0YSoKth6s03o4uaWLunOcSqW0VdOx9FnMAEGtlTw==}
+  '@tamagui/static@1.126.12':
+    resolution: {integrity: sha512-EE4zA4ND3lt2q0EXsZsztUkQF4Vf41VU/0IcyyQ63wrRcE3/zDN55Gf6fMCtTWRg6jYxtsKkWK2CtqJIfl5aOA==}
     peerDependencies:
       react: '*'
 
-  '@tamagui/switch-headless@1.112.12':
-    resolution: {integrity: sha512-JPirCNOIAvxsAaufXjgAhAGGWn8NLKyerW+AX0RcdW+lwuYnA5AMiAc37CNxQgEqxX6UGJgXulwePe/4l133Rw==}
+  '@tamagui/switch-headless@1.126.12':
+    resolution: {integrity: sha512-vuiAtNryUKJrO0v8ab7ey30/2BmxkpMwLgx9mIKJAtcQxNj2YsQBVspyCjQey3J3kytoLHQOwRTBViKZFMuacQ==}
     peerDependencies:
       react: '*'
 
-  '@tamagui/switch@1.112.12':
-    resolution: {integrity: sha512-2rR4lnJtgLTZjTn2ypSFAGuVPa3ikUaKiAVY3nlBx28hVHhYUHHN9Qr1plE/CQrlGGPK8aA4VcodpZsTHlVh+Q==}
+  '@tamagui/switch@1.126.12':
+    resolution: {integrity: sha512-0IKlzb6RUJ7j3uMYuroENTGDJ2EgasYYPWYfgUMOzjPwwB5qbgegibq24GoyOkWbHqCUMidG2iQ5f6A4bq6M8Q==}
     peerDependencies:
       react: '*'
 
-  '@tamagui/tabs@1.112.12':
-    resolution: {integrity: sha512-SczlaOOW4VibC+YOppmQshSimuZe8qiXekvSaA9YEp/CYjfMORIy+Ck36qQW/vIUdrzxz/NADJd+4yuEzQuhBw==}
+  '@tamagui/tabs@1.126.12':
+    resolution: {integrity: sha512-uy8fFfuCKKzkVLNTNEATFiavMra7EciLaTLOd0IfM2Q1FsbpC9IWRhCyUypBKwGvKehKD20QKc33KVaUERpBtQ==}
     peerDependencies:
       react: '*'
 
-  '@tamagui/text@1.112.12':
-    resolution: {integrity: sha512-glGROJvrFEktWmoIsd1G5U06IuHC8vLY3MTLZg7Np3zF/cb64SIvfDTDA9SiFmCbOXNKTtk+9+SVpU73NqZz2Q==}
+  '@tamagui/text@1.126.12':
+    resolution: {integrity: sha512-VeCT4r1k+0Xyg84zDd4MPf7zkOP6A1vHfOqsOOvNTsAADnura3wR9qQ+zFyZ5z2NuPJiRtRdWWVmbJx60yQ3HQ==}
     peerDependencies:
       react: '*'
 
-  '@tamagui/theme-builder@1.112.12':
-    resolution: {integrity: sha512-EhYiUNGiRfqx9/URZlQRza/2t4S1dpKsjSthzA0arJhPv5H3wGmF1qw1XBS43wjTEy8X1hF+1fa+1zm8NLoYnA==}
+  '@tamagui/theme-builder@1.126.12':
+    resolution: {integrity: sha512-RzofAeZjC+j7MKQpZQoXEEEJ6LsRC1qEE1NO6FiZZAWcpTp+xiaWwo63NTY1TvhAtQg8zVMOjX15CXUkKSuB3g==}
 
-  '@tamagui/theme@1.112.12':
-    resolution: {integrity: sha512-6yqmMSZ5Pmt9A4uIdRSUH5s/GFWpA/B17+1XUlYLt0cajRx9bAzFdtHUGmL3iRnPIvAEhEJhUX1124nO6j7lSA==}
+  '@tamagui/theme@1.126.12':
+    resolution: {integrity: sha512-wzOo4XYcJSM88YQ+8fvQYmWr38QWOUo1I8rEq4BKcKOrAstqUudEperdNlX1ZQQXSxEsUMa+/MggQd7v1DQfcw==}
     peerDependencies:
       react: '*'
-
-  '@tamagui/timer@1.112.12':
-    resolution: {integrity: sha512-/mH+iaPJfr91OShPL4cHnswbPv810+17JX/bLQmeeMo2Db4Nu3dMlf0CHdgxXHeL8jHdhWaC50U2Dj2ZmMxQqA==}
 
   '@tamagui/timer@1.116.12':
     resolution: {integrity: sha512-P5R0fd3j3Q3UlgMO3SgRVvJ38iSCEg/eLXz6KNQBxvQ1R33gHYAVojOelE+6GgU5cMsU9OZdXt9n5AjBFgGiYw==}
 
-  '@tamagui/toggle-group@1.112.12':
-    resolution: {integrity: sha512-XwXZwk3NfEg/XanMmIDxv+MUIz8vlpbwiw5sRQVdEBRrAR8YYHppD8NhZUs7IUQ3kK3vThxNV4AV50h4n/JCVg==}
+  '@tamagui/timer@1.126.12':
+    resolution: {integrity: sha512-RSkpQegOBT4swVXPQjjDRqJP9eC8Mzv8ObmoIcbxwoWm/vS0fbn6UwHhHiQrKQvZHHIciXB8HzjRc8ljKxbuuQ==}
+
+  '@tamagui/toggle-group@1.126.12':
+    resolution: {integrity: sha512-FGIXaXYzOlE6CqupkBXU4KaLUsiuLWjCSVxkbl+z/IoBcxUy1hHgtjKCLpZSdZiChBDmCCS2SaZm5O8Z5zPfsg==}
     peerDependencies:
       react: '*'
 
-  '@tamagui/tooltip@1.112.12':
-    resolution: {integrity: sha512-vhrUWfukNHfJPs2XPpj6fSMRI5hJkz55ii7Lp6Js6BdzCoYV+4N24thqcKgp3PCoR8riC5woKotmkV7c3/40oA==}
+  '@tamagui/tooltip@1.126.12':
+    resolution: {integrity: sha512-sJEYRAaUlumuPoTj48N6l8uPpU0Vcj8h1QpeTMSCtK2LioKs3Dvwh1EqkS9Zdz6+GFouUxUCZiPe6S8hvECRlA==}
     peerDependencies:
       react: '*'
-
-  '@tamagui/types@1.112.12':
-    resolution: {integrity: sha512-L/HgxcHwwnx0QV0f6aJFxIIUgRJ9WydDP8tBlvAropF0tinMSzqET8oMZ75/hVni/04vNrU1Mk+Ey12kERXvxg==}
 
   '@tamagui/types@1.116.12':
     resolution: {integrity: sha512-+KO3h4VG7wXOs4EP4kxVntaOdd9qLj+iG2xh30vn2a+mX1dnf0IUXqjdUsQbT/C6WdgVvmKNaZ5tlDXSNLFo9g==}
 
-  '@tamagui/use-callback-ref@1.112.12':
-    resolution: {integrity: sha512-A7OpBkPf+xOIa56cmsNlc/jhC07fURbQyMSlZMbGhEqNzkZ28je37XWMzaNuaNRY/hEdZHreE28Eu57jm3jm+Q==}
+  '@tamagui/types@1.126.12':
+    resolution: {integrity: sha512-fIBHhyKFs6HYDBvHEUiOKHTdSzuLRX5TPIZoh4SH6r3GzmkbElaPErcTe8FgiwJgbkp8NQXog7wiRMRtJKtrYw==}
 
-  '@tamagui/use-constant@1.112.12':
-    resolution: {integrity: sha512-USFmjsjh/PCuTSnhDydXVDW6lBzyH1CFtcnLy4Ivtx56MXJcEwCduBTX8CEB/GEpjMKrLMqqxBzR4iVITwupBg==}
+  '@tamagui/use-callback-ref@1.126.12':
+    resolution: {integrity: sha512-iU9irW+0zSqMiuEEOGZnFhtYa8Rt4EzdzVvg47463ny6ehy3N5DaOYAi1Vzg/ziJLRqu+o8YTO1oYNJwNLbGuw==}
+
+  '@tamagui/use-constant@1.126.12':
+    resolution: {integrity: sha512-Ukjl85j2C2JEh1ge3K8X8iFM7hYK2QAaTO43fu3tr2sUgxR+Kiuro6bYIuktaWc1NCNY38sPKaJwILprFCuH4w==}
     peerDependencies:
       react: '*'
 
-  '@tamagui/use-controllable-state@1.112.12':
-    resolution: {integrity: sha512-EjfZpxn3kdfA9CzTavGhaCXEDqeFAP/0vUWGHMwucCDm+Ahqhwht/KsVoWkN02FXyB1gcAvLSNKOob1KwyYv8A==}
+  '@tamagui/use-controllable-state@1.126.12':
+    resolution: {integrity: sha512-EmVrFYiUgEqqbwtOlvCr3tTzIp9zq84us8zb7PYRcmN4PlsRrYion0BtjHOhcc8pxRntPKpYMbbMMeNi+Crqzw==}
     peerDependencies:
       react: '*'
 
-  '@tamagui/use-debounce@1.112.12':
-    resolution: {integrity: sha512-K2ECWHiocMo1xF/Xz03didOnD/w3nf0SgeLU3/IH+7tdRHhmCzIuBg0DAdFmO2+Mn5aEDafvojYzBdSIcSUbAw==}
-    peerDependencies:
-      react: '*'
-
-  '@tamagui/use-did-finish-ssr@1.112.12':
-    resolution: {integrity: sha512-Avi9xdYZ79rgN08O3znaZypVlSEMq1vq07qmmly7XH237Q5dIVstZfJtcrkc9uvw9/RpecrYne8UmMuy1sM1KQ==}
+  '@tamagui/use-debounce@1.126.12':
+    resolution: {integrity: sha512-8z4AYa4UruX1ZIYFY8oTNvqeBD4+KnbyRGF1xS3qdE17rbFhrzaB/Tn7qt3xuI7M5iCnQOCneyxQ+4ZBfYHyFA==}
     peerDependencies:
       react: '*'
 
@@ -5160,26 +5004,26 @@ packages:
     peerDependencies:
       react: '*'
 
-  '@tamagui/use-direction@1.112.12':
-    resolution: {integrity: sha512-pRhZJhBUSrBjQfiTLmBNlJeVez3sFSfYDNhQmp8uCnJuv08J6oDyYfNXEXeKJZDJh8JKgIxD/XPUtNCsItPAQQ==}
+  '@tamagui/use-did-finish-ssr@1.126.12':
+    resolution: {integrity: sha512-GfH4n3bsF6lscxElAlYlf3fsKrvJbOsUheN7UYyyveKlcYEsT3iAAGXXk/H0/0RVx9sZ4rLX3+zfnf0LNzzgGg==}
     peerDependencies:
       react: '*'
 
-  '@tamagui/use-escape-keydown@1.112.12':
-    resolution: {integrity: sha512-3WAa48LJts55TOgiHY/NmeOEq98MALzpjXsT96SLuSe4mtGtfhBwFca1EbwkA/ZHNMPt7lCMXufsxMqP+IW/lg==}
-
-  '@tamagui/use-event@1.112.12':
-    resolution: {integrity: sha512-2Se3QquSRUcjomfVQHSrWFAEvBzSmSpNLiRIQIEFbevz1n7jE+u/AdKyQRH0KgU32urJ230Fyyij20conX8zjQ==}
+  '@tamagui/use-direction@1.126.12':
+    resolution: {integrity: sha512-KYtKf4UTkzIV1E41CK18pWY0cWXRdo41teYy5oW7NR4fE4PDo6B+cPl0M6S8KOZIxSDeLFfYWnaGztXx8q6r3w==}
     peerDependencies:
       react: '*'
+
+  '@tamagui/use-escape-keydown@1.126.12':
+    resolution: {integrity: sha512-WJxLRifc50u6bYGFvavbzhA0vgCfgzqluiO+fgZKVCFBT7QrgYVrO4FefF96E87HScil8sLnphGpcSOp/MwwNQ==}
 
   '@tamagui/use-event@1.116.12':
     resolution: {integrity: sha512-IE/CAiJLVNpXeOu4yDpUj+dwYqHWfaGD6LNJ7J+iDGJhNzpG5I2gXnQ7rndXdeR3OwBkqAgt9FrMx3I6cLf4FQ==}
     peerDependencies:
       react: '*'
 
-  '@tamagui/use-force-update@1.112.12':
-    resolution: {integrity: sha512-x4Vf5IOpNfeHjax/K7Ow7roMPAHcmw+K6EWdBG8uKpIVQjzQ3U+JlbAcmvzRWCNiwCqS8sd5k/GzttvRDgQtzA==}
+  '@tamagui/use-event@1.126.12':
+    resolution: {integrity: sha512-CNwCRPYSTyHablAg97gjaoZ7VOY8XNY0MfUItug1N1xgezx9TcTq/O056ZLAf8UFHsOsWjnthWcLnPeWCw238g==}
     peerDependencies:
       react: '*'
 
@@ -5188,37 +5032,50 @@ packages:
     peerDependencies:
       react: '*'
 
-  '@tamagui/use-keyboard-visible@1.112.12':
-    resolution: {integrity: sha512-7AJ67970G8bFCfeE+ubnWCxRDi1/Jzj8Dc1MwWq2VhUeF6lipQRgdhNzlaNAbSwR+h/1RgJ64XjK9xy1jKacGA==}
+  '@tamagui/use-force-update@1.126.12':
+    resolution: {integrity: sha512-ChxPzjdDoYNRehAzJRAAFfMZHvTWQLe6XKWj8YzCIXWygKMMTNo9GFsx+4M1dgL82OhV95mwjYTxc4ICsCbL/g==}
     peerDependencies:
       react: '*'
 
-  '@tamagui/use-presence@1.112.12':
-    resolution: {integrity: sha512-qpU6AvQMLubb9xqY6zKr0Ihk6PeJ3vxRjivoXCQL/JWBMe64TM9Tk1cYd7QkyuO3wN1ydLLgpSl7Dn3ANAdYBg==}
+  '@tamagui/use-keyboard-visible@1.126.12':
+    resolution: {integrity: sha512-U/SFooHydfFMviIqLzgDvXOk6JUYIBTLGpOyNLZ5/5rBGiTTLU/TFripNBOUuLDnPR4mbTMvkAhgTWKLe67D8A==}
     peerDependencies:
       react: '*'
 
-  '@tamagui/use-previous@1.112.12':
-    resolution: {integrity: sha512-WQdD8VhOBRNbrKJqnuI2/dYySOXWhzF+TkZHlA1OSQUfQSFFfWVFP16w9SKaVJOAnOL9sG4OuzxUSty+czEyRA==}
-
-  '@tamagui/use-window-dimensions@1.112.12':
-    resolution: {integrity: sha512-znKOxIVIdGT2HuquNg3u8Ai0pNpJgWtljnkm8lPNKpkPrvQS4B/wsDd5+HOV3rr7s76lucXlPxPfMCuYOirW0Q==}
+  '@tamagui/use-presence@1.126.12':
+    resolution: {integrity: sha512-YWgHH00hGQJ5rp8ot0DVPkS4/vkVrjjKa1647y5EiPEiHcUDs1FS5dLAKt9B6tYYaqV30sdXPbM9kBemlgYbXg==}
     peerDependencies:
       react: '*'
 
-  '@tamagui/visually-hidden@1.112.12':
-    resolution: {integrity: sha512-nlR1NtXMJsgh3+WrXOyq6QWeefe9Uom7+AkhmEmpRHj/UlML6HQ5cV1pRgsASRvOpFhDIq1UvDWRrUB001IbRw==}
+  '@tamagui/use-previous@1.126.12':
+    resolution: {integrity: sha512-0i41WIYXIQ/yzk95XCOM0gVt937dJrwm/9j3wX5LPpUXoBKO5k0G08UvvEJgnVYGXiIb6KvM0OuENbDwr+PRFw==}
+
+  '@tamagui/use-window-dimensions@1.126.12':
+    resolution: {integrity: sha512-mRp7P3bzzUbGxJYlWoD59DHgJKfvPJfyReZDG3Hv0BONmZPTIvwvMxB+VUKrhyUBllU4SiZuDdE4+hbdwSSryA==}
     peerDependencies:
       react: '*'
 
-  '@tamagui/vite-plugin@1.112.12':
-    resolution: {integrity: sha512-iMIPmfcrJALKIQ9E5E8+RuE3d9+HKY9M0QZSmLjv+u7gdFUrnSYIOsaVfPFNPva5yvvKcnWOoIdnrRvpom/93A==}
+  '@tamagui/visually-hidden@1.126.12':
+    resolution: {integrity: sha512-M97xl9J2UYDuPROWLbEaD3KIFLDQ78SQB6nYq69GKm0vIkV294PPq3yZrl2npyDvzWUyml5ePAcq1k6YbLS8+A==}
+    peerDependencies:
+      react: '*'
 
-  '@tamagui/web@1.112.12':
-    resolution: {integrity: sha512-6JqU0gyogmMX3ofPALyeVKAze1bshXm+1DSJ2PYJR8hNR5WQhikN0XBX1X65Iq9Fr3wcCg3ZKGKy/5X3H6enCg==}
+  '@tamagui/vite-plugin@1.126.12':
+    resolution: {integrity: sha512-Xa+SiXt9t+FquHKlxE/wD1WOR1ShhTKUboys8KtLh74YUfxu4k29UPSv2iujBdQTG/pr4uxv6+L6CSOe0ewaFA==}
+    peerDependencies:
+      vite: '*'
 
   '@tamagui/web@1.116.12':
     resolution: {integrity: sha512-zMmN2eEk1eBURWfPhXziaCCctQgeM9Yb7pd91VSLeiuhIvA7vDYThXSQl6cvzTDxxbfHYcnH2hkyTf7Rur4WjA==}
+
+  '@tamagui/web@1.126.12':
+    resolution: {integrity: sha512-/Ts/sR8UgMNSafWE/AoOS7EZFidXXeoyjbm9HbvrDVUAU0qzOfm8KVN52gssurxN1W6WaHekUbObB/eWOfwXyA==}
+    peerDependencies:
+      react: '*'
+      react-dom: '*'
+
+  '@tamagui/z-index-stack@1.126.12':
+    resolution: {integrity: sha512-Okq1nWURF/TjZ8Rsx7Y3niR0a7F/clam1vc7UY6pI41jpft+H2CiHIT8U3uR4Qqgv8lnqiqD1p47FfTWWguVVg==}
 
   '@tanstack/query-core@5.32.1':
     resolution: {integrity: sha512-mCWa1wdGb1jiny4+qYegbSeadcFj+Nq65KFSs4A1DRveoIq7SrTwUhqu7hrB6d54cQH5x59DfJvxusn3w1Cj/g==}
@@ -5590,9 +5447,6 @@ packages:
 
   '@types/node@18.19.80':
     resolution: {integrity: sha512-kEWeMwMeIvxYkeg1gTc01awpwLbfMRZXdIhwRcakd/KlK53jmRC26LqcbIt7fnAQTu5GzlnWmzA3H6+l1u6xxQ==}
-
-  '@types/node@20.10.8':
-    resolution: {integrity: sha512-f8nQs3cLxbAFc00vEU59yf9UyGUftkPaLGfvbVOIDdx2i1b8epBqj2aNGyP19fiyXWvlmZ7qC1XLjAzw/OKIeA==}
 
   '@types/node@20.14.10':
     resolution: {integrity: sha512-MdiXf+nDuMvY0gJKxyfZ7/6UFsETO7mGKF54MVD/ekJS6HdFtpZFBgrh6Pseu64XTb2MLyFPlbW6hj8HYRQNOQ==}
@@ -6325,11 +6179,6 @@ packages:
     peerDependencies:
       '@babel/core': ^7.1.2
 
-  babel-plugin-fully-specified@1.3.0:
-    resolution: {integrity: sha512-STW+rXLxwCB839gmwBizuipaDBb/iGZ5Vg0bmfynYLyXRTWgofXDrePuW5VvBJq2x8yB6xvT+3J7Z0U79uQYNw==}
-    peerDependencies:
-      '@babel/core': '*'
-
   babel-plugin-inline-import@3.0.0:
     resolution: {integrity: sha512-thnykl4FMb8QjMjVCuZoUmAM7r2mnTn5qJwrryCvDv6rugbJlTHZMctdjDtEgD0WBAXJOLJSGXN3loooEwx7UQ==}
 
@@ -6494,11 +6343,6 @@ packages:
     engines: {node: ^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7}
     hasBin: true
 
-  browserslist@4.23.3:
-    resolution: {integrity: sha512-btwCFJVjI4YWDNfau8RhZ+B1Q/VLoUITrm3RlP6y1tYGWIOa+InuYiRGXUBXo8nA1qKmHMyLB/iVQg5TT4eFoA==}
-    engines: {node: ^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7}
-    hasBin: true
-
   browserslist@4.24.2:
     resolution: {integrity: sha512-ZIc+Q62revdMcqC6aChtW4jz3My3klmCO1fEmINZY/8J3EpBg5/A/D0AKmBveUh6pgoeycoMkVMko84tuYS+Gg==}
     engines: {node: ^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7}
@@ -6624,9 +6468,6 @@ packages:
 
   caniuse-lite@1.0.30001576:
     resolution: {integrity: sha512-ff5BdakGe2P3SQsMsiqmt1Lc8221NR1VzHj5jXN5vBny9A6fpze94HiVV/n7XRosOlsShJcvMv5mdnpjOGCEgg==}
-
-  caniuse-lite@1.0.30001650:
-    resolution: {integrity: sha512-fgEc7hP/LB7iicdXHUI9VsBsMZmUmlVJeQP2qqQW+3lkqVhbmjEU8zp+h5stWeilX+G7uXuIUIIlWlDw9jdt8g==}
 
   caniuse-lite@1.0.30001678:
     resolution: {integrity: sha512-RR+4U/05gNtps58PEBDZcPWTgEO2MBeoPZ96aQcjmfkBWRIDfN451fW2qyDA9/+HohLLIL5GqiMwA+IB1pWarw==}
@@ -7512,9 +7353,6 @@ packages:
   electron-to-chromium@1.4.626:
     resolution: {integrity: sha512-f7/be56VjRRQk+Ric6PmIrEtPcIqsn3tElyAu9Sh6egha2VLJ82qwkcOdcnT06W+Pb6RUulV1ckzrGbKzVcTHg==}
 
-  electron-to-chromium@1.5.5:
-    resolution: {integrity: sha512-QR7/A7ZkMS8tZuoftC/jfqNkZLQO779SSW3YuZHP4eXpj3EffGLFcB/Xu9AAZQzLccTiCV+EmUo3ha4mQ9wnlA==}
-
   electron-to-chromium@1.5.52:
     resolution: {integrity: sha512-xtoijJTZ+qeucLBDNztDOuQBE1ksqjvNjvqFoST3nGC7fSpqJ+X6BdTBaY5BHG+IhWWmpc6b/KfpeuEDupEPOQ==}
 
@@ -7661,11 +7499,6 @@ packages:
   esbuild@0.19.12:
     resolution: {integrity: sha512-aARqgq8roFBj054KvQr5f1sFu0D65G+miZRCuJyJ0G13Zwx7vRar5Zhn2tkQNzIXcBrNVsv/8stehpj+GAjgbg==}
     engines: {node: '>=12'}
-    hasBin: true
-
-  esbuild@0.24.0:
-    resolution: {integrity: sha512-FuLPevChGDshgSicjisSooU0cemp/sGXR841D5LHMB7mTVOmsEHcAxaH3irL53+8YDIeVNQEySh4DaYU/iuPqQ==}
-    engines: {node: '>=18'}
     hasBin: true
 
   esbuild@0.25.2:
@@ -8815,6 +8648,9 @@ packages:
 
   inline-style-prefixer@6.0.4:
     resolution: {integrity: sha512-FwXmZC2zbeeS7NzGjJ6pAiqRhXR0ugUShSNb6GApMl6da0/XGc4MOJsoWAywia52EEWbXNSy0pzkwz/+Y+swSg==}
+
+  inline-style-prefixer@7.0.1:
+    resolution: {integrity: sha512-lhYo5qNTQp3EvSSp3sRvXMbVQTLrvGV6DycRMJ5dm2BLMiJ30wpXKdDdgX+GmJZ5uQMucwRKHamXSst3Sj/Giw==}
 
   inquirer@8.2.4:
     resolution: {integrity: sha512-nn4F01dxU8VeKfq192IjLsxu0/OmMZ4Lg3xKAns148rCaXP6ntAoEkVYZThWjwON8AlzdZZi6oqnhNbxUG9hVg==}
@@ -10122,6 +9958,11 @@ packages:
     peerDependencies:
       react-native-reanimated: '*'
 
+  moti@0.29.0:
+    resolution: {integrity: sha512-o/blVE3lm0i/6E5X0RLK59SVWEGxo7pQh8dTm+JykVCYY9bcz0lWyZFCO1s+MMNq+nMsSZBX8lkp4im/AZmhyw==}
+    peerDependencies:
+      react-native-reanimated: '*'
+
   ms@2.0.0:
     resolution: {integrity: sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==}
 
@@ -10459,6 +10300,9 @@ packages:
 
   outvariant@1.3.0:
     resolution: {integrity: sha512-yeWM9k6UPfG/nzxdaPlJkB2p08hCg4xP6Lx99F+vP8YF7xyZVfTmJjrrNalkmzudD4WFvNLVudQikqUmF8zhVQ==}
+
+  oxc-transform@0.47.1:
+    resolution: {integrity: sha512-krLyXKa+2RWT9MFcj2q4ffEFFzX3EoypcLGpXMhTW0ayLxmGxyiLYlDlwFwP+5fbaVeeBu36XsVroOZelddl7g==}
 
   p-cancelable@2.1.1:
     resolution: {integrity: sha512-BZOr3nRQHOntUjTrH8+Lh54smKHoHyur8We1V8DSMVrl5A2malOOwuJRnKRDjSnkoeBh4at6BwEnb5I7Jl31wg==}
@@ -11312,6 +11156,12 @@ packages:
       react: ^18.0.0
       react-dom: ^18.0.0
 
+  react-native-web@0.20.0:
+    resolution: {integrity: sha512-OOSgrw+aON6R3hRosCau/xVxdLzbjEcsLysYedka0ZON4ZZe6n9xgeN9ZkoejhARM36oTlUgHIQqxGutEJ9Wxg==}
+    peerDependencies:
+      react: ^18.0.0 || ^19.0.0
+      react-dom: ^18.0.0 || ^19.0.0
+
   react-native-webview@13.8.6:
     resolution: {integrity: sha512-jtZ9OgB2AN6rhDwto6dNL3PtOtl/SI4VN93pZEPbMLvRjqHfxiUrilGllL5fKAXq5Ry5FJyfUi82A4Ii8olZ7A==}
     peerDependencies:
@@ -11369,12 +11219,32 @@ packages:
       '@types/react':
         optional: true
 
+  react-remove-scroll-bar@2.3.8:
+    resolution: {integrity: sha512-9r+yi9+mgU33AKcj6IbT9oRCO78WriSj6t/cF8DWBZJ9aOGPOTEDvdUDz1FwKim7QXWwmHqtdHnRJfhAxEG46Q==}
+    engines: {node: '>=10'}
+    peerDependencies:
+      '@types/react': '*'
+      react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
   react-remove-scroll@2.5.5:
     resolution: {integrity: sha512-ImKhrzJJsyXJfBZ4bzu8Bwpka14c/fQt0k+cyFp/PBhTfyDnU5hjOtM4AG/0AMyy8oKzOTR0lDgJIM7pYXI0kw==}
     engines: {node: '>=10'}
     peerDependencies:
       '@types/react': ^16.8.0 || ^17.0.0 || ^18.0.0
       react: ^16.8.0 || ^17.0.0 || ^18.0.0
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
+  react-remove-scroll@2.6.3:
+    resolution: {integrity: sha512-pnAi91oOk8g8ABQKGF5/M9qxmmOPxaAnopyTHYfqYEwJhyFrbbBtHuSgtKEoH0jpcxx5o3hXqH1mNd9/Oi+8iQ==}
+    engines: {node: '>=10'}
+    peerDependencies:
+      '@types/react': '*'
+      react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc
     peerDependenciesMeta:
       '@types/react':
         optional: true
@@ -11395,6 +11265,16 @@ packages:
     peerDependencies:
       '@types/react': ^16.8.0 || ^17.0.0 || ^18.0.0
       react: ^16.8.0 || ^17.0.0 || ^18.0.0
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
+  react-style-singleton@2.2.3:
+    resolution: {integrity: sha512-b6jSvxvVnyptAiLjbkWLE/lOnR4lfTtDAl+eUC7RZy+QQWc6wRzIV2CE6xBuMmDxc2qIihtDCZD5NPOFl7fRBQ==}
+    engines: {node: '>=10'}
+    peerDependencies:
+      '@types/react': '*'
+      react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc
     peerDependenciesMeta:
       '@types/react':
         optional: true
@@ -12346,8 +12226,8 @@ packages:
     engines: {node: '>=14.0.0'}
     hasBin: true
 
-  tamagui@1.112.12:
-    resolution: {integrity: sha512-elbyYEjKqZP5THwYMKocbU5i+yG0Pi2qhxqHDB6xWn4h9l/ZcpvlFE62klaAQ3TL+ltyBsvnnDb2YzYvNiJ0AQ==}
+  tamagui@1.126.12:
+    resolution: {integrity: sha512-+V8qEG7WQFIx4yFoq+8s39Wtuq6d+edFeA0AsQhBnyI4HfGw78zqTAWDfh9oVLchyOk8NdAmJhHwAj60LglClQ==}
     peerDependencies:
       react: '*'
 
@@ -12779,12 +12659,6 @@ packages:
     peerDependencies:
       browserslist: '>= 4.21.0'
 
-  update-browserslist-db@1.1.0:
-    resolution: {integrity: sha512-EdRAaAyk2cUE1wOf2DkEhzxqOQvFOoRJFNS6NeyJ01Gp2beMRpBAINjM2iDXE3KCuKhwnvHIQCJm6ThL2Z+HzQ==}
-    hasBin: true
-    peerDependencies:
-      browserslist: '>= 4.21.0'
-
   update-browserslist-db@1.1.1:
     resolution: {integrity: sha512-R8UzCaa9Az+38REPiJ1tXlImTJXlVfgHZsglwBD/k6nj76ctsH1E3q4doGrukiLQd3sGQYu56r5+lo5r94l29A==}
     hasBin: true
@@ -12813,6 +12687,16 @@ packages:
       '@types/react':
         optional: true
 
+  use-callback-ref@1.3.3:
+    resolution: {integrity: sha512-jQL3lRnocaFtu3V00JToYz/4QkNWswxijDaCVNZRiRTO3HQDLsdu1ZtmIUvV4yPp+rvWm5j0y0TG/S61cuijTg==}
+    engines: {node: '>=10'}
+    peerDependencies:
+      '@types/react': '*'
+      react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
   use-latest-callback@0.1.9:
     resolution: {integrity: sha512-CL/29uS74AwreI/f2oz2hLTW7ZqVeV5+gxFeGudzQrgkCytrHw33G4KbnQOrRlAEzzAFXi7dDLMC9zhWcVpzmw==}
     peerDependencies:
@@ -12830,6 +12714,16 @@ packages:
     peerDependencies:
       '@types/react': ^16.9.0 || ^17.0.0 || ^18.0.0
       react: ^16.8.0 || ^17.0.0 || ^18.0.0
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
+  use-sidecar@1.1.3:
+    resolution: {integrity: sha512-Fedw0aZvkhynoPYlA5WXrMCAMm+nSWdZt6lzJQ7Ok8S6Q+VsHmHpRWndVRJ8Be0ZbkfPc5LRYH+5XrzXcEeLRQ==}
+    engines: {node: '>=10'}
+    peerDependencies:
+      '@types/react': '*'
+      react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc
     peerDependenciesMeta:
       '@types/react':
         optional: true
@@ -14330,7 +14224,7 @@ snapshots:
     dependencies:
       '@babel/helper-validator-identifier': 7.25.9
       js-tokens: 4.0.0
-      picocolors: 1.0.1
+      picocolors: 1.1.1
 
   '@babel/compat-data@7.23.5': {}
 
@@ -14340,13 +14234,13 @@ snapshots:
     dependencies:
       '@ampproject/remapping': 2.2.0
       '@babel/code-frame': 7.23.5
-      '@babel/generator': 7.25.0
+      '@babel/generator': 7.26.2
       '@babel/helper-compilation-targets': 7.23.6
       '@babel/helper-module-transforms': 7.23.3(@babel/core@7.23.7)
       '@babel/helpers': 7.23.8
       '@babel/parser': 7.23.6
-      '@babel/template': 7.25.0
-      '@babel/traverse': 7.25.3
+      '@babel/template': 7.25.9
+      '@babel/traverse': 7.25.9
       '@babel/types': 7.25.9
       convert-source-map: 2.0.0
       debug: 4.3.7
@@ -14362,7 +14256,7 @@ snapshots:
       '@babel/code-frame': 7.26.2
       '@babel/generator': 7.26.2
       '@babel/helper-compilation-targets': 7.25.9
-      '@babel/helper-module-transforms': 7.25.2(@babel/core@7.25.2)
+      '@babel/helper-module-transforms': 7.26.0(@babel/core@7.25.2)
       '@babel/helpers': 7.25.0
       '@babel/parser': 7.26.2
       '@babel/template': 7.25.9
@@ -14397,13 +14291,6 @@ snapshots:
       '@jridgewell/trace-mapping': 0.3.25
       jsesc: 2.5.2
 
-  '@babel/generator@7.25.6':
-    dependencies:
-      '@babel/types': 7.25.6
-      '@jridgewell/gen-mapping': 0.3.5
-      '@jridgewell/trace-mapping': 0.3.25
-      jsesc: 2.5.2
-
   '@babel/generator@7.26.2':
     dependencies:
       '@babel/parser': 7.26.2
@@ -14413,10 +14300,6 @@ snapshots:
       jsesc: 3.0.2
 
   '@babel/helper-annotate-as-pure@7.22.5':
-    dependencies:
-      '@babel/types': 7.26.0
-
-  '@babel/helper-annotate-as-pure@7.24.7':
     dependencies:
       '@babel/types': 7.26.0
 
@@ -14435,7 +14318,7 @@ snapshots:
     dependencies:
       '@babel/compat-data': 7.23.5
       '@babel/helper-validator-option': 7.25.9
-      browserslist: 4.23.3
+      browserslist: 4.24.2
       lru-cache: 5.1.1
       semver: 6.3.1
 
@@ -14553,13 +14436,6 @@ snapshots:
     dependencies:
       '@babel/types': 7.26.0
 
-  '@babel/helper-module-imports@7.24.7':
-    dependencies:
-      '@babel/traverse': 7.25.9
-      '@babel/types': 7.26.0
-    transitivePeerDependencies:
-      - supports-color
-
   '@babel/helper-module-imports@7.25.9':
     dependencies:
       '@babel/traverse': 7.25.9
@@ -14575,16 +14451,6 @@ snapshots:
       '@babel/helper-simple-access': 7.22.5
       '@babel/helper-split-export-declaration': 7.22.6
       '@babel/helper-validator-identifier': 7.24.7
-
-  '@babel/helper-module-transforms@7.25.2(@babel/core@7.25.2)':
-    dependencies:
-      '@babel/core': 7.25.2
-      '@babel/helper-module-imports': 7.24.7
-      '@babel/helper-simple-access': 7.24.7
-      '@babel/helper-validator-identifier': 7.24.7
-      '@babel/traverse': 7.25.9
-    transitivePeerDependencies:
-      - supports-color
 
   '@babel/helper-module-transforms@7.26.0(@babel/core@7.23.7)':
     dependencies:
@@ -14609,8 +14475,6 @@ snapshots:
       '@babel/types': 7.26.0
 
   '@babel/helper-plugin-utils@7.22.5': {}
-
-  '@babel/helper-plugin-utils@7.24.8': {}
 
   '@babel/helper-plugin-utils@7.25.9': {}
 
@@ -14653,13 +14517,6 @@ snapshots:
   '@babel/helper-simple-access@7.22.5':
     dependencies:
       '@babel/types': 7.26.0
-
-  '@babel/helper-simple-access@7.24.7':
-    dependencies:
-      '@babel/traverse': 7.25.9
-      '@babel/types': 7.26.0
-    transitivePeerDependencies:
-      - supports-color
 
   '@babel/helper-simple-access@7.25.9':
     dependencies:
@@ -14725,19 +14582,11 @@ snapshots:
       '@babel/helper-validator-identifier': 7.25.9
       chalk: 2.4.2
       js-tokens: 4.0.0
-      picocolors: 1.0.1
+      picocolors: 1.1.1
 
   '@babel/parser@7.23.6':
     dependencies:
       '@babel/types': 7.25.6
-
-  '@babel/parser@7.25.3':
-    dependencies:
-      '@babel/types': 7.26.0
-
-  '@babel/parser@7.25.6':
-    dependencies:
-      '@babel/types': 7.26.0
 
   '@babel/parser@7.26.2':
     dependencies:
@@ -15016,7 +14865,7 @@ snapshots:
   '@babel/plugin-syntax-export-namespace-from@7.8.3(@babel/core@7.25.2)':
     dependencies:
       '@babel/core': 7.25.2
-      '@babel/helper-plugin-utils': 7.22.5
+      '@babel/helper-plugin-utils': 7.25.9
 
   '@babel/plugin-syntax-flow@7.23.3(@babel/core@7.23.7)':
     dependencies:
@@ -15158,7 +15007,7 @@ snapshots:
   '@babel/plugin-transform-arrow-functions@7.23.3(@babel/core@7.25.2)':
     dependencies:
       '@babel/core': 7.25.2
-      '@babel/helper-plugin-utils': 7.22.5
+      '@babel/helper-plugin-utils': 7.25.9
 
   '@babel/plugin-transform-arrow-functions@7.25.9(@babel/core@7.23.7)':
     dependencies:
@@ -15555,7 +15404,7 @@ snapshots:
   '@babel/plugin-transform-nullish-coalescing-operator@7.23.4(@babel/core@7.25.2)':
     dependencies:
       '@babel/core': 7.25.2
-      '@babel/helper-plugin-utils': 7.22.5
+      '@babel/helper-plugin-utils': 7.25.9
       '@babel/plugin-syntax-nullish-coalescing-operator': 7.8.3(@babel/core@7.25.2)
 
   '@babel/plugin-transform-nullish-coalescing-operator@7.25.9(@babel/core@7.23.7)':
@@ -15621,7 +15470,7 @@ snapshots:
   '@babel/plugin-transform-optional-chaining@7.23.4(@babel/core@7.25.2)':
     dependencies:
       '@babel/core': 7.25.2
-      '@babel/helper-plugin-utils': 7.22.5
+      '@babel/helper-plugin-utils': 7.25.9
       '@babel/helper-skip-transparent-expression-wrappers': 7.22.5
       '@babel/plugin-syntax-optional-chaining': 7.8.3(@babel/core@7.25.2)
 
@@ -15715,28 +15564,28 @@ snapshots:
   '@babel/plugin-transform-react-jsx-self@7.23.3(@babel/core@7.23.7)':
     dependencies:
       '@babel/core': 7.23.7
-      '@babel/helper-plugin-utils': 7.22.5
+      '@babel/helper-plugin-utils': 7.25.9
 
   '@babel/plugin-transform-react-jsx-self@7.23.3(@babel/core@7.25.2)':
     dependencies:
       '@babel/core': 7.25.2
-      '@babel/helper-plugin-utils': 7.22.5
+      '@babel/helper-plugin-utils': 7.25.9
 
   '@babel/plugin-transform-react-jsx-source@7.23.3(@babel/core@7.23.7)':
     dependencies:
       '@babel/core': 7.23.7
-      '@babel/helper-plugin-utils': 7.22.5
+      '@babel/helper-plugin-utils': 7.25.9
 
   '@babel/plugin-transform-react-jsx-source@7.23.3(@babel/core@7.25.2)':
     dependencies:
       '@babel/core': 7.25.2
-      '@babel/helper-plugin-utils': 7.22.5
+      '@babel/helper-plugin-utils': 7.25.9
 
   '@babel/plugin-transform-react-jsx@7.25.2(@babel/core@7.23.7)':
     dependencies:
       '@babel/core': 7.23.7
-      '@babel/helper-annotate-as-pure': 7.24.7
-      '@babel/helper-module-imports': 7.24.7
+      '@babel/helper-annotate-as-pure': 7.25.9
+      '@babel/helper-module-imports': 7.25.9
       '@babel/helper-plugin-utils': 7.25.9
       '@babel/plugin-syntax-jsx': 7.24.7(@babel/core@7.23.7)
       '@babel/types': 7.26.0
@@ -15746,8 +15595,8 @@ snapshots:
   '@babel/plugin-transform-react-jsx@7.25.2(@babel/core@7.25.2)':
     dependencies:
       '@babel/core': 7.25.2
-      '@babel/helper-annotate-as-pure': 7.24.7
-      '@babel/helper-module-imports': 7.24.7
+      '@babel/helper-annotate-as-pure': 7.25.9
+      '@babel/helper-module-imports': 7.25.9
       '@babel/helper-plugin-utils': 7.25.9
       '@babel/plugin-syntax-jsx': 7.24.7(@babel/core@7.25.2)
       '@babel/types': 7.26.0
@@ -15821,7 +15670,7 @@ snapshots:
   '@babel/plugin-transform-shorthand-properties@7.23.3(@babel/core@7.25.2)':
     dependencies:
       '@babel/core': 7.25.2
-      '@babel/helper-plugin-utils': 7.22.5
+      '@babel/helper-plugin-utils': 7.25.9
 
   '@babel/plugin-transform-shorthand-properties@7.25.9(@babel/core@7.23.7)':
     dependencies:
@@ -15862,7 +15711,7 @@ snapshots:
   '@babel/plugin-transform-template-literals@7.23.3(@babel/core@7.25.2)':
     dependencies:
       '@babel/core': 7.25.2
-      '@babel/helper-plugin-utils': 7.22.5
+      '@babel/helper-plugin-utils': 7.25.9
 
   '@babel/plugin-transform-template-literals@7.25.9(@babel/core@7.23.7)':
     dependencies:
@@ -16161,12 +16010,6 @@ snapshots:
     dependencies:
       regenerator-runtime: 0.14.1
 
-  '@babel/template@7.25.0':
-    dependencies:
-      '@babel/code-frame': 7.24.7
-      '@babel/parser': 7.25.3
-      '@babel/types': 7.25.6
-
   '@babel/template@7.25.9':
     dependencies:
       '@babel/code-frame': 7.26.2
@@ -16182,30 +16025,6 @@ snapshots:
       '@babel/helper-hoist-variables': 7.22.5
       '@babel/helper-split-export-declaration': 7.22.6
       '@babel/parser': 7.23.6
-      '@babel/types': 7.25.6
-      debug: 4.3.7
-      globals: 11.12.0
-    transitivePeerDependencies:
-      - supports-color
-
-  '@babel/traverse@7.25.3':
-    dependencies:
-      '@babel/code-frame': 7.26.2
-      '@babel/generator': 7.26.2
-      '@babel/parser': 7.26.2
-      '@babel/template': 7.25.9
-      '@babel/types': 7.26.0
-      debug: 4.3.7
-      globals: 11.12.0
-    transitivePeerDependencies:
-      - supports-color
-
-  '@babel/traverse@7.25.6':
-    dependencies:
-      '@babel/code-frame': 7.24.7
-      '@babel/generator': 7.25.6
-      '@babel/parser': 7.25.6
-      '@babel/template': 7.25.0
       '@babel/types': 7.25.6
       debug: 4.3.7
       globals: 11.12.0
@@ -16420,9 +16239,6 @@ snapshots:
   '@esbuild/aix-ppc64@0.19.12':
     optional: true
 
-  '@esbuild/aix-ppc64@0.24.0':
-    optional: true
-
   '@esbuild/aix-ppc64@0.25.2':
     optional: true
 
@@ -16430,9 +16246,6 @@ snapshots:
     optional: true
 
   '@esbuild/android-arm64@0.19.12':
-    optional: true
-
-  '@esbuild/android-arm64@0.24.0':
     optional: true
 
   '@esbuild/android-arm64@0.25.2':
@@ -16444,9 +16257,6 @@ snapshots:
   '@esbuild/android-arm@0.19.12':
     optional: true
 
-  '@esbuild/android-arm@0.24.0':
-    optional: true
-
   '@esbuild/android-arm@0.25.2':
     optional: true
 
@@ -16454,9 +16264,6 @@ snapshots:
     optional: true
 
   '@esbuild/android-x64@0.19.12':
-    optional: true
-
-  '@esbuild/android-x64@0.24.0':
     optional: true
 
   '@esbuild/android-x64@0.25.2':
@@ -16468,9 +16275,6 @@ snapshots:
   '@esbuild/darwin-arm64@0.19.12':
     optional: true
 
-  '@esbuild/darwin-arm64@0.24.0':
-    optional: true
-
   '@esbuild/darwin-arm64@0.25.2':
     optional: true
 
@@ -16478,9 +16282,6 @@ snapshots:
     optional: true
 
   '@esbuild/darwin-x64@0.19.12':
-    optional: true
-
-  '@esbuild/darwin-x64@0.24.0':
     optional: true
 
   '@esbuild/darwin-x64@0.25.2':
@@ -16492,9 +16293,6 @@ snapshots:
   '@esbuild/freebsd-arm64@0.19.12':
     optional: true
 
-  '@esbuild/freebsd-arm64@0.24.0':
-    optional: true
-
   '@esbuild/freebsd-arm64@0.25.2':
     optional: true
 
@@ -16502,9 +16300,6 @@ snapshots:
     optional: true
 
   '@esbuild/freebsd-x64@0.19.12':
-    optional: true
-
-  '@esbuild/freebsd-x64@0.24.0':
     optional: true
 
   '@esbuild/freebsd-x64@0.25.2':
@@ -16516,9 +16311,6 @@ snapshots:
   '@esbuild/linux-arm64@0.19.12':
     optional: true
 
-  '@esbuild/linux-arm64@0.24.0':
-    optional: true
-
   '@esbuild/linux-arm64@0.25.2':
     optional: true
 
@@ -16526,9 +16318,6 @@ snapshots:
     optional: true
 
   '@esbuild/linux-arm@0.19.12':
-    optional: true
-
-  '@esbuild/linux-arm@0.24.0':
     optional: true
 
   '@esbuild/linux-arm@0.25.2':
@@ -16540,9 +16329,6 @@ snapshots:
   '@esbuild/linux-ia32@0.19.12':
     optional: true
 
-  '@esbuild/linux-ia32@0.24.0':
-    optional: true
-
   '@esbuild/linux-ia32@0.25.2':
     optional: true
 
@@ -16550,9 +16336,6 @@ snapshots:
     optional: true
 
   '@esbuild/linux-loong64@0.19.12':
-    optional: true
-
-  '@esbuild/linux-loong64@0.24.0':
     optional: true
 
   '@esbuild/linux-loong64@0.25.2':
@@ -16564,9 +16347,6 @@ snapshots:
   '@esbuild/linux-mips64el@0.19.12':
     optional: true
 
-  '@esbuild/linux-mips64el@0.24.0':
-    optional: true
-
   '@esbuild/linux-mips64el@0.25.2':
     optional: true
 
@@ -16574,9 +16354,6 @@ snapshots:
     optional: true
 
   '@esbuild/linux-ppc64@0.19.12':
-    optional: true
-
-  '@esbuild/linux-ppc64@0.24.0':
     optional: true
 
   '@esbuild/linux-ppc64@0.25.2':
@@ -16588,9 +16365,6 @@ snapshots:
   '@esbuild/linux-riscv64@0.19.12':
     optional: true
 
-  '@esbuild/linux-riscv64@0.24.0':
-    optional: true
-
   '@esbuild/linux-riscv64@0.25.2':
     optional: true
 
@@ -16600,9 +16374,6 @@ snapshots:
   '@esbuild/linux-s390x@0.19.12':
     optional: true
 
-  '@esbuild/linux-s390x@0.24.0':
-    optional: true
-
   '@esbuild/linux-s390x@0.25.2':
     optional: true
 
@@ -16610,9 +16381,6 @@ snapshots:
     optional: true
 
   '@esbuild/linux-x64@0.19.12':
-    optional: true
-
-  '@esbuild/linux-x64@0.24.0':
     optional: true
 
   '@esbuild/linux-x64@0.25.2':
@@ -16627,13 +16395,7 @@ snapshots:
   '@esbuild/netbsd-x64@0.19.12':
     optional: true
 
-  '@esbuild/netbsd-x64@0.24.0':
-    optional: true
-
   '@esbuild/netbsd-x64@0.25.2':
-    optional: true
-
-  '@esbuild/openbsd-arm64@0.24.0':
     optional: true
 
   '@esbuild/openbsd-arm64@0.25.2':
@@ -16645,9 +16407,6 @@ snapshots:
   '@esbuild/openbsd-x64@0.19.12':
     optional: true
 
-  '@esbuild/openbsd-x64@0.24.0':
-    optional: true
-
   '@esbuild/openbsd-x64@0.25.2':
     optional: true
 
@@ -16655,9 +16414,6 @@ snapshots:
     optional: true
 
   '@esbuild/sunos-x64@0.19.12':
-    optional: true
-
-  '@esbuild/sunos-x64@0.24.0':
     optional: true
 
   '@esbuild/sunos-x64@0.25.2':
@@ -16669,9 +16425,6 @@ snapshots:
   '@esbuild/win32-arm64@0.19.12':
     optional: true
 
-  '@esbuild/win32-arm64@0.24.0':
-    optional: true
-
   '@esbuild/win32-arm64@0.25.2':
     optional: true
 
@@ -16681,9 +16434,6 @@ snapshots:
   '@esbuild/win32-ia32@0.19.12':
     optional: true
 
-  '@esbuild/win32-ia32@0.24.0':
-    optional: true
-
   '@esbuild/win32-ia32@0.25.2':
     optional: true
 
@@ -16691,9 +16441,6 @@ snapshots:
     optional: true
 
   '@esbuild/win32-x64@0.19.12':
-    optional: true
-
-  '@esbuild/win32-x64@0.24.0':
     optional: true
 
   '@esbuild/win32-x64@0.25.2':
@@ -17117,21 +16864,23 @@ snapshots:
       react: 18.2.0
       react-dom: 18.2.0(react@18.2.0)
 
-  '@floating-ui/react-native@0.10.6(react-native@0.74.5(@babel/core@7.25.2)(@babel/preset-env@7.26.0(@babel/core@7.25.2))(@types/react@18.2.55)(encoding@0.1.13)(react@18.2.0))(react@18.2.0)':
+  '@floating-ui/react-native@0.10.7(react-native@0.74.5(@babel/core@7.25.2)(@babel/preset-env@7.26.0(@babel/core@7.25.2))(@types/react@18.2.55)(encoding@0.1.13)(react@18.2.0))(react@18.2.0)':
     dependencies:
       '@floating-ui/core': 1.6.0
       react: 18.2.0
       react-native: 0.74.5(@babel/core@7.25.2)(@babel/preset-env@7.26.0(@babel/core@7.25.2))(@types/react@18.2.55)(encoding@0.1.13)(react@18.2.0)
 
-  '@floating-ui/react@0.26.24(react-dom@18.2.0(react@18.2.0))(react@18.2.0)':
+  '@floating-ui/react@0.27.8(react-dom@18.2.0(react@18.2.0))(react@18.2.0)':
     dependencies:
       '@floating-ui/react-dom': 2.1.2(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
-      '@floating-ui/utils': 0.2.8
+      '@floating-ui/utils': 0.2.9
       react: 18.2.0
       react-dom: 18.2.0(react@18.2.0)
       tabbable: 6.2.0
 
   '@floating-ui/utils@0.2.8': {}
+
+  '@floating-ui/utils@0.2.9': {}
 
   '@gar/promisify@1.1.3': {}
 
@@ -17580,6 +17329,30 @@ snapshots:
       '@opentelemetry/semantic-conventions': 1.27.0
 
   '@opentelemetry/semantic-conventions@1.27.0': {}
+
+  '@oxc-transform/binding-darwin-arm64@0.47.1':
+    optional: true
+
+  '@oxc-transform/binding-darwin-x64@0.47.1':
+    optional: true
+
+  '@oxc-transform/binding-linux-arm64-gnu@0.47.1':
+    optional: true
+
+  '@oxc-transform/binding-linux-arm64-musl@0.47.1':
+    optional: true
+
+  '@oxc-transform/binding-linux-x64-gnu@0.47.1':
+    optional: true
+
+  '@oxc-transform/binding-linux-x64-musl@0.47.1':
+    optional: true
+
+  '@oxc-transform/binding-win32-arm64-msvc@0.47.1':
+    optional: true
+
+  '@oxc-transform/binding-win32-x64-msvc@0.47.1':
+    optional: true
 
   '@pkgjs/parseargs@0.11.0':
     optional: true
@@ -19100,400 +18873,464 @@ snapshots:
       postcss-selector-parser: 6.0.10
       tailwindcss: 3.4.1
 
-  '@tamagui/accordion@1.112.12(react@18.2.0)':
+  '@tamagui/accordion@1.126.12(react-dom@18.2.0(react@18.2.0))(react-native@0.74.5(@babel/core@7.25.2)(@babel/preset-env@7.26.0(@babel/core@7.25.2))(@types/react@18.2.55)(encoding@0.1.13)(react@18.2.0))(react@18.2.0)':
     dependencies:
-      '@tamagui/collapsible': 1.112.12(react@18.2.0)
-      '@tamagui/collection': 1.112.12(react@18.2.0)
-      '@tamagui/compose-refs': 1.112.12(react@18.2.0)
-      '@tamagui/constants': 1.112.12(react@18.2.0)
-      '@tamagui/core': 1.112.12(react@18.2.0)
-      '@tamagui/create-context': 1.112.12(react@18.2.0)
-      '@tamagui/polyfill-dev': 1.112.12
-      '@tamagui/stacks': 1.112.12(react@18.2.0)
-      '@tamagui/use-controllable-state': 1.112.12(react@18.2.0)
+      '@tamagui/collapsible': 1.126.12(react-dom@18.2.0(react@18.2.0))(react-native@0.74.5(@babel/core@7.25.2)(@babel/preset-env@7.26.0(@babel/core@7.25.2))(@types/react@18.2.55)(encoding@0.1.13)(react@18.2.0))(react@18.2.0)
+      '@tamagui/collection': 1.126.12(react-dom@18.2.0(react@18.2.0))(react-native@0.74.5(@babel/core@7.25.2)(@babel/preset-env@7.26.0(@babel/core@7.25.2))(@types/react@18.2.55)(encoding@0.1.13)(react@18.2.0))(react@18.2.0)
+      '@tamagui/compose-refs': 1.126.12(react@18.2.0)
+      '@tamagui/constants': 1.126.12(react@18.2.0)
+      '@tamagui/core': 1.126.12(react-dom@18.2.0(react@18.2.0))(react-native@0.74.5(@babel/core@7.25.2)(@babel/preset-env@7.26.0(@babel/core@7.25.2))(@types/react@18.2.55)(encoding@0.1.13)(react@18.2.0))(react@18.2.0)
+      '@tamagui/create-context': 1.126.12(react@18.2.0)
+      '@tamagui/polyfill-dev': 1.126.12
+      '@tamagui/stacks': 1.126.12(react-dom@18.2.0(react@18.2.0))(react-native@0.74.5(@babel/core@7.25.2)(@babel/preset-env@7.26.0(@babel/core@7.25.2))(@types/react@18.2.55)(encoding@0.1.13)(react@18.2.0))(react@18.2.0)
+      '@tamagui/text': 1.126.12(react-dom@18.2.0(react@18.2.0))(react-native@0.74.5(@babel/core@7.25.2)(@babel/preset-env@7.26.0(@babel/core@7.25.2))(@types/react@18.2.55)(encoding@0.1.13)(react@18.2.0))(react@18.2.0)
+      '@tamagui/use-controllable-state': 1.126.12(react@18.2.0)
       react: 18.2.0
+    transitivePeerDependencies:
+      - react-dom
+      - react-native
 
-  '@tamagui/adapt@1.112.12(react@18.2.0)':
+  '@tamagui/adapt@1.126.12(react-dom@18.2.0(react@18.2.0))(react-native@0.74.5(@babel/core@7.25.2)(@babel/preset-env@7.26.0(@babel/core@7.25.2))(@types/react@18.2.55)(encoding@0.1.13)(react@18.2.0))(react@18.2.0)':
     dependencies:
-      '@tamagui/constants': 1.112.12(react@18.2.0)
-      '@tamagui/core': 1.112.12(react@18.2.0)
-      '@tamagui/helpers': 1.112.12(react@18.2.0)
+      '@tamagui/constants': 1.126.12(react@18.2.0)
+      '@tamagui/core': 1.126.12(react-dom@18.2.0(react@18.2.0))(react-native@0.74.5(@babel/core@7.25.2)(@babel/preset-env@7.26.0(@babel/core@7.25.2))(@types/react@18.2.55)(encoding@0.1.13)(react@18.2.0))(react@18.2.0)
+      '@tamagui/helpers': 1.126.12(react@18.2.0)
+      '@tamagui/portal': 1.126.12(react-dom@18.2.0(react@18.2.0))(react-native@0.74.5(@babel/core@7.25.2)(@babel/preset-env@7.26.0(@babel/core@7.25.2))(@types/react@18.2.55)(encoding@0.1.13)(react@18.2.0))(react@18.2.0)
+      '@tamagui/z-index-stack': 1.126.12
     transitivePeerDependencies:
       - react
+      - react-dom
+      - react-native
 
-  '@tamagui/alert-dialog@1.112.12(@types/react@18.2.55)(react-dom@18.2.0(react@18.2.0))(react-native@0.74.5(@babel/core@7.25.2)(@babel/preset-env@7.26.0(@babel/core@7.25.2))(@types/react@18.2.55)(encoding@0.1.13)(react@18.2.0))(react@18.2.0)':
+  '@tamagui/alert-dialog@1.126.12(@types/react@18.2.55)(react-dom@18.2.0(react@18.2.0))(react-native@0.74.5(@babel/core@7.25.2)(@babel/preset-env@7.26.0(@babel/core@7.25.2))(@types/react@18.2.55)(encoding@0.1.13)(react@18.2.0))(react@18.2.0)':
     dependencies:
-      '@tamagui/animate-presence': 1.112.12(react@18.2.0)
-      '@tamagui/aria-hidden': 1.112.12(react@18.2.0)
-      '@tamagui/compose-refs': 1.112.12(react@18.2.0)
-      '@tamagui/constants': 1.112.12(react@18.2.0)
-      '@tamagui/core': 1.112.12(react@18.2.0)
-      '@tamagui/create-context': 1.112.12(react@18.2.0)
-      '@tamagui/dialog': 1.112.12(@types/react@18.2.55)(react-dom@18.2.0(react@18.2.0))(react-native@0.74.5(@babel/core@7.25.2)(@babel/preset-env@7.26.0(@babel/core@7.25.2))(@types/react@18.2.55)(encoding@0.1.13)(react@18.2.0))(react@18.2.0)
-      '@tamagui/dismissable': 1.112.12(react@18.2.0)
-      '@tamagui/focus-scope': 1.112.12(react@18.2.0)
-      '@tamagui/helpers': 1.112.12(react@18.2.0)
-      '@tamagui/polyfill-dev': 1.112.12
-      '@tamagui/popper': 1.112.12(react-dom@18.2.0(react@18.2.0))(react-native@0.74.5(@babel/core@7.25.2)(@babel/preset-env@7.26.0(@babel/core@7.25.2))(@types/react@18.2.55)(encoding@0.1.13)(react@18.2.0))(react@18.2.0)
-      '@tamagui/portal': 1.112.12(react@18.2.0)
-      '@tamagui/remove-scroll': 1.112.12(@types/react@18.2.55)(react@18.2.0)
-      '@tamagui/stacks': 1.112.12(react@18.2.0)
-      '@tamagui/text': 1.112.12(react@18.2.0)
-      '@tamagui/use-controllable-state': 1.112.12(react@18.2.0)
+      '@tamagui/animate-presence': 1.126.12(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
+      '@tamagui/aria-hidden': 1.126.12(react@18.2.0)
+      '@tamagui/compose-refs': 1.126.12(react@18.2.0)
+      '@tamagui/constants': 1.126.12(react@18.2.0)
+      '@tamagui/core': 1.126.12(react-dom@18.2.0(react@18.2.0))(react-native@0.74.5(@babel/core@7.25.2)(@babel/preset-env@7.26.0(@babel/core@7.25.2))(@types/react@18.2.55)(encoding@0.1.13)(react@18.2.0))(react@18.2.0)
+      '@tamagui/create-context': 1.126.12(react@18.2.0)
+      '@tamagui/dialog': 1.126.12(@types/react@18.2.55)(react-dom@18.2.0(react@18.2.0))(react-native@0.74.5(@babel/core@7.25.2)(@babel/preset-env@7.26.0(@babel/core@7.25.2))(@types/react@18.2.55)(encoding@0.1.13)(react@18.2.0))(react@18.2.0)
+      '@tamagui/dismissable': 1.126.12(react-dom@18.2.0(react@18.2.0))(react-native@0.74.5(@babel/core@7.25.2)(@babel/preset-env@7.26.0(@babel/core@7.25.2))(@types/react@18.2.55)(encoding@0.1.13)(react@18.2.0))(react@18.2.0)
+      '@tamagui/focus-scope': 1.126.12(react@18.2.0)
+      '@tamagui/helpers': 1.126.12(react@18.2.0)
+      '@tamagui/polyfill-dev': 1.126.12
+      '@tamagui/popper': 1.126.12(react-dom@18.2.0(react@18.2.0))(react-native@0.74.5(@babel/core@7.25.2)(@babel/preset-env@7.26.0(@babel/core@7.25.2))(@types/react@18.2.55)(encoding@0.1.13)(react@18.2.0))(react@18.2.0)
+      '@tamagui/portal': 1.126.12(react-dom@18.2.0(react@18.2.0))(react-native@0.74.5(@babel/core@7.25.2)(@babel/preset-env@7.26.0(@babel/core@7.25.2))(@types/react@18.2.55)(encoding@0.1.13)(react@18.2.0))(react@18.2.0)
+      '@tamagui/remove-scroll': 1.126.12(@types/react@18.2.55)(react@18.2.0)
+      '@tamagui/stacks': 1.126.12(react-dom@18.2.0(react@18.2.0))(react-native@0.74.5(@babel/core@7.25.2)(@babel/preset-env@7.26.0(@babel/core@7.25.2))(@types/react@18.2.55)(encoding@0.1.13)(react@18.2.0))(react@18.2.0)
+      '@tamagui/text': 1.126.12(react-dom@18.2.0(react@18.2.0))(react-native@0.74.5(@babel/core@7.25.2)(@babel/preset-env@7.26.0(@babel/core@7.25.2))(@types/react@18.2.55)(encoding@0.1.13)(react@18.2.0))(react@18.2.0)
+      '@tamagui/use-controllable-state': 1.126.12(react@18.2.0)
       react: 18.2.0
     transitivePeerDependencies:
       - '@types/react'
       - react-dom
       - react-native
 
-  '@tamagui/animate-presence@1.112.12(react@18.2.0)':
+  '@tamagui/animate-presence@1.126.12(react-dom@18.2.0(react@18.2.0))(react@18.2.0)':
     dependencies:
-      '@tamagui/helpers': 1.112.12(react@18.2.0)
-      '@tamagui/use-constant': 1.112.12(react@18.2.0)
-      '@tamagui/use-force-update': 1.112.12(react@18.2.0)
-      '@tamagui/use-presence': 1.112.12(react@18.2.0)
-      '@tamagui/web': 1.112.12(react@18.2.0)
+      '@tamagui/helpers': 1.126.12(react@18.2.0)
+      '@tamagui/use-constant': 1.126.12(react@18.2.0)
+      '@tamagui/use-force-update': 1.126.12(react@18.2.0)
+      '@tamagui/use-presence': 1.126.12(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
+      '@tamagui/web': 1.126.12(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
     transitivePeerDependencies:
       - react
+      - react-dom
 
-  '@tamagui/animate@1.112.12(react@18.2.0)':
+  '@tamagui/animate@1.126.12(react-dom@18.2.0(react@18.2.0))(react@18.2.0)':
     dependencies:
-      '@tamagui/animate-presence': 1.112.12(react@18.2.0)
+      '@tamagui/animate-presence': 1.126.12(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
     transitivePeerDependencies:
       - react
+      - react-dom
 
-  '@tamagui/animations-css@1.112.12(react@18.2.0)':
+  '@tamagui/animations-css@1.126.12(react-dom@18.2.0(react@18.2.0))(react@18.2.0)':
     dependencies:
-      '@tamagui/constants': 1.112.12(react@18.2.0)
-      '@tamagui/cubic-bezier-animator': 1.112.12
-      '@tamagui/use-presence': 1.112.12(react@18.2.0)
-      '@tamagui/web': 1.112.12(react@18.2.0)
+      '@tamagui/constants': 1.126.12(react@18.2.0)
+      '@tamagui/cubic-bezier-animator': 1.126.12
+      '@tamagui/use-presence': 1.126.12(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
+      '@tamagui/web': 1.126.12(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
       react: 18.2.0
+      react-dom: 18.2.0(react@18.2.0)
 
-  '@tamagui/animations-moti@1.112.12(moti@0.28.1(react-dom@18.2.0(react@18.2.0))(react-native-reanimated@3.8.1(patch_hash=iololnqcieadxwydikuxdlowf4)(@babel/core@7.25.2)(react-native@0.74.5(@babel/core@7.25.2)(@babel/preset-env@7.26.0(@babel/core@7.25.2))(@types/react@18.2.55)(encoding@0.1.13)(react@18.2.0))(react@18.2.0))(react@18.2.0))(react@18.2.0)':
+  '@tamagui/animations-moti@1.126.12(react-dom@18.2.0(react@18.2.0))(react-native-reanimated@3.8.1(patch_hash=iololnqcieadxwydikuxdlowf4)(@babel/core@7.25.2)(react-native@0.74.5(@babel/core@7.25.2)(@babel/preset-env@7.26.0(@babel/core@7.25.2))(@types/react@18.2.55)(encoding@0.1.13)(react@18.2.0))(react@18.2.0))(react@18.2.0)':
     dependencies:
-      '@tamagui/use-presence': 1.112.12(react@18.2.0)
-      '@tamagui/web': 1.112.12(react@18.2.0)
-      moti: 0.28.1(react-dom@18.2.0(react@18.2.0))(react-native-reanimated@3.8.1(patch_hash=iololnqcieadxwydikuxdlowf4)(@babel/core@7.25.2)(react-native@0.74.5(@babel/core@7.25.2)(@babel/preset-env@7.26.0(@babel/core@7.25.2))(@types/react@18.2.55)(encoding@0.1.13)(react@18.2.0))(react@18.2.0))(react@18.2.0)
+      '@tamagui/use-presence': 1.126.12(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
+      '@tamagui/web': 1.126.12(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
+      moti: 0.29.0(react-dom@18.2.0(react@18.2.0))(react-native-reanimated@3.8.1(patch_hash=iololnqcieadxwydikuxdlowf4)(@babel/core@7.25.2)(react-native@0.74.5(@babel/core@7.25.2)(@babel/preset-env@7.26.0(@babel/core@7.25.2))(@types/react@18.2.55)(encoding@0.1.13)(react@18.2.0))(react@18.2.0))(react@18.2.0)
       react: 18.2.0
+    transitivePeerDependencies:
+      - react-dom
+      - react-native-reanimated
 
-  '@tamagui/animations-react-native@1.112.12(react@18.2.0)':
+  '@tamagui/animations-react-native@1.126.12(react-dom@18.2.0(react@18.2.0))(react@18.2.0)':
     dependencies:
-      '@tamagui/constants': 1.112.12(react@18.2.0)
-      '@tamagui/use-presence': 1.112.12(react@18.2.0)
-      '@tamagui/web': 1.112.12(react@18.2.0)
+      '@tamagui/constants': 1.126.12(react@18.2.0)
+      '@tamagui/use-presence': 1.126.12(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
+      '@tamagui/web': 1.126.12(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
       react: 18.2.0
+    transitivePeerDependencies:
+      - react-dom
 
-  '@tamagui/aria-hidden@1.112.12(react@18.2.0)':
+  '@tamagui/aria-hidden@1.126.12(react@18.2.0)':
     dependencies:
       aria-hidden: 1.2.3
       react: 18.2.0
 
-  '@tamagui/avatar@1.112.12(react@18.2.0)':
+  '@tamagui/avatar@1.126.12(react-dom@18.2.0(react@18.2.0))(react-native@0.74.5(@babel/core@7.25.2)(@babel/preset-env@7.26.0(@babel/core@7.25.2))(@types/react@18.2.55)(encoding@0.1.13)(react@18.2.0))(react@18.2.0)':
     dependencies:
-      '@tamagui/core': 1.112.12(react@18.2.0)
-      '@tamagui/helpers': 1.112.12(react@18.2.0)
-      '@tamagui/image': 1.112.12(react@18.2.0)
-      '@tamagui/shapes': 1.112.12(react@18.2.0)
-      '@tamagui/text': 1.112.12(react@18.2.0)
+      '@tamagui/core': 1.126.12(react-dom@18.2.0(react@18.2.0))(react-native@0.74.5(@babel/core@7.25.2)(@babel/preset-env@7.26.0(@babel/core@7.25.2))(@types/react@18.2.55)(encoding@0.1.13)(react@18.2.0))(react@18.2.0)
+      '@tamagui/helpers': 1.126.12(react@18.2.0)
+      '@tamagui/image': 1.126.12(react-dom@18.2.0(react@18.2.0))(react-native@0.74.5(@babel/core@7.25.2)(@babel/preset-env@7.26.0(@babel/core@7.25.2))(@types/react@18.2.55)(encoding@0.1.13)(react@18.2.0))(react@18.2.0)
+      '@tamagui/shapes': 1.126.12(react-dom@18.2.0(react@18.2.0))(react-native@0.74.5(@babel/core@7.25.2)(@babel/preset-env@7.26.0(@babel/core@7.25.2))(@types/react@18.2.55)(encoding@0.1.13)(react@18.2.0))(react@18.2.0)
+      '@tamagui/text': 1.126.12(react-dom@18.2.0(react@18.2.0))(react-native@0.74.5(@babel/core@7.25.2)(@babel/preset-env@7.26.0(@babel/core@7.25.2))(@types/react@18.2.55)(encoding@0.1.13)(react@18.2.0))(react@18.2.0)
       react: 18.2.0
+    transitivePeerDependencies:
+      - react-dom
+      - react-native
 
-  '@tamagui/babel-plugin-fully-specified@1.112.12':
+  '@tamagui/babel-plugin-fully-specified@1.126.12':
     dependencies:
       '@babel/core': 7.25.2
     transitivePeerDependencies:
       - supports-color
 
-  '@tamagui/babel-plugin@1.112.12(@swc/helpers@0.5.13)(encoding@0.1.13)(react@18.2.0)':
+  '@tamagui/babel-plugin@1.126.12(@swc/helpers@0.5.13)(encoding@0.1.13)(react-dom@18.2.0(react@18.2.0))(react-native@0.74.5(@babel/core@7.25.2)(@babel/preset-env@7.26.0(@babel/core@7.25.2))(@types/react@18.2.55)(encoding@0.1.13)(react@18.2.0))(react@18.2.0)':
     dependencies:
-      '@babel/generator': 7.25.6
-      '@babel/helper-plugin-utils': 7.24.8
-      '@babel/template': 7.25.0
-      '@babel/traverse': 7.25.6
-      '@tamagui/static': 1.112.12(@swc/helpers@0.5.13)(encoding@0.1.13)(react@18.2.0)
+      '@babel/core': 7.25.2
+      '@babel/generator': 7.26.2
+      '@babel/helper-plugin-utils': 7.25.9
+      '@babel/template': 7.25.9
+      '@babel/traverse': 7.25.9
+      '@tamagui/static': 1.126.12(@swc/helpers@0.5.13)(encoding@0.1.13)(react-dom@18.2.0(react@18.2.0))(react-native@0.74.5(@babel/core@7.25.2)(@babel/preset-env@7.26.0(@babel/core@7.25.2))(@types/react@18.2.55)(encoding@0.1.13)(react@18.2.0))(react@18.2.0)
     transitivePeerDependencies:
       - '@swc/helpers'
       - encoding
       - react
+      - react-dom
+      - react-native
       - supports-color
 
-  '@tamagui/build@1.112.12(@swc/helpers@0.5.13)':
+  '@tamagui/build@1.126.12(@swc/helpers@0.5.13)':
     dependencies:
       '@babel/core': 7.25.2
       '@swc/core': 1.7.26(@swc/helpers@0.5.13)
-      '@tamagui/babel-plugin-fully-specified': 1.112.12
+      '@tamagui/babel-plugin-fully-specified': 1.126.12
       '@types/fs-extra': 9.0.13
-      babel-plugin-fully-specified: 1.3.0(@babel/core@7.25.2)
       chokidar: 3.5.3
-      esbuild: 0.24.0
-      esbuild-plugin-es5: 2.1.1(esbuild@0.24.0)
-      esbuild-register: 3.6.0(esbuild@0.24.0)
+      esbuild: 0.25.2
+      esbuild-plugin-es5: 2.1.1(esbuild@0.25.2)
+      esbuild-register: 3.6.0(esbuild@0.25.2)
       execa: 5.1.1
       fast-glob: 3.3.2
       fs-extra: 11.2.0
       lodash.debounce: 4.0.8
+      oxc-transform: 0.47.1
       typescript: 5.4.5
     transitivePeerDependencies:
       - '@swc/helpers'
       - supports-color
 
-  '@tamagui/button@1.112.12(react@18.2.0)':
+  '@tamagui/button@1.126.12(react-dom@18.2.0(react@18.2.0))(react-native@0.74.5(@babel/core@7.25.2)(@babel/preset-env@7.26.0(@babel/core@7.25.2))(@types/react@18.2.55)(encoding@0.1.13)(react@18.2.0))(react@18.2.0)':
     dependencies:
-      '@tamagui/font-size': 1.112.12(react@18.2.0)
-      '@tamagui/get-button-sized': 1.112.12(react@18.2.0)
-      '@tamagui/helpers': 1.112.12(react@18.2.0)
-      '@tamagui/helpers-tamagui': 1.112.12(react@18.2.0)
-      '@tamagui/stacks': 1.112.12(react@18.2.0)
-      '@tamagui/text': 1.112.12(react@18.2.0)
-      '@tamagui/web': 1.112.12(react@18.2.0)
-      react: 18.2.0
-
-  '@tamagui/card@1.112.12(react@18.2.0)':
-    dependencies:
-      '@tamagui/create-context': 1.112.12(react@18.2.0)
-      '@tamagui/helpers': 1.112.12(react@18.2.0)
-      '@tamagui/stacks': 1.112.12(react@18.2.0)
-      '@tamagui/web': 1.112.12(react@18.2.0)
-      react: 18.2.0
-
-  '@tamagui/checkbox-headless@1.112.12(react-native@0.74.5(@babel/core@7.25.2)(@babel/preset-env@7.26.0(@babel/core@7.25.2))(@types/react@18.2.55)(encoding@0.1.13)(react@18.2.0))(react@18.2.0)':
-    dependencies:
-      '@tamagui/compose-refs': 1.112.12(react@18.2.0)
-      '@tamagui/constants': 1.112.12(react@18.2.0)
-      '@tamagui/create-context': 1.112.12(react@18.2.0)
-      '@tamagui/focusable': 1.112.12(react@18.2.0)
-      '@tamagui/helpers': 1.112.12(react@18.2.0)
-      '@tamagui/label': 1.112.12(react-native@0.74.5(@babel/core@7.25.2)(@babel/preset-env@7.26.0(@babel/core@7.25.2))(@types/react@18.2.55)(encoding@0.1.13)(react@18.2.0))(react@18.2.0)
-      '@tamagui/use-controllable-state': 1.112.12(react@18.2.0)
-      '@tamagui/use-previous': 1.112.12
+      '@tamagui/font-size': 1.126.12(react-dom@18.2.0(react@18.2.0))(react-native@0.74.5(@babel/core@7.25.2)(@babel/preset-env@7.26.0(@babel/core@7.25.2))(@types/react@18.2.55)(encoding@0.1.13)(react@18.2.0))(react@18.2.0)
+      '@tamagui/get-button-sized': 1.126.12(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
+      '@tamagui/helpers': 1.126.12(react@18.2.0)
+      '@tamagui/helpers-tamagui': 1.126.12(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
+      '@tamagui/stacks': 1.126.12(react-dom@18.2.0(react@18.2.0))(react-native@0.74.5(@babel/core@7.25.2)(@babel/preset-env@7.26.0(@babel/core@7.25.2))(@types/react@18.2.55)(encoding@0.1.13)(react@18.2.0))(react@18.2.0)
+      '@tamagui/text': 1.126.12(react-dom@18.2.0(react@18.2.0))(react-native@0.74.5(@babel/core@7.25.2)(@babel/preset-env@7.26.0(@babel/core@7.25.2))(@types/react@18.2.55)(encoding@0.1.13)(react@18.2.0))(react@18.2.0)
+      '@tamagui/web': 1.126.12(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
       react: 18.2.0
     transitivePeerDependencies:
+      - react-dom
       - react-native
 
-  '@tamagui/checkbox@1.112.12(react-native@0.74.5(@babel/core@7.25.2)(@babel/preset-env@7.26.0(@babel/core@7.25.2))(@types/react@18.2.55)(encoding@0.1.13)(react@18.2.0))(react@18.2.0)':
+  '@tamagui/card@1.126.12(react-dom@18.2.0(react@18.2.0))(react-native@0.74.5(@babel/core@7.25.2)(@babel/preset-env@7.26.0(@babel/core@7.25.2))(@types/react@18.2.55)(encoding@0.1.13)(react@18.2.0))(react@18.2.0)':
     dependencies:
-      '@tamagui/checkbox-headless': 1.112.12(react-native@0.74.5(@babel/core@7.25.2)(@babel/preset-env@7.26.0(@babel/core@7.25.2))(@types/react@18.2.55)(encoding@0.1.13)(react@18.2.0))(react@18.2.0)
-      '@tamagui/compose-refs': 1.112.12(react@18.2.0)
-      '@tamagui/constants': 1.112.12(react@18.2.0)
-      '@tamagui/core': 1.112.12(react@18.2.0)
-      '@tamagui/create-context': 1.112.12(react@18.2.0)
-      '@tamagui/focusable': 1.112.12(react@18.2.0)
-      '@tamagui/font-size': 1.112.12(react@18.2.0)
-      '@tamagui/get-token': 1.112.12(react@18.2.0)
-      '@tamagui/helpers': 1.112.12(react@18.2.0)
-      '@tamagui/helpers-tamagui': 1.112.12(react@18.2.0)
-      '@tamagui/label': 1.112.12(react-native@0.74.5(@babel/core@7.25.2)(@babel/preset-env@7.26.0(@babel/core@7.25.2))(@types/react@18.2.55)(encoding@0.1.13)(react@18.2.0))(react@18.2.0)
-      '@tamagui/stacks': 1.112.12(react@18.2.0)
-      '@tamagui/use-controllable-state': 1.112.12(react@18.2.0)
-      '@tamagui/use-previous': 1.112.12
+      '@tamagui/create-context': 1.126.12(react@18.2.0)
+      '@tamagui/helpers': 1.126.12(react@18.2.0)
+      '@tamagui/stacks': 1.126.12(react-dom@18.2.0(react@18.2.0))(react-native@0.74.5(@babel/core@7.25.2)(@babel/preset-env@7.26.0(@babel/core@7.25.2))(@types/react@18.2.55)(encoding@0.1.13)(react@18.2.0))(react@18.2.0)
+      '@tamagui/web': 1.126.12(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
       react: 18.2.0
     transitivePeerDependencies:
+      - react-dom
       - react-native
 
-  '@tamagui/cli-color@1.112.12': {}
-
-  '@tamagui/collapsible@1.112.12(react@18.2.0)':
+  '@tamagui/checkbox-headless@1.126.12(react-dom@18.2.0(react@18.2.0))(react-native@0.74.5(@babel/core@7.25.2)(@babel/preset-env@7.26.0(@babel/core@7.25.2))(@types/react@18.2.55)(encoding@0.1.13)(react@18.2.0))(react@18.2.0)':
     dependencies:
-      '@tamagui/animate-presence': 1.112.12(react@18.2.0)
-      '@tamagui/compose-refs': 1.112.12(react@18.2.0)
-      '@tamagui/core': 1.112.12(react@18.2.0)
-      '@tamagui/create-context': 1.112.12(react@18.2.0)
-      '@tamagui/helpers': 1.112.12(react@18.2.0)
-      '@tamagui/polyfill-dev': 1.112.12
-      '@tamagui/stacks': 1.112.12(react@18.2.0)
-      '@tamagui/use-controllable-state': 1.112.12(react@18.2.0)
+      '@tamagui/compose-refs': 1.126.12(react@18.2.0)
+      '@tamagui/constants': 1.126.12(react@18.2.0)
+      '@tamagui/create-context': 1.126.12(react@18.2.0)
+      '@tamagui/focusable': 1.126.12(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
+      '@tamagui/helpers': 1.126.12(react@18.2.0)
+      '@tamagui/label': 1.126.12(react-dom@18.2.0(react@18.2.0))(react-native@0.74.5(@babel/core@7.25.2)(@babel/preset-env@7.26.0(@babel/core@7.25.2))(@types/react@18.2.55)(encoding@0.1.13)(react@18.2.0))(react@18.2.0)
+      '@tamagui/use-controllable-state': 1.126.12(react@18.2.0)
+      '@tamagui/use-previous': 1.126.12
       react: 18.2.0
+    transitivePeerDependencies:
+      - react-dom
+      - react-native
 
-  '@tamagui/collection@1.112.12(react@18.2.0)':
+  '@tamagui/checkbox@1.126.12(react-dom@18.2.0(react@18.2.0))(react-native@0.74.5(@babel/core@7.25.2)(@babel/preset-env@7.26.0(@babel/core@7.25.2))(@types/react@18.2.55)(encoding@0.1.13)(react@18.2.0))(react@18.2.0)':
     dependencies:
-      '@tamagui/compose-refs': 1.112.12(react@18.2.0)
-      '@tamagui/constants': 1.112.12(react@18.2.0)
-      '@tamagui/core': 1.112.12(react@18.2.0)
-      '@tamagui/create-context': 1.112.12(react@18.2.0)
-      '@tamagui/polyfill-dev': 1.112.12
-      '@tamagui/stacks': 1.112.12(react@18.2.0)
-      '@tamagui/use-controllable-state': 1.112.12(react@18.2.0)
+      '@tamagui/checkbox-headless': 1.126.12(react-dom@18.2.0(react@18.2.0))(react-native@0.74.5(@babel/core@7.25.2)(@babel/preset-env@7.26.0(@babel/core@7.25.2))(@types/react@18.2.55)(encoding@0.1.13)(react@18.2.0))(react@18.2.0)
+      '@tamagui/compose-refs': 1.126.12(react@18.2.0)
+      '@tamagui/constants': 1.126.12(react@18.2.0)
+      '@tamagui/core': 1.126.12(react-dom@18.2.0(react@18.2.0))(react-native@0.74.5(@babel/core@7.25.2)(@babel/preset-env@7.26.0(@babel/core@7.25.2))(@types/react@18.2.55)(encoding@0.1.13)(react@18.2.0))(react@18.2.0)
+      '@tamagui/create-context': 1.126.12(react@18.2.0)
+      '@tamagui/focusable': 1.126.12(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
+      '@tamagui/font-size': 1.126.12(react-dom@18.2.0(react@18.2.0))(react-native@0.74.5(@babel/core@7.25.2)(@babel/preset-env@7.26.0(@babel/core@7.25.2))(@types/react@18.2.55)(encoding@0.1.13)(react@18.2.0))(react@18.2.0)
+      '@tamagui/get-token': 1.126.12(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
+      '@tamagui/helpers': 1.126.12(react@18.2.0)
+      '@tamagui/helpers-tamagui': 1.126.12(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
+      '@tamagui/label': 1.126.12(react-dom@18.2.0(react@18.2.0))(react-native@0.74.5(@babel/core@7.25.2)(@babel/preset-env@7.26.0(@babel/core@7.25.2))(@types/react@18.2.55)(encoding@0.1.13)(react@18.2.0))(react@18.2.0)
+      '@tamagui/stacks': 1.126.12(react-dom@18.2.0(react@18.2.0))(react-native@0.74.5(@babel/core@7.25.2)(@babel/preset-env@7.26.0(@babel/core@7.25.2))(@types/react@18.2.55)(encoding@0.1.13)(react@18.2.0))(react@18.2.0)
+      '@tamagui/use-controllable-state': 1.126.12(react@18.2.0)
+      '@tamagui/use-previous': 1.126.12
       react: 18.2.0
+    transitivePeerDependencies:
+      - react-dom
+      - react-native
 
-  '@tamagui/compose-refs@1.112.12(react@18.2.0)':
+  '@tamagui/cli-color@1.126.12': {}
+
+  '@tamagui/collapsible@1.126.12(react-dom@18.2.0(react@18.2.0))(react-native@0.74.5(@babel/core@7.25.2)(@babel/preset-env@7.26.0(@babel/core@7.25.2))(@types/react@18.2.55)(encoding@0.1.13)(react@18.2.0))(react@18.2.0)':
     dependencies:
+      '@tamagui/animate-presence': 1.126.12(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
+      '@tamagui/compose-refs': 1.126.12(react@18.2.0)
+      '@tamagui/core': 1.126.12(react-dom@18.2.0(react@18.2.0))(react-native@0.74.5(@babel/core@7.25.2)(@babel/preset-env@7.26.0(@babel/core@7.25.2))(@types/react@18.2.55)(encoding@0.1.13)(react@18.2.0))(react@18.2.0)
+      '@tamagui/create-context': 1.126.12(react@18.2.0)
+      '@tamagui/helpers': 1.126.12(react@18.2.0)
+      '@tamagui/polyfill-dev': 1.126.12
+      '@tamagui/stacks': 1.126.12(react-dom@18.2.0(react@18.2.0))(react-native@0.74.5(@babel/core@7.25.2)(@babel/preset-env@7.26.0(@babel/core@7.25.2))(@types/react@18.2.55)(encoding@0.1.13)(react@18.2.0))(react@18.2.0)
+      '@tamagui/use-controllable-state': 1.126.12(react@18.2.0)
       react: 18.2.0
+    transitivePeerDependencies:
+      - react-dom
+      - react-native
+
+  '@tamagui/collection@1.126.12(react-dom@18.2.0(react@18.2.0))(react-native@0.74.5(@babel/core@7.25.2)(@babel/preset-env@7.26.0(@babel/core@7.25.2))(@types/react@18.2.55)(encoding@0.1.13)(react@18.2.0))(react@18.2.0)':
+    dependencies:
+      '@tamagui/compose-refs': 1.126.12(react@18.2.0)
+      '@tamagui/constants': 1.126.12(react@18.2.0)
+      '@tamagui/core': 1.126.12(react-dom@18.2.0(react@18.2.0))(react-native@0.74.5(@babel/core@7.25.2)(@babel/preset-env@7.26.0(@babel/core@7.25.2))(@types/react@18.2.55)(encoding@0.1.13)(react@18.2.0))(react@18.2.0)
+      '@tamagui/create-context': 1.126.12(react@18.2.0)
+      '@tamagui/polyfill-dev': 1.126.12
+      '@tamagui/stacks': 1.126.12(react-dom@18.2.0(react@18.2.0))(react-native@0.74.5(@babel/core@7.25.2)(@babel/preset-env@7.26.0(@babel/core@7.25.2))(@types/react@18.2.55)(encoding@0.1.13)(react@18.2.0))(react@18.2.0)
+      '@tamagui/use-controllable-state': 1.126.12(react@18.2.0)
+      react: 18.2.0
+    transitivePeerDependencies:
+      - react-dom
+      - react-native
 
   '@tamagui/compose-refs@1.116.12(react@18.2.0)':
     dependencies:
       react: 18.2.0
 
-  '@tamagui/config-default@1.112.12(react@18.2.0)':
-    dependencies:
-      '@tamagui/animations-css': 1.112.12(react@18.2.0)
-      '@tamagui/core': 1.112.12(react@18.2.0)
-      '@tamagui/shorthands': 1.112.12
-    transitivePeerDependencies:
-      - react
-
-  '@tamagui/constants@1.112.12(react@18.2.0)':
+  '@tamagui/compose-refs@1.126.12(react@18.2.0)':
     dependencies:
       react: 18.2.0
+
+  '@tamagui/config-default@1.126.12(react-dom@18.2.0(react@18.2.0))(react-native@0.74.5(@babel/core@7.25.2)(@babel/preset-env@7.26.0(@babel/core@7.25.2))(@types/react@18.2.55)(encoding@0.1.13)(react@18.2.0))(react@18.2.0)':
+    dependencies:
+      '@tamagui/animations-css': 1.126.12(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
+      '@tamagui/core': 1.126.12(react-dom@18.2.0(react@18.2.0))(react-native@0.74.5(@babel/core@7.25.2)(@babel/preset-env@7.26.0(@babel/core@7.25.2))(@types/react@18.2.55)(encoding@0.1.13)(react@18.2.0))(react@18.2.0)
+      '@tamagui/shorthands': 1.126.12(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
+    transitivePeerDependencies:
+      - react
+      - react-dom
+      - react-native
 
   '@tamagui/constants@1.116.12(react@18.2.0)':
     dependencies:
       react: 18.2.0
 
-  '@tamagui/core@1.112.12(react@18.2.0)':
-    dependencies:
-      '@tamagui/react-native-use-pressable': 1.112.12(react@18.2.0)
-      '@tamagui/react-native-use-responder-events': 1.112.12(react@18.2.0)
-      '@tamagui/use-event': 1.112.12(react@18.2.0)
-      '@tamagui/web': 1.112.12(react@18.2.0)
-    transitivePeerDependencies:
-      - react
-
-  '@tamagui/create-context@1.112.12(react@18.2.0)':
+  '@tamagui/constants@1.126.12(react@18.2.0)':
     dependencies:
       react: 18.2.0
 
-  '@tamagui/create-theme@1.112.12(react@18.2.0)':
+  '@tamagui/core@1.126.12(react-dom@18.2.0(react@18.2.0))(react-native@0.74.5(@babel/core@7.25.2)(@babel/preset-env@7.26.0(@babel/core@7.25.2))(@types/react@18.2.55)(encoding@0.1.13)(react@18.2.0))(react@18.2.0)':
     dependencies:
-      '@tamagui/web': 1.112.12(react@18.2.0)
+      '@tamagui/react-native-media-driver': 1.126.12(react-dom@18.2.0(react@18.2.0))(react-native@0.74.5(@babel/core@7.25.2)(@babel/preset-env@7.26.0(@babel/core@7.25.2))(@types/react@18.2.55)(encoding@0.1.13)(react@18.2.0))(react@18.2.0)
+      '@tamagui/react-native-use-pressable': 1.126.12(react@18.2.0)
+      '@tamagui/react-native-use-responder-events': 1.126.12(react@18.2.0)
+      '@tamagui/use-event': 1.126.12(react@18.2.0)
+      '@tamagui/web': 1.126.12(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
     transitivePeerDependencies:
       - react
+      - react-dom
+      - react-native
 
-  '@tamagui/cubic-bezier-animator@1.112.12': {}
-
-  '@tamagui/dialog@1.112.12(@types/react@18.2.55)(react-dom@18.2.0(react@18.2.0))(react-native@0.74.5(@babel/core@7.25.2)(@babel/preset-env@7.26.0(@babel/core@7.25.2))(@types/react@18.2.55)(encoding@0.1.13)(react@18.2.0))(react@18.2.0)':
+  '@tamagui/create-context@1.126.12(react@18.2.0)':
     dependencies:
-      '@tamagui/adapt': 1.112.12(react@18.2.0)
-      '@tamagui/animate-presence': 1.112.12(react@18.2.0)
-      '@tamagui/aria-hidden': 1.112.12(react@18.2.0)
-      '@tamagui/compose-refs': 1.112.12(react@18.2.0)
-      '@tamagui/constants': 1.112.12(react@18.2.0)
-      '@tamagui/core': 1.112.12(react@18.2.0)
-      '@tamagui/create-context': 1.112.12(react@18.2.0)
-      '@tamagui/dismissable': 1.112.12(react@18.2.0)
-      '@tamagui/focus-scope': 1.112.12(react@18.2.0)
-      '@tamagui/helpers': 1.112.12(react@18.2.0)
-      '@tamagui/polyfill-dev': 1.112.12
-      '@tamagui/popper': 1.112.12(react-dom@18.2.0(react@18.2.0))(react-native@0.74.5(@babel/core@7.25.2)(@babel/preset-env@7.26.0(@babel/core@7.25.2))(@types/react@18.2.55)(encoding@0.1.13)(react@18.2.0))(react@18.2.0)
-      '@tamagui/portal': 1.112.12(react@18.2.0)
-      '@tamagui/remove-scroll': 1.112.12(@types/react@18.2.55)(react@18.2.0)
-      '@tamagui/sheet': 1.112.12(@types/react@18.2.55)(react@18.2.0)
-      '@tamagui/stacks': 1.112.12(react@18.2.0)
-      '@tamagui/text': 1.112.12(react@18.2.0)
-      '@tamagui/use-controllable-state': 1.112.12(react@18.2.0)
+      react: 18.2.0
+
+  '@tamagui/create-theme@1.126.12(react-dom@18.2.0(react@18.2.0))(react@18.2.0)':
+    dependencies:
+      '@tamagui/web': 1.126.12(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
+    transitivePeerDependencies:
+      - react
+      - react-dom
+
+  '@tamagui/cubic-bezier-animator@1.126.12': {}
+
+  '@tamagui/dialog@1.126.12(@types/react@18.2.55)(react-dom@18.2.0(react@18.2.0))(react-native@0.74.5(@babel/core@7.25.2)(@babel/preset-env@7.26.0(@babel/core@7.25.2))(@types/react@18.2.55)(encoding@0.1.13)(react@18.2.0))(react@18.2.0)':
+    dependencies:
+      '@tamagui/adapt': 1.126.12(react-dom@18.2.0(react@18.2.0))(react-native@0.74.5(@babel/core@7.25.2)(@babel/preset-env@7.26.0(@babel/core@7.25.2))(@types/react@18.2.55)(encoding@0.1.13)(react@18.2.0))(react@18.2.0)
+      '@tamagui/animate-presence': 1.126.12(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
+      '@tamagui/aria-hidden': 1.126.12(react@18.2.0)
+      '@tamagui/compose-refs': 1.126.12(react@18.2.0)
+      '@tamagui/constants': 1.126.12(react@18.2.0)
+      '@tamagui/core': 1.126.12(react-dom@18.2.0(react@18.2.0))(react-native@0.74.5(@babel/core@7.25.2)(@babel/preset-env@7.26.0(@babel/core@7.25.2))(@types/react@18.2.55)(encoding@0.1.13)(react@18.2.0))(react@18.2.0)
+      '@tamagui/create-context': 1.126.12(react@18.2.0)
+      '@tamagui/dismissable': 1.126.12(react-dom@18.2.0(react@18.2.0))(react-native@0.74.5(@babel/core@7.25.2)(@babel/preset-env@7.26.0(@babel/core@7.25.2))(@types/react@18.2.55)(encoding@0.1.13)(react@18.2.0))(react@18.2.0)
+      '@tamagui/focus-scope': 1.126.12(react@18.2.0)
+      '@tamagui/helpers': 1.126.12(react@18.2.0)
+      '@tamagui/polyfill-dev': 1.126.12
+      '@tamagui/popper': 1.126.12(react-dom@18.2.0(react@18.2.0))(react-native@0.74.5(@babel/core@7.25.2)(@babel/preset-env@7.26.0(@babel/core@7.25.2))(@types/react@18.2.55)(encoding@0.1.13)(react@18.2.0))(react@18.2.0)
+      '@tamagui/portal': 1.126.12(react-dom@18.2.0(react@18.2.0))(react-native@0.74.5(@babel/core@7.25.2)(@babel/preset-env@7.26.0(@babel/core@7.25.2))(@types/react@18.2.55)(encoding@0.1.13)(react@18.2.0))(react@18.2.0)
+      '@tamagui/remove-scroll': 1.126.12(@types/react@18.2.55)(react@18.2.0)
+      '@tamagui/sheet': 1.126.12(@types/react@18.2.55)(react-dom@18.2.0(react@18.2.0))(react-native@0.74.5(@babel/core@7.25.2)(@babel/preset-env@7.26.0(@babel/core@7.25.2))(@types/react@18.2.55)(encoding@0.1.13)(react@18.2.0))(react@18.2.0)
+      '@tamagui/stacks': 1.126.12(react-dom@18.2.0(react@18.2.0))(react-native@0.74.5(@babel/core@7.25.2)(@babel/preset-env@7.26.0(@babel/core@7.25.2))(@types/react@18.2.55)(encoding@0.1.13)(react@18.2.0))(react@18.2.0)
+      '@tamagui/text': 1.126.12(react-dom@18.2.0(react@18.2.0))(react-native@0.74.5(@babel/core@7.25.2)(@babel/preset-env@7.26.0(@babel/core@7.25.2))(@types/react@18.2.55)(encoding@0.1.13)(react@18.2.0))(react@18.2.0)
+      '@tamagui/use-controllable-state': 1.126.12(react@18.2.0)
+      '@tamagui/z-index-stack': 1.126.12
       react: 18.2.0
     transitivePeerDependencies:
       - '@types/react'
       - react-dom
       - react-native
 
-  '@tamagui/dismissable@1.112.12(react@18.2.0)':
+  '@tamagui/dismissable@1.126.12(react-dom@18.2.0(react@18.2.0))(react-native@0.74.5(@babel/core@7.25.2)(@babel/preset-env@7.26.0(@babel/core@7.25.2))(@types/react@18.2.55)(encoding@0.1.13)(react@18.2.0))(react@18.2.0)':
     dependencies:
-      '@tamagui/compose-refs': 1.112.12(react@18.2.0)
-      '@tamagui/core': 1.112.12(react@18.2.0)
-      '@tamagui/helpers': 1.112.12(react@18.2.0)
-      '@tamagui/use-escape-keydown': 1.112.12
-      '@tamagui/use-event': 1.112.12(react@18.2.0)
-      react: 18.2.0
-
-  '@tamagui/elements@1.112.12(react@18.2.0)':
-    dependencies:
-      '@tamagui/core': 1.112.12(react@18.2.0)
-      react: 18.2.0
-
-  '@tamagui/fake-react-native@1.112.12': {}
-
-  '@tamagui/floating@1.112.12(react-dom@18.2.0(react@18.2.0))(react-native@0.74.5(@babel/core@7.25.2)(@babel/preset-env@7.26.0(@babel/core@7.25.2))(@types/react@18.2.55)(encoding@0.1.13)(react@18.2.0))(react@18.2.0)':
-    dependencies:
-      '@floating-ui/react-dom': 2.1.2(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
-      '@floating-ui/react-native': 0.10.6(react-native@0.74.5(@babel/core@7.25.2)(@babel/preset-env@7.26.0(@babel/core@7.25.2))(@types/react@18.2.55)(encoding@0.1.13)(react@18.2.0))(react@18.2.0)
+      '@tamagui/compose-refs': 1.126.12(react@18.2.0)
+      '@tamagui/core': 1.126.12(react-dom@18.2.0(react@18.2.0))(react-native@0.74.5(@babel/core@7.25.2)(@babel/preset-env@7.26.0(@babel/core@7.25.2))(@types/react@18.2.55)(encoding@0.1.13)(react@18.2.0))(react@18.2.0)
+      '@tamagui/helpers': 1.126.12(react@18.2.0)
+      '@tamagui/use-escape-keydown': 1.126.12
+      '@tamagui/use-event': 1.126.12(react@18.2.0)
       react: 18.2.0
     transitivePeerDependencies:
       - react-dom
       - react-native
 
-  '@tamagui/focus-scope@1.112.12(react@18.2.0)':
+  '@tamagui/elements@1.126.12(react-dom@18.2.0(react@18.2.0))(react-native@0.74.5(@babel/core@7.25.2)(@babel/preset-env@7.26.0(@babel/core@7.25.2))(@types/react@18.2.55)(encoding@0.1.13)(react@18.2.0))(react@18.2.0)':
     dependencies:
-      '@tamagui/compose-refs': 1.112.12(react@18.2.0)
-      '@tamagui/start-transition': 1.112.12
-      '@tamagui/use-event': 1.112.12(react@18.2.0)
+      '@tamagui/core': 1.126.12(react-dom@18.2.0(react@18.2.0))(react-native@0.74.5(@babel/core@7.25.2)(@babel/preset-env@7.26.0(@babel/core@7.25.2))(@types/react@18.2.55)(encoding@0.1.13)(react@18.2.0))(react@18.2.0)
+      react: 18.2.0
+    transitivePeerDependencies:
+      - react-dom
+      - react-native
+
+  '@tamagui/fake-react-native@1.126.12': {}
+
+  '@tamagui/floating@1.126.12(react-dom@18.2.0(react@18.2.0))(react-native@0.74.5(@babel/core@7.25.2)(@babel/preset-env@7.26.0(@babel/core@7.25.2))(@types/react@18.2.55)(encoding@0.1.13)(react@18.2.0))(react@18.2.0)':
+    dependencies:
+      '@floating-ui/react-dom': 2.1.2(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
+      '@floating-ui/react-native': 0.10.7(react-native@0.74.5(@babel/core@7.25.2)(@babel/preset-env@7.26.0(@babel/core@7.25.2))(@types/react@18.2.55)(encoding@0.1.13)(react@18.2.0))(react@18.2.0)
+      react: 18.2.0
+    transitivePeerDependencies:
+      - react-dom
+      - react-native
+
+  '@tamagui/focus-scope@1.126.12(react@18.2.0)':
+    dependencies:
+      '@tamagui/compose-refs': 1.126.12(react@18.2.0)
+      '@tamagui/start-transition': 1.126.12
+      '@tamagui/use-event': 1.126.12(react@18.2.0)
       react: 18.2.0
 
-  '@tamagui/focusable@1.112.12(react@18.2.0)':
+  '@tamagui/focusable@1.126.12(react-dom@18.2.0(react@18.2.0))(react@18.2.0)':
     dependencies:
-      '@tamagui/compose-refs': 1.112.12(react@18.2.0)
-      '@tamagui/web': 1.112.12(react@18.2.0)
+      '@tamagui/compose-refs': 1.126.12(react@18.2.0)
+      '@tamagui/web': 1.126.12(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
       react: 18.2.0
+    transitivePeerDependencies:
+      - react-dom
 
-  '@tamagui/font-size@1.112.12(react@18.2.0)':
+  '@tamagui/font-size@1.126.12(react-dom@18.2.0(react@18.2.0))(react-native@0.74.5(@babel/core@7.25.2)(@babel/preset-env@7.26.0(@babel/core@7.25.2))(@types/react@18.2.55)(encoding@0.1.13)(react@18.2.0))(react@18.2.0)':
     dependencies:
-      '@tamagui/core': 1.112.12(react@18.2.0)
+      '@tamagui/core': 1.126.12(react-dom@18.2.0(react@18.2.0))(react-native@0.74.5(@babel/core@7.25.2)(@babel/preset-env@7.26.0(@babel/core@7.25.2))(@types/react@18.2.55)(encoding@0.1.13)(react@18.2.0))(react@18.2.0)
       react: 18.2.0
+    transitivePeerDependencies:
+      - react-dom
+      - react-native
 
-  '@tamagui/form@1.112.12(react@18.2.0)':
+  '@tamagui/form@1.126.12(react-dom@18.2.0(react@18.2.0))(react-native@0.74.5(@babel/core@7.25.2)(@babel/preset-env@7.26.0(@babel/core@7.25.2))(@types/react@18.2.55)(encoding@0.1.13)(react@18.2.0))(react@18.2.0)':
     dependencies:
-      '@tamagui/compose-refs': 1.112.12(react@18.2.0)
-      '@tamagui/core': 1.112.12(react@18.2.0)
-      '@tamagui/create-context': 1.112.12(react@18.2.0)
-      '@tamagui/focusable': 1.112.12(react@18.2.0)
-      '@tamagui/get-button-sized': 1.112.12(react@18.2.0)
-      '@tamagui/get-font-sized': 1.112.12(react@18.2.0)
-      '@tamagui/helpers': 1.112.12(react@18.2.0)
-      '@tamagui/text': 1.112.12(react@18.2.0)
+      '@tamagui/compose-refs': 1.126.12(react@18.2.0)
+      '@tamagui/core': 1.126.12(react-dom@18.2.0(react@18.2.0))(react-native@0.74.5(@babel/core@7.25.2)(@babel/preset-env@7.26.0(@babel/core@7.25.2))(@types/react@18.2.55)(encoding@0.1.13)(react@18.2.0))(react@18.2.0)
+      '@tamagui/create-context': 1.126.12(react@18.2.0)
+      '@tamagui/focusable': 1.126.12(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
+      '@tamagui/get-button-sized': 1.126.12(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
+      '@tamagui/get-font-sized': 1.126.12(react-dom@18.2.0(react@18.2.0))(react-native@0.74.5(@babel/core@7.25.2)(@babel/preset-env@7.26.0(@babel/core@7.25.2))(@types/react@18.2.55)(encoding@0.1.13)(react@18.2.0))(react@18.2.0)
+      '@tamagui/helpers': 1.126.12(react@18.2.0)
+      '@tamagui/text': 1.126.12(react-dom@18.2.0(react@18.2.0))(react-native@0.74.5(@babel/core@7.25.2)(@babel/preset-env@7.26.0(@babel/core@7.25.2))(@types/react@18.2.55)(encoding@0.1.13)(react@18.2.0))(react@18.2.0)
       react: 18.2.0
+    transitivePeerDependencies:
+      - react-dom
+      - react-native
 
-  '@tamagui/generate-themes@1.112.12(esbuild@0.24.0)(react@18.2.0)':
+  '@tamagui/generate-themes@1.126.12(esbuild@0.25.2)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)':
     dependencies:
-      '@tamagui/create-theme': 1.112.12(react@18.2.0)
-      '@tamagui/theme-builder': 1.112.12(react@18.2.0)
-      '@tamagui/types': 1.112.12
-      esbuild-register: 3.6.0(esbuild@0.24.0)
+      '@tamagui/create-theme': 1.126.12(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
+      '@tamagui/theme-builder': 1.126.12(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
+      '@tamagui/types': 1.126.12
+      esbuild-register: 3.6.0(esbuild@0.25.2)
       fs-extra: 11.2.0
     transitivePeerDependencies:
       - esbuild
       - react
+      - react-dom
       - supports-color
 
-  '@tamagui/get-button-sized@1.112.12(react@18.2.0)':
+  '@tamagui/get-button-sized@1.126.12(react-dom@18.2.0(react@18.2.0))(react@18.2.0)':
     dependencies:
-      '@tamagui/get-token': 1.112.12(react@18.2.0)
-      '@tamagui/web': 1.112.12(react@18.2.0)
+      '@tamagui/get-token': 1.126.12(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
+      '@tamagui/web': 1.126.12(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
       react: 18.2.0
-
-  '@tamagui/get-font-sized@1.112.12(react@18.2.0)':
-    dependencies:
-      '@tamagui/core': 1.112.12(react@18.2.0)
-      react: 18.2.0
-
-  '@tamagui/get-token@1.112.12(react@18.2.0)':
-    dependencies:
-      '@tamagui/web': 1.112.12(react@18.2.0)
-      react: 18.2.0
-
-  '@tamagui/group@1.112.12(react@18.2.0)':
-    dependencies:
-      '@tamagui/core': 1.112.12(react@18.2.0)
-      '@tamagui/create-context': 1.112.12(react@18.2.0)
-      '@tamagui/helpers': 1.112.12(react@18.2.0)
-      '@tamagui/stacks': 1.112.12(react@18.2.0)
-      '@tamagui/use-controllable-state': 1.112.12(react@18.2.0)
-      react: 18.2.0
-
-  '@tamagui/helpers-node@1.112.12':
-    dependencies:
-      '@tamagui/types': 1.112.12
-
-  '@tamagui/helpers-tamagui@1.112.12(react@18.2.0)':
-    dependencies:
-      '@tamagui/helpers': 1.112.12(react@18.2.0)
-      '@tamagui/web': 1.112.12(react@18.2.0)
-      react: 18.2.0
-
-  '@tamagui/helpers@1.112.12(react@18.2.0)':
-    dependencies:
-      '@tamagui/constants': 1.112.12(react@18.2.0)
-      '@tamagui/simple-hash': 1.112.12
     transitivePeerDependencies:
-      - react
+      - react-dom
+
+  '@tamagui/get-font-sized@1.126.12(react-dom@18.2.0(react@18.2.0))(react-native@0.74.5(@babel/core@7.25.2)(@babel/preset-env@7.26.0(@babel/core@7.25.2))(@types/react@18.2.55)(encoding@0.1.13)(react@18.2.0))(react@18.2.0)':
+    dependencies:
+      '@tamagui/constants': 1.126.12(react@18.2.0)
+      '@tamagui/core': 1.126.12(react-dom@18.2.0(react@18.2.0))(react-native@0.74.5(@babel/core@7.25.2)(@babel/preset-env@7.26.0(@babel/core@7.25.2))(@types/react@18.2.55)(encoding@0.1.13)(react@18.2.0))(react@18.2.0)
+      react: 18.2.0
+    transitivePeerDependencies:
+      - react-dom
+      - react-native
+
+  '@tamagui/get-token@1.126.12(react-dom@18.2.0(react@18.2.0))(react@18.2.0)':
+    dependencies:
+      '@tamagui/web': 1.126.12(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
+      react: 18.2.0
+    transitivePeerDependencies:
+      - react-dom
+
+  '@tamagui/group@1.126.12(react-dom@18.2.0(react@18.2.0))(react-native@0.74.5(@babel/core@7.25.2)(@babel/preset-env@7.26.0(@babel/core@7.25.2))(@types/react@18.2.55)(encoding@0.1.13)(react@18.2.0))(react@18.2.0)':
+    dependencies:
+      '@tamagui/core': 1.126.12(react-dom@18.2.0(react@18.2.0))(react-native@0.74.5(@babel/core@7.25.2)(@babel/preset-env@7.26.0(@babel/core@7.25.2))(@types/react@18.2.55)(encoding@0.1.13)(react@18.2.0))(react@18.2.0)
+      '@tamagui/create-context': 1.126.12(react@18.2.0)
+      '@tamagui/helpers': 1.126.12(react@18.2.0)
+      '@tamagui/stacks': 1.126.12(react-dom@18.2.0(react@18.2.0))(react-native@0.74.5(@babel/core@7.25.2)(@babel/preset-env@7.26.0(@babel/core@7.25.2))(@types/react@18.2.55)(encoding@0.1.13)(react@18.2.0))(react@18.2.0)
+      '@tamagui/use-controllable-state': 1.126.12(react@18.2.0)
+      react: 18.2.0
+    transitivePeerDependencies:
+      - react-dom
+      - react-native
+
+  '@tamagui/helpers-node@1.126.12':
+    dependencies:
+      '@tamagui/types': 1.126.12
+
+  '@tamagui/helpers-tamagui@1.126.12(react-dom@18.2.0(react@18.2.0))(react@18.2.0)':
+    dependencies:
+      '@tamagui/helpers': 1.126.12(react@18.2.0)
+      '@tamagui/web': 1.126.12(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
+      react: 18.2.0
+    transitivePeerDependencies:
+      - react-dom
 
   '@tamagui/helpers@1.116.12(react@18.2.0)':
     dependencies:
@@ -19502,74 +19339,92 @@ snapshots:
     transitivePeerDependencies:
       - react
 
-  '@tamagui/image@1.112.12(react@18.2.0)':
+  '@tamagui/helpers@1.126.12(react@18.2.0)':
     dependencies:
-      '@tamagui/constants': 1.112.12(react@18.2.0)
-      '@tamagui/core': 1.112.12(react@18.2.0)
-      react: 18.2.0
+      '@tamagui/constants': 1.126.12(react@18.2.0)
+      '@tamagui/simple-hash': 1.126.12
+    transitivePeerDependencies:
+      - react
 
-  '@tamagui/label@1.112.12(react-native@0.74.5(@babel/core@7.25.2)(@babel/preset-env@7.26.0(@babel/core@7.25.2))(@types/react@18.2.55)(encoding@0.1.13)(react@18.2.0))(react@18.2.0)':
+  '@tamagui/image@1.126.12(react-dom@18.2.0(react@18.2.0))(react-native@0.74.5(@babel/core@7.25.2)(@babel/preset-env@7.26.0(@babel/core@7.25.2))(@types/react@18.2.55)(encoding@0.1.13)(react@18.2.0))(react@18.2.0)':
     dependencies:
-      '@tamagui/compose-refs': 1.112.12(react@18.2.0)
-      '@tamagui/constants': 1.112.12(react@18.2.0)
-      '@tamagui/create-context': 1.112.12(react@18.2.0)
-      '@tamagui/focusable': 1.112.12(react@18.2.0)
-      '@tamagui/get-button-sized': 1.112.12(react@18.2.0)
-      '@tamagui/get-font-sized': 1.112.12(react@18.2.0)
-      '@tamagui/text': 1.112.12(react@18.2.0)
-      '@tamagui/web': 1.112.12(react@18.2.0)
+      '@tamagui/constants': 1.126.12(react@18.2.0)
+      '@tamagui/core': 1.126.12(react-dom@18.2.0(react@18.2.0))(react-native@0.74.5(@babel/core@7.25.2)(@babel/preset-env@7.26.0(@babel/core@7.25.2))(@types/react@18.2.55)(encoding@0.1.13)(react@18.2.0))(react@18.2.0)
+      react: 18.2.0
+    transitivePeerDependencies:
+      - react-dom
+      - react-native
+
+  '@tamagui/label@1.126.12(react-dom@18.2.0(react@18.2.0))(react-native@0.74.5(@babel/core@7.25.2)(@babel/preset-env@7.26.0(@babel/core@7.25.2))(@types/react@18.2.55)(encoding@0.1.13)(react@18.2.0))(react@18.2.0)':
+    dependencies:
+      '@tamagui/compose-refs': 1.126.12(react@18.2.0)
+      '@tamagui/constants': 1.126.12(react@18.2.0)
+      '@tamagui/create-context': 1.126.12(react@18.2.0)
+      '@tamagui/focusable': 1.126.12(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
+      '@tamagui/get-button-sized': 1.126.12(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
+      '@tamagui/get-font-sized': 1.126.12(react-dom@18.2.0(react@18.2.0))(react-native@0.74.5(@babel/core@7.25.2)(@babel/preset-env@7.26.0(@babel/core@7.25.2))(@types/react@18.2.55)(encoding@0.1.13)(react@18.2.0))(react@18.2.0)
+      '@tamagui/text': 1.126.12(react-dom@18.2.0(react@18.2.0))(react-native@0.74.5(@babel/core@7.25.2)(@babel/preset-env@7.26.0(@babel/core@7.25.2))(@types/react@18.2.55)(encoding@0.1.13)(react@18.2.0))(react@18.2.0)
+      '@tamagui/web': 1.126.12(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
       react: 18.2.0
       react-native: 0.74.5(@babel/core@7.25.2)(@babel/preset-env@7.26.0(@babel/core@7.25.2))(@types/react@18.2.55)(encoding@0.1.13)(react@18.2.0)
+    transitivePeerDependencies:
+      - react-dom
 
-  '@tamagui/linear-gradient@1.112.12(react@18.2.0)':
+  '@tamagui/linear-gradient@1.126.12(react-dom@18.2.0(react@18.2.0))(react-native@0.74.5(@babel/core@7.25.2)(@babel/preset-env@7.26.0(@babel/core@7.25.2))(@types/react@18.2.55)(encoding@0.1.13)(react@18.2.0))(react@18.2.0)':
     dependencies:
-      '@tamagui/core': 1.112.12(react@18.2.0)
-      '@tamagui/stacks': 1.112.12(react@18.2.0)
+      '@tamagui/core': 1.126.12(react-dom@18.2.0(react@18.2.0))(react-native@0.74.5(@babel/core@7.25.2)(@babel/preset-env@7.26.0(@babel/core@7.25.2))(@types/react@18.2.55)(encoding@0.1.13)(react@18.2.0))(react@18.2.0)
+      '@tamagui/stacks': 1.126.12(react-dom@18.2.0(react@18.2.0))(react-native@0.74.5(@babel/core@7.25.2)(@babel/preset-env@7.26.0(@babel/core@7.25.2))(@types/react@18.2.55)(encoding@0.1.13)(react@18.2.0))(react@18.2.0)
       react: 18.2.0
+    transitivePeerDependencies:
+      - react-dom
+      - react-native
 
-  '@tamagui/list-item@1.112.12(react@18.2.0)':
+  '@tamagui/list-item@1.126.12(react-dom@18.2.0(react@18.2.0))(react-native@0.74.5(@babel/core@7.25.2)(@babel/preset-env@7.26.0(@babel/core@7.25.2))(@types/react@18.2.55)(encoding@0.1.13)(react@18.2.0))(react@18.2.0)':
     dependencies:
-      '@tamagui/font-size': 1.112.12(react@18.2.0)
-      '@tamagui/get-font-sized': 1.112.12(react@18.2.0)
-      '@tamagui/get-token': 1.112.12(react@18.2.0)
-      '@tamagui/helpers': 1.112.12(react@18.2.0)
-      '@tamagui/helpers-tamagui': 1.112.12(react@18.2.0)
-      '@tamagui/stacks': 1.112.12(react@18.2.0)
-      '@tamagui/text': 1.112.12(react@18.2.0)
-      '@tamagui/web': 1.112.12(react@18.2.0)
+      '@tamagui/font-size': 1.126.12(react-dom@18.2.0(react@18.2.0))(react-native@0.74.5(@babel/core@7.25.2)(@babel/preset-env@7.26.0(@babel/core@7.25.2))(@types/react@18.2.55)(encoding@0.1.13)(react@18.2.0))(react@18.2.0)
+      '@tamagui/get-font-sized': 1.126.12(react-dom@18.2.0(react@18.2.0))(react-native@0.74.5(@babel/core@7.25.2)(@babel/preset-env@7.26.0(@babel/core@7.25.2))(@types/react@18.2.55)(encoding@0.1.13)(react@18.2.0))(react@18.2.0)
+      '@tamagui/get-token': 1.126.12(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
+      '@tamagui/helpers': 1.126.12(react@18.2.0)
+      '@tamagui/helpers-tamagui': 1.126.12(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
+      '@tamagui/stacks': 1.126.12(react-dom@18.2.0(react@18.2.0))(react-native@0.74.5(@babel/core@7.25.2)(@babel/preset-env@7.26.0(@babel/core@7.25.2))(@types/react@18.2.55)(encoding@0.1.13)(react@18.2.0))(react@18.2.0)
+      '@tamagui/text': 1.126.12(react-dom@18.2.0(react@18.2.0))(react-native@0.74.5(@babel/core@7.25.2)(@babel/preset-env@7.26.0(@babel/core@7.25.2))(@types/react@18.2.55)(encoding@0.1.13)(react@18.2.0))(react@18.2.0)
+      '@tamagui/web': 1.126.12(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
       react: 18.2.0
-
-  '@tamagui/normalize-css-color@1.112.12':
-    dependencies:
-      '@react-native/normalize-color': 2.1.0
+    transitivePeerDependencies:
+      - react-dom
+      - react-native
 
   '@tamagui/normalize-css-color@1.116.12':
     dependencies:
       '@react-native/normalize-color': 2.1.0
 
-  '@tamagui/polyfill-dev@1.112.12': {}
-
-  '@tamagui/popover@1.112.12(@types/react@18.2.55)(react-dom@18.2.0(react@18.2.0))(react-native@0.74.5(@babel/core@7.25.2)(@babel/preset-env@7.26.0(@babel/core@7.25.2))(@types/react@18.2.55)(encoding@0.1.13)(react@18.2.0))(react@18.2.0)':
+  '@tamagui/normalize-css-color@1.126.12':
     dependencies:
-      '@floating-ui/react': 0.26.24(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
-      '@tamagui/adapt': 1.112.12(react@18.2.0)
-      '@tamagui/animate': 1.112.12(react@18.2.0)
-      '@tamagui/aria-hidden': 1.112.12(react@18.2.0)
-      '@tamagui/compose-refs': 1.112.12(react@18.2.0)
-      '@tamagui/constants': 1.112.12(react@18.2.0)
-      '@tamagui/core': 1.112.12(react@18.2.0)
-      '@tamagui/dismissable': 1.112.12(react@18.2.0)
-      '@tamagui/floating': 1.112.12(react-dom@18.2.0(react@18.2.0))(react-native@0.74.5(@babel/core@7.25.2)(@babel/preset-env@7.26.0(@babel/core@7.25.2))(@types/react@18.2.55)(encoding@0.1.13)(react@18.2.0))(react@18.2.0)
-      '@tamagui/focus-scope': 1.112.12(react@18.2.0)
-      '@tamagui/helpers': 1.112.12(react@18.2.0)
-      '@tamagui/polyfill-dev': 1.112.12
-      '@tamagui/popper': 1.112.12(react-dom@18.2.0(react@18.2.0))(react-native@0.74.5(@babel/core@7.25.2)(@babel/preset-env@7.26.0(@babel/core@7.25.2))(@types/react@18.2.55)(encoding@0.1.13)(react@18.2.0))(react@18.2.0)
-      '@tamagui/portal': 1.112.12(react@18.2.0)
-      '@tamagui/remove-scroll': 1.112.12(@types/react@18.2.55)(react@18.2.0)
-      '@tamagui/scroll-view': 1.112.12(react@18.2.0)
-      '@tamagui/sheet': 1.112.12(@types/react@18.2.55)(react@18.2.0)
-      '@tamagui/stacks': 1.112.12(react@18.2.0)
-      '@tamagui/use-controllable-state': 1.112.12(react@18.2.0)
+      '@react-native/normalize-color': 2.1.0
+
+  '@tamagui/polyfill-dev@1.126.12': {}
+
+  '@tamagui/popover@1.126.12(@types/react@18.2.55)(react-dom@18.2.0(react@18.2.0))(react-native@0.74.5(@babel/core@7.25.2)(@babel/preset-env@7.26.0(@babel/core@7.25.2))(@types/react@18.2.55)(encoding@0.1.13)(react@18.2.0))(react@18.2.0)':
+    dependencies:
+      '@floating-ui/react': 0.27.8(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
+      '@tamagui/adapt': 1.126.12(react-dom@18.2.0(react@18.2.0))(react-native@0.74.5(@babel/core@7.25.2)(@babel/preset-env@7.26.0(@babel/core@7.25.2))(@types/react@18.2.55)(encoding@0.1.13)(react@18.2.0))(react@18.2.0)
+      '@tamagui/animate': 1.126.12(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
+      '@tamagui/aria-hidden': 1.126.12(react@18.2.0)
+      '@tamagui/compose-refs': 1.126.12(react@18.2.0)
+      '@tamagui/constants': 1.126.12(react@18.2.0)
+      '@tamagui/core': 1.126.12(react-dom@18.2.0(react@18.2.0))(react-native@0.74.5(@babel/core@7.25.2)(@babel/preset-env@7.26.0(@babel/core@7.25.2))(@types/react@18.2.55)(encoding@0.1.13)(react@18.2.0))(react@18.2.0)
+      '@tamagui/dismissable': 1.126.12(react-dom@18.2.0(react@18.2.0))(react-native@0.74.5(@babel/core@7.25.2)(@babel/preset-env@7.26.0(@babel/core@7.25.2))(@types/react@18.2.55)(encoding@0.1.13)(react@18.2.0))(react@18.2.0)
+      '@tamagui/floating': 1.126.12(react-dom@18.2.0(react@18.2.0))(react-native@0.74.5(@babel/core@7.25.2)(@babel/preset-env@7.26.0(@babel/core@7.25.2))(@types/react@18.2.55)(encoding@0.1.13)(react@18.2.0))(react@18.2.0)
+      '@tamagui/focus-scope': 1.126.12(react@18.2.0)
+      '@tamagui/helpers': 1.126.12(react@18.2.0)
+      '@tamagui/polyfill-dev': 1.126.12
+      '@tamagui/popper': 1.126.12(react-dom@18.2.0(react@18.2.0))(react-native@0.74.5(@babel/core@7.25.2)(@babel/preset-env@7.26.0(@babel/core@7.25.2))(@types/react@18.2.55)(encoding@0.1.13)(react@18.2.0))(react@18.2.0)
+      '@tamagui/portal': 1.126.12(react-dom@18.2.0(react@18.2.0))(react-native@0.74.5(@babel/core@7.25.2)(@babel/preset-env@7.26.0(@babel/core@7.25.2))(@types/react@18.2.55)(encoding@0.1.13)(react@18.2.0))(react@18.2.0)
+      '@tamagui/remove-scroll': 1.126.12(@types/react@18.2.55)(react@18.2.0)
+      '@tamagui/scroll-view': 1.126.12(react-dom@18.2.0(react@18.2.0))(react-native@0.74.5(@babel/core@7.25.2)(@babel/preset-env@7.26.0(@babel/core@7.25.2))(@types/react@18.2.55)(encoding@0.1.13)(react@18.2.0))(react@18.2.0)
+      '@tamagui/sheet': 1.126.12(@types/react@18.2.55)(react-dom@18.2.0(react@18.2.0))(react-native@0.74.5(@babel/core@7.25.2)(@babel/preset-env@7.26.0(@babel/core@7.25.2))(@types/react@18.2.55)(encoding@0.1.13)(react@18.2.0))(react@18.2.0)
+      '@tamagui/stacks': 1.126.12(react-dom@18.2.0(react@18.2.0))(react-native@0.74.5(@babel/core@7.25.2)(@babel/preset-env@7.26.0(@babel/core@7.25.2))(@types/react@18.2.55)(encoding@0.1.13)(react@18.2.0))(react@18.2.0)
+      '@tamagui/use-controllable-state': 1.126.12(react@18.2.0)
       react: 18.2.0
       react-freeze: 1.0.3(react@18.2.0)
     transitivePeerDependencies:
@@ -19577,403 +19432,455 @@ snapshots:
       - react-dom
       - react-native
 
-  '@tamagui/popper@1.112.12(react-dom@18.2.0(react@18.2.0))(react-native@0.74.5(@babel/core@7.25.2)(@babel/preset-env@7.26.0(@babel/core@7.25.2))(@types/react@18.2.55)(encoding@0.1.13)(react@18.2.0))(react@18.2.0)':
+  '@tamagui/popper@1.126.12(react-dom@18.2.0(react@18.2.0))(react-native@0.74.5(@babel/core@7.25.2)(@babel/preset-env@7.26.0(@babel/core@7.25.2))(@types/react@18.2.55)(encoding@0.1.13)(react@18.2.0))(react@18.2.0)':
     dependencies:
-      '@tamagui/compose-refs': 1.112.12(react@18.2.0)
-      '@tamagui/constants': 1.112.12(react@18.2.0)
-      '@tamagui/core': 1.112.12(react@18.2.0)
-      '@tamagui/floating': 1.112.12(react-dom@18.2.0(react@18.2.0))(react-native@0.74.5(@babel/core@7.25.2)(@babel/preset-env@7.26.0(@babel/core@7.25.2))(@types/react@18.2.55)(encoding@0.1.13)(react@18.2.0))(react@18.2.0)
-      '@tamagui/get-token': 1.112.12(react@18.2.0)
-      '@tamagui/stacks': 1.112.12(react@18.2.0)
-      '@tamagui/start-transition': 1.112.12
-      '@tamagui/use-controllable-state': 1.112.12(react@18.2.0)
+      '@tamagui/compose-refs': 1.126.12(react@18.2.0)
+      '@tamagui/constants': 1.126.12(react@18.2.0)
+      '@tamagui/core': 1.126.12(react-dom@18.2.0(react@18.2.0))(react-native@0.74.5(@babel/core@7.25.2)(@babel/preset-env@7.26.0(@babel/core@7.25.2))(@types/react@18.2.55)(encoding@0.1.13)(react@18.2.0))(react@18.2.0)
+      '@tamagui/floating': 1.126.12(react-dom@18.2.0(react@18.2.0))(react-native@0.74.5(@babel/core@7.25.2)(@babel/preset-env@7.26.0(@babel/core@7.25.2))(@types/react@18.2.55)(encoding@0.1.13)(react@18.2.0))(react@18.2.0)
+      '@tamagui/get-token': 1.126.12(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
+      '@tamagui/stacks': 1.126.12(react-dom@18.2.0(react@18.2.0))(react-native@0.74.5(@babel/core@7.25.2)(@babel/preset-env@7.26.0(@babel/core@7.25.2))(@types/react@18.2.55)(encoding@0.1.13)(react@18.2.0))(react@18.2.0)
+      '@tamagui/start-transition': 1.126.12
+      '@tamagui/use-controllable-state': 1.126.12(react@18.2.0)
       react: 18.2.0
     transitivePeerDependencies:
       - react-dom
       - react-native
 
-  '@tamagui/portal@1.112.12(react@18.2.0)':
+  '@tamagui/portal@1.126.12(react-dom@18.2.0(react@18.2.0))(react-native@0.74.5(@babel/core@7.25.2)(@babel/preset-env@7.26.0(@babel/core@7.25.2))(@types/react@18.2.55)(encoding@0.1.13)(react@18.2.0))(react@18.2.0)':
     dependencies:
-      '@tamagui/constants': 1.112.12(react@18.2.0)
-      '@tamagui/core': 1.112.12(react@18.2.0)
-      '@tamagui/stacks': 1.112.12(react@18.2.0)
-      '@tamagui/start-transition': 1.112.12
-      '@tamagui/use-did-finish-ssr': 1.112.12(react@18.2.0)
-      '@tamagui/use-event': 1.112.12(react@18.2.0)
-      react: 18.2.0
-
-  '@tamagui/progress@1.112.12(react@18.2.0)':
-    dependencies:
-      '@tamagui/compose-refs': 1.112.12(react@18.2.0)
-      '@tamagui/core': 1.112.12(react@18.2.0)
-      '@tamagui/create-context': 1.112.12(react@18.2.0)
-      '@tamagui/get-token': 1.112.12(react@18.2.0)
-      '@tamagui/helpers': 1.112.12(react@18.2.0)
-      '@tamagui/stacks': 1.112.12(react@18.2.0)
-      react: 18.2.0
-
-  '@tamagui/proxy-worm@1.112.12': {}
-
-  '@tamagui/radio-group@1.112.12(react-native@0.74.5(@babel/core@7.25.2)(@babel/preset-env@7.26.0(@babel/core@7.25.2))(@types/react@18.2.55)(encoding@0.1.13)(react@18.2.0))(react@18.2.0)':
-    dependencies:
-      '@tamagui/compose-refs': 1.112.12(react@18.2.0)
-      '@tamagui/constants': 1.112.12(react@18.2.0)
-      '@tamagui/core': 1.112.12(react@18.2.0)
-      '@tamagui/create-context': 1.112.12(react@18.2.0)
-      '@tamagui/focusable': 1.112.12(react@18.2.0)
-      '@tamagui/get-token': 1.112.12(react@18.2.0)
-      '@tamagui/helpers': 1.112.12(react@18.2.0)
-      '@tamagui/label': 1.112.12(react-native@0.74.5(@babel/core@7.25.2)(@babel/preset-env@7.26.0(@babel/core@7.25.2))(@types/react@18.2.55)(encoding@0.1.13)(react@18.2.0))(react@18.2.0)
-      '@tamagui/radio-headless': 1.112.12(react-native@0.74.5(@babel/core@7.25.2)(@babel/preset-env@7.26.0(@babel/core@7.25.2))(@types/react@18.2.55)(encoding@0.1.13)(react@18.2.0))(react@18.2.0)
-      '@tamagui/roving-focus': 1.112.12(react@18.2.0)
-      '@tamagui/stacks': 1.112.12(react@18.2.0)
-      '@tamagui/use-controllable-state': 1.112.12(react@18.2.0)
-      '@tamagui/use-previous': 1.112.12
-      react: 18.2.0
-    transitivePeerDependencies:
-      - react-native
-
-  '@tamagui/radio-headless@1.112.12(react-native@0.74.5(@babel/core@7.25.2)(@babel/preset-env@7.26.0(@babel/core@7.25.2))(@types/react@18.2.55)(encoding@0.1.13)(react@18.2.0))(react@18.2.0)':
-    dependencies:
-      '@tamagui/compose-refs': 1.112.12(react@18.2.0)
-      '@tamagui/constants': 1.112.12(react@18.2.0)
-      '@tamagui/create-context': 1.112.12(react@18.2.0)
-      '@tamagui/focusable': 1.112.12(react@18.2.0)
-      '@tamagui/helpers': 1.112.12(react@18.2.0)
-      '@tamagui/label': 1.112.12(react-native@0.74.5(@babel/core@7.25.2)(@babel/preset-env@7.26.0(@babel/core@7.25.2))(@types/react@18.2.55)(encoding@0.1.13)(react@18.2.0))(react@18.2.0)
-      '@tamagui/use-controllable-state': 1.112.12(react@18.2.0)
-      '@tamagui/use-previous': 1.112.12
-      react: 18.2.0
-    transitivePeerDependencies:
-      - react-native
-
-  '@tamagui/react-native-media-driver@1.112.12(react-native@0.74.5(@babel/core@7.25.2)(@babel/preset-env@7.26.0(@babel/core@7.25.2))(@types/react@18.2.55)(encoding@0.1.13)(react@18.2.0))(react@18.2.0)':
-    dependencies:
-      '@tamagui/web': 1.112.12(react@18.2.0)
-      react-native: 0.74.5(@babel/core@7.25.2)(@babel/preset-env@7.26.0(@babel/core@7.25.2))(@types/react@18.2.55)(encoding@0.1.13)(react@18.2.0)
+      '@tamagui/constants': 1.126.12(react@18.2.0)
+      '@tamagui/core': 1.126.12(react-dom@18.2.0(react@18.2.0))(react-native@0.74.5(@babel/core@7.25.2)(@babel/preset-env@7.26.0(@babel/core@7.25.2))(@types/react@18.2.55)(encoding@0.1.13)(react@18.2.0))(react@18.2.0)
+      '@tamagui/stacks': 1.126.12(react-dom@18.2.0(react@18.2.0))(react-native@0.74.5(@babel/core@7.25.2)(@babel/preset-env@7.26.0(@babel/core@7.25.2))(@types/react@18.2.55)(encoding@0.1.13)(react@18.2.0))(react@18.2.0)
+      '@tamagui/start-transition': 1.126.12
+      '@tamagui/use-did-finish-ssr': 1.126.12(react@18.2.0)
+      '@tamagui/use-event': 1.126.12(react@18.2.0)
+      '@tamagui/z-index-stack': 1.126.12
     transitivePeerDependencies:
       - react
+      - react-dom
+      - react-native
+
+  '@tamagui/progress@1.126.12(react-dom@18.2.0(react@18.2.0))(react-native@0.74.5(@babel/core@7.25.2)(@babel/preset-env@7.26.0(@babel/core@7.25.2))(@types/react@18.2.55)(encoding@0.1.13)(react@18.2.0))(react@18.2.0)':
+    dependencies:
+      '@tamagui/compose-refs': 1.126.12(react@18.2.0)
+      '@tamagui/core': 1.126.12(react-dom@18.2.0(react@18.2.0))(react-native@0.74.5(@babel/core@7.25.2)(@babel/preset-env@7.26.0(@babel/core@7.25.2))(@types/react@18.2.55)(encoding@0.1.13)(react@18.2.0))(react@18.2.0)
+      '@tamagui/create-context': 1.126.12(react@18.2.0)
+      '@tamagui/get-token': 1.126.12(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
+      '@tamagui/helpers': 1.126.12(react@18.2.0)
+      '@tamagui/stacks': 1.126.12(react-dom@18.2.0(react@18.2.0))(react-native@0.74.5(@babel/core@7.25.2)(@babel/preset-env@7.26.0(@babel/core@7.25.2))(@types/react@18.2.55)(encoding@0.1.13)(react@18.2.0))(react@18.2.0)
+      react: 18.2.0
+    transitivePeerDependencies:
+      - react-dom
+      - react-native
+
+  '@tamagui/proxy-worm@1.126.12': {}
+
+  '@tamagui/radio-group@1.126.12(react-dom@18.2.0(react@18.2.0))(react-native@0.74.5(@babel/core@7.25.2)(@babel/preset-env@7.26.0(@babel/core@7.25.2))(@types/react@18.2.55)(encoding@0.1.13)(react@18.2.0))(react@18.2.0)':
+    dependencies:
+      '@tamagui/compose-refs': 1.126.12(react@18.2.0)
+      '@tamagui/constants': 1.126.12(react@18.2.0)
+      '@tamagui/core': 1.126.12(react-dom@18.2.0(react@18.2.0))(react-native@0.74.5(@babel/core@7.25.2)(@babel/preset-env@7.26.0(@babel/core@7.25.2))(@types/react@18.2.55)(encoding@0.1.13)(react@18.2.0))(react@18.2.0)
+      '@tamagui/create-context': 1.126.12(react@18.2.0)
+      '@tamagui/focusable': 1.126.12(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
+      '@tamagui/get-token': 1.126.12(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
+      '@tamagui/helpers': 1.126.12(react@18.2.0)
+      '@tamagui/label': 1.126.12(react-dom@18.2.0(react@18.2.0))(react-native@0.74.5(@babel/core@7.25.2)(@babel/preset-env@7.26.0(@babel/core@7.25.2))(@types/react@18.2.55)(encoding@0.1.13)(react@18.2.0))(react@18.2.0)
+      '@tamagui/radio-headless': 1.126.12(react-dom@18.2.0(react@18.2.0))(react-native@0.74.5(@babel/core@7.25.2)(@babel/preset-env@7.26.0(@babel/core@7.25.2))(@types/react@18.2.55)(encoding@0.1.13)(react@18.2.0))(react@18.2.0)
+      '@tamagui/roving-focus': 1.126.12(react-dom@18.2.0(react@18.2.0))(react-native@0.74.5(@babel/core@7.25.2)(@babel/preset-env@7.26.0(@babel/core@7.25.2))(@types/react@18.2.55)(encoding@0.1.13)(react@18.2.0))(react@18.2.0)
+      '@tamagui/stacks': 1.126.12(react-dom@18.2.0(react@18.2.0))(react-native@0.74.5(@babel/core@7.25.2)(@babel/preset-env@7.26.0(@babel/core@7.25.2))(@types/react@18.2.55)(encoding@0.1.13)(react@18.2.0))(react@18.2.0)
+      '@tamagui/use-controllable-state': 1.126.12(react@18.2.0)
+      '@tamagui/use-previous': 1.126.12
+      react: 18.2.0
+    transitivePeerDependencies:
+      - react-dom
+      - react-native
+
+  '@tamagui/radio-headless@1.126.12(react-dom@18.2.0(react@18.2.0))(react-native@0.74.5(@babel/core@7.25.2)(@babel/preset-env@7.26.0(@babel/core@7.25.2))(@types/react@18.2.55)(encoding@0.1.13)(react@18.2.0))(react@18.2.0)':
+    dependencies:
+      '@tamagui/compose-refs': 1.126.12(react@18.2.0)
+      '@tamagui/constants': 1.126.12(react@18.2.0)
+      '@tamagui/create-context': 1.126.12(react@18.2.0)
+      '@tamagui/focusable': 1.126.12(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
+      '@tamagui/helpers': 1.126.12(react@18.2.0)
+      '@tamagui/label': 1.126.12(react-dom@18.2.0(react@18.2.0))(react-native@0.74.5(@babel/core@7.25.2)(@babel/preset-env@7.26.0(@babel/core@7.25.2))(@types/react@18.2.55)(encoding@0.1.13)(react@18.2.0))(react@18.2.0)
+      '@tamagui/use-controllable-state': 1.126.12(react@18.2.0)
+      '@tamagui/use-previous': 1.126.12
+      react: 18.2.0
+    transitivePeerDependencies:
+      - react-dom
+      - react-native
 
   '@tamagui/react-native-media-driver@1.116.12(react-native@0.74.5(@babel/core@7.25.2)(@babel/preset-env@7.26.0(@babel/core@7.25.2))(@types/react@18.2.55)(encoding@0.1.13)(react@18.2.0))':
     dependencies:
       '@tamagui/web': 1.116.12
       react-native: 0.74.5(@babel/core@7.25.2)(@babel/preset-env@7.26.0(@babel/core@7.25.2))(@types/react@18.2.55)(encoding@0.1.13)(react@18.2.0)
 
-  '@tamagui/react-native-svg@1.112.12': {}
+  '@tamagui/react-native-media-driver@1.126.12(react-dom@18.2.0(react@18.2.0))(react-native@0.74.5(@babel/core@7.25.2)(@babel/preset-env@7.26.0(@babel/core@7.25.2))(@types/react@18.2.55)(encoding@0.1.13)(react@18.2.0))(react@18.2.0)':
+    dependencies:
+      '@tamagui/web': 1.126.12(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
+      react-native: 0.74.5(@babel/core@7.25.2)(@babel/preset-env@7.26.0(@babel/core@7.25.2))(@types/react@18.2.55)(encoding@0.1.13)(react@18.2.0)
+    transitivePeerDependencies:
+      - react
+      - react-dom
 
-  '@tamagui/react-native-use-pressable@1.112.12(react@18.2.0)':
+  '@tamagui/react-native-svg@1.126.12': {}
+
+  '@tamagui/react-native-use-pressable@1.126.12(react@18.2.0)':
     dependencies:
       react: 18.2.0
 
-  '@tamagui/react-native-use-responder-events@1.112.12(react@18.2.0)':
+  '@tamagui/react-native-use-responder-events@1.126.12(react@18.2.0)':
     dependencies:
       react: 18.2.0
 
-  '@tamagui/react-native-web-internals@1.112.12':
+  '@tamagui/react-native-web-internals@1.126.12(react-dom@18.2.0(react@18.2.0))':
     dependencies:
-      '@tamagui/normalize-css-color': 1.112.12
-      '@tamagui/react-native-use-pressable': 1.112.12(react@18.2.0)
-      '@tamagui/react-native-use-responder-events': 1.112.12(react@18.2.0)
-      '@tamagui/simple-hash': 1.112.12
+      '@tamagui/normalize-css-color': 1.126.12
+      '@tamagui/react-native-use-pressable': 1.126.12(react@18.2.0)
+      '@tamagui/react-native-use-responder-events': 1.126.12(react@18.2.0)
+      '@tamagui/simple-hash': 1.126.12
+      '@tamagui/web': 1.126.12(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
       react: 18.2.0
-      styleq: 0.1.3
+    transitivePeerDependencies:
+      - react-dom
 
-  '@tamagui/react-native-web-lite@1.112.12(react@18.2.0)':
+  '@tamagui/react-native-web-lite@1.126.12(react-dom@18.2.0(react@18.2.0))(react@18.2.0)':
     dependencies:
-      '@tamagui/normalize-css-color': 1.112.12
-      '@tamagui/react-native-use-pressable': 1.112.12(react@18.2.0)
-      '@tamagui/react-native-use-responder-events': 1.112.12(react@18.2.0)
-      '@tamagui/react-native-web-internals': 1.112.12
+      '@tamagui/normalize-css-color': 1.126.12
+      '@tamagui/react-native-use-pressable': 1.126.12(react@18.2.0)
+      '@tamagui/react-native-use-responder-events': 1.126.12(react@18.2.0)
+      '@tamagui/react-native-web-internals': 1.126.12(react-dom@18.2.0(react@18.2.0))
       invariant: 2.2.4
       react: 18.2.0
-      styleq: 0.1.3
+    transitivePeerDependencies:
+      - react-dom
 
-  '@tamagui/remove-scroll@1.112.12(@types/react@18.2.55)(react@18.2.0)':
+  '@tamagui/remove-scroll@1.126.12(@types/react@18.2.55)(react@18.2.0)':
     dependencies:
       react: 18.2.0
-      react-remove-scroll: 2.5.5(@types/react@18.2.55)(react@18.2.0)
+      react-remove-scroll: 2.6.3(@types/react@18.2.55)(react@18.2.0)
     transitivePeerDependencies:
       - '@types/react'
 
-  '@tamagui/roving-focus@1.112.12(react@18.2.0)':
+  '@tamagui/roving-focus@1.126.12(react-dom@18.2.0(react@18.2.0))(react-native@0.74.5(@babel/core@7.25.2)(@babel/preset-env@7.26.0(@babel/core@7.25.2))(@types/react@18.2.55)(encoding@0.1.13)(react@18.2.0))(react@18.2.0)':
     dependencies:
-      '@tamagui/collection': 1.112.12(react@18.2.0)
-      '@tamagui/compose-refs': 1.112.12(react@18.2.0)
-      '@tamagui/constants': 1.112.12(react@18.2.0)
-      '@tamagui/core': 1.112.12(react@18.2.0)
-      '@tamagui/create-context': 1.112.12(react@18.2.0)
-      '@tamagui/helpers': 1.112.12(react@18.2.0)
-      '@tamagui/use-controllable-state': 1.112.12(react@18.2.0)
-      '@tamagui/use-direction': 1.112.12(react@18.2.0)
-      '@tamagui/use-event': 1.112.12(react@18.2.0)
+      '@tamagui/collection': 1.126.12(react-dom@18.2.0(react@18.2.0))(react-native@0.74.5(@babel/core@7.25.2)(@babel/preset-env@7.26.0(@babel/core@7.25.2))(@types/react@18.2.55)(encoding@0.1.13)(react@18.2.0))(react@18.2.0)
+      '@tamagui/compose-refs': 1.126.12(react@18.2.0)
+      '@tamagui/constants': 1.126.12(react@18.2.0)
+      '@tamagui/core': 1.126.12(react-dom@18.2.0(react@18.2.0))(react-native@0.74.5(@babel/core@7.25.2)(@babel/preset-env@7.26.0(@babel/core@7.25.2))(@types/react@18.2.55)(encoding@0.1.13)(react@18.2.0))(react@18.2.0)
+      '@tamagui/create-context': 1.126.12(react@18.2.0)
+      '@tamagui/helpers': 1.126.12(react@18.2.0)
+      '@tamagui/use-controllable-state': 1.126.12(react@18.2.0)
+      '@tamagui/use-direction': 1.126.12(react@18.2.0)
+      '@tamagui/use-event': 1.126.12(react@18.2.0)
       react: 18.2.0
+    transitivePeerDependencies:
+      - react-dom
+      - react-native
 
-  '@tamagui/scroll-view@1.112.12(react@18.2.0)':
+  '@tamagui/scroll-view@1.126.12(react-dom@18.2.0(react@18.2.0))(react-native@0.74.5(@babel/core@7.25.2)(@babel/preset-env@7.26.0(@babel/core@7.25.2))(@types/react@18.2.55)(encoding@0.1.13)(react@18.2.0))(react@18.2.0)':
     dependencies:
-      '@tamagui/stacks': 1.112.12(react@18.2.0)
-      '@tamagui/web': 1.112.12(react@18.2.0)
+      '@tamagui/stacks': 1.126.12(react-dom@18.2.0(react@18.2.0))(react-native@0.74.5(@babel/core@7.25.2)(@babel/preset-env@7.26.0(@babel/core@7.25.2))(@types/react@18.2.55)(encoding@0.1.13)(react@18.2.0))(react@18.2.0)
+      '@tamagui/web': 1.126.12(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
       react: 18.2.0
+    transitivePeerDependencies:
+      - react-dom
+      - react-native
 
-  '@tamagui/select@1.112.12(@types/react@18.2.55)(react-dom@18.2.0(react@18.2.0))(react-native@0.74.5(@babel/core@7.25.2)(@babel/preset-env@7.26.0(@babel/core@7.25.2))(@types/react@18.2.55)(encoding@0.1.13)(react@18.2.0))(react@18.2.0)':
+  '@tamagui/select@1.126.12(@types/react@18.2.55)(react-dom@18.2.0(react@18.2.0))(react-native@0.74.5(@babel/core@7.25.2)(@babel/preset-env@7.26.0(@babel/core@7.25.2))(@types/react@18.2.55)(encoding@0.1.13)(react@18.2.0))(react@18.2.0)':
     dependencies:
-      '@floating-ui/react': 0.26.24(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
+      '@floating-ui/react': 0.27.8(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
       '@floating-ui/react-dom': 2.1.2(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
-      '@floating-ui/react-native': 0.10.6(react-native@0.74.5(@babel/core@7.25.2)(@babel/preset-env@7.26.0(@babel/core@7.25.2))(@types/react@18.2.55)(encoding@0.1.13)(react@18.2.0))(react@18.2.0)
-      '@tamagui/adapt': 1.112.12(react@18.2.0)
-      '@tamagui/animate-presence': 1.112.12(react@18.2.0)
-      '@tamagui/compose-refs': 1.112.12(react@18.2.0)
-      '@tamagui/constants': 1.112.12(react@18.2.0)
-      '@tamagui/core': 1.112.12(react@18.2.0)
-      '@tamagui/create-context': 1.112.12(react@18.2.0)
-      '@tamagui/dismissable': 1.112.12(react@18.2.0)
-      '@tamagui/focus-scope': 1.112.12(react@18.2.0)
-      '@tamagui/get-token': 1.112.12(react@18.2.0)
-      '@tamagui/helpers': 1.112.12(react@18.2.0)
-      '@tamagui/list-item': 1.112.12(react@18.2.0)
-      '@tamagui/portal': 1.112.12(react@18.2.0)
-      '@tamagui/remove-scroll': 1.112.12(@types/react@18.2.55)(react@18.2.0)
-      '@tamagui/separator': 1.112.12(react@18.2.0)
-      '@tamagui/sheet': 1.112.12(@types/react@18.2.55)(react@18.2.0)
-      '@tamagui/stacks': 1.112.12(react@18.2.0)
-      '@tamagui/text': 1.112.12(react@18.2.0)
-      '@tamagui/use-controllable-state': 1.112.12(react@18.2.0)
-      '@tamagui/use-debounce': 1.112.12(react@18.2.0)
-      '@tamagui/use-event': 1.112.12(react@18.2.0)
-      '@tamagui/use-previous': 1.112.12
+      '@floating-ui/react-native': 0.10.7(react-native@0.74.5(@babel/core@7.25.2)(@babel/preset-env@7.26.0(@babel/core@7.25.2))(@types/react@18.2.55)(encoding@0.1.13)(react@18.2.0))(react@18.2.0)
+      '@tamagui/adapt': 1.126.12(react-dom@18.2.0(react@18.2.0))(react-native@0.74.5(@babel/core@7.25.2)(@babel/preset-env@7.26.0(@babel/core@7.25.2))(@types/react@18.2.55)(encoding@0.1.13)(react@18.2.0))(react@18.2.0)
+      '@tamagui/animate-presence': 1.126.12(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
+      '@tamagui/compose-refs': 1.126.12(react@18.2.0)
+      '@tamagui/constants': 1.126.12(react@18.2.0)
+      '@tamagui/core': 1.126.12(react-dom@18.2.0(react@18.2.0))(react-native@0.74.5(@babel/core@7.25.2)(@babel/preset-env@7.26.0(@babel/core@7.25.2))(@types/react@18.2.55)(encoding@0.1.13)(react@18.2.0))(react@18.2.0)
+      '@tamagui/create-context': 1.126.12(react@18.2.0)
+      '@tamagui/dismissable': 1.126.12(react-dom@18.2.0(react@18.2.0))(react-native@0.74.5(@babel/core@7.25.2)(@babel/preset-env@7.26.0(@babel/core@7.25.2))(@types/react@18.2.55)(encoding@0.1.13)(react@18.2.0))(react@18.2.0)
+      '@tamagui/focus-scope': 1.126.12(react@18.2.0)
+      '@tamagui/get-token': 1.126.12(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
+      '@tamagui/helpers': 1.126.12(react@18.2.0)
+      '@tamagui/list-item': 1.126.12(react-dom@18.2.0(react@18.2.0))(react-native@0.74.5(@babel/core@7.25.2)(@babel/preset-env@7.26.0(@babel/core@7.25.2))(@types/react@18.2.55)(encoding@0.1.13)(react@18.2.0))(react@18.2.0)
+      '@tamagui/portal': 1.126.12(react-dom@18.2.0(react@18.2.0))(react-native@0.74.5(@babel/core@7.25.2)(@babel/preset-env@7.26.0(@babel/core@7.25.2))(@types/react@18.2.55)(encoding@0.1.13)(react@18.2.0))(react@18.2.0)
+      '@tamagui/remove-scroll': 1.126.12(@types/react@18.2.55)(react@18.2.0)
+      '@tamagui/separator': 1.126.12(react-dom@18.2.0(react@18.2.0))(react-native@0.74.5(@babel/core@7.25.2)(@babel/preset-env@7.26.0(@babel/core@7.25.2))(@types/react@18.2.55)(encoding@0.1.13)(react@18.2.0))(react@18.2.0)
+      '@tamagui/sheet': 1.126.12(@types/react@18.2.55)(react-dom@18.2.0(react@18.2.0))(react-native@0.74.5(@babel/core@7.25.2)(@babel/preset-env@7.26.0(@babel/core@7.25.2))(@types/react@18.2.55)(encoding@0.1.13)(react@18.2.0))(react@18.2.0)
+      '@tamagui/stacks': 1.126.12(react-dom@18.2.0(react@18.2.0))(react-native@0.74.5(@babel/core@7.25.2)(@babel/preset-env@7.26.0(@babel/core@7.25.2))(@types/react@18.2.55)(encoding@0.1.13)(react@18.2.0))(react@18.2.0)
+      '@tamagui/text': 1.126.12(react-dom@18.2.0(react@18.2.0))(react-native@0.74.5(@babel/core@7.25.2)(@babel/preset-env@7.26.0(@babel/core@7.25.2))(@types/react@18.2.55)(encoding@0.1.13)(react@18.2.0))(react@18.2.0)
+      '@tamagui/use-controllable-state': 1.126.12(react@18.2.0)
+      '@tamagui/use-debounce': 1.126.12(react@18.2.0)
+      '@tamagui/use-event': 1.126.12(react@18.2.0)
+      '@tamagui/use-previous': 1.126.12
       react: 18.2.0
     transitivePeerDependencies:
       - '@types/react'
       - react-dom
       - react-native
 
-  '@tamagui/separator@1.112.12(react@18.2.0)':
+  '@tamagui/separator@1.126.12(react-dom@18.2.0(react@18.2.0))(react-native@0.74.5(@babel/core@7.25.2)(@babel/preset-env@7.26.0(@babel/core@7.25.2))(@types/react@18.2.55)(encoding@0.1.13)(react@18.2.0))(react@18.2.0)':
     dependencies:
-      '@tamagui/constants': 1.112.12(react@18.2.0)
-      '@tamagui/core': 1.112.12(react@18.2.0)
+      '@tamagui/constants': 1.126.12(react@18.2.0)
+      '@tamagui/core': 1.126.12(react-dom@18.2.0(react@18.2.0))(react-native@0.74.5(@babel/core@7.25.2)(@babel/preset-env@7.26.0(@babel/core@7.25.2))(@types/react@18.2.55)(encoding@0.1.13)(react@18.2.0))(react@18.2.0)
       react: 18.2.0
+    transitivePeerDependencies:
+      - react-dom
+      - react-native
 
-  '@tamagui/shapes@1.112.12(react@18.2.0)':
+  '@tamagui/shapes@1.126.12(react-dom@18.2.0(react@18.2.0))(react-native@0.74.5(@babel/core@7.25.2)(@babel/preset-env@7.26.0(@babel/core@7.25.2))(@types/react@18.2.55)(encoding@0.1.13)(react@18.2.0))(react@18.2.0)':
     dependencies:
-      '@tamagui/stacks': 1.112.12(react@18.2.0)
-      '@tamagui/web': 1.112.12(react@18.2.0)
+      '@tamagui/stacks': 1.126.12(react-dom@18.2.0(react@18.2.0))(react-native@0.74.5(@babel/core@7.25.2)(@babel/preset-env@7.26.0(@babel/core@7.25.2))(@types/react@18.2.55)(encoding@0.1.13)(react@18.2.0))(react@18.2.0)
+      '@tamagui/web': 1.126.12(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
       react: 18.2.0
+    transitivePeerDependencies:
+      - react-dom
+      - react-native
 
-  '@tamagui/sheet@1.112.12(@types/react@18.2.55)(react@18.2.0)':
+  '@tamagui/sheet@1.126.12(@types/react@18.2.55)(react-dom@18.2.0(react@18.2.0))(react-native@0.74.5(@babel/core@7.25.2)(@babel/preset-env@7.26.0(@babel/core@7.25.2))(@types/react@18.2.55)(encoding@0.1.13)(react@18.2.0))(react@18.2.0)':
     dependencies:
-      '@tamagui/animate-presence': 1.112.12(react@18.2.0)
-      '@tamagui/animations-react-native': 1.112.12(react@18.2.0)
-      '@tamagui/compose-refs': 1.112.12(react@18.2.0)
-      '@tamagui/constants': 1.112.12(react@18.2.0)
-      '@tamagui/core': 1.112.12(react@18.2.0)
-      '@tamagui/create-context': 1.112.12(react@18.2.0)
-      '@tamagui/helpers': 1.112.12(react@18.2.0)
-      '@tamagui/portal': 1.112.12(react@18.2.0)
-      '@tamagui/remove-scroll': 1.112.12(@types/react@18.2.55)(react@18.2.0)
-      '@tamagui/scroll-view': 1.112.12(react@18.2.0)
-      '@tamagui/stacks': 1.112.12(react@18.2.0)
-      '@tamagui/use-constant': 1.112.12(react@18.2.0)
-      '@tamagui/use-controllable-state': 1.112.12(react@18.2.0)
-      '@tamagui/use-keyboard-visible': 1.112.12(react@18.2.0)
+      '@tamagui/adapt': 1.126.12(react-dom@18.2.0(react@18.2.0))(react-native@0.74.5(@babel/core@7.25.2)(@babel/preset-env@7.26.0(@babel/core@7.25.2))(@types/react@18.2.55)(encoding@0.1.13)(react@18.2.0))(react@18.2.0)
+      '@tamagui/animate-presence': 1.126.12(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
+      '@tamagui/animations-react-native': 1.126.12(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
+      '@tamagui/compose-refs': 1.126.12(react@18.2.0)
+      '@tamagui/constants': 1.126.12(react@18.2.0)
+      '@tamagui/core': 1.126.12(react-dom@18.2.0(react@18.2.0))(react-native@0.74.5(@babel/core@7.25.2)(@babel/preset-env@7.26.0(@babel/core@7.25.2))(@types/react@18.2.55)(encoding@0.1.13)(react@18.2.0))(react@18.2.0)
+      '@tamagui/create-context': 1.126.12(react@18.2.0)
+      '@tamagui/helpers': 1.126.12(react@18.2.0)
+      '@tamagui/portal': 1.126.12(react-dom@18.2.0(react@18.2.0))(react-native@0.74.5(@babel/core@7.25.2)(@babel/preset-env@7.26.0(@babel/core@7.25.2))(@types/react@18.2.55)(encoding@0.1.13)(react@18.2.0))(react@18.2.0)
+      '@tamagui/remove-scroll': 1.126.12(@types/react@18.2.55)(react@18.2.0)
+      '@tamagui/scroll-view': 1.126.12(react-dom@18.2.0(react@18.2.0))(react-native@0.74.5(@babel/core@7.25.2)(@babel/preset-env@7.26.0(@babel/core@7.25.2))(@types/react@18.2.55)(encoding@0.1.13)(react@18.2.0))(react@18.2.0)
+      '@tamagui/stacks': 1.126.12(react-dom@18.2.0(react@18.2.0))(react-native@0.74.5(@babel/core@7.25.2)(@babel/preset-env@7.26.0(@babel/core@7.25.2))(@types/react@18.2.55)(encoding@0.1.13)(react@18.2.0))(react@18.2.0)
+      '@tamagui/use-constant': 1.126.12(react@18.2.0)
+      '@tamagui/use-controllable-state': 1.126.12(react@18.2.0)
+      '@tamagui/use-did-finish-ssr': 1.126.12(react@18.2.0)
+      '@tamagui/use-keyboard-visible': 1.126.12(react@18.2.0)
+      '@tamagui/z-index-stack': 1.126.12
       react: 18.2.0
     transitivePeerDependencies:
       - '@types/react'
+      - react-dom
+      - react-native
 
-  '@tamagui/shorthands@1.112.12': {}
-
-  '@tamagui/simple-hash@1.112.12': {}
+  '@tamagui/shorthands@1.126.12(react-dom@18.2.0(react@18.2.0))(react@18.2.0)':
+    dependencies:
+      '@tamagui/web': 1.126.12(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
+    transitivePeerDependencies:
+      - react
+      - react-dom
 
   '@tamagui/simple-hash@1.116.12': {}
 
-  '@tamagui/slider@1.112.12(react@18.2.0)':
-    dependencies:
-      '@tamagui/compose-refs': 1.112.12(react@18.2.0)
-      '@tamagui/constants': 1.112.12(react@18.2.0)
-      '@tamagui/core': 1.112.12(react@18.2.0)
-      '@tamagui/create-context': 1.112.12(react@18.2.0)
-      '@tamagui/get-token': 1.112.12(react@18.2.0)
-      '@tamagui/helpers': 1.112.12(react@18.2.0)
-      '@tamagui/stacks': 1.112.12(react@18.2.0)
-      '@tamagui/use-controllable-state': 1.112.12(react@18.2.0)
-      '@tamagui/use-debounce': 1.112.12(react@18.2.0)
-      '@tamagui/use-direction': 1.112.12(react@18.2.0)
-      react: 18.2.0
+  '@tamagui/simple-hash@1.126.12': {}
 
-  '@tamagui/stacks@1.112.12(react@18.2.0)':
+  '@tamagui/slider@1.126.12(react-dom@18.2.0(react@18.2.0))(react-native@0.74.5(@babel/core@7.25.2)(@babel/preset-env@7.26.0(@babel/core@7.25.2))(@types/react@18.2.55)(encoding@0.1.13)(react@18.2.0))(react@18.2.0)':
     dependencies:
-      '@tamagui/core': 1.112.12(react@18.2.0)
+      '@tamagui/compose-refs': 1.126.12(react@18.2.0)
+      '@tamagui/constants': 1.126.12(react@18.2.0)
+      '@tamagui/core': 1.126.12(react-dom@18.2.0(react@18.2.0))(react-native@0.74.5(@babel/core@7.25.2)(@babel/preset-env@7.26.0(@babel/core@7.25.2))(@types/react@18.2.55)(encoding@0.1.13)(react@18.2.0))(react@18.2.0)
+      '@tamagui/create-context': 1.126.12(react@18.2.0)
+      '@tamagui/get-token': 1.126.12(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
+      '@tamagui/helpers': 1.126.12(react@18.2.0)
+      '@tamagui/stacks': 1.126.12(react-dom@18.2.0(react@18.2.0))(react-native@0.74.5(@babel/core@7.25.2)(@babel/preset-env@7.26.0(@babel/core@7.25.2))(@types/react@18.2.55)(encoding@0.1.13)(react@18.2.0))(react@18.2.0)
+      '@tamagui/use-controllable-state': 1.126.12(react@18.2.0)
+      '@tamagui/use-debounce': 1.126.12(react@18.2.0)
+      '@tamagui/use-direction': 1.126.12(react@18.2.0)
       react: 18.2.0
+    transitivePeerDependencies:
+      - react-dom
+      - react-native
 
-  '@tamagui/start-transition@1.112.12':
+  '@tamagui/stacks@1.126.12(react-dom@18.2.0(react@18.2.0))(react-native@0.74.5(@babel/core@7.25.2)(@babel/preset-env@7.26.0(@babel/core@7.25.2))(@types/react@18.2.55)(encoding@0.1.13)(react@18.2.0))(react@18.2.0)':
     dependencies:
+      '@tamagui/core': 1.126.12(react-dom@18.2.0(react@18.2.0))(react-native@0.74.5(@babel/core@7.25.2)(@babel/preset-env@7.26.0(@babel/core@7.25.2))(@types/react@18.2.55)(encoding@0.1.13)(react@18.2.0))(react@18.2.0)
       react: 18.2.0
+    transitivePeerDependencies:
+      - react-dom
+      - react-native
 
-  '@tamagui/static@1.112.12(@swc/helpers@0.5.13)(encoding@0.1.13)(react@18.2.0)':
+  '@tamagui/start-transition@1.126.12': {}
+
+  '@tamagui/static@1.126.12(@swc/helpers@0.5.13)(encoding@0.1.13)(react-dom@18.2.0(react@18.2.0))(react-native@0.74.5(@babel/core@7.25.2)(@babel/preset-env@7.26.0(@babel/core@7.25.2))(@types/react@18.2.55)(encoding@0.1.13)(react@18.2.0))(react@18.2.0)':
     dependencies:
       '@babel/core': 7.25.2
-      '@babel/generator': 7.25.6
-      '@babel/helper-plugin-utils': 7.24.8
-      '@babel/parser': 7.25.6
+      '@babel/generator': 7.26.2
+      '@babel/helper-plugin-utils': 7.25.9
+      '@babel/parser': 7.26.2
       '@babel/plugin-transform-react-jsx': 7.25.2(@babel/core@7.25.2)
       '@babel/runtime': 7.26.0
-      '@babel/traverse': 7.25.6
-      '@babel/types': 7.25.9
-      '@tamagui/build': 1.112.12(@swc/helpers@0.5.13)
-      '@tamagui/cli-color': 1.112.12
-      '@tamagui/config-default': 1.112.12(react@18.2.0)
-      '@tamagui/core': 1.112.12(react@18.2.0)
-      '@tamagui/fake-react-native': 1.112.12
-      '@tamagui/generate-themes': 1.112.12(esbuild@0.24.0)(react@18.2.0)
-      '@tamagui/helpers': 1.112.12(react@18.2.0)
-      '@tamagui/helpers-node': 1.112.12
-      '@tamagui/proxy-worm': 1.112.12
-      '@tamagui/react-native-web-internals': 1.112.12
-      '@tamagui/react-native-web-lite': 1.112.12(react@18.2.0)
-      '@tamagui/shorthands': 1.112.12
-      '@tamagui/types': 1.112.12
+      '@babel/traverse': 7.25.9
+      '@babel/types': 7.26.0
+      '@tamagui/build': 1.126.12(@swc/helpers@0.5.13)
+      '@tamagui/cli-color': 1.126.12
+      '@tamagui/config-default': 1.126.12(react-dom@18.2.0(react@18.2.0))(react-native@0.74.5(@babel/core@7.25.2)(@babel/preset-env@7.26.0(@babel/core@7.25.2))(@types/react@18.2.55)(encoding@0.1.13)(react@18.2.0))(react@18.2.0)
+      '@tamagui/core': 1.126.12(react-dom@18.2.0(react@18.2.0))(react-native@0.74.5(@babel/core@7.25.2)(@babel/preset-env@7.26.0(@babel/core@7.25.2))(@types/react@18.2.55)(encoding@0.1.13)(react@18.2.0))(react@18.2.0)
+      '@tamagui/fake-react-native': 1.126.12
+      '@tamagui/generate-themes': 1.126.12(esbuild@0.25.2)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
+      '@tamagui/helpers': 1.126.12(react@18.2.0)
+      '@tamagui/helpers-node': 1.126.12
+      '@tamagui/proxy-worm': 1.126.12
+      '@tamagui/react-native-web-internals': 1.126.12(react-dom@18.2.0(react@18.2.0))
+      '@tamagui/react-native-web-lite': 1.126.12(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
+      '@tamagui/shorthands': 1.126.12(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
+      '@tamagui/types': 1.126.12
       babel-literal-to-ast: 2.1.0(@babel/core@7.25.2)
-      browserslist: 4.23.3
+      browserslist: 4.24.2
       check-dependency-version-consistency: 4.1.0
-      esbuild: 0.24.0
-      esbuild-register: 3.6.0(esbuild@0.24.0)
+      esbuild: 0.25.2
+      esbuild-register: 3.6.0(esbuild@0.25.2)
+      fast-glob: 3.3.2
       find-cache-dir: 3.3.2
       find-root: 1.1.0
       fs-extra: 11.2.0
       invariant: 2.2.4
+      js-yaml: 4.1.0
       lodash: 4.17.21
       react: 18.2.0
-      react-dom: 18.2.0(react@18.2.0)
-      react-native-web: 0.19.12(encoding@0.1.13)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
+      react-native-web: 0.20.0(encoding@0.1.13)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
     transitivePeerDependencies:
       - '@swc/helpers'
       - encoding
+      - react-dom
+      - react-native
       - supports-color
 
-  '@tamagui/switch-headless@1.112.12(react-native@0.74.5(@babel/core@7.25.2)(@babel/preset-env@7.26.0(@babel/core@7.25.2))(@types/react@18.2.55)(encoding@0.1.13)(react@18.2.0))(react@18.2.0)':
+  '@tamagui/switch-headless@1.126.12(react-dom@18.2.0(react@18.2.0))(react-native@0.74.5(@babel/core@7.25.2)(@babel/preset-env@7.26.0(@babel/core@7.25.2))(@types/react@18.2.55)(encoding@0.1.13)(react@18.2.0))(react@18.2.0)':
     dependencies:
-      '@tamagui/compose-refs': 1.112.12(react@18.2.0)
-      '@tamagui/constants': 1.112.12(react@18.2.0)
-      '@tamagui/helpers': 1.112.12(react@18.2.0)
-      '@tamagui/label': 1.112.12(react-native@0.74.5(@babel/core@7.25.2)(@babel/preset-env@7.26.0(@babel/core@7.25.2))(@types/react@18.2.55)(encoding@0.1.13)(react@18.2.0))(react@18.2.0)
-      '@tamagui/use-previous': 1.112.12
+      '@tamagui/compose-refs': 1.126.12(react@18.2.0)
+      '@tamagui/constants': 1.126.12(react@18.2.0)
+      '@tamagui/helpers': 1.126.12(react@18.2.0)
+      '@tamagui/label': 1.126.12(react-dom@18.2.0(react@18.2.0))(react-native@0.74.5(@babel/core@7.25.2)(@babel/preset-env@7.26.0(@babel/core@7.25.2))(@types/react@18.2.55)(encoding@0.1.13)(react@18.2.0))(react@18.2.0)
+      '@tamagui/use-previous': 1.126.12
       react: 18.2.0
     transitivePeerDependencies:
+      - react-dom
       - react-native
 
-  '@tamagui/switch@1.112.12(react-native@0.74.5(@babel/core@7.25.2)(@babel/preset-env@7.26.0(@babel/core@7.25.2))(@types/react@18.2.55)(encoding@0.1.13)(react@18.2.0))(react@18.2.0)':
+  '@tamagui/switch@1.126.12(react-dom@18.2.0(react@18.2.0))(react-native@0.74.5(@babel/core@7.25.2)(@babel/preset-env@7.26.0(@babel/core@7.25.2))(@types/react@18.2.55)(encoding@0.1.13)(react@18.2.0))(react@18.2.0)':
     dependencies:
-      '@tamagui/compose-refs': 1.112.12(react@18.2.0)
-      '@tamagui/constants': 1.112.12(react@18.2.0)
-      '@tamagui/core': 1.112.12(react@18.2.0)
-      '@tamagui/focusable': 1.112.12(react@18.2.0)
-      '@tamagui/get-token': 1.112.12(react@18.2.0)
-      '@tamagui/helpers': 1.112.12(react@18.2.0)
-      '@tamagui/label': 1.112.12(react-native@0.74.5(@babel/core@7.25.2)(@babel/preset-env@7.26.0(@babel/core@7.25.2))(@types/react@18.2.55)(encoding@0.1.13)(react@18.2.0))(react@18.2.0)
-      '@tamagui/stacks': 1.112.12(react@18.2.0)
-      '@tamagui/switch-headless': 1.112.12(react-native@0.74.5(@babel/core@7.25.2)(@babel/preset-env@7.26.0(@babel/core@7.25.2))(@types/react@18.2.55)(encoding@0.1.13)(react@18.2.0))(react@18.2.0)
-      '@tamagui/use-controllable-state': 1.112.12(react@18.2.0)
-      '@tamagui/use-previous': 1.112.12
+      '@tamagui/compose-refs': 1.126.12(react@18.2.0)
+      '@tamagui/constants': 1.126.12(react@18.2.0)
+      '@tamagui/core': 1.126.12(react-dom@18.2.0(react@18.2.0))(react-native@0.74.5(@babel/core@7.25.2)(@babel/preset-env@7.26.0(@babel/core@7.25.2))(@types/react@18.2.55)(encoding@0.1.13)(react@18.2.0))(react@18.2.0)
+      '@tamagui/focusable': 1.126.12(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
+      '@tamagui/get-token': 1.126.12(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
+      '@tamagui/helpers': 1.126.12(react@18.2.0)
+      '@tamagui/label': 1.126.12(react-dom@18.2.0(react@18.2.0))(react-native@0.74.5(@babel/core@7.25.2)(@babel/preset-env@7.26.0(@babel/core@7.25.2))(@types/react@18.2.55)(encoding@0.1.13)(react@18.2.0))(react@18.2.0)
+      '@tamagui/stacks': 1.126.12(react-dom@18.2.0(react@18.2.0))(react-native@0.74.5(@babel/core@7.25.2)(@babel/preset-env@7.26.0(@babel/core@7.25.2))(@types/react@18.2.55)(encoding@0.1.13)(react@18.2.0))(react@18.2.0)
+      '@tamagui/switch-headless': 1.126.12(react-dom@18.2.0(react@18.2.0))(react-native@0.74.5(@babel/core@7.25.2)(@babel/preset-env@7.26.0(@babel/core@7.25.2))(@types/react@18.2.55)(encoding@0.1.13)(react@18.2.0))(react@18.2.0)
+      '@tamagui/use-controllable-state': 1.126.12(react@18.2.0)
+      '@tamagui/use-previous': 1.126.12
       react: 18.2.0
     transitivePeerDependencies:
+      - react-dom
       - react-native
 
-  '@tamagui/tabs@1.112.12(react@18.2.0)':
+  '@tamagui/tabs@1.126.12(react-dom@18.2.0(react@18.2.0))(react-native@0.74.5(@babel/core@7.25.2)(@babel/preset-env@7.26.0(@babel/core@7.25.2))(@types/react@18.2.55)(encoding@0.1.13)(react@18.2.0))(react@18.2.0)':
     dependencies:
-      '@tamagui/compose-refs': 1.112.12(react@18.2.0)
-      '@tamagui/constants': 1.112.12(react@18.2.0)
-      '@tamagui/create-context': 1.112.12(react@18.2.0)
-      '@tamagui/get-button-sized': 1.112.12(react@18.2.0)
-      '@tamagui/group': 1.112.12(react@18.2.0)
-      '@tamagui/helpers': 1.112.12(react@18.2.0)
-      '@tamagui/roving-focus': 1.112.12(react@18.2.0)
-      '@tamagui/stacks': 1.112.12(react@18.2.0)
-      '@tamagui/use-controllable-state': 1.112.12(react@18.2.0)
-      '@tamagui/use-direction': 1.112.12(react@18.2.0)
-      '@tamagui/web': 1.112.12(react@18.2.0)
+      '@tamagui/compose-refs': 1.126.12(react@18.2.0)
+      '@tamagui/constants': 1.126.12(react@18.2.0)
+      '@tamagui/create-context': 1.126.12(react@18.2.0)
+      '@tamagui/get-button-sized': 1.126.12(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
+      '@tamagui/group': 1.126.12(react-dom@18.2.0(react@18.2.0))(react-native@0.74.5(@babel/core@7.25.2)(@babel/preset-env@7.26.0(@babel/core@7.25.2))(@types/react@18.2.55)(encoding@0.1.13)(react@18.2.0))(react@18.2.0)
+      '@tamagui/helpers': 1.126.12(react@18.2.0)
+      '@tamagui/roving-focus': 1.126.12(react-dom@18.2.0(react@18.2.0))(react-native@0.74.5(@babel/core@7.25.2)(@babel/preset-env@7.26.0(@babel/core@7.25.2))(@types/react@18.2.55)(encoding@0.1.13)(react@18.2.0))(react@18.2.0)
+      '@tamagui/stacks': 1.126.12(react-dom@18.2.0(react@18.2.0))(react-native@0.74.5(@babel/core@7.25.2)(@babel/preset-env@7.26.0(@babel/core@7.25.2))(@types/react@18.2.55)(encoding@0.1.13)(react@18.2.0))(react@18.2.0)
+      '@tamagui/use-controllable-state': 1.126.12(react@18.2.0)
+      '@tamagui/use-direction': 1.126.12(react@18.2.0)
+      '@tamagui/web': 1.126.12(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
       react: 18.2.0
+    transitivePeerDependencies:
+      - react-dom
+      - react-native
 
-  '@tamagui/text@1.112.12(react@18.2.0)':
+  '@tamagui/text@1.126.12(react-dom@18.2.0(react@18.2.0))(react-native@0.74.5(@babel/core@7.25.2)(@babel/preset-env@7.26.0(@babel/core@7.25.2))(@types/react@18.2.55)(encoding@0.1.13)(react@18.2.0))(react@18.2.0)':
     dependencies:
-      '@tamagui/get-font-sized': 1.112.12(react@18.2.0)
-      '@tamagui/helpers-tamagui': 1.112.12(react@18.2.0)
-      '@tamagui/web': 1.112.12(react@18.2.0)
+      '@tamagui/get-font-sized': 1.126.12(react-dom@18.2.0(react@18.2.0))(react-native@0.74.5(@babel/core@7.25.2)(@babel/preset-env@7.26.0(@babel/core@7.25.2))(@types/react@18.2.55)(encoding@0.1.13)(react@18.2.0))(react@18.2.0)
+      '@tamagui/helpers-tamagui': 1.126.12(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
+      '@tamagui/web': 1.126.12(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
       react: 18.2.0
+    transitivePeerDependencies:
+      - react-dom
+      - react-native
 
-  '@tamagui/theme-builder@1.112.12(react@18.2.0)':
+  '@tamagui/theme-builder@1.126.12(react-dom@18.2.0(react@18.2.0))(react@18.2.0)':
     dependencies:
-      '@tamagui/create-theme': 1.112.12(react@18.2.0)
+      '@tamagui/create-theme': 1.126.12(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
       color2k: 2.0.3
     transitivePeerDependencies:
       - react
+      - react-dom
 
-  '@tamagui/theme@1.112.12(react@18.2.0)':
+  '@tamagui/theme@1.126.12(react-dom@18.2.0(react@18.2.0))(react@18.2.0)':
     dependencies:
-      '@tamagui/constants': 1.112.12(react@18.2.0)
-      '@tamagui/web': 1.112.12(react@18.2.0)
+      '@tamagui/constants': 1.126.12(react@18.2.0)
+      '@tamagui/web': 1.126.12(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
       react: 18.2.0
-
-  '@tamagui/timer@1.112.12': {}
+    transitivePeerDependencies:
+      - react-dom
 
   '@tamagui/timer@1.116.12': {}
 
-  '@tamagui/toggle-group@1.112.12(react@18.2.0)':
-    dependencies:
-      '@tamagui/constants': 1.112.12(react@18.2.0)
-      '@tamagui/create-context': 1.112.12(react@18.2.0)
-      '@tamagui/focusable': 1.112.12(react@18.2.0)
-      '@tamagui/font-size': 1.112.12(react@18.2.0)
-      '@tamagui/get-token': 1.112.12(react@18.2.0)
-      '@tamagui/group': 1.112.12(react@18.2.0)
-      '@tamagui/helpers': 1.112.12(react@18.2.0)
-      '@tamagui/helpers-tamagui': 1.112.12(react@18.2.0)
-      '@tamagui/roving-focus': 1.112.12(react@18.2.0)
-      '@tamagui/stacks': 1.112.12(react@18.2.0)
-      '@tamagui/use-controllable-state': 1.112.12(react@18.2.0)
-      '@tamagui/use-direction': 1.112.12(react@18.2.0)
-      '@tamagui/web': 1.112.12(react@18.2.0)
-      react: 18.2.0
+  '@tamagui/timer@1.126.12': {}
 
-  '@tamagui/tooltip@1.112.12(@types/react@18.2.55)(react-dom@18.2.0(react@18.2.0))(react-native@0.74.5(@babel/core@7.25.2)(@babel/preset-env@7.26.0(@babel/core@7.25.2))(@types/react@18.2.55)(encoding@0.1.13)(react@18.2.0))(react@18.2.0)':
+  '@tamagui/toggle-group@1.126.12(react-dom@18.2.0(react@18.2.0))(react-native@0.74.5(@babel/core@7.25.2)(@babel/preset-env@7.26.0(@babel/core@7.25.2))(@types/react@18.2.55)(encoding@0.1.13)(react@18.2.0))(react@18.2.0)':
     dependencies:
-      '@floating-ui/react': 0.26.24(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
-      '@tamagui/compose-refs': 1.112.12(react@18.2.0)
-      '@tamagui/core': 1.112.12(react@18.2.0)
-      '@tamagui/create-context': 1.112.12(react@18.2.0)
-      '@tamagui/floating': 1.112.12(react-dom@18.2.0(react@18.2.0))(react-native@0.74.5(@babel/core@7.25.2)(@babel/preset-env@7.26.0(@babel/core@7.25.2))(@types/react@18.2.55)(encoding@0.1.13)(react@18.2.0))(react@18.2.0)
-      '@tamagui/get-token': 1.112.12(react@18.2.0)
-      '@tamagui/helpers': 1.112.12(react@18.2.0)
-      '@tamagui/polyfill-dev': 1.112.12
-      '@tamagui/popover': 1.112.12(@types/react@18.2.55)(react-dom@18.2.0(react@18.2.0))(react-native@0.74.5(@babel/core@7.25.2)(@babel/preset-env@7.26.0(@babel/core@7.25.2))(@types/react@18.2.55)(encoding@0.1.13)(react@18.2.0))(react@18.2.0)
-      '@tamagui/popper': 1.112.12(react-dom@18.2.0(react@18.2.0))(react-native@0.74.5(@babel/core@7.25.2)(@babel/preset-env@7.26.0(@babel/core@7.25.2))(@types/react@18.2.55)(encoding@0.1.13)(react@18.2.0))(react@18.2.0)
-      '@tamagui/stacks': 1.112.12(react@18.2.0)
-      '@tamagui/text': 1.112.12(react@18.2.0)
-      '@tamagui/use-controllable-state': 1.112.12(react@18.2.0)
+      '@tamagui/constants': 1.126.12(react@18.2.0)
+      '@tamagui/create-context': 1.126.12(react@18.2.0)
+      '@tamagui/focusable': 1.126.12(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
+      '@tamagui/font-size': 1.126.12(react-dom@18.2.0(react@18.2.0))(react-native@0.74.5(@babel/core@7.25.2)(@babel/preset-env@7.26.0(@babel/core@7.25.2))(@types/react@18.2.55)(encoding@0.1.13)(react@18.2.0))(react@18.2.0)
+      '@tamagui/get-token': 1.126.12(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
+      '@tamagui/group': 1.126.12(react-dom@18.2.0(react@18.2.0))(react-native@0.74.5(@babel/core@7.25.2)(@babel/preset-env@7.26.0(@babel/core@7.25.2))(@types/react@18.2.55)(encoding@0.1.13)(react@18.2.0))(react@18.2.0)
+      '@tamagui/helpers': 1.126.12(react@18.2.0)
+      '@tamagui/helpers-tamagui': 1.126.12(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
+      '@tamagui/roving-focus': 1.126.12(react-dom@18.2.0(react@18.2.0))(react-native@0.74.5(@babel/core@7.25.2)(@babel/preset-env@7.26.0(@babel/core@7.25.2))(@types/react@18.2.55)(encoding@0.1.13)(react@18.2.0))(react@18.2.0)
+      '@tamagui/stacks': 1.126.12(react-dom@18.2.0(react@18.2.0))(react-native@0.74.5(@babel/core@7.25.2)(@babel/preset-env@7.26.0(@babel/core@7.25.2))(@types/react@18.2.55)(encoding@0.1.13)(react@18.2.0))(react@18.2.0)
+      '@tamagui/use-controllable-state': 1.126.12(react@18.2.0)
+      '@tamagui/use-direction': 1.126.12(react@18.2.0)
+      '@tamagui/web': 1.126.12(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
+      react: 18.2.0
+    transitivePeerDependencies:
+      - react-dom
+      - react-native
+
+  '@tamagui/tooltip@1.126.12(@types/react@18.2.55)(react-dom@18.2.0(react@18.2.0))(react-native@0.74.5(@babel/core@7.25.2)(@babel/preset-env@7.26.0(@babel/core@7.25.2))(@types/react@18.2.55)(encoding@0.1.13)(react@18.2.0))(react@18.2.0)':
+    dependencies:
+      '@floating-ui/react': 0.27.8(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
+      '@tamagui/compose-refs': 1.126.12(react@18.2.0)
+      '@tamagui/core': 1.126.12(react-dom@18.2.0(react@18.2.0))(react-native@0.74.5(@babel/core@7.25.2)(@babel/preset-env@7.26.0(@babel/core@7.25.2))(@types/react@18.2.55)(encoding@0.1.13)(react@18.2.0))(react@18.2.0)
+      '@tamagui/create-context': 1.126.12(react@18.2.0)
+      '@tamagui/floating': 1.126.12(react-dom@18.2.0(react@18.2.0))(react-native@0.74.5(@babel/core@7.25.2)(@babel/preset-env@7.26.0(@babel/core@7.25.2))(@types/react@18.2.55)(encoding@0.1.13)(react@18.2.0))(react@18.2.0)
+      '@tamagui/get-token': 1.126.12(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
+      '@tamagui/helpers': 1.126.12(react@18.2.0)
+      '@tamagui/polyfill-dev': 1.126.12
+      '@tamagui/popover': 1.126.12(@types/react@18.2.55)(react-dom@18.2.0(react@18.2.0))(react-native@0.74.5(@babel/core@7.25.2)(@babel/preset-env@7.26.0(@babel/core@7.25.2))(@types/react@18.2.55)(encoding@0.1.13)(react@18.2.0))(react@18.2.0)
+      '@tamagui/popper': 1.126.12(react-dom@18.2.0(react@18.2.0))(react-native@0.74.5(@babel/core@7.25.2)(@babel/preset-env@7.26.0(@babel/core@7.25.2))(@types/react@18.2.55)(encoding@0.1.13)(react@18.2.0))(react@18.2.0)
+      '@tamagui/stacks': 1.126.12(react-dom@18.2.0(react@18.2.0))(react-native@0.74.5(@babel/core@7.25.2)(@babel/preset-env@7.26.0(@babel/core@7.25.2))(@types/react@18.2.55)(encoding@0.1.13)(react@18.2.0))(react@18.2.0)
+      '@tamagui/text': 1.126.12(react-dom@18.2.0(react@18.2.0))(react-native@0.74.5(@babel/core@7.25.2)(@babel/preset-env@7.26.0(@babel/core@7.25.2))(@types/react@18.2.55)(encoding@0.1.13)(react@18.2.0))(react@18.2.0)
+      '@tamagui/use-controllable-state': 1.126.12(react@18.2.0)
       react: 18.2.0
     transitivePeerDependencies:
       - '@types/react'
       - react-dom
       - react-native
 
-  '@tamagui/types@1.112.12': {}
-
   '@tamagui/types@1.116.12': {}
 
-  '@tamagui/use-callback-ref@1.112.12': {}
+  '@tamagui/types@1.126.12': {}
 
-  '@tamagui/use-constant@1.112.12(react@18.2.0)':
+  '@tamagui/use-callback-ref@1.126.12': {}
+
+  '@tamagui/use-constant@1.126.12(react@18.2.0)':
     dependencies:
       react: 18.2.0
 
-  '@tamagui/use-controllable-state@1.112.12(react@18.2.0)':
+  '@tamagui/use-controllable-state@1.126.12(react@18.2.0)':
     dependencies:
-      '@tamagui/start-transition': 1.112.12
-      '@tamagui/use-event': 1.112.12(react@18.2.0)
+      '@tamagui/start-transition': 1.126.12
+      '@tamagui/use-event': 1.126.12(react@18.2.0)
       react: 18.2.0
 
-  '@tamagui/use-debounce@1.112.12(react@18.2.0)':
-    dependencies:
-      react: 18.2.0
-
-  '@tamagui/use-did-finish-ssr@1.112.12(react@18.2.0)':
+  '@tamagui/use-debounce@1.126.12(react@18.2.0)':
     dependencies:
       react: 18.2.0
 
@@ -19981,83 +19888,80 @@ snapshots:
     dependencies:
       react: 18.2.0
 
-  '@tamagui/use-direction@1.112.12(react@18.2.0)':
+  '@tamagui/use-did-finish-ssr@1.126.12(react@18.2.0)':
     dependencies:
       react: 18.2.0
 
-  '@tamagui/use-escape-keydown@1.112.12':
+  '@tamagui/use-direction@1.126.12(react@18.2.0)':
     dependencies:
-      '@tamagui/use-callback-ref': 1.112.12
-
-  '@tamagui/use-event@1.112.12(react@18.2.0)':
-    dependencies:
-      '@tamagui/constants': 1.112.12(react@18.2.0)
       react: 18.2.0
+
+  '@tamagui/use-escape-keydown@1.126.12':
+    dependencies:
+      '@tamagui/use-callback-ref': 1.126.12
 
   '@tamagui/use-event@1.116.12(react@18.2.0)':
     dependencies:
       '@tamagui/constants': 1.116.12(react@18.2.0)
       react: 18.2.0
 
-  '@tamagui/use-force-update@1.112.12(react@18.2.0)':
+  '@tamagui/use-event@1.126.12(react@18.2.0)':
     dependencies:
+      '@tamagui/constants': 1.126.12(react@18.2.0)
       react: 18.2.0
 
   '@tamagui/use-force-update@1.116.12(react@18.2.0)':
     dependencies:
       react: 18.2.0
 
-  '@tamagui/use-keyboard-visible@1.112.12(react@18.2.0)':
+  '@tamagui/use-force-update@1.126.12(react@18.2.0)':
     dependencies:
       react: 18.2.0
 
-  '@tamagui/use-presence@1.112.12(react@18.2.0)':
+  '@tamagui/use-keyboard-visible@1.126.12(react@18.2.0)':
     dependencies:
-      '@tamagui/web': 1.112.12(react@18.2.0)
       react: 18.2.0
 
-  '@tamagui/use-previous@1.112.12': {}
-
-  '@tamagui/use-window-dimensions@1.112.12(react@18.2.0)':
+  '@tamagui/use-presence@1.126.12(react-dom@18.2.0(react@18.2.0))(react@18.2.0)':
     dependencies:
-      '@tamagui/constants': 1.112.12(react@18.2.0)
+      '@tamagui/web': 1.126.12(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
+      react: 18.2.0
+    transitivePeerDependencies:
+      - react-dom
+
+  '@tamagui/use-previous@1.126.12': {}
+
+  '@tamagui/use-window-dimensions@1.126.12(react@18.2.0)':
+    dependencies:
+      '@tamagui/constants': 1.126.12(react@18.2.0)
       react: 18.2.0
 
-  '@tamagui/visually-hidden@1.112.12(react@18.2.0)':
+  '@tamagui/visually-hidden@1.126.12(react-dom@18.2.0(react@18.2.0))(react@18.2.0)':
     dependencies:
-      '@tamagui/web': 1.112.12(react@18.2.0)
+      '@tamagui/web': 1.126.12(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
       react: 18.2.0
+    transitivePeerDependencies:
+      - react-dom
 
-  '@tamagui/vite-plugin@1.112.12(@swc/helpers@0.5.13)(encoding@0.1.13)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)':
+  '@tamagui/vite-plugin@1.126.12(@swc/helpers@0.5.13)(encoding@0.1.13)(react-dom@18.2.0(react@18.2.0))(react-native@0.74.5(@babel/core@7.25.2)(@babel/preset-env@7.26.0(@babel/core@7.25.2))(@types/react@18.2.55)(encoding@0.1.13)(react@18.2.0))(react@18.2.0)(vite@5.1.6(@types/node@20.14.10)(lightningcss@1.19.0)(terser@5.36.0))':
     dependencies:
-      '@tamagui/fake-react-native': 1.112.12
-      '@tamagui/proxy-worm': 1.112.12
-      '@tamagui/react-native-svg': 1.112.12
-      '@tamagui/static': 1.112.12(@swc/helpers@0.5.13)(encoding@0.1.13)(react@18.2.0)
+      '@tamagui/fake-react-native': 1.126.12
+      '@tamagui/proxy-worm': 1.126.12
+      '@tamagui/react-native-svg': 1.126.12
+      '@tamagui/react-native-web-lite': 1.126.12(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
+      '@tamagui/static': 1.126.12(@swc/helpers@0.5.13)(encoding@0.1.13)(react-dom@18.2.0(react@18.2.0))(react-native@0.74.5(@babel/core@7.25.2)(@babel/preset-env@7.26.0(@babel/core@7.25.2))(@types/react@18.2.55)(encoding@0.1.13)(react@18.2.0))(react@18.2.0)
       esm-resolve: 1.0.11
       fs-extra: 11.2.0
       outdent: 0.8.0
-      react-native-web: 0.19.12(encoding@0.1.13)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
+      react-native-web: 0.20.0(encoding@0.1.13)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
+      vite: 5.1.6(@types/node@20.14.10)(lightningcss@1.19.0)(terser@5.36.0)
     transitivePeerDependencies:
       - '@swc/helpers'
       - encoding
       - react
       - react-dom
+      - react-native
       - supports-color
-
-  '@tamagui/web@1.112.12(react@18.2.0)':
-    dependencies:
-      '@tamagui/compose-refs': 1.112.12(react@18.2.0)
-      '@tamagui/constants': 1.112.12(react@18.2.0)
-      '@tamagui/helpers': 1.112.12(react@18.2.0)
-      '@tamagui/normalize-css-color': 1.112.12
-      '@tamagui/timer': 1.112.12
-      '@tamagui/types': 1.112.12
-      '@tamagui/use-did-finish-ssr': 1.112.12(react@18.2.0)
-      '@tamagui/use-event': 1.112.12(react@18.2.0)
-      '@tamagui/use-force-update': 1.112.12(react@18.2.0)
-    transitivePeerDependencies:
-      - react
 
   '@tamagui/web@1.116.12':
     dependencies:
@@ -20072,6 +19976,22 @@ snapshots:
       '@tamagui/use-force-update': 1.116.12(react@18.2.0)
       react: 18.2.0
       react-dom: 18.2.0(react@18.2.0)
+
+  '@tamagui/web@1.126.12(react-dom@18.2.0(react@18.2.0))(react@18.2.0)':
+    dependencies:
+      '@tamagui/compose-refs': 1.126.12(react@18.2.0)
+      '@tamagui/constants': 1.126.12(react@18.2.0)
+      '@tamagui/helpers': 1.126.12(react@18.2.0)
+      '@tamagui/normalize-css-color': 1.126.12
+      '@tamagui/timer': 1.126.12
+      '@tamagui/types': 1.126.12
+      '@tamagui/use-did-finish-ssr': 1.126.12(react@18.2.0)
+      '@tamagui/use-event': 1.126.12(react@18.2.0)
+      '@tamagui/use-force-update': 1.126.12(react@18.2.0)
+      react: 18.2.0
+      react-dom: 18.2.0(react@18.2.0)
+
+  '@tamagui/z-index-stack@1.126.12': {}
 
   '@tanstack/query-core@5.32.1': {}
 
@@ -20494,10 +20414,6 @@ snapshots:
       '@types/node': 20.17.6
 
   '@types/node@18.19.80':
-    dependencies:
-      undici-types: 5.26.5
-
-  '@types/node@20.10.8':
     dependencies:
       undici-types: 5.26.5
 
@@ -21485,10 +21401,6 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  babel-plugin-fully-specified@1.3.0(@babel/core@7.25.2):
-    dependencies:
-      '@babel/core': 7.25.2
-
   babel-plugin-inline-import@3.0.0:
     dependencies:
       require-resolve: 0.0.2
@@ -21771,13 +21683,6 @@ snapshots:
       node-releases: 2.0.14
       update-browserslist-db: 1.0.13(browserslist@4.22.2)
 
-  browserslist@4.23.3:
-    dependencies:
-      caniuse-lite: 1.0.30001650
-      electron-to-chromium: 1.5.5
-      node-releases: 2.0.18
-      update-browserslist-db: 1.1.0(browserslist@4.23.3)
-
   browserslist@4.24.2:
     dependencies:
       caniuse-lite: 1.0.30001678
@@ -21972,8 +21877,6 @@ snapshots:
   camelize@1.0.1: {}
 
   caniuse-lite@1.0.30001576: {}
-
-  caniuse-lite@1.0.30001650: {}
 
   caniuse-lite@1.0.30001678: {}
 
@@ -22892,8 +22795,6 @@ snapshots:
 
   electron-to-chromium@1.4.626: {}
 
-  electron-to-chromium@1.5.5: {}
-
   electron-to-chromium@1.5.52: {}
 
   electron-updater@6.3.9:
@@ -23126,12 +23027,12 @@ snapshots:
 
   es6-promisify@7.0.0: {}
 
-  esbuild-plugin-es5@2.1.1(esbuild@0.24.0):
+  esbuild-plugin-es5@2.1.1(esbuild@0.25.2):
     dependencies:
       '@swc/core': 1.7.26(@swc/helpers@0.5.13)
       '@swc/helpers': 0.5.13
       deepmerge: 4.3.1
-      esbuild: 0.24.0
+      esbuild: 0.25.2
 
   esbuild-register@3.6.0(esbuild@0.19.12):
     dependencies:
@@ -23140,10 +23041,10 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  esbuild-register@3.6.0(esbuild@0.24.0):
+  esbuild-register@3.6.0(esbuild@0.25.2):
     dependencies:
       debug: 4.3.7
-      esbuild: 0.24.0
+      esbuild: 0.25.2
     transitivePeerDependencies:
       - supports-color
 
@@ -23197,33 +23098,6 @@ snapshots:
       '@esbuild/win32-arm64': 0.19.12
       '@esbuild/win32-ia32': 0.19.12
       '@esbuild/win32-x64': 0.19.12
-
-  esbuild@0.24.0:
-    optionalDependencies:
-      '@esbuild/aix-ppc64': 0.24.0
-      '@esbuild/android-arm': 0.24.0
-      '@esbuild/android-arm64': 0.24.0
-      '@esbuild/android-x64': 0.24.0
-      '@esbuild/darwin-arm64': 0.24.0
-      '@esbuild/darwin-x64': 0.24.0
-      '@esbuild/freebsd-arm64': 0.24.0
-      '@esbuild/freebsd-x64': 0.24.0
-      '@esbuild/linux-arm': 0.24.0
-      '@esbuild/linux-arm64': 0.24.0
-      '@esbuild/linux-ia32': 0.24.0
-      '@esbuild/linux-loong64': 0.24.0
-      '@esbuild/linux-mips64el': 0.24.0
-      '@esbuild/linux-ppc64': 0.24.0
-      '@esbuild/linux-riscv64': 0.24.0
-      '@esbuild/linux-s390x': 0.24.0
-      '@esbuild/linux-x64': 0.24.0
-      '@esbuild/netbsd-x64': 0.24.0
-      '@esbuild/openbsd-arm64': 0.24.0
-      '@esbuild/openbsd-x64': 0.24.0
-      '@esbuild/sunos-x64': 0.24.0
-      '@esbuild/win32-arm64': 0.24.0
-      '@esbuild/win32-ia32': 0.24.0
-      '@esbuild/win32-x64': 0.24.0
 
   esbuild@0.25.2:
     optionalDependencies:
@@ -23470,7 +23344,7 @@ snapshots:
 
   execa@5.1.1:
     dependencies:
-      cross-spawn: 7.0.3
+      cross-spawn: 7.0.6
       get-stream: 6.0.1
       human-signals: 2.1.0
       is-stream: 2.0.1
@@ -24652,6 +24526,10 @@ snapshots:
     dependencies:
       css-in-js-utils: 3.1.0
       fast-loops: 1.1.3
+
+  inline-style-prefixer@7.0.1:
+    dependencies:
+      css-in-js-utils: 3.1.0
 
   inquirer@8.2.4:
     dependencies:
@@ -26060,7 +25938,7 @@ snapshots:
 
   metro-file-map@0.80.5:
     dependencies:
-      anymatch: 3.1.2
+      anymatch: 3.1.3
       debug: 2.6.9
       fb-watchman: 2.0.2
       graceful-fs: 4.2.11
@@ -26443,6 +26321,14 @@ snapshots:
       - react
       - react-dom
 
+  moti@0.29.0(react-dom@18.2.0(react@18.2.0))(react-native-reanimated@3.8.1(patch_hash=iololnqcieadxwydikuxdlowf4)(@babel/core@7.25.2)(react-native@0.74.5(@babel/core@7.25.2)(@babel/preset-env@7.26.0(@babel/core@7.25.2))(@types/react@18.2.55)(encoding@0.1.13)(react@18.2.0))(react@18.2.0))(react@18.2.0):
+    dependencies:
+      framer-motion: 6.5.1(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
+      react-native-reanimated: 3.8.1(patch_hash=iololnqcieadxwydikuxdlowf4)(@babel/core@7.25.2)(react-native@0.74.5(@babel/core@7.25.2)(@babel/preset-env@7.26.0(@babel/core@7.25.2))(@types/react@18.2.55)(encoding@0.1.13)(react@18.2.0))(react@18.2.0)
+    transitivePeerDependencies:
+      - react
+      - react-dom
+
   ms@2.0.0: {}
 
   ms@2.1.2: {}
@@ -26801,6 +26687,17 @@ snapshots:
   outdent@0.8.0: {}
 
   outvariant@1.3.0: {}
+
+  oxc-transform@0.47.1:
+    optionalDependencies:
+      '@oxc-transform/binding-darwin-arm64': 0.47.1
+      '@oxc-transform/binding-darwin-x64': 0.47.1
+      '@oxc-transform/binding-linux-arm64-gnu': 0.47.1
+      '@oxc-transform/binding-linux-arm64-musl': 0.47.1
+      '@oxc-transform/binding-linux-x64-gnu': 0.47.1
+      '@oxc-transform/binding-linux-x64-musl': 0.47.1
+      '@oxc-transform/binding-win32-arm64-msvc': 0.47.1
+      '@oxc-transform/binding-win32-x64-msvc': 0.47.1
 
   p-cancelable@2.1.1: {}
 
@@ -27729,6 +27626,21 @@ snapshots:
     transitivePeerDependencies:
       - encoding
 
+  react-native-web@0.20.0(encoding@0.1.13)(react-dom@18.2.0(react@18.2.0))(react@18.2.0):
+    dependencies:
+      '@babel/runtime': 7.26.0
+      '@react-native/normalize-colors': 0.74.88
+      fbjs: 3.0.5(encoding@0.1.13)
+      inline-style-prefixer: 7.0.1
+      memoize-one: 6.0.0
+      nullthrows: 1.1.1
+      postcss-value-parser: 4.2.0
+      react: 18.2.0
+      react-dom: 18.2.0(react@18.2.0)
+      styleq: 0.1.3
+    transitivePeerDependencies:
+      - encoding
+
   react-native-webview@13.8.6(react-native@0.74.5(@babel/core@7.23.7)(@babel/preset-env@7.26.0(@babel/core@7.23.7))(@types/react@18.2.55)(encoding@0.1.13)(react@18.2.0))(react@18.2.0):
     dependencies:
       escape-string-regexp: 2.0.0
@@ -27923,6 +27835,14 @@ snapshots:
     optionalDependencies:
       '@types/react': 18.2.55
 
+  react-remove-scroll-bar@2.3.8(@types/react@18.2.55)(react@18.2.0):
+    dependencies:
+      react: 18.2.0
+      react-style-singleton: 2.2.3(@types/react@18.2.55)(react@18.2.0)
+      tslib: 2.8.1
+    optionalDependencies:
+      '@types/react': 18.2.55
+
   react-remove-scroll@2.5.5(@types/react@18.2.55)(react@18.2.0):
     dependencies:
       react: 18.2.0
@@ -27931,6 +27851,17 @@ snapshots:
       tslib: 2.8.1
       use-callback-ref: 1.3.0(@types/react@18.2.55)(react@18.2.0)
       use-sidecar: 1.1.2(@types/react@18.2.55)(react@18.2.0)
+    optionalDependencies:
+      '@types/react': 18.2.55
+
+  react-remove-scroll@2.6.3(@types/react@18.2.55)(react@18.2.0):
+    dependencies:
+      react: 18.2.0
+      react-remove-scroll-bar: 2.3.8(@types/react@18.2.55)(react@18.2.0)
+      react-style-singleton: 2.2.3(@types/react@18.2.55)(react@18.2.0)
+      tslib: 2.8.1
+      use-callback-ref: 1.3.3(@types/react@18.2.55)(react@18.2.0)
+      use-sidecar: 1.1.3(@types/react@18.2.55)(react@18.2.0)
     optionalDependencies:
       '@types/react': 18.2.55
 
@@ -27948,6 +27879,14 @@ snapshots:
     dependencies:
       get-nonce: 1.0.1
       invariant: 2.2.4
+      react: 18.2.0
+      tslib: 2.8.1
+    optionalDependencies:
+      '@types/react': 18.2.55
+
+  react-style-singleton@2.2.3(@types/react@18.2.55)(react@18.2.0):
+    dependencies:
+      get-nonce: 1.0.1
       react: 18.2.0
       tslib: 2.8.1
     optionalDependencies:
@@ -29063,60 +29002,61 @@ snapshots:
     transitivePeerDependencies:
       - ts-node
 
-  tamagui@1.112.12(@types/react@18.2.55)(react-dom@18.2.0(react@18.2.0))(react-native@0.74.5(@babel/core@7.25.2)(@babel/preset-env@7.26.0(@babel/core@7.25.2))(@types/react@18.2.55)(encoding@0.1.13)(react@18.2.0))(react@18.2.0):
+  tamagui@1.126.12(@types/react@18.2.55)(react-dom@18.2.0(react@18.2.0))(react-native@0.74.5(@babel/core@7.25.2)(@babel/preset-env@7.26.0(@babel/core@7.25.2))(@types/react@18.2.55)(encoding@0.1.13)(react@18.2.0))(react@18.2.0):
     dependencies:
-      '@tamagui/accordion': 1.112.12(react@18.2.0)
-      '@tamagui/adapt': 1.112.12(react@18.2.0)
-      '@tamagui/alert-dialog': 1.112.12(@types/react@18.2.55)(react-dom@18.2.0(react@18.2.0))(react-native@0.74.5(@babel/core@7.25.2)(@babel/preset-env@7.26.0(@babel/core@7.25.2))(@types/react@18.2.55)(encoding@0.1.13)(react@18.2.0))(react@18.2.0)
-      '@tamagui/animate-presence': 1.112.12(react@18.2.0)
-      '@tamagui/avatar': 1.112.12(react@18.2.0)
-      '@tamagui/button': 1.112.12(react@18.2.0)
-      '@tamagui/card': 1.112.12(react@18.2.0)
-      '@tamagui/checkbox': 1.112.12(react-native@0.74.5(@babel/core@7.25.2)(@babel/preset-env@7.26.0(@babel/core@7.25.2))(@types/react@18.2.55)(encoding@0.1.13)(react@18.2.0))(react@18.2.0)
-      '@tamagui/compose-refs': 1.112.12(react@18.2.0)
-      '@tamagui/constants': 1.112.12(react@18.2.0)
-      '@tamagui/core': 1.112.12(react@18.2.0)
-      '@tamagui/create-context': 1.112.12(react@18.2.0)
-      '@tamagui/dialog': 1.112.12(@types/react@18.2.55)(react-dom@18.2.0(react@18.2.0))(react-native@0.74.5(@babel/core@7.25.2)(@babel/preset-env@7.26.0(@babel/core@7.25.2))(@types/react@18.2.55)(encoding@0.1.13)(react@18.2.0))(react@18.2.0)
-      '@tamagui/elements': 1.112.12(react@18.2.0)
-      '@tamagui/fake-react-native': 1.112.12
-      '@tamagui/focusable': 1.112.12(react@18.2.0)
-      '@tamagui/font-size': 1.112.12(react@18.2.0)
-      '@tamagui/form': 1.112.12(react@18.2.0)
-      '@tamagui/get-button-sized': 1.112.12(react@18.2.0)
-      '@tamagui/get-font-sized': 1.112.12(react@18.2.0)
-      '@tamagui/get-token': 1.112.12(react@18.2.0)
-      '@tamagui/group': 1.112.12(react@18.2.0)
-      '@tamagui/helpers-tamagui': 1.112.12(react@18.2.0)
-      '@tamagui/image': 1.112.12(react@18.2.0)
-      '@tamagui/label': 1.112.12(react-native@0.74.5(@babel/core@7.25.2)(@babel/preset-env@7.26.0(@babel/core@7.25.2))(@types/react@18.2.55)(encoding@0.1.13)(react@18.2.0))(react@18.2.0)
-      '@tamagui/linear-gradient': 1.112.12(react@18.2.0)
-      '@tamagui/list-item': 1.112.12(react@18.2.0)
-      '@tamagui/polyfill-dev': 1.112.12
-      '@tamagui/popover': 1.112.12(@types/react@18.2.55)(react-dom@18.2.0(react@18.2.0))(react-native@0.74.5(@babel/core@7.25.2)(@babel/preset-env@7.26.0(@babel/core@7.25.2))(@types/react@18.2.55)(encoding@0.1.13)(react@18.2.0))(react@18.2.0)
-      '@tamagui/popper': 1.112.12(react-dom@18.2.0(react@18.2.0))(react-native@0.74.5(@babel/core@7.25.2)(@babel/preset-env@7.26.0(@babel/core@7.25.2))(@types/react@18.2.55)(encoding@0.1.13)(react@18.2.0))(react@18.2.0)
-      '@tamagui/portal': 1.112.12(react@18.2.0)
-      '@tamagui/progress': 1.112.12(react@18.2.0)
-      '@tamagui/radio-group': 1.112.12(react-native@0.74.5(@babel/core@7.25.2)(@babel/preset-env@7.26.0(@babel/core@7.25.2))(@types/react@18.2.55)(encoding@0.1.13)(react@18.2.0))(react@18.2.0)
-      '@tamagui/react-native-media-driver': 1.112.12(react-native@0.74.5(@babel/core@7.25.2)(@babel/preset-env@7.26.0(@babel/core@7.25.2))(@types/react@18.2.55)(encoding@0.1.13)(react@18.2.0))(react@18.2.0)
-      '@tamagui/scroll-view': 1.112.12(react@18.2.0)
-      '@tamagui/select': 1.112.12(@types/react@18.2.55)(react-dom@18.2.0(react@18.2.0))(react-native@0.74.5(@babel/core@7.25.2)(@babel/preset-env@7.26.0(@babel/core@7.25.2))(@types/react@18.2.55)(encoding@0.1.13)(react@18.2.0))(react@18.2.0)
-      '@tamagui/separator': 1.112.12(react@18.2.0)
-      '@tamagui/shapes': 1.112.12(react@18.2.0)
-      '@tamagui/sheet': 1.112.12(@types/react@18.2.55)(react@18.2.0)
-      '@tamagui/slider': 1.112.12(react@18.2.0)
-      '@tamagui/stacks': 1.112.12(react@18.2.0)
-      '@tamagui/switch': 1.112.12(react-native@0.74.5(@babel/core@7.25.2)(@babel/preset-env@7.26.0(@babel/core@7.25.2))(@types/react@18.2.55)(encoding@0.1.13)(react@18.2.0))(react@18.2.0)
-      '@tamagui/tabs': 1.112.12(react@18.2.0)
-      '@tamagui/text': 1.112.12(react@18.2.0)
-      '@tamagui/theme': 1.112.12(react@18.2.0)
-      '@tamagui/toggle-group': 1.112.12(react@18.2.0)
-      '@tamagui/tooltip': 1.112.12(@types/react@18.2.55)(react-dom@18.2.0(react@18.2.0))(react-native@0.74.5(@babel/core@7.25.2)(@babel/preset-env@7.26.0(@babel/core@7.25.2))(@types/react@18.2.55)(encoding@0.1.13)(react@18.2.0))(react@18.2.0)
-      '@tamagui/use-controllable-state': 1.112.12(react@18.2.0)
-      '@tamagui/use-debounce': 1.112.12(react@18.2.0)
-      '@tamagui/use-force-update': 1.112.12(react@18.2.0)
-      '@tamagui/use-window-dimensions': 1.112.12(react@18.2.0)
-      '@tamagui/visually-hidden': 1.112.12(react@18.2.0)
+      '@tamagui/accordion': 1.126.12(react-dom@18.2.0(react@18.2.0))(react-native@0.74.5(@babel/core@7.25.2)(@babel/preset-env@7.26.0(@babel/core@7.25.2))(@types/react@18.2.55)(encoding@0.1.13)(react@18.2.0))(react@18.2.0)
+      '@tamagui/adapt': 1.126.12(react-dom@18.2.0(react@18.2.0))(react-native@0.74.5(@babel/core@7.25.2)(@babel/preset-env@7.26.0(@babel/core@7.25.2))(@types/react@18.2.55)(encoding@0.1.13)(react@18.2.0))(react@18.2.0)
+      '@tamagui/alert-dialog': 1.126.12(@types/react@18.2.55)(react-dom@18.2.0(react@18.2.0))(react-native@0.74.5(@babel/core@7.25.2)(@babel/preset-env@7.26.0(@babel/core@7.25.2))(@types/react@18.2.55)(encoding@0.1.13)(react@18.2.0))(react@18.2.0)
+      '@tamagui/animate-presence': 1.126.12(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
+      '@tamagui/avatar': 1.126.12(react-dom@18.2.0(react@18.2.0))(react-native@0.74.5(@babel/core@7.25.2)(@babel/preset-env@7.26.0(@babel/core@7.25.2))(@types/react@18.2.55)(encoding@0.1.13)(react@18.2.0))(react@18.2.0)
+      '@tamagui/button': 1.126.12(react-dom@18.2.0(react@18.2.0))(react-native@0.74.5(@babel/core@7.25.2)(@babel/preset-env@7.26.0(@babel/core@7.25.2))(@types/react@18.2.55)(encoding@0.1.13)(react@18.2.0))(react@18.2.0)
+      '@tamagui/card': 1.126.12(react-dom@18.2.0(react@18.2.0))(react-native@0.74.5(@babel/core@7.25.2)(@babel/preset-env@7.26.0(@babel/core@7.25.2))(@types/react@18.2.55)(encoding@0.1.13)(react@18.2.0))(react@18.2.0)
+      '@tamagui/checkbox': 1.126.12(react-dom@18.2.0(react@18.2.0))(react-native@0.74.5(@babel/core@7.25.2)(@babel/preset-env@7.26.0(@babel/core@7.25.2))(@types/react@18.2.55)(encoding@0.1.13)(react@18.2.0))(react@18.2.0)
+      '@tamagui/compose-refs': 1.126.12(react@18.2.0)
+      '@tamagui/constants': 1.126.12(react@18.2.0)
+      '@tamagui/core': 1.126.12(react-dom@18.2.0(react@18.2.0))(react-native@0.74.5(@babel/core@7.25.2)(@babel/preset-env@7.26.0(@babel/core@7.25.2))(@types/react@18.2.55)(encoding@0.1.13)(react@18.2.0))(react@18.2.0)
+      '@tamagui/create-context': 1.126.12(react@18.2.0)
+      '@tamagui/dialog': 1.126.12(@types/react@18.2.55)(react-dom@18.2.0(react@18.2.0))(react-native@0.74.5(@babel/core@7.25.2)(@babel/preset-env@7.26.0(@babel/core@7.25.2))(@types/react@18.2.55)(encoding@0.1.13)(react@18.2.0))(react@18.2.0)
+      '@tamagui/elements': 1.126.12(react-dom@18.2.0(react@18.2.0))(react-native@0.74.5(@babel/core@7.25.2)(@babel/preset-env@7.26.0(@babel/core@7.25.2))(@types/react@18.2.55)(encoding@0.1.13)(react@18.2.0))(react@18.2.0)
+      '@tamagui/fake-react-native': 1.126.12
+      '@tamagui/focusable': 1.126.12(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
+      '@tamagui/font-size': 1.126.12(react-dom@18.2.0(react@18.2.0))(react-native@0.74.5(@babel/core@7.25.2)(@babel/preset-env@7.26.0(@babel/core@7.25.2))(@types/react@18.2.55)(encoding@0.1.13)(react@18.2.0))(react@18.2.0)
+      '@tamagui/form': 1.126.12(react-dom@18.2.0(react@18.2.0))(react-native@0.74.5(@babel/core@7.25.2)(@babel/preset-env@7.26.0(@babel/core@7.25.2))(@types/react@18.2.55)(encoding@0.1.13)(react@18.2.0))(react@18.2.0)
+      '@tamagui/get-button-sized': 1.126.12(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
+      '@tamagui/get-font-sized': 1.126.12(react-dom@18.2.0(react@18.2.0))(react-native@0.74.5(@babel/core@7.25.2)(@babel/preset-env@7.26.0(@babel/core@7.25.2))(@types/react@18.2.55)(encoding@0.1.13)(react@18.2.0))(react@18.2.0)
+      '@tamagui/get-token': 1.126.12(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
+      '@tamagui/group': 1.126.12(react-dom@18.2.0(react@18.2.0))(react-native@0.74.5(@babel/core@7.25.2)(@babel/preset-env@7.26.0(@babel/core@7.25.2))(@types/react@18.2.55)(encoding@0.1.13)(react@18.2.0))(react@18.2.0)
+      '@tamagui/helpers-tamagui': 1.126.12(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
+      '@tamagui/image': 1.126.12(react-dom@18.2.0(react@18.2.0))(react-native@0.74.5(@babel/core@7.25.2)(@babel/preset-env@7.26.0(@babel/core@7.25.2))(@types/react@18.2.55)(encoding@0.1.13)(react@18.2.0))(react@18.2.0)
+      '@tamagui/label': 1.126.12(react-dom@18.2.0(react@18.2.0))(react-native@0.74.5(@babel/core@7.25.2)(@babel/preset-env@7.26.0(@babel/core@7.25.2))(@types/react@18.2.55)(encoding@0.1.13)(react@18.2.0))(react@18.2.0)
+      '@tamagui/linear-gradient': 1.126.12(react-dom@18.2.0(react@18.2.0))(react-native@0.74.5(@babel/core@7.25.2)(@babel/preset-env@7.26.0(@babel/core@7.25.2))(@types/react@18.2.55)(encoding@0.1.13)(react@18.2.0))(react@18.2.0)
+      '@tamagui/list-item': 1.126.12(react-dom@18.2.0(react@18.2.0))(react-native@0.74.5(@babel/core@7.25.2)(@babel/preset-env@7.26.0(@babel/core@7.25.2))(@types/react@18.2.55)(encoding@0.1.13)(react@18.2.0))(react@18.2.0)
+      '@tamagui/polyfill-dev': 1.126.12
+      '@tamagui/popover': 1.126.12(@types/react@18.2.55)(react-dom@18.2.0(react@18.2.0))(react-native@0.74.5(@babel/core@7.25.2)(@babel/preset-env@7.26.0(@babel/core@7.25.2))(@types/react@18.2.55)(encoding@0.1.13)(react@18.2.0))(react@18.2.0)
+      '@tamagui/popper': 1.126.12(react-dom@18.2.0(react@18.2.0))(react-native@0.74.5(@babel/core@7.25.2)(@babel/preset-env@7.26.0(@babel/core@7.25.2))(@types/react@18.2.55)(encoding@0.1.13)(react@18.2.0))(react@18.2.0)
+      '@tamagui/portal': 1.126.12(react-dom@18.2.0(react@18.2.0))(react-native@0.74.5(@babel/core@7.25.2)(@babel/preset-env@7.26.0(@babel/core@7.25.2))(@types/react@18.2.55)(encoding@0.1.13)(react@18.2.0))(react@18.2.0)
+      '@tamagui/progress': 1.126.12(react-dom@18.2.0(react@18.2.0))(react-native@0.74.5(@babel/core@7.25.2)(@babel/preset-env@7.26.0(@babel/core@7.25.2))(@types/react@18.2.55)(encoding@0.1.13)(react@18.2.0))(react@18.2.0)
+      '@tamagui/radio-group': 1.126.12(react-dom@18.2.0(react@18.2.0))(react-native@0.74.5(@babel/core@7.25.2)(@babel/preset-env@7.26.0(@babel/core@7.25.2))(@types/react@18.2.55)(encoding@0.1.13)(react@18.2.0))(react@18.2.0)
+      '@tamagui/react-native-media-driver': 1.126.12(react-dom@18.2.0(react@18.2.0))(react-native@0.74.5(@babel/core@7.25.2)(@babel/preset-env@7.26.0(@babel/core@7.25.2))(@types/react@18.2.55)(encoding@0.1.13)(react@18.2.0))(react@18.2.0)
+      '@tamagui/scroll-view': 1.126.12(react-dom@18.2.0(react@18.2.0))(react-native@0.74.5(@babel/core@7.25.2)(@babel/preset-env@7.26.0(@babel/core@7.25.2))(@types/react@18.2.55)(encoding@0.1.13)(react@18.2.0))(react@18.2.0)
+      '@tamagui/select': 1.126.12(@types/react@18.2.55)(react-dom@18.2.0(react@18.2.0))(react-native@0.74.5(@babel/core@7.25.2)(@babel/preset-env@7.26.0(@babel/core@7.25.2))(@types/react@18.2.55)(encoding@0.1.13)(react@18.2.0))(react@18.2.0)
+      '@tamagui/separator': 1.126.12(react-dom@18.2.0(react@18.2.0))(react-native@0.74.5(@babel/core@7.25.2)(@babel/preset-env@7.26.0(@babel/core@7.25.2))(@types/react@18.2.55)(encoding@0.1.13)(react@18.2.0))(react@18.2.0)
+      '@tamagui/shapes': 1.126.12(react-dom@18.2.0(react@18.2.0))(react-native@0.74.5(@babel/core@7.25.2)(@babel/preset-env@7.26.0(@babel/core@7.25.2))(@types/react@18.2.55)(encoding@0.1.13)(react@18.2.0))(react@18.2.0)
+      '@tamagui/sheet': 1.126.12(@types/react@18.2.55)(react-dom@18.2.0(react@18.2.0))(react-native@0.74.5(@babel/core@7.25.2)(@babel/preset-env@7.26.0(@babel/core@7.25.2))(@types/react@18.2.55)(encoding@0.1.13)(react@18.2.0))(react@18.2.0)
+      '@tamagui/slider': 1.126.12(react-dom@18.2.0(react@18.2.0))(react-native@0.74.5(@babel/core@7.25.2)(@babel/preset-env@7.26.0(@babel/core@7.25.2))(@types/react@18.2.55)(encoding@0.1.13)(react@18.2.0))(react@18.2.0)
+      '@tamagui/stacks': 1.126.12(react-dom@18.2.0(react@18.2.0))(react-native@0.74.5(@babel/core@7.25.2)(@babel/preset-env@7.26.0(@babel/core@7.25.2))(@types/react@18.2.55)(encoding@0.1.13)(react@18.2.0))(react@18.2.0)
+      '@tamagui/switch': 1.126.12(react-dom@18.2.0(react@18.2.0))(react-native@0.74.5(@babel/core@7.25.2)(@babel/preset-env@7.26.0(@babel/core@7.25.2))(@types/react@18.2.55)(encoding@0.1.13)(react@18.2.0))(react@18.2.0)
+      '@tamagui/tabs': 1.126.12(react-dom@18.2.0(react@18.2.0))(react-native@0.74.5(@babel/core@7.25.2)(@babel/preset-env@7.26.0(@babel/core@7.25.2))(@types/react@18.2.55)(encoding@0.1.13)(react@18.2.0))(react@18.2.0)
+      '@tamagui/text': 1.126.12(react-dom@18.2.0(react@18.2.0))(react-native@0.74.5(@babel/core@7.25.2)(@babel/preset-env@7.26.0(@babel/core@7.25.2))(@types/react@18.2.55)(encoding@0.1.13)(react@18.2.0))(react@18.2.0)
+      '@tamagui/theme': 1.126.12(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
+      '@tamagui/toggle-group': 1.126.12(react-dom@18.2.0(react@18.2.0))(react-native@0.74.5(@babel/core@7.25.2)(@babel/preset-env@7.26.0(@babel/core@7.25.2))(@types/react@18.2.55)(encoding@0.1.13)(react@18.2.0))(react@18.2.0)
+      '@tamagui/tooltip': 1.126.12(@types/react@18.2.55)(react-dom@18.2.0(react@18.2.0))(react-native@0.74.5(@babel/core@7.25.2)(@babel/preset-env@7.26.0(@babel/core@7.25.2))(@types/react@18.2.55)(encoding@0.1.13)(react@18.2.0))(react@18.2.0)
+      '@tamagui/use-controllable-state': 1.126.12(react@18.2.0)
+      '@tamagui/use-debounce': 1.126.12(react@18.2.0)
+      '@tamagui/use-force-update': 1.126.12(react@18.2.0)
+      '@tamagui/use-window-dimensions': 1.126.12(react@18.2.0)
+      '@tamagui/visually-hidden': 1.126.12(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
+      '@tamagui/z-index-stack': 1.126.12
       react: 18.2.0
     transitivePeerDependencies:
       - '@types/react'
@@ -29543,12 +29483,6 @@ snapshots:
       escalade: 3.2.0
       picocolors: 1.0.1
 
-  update-browserslist-db@1.1.0(browserslist@4.23.3):
-    dependencies:
-      browserslist: 4.23.3
-      escalade: 3.2.0
-      picocolors: 1.0.1
-
   update-browserslist-db@1.1.1(browserslist@4.24.2):
     dependencies:
       browserslist: 4.24.2
@@ -29579,6 +29513,13 @@ snapshots:
     optionalDependencies:
       '@types/react': 18.2.55
 
+  use-callback-ref@1.3.3(@types/react@18.2.55)(react@18.2.0):
+    dependencies:
+      react: 18.2.0
+      tslib: 2.8.1
+    optionalDependencies:
+      '@types/react': 18.2.55
+
   use-latest-callback@0.1.9(react@18.2.0):
     dependencies:
       react: 18.2.0
@@ -29588,6 +29529,14 @@ snapshots:
       react: 18.2.0
 
   use-sidecar@1.1.2(@types/react@18.2.55)(react@18.2.0):
+    dependencies:
+      detect-node-es: 1.1.0
+      react: 18.2.0
+      tslib: 2.8.1
+    optionalDependencies:
+      '@types/react': 18.2.55
+
+  use-sidecar@1.1.3(@types/react@18.2.55)(react@18.2.0):
     dependencies:
       detect-node-es: 1.1.0
       react: 18.2.0
@@ -29749,17 +29698,6 @@ snapshots:
       - rollup
       - supports-color
       - typescript
-
-  vite@5.1.6(@types/node@20.10.8)(lightningcss@1.19.0)(terser@5.36.0):
-    dependencies:
-      esbuild: 0.19.12
-      postcss: 8.4.35
-      rollup: 4.13.0
-    optionalDependencies:
-      '@types/node': 20.10.8
-      fsevents: 2.3.3
-      lightningcss: 1.19.0
-      terser: 5.36.0
 
   vite@5.1.6(@types/node@20.14.10)(lightningcss@1.19.0)(terser@5.36.0):
     dependencies:


### PR DESCRIPTION
Cleans up the console by:

- no longer throwing bad fetch errors for embeds/avoiding attempts to fetch twitter emebeds on web
- fixing up Reference.tsx (we were passing context values as props in many places, or spreading props where we shouldn't) to get rid of a few errors about props being passed to a DOM element that shouldn't have been  (`actionIcon` and `contentSize`) .
- remove `isNotice` from the ContentContext initialization, removes the error log about `isNotice` being passed to a DOM element.
- Updates tamagui to the latest version to get rid of the forwardRef/bad setState() spam (https://github.com/tamagui/tamagui/issues/1828). Updating to the latest tamagui caused some uses of Text to appear too small (specifically, the section headers on the GroupChannelsScreenView, which should have been using our existing component anyway, and the "Starting Up..." text on desktop).

To get rid of the multiple messages from sqlocal about transactions we'll need to update sqlocal. Do we wanna do that now or wait? I feel like that message is pretty innocuous since it's short (and not an error).

fixes tlon-4228