### PR TITLE
queries, postUtils, ChatMessage: consistent nickname display in reaction tooltip

### DIFF
--- a/packages/app/ui/components/ChatMessage/ReactionsDisplay.tsx
+++ b/packages/app/ui/components/ChatMessage/ReactionsDisplay.tsx
@@ -59,19 +59,23 @@ export function ReactionsDisplay({
     ]
   );
 
-  const firstThreeReactionUsers = useCallback(
-    (reaction: ReactionListItem) =>
-      reaction.users
-        ? reaction.users
-            .slice(0, 3)
-            .map((user) => user.name || user.id)
-            .join(', ') +
-          (reaction.users.length > 3
-            ? ` +${reaction.users.length - 3} more`
-            : '')
-        : '',
-    []
-  );
+  const firstThreeReactionUsers = useCallback((reaction: ReactionListItem) => {
+    if (!reaction.users || reaction.users.length === 0) {
+      return '';
+    }
+
+    const userNames = reaction.users
+      .slice(0, 3)
+      .map((user) => {
+        // Defensive logic: ensure we have a valid name or fall back to id
+        const name = user.name && user.name.trim() !== '' ? user.name : user.id;
+        return name || 'Unknown'; // Final fallback if both are somehow empty
+      })
+      .join(', ');
+
+    const moreCount = reaction.users.length - 3;
+    return userNames + (moreCount > 0 ? ` +${moreCount} more` : '');
+  }, []);
 
   if (minimal) {
     if (reactionDetails.list.length === 0) {

--- a/packages/app/ui/utils/postUtils.test.ts
+++ b/packages/app/ui/utils/postUtils.test.ts
@@ -1,0 +1,348 @@
+import * as db from '@tloncorp/shared/db';
+import { describe, expect, test } from 'vitest';
+
+import { computeReactionDetails } from './postUtils';
+
+describe('computeReactionDetails', () => {
+  describe('contact name resolution', () => {
+    test('should use custom nickname when available', () => {
+      const reactions: db.Reaction[] = [
+        {
+          postId: 'post-1',
+          contactId: '~zod',
+          value: '👍',
+          contact: {
+            id: '~zod',
+            customNickname: 'Custom Name',
+            peerNickname: 'Peer Name',
+          } as db.Contact,
+        },
+      ];
+
+      const result = computeReactionDetails(reactions, '~sampel-palnet');
+
+      expect(result.list[0].users[0].name).toBe('Custom Name');
+    });
+
+    test('should fall back to peer nickname when custom nickname is empty', () => {
+      const reactions: db.Reaction[] = [
+        {
+          postId: 'post-1',
+          contactId: '~zod',
+          value: '👍',
+          contact: {
+            id: '~zod',
+            customNickname: '',
+            peerNickname: 'Peer Name',
+          } as db.Contact,
+        },
+      ];
+
+      const result = computeReactionDetails(reactions, '~sampel-palnet');
+
+      expect(result.list[0].users[0].name).toBe('Peer Name');
+    });
+
+    test('should fall back to peer nickname when custom nickname is null', () => {
+      const reactions: db.Reaction[] = [
+        {
+          postId: 'post-1',
+          contactId: '~zod',
+          value: '👍',
+          contact: {
+            id: '~zod',
+            customNickname: null,
+            peerNickname: 'Peer Name',
+          } as db.Contact,
+        },
+      ];
+
+      const result = computeReactionDetails(reactions, '~sampel-palnet');
+
+      expect(result.list[0].users[0].name).toBe('Peer Name');
+    });
+
+    test('should fall back to contact ID when both nicknames are empty', () => {
+      const reactions: db.Reaction[] = [
+        {
+          postId: 'post-1',
+          contactId: '~zod',
+          value: '👍',
+          contact: {
+            id: '~zod',
+            customNickname: '',
+            peerNickname: '',
+          } as db.Contact,
+        },
+      ];
+
+      const result = computeReactionDetails(reactions, '~sampel-palnet');
+
+      expect(result.list[0].users[0].name).toBe('~zod');
+    });
+
+    test('should handle whitespace-only nicknames by trimming and falling back', () => {
+      const reactions: db.Reaction[] = [
+        {
+          postId: 'post-1',
+          contactId: '~zod',
+          value: '👍',
+          contact: {
+            id: '~zod',
+            customNickname: '   ',
+            peerNickname: ' Valid Name ',
+          } as db.Contact,
+        },
+      ];
+
+      const result = computeReactionDetails(reactions, '~sampel-palnet');
+
+      expect(result.list[0].users[0].name).toBe('Valid Name');
+    });
+
+    test('should fall back to contact ID when both nicknames are null', () => {
+      const reactions: db.Reaction[] = [
+        {
+          postId: 'post-1',
+          contactId: '~zod',
+          value: '👍',
+          contact: {
+            id: '~zod',
+            customNickname: null,
+            peerNickname: null,
+          } as db.Contact,
+        },
+      ];
+
+      const result = computeReactionDetails(reactions, '~sampel-palnet');
+
+      expect(result.list[0].users[0].name).toBe('~zod');
+    });
+
+    test('should fall back to contact ID when contact is null', () => {
+      const reactions: db.Reaction[] = [
+        {
+          postId: 'post-1',
+          contactId: '~zod',
+          value: '👍',
+          contact: null,
+        },
+      ];
+
+      const result = computeReactionDetails(reactions, '~sampel-palnet');
+
+      expect(result.list[0].users[0].name).toBe('~zod');
+    });
+
+    test('should fall back to contact ID when contact is undefined', () => {
+      const reactions: db.Reaction[] = [
+        {
+          postId: 'post-1',
+          contactId: '~zod',
+          value: '👍',
+          contact: undefined,
+        },
+      ];
+
+      const result = computeReactionDetails(reactions, '~sampel-palnet');
+
+      expect(result.list[0].users[0].name).toBe('~zod');
+    });
+
+    test('should fall back to "Unknown User" when contactId is also empty', () => {
+      const reactions: db.Reaction[] = [
+        {
+          postId: 'post-1',
+          contactId: '',
+          value: '👍',
+          contact: {
+            id: '',
+            customNickname: '',
+            peerNickname: '',
+          } as db.Contact,
+        },
+      ];
+
+      const result = computeReactionDetails(reactions, '~sampel-palnet');
+
+      expect(result.list[0].users[0].name).toBe('Unknown User');
+    });
+
+    test('should use peer nickname when custom nickname is empty and peer nickname is available', () => {
+      const reactions: db.Reaction[] = [
+        {
+          postId: 'post-1',
+          contactId: '~zod',
+          value: '👍',
+          contact: {
+            id: '~zod',
+            customNickname: '',
+            peerNickname: 'Peer Name',
+          } as db.Contact,
+        },
+      ];
+
+      const result = computeReactionDetails(reactions, '~sampel-palnet');
+
+      expect(result.list[0].users[0].name).toBe('Peer Name');
+    });
+
+    test('should handle multiple users with different name resolution scenarios', () => {
+      const reactions: db.Reaction[] = [
+        {
+          postId: 'post-1',
+          contactId: '~zod',
+          value: '👍',
+          contact: {
+            id: '~zod',
+            customNickname: 'Custom Name',
+            peerNickname: 'Peer Name',
+          } as db.Contact,
+        },
+        {
+          postId: 'post-1',
+          contactId: '~bus',
+          value: '👍',
+          contact: {
+            id: '~bus',
+            customNickname: '',
+            peerNickname: 'Bus Peer Name',
+          } as db.Contact,
+        },
+        {
+          postId: 'post-1',
+          contactId: '~web',
+          value: '👍',
+          contact: {
+            id: '~web',
+            customNickname: '',
+            peerNickname: '',
+          } as db.Contact,
+        },
+      ];
+
+      const result = computeReactionDetails(reactions, '~sampel-palnet');
+
+      const users = result.list[0].users;
+      expect(users[0].name).toBe('Custom Name');
+      expect(users[1].name).toBe('Bus Peer Name');
+      expect(users[2].name).toBe('~web');
+    });
+
+    test('should be consistent between first reaction and additional reactions', () => {
+      const reactions: db.Reaction[] = [
+        {
+          postId: 'post-1',
+          contactId: '~zod',
+          value: '👍',
+          contact: {
+            id: '~zod',
+            customNickname: '',
+            peerNickname: 'Peer Name',
+          } as db.Contact,
+        },
+        {
+          postId: 'post-1',
+          contactId: '~bus',
+          value: '👍',
+          contact: {
+            id: '~bus',
+            customNickname: '',
+            peerNickname: 'Bus Peer Name',
+          } as db.Contact,
+        },
+      ];
+
+      const result = computeReactionDetails(reactions, '~sampel-palnet');
+
+      const users = result.list[0].users;
+      expect(users[0].name).toBe('Peer Name');
+      expect(users[1].name).toBe('Bus Peer Name');
+    });
+  });
+
+  describe('reaction aggregation', () => {
+    test('should aggregate reactions by value', () => {
+      const reactions: db.Reaction[] = [
+        {
+          postId: 'post-1',
+          contactId: '~zod',
+          value: '👍',
+          contact: {
+            id: '~zod',
+            customNickname: 'Zod',
+            peerNickname: null,
+          } as db.Contact,
+        },
+        {
+          postId: 'post-1',
+          contactId: '~bus',
+          value: '👍',
+          contact: {
+            id: '~bus',
+            customNickname: 'Bus',
+            peerNickname: null,
+          } as db.Contact,
+        },
+        {
+          postId: 'post-1',
+          contactId: '~web',
+          value: '❤️',
+          contact: {
+            id: '~web',
+            customNickname: 'Web',
+            peerNickname: null,
+          } as db.Contact,
+        },
+      ];
+
+      const result = computeReactionDetails(reactions, '~sampel-palnet');
+
+      expect(result.list).toHaveLength(2);
+      expect(result.list[0].value).toBe('👍');
+      expect(result.list[0].count).toBe(2);
+      expect(result.list[1].value).toBe('❤️');
+      expect(result.list[1].count).toBe(1);
+    });
+
+    test('should track self reactions', () => {
+      const reactions: db.Reaction[] = [
+        {
+          postId: 'post-1',
+          contactId: '~zod',
+          value: '👍',
+          contact: {
+            id: '~zod',
+            customNickname: 'Zod',
+            peerNickname: null,
+          } as db.Contact,
+        },
+      ];
+
+      const result = computeReactionDetails(reactions, '~zod');
+
+      expect(result.self.didReact).toBe(true);
+      expect(result.self.value).toBe('👍');
+    });
+
+    test('should not mark as self reaction when user is not the reactor', () => {
+      const reactions: db.Reaction[] = [
+        {
+          postId: 'post-1',
+          contactId: '~zod',
+          value: '👍',
+          contact: {
+            id: '~zod',
+            customNickname: 'Zod',
+            peerNickname: null,
+          } as db.Contact,
+        },
+      ];
+
+      const result = computeReactionDetails(reactions, '~sampel-palnet');
+
+      expect(result.self.didReact).toBe(false);
+      expect(result.self.value).toBe('');
+    });
+  });
+});

--- a/packages/app/ui/utils/postUtils.test.ts
+++ b/packages/app/ui/utils/postUtils.test.ts
@@ -168,25 +168,6 @@ describe('computeReactionDetails', () => {
       expect(result.list[0].users[0].name).toBe('Unknown User');
     });
 
-    test('should use peer nickname when custom nickname is empty and peer nickname is available', () => {
-      const reactions: db.Reaction[] = [
-        {
-          postId: 'post-1',
-          contactId: '~zod',
-          value: '👍',
-          contact: {
-            id: '~zod',
-            customNickname: '',
-            peerNickname: 'Peer Name',
-          } as db.Contact,
-        },
-      ];
-
-      const result = computeReactionDetails(reactions, '~sampel-palnet');
-
-      expect(result.list[0].users[0].name).toBe('Peer Name');
-    });
-
     test('should handle multiple users with different name resolution scenarios', () => {
       const reactions: db.Reaction[] = [
         {

--- a/packages/app/ui/utils/postUtils.tsx
+++ b/packages/app/ui/utils/postUtils.tsx
@@ -18,58 +18,72 @@ export interface ReactionDetails {
   aggregate: Record<string, ReactionListItem>;
   list: ReactionListItem[];
 }
+
+function resolveContactName(
+  contact: db.Contact | null | undefined,
+  contactId: string
+): string {
+  // Priority: customNickname (if not empty) -> peerNickname (if not empty) -> contactId
+  if (contact?.customNickname && contact.customNickname.trim() !== '') {
+    return contact.customNickname.trim();
+  }
+  if (contact?.peerNickname && contact.peerNickname.trim() !== '') {
+    return contact.peerNickname.trim();
+  }
+  // Final fallback: ensure contactId is valid
+  return contactId && contactId.trim() !== '' ? contactId : 'Unknown User';
+}
+
+export function computeReactionDetails(
+  reactions: db.Reaction[],
+  ourId: string
+): ReactionDetails {
+  const details = {
+    self: {
+      didReact: false,
+      value: '',
+    },
+    aggregate: {},
+    list: [],
+  } as ReactionDetails;
+
+  reactions.forEach((reaction) => {
+    if (details.aggregate[reaction.value]) {
+      details.aggregate[reaction.value].count++;
+      details.aggregate[reaction.value].users.push({
+        id: reaction.contactId,
+        name: resolveContactName(reaction.contact, reaction.contactId),
+      });
+    } else {
+      details.aggregate[reaction.value] = {
+        value: reaction.value,
+        count: 1,
+        users: [
+          {
+            id: reaction.contactId,
+            name: resolveContactName(reaction.contact, reaction.contactId),
+          },
+        ],
+      };
+    }
+    if (reaction.contactId === ourId) {
+      details.self.didReact = true;
+      details.self.value = reaction.value;
+    }
+    details.list = Object.values(details.aggregate);
+  });
+
+  return details;
+}
+
 export function useReactionDetails(
   reactions: db.Reaction[],
   ourId: string
 ): ReactionDetails {
-  return useMemo(() => {
-    const details = {
-      self: {
-        didReact: false,
-        value: '',
-      },
-      aggregate: {},
-      list: [],
-    } as ReactionDetails;
-
-    reactions.forEach((reaction) => {
-      if (details.aggregate[reaction.value]) {
-        details.aggregate[reaction.value].count++;
-        details.aggregate[reaction.value].users.push({
-          id: reaction.contactId,
-          name:
-            reaction.contact?.customNickname ??
-            reaction.contact?.peerNickname ??
-            reaction.contactId,
-        });
-      } else {
-        details.aggregate[reaction.value] = {
-          value: reaction.value,
-          count: 1,
-          users: [
-            {
-              id: reaction.contactId,
-              name:
-                reaction.contact?.customNickname &&
-                reaction.contact.customNickname !== ''
-                  ? reaction.contact.customNickname
-                  : reaction.contact?.peerNickname &&
-                      reaction.contact.peerNickname !== ''
-                    ? reaction.contact.peerNickname
-                    : reaction.contactId,
-            },
-          ],
-        };
-      }
-      if (reaction.contactId === ourId) {
-        details.self.didReact = true;
-        details.self.value = reaction.value;
-      }
-      details.list = Object.values(details.aggregate);
-    });
-
-    return details;
-  }, [reactions, ourId]);
+  return useMemo(
+    () => computeReactionDetails(reactions, ourId),
+    [reactions, ourId]
+  );
 }
 
 export type GroupedReactions = Record<

--- a/packages/shared/src/db/queries.ts
+++ b/packages/shared/src/db/queries.ts
@@ -1328,7 +1328,11 @@ export const getThreadPosts = createReadQuery(
       where: eq($posts.parentId, parentId),
       with: {
         author: true,
-        reactions: true,
+        reactions: {
+          with: {
+            contact: true,
+          },
+        },
       },
       orderBy: [desc($posts.receivedAt)],
     });
@@ -2667,7 +2671,11 @@ export const getChannelPostsAround = createReadQuery(
       where: eq($posts.id, postId),
       with: {
         author: true,
-        reactions: true,
+        reactions: {
+          with: {
+            contact: true,
+          },
+        },
       },
     });
 
@@ -2684,7 +2692,11 @@ export const getChannelPostsAround = createReadQuery(
       limit: 25,
       with: {
         author: true,
-        reactions: true,
+        reactions: {
+          with: {
+            contact: true,
+          },
+        },
       },
     });
 
@@ -2695,7 +2707,11 @@ export const getChannelPostsAround = createReadQuery(
       limit: 25,
       with: {
         author: true,
-        reactions: true,
+        reactions: {
+          with: {
+            contact: true,
+          },
+        },
       },
     });
 
@@ -2717,7 +2733,11 @@ export const getChannelSearchResults = createReadQuery(
       orderBy: [desc($posts.receivedAt)],
       with: {
         author: true,
-        reactions: true,
+        reactions: {
+          with: {
+            contact: true,
+          },
+        },
       },
     });
   },
