### PR TITLE
groups: normalize channel kind in active-channels sync

### DIFF
--- a/desk/app/groups.hoon
+++ b/desk/app/groups.hoon
@@ -3424,9 +3424,8 @@
       =/  pre=path
         /(scot %p our.bowl)/channels/(scot %da now.bowl)
       =/  active
-        ?.  ?=(?(%diary %heap %chat) p.nest)  |
-        =/  =kind:d  p.nest
-        .^(? %gu (weld pre /v3/[kind]/(scot %p p.q.nest)/[q.q.nest]))
+        ?.  ?=(kind:d p.nest)  |
+        .^(? %gu (weld pre /v3/[p.nest]/(scot %p p.q.nest)/[q.q.nest]))
       =?  active-channels.group  active
         (~(put by active-channels.group) nest)
       ?:  go-our-host  go-core

--- a/desk/app/groups.hoon
+++ b/desk/app/groups.hoon
@@ -3423,7 +3423,10 @@
       ::
       =/  pre=path
         /(scot %p our.bowl)/channels/(scot %da now.bowl)
-      =/  active  .^(? %gu (weld pre /v3/[p.nest]/(scot %p p.q.nest)/[q.q.nest]))
+      =/  active
+        ?.  ?=(?(%diary %heap %chat) p.nest)  |
+        =/  =kind:d  p.nest
+        .^(? %gu (weld pre /v3/[kind]/(scot %p p.q.nest)/[q.q.nest]))
       =?  active-channels.group  active
         (~(put by active-channels.group) nest)
       ?:  go-our-host  go-core


### PR DESCRIPTION
## Summary

Some third-party developers (notably %quorum) seem to be using groups to host their custom content unsupported by channels. They do this by modifying the group-side nest kind. This causes crashes on ships hosting such content.

## Changes

We normalize the nest kind and cast it to the channels $kind type, ensuring the scry
is going to succeed.

## How did I test?

I have setup two ships and created a group with multiple channels. I have confirmed that the `active-channels` set is correctly updated. I have then setup a new channel, which was correctly reflected in `active-channels` on the subscriber.

## Risks and impact

- Safe to rollback without consulting PR author? Yes
- Affects important code area:
  - [ ] Onboarding
  - [x] State / providers
  - [ ] Message sync
  - [x] Channel display
  - [ ] Notifications

## Rollback plan

Revert.