### PR TITLE
metagrab: fetch HEAD before doing a full GET

### DIFF
--- a/desk/app/metagrab.hoon
+++ b/desk/app/metagrab.hoon
@@ -104,17 +104,17 @@
   ==
 ::
 ++  fetch
-  |=  [url=@t uas=@t]
+  |=  [met=?(%head %get) url=@t uas=@t]
   ^-  card
   =/  =header-list:http
     :~  ['user-agent' uas]
         ['accept' '*/*']
     ==
   =/  =request:http
-    [%'GET' url header-list ~]
+    [?-(met %head %'HEAD', %get %'GET') url header-list ~]
   ::NOTE  outbound-config is actually meaningless,
   ::      iris doesn't do anything with it at present...
-  [%pass /fetch/(scot %t url) %arvo %i %request request *outbound-config:iris]
+  [%pass /fetch/(scot %t url)/(scot %t uas)/[met] %arvo %i %request request *outbound-config:iris]
 ::
 ++  extract-data
   |=  $:  url=@t
@@ -150,12 +150,15 @@
   ::
   ?:  |((lth cod 200) (gte cod 600))
     [& %bad (cat 3 'strange status code ' (scot %ud cod))]
-  ?~  dat
-    [| %bad 'no response body']
+  =/  content-type=@t
+    ?^  dat  type.u.dat
+    (fall (get-header:http 'content-type' headers) 'unknown')
   ::  non-html
   ::
-  ?.  =('text/html' (end 3^9 type.u.dat))
-    [| %200 %file type.u.dat]
+  ?.  =('text/html' (end 3^9 content-type))
+    [| %200 %file content-type]  ::TODO  (get-header:http 'content-length')
+  ?~  dat
+    [| %bad 'no response body']
   ::  extract the head section
   ::
   =/  head=(unit @t)
@@ -290,7 +293,7 @@
       %noun
     =+  url=!<(@t vase)
     ?>  ?=(^ (de-purl:html url))
-    [[(fetch url user-agent) ~] this]
+    [[(fetch %head url user-agent) ~] this]
   ::
       %handle-http-request
     =+  !<(order:hutils vase)
@@ -340,7 +343,7 @@
           %+  fall
             (get-header:http 'user-agent' header-list.request)
           user-agent
-        [[(fetch u.target uas) ~] this]
+        [[(fetch %head u.target uas) ~] this]
       ::  we have a valid cache entry.
       ::  if it's a redirect where we know the next target,
       ::  and can make a request to that,
@@ -369,12 +372,11 @@
     %-  (slog dap.bowl 'failed to eyre-bind' ~)
     [~ this]
   ::
-      [%fetch @ ?([@ ~] ~)]
-    =/  url=@t  (slav %t i.t.wire)
+      [%fetch @ @ ?(%head %get) ~]
+    =/  url=@t   (slav %t i.t.wire)
     =.  url.log  `url
-    =/  uas=@t
-      ?~  t.t.wire  user-agent
-      (fall (slaw %t i.t.t.wire) user-agent)
+    =/  uas=@t   (fall (slaw %t i.t.t.wire) user-agent)
+    =/  met      i.t.t.t.wire
     ?>  ?=([%iris %http-response *] sign)
     =*  res  client-response.sign
     ::  %progress responses are unexpected, the runtime doesn't support them
@@ -389,11 +391,28 @@
     ::  request. simply retry.
     ::
     ?:  ?=(%cancel -.res)
-      [[(fetch url uas) ~] this]
+      ::REVIEW  this can become a source of retry loops.
+      ::        should we just serve a 500 in these cases?
+      ::        incoming connections will have gotten killed anyway...
+      [[(fetch met url uas) ~] this]
     ::
     ?>  ?=(%finished -.res)
     =*  cod  status-code.response-header.res
     ?.  &((gte cod 300) (lth cod 400))
+      ::  if this was a head request,
+      ::  and the response would be an html page,
+      ::  fetch it in full
+      ::
+      ?:  ?&  ?=(%head met)
+            ::
+              .=  `'text/html'
+              %+  bind
+                (get-header:http 'content-type' headers.response-header.res)
+              (cury end 3^9)
+          ==
+        [[(fetch %get url uas) ~] this]
+      ::  otherwise, this is the most we'll fetch, now process the data
+      ::
       =/  [report=? =result]
         (extract-data url [response-header full-file]:res)
       %-  ?.  report  same
@@ -432,7 +451,7 @@
         ==
       ::  no valid cache entry, start a new fetch
       ::
-      [[(fetch u.nex uas)]~ this]
+      [[(fetch %head u.nex uas)]~ this]
     ::TODO  detect redirect loops
     ::  we have a valid cache entry.
     ::  if it's a redirect where we know the next target,

