### PR TITLE
fix channels perms persistance issue

### DIFF
--- a/desk/app/groups.hoon
+++ b/desk/app/groups.hoon
@@ -1774,6 +1774,16 @@
     |=  [=time =diff:g]
     ^+  go-core
     =.  go-core
+      ::  For channel edits, only emit update if something actually changed
+      ?:  ?&  ?=(%channel -.diff)
+              ?=(%edit -.q.diff)
+          ==
+        =/  =channel:g  (~(got by channels.group) p.diff)
+        =/  new-channel=channel:g  channel.q.diff
+        ::  Only emit update if channel data actually changed
+        ?.  =(channel new-channel)
+          (go-tell-update time diff)
+        go-core
       (go-tell-update time diff)
     =.  net
       ?:    ?=(%pub -.net)


### PR DESCRIPTION
## Summary

fixes tlon-4468

Users were seeing an issue where channel permissions made on web were not reflected on the mobile client unless they killed the app and re-opened. It turns out this was caused by `updateChannel` being constructed in such a way that we didn't attempt to update channel permissions if we didn't receive both `writerRoles` and `readerRoles` in the update. For instance, we would receive an event on the channels subscription indicating we needed to add writers, but that event only contained `writerRoles`; we would pass that to `updateChannel`, and that query would complete without updating the `writers` property because we didn't have both roles arrays. The fix here was just to account for the fact that we could receive updates that are only about readers or writers.

My original theory about duplicate events, etc, was incorrect. However, I do think we should avoid sending unnecessary events from the backend. `%groups` was sending a totally unnecessary event when `writersRoles` changed (`%groups` does not track state for writers, that is tracked in `%channels`). I would think this could cause problems, where hearing an unnecessary/duplicate update could cause race condition issues, especially with `syncGroup`'s optimization logic that attempts to prevent subsequent/unnecessary syncs. If we want to leave the change that fixes this out though, that's fine. It's totally unnecessary to fix the issue here.

I also noticed an issue with the ChatOptionsSheet's action buttons sometimes being unresponsive on iOS. I hit my head against a wall for a while trying to figure out what is causing this and came up short. Will make a separate issue.

## Changes

- fix the `updateChannels` query, account for the fact that we could only hear about an update with either `writerRoles` or `readerRoles`.
- prevent `%groups` from sending out an update when the channel diff matches what we already have in agent state.

## How did I test?

Tested on web and iOS. Open up the edit channel screen for one particular channel on both clients. Add/remove reader or writer roles on one client, watch them update on the other client as soon as we get the events.

## Risks and impact

- Safe to rollback without consulting PR author? Yes
- Affects important code area:
  - [ ] Onboarding
  - [x] State / providers (kinda. it's the db)
  - [ ] Message sync
  - [ ] Channel display
  - [ ] Notifications

## Rollback plan

revert
