### PR TITLE
channels: prevent duplicate post sending

### DIFF
--- a/desk/app/channels.hoon
+++ b/desk/app/channels.hoon
@@ -204,10 +204,11 @@
   |%
   +$  card  card:agent:gall
   +$  current-state
-    $:  %10
+    $:  %11
         =v-channels:c
         voc=(map [nest:c plan:c] (unit said:c))
         hidden-posts=(set id-post:c)
+        debounce=(jug nest:c @da)  ::  temporary bandaid
       ::
         ::  .pending-ref-edits: for migration, see also +poke %negotiate-notif
         ::
@@ -338,12 +339,17 @@
     ::
     [%arvo %b %wait (add now.bowl (~(rad og (sham our.bowl nest)) ~m15))]
   =.  cor  (emil caz-9)
-  ?>  ?=(%10 -.old)
+  =?  old  ?=(%10 -.old)  (state-10-to-11 old)
+  ?>  ?=(%11 -.old)
+  ::  periodically clear .debounce to avoid space leak
+  ::
+  =.  debounce  ~
   =.  state  old
   inflate-io
   ::
   +$  versioned-state
-    $%  state-10
+    $%  state-11
+        state-10
         state-9
         state-8
         state-7
@@ -355,7 +361,20 @@
         state-1
         state-0
     ==
-  +$  state-10  current-state
+  +$  state-11  current-state
+  +$  state-10
+    $:  %10
+        =v-channels:v9:c
+        voc=(map [nest:v9:c plan:v9:c] (unit said:v9:c))
+        hidden-posts=(set id-post:v9:c)
+      ::
+        ::  .pending-ref-edits: for migration, see also +poke %negotiate-notif
+        ::
+        pending-ref-edits=(jug ship [=kind:v9:c name=term])
+        :: delayed resubscribes
+        =^subs:s
+        =pimp:imp
+    ==
   +$  state-9
     $:  %9  ::NOTE  otherwise identical to state-8
         =v-channels:v8:c
@@ -408,6 +427,11 @@
         =^subs:s
         =pimp:imp
     ==
+  ::
+  ++  state-10-to-11
+    |=  state-10
+    ^-  state-11
+    [%11 v-channels voc hidden-posts debounce=~ pending-ref-edits subs pimp]
   ::
   ++  state-9-to-10
     |=  s=state-9
@@ -1583,6 +1607,16 @@
       ?(%read %read-at %watch %unwatch)  (ca-a-remark a-channel)
     ::
         %post
