### PR TITLE
queries: make sure we don't drop blocks

### DIFF
--- a/packages/shared/src/db/queries.test.ts
+++ b/packages/shared/src/db/queries.test.ts
@@ -1,8 +1,10 @@
 import { expect, test } from 'vitest';
 
+import { v0PeersToClientProfiles } from '../api';
 import { toClientGroups } from '../api/groupsApi';
 import * as schema from '../db/schema';
 import { syncInitData } from '../store/sync';
+import contactsResponse from '../test/contacts.json';
 import groupsResponse from '../test/groups.json';
 import {
   getClient,
@@ -63,6 +65,36 @@ test('uses init data to get chat list', async () => {
     '~barmyl-sigted/network-being',
     '~salfer-biswed/gamers',
   ]);
+});
+
+test('inserts contacts without overriding block data', async () => {
+  // setup
+  setScryOutputs([initResponse]);
+  await syncInitData();
+
+  const blocks = [
+    '~nocsyx-lassul',
+    '~ravmel-ropdyl',
+    '~fonrym-radfur-nocsyx-lassul',
+  ];
+  const blockedUsers = await queries.getBlockedUsers();
+  expect(blockedUsers.map((b) => b.id)).toEqual(blocks);
+
+  const contacts = v0PeersToClientProfiles(contactsResponse);
+  // nocsyx and ravmel are in contacts, but blocked
+  expect(
+    contacts.filter(
+      (c) => c.id === '~nocsyx-lassul' || c.id === '~ravmel-ropdyl'
+    )
+  ).toBeTruthy();
+  // fonrym is blocked, but not in contacts
+  expect(
+    contacts.find((c) => c.id === '~fonrym-radfur-nocsyx-lassul')
+  ).toBeFalsy();
+  // insert contacts
+  await queries.insertContacts(contacts);
+  const newBlockedUsers = await queries.getBlockedUsers();
+  expect(newBlockedUsers.map((b) => b.id)).toEqual(blocks);
 });
 
 const refDate = Date.now();

--- a/packages/shared/src/db/queries.ts
+++ b/packages/shared/src/db/queries.ts
@@ -3716,7 +3716,7 @@ export const insertContacts = createWriteQuery(
         .values(contactsData)
         .onConflictDoUpdate({
           target: $contacts.id,
-          set: conflictUpdateSetAll($contacts),
+          set: conflictUpdateSetAll($contacts, ['isBlocked']),
         });
 
       if (targetGroups.length) {

--- a/packages/shared/src/test/helpers.ts
+++ b/packages/shared/src/test/helpers.ts
@@ -2,7 +2,7 @@ import Database from 'better-sqlite3';
 import { BetterSQLite3Database, drizzle } from 'drizzle-orm/better-sqlite3';
 import { migrate } from 'drizzle-orm/better-sqlite3/migrator';
 import tmp from 'tmp';
-import { MockedFunction, beforeAll, beforeEach, vi } from 'vitest';
+import { beforeAll, beforeEach, vi } from 'vitest';
 
 import { scry } from '../api/urbit';
 import { setClient } from '../db';

--- a/packages/shared/src/test/init.json
+++ b/packages/shared/src/test/init.json
@@ -11570,7 +11570,11 @@
       }
     },
     "invited": [],
-    "blocked": [],
+    "blocked": [
+      "~nocsyx-lassul",
+      "~ravmel-ropdyl",
+      "~fonrym-radfur-nocsyx-lassul"
+    ],
     "blocked-by": []
   },
   "pins": ["0v4.00000.qd6oi.a3f6t.5sd9v.fjmp2"],


### PR DESCRIPTION
## Summary

This simply makes sure we don't empty out `isBlocked` if a contact is already in the DB and we're inserting it (because we just inserted it from blocks).

## Changes

- changes the `onConflictDoUpdate` to ignore `isBlocked`
- adds a test case to make sure this doesn't change

## How did I test?

Run `pnpm test` and also navigate to Blocked Users screen

## Risks and impact

- Safe to rollback without consulting PR author? Yes
- Affects important code area:
  - [ ] Onboarding
  - [ ] State / providers
  - [ ] Message sync
  - [ ] Channel display
  - [ ] Notifications

## Rollback plan

n/a

## Screenshots / videos

n/a
