### PR TITLE
anchor-lock: dont scroll to anchor if we already have

### DIFF
--- a/packages/app/ui/components/Channel/useAnchorScrollLock.ts
+++ b/packages/app/ui/components/Channel/useAnchorScrollLock.ts
@@ -92,6 +92,7 @@ export function useAnchorScrollLock({
 
       if (
         !userHasScrolled &&
+        !didScrollToAnchor &&
         post.id === anchor?.postId &&
         flatListRef.current &&
         anchor?.postId === currentAnchorId.current &&


### PR DESCRIPTION
## Summary

OTT, fixes TLON-4156

## Changes

- simply uses boolean check to make sure we haven't already scrolled to anchor

## How did I test?

This is one way to simulate it. I think in reality this happens more with images/embeds but I didn't want to chase that.

Have two ships belonging to the same channel, while one ship (A) is away, create enough messages from the other ship (B) that would scroll you up a screen. Then from ship A, visit the channel with the unreads. It should bring you to the unread anchor (may be slightly above top of viewport). After this happens scroll to the bottom of the chat. Then from ship B post a message with lots of text like lorem ipsum. Then on ship A resize the window. It should not scroll you back up to the anchor with this change (but it will in production). 

This makes a call to `handleItemLayout` which we give to the scroller that does the anchor scrolling. Its unclear why we use this function to scroll to the anchor, but it seems like there's probably a better place to call this.

## Risks and impact

- Safe to rollback without consulting PR author? Yes
- Affects important code area:
  - [ ] Onboarding
  - [ ] State / providers
  - [ ] Message sync
  - [X] Channel display
  - [ ] Notifications

## Rollback plan

<!-- Describe the steps to revert these changes if needed. -->

## Screenshots / videos

<!-- Attach any relevant media. -->
