### PR TITLE
web: remove some erroneous react-native-gesture-handler imports

### DIFF
--- a/packages/app/fixtures/PostReference.fixture.tsx
+++ b/packages/app/fixtures/PostReference.fixture.tsx
@@ -1,6 +1,6 @@
 import * as db from '@tloncorp/shared/db';
 import { PropsWithChildren } from 'react';
-import { ScrollView } from 'react-native-gesture-handler';
+import { ScrollView } from 'react-native';
 
 import { View } from '../ui';
 import {

--- a/packages/app/ui/components/BigInput.tsx
+++ b/packages/app/ui/components/BigInput.tsx
@@ -11,8 +11,7 @@ import {
 } from '@tloncorp/ui';
 import { ImagePickerAsset } from 'expo-image-picker';
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
-import { KeyboardAvoidingView, Platform } from 'react-native';
-import { TouchableOpacity } from 'react-native-gesture-handler';
+import { KeyboardAvoidingView, Platform, TouchableOpacity } from 'react-native';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
 import { Input, XStack, getTokenValue, useTheme } from 'tamagui';
 


### PR DESCRIPTION
## Summary

There were two more places where we were accidentally importing components from `react-native-gesture-handler` where we should have been importing from `react-native`. This fixes those imports.

We can't import anything from `react-native-gesture-handler` on components that need to be rendered on web, because of the `Error: findNodeHandle is not supported on web. Use the ref property on the component instead.` issue.

As far as I can tell, after this PR, there will be no places on web where a use could run into a gesture handler component (and I don't think we plan on allowing web users to use gestures at all, for now).

## Changes

Changed some import statements.

## How did I test?

Ran locally and made sure the app didn't crash/show white screen.

## Risks and impact

- Safe to rollback without consulting PR author? No, the notebook input won't work.

## Rollback plan

You'd ned to find another workaround for this issue.