### PR TITLE
e2e: fix process cleanup issues

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -246,13 +246,20 @@ When using Claude Code with the Playwright MCP server for e2e testing:
 **Important Scripts:**
 -   `./start-playwright-dev.sh` - Starts ships in background, returns when ready
 -   `./stop-playwright-dev.sh` - Comprehensive cleanup of all e2e processes
+-   `./apps/tlon-web/rube-cleanup.sh` - Emergency cleanup when processes are stuck
 -   `pnpm e2e:playwright-dev` - Starts ships and web servers (runs indefinitely)
 -   `pnpm e2e:test <file>` - Runs a single test file with ship setup
+-   `pnpm e2e` - Full test suite (now properly handles Ctrl+C interruption)
+
+**Process Cleanup Improvements:**
+-   **Automatic cleanup**: Ctrl+C now properly cleans up all processes including Urbit serf sub-processes
+-   **Emergency cleanup**: Run `./apps/tlon-web/rube-cleanup.sh` if processes get stuck
+-   **Pattern-based killing**: Infrastructure uses pattern matching to find and kill all related processes
 
 **Common E2E Testing Pitfalls:**
 -   **Ship readiness**: Checking for `.http.ports` files doesn't mean ships are ready - wait for SHIP_SETUP_COMPLETE
 -   **Desk updates**: Applying desk updates can take 5-10 minutes, default timeouts may be too short
--   **Process cleanup**: Always ensure proper cleanup of Urbit ships and web servers (ports 3000-3003, 35453, 36963, 38473, 39983)
+-   **Process cleanup**: Now handled automatically, but use `rube-cleanup.sh` for emergency recovery
 -   **Manifest changes**: Always backup `shipManifest.json` before modifying - it's critical for e2e tests
 
 **GCP Integration for E2E Archives:**

--- a/apps/tlon-web/e2e/README.md
+++ b/apps/tlon-web/e2e/README.md
@@ -366,6 +366,26 @@ The Rube system automatically:
 -   Browser console: Accessible through debug mode, also accessible through Playwright traces
 -   Network requests: Captured in Playwright traces, also accessible through debug mode
 
