### PR TITLE
unreads: accurate in-chat markers for desktop

### DIFF
--- a/apps/tlon-mobile/ios/Podfile.lock
+++ b/apps/tlon-mobile/ios/Podfile.lock
@@ -2209,46 +2209,46 @@ EXTERNAL SOURCES:
 SPEC CHECKSUMS:
   boost: d3f49c53809116a5d38da093a8aa78bf551aed09
   BranchSDK: cb046c2714b03e573484ce9e349e2ddbad7016e8
-  DoubleConversion: fea03f2699887d960129cc54bba7e52542b6f953
-  EASClient: 1509a9a6b48b932ec61667644634daf2562983b8
-  EXApplication: c08200c34daca7af7fd76ac4b9d606077410e8ad
-  EXAV: afa491e598334bbbb92a92a2f4dd33d7149ad37f
-  EXConstants: 409690fbfd5afea964e5e9d6c4eb2c2b59222c59
-  EXImageLoader: ab589d67d6c5f2c33572afea9917304418566334
+  DoubleConversion: 76ab83afb40bddeeee456813d9c04f67f78771b5
+  EASClient: 95592393d6d1e60609f0afb373191d918c687b98
+  EXApplication: ec862905fdab3a15bf6bd8ca1a99df7fc02d7762
+  EXAV: 64e72329d2f8c2ba13608fed4a713af4e793242d
+  EXConstants: 89d35611505a8ce02550e64e43cd05565da35f9a
+  EXImageLoader: 1fe96c70cdc78bedc985ec4b1fab5dd8e67dc38b
   EXJSONUtils: 30c17fd9cc364d722c0946a550dfbf1be92ef6a4
