### PR TITLE
channels: retain mark types across protocol change

### DIFF
--- a/desk/lib/channel-json.hoon
+++ b/desk/lib/channel-json.hoon
@@ -1217,6 +1217,57 @@
           inline+(ar inline)
       ==
     ::
+    ++  inline
+      |=  j=json
+      ^-  inline:v7:old:c
+      ?:  ?=([%s *] j)  p.j
+      =>  .(j `json`j)
+      %.  j
+      %-  of
+      :~  italics/(ar inline)
+          bold/(ar inline)
+          strike/(ar inline)
+          blockquote/(ar inline)
+          ship/ship
+          inline-code/so
+          code/so
+          tag/so
+          break/ul
+      ::
+        :-  %block
+        %-  ot
+        :~  index/ni
+            text/so
+        ==
+      ::
+        :-  %link
+        %-  ot
+        :~  href/so
+            content/so
+        ==
+      ::
+        :-  %task
+        %-  ot
+        :~  checked/bo
+            content/(ar inline)
+        ==
+      ==
+    ::
+    ++  listing
+      |=  j=json
+      ^-  listing:v7:old:c
+      %.  j
+      %-  of
+      :~
+        item/(ar inline)
+        :-  %list
+        %-  ot
+        :~  type/(su (perk %ordered %unordered %tasklist ~))
+            items/(ar listing)
+            contents/(ar inline)
+        ==
+      ==
+    ::
     ++  block
       ^-  $-(json block:v7:old:c)
       %-  of

--- a/desk/lib/channel-utils.hoon
+++ b/desk/lib/channel-utils.hoon
@@ -451,9 +451,42 @@
 ++  verse-1
   |=  =verse:c
   ^-  verse:v7:old:c
-  ?.  ?=([%block %link *] verse)
-    verse
-  [%inline [%link [. .]:url.p.verse] ~]  ::REVIEW
+  ?+  verse  verse
+      [%inline *]
+    [%inline (turn p.verse inline-1)]
+  ::
+      [%block %header *]
+    verse(q.p (turn q.p.verse inline-1))
+  ::
+      [%block %listing *]
+    verse(p.p (listing-1 p.p.verse))
+  ::
+      [%block %link *]
+    [%inline [%link [. .]:url.p.verse] ~]  ::REVIEW
+  ==
+::
+++  listing-1
+  |=  =listing:c
+  ^-  listing:v7:old:c
+  ?-  -.listing
+    %list  listing(q (turn q.listing listing-1), r (turn r.listing inline-1))
+    %item  listing(p (turn p.listing inline-1))
+  ==
+::
+++  inline-1
+  |=  =inline:c
+  ^-  inline:v7:old:c
+  ?@  inline  inline
+  ?+  -.inline  inline
+      ?(%italics %bold %strike %blockquote)
+    inline(p (turn p.inline inline-1))
+  ::
+      %task
+    inline(q (turn q.inline inline-1))
+  ::
+      %sect
+    (cat 3 '@' ?~(p.inline 'all' p.inline))
+  ==
 ::
 ++  essay-1
   |=  =essay:c

--- a/desk/mar/channel/response-1.hoon
+++ b/desk/mar/channel/response-1.hoon
@@ -1,15 +1,15 @@
 /-  d=channels
 /+  j=channel-json
-|_  =r-channels:d
+|_  =r-channels:v7:old:d
 ++  grad  %noun
 ++  grow
   |%
   ++  noun  r-channels
-  ++  json  (r-channels:enjs:j r-channels)
+  ++  json  (r-channels:v7:enjs:j r-channels)
   --
 ++  grab
   |%
-  ++  noun  r-channels:d
+  ++  noun  r-channels:v7:old:d
 
   --
 --

--- a/desk/sur/channels.hoon
+++ b/desk/sur/channels.hoon
@@ -636,9 +636,33 @@
       $%  [%block p=block]
           [%inline p=(list inline)]
       ==
+    +$  listing
+      $%  [%list p=?(%ordered %unordered %tasklist) q=(list listing) r=(list inline)]
+          [%item p=(list inline)]
+      ==
     +$  block
-      $~  [%rule ~]
-      $<(%link ^block)
+      $%  [%image src=cord height=@ud width=@ud alt=cord]
+          [%cite =cite:c]
+          [%header p=?(%h1 %h2 %h3 %h4 %h5 %h6) q=(list inline)]
+          [%listing p=listing]
+          [%rule ~]
+          [%code code=cord lang=cord]
+      ==
+    +$  inline
+      $@  @t
+      $%  [%italics p=(list inline)]
+          [%bold p=(list inline)]
+          [%strike p=(list inline)]
+          [%blockquote p=(list inline)]
+          [%inline-code p=cord]
+          [%code p=cord]
+          [%ship p=ship]
+          [%block p=@ud q=cord]
+          [%tag p=cord]
+          [%link p=cord q=cord]
+          [%task p=?(%.y %.n) q=(list inline)]
+          [%break ~]
+      ==
     +$  v-replies     ((mop id-reply (unit v-reply)) lte)
     +$  channels  (map nest channel)
     ++  channel


### PR DESCRIPTION
The recursive changes to the $inline type (specifically the %sect addition) and the presence of both $inline and $block in $listing had gone unnoticed, resulting in mark types changing unintentionally.

Here, we make sure all affected types get a proper entry in +v7 in /sur/channels, and that mark files use that older type version as necessary.

Mandatory utils and json changes included.

Note that the %channel-update and %channel-checkpoint marks, which are emitted by channels-server, still change due to the protocol changes. Since these marks only ever come out of channels-server, and interaction with that agent is (intended to be) gated behind version negotiation, we just let that happen.