### PR TITLE
cosmos: mock store for StoreProvider in FixtureWrapper

### DIFF
--- a/cosmos.imports.ts
+++ b/cosmos.imports.ts
@@ -69,7 +69,7 @@ import * as decorator0 from './packages/app/fixtures/cosmos.decorator';
 import * as decorator1 from './apps/tlon-mobile/src/fixtures/cosmos.decorator';
 
 export const rendererConfig: RendererConfig = {
-  "playgroundUrl": "http://localhost:5001",
+  "playgroundUrl": "http://localhost:5002",
   "rendererUrl": null
 };
 

--- a/packages/app/fixtures/FixtureWrapper.tsx
+++ b/packages/app/fixtures/FixtureWrapper.tsx
@@ -2,7 +2,7 @@
 import { NavigationContainer } from '@react-navigation/native';
 import { QueryClientProvider, queryClient } from '@tloncorp/shared';
 import { internalConfigureClient } from '@tloncorp/shared/api';
-import { type PropsWithChildren, useEffect, useState } from 'react';
+import { type PropsWithChildren, useEffect, useMemo, useState } from 'react';
 import { useFixtureSelect } from 'react-cosmos/client';
 import { GestureHandlerRootView } from 'react-native-gesture-handler';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
@@ -12,11 +12,39 @@ import type { ColorProp } from '../ui';
 import {
   AppDataContextProvider,
   ChatOptionsProvider,
+  StoreProvider,
   Theme,
   ToastProvider,
   View,
 } from '../ui';
 import { initialContacts } from './fakeData';
