### PR TITLE
web: fix imageviewer crash

### DIFF
--- a/packages/app/ui/components/ImageViewerScreenView.tsx
+++ b/packages/app/ui/components/ImageViewerScreenView.tsx
@@ -15,6 +15,7 @@ import {
 } from 'react-native';
 import {
   Directions,
+  FlingGesture,
   Gesture,
   GestureDetector,
 } from 'react-native-gesture-handler';
@@ -67,7 +68,7 @@ export function ImageViewerScreenView(props: {
   }
 
   const dismissGesture = Gesture.Fling()
-    .enabled(isAtMinZoom)
+    .enabled(isAtMinZoom && !isWeb)
     .direction(Directions.DOWN)
     .onEnd((_event, success) => {
       if (success) {
@@ -276,115 +277,112 @@ export function ImageViewerScreenView(props: {
   };
 
   return (
-    <ImageViewerContainer>
-      <GestureDetector gesture={dismissGesture}>
-        <ZStack
-          flex={1}
-          backgroundColor="$black"
-          paddingTop={top}
-          data-testid="image-viewer"
-        >
-          <View flex={1}>
-            {isWeb ? (
-              <Zoomable
-                ref={zoomableRef}
-                data-testid="zoomable-image"
-                style={{
-                  flex: 1,
-                  height: '100%',
-                  alignItems: 'center',
-                  justifyContent: 'center',
-                }}
-                isDoubleTapEnabled
-                isSingleTapEnabled
-                isPanEnabled
-                minScale={0.1}
-                onPinchEnd={handlePinchEnd}
-                onDoubleTap={onDoubleTap}
-                onSingleTap={onSingleTap}
-                maxPanPointers={maxPanPointers}
-              >
-                <Image
-                  source={{
-                    uri: props.uri,
-                  }}
-                  data-testid="image"
-                  style={{
-                    height: 'auto',
-                    maxWidth: Dimensions.get('window').width,
-                    maxHeight: Dimensions.get('window').height - top,
-                  }}
-                />
-              </Zoomable>
-            ) : (
-              <ImageZoom
-                ref={zoomableRef}
-                uri={props.uri}
-                style={{ flex: 1 }}
-                isDoubleTapEnabled
-                isSingleTapEnabled
-                isPanEnabled
-                width={Dimensions.get('window').width}
-                maxPanPointers={maxPanPointers}
-                minScale={0.1}
-                onPinchEnd={handlePinchEnd}
-                onDoubleTap={onDoubleTap}
-                onSingleTap={onSingleTap}
-              />
-            )}
-          </View>
-
-          {/* overlay */}
-          {showOverlay ? (
-            <YStack
-              position="absolute"
-              width="100%"
-              padding="$xl"
-              paddingTop={isWeb ? 16 : top}
+    <ImageViewerContainer dismissGesture={dismissGesture}>
+      <ZStack
+        flex={1}
+        backgroundColor="$black"
+        paddingTop={top}
+        data-testid="image-viewer"
+      >
+        <View flex={1}>
+          {isWeb ? (
+            <View
+              flex={1}
+              height="100%"
+              alignItems="center"
+              justifyContent="center"
             >
-              <XStack
-                justifyContent={isWeb ? 'flex-end' : 'space-between'}
-                gap="$m"
-              >
-                <TouchableOpacity
-                  onPress={handleDownloadImage}
-                  activeOpacity={0.8}
-                >
-                  <Stack
-                    padding="$m"
-                    backgroundColor="$darkOverlay"
-                    borderRadius="$l"
-                  >
-                    <Icon type="ArrowDown" size="$l" color="$white" />
-                  </Stack>
-                </TouchableOpacity>
+              <Image
+                source={{
+                  uri: props.uri,
+                }}
+                data-testid="image"
+                style={{
+                  height: 'auto',
+                  maxWidth: Dimensions.get('window').width,
+                  maxHeight: Dimensions.get('window').height - top,
+                }}
+              />
+            </View>
+          ) : (
+            <ImageZoom
+              ref={zoomableRef}
+              uri={props.uri}
+              style={{ flex: 1 }}
+              isDoubleTapEnabled
+              isSingleTapEnabled
+              isPanEnabled
+              width={Dimensions.get('window').width}
+              maxPanPointers={maxPanPointers}
+              minScale={0.1}
+              onPinchEnd={handlePinchEnd}
+              onDoubleTap={onDoubleTap}
+              onSingleTap={onSingleTap}
+            />
+          )}
+        </View>
 
-                <TouchableOpacity
-                  onPress={() => props.goBack()}
-                  activeOpacity={0.8}
+        {/* overlay */}
+        {showOverlay ? (
+          <YStack
+            position="absolute"
+            width="100%"
+            padding="$xl"
+            paddingTop={isWeb ? 16 : top}
+          >
+            <XStack
+              justifyContent={isWeb ? 'flex-end' : 'space-between'}
+              gap="$m"
+            >
+              <TouchableOpacity
+                onPress={handleDownloadImage}
+                activeOpacity={0.8}
+              >
+                <Stack
+                  padding="$m"
+                  backgroundColor="$darkOverlay"
+                  borderRadius="$l"
                 >
-                  <Stack
-                    padding="$m"
-                    backgroundColor="$darkOverlay"
-                    borderRadius="$l"
-                  >
-                    <Icon type="Close" size="$l" color="$white" />
-                  </Stack>
-                </TouchableOpacity>
-              </XStack>
-            </YStack>
-          ) : null}
-        </ZStack>
-      </GestureDetector>
+                  <Icon type="ArrowDown" size="$l" color="$white" />
+                </Stack>
+              </TouchableOpacity>
+
+              <TouchableOpacity
+                onPress={() => props.goBack()}
+                activeOpacity={0.8}
+              >
+                <Stack
+                  padding="$m"
+                  backgroundColor="$darkOverlay"
+                  borderRadius="$l"
+                >
+                  <Icon type="Close" size="$l" color="$white" />
+                </Stack>
+              </TouchableOpacity>
+            </XStack>
+          </YStack>
+        ) : null}
+      </ZStack>
     </ImageViewerContainer>
   );
 }
 
-function ImageViewerContainer(props: PropsWithChildren) {
+function ImageViewerContainer(
+  props: PropsWithChildren<{ dismissGesture?: FlingGesture }>
+) {
   // on web, we wrap in a modal to escape the drawer navigators
   if (isWeb) {
     return <Modal animationType="none">{props.children}</Modal>;
   }
 
-  return props.children;
+  if (!props.dismissGesture) {
+    console.error('ImageViewerContainer requires a dismissGesture on mobile');
+    return null;
+  }
+
+  return (
+    <GestureDetector gesture={props.dismissGesture}>
+      {props.children}
+    </GestureDetector>
+  );
 }


### PR DESCRIPTION
## Summary

Our newly upgraded Tamagui pulls in a newer `react-native-web` runtime. The required version prevents `findNodeHandle` calls, which have been deprecated in React itself. Our web implementation of the `ImageViewer` lightbox has a gesture detector + touch enabled zoom that calls out to this now invalid `findNodeHandle` api, causing a crash.

I'm not totally clear on where the call is happening. Removing `GestureDetector` or `Zoomable` independently doesn't solve the issue, but ripping out both does. There's [some old discussion](https://github.com/software-mansion/react-native-gesture-handler/issues/1036#event-6342907979) in `react-native-gesture-handler` about avoiding these calls.

## Changes

- Only wrap in a `GestureDetector` on mobile
- Display a standard image in the lightbox instead of one from `react-native-image-zoom`

As far as I can tell, the zoom functionality wasn't working on web anyhow. So removing this should have no UX impact.

## How did I test?

Click an image in chat before and after the changes on Web.

## Risks and impact

- Safe to rollback without consulting PR author? No
- Affects important code area:
  - [ ] Onboarding
  - [ ] State / providers
  - [ ] Message sync
  - [x] Channel display
  - [ ] Notifications

## Rollback plan

The PR can be reverted, but we'll need a replacement fix immediately.

## Screenshots / videos
N/A

Fixes TLON-4342
