### PR TITLE
image: fix detection for file/data URIs

### DIFF
--- a/packages/app/ui/components/AttachmentSheet.tsx
+++ b/packages/app/ui/components/AttachmentSheet.tsx
@@ -1,4 +1,4 @@
-import { createDevLogger } from '@tloncorp/shared';
+import { PLACEHOLDER_ASSET_URI, createDevLogger } from '@tloncorp/shared';
 import * as ImagePicker from 'expo-image-picker';
 import { useCallback, useMemo } from 'react';
 import { Platform } from 'react-native';
@@ -34,7 +34,7 @@ export default function AttachmentSheet({
   const placeholderAsset: ImagePicker.ImagePickerAsset = useMemo(
     () => ({
       assetId: 'placeholder-asset-id',
-      uri: 'placeholder-image-uri',
+      uri: PLACEHOLDER_ASSET_URI,
       width: 300,
       height: 300,
       fileName: 'camera-image.jpg',
@@ -50,7 +50,7 @@ export default function AttachmentSheet({
   const removePlaceholderAttachment = useCallback(() => {
     const placeholderToRemove = {
       type: 'image' as const,
-      file: { uri: 'placeholder-image-uri' } as ImagePicker.ImagePickerAsset,
+      file: { uri: PLACEHOLDER_ASSET_URI } as ImagePicker.ImagePickerAsset,
     };
 
     removeAttachment(placeholderToRemove);
@@ -126,11 +126,13 @@ export default function AttachmentSheet({
           }
         }
 
-        // Immediately set the placeholder attachment to show in the UI
+        // Wait for the attachment sheet to pop, then set the placeholder attachment to show in the UI
         // skip on web, the browser doesn't like trying to load a file that doesn't exist
-        if (Platform.OS !== 'web') {
-          attachAssets([placeholderAsset]);
-        }
+        setTimeout(() => {
+          if (Platform.OS !== 'web') {
+            attachAssets([placeholderAsset]);
+          }
+        }, 200);
 
         const result = await ImagePicker.launchImageLibraryAsync({
           mediaTypes: ImagePicker.MediaTypeOptions.Images,

--- a/packages/shared/src/store/storage/storageActions.ts
+++ b/packages/shared/src/store/storage/storageActions.ts
@@ -19,8 +19,10 @@ import {
 
 const logger = createDevLogger('storageActions', false);
 
+export const PLACEHOLDER_ASSET_URI = 'placeholder-asset-id';
+
 export const uploadAsset = async (asset: ImagePickerAsset, isWeb = false) => {
-  if (asset.uri === 'placeholder-image-uri') {
+  if (asset.uri === PLACEHOLDER_ASSET_URI) {
     logger.log('placeholder image, skipping upload');
     return;
   }


### PR DESCRIPTION
It looks like these weren't being properly detected by our validator. For data URIs, it has a built in method which we instead use. For file URIs, it doesn't like certain forms (_file:///_) so we detect manually.

Also noticed the placeholder asset behavior on mobile looked wonky with the fallback. Special cased that while I was in there.