### PR TITLE
reactions: fix handling of new reactions in chat and channels

### DIFF
--- a/desk/lib/channel-utils.hoon
+++ b/desk/lib/channel-utils.hoon
@@ -156,7 +156,7 @@
   :*  id.v-post
       seq.v-post
       mod-at.v-post
-      (uv-reacts-1 reacts.v-post)
+      (uv-reacts-2 reacts.v-post)
       (uv-replies-2 id.v-post replies.v-post)
       (get-reply-meta v-post)
   ==
@@ -270,7 +270,7 @@
   :*  id.post
       seq.post
       mod-at.post
-      (uv-reacts-1 reacts.post)
+      (uv-reacts-2 reacts.post)
       *replies:c
       (get-reply-meta post)
   ==

--- a/packages/app/ui/components/ChatMessage/ChatMessageActions/EmojiToolbar.tsx
+++ b/packages/app/ui/components/ChatMessage/ChatMessageActions/EmojiToolbar.tsx
@@ -1,5 +1,6 @@
+import { createDevLogger } from '@tloncorp/shared';
 import * as db from '@tloncorp/shared/db';
-import { useIsWindowNarrow } from '@tloncorp/ui';
+import { getNativeEmoji, useIsWindowNarrow } from '@tloncorp/ui';
 import { Button } from '@tloncorp/ui';
 import { SizableEmoji } from '@tloncorp/ui';
 import { Icon } from '@tloncorp/ui';
@@ -10,6 +11,8 @@ import { useCurrentUserId } from '../../../contexts';
 import useOnEmojiSelect from '../../../hooks/useOnEmojiSelect';
 import { ReactionDetails, useReactionDetails } from '../../../utils/postUtils';
 import { EmojiPickerSheet } from '../../Emoji/EmojiPickerSheet';
