### PR TITLE
Properly handle groups watch nack

### DIFF
--- a/desk/app/groups.hoon
+++ b/desk/app/groups.hoon
@@ -2976,13 +2976,7 @@
       ?^  p.sign
         %-  (fail:log %watch-ack 'group watch failed' u.p.sign)
         ?.  (~(has by foreigns) flag)
-          ::TODO  this should not be possible, but if it happens
-          ::      we don't have an invitation, and thus no way to rejoin.
-          ::      the user will still see the group, but it is going
-          ::      to be stale. it would be best to somehow surface
-          ::      it at the frontend.
-          ::
-          go-core
+          (go-safe-sub &)
         ::  join in progress, set error and leave the group
         ::  to allow re-joining.
         ::


### PR DESCRIPTION
## Summary

The groups agent did not issue a leave for the upgraded group updates subscription path. This caused lib-negotiate to automatically try to re-establish subscription on the old path, resulting in a watch-nack which the agent did not expect, and silently ignored, as it wasn't in the "group join in progress" state. We fix this by properly handling watch-nacks.

## Changes

The one line fix here is to re-establish the subscription on a watch-nack, even though we are not trying to join the group. We can consider whether it would be more proper to handle this in the following way instead:
1. Issue leaves for deprecated subscriptions during migration, which is going to prevent lib-negotiate from trying to inflate them.
2. Restore no-op on watch-nacks, but log them as critical errors, since they should not occur given the fact that we use protocol negotiation.
 
## How did I test?

I have reproduced TLON-4659 using two local moons. Observed the joiner to silently drop the subscription to the group during migration. After applying the fix, I have attempted to repeat the reproduction, and instead observed that the subscription is correctly re-established.

## Risks and impact

This problem would affect all ships post migration. That it wasn't caught earlier must have caused by the fact that any subsequent agent reload, such as triggered by an unrelated fix, would prompt the subscriber to correctly re-establish the subscription, thus hiding the issue.

- Safe to rollback without consulting PR author? No.
- Affects important code area:
  - [ ] Onboarding
  - [x] State / providers
  - [x] Message sync
  - [ ] Channel display
  - [x] Notifications

## Rollback plan
Should not be rolled back under any circumstances, as it would break subscriptions.
