### PR TITLE
channels/server: ;; instead of !< for sequence nr pokes

### DIFF
--- a/desk/app/channels-server.hoon
+++ b/desk/app/channels-server.hoon
@@ -402,7 +402,7 @@
       ==
     ::
         [%send-sequence-numbers *]
-      =+  !<([%send-sequence-numbers =nest:c] vase)
+      =+  ;;([%send-sequence-numbers =nest:c] q.vase)
       ?~  can=(~(get by v-channels) nest)  cor
       =;  =cage
         (emit [%pass /numbers %agent [src.bowl %channels] %poke cage])

--- a/desk/app/channels.hoon
+++ b/desk/app/channels.hoon
@@ -656,7 +656,7 @@
       ==
     ::
         [%sequence-numbers * @ *]
-      =+  !<([%sequence-numbers =nest:c count=@ud seqs=(list [id=id-post:c seq=(unit @ud)])] vase)
+      =+  ;;([%sequence-numbers =nest:c count=@ud seqs=(list [id=id-post:c seq=(unit @ud)])] q.vase)
       ?>  =(src.bowl ship.nest)
       ?.  (~(has by v-channels) nest)  cor
       =.  v-channels

--- a/desk/tests/app/channels-server.hoon
+++ b/desk/tests/app/channels-server.hoon
@@ -12,6 +12,57 @@
 --
 ::
 |%
+::  channels agent will send pokes requesting sequence nrs, we must respond
+::
+++  test-send-sequence-nrs
+  %-  eval-mare
+  =/  m  (mare ,~)
+  ;<  *  bind:m  (do-init dap agent)
+  ::  channel doesn't exist, should no-op
+  ::
+  ;<  caz=(list card)  bind:m
+    ((do-as ~fun) (do-poke %noun !>([%send-sequence-numbers *nest:c])))
+  ;<  ~  bind:m  (ex-cards caz ~)
+  ::  channel exists, should send list of seqs nrs
+  ::
+  =/  state=state-8
+    =;  chan=v-channel:c
+      [%8 (~(put by *v-channels:c) *nest:c chan) *hooks:h *pimp:imp]
+    =;  posts
+      :_  *local:v-channel:c
+      ^-  global:v-channel:c
+      [posts count=333 *(rev:c arranged-posts:c) *(rev:c view:c) *(rev:c sort:c) *(rev:c perm:c) *(rev:c (unit @t))]
+    %+  gas:on-v-posts:c  ~
+    =*  k  ~2025.8.4
+    =;  p=v-post:c
+      [k `p]~
+    :*  [id=k seq=777 mod-at=k replies=~ reacts=~]
+        rev=0
+        [content=[[%inline 'a' ~] ~] author=~zod sent=k]
+        [kind=/chat meta=~ blob=~]
+    ==
+  ::  edit carefully to work around lib negotiate state.
+  ::  yes, the inner state is double-vased!
+  ::
+  ;<  save=vase  bind:m  get-save
+  =.  save
+    ;:  slop
+      (slot 2 save)  ::  lib discipline
+      (slot 6 save)  ::  lib negotiate
+      !>(!>(state))  ::  negotiate's double-vasing
+    ==
+  ;<  *  bind:m  (do-load agent `save)
+  ;<  caz=(list card)  bind:m
+    ((do-as ~fun) (do-poke %noun !>([%send-sequence-numbers *nest:c])))
+  %+  ex-cards  caz
+  =/  =vase
+    !>  :^  %sequence-numbers  *nest:c
+      333
+    ^-  (list [id-post:c (unit @ud)])
+    :~  [~2025.8.4 `777]
+    ==
+  :~  (ex-poke /numbers [~fun %channels] %noun vase)
+  ==
 ::  migration 7->8 used to drop message tombstones.
 ::  if we're in that state, we must recover them from the log.
 ::

--- a/desk/tests/app/channels-server.hoon
+++ b/desk/tests/app/channels-server.hoon
@@ -130,7 +130,12 @@
     ::  yes, the inner state is double-vased!
     ::
     ;<  save=vase  bind:m  get-save
-    =.  save  (slop (slot 2 save) !>(!>(bad-state)))
+    =.  save
+      ;:  slop
+        (slot 2 save)      ::  lib discipline
+        (slot 6 save)      ::  lib negotiate
+        !>(!>(bad-state))  :: negotiate's double-vasing
+      ==
     ;<  caz=(list card:agent:gall)  bind:m  (do-load agent `save)
     ::
     ;<  ~  bind:m  (ex-cards caz ~)
