### PR TITLE
channels: fix erroneous merge

### DIFF
--- a/desk/app/channels.hoon
+++ b/desk/app/channels.hoon
@@ -926,7 +926,7 @@
       [%x %v2 %channels full=?(~ [%full ~])]
     ``channels-2+!>(`channels:v1:old:c`(uv-channels:utils v-channels ?=(^ full.pole)))
     ::
-      [%x %v3 %channels ~]
+      [%x %v3 %v-channels ~]
     ``channels-3+!>(v-channels)
     ::
       [%x %v3 %channels full=?(~ [%full ~])]


### PR DESCRIPTION
## Summary

When we merged develop into release-channels-updates at some point, we messed up the path of this scry

## Changes

- corrected scry path

## How did I test?

I did not

## Risks and impact

- Safe to rollback without consulting PR author? (Yes | No)
- Affects important code area:
  - [ ] Onboarding
  - [ ] State / providers
  - [ ] Message sync
  - [ ] Channel display
  - [ ] Notifications

## Rollback plan

<!-- Describe the steps to revert these changes if needed. -->

## Screenshots / videos

<!-- Attach any relevant media. -->
