### PR TITLE
fix gallery image previews

### DIFF
--- a/packages/app/ui/components/GalleryPost/GalleryPost.tsx
+++ b/packages/app/ui/components/GalleryPost/GalleryPost.tsx
@@ -448,6 +448,7 @@ function SmallPreview({
   ) : (
     <PreviewFrame {...props} previewType={content[0]?.type ?? 'unsupported'}>
       <SmallContentRenderer
+        height={'100%'}
         content={containsPreviewableContent ? content.slice(0, 1) : content}
       />
     </PreviewFrame>


### PR DESCRIPTION
Fixes TLON-4253.

Looks like `height: 100%` got accidentally removed in the preview update.