### PR TITLE
channels: sequence number recovery

### DIFF
--- a/desk/app/channels-server.hoon
+++ b/desk/app/channels-server.hoon
@@ -107,10 +107,10 @@
   =?  old  ?=(%5 -.old)  (state-5-to-6 old)
   =?  old  ?=(%6 -.old)  (state-6-to-7 old)
   =?  old  ?=(%7 -.old)  (state-7-to-8 old)
-  =^  moz-8=(list card)  old
+  =^  caz-8=(list card)  old
     ?.  ?=(%8 -.old)  [~ old]
     (state-8-to-9 old)
-  =.  cor  (emil moz-8)
+  =.  cor  (emil caz-8)
   ?>  ?=(%9 -.old)
   =.  state  old
   inflate-io
@@ -363,11 +363,25 @@
       %noun
     ?+  q.vase  !!
         %pimp-ready
+      ?>  =(our src):bowl
       ?-  pimp
         ~         cor(pimp `&+~)
         [~ %& *]  cor
         [~ %| *]  (run-import p.u.pimp)
       ==
+    ::
+        [%send-sequence-numbers *]
+      =+  !<([%send-sequence-numbers =nest:c] vase)
+      ?~  can=(~(get by v-channels) nest)  cor
+      =;  =cage
+        (emit [%pass /numbers %agent [src.bowl %channels] %poke cage])
+      :-  %noun
+      !>  :+  %sequence-numbers
+        nest
+      ^-  (list [id-post:c @ud])
+      %+  murn  (tap:on-v-posts:c posts.u.can)
+      |=  [i=id-post:c p=(unit v-post:c)]
+      ?~(p ~ (some [i seq.u.p]))
     ==
   ::
       %channel-command
@@ -545,9 +559,10 @@
   |=  [=(pole knot) =sign:agent:gall]
   ^+  cor
   ?+    pole  ~|(bad-agent-wire+pole !!)
-    [%logs ~]  cor
-    [%pimp ~]  cor
-    [%wake ~]  cor
+    [%logs ~]     cor
+    [%pimp ~]     cor
+    [%wake ~]     cor
+    [%numbers ~]  cor
   ::
       [=kind:c *]
     ?+    -.sign  !!

--- a/desk/app/channels-server.hoon
+++ b/desk/app/channels-server.hoon
@@ -376,8 +376,8 @@
       =;  =cage
         (emit [%pass /numbers %agent [src.bowl %channels] %poke cage])
       :-  %noun
-      !>  :+  %sequence-numbers
-        nest
+      !>  :^  %sequence-numbers  nest
+        count.u.can
       ^-  (list [id-post:c @ud])
       %+  murn  (tap:on-v-posts:c posts.u.can)
       |=  [i=id-post:c p=(unit v-post:c)]

--- a/desk/app/channels-server.hoon
+++ b/desk/app/channels-server.hoon
@@ -17,7 +17,7 @@
   |%
   +$  card  card:agent:gall
   +$  current-state
-    $:  %8
+    $:  %9
         =v-channels:c
         =hooks:h
         =pimp:imp
@@ -107,12 +107,17 @@
   =?  old  ?=(%5 -.old)  (state-5-to-6 old)
   =?  old  ?=(%6 -.old)  (state-6-to-7 old)
   =?  old  ?=(%7 -.old)  (state-7-to-8 old)
-  ?>  ?=(%8 -.old)
+  =^  moz-8=(list card)  old
+    ?.  ?=(%8 -.old)  [~ old]
+    (state-8-to-9 old)
+  =.  cor  (emil moz-8)
+  ?>  ?=(%9 -.old)
   =.  state  old
   inflate-io
   ::
   +$  versioned-state
-    $%  state-8
+    $%  state-9
+        state-8
         state-7
         state-6
         state-5
@@ -122,7 +127,13 @@
         state-1
         state-0
     ==
-  +$  state-8  current-state
+  +$  state-9  current-state
+  +$  state-8
+    $:  %8
+        =v-channels:c
+        =hooks:h
+        =pimp:imp
+    ==
   +$  state-7
     $:  %7
         =v-channels:v7:old:c
@@ -134,6 +145,29 @@
       =v-channels:v7:old:c
       =pimp:imp
     ==
+  ++  state-8-to-9
+    |=  s=state-8
+    ^-  (quip card state-9)
+    =-  [caz s(- %9, v-channels chans)]
+    %+  roll  ~(tap by v-channels.s)
+    |=  $:  [k=nest:c v=v-channel:c]
+            [caz=(list card) chans=v-channels:c]
+        ==
+    ^+  [caz chans]
+    =-  [(weld coz caz) (~(put by chans) k chan)]
+    %+  roll  (tap:log-on:c log.v)
+    |=  $:  [t=time u=u-channel:c]
+            [coz=(list card) chan=_v]
+        ==
+    ?.  ?=([%post * %set ~] u)  [coz chan]
+    ~?  ?=([~ ~ *] (get:on-v-posts:c posts.chan id.u))
+      %strange-existing-deleted-posts
+    :-  :_  coz
+        =/  paths=(list path)
+          ~(ca-subscription-paths ca-core k chan |)
+        [%give %fact paths %channel-update !>(`update:c`[t u])]
+    =-  chan(posts -)
+    (put:on-v-posts:c posts.chan id.u ~)
   ++  state-7-to-8
     |=  s=state-7
     ^-  state-8

--- a/desk/app/channels.hoon
+++ b/desk/app/channels.hoon
@@ -522,13 +522,15 @@
         [~ %| *]  (run-import p.u.pimp)
       ==
     ::
-        [%sequence-numbers * *]
-      =+  !<([%sequence-numbers =nest:c seqs=(list [id=id-post:c seq=@ud])] vase)
+        [%sequence-numbers * @ *]
+      =+  !<([%sequence-numbers =nest:c count=@ud seqs=(list [id=id-post:c seq=@ud])] vase)
       ?>  =(src.bowl ship.nest)
       ?.  (~(has by v-channels) nest)  cor
       =.  v-channels
         %+  ~(jab by v-channels)  nest
         |=  channel=v-channel:c
+        =.  count.channel  count
+        |-
         ?~  seqs  channel
         =*  next  $(seqs t.seqs)
         ?~  p=(get:on-v-posts:c posts.channel id.i.seqs)  next
@@ -1612,7 +1614,7 @@
     =/  old  posts.channel
     =.  posts.channel
       ((uno:mo-v-posts:c posts.channel posts.chk) ca-apply-unit-post)
-    =.  count.channel  ~(wyt by posts.channel)
+    =.  count.channel  count.chk
     =?  ca-core  &(send !=(old posts.channel))
       %+  ca-response  %posts
       %+  gas:on-posts:c  *posts:c
@@ -1730,7 +1732,7 @@
           (on-post:ca-hark id-post u.post.u-post)
         =.  posts.channel  (put:on-v-posts:c posts.channel id-post post.u-post)
         =?  count.channel  ?=(^ post.u-post)
-          +(count.channel)
+          (max count.channel seq.u.post.u-post)
         =?  pending.channel  ?=(^ post.u-post)
           =/  client-id  [author sent]:u.post.u-post
           pending.channel(posts (~(del by posts.pending.channel) client-id))

--- a/desk/app/channels.hoon
+++ b/desk/app/channels.hoon
@@ -32,7 +32,7 @@
   |%
   +$  card  card:agent:gall
   +$  current-state
-    $:  %8
+    $:  %9
         =v-channels:c
         voc=(map [nest:c plan:c] (unit said:c))
         hidden-posts=(set id-post:c)
@@ -139,12 +139,26 @@
   =?  old  ?=(%5 -.old)  (state-5-to-6 old)
   =?  old  ?=(%6 -.old)  (state-6-to-7 old)
   =?  old  ?=(%7 -.old)  (state-7-to-8 old)
-  ?>  ?=(%8 -.old)
+  =^  caz-8=(list card)  old
+    ?.  ?=(%8 -.old)  [~ old]
+    :_  old(- %9)
+    %+  turn  ~(tap in ~(key by v-channels.old))
+    |=  =nest:c
+    ^-  card
+    :+  %pass
+      /numbers/[kind.nest]/(scot %p ship.nest)/[name.nest]
+    ::  slightly staggered to spread load. might not be strictly necessary
+    ::  for this, but good practice.
+    ::
+    [%arvo %b %wait (add now.bowl (~(rad og (sham our.bowl nest)) ~m15))]
+  =.  cor  (emil caz-8)
+  ?>  ?=(%9 -.old)
   =.  state  old
   inflate-io
   ::
   +$  versioned-state
-    $%  state-8
+    $%  state-9
+        state-8
         state-7
         state-6
         state-5
@@ -154,7 +168,20 @@
         state-1
         state-0
     ==
-  +$  state-8  current-state
+  +$  state-9  current-state
+  +$  state-8
+    $:  %8
+        =v-channels:c
+        voc=(map [nest:c plan:c] (unit said:c))
+        hidden-posts=(set id-post:c)
+      ::
+        ::  .pending-ref-edits: for migration, see also +poke %negotiate-notif
+        ::
+        pending-ref-edits=(jug ship [=kind:c name=term])
+        :: delayed resubscribes
+        =^subs:s
+        =pimp:imp
+    ==
   +$  state-7
     $:  %7
         =v-channels:v7:old:c
@@ -488,11 +515,28 @@
       ca-abet:(ca-safe-sub:(ca-abed:ca-core nest) |)
     ::
         %pimp-ready
+      ?>  =(our src):bowl
       ?-  pimp
         ~         cor(pimp `&+~)
         [~ %& *]  cor
         [~ %| *]  (run-import p.u.pimp)
       ==
