### PR TITLE
ChatMessageActions: hide certain actions for !canWrite

### DIFF
--- a/packages/app/ui/components/ChatMessage/ChatMessage.tsx
+++ b/packages/app/ui/components/ChatMessage/ChatMessage.tsx
@@ -9,7 +9,8 @@ import { isEqual } from 'lodash';
 import { ComponentProps, memo, useCallback, useMemo, useState } from 'react';
 import { View, XStack, YStack, isWeb } from 'tamagui';
 
-import { useChannelContext } from '../../contexts';
+import { useChannelContext, useCurrentUserId } from '../../contexts';
+import { useCanWrite } from '../../utils/channelUtils';
 import AuthorRow from '../AuthorRow';
 import { DefaultRendererProps } from '../PostContent/BlockRenderer';
 import { createContentRenderer } from '../PostContent/ContentRenderer';
@@ -61,9 +62,11 @@ const ChatMessage = ({
   const [isHovered, setIsHovered] = useState(false);
   const [isPopoverOpen, setIsPopoverOpen] = useState(false);
   const channel = useChannelContext();
+  const currentUserId = useCurrentUserId();
+  const canWrite = useCanWrite(channel, currentUserId);
   const postActionIds = useMemo(
-    () => ChannelAction.channelActionIdsFor({ channel }),
-    [channel]
+    () => ChannelAction.channelActionIdsFor({ channel, canWrite }),
+    [channel, canWrite]
   );
 
   const isNotice = post.type === 'notice';

--- a/packages/app/ui/components/ChatMessage/ChatMessageActions/Component.tsx
+++ b/packages/app/ui/components/ChatMessage/ChatMessageActions/Component.tsx
@@ -1,3 +1,4 @@
+import * as store from '@tloncorp/shared/store';
 import { useIsWindowNarrow } from '@tloncorp/ui';
 import React, { useEffect, useState } from 'react';
 import { Dimensions, LayoutChangeEvent } from 'react-native';
@@ -10,7 +11,9 @@ import Animated, {
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
 import { Popover, View, XStack, YStack } from 'tamagui';
 
+import { useCurrentUserId } from '../../../contexts';
 import { triggerHaptic } from '../../../utils';
+import { useCanWrite } from '../../../utils/channelUtils';
 import { EmojiToolbar } from './EmojiToolbar';
 import MessageActions from './MessageActions';
 import { MessageContainer } from './MessageContainer';
@@ -38,6 +41,9 @@ export function ChatMessageActions({
   onOpenChange,
   mode,
 }: ChatMessageActionsProps) {
+  const currentUserId = useCurrentUserId();
+  const channel = store.useChannel({ id: post.channelId });
+  const canWrite = useCanWrite(channel.data, currentUserId);
   const insets = useSafeAreaInsets();
   const PADDING_THRESHOLD = 40;
 
@@ -154,13 +160,15 @@ export function ChatMessageActions({
             padding={1}
           >
             <YStack gap="$xs">
-              <XStack justifyContent="center">
-                <EmojiToolbar
-                  post={post}
-                  onDismiss={onDismiss}
-                  openExternalSheet={onShowEmojiPicker}
-                />
-              </XStack>
+              {canWrite && (
+                <XStack justifyContent="center">
+                  <EmojiToolbar
+                    post={post}
+                    onDismiss={onDismiss}
+                    openExternalSheet={onShowEmojiPicker}
+                  />
+                </XStack>
+              )}
               <MessageActions
                 post={post}
                 postActionIds={postActionIds}
@@ -184,7 +192,7 @@ export function ChatMessageActions({
             paddingHorizontal="$xl"
           >
             <YStack gap="$xs">
-              <EmojiToolbar post={post} onDismiss={onDismiss} />
+              {canWrite && <EmojiToolbar post={post} onDismiss={onDismiss} />}
               <MessageContainer post={post} />
               <MessageActions
                 post={post}

--- a/packages/app/ui/components/ChatMessage/ChatMessageActions/Component.tsx
+++ b/packages/app/ui/components/ChatMessage/ChatMessageActions/Component.tsx
@@ -43,7 +43,7 @@ export function ChatMessageActions({
 }: ChatMessageActionsProps) {
   const currentUserId = useCurrentUserId();
   const channel = store.useChannel({ id: post.channelId });
-  const canWrite = useCanWrite(channel.data, currentUserId);
+  const canWrite = useCanWrite(channel.data!, currentUserId);
   const insets = useSafeAreaInsets();
   const PADDING_THRESHOLD = 40;
 

--- a/packages/app/ui/components/ChatMessage/ChatMessageActions/MessageActions.tsx
+++ b/packages/app/ui/components/ChatMessage/ChatMessageActions/MessageActions.tsx
@@ -90,8 +90,7 @@ const ConnectedAction = memo(function ConnectedAction({
         // only show start thread if
         // 1. the message is delivered
         // 2. the message isn't a reply
-        // 3. an existing thread for that message doesn't already exist
-        return !post.deliveryStatus && !post.parentId && post.replyCount === 0;
+        return !post.deliveryStatus && !post.parentId;
       case 'muteThread':
         // only show mute for threads
         return post.parentId;
@@ -117,7 +116,6 @@ const ConnectedAction = memo(function ConnectedAction({
     actionId,
     post.deliveryStatus,
     post.parentId,
-    post.replyCount,
     post.authorId,
     post.reactions?.length,
     currentUserId,

--- a/packages/app/ui/components/ChatMessage/ReactionsDisplay.tsx
+++ b/packages/app/ui/components/ChatMessage/ReactionsDisplay.tsx
@@ -25,7 +25,7 @@ export function ReactionsDisplay({
   const currentUserId = useCurrentUserId();
   const [sheetOpen, setSheetOpen] = useState(false);
   const channel = store.useChannel({ id: post.channelId });
-  const canWrite = useCanWrite(channel.data, currentUserId);
+  const canWrite = useCanWrite(channel.data!, currentUserId);
 
   const handleSelectEmoji = useOnEmojiSelect(post, () => setSheetOpen(false));
 

--- a/packages/app/ui/components/GalleryPost/GalleryPost.tsx
+++ b/packages/app/ui/components/GalleryPost/GalleryPost.tsx
@@ -31,7 +31,8 @@ import {
 import { View, XStack, styled } from 'tamagui';
 
 import { RootStackParamList } from '../../../navigation/types';
-import { useChannelContext, useRequests } from '../../contexts';
+import { useChannelContext, useCurrentUserId, useRequests } from '../../contexts';
+import { useCanWrite } from '../../utils/channelUtils';
 import { MinimalRenderItemProps } from '../../contexts/componentsKits';
 import { DetailViewAuthorRow } from '../AuthorRow';
 import { ChatMessageActions } from '../ChatMessage/ChatMessageActions/Component';
@@ -69,9 +70,11 @@ export function GalleryPost({
     hideOverflowMenu?: boolean;
   }) {
   const channel = useChannelContext();
+  const currentUserId = useCurrentUserId();
+  const canWrite = useCanWrite(channel, currentUserId);
   const postActionIds = useMemo(
-    () => ChannelAction.channelActionIdsFor({ channel }),
-    [channel]
+    () => ChannelAction.channelActionIdsFor({ channel, canWrite }),
+    [channel, canWrite]
   );
   const [showRetrySheet, setShowRetrySheet] = useState(false);
   const [isPopoverOpen, setIsPopoverOpen] = useState(false);

--- a/packages/app/ui/components/NotebookPost/NotebookPost.tsx
+++ b/packages/app/ui/components/NotebookPost/NotebookPost.tsx
@@ -21,7 +21,8 @@ import {
   styled,
 } from 'tamagui';
 
-import { useChannelContext } from '../../contexts';
+import { useChannelContext, useCurrentUserId } from '../../contexts';
+import { useCanWrite } from '../../utils/channelUtils';
 import { MinimalRenderItemProps } from '../../contexts/componentsKits';
 import { DetailViewAuthorRow } from '../AuthorRow';
 import { ChatMessageActions } from '../ChatMessage/ChatMessageActions/Component';
@@ -59,9 +60,11 @@ export function NotebookPost({
   const [isPopoverOpen, setIsPopoverOpen] = useState(false);
   const [isHovered, setIsHovered] = useState(false);
   const channel = useChannelContext();
+  const currentUserId = useCurrentUserId();
+  const canWrite = useCanWrite(channel, currentUserId);
   const postActionIds = useMemo(
-    () => ChannelAction.channelActionIdsFor({ channel }),
-    [channel]
+    () => ChannelAction.channelActionIdsFor({ channel, canWrite }),
+    [channel, canWrite]
   );
 
   const handleLongPress = useCallback(() => {

--- a/packages/shared/src/types/ChannelActions.ts
+++ b/packages/shared/src/types/ChannelActions.ts
@@ -23,15 +23,19 @@ export interface StaticSpec {
 
 export function channelActionIdsFor({
   channel,
+  canWrite,
 }: {
   channel: db.Channel;
+  canWrite?: boolean;
 }): Id[] {
   const channelType = channel?.type;
+  let actions: Id[] = [];
+  
   switch (channelType) {
     case undefined:
       return [];
     case 'gallery':
-      return [
+      actions = [
         'startThread',
         'muteThread',
         'copyRef',
@@ -41,8 +45,9 @@ export function channelActionIdsFor({
         'visibility',
         'delete',
       ];
+      break;
     case 'notebook':
-      return [
+      actions = [
         'startThread',
         'muteThread',
         'copyRef',
@@ -52,9 +57,10 @@ export function channelActionIdsFor({
         'visibility',
         'delete',
       ];
+      break;
     case 'dm':
     case 'groupDm':
-      return [
+      actions = [
         'quote',
         'startThread',
         'muteThread',
@@ -63,8 +69,9 @@ export function channelActionIdsFor({
         'visibility',
         'delete',
       ];
+      break;
     case 'chat':
-      return [
+      actions = [
         'quote',
         'startThread',
         'muteThread',
@@ -77,7 +84,16 @@ export function channelActionIdsFor({
         'report',
         'delete',
       ];
+      break;
   }
+
+  // Filter out write-dependent actions if user cannot write
+  if (canWrite === false) {
+    const writeOnlyActions: Id[] = ['quote', 'startThread', 'edit'];
+    actions = actions.filter(action => !writeOnlyActions.includes(action));
+  }
+
+  return actions;
 }
 export function staticSpecForId(id: Id): StaticSpec {
   return STATIC_SPECS[id];


### PR DESCRIPTION
## Summary

Fixes TLON-4628 by removing the ability to...

- add emoji reactions (edit)
- quote
- comment / reply

... for posts in channels you do not have write access to.

## Changes

Imports the channel context into Chat messages, Gallery blocks, and Notebook posts so we have the user's canRead / canWrite status. Passes this down to the message actions component, which then uses a filter in the channelActionIdsFor function to only allow those we deem OK for writers. Also uses canWrite to hide the emoji quick-reaction block.

Also restores the "Reply" or "Comment" option for posts that already have a thread under them.

## How did I test?

- Go to Gallery, Notebook, and Chat channels you have read-only access to
- Access the message actions menu for each
- You should be able to:
  - Copy a reference link
  - Forward
  - Report
  - Hide

Then...

- Go to Gallery, Notebook, and Chat channels you have read and write access to
- Access the message actions menu for each
- You should be able to:
  - React with an emoji
  - Quote (in Chat)
  - Reply ("Comment" in Notebooks and Galleries)
  - Copy a reference link
  - Forward
  - Copy the message text (in Chat)
  - Report
  - Hide
  - Edit (if your own)
  - Delete (if your own or admin)

## Risks and impact

- Safe to rollback without consulting PR author? Yes
- Affects important code area:
  - [ ] Onboarding
  - [x] State / providers
  - [ ] Message sync
  - [x] Channel display
  - [ ] Notifications

## Rollback plan

git revert

## Screenshots / videos

Write access w/ admin role:

<img width="343" height="471" alt="Screenshot 2025-07-29 at 3 45 45 PM" src="https://github.com/user-attachments/assets/a357417f-c9bf-4f86-b1d3-d82f7522b706" />

Write access w/o admin role:

<img width="287" height="376" alt="image" src="https://github.com/user-attachments/assets/6c42d0e6-98c6-467f-9f32-6955af3f92ea" />

No write access:

<img width="151" height="213" alt="image" src="https://github.com/user-attachments/assets/72905982-8a4a-4f23-9eaf-8814e4d6a0eb" />

