### PR TITLE
channels: /range endpoint tweaks

### DIFF
--- a/desk/app/channels.hoon
+++ b/desk/app/channels.hoon
@@ -2745,7 +2745,7 @@
           `key:(head older)
         =/  count  (wyt:on-v-posts:c posts)
         =/  latest=@ud
-          ?~  latest=(ram:on-v-posts:c posts.channel)  1
+          ?~  latest=(ram:on-v-posts:c posts.channel)  0
           ?-  -.val.u.latest
             %&  seq.val.u.latest
             %|  seq.val.u.latest

--- a/desk/app/channels.hoon
+++ b/desk/app/channels.hoon
@@ -2635,7 +2635,7 @@
       =;  =paged-posts:c
         ``channel-posts-4+!>(paged-posts)
       =/  latest=@ud
-        ?~  latest=(ram:on-v-posts:c posts.channel)  1
+        ?~  latest=(ram:on-v-posts:c posts.channel)  0
         ?-  -.val.u.latest
           %&  seq.val.u.latest
           %|  seq.val.u.latest

--- a/desk/app/channels.hoon
+++ b/desk/app/channels.hoon
@@ -2834,7 +2834,7 @@
           %|  seq.p.i.posts
         ==
       ?:  (gth seq end)    $(posts t.posts)
-      ?:  (lth seq start)  ~  ::  done
+      ?:  &(!=(0 seq) (lth seq start))  ~  ::  done
       [i.posts $(posts t.posts)]
     ::
         [%post time=@ ~]


### PR DESCRIPTION
## Summary

Fixes two small issues with the `/range` endpoint identified by @latter-bolden.

## Changes

- Give `newest: 0` instead of `newest: 1` if a channel has no posts yet.
- Don't respect messages with `seq=0` while traversing the message list for building the `/range` response.

## How did I test?

Tested manually by running queries and observing the changes. 

## Risks and impact

- Yes, safe to rollback without consulting PR author.
- Affects important code area:
  - [ ] Onboarding
  - [ ] State / providers
  - [x] Message sync
  - [ ] Channel display
  - [ ] Notifications

## Rollback plan

Could just revert if needed. This endpoint isn't used in production yet.
