### PR TITLE
chat: highlight search text in search results

### DIFF
--- a/packages/app/fixtures/ChatMessage.fixture.tsx
+++ b/packages/app/fixtures/ChatMessage.fixture.tsx
@@ -308,6 +308,33 @@ const PostSpecimen = ({ label, post }: { label: string; post: db.Post }) => {
   );
 };
 
+const SearchHighlightFixture = () => {
+  const searchPost = makePost(
+    exampleContacts.mark,
+    [content.verse.inline('This is a message with some text that contains search terms like hello and world.')],
+    { replyCount: 0 }
+  );
+  
+  return (
+    <ChatMessageFixtureWrapper>
+      <View gap="$xl">
+        <View>
+          <Text size="$label/m" color="$tertiaryText" marginBottom="$s">Search query: "hello"</Text>
+          <ChatMessage post={searchPost} showAuthor={true} showReplies={true} searchQuery="hello" />
+        </View>
+        <View>
+          <Text size="$label/m" color="$tertiaryText" marginBottom="$s">Search query: "world"</Text>
+          <ChatMessage post={searchPost} showAuthor={true} showReplies={true} searchQuery="world" />
+        </View>
+        <View>
+          <Text size="$label/m" color="$tertiaryText" marginBottom="$s">Search query: "message text"</Text>
+          <ChatMessage post={searchPost} showAuthor={true} showReplies={true} searchQuery="message text" />
+        </View>
+      </View>
+    </ChatMessageFixtureWrapper>
+  );
+};
+
 export default {
   All: (
     <ScrollFixture
@@ -331,6 +358,7 @@ export default {
     />
   ),
   MessageStates: <PostVariantsFixture post={postWithText} />,
+  SearchHighlight: <SearchHighlightFixture />,
   Image: <SinglePostFixture post={postWithImage} />,
   Video: <SinglePostFixture post={postWithVideo} />,
   Text: <SinglePostFixture post={postWithText} />,

--- a/packages/app/ui/components/ChannelSearch/SearchResults.tsx
+++ b/packages/app/ui/components/ChannelSearch/SearchResults.tsx
@@ -12,9 +12,11 @@ import { SearchState } from './types';
 function SearchResultComponent({
   onPress,
   post,
+  searchQuery,
 }: {
   onPress: () => void;
   post: db.Post;
+  searchQuery: string;
 }) {
   return (
     <View marginBottom="$m">
@@ -23,6 +25,7 @@ function SearchResultComponent({
         showAuthor
         hideProfilePreview
         onPress={onPress}
+        searchQuery={searchQuery}
       />
     </View>
   );
@@ -50,9 +53,13 @@ export function SearchResults({
 
   const renderItem = useCallback(
     ({ item: post }: { item: db.Post }) => (
-      <SearchResult onPress={() => navigateToPost(post)} post={post} />
+      <SearchResult
+        onPress={() => navigateToPost(post)}
+        post={post}
+        searchQuery={search.query}
+      />
     ),
-    [navigateToPost]
+    [navigateToPost, search.query]
   );
 
   const ListFooterComponent = useMemo(() => {

--- a/packages/app/ui/components/ChatMessage/ChatMessage.tsx
+++ b/packages/app/ui/components/ChatMessage/ChatMessage.tsx
@@ -39,6 +39,7 @@ const ChatMessage = ({
   setViewReactionsPost,
   isHighlighted,
   hideOverflowMenu,
+  searchQuery,
 }: {
   post: db.Post;
   showAuthor?: boolean;
@@ -56,6 +57,7 @@ const ChatMessage = ({
   setViewReactionsPost?: (post: db.Post) => void;
   isHighlighted?: boolean;
   hideOverflowMenu?: boolean;
+  searchQuery?: string;
 }) => {
   const [showRetrySheet, setShowRetrySheet] = useState(false);
   const [isHovered, setIsHovered] = useState(false);
@@ -247,6 +249,7 @@ const ChatMessage = ({
             isNotice={post.type === 'notice'}
             onPressImage={handleImagePressed}
             onLongPress={handleLongPress}
+            searchQuery={searchQuery}
           />
         </View>
 
@@ -373,7 +376,8 @@ export default memo(ChatMessage, (prev, next) => {
     prev.onPressReplies === next.onPressReplies &&
     prev.onPressImage === next.onPressImage &&
     prev.onLongPress === next.onLongPress &&
-    prev.onPress === next.onPress;
+    prev.onPress === next.onPress &&
+    prev.searchQuery === next.searchQuery;
 
   return isPostEqual && areOtherPropsEqual;
 });

--- a/packages/app/ui/components/PostContent/ContentRenderer.tsx
+++ b/packages/app/ui/components/PostContent/ContentRenderer.tsx
@@ -56,6 +56,7 @@ function ContentRenderer({
   onPressImage,
   onLongPress,
   isNotice,
+  searchQuery,
   ...rest
 }: ContentRendererProps & {
   content: PostContent;
@@ -65,6 +66,7 @@ function ContentRenderer({
       onPressImage={onPressImage}
       onLongPress={onLongPress}
       isNotice={isNotice}
+      searchQuery={searchQuery}
     >
       <ContentRendererFrame {...rest}>
         {content.map((block, k) => {

--- a/packages/app/ui/components/PostContent/InlineRenderer.tsx
+++ b/packages/app/ui/components/PostContent/InlineRenderer.tsx
@@ -21,6 +21,7 @@ import { ColorTokens, styled } from 'tamagui';
 import { useChannelContext, useNavigation, useRequests } from '../../contexts';
 import { ALL_MENTION_ID } from '../BareChatInput/useMentions';
 import { useContactName } from '../ContactNameV2';
+import { useContentContext } from './contentUtils';
 
 export const CodeText = styled(Text, {
   name: 'CodeText',
@@ -44,6 +45,12 @@ export const BoldText = styled(RawText, {
 export const ItalicText = styled(RawText, {
   name: 'ItalicText',
   fontStyle: 'italic',
+});
+
+export const HighlightedText = styled(RawText, {
+  name: 'HighlightedText',
+  backgroundColor: '$yellowSoft',
+  color: '$primaryText',
 });
 
 export const MentionText = styled(Text, {
@@ -124,6 +131,26 @@ export function InlineStyle({
   );
 }
 
+function highlightSearchTerm(
+  text: string,
+  searchQuery: string
+): React.ReactNode {
+  if (!searchQuery || searchQuery.trim() === '') {
+    return text;
+  }
+
+  const parts = text.split(
+    new RegExp(`(${searchQuery.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')})`, 'gi')
+  );
+
+  return parts.map((part, index) => {
+    if (part.toLowerCase() === searchQuery.toLowerCase()) {
+      return <HighlightedText key={index}>{part}</HighlightedText>;
+    }
+    return part;
+  });
+}
+
 export function InlineText({
   inline,
   color,
@@ -131,6 +158,17 @@ export function InlineText({
   inline: TextInlineData;
   color?: ColorTokens;
 }) {
+  const { searchQuery } = useContentContext();
+
+  if (searchQuery) {
+    const highlightedText = highlightSearchTerm(inline.text, searchQuery);
+    return color ? (
+      <RawText color={color}>{highlightedText}</RawText>
+    ) : (
+      highlightedText
+    );
+  }
+
   return color ? <RawText color={color}>{inline.text}</RawText> : inline.text;
 }
 

--- a/packages/app/ui/components/PostContent/contentUtils.tsx
+++ b/packages/app/ui/components/PostContent/contentUtils.tsx
@@ -29,6 +29,7 @@ export interface ContentContextProps {
   isNotice?: boolean;
   onPressImage?: (src: string) => void;
   onLongPress?: () => void;
+  searchQuery?: string;
 }
 
 export const ContentContext = createStyledContext<ContentContextProps>();


### PR DESCRIPTION
## Summary

fixes tlon-4320

Adds highlighting for search query text in search results.

## Changes

- Added optional `searchQuery` parameter to pass search terms through the content rendering system
- Created `highlightSearchTerm` utility function with case-insensitive regex matching and proper escaping of special characters
- Added styled component using `$yellowSoft` background color for highlighted search terms
- Modified to apply highlighting when search query is present in context
- Updated component chain (`SearchResults` → `SearchResultComponent` → `ChatMessage` → `ContentRenderer`) to pass search query from search screen to text rendering

## How did I test?

Tested on web and iOS.

## Risks and impact

- Safe to rollback without consulting PR author? Yes
- Affects important code area:
  - [ ] Onboarding
  - [ ] State / providers
  - [ ] Message sync
  - [x] Channel display
  - [ ] Notifications

## Rollback plan

Revert

## Screenshots / videos

Desktop web:
<img width="1245" height="1354" alt="image" src="https://github.com/user-attachments/assets/2b952dc4-a0d0-4656-9152-701195878888" />

iOS:
<img width="1179" height="2556" alt="Simulator Screenshot - iPhone 16 - 2025-07-31 at 08 56 00" src="https://github.com/user-attachments/assets/f9aac3f7-8a51-4f44-89bb-b9468cbb299b" />

