### PR TITLE
InviteUsersWidget: disable users who are already members to prevent double-inviting

### DIFF
--- a/packages/app/ui/components/InviteUsersWidget.tsx
+++ b/packages/app/ui/components/InviteUsersWidget.tsx
@@ -22,6 +22,11 @@ const InviteUsersWidgetComponent = ({
   const [loading, setLoading] = useState(false);
   const [invitees, setInvitees] = useState<string[]>([]);
 
+  // Extract existing group member IDs to mark them as immutable
+  const existingMemberIds = useMemo(() => {
+    return group.members?.map(member => member.contactId) ?? [];
+  }, [group.members]);
+
   const handleInviteGroupMembers = useCallback(async () => {
     setLoading(true);
     try {
@@ -61,6 +66,7 @@ const InviteUsersWidgetComponent = ({
           searchPlaceholder="Filter by nickname, @p"
           onSelectedChange={setInvitees}
           onScrollChange={onScrollChange}
+          immutableIds={existingMemberIds}
         />
       </ActionSheet.ContentBlock>
       <ActionSheet.ContentBlock>


### PR DESCRIPTION
## Summary

Fixes TLON-4622 by preventing the user from inviting contacts and other ships who are already members to the group again.

## Changes

When users access the "Invite people" menu, the InviteUsersWidget now extracts all existing group member IDs. These member IDs are passed to the ContactBook component as the immutableIds prop.

The ContactBook component then uses these IDs to mark contacts as immutable, which shows a blue checkmark next to their names, prevents them from being selected for invitation, and provides clear visual feedback that they're already group members.

## How did I test?

- Select the "Invite people" group option for a group you have invite rights for (admin/host of a private/secret group or member of a public group)
- Note that if some of your contacts are in the group, they are unselectable
- Enter a portion of a valid ship name you know is in the group but not in your contacts
- Note that they are marked ineligible as well
- 
## Risks and impact

- Safe to rollback without consulting PR author? Yes
- Affects important code area:
  - [ ] Onboarding
  - [x] State / providers
  - [ ] Message sync
  - [ ] Channel display
  - [ ] Notifications

## Rollback plan

git revert

## Screenshots / videos

<img width="1468" height="969" alt="Screenshot 2025-07-29 at 10 36 13 AM" src="https://github.com/user-attachments/assets/86d1af80-0ee5-4dbe-912d-f36a864ce1ae" />

<img width="1468" height="969" alt="Screenshot 2025-07-29 at 10 36 10 AM" src="https://github.com/user-attachments/assets/7c4ef99d-24b9-4ddb-8da3-a206090ad0ac" />
