### PR TITLE
content-helpers: make sure we extract the text for code blocks

### DIFF
--- a/packages/shared/src/logic/content-helpers.test.ts
+++ b/packages/shared/src/logic/content-helpers.test.ts
@@ -2,7 +2,7 @@ import { expect, test } from 'vitest';
 
 import { Mention, textAndMentionsToContent } from './content-helpers';
 
-test('textAndMentionsToContent', () => {
+test('textAndMentionsToContent: multiline mentions', () => {
   const text = "User One Hello, world! here's more to the message.\nUser Two";
   const mentions: Mention[] = [
     { id: 'user1', display: 'User One', start: 0, end: 7 },
@@ -41,6 +41,92 @@ test('textAndMentionsToContent', () => {
           {
             type: 'text',
             text: ' ',
+          },
+        ],
+      },
+    ],
+  });
+});
+
+test('textAndMentionsToContent: code blocks without mentions', () => {
+  const text = 'This is a code block:\n```\nconst x = 42;\n```';
+  const mentions: Mention[] = [];
+
+  const result = textAndMentionsToContent(text, mentions);
+
+  expect(result).toEqual({
+    type: 'doc',
+    content: [
+      {
+        type: 'paragraph',
+        content: [
+          {
+            type: 'text',
+            text: 'This is a code block: ',
+          },
+        ],
+      },
+      {
+        type: 'codeBlock',
+        attrs: {
+          language: 'plaintext',
+        },
+        content: [
+          {
+            type: 'text',
+            text: 'const x = 42;',
+          },
+        ],
+      },
+    ],
+  });
+});
+
+test('textAndMentionsToContent: mixed text mentions with code blocks in between', () => {
+  const text =
+    'This is a code block:\n```\nconst x = 42;\n```\nUser One Hello, world!';
+  const mentions: Mention[] = [
+    { id: 'user1', display: 'User One', start: 45, end: 52 },
+  ];
+
+  const result = textAndMentionsToContent(text, mentions);
+
+  expect(result).toEqual({
+    type: 'doc',
+    content: [
+      {
+        type: 'paragraph',
+        content: [
+          {
+            type: 'text',
+            text: 'This is a code block: ',
+          },
+        ],
+      },
+      {
+        type: 'codeBlock',
+        attrs: {
+          language: 'plaintext',
+        },
+        content: [
+          {
+            type: 'text',
+            text: 'const x = 42;',
+          },
+        ],
+      },
+      {
+        type: 'paragraph',
+        content: [
+          {
+            type: 'mention',
+            attrs: {
+              id: 'user1',
+            },
+          },
+          {
+            type: 'text',
+            text: ' Hello, world! ',
           },
         ],
       },

--- a/packages/shared/src/logic/content-helpers.ts
+++ b/packages/shared/src/logic/content-helpers.ts
@@ -326,7 +326,7 @@ export function textAndMentionsToContent(
           content: [
             {
               type: 'text',
-              text: currentCodeBlock.join('\n'),
+              text: currentCodeBlock.map((line) => line.text).join('\n'),
             },
           ],
           attrs: {


### PR DESCRIPTION
OTT reported by in support channel