### PR TITLE
ChatOptionsSheet: make sure pane state is reset when the sheet/popover is closed.

### DIFF
--- a/packages/app/ui/components/ChatOptionsSheet.tsx
+++ b/packages/app/ui/components/ChatOptionsSheet.tsx
@@ -140,6 +140,12 @@ export function GroupOptionsSheetLoader({
     setPane('initial');
   }, [setPane]);
 
+  useEffect(() => {
+    if (!open) {
+      resetPane();
+    }
+  }, [open, resetPane]);
+
   const title = utils.useGroupTitle(group) ?? 'Loading...';
   const currentUserId = useCurrentUserId();
   const currentUserIsAdmin = utils.useIsAdmin(groupId, currentUserId);


### PR DESCRIPTION
## Summary
fixes tlon-4366

We added this fix at some point to ChannelOptionsSheetLoader but didn't make the same change to GroupOptionsSheetLoader. We just need to call `resetPane()` when we hear that the sheet is not open so we can avoid having the last pane appear when the sheet is opened again.

## How did I test?

Web

## Risks and impact

- Safe to rollback without consulting PR author? Yes

## Rollback plan

Revert