### PR TITLE
various: /lib/discipline integration

### DIFF
--- a/desk/app/channels-server.hoon
+++ b/desk/app/channels-server.hoon
@@ -4,8 +4,49 @@
 ::
 /-  c=channels, g=groups, h=hooks, m=meta
 /+  utils=channel-utils, imp=import-aid
-/+  default-agent, verb, dbug, neg=negotiate, logs
+/+  default-agent, verb, dbug,
+    neg=negotiate, discipline, logs
 /+  hj=hooks-json
+::
+/%  m-channel-checkpoint    %channel-checkpoint
+/%  m-channel-denied        %channel-denied
+/%  m-channel-logs          %channel-logs
+/%  m-channel-said-1        %channel-said-1
+/%  m-channel-update        %channel-update
+/%  m-hook-channel-preview  %hook-channel-preview
+/%  m-hook-full             %hook-full
+/%  m-hook-response-0       %hook-response-0
+/%  m-hook-template         %hook-template
+::
+%-  %-  discipline
+    :+  ::  marks
+        ::
+        :~  :+  %channel-checkpoint    |  -:!>(*vale:m-channel-checkpoint)
+            :+  %channel-denied        |  -:!>(*vale:m-channel-denied)
+            :+  %channel-logs          |  -:!>(*vale:m-channel-logs)
+            :+  %channel-said-1        |  -:!>(*vale:m-channel-said-1)
+            :+  %channel-update        |  -:!>(*vale:m-channel-update)
+            :+  %hook-channel-preview  |  -:!>(*vale:m-hook-channel-preview)
+            :+  %hook-full             |  -:!>(*vale:m-hook-full)
+            :+  %hook-response-0       |  -:!>(*vale:m-hook-response-0)
+            :+  %hook-template         |  -:!>(*vale:m-hook-template)
+        ==
+      ::  facts
+      ::
+      :~  [/$/$/checkpoint %channel-checkpoint ~]
+          [/$/$/create %channel-update ~]
+          [/$/$/updates %channel-update %channel-logs ~]
+          [/said %channel-said-1 %channel-denied ~]
+        ::
+          [/v0/hooks %hook-response-0 ~]
+          [/v0/hooks/full %hook-full ~]
+          [/v0/hooks/preview %hook-channel-preview ~]
+          [/v0/hooks/template %hook-template ~]
+      ==
+    ::  scries
+    ::
+    :~  [/x/v0/hooks %hook-full]
+    ==
 ::
 %-  %-  agent:neg
     [| [~.channels^%2 ~ ~] ~]

--- a/desk/app/channels.hoon
+++ b/desk/app/channels.hoon
@@ -10,14 +10,147 @@
 ::
 /-  c=channels, g=groups, ha=hark, activity
 /-  meta
-/+  default-agent, verb, dbug, sparse, neg=negotiate, imp=import-aid, logs
+/+  default-agent, verb, dbug,
+    neg=negotiate, discipline, logs,
+    sparse, imp=import-aid
 /+  utils=channel-utils, volume, s=subscriber, em=emojimart
 ::  performance, keep warm
 /+  channel-json
 ::
