### PR TITLE
gallery: fix issue with editing gallery link blocks

### DIFF
--- a/packages/app/ui/components/draftInputs/GalleryInput.tsx
+++ b/packages/app/ui/components/draftInputs/GalleryInput.tsx
@@ -1,5 +1,6 @@
 import { extractContentTypesFromPost } from '@tloncorp/shared';
 import * as db from '@tloncorp/shared/db';
+import * as domain from '@tloncorp/shared/domain';
 import * as logic from '@tloncorp/shared/logic';
 import { Block, constructStory } from '@tloncorp/shared/urbit';
 import { ParentAgnosticKeyboardAvoidingView } from '@tloncorp/ui';
@@ -46,8 +47,12 @@ export function GalleryInput({
 
   const safeAreaInsets = useSafeAreaInsets();
   const captionInputRef = useRef<TextInput>(null);
-  const { resetAttachments, waitForAttachmentUploads, attachAssets } =
-    useAttachmentContext();
+  const {
+    resetAttachments,
+    waitForAttachmentUploads,
+    addAttachment,
+    attachAssets,
+  } = useAttachmentContext();
   const theme = useTheme();
 
   const [route, setRoute] = useState<GalleryRoute>('gallery');
@@ -65,7 +70,7 @@ export function GalleryInput({
       const { blocks } = extractContentTypesFromPost(editingPost);
 
       // Check if the first block is an image - if so, it's an image gallery post
-      if (blocks.length > 0 && 'image' in blocks[0]) {
+      if (blocks.length > 0) {
         setRoute('image');
 
         // Extract caption from the post if it exists (should be in the inline content)
@@ -111,6 +116,18 @@ export function GalleryInput({
           setRoute('image');
           setCanPost(true);
         }
+
+        if ('link' in blocks[0]) {
+          const linkBlock = blocks[0].link as { url: string };
+          console.log('linkBlock', linkBlock);
+          const mockAttachment: domain.LinkAttachment = {
+            type: 'link' as const,
+            url: linkBlock.url,
+          };
+          addAttachment(mockAttachment);
+          setRoute('link');
+          setCanPost(true);
+        }
       } else {
         // If not an image post, use the BigInput for editing text gallery posts
         setRoute('text');
@@ -120,7 +137,7 @@ export function GalleryInput({
       // Default to BigInput if we can't determine the type
       setRoute('link');
     }
-  }, [editingPost, storeDraft, attachAssets]);
+  }, [editingPost, storeDraft, attachAssets, addAttachment]);
 
   // Reset all gallery-related state
   const resetGalleryState = useCallback(() => {


### PR DESCRIPTION
## Summary
fixes tlon-4443

We had an issue where if a user posted a link block in a gallery and went back to edit it the link would disappear after their edit. We have a `useEffect` in the `GalleryInput` component where we try to determine what the post type is and route the user to the correct input. We weren't accounting for links there.

## Changes

Updates that `useEffect` to account for link blocks, adds a `mockAttachment` so we can re-attach the link.

## How did I test?

Tested on web.

## Risks and impact

- Safe to rollback without consulting PR author? Yes
- Affects important code area: N/A

## Rollback plan

Revert

## Screenshots / videos

https://github.com/user-attachments/assets/d4ac8773-3110-465d-b77e-a9ec78b8f569


