### PR TITLE
android: bump targetSdkVersion to 35

### DIFF
--- a/apps/tlon-mobile/android/build.gradle
+++ b/apps/tlon-mobile/android/build.gradle
@@ -5,7 +5,7 @@ buildscript {
         buildToolsVersion = findProperty('android.buildToolsVersion') ?: '34.0.0'
         minSdkVersion = Integer.parseInt(findProperty('android.minSdkVersion') ?: '28')
         compileSdkVersion = Integer.parseInt(findProperty('android.compileSdkVersion') ?: '34')
-        targetSdkVersion = Integer.parseInt(findProperty('android.targetSdkVersion') ?: '34')
+        targetSdkVersion = Integer.parseInt(findProperty('android.targetSdkVersion') ?: '35')
         kotlinVersion = findProperty('android.kotlinVersion') ?: '1.9.23'
 
         ndkVersion = "26.1.10909125"


### PR DESCRIPTION
## Summary

Make google happy by bumping targetSdkVersion to 35.

fixes tlon-4508

## Changes

Changes `34` to `35`.

## How did I test?

I made sure the app still builds with targetSdkVersion 35, it does.

## Risks and impact

- Safe to rollback without consulting PR author? Yes, but google will be mad.
- Affects important code area:
  - [ ] Onboarding
  - [ ] State / providers
  - [ ] Message sync
  - [ ] Channel display
  - [ ] Notifications

## Rollback plan

revert the merge commit