### PR TITLE
chat: fix dm responses

### DIFF
--- a/desk/app/chat.hoon
+++ b/desk/app/chat.hoon
@@ -1559,13 +1559,14 @@
     =/  =whom:c  [%club id]
     =/  response=(unit response:writs:c)  (diff-to-response diff pact.club)
     ?~  response  cu-core
-    =/  old-response-3  [whom (old-response-writs-3:pac u.response)]
-    =/  new-response  [whom u.response]
+    =/  old-response-3=[whom:old-3 response:writs:old-3]
+      [whom (old-response-writs-3:pac u.response)]
+    =/  new-response=[whom:c response:writs:c]  [whom u.response]
     =.  cor
-      =/  cage  writ-response+!>(`[whom:old-3 response:writs:old-3]`old-response-3)
+      =/  cage  writ-response+!>(old-response-3)
       (emit %give %fact ~[/ cu-area-old cu-area-writs-old] cage)
     =.  cor
-      =/  =cage  writ-response-1+!>(`[whom:c response:writs:c]`new-response)
+      =/  =cage  writ-response-1+!>(new-response)
       (emit %give %fact ~[/v1 cu-area cu-area-writs] cage)
     cu-core
   ::
@@ -1975,14 +1976,15 @@
     =/  =whom:c  [%ship ship]
     =/  response=(unit response:writs:c)  (diff-to-response diff pact.dm)
     ?~  response  di-core
-    =/  old-response-3  [whom (old-response-writs-3:pac u.response)]
-    =/  new-response  [whom u.response]
+    =/  old-response-3=[whom:old-3 response:writs:old-3]
+      [whom (old-response-writs-3:pac u.response)]
+    =/  new-response=[whom:c response:writs:c]  [whom u.response]
     =.  cor
       =/  =cage
-        writ-response+!>(`[whom:old-3 response:writs:old-3]`old-response-3)
+        writ-response+!>(old-response-3)
       (emit %give %fact ~[/ di-area-old di-area-writs-old] cage)
     =.  cor
-      =/  =cage  writ-response-1+!>(`[whom:c response:writs:c]`new-response)
+      =/  =cage  writ-response-1+!>(new-response)
       (emit %give %fact ~[/v1 di-area di-area-writs] cage)
     di-core
   ::

--- a/desk/app/chat.hoon
+++ b/desk/app/chat.hoon
@@ -1556,22 +1556,17 @@
   ::
   ++  cu-give-writs-diff
     |=  =diff:writs:c
+    =/  =whom:c  [%club id]
     =/  response=(unit response:writs:c)  (diff-to-response diff pact.club)
     ?~  response  cu-core
+    =/  old-response-3  [whom (old-response-writs-3:pac u.response)]
+    =/  new-response  [whom u.response]
     =.  cor
-      =/  old-response-3  [[%club id] (old-response-writs-3:pac u.response)]
-      =/  cage  writ-response+!>(old-response-3)
-      (emit %give %fact ~[/ cu-area-old] cage)
+      =/  cage  writ-response+!>(`[whom:old-3 response:writs:old-3]`old-response-3)
+      (emit %give %fact ~[/ cu-area-old cu-area-writs-old] cage)
     =.  cor
-      =/  =cage  writ-response-1+!>(response)
-      (emit %give %fact ~[/v1 cu-area] cage)
-    =.  cor
-      =/  old-response-3  [[%club id] (old-response-writs-3:pac u.response)]
-      =/  =cage  writ-response+!>(old-response-3)
-      (emit %give %fact ~[/ cu-area-writs-old] cage)
-    =.  cor
-      =/  =cage  writ-response-1+!>(response)
-      (emit %give %fact ~[/v1 cu-area-writs] cage)
+      =/  =cage  writ-response-1+!>(`[whom:c response:writs:c]`new-response)
+      (emit %give %fact ~[/v1 cu-area cu-area-writs] cage)
     cu-core
   ::
   ++  cu-diff
@@ -1977,22 +1972,18 @@
   ::
   ++  di-give-writs-diff
     |=  =diff:writs:c
+    =/  =whom:c  [%ship ship]
     =/  response=(unit response:writs:c)  (diff-to-response diff pact.dm)
     ?~  response  di-core
+    =/  old-response-3  [whom (old-response-writs-3:pac u.response)]
+    =/  new-response  [whom u.response]
     =.  cor
-      =/  old-response-3  [[%ship ship] (old-response-writs-3:pac u.response)]
-      =/  =cage  writ-response+!>(old-response-3)
-      (emit %give %fact ~[/ di-area-old] cage)
+      =/  =cage
+        writ-response+!>(`[whom:old-3 response:writs:old-3]`old-response-3)
+      (emit %give %fact ~[/ di-area-old di-area-writs-old] cage)
     =.  cor
