### PR TITLE
chat-message: fixing cursor

### DIFF
--- a/packages/app/ui/components/ChatMessage/ChatMessage.tsx
+++ b/packages/app/ui/components/ChatMessage/ChatMessage.tsx
@@ -174,7 +174,7 @@ const ChatMessage = ({
       onHoverIn={handleHoverIn}
       onHoverOut={handleHoverOut}
       pressStyle="unset"
-      cursor="none"
+      cursor="default"
     >
       <YStack
         backgroundColor={isHighlighted ? '$secondaryBackground' : undefined}

--- a/packages/app/ui/components/ChatMessage/ReactionsDisplay.tsx
+++ b/packages/app/ui/components/ChatMessage/ReactionsDisplay.tsx
@@ -81,7 +81,7 @@ export function ReactionsDisplay({
     const remainingCount = reactionDetails.list.length - 2;
 
     return (
-      <Pressable onPress={() => handleOpenReactions(post)}>
+      <Pressable onPress={() => handleOpenReactions(post)} cursor="default">
         <XStack gap="$2xs" alignItems="center">
           {displayedReactions.map((reaction) => (
             <Pressable
@@ -130,6 +130,7 @@ export function ReactionsDisplay({
       <Pressable
         borderRadius="$m"
         onLongPress={() => handleOpenReactions(post)}
+        cursor="default"
       >
         <XStack borderRadius="$m" gap="$xs" flexWrap="wrap">
           {reactionDetails.list.map((reaction) => (

--- a/packages/app/ui/components/PostContent/BlockRenderer.tsx
+++ b/packages/app/ui/components/PostContent/BlockRenderer.tsx
@@ -31,6 +31,7 @@ export const BlockWrapper = styled(View, {
   name: 'ContentBlock',
   context: ContentContext,
   padding: '$l',
+  cursor: 'default',
   variants: {
     isNotice: {
       true: {

--- a/packages/ui/src/components/Pressable.tsx
+++ b/packages/ui/src/components/Pressable.tsx
@@ -79,7 +79,7 @@ export default function Pressable({
         group
         onPress={onPressLink ?? onPress}
         onLongPress={longPressHandler}
-        cursor="pointer"
+        cursor={stackProps.cursor || 'pointer'}
         // Pressable always blocks touches from bubbling to ancestors, even if
         // no handlers are attached.
         // To allow bubbling, disable the Pressable (mixin) when no handlers
@@ -91,13 +91,16 @@ export default function Pressable({
     );
   }
 
+  if ('cursor' in stackProps) {
+    console.log(stackProps);
+  }
   return (
     <StackComponent
       {...stackProps}
       onPress={onPress}
       onLongPress={longPressHandler}
       disabled={!hasInteractionHandler}
-      cursor="pointer"
+      cursor={stackProps.cursor || 'pointer'}
     >
       {children}
     </StackComponent>


### PR DESCRIPTION
## Summary

Fixes TLON-3973 by making sure we have `cursor="default"` in places where we're wrapping a multi-faceted item like `ChatMessage` in a `Pressable` to make sure we can attach things like long presses. The pointer cursor should be reserved for actual buttons. 

## Changes

- made Pressable carry any cursor settings through
- replaced `none` with `default` because this was making the cursor disappear
- applied `cursor="default"` to `BlockRenderer` and `ReactionsDisplay` in places where it was incorrect to have the value be `"pointer"`

## How did I test?

Manually tested with pnpm dev hovering over chat messages to make sure we didn't see places with pointer where it should be default.

## Risks and impact

- Safe to rollback without consulting PR author? Yes
- Affects important code area:
  - [ ] Onboarding
  - [ ] State / providers
  - [ ] Message sync
  - [ ] Channel display
  - [ ] Notifications

## Rollback plan

<!-- Describe the steps to revert these changes if needed. -->

## Screenshots / videos

<!-- Attach any relevant media. -->
