### PR TITLE
e2e: notebooks, galleries, and documentation

### DIFF
--- a/apps/tlon-web/e2e/README.md
+++ b/apps/tlon-web/e2e/README.md
@@ -6,7 +6,8 @@ This directory contains end-to-end tests for the Tlon web app using Playwright. 
 
 -   First run: `pnpm e2e` (downloads ships, ~15 min)
 -   Development: `pnpm e2e:ui` (interactive debugging)
--   Single test: `npx playwright test filename.spec.ts`
+-   Single test: `pnpm e2e:test filename.spec.ts` (automatic ship management)
+-   Single test (manual): `npx playwright test filename.spec.ts` (requires running ships)
 -   View results: `npx playwright show-report`
 
 ## Overview
@@ -100,6 +101,9 @@ The testing environment uses three pre-configured Urbit ships:
 # Run all tests with full setup
 pnpm e2e
 
+# Run a single test with automatic ship management
+pnpm e2e:test chat-functionality.spec.ts
+
 # Run tests with playwright debug UI
 pnpm e2e:debug
 
@@ -116,9 +120,12 @@ pnpm e2e:codegen
 ### Advanced Usage
 
 ```bash
-# Run specific test file
+# Run specific test file (requires manual ship setup)
 npx playwright test chat-functionality.spec.ts
 # Note: you must have all three test ships running on your machine in order to run any tests, and you cannot have any vite servers running
+
+# Run specific test file with automatic ship management (recommended for development)
+pnpm e2e:test chat-functionality.spec.ts
 
 # Run tests matching pattern
 npx playwright test --grep "group"
@@ -189,6 +196,22 @@ The `helpers.ts` file provides numerous utility functions:
 -   `CI`: Enables CI-specific configurations
 
 ## Development Workflow
+
+### Running Individual Tests
+
+For development convenience, use the automated single-test runner:
+
+```bash
+# This will automatically:
+# 1. Boot all three ships (zod, bus, ten) without running tests
+# 2. Start the web servers
+# 3. Wait for everything to be ready
+# 4. Run your specific test only
+# 5. Clean up all processes when done
+pnpm e2e:test notebook-functionality.spec.ts
+```
+
+The script (located at `rube/run-single-test.ts`) uses a modified version of rube that stops before running the full test suite, then executes only your specific test. This handles all the orchestration for you, so you don't need to manually start ships or remember to clean up afterwards. This is especially useful when iterating on a single test during development.
 
 ### Adding New Tests
 
@@ -273,12 +296,12 @@ When adding new test scenarios:
 -   Tests run on every pull request via `.github/workflows/ci.yml`
 -   Playwright browsers are cached, but ship piers are **not cached** (due to current issues)
 -   Each CI run downloads fresh ship images (~1.5GB total)
--   Full CI run including setup takes approximately 10-15 minutes
+-   Full CI run including setup takes approximately 7-10 minutes
 
 ### CI-Specific Behavior
 
 -   `CI=true` environment variable enables CI-specific configurations
--   Ships download fresh on each run (no state persistence between CI runs)
+-   Ships download fresh on each run (no state persistence between CI runs, or _any_ **rube** runs)
 -   Playwright runs in headless mode only
 -   HTML reports are uploaded as GitHub artifacts with 30-day retention
 
@@ -292,7 +315,7 @@ npx playwright show-report /path/to/downloaded/playwright-report
 
 ## Performance Considerations
 
--   Full test suite takes approximately 10-15 minutes
+-   Full test suite takes approximately 7-10 minutes
 -   Each ship requires ~500MB disk space + memory for Urbit process
 -   Tests run sequentially to avoid state conflicts
 -   Consider running subset of tests (or a single test) during development

--- a/apps/tlon-web/e2e/README.md
+++ b/apps/tlon-web/e2e/README.md
@@ -1,0 +1,298 @@
+# End-to-End Testing with Playwright
+
+This directory contains end-to-end tests for the Tlon web app using Playwright. The testing setup includes a custom orchestration system called **Rube** that manages fake Urbit ships for comprehensive testing scenarios.
+
+## Quick Reference
+
+-   First run: `pnpm e2e` (downloads ships, ~15 min)
+-   Development: `pnpm e2e:ui` (interactive debugging)
+-   Single test: `npx playwright test filename.spec.ts`
+-   View results: `npx playwright show-report`
+
+## Overview
+
+Our e2e testing infrastructure provides:
+
+-   Automated Urbit ship management and setup
+-   Cross-ship communication testing
+-   Comprehensive UI interaction testing
+-   Authentication and session management
+-   Parallel test execution capabilities (not yet implemented)
+
+## Architecture
+
+### Core Components
+
+1. **Rube Orchestration System** (`../rube/index.ts`)
+
+    - Downloads and manages Urbit ships
+    - Handles ship booting and updating to the latest backend code
+    - Manages development server (vite) instances
+    - Coordinates test environment setup
+
+2. **Ship Manifest** (`shipManifest.json`)
+
+    - Defines available test ships (zod, bus, and ten for now)
+    - Contains ship URLs, ports, and authentication codes
+    - Maps ship instances to web application URLs
+
+3. **Authentication Setup** (`auth.setup.ts`)
+
+    - Handles login for each test ship
+    - Stores authentication state for reuse
+    - Runs before test execution
+
+4. **Test Helpers** (`helpers.ts`)
+    - Reusable functions for common UI interactions
+    - Group management utilities
+    - Message and channel operations
+    - Navigation and verification helpers
+
+## Available Test Ships
+
+The testing environment uses three pre-configured Urbit ships:
+
+| Ship | Web URL               | HTTP Port | Auth File        | Purpose                                                                       |
+| ---- | --------------------- | --------- | ---------------- | ----------------------------------------------------------------------------- |
+| ~zod | http://localhost:3000 | 35453     | `.auth/zod.json` | Primary test ship                                                             |
+| ~bus | http://localhost:3001 | 36963     | `.auth/bus.json` | Secondary ship for protocol mismatch tests (purposefully not kept up to date) |
+| ~ten | http://localhost:3002 | 38473     | `.auth/ten.json` | Third ship for cross-ship testing                                             |
+
+## Test Categories
+
+### Functional Tests
+
+-   **Chat Functionality** (`chat-functionality.spec.ts`) - Message sending, reactions, threads
+-   **Direct Messages** (`direct-message.spec.ts`) - DM creation and management
+-   **Thread Functionality** (`thread-functionality.spec.ts`) - Thread creation and replies
+-   **Notebook Functionality** (`notebook-functionality.spec.ts`) - Long-form content creation
+-   **Gallery Functionality** (`gallery-functionality.spec.ts`) - Media sharing and galleries
+
+### Group Management
+
+-   **Group Lifecycle** (`group-lifecycle.spec.ts`) - Group creation and deletion
+-   **Group Customization** (`group-customization.spec.ts`) - Branding and appearance
+-   **Group Info & Settings** (`group-info-settings.spec.ts`) - Configuration management
+-   **Roles Management** (`roles-management.spec.ts`) - Permission and role assignment
+
+### Cross-Ship Testing
+
+-   **Group Cross-Ship Visibility** (`group-cross-ship-visibility.spec.ts`) - Multi-ship interactions
+-   **Direct Message Mismatch** (`direct-message-mismatch.spec.ts`) - Error handling between ships
+-   **Group Protocol Mismatch** (`group-protocol-mismatch.spec.ts`) - Version compatibility testing
+
+### System Tests
+
+-   **App Settings** (`app-settings.spec.ts`) - Application configuration
+-   **Profile Functionality** (`profile-functionality.spec.ts`) - User profile management
+
+## Running Tests
+
+### Prerequisites
+
+-   Node.js and pnpm installed
+-   Sufficient disk space for ship downloads (~500MB per ship)
+-   Available ports: 3000-3002, 35453, 36963, 38473
+
+### Basic Commands
+
+```bash
+# Run all tests with full setup
+pnpm e2e
+
+# Run tests with playwright debug UI
+pnpm e2e:debug
+
+# Open Playwright UI for interactive testing
+pnpm e2e:ui
+
+# Run tests in headed mode (visible browser)
+pnpm e2e:headed
+
+# Generate test code using Playwright codegen
+pnpm e2e:codegen
+```
+
+### Advanced Usage
+
+```bash
+# Run specific test file
+npx playwright test chat-functionality.spec.ts
+# Note: you must have all three test ships running on your machine in order to run any tests, and you cannot have any vite servers running
+
+# Run tests matching pattern
+npx playwright test --grep "group"
+
+# Serve a playwright test report that you downloaded from github:
+npx playwright show-report /path/to/the-report-dir
+```
+
+## Test Structure
+
+### Typical Test File Structure
+
+```typescript
+import { expect, test } from '@playwright/test';
+
+import * as helpers from './helpers';
+import shipManifest from './shipManifest.json';
+
+// Use authentication state for specific ship
+test.use({ storageState: shipManifest['~zod'].authFile });
+
+test('test description', async ({ page }) => {
+    // Navigate to app
+    await page.goto(`${shipManifest['~zod'].webUrl}/apps/groups/`);
+
+    // Handle welcome flow
+    await helpers.clickThroughWelcome(page);
+
+    // Test-specific logic using helpers
+    await helpers.createGroup(page);
+    await helpers.sendMessage(page, 'Hello world');
+
+    // Assertions
+    await expect(page.getByText('Hello world')).toBeVisible();
+
+    // Cleanup
+    await helpers.deleteGroup(page);
+});
+```
+
+### Helper Functions
+
+The `helpers.ts` file provides numerous utility functions:
+
+-   **Navigation**: `navigateBack()`, `clickThroughWelcome()`
+-   **Group Management**: `createGroup()`, `deleteGroup()`, `openGroupSettings()`
+-   **Messaging**: `sendMessage()`, `reactToMessage()`, `startThread()`
+-   **Channel Operations**: `createChannel()`, `editChannel()`, `deleteChannel()`
+-   **User Management**: `createRole()`, `assignRoleToMember()`
+-   **Form Interactions**: `fillFormField()`
+-   **Verification**: `verifyElementCount()`, `verifyMessagePreview()`
+
+## Configuration
+
+### Playwright Configuration (`../playwright.config.ts`)
+
+-   **Timeout**: 60 seconds per test
+-   **Retries**: 2 attempts on failure
+-   **Workers**: 1 (to avoid conflicts between ships)
+-   **Browser**: Chromium (Firefox/Safari commented out)
+-   **Traces**: Retained on failure for debugging
+-   **Screenshots/Videos**: Captured on failure
+
+### Environment Variables
+
+-   `SHIP_NAME`: Target specific ship for testing (zod, bus, ten)
+-   `DEBUG_PLAYWRIGHT`: Enable debug output
+-   `CI`: Enables CI-specific configurations
+
+## Development Workflow
+
+### Adding New Tests
+
+1. Create new `.spec.ts` file in the `e2e` directory
+2. Import required helpers and ship manifest
+3. Use appropriate authentication state
+4. Follow established patterns for navigation and cleanup
+5. Add reusable functions to `helpers.ts` if needed
+
+### Debugging Tests
+
+1. Use `pnpm e2e:debug` for console output
+2. Run `pnpm e2e:ui` for interactive debugging
+3. Use `pnpm e2e:headed` to see browser actions
+4. Check generated traces, screenshots, and videos in `playwright-report/` (normally opened in your browser automatically if tests fail, can be opened by running `npx playwright show-report`)
+
+### Ship Management
+
+The Rube system automatically:
+
+-   Downloads ship images from bootstrap.urbit.org
+-   Extracts and configures ship instances
+-   Boots ships with correct ports and settings
+-   Mounts and commits desk changes
+-   Manages authentication and readiness checks
+
+## Troubleshooting
+
+### Common Issues
+
+1. **Port conflicts**: Ensure ports 3000-3002, 35453, 36963, 38473 are available
+2. **Ship download failures**: Check internet connection and bootstrap.urbit.org availability
+3. **Authentication failures**: Delete `.auth/` directory and re-run tests
+4. **Timeout errors**: Increase timeout in configuration or check ship readiness
+
+### Logs and Debugging
+
+-   Playwright traces: `test-results/`
+-   Ship logs: Check rube output for Urbit ship status
+-   Browser console: Accessible through debug mode, also accessible through Playwright traces
+-   Network requests: Captured in Playwright traces, also accessible through debug mode
+
+## Maintenance
+
+### Updating Ship Images
+
+Ship images are periodically updated. To use newer versions:
+
+1. Update URLs in `shipManifest.json`
+2. Delete existing ship files in `rube/` directory
+3. Re-run tests to download fresh images
+
+### Test Data Cleanup
+
+Tests are designed to be self-cleaning, but manual cleanup may be needed:
+
+-   Remove test groups and channels
+-   Clear browser storage states
+-   Reset ship states if needed
+
+## Contributing
+
+When adding new test scenarios:
+
+1. Follow existing naming conventions
+2. Use helper functions for common operations
+3. Ensure proper cleanup in test teardown
+4. Add new helpers for reusable patterns
+5. Update this documentation for significant changes
+
+## Test Isolation
+
+-   Each test should be independent and self-cleaning
+-   Ship state persists between test file runs, but is reset when **rube** restarts
+-   Tests use cleanup helpers to remove created groups/channels
+-   Authentication state is reused across tests for performance
+
+## Continuous Integration
+
+### GitHub Actions Workflow
+
+-   Tests run on every pull request via `.github/workflows/ci.yml`
+-   Playwright browsers are cached, but ship piers are **not cached** (due to current issues)
+-   Each CI run downloads fresh ship images (~1.5GB total)
+-   Full CI run including setup takes approximately 10-15 minutes
+
+### CI-Specific Behavior
+
+-   `CI=true` environment variable enables CI-specific configurations
+-   Ships download fresh on each run (no state persistence between CI runs)
+-   Playwright runs in headless mode only
+-   HTML reports are uploaded as GitHub artifacts with 30-day retention
+
+### Accessing CI Test Results
+
+```bash
+# Download the playwright-report artifact from GitHub Actions
+# Then serve it locally:
+npx playwright show-report /path/to/downloaded/playwright-report
+```
+
+## Performance Considerations
+
+-   Full test suite takes approximately 10-15 minutes
+-   Each ship requires ~500MB disk space + memory for Urbit process
+-   Tests run sequentially to avoid state conflicts
+-   Consider running subset of tests (or a single test) during development

--- a/apps/tlon-web/e2e/gallery-functionality.spec.ts
+++ b/apps/tlon-web/e2e/gallery-functionality.spec.ts
@@ -113,6 +113,12 @@ test('should test gallery functionality', async ({ page }) => {
     page.getByText('You have hidden or reported this post').first()
   ).toBeVisible();
 
+  // Delete the post
+  await helpers.deletePost(page, 'You have hidden or reported this post');
+  await expect(
+    page.getByText('You have hidden or reported this post').first()
+  ).not.toBeVisible();
+
   // Clean up
   await helpers.cleanupExistingGroup(page);
 });

--- a/apps/tlon-web/e2e/gallery-functionality.spec.ts
+++ b/apps/tlon-web/e2e/gallery-functionality.spec.ts
@@ -1,0 +1,118 @@
+import { expect, test } from '@playwright/test';
+
+import * as helpers from './helpers';
+import shipManifest from './shipManifest.json';
+
+const zodUrl = `${shipManifest['~zod'].webUrl}/apps/groups/`;
+
+test.use({ storageState: shipManifest['~zod'].authFile });
+
+test('should test gallery functionality', async ({ page }) => {
+  await page.goto(zodUrl);
+  await helpers.clickThroughWelcome(page);
+  await page.evaluate(() => {
+    window.toggleDevTools();
+  });
+
+  // Assert that we're on the Home page
+  await expect(page.getByText('Home')).toBeVisible();
+
+  // Clean up any existing group on zod
+  await helpers.cleanupExistingGroup(page, 'Test Group');
+  await helpers.cleanupExistingGroup(page, '~ten, ~zod');
+  await helpers.cleanupExistingGroup(page);
+
+  // Create a new group
+  await helpers.createGroup(page);
+
+  // Navigate back to Home and verify group creation
+  await helpers.navigateBack(page);
+
+  if (await page.getByText('Home').isVisible()) {
+    await expect(page.getByText('Untitled group')).toBeVisible();
+    await page.getByText('Untitled group').click();
+    await expect(page.getByText('Untitled group').first()).toBeVisible();
+  }
+
+  // Create a new gallery channel
+  await helpers.openGroupSettings(page);
+  await page.getByTestId('GroupChannels').getByText('Channels').click();
+  await helpers.createChannel(page, 'Test Gallery', 'gallery');
+
+  // Navigate to the gallery channel
+  await page.getByTestId('ChannelListItem-Test Gallery').click();
+
+  // Create a new gallery post
+  await helpers.createGalleryPost(page, 'Test Gallery Post Content');
+
+  // Navigate to the post
+  await page
+    .getByText('Test Gallery Post Content')
+    .first()
+    .click({ force: true });
+  await expect(
+    page
+      .getByTestId('GalleryPostContent')
+      .getByText('Test Gallery Post Content')
+  ).toBeVisible();
+  await expect(page.getByTestId('MessageInput')).toBeVisible();
+
+  // Add a reply to the post
+  await helpers.sendMessage(page, 'This is a reply');
+
+  // Navigate back to the channel
+  await helpers.navigateBack(page);
+
+  // Edit the post
+  await helpers.longPressMessage(page, 'Test Gallery Post Content');
+  await page.getByText('Edit post').click();
+  await expect(
+    page.locator('iframe').contentFrame().getByRole('paragraph')
+  ).toBeVisible();
+  await page.locator('iframe').contentFrame().getByRole('paragraph').click();
+  await page
+    .locator('iframe')
+    .contentFrame()
+    .locator('div')
+    .nth(2)
+    .fill('Edited text...');
+  await page.getByTestId('BigInputPostButton').click();
+  await expect(
+    page.getByTestId('GalleryPostContentPreview').getByText('Edited text...')
+  ).toBeVisible();
+
+  // Navigate back to the channel
+  await expect(
+    page.getByTestId('GalleryPostContentPreview').getByText('Edited text...')
+  ).toBeVisible();
+
+  // Hide the post
+  await helpers.longPressMessage(page, 'Edited text...');
+  await page.getByText('Hide post').click();
+  await expect(
+    page.getByTestId('GalleryPostContentPreview').getByText('Edited text...')
+  ).not.toBeVisible();
+  await expect(
+    page.getByText('You have hidden or reported this post').first()
+  ).toBeVisible();
+
+  // Show the post
+  await helpers.longPressMessage(page, 'You have hidden or reported this post');
+  await page.getByText('Show post').click();
+  await expect(
+    page.getByTestId('GalleryPostContentPreview').getByText('Edited text...')
+  ).toBeVisible();
+
+  // Report the post
+  await helpers.longPressMessage(page, 'Edited text...');
+  await page.getByText('Report post').click();
+  await expect(
+    page.getByTestId('GalleryPostContentPreview').getByText('Edited text...')
+  ).not.toBeVisible();
+  await expect(
+    page.getByText('You have hidden or reported this post').first()
+  ).toBeVisible();
+
+  // Clean up
+  await helpers.cleanupExistingGroup(page);
+});

--- a/apps/tlon-web/e2e/helpers.ts
+++ b/apps/tlon-web/e2e/helpers.ts
@@ -181,19 +181,22 @@ export async function unassignRoleFromMember(
 }
 
 /**
- * Creates a new channel with title and optional description
+ * Creates a new channel with title and type
  */
 export async function createChannel(
   page: Page,
   title: string,
-  description?: string
+  type: 'chat' | 'notebook' | 'gallery' = 'chat'
 ) {
   await page.getByText('New Channel').click();
   await expect(page.getByText('Create a new channel')).toBeVisible();
 
   await fillFormField(page, 'ChannelTitleInput', title);
-  if (description) {
-    await fillFormField(page, 'ChannelDescriptionInput', description);
+
+  if (type === 'notebook') {
+    await page.getByText('Notebook', { exact: true }).click();
+  } else if (type === 'gallery') {
+    await page.getByText('Gallery', { exact: true }).click();
   }
 
   await page.getByText('Create channel').click();
@@ -403,6 +406,31 @@ export async function changeGroupIcon(page: Page, imagePath?: string) {
   }
 }
 
+// Notebook-related helper functions
+
+/**
+ * Creates a new notebook post
+ */
+export async function createNotebookPost(
+  page: Page,
+  title: string,
+  content: string
+) {
+  await page.getByTestId('AddNotebookPost').click();
+  await page.getByRole('textbox', { name: 'New Title' }).click();
+  await page.getByRole('textbox', { name: 'New Title' }).fill(title);
+  await page.locator('iframe').contentFrame().getByRole('paragraph').click();
+  await page
+    .locator('iframe')
+    .contentFrame()
+    .locator('div')
+    .nth(2)
+    .fill(content);
+  await page.getByTestId('BigInputPostButton').click();
+  await page.waitForTimeout(500);
+  await expect(page.getByText(title)).toBeVisible();
+}
+
 // Chat-related helper functions
 
 /**
@@ -421,7 +449,7 @@ export async function sendMessage(page: Page, message: string) {
  */
 export async function longPressMessage(page: Page, messageText: string) {
   // Not really a longpress since this is web.
-  await page.getByText(messageText).first().click();
+  await page.getByText(messageText).first().hover();
   await page.waitForTimeout(1000);
   await page.getByTestId('MessageActionsTrigger').click();
   await page.waitForTimeout(500);

--- a/apps/tlon-web/e2e/helpers.ts
+++ b/apps/tlon-web/e2e/helpers.ts
@@ -431,6 +431,26 @@ export async function createNotebookPost(
   await expect(page.getByText(title)).toBeVisible();
 }
 
+// Gallery-related helper functions
+
+/**
+ * Creates a new gallery post
+ */
+export async function createGalleryPost(page: Page, content: string) {
+  await page.getByTestId('AddGalleryPost').click();
+  await page.getByTestId('AddGalleryPostText').click();
+  await page.locator('iframe').contentFrame().getByRole('paragraph').click();
+  await page
+    .locator('iframe')
+    .contentFrame()
+    .locator('div')
+    .nth(2)
+    .fill(content);
+  await page.getByTestId('BigInputPostButton').click();
+  await page.waitForTimeout(500);
+  await expect(page.getByText(content).first()).toBeVisible();
+}
+
 // Chat-related helper functions
 
 /**
@@ -449,7 +469,7 @@ export async function sendMessage(page: Page, message: string) {
  */
 export async function longPressMessage(page: Page, messageText: string) {
   // Not really a longpress since this is web.
-  await page.getByText(messageText).first().hover();
+  await page.getByText(messageText).first().hover({ force: true });
   await page.waitForTimeout(1000);
   await page.getByTestId('MessageActionsTrigger').click();
   await page.waitForTimeout(500);

--- a/apps/tlon-web/e2e/helpers.ts
+++ b/apps/tlon-web/e2e/helpers.ts
@@ -1,7 +1,7 @@
 import { Page, expect } from '@playwright/test';
 
 export async function clickThroughWelcome(page: Page) {
-  await page.waitForTimeout(3000);
+  await page.waitForTimeout(10000);
   if (await page.getByText('Welcome to Tlon Messenger').isVisible()) {
     await page.getByTestId('lets-get-started').click();
     await page.getByTestId('got-it').click();
@@ -638,6 +638,15 @@ export async function deleteMessage(
   } else {
     await expect(page.getByText('Message deleted').first()).toBeVisible();
   }
+}
+
+/**
+ * Deletes a post
+ */
+export async function deletePost(page: Page, postText: string) {
+  await longPressMessage(page, postText);
+  await page.getByText('Delete post').click();
+  await expect(page.getByText(postText, { exact: true })).not.toBeVisible();
 }
 
 /**

--- a/apps/tlon-web/e2e/notebook-functionality.spec.ts
+++ b/apps/tlon-web/e2e/notebook-functionality.spec.ts
@@ -1,0 +1,117 @@
+import { expect, test } from '@playwright/test';
+
+import * as helpers from './helpers';
+import shipManifest from './shipManifest.json';
+
+const zodUrl = `${shipManifest['~zod'].webUrl}/apps/groups/`;
+
+test.use({ storageState: shipManifest['~zod'].authFile });
+
+test('should test notebook functionality', async ({ page }) => {
+  await page.goto(zodUrl);
+  await helpers.clickThroughWelcome(page);
+  await page.evaluate(() => {
+    window.toggleDevTools();
+  });
+
+  // Assert that we're on the Home page
+  await expect(page.getByText('Home')).toBeVisible();
+
+  // Clean up any existing group on zod
+  await helpers.cleanupExistingGroup(page, 'Test Group');
+  await helpers.cleanupExistingGroup(page, '~ten, ~zod');
+  await helpers.cleanupExistingGroup(page);
+
+  // Create a new group
+  await helpers.createGroup(page);
+
+  // Navigate back to Home and verify group creation
+  await helpers.navigateBack(page);
+
+  if (await page.getByText('Home').isVisible()) {
+    await expect(page.getByText('Untitled group')).toBeVisible();
+    await page.getByText('Untitled group').click();
+    await expect(page.getByText('Untitled group').first()).toBeVisible();
+  }
+
+  // Create a new notebook channel
+  await helpers.openGroupSettings(page);
+  await page.getByTestId('GroupChannels').getByText('Channels').click();
+  await helpers.createChannel(page, 'Test Notebook', 'notebook');
+
+  // navigate to the notebook channel
+  await page
+    .getByTestId('ChannelListItem-Test Notebook')
+    .getByText('Test Notebook')
+    .click();
+
+  // create a new notebook post
+  await helpers.createNotebookPost(page, 'New notebook post', 'Some text...');
+
+  // verify the notebook post is created
+  await expect(page.getByText('New notebook post')).toBeVisible();
+
+  // navigate to the post
+  await page.getByText('New notebook post').click();
+  await expect(page.getByText('No replies yet')).toBeVisible();
+  await expect(
+    page.getByTestId('NotebookPostContent').getByText('Some text...')
+  ).toBeVisible();
+  await expect(page.getByTestId('MessageInput')).toBeVisible();
+
+  // Add a reply to the post
+  await helpers.sendMessage(page, 'This is a reply');
+
+  // Edit the post
+  await page.getByTestId('ChannelHeaderEditButton').click();
+  await expect(
+    page.getByRole('textbox', {
+      name: 'New Title',
+    })
+  ).toBeVisible();
+  await page.getByRole('textbox', { name: 'New Title' }).fill('Edited title');
+  await page.locator('iframe').contentFrame().getByRole('paragraph').click();
+  await page
+    .locator('iframe')
+    .contentFrame()
+    .locator('div')
+    .nth(2)
+    .fill('Edited text...');
+  await page.getByTestId('BigInputPostButton').click();
+  await expect(
+    page.getByTestId('NotebookPostHeaderDetailView').getByText('Edited title')
+  ).toBeVisible();
+  await expect(
+    page.getByTestId('NotebookPostContent').getByText('Edited text...')
+  ).toBeVisible();
+
+  // Navigate back to the channel
+  await helpers.navigateBack(page);
+
+  // Hide the post
+  await helpers.longPressMessage(page, 'Edited text...');
+  await page.getByText('Hide post').click();
+  await expect(page.getByText('Edited title')).not.toBeVisible();
+  await expect(
+    page.getByText('You have hidden or reported this post').first()
+  ).toBeVisible();
+
+  // Show the post
+  await helpers.longPressMessage(page, 'You have hidden or reported this post');
+  await page.getByText('Show post').click();
+  await expect(page.getByText('Edited title')).toBeVisible();
+  await expect(
+    page.getByTestId('NotebookPostContentSummary').getByText('Edited text...')
+  ).toBeVisible();
+
+  // Report the post
+  await helpers.longPressMessage(page, 'Edited text...');
+  await page.getByText('Report post').click();
+  await expect(page.getByText('Edited title')).not.toBeVisible();
+  await expect(
+    page.getByText('You have hidden or reported this post').first()
+  ).toBeVisible();
+
+  // clean up
+  await helpers.cleanupExistingGroup(page);
+});

--- a/apps/tlon-web/e2e/notebook-functionality.spec.ts
+++ b/apps/tlon-web/e2e/notebook-functionality.spec.ts
@@ -112,6 +112,12 @@ test('should test notebook functionality', async ({ page }) => {
     page.getByText('You have hidden or reported this post').first()
   ).toBeVisible();
 
+  // Delete the post
+  await helpers.deletePost(page, 'You have hidden or reported this post');
+  await expect(
+    page.getByText('You have hidden or reported this post').first()
+  ).not.toBeVisible();
+
   // clean up
   await helpers.cleanupExistingGroup(page);
 });

--- a/apps/tlon-web/package.json
+++ b/apps/tlon-web/package.json
@@ -27,8 +27,6 @@
     "rube": "tsc --isolatedModules --skipLibCheck ./rube/index.ts --outDir ./rube/dist && node ./rube/dist/index.js",
     "e2e": "pnpm rube",
     "e2e:debug": "cross-env DEBUG_PLAYWRIGHT=true pnpm e2e",
-    "e2e:debug:zod": "cross-env DEBUG_PLAYWRIGHT=true SHIP_NAME=zod pnpm e2e",
-    "e2e:debug:bus": "cross-env DEBUG_PLAYWRIGHT=true SHIP_NAME=bus pnpm e2e",
     "e2e:ui": "playwright test --ui",
     "e2e:headed": "playwright test --headed",
     "e2e:codegen": "playwright codegen"

--- a/apps/tlon-web/package.json
+++ b/apps/tlon-web/package.json
@@ -29,7 +29,8 @@
     "e2e:debug": "cross-env DEBUG_PLAYWRIGHT=true pnpm e2e",
     "e2e:ui": "playwright test --ui",
     "e2e:headed": "playwright test --headed",
-    "e2e:codegen": "playwright codegen"
+    "e2e:codegen": "playwright codegen",
+    "e2e:test": "tsc --isolatedModules --skipLibCheck ./rube/run-single-test.ts --outDir ./rube/dist && node ./rube/dist/run-single-test.js"
   },
   "lint-staged": {
     "*.{js,jsx,ts,tsx}": [

--- a/apps/tlon-web/playwright.config.ts
+++ b/apps/tlon-web/playwright.config.ts
@@ -17,7 +17,7 @@ const webServers = Object.entries(shipManifest).map(
 export default defineConfig({
   testDir: './e2e',
 
-  timeout: 60 * 1000,
+  timeout: 120 * 1000,
 
   /* Run tests in files in parallel */
   fullyParallel: false,

--- a/apps/tlon-web/rube/index.ts
+++ b/apps/tlon-web/rube/index.ts
@@ -28,7 +28,7 @@ const manifestPath = path.join(
 );
 const shipManifest = JSON.parse(fs.readFileSync(manifestPath, 'utf8'));
 
-interface Ship {
+export interface Ship {
   authFile: string;
   downloadUrl: string;
   url: string;
@@ -723,6 +723,21 @@ const main = async () => {
     await getStartHashes();
     await copyDesks();
     await commitDesks();
+
+    // Check if we should skip running tests (for single test runner)
+    if (process.env.SKIP_TESTS === 'true') {
+      console.log(
+        '✅ Ship setup complete! Skipping test execution as requested.'
+      );
+      console.log('SHIP_SETUP_COMPLETE');
+      // Keep the process running so ships stay alive
+      console.log('Ships and web servers are ready. Press Ctrl+C to stop.');
+
+      // Keep the process alive by waiting indefinitely
+      await new Promise(() => {}); // This will never resolve
+      return;
+    }
+
     await runPlaywrightTests();
 
     console.timeEnd('Total Script Execution');

--- a/apps/tlon-web/rube/run-single-test.ts
+++ b/apps/tlon-web/rube/run-single-test.ts
@@ -1,0 +1,199 @@
+#!/usr/bin/env node
+import * as childProcess from 'child_process';
+import * as fs from 'fs';
+import fetch from 'node-fetch';
+import * as path from 'path';
+
+import { Ship } from './index';
+
+// Get the test file from command line arguments
+const testFile = process.argv[2];
+
+if (!testFile) {
+  console.error('Usage: pnpm e2e:test <test-file.spec.ts>');
+  console.error('Example: pnpm e2e:test chat-functionality.spec.ts');
+  process.exit(1);
+}
+
+// Validate that the test file exists
+// Note: __dirname will be rube/dist when compiled, so we need to go up two levels
+const testPath = path.join(__dirname, '../../e2e', testFile);
+if (!fs.existsSync(testPath)) {
+  console.error(`Test file not found: ${testPath}`);
+  process.exit(1);
+}
+
+let rubeProcess: childProcess.ChildProcess | null = null;
+let isShuttingDown = false;
+
+// Handle cleanup on exit
+process.on('SIGINT', cleanup);
+process.on('SIGTERM', cleanup);
+process.on('exit', cleanup);
+
+async function cleanup() {
+  if (isShuttingDown) return;
+  isShuttingDown = true;
+
+  console.log('\n🧹 Cleaning up...');
+
+  if (rubeProcess && !rubeProcess.killed && rubeProcess.pid) {
+    console.log('Killing rube process...');
+    try {
+      // Kill the entire process group to ensure all child processes are terminated
+      process.kill(-rubeProcess.pid, 'SIGTERM');
+    } catch (error) {
+      console.log('Process already terminated');
+    }
+  }
+
+  // Additional cleanup - kill any remaining processes on our test ports
+  const ports = ['3000', '3001', '3002', '35453', '36963', '38473'];
+  for (const port of ports) {
+    try {
+      childProcess.exec(`lsof -ti:${port} | xargs kill -9 2>/dev/null || true`);
+    } catch (error) {
+      // Ignore errors - processes might not exist
+    }
+  }
+
+  console.log('Cleanup complete!');
+}
+
+async function waitForReadiness() {
+  console.log('⏳ Waiting for Urbit ships to be ready...');
+
+  // Import ship manifest to get Urbit ship URLs (not web server URLs)
+  // Note: __dirname will be rube/dist when compiled, so we need to go up two levels
+  const shipManifest = require('../../e2e/shipManifest.json');
+  const shipUrls = Object.values(shipManifest).map((ship: Ship) => ship.url);
+
+  const maxAttempts = 60; // 5 minutes
+  let attempts = 0;
+
+  while (attempts < maxAttempts) {
+    try {
+      // Check if all Urbit ships are responding
+      const checks = shipUrls.map((url) =>
+        fetch(`${url}/~/scry/hood/kiln/pikes.json`)
+          .then((res) => res.status < 500)
+          .catch(() => false)
+      );
+
+      const results = await Promise.all(checks);
+
+      if (results.every((ready) => ready)) {
+        console.log(
+          '✅ All Urbit ships are ready! (Web servers will be started by Playwright)'
+        );
+        return true;
+      }
+    } catch (error) {
+      // Continue waiting
+    }
+
+    attempts++;
+    process.stdout.write('.');
+    await new Promise((resolve) => setTimeout(resolve, 5000)); // Wait 5 seconds
+  }
+
+  throw new Error('Timeout waiting for Urbit ships to be ready');
+}
+
+async function runTest(): Promise<void> {
+  console.log(`🧪 Running test: ${testFile}`);
+
+  return new Promise<void>((resolve, reject) => {
+    const testProcess = childProcess.spawn(
+      'npx',
+      ['playwright', 'test', testFile, '--retries=0'],
+      {
+        stdio: 'inherit',
+        cwd: path.join(__dirname, '../..'), // Go up two levels from rube/dist
+      }
+    );
+
+    testProcess.on('close', (code: number | null) => {
+      if (code === 0) {
+        console.log('✅ Test completed successfully!');
+        resolve();
+      } else {
+        console.log(`❌ Test failed with exit code ${code}`);
+        reject(new Error(`Test failed with exit code ${code}`));
+      }
+    });
+
+    testProcess.on('error', (error: Error) => {
+      console.error('Failed to start test process:', error);
+      reject(error);
+    });
+  });
+}
+
+async function main() {
+  try {
+    console.log(
+      '🚀 Starting ships and web servers (without running full test suite)...'
+    );
+
+    // Start rube with SKIP_TESTS flag to only setup ships
+    rubeProcess = childProcess.spawn('pnpm', ['rube'], {
+      stdio: ['ignore', 'pipe', 'pipe'],
+      cwd: path.join(__dirname, '../..'), // Go up two levels from rube/dist
+      detached: true, // Create a new process group
+      env: {
+        ...process.env,
+        SKIP_TESTS: 'true', // This tells rube to stop before running tests
+      },
+    });
+
+    let setupComplete = false;
+
+    // Log rube output and watch for completion signal
+    if (rubeProcess.stdout) {
+      rubeProcess.stdout.on('data', (data: Buffer) => {
+        const output = data.toString();
+        process.stdout.write(`[rube] ${output}`);
+
+        // Look for the signal that ship setup is complete
+        if (output.includes('SHIP_SETUP_COMPLETE')) {
+          console.log('✅ Ship setup detected as complete!');
+          setupComplete = true;
+        }
+      });
+    }
+
+    if (rubeProcess.stderr) {
+      rubeProcess.stderr.on('data', (data: Buffer) => {
+        process.stderr.write(`[rube] ${data}`);
+      });
+    }
+
+    rubeProcess.on('error', (error: Error) => {
+      console.error('Failed to start rube:', error);
+      process.exit(1);
+    });
+
+    rubeProcess.on('close', (code: number | null) => {
+      if (!isShuttingDown && !setupComplete) {
+        console.error(`Rube process exited unexpectedly with code ${code}`);
+        process.exit(1);
+      }
+    });
+
+    // Wait for ships to be ready
+    await waitForReadiness();
+
+    // Run the single test
+    await runTest();
+
+    console.log('🎉 Test run complete!');
+  } catch (error) {
+    console.error('Error:', error.message);
+    process.exit(1);
+  } finally {
+    cleanup();
+  }
+}
+
+main();

--- a/packages/app/ui/components/ActionSheet.tsx
+++ b/packages/app/ui/components/ActionSheet.tsx
@@ -44,6 +44,7 @@ export type Action = {
   endIcon?: IconType | ReactElement;
   startIcon?: IconType | ReactElement;
   accent?: Accent;
+  testID?: string;
 };
 
 export type ActionRenderProps = {
@@ -662,7 +663,11 @@ export const SimpleActionSheet = ({
       <ActionSheet.Content>
         <ActionSheet.ActionGroup accent={accent ?? 'neutral'}>
           {actions.map((action, index) => (
-            <ActionSheet.Action key={index} action={action} />
+            <ActionSheet.Action
+              key={index}
+              action={action}
+              testID={action.testID}
+            />
           ))}
         </ActionSheet.ActionGroup>
       </ActionSheet.Content>

--- a/packages/app/ui/components/AddGalleryPost.tsx
+++ b/packages/app/ui/components/AddGalleryPost.tsx
@@ -1,7 +1,7 @@
 import { ImagePickerAsset } from 'expo-image-picker';
 import { useCallback } from 'react';
 
-import { SimpleActionSheet } from './ActionSheet';
+import { Action, SimpleActionSheet } from './ActionSheet';
 import AttachmentSheet from './AttachmentSheet';
 import { GalleryRoute } from './draftInputs/shared';
 
@@ -14,24 +14,27 @@ export default function AddGalleryPost({
   setRoute: (route: GalleryRoute) => void;
   onSetImage: (assets: ImagePickerAsset[]) => void;
 }) {
-  const actions = [
+  const actions: Action[] = [
     {
       title: 'Image',
       action: () => {
         setRoute('add-attachment');
       },
+      testID: 'AddGalleryPostImage',
     },
     {
       title: 'Text',
       action: () => {
         setRoute('text');
       },
+      testID: 'AddGalleryPostText',
     },
     {
       title: 'Link',
       action: () => {
         setRoute('link');
       },
+      testID: 'AddGalleryPostLink',
     },
   ];
 

--- a/packages/app/ui/components/Channel/ChannelHeader.tsx
+++ b/packages/app/ui/components/Channel/ChannelHeader.tsx
@@ -180,7 +180,10 @@ export function ChannelHeader({
               )
             ) : null}
             {showEditButton && (
-              <ScreenHeader.TextButton onPress={goToEdit}>
+              <ScreenHeader.TextButton
+                onPress={goToEdit}
+                testID="ChannelHeaderEditButton"
+              >
                 Edit
               </ScreenHeader.TextButton>
             )}

--- a/packages/app/ui/components/GalleryPost/GalleryPost.tsx
+++ b/packages/app/ui/components/GalleryPost/GalleryPost.tsx
@@ -74,7 +74,6 @@ export function GalleryPost({
   const [showRetrySheet, setShowRetrySheet] = useState(false);
   const [isPopoverOpen, setIsPopoverOpen] = useState(false);
   const [isHovered, setIsHovered] = useState(false);
-  const [overFlowIsHovered, setOverFlowIsHovered] = useState(false);
   const showHeaderFooter = showAuthor && !post.hidden && !post.isDeleted;
   const embedded = useMemo(
     () => JSONValue.asBoolean(contentRendererConfiguration?.embedded, false),
@@ -119,12 +118,9 @@ export function GalleryPost({
     setIsHovered(false);
   }, []);
 
-  const onOverflowHoverIn = useCallback(() => {
-    setOverFlowIsHovered(true);
-  }, []);
-
-  const onOverflowHoverOut = useCallback(() => {
-    setOverFlowIsHovered(false);
+  const handleOverflowPress = useCallback((e: any) => {
+    // Stop propagation to prevent parent onPress from firing
+    e.stopPropagation();
   }, []);
 
   if (post.isDeleted) {
@@ -145,7 +141,7 @@ export function GalleryPost({
 
   return (
     <Pressable
-      onPress={overFlowIsHovered || isPopoverOpen ? undefined : handlePress}
+      onPress={handlePress}
       onLongPress={handleLongPress}
       onHoverIn={onHoverIn}
       onHoverOut={onHoverOut}
@@ -154,6 +150,7 @@ export function GalleryPost({
       <GalleryPostFrame {...props}>
         {showHeaderFooter && <GalleryPostHeader post={post} />}
         <GalleryContentRenderer
+          testID="GalleryPostContentPreview"
           post={post}
           pointerEvents="none"
           size={size}
@@ -170,7 +167,12 @@ export function GalleryPost({
           onPressRetry={handleRetryPressed}
         />
         {!hideOverflowMenu && (isPopoverOpen || isHovered) && (
-          <View position="absolute" top={36} right={4}>
+          <Pressable
+            position="absolute"
+            top={36}
+            right={4}
+            onPress={handleOverflowPress}
+          >
             <ChatMessageActions
               post={post}
               postActionIds={postActionIds}
@@ -185,14 +187,14 @@ export function GalleryPost({
                 <Button
                   borderWidth="unset"
                   size="$xs"
-                  onHoverIn={onOverflowHoverIn}
-                  onHoverOut={onOverflowHoverOut}
+                  onPress={handleOverflowPress}
+                  testID="MessageActionsTrigger"
                 >
                   <Icon type="Overflow" />
                 </Button>
               }
             />
-          </View>
+          </Pressable>
         )}
       </GalleryPostFrame>
     </Pressable>
@@ -344,6 +346,7 @@ export function GalleryPostDetailView({
           post={post}
           size="$l"
           onPressImage={handlePressImage}
+          testID="GalleryPostContent"
         />
       </View>
 
@@ -398,7 +401,7 @@ export function GalleryContentRenderer({
 
   if (post.hidden) {
     return (
-      <ErrorPlaceholder>You have hidden or flagged this post</ErrorPlaceholder>
+      <ErrorPlaceholder>You have hidden or reported this post</ErrorPlaceholder>
     );
   } else if (post.isDeleted) {
     return <ErrorPlaceholder>This post has been deleted</ErrorPlaceholder>;

--- a/packages/app/ui/components/NotebookPost/NotebookPost.tsx
+++ b/packages/app/ui/components/NotebookPost/NotebookPost.tsx
@@ -58,7 +58,6 @@ export function NotebookPost({
   const [showRetrySheet, setShowRetrySheet] = useState(false);
   const [isPopoverOpen, setIsPopoverOpen] = useState(false);
   const [isHovered, setIsHovered] = useState(false);
-  const [overFlowIsHovered, setOverFlowIsHovered] = useState(false);
   const channel = useChannelContext();
   const postActionIds = useMemo(
     () => ChannelAction.channelActionIdsFor({ channel }),
@@ -105,12 +104,9 @@ export function NotebookPost({
     setIsHovered(false);
   }, []);
 
-  const onOverflowHoverIn = useCallback(() => {
-    setOverFlowIsHovered(true);
-  }, []);
-
-  const onOverflowHoverOut = useCallback(() => {
-    setOverFlowIsHovered(false);
+  const handleOverflowPress = useCallback((e: any) => {
+    // Stop propagation to prevent parent onPress from firing
+    e.stopPropagation();
   }, []);
 
   if (!post || post.isDeleted) {
@@ -120,7 +116,7 @@ export function NotebookPost({
   const hasReplies = post.replyCount && post.replyTime && post.replyContactIds;
   return (
     <Pressable
-      onPress={overFlowIsHovered || isPopoverOpen ? undefined : handlePress}
+      onPress={handlePress}
       onHoverIn={onHoverIn}
       onHoverOut={onHoverOut}
       onLongPress={handleLongPress}
@@ -139,7 +135,7 @@ export function NotebookPost({
             alignItems="center"
           >
             <Text color="$tertiaryText" size="$body">
-              You have hidden this post.
+              You have hidden or reported this post.
             </Text>
           </XStack>
         ) : (
@@ -148,6 +144,7 @@ export function NotebookPost({
               post={post}
               showDate={showDate}
               showAuthor={showAuthor && viewMode !== 'activity'}
+              testID="NotebookPostHeader"
             />
 
             {viewMode !== 'activity' && (
@@ -156,6 +153,7 @@ export function NotebookPost({
                 color="$secondaryText"
                 numberOfLines={3}
                 paddingBottom={showReplies && hasReplies ? 0 : '$m'}
+                testID="NotebookPostContentSummary"
               >
                 {post.textContent}
               </Text>
@@ -179,7 +177,12 @@ export function NotebookPost({
           </XStack>
         ) : null}
         {!hideOverflowMenu && (isPopoverOpen || isHovered) && (
-          <View position="absolute" top={12} right={12}>
+          <Pressable
+            position="absolute"
+            top={12}
+            right={12}
+            onPress={handleOverflowPress}
+          >
             <ChatMessageActions
               post={post}
               postActionIds={postActionIds}
@@ -195,14 +198,14 @@ export function NotebookPost({
                   backgroundColor="transparent"
                   borderWidth="unset"
                   size="$l"
-                  onHoverIn={onOverflowHoverIn}
-                  onHoverOut={onOverflowHoverOut}
+                  onPress={handleOverflowPress}
+                  testID="MessageActionsTrigger"
                 >
                   <Icon type="Overflow" />
                 </Button>
               }
             />
-          </View>
+          </Pressable>
         )}
       </NotebookPostFrame>
       <SendPostRetrySheet
@@ -289,11 +292,13 @@ export function NotebookPostDetailView({ post }: { post: db.Post }) {
         paddingBottom={'$2xl'}
         borderBottomWidth={1}
         borderBottomColor="$border"
+        testID="NotebookPostHeaderDetailView"
       />
       <NotebookContentRenderer
         marginTop="$-l"
         marginHorizontal="$-l"
         paddingHorizontal="$xl"
+        testID="NotebookPostContent"
         content={
           post.editStatus === 'failed' || post.editStatus === 'pending'
             ? lastEditContent

--- a/packages/app/ui/components/draftInputs/GalleryInput.tsx
+++ b/packages/app/ui/components/draftInputs/GalleryInput.tsx
@@ -351,6 +351,7 @@ export function GalleryInput({
               key="gallery"
               type="Add"
               onPress={handleAdd}
+              testID="AddGalleryPost"
             />
             <Notices.CollectionInputTooltip channelId={channel.id} />
           </>

--- a/packages/app/ui/components/draftInputs/NotebookInput.tsx
+++ b/packages/app/ui/components/draftInputs/NotebookInput.tsx
@@ -56,6 +56,7 @@ export function NotebookInput({
               key="notebook"
               type="Add"
               onPress={handleAdd}
+              testID="AddNotebookPost"
             />
             <WayfindingNotices.NotebookInputTooltip
               channelId={draftInputContext.channel.id}


### PR DESCRIPTION
## Summary

Adds notebook and gallery end to end tests.

Adds documentation for end to end tests.

Adds a new npm script, `e2e:test`, that allows for devs to run single test files with ship management (starts all three ships for you, runs playwright tests, shuts everything down).

fixes tlon-4393
fixes tlon-4392
fixes tlon-4478

## Changes

Adds new test files, makes some changes to relevant components to make the tests run reliably.

## How did I test?

These are tests.

## Risks and impact

- Safe to rollback without consulting PR author? Yes
- Affects important code area:
  - [ ] Onboarding
  - [ ] State / providers
  - [ ] Message sync
  - [ ] Channel display
  - [ ] Notifications
  - [x] N/A

## Rollback plan

just revert the merge commit
