### PR TITLE
metagrab: better redirect handling

### DIFF
--- a/desk/app/metagrab.hoon
+++ b/desk/app/metagrab.hoon
@@ -120,7 +120,6 @@
           [response-header:http dat=(unit mime-data:iris)]
       ==
   ^-  [report=? result]
-  ~?  ?=(^ dat)  size=p.data.u.dat
   =*  cod  status-code
   ::  redirects
   ::

--- a/desk/app/metagrab.hoon
+++ b/desk/app/metagrab.hoon
@@ -383,6 +383,9 @@
     ::
     =/  nex=(unit @t)
       (get-header:http 'location' headers.response-header.res)
+    ::  the location value could be relative, make sure to resolve it first
+    ::
+    =?  nex    ?=(^ nex)  `(expand-url:mg url u.nex)
     =.  cache  (~(put by cache) url now.bowl %300 nex)
     ?~  nex
       :-  (give-response (~(get ju await) url) now.bowl %300 ~)

--- a/desk/app/metagrab.hoon
+++ b/desk/app/metagrab.hoon
@@ -61,7 +61,7 @@
     ::
       :-  'result'
       ?-  -.wat
-        %300  ?>(?=(~ nex.wat) ~)
+        %300  ?~(nex.wat ~ s+u.nex.wat)
         %400  ?~(bod.wat ~ s+u.bod.wat)
         %500  ?~(bod.wat ~ s+u.bod.wat)
       ::


### PR DESCRIPTION
Primarily: the url in the location header is allowed to be relative. We need to make sure to resolve it against the base url before working with it.

(`+expand-url` resolves absolute urls to themselves, no concerns there.)