### PR TITLE
fix channel failure to display

### DIFF
--- a/packages/app/ui/components/Channel/useAnchorScrollLock.ts
+++ b/packages/app/ui/components/Channel/useAnchorScrollLock.ts
@@ -38,10 +38,22 @@ export function useAnchorScrollLock({
 }) {
   const [userHasScrolled, setUserHasScrolled] = useState(false);
   const [didAnchorSearchTimeout, setDidAnchorSearchTimeout] = useState(false);
+  const [didScrollToAnchor, setDidScrollToAnchor] = useState(false);
   const currentAnchorId = useRef<string | undefined>(anchor?.postId);
   const renderedPostsRef = useRef(new Set<string>());
   const isScrollAttemptActiveRef = useRef(false);
-  const readyToDisplayPosts = !anchor?.postId || didAnchorSearchTimeout;
+  const readyToDisplayPosts =
+    !anchor?.postId || didAnchorSearchTimeout || didScrollToAnchor;
+
+  const showPostsTimeoutRef = useRef<NodeJS.Timeout | null>(null);
+  useEffect(() => {
+    if (posts?.length && !showPostsTimeoutRef.current && !readyToDisplayPosts) {
+      showPostsTimeoutRef.current = setTimeout(() => {
+        logger.log('posts are ready for display');
+        setDidAnchorSearchTimeout(true);
+      }, 2000);
+    }
+  }, [posts?.length, didAnchorSearchTimeout, readyToDisplayPosts]);
 
   // Find the index of the anchor post in the posts array
   const anchorIndex = useMemo(() => {
@@ -116,6 +128,7 @@ export function useAnchorScrollLock({
         } catch (e) {
           logger.error('error scrolling to anchor post', e);
         } finally {
+          setDidScrollToAnchor(true);
           isScrollAttemptActiveRef.current = false;
         }
       }


### PR DESCRIPTION
## Summary

This PR fixes an intermittent failure to display channel contents. Previously, if the scroller entered a state where it had more loaded posts than the FlatList would render before user interaction, we'd never toggle the opacity of the channel contents. To remedy that, we've added additional fallbacks to ensure the opacity always gets set if posts are available.

## Changes

- Toggle opacity after anchor post is rendered + scrolled to
- Toggle opacity two seconds after any posts are available, no matter what.

## How did I test?

Tested in channels with and without unreads on both mobile and desktop.

## Risks and impact

- Safe to rollback without consulting PR author? Yes
- Affects important code area:
  - [ ] Onboarding
  - [ ] State / providers
  - [ ] Message sync
  - [X] Channel display
  - [ ] Notifications

## Rollback plan

`git revert`
