### PR TITLE
groups: visually handle situation where a user does not have access to any channels in a group

### DIFF
--- a/packages/app/navigation/utils.ts
+++ b/packages/app/navigation/utils.ts
@@ -450,7 +450,13 @@ export async function getMainGroupRoute(
     }
 
     if (!isWindowNarrow) {
-      return getDesktopChannelRoute('Home', group.channels[0].id, groupId);
+      if (group.channels.length > 0) {
+        return getDesktopChannelRoute('Home', group.channels[0].id, groupId);
+      }
+      return {
+        name: 'GroupChannels',
+        params: { groupId },
+      } as const;
     }
 
     return {

--- a/packages/app/ui/components/GroupChannelsScreenView.tsx
+++ b/packages/app/ui/components/GroupChannelsScreenView.tsx
@@ -1,7 +1,7 @@
 import { FlashList, ListRenderItem } from '@shopify/flash-list';
 import * as db from '@tloncorp/shared/db';
 import * as logic from '@tloncorp/shared/logic';
-import { SectionListHeader, useIsWindowNarrow } from '@tloncorp/ui';
+import { SectionListHeader, Text, useIsWindowNarrow } from '@tloncorp/ui';
 import { LoadingSpinner } from '@tloncorp/ui';
 import React, { useCallback, useMemo, useRef, useState } from 'react';
 import { LayoutChangeEvent } from 'react-native';
@@ -299,6 +299,21 @@ export const GroupChannelsScreenView = React.memo(
               paddingBottom: insets.bottom,
             }}
           />
+        ) : group && group.channels && group.channels.length === 0 ? (
+          <YStack
+            flex={1}
+            justifyContent="center"
+            alignItems="center"
+            gap="$m"
+            padding="$m"
+          >
+            <Text color="$primaryText" fontSize="$m" textAlign="center">
+              You don&apos;t have access to any channels in this group.
+            </Text>
+            <Text color="$primaryText" fontSize="$m" textAlign="center">
+              Please contact the group host to request access.
+            </Text>
+          </YStack>
         ) : (
           <YStack flex={1} justifyContent="center" alignItems="center">
             <LoadingSpinner />


### PR DESCRIPTION
## Summary

We had no way to visually represent the state that a user can get into when they're a member of a group but they don't have access to any channels in that group. On desktop, the user would press the group's list item in the ChatList and it wouldn't go anywhere (`getMainGroupRoute` in our navigation utils assumed that we would always have some channel id that could be used to build a route), and on mobile you could press it and get navigated to a blank white screen where the group's channels list should be.

The fix for this, imo, is to show a message in `GroupChannelsScreenView` when we know we have data for the group but we don't have any channels (and for desktop, to route the user to the `GroupChannels` route where this message will be shown).

## Changes

- Add new message/case in `GroupChannelsScreenView` to account for this state.
- Update `getMainGroupRoute` in `packages/app/navigation/utils.ts` to return the route for `GroupChannels` if we find that we don't have any channels for a group.

## How did I test?

Tested on web and iOS.

## Risks and impact

- Safe to rollback without consulting PR author? Yes
## Rollback plan

Revert

## Screenshots / videos

<img width="1219" height="1357" alt="image" src="https://github.com/user-attachments/assets/ecd6c8b1-5523-4bf0-8237-94e792389e13" />
<img width="1170" height="2532" alt="Home App Screenshot iPhone 12 Pro" src="https://github.com/user-attachments/assets/ec7ba75d-0c10-4406-b6e7-47426342cd60" />
