### PR TITLE
groups: properly upgrade group subscriptions

### DIFF
--- a/desk/app/groups.hoon
+++ b/desk/app/groups.hoon
@@ -1295,12 +1295,7 @@
       ::  so we must re-subscribe on the new path post load.
       ::
       [%load %v7 %subscriptions ~]
-    =.  cor
-      %+  roll
-        ~(tap by groups)
-      |=  [[=flag:g [=net:g *]] =_cor]
-      go-abet:(go-safe-sub:(go-abed:go-core:cor flag) |)
-    cor
+    inflate-io
   ==
 ::  does not overwite if wire and dock exist.  maybe it should
 ::  leave/rewatch if the path differs?
@@ -2998,6 +2993,12 @@
       ?^  p.sign
         %-  (fail:log %watch-ack 'group watch failed' u.p.sign)
         ?.  (~(has by foreigns) flag)
+          ::TODO  this should not be possible, but if it happens
+          ::      we don't have an invitation, and thus no way to rejoin.
+          ::      the user will still see the group, but it is going
+          ::      to be stale. it would be best to somehow surface
+          ::      it at the client.
+          ::
           %-  (tell:log %crit 'misguided group watch-ack' ~)
           go-core
         ::  join in progress, set error and leave the group


### PR DESCRIPTION
## Summary

The groups agent did not issue a leave for the upgraded group updates subscription path. This caused lib-negotiate to automatically try to re-establish subscription on the old path, resulting in a watch-nack which the agent did not expect, and silently ignored, as it wasn't in the "group join in progress" state. We fix this by issuing leaves, properly handling watch-nacks and re-establishing subscriptions post migration.

## Changes

The fix consists of three parts:
1. We issue leaves for deprecated subscriptions during migration, which is going to prevent reception of watch-nack.
2. We nonetheless log any watch-nacks on group updates wire as critical error, as they now should be truly unexpected.
3. We safely re-subscribe to each group post migration. This guarantees that all old subscriptions are replaced by subscriptions to the new endpoint.
 
## How did I test?

I have reproduced TLON-4659 using two local moons. Observed the joiner to silently drop the subscription to the group during migration. After applying the fix, I have attempted to repeat the reproduction, and instead observed that the subscription is correctly re-established, while the watch-ack is no longer received.

## Risks and impact

This problem would affect all ships post migration. That it wasn't caught earlier must have caused by the fact that any subsequent agent reload, such as triggered by an unrelated fix, would prompt the subscriber to correctly re-establish the subscription, thus hiding the issue. 

- Safe to rollback without consulting PR author? No.
- Affects important code area:
  - [ ] Onboarding
  - [x] State / providers
  - [x] Message sync
  - [ ] Channel display
  - [x] Notifications

## Rollback plan
Should not be rolled back under any circumstances, as it would break subscriptions.

Closes TLON-4659