### PR TITLE
groups: handle appropriate mark/type for /v1 sub

### DIFF
--- a/desk/app/groups.hoon
+++ b/desk/app/groups.hoon
@@ -1097,7 +1097,8 @@
     (watch-channels &)
   ::
       %fact
-    =+  !<(=r-channels:d q.cage.sign)
+    ?.  =(%channel-response-2 p.cage.sign)  cor
+    =+  !<(=r-channels:v7:old:d q.cage.sign)
     =*  rc  r-channel.r-channels
     ?+    -.rc  cor
         %create


### PR DESCRIPTION
## Summary

Use the type that matches the mark, and actually check the mark when we receive facts.

For the issue described in TLON-4431, though this may not close that ticket entirely.

## Changes

Groups agent subscribes to channels on /v1, which is going to give %toggle-post and %channel-response-2 facts. In addition to only handling responses, we want to make sure we use the now-older type when unpacking the vase.

## How did I test?

It compiles even with the changed type. ~~No deeper testing (yet).~~ Hit the codepath, it no longer crashes.

## Risks and impact

- Safe to rollback without consulting PR author, yes.
- Affects important code area:
  - [ ] Onboarding
  - [ ] State / providers
  - [ ] Message sync
  - [ ] Channel display
  - [ ] Notifications

## Rollback plan

Code-only change.

## Screenshots / videos

Maybe one day.

## Additional concerns

We might be dropping changes in between kicks and resubscribes on the floor entirely. The subscription doesn't give an initial fact, we never scry out current state from channels agent. Wondering if this could cause inconsistencies?
