### PR TITLE
channel-utils: best-effort kind-data downconvert

### DIFF
--- a/desk/lib/channel-utils.hoon
+++ b/desk/lib/channel-utils.hoon
@@ -493,14 +493,15 @@
   ^-  essay:v7:old:c
   :-  (memo-1 -.essay)
   ^-  kind-data:v7:old:c
-  ?+    kind.essay  ~|(essay-1-fail+kind.essay !!)
+  ?+    kind.essay  [%chat ~]
     [%chat $@(~ [%notice ~])]  kind.essay
+    [%chat *]                  [%chat ~]
   ::
-      [%diary ~]
+      [%diary *]
     ?~  meta.essay  [%diary '' '']
     [%diary title image]:u.meta.essay
   ::
-      [%heap ~]
+      [%heap *]
     ?~  meta.essay  [%heap ~]
     [%heap `title.u.meta.essay]
   ==


### PR DESCRIPTION
## Summary

We might receive all kinds of `kind=path` values for message previews/reference resolution. We generally shouldn't crash on these, especially not in logic that's just there to give old-style data on old subscription paths. We remove the crash and fall back to `[%chat ~]` in unrecognized cases.

## Changes

First, we must respect /[kind]/unknown paths and similar, since those will be produced for missing or deleted posts.

Kinds we don't recognize at all will now simply fall back to pretending to be %chat messages, instead of crashing the whole event when they get processed.

## How did I test?

Smoke-tested for message handling in general.

## Risks and impact

- Yes, safe to rollback without consulting PR author.
- Affects important code area:
  - [ ] Onboarding
  - [ ] State / providers
  - [ ] Message sync
  - [ ] Channel display
  - [ ] Notifications

## Rollback plan

Revert.