-  EXManifests: c1fab4c3237675e7b0299ea8df0bcb14baca4f42
-  EXNotifications: 85496c9fab09d759d0e4ff594bca078ab817c40c
-  Expo: 8c995afb875c15bf8439af0b20bcb9ed8f90d0bd
-  expo-dev-client: 0cec8ec81fd01c10d9afcd9f6de3768b10644aee
-  expo-dev-launcher: 45a630560cf5316b3f85ba4007d09c2557521fad
-  expo-dev-menu: f9488841a1e709bb7d34f2c519af5e79c33a043b
-  expo-dev-menu-interface: 5764ad537419c1a5e8f66f668e29c81e8aca290c
-  ExpoAsset: 323700f291684f110fb55f0d4022a3362ea9f875
-  ExpoBackgroundFetch: a06c553ecaf0bade0acd691042d996b9ce926327
-  ExpoBattery: 4b21f628f2b70af3af66e83c566949ba9cc65eb1
-  ExpoBlur: 4d32f9e33bab18ae2ee079c7b0422e4210d49c97
-  ExpoClipboard: 23d203f5d4843699fbc45be1cc4fe1fbd811a6fa
-  ExpoContacts: 67cc93caa3e5023dd245f9e0ef26856aaa005c3e
-  ExpoDevice: fc94f0e42ecdfd897e7590f2874fc64dfa7e9b1c
-  ExpoFileSystem: 80bfe850b1f9922c16905822ecbf97acd711dc51
-  ExpoFont: 00756e6c796d8f7ee8d211e29c8b619e75cbf238
-  ExpoHaptics: 5a3a88971af384255baf2504f38b41189cec6984
-  ExpoImage: 42162e3d264ce07a62766d6bd26bd299fe4c6faa
-  ExpoImageManipulator: aea99205c66043a00a0af90e345395637b9902fa
-  ExpoImagePicker: 1e696c26a3e5c01a0ab1b99897db3da59c04a141
-  ExpoKeepAwake: 3b8815d9dd1d419ee474df004021c69fdd316d08
-  ExpoLinearGradient: 8cec4a09426d8934c433e83cb36262d72c667fce
-  ExpoLocalization: f04eeec2e35bed01ab61c72ee1768ec04d093d01
-  ExpoMailComposer: e6da16de4682fba919051b2e680f804af00341f3
-  ExpoMediaLibrary: 81573bcbd50cbd0a3ef57216c93593157d32b558
-  ExpoModulesCore: 1914927fe4a693215b1ed57eb934c15641d4aef7
-  ExpoSecureStore: 060cebcb956b80ddae09821610ac1aa9e1ac74cd
-  ExpoSMS: a5184fc4d4b33071b2dd9d43bb9ac8ef952b1dd7
-  EXSplashScreen: e9758d6c15f77f8f358cb98513f1f9e32eca388c
+  EXManifests: ebb7f551c340c0d06f3ecd9ae662e418bf68417c
+  EXNotifications: 6ce128c0d3d3d161cd68bfd07d593db40e140396
+  Expo: ed0a748eb6be0efd2c3df7f6de3f3158a14464c9
+  expo-dev-client: 67bfa449de8ee3e3cd88a6945a8058819fffb0f0
+  expo-dev-launcher: f58f89fedd75f253811e9d667ee1d55a3ffc490f
+  expo-dev-menu: 65c50c838ef948aa8843a85708d0d13ce796a9d2
+  expo-dev-menu-interface: 5c6b79875bf0ab1251ea9962f60968fe39ed2637
+  ExpoAsset: 286fee7ba711ce66bf20b315e68106b13b8629fc
+  ExpoBackgroundFetch: 2988b27bc95f322e856dbd44060b6951fdfe8950
+  ExpoBattery: 9575fe12e063206275013cf0dfc1583e8e7fd00c
+  ExpoBlur: 99901a4531f5d3ac4a19b362907b8f75da4ed9c8
+  ExpoClipboard: 243e22ff4161bbffcd3d2db469ae860ddc1156be
+  ExpoContacts: 7ff826023ae74e6f29876a0942e00722c9b7bdf4
+  ExpoDevice: 84b3ed79df1234c17edfbf335f6ecf3c636f74de
+  ExpoFileSystem: 2988caaf68b7cb706e36d382829d99811d9d76a5
+  ExpoFont: 38dddf823e32740c2a9f37c926a33aeca736b5c4
+  ExpoHaptics: 9f47be324f691b6291c17c216189ab832d1a4d69
+  ExpoImage: 8fe3bbd2cae98bc004efec6fc4387837c9d30e10
+  ExpoImageManipulator: eb92d3ac4bad0fe96258f17273b9e295e87447be
+  ExpoImagePicker: 7038c1740853c170002c491de63f9f9780c8139b
+  ExpoKeepAwake: dd02e65d49f1cfd9194640028ae2857e536eb1c9
+  ExpoLinearGradient: 4c44b3803b441724874b232e6520b51ca6a50db1
+  ExpoLocalization: 1b4195ed48148c7f52ce790d3965cc19483fcbf2
+  ExpoMailComposer: 456b7e4ef0f5580f4353eacae69caf7604c84dce
+  ExpoMediaLibrary: b30366bf8f938166b1fe2d019e5b15337349d91e
+  ExpoModulesCore: c11bcbf466b123a92eb66ab2ae9e0eaef61b7e97
+  ExpoSecureStore: 6506992a9f53c94ea716c54d4a63144965945c2c
+  ExpoSMS: 66d89a3c897602621bb711f3d23814cea80924fb
+  EXSplashScreen: 02d4bb2d7a6b05b4434126e01ee2e6872088f4ae
   EXStructuredHeaders: cb8d1f698e144f4c5547b4c4963e1552f5d2b457
-  EXTaskManager: 9c3520305c3aa1b4a12a7c6d1e3f85f2779c06e9
-  EXUpdates: 6ad461865eaf5f50c06bf9b671e08fa7221bd7ae
-  EXUpdatesInterface: 996527fd7d1a5d271eb523258d603f8f92038f24
+  EXTaskManager: b515b853fd97286a25cb643978ff7fa456f3139a
+  EXUpdates: ebe3c09f7f119648a7f92295ea0d8418c799cdf6
+  EXUpdatesInterface: c3a9494c2173db6442c7d5ad4e5b984972760fd3
   FBLazyVector: ac12dc084d1c8ec4cc4d7b3cf1b0ebda6dab85af
   Firebase: 91fefd38712feb9186ea8996af6cbdef41473442
   FirebaseABTesting: d87f56707159bae64e269757a6e963d490f2eebe
