### PR TITLE
BigInput: use actual uploaded image url for header image on send, disable post button while sending

### DIFF
--- a/packages/app/ui/components/BigInput.tsx
+++ b/packages/app/ui/components/BigInput.tsx
@@ -167,9 +167,7 @@ export function BigInput({
           metadata.image = attachment.uploadState.remoteUri;
         }
       } else {
-        // Always include image field for notebooks, even if null
-        // This ensures we can clear an image by setting it to null
-        metadata.image = imageUri;
+        metadata.image = null;
       }
     }
 

--- a/packages/app/ui/components/BigInput.tsx
+++ b/packages/app/ui/components/BigInput.tsx
@@ -57,6 +57,7 @@ export function BigInput({
   const [hasImageChanges, setHasImageChanges] = useState(false);
   const [showFormatMenu, setShowFormatMenu] = useState(!isWindowNarrow);
   const [isButtonEnabled, setIsButtonEnabled] = useState(false);
+  const [isSending, setIsSending] = useState(false);
   const editorRef = useRef<{ editor: TlonEditorBridge | null }>(null);
   const insets = useSafeAreaInsets();
   const theme = useTheme();
@@ -117,6 +118,7 @@ export function BigInput({
 
   // Handle sending/editing the post
   const handleSend = useCallback(async () => {
+    setIsSending(true);
     if (!editorRef.current?.editor) return;
 
     const json = await editorRef.current.editor.getJSON();
@@ -149,9 +151,26 @@ export function BigInput({
         metadata.title = title;
       }
 
-      // Always include image field for notebooks, even if null
-      // This ensures we can clear an image by setting it to null
-      metadata.image = imageUri;
+      if (imageUri) {
+        const attachment = attachments.find(
+          (attachment) =>
+            attachment.type === 'image' &&
+            attachment.uploadState?.status === 'success' &&
+            attachment.file?.uri === imageUri
+        );
+        if (
+          attachment &&
+          attachment.type === 'image' &&
+          attachment.uploadState &&
+          'remoteUri' in attachment.uploadState
+        ) {
+          metadata.image = attachment.uploadState.remoteUri;
+        }
+      } else {
+        // Always include image field for notebooks, even if null
+        // This ensures we can clear an image by setting it to null
+        metadata.image = imageUri;
+      }
     }
 
     try {
@@ -217,6 +236,8 @@ export function BigInput({
     } catch (error) {
       logger.error('Failed to save post:', error);
       // Don't clear draft if save failed
+    } finally {
+      setIsSending(false);
     }
   }, [
     send,
@@ -231,6 +252,7 @@ export function BigInput({
     setShowFormatMenu,
     clearAttachments,
     attachments,
+    isSending,
   ]);
 
   // Register the "Post" button in the header
@@ -241,12 +263,12 @@ export function BigInput({
           key="big-input-post"
           onPress={handleSend}
           testID="BigInputPostButton"
-          disabled={!isButtonEnabled}
+          disabled={!isButtonEnabled || isSending}
         >
           {editingPost ? 'Save' : 'Post'}
         </ScreenHeader.TextButton>
       ),
-      [handleSend, editingPost, isButtonEnabled]
+      [handleSend, editingPost, isButtonEnabled, isSending]
     )
   );
 


### PR DESCRIPTION
## Summary
fixes tlon-4532

We were taking the `uri` value given to us by Expo's ImagePicker and setting `metadata.image` to that value. The value from ImagePicker is just the local URI for the image, not the URI for the uploaded file.

We also weren't disabling the `Post` button while we were in the middle of a send, and send waits for image attachments to upload, so you could get into a state where:

1) you press the Post button
2) you see no visual response (but actually we're waiting on an upload)
3) you press the button again
4) nothing happens
5) you press again and finally something happens
6) now you see three posts in the index.

It would be great if we could just have the user press send and immediately see their post, I assume the upcoming queueing work will achieve that for notebook posts as well. For now, this simple fix should hold us over.

This was probably not caught when we switched over to the new notebook editor a few months back because it *looks like* it works if you only test with one client (and you don't go look from another client or ship).

### Why did it look like it worked on desktop?

Because we were setting the `metadata.image` property to a base64 data url! 

## Changes

We send the `remoteUri` from the `Attachment` that we grab from the attachment context where that attachment's file URI matches the one we have in our local `imageUri` state.

We disable the Post button while we're sending using local `isSending` state.

## How did I test?

Tested on iOS in simulator and web on desktop.

## Risks and impact

- Safe to rollback without consulting PR author? Yes
- Affects important code area: N/A

## Rollback plan

Revert the merge commit.