### PR TITLE
perf: batch contact inserts into db

### DIFF
--- a/apps/tlon-web/src/app.tsx
+++ b/apps/tlon-web/src/app.tsx
@@ -155,13 +155,6 @@ function AppRoutes() {
   const { data: groupData } = store.useGroup({
     id: groupId,
   });
-  const { data, refetch, isRefetching, isFetching } = contactsQuery;
-
-  useEffect(() => {
-    if (data?.length === 0 && !isRefetching && !isFetching) {
-      refetch();
-    }
-  }, [data?.length, isRefetching, isFetching, refetch]);
 
   const isMobile = useIsMobile();
   const isDarkMode = useIsDarkMode();

--- a/packages/shared/src/db/queries.ts
+++ b/packages/shared/src/db/queries.ts
@@ -3714,26 +3714,36 @@ export const insertContacts = createWriteQuery(
     });
 
     await withTransactionCtx(ctx, async (txCtx) => {
-      await txCtx.db
-        .insert($contacts)
-        .values(contactsData)
-        .onConflictDoUpdate({
-          target: $contacts.id,
-          set: conflictUpdateSetAll($contacts, ['isBlocked']),
-        });
+      // Batch size to avoid SQLite variable limits
+      const BATCH_SIZE = 100;
+
+      for (let i = 0; i < contactsData.length; i += BATCH_SIZE) {
+        const batch = contactsData.slice(i, i + BATCH_SIZE);
+
+        await txCtx.db
+          .insert($contacts)
+          .values(batch)
+          .onConflictDoUpdate({
+            target: $contacts.id,
+            set: conflictUpdateSetAll($contacts, ['isBlocked']),
+          });
+      }
 
       if (targetGroups.length) {
-        await txCtx.db
-          .insert($groups)
-          .values(targetGroups)
-          .onConflictDoNothing();
+        for (let i = 0; i < targetGroups.length; i += BATCH_SIZE) {
+          const batch = targetGroups.slice(i, i + BATCH_SIZE);
+          await txCtx.db.insert($groups).values(batch).onConflictDoNothing();
+        }
       }
       // TODO: Remove stale pinned groups
       if (contactGroups.length) {
-        await txCtx.db
-          .insert($contactGroups)
-          .values(contactGroups)
-          .onConflictDoNothing();
+        for (let i = 0; i < contactGroups.length; i += BATCH_SIZE) {
+          const batch = contactGroups.slice(i, i + BATCH_SIZE);
+          await txCtx.db
+            .insert($contactGroups)
+            .values(batch)
+            .onConflictDoNothing();
+        }
       }
 
       // clear existing
@@ -3742,19 +3752,27 @@ export const insertContacts = createWriteQuery(
         .where(not(eq($attestations.contactId, currentUserId)));
 
       if (contactAttestations.length) {
-        // reset to current
-        await txCtx.db
-          .insert($attestations)
-          .values(contactAttestations.map((a) => a.attestation as Attestation))
-          .onConflictDoUpdate({
-            target: $attestations.id,
-            set: conflictUpdateSetAll($attestations),
-          });
+        const attestationsToInsert = contactAttestations.map(
+          (a) => a.attestation as Attestation
+        );
+        for (let i = 0; i < attestationsToInsert.length; i += BATCH_SIZE) {
+          const batch = attestationsToInsert.slice(i, i + BATCH_SIZE);
+          await txCtx.db
+            .insert($attestations)
+            .values(batch)
+            .onConflictDoUpdate({
+              target: $attestations.id,
+              set: conflictUpdateSetAll($attestations),
+            });
+        }
 
-        await txCtx.db
-          .insert($contactAttestations)
-          .values(contactAttestations)
-          .onConflictDoNothing();
+        for (let i = 0; i < contactAttestations.length; i += BATCH_SIZE) {
+          const batch = contactAttestations.slice(i, i + BATCH_SIZE);
+          await txCtx.db
+            .insert($contactAttestations)
+            .values(batch)
+            .onConflictDoNothing();
+        }
       }
     });
   },

