### PR TITLE
channels: add /range endpoint, fetching by seq nr

### DIFF
--- a/desk/app/channels.hoon
+++ b/desk/app/channels.hoon
@@ -2776,6 +2776,33 @@
       =.  out  (put:on-v-posts:c out changed u.post)
       $(updated t.updated)
     ::
+        [%range start=@ end=@ mode=?(%outline %post) ~]
+      ::TODO  support @da format in path for id (or timestamp) ranges?
+      =/  start=@ud
+        ?:  =(%$ start.pole)  1
+        (slav %ud start.pole)
+      =/  end=@ud
+        ?:  =(%$ end.pole)  (wyt:on posts.channel)  ::TODO  better end
+        (slav %ud end.pole)
+      %-  give-posts
+      :+  mode.pole  version
+      ::  queries near end more common, so we make a newest-first list,
+      ::  and walk it "backwards" until we extract our desired range
+      ::
+      =/  posts=(list [id-post:c p=(may:c v-post:c)])
+        (bap:on posts.channel)
+      =|  out=(list [id-post:c (may:c v-post:c)])
+      |-
+      ?~  posts  ~
+      =/  seq=@ud
+        ?-  -.p.i.posts
+          %&  seq.p.i.posts
+          %|  seq.p.i.posts
+        ==
+      ?:  (gth seq end)    $(posts t.posts)
+      ?:  (lth seq start)  ~  ::  done
+      [i.posts $(posts t.posts)]
+    ::
         [%post time=@ ~]
       =/  time  (slav %ud time.pole)
       =/  post  (get:on posts.channel time)


### PR DESCRIPTION
## Summary

Adds a new `/range` scry endpoint in channels for fetching messages by sequence number range.

## Changes

Fetch messages by sequence number. Leave start or end empty to get from the start or to the end. /v4 and onward will include tombstone metadata instead of just putting the post as `null`.

Targeting the tombstones PR, since this is most useful/practical when sequence nrs on deleted messages are also given in the response, and to avoid unnecessary conflicts.

## How did I test?

Tested by calling up the endpoint manually from the browser. Fetches the requested range and converts to json just fine.

## Risks and impact

I think I did perf tests on code very similar to this for initial research, but I'll want to run another quick test to make sure there's nothing egregious here. Slight chance a manual in-order walk of the tree would be faster, but listifying and walking that instead as we do now shouldn't be horribly slow.

- Yes, safe to rollback without consulting PR author.
- Affects important code area:
  - [ ] Onboarding
  - [ ] State / providers
  - [ ] Message sync
  - [ ] Channel display
  - [ ] Notifications

## Rollback plan

Can just revert, until this endpoint starts getting client-side usage.

## Screenshots / videos

Nay.
