### PR TITLE
bait: allow GET requests from any cross-origin

### DIFF
--- a/desk/app/bait.hoon
+++ b/desk/app/bait.hoon
@@ -114,6 +114,19 @@
     ?+    method.request  (give not-found:gen:server)
       %'GET'  (get-request line)
     ::
+        %'OPTIONS'
+      %-  give
+      =;  =header-list:http
+        [[204 header-list] ~]
+      :~  :-  'access-control-allow-methods'
+          =-  (fall - '*')
+          (get-header:http 'access-control-request-method' header-list.request)
+        ::
+          :-  'access-control-allow-headers'
+          =-  (fall - '*')
+          (get-header:http 'access-control-request-headers' header-list.request)
+      ==
+    ::
         %'POST'
       ?~  body.request
         :_  (give-not-found 'body not found')

--- a/desk/app/bait.hoon
+++ b/desk/app/bait.hoon
@@ -178,26 +178,30 @@
     ++  get-request
       |=  =(pole knot)
       ^-  (list card)
-      ?+  pole  (give not-found:gen:server)
+      %-  give
+      =<  %_  .  headers.response-header
+            [['access-control-allow-origin' '*'] headers.response-header]
+          ==
+      ?+  pole  not-found:gen:server
           [%bait %who ~]
-        (give (json-response:gen:server s+(scot %p our.bowl)))
+        (json-response:gen:server s+(scot %p our.bowl))
       ::
           [ship=@ name=@ %metadata ~]
         =/  token  (crip "{(trip ship.pole)}/{(trip name.pole)}")
         =/  =metadata:reel
           (~(gut by token-metadata) token *metadata:reel)
-        (give (json-response:gen:server (enjs-metadata metadata)))
+        (json-response:gen:server (enjs-metadata metadata))
       ::
           [token=@ %metadata ~]
         =/  =metadata:reel
           (~(gut by token-metadata) token.pole *metadata:reel)
-        (give (json-response:gen:server (enjs-metadata metadata)))
+        (json-response:gen:server (enjs-metadata metadata))
       ::
           [token=* ~]
         =/  token  (crip (join '/' pole))
         =/  =metadata:reel
           (~(gut by token-metadata) token *metadata:reel)
-        (give (manx-response:gen:server (landing-page metadata)))
+        (manx-response:gen:server (landing-page metadata))
       ==
     ::
     ++  give-not-found


### PR DESCRIPTION
## Summary

Make bait agent serve appropriate CORS-related headers when responding to GET requests.

## Changes

Since we want to pull lure link metadata from browser contexts, and theres no problem with the bait/lure service allowing this kind of access, we must include an Access-Control-Allow-Origin header to appease browser security mechanism.

Here, we do so for every GET request handled by the bait agent.

I'm assuming we only care about [the simple requests case](https://developer.mozilla.org/en-US/docs/Web/HTTP/Guides/CORS#simple_requests), where we _never_ send credentials. We shouldn't need to, so we shouldn't.

## How did I test?

It's on loshut-lonreg right now! You can see the header being returned correctly. @latter-bolden take her for a spin, see how she drives.

## Risks and impact

- Yes, safe to rollback without consulting PR author.
- Affects important code area:
  - [ ] Onboarding
  - [ ] State / providers
  - [ ] Message sync
  - [ ] Channel display
  - [ ] Notifications

## Rollback plan

`git revert afc64e5`

## Screenshots / videos

![image](https://github.com/user-attachments/assets/4be2e4ab-e360-41f1-b609-ca9b039eda17)
