### PR TITLE
fix scrolling in create chat sheet

### DIFF
--- a/packages/app/ui/components/ContactBook.tsx
+++ b/packages/app/ui/components/ContactBook.tsx
@@ -122,17 +122,8 @@ export function ContactBook({
     [selected, immutableSet, multiSelect, handleSelect]
   );
 
-  const scrollPosition = useRef(0);
-  const handleScroll = useCallback(
-    (event: NativeSyntheticEvent<NativeScrollEvent>) => {
-      scrollPosition.current = event.nativeEvent.contentOffset.y;
-    },
-    []
-  );
   const onTouchStart = useCallback(() => {
-    if (scrollPosition.current > 0) {
-      onScrollChange?.(true);
-    }
+    onScrollChange?.(true);
   }, [onScrollChange]);
 
   const onTouchEnd = useCallback(
@@ -202,7 +193,6 @@ export function ContactBook({
           <BlockSectionList
             ListHeaderComponent={!showSearchResults ? quickActions : null}
             sections={sections}
-            onScroll={handleScroll}
             onTouchStart={onTouchStart}
             onTouchEnd={onTouchEnd}
             renderItem={renderItem}


### PR DESCRIPTION
## Summary

Fixes broken scrolling in the `ContactBook` within `CreateChatSheet`. This will break closing the sheet by scrolling past the top of the contact list, but swiping down from the top of the sheet or dragging the handle still work. Fixes TLON-4514.

## Changes

Modified `scrollChange` event in `ContactBook` (used to disable drag in the parent sheet, allowing the child `ScrollView` to be scrolled) to always fire on touch start instead of only when scroll offset is greater than 0.

## How did I test?

Tested in iOS simulator. 

## Risks and impact

- Safe to rollback without consulting PR author? Yes
