### PR TITLE
chat: add missing wire

### DIFF
--- a/desk/app/chat.hoon
+++ b/desk/app/chat.hoon
@@ -971,11 +971,11 @@
     %-  (slog leaf/"Failed to heed contact {(trip ship.pole)}" u.p.sign)
     cor
   ::
-      [%v1 %dm ship=@ rest=*]
+      [?(%v1 %v2) %dm ship=@ rest=*]
     =/  =ship  (slav %p ship.pole)
     di-abet:(di-agent:(di-abed:di-core ship) rest.pole sign)
   ::
-      [%v1 %club id=@ rest=*]
+      [?(%v1 %v2) %club id=@ rest=*]
     =/  =id:club:c  (slav %uv id.pole)
     cu-abet:(cu-agent:(cu-abed id) rest.pole sign)
   ==


### PR DESCRIPTION
## Summary

We missed a wire when adding sequence numbers to %chat. This adds that in.

## Changes

- Adds support for v2 wires

## How did I test?

Compiled and manually added slog to on-fail to make sure we aren't seeing crashes (removed before committing)

## Risks and impact

- Safe to rollback without consulting PR author? Yes
- Affects important code area:
  - [ ] Onboarding
  - [ ] State / providers
  - [ ] Message sync
  - [ ] Channel display
  - [ ] Notifications

## Rollback plan

<!-- Describe the steps to revert these changes if needed. -->

## Screenshots / videos

<!-- Attach any relevant media. -->