-      =/  =cage  writ-response-1+!>(response)
-      (emit %give %fact ~[/v1 di-area] cage)
-    =.  cor
-      =/  old-response-3  [[%ship ship] (old-response-writs-3:pac u.response)]
-      =/  =cage  writ-response+!>(old-response-3)
-      (emit %give %fact ~[/ di-area-writs-old] cage)
-    =.  cor
-      =/  =cage  writ-response+!>(response)
-      (emit %give %fact ~[/v1 di-area-writs] cage)
+      =/  =cage  writ-response-1+!>(`[whom:c response:writs:c]`new-response)
+      (emit %give %fact ~[/v1 di-area di-area-writs] cage)
     di-core
   ::
   ++  di-ingest-diff

--- a/packages/shared/src/api/apiUtils.ts
+++ b/packages/shared/src/api/apiUtils.ts
@@ -1,7 +1,6 @@
 import {
   formatUd as baseFormatUd,
   daToUnix,
-  isValidPatp,
   parseUd,
   unixToDa,
 } from '@urbit/aura';
@@ -189,7 +188,7 @@ export function deriveFullWrit(
 ): ub.Writ {
   const time = delta.add.time
     ? bigInt(delta.add.time).toString()
-    : unixToDa(delta.add.memo.sent).toString();
+    : unixToDa(delta.add.essay.sent).toString();
 
   const seal: ub.WritSeal = {
     id,
@@ -203,14 +202,7 @@ export function deriveFullWrit(
     },
   };
 
-  const essay: ub.WritEssay = {
-    ...delta.add.memo,
-    'kind-data': {
-      chat: 'kind' in delta.add ? delta.add.kind : null,
-    },
-  };
-
-  return { seal, essay };
+  return { seal, essay: delta.add.essay };
 }
 
 export function deriveFullWritReply({

--- a/packages/shared/src/api/chatApi.ts
+++ b/packages/shared/src/api/chatApi.ts
@@ -108,7 +108,7 @@ export function subscribeToChatUpdates(
   subscribe(
     {
       app: 'chat',
-      path: '/',
+      path: '/v1',
     },
     (event: ub.WritResponse | ub.ClubAction | string[]) => {
       logger.log('raw chat sub event', event);

--- a/packages/shared/src/api/postsApi.ts
+++ b/packages/shared/src/api/postsApi.ts
@@ -52,7 +52,7 @@ export function chatAction(
   if (whomIsDm(whom)) {
     const action: Poke<DmAction> = {
       app: 'chat',
-      mark: 'chat-dm-action',
+      mark: 'chat-dm-action-1',
       json: {
         ship: whom,
         diff: {
@@ -67,7 +67,7 @@ export function chatAction(
   const diff: WritDiff = { id, delta };
   const action: Poke<ClubAction> = {
     app: 'chat',
-    mark: 'chat-club-action-0',
+    mark: 'chat-club-action-1',
     json: {
       id: whom,
       diff: {
@@ -147,22 +147,21 @@ export const sendPost = async ({
   if (channelType === 'dm' || channelType === 'groupDm') {
     const delta: WritDeltaAdd = {
       add: {
-        memo: {
+        essay: {
           content,
           sent: sentAt,
           author: authorId,
-          kind: '/dm',
+          kind: '/chat',
           meta: null,
           blob: null,
         },
-        kind: null,
         time: null,
       },
     };
 
     const action = chatAction(
       channelId,
-      `${delta.add.memo.author}/${formatUd(unixToDa(delta.add.memo.sent).toString())}`,
+      `${delta.add.essay.author}/${formatUd(unixToDa(delta.add.essay.sent).toString())}`,
       delta
     );
     await poke(action);
@@ -299,9 +298,6 @@ export const sendReply = async ({
               content,
               author: authorId,
               sent: sentAt,
-              kind: '/dm',
-              meta: null,
-              blob: null,
             },
             time: null,
           },
@@ -470,7 +466,7 @@ export async function addReaction({
     if (isDmChannelId(channelId)) {
       await poke({
         app: 'chat',
-        mark: 'chat-dm-action',
+        mark: 'chat-dm-action-1',
         json: {
           ship: channelId,
           diff: {
@@ -488,7 +484,7 @@ export async function addReaction({
     } else {
       await poke({
         app: 'chat',
-        mark: 'chat-club-action-0',
+        mark: 'chat-club-action-1',
         json: {
           id: channelId,
           diff: {
@@ -549,7 +545,7 @@ export async function removeReaction({
     if (isDmChannelId(channelId)) {
       return poke({
         app: 'chat',
-        mark: 'chat-dm-action',
+        mark: 'chat-dm-action-1',
         json: {
           ship: channelId,
           diff: {
@@ -563,7 +559,7 @@ export async function removeReaction({
     } else {
       return poke({
         app: 'chat',
-        mark: 'chat-club-action-0',
+        mark: 'chat-club-action-1',
         json: {
           id: channelId,
           diff: {

--- a/packages/shared/src/urbit/channel.ts
+++ b/packages/shared/src/urbit/channel.ts
@@ -25,8 +25,16 @@ export interface WritEssay extends PostEssay {
 export interface WritSeal extends PostSeal {
   time: number;
 }
+
+export type BotProfile = {
+  ship: Ship;
+  nickname: string | null;
+  avatar: string | null;
+};
+
 export type Patda = string;
 export type Ship = string;
+export type Author = Ship | BotProfile;
 export type Nest = string;
 
 export interface ReplyMeta {

--- a/packages/shared/src/urbit/dms.ts
+++ b/packages/shared/src/urbit/dms.ts
@@ -4,7 +4,7 @@ import _ from 'lodash';
 import BTree from 'sorted-btree';
 
 import {
-  KindDataChat,
+  Memo,
   PostEssay,
   PostSeal,
   PostSealDataResponse,
@@ -22,9 +22,9 @@ export interface Writ {
   essay: WritEssay;
 }
 
-export interface WritEssay extends PostEssay {
-  'kind-data': KindDataChat;
-}
+export type WritEssay = PostEssay;
+
+export type WritMemo = Memo;
 
 export interface WritReplySeal extends ReplySeal {
   time: string;
@@ -33,8 +33,6 @@ export interface WritReplySeal extends ReplySeal {
 export interface WritReply extends Reply {
   seal: WritReplySeal;
 }
-
-export type WritMemo = Omit<PostEssay, 'kind-data'>;
 
 export interface WritReplyReferenceResponse {
   reply: {
@@ -51,8 +49,7 @@ export interface WritSeal extends PostSeal {
 
 export interface WritDeltaAdd {
   add: {
-    memo: WritMemo;
-    kind: null;
+    essay: WritEssay;
     time: string | null;
   };
 }
@@ -120,7 +117,7 @@ export interface WritDiff {
 
 export interface WritResponseAdd {
   add: {
-    memo: WritMemo;
+    essay: WritEssay;
     time: string;
   };
 }

--- a/packages/shared/src/urbit/utils.ts
+++ b/packages/shared/src/urbit/utils.ts
@@ -7,7 +7,6 @@ import { GroupJoinStatus, GroupPrivacy } from '../db/schema';
 import { createDevLogger } from '../debug';
 import * as ub from './channel';
 import * as ubc from './content';
-import * as ubd from './dms';
 import * as ubg from './groups';
 
 const logger = createDevLogger('urbitUtils', false);
@@ -300,57 +299,6 @@ export function getInlineContent(inline: ubc.Inline): string {
   } else {
     return inline;
   }
-}
-
-function makeId(our: string) {
-  const sent = Date.now();
-  return {
-    id: `${our}/${formatUd(unixToDa(sent))}`,
-    sent,
-  };
-}
-
-export function createMessage(
-  our: string,
-  mem: ub.PostEssay,
-  replying?: string
-): {
-  id: string;
-  cacheId: ub.CacheId;
-  delta: ubd.WritDeltaAdd | ubd.ReplyDelta;
-} {
-  const { id, sent } = makeId(our);
-  const cacheId = { author: mem.author, sent };
-  const memo: ub.PostEssay = {
-    ...mem,
-    sent,
-  };
-
-  let delta: ubd.WritDeltaAdd | ubd.ReplyDelta;
-  if (!replying) {
-    delta = {
-      add: {
-        memo,
-        kind: null,
-        time: null,
-      },
-    };
-  } else {
-    delta = {
-      reply: {
-        id,
-        meta: null,
-        delta: {
-          add: {
-            memo,
-            time: null,
-          },
-        },
-      },
-    };
-  }
-
-  return { id, cacheId, delta };
 }
 
 export function whomIsDm(whom: string): boolean {


### PR DESCRIPTION
## Summary

We somehow did not catch that we weren't using the new marks and subscriptions from the upgrade. Additionally after using those, we discovered an issue with the way that %chat was trying to give responses. This fixes both of those so that DMs now are able to send the new link blocks.

## Changes

- adjusted the way we were giving `writ-response-1` and `writ-response` so that the types were correct and checked
- swapped our %chat subscription to v1
- swapped our chat types to match new backend types
- swapped poke marks to match

## How did I test?

Manually live on screenshare

## Risks and impact

- Safe to rollback without consulting PR author? No
- Affects important code area:
  - [ ] Onboarding
  - [ ] State / providers
  - [ ] Message sync
  - [ ] Channel display
  - [ ] Notifications

## Rollback plan

Consult the author

## Screenshots / videos

n/a