@@ -2263,7 +2263,7 @@ SPEC CHECKSUMS:
   FirebaseSessions: dbd14adac65ce996228652c1fc3a3f576bdf3ecc
   FirebaseSharedSwift: 20530f495084b8d840f78a100d8c5ee613375f6e
   fmt: 4c2741a687cc09f0634a2e2c72a838b99f1ff120
-  glog: c5d68082e772fa1c511173d6b30a9de2c05a69a2
+  glog: fdfdfe5479092de0c4bdbebedd9056951f092c4f
   GoogleDataTransport: 6c09b596d841063d76d4288cc2d2f42cc36e1e2a
   GoogleUtilities: ea963c370a38a8069cc5f7ba4ca849a60b6d7d15
   hermes-engine: 8c1577f3fdb849cbe7729c2e7b5abc4b845e88f8
@@ -2271,89 +2271,89 @@ SPEC CHECKSUMS:
   libdav1d: 23581a4d8ec811ff171ed5e2e05cd27bad64c39f
   libwebp: 02b23773aedb6ff1fd38cec7a77b81414c6842a8
   nanopb: 438bc412db1928dac798aa6fd75726007be04262
-  op-sqlite: 9212b6959f38040b51bd51d415dbf4e6637280f4
+  op-sqlite: f800d2eeb9ca5c8931c612d4673f559fa23a5889
   PromisesObjC: f5707f49cb48b9636751c5b2e7d227e43fba9f47
   PromisesSwift: 9d77319bbe72ebf6d872900551f7eeba9bce2851
-  RCT-Folly: 02617c592a293bd6d418e0a88ff4ee1f88329b47
+  RCT-Folly: 5dc73daec3476616d19e8a53f0156176f7b55461
   RCTDeprecation: 3afceddffa65aee666dafd6f0116f1d975db1584
   RCTRequired: ec1239bc9d8bf63e10fb92bd8b26171a9258e0c1
   RCTTypeSafety: f5ecbc86c5c5fa163c05acb7a1c5012e15b5f994
   ReachabilitySwift: 32793e867593cfc1177f5d16491e3a197d2fccda
   React: fc9fa7258eff606f44d58c5b233a82dc9cf09018
   React-callinvoker: e3fab14d69607fb7e8e3a57e5a415aed863d3599
-  React-Codegen: f3266d1f9d02a2572a5d917542ad8fc977270852
-  React-Core: 3a5fd9e781cecf87803e5b091496a606a3df774a
-  React-CoreModules: cbf4707dafab8f9f826ac0c63a07d0bf5d01e256
-  React-cxxreact: 7b188556271e3c7fdf22a04819f6a6225045b9dd
+  React-Codegen: 8e6bdcc6e6cf833bc9d0a7ad4c9fc8d6e7f081b2
+  React-Core: c3f589f104983dec3c3eeec5e70d61aa811bc236
+  React-CoreModules: 864932ddae3ead5af5bfb05f9bbc2cedcb958b39
+  React-cxxreact: bd9146108c44e6dbb99bba4568ce7af0304a2419
   React-debug: 2d6f912c0c4c91a9fde617d8425088af7315c10b
-  React-Fabric: 47ff62e0c7f017606585327f6016190625295c5e
-  React-FabricImage: 823627aa521b4ecc896334f0dbf2bc8376edbf1e
+  React-Fabric: bdc743e99c11fdf1c2523bdd500827431e550fa8
+  React-FabricImage: 0d72f410fb5d6106e9f6fc6c60851ea5a39e7e88
   React-featureflags: 2a4555681de0d4b683d98d7e9fd7bdf9e9ce1aa2
