### PR TITLE
fix toast crash on Android fixtures due to missing safe area context

### DIFF
--- a/packages/app/fixtures/cosmos.decorator.tsx
+++ b/packages/app/fixtures/cosmos.decorator.tsx
@@ -1,13 +1,15 @@
 import React from 'react';
 import { SafeAreaProvider } from 'react-native-safe-area-context';
 
-import { StoreProvider, TamaguiProvider, config } from '../ui';
+import { PortalProvider, StoreProvider, TamaguiProvider, config } from '../ui';
 
 // eslint-disable-next-line
 export default ({ children }: { children: React.ReactNode }) => (
   <TamaguiProvider defaultTheme={'light'} config={config}>
     <StoreProvider stub>
-      <SafeAreaProvider>{children}</SafeAreaProvider>
+      <SafeAreaProvider>
+        <PortalProvider>{children}</PortalProvider>
+      </SafeAreaProvider>
     </StoreProvider>
   </TamaguiProvider>
 );


### PR DESCRIPTION
Previously, Android fixtures that rendered `Toast` would crash due to missing safe area context.

## Changes
- Stop using default providers, so that:
  - Toast's `Portal` accesses an explicit `PortalProvider`
  - `PortalProvider`'s mount point can access the `SafeAreaProvider`'s context

## How did I test?
Opened the `Channel.notebook` and `Toast` fixtures – before change, these crashed on Android; after, they ran on Android (and toasts showed as expected). Fixtures showed as expected on iOS and web as well.

## Risks and impact

- Safe to rollback without consulting PR author? Yes
- Affects important code area:
  - [ ] Onboarding
  - [ ] State / providers
  - [ ] Message sync
  - [ ] Channel display
  - [ ] Notifications

## Rollback plan

git revert