### PR TITLE
threads: fix thread mute issue

### DIFF
--- a/packages/shared/src/store/activityActions.ts
+++ b/packages/shared/src/store/activityActions.ts
@@ -72,13 +72,19 @@ export async function muteThread({
   thread: db.Post;
 }) {
   const initialSettings = await db.getVolumeSetting(thread.id);
+  // if we don't have a parent post then we are the parent post
+  // note: we don't currently allow users to mute the root/parent post in the UI
+  const parentPost = await db.getPost({ postId: thread.parentId ?? thread.id });
 
   db.setVolumes({
     volumes: [{ itemId: thread.id, itemType: 'thread', level: 'soft' }],
   });
 
   try {
-    const { source } = api.getThreadSource({ channel, post: thread });
+    const { source } = api.getThreadSource({
+      channel,
+      post: parentPost ?? thread,
+    });
     const volume = ub.getVolumeMap('soft', true);
     await api.adjustVolumeSetting(source, volume);
   } catch (e) {


### PR DESCRIPTION
## Summary

fixes tlon-4472

Fixes an issue where the "mute thread" action on a message never worked.

## Changes

We had been passing the child post as the `source` for the volume setting adjustment, rather than the parent. The fix is just grabbing the parent post and using that as the `source` instead. If we don't have a parent post ID, then we are the parent, and we pass the post itself instead (we currently don't allow muting the root/parent post in the UI, but this enables us to allow that in the future if we want).

## How did I test?

Tested on web.

## Risks and impact

- Safe to rollback without consulting PR author? Yes
- Affects important code area: N/A

## Rollback plan

Revert
