### PR TITLE
invite sheet: add loading indicator, error tracking. fix cosmos fixture

### DIFF
--- a/packages/app/fixtures/InviteUsersSheet.fixture.tsx
+++ b/packages/app/fixtures/InviteUsersSheet.fixture.tsx
@@ -1,18 +1,53 @@
-import { AppDataContextProvider, InviteUsersSheet } from '../ui';
+import * as baseStore from '@tloncorp/shared/store';
+import { useMemo } from 'react';
+
+import { AppDataContextProvider, InviteUsersSheet, StoreProvider } from '../ui';
 import { FixtureWrapper } from './FixtureWrapper';
 import { group, initialContacts } from './fakeData';
 
+function spyOn<T extends object, MethodName extends keyof T>(
+  base: T,
+  method: MethodName,
+  fn: T[MethodName]
+) {
+  return new Proxy(base, {
+    get(target, prop) {
+      if (prop === method) {
+        return fn;
+      }
+      return target[prop as keyof T];
+    },
+  });
+}
+
+function InviteUsersSheetFixture() {
+  const store = useMemo(() => {
+    const mockUseGroup = () => ({
+      data: group,
+      isLoading: false,
+      error: null,
+    });
+
+    // @ts-expect-error - fixture mock
+    return spyOn(baseStore, 'useGroup', mockUseGroup);
+  }, []);
+
+  return (
+    <StoreProvider stub={store}>
+      <FixtureWrapper>
+        <AppDataContextProvider currentUserId="~zod" contacts={initialContacts}>
+          <InviteUsersSheet
+            open
+            onOpenChange={() => {}}
+            onInviteComplete={() => {}}
+            groupId={group.id}
+          />
+        </AppDataContextProvider>
+      </FixtureWrapper>
+    </StoreProvider>
+  );
+}
+
 export default {
-  basic: (
-    <FixtureWrapper>
-      <AppDataContextProvider currentUserId="~zod" contacts={initialContacts}>
-        <InviteUsersSheet
-          open
-          onOpenChange={() => {}}
-          onInviteComplete={() => {}}
-          groupId={group.id}
-        />
-      </AppDataContextProvider>
-    </FixtureWrapper>
-  ),
+  basic: <InviteUsersSheetFixture />,
 };

--- a/packages/app/ui/components/InviteUsersSheet.tsx
+++ b/packages/app/ui/components/InviteUsersSheet.tsx
@@ -1,7 +1,7 @@
-import * as store from '@tloncorp/shared/store';
 import React, { useRef } from 'react';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
 
+import { useStore } from '../contexts/storeContext';
 import { ActionSheet } from './ActionSheet';
 import { InviteUsersWidget } from './InviteUsersWidget';
 
@@ -18,6 +18,7 @@ const InviteUsersSheetComponent = ({
 }) => {
   const { bottom } = useSafeAreaInsets();
   const hasOpened = useRef(open);
+  const store = useStore();
   const { data: group } = store.useGroup({ id: groupId });
 
   if (!hasOpened.current && open) {

--- a/packages/app/ui/components/InviteUsersWidget.tsx
+++ b/packages/app/ui/components/InviteUsersWidget.tsx
@@ -1,3 +1,4 @@
+import { createDevLogger } from '@tloncorp/shared';
 import * as db from '@tloncorp/shared/db';
 import * as store from '@tloncorp/shared/store';
 import { Button } from '@tloncorp/ui';
@@ -6,6 +7,8 @@ import React, { useCallback, useMemo, useState } from 'react';
 import { ActionSheet } from './ActionSheet';
 import { ContactBook } from './ContactBook';
 import { InviteFriendsToTlonButton } from './InviteFriendsToTlonButton';
+
+const logger = createDevLogger('InviteUsersWidget', false);
 
 const InviteUsersWidgetComponent = ({
   group,
@@ -19,13 +22,21 @@ const InviteUsersWidgetComponent = ({
 
   const handleInviteGroupMembers = useCallback(async () => {
     setLoading(true);
-    await store.inviteGroupMembers({
-      groupId: group.id,
-      contactIds: invitees,
-    });
-
-    setLoading(false);
-    onInviteComplete();
+    try {
+      await store.inviteGroupMembers({
+        groupId: group.id,
+        contactIds: invitees,
+      });
+      setLoading(false);
+      onInviteComplete();
+    } catch (error) {
+      logger.trackError('Error inviting group members', {
+        errorMessage: error.message,
+        errorStack: error.stack,
+      });
+    } finally {
+      setLoading(false);
+    }
   }, [invitees, group.id, onInviteComplete]);
 
   const buttonText = useMemo(() => {

--- a/packages/app/ui/components/InviteUsersWidget.tsx
+++ b/packages/app/ui/components/InviteUsersWidget.tsx
@@ -14,14 +14,17 @@ const InviteUsersWidgetComponent = ({
   group: db.Group;
   onInviteComplete: () => void;
 }) => {
+  const [loading, setLoading] = useState(false);
   const [invitees, setInvitees] = useState<string[]>([]);
 
   const handleInviteGroupMembers = useCallback(async () => {
+    setLoading(true);
     await store.inviteGroupMembers({
       groupId: group.id,
       contactIds: invitees,
     });
 
+    setLoading(false);
     onInviteComplete();
   }, [invitees, group.id, onInviteComplete]);
 
@@ -50,10 +53,12 @@ const InviteUsersWidgetComponent = ({
         <Button
           hero
           onPress={handleInviteGroupMembers}
-          disabled={invitees.length === 0}
+          disabled={invitees.length === 0 || loading}
           gap="$xl"
         >
-          <Button.Text width="auto">{buttonText}</Button.Text>
+          <Button.Text width="auto">
+            {loading ? 'Inviting...' : buttonText}
+          </Button.Text>
         </Button>
       </ActionSheet.ContentBlock>
     </>

--- a/packages/shared/src/store/groupActions.ts
+++ b/packages/shared/src/store/groupActions.ts
@@ -297,7 +297,10 @@ export async function inviteGroupMembers({
       await api.inviteGroupMembers({ groupId, contactIds });
     }
   } catch (e) {
-    console.error('Failed to invite group members', e);
+    logger.trackError('Failed to invite group members', {
+      errorMessage: e.message,
+      errorStack: e.stack,
+    });
     // rollback optimistic update
     await db.removeChatMembers({
       chatId: groupId,


### PR DESCRIPTION
## Summary
fixes tlon-4409

We weren't:
- indicating that anything was happening while attempting the invite
- disabling the button during the attempt
- logging any errors if the attempt failed

This fixes those things, and also updates the component to use the new `useStore` hook and fixes the broken cosmos fixture.

## How did I test?

Tested on web.

## Risks and impact

- Safe to rollback without consulting PR author? Yes, but we'll lose these things.
- Affects important code area:
N/A

## Rollback plan

Revert the merge commit.