@@ -143,6 +148,8 @@
       (~(put by *v-channels:c) *nest:c chan)
     ::  again, carefully work around lib negotiate state.
     ::
-    (ex-equal !<(vase (slot 3 save)) !>(fixed-state))
+    =.  save  (slot 3 save)           ::  lib discipline
+    =.  save  !<(vase (slot 3 save))  ::  lib negotiate
+    (ex-equal save !>(fixed-state))
   --
 --

--- a/desk/tests/app/channels-server.hoon
+++ b/desk/tests/app/channels-server.hoon
@@ -53,7 +53,7 @@
     ==
   ;<  *  bind:m  (do-load agent `save)
   ;<  caz=(list card)  bind:m
-    ((do-as ~fun) (do-poke %noun !>([%send-sequence-numbers *nest:c])))
+    ((do-as ~fun) (do-poke %noun -:!>(**) [%send-sequence-numbers *nest:c]))
   %+  ex-cards  caz
   =/  =vase
     !>  :^  %sequence-numbers  *nest:c

--- a/desk/tests/app/channels.hoon
+++ b/desk/tests/app/channels.hoon
@@ -185,11 +185,6 @@
     ::TODO  annoying, can't do +do-load directly, but it always calls
     ::      +on-save, even if we provide a vase
     :: ;<  *  bind:m  (do-init dap channels-agent)
-    ::  edit carefully to work around lib negotiate state.
-    ::  yes, the inner state is double-vased!
-    ::
-    :: ;<  save=vase  bind:m  get-save
-    :: =.  save  (slop (slot 2 save) !>(!>(bad-state)))
     ;<  *  bind:m  (do-load channels-agent `!>(bad-state))
     ;<  caz=(list card)  bind:m
       =;  seqs=(list [id-post:c (unit @ud)])
@@ -212,8 +207,10 @@
       =.  posts.chan
         +:(del:on-v-posts:c posts.chan missing-key)
       (~(put by *v-channels:c) *nest:c chan)
-    ::  again, carefully work around lib negotiate state.
+    ::  carefully work around wrapper library state
     ::
-    (ex-equal !<(vase (slot 3 save)) !>(fixed-state))
+    =.  save  (slot 3 save)           ::  lib discipline
+    =.  save  !<(vase (slot 3 save))  ::  lib negotiate
+    (ex-equal save !>(fixed-state))
   --
 --

--- a/desk/tests/app/channels.hoon
+++ b/desk/tests/app/channels.hoon
@@ -188,7 +188,7 @@
     ;<  *  bind:m  (do-load channels-agent `!>(bad-state))
     ;<  caz=(list card)  bind:m
       =;  seqs=(list [id-post:c (unit @ud)])
-        (do-poke %noun !>([%sequence-numbers *nest:c 3 seqs]))
+        (do-poke %noun `vase`[-:!>(**) %sequence-numbers *nest:c 3 seqs])
       :~  [missing-key `1]
           [tombstone-key ~]
           [misnumber-key `3]


### PR DESCRIPTION
## Summary

In real-world conditions, the vases coming in to agents will have the types on them that match the marks on their cages. The tests were failing to account for this, and so didn't catch that this code was subtly broken. We patch both the tests and the code here.

## Changes

First we patch up the existing tests to account for the new discipline wrapper properly. Then we add a new test for the channels-server side of the poke-based sequence nr negotiation flow.

With that setup done, we patch the tests to more accurately simulate real-world invocations, and finally make one-line changes to the agent code to handle these invocations correctly.

## How did I test?

Updated the tests to be more accurate, which made them fail. Updated the code to make the new tests pass.

## Risks and impact

`;;` is notorious for being slow in some select cases. ~~I haven't yet tested this with real-world amounts of content. Please hold off on merge until I (or you, dear reviewer) do so and confirm that it's Probably Fine™.~~ I have confirmed this is not hilariously slow. For ~6k sequence nrs, the `;;` only takes 14ms.

- Yes, safe to rollback without consulting PR author.
- Affects important code area:
  - [ ] Onboarding
  - [ ] State / providers
  - [ ] Message sync
  - [ ] Channel display
  - [ ] Notifications

## Rollback plan

Just revert, I suppose.

## Screenshots / videos

<img width="769" height="704" alt="image" src="https://github.com/user-attachments/assets/5641ff6e-1709-4fbf-90b2-671321d3790b" />

