### PR TITLE
stick to scroll bottom before caught up if user sends a post

### DIFF
--- a/packages/app/ui/components/Channel/PostList/PostList.web.tsx
+++ b/packages/app/ui/components/Channel/PostList/PostList.web.tsx
@@ -152,11 +152,29 @@ const PostListSingleColumn: PostListComponent = React.forwardRef(
       insideScrolledToBottomBoundary,
     ]);
 
+    const hasInFlightPost = React.useMemo(
+      () =>
+        postsWithNeighbors.some(
+          (x) =>
+            x.post.deliveryStatus === 'pending' ||
+            x.post.deliveryStatus === 'enqueued'
+        ),
+      [postsWithNeighbors]
+    );
     useStickToScrollStart({
       scrollerContentsKey: orderedData,
       scrollerRef,
       inverted,
-      hasNewerPosts,
+      // - If we don't have all the newest posts, we want to wait to autoscroll
+      //   to the newer messages until we've loaded everything - otherwise, we'll
+      //   scroll on each page that comes in, which is jarring.
+      // - However, we opt out of this behavior if the user sends a message
+      //   before load is completed: we definitely want to show and scroll to any
+      //   newly-sent message, regardless of channel load state. (If this case is
+      //   triggered during a long "catch up" load, we'll autoscroll on each page
+      //   load until the channel is fully loaded. It'd be better to only scroll
+      //   to the sent message once, but I don't see a robust way of doing that.)
+      disable: hasNewerPosts && !hasInFlightPost,
     });
 
     React.useImperativeHandle(forwardedRef, () => ({
@@ -518,13 +536,13 @@ function useStickToScrollStart({
   inverted,
   scrollerContentsKey,
   scrollerRef,
-  hasNewerPosts,
+  disable,
 }: {
   inverted: boolean;
   /** This value must change when the scroll height of the scroller changes */
   scrollerContentsKey: unknown;
   scrollerRef: React.RefObject<HTMLDivElement>;
-  hasNewerPosts: boolean;
+  disable: boolean;
 }) {
   const shouldStickToStartRef = React.useRef(false);
 
@@ -534,8 +552,8 @@ function useStickToScrollStart({
   });
 
   React.useEffect(() => {
-    shouldStickToStartRef.current = !hasNewerPosts && isAtStart;
-  }, [isAtStart, hasNewerPosts]);
+    shouldStickToStartRef.current = !disable && isAtStart;
+  }, [isAtStart, disable]);
 
   React.useEffect(() => {
     const scroller = scrollerRef.current;


### PR DESCRIPTION
## Summary
fixes TLON-4668

Fixes bug where new web scroller would not scroll to bottom after sending a post while channel was still loading newer posts ("catching up") by sticking to scroll bottom after sending a message even if channel is still catching up (and maintaining rules about user already viewing bottom of scroll in order to stick to bottom of scroll).

### Cause

We pause this "stick to scroll start" functionality whenever we believe the channel may have newer posts that are not yet loaded (`hasNewerPosts`) https://github.com/tloncorp/tlon-apps/blob/44c6211621fce584c4a90f43a002f7a2551c3559/packages/app/ui/components/Channel/PostList/PostList.web.tsx#L155-L160 – the thought here is that, if we load new messages in, we want to scroll to those once instead of "stuttering" two scroll-to-bottoms

We always start a `useChannelPosts` query with `hasNewerPosts` as true, since we need to pull from backend to see if we don't know about any new posts

So there will always be a span of time while waiting for that first fetch where `hasNewerPosts` is true, and so we block scroll-to-bottom

**Why is this a bug on the new web scroller and not on the old `FlatList`?** The old FlatList does not pause stick-to-scroll-start while we're waiting for newer posts[^0] – so the new posts sent by this client are scrolled-to as normal.

[^0]: In code, it looks like we should be pausing: https://github.com/tloncorp/tlon-apps/blob/9e37862c50664f7ed76f3a6dabbdcec7fff4055c/packages/app/ui/components/Channel/useAnchorScrollLock.ts#L160 but when testing on web, each page loading into the channel triggers a scroll-to-start. Maybe this is a bug on RNW FlatList?

## Changes
Disable `PostList.web`'s "stick to scroll start" when `hasNewerPosts && !hasInFlightPost` instead of just `hasNewerPosts`.

## How did I test?
<details>

<summary>I used this patch to simulate slow channel post loads</summary>

```diff
diff --git a/packages/shared/src/store/useChannelPosts.ts b/packages/shared/src/store/useChannelPosts.ts
index 90bab19d6..c8cfeb82a 100644
--- a/packages/shared/src/store/useChannelPosts.ts
+++ b/packages/shared/src/store/useChannelPosts.ts
@@ -85,6 +85,20 @@ export const useChannelPosts = (options: UseChannelPostsParams) => {
     },
     retryDelay: () => 500,
     queryFn: async (ctx): Promise<PostQueryPage> => {
+      const shouldPause = true;
+      if (shouldPause) {
+        console.log('Pausing; use __resolve() to continue', ctx.pageParam);
+        await new Promise<void>((resolve) => {
+          const prev = (window.global as any).__resolve;
+          Object.assign(window.global, {
+            __resolve: () => {
+              prev?.();
+              resolve();
+            },
+          });
+        });
+      }
+
       const queryOptions = ctx.pageParam || options;
       postsLogger.log('loading posts', { queryOptions, options });
       // We should figure out why this is necessary.

```

</details>

I did testing all on web.

I entered a channel, sent a post before channel completed load (i.e. while `hasNewerPosts=true`), and saw that the post was scrolled to become visible, and remained visible while channel loaded it.
I repeated this, sending the post at the following points:
- Before any `useChannelPosts` query completed (i.e. blank channel screen)
- After initial `useChannelPosts` query completed (i.e. posts loaded, but `hasNewerPosts` is still true because we need to do one more `newer` query)
- After initial `useChannelPosts` query completed but before we fetched a new message from server (loaded initial batch -> sent post A from this client -> continue query, receiving another post B from server -> see [ `initial batch`, `post B`, `post A` ] correctly ordered

Opened a channel with multiple pages of unloaded messages – without sending a message, the channel kept anchored at my latest unread while loading newer pages.

## Risks and impact

- Safe to rollback without consulting PR author? Yes
- Affects important code area:
  - [ ] Onboarding
  - [ ] State / providers
  - [ ] Message sync
  - [x] Channel display
  - [ ] Notifications

## Rollback plan
git revert

## Screenshots / videos
These demos pause the `useChannelPosts` query function on each invocation – running `__resolve()` in the console is resuming that function (simulating a slow load).

| Before | After |
| --- | --- |
| <video src="https://github.com/user-attachments/assets/40470e66-6dd0-425f-9817-b2f79b8bf18d" /> | <video src="https://github.com/user-attachments/assets/02631d2c-c810-4e80-9a11-b325ac6d7c3c" /> | 