### PR TITLE
embeds: avoid duplicate display

### DIFF
--- a/packages/app/ui/components/PostContent/contentUtils.tsx
+++ b/packages/app/ui/components/PostContent/contentUtils.tsx
@@ -215,10 +215,10 @@ export function convertContent(input: unknown): PostContent {
     } else if ('inline' in verse) {
       // if we already have an embed or link block, avoid duplicating it
       // if there's another one inline
-      const supressInlineEmbeds = blocks.some(
+      const suppressInlineEmbeds = blocks.some(
         (b) => b.type === 'embed' || b.type === 'link'
       );
-      blocks.push(...convertTopLevelInline(verse, supressInlineEmbeds));
+      blocks.push(...convertTopLevelInline(verse, suppressInlineEmbeds));
     } else {
       console.warn('Unhandled verse type:', { verse });
       blocks.push({
@@ -261,7 +261,7 @@ export function usePostLastEditContent(post: Post): BlockData[] {
 
 function convertTopLevelInline(
   verse: ub.VerseInline,
-  supressInlineEmbeds?: boolean
+  suppressInlineEmbeds?: boolean
 ): BlockData[] {
   const blocks: BlockData[] = [];
   let currentInlines: ub.Inline[] = [];
@@ -271,7 +271,7 @@ function convertTopLevelInline(
       // Process the inlines to extract trusted embeds and split paragraphs
       const processedBlocks = processParagraphsAndEmbeds(
         currentInlines,
-        supressInlineEmbeds
+        suppressInlineEmbeds
       );
       blocks.push(...processedBlocks);
       currentInlines = [];
@@ -318,7 +318,7 @@ function convertTopLevelInline(
 // Process inlines to extract embeds as separate blocks
 function processParagraphsAndEmbeds(
   inlines: ub.Inline[],
-  supressInlineEmbeds?: boolean
+  suppressInlineEmbeds?: boolean
 ): BlockData[] {
   const blocks: BlockData[] = [];
   let currentSegment: ub.Inline[] = [];
@@ -350,7 +350,7 @@ function processParagraphsAndEmbeds(
       const isEmbed = isTrustedEmbed(inline.link.href);
       const isNotFormattedText = inline.link.href === inline.link.content;
 
-      if (isEmbed && isNotFormattedText && !supressInlineEmbeds) {
+      if (isEmbed && isNotFormattedText && !suppressInlineEmbeds) {
         // Flush the current segment before adding the embed
         flushSegment();
 


### PR DESCRIPTION
## Summary

We previously parsed embeds from inline links, but now we attach them directly as rich link blocks. We need to avoid displaying duplicates, so we should avoid doing legacy inline parsing if we already have an attached link block. 

## Changes

Update the inline parser to avoid extracting embeds if a top level link block already exists.

## How did I test?

Post a youtube link without removing the URL.

## Risks and impact

- Safe to rollback without consulting PR author? Yes
- Affects important code area:
  - [ ] Onboarding
  - [ ] State / providers
  - [ ] Message sync
  - [x] Channel display
  - [ ] Notifications

## Rollback plan

Revert the PR and push an alternative fix.
