### PR TITLE
fix thread emoji reactions

### DIFF
--- a/packages/shared/src/store/postActions.ts
+++ b/packages/shared/src/store/postActions.ts
@@ -665,6 +665,7 @@ export async function addPostReaction(
         emoji,
         our: currentUserId,
         postAuthor: post.authorId,
+        parentId: post.parentId || undefined,
       })
     );
   } catch (e) {
@@ -754,6 +755,7 @@ export async function removePostReaction(post: db.Post, currentUserId: string) {
         postId: post.id,
         our: currentUserId,
         postAuthor: post.authorId,
+        parentId: post.parentId || undefined,
       })
     );
   } catch (e) {

--- a/packages/shared/src/urbit/dms.ts
+++ b/packages/shared/src/urbit/dms.ts
@@ -58,14 +58,14 @@ interface WritDeltaDel {
   del: null;
 }
 
-interface WritDeltaAddReact {
+export interface WritDeltaAddReact {
   'add-react': {
     react: string;
     author: string;
   };
 }
 
-interface WritDeltaDelReact {
+export interface WritDeltaDelReact {
   'del-react': string;
 }
 


### PR DESCRIPTION
## Summary

We weren't sending a parentId (or the related pokes) for adding/remove reactions to thread reply messages.

## Changes

Pass in the parentId to `addReaction` and `removeReaction`, add the relevant pokes.

## How did I test?

Tested on web.

## Risks and impact

- Safe to rollback without consulting PR author? Yes

## Rollback plan

Revert