### PR TITLE
mobile: fix query client provider regression

### DIFF
--- a/apps/tlon-mobile/src/App.main.tsx
+++ b/apps/tlon-mobile/src/App.main.tsx
@@ -153,29 +153,29 @@ export default function ConnectedApp() {
   return (
     <ErrorBoundary>
       <FeatureFlagConnectedInstrumentationProvider>
-        <TamaguiProvider>
-          <ShipProvider>
-            <NavigationContainer
-              theme={isDarkMode ? DarkTheme : DefaultTheme}
-              ref={navigationContainerRef}
-            >
-              <StoreProvider>
-                <BranchProvider>
-                  <PostHogProvider
-                    client={posthogAsync}
-                    autocapture={{
-                      captureTouches: false,
-                    }}
-                    options={{
-                      enable:
-                        process.env.NODE_ENV !== 'test' ||
-                        !!process.env.POST_HOG_IN_DEV,
-                    }}
-                  >
-                    <GestureHandlerRootView style={{ flex: 1 }}>
-                      <SafeAreaProvider>
-                        <MigrationCheck>
-                          <QueryClientProvider client={queryClient}>
+        <QueryClientProvider client={queryClient}>
+          <TamaguiProvider>
+            <ShipProvider>
+              <NavigationContainer
+                theme={isDarkMode ? DarkTheme : DefaultTheme}
+                ref={navigationContainerRef}
+              >
+                <StoreProvider>
+                  <BranchProvider>
+                    <PostHogProvider
+                      client={posthogAsync}
+                      autocapture={{
+                        captureTouches: false,
+                      }}
+                      options={{
+                        enable:
+                          process.env.NODE_ENV !== 'test' ||
+                          !!process.env.POST_HOG_IN_DEV,
+                      }}
+                    >
+                      <GestureHandlerRootView style={{ flex: 1 }}>
+                        <SafeAreaProvider>
+                          <MigrationCheck>
                             <SignupProvider>
                               <PortalProvider>
                                 <App />
@@ -189,16 +189,16 @@ export default function ConnectedApp() {
                                 />
                               )}
                             </SignupProvider>
-                          </QueryClientProvider>
-                        </MigrationCheck>
-                      </SafeAreaProvider>
-                    </GestureHandlerRootView>
-                  </PostHogProvider>
-                </BranchProvider>
-              </StoreProvider>
-            </NavigationContainer>
-          </ShipProvider>
-        </TamaguiProvider>
+                          </MigrationCheck>
+                        </SafeAreaProvider>
+                      </GestureHandlerRootView>
+                    </PostHogProvider>
+                  </BranchProvider>
+                </StoreProvider>
+              </NavigationContainer>
+            </ShipProvider>
+          </TamaguiProvider>
+        </QueryClientProvider>
       </FeatureFlagConnectedInstrumentationProvider>
     </ErrorBoundary>
   );


### PR DESCRIPTION
Mobile is broken on `develop` right now.  It can't find the React Query `queryClient` which causes a crash. We can't cut mobile builds and any branching/merging off `develop` will be affected.

I opened https://github.com/tloncorp/tlon-apps/pull/4805 to address the root issue, but that's a risky changes we should further vet before merging.

Hoisting the `QueryClientProvider` higher up in the stack fixes the symptom on mobile. I think it's worth adding a bandaid immediately so we can continue operating normally.