-  React-graphics: edbd2a6c018b2e2d541ab8cb886cc31babf14646
-  React-hermes: a7054fbcbda3957e3c5eaad06ef9bf79998d535a
-  React-ImageManager: 314824c4bb6f152699724dc9eb3ce544b87048bd
-  React-jserrorhandler: fffe10523886a352161ef492af2063651721c8ee
-  React-jsi: f3ce1dd2e950b6ad12b65ea3ef89168f1b94c584
-  React-jsiexecutor: b4df3a27973d82f9abf3c4bd0f88e042cda25f16
-  React-jsinspector: 2ea90b8e53970a1fea1449fb8e6419e21ca79867
-  React-jsitracing: c83efb63c8e9e1dff72a3c56e88ae1c530a87795
-  React-logger: 257858bd55f3a4e1bc0cf07ddc8fb9faba6f8c7c
-  React-Mapbuffer: dce508662b995ffefd29e278a16b78217039d43d
-  react-native-branch: 021b9c261f732d0950e9a304284779d48bf81109
-  react-native-context-menu-view: dcec18eb8882e20596dbb75802e7d19cb87dac02
-  react-native-cookies: f54fcded06bb0cda05c11d86788020b43528a26c
-  react-native-get-random-values: 21325b2244dfa6b58878f51f9aa42821e7ba3d06
-  react-native-netinfo: bdb108d340cdb41875c9ced535977cac6d2ff321
-  react-native-safe-area-context: a240ad4b683349e48b1d51fed1611138d1bdad97
-  react-native-skia: b12c8f714ac911fa9437fa6c8f81b74c5c90a59e
-  react-native-webview: 5951c8e0d457322e39c580778dd8505daf3f0327
+  React-graphics: 7b0f29341f82b5aac0f956a8a7f3c02b6ddfceab
+  React-hermes: 177b1efdf3b8f10f4ca12b624b83fb4d4ccb2884
+  React-ImageManager: c649561999bf66aff58e2d89b470a0d6d3a32122
+  React-jserrorhandler: c072daf0ab61334efbfaa966afeb0e3b2db520c8
+  React-jsi: 0abe1b0881b67caf8d8df6a57778dd0d3bb9d9a5
+  React-jsiexecutor: f6ca8c04f19f6a3acaa9610f7fb728f39d6e3248
+  React-jsinspector: 782332199759466a60b1a3b698902351c7faba9f
+  React-jsitracing: d73503c33d42ae2c0732945338cff966e41cc51e
+  React-logger: 780b9ee9cec7d44eabc4093de90107c379078cb6
+  React-Mapbuffer: 32481ad50f09c781bdb408b302757e0c9285d6db
+  react-native-branch: 5d4ecda7bae040542f6c9f651a05d3df23d8b35a
+  react-native-context-menu-view: c7477ad2a9b5005eb45dd168c2dcdd64526dba77
+  react-native-cookies: d648ab7025833b977c0b19e142503034f5f29411
+  react-native-get-random-values: d16467cf726c618e9c7a8c3c39c31faa2244bbba
+  react-native-netinfo: 2e3c27627db7d49ba412bfab25834e679db41e21
+  react-native-safe-area-context: df9763c5de6fa38883028e243a0b60123acb8858
+  react-native-skia: 246ca62b186973d6ba04dbd0244d5238c753a561
+  react-native-webview: f246abd8b2fa884686628a64e791579e66e09d0c
   React-nativeconfig: f326487bc61eba3f0e328da6efb2711533dcac46
-  React-NativeModulesApple: d89733f5baed8b9249ca5a8e497d63c550097312
+  React-NativeModulesApple: ab18cfc286c91012535b94553222f455eedf2c53
   React-perflogger: ed4e0c65781521e0424f2e5e40b40cc7879d737e
   React-RCTActionSheet: 49d53ff03bb5688ca4606c55859053a0cd129ea5
