### PR TITLE
chat: rip out old pins which are no longer used

### DIFF
--- a/desk/app/chat.hoon
+++ b/desk/app/chat.hoon
@@ -19,7 +19,6 @@
 /%  m-chat-heads           %chat-heads
 /%  m-chat-heads-1         %chat-heads-1
 /%  m-chat-paged-writs     %chat-paged-writs
-/%  m-chat-pins            %chat-pins
 /%  m-chat-scam            %chat-scam
 /%  m-chat-scam-1          %chat-scam-1
 /%  m-chat-scan            %chat-scan
@@ -48,7 +47,6 @@
             :+  %chat-heads           &  -:!>(*vale:m-chat-heads)
             :+  %chat-heads-1         &  -:!>(*vale:m-chat-heads-1)
             :+  %chat-paged-writs     &  -:!>(*vale:m-chat-paged-writs)
-            :+  %chat-pins            &  -:!>(*vale:m-chat-pins)
             :+  %chat-scam            &  -:!>(*vale:m-chat-scam)
             :+  %chat-scam-1          &  -:!>(*vale:m-chat-scam-1)
             :+  %chat-scan            &  -:!>(*vale:m-chat-scan)
@@ -98,7 +96,6 @@
         [/x/hidden-messages %hidden-messages]
         [/x/init %noun]
         [/x/old %noun]
-        [/x/pins %chat-pins]
         [/x/unreads %chat-unreads]
       ::
         [/x/v1/club/$/writs %chat-paged-writs]
@@ -915,8 +912,6 @@
     [%x %old ~]  ``noun+!>(old-chats)  ::  legacy data, for migration use
   ::
     [%x %clubs ~]  ``clubs+!>((~(run by clubs) |=(=club:c crew.club)))
-  ::
-    [%x %pins ~]  ``chat-pins+!>(pins)
   ::
     [%x %blocked ~]  ``ships+!>(blocked)
   ::


### PR DESCRIPTION
## Summary

We were checking for behavior we no longer support or use, and it was causing failures. This just rips it out instead.

## Changes

- removed /pins scry in %chat
- removed lib/discipline checks for %chat-pins mark

## How did I test?

Compiling the hoon

## Risks and impact

- Safe to rollback without consulting PR author? Yes
- Affects important code area:
  - [ ] Onboarding
  - [ ] State / providers
  - [ ] Message sync
  - [ ] Channel display
  - [ ] Notifications

## Rollback plan

<!-- Describe the steps to revert these changes if needed. -->

## Screenshots / videos

<!-- Attach any relevant media. -->
