### PR TITLE
avoid blank screen on Android notification tap

### DIFF
--- a/apps/tlon-mobile/android/app/src/main/java/io/tlon/landscape/notifications/NotificationManager.kt
+++ b/apps/tlon-mobile/android/app/src/main/java/io/tlon/landscape/notifications/NotificationManager.kt
@@ -61,7 +61,7 @@ suspend fun processNotification(context: Context, uid: String) {
     )
 
     val tapIntent = Intent(context, MainActivity::class.java)
-    tapIntent.setFlags(Intent.FLAG_ACTIVITY_NEW_TASK or Intent.FLAG_ACTIVITY_CLEAR_TASK)
+    tapIntent.setFlags(Intent.FLAG_ACTIVITY_SINGLE_TOP or Intent.FLAG_ACTIVITY_CLEAR_TOP)
     tapIntent.replaceExtras(extras)
     val tapPendingIntent =
         PendingIntent.getActivity(context, id, tapIntent, PendingIntent.FLAG_IMMUTABLE)

--- a/apps/tlon-mobile/android/app/src/main/java/io/tlon/landscape/notifications/NotificationManager.kt
+++ b/apps/tlon-mobile/android/app/src/main/java/io/tlon/landscape/notifications/NotificationManager.kt
@@ -63,8 +63,12 @@ suspend fun processNotification(context: Context, uid: String) {
     val tapIntent = Intent(context, MainActivity::class.java)
     tapIntent.setFlags(Intent.FLAG_ACTIVITY_SINGLE_TOP or Intent.FLAG_ACTIVITY_CLEAR_TOP)
     tapIntent.replaceExtras(extras)
-    val tapPendingIntent =
-        PendingIntent.getActivity(context, id, tapIntent, PendingIntent.FLAG_IMMUTABLE)
+    val tapPendingIntent = PendingIntent.getActivity(
+        context,
+        id,
+        tapIntent,
+        PendingIntent.FLAG_IMMUTABLE or PendingIntent.FLAG_UPDATE_CURRENT
+    )
 
     val markAsReadIntent = Intent(
         context,


### PR DESCRIPTION
fixes TLON-4235

Changes the flags passed to the tap intent on the notification so that tapping a notification no longer restarts the main activity, causing a React remount.

## What caused this bug?
My hypothesis for this bug's cause is:
1. User launches app
2. App starts spinning on _lots_ of DB queries. (Try logging every query that gets run in `createQuery`!) These take a long time to resolve – this is bad but not the main cause of this bug.
3. Close (i.e. background) the app.
4. Receive a notification
5. Tap on the notification – this triggers our "tap intent" that causes the `MainActivity` to (re)launch
6. Because we configured the tap intent with the flags `Intent.FLAG_ACTIVITY_NEW_TASK or Intent.FLAG_ACTIVITY_CLEAR_TASK`... https://github.com/tloncorp/tlon-apps/blob/af5459041ee09b8ed82733c910c3961e355feff6/apps/tlon-mobile/android/app/src/main/java/io/tlon/landscape/notifications/NotificationManager.kt#L63-L64 ... the React app gets remounted – **but the queued DB queries are still running**[^1]
7. `<MigrationsCheck>` blocks the app UI from mounting, and starts a query to migrate the DB
8. The migration query "interrupts"[^2] the ongoing queries from the previous instance of the app, and both sides are confused: the orphaned queries report errors like `[op-sqlite] statement execution error: cannot commit - no transaction is active`, and the migration request hangs, neither erroring nor completing (causing `<MigrationCheck>` to forever block the main UI from loading)

[^1]: something about this seems wrong – I think we _do_ want queries to continue while the app is backgrounded, but all queries should get canceled(?) if the app is remounted
[^2]: not sure what the mechanism here is – my guess is that the migration query is sending an `END` that is ending the ongoing orphaned transaction instead of the migration transaction

Before this PR's changes, killing the app and tapping notification navigates correctly – which matches the hypothesis since the orphaned queries got killed.

## Changes
Main change is to use `FLAG_ACTIVITY_SINGLE_TOP or Intent.FLAG_ACTIVITY_CLEAR_TOP` as the flag set for the tap intent. The Android docs are not very helpful for which flags to use, so I'm just using LLM + Stack Overflow's recommendation for this use case.

[Ensure we modify existing intent instead of recreating it](https://github.com/tloncorp/tlon-apps/pull/4824/commits/973a4169d6d95dfffd88f78a7b4d85c41c8d8403) was another recommendation I saw online – probably not an issue for us unless we somehow double-send notifications, but seems like a nice safeguard.

## How did I test?
I only tested Android, as only native Android code was touched.

Using a `previewDebug` Android build:
1. Background a logged-in client
2. Send DM post triggering notification to client
3. Tap on notification

- Client navigates to DM correctly
- Tapping the Android system back button brings me back to the OS home screen
- App switcher has Tlon app moved to latest app, with rest of app stack untouched (not sure if this is relevant, sort of sounds like some of the intent flags can manipulate this stack)

<!-- Describe your testing process. -->

## Risks and impact

- [x] Safe to rollback without consulting PR author
- Affects important code area:
  - [ ] Onboarding
  - [ ] State / providers
  - [ ] Message sync
  - [ ] Channel display
  - [x] Notifications

## Rollback plan

git revert

## Screenshots / videos

<!-- Attach any relevant media. -->
