### PR TITLE
chat: fix longpress on chat images

### DIFF
--- a/packages/app/ui/components/ChatMessage/ChatMessage.tsx
+++ b/packages/app/ui/components/ChatMessage/ChatMessage.tsx
@@ -245,6 +245,7 @@ const ChatMessage = ({
             content={post.editStatus === 'failed' ? lastEditContent : content}
             isNotice={post.type === 'notice'}
             onPressImage={handleImagePressed}
+            onLongPress={handleLongPress}
           />
         </View>
 


### PR DESCRIPTION
## Summary

Fixes the issue where users couldn't longpress on an image (posted to chat) to bring up the chat message actions (so they can react, quote it, start a thread, etc.)

## Changes

We actually do account for handling longpress on images in BlockRenderer, we just weren't passing the `handleLongPress` handler as a prop into ChatContentRenderer. If we pass it in, long pressing on an image in a chat works as expected.

## How did I test?

Tested on the iOS simulator and Android emulator.

## Risks and impact

- Safe to rollback without consulting PR author? Yes, but the bug will come back.
- Affects important code area:
  - [ ] Onboarding
  - [ ] State / providers
  - [ ] Message sync
  - [ ] Channel display
  - [ ] Notifications

## Rollback plan

Revert the merge commit.

## Screenshots / videos


https://github.com/user-attachments/assets/970025a0-90a4-4ac8-9e4b-944eb06e4d03