-::  compile all marks
-::XX  /~ rune is broken, see urbit issue #5242
-:: /~  marks  *  /mar/channel
+/%  m-channel-heads           %channel-heads
+/%  m-channel-heads-2         %channel-heads-2
+/%  m-channel-perm            %channel-perm
+/%  m-channel-post            %channel-post
+/%  m-channel-post-2          %channel-post-2
+/%  m-channel-post-3          %channel-post-3
+/%  m-channel-posts           %channel-posts
+/%  m-channel-posts-2         %channel-posts-2
+/%  m-channel-posts-3         %channel-posts-3
+/%  m-channel-replies         %channel-replies
+/%  m-channel-replies-2       %channel-replies-2
+/%  m-channel-replies-3       %channel-replies-3
+/%  m-channel-reply           %channel-reply
+/%  m-channel-reply-2         %channel-reply-2
+/%  m-channel-response        %channel-response
+/%  m-channel-response-2      %channel-response-2
+/%  m-channel-response-3      %channel-response-3
+/%  m-channel-said            %channel-said
+/%  m-channel-said-1          %channel-said-1
+/%  m-channel-scan            %channel-scan
+/%  m-channel-simple-post     %channel-simple-post
+/%  m-channel-simple-posts    %channel-simple-posts
+::NOTE  these fail to build with /%, but can be built from dojo just fine.
+::      presuming a mark filepath resolution bug in clay...
+:: /%  m-channel-simple-replies  %channel-simple-replies
+:: /%  m-channel-simple-reply    %channel-simple-reply
+/%  m-channel-unread-update   %channel-unread-update
+/%  m-channel-unreads         %channel-unreads
+/%  m-channels                %channels
+/%  m-channels-2              %channels-2
+/%  m-channels-3              %channels-3
+/%  m-hidden-posts            %hidden-posts
+/%  m-hook-channel-preview    %hook-channel-preview
+/%  m-toggle-post             %toggle-post
+::
+%-  %-  discipline
+    :+  ::  marks
+        ::
+        :~  :+  %channel-heads           &  -:!>(*vale:m-channel-heads)
+            :+  %channel-heads-2         &  -:!>(*vale:m-channel-heads-2)
+            :+  %channel-perm            &  -:!>(*vale:m-channel-perm)
+            :+  %channel-post            &  -:!>(*vale:m-channel-post)
+            :+  %channel-post-2          &  -:!>(*vale:m-channel-post-2)
+            :+  %channel-post-3          &  -:!>(*vale:m-channel-post-3)
+            :+  %channel-posts           &  -:!>(*vale:m-channel-posts)
+            :+  %channel-posts-2         &  -:!>(*vale:m-channel-posts-2)
+            :+  %channel-posts-3         &  -:!>(*vale:m-channel-posts-3)
+            :+  %channel-replies         &  -:!>(*vale:m-channel-replies)
+            :+  %channel-replies-2       &  -:!>(*vale:m-channel-replies-2)
+            :+  %channel-replies-3       &  -:!>(*vale:m-channel-replies-3)
+            :+  %channel-reply           &  -:!>(*vale:m-channel-reply)
+            :+  %channel-reply-2         &  -:!>(*vale:m-channel-reply-2)
+            :+  %channel-response        &  -:!>(*vale:m-channel-response)
+            :+  %channel-response-2      &  -:!>(*vale:m-channel-response-2)
+            :+  %channel-response-3      &  -:!>(*vale:m-channel-response-3)
+            :+  %channel-said            &  -:!>(*vale:m-channel-said)
+            :+  %channel-said-1          &  -:!>(*vale:m-channel-said-1)
+            :+  %channel-scan            &  -:!>(*vale:m-channel-scan)
+            :+  %channel-simple-post     &  -:!>(*vale:m-channel-simple-post)
+            :+  %channel-simple-posts    &  -:!>(*vale:m-channel-simple-posts)
+            :: :+  %channel-simple-replies  &  -:!>(*vale:m-channel-simple-replies)
+            :: :+  %channel-simple-reply    &  -:!>(*vale:m-channel-simple-reply)
+            :+  %channel-unread-update   &  -:!>(*vale:m-channel-unread-update)
+            :+  %channel-unreads         &  -:!>(*vale:m-channel-unreads)
+            :+  %channels                &  -:!>(*vale:m-channels)
+            :+  %channels-2              &  -:!>(*vale:m-channels-2)
+            :+  %channels-3              &  -:!>(*vale:m-channels-3)
+            :+  %hidden-posts            &  -:!>(*vale:m-hidden-posts)
+            :+  %hook-channel-preview    &  -:!>(*vale:m-hook-channel-preview)
+            :+  %toggle-post             &  -:!>(*vale:m-toggle-post)
+        ==
+      ::  facts
+      ::
+      :~  [/ %channel-response %toggle-post ~]
+          [/said %channel-said ~]
+          [/unreads %channel-unread-update ~]
+        ::
+          [/v0 %channel-response ~]
+          [/v0/said %channel-said ~]
+          [/v0/unreads %channel-unread-update ~]
+        ::
+          [/v1 %channel-response-2 ~]
+          [/v1/hooks/preview %hook-channel-preview ~]  ::REVIEW
+          [/v1/said %channel-said ~]
+          [/v1/unreads %channel-unread-update ~]
+        ::
+          [/v2 %channel-response-3 ~]
+          [/v2/said %channel-said-1 ~]
+        ::
+          [/v3/said %channel-said-1 ~]
+      ==
+    ::  scries
+    ::
+    :~  [/x/$/$/$/perm %channel-perm]
+        [/x/$/$/$/posts %channel-posts]
+        [/x/$/$/$/search %channel-scan]
+        [/x/$/init %noun]
+        [/x/channels %channels]
+        [/x/init %noun]
+        [/x/pins %channel-pins]
+        [/x/unreads %channel-unreads]
+      ::
+        [/x/v0/$/$/$/posts %channel-simple-posts]
+        [/x/v0/$/$/$/posts/post %channel-simple-post]
+        [/x/v0/$/$/$/posts/post/id/$/replies %channel-simple-replies]
+        [/x/v0/$/$/$/posts/post/id/$/replies/reply %channel-simple-reply]
+        [/x/v0/channels %channels]
+        [/x/v0/hidden-posts %hidden-posts]
+        [/x/v0/unreads %channel-unreads]
+      ::
+        [/x/v1/$/$/$/posts %channel-posts]
+        [/x/v1/$/$/$/posts/post %channel-post]
+        [/x/v1/$/$/$/posts/post/id/$/replies %channel-replies]
+        [/x/v1/$/$/$/posts/post/id/$/replies/reply %channel-reply]
+        [/x/v1/channels %channels]
+        [/x/v1/hidden-posts %hidden-posts]
+        [/x/v1/unreads %channel-unreads]
+      ::
+        [/x/v2/$/$/$/posts %channel-posts-2]
+        [/x/v2/$/$/$/posts/post %channel-post-2]
+        [/x/v2/$/$/$/posts/post/id/$/replies %channel-replies-2]
+        [/x/v2/$/$/$/posts/post/id/$/replies/reply %channel-reply]
+        [/x/v2/channels %channels-2]
+        [/x/v2/heads %channel-heads]
+      ::
+        [/x/v3/$/$/$/posts %channel-posts-3]
+        [/x/v3/$/$/$/posts/post %channel-post-3]
+        [/x/v3/$/$/$/posts/post/id/$/replies %channel-replies-3]
+        [/x/v3/$/$/$/posts/post/id/$/replies/reply %channel-reply-2]
+        [/x/v3/channels %channels-3]
+        [/x/v3/heads %channel-heads-2]
+        [/x/v3/said %noun]
+        [/x/v3/v-channels %channels-3]  ::REVIEW  shenanigans!
+    ==
 ::
 =/  verbose  |
 %-  %-  agent:neg

