### PR TITLE
navigation: add param extractor functions to navigation utils, move param extraction out of components

### DIFF
--- a/packages/app/features/top/ChannelScreen.tsx
+++ b/packages/app/features/top/ChannelScreen.tsx
@@ -6,7 +6,6 @@ import {
   useChannelContext,
 } from '@tloncorp/shared';
 import * as db from '@tloncorp/shared/db';
-import * as logic from '@tloncorp/shared/logic';
 import * as store from '@tloncorp/shared/store';
 import {
   useCanUpload,
@@ -24,6 +23,11 @@ import { useGroupActions } from '../../hooks/useGroupActions';
 import { useFeatureFlag } from '../../lib/featureFlags';
 import type { RootStackParamList } from '../../navigation/types';
 import {
+  getChannelId,
+  getSelectedPostId,
+  shouldStartDraft,
+} from '../../navigation/utils';
+import {
   AttachmentProvider,
   Channel,
   ChannelSwitcherSheet,
@@ -38,11 +42,10 @@ const logger = createDevLogger('ChannelScreen', false);
 type Props = NativeStackScreenProps<RootStackParamList, 'Channel'>;
 
 export default function ChannelScreen(props: Props) {
-  const { channelId, selectedPostId, startDraft } = props.route.params ?? {
-    channelId: '',
-    selectedPostId: '',
-    startDraft: false,
-  };
+  const channelId = getChannelId(props.route) ?? '';
+  const selectedPostId = getSelectedPostId(props.route) ?? '';
+  const startDraft = shouldStartDraft(props.route);
+
   const [currentChannelId, setCurrentChannelId] = React.useState(channelId);
 
   useEffect(() => {

--- a/packages/app/navigation/desktop/MessagesNavigator.tsx
+++ b/packages/app/navigation/desktop/MessagesNavigator.tsx
@@ -22,6 +22,7 @@ import { UserProfileScreen } from '../../features/top/UserProfileScreen';
 import { DESKTOP_SIDEBAR_WIDTH, useGlobalSearch } from '../../ui';
 import { GroupSettingsStack } from '../GroupSettingsStack';
 import { HomeDrawerParamList } from '../types';
+import { getChannelId } from '../utils';
 import { MessagesSidebar } from './MessagesSidebar';
 
 const MessagesDrawer = createDrawerNavigator();
@@ -66,8 +67,11 @@ export const MessagesNavigator = () => {
 const DrawerContent = memo((props: DrawerContentComponentProps) => {
   const state = props.state as NavigationState<HomeDrawerParamList>;
   const focusedRoute = state.routes[props.state.index];
-  if (focusedRoute.params && 'channelId' in focusedRoute.params) {
-    return <MessagesSidebar focusedChannelId={focusedRoute.params.channelId} />;
+  
+  const channelId = getChannelId(focusedRoute);
+  
+  if (channelId) {
+    return <MessagesSidebar focusedChannelId={channelId} />;
   } else {
     return <MessagesSidebar />;
   }
@@ -96,14 +100,8 @@ function ChannelStack(
   props: NativeStackScreenProps<HomeDrawerParamList, 'Channel'>
 ) {
   const navKey = () => {
-    if ('channelId' in props.route.params) {
-      return props.route.params.channelId;
-    }
-    if (props.route.params.params && 'channelId' in props.route.params.params) {
-      return props.route.params.params.channelId;
-    }
-
-    return 'none';
+    const channelId = getChannelId(props.route);
+    return channelId || 'none';
   };
 
   return (

--- a/packages/app/navigation/desktop/ProfileNavigator.tsx
+++ b/packages/app/navigation/desktop/ProfileNavigator.tsx
@@ -21,6 +21,7 @@ import {
   isWeb,
 } from '../../ui';
 import { ProfileDrawerParamList } from '../types';
+import { getUserId } from '../utils';
 
 const ProfileDrawer = createDrawerNavigator();
 
@@ -28,6 +29,8 @@ function DrawerContent(props: DrawerContentComponentProps) {
   const state = props.state as NavigationState<ProfileDrawerParamList>;
   const { navigate } = props.navigation;
   const focusedRoute = state.routes[props.state.index];
+
+  const userId = getUserId(focusedRoute);
 
   const { data: userContacts } = store.useUserContacts();
   const { data: suggestions } = store.useSuggestedContacts();
@@ -82,7 +85,7 @@ function DrawerContent(props: DrawerContentComponentProps) {
       <ContactsScreenView
         contacts={userContacts ?? []}
         suggestions={suggestions ?? []}
-        focusedContactId={focusedRoute.params?.userId}
+        focusedContactId={userId}
         onContactPress={onContactPress}
         onAddContact={onAddContact}
         onContactLongPress={onContactLongPress}

--- a/packages/app/navigation/desktop/SettingsNavigator.tsx
+++ b/packages/app/navigation/desktop/SettingsNavigator.tsx
@@ -20,6 +20,7 @@ import { useCurrentUserId } from '../../hooks/useCurrentUser';
 import { useHandleLogout } from '../../hooks/useHandleLogout';
 import { useResetDb } from '../../hooks/useResetDb';
 import { DESKTOP_SIDEBAR_WIDTH, SettingsScreenView } from '../../ui';
+import { getRouteName } from '../utils';
 
 const SettingsDrawer = createDrawerNavigator();
 
@@ -31,7 +32,7 @@ function DrawerContent(props: DrawerContentComponentProps) {
   const { dmLink } = useDMLureLink();
   const hasHostedAuth = useHasHostedAuth();
   const focusedRoute = props.state.routes[props.state.index];
-
+  const routeName = getRouteName(focusedRoute);
   const onAppInfoPressed = useCallback(() => {
     navigate('AppInfo');
   }, [navigate]);
@@ -78,7 +79,7 @@ function DrawerContent(props: DrawerContentComponentProps) {
       onThemePressed={onThemePressed}
       onPrivacyPressed={onPrivacyPressed}
       dmLink={dmLink}
-      focusedRouteName={focusedRoute.name}
+      focusedRouteName={routeName}
     />
   );
 }

--- a/packages/app/navigation/utils.ts
+++ b/packages/app/navigation/utils.ts
@@ -475,3 +475,151 @@ export function screenNameFromChannelId(channelId: string) {
       ? 'GroupDM'
       : 'Channel';
 }
+
+/**
+ * Safely extracts a channel ID from navigation route parameters
+ * handling various parameter structures in the navigation system.
+ * 
+ * @param route Any navigation route object
+ * @returns The channel ID if found, undefined otherwise
+ */
+export function getChannelId(route: any): string | undefined {
+  return getParamValue<string>(route, 'channelId');
+}
+
+/**
+ * Safely extracts a group ID from navigation route parameters
+ * handling various parameter structures in the navigation system.
+ * 
+ * @param route Any navigation route object
+ * @returns The group ID if found, undefined otherwise
+ */
+export function getGroupId(route: any): string | undefined {
+  return getParamValue<string>(route, 'groupId');
+}
+
+/**
+ * Safely extracts a user ID from navigation route parameters
+ * handling various parameter structures in the navigation system.
+ * 
+ * @param route Any navigation route object
+ * @returns The user ID if found, undefined otherwise
+ */
+export function getUserId(route: any): string | undefined {
+  return getParamValue<string>(route, 'userId');
+}
+
+/**
+ * Safely extracts chat details (chatId and chatType) from route parameters
+ * 
+ * @param route Any navigation route object
+ * @returns Object with chatId and chatType if found, undefined otherwise
+ */
+export function getChatDetails(route: any): { chatId: string; chatType: 'group' | 'channel' } | undefined {
+  const chatId = getParamValue<string>(route, 'chatId');
+  const chatType = getParamValue<'group' | 'channel'>(route, 'chatType');
+  
+  if (chatId && chatType) {
+    return { chatId, chatType };
+  }
+  
+  return undefined;
+}
+
+/**
+ * Safely extracts a post ID from navigation route parameters
+ * 
+ * @param route Any navigation route object
+ * @returns The post ID if found, undefined otherwise
+ */
+export function getPostId(route: any): string | undefined {
+  return getParamValue<string>(route, 'postId');
+}
+
+/**
+ * Safely extracts a selected post ID from navigation route parameters
+ * 
+ * @param route Any navigation route object
+ * @returns The selected post ID if found, undefined otherwise
+ */
+export function getSelectedPostId(route: any): string | undefined {
+  return getParamValue<string>(route, 'selectedPostId');
+}
+
+/**
+ * Safely extracts an author ID from navigation route parameters
+ * 
+ * @param route Any navigation route object
+ * @returns The author ID if found, undefined otherwise
+ */
+export function getAuthorId(route: any): string | undefined {
+  return getParamValue<string>(route, 'authorId');
+}
+
+/**
+ * Safely checks if the startDraft flag is set in the navigation route parameters
+ * 
+ * @param route Any navigation route object
+ * @returns True if startDraft is set, false otherwise
+ */
+export function shouldStartDraft(route: any): boolean {
+  return getParamValue<boolean>(route, 'startDraft') === true;
+}
+
+/**
+ * Safely extracts the route name from navigation route parameters
+ * 
+ * @param route Any navigation route object
+ * @returns The route name if found, undefined otherwise
+ */
+export function getRouteName(route: any): string | undefined {
+  return getParamValue<string>(route, 'name');
+}
+
+/**
+ * Generic function to safely extract parameters from navigation route objects
+ * handling various parameter structures in the navigation system.
+ * 
+ * @param route Any navigation route object
+ * @param paramName The name of the parameter to extract
+ * @param defaultValue Optional default value to return if parameter is not found
+ * @returns The parameter value if found, defaultValue or undefined otherwise
+ */
+export function getParamValue<T>(
+  route: any,
+  paramName: string,
+  defaultValue?: T
+): T | undefined {
+  // Handle null or undefined route
+  if (!route) return defaultValue;
+  
+  // Direct access - route.params[paramName]
+  if (route.params && typeof route.params[paramName] !== 'undefined') {
+    return route.params[paramName] as T;
+  }
+  
+  // Nested params - route.params.params[paramName]
+  if (route.params?.params && typeof route.params.params[paramName] !== 'undefined') {
+    return route.params.params[paramName] as T;
+  }
+  
+  // Screen → params pattern often used in nested navigators
+  if (
+    route.params?.screen && 
+    route.params.params && 
+    typeof route.params.params[paramName] !== 'undefined'
+  ) {
+    return route.params.params[paramName] as T;
+  }
+  
+  // Deep nesting common in desktop navigators
+  if (
+    route.params?.params?.screen && 
+    route.params.params.params && 
+    typeof route.params.params.params[paramName] !== 'undefined'
+  ) {
+    return route.params.params.params[paramName] as T;
+  }
+  
+  return defaultValue;
+}


### PR DESCRIPTION
This gives us just one place to check for navigation param related logic, which is pretty tricky in our app since we make heavy use of nested navigators.

I'm pen to other ideas on how to get this logic out of our components and into one central location, btw.

also fixes tlon-4273