### PR TITLE
BareChatInput: don't send on enter with empty editor

### DIFF
--- a/packages/app/ui/components/BareChatInput/index.tsx
+++ b/packages/app/ui/components/BareChatInput/index.tsx
@@ -206,7 +206,6 @@ export default function BareChatInput({
 }: MessageInputProps) {
   const { bottom, top } = useSafeAreaInsets();
   const { height } = useWindowDimensions();
-  const store = useStore();
   const headerHeight = 48;
   const maxInputHeightBasic = useMemo(
     () => height - headerHeight - bottom - top,
@@ -536,7 +535,10 @@ export default function BareChatInput({
 
   // Check if editor is empty
   useEffect(() => {
-    setEditorIsEmpty(controlledText === '' && attachments.length === 0);
+    setEditorIsEmpty(
+      (controlledText === '' || controlledText.trim() === '') &&
+        attachments.length === 0
+    );
   }, [controlledText, attachments]);
 
   const adjustInputHeightProgrammatically = useCallback(() => {
@@ -764,7 +766,7 @@ export default function BareChatInput({
           mentionRef.current?.handleMentionKey('Enter');
         } else if (editingPost) {
           handleEdit();
-        } else {
+        } else if (!editorIsEmpty) {
           handleSend();
         }
       }
@@ -777,6 +779,7 @@ export default function BareChatInput({
       handleSend,
       handleMentionEscape,
       hasMentionCandidates,
+      editorIsEmpty,
     ]
   );
 


### PR DESCRIPTION
## Summary

Fixes a particularly annoying TLON-4303 where if you focus on the chat input on web and press Enter, it will send a blank message, which looks like a message rendering failure in the chat log.

## Changes

- Adds a final check to sending the message to see if the editor is empty
- Adds an additional condition to determining if the editor is empty (since it's possible to send space-only characters and spam the channel with whitespace)

## How did I test?

- Open a Chat channel on web
- Focus on the input
- Press Enter immediately

## Risks and impact

- Safe to rollback without consulting PR author? Yes
- Affects important code area:
  - [ ] Onboarding
  - [ ] State / providers
  - [ ] Message sync
  - [x] Channel display
  - [ ] Notifications

## Rollback plan

Revert away

## Screenshots / videos

Before:
![image](https://github.com/user-attachments/assets/f77adc0d-915b-4270-8bac-ffbb8df32daa)

After (I am pressing the Enter key here):
![image](https://github.com/user-attachments/assets/5004f0c8-5594-4148-a5c6-11d5c73c9b03)

After (I have inserted lots of spaces and am pressing Enter):
![image](https://github.com/user-attachments/assets/a7b31a81-c9bb-4533-afa0-f5e0605f01d9)
