### PR TITLE
channels: include latest seq nr in paged responses

### DIFF
--- a/desk/app/channels.hoon
+++ b/desk/app/channels.hoon
@@ -79,7 +79,7 @@
             :+  %channel-posts           &  -:!>(*vale:m-channel-posts)
             :+  %channel-posts-2         &  -:!>(*vale:m-channel-posts-2)
             :+  %channel-posts-3         &  -:!>(*vale:m-channel-posts-3)
-            :+  %channel-posts-4         &  -:!>(*vale:m-channel-posts-4)
+            :+  %channel-posts-4         |  -:!>(*vale:m-channel-posts-4)  ::TODO  make strict
             :+  %channel-replies         &  -:!>(*vale:m-channel-replies)
             :+  %channel-replies-2       &  -:!>(*vale:m-channel-replies-2)
             :+  %channel-replies-3       &  -:!>(*vale:m-channel-replies-3)
@@ -2624,7 +2624,13 @@
         %v4
       =;  =paged-posts:c
         ``channel-posts-4+!>(paged-posts)
-      :_  [newer older (wyt:on-v-posts:c posts.channel)]
+      =/  latest=@ud
+        ?~  latest=(ram:on-v-posts:c posts.channel)  1
+        ?-  -.val.u.latest
+          %&  seq.val.u.latest
+          %|  seq.val.u.latest
+        ==
+      :_  [newer older latest (wyt:on-v-posts:c posts.channel)]
       ?:  =(%post mode)  (uv-posts-3:utils posts)
       (uv-posts-without-replies-3:utils posts)
     ==
@@ -2728,6 +2734,12 @@
             ~
           `key:(head older)
         =/  count  (wyt:on-v-posts:c posts)
+        =/  latest=@ud
+          ?~  latest=(ram:on-v-posts:c posts.channel)  1
+          ?-  -.val.u.latest
+            %&  seq.val.u.latest
+            %|  seq.val.u.latest
+          ==
         ?-  version
         ::
             %v1
@@ -2747,7 +2759,7 @@
         ::
             %v4
             =/  =paged-posts:c
-              [(uv-posts-3:utils posts) newer older count]
+              [(uv-posts-3:utils posts) newer older latest count]
             ``channel-posts-4+!>(paged-posts)
         ==
       ::  walk both posts and logs, in chronological order, newest-first,

--- a/desk/lib/channel-json.hoon
+++ b/desk/lib/channel-json.hoon
@@ -153,6 +153,7 @@
     :~  posts+(posts posts.pn)
         newer+?~(newer.pn ~ (id u.newer.pn))
         older+?~(older.pn ~ (id u.older.pn))
+        newest+(numb newest.pn)
         total+(numb total.pn)
     ==
   ++  paged-simple-posts
@@ -161,6 +162,7 @@
     :~  posts+(simple-posts posts.pn)
         newer+?~(newer.pn ~ (id u.newer.pn))
         older+?~(older.pn ~ (id u.older.pn))
+        newest+(numb newest.pn)
         total+(numb total.pn)
     ==
   +|  %rr

--- a/desk/sur/channels.hoon
+++ b/desk/sur/channels.hoon
@@ -538,12 +538,14 @@
   $:  =posts
       newer=(unit time)
       older=(unit time)
+      newest=@ud
       total=@ud
   ==
 +$  paged-simple-posts
   $:  posts=simple-posts
       newer=(unit time)
       older=(unit time)
+      newest=@ud
       total=@ud
   ==
 +$  posts  ((mop id-post (may post)) lte)


### PR DESCRIPTION
## Summary

Per @latter-bolden's request, we now include the latest sequence nr in paged post responses.

## Changes

We modify the paged post types to include the sequence number of the newest message. Note that we don't bump any api versions here and change the mark type directly: we're working with the new version of the api introduced by #4963 which hasn't yet gone live.

As a small precaution for development ships, we temporarily set the `%paged-posts-4` mark to not be strictly checked by lib discipline.

## How did I test?

Manually did an http scry and saw the new value included in the result.

## Risks and impact

- Not quite safe to rollback without consulting PR author, though until this makes it to `develop` or onward it's pretty much free game.
- Affects important code area:
  - [ ] Onboarding
  - [ ] State / providers
  - [x] Message sync
  - [ ] Channel display
  - [ ] Notifications

## Rollback plan

Revert, but make sure client code isn't using affected endpoints.

## Screenshots / videos

???