--- a/desk/app/channels.hoon
+++ b/desk/app/channels.hoon
@@ -149,7 +149,7 @@
         [/x/v3/channels %channels-3]
         [/x/v3/heads %channel-heads-2]
         [/x/v3/said %noun]
-        [/x/v3/v-channels %channels-3]  ::REVIEW  shenanigans!
+        [/x/v3/v-channels %noun]
     ==
 ::
 =/  verbose  |
@@ -1060,7 +1060,7 @@
     ``channels-2+!>(`channels:v1:old:c`(uv-channels:utils v-channels ?=(^ full.pole)))
     ::
       [%x %v3 %v-channels ~]
-    ``channels-3+!>(v-channels)
+    ``noun+!>(v-channels)
     ::
       [%x %v3 %channels full=?(~ [%full ~])]
     ``channels-3+!>(`channels:c`(uv-channels-2:utils v-channels ?=(^ full.pole)))

--- a/desk/app/chat.hoon
+++ b/desk/app/chat.hoon
@@ -76,7 +76,6 @@
           [/epic %epic ~]
           [/unreads %chat-unread-update ~]
         ::
-          [/v1 %chat-club-action-1 %writ-response ~]
           [/v1 %chat-club-action-1 %writ-response-1 ~]
           [/v1/club/$ %writ-response-1 ~]
           [/v1/clubs %chat-club-action-1 ~]

