### PR TITLE
images: prevent crash from bad image source

### DIFF
--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -60,6 +60,7 @@
     "browser-or-node": "^3.0.0",
     "exponential-backoff": "^3.1.1",
     "sorted-btree": "^1.8.1",
+    "validator": "^13.7.0",
     "uuid": "^9.0.0"
   },
   "devDependencies": {

--- a/packages/ui/src/components/ErrorBoundary.tsx
+++ b/packages/ui/src/components/ErrorBoundary.tsx
@@ -1,0 +1,58 @@
+import { createDevLogger } from '@tloncorp/shared';
+import * as React from 'react';
+import { View } from 'tamagui';
+
+import { Text } from './TextV2';
+
+const logger = createDevLogger('ErrorBoundary', true);
+
+interface ErrorBoundaryProps {
+  children: React.ReactNode;
+  fallback?: React.ReactNode;
+}
+
+interface ErrorBoundaryState {
+  hasError: boolean;
+}
+
+export class ErrorBoundary extends React.Component<
+  ErrorBoundaryProps,
+  ErrorBoundaryState
+> {
+  constructor(props: ErrorBoundaryProps) {
+    super(props);
+    this.state = { hasError: false };
+  }
+
+  static getDerivedStateFromError(error: Error) {
+    return { hasError: true };
+  }
+
+  componentDidCatch(error: Error, info: React.ErrorInfo) {
+    logger.trackError('Error boundary triggered', {
+      errorMessage: error.message,
+      errorStack: error.stack,
+      componentStack: info.componentStack,
+    });
+  }
+
+  render() {
+    if (this.state.hasError) {
+      if (this.props.fallback) {
+        return this.props.fallback;
+      }
+      return (
+        <View flex={1} justifyContent="center" alignItems="center">
+          <Text fontSize="$l" color="$negativeActionText">
+            Something went wrong
+          </Text>
+          <Text color="$secondaryText">
+            An error report has been submitted.
+          </Text>
+        </View>
+      );
+    }
+
+    return this.props.children;
+  }
+}

--- a/packages/ui/src/index.ts
+++ b/packages/ui/src/index.ts
@@ -31,3 +31,4 @@ export * from './contexts/globalSearch';
 export { useCopy } from './hooks/useCopy';
 export { default as useIsWindowNarrow } from './hooks/useIsWindowNarrow';
 export * from './utils';
+export * from './components/ErrorBoundary';

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1101,6 +1101,9 @@ importers:
       uuid:
         specifier: ^9.0.0
         version: 9.0.0
+      validator:
+        specifier: ^13.7.0
+        version: 13.7.0
       zustand:
         specifier: ^3.7.2
         version: 3.7.2(react@18.2.0)


### PR DESCRIPTION
After switching to `expo-image` on web, we're seeing a crash if the passed image `source` is a hex code instead of a URL. There are some legacy agent states that have image meta set to colors.

To prevent this, the image component validates the source string is a URL before attempting to render. I also added an error boundary that uses the existing fallbacks in case we encounter other errors — a crashing image component should never take down the whole app like it did in this case.

Fixes TLON-4287