### PR TITLE
Robustly handle log replay at the client side

### DIFF
--- a/desk/app/groups.hoon
+++ b/desk/app/groups.hoon
@@ -3026,6 +3026,7 @@
       ?>  (gte time.update time.net)
       [%sub time.update init.net]
     =*  u-group  u-group.update
+    ~&  go-u-group+update
     ?-  -.u-group
       %create        (go-u-create group.u-group)
       %meta          (go-u-meta data.u-group)
@@ -3198,6 +3199,7 @@
   ++  go-u-seat
     |=  [ships=(set ship) =u-seat:g]
     ^+  go-core
+    ~&  go-u-seat+[ships u-seat]
     ?-    -.u-seat
         %add
       =.  go-core  (go-response %seat ships [%add seat.u-seat])
@@ -3244,7 +3246,8 @@
       =.  go-core
         %-  ~(rep in ships)
         |=  [=ship =_go-core]
-        =+  seat=(~(got by seats.group) ship)
+        ?~  tea=(~(get by seats.group) ship)  go-core
+        =*  seat  u.tea
         ?:  =(~ (~(dif in roles.u-seat) roles.seat))  go-core
         (go-activity:go-core %role ship roles.u-seat)
       ?:  go-our-host  go-core
@@ -3263,7 +3266,8 @@
       =.  go-core
         %-  ~(rep in ships)
         |=  [=ship =_go-core]
-        =+  seat=(~(got by seats.group) ship)
+        ?~  tea=(~(get by seats.group) ship)  go-core
+        =*  seat  u.tea
         ?:  =(~ (~(int in roles.u-seat) roles.seat))  go-core
         (go-activity:go-core %role ship roles.u-seat)
       ?:  go-our-host  go-core

--- a/desk/app/groups.hoon
+++ b/desk/app/groups.hoon
@@ -853,8 +853,6 @@
     %+  roll
       ~(tap by groups)
     |=  [[=flag:g [=net:g *]] =_cor]
-    ::  only resubscribe to remote groups
-    ?:  ?=(%pub -.net)  cor
     go-abet:(go-safe-sub:(go-abed:go-core:cor flag) |)
   cor
 ::
@@ -2976,8 +2974,12 @@
       ?^  p.sign
         %-  (fail:log %watch-ack 'group watch failed' u.p.sign)
         ?.  (~(has by foreigns) flag)
-          ::TODO this should not be possible, but if it happens
-          ::     we don't have an invitation, thus no way to rejoin.
+          ::TODO  this should not be possible, but if it happens
+          ::      we don't have an invitation, and thus no way to rejoin.
+          ::      the user will still see the group, but it is going
+          ::      to be stale. it would be best to somehow surface
+          ::      it at the frontend.
+          ::
           go-core
         ::  join in progress, set error and leave the group
         ::  to allow re-joining.

--- a/desk/app/groups.hoon
+++ b/desk/app/groups.hoon
@@ -1365,7 +1365,8 @@
       (~(ges cy:t con.response) groups+%flag)
     ?:  |(?=(~ groups) =(~ u.groups))  cor  ::TMI
     %+  roll  ~(tap in u.groups)
-    |=  [val=$>(%flag value:t) =_cor]
+    |=  [val=value:t =_cor]
+    ?>  ?=(%flag -.val)
     fi-abet:(fi-watch:(fi-abed:fi-core:cor p.val) %v1 /preview)
   ==
 ::
@@ -2612,7 +2613,8 @@
     |=  =ship
     ^-  ?
     ?:  =(ship p.flag)  &
-    =/  =seat:g  (~(got by seats.group) ship)
+    ?~   tea=(~(get by seats.group) ship)  |
+    =*  seat  u.tea
     !=(~ (~(int in roles.seat) admins.group))
   ::  +go-is-banned: check whether the ship is banned
   ::

--- a/desk/app/groups.hoon
+++ b/desk/app/groups.hoon
@@ -3028,7 +3028,6 @@
       ?>  (gte time.update time.net)
       [%sub time.update init.net]
     =*  u-group  u-group.update
-    ~&  go-u-group+update
     ?-  -.u-group
       %create        (go-u-create group.u-group)
       %meta          (go-u-meta data.u-group)
@@ -3201,7 +3200,6 @@
   ++  go-u-seat
     |=  [ships=(set ship) =u-seat:g]
     ^+  go-core
-    ~&  go-u-seat+[ships u-seat]
     ?-    -.u-seat
         %add
       =.  go-core  (go-response %seat ships [%add seat.u-seat])

--- a/desk/app/groups.hoon
+++ b/desk/app/groups.hoon
@@ -2975,11 +2975,15 @@
         fi-abet:(fi-watched:(fi-abed:fi-core flag) p.sign)
       ?^  p.sign
         %-  (fail:log %watch-ack 'group watch failed' u.p.sign)
-        ?:  (~(has by foreigns) flag)
-          ::  join in progress, leave the group to allow re-joining
-          (go-leave &)
-        ::TODO we should probably try resubscribing with a delay
-        go-core
+        ?.  (~(has by foreigns) flag)
+          ::TODO this should not be possible, but if it happens
+          ::     we don't have an invitation, thus no way to rejoin.
+          go-core
+        ::  join in progress, set error and leave the group
+        ::  to allow re-joining.
+        ::
+        =.  cor  fi-abet:fi-error:(fi-abed:fi-core flag)
+        (go-leave &)
       go-core
     ::
         %fact


### PR DESCRIPTION
## Summary

In some cases full group log replay would fail at the subscriber side – a seat might not always be present when targeted by other updates. While this has been observed already in TLON-4657, in this case a seat could be already deleted, or not yet instantiated while some other update tried to reference it.

## Changes

In particular, we found and fix two cases here:
1. A group host would incorrectly try to issue notification for a seat that already had been deleted in an +se-core update. We detect a missing seat and do not attempt to send the notification.
2. A subscriber would try to check his own admin permissions for certain events during log replay, forgetting that in fact his own seat might not yet be created.

## How did I test?

I repeated the reproduction in TLON-4657 and observed the ship joining without problem, and the old traces not appearing anymore.

## Risks and impact

- Safe to rollback without consulting PR author? It is not safe to rollback, unless we want to see the same bug.
- Affects important code area:
  - [x] Onboarding
  - [x] State / providers
  - [ ] Message sync
  - [ ] Channel display
  - [x] Notifications

## Rollback plan
Should not be rolled back.

Fixes TLON-4657
