### PR TITLE
db: avoid nesting transactions

### DIFF
--- a/packages/shared/src/db/queries.ts
+++ b/packages/shared/src/db/queries.ts
@@ -1305,12 +1305,12 @@ export const insertChannelOrder = createWriteQuery(
     channelsInit: Pick<ChannelInit, 'channelId' | 'order'>[],
     ctx: QueryCtx
   ) => {
-    await ctx.db.transaction(async (tx) => {
+    await withTransactionCtx(ctx, async (txc) => {
       await Promise.all(
         channelsInit.map(async (chanInit) => {
           if (!chanInit.order) return;
 
-          await tx
+          await txc.db
             .update($channels)
             .set({ order: chanInit.order })
             .where(eq($channels.id, chanInit.channelId));


### PR DESCRIPTION
## Summary

The issue here was a transaction being initiated via Drizzle's built in transaction helper rather than via our queue implementation. If they happened to collide poorly, we'd get one of the following errors:

```
[op-sqlite] statement execution error: cannot commit - no transaction is active
[op-sqlite] statement execution error: cannot rollback - no transaction is active
[op-sqlite] statement execution error: cannot start a transaction within a transaction
```

Removing the Drizzle reference prevents these from occurring. We also weren't handling nested transactions, so this adds logic to detect if we're already in one without locking up. 

## Changes

- remove the offending Drizzle transaction in `insertChannelOrder`
- adds a `meta` field to `QueryCtx` for tracking whether we're already within a transaction
- adds tracked logging for transaction errors and failed rollbacks

## How did I test?

Running a dev build on my physical device, creating multiple groups would reliably trigger DB errors before adding the change.

## Risks and impact

- Safe to rollback without consulting PR author? Yes
- Affects important code area: local DB

## Rollback plan

Safe to just revert.


Fixes TLON-4411
