### PR TITLE
chat: stop sending %epic facts to all subs

### DIFF
--- a/desk/app/chat.hoon
+++ b/desk/app/chat.hoon
@@ -9,7 +9,6 @@
 /+  utils=channel-utils
 /+  volume
 /+  wood-lib=wood
-/+  epos-lib=saga
 ::  performance, keep warm
 /+  chat-json
 ::
@@ -227,7 +226,6 @@
   --
 |_  [=bowl:gall cards=(list card)]
 +*  wood  ~(. wood-lib [bowl wood-state])
-    epos  ~(. epos-lib [bowl %chat-update okay])
 ++  abet  [(flop cards) state]
 ++  cor   .
 ++  emit  |=(=card cor(cards [card cards]))
@@ -252,7 +250,7 @@
   =?  old  ?=(%7 -.old)  (state-7-to-8 old)
   =?  old  ?=(%8 -.old)  (state-8-to-9 old)
   ?>  ?=(%9 -.old)
-  (emil(state old) (drop load:epos))
+  cor(state old)
   ::
   +$  versioned-state
     $%  state-9


### PR DESCRIPTION
## Summary

Chat agent had retained epic-era version negotiation logic, where it sends %epic facts to all incoming subscriptions during load. This removes that logic.

## Changes

/lib/saga's +load trawls incoming subscriptions and gives an %epic fact to every subscription coming in from outside. Aside from being a legacy codepath, this rubs up against the /lib/discipline integration, which wants every subscription path to specify its potential marks.

Instead of adding %epic to every subscription endpoint specification, we rip out that codepath for %epic fact giving. For up-to-date ships, this hasn't been in relevant use since the big update in #2817, about a year and a half ago. That's been plenty of time for newer clients to send out %epic facts to way-behind subscribers, too.

Messaging between ships should generally not be impacted by this. We have fallback logic for the chat pokes, anyway.

## How did I test?

Compiled, observed that it no longer produces %epic facts on-load.

## Risks and impact

- Safe to rollback without consulting PR author, sure.
- Affects important code area:
  - [ ] Onboarding
  - [ ] State / providers
  - [ ] Message sync
  - [ ] Channel display
  - [ ] Notifications

## Rollback plan

Revert.

## Screenshots / videos

🖼️
