### PR TITLE
Fix group join performance

### DIFF
--- a/desk/app/groups.hoon
+++ b/desk/app/groups.hoon
@@ -2632,6 +2632,8 @@
         %flag-reply  [%flag-reply key parent nest group]
       ==
     go-core
+  ::  +go-is-init: check if group is initialized
+  ++  go-is-init  |(?=(%pub -.net) init.net)
   ::  +go-is-admin: check whether the ship has admin rights
   ::
   ++  go-is-admin
@@ -3034,12 +3036,15 @@
   ++  go-apply-log
     |=  =log:g
     ?~  log  go-core
+    =+  was-init=go-is-init
     =.  go-core
       %+  roll  (tap:log-on:g log)
       |=  [=update:g =_go-core]
       (go-u-group:go-core update)
     =?  net  ?=(%sub -.net)
       [%sub time.net &]
+    =?  go-core  !was-init
+      (go-response [%create group])
     ::  join the channels upon initial group log
     ::
     =/  readable-channels
@@ -3076,7 +3081,10 @@
   ++  go-u-create
     |=  gr=group:g
     ^+  go-core
-    =.  go-core  (go-response [%create gr])
+    ::  nb: we don't send out a response here because
+    ::  a synthetic %create response is sent after
+    ::  the group log has been fully applied in +go-apply-log.
+    ::
     ?:  go-our-host  go-core
     ::
     ?>  ?=(%sub -.net)
@@ -3634,6 +3642,10 @@
   ++  go-response
     |=  =r-group:g
     ^+  go-core
+    ::  do not sent out responses until group log
+    ::  has been applied, and the group initialized.
+    ::
+    ?.  go-is-init  go-core
     ::  v1 response
     ::
     =/  r-groups-7=r-groups:v7:gv  [flag r-group]


### PR DESCRIPTION
## Summary

The new groups agent introduced a sync mechanism that is also used from channels. New group members receive the group log and apply it locally. However, each group update caused a response to be emitted to the client, slowing down the group join process. This PR fixes this by preventing responses from being generated until the group log has been fully applied. At the end of the process a synthetic group %create response is sent to the client.

## Changes

`+go-response` is modified to only send out responses after group initialization has completed.
`+go-apply-log` now sends a single synthetic %create event, but only upon group initialization.

## How did I test?

Joined Tlon's group, which before the fix took about 2 minutes join. With this fix the join time is down to about 10 seconds.

## Risks and impact

- Safe to rollback without consulting PR author? (Yes | No) Yes, but will significantly slow down the group join time.
- Affects important code area:
  - [x] Onboarding
  - [x] State / providers
  - [x] Message sync
  - [ ] Channel display
  - [ ] Notifications

## Rollback plan

Can be reverted at the cost of slowing down join time.

PR against the other fix for clarity. We should remember to retarget after the other fix goes in.