### PR TITLE
track errors when attempting to load posts

### DIFF
--- a/packages/shared/src/store/useChannelPosts.ts
+++ b/packages/shared/src/store/useChannelPosts.ts
@@ -75,6 +75,16 @@ export const useChannelPosts = (options: UseChannelPostsParams) => {
       count: firstPageCount,
     } as UseChannelPostsPageParams,
     refetchOnMount: false,
+    retry(failureCount, error) {
+      postsLogger.trackError('failed to load posts', {
+        errorMessage: error.message,
+        errorStack: error.stack,
+      });
+      if (failureCount > 3) {
+        return false;
+      }
+      return true;
+    },
     queryFn: async (ctx): Promise<PostQueryPage> => {
       const queryOptions = ctx.pageParam || options;
       postsLogger.log('loading posts', { queryOptions, options });


### PR DESCRIPTION
Small first PR for improving channel load telemetry -- this tracks a posthog error when we fail to retrieve posts for any reason.