### PR TITLE
android: fix issue with KeyboardAvoidingView

### DIFF
--- a/apps/tlon-mobile/android/app/src/main/java/io/tlon/landscape/MainActivity.java
+++ b/apps/tlon-mobile/android/app/src/main/java/io/tlon/landscape/MainActivity.java
@@ -3,6 +3,10 @@ package io.tlon.landscape;
 import android.os.Build;
 import android.os.Bundle;
 import android.content.Intent;
+import android.view.View;
+import androidx.core.view.ViewCompat;
+import androidx.core.view.WindowInsetsCompat;
+import androidx.core.graphics.Insets;
 
 import com.facebook.react.ReactActivity;
 import com.facebook.react.ReactActivityDelegate;
@@ -22,6 +26,22 @@ public class MainActivity extends ReactActivity {
     // This is required for expo-splash-screen.
     setTheme(R.style.AppTheme);
     super.onCreate(null);
+    
+    // Handle window insets for Android API 35+
+    // ref: https://github.com/facebook/react-native/issues/49759#issuecomment-3048056660
+    if (Build.VERSION.SDK_INT >= 35) {
+        View rootView = findViewById(android.R.id.content);
+        ViewCompat.setOnApplyWindowInsetsListener(rootView, (v, insets) -> {
+            Insets innerPadding = insets.getInsets(WindowInsetsCompat.Type.ime());
+            rootView.setPadding(
+                innerPadding.left,
+                innerPadding.top,
+                innerPadding.right,
+                innerPadding.bottom
+            );
+            return insets;
+        });
+    }
   }
 
   /**


### PR DESCRIPTION
## Summary
fixes tlon-4543.

Apparently:

> Before targeting SDK 35, using android:windowSoftInputMode=”adjustResize” was all you needed to maintain focus on — for example — an EditText in a RecyclerView when opening an IME. With “adjustResize”, the framework treated the IME as the system window, and the window’s root views were padded so content avoids the system window.

> After targeting SDK 35, you must also account for the IME using ViewCompat.setOnApplyWindowInsetsListener and WindowInsetsCompat.Type.ime() because the framework will not pad the window’s root views.

see: https://stackoverflow.com/questions/79177674/windowsoftinputmode-adjustresize-doesnt-work-in-target-sdk-35/79364446#79364446

https://github.com/facebook/react-native/issues/49759#issuecomment-3048056660


## How did I test?

Tested on physical android device running android 15.

## Risks and impact

- Safe to rollback without consulting PR author? Yes

## Rollback plan

revert