+import * as baseStore from '@tloncorp/shared/store';
+
+// Create a fixture-specific store mock that returns proper React Query objects
+function createFixtureStore() {
+  return new Proxy(baseStore, {
+    get: (target, prop) => {
+      const propName = prop.toString();
+      
+      // Handle React Query hooks that should return query result objects
+      if (propName.startsWith('use') && !['usePostDraftCallbacks'].includes(propName)) {
+        return () => ({
+          data: undefined,
+          isLoading: false,
+          error: null,
+          isSuccess: false,
+          isError: false,
+          refetch: () => Promise.resolve(),
+          queryKey: [],
+          enabled: true,
+        });
+      }
+      
+      // For non-hook functions, return no-op functions
+      return () => {};
+    },
+  });
+}
 
 type FixtureWrapperProps = PropsWithChildren<{
   fillWidth?: boolean;
@@ -71,60 +99,64 @@ const InnerWrapper = ({
     options: ['light', 'dark'],
   });
 
+  const fixtureStore = useMemo(() => createFixtureStore(), []);
+
   return (
     <QueryClientProvider client={queryClient}>
       <GestureHandlerRootView style={{ flex: 1 }}>
-        <AppDataContextProvider
-          currentUserId="~zod"
-          contacts={[...initialContacts]}
-          branchDomain="test"
-          branchKey="test"
-          calmSettings={{
-            disableRemoteContent: false,
-            disableAvatars: false,
-            disableNicknames: false,
-          }}
-        >
-          <ChatOptionsProvider {...useChatSettingsNavigation()}>
-            <Theme name={theme}>
-              <View
-                flex={1}
-                paddingBottom={safeArea ? insets.bottom : 0}
-                paddingTop={safeArea ? insets.top : 0}
-              >
+        <StoreProvider stub={fixtureStore}>
+          <AppDataContextProvider
+            currentUserId="~zod"
+            contacts={[...initialContacts]}
+            branchDomain="test"
+            branchKey="test"
+            calmSettings={{
+              disableRemoteContent: false,
+              disableAvatars: false,
+              disableNicknames: false,
+            }}
+          >
+            <ChatOptionsProvider {...useChatSettingsNavigation()}>
+              <Theme name={theme}>
                 <View
-                  backgroundColor={backgroundColor ?? '$secondaryBackground'}
                   flex={1}
-                  flexDirection="column"
-                  width={fillWidth ? '100%' : 'unset'}
-                  height={fillHeight ? '100%' : 'unset'}
-                  justifyContent={
-                    verticalAlign === 'top'
-                      ? 'flex-start'
-                      : verticalAlign === 'bottom'
-                        ? 'flex-end'
-                        : 'center'
-                  }
-                  alignItems={
-                    horizontalAlign === 'left'
-                      ? 'flex-start'
-                      : horizontalAlign === 'right'
-                        ? 'flex-end'
-                        : 'center'
-                  }
+                  paddingBottom={safeArea ? insets.bottom : 0}
+                  paddingTop={safeArea ? insets.top : 0}
                 >
                   <View
-                    backgroundColor={innerBackgroundColor ?? '$background'}
+                    backgroundColor={backgroundColor ?? '$secondaryBackground'}
+                    flex={1}
+                    flexDirection="column"
                     width={fillWidth ? '100%' : 'unset'}
                     height={fillHeight ? '100%' : 'unset'}
+                    justifyContent={
+                      verticalAlign === 'top'
+                        ? 'flex-start'
+                        : verticalAlign === 'bottom'
+                          ? 'flex-end'
+                          : 'center'
+                    }
+                    alignItems={
+                      horizontalAlign === 'left'
+                        ? 'flex-start'
+                        : horizontalAlign === 'right'
+                          ? 'flex-end'
+                          : 'center'
+                    }
                   >
-                    {children}
+                    <View
+                      backgroundColor={innerBackgroundColor ?? '$background'}
+                      width={fillWidth ? '100%' : 'unset'}
+                      height={fillHeight ? '100%' : 'unset'}
+                    >
+                      {children}
+                    </View>
                   </View>
                 </View>
-              </View>
-            </Theme>
-          </ChatOptionsProvider>
-        </AppDataContextProvider>
+              </Theme>
+            </ChatOptionsProvider>
+          </AppDataContextProvider>
+        </StoreProvider>
       </GestureHandlerRootView>
     </QueryClientProvider>
   );

--- a/packages/app/fixtures/InviteUsersSheet.fixture.tsx
+++ b/packages/app/fixtures/InviteUsersSheet.fixture.tsx
@@ -22,10 +22,15 @@ function spyOn<T extends object, MethodName extends keyof T>(
 
 function InviteUsersSheetFixture() {
   const store = useMemo(() => {
-    const mockUseGroup = () => ({
-      data: group,
+    const mockUseGroup = ({ id }: { id?: string }) => ({
+      data: id ? group : undefined,
       isLoading: false,
       error: null,
+      isSuccess: !!id,
+      isError: false,
+      refetch: () => Promise.resolve(),
+      queryKey: ['group', id],
+      enabled: !!id,
     });
 
     // @ts-expect-error - fixture mock
@@ -33,8 +38,8 @@ function InviteUsersSheetFixture() {
   }, []);
 
   return (
-    <StoreProvider stub={store}>
-      <FixtureWrapper>
+    <FixtureWrapper>
+      <StoreProvider stub={store}>
         <AppDataContextProvider currentUserId="~zod" contacts={initialContacts}>
           <InviteUsersSheet
             open
@@ -43,8 +48,8 @@ function InviteUsersSheetFixture() {
             groupId={group.id}
           />
         </AppDataContextProvider>
-      </FixtureWrapper>
-    </StoreProvider>
+      </StoreProvider>
+    </FixtureWrapper>
   );
 }
 


### PR DESCRIPTION
## Summary

Adds a mock store for the StoreProvider in our Cosmos fixtures.

## Changes

Many of our components use react-query hooks and therefore expect real data. Cosmos obviously runs components in isolation without real Urbit backend connections, a database with actual data, or network requests to populate stores.

When there's no real backend, store hooks return `undefined` instead of proper react-query objects. When we try to destructure `{ data: group }` from `undefined`, Cosmos would throw an error and fail to render the component.

I am unsure about where we depend on `storeContext.tsx`'s use of returning something other than a react-query object, so I opted to mock a second store out in `FixtureWrapper`, where the `data` prop is safe to restructure since `group` "safely" returns as `undefined`.  

## How did I test?

pnpm cosmos

## Risks and impact

- Safe to rollback without consulting PR author? Yes
- Affects important code area:
  - [ ] Onboarding
  - [x] State / providers
  - [ ] Message sync
  - [ ] Channel display
  - [ ] Notifications

## Rollback plan

git revert