### PR TITLE
groups-ui: complete /v2/heads transition wrt chat

### DIFF
--- a/desk/app/groups-ui.hoon
+++ b/desk/app/groups-ui.hoon
@@ -169,7 +169,7 @@
   ::
       [%x %v2 %heads since=?(~ [u=@ ~])]
     =+  .^(chan=channel-heads:d (scry %gx %channels %v3 %heads (snoc since.pole %channel-heads-2)))
-    =+  .^(chat=chat-heads:c (scry %gx %chat %v1 %heads (snoc since.pole %chat-heads-1)))
+    =+  .^(chat=chat-heads:c (scry %gx %chat %v2 %heads (snoc since.pole %chat-heads-2)))
     ``ui-heads-2+!>(`mixed-heads-2:u`[chan chat])
   ::
       [%x %v2 %init ~]


### PR DESCRIPTION
## Summary

The groups-ui `/v2/heads` scry was crashing due to a type mismatch on one its internal scry into chat agent. We make that scry a newer endpoint to resolve this.

## Changes

This got missed during the sequence number addition in #4867. The scry into chat was using the new (updated) type for the old endpoint.

Ideally, you'd bump the entire groups-ui endpoint here, since part of its type changes. However, /v2/heads was never integrated into the client. We can get away with just updating the scry to retrieve data with the new (updated) types from chat and call it a day.

(Perhaps in a fully discipline'd world these kinds of shenanigans wouldn't fly, but we don't live there yet...)

## How did I test?

Saw the scry (via http) fail before my change. Got a json response back after my change. The response includes sequence numbers for chat messages. (Notably, but out of scope, those numbers are `number`s for chat, and `string`s for channels.

## Risks and impact

- Safe to rollback without consulting PR author, sure.
- Affects important code area:
  - [ ] Onboarding
  - [ ] State / providers
  - [ ] Message sync
  - [ ] Channel display
  - [ ] Notifications

## Rollback plan

Revert.

## Screenshots / videos

Nashi.