@@ -3289,7 +3309,11 @@ export const getPostWithRelations = createReadQuery(
         where: eq($posts.id, id),
         with: {
           author: true,
-          reactions: true,
+          reactions: {
+            with: {
+              contact: true,
+            },
+          },
           threadUnread: true,
           volumeSettings: true,
         },


### PR DESCRIPTION
## Summary

Fixes TLON-4536 where we weren't querying for contact details along with reactions to posts, which caused an issue where nicknames occasionally would fail to display in the reaction tooltip on desktop. Furthermore, this adds an additional step to the nickname computation to show overridden nicknames.

## Changes

- Modifies the getThreadPosts, getChannelPostsAround (beforePosts, afterPosts), getChannelSearchResults, and getPostWithRelations queries to also include contact details (root cause)
- Moves the more complex logic for useReactionDetails inside its own function, which is still memoized and returned in the parent hook
- Computes the "correct" nickname to show in the reaction details following the override/user-set/bare-patp priority chain
- Defensively trims the list to 3 reactors as before

## How did I test?

- Navigate into a channel on desktop using either develop or production.
- Do not click on anyone's profile, do not load any other data, etc.
- Hover over an emoji reaction a few people have added to a message.
- Note that you will not see their nickname -- or, you might. Sometimes!
- Apply the fix
- Repeat the process above
- Note you will now see their nicknames displayed in the tooltip
- Add one of the reactors as a Contact and set a custom nickname for them
- Navigate back to the channel and hover back over the reaction
- Note you will now see their overridden nickname displayed in the tooltip

I added a unit test to ensure the logic for displaying the correct nickname is sound. 

## Risks and impact

- Safe to rollback without consulting PR author? Yes
- Affects important code area:
  - [ ] Onboarding
  - [ ] State / providers
  - [x] Message sync
  - [x] Channel display
  - [ ] Notifications

## Rollback plan

git revert
