### PR TITLE
chat input: fix image paste

### DIFF
--- a/packages/app/ui/components/BareChatInput/index.tsx
+++ b/packages/app/ui/components/BareChatInput/index.tsx
@@ -252,6 +252,8 @@ export default function BareChatInput({
   const maxInputHeight = useKeyboardHeight(maxInputHeightBasic);
   const inputRef = useRef<TextInput>(null);
 
+  usePasteHandler(addAttachment);
+
   const [isSending, setIsSending] = useState(false);
   const [linkMetaLoading, setLinkMetaLoading] = useState(false);
   const disableSend = useMemo(() => {

--- a/packages/ui/src/components/Image.tsx
+++ b/packages/ui/src/components/Image.tsx
@@ -85,7 +85,10 @@ function isValidImageSource(source: any) {
       return true;
     }
 
-    if (typeof uri === 'string' && uri.startsWith('file://')) {
+    if (
+      typeof uri === 'string' &&
+      (uri.startsWith('file:') || uri.startsWith('blob:'))
+    ) {
       // permit file URIs
       return true;
     }


### PR DESCRIPTION
## Summary

We broke image paste on the protocol release branch. This restores that functionality (while still handling image link pastes as well)

## Changes

- use the existing `usePasteHandler` in `BareChatInput`
- permit `blob` source paths for images in our base `Image` component

## How did I test?

Pasted images on web. ~Waiting for mobile to finish building, will try there as well~ it appears we don't support pasting images on mobile, its absence there isn't a regression

## Risks and impact

- Safe to rollback without consulting PR author? yes
- Affects important code area:
  - [ ] Onboarding
  - [ ] State / providers
  - [ ] Message sync
  - [ ] Channel display
  - [ ] Notifications

## Rollback plan

Revert and push alternative fix.

Fixes TLON-4378
