### PR TITLE
embeds: store as rich link blocks

### DIFF
--- a/packages/app/ui/components/BareChatInput/index.tsx
+++ b/packages/app/ui/components/BareChatInput/index.tsx
@@ -311,44 +311,41 @@ export default function BareChatInput({
           const parsedUrl = new URL(urlMatch);
           parsedUrl.hash = '';
           const url = parsedUrl.toString();
-          const isEmbed = isTrustedEmbed(url);
 
-          if (!isEmbed) {
-            setLinkMetaLoading(true);
-            store
-              .getLinkMetaWithFallback(url)
-              .then((linkMetadata) => {
-                // todo: handle error case with toast or similar
-                if (!linkMetadata) {
-                  return;
-                }
+          setLinkMetaLoading(true);
+          store
+            .getLinkMetaWithFallback(url)
+            .then((linkMetadata) => {
+              // todo: handle error case with toast or similar
+              if (!linkMetadata) {
+                return;
+              }
 
-                // first add the link attachment
-                if (linkMetadata.type === 'page') {
-                  const { type, ...rest } = linkMetadata;
+              // first add the link attachment
+              if (linkMetadata.type === 'page') {
+                const { type, ...rest } = linkMetadata;
+                addAttachment({
+                  type: 'link',
+                  resourceType: type,
+                  ...rest,
+                });
+              }
+
+              if (linkMetadata.type === 'file') {
+                if (linkMetadata.isImage) {
                   addAttachment({
-                    type: 'link',
-                    resourceType: type,
-                    ...rest,
+                    type: 'image',
+                    file: {
+                      uri: url,
+                      height: 300,
+                      width: 300,
+                      mimeType: linkMetadata.mime,
+                    },
                   });
                 }
-
-                if (linkMetadata.type === 'file') {
-                  if (linkMetadata.isImage) {
-                    addAttachment({
-                      type: 'image',
-                      file: {
-                        uri: url,
-                        height: 300,
-                        width: 300,
-                        mimeType: linkMetadata.mime,
-                      },
-                    });
-                  }
-                }
-              })
-              .finally(() => setLinkMetaLoading(false));
-          }
+              }
+            })
+            .finally(() => setLinkMetaLoading(false));
         }
       }
 

--- a/packages/app/ui/components/ChatMessage/ChatMessage.tsx
+++ b/packages/app/ui/components/ChatMessage/ChatMessage.tsx
@@ -320,6 +320,7 @@ const ChatContentRenderer = createContentRenderer({
     image: isWeb ? WebChatImageRenderer : undefined,
     link: {
       renderDescription: false,
+      renderEmbed: true,
       maxWidth: 600,
       imageProps: {
         aspectRatio: 2,

--- a/packages/app/ui/components/GalleryPost/GalleryPost.tsx
+++ b/packages/app/ui/components/GalleryPost/GalleryPost.tsx
@@ -553,6 +553,7 @@ const LargeContentRenderer = createContentRenderer({
     link: {
       ...noWrapperPadding,
       minHeight: 300,
+      renderEmbed: true,
       imageProps: {
         aspectRatio: 1.5,
       },

--- a/packages/app/ui/components/PostContent/BlockRenderer.tsx
+++ b/packages/app/ui/components/PostContent/BlockRenderer.tsx
@@ -1,3 +1,4 @@
+import { isTrustedEmbed } from '@tloncorp/shared';
 import { Icon, Image, Pressable, Text, useCopy } from '@tloncorp/ui';
 import { ImageLoadEventData } from 'expo-image';
 import React, {
@@ -219,6 +220,7 @@ export function LinkBlock({
   renderTitle = true,
   renderImage = true,
   clickable = true,
+  renderEmbed = false,
   ...props
 }: {
   block: cn.LinkBlockData;
@@ -226,6 +228,7 @@ export function LinkBlock({
   renderDescription?: boolean;
   renderTitle?: boolean;
   renderImage?: boolean;
+  renderEmbed?: boolean;
   imageProps?: ComponentProps<typeof ContentImage>;
 } & ComponentProps<typeof Reference.Frame>) {
   const domain = useMemo(() => {
@@ -240,6 +243,14 @@ export function LinkBlock({
       Linking.openURL(block.url);
     }
   }, [block.url]);
+
+  if (renderEmbed && isTrustedEmbed(block.url)) {
+    const embedBlock: cn.EmbedBlockData = {
+      type: 'embed',
+      url: block.url,
+    };
+    return <EmbedBlock block={embedBlock} {...props} />;
+  }
 
   return (
     <Reference.Frame {...props} onPress={clickable ? onPress : undefined}>

--- a/packages/app/ui/components/draftInputs/LinkInput.tsx
+++ b/packages/app/ui/components/draftInputs/LinkInput.tsx
@@ -162,13 +162,6 @@ export function LinkInput({ editingPost, isPosting, onSave }: LinkInputProps) {
     }
 
     const { url: retrievedUrl, type, ...meta } = data;
-    if (isEmbed) {
-      return {
-        type: 'embed',
-        url,
-      };
-    }
-
     return {
       ...meta,
       type: 'link',


### PR DESCRIPTION
Updates our handling for embeddable links. Previously we were storing them as inline links without metadata. Now, we'll fetch nice previews for them and have this data available in contexts where we don't want to render an embed.

Updates the Link block renderer to optionally display as an embed if one is available.

Notably, this means we'll get nice rich previews in galleries instead of the embed falling back to a raw URL string.

Fixes TLON-4309