### PR TITLE
queries: split perms and order to avoid transaction issues

### DIFF
--- a/packages/shared/src/api/channelsApi.ts
+++ b/packages/shared/src/api/channelsApi.ts
@@ -168,9 +168,9 @@ export function toClientChannelsInit(
 
 export type ChannelInit = {
   channelId: string;
-  order?: string[];
-  writers?: string[];
-  readers?: string[];
+  order: string[];
+  writers: string[];
+  readers: string[];
 };
 
 export function toClientChannelInit(

--- a/packages/shared/src/db/queries.ts
+++ b/packages/shared/src/db/queries.ts
@@ -1243,7 +1243,7 @@ export const getFlaggedPosts = createReadQuery(
 
 export const insertChannelPerms = createWriteQuery(
   'insertChannelPerms',
-  async (channelsInit: ChannelInit[], ctx: QueryCtx) => {
+  async (channelsInit: Omit<ChannelInit, 'order'>[], ctx: QueryCtx) => {
     const writers = channelsInit.flatMap((chanInit) =>
       (chanInit.writers || []).map((writer) => ({
         channelId: chanInit.channelId,
@@ -1301,7 +1301,10 @@ export const insertChannelPerms = createWriteQuery(
 
 export const insertChannelOrder = createWriteQuery(
   'insertChannelOrder',
-  async (channelsInit: Array<{ order: string[] }>, ctx: QueryCtx) => {
+  async (
+    channelsInit: Pick<ChannelInit, 'channelId' | 'order'>[],
+    ctx: QueryCtx
+  ) => {
     await ctx.db.transaction(async (tx) => {
       await Promise.all(
         channelsInit.map(async (chanInit) => {

--- a/packages/shared/src/db/queries.ts
+++ b/packages/shared/src/db/queries.ts
@@ -1301,7 +1301,7 @@ export const insertChannelPerms = createWriteQuery(
 
 export const insertChannelOrder = createWriteQuery(
   'insertChannelOrder',
-  async (channelsInit: ChannelInit[], ctx: QueryCtx) => {
+  async (channelsInit: Array<{ order: string[] }>, ctx: QueryCtx) => {
     await ctx.db.transaction(async (tx) => {
       await Promise.all(
         channelsInit.map(async (chanInit) => {

--- a/packages/shared/src/db/queries.ts
+++ b/packages/shared/src/db/queries.ts
@@ -1295,7 +1295,13 @@ export const insertChannelPerms = createWriteQuery(
           set: conflictUpdateSetAll($channelWriters),
         });
     }
+  },
+  ['channelWriters', 'channels']
+);
 
+export const insertChannelOrder = createWriteQuery(
+  'insertChannelOrder',
+  async (channelsInit: ChannelInit[], ctx: QueryCtx) => {
     await ctx.db.transaction(async (tx) => {
       await Promise.all(
         channelsInit.map(async (chanInit) => {
@@ -1309,7 +1315,7 @@ export const insertChannelPerms = createWriteQuery(
       );
     });
   },
-  ['channelWriters', 'channels']
+  ['channels']
 );
 
 export const getThreadPosts = createReadQuery(

--- a/packages/shared/src/store/sync.ts
+++ b/packages/shared/src/store/sync.ts
@@ -94,6 +94,9 @@ export const syncInitData = async (
       .insertChannelPerms(initData.channelPerms, queryCtx)
       .then(() => logger.crumb('inserted channel perms'));
     await db
+      .insertChannelOrder(initData.channelPerms, queryCtx)
+      .then(() => logger.crumb('inserted channel order'));
+    await db
       .setLeftGroups({ joinedGroupIds: initData.joinedGroups }, queryCtx)
       .then(() => logger.crumb('set left groups'));
     await db


### PR DESCRIPTION
## Summary

This was causing channels to not load and was a late addition to my role change PR so that's why it didn't get caught. I wasn't sure how to keep `insertChannelPerms` with order insertion.

## Changes

- this splits inserting channel perms and order insertion since they aren't really required to be together
- adds new order insertion to sync

## How did I test?

Manually attempting to load channels and ran `pnpm test`

## Risks and impact

- Safe to rollback without consulting PR author? Yes
- Affects important code area:
  - [ ] Onboarding
  - [ ] State / providers
  - [ ] Message sync
  - [ ] Channel display
  - [ ] Notifications

## Rollback plan

<!-- Describe the steps to revert these changes if needed. -->

## Screenshots / videos

<!-- Attach any relevant media. -->
