### PR TITLE
mentions: add e2e tests for users, roles, and all

### DIFF
--- a/apps/tlon-web/e2e/chat-functionality.spec.ts
+++ b/apps/tlon-web/e2e/chat-functionality.spec.ts
@@ -24,13 +24,16 @@ test('should test comprehensive chat functionality', async ({ page }) => {
 
   // Create a new group
   await helpers.createGroup(page);
+  const groupName = '~bus, ~zod';
+
+  await helpers.inviteMembersToGroup(page, ['bus']);
 
   // Navigate back to Home and verify group creation
   await helpers.navigateBack(page);
   if (await page.getByText('Home').isVisible()) {
-    await expect(page.getByText('Untitled group')).toBeVisible();
-    await page.getByText('Untitled group').click();
-    await expect(page.getByText('Untitled group').first()).toBeVisible();
+    await expect(page.getByText(groupName)).toBeVisible();
+    await page.getByText(groupName).click();
+    await expect(page.getByText(groupName).first()).toBeVisible();
   }
 
   // Send a message in the General channel
@@ -68,9 +71,9 @@ test('should test comprehensive chat functionality', async ({ page }) => {
   // Navigate away and back to work around potential bug mentioned in Maestro test
   await helpers.navigateBack(page);
   if (await page.getByText('Home').isVisible()) {
-    await expect(page.getByText('Untitled group')).toBeVisible();
-    await page.getByText('Untitled group').click();
-    await expect(page.getByText('Untitled group').first()).toBeVisible();
+    await expect(page.getByText(groupName)).toBeVisible();
+    await page.getByText(groupName).click();
+    await expect(page.getByText(groupName).first()).toBeVisible();
   }
 
   // Report the message
@@ -88,11 +91,35 @@ test('should test comprehensive chat functionality', async ({ page }) => {
   await helpers.sendMessage(page, 'Edit this message');
   await helpers.editMessage(page, 'Edit this message', 'Edited message');
 
+  // Mention a user in a message
+  await page.getByTestId('MessageInput').click();
+  await page.fill('[data-testid="MessageInput"]', 'mentioning @bus');
+  await page.getByTestId('~bus-contact').click();
+  await page.getByTestId('MessageInputSendButton').click();
+  // Wait for message to appear
+  await expect(page.getByText('mentioning ~bus')).toBeVisible();
+
+  // Mention all in a message
+  await page.getByTestId('MessageInput').click();
+  await page.fill('[data-testid="MessageInput"]', 'mentioning @all');
+  await page.getByTestId('-all--group').click();
+  await page.getByTestId('MessageInputSendButton').click();
+  // Wait for message to appear
+  await expect(page.getByText('mentioning @all')).toBeVisible();
+
+  // Mention a role in a message
+  await page.getByTestId('MessageInput').click();
+  await page.fill('[data-testid="MessageInput"]', 'mentioning @admin');
+  await page.getByTestId('admin-group').click();
+  await page.getByTestId('MessageInputSendButton').click();
+  // Wait for message to appear
+  await expect(page.getByText('mentioning @admin')).toBeVisible();
+
   // Delete the group and clean up
   await helpers.openGroupSettings(page);
-  await helpers.deleteGroup(page);
+  await helpers.deleteGroup(page, groupName);
 
   // Verify we're back at Home and group is deleted
   await expect(page.getByText('Home')).toBeVisible();
-  await expect(page.getByText('Untitled group')).not.toBeVisible();
+  await expect(page.getByText(groupName)).not.toBeVisible();
 });

--- a/apps/tlon-web/e2e/helpers.ts
+++ b/apps/tlon-web/e2e/helpers.ts
@@ -24,6 +24,18 @@ export async function createGroup(page: Page) {
   }
 }
 
+export async function inviteMembersToGroup(page: Page, memberIds: string[]) {
+  await page.getByTestId('GroupOptionsSheetTrigger').first().click();
+  await page.getByText('Invite people').click();
+
+  for (const memberId of memberIds) {
+    await page.getByPlaceholder('Filter by nickname').fill(memberId);
+    await page.getByTestId('ContactRow').first().click();
+  }
+
+  await page.getByText('continue').click();
+}
+
 export async function deleteGroup(page: Page, groupName?: string) {
   await page.getByTestId('GroupLeaveAction-Delete group').click();
   await expect(

--- a/packages/app/features/top/ChannelScreen.tsx
+++ b/packages/app/features/top/ChannelScreen.tsx
@@ -15,7 +15,13 @@ import {
   usePostWithRelations,
 } from '@tloncorp/shared/store';
 import { Story } from '@tloncorp/shared/urbit';
-import React, { useCallback, useEffect, useMemo, useRef } from 'react';
+import React, {
+  useCallback,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+} from 'react';
 
 import { useChannelNavigation } from '../../hooks/useChannelNavigation';
 import { useChatSettingsNavigation } from '../../hooks/useChatSettingsNavigation';
@@ -26,7 +32,9 @@ import {
   Channel,
   ChatOptionsProvider,
   INITIAL_POSTS_PER_PAGE,
+  InviteUsersSheet,
   useCurrentUserId,
+  useIsWindowNarrow,
 } from '../../ui';
 
 const logger = createDevLogger('ChannelScreen', false);
@@ -40,6 +48,7 @@ export default function ChannelScreen(props: Props) {
     startDraft: false,
   };
   const [currentChannelId, setCurrentChannelId] = React.useState(channelId);
+  const isWindowNarrow = useIsWindowNarrow();
 
   useEffect(() => {
     setCurrentChannelId(channelId);
@@ -328,6 +337,17 @@ export default function ChannelScreen(props: Props) {
     }
   }, [channel?.type, channel?.id, channel?.groupId]);
 
+  const [inviteSheetGroup, setInviteSheetGroup] = useState<string | null>();
+  const handlePressInvite = useCallback((groupId: string) => {
+    setInviteSheetGroup(groupId);
+  }, []);
+
+  const handleInviteSheetOpenChange = useCallback((open: boolean) => {
+    if (!open) {
+      setInviteSheetGroup(null);
+    }
+  }, []);
+
   const canUpload = useCanUpload();
 
   const chatOptionsNavProps = useChatSettingsNavigation();
@@ -368,6 +388,7 @@ export default function ChannelScreen(props: Props) {
       useGroup={store.useGroup}
       onPressConfigureChannel={handleConfigureChannel}
       {...chatOptionsNavProps}
+      onPressInvite={handlePressInvite}
     >
       <AttachmentProvider canUpload={canUpload} uploadAsset={store.uploadAsset}>
         <Channel
@@ -415,6 +436,14 @@ export default function ChannelScreen(props: Props) {
           startDraft={startDraft}
           onPressScrollToBottom={handleScrollToBottom}
         />
+        {!isWindowNarrow && (
+          <InviteUsersSheet
+            open={!!inviteSheetGroup}
+            onOpenChange={handleInviteSheetOpenChange}
+            groupId={inviteSheetGroup ?? undefined}
+            onInviteComplete={() => setInviteSheetGroup(null)}
+          />
+        )}
       </AttachmentProvider>
     </ChatOptionsProvider>
   );

--- a/packages/app/ui/components/MentionPopup.tsx
+++ b/packages/app/ui/components/MentionPopup.tsx
@@ -37,7 +37,11 @@ function MentionOptionItem({
   const isContact = option.type === 'contact';
   const size = '$4xl';
   return (
-    <Pressable borderRadius="$xl" onPress={handlePress}>
+    <Pressable
+      borderRadius="$xl"
+      onPress={handlePress}
+      data-testid={`${option.id}-${option.type}`}
+    >
       <ListItem
         alignItems="center"
         justifyContent="flex-start"


### PR DESCRIPTION
## Summary

Adds e2e tests for mentions as requested in tloncorp/tlon-apps#4865

## Changes

- adds invite mechanism to helpers
- invites bus to test group for chat (for mentions)
- adds three steps to chat spec to mention a user, role, group

## How did I test?

`pnpm e2e:debug`

## Risks and impact

- Safe to rollback without consulting PR author? Yes
- Affects important code area:
  - [ ] Onboarding
  - [ ] State / providers
  - [ ] Message sync
  - [ ] Channel display
  - [ ] Notifications

## Rollback plan

<!-- Describe the steps to revert these changes if needed. -->

## Screenshots / videos

<!-- Attach any relevant media. -->
