### PR TITLE
ops: copy provider ordering fix onto release branch

### DIFF
--- a/apps/tlon-mobile/src/App.main.tsx
+++ b/apps/tlon-mobile/src/App.main.tsx
@@ -153,29 +153,29 @@ export default function ConnectedApp() {
   return (
     <ErrorBoundary>
       <FeatureFlagConnectedInstrumentationProvider>
-        <TamaguiProvider>
-          <ShipProvider>
-            <NavigationContainer
-              theme={isDarkMode ? DarkTheme : DefaultTheme}
-              ref={navigationContainerRef}
-            >
-              <StoreProvider>
-                <BranchProvider>
-                  <PostHogProvider
-                    client={posthogAsync}
-                    autocapture={{
-                      captureTouches: false,
-                    }}
-                    options={{
-                      enable:
-                        process.env.NODE_ENV !== 'test' ||
-                        !!process.env.POST_HOG_IN_DEV,
-                    }}
-                  >
-                    <GestureHandlerRootView style={{ flex: 1 }}>
-                      <SafeAreaProvider>
-                        <MigrationCheck>
-                          <QueryClientProvider client={queryClient}>
+        <QueryClientProvider client={queryClient}>
+          <TamaguiProvider>
+            <ShipProvider>
+              <NavigationContainer
+                theme={isDarkMode ? DarkTheme : DefaultTheme}
+                ref={navigationContainerRef}
+              >
+                <StoreProvider>
+                  <BranchProvider>
+                    <PostHogProvider
+                      client={posthogAsync}
+                      autocapture={{
+                        captureTouches: false,
+                      }}
+                      options={{
+                        enable:
+                          process.env.NODE_ENV !== 'test' ||
+                          !!process.env.POST_HOG_IN_DEV,
+                      }}
+                    >
+                      <GestureHandlerRootView style={{ flex: 1 }}>
+                        <SafeAreaProvider>
+                          <MigrationCheck>
                             <SignupProvider>
                               <PortalProvider>
                                 <App />
@@ -189,16 +189,16 @@ export default function ConnectedApp() {
                                 />
                               )}
                             </SignupProvider>
-                          </QueryClientProvider>
-                        </MigrationCheck>
-                      </SafeAreaProvider>
-                    </GestureHandlerRootView>
-                  </PostHogProvider>
-                </BranchProvider>
-              </StoreProvider>
-            </NavigationContainer>
-          </ShipProvider>
-        </TamaguiProvider>
+                          </MigrationCheck>
+                        </SafeAreaProvider>
+                      </GestureHandlerRootView>
+                    </PostHogProvider>
+                  </BranchProvider>
+                </StoreProvider>
+              </NavigationContainer>
+            </ShipProvider>
+          </TamaguiProvider>
+        </QueryClientProvider>
       </FeatureFlagConnectedInstrumentationProvider>
     </ErrorBoundary>
   );


### PR DESCRIPTION
OTT

We fixed the queryclient ordering on `develop`, but it's still breaking mobile on the protocol upgrade branch