### PR TITLE
ChatOptionsSheet: disable channel leave for hosts

### DIFF
--- a/packages/app/fixtures/ChatOptionsSheet.fixture.tsx
+++ b/packages/app/fixtures/ChatOptionsSheet.fixture.tsx
@@ -9,46 +9,137 @@ import { AppDataContextProvider } from '../ui/contexts/appDataContext';
 import { ChatOptionsProvider } from '../ui/contexts/chatOptions';
 import { FixtureWrapper } from './FixtureWrapper';
 
-const mockChannel = (isHost: boolean) =>
-  ({
+interface ChannelMock {
+  channel: db.Channel;
+}
+
+interface GroupMock {
+  group: db.Group;
+  groupUnread: db.GroupUnread | null;
+}
+
+const createMockData = (params: {
+  type: 'channel' | 'dm' | 'groupDm' | 'group';
+  isHost?: boolean;
+  unreadCount?: number;
+  privacy?: 'public' | 'private' | 'secret';
+  contactsCount?: number;
+}): ChannelMock | GroupMock => {
+  const {
+    type,
+    isHost = false,
+    unreadCount = 0,
+    privacy = 'public',
+    contactsCount = 1,
+  } = params;
+
+  const timestamp = Date.now();
+
+  if (type === 'group') {
+    if (unreadCount > 0) {
+      const group: db.Group = {
+        id: 'group/~sampel-palnet/test-group',
+        title: 'Test Group',
+        privacy,
+        currentUserIsMember: true,
+        currentUserIsHost: isHost,
+        hostUserId: '~sampel-palnet',
+        members: [],
+      } as db.Group;
+
+      // @ts-expect-error - dynamic property for UI
+      group.unread = {
+        count: unreadCount,
+      };
+
+      const groupUnread: db.GroupUnread = {
+        groupId: group.id,
+        updatedAt: timestamp,
+        count: unreadCount,
+        notifyCount: 0,
+        notify: false,
+      } as db.GroupUnread;
+
+      return { group, groupUnread };
+    } else {
+      const group: db.Group = {
+        id: 'group/~sampel-palnet/test-group',
+        title: 'Test Group',
+        privacy,
+        currentUserIsMember: true,
+        currentUserIsHost: isHost,
+        hostUserId: '~sampel-palnet',
+        members: [],
+      } as db.Group;
+
+      // @ts-expect-error - dynamic property for UI display
+      group.unread = {
+        count: 0,
+      };
+
+      const groupUnread: db.GroupUnread = {
+        groupId: group.id,
+        updatedAt: timestamp,
+        count: 0,
+        notifyCount: 0,
+        notify: false,
+      } as db.GroupUnread;
+
+      return { group, groupUnread };
+    }
+  }
+
+  if (type === 'dm' || type === 'groupDm') {
+    const members = Array.from({ length: contactsCount }, (_, i) => ({
+      contactId: `~${i === 0 ? 'sampel-palnet' : i}`,
+      membershipType: 'channel',
+    }));
+
+    const channel: db.Channel = {
+      id: `${type}/~sampel-palnet/${type === 'dm' ? 'direct-chat' : 'group-chat'}`,
+      type,
+      title: type === 'dm' ? undefined : 'Club',
+      groupId: undefined,
+      currentUserIsMember: true,
+      currentUserIsHost: false,
+      contactId: type === 'dm' ? '~zod' : undefined,
+      members: type === 'groupDm' ? members : undefined,
+    } as db.Channel;
+
+    if (unreadCount > 0) {
+      // @ts-expect-error - dynamic property for UI display
+      channel.unread = {
+        count: unreadCount,
+      };
+    } else {
+      // @ts-expect-error - dynamic property for UI display
+      channel.unread = { count: 0 };
+    }
+
+    return { channel };
+  }
+
+  const channel: db.Channel = {
     id: 'chat/~sampel-palnet/test-channel',
     type: 'chat',
     title: 'Test Channel',
     groupId: 'group/~sampel-palnet/test-group',
     currentUserIsMember: true,
     currentUserIsHost: isHost,
-    unreadCount: 0,
-  }) as db.Channel;
-
-const mockDM = (isDM: 'dm' | 'groupDm', contactsCount = 1) => {
-  const members = Array.from({ length: contactsCount }, (_, i) => ({
-    contactId: `~${i === 0 ? 'sampel-palnet' : i}`,
-    membershipType: 'channel',
-  }));
-
-  return {
-    id: `${isDM}/~sampel-palnet/${isDM === 'dm' ? 'direct-chat' : 'group-chat'}`,
-    type: isDM,
-    title: isDM === 'dm' ? undefined : 'Club',
-    groupId: undefined,
-    currentUserIsMember: true,
-    currentUserIsHost: false,
-    unreadCount: 0,
-    contactId: isDM === 'dm' ? '~zod' : undefined,
-    members: isDM === 'groupDm' ? members : undefined,
   } as db.Channel;
-};
 
-const mockGroup = (isHost: boolean, privacy: 'public' | 'private' | 'secret') =>
-  ({
-    id: 'group/~sampel-palnet/test-group',
-    title: 'Test Group',
-    privacy,
-    currentUserIsMember: true,
-    currentUserIsHost: isHost,
-    hostUserId: '~sampel-palnet',
-    members: [],
-  }) as db.Group;
+  if (unreadCount > 0) {
+    // @ts-expect-error - dynamic property for UI display
+    channel.unread = {
+      count: unreadCount,
+    };
+  } else {
+    // @ts-expect-error - dynamic property for UI display
+    channel.unread = { count: 0 };
+  }
+
+  return { channel };
+};
 
 const mockFunctions = {
   onPressGroupMeta: () => {},
@@ -72,6 +163,13 @@ const mockFunctions = {
 
 const ChannelOptions = () => {
   const [isHost] = useValue('Is Host', { defaultValue: false });
+  const [unreadCount] = useValue('Unread Count', { defaultValue: 0 });
+
+  const mock = createMockData({
+    type: 'channel',
+    isHost,
+    unreadCount,
+  }) as ChannelMock;
 
   return (
     <AppDataContextProvider>
@@ -79,7 +177,7 @@ const ChannelOptions = () => {
         <ChatOptionsProvider {...mockFunctions}>
           <ChannelOptionsSheetContent
             chatTitle={`Test Channel (${isHost ? "you're the host" : "you're a member"})`}
-            channel={mockChannel(isHost)}
+            channel={mock.channel}
             onPressNotifications={() => {}}
             onOpenChange={() => {}}
           />
@@ -91,10 +189,18 @@ const ChannelOptions = () => {
 
 const GroupOptions = () => {
   const [isHost] = useValue('Is Host', { defaultValue: false });
+  const [unreadCount] = useValue('Unread Count', { defaultValue: 0 });
   const [privacy] = useSelect('Privacy', {
     options: ['public', 'private', 'secret'],
     defaultValue: 'public',
   });
+
+  const mock = createMockData({
+    type: 'group',
+    isHost,
+    unreadCount,
+    privacy: privacy as 'public' | 'private' | 'secret',
+  }) as GroupMock;
 
   return (
     <AppDataContextProvider>
@@ -102,11 +208,8 @@ const GroupOptions = () => {
         <ChatOptionsProvider {...mockFunctions}>
           <GroupOptionsSheetContent
             chatTitle={`${privacy.charAt(0).toUpperCase() + privacy.slice(1)} Group (${isHost ? "you're the host" : "you're a member"})`}
-            group={mockGroup(
-              isHost,
-              privacy as 'public' | 'private' | 'secret'
-            )}
-            groupUnread={null}
+            group={mock.group}
+            groupUnread={mock.groupUnread}
             currentUserIsAdmin={isHost}
             onPressNotifications={() => {}}
             onPressSort={() => {}}
@@ -128,6 +231,14 @@ const DMOptions = () => {
     defaultValue: dmType === 'dm' ? 1 : 3,
   });
 
+  const [unreadCount] = useValue('Unread Count', { defaultValue: 0 });
+
+  const mock = createMockData({
+    type: dmType as 'dm' | 'groupDm',
+    contactsCount: memberCount,
+    unreadCount,
+  }) as ChannelMock;
+
   const title =
     dmType === 'dm' ? 'Direct Message' : `Group DM (${memberCount} members)`;
 
@@ -137,7 +248,7 @@ const DMOptions = () => {
         <ChatOptionsProvider {...mockFunctions}>
           <ChannelOptionsSheetContent
             chatTitle={title}
-            channel={mockDM(dmType as 'dm' | 'groupDm', memberCount)}
+            channel={mock.channel}
             onPressNotifications={() => {}}
             onOpenChange={() => {}}
           />

--- a/packages/app/fixtures/ChatOptionsSheet.fixture.tsx
+++ b/packages/app/fixtures/ChatOptionsSheet.fixture.tsx
@@ -1,0 +1,154 @@
+import * as db from '@tloncorp/shared/db';
+import { useSelect, useValue } from 'react-cosmos/client';
+
+import {
+  ChannelOptionsSheetContent,
+  GroupOptionsSheetContent,
+} from '../ui/components/ChatOptionsSheet';
+import { AppDataContextProvider } from '../ui/contexts/appDataContext';
+import { ChatOptionsProvider } from '../ui/contexts/chatOptions';
+import { FixtureWrapper } from './FixtureWrapper';
+
+const mockChannel = (isHost: boolean) =>
+  ({
+    id: 'chat/~sampel-palnet/test-channel',
+    type: 'chat',
+    title: 'Test Channel',
+    groupId: 'group/~sampel-palnet/test-group',
+    currentUserIsMember: true,
+    currentUserIsHost: isHost,
+    unreadCount: 0,
+  }) as db.Channel;
+
+const mockDM = (isDM: 'dm' | 'groupDm', contactsCount = 1) => {
+  const members = Array.from({ length: contactsCount }, (_, i) => ({
+    contactId: `~${i === 0 ? 'sampel-palnet' : i}`,
+    membershipType: 'channel',
+  }));
+
+  return {
+    id: `${isDM}/~sampel-palnet/${isDM === 'dm' ? 'direct-chat' : 'group-chat'}`,
+    type: isDM,
+    title: isDM === 'dm' ? undefined : 'Club',
+    groupId: undefined,
+    currentUserIsMember: true,
+    currentUserIsHost: false,
+    unreadCount: 0,
+    contactId: isDM === 'dm' ? '~zod' : undefined,
+    members: isDM === 'groupDm' ? members : undefined,
+  } as db.Channel;
+};
+
+const mockGroup = (isHost: boolean, privacy: 'public' | 'private' | 'secret') =>
+  ({
+    id: 'group/~sampel-palnet/test-group',
+    title: 'Test Group',
+    privacy,
+    currentUserIsMember: true,
+    currentUserIsHost: isHost,
+    hostUserId: '~sampel-palnet',
+    members: [],
+  }) as db.Group;
+
+const mockFunctions = {
+  onPressGroupMeta: () => {},
+  onPressGroupMembers: () => {},
+  onPressManageChannels: () => {},
+  onPressInvite: () => {},
+  onPressGroupPrivacy: () => {},
+  onPressChannelMembers: () => {},
+  onPressChannelMeta: () => {},
+  onPressChannelTemplate: () => {},
+  onPressRoles: () => {},
+  onPressChatDetails: () => {},
+  leaveGroup: async () => {},
+  leaveChannel: () => {},
+  onLeaveGroup: () => {},
+  togglePinned: () => {},
+  markChannelRead: () => {},
+  markGroupRead: () => {},
+  updateVolume: () => {},
+};
+
+const ChannelOptions = () => {
+  const [isHost] = useValue('Is Host', { defaultValue: false });
+
+  return (
+    <AppDataContextProvider>
+      <FixtureWrapper>
+        <ChatOptionsProvider {...mockFunctions}>
+          <ChannelOptionsSheetContent
+            chatTitle={`Test Channel (${isHost ? "you're the host" : "you're a member"})`}
+            channel={mockChannel(isHost)}
+            onPressNotifications={() => {}}
+            onOpenChange={() => {}}
+          />
+        </ChatOptionsProvider>
+      </FixtureWrapper>
+    </AppDataContextProvider>
+  );
+};
+
+const GroupOptions = () => {
+  const [isHost] = useValue('Is Host', { defaultValue: false });
+  const [privacy] = useSelect('Privacy', {
+    options: ['public', 'private', 'secret'],
+    defaultValue: 'public',
+  });
+
+  return (
+    <AppDataContextProvider>
+      <FixtureWrapper>
+        <ChatOptionsProvider {...mockFunctions}>
+          <GroupOptionsSheetContent
+            chatTitle={`${privacy.charAt(0).toUpperCase() + privacy.slice(1)} Group (${isHost ? "you're the host" : "you're a member"})`}
+            group={mockGroup(
+              isHost,
+              privacy as 'public' | 'private' | 'secret'
+            )}
+            groupUnread={null}
+            currentUserIsAdmin={isHost}
+            onPressNotifications={() => {}}
+            onPressSort={() => {}}
+            onOpenChange={() => {}}
+          />
+        </ChatOptionsProvider>
+      </FixtureWrapper>
+    </AppDataContextProvider>
+  );
+};
+
+const DMOptions = () => {
+  const [dmType] = useSelect('DM Type', {
+    options: ['dm', 'groupDm'],
+    defaultValue: 'dm',
+  });
+
+  const [memberCount] = useValue('Member Count', {
+    defaultValue: dmType === 'dm' ? 1 : 3,
+  });
+
+  const title =
+    dmType === 'dm' ? 'Direct Message' : `Group DM (${memberCount} members)`;
+
+  return (
+    <AppDataContextProvider>
+      <FixtureWrapper>
+        <ChatOptionsProvider {...mockFunctions}>
+          <ChannelOptionsSheetContent
+            chatTitle={title}
+            channel={mockDM(dmType as 'dm' | 'groupDm', memberCount)}
+            onPressNotifications={() => {}}
+            onOpenChange={() => {}}
+          />
+        </ChatOptionsProvider>
+      </FixtureWrapper>
+    </AppDataContextProvider>
+  );
+};
+
+export default {
+  'Channel Options': ChannelOptions,
+  'Group Options': GroupOptions,
+  'DM Options': DMOptions,
+};

--- a/packages/app/ui/components/ChatOptionsSheet.tsx
+++ b/packages/app/ui/components/ChatOptionsSheet.tsx
@@ -230,7 +230,7 @@ export function GroupOptionsSheetLoader({
   );
 }
 
-function GroupOptionsSheetContent({
+export function GroupOptionsSheetContent({
   chatTitle,
   group,
   groupUnread,
@@ -579,7 +579,7 @@ const ChannelOptionsSheetLoader = memo(
 );
 ChannelOptionsSheetLoader.displayName = 'ChannelOptionsSheetLoader';
 
-function ChannelOptionsSheetContent({
+export function ChannelOptionsSheetContent({
   chatTitle,
   channel,
   onPressConfigureChannel,
@@ -609,7 +609,7 @@ function ChannelOptionsSheetContent({
     channel.groupId ?? '',
     currentUserId
   );
-  const currentUserIsHost = group?.currentUserIsHost ?? false;
+  const currentUserIsChannelHost = channel.currentUserIsHost ?? false;
 
   const groupTitle = utils.useGroupTitle(group) ?? 'group';
   const isSingleChannelGroup = group?.channels?.length === 1;
@@ -690,7 +690,15 @@ function ChannelOptionsSheetContent({
             action: wrappedAction.bind(null, onPressChannelTemplate),
           },
         ],
-        !currentUserIsHost && [
+        currentUserIsChannelHost && [
+          'negative',
+          {
+            title: 'Cannot leave channel',
+            description: 'Host (you) must delete to leave',
+            disabled: true,
+          },
+        ],
+        !currentUserIsChannelHost && [
           'negative',
           {
             title: group ? `Leave channel` : 'Leave chat',
@@ -716,7 +724,7 @@ function ChannelOptionsSheetContent({
       onPressConfigureChannel,
       hooksPreview,
       onPressChannelTemplate,
-      currentUserIsHost,
+      currentUserIsChannelHost,
       leaveChannel,
     ]
   );
@@ -751,7 +759,7 @@ function ChannelOptionsSheetContent({
   );
 }
 
-function ChatOptionsSheetContent({
+export function ChatOptionsSheetContent({
   actionGroups,
   title,
   subtitle,


### PR DESCRIPTION
Fixes TLON-4183 by adding a simple check to see if the user is the channel host; if not, then we display a message that they have to delete the channel and can't leave it on their own accord.

This also adds a pretty robust fixture for the ChatOptionsSheet, which:

- Splits the demonstration out into three cases: individual channel, group, and DM
- Adds options for unread counts to show and hide the "Mark all as read" option
- Adds options for group privacy to toggle invite availability for members
- Adds an option for host/member status to test TLON-4183 ;)

![rec](https://github.com/user-attachments/assets/9d696214-8405-436e-8ac9-854ec7d6cb68)
