### PR TITLE
Robustly handle inconsistent gangs state during the migration

### DIFF
--- a/desk/app/groups.hoon
+++ b/desk/app/groups.hoon
@@ -840,7 +840,13 @@
       ^-  (unit (pair flag:g gang:v6:gv))
       ?~  group=(~(get by groups) flag)
         `[flag gang]
-      ?:  ?=(%pub -<.u.group)  ~
+      =*  net  -.u.group
+      ?:  ?=(%pub -.net)  ~
+      ::  drop gang for groups that are already initialized,
+      ::  otherwise we risk losing user data during migration
+      ::  of group join flows. see /load/v7/foreigns case in +arvo.
+      ::
+      ?:  load.net  ~
       `[flag gang]
     :-  caz
     :*  %7
@@ -1231,6 +1237,7 @@
     ?~  progress.far  cor
     ?:  ?=(?(%done %error) u.progress.far)  cor
     =*  fc  (fi-abed:fi-core:cor flag)
+    ::
     =.  cor  fi-abet:fi-cancel:fc
     =<  fi-abet
     ?-    u.progress.far
@@ -1264,7 +1271,6 @@
     %-  se-compat-send-invites:(se-abed:se-core:cor flag)
     ~(key by pending.admissions.group)
   ::
-      ::
       ::  v6 -> v7 migrate invitations
       ::
       ::  some ships might be behind at the time of migration.
@@ -2183,6 +2189,8 @@
       %+  roll  ~(tap in ships)
       |=  [=ship ivl=(list ship) =_se-core]
       ?.  (can-poke:neg bowl ship %groups)
+        =.  se-core
+          (emit:se-core (initiate:neg [ship dap.bowl]))
         ::  retry .retry times with doubling .delay
         ::
         =+  delay=~h1
@@ -2191,7 +2199,7 @@
           %+  weld  /server/(scot %p our.bowl)/[q.flag]
           /invite/retry/(scot %p ship)/(scot %ud retry)/(scot %dr delay)
         :-  ivl
-        (emit [%pass wire %arvo %b %wait (add now.bowl delay)])
+        (emit:se-core [%pass wire %arvo %b %wait (add now.bowl delay)])
       :-  [ship ivl]
       se-core
     ?:  =(~ ivl)  se-core
@@ -2999,11 +3007,17 @@
           ::      to be stale. it would be best to somehow surface
           ::      it at the client.
           ::
-          %-  (tell:log %crit 'misguided group watch-ack' ~)
+          %-  (tell:log %crit 'misguided group watch-nack' ~)
           go-core
         ::  join in progress, set error and leave the group
         ::  to allow re-joining.
         ::
+        ::  however, do not leave the group if it was already initialized
+        ::  to avoid data loss.
+        ::
+        ?:  &(?=(%sub -.net) init.net)
+          %-  (tell:log %crit 'watch-nack for initialized group' ~)
+          go-core
         =.  cor  fi-abet:fi-error:(fi-abed:fi-core flag)
         (go-leave &)
       go-core

--- a/desk/app/groups.hoon
+++ b/desk/app/groups.hoon
@@ -1295,12 +1295,7 @@
       ::  so we must re-subscribe on the new path post load.
       ::
       [%load %v7 %subscriptions ~]
-    =.  cor
-      %+  roll
-        ~(tap by groups)
-      |=  [[=flag:g [=net:g *]] =_cor]
-      go-abet:(go-safe-sub:(go-abed:go-core:cor flag) |)
-    cor
+    inflate-io
   ==
 ::  does not overwite if wire and dock exist.  maybe it should
 ::  leave/rewatch if the path differs?
@@ -2998,6 +2993,12 @@
       ?^  p.sign
         %-  (fail:log %watch-ack 'group watch failed' u.p.sign)
         ?.  (~(has by foreigns) flag)
+          ::TODO  this should not be possible, but if it happens
+          ::      we don't have an invitation, and thus no way to rejoin.
+          ::      the user will still see the group, but it is going
+          ::      to be stale. it would be best to somehow surface
+          ::      it at the client.
+          ::
           %-  (tell:log %crit 'misguided group watch-ack' ~)
           go-core
         ::  join in progress, set error and leave the group

--- a/desk/lib/groups-conv.hoon
+++ b/desk/lib/groups-conv.hoon
@@ -1052,7 +1052,7 @@
               %open
             ?-  -.p.diff
               %add-ships  [%entry %ban %add-ships p.p.diff]~
-              %del-ships  [%entry %ban %add-ships p.p.diff]~
+              %del-ships  [%entry %ban %del-ships p.p.diff]~
               %add-ranks  [%entry %ban %add-ranks p.p.diff]~
               %del-ranks  [%entry %ban %del-ranks p.p.diff]~
             ==


### PR DESCRIPTION
## Summary

We prune bad gangs entries for groups that are already joined and initialized. Without this, a migration running on a ship which contains "join in progress" despite being already joined to the group would trigger a re-join and the ship would have left the group, deleting its local state.

## Changes

We introduce two changes to make the agent robust against this and similar problems in the future. 
1. Most immediately, we prune the gangs state removing entries for groups that are already joined  and had been initialized. 
2. We handle a watch-nack for a group robustly – if a group is already joined and initialized, we don't leave the group, but only log a critical error. 

By the way, we improve `+se-compat-send-invites` by initiating negotiation before issuing an invite poke. (Also fixing a `+roll` bug where `+se-core` `+emit` was not properly referenced)

## How did I test?

Two fake ships running old groups were setup to reproduce this bug.
~zod hosted four groups: two public groups A, B, and two private groups C D. ~dev joined all four groups.
Next, ~dev gangs state was poisoned. A gang was inserted for public group A and the progress set to %added. Private group C was poisoned in the same way.
The group host ~zod was then migrated. After ~zod migrated, ~dev was migrated.

It was observed that immediately after ~dev completed migration, poisoned groups A and C disappeared from the state, and an error message was shown in the client, thus reproducing the issue. The good groups B and D were migrated without problems.

The same scenario was then repeated with the fix deployed. This time all four groups migrated without problems, and the poisoned gangs state was cleared.

## Risks and impact

- Safe to rollback without consulting PR author? Rolling back risks triggering the bug at some unfortunate ships.
- Affects important code area:
  - [ ] Onboarding
  - [x] State / providers
  - [x] Message sync
  - [x] Channel display
  - [ ] Notifications

Fixes TLON-4663