--- a/packages/shared/src/store/sync.ts
+++ b/packages/shared/src/store/sync.ts
@@ -367,7 +367,7 @@ export const syncContacts = async (ctx?: SyncCtx, yieldWriter = false) => {
   const contacts = await syncQueue.add('contacts', ctx, () =>
     api.getContacts()
   );
-  logger.log('got contacts from api', contacts);
+  logger.log('got contacts from api', contacts.length, 'contacts');
 
   const writer = async () => {
     try {


### PR DESCRIPTION
## Summary
fixes tlon-4510

I noticed that on Chrome (but not the Safari PWA that I use daily on desktop), the web app was (only recently, and only on ~finned-palmer):

1) pegging the CPU
2) not showing any contacts data.

I first did a trace to find out what was causing the app to use so much CPU, saw that it was caused by timers.

I then used this snippet from Claude to find where the timer calls are coming from by placing it in main.tsx:

```
const originalSetTimeout = window.setTimeout;
const originalSetInterval = window.setInterval;

let timerCount = 0;

window.setTimeout = function(callback, delay, ...args) {
  timerCount++;
  console.trace(`setTimeout #${timerCount} created with delay ${delay}ms`);
  return originalSetTimeout.call(this, callback, delay, ...args);
};

window.setInterval = function(callback, delay, ...args) {
  timerCount++;
  console.trace(`setInterval #${timerCount} created with delay ${delay}ms`);
  return originalSetInterval.call(this, callback, delay, ...args);
};
```

This pointed me to the `refetch()` call in the `useEffect` on line 162 of app.tsx:
```
  const { data, refetch, isRefetching, isFetching } = contactsQuery;

  useEffect(() => {
    if (data?.length === 0 && !isRefetching && !isFetching) {
      refetch();
    }
  }, [data?.length, isRefetching, isFetching, refetch]);
```

This `refetch` is from our `contactsQuery`. If I commented this out, the perf issue went away. I noticed that `data.length` was always `0`, which was causing this effect to run continuously. (As an aside, it's not clear to me that we need to be pulling in useContacts (or using this useEffect) here at all. I originally included this as a band-aid when I first started working on the web app and noticed that contacts weren't loading in via the initial sync. Removing this code seems to have no effect on whether contacts are loaded in now, after this fix or on ships with a smaller number of contacts currently)

I checked to make sure that we were actually getting contacts from the backend, and we were.

I noticed that we had a sqlite error in the console:

```
Failed to load cached contacts Error: SQLITE_ERROR: sqlite3 result code 1: too many SQL variables
    at toss3 (sqlite3-bundler-frie…v=6498a523:10701:17)
    at checkSqlite3Rc (sqlite3-bundler-frie…v=6498a523:10720:13)
    at DB.checkRc (sqlite3-bundler-frie…v=6498a523:11033:42)
    at DB.exec (sqlite3-bundler-frie…v=6498a523:11167:20)
    at execOnDb (exec-on-db.js?v=6498a523:6:21)
    at SQLocalProcessor.value [as exec] (processor.js?v=6498a523:186:51)
overrideMethod	@	hook.js:608
loadCachedContacts	@	cachedData.web.ts:37
await in loadCachedContacts		
(anonymous)	@	sync.ts:1577
withCtxOrDefault	@	query.ts:190
batchEffects	@	query.ts:167
syncStart	@	sync.ts:1552
syncStart	@	app.tsx:433
await in syncStart		
(anonymous)	@	app.tsx:502
```

It looked like we were trying to insert too many contacts (in my case, 3655 total) into the db at once.

I updated the insertContacts query to use batching, now the insert works fine. `data.length` from `useContacts` was now non-zero, so the `useEffect` stopped running continuously, CPU usage was normal, and contacts data now shows up in the app.

I went ahead and removed the use of `useContacts` and the associated `useEffect` from `app.tsx`, since it's not necessary.

I have no idea why this was seemingly only affecting CPU usage on Chrome and not Safari. I assume this is safari being very strict about throttling timers. The other weird thing was that my Safari PWA was showing my contact data just fine, but if I loaded the web app in Safari itself it wouldn't. Safari also didn't show the sqlite error message in the console for either the PWA or in Safari itself (even though the contacts data wasn't showing up when loading the web app in Safari itself). With these changes, the app now works fine in both browsers.

I checked Firefox, and it does show the same behavior as chrome (missing contacts data, heavy CPU usage, and the sqlite error). With these changes, it's also fine.

## How did I test?

Tested by pointing the local vite dev server to my ship, testing on Chrome, Safari, and Firefox.

Also ran the app in the iOS simulator and Android emulator just in case, was fine on both (contacts loaded in just fine).

## Risks and impact

- Safe to rollback without consulting PR author? No, the issue will come back.

## Rollback plan

Revert the merge commit.