+### Process Cleanup
+
+The e2e infrastructure now includes robust cleanup handling:
+
+1. **Automatic cleanup on Ctrl+C**: When you interrupt `pnpm e2e` or other e2e commands with Ctrl+C, all processes (including Urbit ships and their serf sub-processes) are now properly cleaned up.
+
+2. **Emergency cleanup script**: If processes get stuck or orphaned, use the emergency cleanup script:
+   ```bash
+   ./rube-cleanup.sh
+   ```
+   This will forcefully terminate all rube-related processes including:
+   - Urbit ships and serf processes
+   - Vite dev servers
+   - Any orphaned Node.js processes from the test infrastructure
+
+3. **How cleanup works**: The infrastructure uses pattern-based process killing to ensure even untracked sub-processes (like Urbit's serf) are properly terminated. This happens automatically when:
+   - Tests complete normally
+   - You interrupt with Ctrl+C
+   - The process exits for any reason
+
 ## Maintenance
 
 ### Updating Ship Images

--- a/apps/tlon-web/package.json
+++ b/apps/tlon-web/package.json
@@ -24,7 +24,7 @@
     "serve-sw": "vite preview --mode sw",
     "tsc": "tsc --noEmit",
     "cosmos": "cosmos",
-    "rube": "tsc --isolatedModules --skipLibCheck ./rube/index.ts --outDir ./rube/dist && node ./rube/dist/index.js",
+    "rube": "./rube-runner.sh",
     "e2e": "pnpm rube",
     "e2e:force": "cross-env FORCE_EXTRACTION=true pnpm e2e",
     "e2e:debug": "cross-env DEBUG_PLAYWRIGHT=true pnpm e2e",

--- a/apps/tlon-web/rube-cleanup.sh
+++ b/apps/tlon-web/rube-cleanup.sh
@@ -1,0 +1,197 @@
+#!/bin/bash
+
+# Emergency cleanup script for rube e2e test infrastructure
+# 
+# Purpose: Forcefully terminate all rube-related processes when normal cleanup fails
+# 
+# Usage: ./rube-cleanup.sh
+# 
+# What it does:
+# - Kills all Node.js processes running rube scripts
+# - Terminates Urbit ships and their serf sub-processes
+# - Cleans up processes on all e2e ports (3000-3003, 35453, 36963, 38473, 39983)
+# - Removes PID and lock files that might prevent scripts from running
+# - Verifies all processes are terminated
+#
+# When to use:
+# - When Ctrl+C doesn't properly clean up processes
+# - When you see "port already in use" errors
+# - When ships or web servers are stuck running
+# - After a script crashes without cleanup
+
+echo "🧹 Rube Emergency Cleanup Script"
+echo "================================"
+echo ""
+
+# Get the script's directory
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+RUBE_DIR="$SCRIPT_DIR/rube"
+DIST_DIR="$SCRIPT_DIR/rube/dist"
+
+# Colors for output
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+NC='\033[0m' # No Color
+
+# Function to kill processes on a specific port
+kill_port() {
+    local port=$1
+    local pids=$(lsof -ti:$port 2>/dev/null || true)
+    if [ -n "$pids" ]; then
+        echo -e "${YELLOW}  Killing processes on port $port: $pids${NC}"
+        echo "$pids" | xargs kill -9 2>/dev/null || true
+        return 0
+    fi
+    return 1
+}
+
+echo "🔍 Step 1: Looking for running rube/node processes..."
+echo ""
+
+# Kill node processes running rube scripts
+RUBE_PIDS=$(ps aux | grep -E "node.*rube/(dist/)?index\.js|node.*rube/(dist/)?playwright-dev\.js|node.*rube/(dist/)?run-single-test\.js" | grep -v grep | awk '{print $2}' || true)
+if [ -n "$RUBE_PIDS" ]; then
+    echo -e "${YELLOW}Found rube node processes:${NC}"
+    echo "$RUBE_PIDS"
+    echo "$RUBE_PIDS" | xargs kill -9 2>/dev/null || true
+    echo -e "${GREEN}✅ Killed rube node processes${NC}"
+else
+    echo "  No rube node processes found"
+fi
+
+echo ""
+echo "🔍 Step 2: Looking for Urbit binary processes..."
+echo ""
+
+# Kill Urbit binary processes
+URBIT_BINARY="$DIST_DIR/urbit_extracted/urbit"
+if [ -f "$URBIT_BINARY" ]; then
+    URBIT_PIDS=$(ps aux | grep "$URBIT_BINARY" | grep -v grep | awk '{print $2}' || true)
+    if [ -n "$URBIT_PIDS" ]; then
+        echo -e "${YELLOW}Found Urbit processes:${NC}"
+        echo "$URBIT_PIDS"
+        echo "$URBIT_PIDS" | xargs kill -9 2>/dev/null || true
+        echo -e "${GREEN}✅ Killed Urbit processes${NC}"
+    else
+        echo "  No Urbit processes found"
+    fi
+else
+    # Try to find any urbit process from rube directory
+    URBIT_PIDS=$(ps aux | grep -E "urbit.*rube/dist" | grep -v grep | awk '{print $2}' || true)
+    if [ -n "$URBIT_PIDS" ]; then
+        echo -e "${YELLOW}Found Urbit processes (fallback):${NC}"
+        echo "$URBIT_PIDS"
+        echo "$URBIT_PIDS" | xargs kill -9 2>/dev/null || true
+        echo -e "${GREEN}✅ Killed Urbit processes${NC}"
+    else
+        echo "  No Urbit processes found"
+    fi
+fi
+
+echo ""
+echo "🔍 Step 3: Cleaning up processes on e2e ports..."
+echo ""
+
+# Kill processes on known e2e ports
+# Web server ports
+WEB_PORTS="3000 3001 3002 3003"
+# Urbit HTTP ports
+URBIT_PORTS="35453 36963 38473 39983"
+# Urbit loopback ports (from shipManifest)
+LOOPBACK_PORTS="34543 36053 37563 39073"
+
+FOUND_PROCESSES=false
+for port in $WEB_PORTS $URBIT_PORTS $LOOPBACK_PORTS; do
+    if kill_port $port; then
+        FOUND_PROCESSES=true
+    fi
+done
+
+if [ "$FOUND_PROCESSES" = false ]; then
+    echo "  No processes found on e2e ports"
+fi
+
+echo ""
+echo "🔍 Step 4: Killing Vite dev server processes..."
+echo ""
+
+# Kill vite dev server processes
+VITE_PIDS=$(ps aux | grep "vite dev" | grep -v grep | awk '{print $2}' || true)
+if [ -n "$VITE_PIDS" ]; then
+    echo -e "${YELLOW}Found Vite dev server processes:${NC}"
+    echo "$VITE_PIDS"
+    echo "$VITE_PIDS" | xargs kill -9 2>/dev/null || true
+    echo -e "${GREEN}✅ Killed Vite processes${NC}"
+else
+    echo "  No Vite dev server processes found"
+fi
+
+echo ""
+echo "🔍 Step 5: Cleaning up PID and lock files..."
+echo ""
+
+# Clean up PID files
+PID_FILES=(
+    "$DIST_DIR/.rube.pid"
+    "$DIST_DIR/.rube-children.json"
+    "$DIST_DIR/.run-single-test.pid"
+    "$SCRIPT_DIR/.playwright-dev.pid"
+    "$SCRIPT_DIR/playwright-dev.log"
+)
+
+FOUND_FILES=false
+for file in "${PID_FILES[@]}"; do
+    if [ -f "$file" ]; then
+        echo -e "${YELLOW}  Removing: $file${NC}"
+        rm -f "$file"
+        FOUND_FILES=true
+    fi
+done
+
+# Clean up ship lock files
+for ship_dir in "$DIST_DIR"/zod "$DIST_DIR"/bus "$DIST_DIR"/ten "$DIST_DIR"/mug; do
+    if [ -d "$ship_dir" ]; then
+        LOCK_FILE="$ship_dir/.vere.lock"
+        HTTP_PORTS_FILE="$ship_dir/.http.ports"
+        
+        if [ -f "$LOCK_FILE" ]; then
+            echo -e "${YELLOW}  Removing: $LOCK_FILE${NC}"
+            rm -f "$LOCK_FILE"
+            FOUND_FILES=true
+        fi
+        
+        if [ -f "$HTTP_PORTS_FILE" ]; then
+            echo -e "${YELLOW}  Removing: $HTTP_PORTS_FILE${NC}"
+            rm -f "$HTTP_PORTS_FILE"
+            FOUND_FILES=true
+        fi
+    fi
+done
+
+if [ "$FOUND_FILES" = false ]; then
+    echo "  No PID or lock files found"
+fi
+
+echo ""
+echo "🔍 Step 6: Final verification..."
+echo ""
+
+# Check if any processes are still running on e2e ports
+REMAINING=$(lsof -ti:3000,3001,3002,35453,36963,38473 2>/dev/null || true)
+if [ -n "$REMAINING" ]; then
+    echo -e "${RED}⚠️  Warning: Some processes may still be running:${NC}"
+    echo "$REMAINING"
+    echo "You may need to kill them manually: kill -9 $REMAINING"
+else
+    echo -e "${GREEN}✅ All e2e processes have been cleaned up successfully!${NC}"
+fi
+
+echo ""
+echo "🎉 Cleanup complete!"
+echo ""
+echo "You can now safely run:"
+echo "  pnpm e2e"
+echo "  pnpm e2e:test <test-file>"
+echo "  pnpm e2e:playwright-dev"
+echo ""

--- a/apps/tlon-web/rube-runner.sh
+++ b/apps/tlon-web/rube-runner.sh
@@ -1,0 +1,29 @@
+#!/bin/bash
+#
+# Wrapper script for proper signal forwarding to the rube e2e test infrastructure
+#
+# Purpose: Ensures signals (like Ctrl+C) are properly forwarded to the Node.js process
+#
+# Why this exists:
+# - pnpm/npm don't properly forward signals through command chains (e.g., "tsc && node")
+# - Without proper signal forwarding, cleanup handlers don't run when you hit Ctrl+C
+# - This causes Urbit ships and web servers to keep running after script termination
+#
+# How it works:
+# - Compiles TypeScript first
+# - Uses 'exec' to replace the shell process with Node.js
+# - This ensures Node.js receives signals directly, not through shell intermediaries
+# - Cleanup handlers in index.ts can then properly terminate all child processes
+
+# Compile TypeScript
+echo "Compiling rube..."
+npx tsc --isolatedModules --skipLibCheck ./rube/index.ts --outDir ./rube/dist
+
+if [ $? -ne 0 ]; then
+    echo "TypeScript compilation failed"
+    exit 1
+fi
+
+# Run the Node.js process and forward all signals
+echo "Starting rube..."
+exec node ./rube/dist/index.js "$@"

--- a/apps/tlon-web/rube/README-ARCHIVING.md
+++ b/apps/tlon-web/rube/README-ARCHIVING.md
@@ -232,14 +232,19 @@ If archived ships fail to boot during verification:
 
 If you see port conflict errors:
 ```bash
-# Kill any existing e2e processes
+# Kill any existing e2e processes (preferred method)
 ./stop-playwright-dev.sh
+
+# Or use the emergency cleanup script
+./apps/tlon-web/rube-cleanup.sh
 
 # Or manually kill processes on e2e ports
 for port in 3000 3001 3002 35453 36963 38473; do
   lsof -ti:$port | xargs kill -9 2>/dev/null || true
 done
 ```
+
+Note: The infrastructure now includes improved cleanup handling that automatically terminates all processes (including Urbit serf sub-processes) when scripts are interrupted with Ctrl+C.
 
 ## Manual Archive Process (Fallback)
 

--- a/apps/tlon-web/rube/index.ts
+++ b/apps/tlon-web/rube/index.ts
@@ -19,6 +19,9 @@ import * as zlib from 'zlib';
 
 const spawnedProcesses: childProcess.ChildProcess[] = [];
 const startHashes: { [ship: string]: { [desk: string]: string } } = {};
+const rubeDir = __dirname;
+const pidFile = path.join(rubeDir, '.rube.pid');
+const childrenFile = path.join(rubeDir, '.rube-children.json');
 
 const manifestPath = path.join(
   __dirname,
@@ -199,43 +202,62 @@ const getUrbitBinary = async () => {
 };
 
 const killExistingUrbitProcesses = async (): Promise<void> => {
-  const pathToBinary = path.join(__dirname, 'urbit_extracted/urbit');
   console.log('Kill existing urbit processes');
-  const command = `ps aux | grep urbit | grep ${pathToBinary} | awk '{print $2}' | xargs kill -9`;
+  const command = killExistingUrbitCommand();
 
-  return new Promise((resolve, reject) => {
-    childProcess.exec(command, (error, stdout, stderr) => {
-      if (error && !error.message.includes('No such process')) {
-        console.error(`Error killing process: ${error.message}`);
-        reject(error);
-        return;
-      }
-      if (stderr && !stderr.includes('No such process')) {
-        console.error(`stderr: ${stderr}`);
+  return new Promise((resolve) => {
+    childProcess.exec(
+      command,
+      { maxBuffer: 1024 * 1024 },
+      (error, stdout, stderr) => {
+        // Always resolve - we don't want to fail if there's nothing to kill
+        if (error) {
+          // Only log if it's not a "no process" error
+          if (
+            !error.message.includes('No such process') &&
+            !error.message.includes('SIGKILL')
+          ) {
+            console.log(`Note: ${error.message}`);
+          }
+        }
+        if (stderr && !stderr.includes('No such process')) {
+          console.log(`stderr: ${stderr}`);
+        }
+        if (stdout && stdout.trim()) {
+          console.log(`Killed processes: ${stdout}`);
+        }
         resolve();
-        return;
       }
-      resolve();
-      console.log(`stdout: ${stdout}`);
-    });
+    );
   });
 };
 
 const killExistingViteDevServerProcesses = async (): Promise<void> => {
-  const command = `ps aux | grep "vite dev" | awk '{print $2}' | xargs kill -9`;
+  const command = killExistingViteCommand();
   return new Promise((resolve) => {
-    childProcess.exec(command, (error, stdout, stderr) => {
-      if (error) {
-        console.error(
-          `Error killing vite dev server processes: ${error.message}`
-        );
+    childProcess.exec(
+      command,
+      { maxBuffer: 1024 * 1024 },
+      (error, stdout, stderr) => {
+        // Always resolve - we don't want to fail if there's nothing to kill
+        if (
+          error &&
+          !error.message.includes('No such process') &&
+          !error.message.includes('SIGKILL')
+        ) {
+          console.log(`Note killing vite processes: ${error.message}`);
+        }
+        if (stderr && !stderr.includes('No such process')) {
+          console.log(`stderr: ${stderr}`);
+        }
+        if (stdout && stdout.trim()) {
+          console.log(`Killed vite processes: ${stdout}`);
+        } else {
+          console.log(`No vite dev server processes to kill`);
+        }
+        resolve();
       }
-      if (stderr && !stderr.includes('No such process')) {
-        console.error(`stderr: ${stderr}`);
-      }
-      console.log(`Killed vite dev server processes`);
-      resolve();
-    });
+    );
   });
 };
 
@@ -764,38 +786,171 @@ const runPlaywrightTests = async (shipsNeedingUpdates: string[]) => {
   }
 };
 
-const cleanupSpawnedProcesses = async () => {
+const cleanupSpawnedProcesses = () => {
   console.log('Cleaning up spawned processes...');
-  const killPromises = spawnedProcesses.map((proc) => {
-    if (!proc.killed) {
-      console.log(`Killing process PID: ${proc.pid}`);
-      proc.kill();
-      return new Promise((resolve) => proc.on('close', resolve));
+
+  // First disconnect stdio to prevent output after exit
+  spawnedProcesses.forEach((proc) => {
+    if (!proc.killed && proc.pid) {
+      try {
+        // Disconnect stdio streams to prevent output
+        if (proc.stdout) proc.stdout.destroy();
+        if (proc.stderr) proc.stderr.destroy();
+        if (proc.stdin) proc.stdin.destroy();
+      } catch {
+        // Ignore errors
+      }
     }
-    return Promise.resolve();
   });
-  await Promise.all(killPromises);
-  await killExistingUrbitProcesses();
-  await killExistingViteDevServerProcesses();
+
+  // Then try graceful termination with SIGTERM for direct children
+  spawnedProcesses.forEach((proc) => {
+    if (!proc.killed && proc.pid) {
+      try {
+        console.log(`Killing process PID: ${proc.pid}`);
+        proc.kill('SIGTERM');
+      } catch {
+        // Process may already be dead
+      }
+    }
+  });
+
+  // Give processes 1 second to terminate gracefully
+  const timeout = Date.now() + 1000;
+  while (Date.now() < timeout) {
+    if (spawnedProcesses.every((p) => p.killed)) break;
+  }
+
+  // Force kill any remaining direct children
+  spawnedProcesses.forEach((proc) => {
+    if (!proc.killed && proc.pid) {
+      try {
+        proc.kill('SIGKILL');
+      } catch {
+        // Process may already be dead
+      }
+    }
+  });
+
+  // CRITICAL: Use pattern-based killing to clean up all Urbit processes
+  // This is necessary because Urbit spawns serf sub-processes that aren't tracked
+  try {
+    // Kill all Urbit processes matching our rube pattern
+    const killUrbitCmd = `ps aux | grep urbit | grep "rube/dist" | grep -v grep | awk '{print $2}' | while read pid; do kill -9 $pid 2>/dev/null; done`;
+    childProcess.execSync(killUrbitCmd, { stdio: 'ignore' });
+
+    // Also use our existing commands as additional cleanup
+    childProcess.execSync(killExistingUrbitCommand(), { stdio: 'ignore' });
+    childProcess.execSync(killExistingViteCommand(), { stdio: 'ignore' });
+
+    // Kill any processes on our known ports
+    const ports = [
+      '35453',
+      '36963',
+      '38473',
+      '39983',
+      '3000',
+      '3001',
+      '3002',
+      '3003',
+    ];
+    ports.forEach((port) => {
+      try {
+        // First try lsof (most common)
+        try {
+          const cmd = `command -v lsof >/dev/null 2>&1 && lsof -ti:${port} | xargs kill -9 2>/dev/null || true`;
+          childProcess.execSync(cmd, { stdio: 'ignore' });
+        } catch {
+          // If lsof doesn't exist, try fuser as fallback
+          try {
+            const cmd = `command -v fuser >/dev/null 2>&1 && fuser -k ${port}/tcp 2>/dev/null || true`;
+            childProcess.execSync(cmd, { stdio: 'ignore' });
+          } catch {
+            // Neither tool available - skip port cleanup
+          }
+        }
+      } catch {
+        // Ignore errors for ports that may not be in use
+      }
+    });
+  } catch {
+    // Ignore command errors
+  }
+
+  // Clean up PID files
+  try {
+    fs.unlinkSync(pidFile);
+    fs.unlinkSync(childrenFile);
+  } catch {
+    // Ignore PID file cleanup errors
+  }
+
+  // Verify cleanup was successful
+  try {
+    const remainingUrbit = childProcess
+      .execSync(
+        `ps aux | grep urbit | grep "rube/dist" | grep -v grep | wc -l`,
+        { encoding: 'utf8' }
+      )
+      .trim();
+
+    if (remainingUrbit !== '0') {
+      console.log(
+        `⚠️ Warning: ${remainingUrbit} Urbit processes may still be running after cleanup`
+      );
+      console.log('  Run ./rube-cleanup.sh for complete cleanup');
+    }
+  } catch {
+    // Ignore verification errors
+  }
+
   console.log('Cleanup complete.');
 };
 
-process.on('exit', () => {
+const killExistingUrbitCommand = (): string => {
+  const pathToBinary = path.join(__dirname, 'urbit_extracted/urbit');
+  // Use a subshell to handle empty xargs input gracefully on both macOS and Linux
+  return `pids=$(ps aux | grep urbit | grep ${pathToBinary} | grep -v grep | awk '{print $2}'); [ -n "$pids" ] && echo "$pids" | xargs kill -9 2>/dev/null || true`;
+};
+
+const killExistingViteCommand = (): string => {
+  // Use a subshell to handle empty xargs input gracefully on both macOS and Linux
+  return `pids=$(ps aux | grep "vite dev" | grep -v grep | awk '{print $2}'); [ -n "$pids" ] && echo "$pids" | xargs kill -9 2>/dev/null || true`;
+};
+
+// Synchronous cleanup handlers for reliability
+let hasCleanedUp = false;
+
+const performCleanup = () => {
+  if (hasCleanedUp) return;
+  hasCleanedUp = true;
   cleanupSpawnedProcesses();
+};
+
+process.on('exit', (code) => {
+  // Always try cleanup on exit if not done yet
+  if (!hasCleanedUp) {
+    console.log(`Process exiting with code ${code}, running cleanup...`);
+    performCleanup();
+  }
 });
-process.on('SIGINT', async () => {
-  await cleanupSpawnedProcesses();
+
+process.on('SIGINT', () => {
+  console.log('\nReceived SIGINT, cleaning up...');
+  performCleanup();
   console.log('SIGINT cleanup finished.');
   process.exit(0);
 });
-process.on('SIGTERM', async () => {
-  await cleanupSpawnedProcesses();
+
+process.on('SIGTERM', () => {
+  console.log('\nReceived SIGTERM, cleaning up...');
+  performCleanup();
   console.log('SIGTERM cleanup finished.');
   process.exit(0);
 });
-process.on('uncaughtException', async (err) => {
+process.on('uncaughtException', (err) => {
   console.error('Uncaught exception:', err);
-  await cleanupSpawnedProcesses();
+  cleanupSpawnedProcesses();
   console.log('Uncaught exception cleanup finished.');
   process.exit(1);
 });
@@ -1010,8 +1165,49 @@ const setReelServiceShip = async () => {
   await new Promise((resolve) => setTimeout(resolve, 2000));
 };
 
+const checkExistingInstance = (): boolean => {
+  try {
+    if (fs.existsSync(pidFile)) {
+      const oldPid = parseInt(fs.readFileSync(pidFile, 'utf8'));
+      // Check if process is still running
+      try {
+        process.kill(oldPid, 0);
+        return true; // Process exists
+      } catch {
+        // Process doesn't exist, clean up stale file
+        fs.unlinkSync(pidFile);
+      }
+    }
+  } catch {
+    // Ignore file read errors
+  }
+  return false;
+};
+
+const savePidFiles = () => {
+  try {
+    // Save main process PID
+    fs.writeFileSync(pidFile, process.pid.toString());
+
+    // Save children PIDs
+    const childPids = spawnedProcesses.filter((p) => p.pid).map((p) => p.pid);
+    fs.writeFileSync(childrenFile, JSON.stringify(childPids));
+  } catch (e) {
+    console.error('Error saving PID files:', e);
+  }
+};
+
 const main = async () => {
   console.time('Total Script Execution');
+
+  // Check for existing instance
+  if (checkExistingInstance()) {
+    console.error('❌ Another rube instance is already running!');
+    console.error(`Check PID file: ${pidFile}`);
+    console.error('To force cleanup, run: ./rube-cleanup.sh');
+    process.exit(1);
+  }
+
   if (targetShip && !ships[targetShip]) {
     console.error(`Invalid ship name: ${targetShip}`);
     process.exit(1);
@@ -1028,6 +1224,7 @@ const main = async () => {
     await killExistingUrbitProcesses();
 
     bootAllShips();
+    savePidFiles(); // Save PIDs after spawning processes
 
     await checkShipReadinessForCommands();
     await getPortsFromFiles();

--- a/apps/tlon-web/rube/run-single-test.ts
+++ b/apps/tlon-web/rube/run-single-test.ts
@@ -44,13 +44,14 @@ if (!fs.existsSync(testPath)) {
 
 let rubeProcess: childProcess.ChildProcess | null = null;
 let isShuttingDown = false;
+const pidFile = path.join(__dirname, '.run-single-test.pid');
 
 // Handle cleanup on exit
 process.on('SIGINT', cleanup);
 process.on('SIGTERM', cleanup);
 process.on('exit', cleanup);
 
-async function cleanup() {
+function cleanup() {
   if (isShuttingDown) return;
   isShuttingDown = true;
 
@@ -59,10 +60,49 @@ async function cleanup() {
   if (rubeProcess && !rubeProcess.killed && rubeProcess.pid) {
     console.log('Killing rube process...');
     try {
-      // Kill the entire process group to ensure all child processes are terminated
-      process.kill(-rubeProcess.pid, 'SIGTERM');
+      // Try graceful termination first
+      rubeProcess.kill('SIGTERM');
+
+      // Give it a moment to terminate gracefully
+      const timeout = Date.now() + 1000;
+      while (Date.now() < timeout) {
+        try {
+          process.kill(rubeProcess.pid, 0); // Check if still alive
+        } catch {
+          break; // Process is dead
+        }
+      }
+
+      // Force kill if still running
+      try {
+        rubeProcess.kill('SIGKILL');
+      } catch {}
     } catch (error) {
       console.log('Process already terminated');
+    }
+  }
+
+  // CRITICAL: Use pattern-based killing to clean up all Urbit processes
+  // This is necessary because Urbit spawns serf sub-processes that aren't tracked
+  try {
+    // Kill all Urbit processes matching our rube pattern
+    console.log('Killing Urbit processes...');
+    // Use a subshell to handle empty output gracefully on macOS
+    const killUrbitCmd = `pids=$(ps aux | grep urbit | grep "rube/dist" | grep -v grep | awk '{print $2}'); [ -n "$pids" ] && echo "$pids" | xargs kill -9 2>/dev/null || true`;
+    childProcess.execSync(killUrbitCmd, { stdio: 'ignore' });
+
+    // Also kill any node processes running rube
+    const killNodeRubeCmd = `pids=$(ps aux | grep "node.*rube/dist/index.js" | grep -v grep | awk '{print $2}'); [ -n "$pids" ] && echo "$pids" | xargs kill -9 2>/dev/null || true`;
+    childProcess.execSync(killNodeRubeCmd, { stdio: 'ignore' });
+
+    // Also kill any Vite dev server processes
+    console.log('Killing Vite processes...');
+    const killViteCmd = `pids=$(ps aux | grep "vite dev" | grep -v grep | awk '{print $2}'); [ -n "$pids" ] && echo "$pids" | xargs kill -9 2>/dev/null || true`;
+    childProcess.execSync(killViteCmd, { stdio: 'ignore' });
+  } catch (error) {
+    // Only log if it's a real error, not just "no processes found"
+    if (error.status !== 1) {
+      console.log('Error during pattern-based cleanup:', error.message);
     }
   }
 
@@ -92,13 +132,56 @@ async function cleanup() {
   const uniquePorts = Array.from(new Set(ports));
   for (const port of uniquePorts) {
     try {
-      childProcess.exec(`lsof -ti:${port} | xargs kill -9 2>/dev/null || true`);
+      // First try lsof (most common)
+      try {
+        childProcess.execSync(
+          `command -v lsof >/dev/null 2>&1 && lsof -ti:${port} | xargs kill -9 2>/dev/null || true`,
+          { stdio: 'ignore' }
+        );
+      } catch {
+        // If lsof doesn't exist, try fuser as fallback
+        try {
+          childProcess.execSync(
+            `command -v fuser >/dev/null 2>&1 && fuser -k ${port}/tcp 2>/dev/null || true`,
+            { stdio: 'ignore' }
+          );
+        } catch {
+          // Neither tool available - skip port cleanup
+        }
+      }
     } catch (error) {
       // Ignore errors - processes might not exist
     }
   }
 
+  // Clean up PID file
+  try {
+    fs.unlinkSync(pidFile);
+  } catch {}
+
+  // Verify cleanup was successful
+  try {
+    const remainingUrbit = childProcess
+      .execSync(
+        `ps aux | grep urbit | grep "rube/dist" | grep -v grep | wc -l`,
+        { encoding: 'utf8' }
+      )
+      .trim();
+
+    if (remainingUrbit !== '0') {
+      console.log(
+        `⚠️ Warning: ${remainingUrbit} Urbit processes may still be running after cleanup`
+      );
+      console.log('  Run ./rube-cleanup.sh for complete cleanup');
+    }
+  } catch {
+    // Ignore verification errors
+  }
+
   console.log('Cleanup complete!');
+
+  // Exit the process after cleanup
+  process.exit(0);
 }
 
 async function waitForReadiness() {
@@ -197,6 +280,26 @@ async function runTest(): Promise<void> {
 
 async function main() {
   try {
+    // Check for existing instance
+    if (fs.existsSync(pidFile)) {
+      try {
+        const oldPid = parseInt(fs.readFileSync(pidFile, 'utf8'));
+        process.kill(oldPid, 0);
+        console.error(
+          '❌ Another run-single-test instance is already running!'
+        );
+        console.error(`PID: ${oldPid}`);
+        console.error('Kill it first or wait for it to complete.');
+        process.exit(1);
+      } catch {
+        // Process doesn't exist, clean up stale file
+        fs.unlinkSync(pidFile);
+      }
+    }
+
+    // Save our PID
+    fs.writeFileSync(pidFile, process.pid.toString());
+
     console.log(
       '🚀 Starting ships and web servers (without running full test suite)...'
     );
@@ -205,7 +308,7 @@ async function main() {
     rubeProcess = childProcess.spawn('pnpm', ['rube'], {
       stdio: ['ignore', 'pipe', 'pipe'],
       cwd: path.join(__dirname, '../..'), // Go up two levels from rube/dist
-      detached: true, // Create a new process group
+      // Don't detach - we want it to be part of our process group for cleanup
       env: {
         ...process.env,
         SKIP_TESTS: 'true', // This tells rube to stop before running tests
@@ -250,10 +353,18 @@ async function main() {
     await new Promise<void>((resolve) => {
       let dots = 0;
       const startTime = Date.now();
+      let timer: NodeJS.Timeout | null = null;
 
       console.log('⏳ Waiting for ships to complete setup');
 
       const checkSetup = () => {
+        if (isShuttingDown) {
+          // Stop the timer if we're shutting down
+          if (timer) clearTimeout(timer);
+          resolve();
+          return;
+        }
+
         if (setupComplete) {
           // Clear the current line and print completion message
           process.stdout.write('\r' + ' '.repeat(60) + '\r');
@@ -269,7 +380,7 @@ async function main() {
           process.stdout.write(
             `\r   Setting up ships${dotString} (${timeString})`
           );
-          setTimeout(checkSetup, 1000);
+          timer = setTimeout(checkSetup, 1000);
         }
       };
       checkSetup();


### PR DESCRIPTION
## Summary

Fixes critical e2e test process cleanup issues where interrupting scripts with Ctrl+C left zombie processes running. Resolves "port already in use" errors and improves CI reliability by ensuring proper signal forwarding and comprehensive process termination.

## Changes

- Created `rube-runner.sh` wrapper script that uses `exec` to ensure proper signal forwarding to Node.js processes
- Updated `package.json` to use wrapper script instead of command chaining that prevented signal propagation
- Enhanced cleanup handlers in `rube/index.ts` to disconnect stdio before termination and prevent output after shell prompt
- Added pattern-based process killing to handle Urbit serf sub-processes that aren't tracked as direct children
- Implemented PID file management to detect existing instances and prevent conflicts
- Created `rube-cleanup.sh` emergency cleanup script for manually terminating stuck processes
- Updated process cleanup to handle all e2e ports (web servers, Urbit HTTP, loopback)
- Added comprehensive documentation updates in `CLAUDE.md` and README files
- Enhanced signal handlers to use synchronous cleanup instead of async for reliability

## How did I test?

- Manually tested Ctrl+C interruption during various stages of e2e test execution
- Verified no zombie processes remain after script termination using `ps aux` and `lsof`
- Tested emergency cleanup script with deliberately stuck processes
- Confirmed "port already in use" errors no longer occur after interruption
- Tested PID file detection prevents multiple concurrent instances
- Verified pattern-based killing successfully terminates Urbit serf sub-processes
- Ran full e2e test suite to ensure no regressions in normal execution flow

## Risks and impact

- Safe to rollback without consulting PR author? Yes
- Affects important code area: N/A

## Rollback plan

Revert

## Screenshots / videos

N/A