--- a/desk/app/chat.hoon
+++ b/desk/app/chat.hoon
@@ -2,7 +2,9 @@
 /-  old-3=chat-3, old-2=chat-2
 /-  ha=hark
 /-  contacts-0
-/+  default-agent, verb-lib=verb, dbug, neg=negotiate, em=emojimart, logs
+/+  default-agent, verb-lib=verb, dbug,
+    neg=negotiate, discipline, logs,
+    em=emojimart
 /+  pac=dm
 /+  utils=channel-utils
 /+  volume
@@ -10,7 +12,105 @@
 /+  epos-lib=saga
 ::  performance, keep warm
 /+  chat-json
-/*  desk-bill  %bill  /desk/bill
+::
+/%  m-chat-blocked-by      %chat-blocked-by
+/%  m-chat-club-action     %chat-club-action
+/%  m-chat-club-action-1   %chat-club-action-1
+/%  m-chat-heads           %chat-heads
+/%  m-chat-heads-1         %chat-heads-1
+/%  m-chat-paged-writs     %chat-paged-writs
+/%  m-chat-pins            %chat-pins
+/%  m-chat-scam            %chat-scam
+/%  m-chat-scam-1          %chat-scam-1
+/%  m-chat-scan            %chat-scan
+/%  m-chat-scan-1          %chat-scan-1
+/%  m-chat-toggle-message  %chat-toggle-message
+/%  m-chat-unblocked-by    %chat-unblocked-by
+/%  m-chat-unread-update   %chat-unread-update
+/%  m-chat-unreads         %chat-unreads
+/%  m-chat-writ-1          %chat-writ-1
+/%  m-clubs                %clubs
+/%  m-epic                 %epic
+/%  m-hidden-messages      %hidden-messages
+/%  m-ships                %ships
+/%  m-writ                 %writ
+/%  m-writ-response        %writ-response
+/%  m-writ-response-1      %writ-response-1
+::
+/*  desk-bill  %bill  /desk/bill  ::  keep warm
+::
+%-  %-  discipline
+    :+  ::  marks
+        ::
+        :~  :+  %chat-blocked-by      &  -:!>(*vale:m-chat-blocked-by)
+            :+  %chat-club-action     &  -:!>(*vale:m-chat-club-action)
+            :+  %chat-club-action-1   &  -:!>(*vale:m-chat-club-action-1)
+            :+  %chat-heads           &  -:!>(*vale:m-chat-heads)
+            :+  %chat-heads-1         &  -:!>(*vale:m-chat-heads-1)
+            :+  %chat-paged-writs     &  -:!>(*vale:m-chat-paged-writs)
+            :+  %chat-pins            &  -:!>(*vale:m-chat-pins)
+            :+  %chat-scam            &  -:!>(*vale:m-chat-scam)
+            :+  %chat-scam-1          &  -:!>(*vale:m-chat-scam-1)
+            :+  %chat-scan            &  -:!>(*vale:m-chat-scan)
+            :+  %chat-scan-1          &  -:!>(*vale:m-chat-scan-1)
+            :+  %chat-toggle-message  &  -:!>(*vale:m-chat-toggle-message)
+            :+  %chat-unblocked-by    &  -:!>(*vale:m-chat-unblocked-by)
+            :+  %chat-unread-update   &  -:!>(*vale:m-chat-unread-update)
+            :+  %chat-unreads         &  -:!>(*vale:m-chat-unreads)
+            :+  %chat-writ-1          &  -:!>(*vale:m-chat-writ-1)
+            :+  %clubs                &  -:!>(*vale:m-clubs)
+            :+  %epic                 &  -:!>(*vale:m-epic)
+            :+  %hidden-messages      &  -:!>(*vale:m-hidden-messages)
+            :+  %ships                &  -:!>(*vale:m-ships)
+            :+  %writ                 &  -:!>(*vale:m-writ)
+            :+  %writ-response        &  -:!>(*vale:m-writ-response)
+            :+  %writ-response-1      &  -:!>(*vale:m-writ-response-1)
+        ==
+      ::  facts
+      ::
+      :~  [/ %chat-blocked-by %chat-unblocked-by %chat-toggle-message %chat-club-action %writ-response %ships ~]
+          [/club/$ %writ-response ~]
+          [/clubs %chat-club-action ~]
+          [/dm/$ %writ-response ~]
+          [/dm/invited %ships ~]
+          [/epic %epic ~]
+          [/unreads %chat-unread-update ~]
+        ::
+          [/v1 %chat-club-action-1 %writ-response ~]
+          [/v1 %chat-club-action-1 %writ-response-1 ~]
+          [/v1/club/$ %writ-response-1 ~]
+          [/v1/clubs %chat-club-action-1 ~]
+          [/v1/dm/$ %writ-response-1 ~]
+      ==
+    ::  scries
+    ::
+    :~  [/x/blocked %ships]
+        [/x/blocked-by %ships]
+        [/x/clubs %clubs]
+        [/x/dm %ships]
+        [/x/dm/$/search %chat-scan]
+        [/x/dm/$/search/bounded %chat-scam]
+        [/x/dm/$/writs %chat-paged-writs]
+        [/x/dm/$/writs/writ %writ]
+        [/x/dm/archive %ships]
+        [/x/dm/invited %ships]
+        [/x/full %noun]
+        [/x/heads %chat-heads]
+        [/x/hidden-messages %hidden-messages]
+        [/x/init %noun]
+        [/x/old %noun]
+        [/x/pins %chat-pins]
+        [/x/unreads %chat-unreads]
+      ::
+        [/x/v1/club/$/writs %chat-paged-writs]
+        [/x/v1/club/$/writs/writ %chat-writ-1]
+        [/x/v1/dm/$/search %chat-scan-1]
+        [/x/v1/dm/$/search/bounded %chat-scam-1]
+        [/x/v1/dm/$/writs %chat-paged-writs-1]
+        [/x/v1/dm/$/writs/writ %chat-writ-1]
+        [/x/v1/heads %chat-heads-1]
+        [/x/v1/init %noun]
+    ==
 ::
 %-  %-  agent:neg
     :+  |

--- a/desk/mar/chat/blocked-by.hoon
+++ b/desk/mar/chat/blocked-by.hoon
@@ -9,6 +9,6 @@
   --
 ++  grab
   |%
-  ++  noun  ship
+  ++  noun  ship:c
   --
 --

--- a/desk/mar/chat/unblocked-by.hoon
+++ b/desk/mar/chat/unblocked-by.hoon
@@ -9,6 +9,6 @@
   --
 ++  grab
   |%
-  ++  noun  ship
+  ++  noun  ship:c
   --
 --


### PR DESCRIPTION
## Summary

Apply /lib/discipline to chat, channels and channels-server agents.

## Changes

We do a best-effort manual search through the codebase for facts and
scries as they're currently implemented, and explicate their behavior as
arguments to /lib/discipline. This will help us maintain consistent
types and apis going forward.

We also patch up some marks which were found to be broken during this.

## How did I test?

Ran on a local fakezod, used the web client, checked to see if there were any prints from the discipline library. There are not. Note that I did not hit every conceivable codepath, or every old version of the api.

## Risks and impact

- Yes, safe to rollback without consulting PR author.
- Affects important code area:
  - [ ] Onboarding
  - [ ] State / providers
  - [ ] Message sync
  - [ ] Channel display
  - [ ] Notifications

## Rollback plan

`gh revert #4902`

## Screenshots / videos

![image](https://github.com/user-attachments/assets/85ed146e-45ca-4a38-99eb-6e28b256c32c)