--- a/desk/app/metagrab.hoon
+++ b/desk/app/metagrab.hoon
@@ -397,13 +397,13 @@
       ~&  [dap.bowl %strange-iris-progress-response]
       [%cancel ~]
     ::  we might get a %cancel if the runtime was restarted during our
-    ::  request. simply retry.
+    ::  request. it's unlikely but possible that we are somehow the cause
+    ::  of the runtime restart. in an abundance of caution, drop the request.
+    ::  (inbound requests _should_ have gotten closed during restart, anyway.)
     ::
     ?:  ?=(%cancel -.res)
-      ::REVIEW  this can become a source of retry loops.
-      ::        should we just serve a 500 in these cases?
-      ::        incoming connections will have gotten killed anyway...
-      [[(fetch met url uas) ~] this]
+      :-  (give-response (~(get ju await) url) now.bowl %bad 'cancelled')
+      this(await (~(del by await) url))
     ::
     ?>  ?=(%finished -.res)
     =*  cod  status-code.response-header.res

--- a/desk/app/metagrab.hoon
+++ b/desk/app/metagrab.hoon
@@ -14,8 +14,8 @@
 |%
 +$  card  card:agent:gall
 ::
-+$  state-0
-  $:  %0
++$  state-1
+  $:  %1
       cache=(map @t response)  ::  cached results
       await=(jug @t @ta)       ::  pending, w/ response targets
   ==
@@ -30,7 +30,7 @@
 ::
 +$  data
   $%  [%page meta=(jar @t entry:mg)]
-      [%file mime=@t]
+      [%file mime=@t size=(unit @ud)]
   ==
 ::
 +$  response
@@ -72,6 +72,7 @@
             %file
           :~  'type'^s+'file'
               'mime'^s+mime.dat.wat
+              'size'^?~(size.dat.wat ~ (numb u.size.dat.wat))
           ==
         ::
             %page
@@ -156,7 +157,11 @@
   ::  non-html
   ::
   ?.  =('text/html' (end 3^9 content-type))
-    [| %200 %file content-type]  ::TODO  (get-header:http 'content-length')
+    =;  size=(unit @ud)
+      [| %200 %file content-type size]
+    %+  biff
+      (get-header:http 'content-length' headers)
+    (curr rush dum:ag)
   ?~  dat
     [| %bad 'no response body']
   ::  extract the head section
@@ -257,7 +262,7 @@
   --
 --
 ::
-=|  state-0
+=|  state-1
 =*  state  -
 ::
 =+  log=l
@@ -279,11 +284,15 @@
 ::
 ++  on-load
   |=  ole=vase
-  ^-  (quip card _this)
-  =+  old=!<(state-0 ole)
-  =.  state  old
-  =.  cache  ~
-  [~ this]
+  |^  ^-  (quip card _this)
+      =+  old=!<(state-any ole)
+      =?  old  ?=(%0 -.old)  *state-1
+      ?>  ?=(%1 -.old)
+      =.  state  old
+      =.  cache  ~
+      [~ this]
+  +$  state-any  $%([%0 *] state-1)
+  --
 ::
 ++  on-poke
   |=  [=mark =vase]


### PR DESCRIPTION
## Summary

Makes metagrab fetch HEAD first, and only do a full GET if it's necessary (for getting & parsing an html page).

## Changes

We only care about the response body when it's an html page. In all
other cases, we discard the body entirely and only extract data from the
headers.

Some urls might point to very large resources. Past a certain point, the
response is too big for vere to handle properly, and it will die.

Vere-side fix for that is forthcoming, but it's also not necessary for
metagrab to request the full responses in the first place. Instead, a
HEAD request will suffice.

Here, instead of going straight to a GET request, we always make a HEAD
request first. If the response has a text/html content-type, we proceed
with the GET request as normal. Otherwise, we make do with the headers.

Additionally, we now include a `size` field for `type: "file"` responses, and we no longer retry fetches whose request was `%cancel`ed by iris/cttp.c, lest we accidentally get into a crash-retry loop.

## How did I test?

Tested the metagrab endpoint on a local fakezod with html page urls, file urls, and specifically the 1.2gb file that made us discover the problems with doing straight GET requests always.

## Risks and impact

- Safe to rollback without consulting PR author, yes.
- Affects important code area:
  - [ ] Onboarding
  - [ ] State / providers
  - [ ] Message sync
  - [ ] Channel display
  - [ ] Notifications

## Rollback plan

State type change in ffcee37 need some additional attention during rollback, but can follow the same pattern of just ditching the previous state entirely. It's all transient/cache, anyway.

## Screenshots / videos

If only.
