### PR TITLE
track ordered posts from backend; add API binding to set ordered posts

### DIFF
--- a/packages/shared/src/api/channelsApi.ts
+++ b/packages/shared/src/api/channelsApi.ts
@@ -168,6 +168,7 @@ export function toClientChannelsInit(
 
 export type ChannelInit = {
   channelId: string;
+  order: string[];
   writers: string[];
   readers: string[];
 };
@@ -177,7 +178,12 @@ export function toClientChannelInit(
   channel: ub.Channel,
   readers: string[]
 ): ChannelInit {
-  return { channelId: id, writers: channel.perms.writers ?? [], readers };
+  return {
+    channelId: id,
+    writers: channel.perms.writers ?? [],
+    readers,
+    order: channel.order.map(x => getCanonicalPostId(x)),
+  };
 }
 
 export const toChannelsUpdate = (

--- a/packages/shared/src/api/channelsApi.ts
+++ b/packages/shared/src/api/channelsApi.ts
@@ -417,6 +417,24 @@ export const searchChannel = async (params: {
   return { posts, cursor };
 };
 
+export const setOrder = async (
+  channelId: string,
+  arrangedPostIds: string[]
+) => {
+  await poke({
+    app: 'channels',
+    mark: 'channel-action',
+    json: {
+      channel: {
+        nest: channelId,
+        action: {
+          order: arrangedPostIds,
+        },
+      },
+    },
+  });
+};
+
 export const leaveChannel = async (channelId: string) => {
   return trackedPoke<ub.ChannelsResponse>(
     {

--- a/packages/shared/src/api/channelsApi.ts
+++ b/packages/shared/src/api/channelsApi.ts
@@ -61,6 +61,11 @@ export type WritersUpdate = {
   writers: string[];
   groupId: string | null;
 };
+export type OrderUpdate = {
+  type: 'updateOrder';
+  channelId: string;
+  order: string[];
+};
 export type CreateChannelUpdate = {
   type: 'createChannel';
   channelId: string;
@@ -102,6 +107,7 @@ export type ChannelsUpdate =
   | LeaveChannelSuccessUpdate
   | InitialPostsOnChannelJoin
   // | MarkChannelReadUpdate
+  | OrderUpdate
   | WritersUpdate;
 
 export const createChannel = async ({
@@ -198,6 +204,14 @@ export const toChannelsUpdate = (
   const channelId = channelEvent.nest;
 
   if ('response' in channelEvent) {
+    if ('order' in channelEvent.response) {
+      return {
+        type: 'updateOrder',
+        channelId,
+        order: channelEvent.response.order.map((id) => getCanonicalPostId(id)),
+      };
+    }
+
     if ('perm' in channelEvent.response) {
       return {
         type: 'updateWriters',

--- a/packages/shared/src/db/migrations/0000_massive_wrecking_crew.sql
+++ b/packages/shared/src/db/migrations/0000_massive_wrecking_crew.sql
@@ -100,6 +100,7 @@ CREATE TABLE `channels` (
 	`remote_updated_at` integer,
 	`last_viewed_at` integer,
 	`content_configuration` text,
+	`posts_order` text,
 	FOREIGN KEY (`group_id`) REFERENCES `groups`(`id`) ON UPDATE no action ON DELETE cascade
 );
 --> statement-breakpoint

--- a/packages/shared/src/db/migrations/meta/0000_snapshot.json
+++ b/packages/shared/src/db/migrations/meta/0000_snapshot.json
@@ -1,7 +1,7 @@
 {
   "version": "6",
   "dialect": "sqlite",
-  "id": "7674a8c6-ec53-4c3c-8429-1117c2fe66f9",
+  "id": "5d647bb5-bb38-4cd4-a491-d5e0d5731f93",
   "prevId": "00000000-0000-0000-0000-000000000000",
   "tables": {
     "activity_event_contact_group_pins": {
@@ -651,6 +651,13 @@
         },
         "content_configuration": {
           "name": "content_configuration",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "posts_order": {
+          "name": "posts_order",
           "type": "text",
           "primaryKey": false,
           "notNull": false,

--- a/packages/shared/src/db/migrations/meta/_journal.json
+++ b/packages/shared/src/db/migrations/meta/_journal.json
@@ -5,8 +5,8 @@
     {
       "idx": 0,
       "version": "6",
-      "when": 1746555760653,
-      "tag": "0000_simple_vapor",
+      "when": 1747848675093,
+      "tag": "0000_massive_wrecking_crew",
       "breakpoints": true
     }
   ]

--- a/packages/shared/src/db/migrations/migrations.js
+++ b/packages/shared/src/db/migrations/migrations.js
@@ -1,7 +1,7 @@
 // This file is required for Expo/React Native SQLite migrations - https://orm.drizzle.team/quick-sqlite/expo
 
 import journal from './meta/_journal.json';
-import m0000 from './0000_simple_vapor.sql';
+import m0000 from './0000_massive_wrecking_crew.sql';
 
   export default {
     journal,

--- a/packages/shared/src/db/modelBuilders.ts
+++ b/packages/shared/src/db/modelBuilders.ts
@@ -261,6 +261,7 @@ export function buildChannel(
     | 'lastViewedAt'
     | 'members'
     | 'postCount'
+    | 'order'
     | 'remoteUpdatedAt'
     | 'syncedAt'
     | 'title'
@@ -288,6 +289,7 @@ export function buildChannel(
     lastViewedAt: null,
     members: [],
     postCount: null,
+    order: null,
     remoteUpdatedAt: null,
     syncedAt: null,
     title: '',

--- a/packages/shared/src/db/queries.ts
+++ b/packages/shared/src/db/queries.ts
@@ -1277,6 +1277,17 @@ export const insertChannelPerms = createWriteQuery(
           set: conflictUpdateSetAll($channelWriters),
         });
     }
+
+    await ctx.db.transaction(async (tx) => {
+      await Promise.all(
+        channelsInit.map(async (chanInit) => {
+          await tx
+            .update($channels)
+            .set({ order: chanInit.order })
+            .where(eq($channels.id, chanInit.channelId));
+        })
+      );
+    });
   },
   ['channelWriters', 'channels']
 );

--- a/packages/shared/src/db/schema.ts
+++ b/packages/shared/src/db/schema.ts
@@ -885,6 +885,10 @@ export const channels = sqliteTable(
     contentConfiguration: text('content_configuration', {
       mode: 'json',
     }).$type<ChannelContentConfiguration>(),
+
+    order: text('posts_order', {
+      mode: 'json',
+    }).$type<string[]>(),
   },
   (table) => ({
     lastPostIdIndex: index('last_post_id').on(table.lastPostId),
@@ -921,7 +925,11 @@ export const channelRelations = relations(channels, ({ one, many }) => ({
   }),
 }));
 
-export type PostDeliveryStatus = 'pending' | 'sent' | 'failed' | 'needs_verification';
+export type PostDeliveryStatus =
+  | 'pending'
+  | 'sent'
+  | 'failed'
+  | 'needs_verification';
 
 export const posts = sqliteTable(
   'posts',

--- a/packages/shared/src/store/dbHooks.ts
+++ b/packages/shared/src/store/dbHooks.ts
@@ -504,14 +504,15 @@ export const usePostWithThreadUnreads = (options: { id: string }) => {
 };
 
 export const usePostWithRelations = (
-  options: { id: string },
+  options: { id: string } | null,
   initialData?: db.Post
 ) => {
   return useQuery({
-    queryKey: ['post', options.id],
+    enabled: options != null,
+    queryKey: ['post', options?.id],
     staleTime: Infinity,
     ...(initialData ? { initialData } : {}),
-    queryFn: () => db.getPostWithRelations(options),
+    queryFn: () => (options == null ? null : db.getPostWithRelations(options)),
   });
 };
 

--- a/packages/shared/src/store/sync.ts
+++ b/packages/shared/src/store/sync.ts
@@ -1153,6 +1153,15 @@ export const handleChannelsUpdate = async (
         ctx
       );
       break;
+    case 'updateOrder':
+      await db.updateChannel(
+        {
+          id: update.channelId,
+          order: update.order,
+        },
+        ctx
+      );
+      break;
     case 'deletePost':
       await db.markPostAsDeleted(update.postId, ctx);
       await db.updateChannel({ id: update.channelId, lastPostId: null }, ctx);


### PR DESCRIPTION
part of TLON-4215

Adds plumbing to support pinned posts using existing "ordered posts" API feature.

## Changes
- Sync changes to a channel's `order` from backend to client DB (under `postOrder` – `order` is reserved by Drizzle for the SQL feature).[^0]
- Add `setOrder` API method to directly set a channel's `order` on backend
- [extra] [Disable usePostWithRelations by passing null options](https://github.com/tloncorp/tlon-apps/commit/886417ee7494557ed750f5aa2cb799463b0420c4) – I added this when adding UI code to test pins; slipping it in here because I think it's a good change (i.e. if a component doesn't yet have a post ID, it can now pass `null` instead of an empty string to the hook until it gets an ID)

## How did I test?

[`dil/pinned-posts`](../tree/dil/pinned-posts)[^1] has changes to UI to allow pinning a single post and showing it in the chat options sheet. I manually ran through that flow (pinning post in a channel; going to a channel without a pinned post; opening channel options in both).

## Risks and impact

- [x] Safe to rollback without consulting PR author
- Affects important code area:
  - [ ] Onboarding
  - [x] ~State~ Database / providers
  - [ ] Message sync
  - [ ] Channel display
  - [ ] Notifications

## Screenshots / video
Recorded using the UI changes from [`dil/pinned-posts`](../tree/dil/pinned-posts):
https://github.com/user-attachments/assets/7c282e89-bf08-45da-9f65-99d77383c428



[^0]: This is a simple JSON array – for a true pinned posts feature, we should probably have a separate merge table; but a static array seems okay while the API can only directly set `order` (i.e. no append / remove specific item, so to make a mutation, we need to either know the previous pinned set or replace all items)
[^1]: Importing `PostView` in `ChatOptionsSheet` opened a can of circular dependencies – that branch will randomly crash when navigating to different screens, complaining that a React component is undefined. More info in [this ticket](https://linear.app/tlon/issue/TLON-4269/client-js-code-has-circular-imports-causing-react-breakage-when-adding).