### PR TITLE
ActivitySummaryMessage: fix plurality for group join requests

### DIFF
--- a/packages/app/ui/components/Activity/ActivitySummaryMessage.tsx
+++ b/packages/app/ui/components/Activity/ActivitySummaryMessage.tsx
@@ -18,6 +18,7 @@ function SummaryMessageRaw({
   const count = summary.all.length;
   const plural = summary.all.length > 1;
   const authors = useActivitySummaryAuthors(summary);
+  const shipsPlural = authors.length > 1;
 
   if (
     authors.length === 1 &&
@@ -122,7 +123,7 @@ function SummaryMessageRaw({
     return (
       <SummaryText>
         <ActivitySummaryAuthorList contactIds={authors} />
-        {` ${plural ? 'are' : 'is'} requesting to join the group`}
+        {` ${shipsPlural ? 'are' : 'is'} requesting to join the group`}
       </SummaryText>
     );
   }


### PR DESCRIPTION
## Summary

Fixes TLON-4488 by using the correct grammar for single or multiple ships asking for permission to join a group.

## Changes

In ActivitySummaryMessage, plurality for the rest of the relevancy types is determined by summary.all.length > 1, but for this case it should be determined by authors.length > 1.

The summary.all array contains all the activity events, which could include multiple events from the same user, while authors contains the unique list of users. So even if there's only one user requesting to join, if they have multiple events in summary.all, it would incorrectly show "are" instead of "is".

Therefore, we should see the following notifications for...

```
1 ship: "~zod is requesting to join the group"
2 ships: "~zod and ~bus are requesting to join the group"
3 ships: "~zod, ~bus, and ~web are requesting to join the group"
5+ ships: "~zod, ~bus, ~web, and others are requesting to join the group"
```

## How did I test?

- Create a group on ship A, make it private
- Note the group "flag"
- On ship B, join the group via shortcode from the + button and request to join
- On ship C, join the group via shortcode from the + button and request to join
- On ship A, you should see that two ships "are" requesting to join. Admit or deny them
- On ship D, join the group via shortcode from the + button and request to join
- On ship A, you shouls see that one ship "is" requesting to join

## Risks and impact

- Safe to rollback without consulting PR author? Yes
- Affects important code area:
  - [ ] Onboarding
  - [ ] State / providers
  - [ ] Message sync
  - [ ] Channel display
  - [x] Notifications

## Rollback plan

git revert
