### PR TITLE
links: show previews for file links, send proper metadata for file links in gallery LinkInput

### DIFF
--- a/packages/app/ui/components/BareChatInput/index.tsx
+++ b/packages/app/ui/components/BareChatInput/index.tsx
@@ -379,6 +379,15 @@ export default function BareChatInput({
                     },
                   });
                 }
+
+                const fileType = linkMetadata.mime.split('/')[1];
+
+                addAttachment({
+                  type: 'link',
+                  url: url,
+                  title: fileType,
+                  description: fileType,
+                });
               }
             })
             .finally(() => {

--- a/packages/app/ui/components/draftInputs/LinkInput.tsx
+++ b/packages/app/ui/components/draftInputs/LinkInput.tsx
@@ -155,9 +155,13 @@ export function LinkInput({ editingPost, isPosting, onSave }: LinkInputProps) {
         };
       }
 
+      const fileType = data.mime.split('/')[1];
+
       return {
-        ...data,
         type: 'link',
+        url: data.url,
+        title: fileType,
+        description: fileType,
       };
     }
 


### PR DESCRIPTION
## Summary
fixes tlon-4551

In the Gallery `LinkInput` component we were just spreading whatever `data` we received back from `useLinkGrabber` right into what was supposed to have been a `Link` block. For files, that data looks like this:

```
type FileMetadata = {
  url: string;
  type: 'file';
  mime: string;
  isImage?: boolean;
};
```

This is not a valid `Link` block, so we'd get a `cast-fail` when poking the backend with a new post where this was in our `essay`'s `content`.

Instead of just spreading the `data` into what is supposed to be the link block, I construct a valid link block with a `title` and `description` that consist of just the file type (pulled from the `mime` field we get from `FileMetadata`).

This fixes the issue and also gives us the filetype in the preview. We could, in the future, show specific icons for different filetypes.

I also updated BareChatInput to show link previews with file types (it did not have the same issue as LinkInput, though. In BareChatInput we just didn't send a `Link` block if the linked file was not an image).


## How did I test?

Tested on web and iOS.

## Risks and impact

- Safe to rollback without consulting PR author? Yes
- Affects important code area: N/A

## Rollback plan

Revert.

## Screenshots / videos

<img width="548" height="343" alt="image" src="https://github.com/user-attachments/assets/396fc296-c567-4a32-8c20-41555b9896e7" />
