### PR TITLE
fix italic, header notebook content rendering

### DIFF
--- a/packages/app/fixtures/FixtureWrapper.tsx
+++ b/packages/app/fixtures/FixtureWrapper.tsx
@@ -1,7 +1,8 @@
 // tamagui-ignore
 import { NavigationContainer } from '@react-navigation/native';
 import { QueryClientProvider, queryClient } from '@tloncorp/shared';
-import type { PropsWithChildren } from 'react';
+import { internalConfigureClient } from '@tloncorp/shared/api';
+import { type PropsWithChildren, useEffect, useState } from 'react';
 import { useFixtureSelect } from 'react-cosmos/client';
 import { GestureHandlerRootView } from 'react-native-gesture-handler';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
@@ -27,11 +28,26 @@ type FixtureWrapperProps = PropsWithChildren<{
   safeArea?: boolean;
 }>;
 
+function MockedUrbitClientProvider({ children }: PropsWithChildren<object>) {
+  const [ready, setReady] = useState(false);
+  useEffect(() => {
+    internalConfigureClient({
+      shipName: 'zod',
+      shipUrl: 'whitehouse.com',
+    });
+    setReady(true);
+  }, []);
+
+  return <>{ready ? children : null}</>;
+}
+
 export const FixtureWrapper = (props: FixtureWrapperProps) => {
   return (
     <ToastProvider>
       <NavigationContainer>
-        <InnerWrapper {...props} />
+        <MockedUrbitClientProvider>
+          <InnerWrapper {...props} />
+        </MockedUrbitClientProvider>
       </NavigationContainer>
     </ToastProvider>
   );

--- a/packages/app/fixtures/NotebookPost.fixture.tsx
+++ b/packages/app/fixtures/NotebookPost.fixture.tsx
@@ -1,0 +1,23 @@
+import { convertContent } from '@tloncorp/shared';
+import { ScrollView } from 'tamagui';
+
+import { NotebookContentRenderer } from '../ui/components/NotebookPost/NotebookPost';
+import { FixtureWrapper } from './FixtureWrapper';
+import { postWithEverything as post } from './contentHelpers';
+
+export default {
+  NotebookContentRenderer: () => {
+    return (
+      <FixtureWrapper fillWidth safeArea>
+        <ScrollView automaticallyAdjustContentInsets>
+          <NotebookContentRenderer
+            marginTop="$-l"
+            marginHorizontal="$-l"
+            paddingHorizontal="$xl"
+            content={convertContent(post.content)}
+          />
+        </ScrollView>
+      </FixtureWrapper>
+    );
+  },
+};

--- a/packages/app/fixtures/contentHelpers.tsx
+++ b/packages/app/fixtures/contentHelpers.tsx
@@ -549,6 +549,80 @@ export const postWithSingleEmoji = makePost(exampleContacts.emotive, [
   verse.inline('🙏', inline.break()),
 ]);
 
+export const postWithEverything = makePost(exampleContacts.mark, [
+  block.header('h1', inline.text('All Features Test')),
+  verse.inline(
+    'This post demonstrates ',
+    inline.bold('bold'),
+    ', ',
+    inline.italics('italics'),
+    ', ',
+    inline.strikethrough('strikethrough'),
+    ', ',
+    inline.inlineCode('inline code'),
+    ', ',
+    inline.link('https://example.com', 'a link'),
+    ', and a mention: ',
+    inline.ship('~fabled-faster'),
+    '.'
+  ),
+  verse.inline(
+    inline.blockquote(
+      'We are shaped by our thoughts; we become what we think. When the mind is pure, joy follows like a shadow that never leaves.'
+    )
+  ),
+  block.code('console.log("Hello, world!");', 'js'),
+  block.randomImage(640, 480),
+  block.rule(),
+  block.header('h2', inline.text('Lists')),
+  block.list(
+    'unordered',
+    [inline.text('Here’s an unordered list:')],
+    [
+      listItem.basic(inline.text('Item one')),
+      listItem.basic(inline.text('Item two')),
+      list(
+        'ordered',
+        [inline.text('Nested ordered list')],
+        [
+          listItem.basic(inline.text('Sub-item one')),
+          listItem.basic(inline.text('Sub-item two')),
+        ]
+      ),
+    ]
+  ),
+  block.list(
+    'tasklist',
+    [inline.text('Tasks')],
+    [
+      { item: [listItem.task(true, inline.text('Do thing one'))] },
+      { item: [listItem.task(false, inline.text('Do thing two'))] },
+    ]
+  ),
+  block.header('h3', inline.text('References')),
+  verse.block({
+    cite: {
+      chan: {
+        nest: tlonLocalIntros.id,
+        where: referencedChatPost.id,
+      },
+    },
+  }),
+  verse.block({
+    cite: {
+      group: group.id,
+    },
+  }),
+  verse.block({
+    cite: {
+      desk: {
+        flag: 'diary',
+        where: '~zod',
+      },
+    },
+  }),
+]);
+
 export const postsByType = {
   image: postWithImage,
   text: postWithText,
@@ -595,6 +669,7 @@ const postsMap: Record<string, db.Post> = Object.fromEntries(
     postWithHidden,
     postWithEmoji,
     postWithSingleEmoji,
+    postWithEverything,
   ].map((p) => [p.id, p])
 );
 

--- a/packages/app/fixtures/contentHelpers.tsx
+++ b/packages/app/fixtures/contentHelpers.tsx
@@ -169,16 +169,16 @@ export function list(
   };
 }
 
