### PR TITLE
links: fix form deletion + block send while loading

### DIFF
--- a/packages/app/ui/components/draftInputs/GalleryInput.tsx
+++ b/packages/app/ui/components/draftInputs/GalleryInput.tsx
@@ -335,11 +335,13 @@ export function GalleryInput({
     [
       isPosting,
       isEditingPost,
-      editingPost,
-      send,
       editPost,
-      onPresentationModeChange,
+      editingPost,
       resetGalleryState,
+      setEditingPost,
+      onPresentationModeChange,
+      send,
+      channel.id,
     ]
   );
 

--- a/packages/app/ui/components/draftInputs/LinkInput.tsx
+++ b/packages/app/ui/components/draftInputs/LinkInput.tsx
@@ -92,11 +92,7 @@ export function LinkInput({ editingPost, isPosting, onSave }: LinkInputProps) {
   // loading state will not be set until the debounce fires.
   const [isPendingDebounce, setIsPendingDebounce] = useState(false);
   useEffect(() => {
-    if (form.url !== url) {
-      setIsPendingDebounce(true);
-    } else {
-      setIsPendingDebounce(false);
-    }
+    setIsPendingDebounce(form.url !== url);
   }, [form.url, url]);
   const { data, isLoading } = store.useLinkGrabber(url);
   const hasIssue = data && (data.type === 'error' || data.type === 'redirect');

--- a/packages/app/ui/components/draftInputs/LinkInput.tsx
+++ b/packages/app/ui/components/draftInputs/LinkInput.tsx
@@ -10,7 +10,7 @@ import * as db from '@tloncorp/shared/db';
 import * as store from '@tloncorp/shared/store';
 import * as ub from '@tloncorp/shared/urbit';
 import { Text } from '@tloncorp/ui';
-import { useCallback, useEffect, useMemo } from 'react';
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { useForm } from 'react-hook-form';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
 import { ScrollView, View, useTheme } from 'tamagui';
@@ -66,6 +66,11 @@ export function LinkInput({ editingPost, isPosting, onSave }: LinkInputProps) {
     return getRichLinkMetadata(blocks[0]);
   }, [editingPost]);
 
+  const lastPreloadedRef = useRef<{
+    title: string | null;
+    description: string | null;
+  }>({ title: null, description: null });
+
   const {
     control,
     watch,
@@ -92,8 +97,13 @@ export function LinkInput({ editingPost, isPosting, onSave }: LinkInputProps) {
   useEffect(() => {
     if (data && data.type === 'page') {
       const newTitle = data.title || '';
-      if (form.title === '' && newTitle !== form.title) {
-        setValue('title', data.title || '', {
+      if (
+        form.title === '' &&
+        newTitle !== form.title &&
+        lastPreloadedRef.current?.title !== data.title
+      ) {
+        lastPreloadedRef.current.title = newTitle;
+        setValue('title', newTitle, {
           shouldTouch: true,
           shouldDirty: true,
           shouldValidate: true,
@@ -101,7 +111,12 @@ export function LinkInput({ editingPost, isPosting, onSave }: LinkInputProps) {
       }
 
       const newDescription = data.description || '';
-      if (form.description === '' && newDescription !== form.description) {
+      if (
+        form.description === '' &&
+        newDescription !== form.description &&
+        lastPreloadedRef.current?.description !== data.description
+      ) {
+        lastPreloadedRef.current.description = newDescription;
         setValue('description', newDescription, {
           shouldTouch: true,
           shouldDirty: true,
@@ -109,7 +124,7 @@ export function LinkInput({ editingPost, isPosting, onSave }: LinkInputProps) {
         });
       }
     }
-  }, [data, form]);
+  }, [data, form, setValue]);
 
   const block: BlockData | null = useMemo(() => {
     if (!data || hasIssue) {


### PR DESCRIPTION
OTT

- form deletion was just a logic bug with it re-inserting the default title if it detected the input was empty
- chat was not attempting to block send while loading, now it does via a state variable
- gallery was attempting to block, but it wasn't effective until the debounce triggered

Fixes TLON-4276
Fixes TLON-4297