### PR TITLE
sync: don't subscribe to reel on-reconnect

### DIFF
--- a/packages/shared/src/store/sync.ts
+++ b/packages/shared/src/store/sync.ts
@@ -1487,16 +1487,6 @@ export const handleDiscontinuity = async () => {
 };
 
 export const handleChannelStatusChange = async (status: ChannelStatus) => {
-  // Since Eyre doesn't send a response body when opening an event
-  // source request, the reconnect request won't resolve until we get a new fact
-  // or a heartbeat. We call this method to manually trigger a fact -- anything
-  // that does so would work.
-  //
-  // Eyre issue is fixed in this PR, https://github.com/urbit/urbit/pull/7080,
-  // we should remove this hack once 410 is rolled out.
-  if (status === 'reconnecting') {
-    api.checkExistingUserInviteLink();
-  }
   updateSession({ channelStatus: status });
 
   // Trigger verification for posts marked as 'needs_verification' when connection becomes active


### PR DESCRIPTION
## Summary

Stop doing an unnecessary reel subscription during reconnect.

## Changes

This workaround was added to deal with the fact that eyre didn't send initial bytes down the SSE pipe, which caused clients to not consider the connection established until it did.

urbit/urbit#7080 fixed that and went out with 410. We should no longer need this workaround.

## How did I test?

It worked without this workaround before the eyre change.

## Risks and impact

- Yes, safe to rollback without consulting PR author?
- Affects important code area:
  - [ ] Onboarding
  - [ ] State / providers
  - [ ] Message sync
  - [ ] Channel display
  - [ ] Notifications

## Rollback plan

Safe and trivial to rollback.

## Screenshots / videos

No.
