### PR TITLE
MessageActions: rename select message actions

### DIFF
--- a/apps/tlon-web/e2e/helpers.ts
+++ b/apps/tlon-web/e2e/helpers.ts
@@ -423,7 +423,7 @@ export async function longPressMessage(page: Page, messageText: string) {
  */
 export async function startThread(page: Page, messageText: string) {
   await longPressMessage(page, messageText);
-  await page.getByText('Start thread').click();
+  await page.getByText('Reply').click();
   await page.waitForTimeout(500);
   await expect(page.getByRole('textbox', { name: 'Reply' })).toBeVisible();
 }
@@ -482,7 +482,7 @@ export async function quoteReply(
   isDM = false
 ) {
   await longPressMessage(page, originalMessage);
-  await page.getByText('Reply', { exact: true }).click();
+  await page.getByText('Quote', { exact: true }).click();
 
   // Verify quote interface appears
   if (!isDM) {
@@ -517,7 +517,7 @@ export async function threadQuoteReply(
   await page.waitForTimeout(500);
   await page.getByTestId('MessageActionsTrigger').click();
   await page.waitForTimeout(500);
-  await page.getByText('Reply', { exact: true }).click();
+  await page.getByText('Quote', { exact: true }).click();
 
   // Verify quote interface appears
   await expect(page.getByText('Chat Post')).toBeVisible();

--- a/packages/app/ui/components/ChatMessage/ChatMessageActions/MessageActions.tsx
+++ b/packages/app/ui/components/ChatMessage/ChatMessageActions/MessageActions.tsx
@@ -308,7 +308,7 @@ export function useDisplaySpecForChannelActionId(
         return { label: isMuted ? 'Unmute thread' : 'Mute thread' };
 
       case 'quote':
-        return { label: 'Reply' };
+        return { label: 'Quote' };
 
       case 'report':
         return {
@@ -318,8 +318,8 @@ export function useDisplaySpecForChannelActionId(
       case 'startThread':
         return {
           label: ['dm', 'groupDm', 'chat'].includes(channel?.type)
-            ? 'Start thread'
-            : 'Comment on post',
+            ? 'Reply'
+            : 'Comment',
         };
 
       case 'forward':


### PR DESCRIPTION
## Summary

Renames "Start thread" in Chat channels to "Reply," then renames "Reply" to the more-accurate "Quote." "Quote" appears both in the root of the channel and in threads; "Reply" does not appear in threads (since we only allow one level of nesting).

## Changes

- Changes the text labels in MessageActions
- Changes the e2e tests (helpers.tsx) to accommodate the language change

## How did I test?

I ran the e2e tests locally to ensure no breakages.

## Risks and impact

- Safe to rollback without consulting PR author? (Yes)
- Affects important code area:
  - [ ] Onboarding
  - [ ] State / providers
  - [ ] Message sync
  - [x] Channel display
  - [ ] Notifications

## Rollback plan

Simply revert as needed.

## Screenshots / videos

<img width="427" alt="Screenshot 2025-06-18 at 8 36 08 AM" src="https://github.com/user-attachments/assets/80aa9694-a554-44d8-8c5c-47bace672e8d" />
