### PR TITLE
chat: don't blow away link previews when editing

### DIFF
--- a/packages/app/ui/components/BareChatInput/index.tsx
+++ b/packages/app/ui/components/BareChatInput/index.tsx
@@ -764,6 +764,14 @@ export default function BareChatInput({
                   },
                 });
               }
+              if ('link' in b) {
+                attachments.push({
+                  type: 'link',
+                  url: b.link.url,
+                  resourceType: 'page',
+                  ...b.link.meta,
+                });
+              }
             });
 
             resetAttachments(attachments);


### PR DESCRIPTION
## Summary

fixes tlon-4499

First off: I was wrong, other attachments stick around just fine for chat input when editing.

The issue was just that we weren't accounting for the link block type in the `useEffect` we use to set initial content. Pretty simple fix.

I looked into the separate issue that @jamesacklin mentioned about links getting cleared out when editing a gallery post. Looks totally unrelated.

## Changes

Account for the `'link'` block type in our content initialization `useEffect`.

## How did I test?

Test on web and iOS sim.

## Risks and impact

- Safe to rollback without consulting PR author? Yes
- Affects important code area: N/A

## Rollback plan

Revert the merge commit

## Screenshots / videos


https://github.com/user-attachments/assets/fe23c7a4-d7b0-48be-b3a7-9feb6cffe659