-  React-RCTAnimation: 07b4923885c52c397c4ec103924bf6e53b42c73e
-  React-RCTAppDelegate: 316e295076734baf9bdf1bfac7d92ab647aed930
-  React-RCTBlob: 85c57b0d5e667ff8a472163ba3af0628171a64bb
-  React-RCTFabric: 62695e345da7c451b05a131f0c6ba80367dbd5c3
-  React-RCTImage: b965c85bec820e2a9c154b1fb00a2ecdd59a9c92
-  React-RCTLinking: 75f04a5f27c26c4e73a39c50df470820d219df79
-  React-RCTNetwork: c1a9143f4d5778efc92da40d83969d03912ccc24
-  React-RCTSettings: c6800f91c0ecd48868cd5db754b0b0a7f5ffe039
-  React-RCTText: b923e24f9b7250bc4f7ab154c4168ad9f8d8fc9d
-  React-RCTVibration: 08c4f0c917c435b3619386c25a94ee5d64c250f0
-  React-rendererdebug: fac75dc155e1202cfc187485a6e4f6e842fcc5c7
+  React-RCTAnimation: 3075449f26cb98a52bcbf51cccd0c7954e2a71db
+  React-RCTAppDelegate: 9a419c4dda9dd039ad851411546dd297b930c454
+  React-RCTBlob: e81ab773a8fc1e9dceed953e889f936a7b7b3aa6
+  React-RCTFabric: 0b4163b65e0be4a7521e59dfe12a52159301c88b
+  React-RCTImage: d570531201c6dce7b5b63878fa8ecec0cc311c4c
+  React-RCTLinking: af888972b925d2811633d47853c479e88c35eb4d
+  React-RCTNetwork: 5728a06ff595003eca628f43f112a804f4a9a970
+  React-RCTSettings: ba3665b0569714a8aaceee5c7d23b943e333fa55
+  React-RCTText: b733fa984f0336b072e47512898ba91214f66ddb
+  React-RCTVibration: 0cbcbbd8781b6f6123671bae9ee5dd20d621af6c
+  React-rendererdebug: d005c4641b9bae31c2bcccf0579d6a35105f5c6f
   React-rncore: 12dc32f08f195e573e9d969a348b976a3d057bbc
-  React-RuntimeApple: 5c7591dd19de1c7fefe8e61cf934d8f8f9fc0409
-  React-RuntimeCore: ec3c8be706ca2e4607eb8c675d32512352501f9e
+  React-RuntimeApple: b9183d85d31f20b358738231cfb2fb5ee795980f
+  React-RuntimeCore: c548c0b9134ca7149f0979deabf71eaa1c2fde90
   React-runtimeexecutor: 0e688aefc14c6bc8601f4968d8d01c3fb6446844
-  React-RuntimeHermes: df243bd7c8d4ba3bd237ce6ded22031e02d37908
-  React-runtimescheduler: db7189185a2e5912b0d17194302e501f801a381e
-  React-utils: 3f1fcffc14893afb9a7e5b7c736353873cc5fc95
-  ReactCommon: f79ae672224dc1e6c2d932062176883c98eebd57
-  recaptcha-enterprise-react-native: 7d63c5bdde3b48996b984a86ac2b536a1d8f5f16
+  React-RuntimeHermes: caf82d8f3cb32eeb54bd9b4079aa58a11c77ba3a
+  React-runtimescheduler: 914607b0f1a58e1a8366c13f8d2efb49c17d57d1
+  React-utils: 3c4b8677afc614f15357ad66fcc3e61bc21a42db
+  ReactCommon: cfb89afbdafafbf049c719db9cb61ac4d38af434
+  recaptcha-enterprise-react-native: 82f186a0ab29c91c4d4bd08f7758f849e91b4558
   RecaptchaEnterprise: dc302910b77963a0cc6f6908407e30b35268a755
   RecaptchaInterop: 7d1a4a01a6b2cb1610a47ef3f85f0c411434cb21
