### PR TITLE
fix text indents in messages

### DIFF
--- a/packages/shared/src/logic/content-helpers.test.ts
+++ b/packages/shared/src/logic/content-helpers.test.ts
@@ -49,7 +49,7 @@ test('textAndMentionsToContent: multiline mentions', () => {
 });
 
 test('textAndMentionsToContent: code blocks without mentions', () => {
-  const text = 'This is a code block:\n```\nconst x = 42;\n```';
+  const text = 'This is a code block:\n```\n  const x = 42;\n```';
   const mentions: Mention[] = [];
 
   const result = textAndMentionsToContent(text, mentions);
@@ -74,7 +74,7 @@ test('textAndMentionsToContent: code blocks without mentions', () => {
         content: [
           {
             type: 'text',
-            text: 'const x = 42;',
+            text: '  const x = 42;',
           },
         ],
       },

--- a/packages/shared/src/logic/content-helpers.ts
+++ b/packages/shared/src/logic/content-helpers.ts
@@ -318,7 +318,7 @@ export function textAndMentionsToContent(
       (mention) => mention.start >= absoluteStart && mention.end < absoluteEnd
     );
     normalizedLines.push({
-      text: line.trim(),
+      text: line.trimEnd(),
       mentions: found.map((mention) => ({
         ...mention,
         start: mention.start - absoluteStart,

--- a/packages/shared/src/logic/content-helpers.ts
+++ b/packages/shared/src/logic/content-helpers.ts
@@ -103,7 +103,8 @@ interface Line {
 }
 
 const processLine = (line: Line): JSONContent => {
-  const { text, mentions } = line;
+  const { text: rawText, mentions } = line;
+  const text = rawText.trim();
   const parsedContent: JSONContent[] = [];
   let isBolding = false;
   let isItalicizing = false;
@@ -318,7 +319,7 @@ export function textAndMentionsToContent(
       (mention) => mention.start >= absoluteStart && mention.end < absoluteEnd
     );
     normalizedLines.push({
-      text: line.trimEnd(),
+      text: line,
       mentions: found.map((mention) => ({
         ...mention,
         start: mention.start - absoluteStart,


### PR DESCRIPTION
## Summary

Fix indents in codeblocks. Fixes TLON-4403

## Changes

Move removal of leading / trailing text to `processLine`, which is not used on codeblock lines. There may be an argument for removing leading trimming altogether (there are some non-codeblock cases where this is desirable), but I've kept that behavior for now to keep the change to behavior small.

## How did I test?

Tested on web, modified `content-helpers` test code to cover indent in code block.

## Risks and impact

- Safe to rollback without consulting PR author? Yes
