### PR TITLE
gallery: fix missing sent time issue

### DIFF
--- a/packages/app/ui/components/AuthorRow.tsx
+++ b/packages/app/ui/components/AuthorRow.tsx
@@ -87,11 +87,15 @@ export function DetailViewAuthorRow({
   const shouldTruncate = showEditedIndicator || deliveryFailed;
 
   const timeDisplay = useMemo(() => {
-    if (!showSentAt) {
+    if (!showSentAt || !sent) {
       return null;
     }
     const date = new Date(sent ?? 0);
-    return utils.makePrettyTime(date);
+    if (utils.isToday(date.getTime())) {
+      return utils.makePrettyTime(date);
+    }
+    const { asString } = utils.makePrettyDayAndDateAndTime(date);
+    return asString;
   }, [showSentAt, sent]);
 
   return (

--- a/packages/app/ui/components/GalleryPost/GalleryPost.tsx
+++ b/packages/app/ui/components/GalleryPost/GalleryPost.tsx
@@ -353,6 +353,7 @@ export function GalleryPostDetailView({
       <View gap="$2xl" padding="$xl">
         <DetailViewAuthorRow
           authorId={post.authorId}
+          sent={post.sentAt}
           color="$primaryText"
           showSentAt={true}
         />


### PR DESCRIPTION
## Summary
fixes tlon-4353

`DetailViewAuthorRow` has an optional `sent` (for the post's sent time) prop and a `showSentAt` prop. If `showSentAt` was `true`, then we tried to show the pretty sent time for the post. *But*, if you passed `showSentAt` but didn't also pass a `sent` prop, we would try to make a pretty time from `new Date(0)`. So, all gallery posts were just showing the pretty time for `new Date(0)` since we were passing just `showSentAt` and not `sent`.

This PR fixes the issue by:
- actually passing the sent time
- not showing the timeDisplay at all if we don't have `sent`.

It also updates `timeDisplay` to show either the prettyTime (if the post was made today) or the prettyDayAndDateAndTime (if it wasn't made today).

## How did I test?

Tested on web.

## Risks and impact
None afaict.

## Rollback plan

Revert the merge commit.

## Screenshots / videos

![image](https://github.com/user-attachments/assets/296db6e2-679f-4b47-aeb0-aaaf0da69a92)
