### PR TITLE
links: use rich preview fallback

### DIFF
--- a/packages/app/features/settings/PrivacyScreen.tsx
+++ b/packages/app/features/settings/PrivacyScreen.tsx
@@ -175,9 +175,7 @@ export function PrivacySettingsScreen(props: Props) {
 
         <YStack paddingHorizontal="$l" paddingTop="$2xl" gap="$xl">
           <XStack justifyContent="space-between" alignItems="center">
-            <SizableText flexShrink={1}>
-              Disable centralized features
-            </SizableText>
+            <SizableText flexShrink={1}>Disable Tlon helpers</SizableText>
             <Switch
               style={{ flexShrink: 0 }}
               value={state.disableTlonInfraEnhancement}
@@ -185,8 +183,9 @@ export function PrivacySettingsScreen(props: Props) {
             ></Switch>
           </XStack>
           <Text size="$label/s" color="$secondaryText">
-            If disabled, the app will avoid falling back to Tlon's
-            infrastructure for progressive enhancements (e.g. link previews).
+            Your ship will always attempt to generate rich link previews
+            locally. If disabled, the app will avoid making backup requests to
+            Tlon's service if local generation fails.
           </Text>
         </YStack>
 

--- a/packages/app/features/settings/PrivacyScreen.tsx
+++ b/packages/app/features/settings/PrivacyScreen.tsx
@@ -23,6 +23,7 @@ interface PrivacyState {
   phoneDiscoverable: boolean;
   disableNicknames: boolean;
   disableAvatars: boolean;
+  disableTlonInfraEnhancement: boolean;
 }
 
 export function PrivacySettingsScreen(props: Props) {
@@ -30,15 +31,17 @@ export function PrivacySettingsScreen(props: Props) {
   const phoneAttest = store.useCurrentUserPhoneAttestation();
   const telemetry = useTelemetry();
   const { data: calmSettings } = store.useCalmSettings();
+  const { data: settings } = store.useSettings();
 
   const [state, setState] = useState<PrivacyState>({
     phoneDiscoverable: parsePhoneDiscoverability(phoneAttest),
     telemetryDisabled: telemetry.getIsOptedOut(),
     disableNicknames: calmSettings?.disableNicknames ?? false,
     disableAvatars: calmSettings?.disableAvatars ?? false,
+    disableTlonInfraEnhancement: settings?.disableTlonInfraEnhancement ?? false,
   });
 
-  // Update state when calm settings change
+  // Update state when settings change
   useEffect(() => {
     if (calmSettings) {
       setState((prev) => ({
@@ -48,6 +51,16 @@ export function PrivacySettingsScreen(props: Props) {
       }));
     }
   }, [calmSettings]);
+
+  useEffect(() => {
+    if (settings) {
+      setState((prev) => ({
+        ...prev,
+        disableTlonInfraEnhancement:
+          settings.disableTlonInfraEnhancement ?? false,
+      }));
+    }
+  }, [settings]);
 
   useEffect(() => {
     if (phoneAttest) {
@@ -106,6 +119,17 @@ export function PrivacySettingsScreen(props: Props) {
     }
   }, [state.disableAvatars, store]);
 
+  const toggleDisableTlonInfraEnhancement = useCallback(async () => {
+    const nextValue = !state.disableTlonInfraEnhancement;
+    setState((prev) => ({ ...prev, disableTlonInfraEnhancement: nextValue }));
+    try {
+      await store.updateDisableTlonInfraEnhancement(nextValue);
+    } catch (e) {
+      triggerHaptic('error');
+      setState((prev) => ({ ...prev, disableAvatars: !nextValue }));
+    }
+  }, [state.disableTlonInfraEnhancement, store]);
+
   return (
     <View flex={1} backgroundColor="$background">
       <ScreenHeader
@@ -148,6 +172,23 @@ export function PrivacySettingsScreen(props: Props) {
             </Text>
           </YStack>
         )}
+
+        <YStack paddingHorizontal="$l" paddingTop="$2xl" gap="$xl">
+          <XStack justifyContent="space-between" alignItems="center">
+            <SizableText flexShrink={1}>
+              Disable centralized features
+            </SizableText>
+            <Switch
+              style={{ flexShrink: 0 }}
+              value={state.disableTlonInfraEnhancement}
+              onValueChange={toggleDisableTlonInfraEnhancement}
+            ></Switch>
+          </XStack>
+          <Text size="$label/s" color="$secondaryText">
+            If disabled, the app will avoid falling back to Tlon's
+            infrastructure for progressive enhancements (e.g. link previews).
+          </Text>
+        </YStack>
 
         <YStack paddingHorizontal="$l" paddingTop="$2xl" gap="$xl">
           <XStack justifyContent="space-between" alignItems="center">

--- a/packages/app/ui/components/BareChatInput/index.tsx
+++ b/packages/app/ui/components/BareChatInput/index.tsx
@@ -6,7 +6,6 @@ import {
   extractContentTypesFromPost,
   isTrustedEmbed,
 } from '@tloncorp/shared';
-import * as api from '@tloncorp/shared/api';
 import {
   contentReferenceToCite,
   toContentReference,
@@ -316,8 +315,8 @@ export default function BareChatInput({
 
           if (!isEmbed) {
             setLinkMetaLoading(true);
-            api
-              .getLinkMetadata(url)
+            store
+              .getLinkMetaWithFallback(url)
               .then((linkMetadata) => {
                 // todo: handle error case with toast or similar
                 if (!linkMetadata) {

--- a/packages/app/ui/components/PostContent/BlockRenderer.tsx
+++ b/packages/app/ui/components/PostContent/BlockRenderer.tsx
@@ -242,7 +242,11 @@ export function LinkBlock({
   }, [block.url]);
 
   return (
-    <Reference.Frame {...props} onPress={clickable ? onPress : undefined}>
+    <Reference.Frame
+      {...props}
+      maxWidth={400}
+      onPress={clickable ? onPress : undefined}
+    >
       <Reference.Header>
         <Reference.Title>
           <Icon type="Link" color="$tertiaryText" customSize={[12, 12]} />

--- a/packages/app/ui/components/PostContent/BlockRenderer.tsx
+++ b/packages/app/ui/components/PostContent/BlockRenderer.tsx
@@ -242,11 +242,7 @@ export function LinkBlock({
   }, [block.url]);
 
   return (
-    <Reference.Frame
-      {...props}
-      maxWidth={400}
-      onPress={clickable ? onPress : undefined}
-    >
+    <Reference.Frame {...props} onPress={clickable ? onPress : undefined}>
       <Reference.Header>
         <Reference.Title>
           <Icon type="Link" color="$tertiaryText" customSize={[12, 12]} />

--- a/packages/shared/src/api/settingsApi.ts
+++ b/packages/shared/src/api/settingsApi.ts
@@ -27,6 +27,7 @@ function getBucket(key: string): string {
     case 'activitySeenTimestamp':
     case 'completedWayfindingSplash':
     case 'completedWayfindingTutorial':
+    case 'disableTlonInfraEnhancement':
       return 'groups';
     case 'disableAvatars':
     case 'disableNicknames':
@@ -113,6 +114,8 @@ export const toClientSettings = (
       settings.desk.groups?.completedWayfindingSplash ?? false,
     completedWayfindingTutorial:
       settings.desk.groups?.completedWayfindingTutorial ?? false,
+    disableTlonInfraEnhancement:
+      settings.desk.groups?.disableTlonInfraEnhancement ?? false,
   };
 };
 

--- a/packages/shared/src/db/migrations/0000_shocking_hulk.sql
+++ b/packages/shared/src/db/migrations/0000_shocking_hulk.sql
@@ -359,7 +359,8 @@ CREATE TABLE `settings` (
 	`notebook_settings` text,
 	`activity_seen_timestamp` integer,
 	`completed_wayfinding_splash` integer,
-	`completed_wayfinding_tutorial` integer
+	`completed_wayfinding_tutorial` integer,
+	`disable_tlon_infra_enhancement` integer
 );
 --> statement-breakpoint
 CREATE TABLE `system_contact_sent_invites` (

--- a/packages/shared/src/db/migrations/meta/0000_snapshot.json
+++ b/packages/shared/src/db/migrations/meta/0000_snapshot.json
@@ -1,7 +1,7 @@
 {
   "version": "6",
   "dialect": "sqlite",
-  "id": "6e0f6081-47e3-44b5-bf2f-55756a9c8458",
+  "id": "85ae1265-0891-4d62-8976-e70dde4e41a5",
   "prevId": "00000000-0000-0000-0000-000000000000",
   "tables": {
     "activity_event_contact_group_pins": {
@@ -2391,6 +2391,13 @@
         },
         "completed_wayfinding_tutorial": {
           "name": "completed_wayfinding_tutorial",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "disable_tlon_infra_enhancement": {
+          "name": "disable_tlon_infra_enhancement",
           "type": "integer",
           "primaryKey": false,
           "notNull": false,

--- a/packages/shared/src/db/migrations/meta/_journal.json
+++ b/packages/shared/src/db/migrations/meta/_journal.json
@@ -5,8 +5,8 @@
     {
       "idx": 0,
       "version": "6",
-      "when": 1747434112777,
-      "tag": "0000_natural_cable",
+      "when": 1747975454572,
+      "tag": "0000_shocking_hulk",
       "breakpoints": true
     }
   ]

--- a/packages/shared/src/db/migrations/migrations.js
+++ b/packages/shared/src/db/migrations/migrations.js
@@ -1,7 +1,7 @@
 // This file is required for Expo/React Native SQLite migrations - https://orm.drizzle.team/quick-sqlite/expo
 
 import journal from './meta/_journal.json';
-import m0000 from './0000_natural_cable.sql';
+import m0000 from './0000_shocking_hulk.sql';
 
   export default {
     journal,

--- a/packages/shared/src/db/schema.ts
+++ b/packages/shared/src/db/schema.ts
@@ -55,6 +55,7 @@ export const settings = sqliteTable('settings', {
   activitySeenTimestamp: timestamp('activity_seen_timestamp'),
   completedWayfindingSplash: boolean('completed_wayfinding_splash'),
   completedWayfindingTutorial: boolean('completed_wayfinding_tutorial'),
+  disableTlonInfraEnhancement: boolean('disable_tlon_infra_enhancement'),
 });
 
 export const systemContacts = sqliteTable('system_contacts', {

--- a/packages/shared/src/store/dbHooks.ts
+++ b/packages/shared/src/store/dbHooks.ts
@@ -73,6 +73,14 @@ export const usePins = (
   });
 };
 
+export const useSettings = () => {
+  const deps = useKeyFromQueryDeps(db.getSettings);
+  return useQuery({
+    queryKey: ['settings', deps],
+    queryFn: () => db.getSettings(),
+  });
+};
+
 export const useCalmSettings = () => {
   const deps = useKeyFromQueryDeps(db.getSettings);
   return useQuery({

--- a/packages/shared/src/store/metagrabActions.ts
+++ b/packages/shared/src/store/metagrabActions.ts
@@ -1,12 +1,41 @@
 import { useQuery } from '@tanstack/react-query';
 
-import { getLinkMetadata } from '../api';
+import { getFallbackLinkMetadata, getLinkMetadata } from '../api';
+import * as db from '../db';
+import { createDevLogger } from '../debug';
 import { isValidUrl } from '../logic';
+
+const logger = createDevLogger('metagrabActions', false);
+
+export async function getLinkMetaWithFallback(url: string) {
+  logger.trackEvent('Attempting metagrab link preview');
+  const response = await getLinkMetadata(url);
+
+  const failedToGetMeta =
+    response.type === 'error' || response.type === 'redirect';
+  const metaInsufficient =
+    response.type === 'page' &&
+    !response.title &&
+    !response.previewImageUrl &&
+    !response.description;
+
+  if (failedToGetMeta || metaInsufficient) {
+    const settings = await db.getSettings();
+    const shouldUseFallback = !settings?.disableTlonInfraEnhancement;
+    if (shouldUseFallback) {
+      logger.trackEvent('Attempting fallback link preview', { url });
+      const fallbackResponse = await getFallbackLinkMetadata(url);
+      return fallbackResponse;
+    }
+  }
+
+  return response;
+}
 
 export function useLinkGrabber(url: string) {
   return useQuery({
     queryKey: ['metagrab', url],
-    queryFn: () => getLinkMetadata(url),
+    queryFn: () => getLinkMetaWithFallback(url),
     enabled: !!url && isValidUrl(url),
   });
 }

--- a/packages/shared/src/store/settingsActions.ts
+++ b/packages/shared/src/store/settingsActions.ts
@@ -147,3 +147,22 @@ export async function updateTheme(theme: AppTheme) {
     throw new Error('Failed to update theme setting');
   }
 }
+
+export async function updateDisableTlonInfraEnhancement(disabled: boolean) {
+  const existing = await db.getSettings();
+  const oldValue = existing?.disableTlonInfraEnhancement;
+
+  try {
+    // optimistic update
+    await db.insertSettings({ disableTlonInfraEnhancement: disabled });
+    await setSetting('disableTlonInfraEnhancement', disabled);
+  } catch (e) {
+    logger.trackError('Error updating disable tlon infra setting', {
+      disabled,
+      severity: AnalyticsSeverity.Medium,
+      errorMessage: e.message,
+      errorStack: e.stack,
+    });
+    await db.insertSettings({ disableTlonInfraEnhancement: oldValue });
+  }
+}

--- a/packages/shared/src/urbit/settings.ts
+++ b/packages/shared/src/urbit/settings.ts
@@ -68,6 +68,7 @@ export type GroupsSettings = {
   activitySeenTimestamp?: number;
   completedWayfindingSplash?: boolean;
   completedWayfindingTutorial?: boolean;
+  disableTlonInfraEnhancement?: boolean;
 };
 
 export type TalkSettings = {


### PR DESCRIPTION
Adds the option to fallback to our cloud infra for link previews that are hard to get. The fallback serverless function is already deployed.

Adds a privacy option to disable the fallback option and rely only on `%metagrab` itself.

To test, try any of the links that we were having trouble with.

Fixes TLON-4308