### PR TITLE
groups: checking from self higher up to avoid fact return src mixup

### DIFF
--- a/desk/app/groups.hoon
+++ b/desk/app/groups.hoon
@@ -144,8 +144,8 @@
       [~.groups^%1 ~ ~]
     %-  my
     :~  %groups^[~.groups^%1 ~ ~]
-        %channels^[~.channels^%3 ~ ~]
-        %channels-server^[~.channels^%3 ~ ~]
+        %channels^[~.channels^%2 ~ ~]
+        %channels-server^[~.channels^%2 ~ ~]
     ==
 %-  agent:dbug
 %+  verb  |

--- a/desk/app/groups.hoon
+++ b/desk/app/groups.hoon
@@ -144,8 +144,8 @@
       [~.groups^%1 ~ ~]
     %-  my
     :~  %groups^[~.groups^%1 ~ ~]
-        %channels^[~.channels^%2 ~ ~]
-        %channels-server^[~.channels^%2 ~ ~]
+        %channels^[~.channels^%3 ~ ~]
+        %channels-server^[~.channels^%3 ~ ~]
     ==
 %-  agent:dbug
 %+  verb  |
@@ -324,6 +324,7 @@
     ::
         %group-action-4
       =+  !<(=a-groups:v7:gv vase)
+      ?>  from-self
       ?-    -.a-groups
           %group
         =/  group-core  (go-abed:go-core flag.a-groups)
@@ -334,7 +335,6 @@
         go-abet:(go-a-invite:group-core a-invite.a-groups)
       ::
           %leave
-        ?>  from-self
         =/  group-core  (go-abed:go-core flag.a-groups)
         go-abet:(go-leave:group-core &)
       ==
@@ -2804,7 +2804,6 @@
   ::
   ++  go-a-invite
     |=  =a-invite:g
-    ?>  from-self
     ?:  =(ship.a-invite src.bowl)  go-core
     ?:  &(?=(~ token.a-invite) !?=(%public privacy.ad))
       ::  if we don't have a suitable token for a non-public group,
@@ -2839,7 +2838,6 @@
   ++  go-a-group
     |=  =a-group:g
     ^+  go-core
-    ?>  from-self
     (go-send-command /command/[-.a-group] `c-group:g`a-group)
   ::  +go-send-command:  send command to the group host
   ::


### PR DESCRIPTION
## Summary

Fixes issue found in onboarding testing with non-host admin created invites. 

## Changes

- moved `?>  from-self` check to be in more idiomatic place

## How did I test?

<!-- Describe your testing process. -->

## Risks and impact

- Safe to rollback without consulting PR author? (Yes | No)
- Affects important code area:
  - [ ] Onboarding
  - [ ] State / providers
  - [ ] Message sync
  - [ ] Channel display
  - [ ] Notifications

## Rollback plan

<!-- Describe the steps to revert these changes if needed. -->

## Screenshots / videos

<!-- Attach any relevant media. -->
