### PR TITLE
MessageActions: only show admin edit for notebook posts themselves

### DIFF
--- a/packages/app/ui/components/ChatMessage/ChatMessageActions/MessageActions.tsx
+++ b/packages/app/ui/components/ChatMessage/ChatMessageActions/MessageActions.tsx
@@ -96,10 +96,11 @@ const ConnectedAction = memo(function ConnectedAction({
         // only show mute for threads
         return post.parentId;
       case 'edit':
-        // only show edit for current user's posts OR admins of notebook posts
+        // only show edit for current user's posts
+        // OR admins for top-level notebook posts
         return (
           post.authorId === currentUserId ||
-          (channel.type === 'notebook' && currentUserIsAdmin)
+          (channel.type === 'notebook' && currentUserIsAdmin && !post.parentId)
         );
       case 'delete':
         // only show delete for current user's posts


### PR DESCRIPTION
## Summary

Fixes TLON-4371 by only showing the edit button for admins of a group containing a Notebook channel for the Notebook posts themselves, not the comments beneath.

## Changes

Adds a condition to the show/hide logic for the edit action in MessageActions. If the post does not have a parent, we can assume it's at the root level of the channel.

## How did I test?

- Navigate to a group where you are the admin and others have commented on notebook posts
- Click the ... message actions on anothers' comment
- Observe that you are now no longer able to edit the comment (which didn't work anyway, hence TLON-4371)

## Risks and impact

- Safe to rollback without consulting PR author? Yes
- Affects important code area:
  - [ ] Onboarding
  - [ ] State / providers
  - [ ] Message sync
  - [x] Channel display
  - [ ] Notifications

## Rollback plan

git revert