-  RNCAsyncStorage: 826b603ae9c0f88b5ac4e956801f755109fa4d5c
-  RNCClipboard: 090462274cc05b02628bd158baf6d73c3abe8441
-  RNDeviceInfo: db5c64a060e66e5db3102d041ebe3ef307a85120
-  RNFBApp: 91311b27bc9a33e23b76a62825afd1635501018a
-  RNFBCrashlytics: c3219ef7a0c779f2428236215781c38e7892f6f9
-  RNFBPerf: 2c926ff255c704a644dd53572008cba47c67ada0
-  RNFlashList: b521ebdd7f9352673817f1d98e8bdc0c8cf8545b
-  RNGestureHandler: 83fd202dbc0b8971414c5c7c56ddd9f5cde05911
-  RNReanimated: da754bc4658fb6089cceb9c6a896a875a57ffd65
-  RNScreens: 30249f9331c3b00ae7cb7922e11f58b3ed369c07
-  RNSVG: 43b64ed39c14ce830d840903774154ca0c1f27ec
+  RNCAsyncStorage: aa75595c1aefa18f868452091fa0c411a516ce11
+  RNCClipboard: c20b93d3a1b47ce86dcffa5c0af5dd59938e47e1
+  RNDeviceInfo: addb9b427c2822a2d8e94c87a136a224e0af738c
+  RNFBApp: e905ce948d9290555d9ab1303449827eb5119b5c
+  RNFBCrashlytics: e9459c8656ccbbb53d12afe47b4a96194c858745
+  RNFBPerf: ae6cfdac3e06eab3d4d092944e979e95a69b0179
+  RNFlashList: 23b2c67aa684179d29c8c2f468c6f5334e609951
+  RNGestureHandler: d16bf84ca5c7bec133dfc39abb825f1a03bcdbb5
+  RNReanimated: 29533404792c6a5559e7787f847e28afd2987961
+  RNScreens: 5b35d863db10f9be81da4e8f4e08096ee7644f8c
+  RNSVG: 0e7deccab0678200815104223aadd5ca734dd41d
   SDWebImage: 8a6b7b160b4d710e2a22b6900e25301075c34cb3
   SDWebImageAVIFCoder: 00310d246aab3232ce77f1d8f0076f8c4b021d90
   SDWebImageSVGCoder: 15a300a97ec1c8ac958f009c02220ac0402e936c
   SDWebImageWebPCoder: e38c0a70396191361d60c092933e22c20d5b1380
   SocketRocket: abac6f5de4d4d62d24e11868d7a2f427e0ef940d
   sqlite3: 02d1f07eaaa01f80a1c16b4b31dfcbb3345ee01a
-  tentap: 894034e59cab6e324f6e6d7e63ad0b3f4de3b884
+  tentap: df63fcf1918a946fccbc9809a48c194c4d9aef5b
   UMAppLoader: f17a5ee8e85b536ace0fc254b447a37ed198d57e
   Yoga: 33622183a85805e12703cd618b2c16bfd18bfffb
 
 PODFILE CHECKSUM: 50b932f45bd6a47ee73697ad8ebd9a73d29442ab
 
-COCOAPODS: 1.15.2
+COCOAPODS: 1.16.2