-export const makePost = (
+export function makePost(
   contact: db.Contact,
   content: PostContent,
-  extra?: any
-) => {
+  extra?: object
+): db.Post {
   const post = createFakePost('chat', JSON.stringify(content));
   post.authorId = contact.id;
   post.author = contact;
   return { ...post, reactions: [], ...extra };
-};
+}
 export const exampleContacts = {
   eleanor: { nickname: 'eleanor', id: randomContactId() },
   mark: { nickname: 'mark', id: randomContactId() },

--- a/packages/app/ui/components/NotebookPost/NotebookPost.tsx
+++ b/packages/app/ui/components/NotebookPost/NotebookPost.tsx
@@ -306,7 +306,7 @@ export function NotebookPostDetailView({ post }: { post: db.Post }) {
 
 const NotebookLineBreak = () => `\n\n`;
 
-const NotebookContentRenderer = createContentRenderer({
+export const NotebookContentRenderer = createContentRenderer({
   inlineRenderers: {
     lineBreak: NotebookLineBreak,
   },

--- a/packages/app/ui/components/PostContent/BlockRenderer.tsx
+++ b/packages/app/ui/components/PostContent/BlockRenderer.tsx
@@ -466,6 +466,7 @@ export const HeaderText = styled(Text, {
     },
   } as const,
 });
+HeaderText.displayName = 'HeaderText';
 
 export function EmbedBlock({
   block,

--- a/packages/app/ui/components/PostContent/BlockRenderer.tsx
+++ b/packages/app/ui/components/PostContent/BlockRenderer.tsx
@@ -428,7 +428,7 @@ export function HeaderBlock({
   ...props
 }: { block: cn.HeaderBlockData } & ComponentProps<typeof HeaderText>) {
   return (
-    <HeaderText tag={block.level} {...props}>
+    <HeaderText level={block.level} {...props}>
       {block.children.map((con, i) => (
         <InlineRenderer key={`${con}-${i}`} inline={con} />
       ))}
@@ -438,7 +438,7 @@ export function HeaderBlock({
 
 export const HeaderText = styled(Text, {
   variants: {
-    tag: {
+    level: {
       h1: {
         fontSize: 24,
         fontWeight: 'bold',

--- a/packages/app/ui/components/PostContent/BlockRenderer.tsx
+++ b/packages/app/ui/components/PostContent/BlockRenderer.tsx
@@ -428,7 +428,7 @@ export function HeaderBlock({
   ...props
 }: { block: cn.HeaderBlockData } & ComponentProps<typeof HeaderText>) {
   return (
-    <HeaderText level={block.level} {...props}>
+    <HeaderText tag={block.level} level={block.level} {...props}>
       {block.children.map((con, i) => (
         <InlineRenderer key={`${con}-${i}`} inline={con} />
       ))}

--- a/packages/ui/tamagui.config.ts
+++ b/packages/ui/tamagui.config.ts
@@ -340,8 +340,10 @@ export const themes = {
 };
 
 export const systemFont = createFont({
-  family:
-    'System, -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, sans-serif',
+  family: Platform.select({
+    web: '-apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, sans-serif',
+    default: 'System',
+  }),
   size: {
     xs: 12,
     s: 14,


### PR DESCRIPTION
fixes TLON-4027
Fixes italics and headers, which were both rendering as plaintext on iOS/Android for different reasons.

## Changes
- Headers were using a custom Tamagui `tag` variant on the `HeaderText` component. There's also a `tag` prop on the underlying Tamagui `Text` component, which instructs Tamagui Web to use a specific HTML tag. I think overloading this prop as a variant was not (stopped?) working; changing the variant name to something else brought back formatting on `HeaderText`.
  - With this change, headings on web became a little smaller on my browser, since we're using our own font sizes instead of the default `h1` etc font sizes.
- We were previously using a "font stack" when defining the Tamagui `body` font's `family`: https://github.com/tloncorp/tlon-apps/blob/0885e43346a599c917eb1cc28d2b1725245b0b19/packages/ui/tamagui.config.ts#L343-L344 This probably works well for web, but this appears to not work on native – this wasn't super visible because native would fall back to system font family, which looked almost the same – but this appears to break italics (but not bold or strikethrough?). In any case, swapping out the font stack for a single `System` font on iOS/Android fixes the issue.
- [extra] 0885e43 makes a fixture helper's typing stricter, which I was using in some deleted debug code – seems like a positive change

## How did I test?
on iOS + Android + web:
- [Add NotebookContentRenderer fixture](https://github.com/tloncorp/tlon-apps/pull/4871/commits/c25498d04bc14836c119fa6c6631ed284c6bedf7)
- [Add example post with all content features](https://github.com/tloncorp/tlon-apps/pull/4871/commits/f885953b5c401f1c0364a4a9eb1fcc8f09daad15)
- Look at fixture

also
- looked at some live notebook posts
- checked that web still uses `h1`, `h2`, etc for headings

## Risks and impact

- Safe to rollback without consulting PR author? Yes
- Affects important code area:
  - [ ] Onboarding
  - [ ] State / providers
  - [ ] Message sync
  - [ ] Channel display
  - [ ] Notifications

## Rollback plan

git revert

## Screenshots / videos

| Platform | Before | After |
| --- | --- | --- |
| iOS | ![Simulator Screenshot - iPhone 16 Pro - 2025-06-19 at 21 01 41](https://github.com/user-attachments/assets/972256e2-76ce-4bc4-b3bf-0496b7ed0ff5) ![Simulator Screenshot - iPhone 16 Pro - 2025-06-19 at 21 01 44](https://github.com/user-attachments/assets/c3ce69b3-f520-45a4-9a56-f35e664859b9) | ![Simulator Screenshot - iPhone 16 Pro - 2025-06-19 at 20 57 47](https://github.com/user-attachments/assets/bc7a13e3-d457-4333-bc18-3ddd6951d871) ![Simulator Screenshot - iPhone 16 Pro - 2025-06-19 at 20 57 51](https://github.com/user-attachments/assets/e3d3a8d8-7e22-4e52-99ca-9df97466e3a4) |
| Android | <img width="355" alt="Screenshot 2025-06-19 at 9 05 07 PM" src="https://github.com/user-attachments/assets/aba2af86-b5bf-4964-99be-d08dbf78a960" /> <img width="354" alt="Screenshot 2025-06-19 at 9 05 00 PM" src="https://github.com/user-attachments/assets/f6cae206-2f5a-4610-9c72-08aa75e1e8b9" />  |  <img width="361" alt="Screenshot 2025-06-19 at 8 59 06 PM" src="https://github.com/user-attachments/assets/f9ebff37-3755-4a36-9c83-35263a8a8a2a" /> <img width="356" alt="Screenshot 2025-06-19 at 8 59 01 PM" src="https://github.com/user-attachments/assets/11559965-6e5f-4e0c-8ad7-ab64a19fd146" />  |
| Web | ![Screen Shot 2025-06-19 at 22 27 42](https://github.com/user-attachments/assets/6bd288d3-19a4-44bf-9161-31b0cdc68e80) | ![Screen Shot 2025-06-19 at 22 29 37](https://github.com/user-attachments/assets/4a93681d-94e3-4731-bcc1-1f4e2ae318e5) |