+
+const logger = createDevLogger('EmojiToolbar', false);
 
 export function EmojiToolbar({
   post,
@@ -26,6 +29,18 @@ export function EmojiToolbar({
   const isWindowNarrow = useIsWindowNarrow();
 
   const handlePress = useOnEmojiSelect(post, onDismiss);
+
+  const handleToolbarPress = useCallback(
+    (shortCode: string) => {
+      const nativeEmoji = getNativeEmoji(shortCode);
+      if (!nativeEmoji) {
+        logger.trackError(`No native emoji found`, { shortCode });
+        return;
+      }
+      handlePress(nativeEmoji);
+    },
+    [handlePress]
+  );
 
   const lastShortCode =
     details.self.didReact &&
@@ -56,25 +71,25 @@ export function EmojiToolbar({
         <EmojiToolbarButton
           details={details}
           shortCode="+1"
-          handlePress={handlePress}
+          handlePress={handleToolbarPress}
           testID="EmojiToolbarButton-thumb"
         />
         <EmojiToolbarButton
           details={details}
           shortCode="heart"
-          handlePress={handlePress}
+          handlePress={handleToolbarPress}
           testID="EmojiToolbarButton-heart"
         />
         <EmojiToolbarButton
           details={details}
           shortCode="laughing"
-          handlePress={handlePress}
+          handlePress={handleToolbarPress}
           testID="EmojiToolbarButton-laughing"
         />
         <EmojiToolbarButton
           details={details}
           shortCode={lastShortCode}
-          handlePress={handlePress}
+          handlePress={handleToolbarPress}
           testID="EmojiToolbarButton-last"
         />
         <Button padding="$xs" borderWidth={0} onPress={handleSheetOpen}>

--- a/packages/app/ui/components/ChatMessage/ReactionsDisplay.tsx
+++ b/packages/app/ui/components/ChatMessage/ReactionsDisplay.tsx
@@ -42,9 +42,14 @@ export function ReactionsDisplay({
   const handleModifyYourReaction = useCallback(
     (value: string) => {
       triggerHaptic('baseButtonClick');
-      reactionDetails.self.didReact
-        ? store.removePostReaction(post, currentUserId)
-        : store.addPostReaction(post, value, currentUserId);
+      if (
+        reactionDetails.self.didReact &&
+        reactionDetails.self.value === value
+      ) {
+        store.removePostReaction(post, currentUserId);
+      } else {
+        store.addPostReaction(post, value, currentUserId);
+      }
     },
     [currentUserId, post, reactionDetails.self.didReact]
   );

--- a/packages/app/ui/components/Emoji/EmojiPickerSheet.tsx
+++ b/packages/app/ui/components/Emoji/EmojiPickerSheet.tsx
@@ -1,5 +1,6 @@
 import { FlashList } from '@shopify/flash-list';
-import { useIsWindowNarrow } from '@tloncorp/ui';
+import { createDevLogger } from '@tloncorp/shared';
+import { getNativeEmoji, useIsWindowNarrow } from '@tloncorp/ui';
 import { Button } from '@tloncorp/ui';
 import { KeyboardAvoidingView } from '@tloncorp/ui';
 import { Sheet } from '@tloncorp/ui';
@@ -21,6 +22,7 @@ import { VisuallyHidden } from 'tamagui';
 import { SearchBar } from '../SearchBar';
 
 const EMOJI_SIZE = 32;
+const logger = createDevLogger('EmojiPickerSheet', false);
 
 const MemoizedEmojiButton = React.memo(function MemoizedEmojiButtonComponent({
   item,
@@ -45,7 +47,7 @@ const MemoizedEmojiButton = React.memo(function MemoizedEmojiButtonComponent({
 
 export function EmojiPickerSheet(
   props: ComponentProps<typeof Sheet> & {
-    onEmojiSelect: (shortCode: string) => void;
+    onEmojiSelect: (value: string) => void;
   }
 ) {
   const [scrolling, setIsScrolling] = useState(false);
@@ -79,7 +81,13 @@ export function EmojiPickerSheet(
 
   const handleEmojiSelect = useCallback(
     (shortCode: string) => {
-      onEmojiSelect(shortCode);
+      const nativeEmoji = getNativeEmoji(shortCode);
+      if (!nativeEmoji) {
+        // should never hit this, but just in case
+        logger.trackError(`No native emoji found`, { shortCode });
+        return;
+      }
+      onEmojiSelect(nativeEmoji);
       props.onOpenChange?.(false);
     },
     [onEmojiSelect, props]

--- a/packages/app/ui/hooks/useOnEmojiSelect.tsx
+++ b/packages/app/ui/hooks/useOnEmojiSelect.tsx
@@ -14,13 +14,13 @@ export default function useOnEmojiSelect(
   const details = useReactionDetails(post?.reactions ?? [], currentUserId);
 
   const onEmojiSelect = useCallback(
-    async (shortCode: string) => {
+    async (value: string) => {
       if (!post) {
         return;
       }
-      details.self.didReact && details.self.value.includes(shortCode)
+      details.self.didReact && details.self.value.includes(value)
         ? store.removePostReaction(post, currentUserId)
-        : store.addPostReaction(post, shortCode, currentUserId);
+        : store.addPostReaction(post, value, currentUserId);
 
       triggerHaptic('success');
 

--- a/packages/shared/src/api/chatApi.ts
+++ b/packages/shared/src/api/chatApi.ts
@@ -175,7 +175,7 @@ export function subscribeToChatUpdates(
         return eventHandler({
           type: 'addReaction',
           postId: id,
-          userId: addReact.ship,
+          userId: addReact.author,
           react: addReact.react,
         });
       }
@@ -221,7 +221,7 @@ export function subscribeToChatUpdates(
           return eventHandler({
             type: 'addReaction',
             postId: replyId,
-            userId: addReact.ship,
+            userId: addReact.author,
             react: addReact.react,
           });
         }

--- a/packages/shared/src/store/postActions.ts
+++ b/packages/shared/src/store/postActions.ts
@@ -442,7 +442,7 @@ export async function reportPost({
 
 export async function addPostReaction(
   post: db.Post,
-  shortCode: string,
+  emoji: string,
   currentUserId: string
 ) {
   const channel = await db.getChannel({ id: post.channelId });
@@ -455,20 +455,18 @@ export async function addPostReaction(
     AnalyticsEvent.ActionReact,
     logic.getModelAnalytics({ post, channel, group })
   );
-  const formattedShortcode = shortCode.replace(/^(?!:)(.*)$(?<!:)/, ':$1:');
 
   // optimistic update
+  await db.deletePostReaction({ postId: post.id, contactId: currentUserId });
   await db.insertPostReactions({
-    reactions: [
-      { postId: post.id, value: formattedShortcode, contactId: currentUserId },
-    ],
+    reactions: [{ postId: post.id, value: emoji, contactId: currentUserId }],
   });
 
   try {
     await api.addReaction({
       channelId: post.channelId,
       postId: post.id,
-      shortCode: formattedShortcode,
+      emoji,
       our: currentUserId,
       postAuthor: post.authorId,
     });

--- a/packages/shared/src/urbit/channel.ts
+++ b/packages/shared/src/urbit/channel.ts
@@ -36,6 +36,7 @@ export type Patda = string;
 export type Ship = string;
 export type Author = Ship | BotProfile;
 export type Nest = string;
+export type React = string | { any: string };
 
 export interface ReplyMeta {
   replyCount: number;
@@ -45,7 +46,7 @@ export interface ReplyMeta {
 
 export interface PostSeal {
   id: string;
-  reacts: { [ship: Ship]: string };
+  reacts: { [ship: Ship]: React };
   replies: ReplyTuple[] | null;
   meta: ReplyMeta;
 }
@@ -54,7 +55,7 @@ export interface ReplySeal {
   id: string;
   'parent-id': string;
   reacts: {
-    [ship: Ship]: string;
+    [ship: Ship]: React;
   };
 }
 
@@ -176,7 +177,7 @@ interface PostActionDel {
 interface PostActionAddReact {
   'add-react': {
     id: string;
-    react: string;
+    react: React;
     ship: string;
   };
 }
@@ -380,9 +381,9 @@ export type PostResponse =
   | { set: Post | null }
   | { reply: { id: string; 'r-reply': ReplyResponse; meta: ReplyMeta } }
   | { essay: PostEssay }
-  | { reacts: Record<string, string> };
+  | { reacts: Record<string, React> };
 
-export type ReplyResponse = { set: Reply } | { reacts: Record<string, string> };
+export type ReplyResponse = { set: Reply } | { reacts: Record<string, React> };
 
 export interface ChannelPostResponse {
   post: {
@@ -625,7 +626,7 @@ export interface PostSealDataResponse {
   id: string;
   replies: Replies;
   reacts: {
-    [ship: Ship]: string;
+    [ship: Ship]: React;
   };
   meta: {
     replyCount: number;

--- a/packages/shared/src/urbit/dms.ts
+++ b/packages/shared/src/urbit/dms.ts
@@ -61,7 +61,7 @@ interface WritDeltaDel {
 interface WritDeltaAddReact {
   'add-react': {
     react: string;
-    ship: string;
+    author: string;
   };
 }
 
@@ -82,7 +82,7 @@ export interface ReplyDeltaDel {
 
 export interface ReplyDeltaAddReact {
   'add-react': {
-    ship: string;
+    author: string;
     react: string;
   };
 }


### PR DESCRIPTION
## Summary

We had a variety of unfound issues with reactions that needed to be resolved.

## Changes

- %channels scries were erroneously down-converting emoji to shortcodes
- the client was sending shortcodes instead of unicode which is what the backend expects now
- there was a type mismatch with %chat pokes where we were sending with key `ship` instead of the new `author` key
- fixed small bug where clicking on a row of reactions while already having one would only clear yours out instead of swapping to the one you clicked on
- updated client to filter out custom reactions for now
- fixed issue where reacting to your own message in a DM had no effect because of an incorrect ID

## How did I test?

Manually on screenshare

## Risks and impact

- Safe to rollback without consulting PR author? (Yes | No)
- Affects important code area:
  - [ ] Onboarding
  - [ ] State / providers
  - [ ] Message sync
  - [ ] Channel display
  - [ ] Notifications

## Rollback plan

<!-- Describe the steps to revert these changes if needed. -->

## Screenshots / videos

<!-- Attach any relevant media. -->