--- a/packages/app/ui/components/Channel/Scroller.tsx
+++ b/packages/app/ui/components/Channel/Scroller.tsx
@@ -771,6 +771,8 @@ const ScrollerItem = React.memo(BaseScrollerItem, (prev, next) => {
   const isIndexEqual = prev.index === next.index;
 
   const areOtherPropsEqual =
+    prev.showUnreadDivider === next.showUnreadDivider &&
+    prev.unreadCount === next.unreadCount &&
     prev.showAuthor === next.showAuthor &&
     prev.showReplies === next.showReplies &&
     prev.onPressReplies === next.onPressReplies &&

--- a/packages/app/ui/components/Channel/index.tsx
+++ b/packages/app/ui/components/Channel/index.tsx
@@ -67,7 +67,7 @@ const useApp = () => {};
 
 interface ChannelProps {
   channel: db.Channel;
-  initialChannelUnread?: db.ChannelUnread | null;
+  channelUnread?: db.ChannelUnread | null;
   selectedPostId?: string | null;
   posts: db.Post[] | null;
   group: db.Group | null;
@@ -118,7 +118,7 @@ export const Channel = forwardRef<ChannelMethods, ChannelProps>(
   function Channel(
     {
       channel,
-      initialChannelUnread,
+      channelUnread,
       posts,
       selectedPostId,
       group,
@@ -393,7 +393,7 @@ export const Channel = forwardRef<ChannelMethods, ChannelProps>(
                                     goToPost,
                                     hasNewerPosts,
                                     hasOlderPosts,
-                                    initialChannelUnread,
+                                    channelUnread,
                                     isLoadingPosts: isLoadingPosts ?? false,
                                     loadPostsError,
                                     onPressDelete,

--- a/packages/app/ui/components/Channel/useAnchorScrollLock.ts
+++ b/packages/app/ui/components/Channel/useAnchorScrollLock.ts
@@ -92,6 +92,7 @@ export function useAnchorScrollLock({
 
       if (
         !userHasScrolled &&
+        !didScrollToAnchor &&
         post.id === anchor?.postId &&
         flatListRef.current &&
         anchor?.postId === currentAnchorId.current &&

--- a/packages/app/ui/components/DetailView.tsx
+++ b/packages/app/ui/components/DetailView.tsx
@@ -12,7 +12,7 @@ import { NotebookPostDetailView } from './NotebookPost/NotebookPost';
 export interface DetailViewProps {
   post: db.Post;
   channel: db.Channel;
-  initialPostUnread?: db.ThreadUnreadState | null;
+  postUnread?: db.ThreadUnreadState | null;
   children?: JSX.Element;
   editingPost?: db.Post;
   setEditingPost?: (post: db.Post | undefined) => void;
@@ -30,7 +30,7 @@ export interface DetailViewProps {
 export const DetailView = ({
   post,
   channel,
-  initialPostUnread,
+  postUnread,
   editingPost,
   setEditingPost,
   posts,
@@ -86,12 +86,10 @@ export const DetailView = ({
           onPressRetry={onPressRetry}
           onPressDelete={onPressDelete}
           firstUnreadId={
-            initialPostUnread?.count ?? 0 > 0
-              ? initialPostUnread?.firstUnreadPostId
-              : null
+            postUnread?.count ?? 0 > 0 ? postUnread?.firstUnreadPostId : null
           }
           renderEmptyComponent={RepliesEmptyComponent}
-          unreadCount={initialPostUnread?.count ?? 0}
+          unreadCount={postUnread?.count ?? 0}
           activeMessage={activeMessage}
           setActiveMessage={setActiveMessage}
         />
@@ -101,7 +99,7 @@ export const DetailView = ({
     containingProperties,
     activeMessage,
     editingPost,
-    initialPostUnread,
+    postUnread,
     isChat,
     onPressDelete,
     onPressImage,

--- a/packages/app/ui/components/PostScreenView.tsx
+++ b/packages/app/ui/components/PostScreenView.tsx
@@ -382,17 +382,10 @@ function SinglePostView({
     draftKey: store.draftKeyFor.thread({ parentPostId: parentPost.id }),
   });
 
-  // for the unread thread divider, we care about the unread state when you enter but don't want it to update over
-  // time
-  const [initialThreadUnread, setInitialThreadUnread] =
-    useState<db.ThreadUnreadState | null>(null);
-  useEffect(() => {
-    async function initializeChannelUnread() {
-      const unread = await db.getThreadUnreadState({ parentId: parentPost.id });
-      setInitialThreadUnread(unread ?? null);
-    }
-    initializeChannelUnread();
-  }, [parentPost.id]);
+  const { data: threadUnread } = store.useThreadUnread({
+    parentId: parentPost.id,
+    channelId: channel.id,
+  });
 
   const { data: threadPosts } = store.useThreadPosts({
     postId: parentPost.id,
@@ -485,7 +478,7 @@ function SinglePostView({
         <DetailView
           post={parentPost}
           channel={channel}
-          initialPostUnread={initialThreadUnread}
+          postUnread={threadUnread}
           onPressImage={handleGoToImage}
           editingPost={editingPost}
           setEditingPost={setEditingPost}

--- a/packages/app/ui/components/postCollectionViews/ListPostCollectionView.tsx
+++ b/packages/app/ui/components/postCollectionViews/ListPostCollectionView.tsx
@@ -77,12 +77,12 @@ export const ListPostCollection: IPostCollectionView = forwardRef(
 
       if (collectionLayout.enableUnreadAnchor) {
         if (
-          ctx.initialChannelUnread?.countWithoutThreads &&
-          ctx.initialChannelUnread.firstUnreadPostId
+          ctx.channelUnread?.countWithoutThreads &&
+          ctx.channelUnread.firstUnreadPostId
         ) {
           return {
             type: 'unread',
-            postId: ctx.initialChannelUnread.firstUnreadPostId,
+            postId: ctx.channelUnread.firstUnreadPostId,
           };
         }
       }
@@ -91,7 +91,7 @@ export const ListPostCollection: IPostCollectionView = forwardRef(
     }, [
       collectionLayout.enableUnreadAnchor,
       ctx.selectedPostId,
-      ctx.initialChannelUnread,
+      ctx.channelUnread,
     ]);
 
     return (
@@ -109,11 +109,11 @@ export const ListPostCollection: IPostCollectionView = forwardRef(
         channel={ctx.channel}
         collectionLayoutType={collectionLayoutType}
         firstUnreadId={
-          ctx.initialChannelUnread?.countWithoutThreads ?? 0 > 0
-            ? ctx.initialChannelUnread?.firstUnreadPostId
+          ctx.channelUnread?.countWithoutThreads ?? 0 > 0
+            ? ctx.channelUnread?.firstUnreadPostId
             : null
         }
-        unreadCount={ctx.initialChannelUnread?.countWithoutThreads ?? 0}
+        unreadCount={ctx.channelUnread?.countWithoutThreads ?? 0}
         onPressPost={canDrillIntoPost ? ctx.goToPost : undefined}
         onPressReplies={ctx.goToPost}
         onPressImage={ctx.goToImageViewer}

--- a/packages/app/ui/contexts/postCollection.ts
+++ b/packages/app/ui/contexts/postCollection.ts
@@ -12,7 +12,7 @@ export interface PostCollectionContextValue {
   goToPost: (post: db.Post) => void;
   hasNewerPosts?: boolean;
   hasOlderPosts?: boolean;
-  initialChannelUnread?: db.ChannelUnread | null;
+  channelUnread?: db.ChannelUnread | null;
   isLoadingPosts: boolean;
   loadPostsError?: Error | null;
   onPressDelete: (post: db.Post) => void;

--- a/packages/shared/src/db/queries.ts
+++ b/packages/shared/src/db/queries.ts
@@ -1338,11 +1338,17 @@ export const getThreadPosts = createReadQuery(
 
 export const getThreadUnreadState = createReadQuery(
   'getThreadUnreadState',
-  ({ parentId }: { parentId: string }, ctx: QueryCtx) => {
+  (
+    { parentId, channelId }: { parentId: string; channelId: string },
+    ctx: QueryCtx
+  ) => {
     if (!parentId) return Promise.resolve(null);
 
     return ctx.db.query.threadUnreads.findFirst({
-      where: eq($threadUnreads.threadId, parentId),
+      where: and(
+        eq($threadUnreads.threadId, parentId),
+        eq($threadUnreads.channelId, channelId)
+      ),
     });
   },
   ['posts']

--- a/packages/shared/src/store/dbHooks.ts
+++ b/packages/shared/src/store/dbHooks.ts
@@ -169,6 +169,28 @@ export const useUnreadsCountWithoutMuted = () => {
   });
 };
 
+export const useChannelUnread = (channelId: string) => {
+  const deps = useKeyFromQueryDeps(db.getChannelUnread);
+  return useQuery({
+    queryKey: [['channelUnread', channelId], deps],
+    queryFn: () => db.getChannelUnread({ channelId }),
+  });
+};
+
+export const useThreadUnread = ({
+  parentId,
+  channelId,
+}: {
+  parentId: string;
+  channelId: string;
+}) => {
+  const deps = useKeyFromQueryDeps(db.getThreadUnreadState);
+  return useQuery({
+    queryKey: [['threadUnread', { parentId, channelId }], deps],
+    queryFn: () => db.getThreadUnreadState({ parentId, channelId }),
+  });
+};
+
 export const useGroupVolumeLevel = (groupId: string) => {
   const deps = useKeyFromQueryDeps(db.getGroupVolumeSetting);
   return useQuery({


### PR DESCRIPTION
## Summary

Fixes TLON-4437. This has been bothering me since we pushed out the desktop client. Essentially, we previously had the assumption that anytime we were entering a channel, we would only need to cache the unread upon entry. On mobile this is fine, because navigation "upwards" results in the `ChannelScreen` being unmounted, however on desktop this is a problem because navigating away from a channel doesn't actually unmount. 

## Changes

<!-- Outline specific changes made in this PR. -->

## How did I test?

<!-- Describe your testing process. -->

## Risks and impact

- Safe to rollback without consulting PR author? (Yes | No)
- Affects important code area:
  - [ ] Onboarding
  - [ ] State / providers
  - [ ] Message sync
  - [ ] Channel display
  - [ ] Notifications

## Rollback plan

<!-- Describe the steps to revert these changes if needed. -->

## Screenshots / videos

<!-- Attach any relevant media. -->
