### PR TITLE
unreads: reset marker if screen goes out of focus

### DIFF
--- a/packages/app/features/top/ChannelScreen.tsx
+++ b/packages/app/features/top/ChannelScreen.tsx
@@ -1,4 +1,4 @@
-import { useFocusEffect } from '@react-navigation/native';
+import { useFocusEffect, useIsFocused } from '@react-navigation/native';
 import type { NativeStackScreenProps } from '@react-navigation/native-stack';
 import {
   configurationFromChannel,
@@ -127,14 +127,18 @@ export default function ChannelScreen(props: Props) {
   const [initialChannelUnread, setInitialChannelUnread] =
     React.useState<db.ChannelUnread | null>(null);
   const [unreadDidInitialize, setUnreadDidInitialize] = React.useState(false);
+  const isFocused = useIsFocused();
   useEffect(() => {
     async function initializeChannelUnread() {
       const unread = await db.getChannelUnread({ channelId: currentChannelId });
       setInitialChannelUnread(unread ?? null);
       setUnreadDidInitialize(true);
     }
-    initializeChannelUnread();
-  }, [currentChannelId]);
+
+    if (isFocused) {
+      initializeChannelUnread();
+    }
+  }, [currentChannelId, isFocused]);
 
   const { navigateToImage, navigateToPost, navigateToRef, navigateToSearch } =
     useChannelNavigation({ channelId: currentChannelId });


### PR DESCRIPTION
## Summary

Fixes TLON-4437. Because of our route setup, going from dm to a channel back to dm meant that the dm never unmounted (because its on the stack just not visible). This changes it so that if the screen goes out of focus aka not visible and then back in, reset the initial unread state that we cached. This does mean that quickly going into a channel with unreads then out will immediately clear the marker.

What this doesn't fix is that if you're in a channel with a marker, and you receive new messages, the count will be incorrect.

## Changes

Stated in summary

## How did I test?

Setup two ships A and B, on B send A a DM so that A has 1 unread. On A, visit the DM with B and then navigate to another channel then come back to the DM with B. The unread marker should be cleared. Similarly you can do the same exercise but while ship A is in a channel have B dm multiple times again. When you return to the DM on A, you should see the updated unread count.

## Risks and impact

- Safe to rollback without consulting PR author? Yes
- Affects important code area:
  - [ ] Onboarding
  - [ ] State / providers
  - [ ] Message sync
  - [ ] Channel display
  - [ ] Notifications

## Rollback plan

<!-- Describe the steps to revert these changes if needed. -->

## Screenshots / videos

<!-- Attach any relevant media. -->
