### PR TITLE
channels-server: handle signs from /request-join wire

### DIFF
--- a/desk/app/channels-server.hoon
+++ b/desk/app/channels-server.hoon
@@ -593,10 +593,11 @@
   |=  [=(pole knot) =sign:agent:gall]
   ^+  cor
   ?+    pole  ~|(bad-agent-wire+pole !!)
-    [%logs ~]     cor
-    [%pimp ~]     cor
-    [%wake ~]     cor
-    [%numbers ~]  cor
+    [%logs ~]          cor
+    [%pimp ~]          cor
+    [%wake ~]          cor
+    [%numbers ~]       cor
+    [%request-join ~]  cor
   ::
       [=kind:c *]
     ?+    -.sign  !!


### PR DESCRIPTION

## Changes

A poke was added in #4996 that uses this wire, but no handling of the resulting signs was implemented. We don't particularly care what the member does with the "please join" notification, so we just no-op whenever we get a result.

## How did I test?

The proof writes itself.

## Risks and impact

- Sure, safe to rollback without consulting PR author if you really must.
- Affects important code area:
  - [ ] Onboarding
  - [ ] State / providers
  - [ ] Message sync
  - [ ] Channel display
  - [ ] Notifications

## Rollback plan

`git revert`