### PR TITLE
mobile: fix missing reaction emojis

### DIFF
--- a/packages/app/ui/components/ChatMessage/ReactionsDisplay.tsx
+++ b/packages/app/ui/components/ChatMessage/ReactionsDisplay.tsx
@@ -51,7 +51,12 @@ export function ReactionsDisplay({
         store.addPostReaction(post, value, currentUserId);
       }
     },
-    [currentUserId, post, reactionDetails.self.didReact]
+    [
+      currentUserId,
+      post,
+      reactionDetails.self.didReact,
+      reactionDetails.self.value,
+    ]
   );
 
   const firstThreeReactionUsers = useCallback(


### PR DESCRIPTION
## Summary

More lingering emoji parse issues. Saw some missing from the map when attempting to parse as short code.

## Changes

- in `getNativeEmoji`, account for input that's already a raw emoji when passed in
- found a missing callback dep in the ReactionDisplay

## How did I test?

Checked a reaction that was missing (🫡) before and after

## Risks and impact

- Safe to rollback without consulting PR author? Yes
- Affects important code area:  Channel display

## Rollback plan

Revert and re-open the issue

Fixes TLON-4388
