### PR TITLE
link input: fix URL validation issue

### DIFF
--- a/packages/shared/src/logic/utils.ts
+++ b/packages/shared/src/logic/utils.ts
@@ -22,7 +22,7 @@ export const IMAGE_REGEX =
   /(\.jpg|\.img|\.png|\.gif|\.tiff|\.jpeg|\.webp|\.svg)(?:\?.*)?$/i;
 export const AUDIO_REGEX = /(\.mp3|\.wav|\.ogg|\.m4a)(?:\?.*)?$/i;
 export const VIDEO_REGEX = /(\.mov|\.mp4|\.ogv|\.webm)(?:\?.*)?$/i;
-export const URL_REGEX = /(https?:\/\/[^\s]+)/i;
+export const URL_REGEX = /^https?:\/\/[^\s]+$/i;
 export const PATP_REGEX = /(~[a-z0-9-]+)/i;
 export const IMAGE_URL_REGEX =
   /^(http(s?):)([/.\w\s-:]|%2*)*\.(?:jpg|img|png|gif|tiff|jpeg|webp|svg)(?:\?.*)?$/i;


### PR DESCRIPTION
## Summary

fixes tlon-4550.

Our `URL_REGEX` only checked if a string contained a valid URL *anywhere* in the string, not whether the string is *only* a valid URL. So a user could input any string into the URL input on gallery's LinkInput and it would be considered valid so long as that string had a URL within it. Adding the `^` and `$` anchors to the regex pattern fixes this.

The crash that Eleanor was seeing was caused by BlockRenderer attempting to render a link block where the URL was one of these invalid strings that contained URLs but weren't *just* URLs. We shouldn't crash in this case, we should just show a URL preview that tells the user the URL is invalid (and going forward, there shouldn't be anymore invalid URLs that we attempt to render in BlockRenderer).


## How did I test?

Tested on web.

## Risks and impact

- Safe to rollback without consulting PR author? Yes
- Affects important code area: N/A

## Rollback plan

Revert

## Screenshots / videos

Link blocks with invalid URLs will now render like this:
<img width="806" height="599" alt="image" src="https://github.com/user-attachments/assets/45941192-bf7b-4d63-b07b-11f0751c7cf3" />

