### PR TITLE
link display tweaks

### DIFF
--- a/packages/app/tsconfig.json
+++ b/packages/app/tsconfig.json
@@ -8,7 +8,8 @@
     "paths": {
       "sqlocal/drizzle": ["node_modules/sqlocal/dist/drizzle"],
       // needed to prevent TS mistakenly finding the old-web posthog-js version in root node_modules
-      "posthog-js": ["node_modules/posthog-js"]
+      "posthog-js": ["node_modules/posthog-js"],
+      "expo-image": ["node_modules/expo-image"]
     }
   }
 }

--- a/packages/app/ui/components/ChatMessage/ChatMessage.tsx
+++ b/packages/app/ui/components/ChatMessage/ChatMessage.tsx
@@ -300,7 +300,7 @@ const ChatMessage = ({
 const WebChatImageRenderer: DefaultRendererProps['image'] = {
   alignItems: 'flex-start',
   imageProps: {
-    maxWidth: 400,
+    maxWidth: 600,
     maxHeight: 400,
   },
 };
@@ -312,10 +312,18 @@ const ChatContentRenderer = createContentRenderer({
     },
     reference: {
       contentSize: '$l',
+      maxWidth: 600,
     },
     image: isWeb ? WebChatImageRenderer : undefined,
     link: {
-      maxWidth: 400,
+      renderDescription: false,
+      maxWidth: 600,
+      imageProps: {
+        aspectRatio: 2,
+      },
+    },
+    code: {
+      maxWidth: 600,
     },
   },
 });

--- a/packages/app/ui/components/GalleryPost/GalleryPost.tsx
+++ b/packages/app/ui/components/GalleryPost/GalleryPost.tsx
@@ -453,7 +453,6 @@ const PreviewFrame = styled(View, {
         case 'reference':
           return {
             backgroundColor: '$secondaryBackground',
-            paddingTop: '$3xl',
           };
         case 'paragraph':
         case 'list':
@@ -550,6 +549,7 @@ const LargeContentRenderer = createContentRenderer({
     },
     link: {
       ...noWrapperPadding,
+      minHeight: 300,
       imageProps: {
         aspectRatio: 1.5,
       },
@@ -595,6 +595,12 @@ const SmallContentRenderer = createContentRenderer({
     },
     link: {
       borderRadius: 0,
+      borderWidth: 0,
+      renderDescription: false,
+      imageProps: {
+        height: '66%',
+        aspectRatio: 'unset',
+      },
       ...noWrapperPadding,
     },
   },

--- a/packages/app/ui/components/PostContent/BlockRenderer.tsx
+++ b/packages/app/ui/components/PostContent/BlockRenderer.tsx
@@ -12,15 +12,7 @@ import React, {
   useState,
 } from 'react';
 import { Linking, Platform } from 'react-native';
-import {
-  ScrollView,
-  TamaguiComponent,
-  View,
-  ViewStyle,
-  XStack,
-  YStack,
-  styled,
-} from 'tamagui';
+import { ScrollView, View, ViewStyle, XStack, YStack, styled } from 'tamagui';
 
 import {
   ContentReferenceLoader,

--- a/packages/app/ui/components/PostContent/BlockRenderer.tsx
+++ b/packages/app/ui/components/PostContent/BlockRenderer.tsx
@@ -223,11 +223,17 @@ const BigEmojiText = styled(Text, {
 export function LinkBlock({
   block,
   imageProps,
+  renderDescription = true,
+  renderTitle = true,
+  renderImage = true,
   clickable = true,
   ...props
 }: {
   block: cn.LinkBlockData;
   clickable?: boolean;
+  renderDescription?: boolean;
+  renderTitle?: boolean;
+  renderImage?: boolean;
   imageProps?: ComponentProps<typeof ContentImage>;
 } & ComponentProps<typeof Reference.Frame>) {
   const domain = useMemo(() => {
@@ -243,22 +249,6 @@ export function LinkBlock({
     }
   }, [block.url]);
 
-  const aspectRatio = useMemo(() => {
-    if (!block.previewImageHeight || !block.previewImageWidth) {
-      return 1.5;
-    }
-
-    try {
-      return (
-        parseInt(block.previewImageWidth) / parseInt(block.previewImageHeight)
-      );
-    } catch (e) {
-      console.error('Error parsing aspect ratio', e);
-    }
-
-    return 1.5;
-  }, [block.previewImageHeight, block.previewImageWidth]);
-
   return (
     <Reference.Frame {...props} onPress={clickable ? onPress : undefined}>
       <Reference.Header>
@@ -268,28 +258,39 @@ export function LinkBlock({
         </Reference.Title>
       </Reference.Header>
       <Reference.Body>
-        {block.previewImageUrl && (
+        {renderImage && block.previewImageUrl && (
           <ContentImage
+            fallback={null}
             source={block.previewImageUrl}
             flex={1}
-            aspectRatio={aspectRatio}
+            aspectRatio={2}
+            flexShrink={0}
             width="100%"
             contentFit="cover"
+            contentPosition="center"
             {...imageProps}
           />
         )}
         <YStack flex={0} padding="$xl" gap="$xl">
           <YStack gap="$s">
             <Text fontWeight="500" color="$secondaryText">
-              {block.siteName}
+              {block.siteName && block.siteName.length > 0
+                ? block.siteName
+                : domain}
             </Text>
-            <Text size="$label/m" numberOfLines={1}>
-              {block.title}
-            </Text>
+            {renderTitle && (
+              <Text size="$label/m" numberOfLines={1}>
+                {block.title && block.title.length > 0
+                  ? block.title
+                  : block.url}
+              </Text>
+            )}
           </YStack>
-          <Text size="$label/s" color="$secondaryText">
-            {block.description}
-          </Text>
+          {block.description && renderDescription && (
+            <Text size="$label/s" color="$secondaryText">
+              {block.description}
+            </Text>
+          )}
         </YStack>
       </Reference.Body>
     </Reference.Frame>
@@ -368,7 +369,7 @@ export function ImageBlock({
   );
 }
 
-const ContentImage: TamaguiComponent = styled(Image, {
+const ContentImage = styled(Image, {
   name: 'ContentImage',
   context: cn.ContentContext,
   width: '100%',

--- a/packages/ui/src/components/Image.tsx
+++ b/packages/ui/src/components/Image.tsx
@@ -31,7 +31,7 @@ const DefaultImageFallback = View.styleable((props, ref) => {
 const StyledBaseImage = styled(BaseImage, { name: 'StyledExpoImage' });
 
 export const Image = StyledBaseImage.styleable<{
-  fallback?: ReactElement;
+  fallback?: ReactElement | null;
 }>(
   ({ fallback, onError, ...props }, ref) => {
     const [hasErrored, setHasErrored] = useState(false);
@@ -48,7 +48,7 @@ export const Image = StyledBaseImage.styleable<{
       return !isValid || hasErrored;
     }, [props.source, hasErrored]);
 
-    if (showFallback && fallback) {
+    if (showFallback && fallback !== undefined) {
       return fallback;
     }
 


### PR DESCRIPTION
A number of visual fixes for link display:

- Fix double borders on link blocks in galleries
- Set max width on link blocks in chat channels
- Remove descriptions from link blocks in galleries and chat channels
- Better handling for links with missing titles, descriptions, or images
- Reconcile max widths of images + other blocks
- Fix extra space above references in galleries
- Improves image component types