+    ::
+        [%sequence-numbers * *]
+      =+  !<([%sequence-numbers =nest:c seqs=(list [id=id-post:c seq=@ud])] vase)
+      ?>  =(src.bowl ship.nest)
+      ?.  (~(has by v-channels) nest)  cor
+      =.  v-channels
+        %+  ~(jab by v-channels)  nest
+        |=  channel=v-channel:c
+        ?~  seqs  channel
+        =*  next  $(seqs t.seqs)
+        ?~  p=(get:on-v-posts:c posts.channel id.i.seqs)  next
+        ?~  u.p  next
+        =.  posts.channel
+          (put:on-v-posts:c posts.channel id.i.seqs u.p(seq.u seq.i.seqs))
+        next
+      cor
     ==
   ::
     :: TODO: add transfer/import channels
@@ -815,7 +859,19 @@
       ~          cor
       [%pimp ~]  cor
       [%logs ~]  cor
+  ::
+      [%numbers *]
+    ?>  ?=(%poke-ack -.sign)
+    ?~  p.sign
+      ::  they accepted, we will receive the sequence numbers
+      ::
+      cor
+    ::  they refused, we will retry again later
     ::
+    =/  stagger=@dr
+      (~(rad og (sham our.bowl pole)) ~m15)
+    (emit [%pass pole %arvo %b %wait :(add now.bowl ~h1 stagger)])
+  ::
       [%hark ~]
     ?>  ?=(%poke-ack -.sign)
     ?~  p.sign  cor
