### PR TITLE
metagrab: rejected/challenged request handling

### DIFF
--- a/desk/app/metagrab.hoon
+++ b/desk/app/metagrab.hoon
@@ -133,7 +133,19 @@
     ::TODO  extract message from response body somehow?
     ?:  (gte cod 500)
       [%500 ?~(dat `(scot %ud cod) `q.data.u.dat)]
-    [%400 `(scot %ud cod)]
+    ::  experimental bot-protection detection, which the client may
+    ::  want to know about so it can retry in a more advanced way.
+    ::
+    :-  %400
+    ?:  ?|  ::  datadome header
+            ::
+            =(`'protected' (get-header:http 'x-datadome' headers))
+            ::  captcha service in response body
+            ::
+            &(?=(^ dat) ?=(^ (find "captcha-delivery.com" (trip q.data.u.dat))))
+        ==
+      `'possibly-blocked'
+    `(scot %ud cod)
   ::  miscellaneous
   ::
   ?:  |((lth cod 200) (gte cod 600))


### PR DESCRIPTION
Two things:

First, we update the user-agent logic to pull the user-agent string from the user's original request. Only if that's absent do we fall back to the hardcoded fake chrome string.

Second, we add a small set of heuristics for the experimental feature of detecting when our request gets rejected for bot/scraper protection reasons. In that case, we put a `possibly-blocked` string in the `result` field (for `status: 400` results). The client might be able to use this to message differently about the failure, or retry in some other way.