### PR TITLE
groups: delete tokens without crashing

### DIFF
--- a/desk/app/groups.hoon
+++ b/desk/app/groups.hoon
@@ -3173,7 +3173,6 @@
       ::TODO if a token we had used for inviting someone to the group
       ::     has been revoked, we should signal to the invitee.
       ::
-      ?>  (~(has by tokens.ad) token.u-token)
       =.  tokens.ad  (~(del by tokens.ad) token.u-token)
       go-core
     ==


### PR DESCRIPTION
## Summary

In new groups there are three kinds of updates that are restricted to admin members. These are: token, pending ships, and entry requests. A non-admin ship should never hear about such updates. However, we presently don't correctly handle a case of a previously non-admin member that acquired admin rights and heard about token deletion.

The chance of this happening is minimal, because for now we neither delete tokens, nor expose this functionality to the user, but we should deploy this change as a safeguard before a proper fix to this problem, in connection with robust group resubcriptions is implemented.
  
## Changes

Removes assertion and prevents crashing on non-existent token deletion.

## How did I test?

Compiled.

## Risks and impact

- Safe to rollback without consulting PR author? No, because could trigger a group desync.
- Affects important code area:
  - [ ] Onboarding
  - [x] State / providers
  - [ ] Message sync
  - [x] Channel display
  - [ ] Notifications

## Rollback plan

Can be simply reverted.