+      ::  the client retries very aggressively. as a temporary bandaid,
+      ::  track the post we've sent, and silently drop any duplicates
+      ::  (based on the .sent timestamp).
+      ::
+      ?:  ?&  ?=(%add -.c-post.a-channel)
+              (~(has ju debounce) nest sent.essay.c-post.a-channel)
+          ==
+        ca-core
+      =?  debounce  ?=(%add -.c-post.a-channel)
+        (~(put ju debounce) nest sent.essay.c-post.a-channel)
       =/  source=(unit source:activity)
         ?.  ?=(%reply -.c-post.a-channel)
           `[%channel nest group.perm.perm.channel]

--- a/desk/tests/app/channels.hoon
+++ b/desk/tests/app/channels.hoon
@@ -3,10 +3,11 @@
 /=  channels-agent  /app/channels
 |%
 +$  current-state
-  $:  %10
+  $:  %11
       =v-channels:c
       voc=(map [nest:c plan:c] (unit said:c))
       hidden-posts=(set id-post:c)
+      debounce=(jug nest:c @da)
     ::
       ::  .pending-ref-edits: for migration, see also +poke %negotiate-notif
       ::
@@ -99,6 +100,45 @@
   ;<  *  bind:m  (do-poke %channel-action-1 !>([%channel the-nest %join the-group]))
   (do-agent chk-wire the-dock %watch-ack ~)
 ::
+::  should have a temporary debounce bandaid in place that prevents messages
+::  with the same sent-at timestamp from being sent repeatedly
+::
+++  test-debounce
+  %-  eval-mare
+  =/  m  (mare ,~)
+  ;<  ~  bind:m  (set-scry-gate scry)
+  ;<  *  bind:m  (do-init %channels channels-agent)
+  ;<  *  bind:m
+    %+  do-poke  %channel-action-1
+    !>  ^-  a-channels:c
+    [%create %chat %test *flag:gv:c 'title' 'desc' ~ ~ ~]
+  ;<  save-1=vase  bind:m  get-save
+  =/  send=a-channels:c
+    =;  =essay:c
+      [%channel [%chat ~zod %test] %post %add essay]
+    [[*story:c ~zod sent=~2025.8.7] /chat ~ ~]
+  ::  first time posting should process as normal:
+  ::  give facts, update state.
+  ::
+  ;<  caz=(list card)  bind:m  (do-poke %channel-action-1 !>(send))
+  ;<  ~  bind:m  (ex-cards caz [. . . . . ~]:|=(* ~))
+  ;<  save-2=vase  bind:m  get-save
+  ;<  ~  bind:m
+    ^-  form:m
+    |=  s=state
+    ?.  =(q.save-1 q.save-2)  &+[~ s]
+    |+['expected state to change, it did not']~
+  ::  second time posting should no-op:
+  ::  no cards, state unchanged.
+  ::
+  ;<  caz=(list card)  bind:m  (do-poke %channel-action-1 !>(send))
+  ;<  ~  bind:m  (ex-cards caz ~)
+  ;<  save-3=vase  bind:m  get-save
+  ^-  form:m
+  |=  s=state
+  ?:  =(q.save-2 q.save-3)  &+[~ s]
+  |+['expected state to be unchanged, but it changed']~
+::
 ::  migration 7->8 used to drop message tombstones.
 ::  if we're in that state, we must recover them from the log.
 ::
@@ -161,7 +201,7 @@
     =/  m  (mare ,~)
     =/  bad-state=current-state
       =;  chans=v-channels:c
-        [%10 chans ~ ~ ~ *^subs:s *pimp:imp]
+        [%11 chans ~ ~ ~ ~ *^subs:s *pimp:imp]
       =/  chan=v-channel:c
         sequence-fix-test-channel
       ::  bad 7->8 migration in old code had dropped the tombstone
@@ -198,7 +238,7 @@
     ;<  save=vase  bind:m  get-save
     =/  fixed-state=current-state
       =;  chans=v-channels:c
-        [%10 chans ~ ~ ~ *^subs:s *pimp:imp]
+        [%11 chans ~ ~ ~ ~ *^subs:s *pimp:imp]
       =/  chan=v-channel:c
         sequence-fix-test-channel
       ::  missing message will not have magically recovered,
@@ -267,7 +307,7 @@
     =/  m  (mare ,~)
     =/  bad-state=current-state
       =;  chans=v-channels:c
-        [%10 chans ~ ~ ~ *^subs:s *pimp:imp]
+        [%11 chans ~ ~ ~ ~ *^subs:s *pimp:imp]
       =/  chan=v-channel:c
         sequence-fix-test-channel
       ::  client had just bunted tombstones
@@ -321,7 +361,7 @@
     ;<  save=vase  bind:m  get-save
     =/  fixed-state=current-state
       =;  chans=v-channels:c
-        [%10 chans ~ ~ ~ *^subs:s *pimp:imp]
+        [%11 chans ~ ~ ~ ~ *^subs:s *pimp:imp]
       =/  chan=v-channel:c
         sequence-fix-test-channel
       (~(put by *v-channels:c) *nest:c chan)


### PR DESCRIPTION


## Summary

Detects duplicate message sends and prevents them from being processed.

## Changes

The client does not always have enough information to know whether its message send made it into the backend, so it retries rather aggressively. This may result in messages being sent multiple times.

Here, we make the backend track the sent-at timestamps for messages. The client guarantees that each has a unique sent-at timestamp, so we can use those to detect and prevent duplicate messages from being sent.

Even though it's ephemeral state, we must unfortunately add it into the $state type proper. The alternative is threading is all the way through into and out of the helper core, which would be less than pretty.

## How did I test?

Wrote and ran the tests. Also tested by manually poking with the same poke repeatedly.

## Risks and impact

- Safe to rollback without consulting PR author, but will require state migration to fully undo.
- Affects important code area:
  - [ ] Onboarding
  - [ ] State / providers
  - [ ] Message sync
  - [ ] Channel display
  - [ ] Notifications

## Rollback plan

Drop from state. Alternatively, just rip out the logic and leave the state type as-is.
