### PR TITLE
groups: fix refactor issues with index previews

### DIFF
--- a/desk/app/groups.hoon
+++ b/desk/app/groups.hoon
@@ -854,7 +854,7 @@
     (emit %give %kick ~ ~)
   ::
       [%server %groups %index ~]
-    se-abet:se-watch-index:se-core
+    cor:se-watch-index:se-core
   ::
     ::
     ::  client paths
@@ -877,13 +877,13 @@
     ::  deprecated
     [%groups %ui ~]  ?>(from-self cor)
   ::
-      [%v1 %foreigns ship=@ name=@ rest=*]
-    =+  ship=(slav %p ship.pole)
-    fi-abet:(fi-watch:(fi-abed:fi-core ship name.pole) %v1 rest.pole)
-  ::
       [%v1 %foreigns %index ship=@ ~]
     =+  ship=(slav %p ship.pole)
     fi-abet:(fi-watch-index:fi-core %v1 ship)
+  ::
+      [%v1 %foreigns ship=@ name=@ rest=*]
+    =+  ship=(slav %p ship.pole)
+    fi-abet:(fi-watch:(fi-abed:fi-core ship name.pole) %v1 rest.pole)
   ::
       ::  deprecated
       [%gangs ship=@ name=@ %preview ~]
@@ -1078,6 +1078,10 @@
       cor
     go-abet:(go-agent:(go-abed:go-core ship name.pole) rest.pole sign)
   ::
+      [%foreigns %index ship=@ ~]
+    =+  ship=(slav %p ship.pole)
+    fi-abet:(fi-take-index:fi-core ship sign)
+  ::
       [%foreigns ship=@ name=@ rest=*]
     =/  ship  (slav %p ship.pole)
     ?:  ?&  ?=(%kick -.sign)
@@ -1087,10 +1091,6 @@
       ::
       cor
     fi-abet:(fi-agent:(fi-abed:fi-core ship name.pole) rest.pole sign)
-  ::
-      [%foreigns %index ship=@ ~]
-    =+  ship=(slav %p ship.pole)
-    fi-abet:(fi-take-index:fi-core ship sign)
   ::
       [%chan app=@ ship=@ name=@ rest=*]
     =/  =ship  (slav %p ship.pole)
@@ -2340,7 +2340,7 @@
     ^-  (unit [flag:g preview:v7:gv])
     ?.  &(=(our.bowl p.flag) !?=(%secret privacy.admissions.group))
       ~
-    `[flag se-preview]
+    `[flag se-preview:(se-abed flag)]
   ::  +se-is-admin-u-group: check if group update is restricted
   ::
   ++  se-is-admin-update


### PR DESCRIPTION
## Summary

Found a few issues while I was testing changes, mostly around path specificity and core referencing. This addresses all that I've found so far.

## Changes

- Fixed index previews not initializing `se-core` with group
- Fixed index preview crashing because of check in se-abet, since we aren't modifying we didn't need to call `se-abet`
- Fixed path matching order so we actually hit the cases for `%index`

## How did I test?

Manually using two ships across the network.

## Risks and impact

- Safe to rollback without consulting PR author? Yes
- Affects important code area:
  - [ ] Onboarding
  - [ ] State / providers
  - [ ] Message sync
  - [ ] Channel display
  - [ ] Notifications

## Rollback plan

<!-- Describe the steps to revert these changes if needed. -->

## Screenshots / videos

<!-- Attach any relevant media. -->
