### PR TITLE
mobile: fix certain emojis

### DIFF
--- a/apps/tlon-web/src/logic/utils.ts
+++ b/apps/tlon-web/src/logic/utils.ts
@@ -38,7 +38,6 @@ import anyAscii from 'any-ascii';
 import bigInt, { BigInteger } from 'big-integer';
 import { hsla, parseToHsla, parseToRgba } from 'color2k';
 import { differenceInDays, endOfToday, format } from 'date-fns';
-import emojiRegex from 'emoji-regex';
 import _ from 'lodash';
 import { useCallback, useMemo, useRef, useState } from 'react';
 import ob from 'urbit-ob';
@@ -767,18 +766,6 @@ export function getAppName(
   }
 
   return app.title || app.desk;
-}
-
-export function isSingleEmoji(input: string): boolean {
-  const regex = emojiRegex();
-  const matches = input.match(regex);
-
-  return (
-    (matches &&
-      matches.length === 1 &&
-      matches.length === _.split(input, '').length) ??
-    false
-  );
 }
 
 export function initializeMap<T>(items: Record<string, T>) {

--- a/packages/ui/src/components/Emoji/SizableEmoji.tsx
+++ b/packages/ui/src/components/Emoji/SizableEmoji.tsx
@@ -3,7 +3,6 @@ import { FontSizeTokens, SizableTextProps, getFontSize } from 'tamagui';
 import { SizableText } from 'tamagui';
 
 import { getNativeEmoji } from './data';
-import { isEmoji } from './utils';
 
 // unclear what this should be (or how it should be calculated), but seems
 // to work?
@@ -17,13 +16,7 @@ export function SizableEmoji(
 ) {
   const { emojiInput, fontSize, ...rest } = props;
   const lineHeight = getFontSize(fontSize) + MAGIC_HEIGHT_ADJUSTMENT_CONSTANT;
-  const finalEmoji = useMemo(() => {
-    const emoji = getNativeEmoji(emojiInput);
-
-    const isDirectEmoji = isEmoji(emojiInput) && !emoji;
-
-    return isDirectEmoji ? emojiInput : emoji;
-  }, [emojiInput]);
+  const finalEmoji = useMemo(() => getNativeEmoji(emojiInput), [emojiInput]);
 
   return (
     <SizableText {...rest} lineHeight={lineHeight} fontSize={fontSize}>

--- a/packages/ui/src/components/Emoji/utils.ts
+++ b/packages/ui/src/components/Emoji/utils.ts
@@ -1,6 +1,0 @@
-import emojiRegex from 'emoji-regex';
-
-export function isEmoji(emojiInput: string) {
-  const regex = emojiRegex();
-  return regex.test(emojiInput);
-}


### PR DESCRIPTION
## Summary

Our regex for detecting native emojis wasn't comprehensive enough to cover all cases of mobile input. The result was displaying our fallback _stop sign_ emoji instead of the desired one.

We've tried custom regex's (including `\p{Emoji_Presentation}`) as well as libraries without finding a solution that covers all cases. The change in this PR is to instead default to displaying whatever's passed in, so long as it's under a character count threshold.

Since this biases towards showing whatever is received,  we may end up displaying non-emoji short strings if users manually insert them. However the UI will only ever permit actual emojis to be sent, so you'd have to issue pokes manually to abuse this.

## How did I test?

- tested with the violating emoji before and after

## Risks and impact

- Safe to rollback without consulting PR author? Yes
- Affects important code area: message display
