### PR TITLE
ReadOnlyNotice: remove single-quotes around message

### DIFF
--- a/packages/app/ui/components/Channel/ReadOnlyNotice.tsx
+++ b/packages/app/ui/components/Channel/ReadOnlyNotice.tsx
@@ -14,7 +14,7 @@ export function ReadOnlyNotice({
 }) {
   const Message =
     type === 'read-only' ? (
-      <>'This channel is read-only for you.'</>
+      <>This channel is read-only for you.</>
     ) : type === 'no-longer-read' ? (
       <>You no longer have permission to read this channel.</>
     ) : (


### PR DESCRIPTION
This was annoying me. At one point in the past we used to just return a string instead of a React fragment. I assume we simply missed this.