### PR TITLE
Close message actions menu after selection is made on desktop

### DIFF
--- a/packages/app/ui/components/ChatMessage/ChatMessage.tsx
+++ b/packages/app/ui/components/ChatMessage/ChatMessage.tsx
@@ -275,7 +275,10 @@ const ChatMessage = ({
           <ChatMessageActions
             post={post}
             postActionIds={postActionIds}
-            onDismiss={() => setIsPopoverOpen(false)}
+            onDismiss={() => {
+              setIsPopoverOpen(false);
+              setIsHovered(false);
+            }}
             onOpenChange={setIsPopoverOpen}
             onReply={handleRepliesPressed}
             onEdit={onPressEdit}

--- a/packages/app/ui/components/GalleryPost/GalleryPost.tsx
+++ b/packages/app/ui/components/GalleryPost/GalleryPost.tsx
@@ -162,7 +162,10 @@ export function GalleryPost({
             <ChatMessageActions
               post={post}
               postActionIds={postActionIds}
-              onDismiss={() => setIsPopoverOpen(false)}
+              onDismiss={() => {
+                setIsPopoverOpen(false);
+                setIsHovered(false);
+              }}
               onOpenChange={setIsPopoverOpen}
               onReply={handlePress}
               onEdit={onPressEdit}

--- a/packages/app/ui/components/NotebookPost/NotebookPost.tsx
+++ b/packages/app/ui/components/NotebookPost/NotebookPost.tsx
@@ -178,7 +178,10 @@ export function NotebookPost({
             <ChatMessageActions
               post={post}
               postActionIds={postActionIds}
-              onDismiss={() => setIsPopoverOpen(false)}
+              onDismiss={() => {
+                setIsPopoverOpen(false);
+                setIsHovered(false);
+              }}
               onOpenChange={setIsPopoverOpen}
               onEdit={onPressEdit}
               onReply={handlePress}


### PR DESCRIPTION
This issue actually exists on develop as well. Since we weren't setting `isHovered` to false the ChatMessageActions menu would continue to show even after the `dismiss` function in MessageActions.tsx was called for the action, since `onDismiss` did not also call `setIsHovered` with `false`.

The issue wasn't that we were navigating to the notebook post when pressing the "copy ref" action, it was that we were navigating to it if we pressed that action *twice*.