### PR TITLE
ops: bump nockjs version

### DIFF
--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -54,7 +54,7 @@
     "expo-contacts": "~13.0.5",
     "expo-localization": "~15.0.3",
     "@urbit/aura": "^2.0.1",
-    "@urbit/nockjs": "github:urbit/nockjs#8ed20e5",
+    "@urbit/nockjs": "^1.6.0",
     "any-ascii": "^0.3.1",
     "big-integer": "^1.6.52",
     "browser-or-node": "^3.0.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1069,8 +1069,8 @@ importers:
         specifier: ^2.0.1
         version: 2.0.1
       '@urbit/nockjs':
-        specifier: github:urbit/nockjs#8ed20e5
-        version: https://codeload.github.com/urbit/nockjs/tar.gz/8ed20e5
+        specifier: ^1.6.0
+        version: 1.6.0
       any-ascii:
         specifier: ^0.3.1
         version: 0.3.2(patch_hash=5ofxtlxe6za2xqrbq5pqbz7wb4)
@@ -5854,9 +5854,8 @@ packages:
   '@urbit/http-api@3.2.0-dev':
     resolution: {integrity: sha512-phG35u7Uhlg4ZIRt/7mVum9KuR0j7XrxMnYsRUlRk3XgsXgDDNOgT7tvKeY6+L2PTblUOBqcVqNWNtzAOsy3hQ==}
 
-  '@urbit/nockjs@https://codeload.github.com/urbit/nockjs/tar.gz/8ed20e5':
-    resolution: {tarball: https://codeload.github.com/urbit/nockjs/tar.gz/8ed20e5}
-    version: 1.5.0
+  '@urbit/nockjs@1.6.0':
+    resolution: {integrity: sha512-f2xCIxoYQh+bp/p6qztvgxnhGsnUwcrSSvW2CUKX7BPPVkDNppQCzCVPWo38TbqgChE7wh6rC1pm6YNCOyFlQA==}
 
   '@urbit/sigil-js@2.2.0':
     resolution: {integrity: sha512-UNtRJ0K4CAXe+IP4wARNRMjuI5GTF2MNj9FL5l4RSMddCPJqSWSpkrYcREBI4AOB+80AEyN1kK/jtzhlm5WW+w==}
@@ -20835,7 +20834,7 @@ snapshots:
       browser-or-node: 1.3.0
       core-js: 3.24.1
 
-  '@urbit/nockjs@https://codeload.github.com/urbit/nockjs/tar.gz/8ed20e5': {}
+  '@urbit/nockjs@1.6.0': {}
 
   '@urbit/sigil-js@2.2.0':
     dependencies:


### PR DESCRIPTION
OTT

We published the new version with the changes that required us to use the git tag.