### PR TITLE
groups: change to correct type for take-contact

### DIFF
--- a/desk/app/groups.hoon
+++ b/desk/app/groups.hoon
@@ -1157,10 +1157,10 @@
     cor
   ::
       %fact
-    =+  !<(=update-0:tac q.cage.sign)
-    ?~  con.update-0  cor
+    =+  !<(=news-0:tac q.cage.sign)
+    ?~  con.news-0  cor
     %-  emil
-    %+  turn  ~(tap in groups.con.update-0)
+    %+  turn  ~(tap in groups.con.news-0)
     |=  =flag:g
     [%pass /gangs/(scot %p p.flag)/[q.flag]/preview %agent [p.flag dap.bowl] %watch /v1/groups/(scot %p p.flag)/[q.flag]/preview]
   ==


### PR DESCRIPTION
## Summary

OTT, we've had the wrong type since at least https://github.com/tloncorp/tlon-apps/commit/090064947280d4d2e342227783e63598c4356b8c 

## Changes

- changed update-0 to news-0

## How did I test?

Manually changing profile from one ship and watching terminal from listening ship

## Risks and impact

- Safe to rollback without consulting PR author? Yes
- Affects important code area:
  - [ ] Onboarding
  - [ ] State / providers
  - [ ] Message sync
  - [ ] Channel display
  - [ ] Notifications

## Rollback plan

<!-- Describe the steps to revert these changes if needed. -->

## Screenshots / videos

<!-- Attach any relevant media. -->
