### PR TITLE
ActionSheet: fix issue with unreliable button presses

### DIFF
--- a/packages/app/ui/components/ActionSheet.tsx
+++ b/packages/app/ui/components/ActionSheet.tsx
@@ -565,9 +565,18 @@ function ActionSheetAction({
     pressStarted.current = false;
   }, [action, accent]);
 
+  const handlePress = useCallback(() => {
+    if (accent !== 'disabled' && !action.disabled && action.action) {
+      action.action();
+    }
+  }, [action, accent]);
+
   if (action.render) {
     return action.render({ action });
   }
+
+  // Use regular onPress on desktop/web where popovers work fine
+  const useAlternativePress = Platform.OS !== 'web' && isWindowNarrow;
 
   return (
     <ActionSheetActionFrame
@@ -578,8 +587,9 @@ function ActionSheetAction({
             ? 'disabled'
             : action.accent ?? accent
       }
-      onPressIn={handlePressIn}
-      onPressOut={handlePressOut}
+      {...(useAlternativePress
+        ? { onPressIn: handlePressIn, onPressOut: handlePressOut }
+        : { onPress: handlePress })}
       height={isWindowNarrow ? undefined : '$4xl'}
       testID={testID}
       disabled={action.disabled}

--- a/packages/app/ui/components/ActionSheet.tsx
+++ b/packages/app/ui/components/ActionSheet.tsx
@@ -547,23 +547,6 @@ function ActionSheetAction({
 }) {
   const isWindowNarrow = useIsWindowNarrow();
   const accent: Accent = useContext(ActionSheetActionGroupContext).accent;
-  const pressStarted = useRef(false);
-
-  const handlePressIn = useCallback(() => {
-    pressStarted.current = true;
-  }, []);
-
-  const handlePressOut = useCallback(() => {
-    if (
-      pressStarted.current &&
-      accent !== 'disabled' &&
-      !action.disabled &&
-      action.action
-    ) {
-      action.action();
-    }
-    pressStarted.current = false;
-  }, [action, accent]);
 
   const handlePress = useCallback(() => {
     if (accent !== 'disabled' && !action.disabled && action.action) {
@@ -575,9 +558,6 @@ function ActionSheetAction({
     return action.render({ action });
   }
 
-  // Use regular onPress on desktop/web where popovers work fine
-  const useAlternativePress = Platform.OS !== 'web' && isWindowNarrow;
-
   return (
     <ActionSheetActionFrame
       type={
@@ -587,12 +567,9 @@ function ActionSheetAction({
             ? 'disabled'
             : action.accent ?? accent
       }
-      {...(useAlternativePress
-        ? { onPressIn: handlePressIn, onPressOut: handlePressOut }
-        : { onPress: handlePress })}
+      onPress={handlePress}
       height={isWindowNarrow ? undefined : '$4xl'}
       testID={testID}
-      disabled={action.disabled}
     >
       {action.startIcon &&
         resolveIcon(action.startIcon, action.accent ?? accent)}

--- a/packages/app/ui/components/ChatOptionsSheet.tsx
+++ b/packages/app/ui/components/ChatOptionsSheet.tsx
@@ -796,9 +796,9 @@ export function ChatOptionsSheetContent({
           </ActionSheet.MainContent>
         </ActionSheet.Header>
       )}
-      <ActionSheet.ScrollableContent width={isWindowNarrow ? '100%' : 240}>
+      <ActionSheet.Content width={isWindowNarrow ? '100%' : 240}>
         <ActionSheet.SimpleActionGroupList actionGroups={actionGroups} />
-      </ActionSheet.ScrollableContent>
+      </ActionSheet.Content>
     </>
   );
 }


### PR DESCRIPTION
## Summary
Fixes tlon-4602.

~Fix intermittent button press issues in ActionSheet on iOS where buttons required multiple taps to trigger actions (or, in some cases, the buttons would never trigger the actions at all). Replaced unreliable onPress callbacks with onPressIn/onPressOut events and manual state tracking to ensure reliable touch handling in modal contexts.~

~I assume there is something happening here that is causing normal onPress to fail because we're in a modal context. When we were using onPress you could still see the press register visually (the press style would be applied), but the handler would never fire.~

Update: the issue was resolved by switching from `ActionSheet.ScrollableContent` to `ActionSheet.Content` in `ChatOptionsSheet`. The `onPressIn`/`onPressOut` solution was unnecessary, and I don't see any reason why we should need to scroll this content.

## Changes

- Use `ActionSheet.ScrollableContent` rather than `ActionSheet.Content` in `ChatOptionsSheet`.
- Move `handlePress` into a `useCallback`

## How did I test?

Tested on iOS, web, and Android.

## Risks and impact

- Safe to rollback without consulting PR author? Yes
- Affects important code area: N/A

## Rollback plan

revert

## Screenshots / videos

https://github.com/user-attachments/assets/64766f3b-f1b1-4f3c-8753-1f89a60f1bbb

