### PR TITLE
desktop: handle tall popovers

### DIFF
--- a/packages/app/ui/components/ActionSheet.tsx
+++ b/packages/app/ui/components/ActionSheet.tsx
@@ -139,6 +139,8 @@ const ActionSheetComponent = ({
   const { bottom } = useSafeAreaInsets();
   const { height } = useWindowDimensions();
   const maxHeight = height - bottom - getTokenValue('$2xl');
+  // For popovers, use a more conservative max height to ensure it fits in viewport
+  const popoverMaxHeight = Math.min(maxHeight, height * 0.5);
 
   if (!hasOpened.current && open) {
     hasOpened.current = true;
@@ -156,10 +158,22 @@ const ActionSheetComponent = ({
         onOpenChange={onOpenChange}
         allowFlip
         placement="bottom-end"
+        strategy="fixed"
       >
         <Popover.Trigger>{trigger}</Popover.Trigger>
-        <Popover.Content padding={1} borderColor="$border" borderWidth={1}>
-          {children}
+        <Popover.Content
+          padding={1}
+          borderColor="$border"
+          borderWidth={1}
+          maxHeight={popoverMaxHeight}
+          overflow="hidden"
+        >
+          <ScrollView
+            maxHeight={popoverMaxHeight - 32}
+            showsVerticalScrollIndicator={true}
+          >
+            {children}
+          </ScrollView>
         </Popover.Content>
       </Popover>
     );


### PR DESCRIPTION
## Summary

fixes tlon-4023 by ensuring our popovers on desktop can only be so tall and can be scrolled if the content is long enough.

## Changes

- Added `maxHeight` constraint to popover mode in ActionSheet component (50% of viewport height)
- Wrapped popover content in `ScrollView` with vertical scroll indicators when content overflows
- Added `overflow: hidden` to prevent content bleeding outside popover bounds
- Set `strategy="fixed"` for better viewport positioning on desktop
- Maintained existing `allowFlip` behavior for automatic placement adjustment

## How did I test?

Tested on web. Doesn't effect mobile.

## Risks and impact

- Safe to rollback without consulting PR author? Yes
- Affects important code area: N/A

## Rollback plan

Revert

## Screenshots / videos


https://github.com/user-attachments/assets/f7b34110-5e2b-4b67-b021-1ed35e79bbee


