### PR TITLE
grouper: make sure we use the right mark and handle logging correctly

### DIFF
--- a/desk/app/grouper.hoon
+++ b/desk/app/grouper.hoon
@@ -131,7 +131,6 @@
       ?~  p.sign  `this
       %-  (slog leaf/"Poke failed {<wire>}" u.p.sign)
       `this
-    ?>  ?=([%dm ship=@ token=@ ~] wire)
     =*  joiner  i.t.wire
     =*  token  i.t.t.wire
     :_  this

--- a/desk/app/grouper.hoon
+++ b/desk/app/grouper.hoon
@@ -126,8 +126,34 @@
       `this(outstanding-pokes (~(del in outstanding-pokes) [src.bowl i.t.t.wire]))
     ==
   ?-  -.sign
-      %poke-ack   `this
+      %poke-ack
+    ?.  ?=([%dm ship=@ token=@ ~] wire)
+      ?~  p.sign  `this
+      %-  (slog leaf/"Poke failed {<wire>}" u.p.sign)
+      `this
+    ?>  ?=([%dm ship=@ token=@ ~] wire)
+    =*  joiner  i.t.wire
+    =*  token  i.t.t.wire
+    :_  this
+    :_  ~
+    ?~  p.sign
+      %^  tell:log  %info
+        ~[leaf+"{<joiner>} invited to DM"]
+      :~  'event'^s+'DM Invite Sent'
+          'flow'^s+'lure'
+          'lure-id'^s+token
+          'lure-joiner'^s+joiner
+      ==
+    %^  tell:log  %crit
+      u.p.sign
+    :~  'event'^s+'DM Invite Fail'
+        'flow'^s+'lure'
+        'lure-id'^s+token
+        'lure-joiner'^s+joiner
+    ==
+  ::
       %watch-ack  `this
+  ::
       %kick
     :_  this
     ~[(bite-subscribe bowl)]
@@ -158,7 +184,7 @@
         :_  ~
         %^  lure-log  %crit  dm-event
         ~[leaf+"inviter {<u.inviter>} is foreign"]
-      =/  wir=^wire  /dm/(scot %p joiner.bite)
+      =/  wir=^wire  /dm/(scot %p joiner.bite)/[token.bite]
       =/  =dock  [our.bowl %chat]
       =/  =id:c  [our now]:bowl
       =/  =memo:ch
@@ -166,10 +192,8 @@
       =/  =action:dm:c
         :-  joiner.bite
         [id %add %*(. *essay:ch - memo, kind [%chat %notice ~]) ~]
-      =/  =cage  chat-dm-action+!>(`action:dm:c`action)
-      =*  dez  %^  lure-log  %info  'DM Invite Sent'
-               ~[leaf+"{<joiner.bite>} invited to DM"]
-      (snoc [dez caz] [%pass wir %agent dock %poke cage])
+      =/  =cage  chat-dm-action-1+!>(`action:dm:c`action)
+      (snoc caz [%pass wir %agent dock %poke cage])
     ::
     =+  invite-type=(~(get by fields.metadata.bite) 'inviteType')
     ::


### PR DESCRIPTION
## Summary

This fixes an issue found where newly joining ships were not getting a DM invite from their inviter. This was caused by a mark/type mismatch. Additionally logging was lacking here so I fixed that too.
 
## Changes

- change `chat-dm-action` to `chat-dm-action-1` to match the type we were sending
- move 'DM Invite Sent' event to only send on successful poke to ourselves
- add 'DM Invite Fail' event when we get a poke-nack

## How did I test?

Ran changes locally, used personal invite lure and sent an HTTP request to simulate a bite.

## Risks and impact

- Safe to rollback without consulting PR author? Yes
- Affects important code area:
  - [ ] Onboarding
  - [ ] State / providers
  - [ ] Message sync
  - [ ] Channel display
  - [ ] Notifications

## Rollback plan

<!-- Describe the steps to revert these changes if needed. -->

## Screenshots / videos

<!-- Attach any relevant media. -->
