### PR TITLE
e2e: add test for unreads, remove some unnecessary lingering cleanup steps in other tests 

### DIFF
--- a/apps/tlon-web/e2e/forwarding-functionality.spec.ts
+++ b/apps/tlon-web/e2e/forwarding-functionality.spec.ts
@@ -13,12 +13,6 @@ test('Forward chat message from group channel to DM - verify toast and reference
   // Assert that we're on the Home page
   await expect(zodPage.getByText('Home')).toBeVisible();
 
-  // Clean up any existing groups and DMs
-  await helpers.cleanupExistingGroup(zodPage, '~ten, ~zod');
-  if (await zodPage.getByText('~ten', { exact: true }).isVisible()) {
-    await helpers.leaveDM(zodPage, '~ten');
-  }
-
   // Create DM between ~zod and ~ten
   await helpers.createDirectMessage(zodPage, '~ten');
   await zodPage.getByTestId('HomeNavIcon').click();

--- a/apps/tlon-web/e2e/gallery-functionality.spec.ts
+++ b/apps/tlon-web/e2e/gallery-functionality.spec.ts
@@ -10,11 +10,6 @@ test('should test gallery functionality', async ({ zodSetup, tenSetup }) => {
   // Assert that we're on the Home page
   await expect(zodPage.getByText('Home')).toBeVisible();
 
-  // Clean up any existing group on zod
-  await helpers.cleanupExistingGroup(zodPage, 'Test Group');
-  await helpers.cleanupExistingGroup(zodPage, '~ten, ~zod');
-  await helpers.cleanupExistingGroup(zodPage);
-
   // Create a new group
   await helpers.createGroup(zodPage);
   const groupName = '~ten, ~zod';
@@ -147,7 +142,4 @@ test('should test gallery functionality', async ({ zodSetup, tenSetup }) => {
   await expect(
     zodPage.getByText('You have hidden or reported this post').first()
   ).not.toBeVisible();
-
-  // Clean up
-  await helpers.cleanupExistingGroup(zodPage);
 });

--- a/apps/tlon-web/e2e/group-customization.spec.ts
+++ b/apps/tlon-web/e2e/group-customization.spec.ts
@@ -11,10 +11,6 @@ test('should customize group name, icon, and description', async ({
   // Assert that we're on the Home page
   await expect(page.getByText('Home')).toBeVisible();
 
-  // Clean up any existing group
-  await helpers.cleanupExistingGroup(page);
-  await helpers.cleanupExistingGroup(page, '~ten, ~zod');
-
   // Create a new group
   await helpers.createGroup(page);
 
@@ -57,11 +53,4 @@ test('should customize group name, icon, and description', async ({
     await expect(descriptionField).toHaveValue('This is a test group');
   }
   await page.getByText('Cancel').click();
-
-  // Delete the group and clean up
-  await helpers.deleteGroup(page, 'My Group');
-
-  // Verify we're back at Home and the renamed group is deleted
-  await expect(page.getByText('Home')).toBeVisible();
-  await expect(page.getByText('My Group')).not.toBeVisible();
 });

--- a/apps/tlon-web/e2e/group-info-settings.spec.ts
+++ b/apps/tlon-web/e2e/group-info-settings.spec.ts
@@ -10,10 +10,6 @@ test('should handle complete group lifecycle with settings management', async ({
 
   await expect(page.getByText('Home')).toBeVisible();
 
-  // Clean up any existing group
-  await helpers.cleanupExistingGroup(page);
-  await helpers.cleanupExistingGroup(page, '~ten, ~zod');
-
   // Create a new group
   await helpers.createGroup(page);
 
@@ -185,7 +181,4 @@ test('should handle complete group lifecycle with settings management', async ({
 
   await helpers.navigateBack(page);
   await helpers.verifyElementCount(page, 'GroupChannels', 1);
-
-  // Delete group
-  await helpers.deleteGroup(page);
 });

--- a/apps/tlon-web/e2e/group-lifecycle.spec.ts
+++ b/apps/tlon-web/e2e/group-lifecycle.spec.ts
@@ -9,10 +9,6 @@ test('should create, verify, and delete a group', async ({ zodPage }) => {
   // Assert that we're on the Home page
   await expect(page.getByText('Home')).toBeVisible();
 
-  // Clean up any existing group
-  await helpers.cleanupExistingGroup(page);
-  await helpers.cleanupExistingGroup(page, '~ten, ~zod');
-
   // Create a new group (this handles the entire creation flow)
   await helpers.createGroup(page);
 

--- a/apps/tlon-web/e2e/group-protocol-mismatch.spec.ts
+++ b/apps/tlon-web/e2e/group-protocol-mismatch.spec.ts
@@ -14,9 +14,6 @@ test('should invite ~bus to a group and test protocol mismatch', async ({
   await helpers.rejectGroupInvite(busPage);
 
   // Step 1: ~zod creates a group and invites ~bus
-  // Clean up any existing group on zod
-  await helpers.cleanupExistingGroup(zodPage);
-  await helpers.cleanupExistingGroup(zodPage, '~bus, ~zod');
 
   // Create a new group on zod
   await helpers.createGroup(zodPage);

--- a/apps/tlon-web/e2e/helpers.ts
+++ b/apps/tlon-web/e2e/helpers.ts
@@ -13,7 +13,7 @@ export async function navigateToChannel(page: Page, channelName: string) {
 
 export async function createGroup(page: Page) {
   await page.getByTestId('CreateChatSheetTrigger').click();
-  await page.getByText('New group').click();
+  await page.getByText('New group', { exact: true }).click();
   await page.getByText('Select contacts to invite').click();
   await page.getByText('Create group').click();
 
@@ -834,6 +834,28 @@ export async function verifyMessagePreview(
     await expect(
       page.getByTestId(`ChannelListItem-${channelTitle}`).getByText(messageText)
     ).toBeVisible({ timeout: 15000 });
+  }
+}
+
+/**
+ * Verifies unread count badge on channel list item
+ */
+export async function verifyUnreadCount(
+  page: Page,
+  channelName: string,
+  expectedCount: number
+) {
+  const channelItem = page.getByTestId(`ChannelListItem-${channelName}`);
+  
+  if (expectedCount === 0) {
+    // Should not have unread count visible - look for any text that matches numbers
+    const countText = channelItem.getByText(/^\d+$/, { exact: true });
+    await expect(countText).not.toBeVisible();
+  } else {
+    // Should show the expected count - look for text with the number
+    await expect(
+      channelItem.getByText(expectedCount.toString(), { exact: true })
+    ).toBeVisible({ timeout: 10000 });
   }
 }
 

--- a/apps/tlon-web/e2e/helpers.ts
+++ b/apps/tlon-web/e2e/helpers.ts
@@ -275,10 +275,7 @@ export async function forwardMessageToDM(
 /**
  * Forwards a group reference to a specified channel
  */
-export async function forwardGroupReference(
-  page: Page,
-  channelName: string
-) {
+export async function forwardGroupReference(page: Page, channelName: string) {
   // Click the Forward button in group info
   await page.getByText('Forward').click();
 
@@ -303,7 +300,9 @@ export async function forwardGroupReference(
   await expect(page.getByText('Forwarded')).toBeVisible({ timeout: 5000 });
 
   // Verify modal closes
-  await expect(page.getByText('Forward to channel')).not.toBeVisible({ timeout: 3000 });
+  await expect(page.getByText('Forward to channel')).not.toBeVisible({
+    timeout: 3000,
+  });
 }
 
 /**
@@ -845,8 +844,9 @@ export async function verifyUnreadCount(
   channelName: string,
   expectedCount: number
 ) {
+  await page.waitForTimeout(1000);
   const channelItem = page.getByTestId(`ChannelListItem-${channelName}`);
-  
+
   if (expectedCount === 0) {
     // Should not have unread count visible - look for any text that matches numbers
     const countText = channelItem.getByText(/^\d+$/, { exact: true });

--- a/apps/tlon-web/e2e/notebook-functionality.spec.ts
+++ b/apps/tlon-web/e2e/notebook-functionality.spec.ts
@@ -10,11 +10,6 @@ test('should test notebook functionality', async ({ zodSetup, tenSetup }) => {
   // Assert that we're on the Home page
   await expect(zodPage.getByText('Home')).toBeVisible();
 
-  // Clean up any existing group on zod
-  await helpers.cleanupExistingGroup(zodPage, 'Test Group');
-  await helpers.cleanupExistingGroup(zodPage, '~ten, ~zod');
-  await helpers.cleanupExistingGroup(zodPage);
-
   // Create a new group
   await helpers.createGroup(zodPage);
   const groupName = '~ten, ~zod';

--- a/apps/tlon-web/e2e/roles-management.spec.ts
+++ b/apps/tlon-web/e2e/roles-management.spec.ts
@@ -10,9 +10,6 @@ test('should manage roles lifecycle: create, assign, modify permissions, rename,
 
   await expect(page.getByText('Home')).toBeVisible();
 
-  // Clean up any existing "Untitled group"
-  await helpers.cleanupExistingGroup(page);
-
   // Create a new group
   await helpers.createGroup(page);
 
@@ -185,11 +182,4 @@ test('should manage roles lifecycle: create, assign, modify permissions, rename,
 
   // Verify role count is back to 1
   await helpers.verifyElementCount(page, 'GroupRoles', 1);
-
-  // Delete the group
-  await helpers.deleteGroup(page);
-
-  // Verify we're back at Home and group is deleted
-  await expect(page.getByText('Home')).toBeVisible();
-  await expect(page.getByText('Untitled group')).not.toBeVisible();
 });

--- a/apps/tlon-web/e2e/test-fixtures.ts
+++ b/apps/tlon-web/e2e/test-fixtures.ts
@@ -29,7 +29,6 @@ async function performCleanup(page: Page, shipName: string) {
       await helpers.cleanupExistingGroup(page, '~ten, ~zod');
       await helpers.cleanupExistingGroup(page, '~bus, ~zod');
       await helpers.cleanupExistingGroup(page);
-      await helpers.cleanupExistingGroup(page, 'Test Group');
       await helpers.cleanupExistingGroup(page, 'Invite Test');
     } else if (shipName === 'ten') {
       if (await page.getByTestId('ChannelListItem-~zod').isVisible()) {

--- a/apps/tlon-web/e2e/thread-functionality.spec.ts
+++ b/apps/tlon-web/e2e/thread-functionality.spec.ts
@@ -9,9 +9,6 @@ test('should test comprehensive thread functionality', async ({ zodPage }) => {
   // Assert that we're on the Home page
   await expect(page.getByText('Home')).toBeVisible();
 
-  // Clean up any existing group
-  await helpers.cleanupExistingGroup(page);
-
   // Create a new group
   await helpers.createGroup(page);
 
@@ -68,12 +65,4 @@ test('should test comprehensive thread functionality', async ({ zodPage }) => {
 
   // Navigate back to the main channel
   await helpers.navigateBack(page);
-
-  // Delete the group and clean up
-  await helpers.openGroupSettings(page);
-  await helpers.deleteGroup(page);
-
-  // Verify we're back at Home and group is deleted
-  await expect(page.getByText('Home')).toBeVisible();
-  await expect(page.getByText('Untitled group')).not.toBeVisible();
 });

--- a/packages/app/ui/components/ListItem/GroupListItem.tsx
+++ b/packages/app/ui/components/ListItem/GroupListItem.tsx
@@ -191,6 +191,7 @@ export const GroupListItem = ({
                     count={unreadCount}
                     muted={logic.isMuted(model.volumeSettings?.level, 'group')}
                     marginTop={isWeb ? 3 : 'unset'}
+                    testID="UnreadCount"
                   />
                 </>
               )}

--- a/packages/app/ui/components/ListItem/ListItem.tsx
+++ b/packages/app/ui/components/ListItem/ListItem.tsx
@@ -203,7 +203,11 @@ const ListItemCount = ({
         {muted && (
           <Icon type="Muted" customSize={[12, 12]} color={foregroundColor} />
         )}
-        <Text size="$label/m" color={foregroundColor}>
+        <Text
+          testID="UnreadCountNumber"
+          size="$label/m"
+          color={foregroundColor}
+        >
           {numberWithMax(count, 256)}
         </Text>
       </ListItemCountNumber>


### PR DESCRIPTION
## Summary

This adds a new test for unreads and removes some lingering cleanup steps in individual tests that we no longer need (covered by our test fixtures).


## How did I test?

These are tests.

## Risks and impact

- Safe to rollback without consulting PR author? Yes

## Rollback plan

Revert
