### PR TITLE
chat: resequence chats to restore missing numbers

### DIFF
--- a/desk/app/chat.hoon
+++ b/desk/app/chat.hoon
@@ -369,6 +369,43 @@
   ++  four     old-4
   ++  five     c
   ::
+<<<<<<< Updated upstream
+=======
+  ++  state-9-to-10
+    |=  state-9
+    ^-  state-10
+    :*  %10
+        (~(run by dms) dm-9-to-10)
+        (~(run by clubs) club-9-to-10)
+        pins
+        sends
+        blocked
+        blocked-by
+        hidden-messages
+        old-chats
+        old-pins
+    ==
+  ++  club-9-to-10
+    |=  =club:v5:cv
+    ^-  club:v6:cv
+    club(pact (pact-9-to-10 pact.club))
+  ++  dm-9-to-10
+    |=  =dm:v5:cv
+    ^-  dm:v6:cv
+    dm(pact (pact-9-to-10 pact.dm))
+  ++  pact-9-to-10
+    |=  pact:v5:cv
+    ^-  pact:v6:cv
+    =;  [num=@ud writs=(list [time (may:v6:cv writ:v6:cv)])]
+      [num (gas:on:writs:v6:cv ~ writs) dex upd=~]
+    %+  roll  (tap:on:writs:v5:cv wit)
+    |=  [[=time =writ:v5:cv] num=@ud writs=(list [time (may:v6:cv writ:v6:cv)])]
+    ^+  [num writs]
+    =.  num  +(num)
+    :-  num
+    =/  new-writ  (v6:writ:v5:cc writ)
+    [[time %& new-writ(seq num)] writs]
+>>>>>>> Stashed changes
   ++  state-8-to-9
     |=  state-8
     ^-  state-9


### PR DESCRIPTION
## Summary

We found this when testing the tombstones migration. Because chats were sequenced before the tombstone work, any deletes that have happened since will create gaps in the sequence. This runs the same sequencing logic as the previous update, but now that we have tombstones we should never drop a number.

## Changes

<!-- Outline specific changes made in this PR. -->

## How did I test?

<!-- Describe your testing process. -->

## Risks and impact

- Safe to rollback without consulting PR author? (Yes | No)
- Affects important code area:
  - [ ] Onboarding
  - [ ] State / providers
  - [ ] Message sync
  - [ ] Channel display
  - [ ] Notifications

## Rollback plan

<!-- Describe the steps to revert these changes if needed. -->

## Screenshots / videos

<!-- Attach any relevant media. -->
