### PR TITLE
gallery detail view: fix issue with the send button not working on the reply input

### DIFF
--- a/packages/app/ui/components/PostScreenView.tsx
+++ b/packages/app/ui/components/PostScreenView.tsx
@@ -698,6 +698,7 @@ export function PresentationalCarouselPostScreenContent({
           initialNumToRender: 3,
           maxToRenderPerBatch: 3,
           windowSize: 3,
+          keyboardShouldPersistTaps: 'handled',
         }}
       >
         {carouselChildren}


### PR DESCRIPTION
## Summary
fixes tlon-4282

There was an issue with the reply input's send button not being pressable/interactable on mobile when the keyboard was open. The user could type some text with their keyboard, then press the send/arrowup button, the keyboard would then dismiss, and the user's message wouldn't be sent. If the user then pressed the send button *again* after the keyboard was dismissed, the message would send. This only happened in the Gallery detail view, not Notebook or the chat-like channels.

The Gallery detail view was the only one rendered within a Carousel, which is what led me to look at Carousel.

It turns out that this was happening because touch events were getting captured by the FlatList in Carousel while the keyboard was open. Apparently, we need to pass `"handled"` to the `keyboardShouldPersistTaps` prop on FlatList if we don't want FlatList itself to determine when/if the keyboard should be dismissed.

More details on this prop (FlatList inherits it from ScrollView): https://reactnative.dev/docs/scrollview#keyboardshouldpersisttaps

The carousel functionality still works as intended with this change.

## Changes

Passes `"handled"` to `keyboardShouldPeristTaps` prop on FlatList in the Carousel component.

## How did I test?

Tested on iOS simulator and Android emulator. 

## Risks and impact

- Safe to rollback without consulting PR author? Yes, but we'll still have this bug.
- Affects important code area:
  - [ ] Onboarding
  - [ ] State / providers
  - [ ] Message sync
  - [ ] Channel display
  - [ ] Notifications

## Rollback plan

Revert the merge commit.

## Screenshots / videos

https://github.com/user-attachments/assets/29f4bbb6-74c0-43f5-aa74-8a1500acb245


