### PR TITLE
DMs: fix double embed issue

### DIFF
--- a/packages/app/ui/components/BareChatInput/index.tsx
+++ b/packages/app/ui/components/BareChatInput/index.tsx
@@ -315,13 +315,17 @@ export default function BareChatInput({
           const url = parsedUrl.toString();
 
           setLinkMetaLoading(true);
+          bareChatInputLogger.log('getting link metadata', { url });
           store
             .getLinkMetaWithFallback(url)
             .then((linkMetadata) => {
               // todo: handle error case with toast or similar
               if (!linkMetadata) {
+                bareChatInputLogger.error('no link metadata', { url });
                 return;
               }
+
+              bareChatInputLogger.log('link metadata', { linkMetadata });
 
               // first add the link attachment
               if (linkMetadata.type === 'page') {


### PR DESCRIPTION
## Summary

fixes tlon-4384.

The original problem was that posts from %chat were always in a different order than posts from %channels, and `convertContentSafe` inconsistently handled duplicate embeds/links depending on verse processing order:

- %channels case (block -> inline): Successfully suppressed duplicate inline embeds when a link block already existed
- %chat case (inline -> block): Failed to suppress duplicate link blocks when an embed block already existed

This created different output structures for the same URL depending on whether the rich metadata (block) or basic link (inline) was processed first.

## Changes

- Replace global embed suppression with URL-specific deduplication logic
- Rich link blocks now replace basic embed blocks for the same URL
- Always preserve inline links in paragraph text regardless of embed creation
- Ensures consistent output regardless of verse processing order (block→inline vs inline→block)

## How did I test?

Tested in simulator and on web by posting links to embeddable content (X/youtube links) in DMs.

## Risks and impact

- Safe to rollback without consulting PR author? Yes, but the bug will come back.

## Rollback plan

Revert the merge commit

## Screenshots / videos


https://github.com/user-attachments/assets/4b255e05-c849-4239-b53f-102d1d51fea4

