### PR TITLE
GroupMetaScreen: correctly navigate via "Cancel"

### DIFF
--- a/apps/tlon-web/e2e/group-customization.spec.ts
+++ b/apps/tlon-web/e2e/group-customization.spec.ts
@@ -22,7 +22,22 @@ test('should customize group name, icon, and description', async ({
     await expect(page.getByText('Untitled group').first()).toBeVisible();
   }
 
-  // Open the Customize group screen
+  // Verify we're in the blank channel state (Welcome to your group! message)
+  await expect(page.getByText('Welcome to your group!')).toBeVisible();
+
+  // Open the Customize group screen from the blank channel
+  await helpers.openGroupCustomization(page);
+
+  // Verify we're on the group customization screen
+  await expect(page.getByText('Edit group info')).toBeVisible();
+
+  // Click Cancel to verify navigation back to blank channel
+  await page.getByText('Cancel').click();
+
+  // Verify we're back to the blank channel state
+  await expect(page.getByText('Welcome to your group!')).toBeVisible();
+
+  // Open the Customize group screen again to continue with the test
   await helpers.openGroupCustomization(page);
 
   // Change the group name
@@ -54,3 +69,4 @@ test('should customize group name, icon, and description', async ({
   }
   await page.getByText('Cancel').click();
 });
+

--- a/packages/app/features/groups/GroupMetaScreen.tsx
+++ b/packages/app/features/groups/GroupMetaScreen.tsx
@@ -44,6 +44,7 @@ export function GroupMetaScreen(props: Props) {
   const handleGoBack = useHandleGoBack(navigation, {
     groupId,
     fromChatDetails,
+    fromBlankChannel,
   });
 
   const handleSubmit = useCallback(

--- a/packages/app/hooks/useChatSettingsNavigation.ts
+++ b/packages/app/hooks/useChatSettingsNavigation.ts
@@ -13,12 +13,18 @@ export const useHandleGoBack = (
     GroupSettingsStackParamList,
     keyof GroupSettingsStackParamList
   >,
-  params: { groupId: string; fromChatDetails?: boolean }
+  params: {
+    groupId: string;
+    fromChatDetails?: boolean;
+    fromBlankChannel?: boolean;
+  }
 ) => {
-  const { groupId, fromChatDetails } = params;
+  const { groupId, fromChatDetails, fromBlankChannel } = params;
 
   return useCallback(() => {
-    if (fromChatDetails) {
+    if (fromBlankChannel) {
+      navigation.goBack();
+    } else if (fromChatDetails) {
       navigation.getParent()?.navigate('ChatDetails', {
         chatType: 'group',
         chatId: groupId,
@@ -26,7 +32,7 @@ export const useHandleGoBack = (
     } else {
       navigation.goBack();
     }
-  }, [navigation, fromChatDetails, groupId]);
+  }, [navigation, fromChatDetails, fromBlankChannel, groupId]);
 };
 
 export const useChatSettingsNavigation = () => {


### PR DESCRIPTION
## Summary

Fixes TLON-4627 by navigating the user back to the blank channel screen if they hit the "Customize" button, then Cancel their edits.

## Changes

We weren't handling the fromBlankChannel prop in the useHandleGoBack hook in the group settings navigation hooks, so we were navigating "backwards" in the stack rather than the historical "back." 

## How did I test?

- Create a group
- Click "Customize" in the blank channel notice
- Click "Cancel"
- Should be navigated back to the blank channel
- Go to the kebab menu, select "Group Settings & Info"
- Click "Edit" in the upper-right
- Click "Cancel"
- Should be navigated back to the group settings & info screen

## Risks and impact

- Safe to rollback without consulting PR author? Yes
- Affects important code area:
  - [ ] Onboarding
  - [ ] State / providers
  - [ ] Message sync
  - [ ] Channel display
  - [ ] Notifications
  - [x] Navigation 

## Rollback plan

git revert