@@ -995,6 +1051,13 @@
     =^  caz=(list card)  subs
       (~(handle-wakeup s [subs bowl]) pole)
     (emil caz)
+  ::
+      [%numbers kind=?(%chat %diary %heap) ship=@ name=@ ~]
+    =/  host=ship  (slav %p ship.pole)
+    =/  =nest:c    [kind.pole host name.pole]
+    %-  emit
+    =/  =cage  [%noun !>([%send-sequence-numbers nest])]
+    [%pass pole %agent [host %channels-server] %poke cage]
   ==
 ::
 ++  unreads

--- a/desk/lib/channel-utils.hoon
+++ b/desk/lib/channel-utils.hoon
@@ -1347,7 +1347,11 @@
   ::
   =.  count  +(count)
   :-  count
-  ?~  post  posts
+  ?~  post
+    ::NOTE  this used to just produce .posts as-is,
+    ::      which meant deleted msg tombstones got dropped!
+    ::      you will find logic to recover those in both channels agents.
+    (put:on-v-posts:c posts id-post ~)
   ::  insert seq and mod-at into seal
   ::
   =;  new-post=v-post:c


### PR DESCRIPTION
## Summary

Recent channels protocol upgrade added sequence numbers. This had two problems:
1. The way the migration was implemented caused tombstones for deleted messages to be dropped from state.
2. Channels agent is not guaranteed to have the full message backlog, and so might come up with different sequence numbers than the host.

This PR attempts to post-hoc fix those problem.

## Changes

9da6784 makes the channels-server recover deleted messages from the log: it inserts the tombstones back into the `posts` map and sends out `%channel-update` facts to all subscribers. This solves (1).

a68a2f4 makes channels agent ask the host of each channel it knows about to send back the sequence number for each message. If the host hasn't updated yet, it will nack, and channels agent will retry later. If it understands the request, it will poke back with a list of `id-post`-sequence-number pairs. The channels agent will apply this to the messages it has in state. This solves (2).

1eaab50 attempts to make sure that subscribers always have the same `count` on a channel that the publisher does, and respects the highest number it's heard from the host (as opposed to blindly incrementing the number like we do now).

1442fab fixes the migration logic that caused (1). This way, the "host re-sends the tombstones" fix doesn't need to be re-run for subscribers that are late to the party. (REVIEW: Can we _guarantee_ subscribers retain their tombstones? Unclear. Certainly it'd require another "negotiation" mechanism, which is complexity that might be greater than the size of the gap it'd fill.)

## How did I test?

Ran the bad migration, observed dropped state. Ran the migration from this PR, observed deleted message tombstones returned in both agents.

Have not yet tested over the network, have not yet tested with partial backlog (for which the sequence number negotiation part is important).

## Risks and impact

The sequence number "negotiation" in a68a2f4 feels a tad risky, especially when imagining a ship that is in a ton of channels. The perceived risk is around processing load. To mitigate, we spread these out over 15 minutes, and wait at least an hour between retries. Individual negotiations shouldn't be horrible, but we can and should try to pull some numbers.

- Not safe to rollback without consulting PR author.
- Affects important code area:
  - [ ] Onboarding
  - [ ] State / providers
  - [x] Message sync
  - [ ] Channel display
  - [ ] Notifications

## Rollback plan

We actually don't change the state type, so rolling back would be easy (but doesn't work out-the-box due to state version tag).

## Screenshots / videos

Nah.
