### PR TITLE
use-negotiate: correctly account for group dms

### DIFF
--- a/packages/shared/src/store/useChannelContext.ts
+++ b/packages/shared/src/store/useChannelContext.ts
@@ -66,17 +66,15 @@ export const useChannelContext = ({
     [channelId, isDM]
   );
 
-  const negotiationStatus = useNegotiate(
-    channelHost,
-    isDM ? 'chat' : 'channels',
-    isDM ? 'chat' : 'channels-server'
-  );
+  const app = isDM || isGroupDm ? 'chat' : 'channels';
+  const agent = isDM || isGroupDm ? 'chat' : 'channels-server';
+  const negotiationStatus = useNegotiate(channelHost, app, agent);
   const multiNegotiationStatus = useNegotiateMulti(
     channelQuery.data
       ? (channelQuery.data.members || []).map((m) => m.contactId)
       : [],
-    isDM ? 'chat' : 'channels',
-    isDM ? 'chat' : 'channels-server'
+    app,
+    agent
   );
 
   // Draft


### PR DESCRIPTION
## Summary

Fixes TLON-4413, we were looking at the wrong app/agent for negotiations

## Changes

- made sure that app and agent are correct in cases of group dms

## How did I test?

Manual

## Risks and impact

- Safe to rollback without consulting PR author? (Yes | No)
- Affects important code area:
  - [ ] Onboarding
  - [ ] State / providers
  - [ ] Message sync
  - [ ] Channel display
  - [ ] Notifications

## Rollback plan

<!-- Describe the steps to revert these changes if needed. -->

## Screenshots / videos

<!-- Attach any relevant media. -->
