### PR TITLE
clear app badge on every launch

### DIFF
--- a/apps/tlon-mobile/src/App.main.tsx
+++ b/apps/tlon-mobile/src/App.main.tsx
@@ -30,6 +30,7 @@ import { posthogAsync } from '@tloncorp/app/utils/posthog';
 import { QueryClientProvider, queryClient } from '@tloncorp/shared/api';
 import * as db from '@tloncorp/shared/db';
 import { ToastProvider } from '@tloncorp/ui';
+import { setBadgeCountAsync } from 'expo-notifications';
 import { PostHogProvider } from 'posthog-react-native';
 import type { PropsWithChildren } from 'react';
 import { useEffect, useMemo, useState } from 'react';
@@ -101,6 +102,8 @@ const App = () => {
   const showSplashSequence = useMemo(() => {
     return showAuthenticatedApp && needsSplashSequence;
   }, [showAuthenticatedApp, needsSplashSequence]);
+
+  useClearAppBadgeUnconditionally();
 
   return (
     <View height={'100%'} width={'100%'} backgroundColor="$background">
@@ -219,3 +222,11 @@ const DevTools = ({
   useReactNavigationDevTools(navigationContainerRef);
   return null;
 };
+
+function useClearAppBadgeUnconditionally() {
+  useEffect(() => {
+    setBadgeCountAsync(0).catch((err) => {
+      console.error('Failed to set badge count', err);
+    });
+  }, []);
+}


### PR DESCRIPTION
fixes TLON-4332

Sets app badge to 0 on every app mount.
This should be removed once "real" app badging is added (see TLON-985)

## How did I test?
1. Manually set badge count to 15 via `setBadgeCountAsync`; launch app and check the badge is stickily 15
2. Revert manual change
3. Launch app
4. Check app badge – count is cleared

Tested on iOS, with and without notification permissions
Tested on Android, but my Android launcher(?) doesn't have visible badges – it looks like there may be issues with this API on Android https://github.com/expo/expo/issues/13311 but I'm considering this to be a quickfix (and at least this change doesn't cause any visible issues?)

## Risks and impact

- Safe to rollback without consulting PR author? Yes
- Affects important code area:
  - [ ] Onboarding
  - [ ] State / providers
  - [ ] Message sync
  - [ ] Channel display
  - [x] Notifications

## Rollback plan

git revert

## Screenshots / videos

<!-- Attach any relevant media. -->
