### PR TITLE
channels: content negotiation fixes

### DIFF
--- a/desk/app/channels.hoon
+++ b/desk/app/channels.hoon
@@ -741,6 +741,24 @@
         [~ %| *]  (run-import p.u.pimp)
       ==
     ::
+        [?(%request-seqs %request-tombs) nest:c]
+      ::NOTE  if the poke we send from this gets nacked, we will set a timer
+      ::      to retry. if the ship/situation is healthy there will likely
+      ::      already be a timer for retrying this poke. having multiple timers
+      ::      isn't the end of the world, it will just do the same work twice,
+      ::      with any subsequent invocations being no-ops. nonetheless,
+      ::      probably best to not run this indiscriminately. check for
+      ::      presence of the relevant timers for this agent first! patience.
+      ::NOTE  we set the timer instead of sending the poke right away. timer
+      ::      handling will check lib negotiate before poking.
+      =+  ;;(=nest:c +.q.vase)
+      %-  emit
+      =/  =wire  /[kind.nest]/(scot %p ship.nest)/[name.nest]
+      :+  %pass
+        :_  wire
+        [?-(-.q.vase %request-seqs %numbers, %request-tombs %tombstones)]
+      [%arvo %b %wait now.bowl]
+    ::
         [%sequence-numbers * @ *]
       =+  ;;([%sequence-numbers =nest:c count=@ud seqs=(list [id=id-post:c seq=(unit @ud)])] q.vase)
       ?>  =(src.bowl ship.nest)

--- a/desk/app/channels.hoon
+++ b/desk/app/channels.hoon
@@ -1352,15 +1352,21 @@
     =/  host=ship  (slav %p ship.pole)
     =/  =nest:c    [kind.pole host name.pole]
     %-  emit
+    :+  %pass  pole
+    ?.  (can-poke:neg bowl host %channels-server)
+      [%arvo %b %wait :(add now.bowl ~m15 (~(rad og eny.bowl) ~m15))]
     =/  =cage  [%noun !>([%send-sequence-numbers nest])]
-    [%pass pole %agent [host %channels-server] %poke cage]
+    [%agent [host %channels-server] %poke cage]
   ::
       [%tombstones kind=?(%chat %diary %heap) ship=@ name=@ ~]
     =/  host=ship  (slav %p ship.pole)
     =/  =nest:c    [kind.pole host name.pole]
     %-  emit
+    :+  %pass  pole
+    ?.  (can-poke:neg bowl host %channels-server)
+      [%arvo %b %wait :(add now.bowl ~m15 (~(rad og eny.bowl) ~m15))]
     =/  =cage  [%noun !>([%send-tombstones nest])]
-    [%pass pole %agent [host %channels-server] %poke cage]
+    [%agent [host %channels-server] %poke cage]
   ==
 ::
 ++  unreads

--- a/desk/app/channels.hoon
+++ b/desk/app/channels.hoon
@@ -313,31 +313,29 @@
   =?  old  ?=(%5 -.old)  (state-5-to-6 old)
   =?  old  ?=(%6 -.old)  (state-6-to-7 old)
   =?  old  ?=(%7 -.old)  (state-7-to-8 old)
-  =^  caz-8=(list card)  old
-    ?.  ?=(%8 -.old)  [~ old]
-    :_  (state-8-to-9 old)
-    %+  turn  ~(tap in ~(key by v-channels.old))
-    |=  =nest:c
-    ^-  card
-    :+  %pass
-      /numbers/[kind.nest]/(scot %p ship.nest)/[name.nest]
-    ::  slightly staggered to spread load. might not be strictly necessary
-    ::  for this, but good practice.
-    ::
-    [%arvo %b %wait (add now.bowl (~(rad og (sham our.bowl nest)) ~m15))]
-  =.  cor  (emil caz-8)
+  =?  old  ?=(%8 -.old)  (state-8-to-9 old)
   =^  caz-9=(list card)  old
     ?.  ?=(%9 -.old)  [~ old]
     :_  (state-9-to-10 old)
+    %-  zing
     %+  turn  ~(tap in ~(key by v-channels.old))
     |=  =nest:c
-    ^-  card
-    :+  %pass
-      /tombstones/[kind.nest]/(scot %p ship.nest)/[name.nest]
-    ::  slightly staggered to spread load. might not be strictly necessary
-    ::  for this, but good practice.
-    ::
-    [%arvo %b %wait (add now.bowl (~(rad og (sham our.bowl nest)) ~m15))]
+    ^-  (list card)
+    =/  =wire
+      /[kind.nest]/(scot %p ship.nest)/[name.nest]
+    =/  note=note-arvo
+      ::  slightly staggered to spread load. might not be strictly necessary
+      ::  for this, but good practice.
+      ::
+      [%b %wait (add now.bowl (~(rad og (sham our.bowl nest)) ~m15))]
+    ::NOTE  we used to do the /numbers ones during 8-to-9 migration,
+    ::      but the logic for handling those timer events was flawed initially,
+    ::      so we re-set those timers here to retry. if this results in
+    ::      duplicate timers, so be it. doing the work twice is wasteful but
+    ::      harmless.
+    :~  [%pass [%numbers wire] %arvo note]
+        [%pass [%tombstones wire] %arvo note]
+    ==
   =.  cor  (emil caz-9)
   ?>  ?=(%10 -.old)
   =.  state  old

--- a/desk/app/channels.hoon
+++ b/desk/app/channels.hoon
@@ -279,6 +279,7 @@
 |_  [=bowl:gall cards=(list card)]
 ++  abet  [(flop cards) state]
 ++  cor   .
+++  plog  ~(. logs [our.bowl /logs])
 ++  emit  |=(=card cor(cards [card cards]))
 ++  emil  |=(caz=(list card) cor(cards (welp (flop caz) cards)))
 ++  give  |=(=gift:agent:gall (emit %give gift))
@@ -743,6 +744,7 @@
         [%sequence-numbers * @ *]
       =+  ;;([%sequence-numbers =nest:c count=@ud seqs=(list [id=id-post:c seq=(unit @ud)])] q.vase)
       ?>  =(src.bowl ship.nest)
+      =.  cor  (emit (tell:plog %info ~['receiving sequence nrs' >nest<] ~))
       ?.  (~(has by v-channels) nest)  cor
       =.  v-channels
         %+  ~(jab by v-channels)  nest
@@ -768,6 +770,7 @@
         [%tombstones * *]
       =+  ;;([%tombstones =nest:c tombs=(list [id=id-post:v9:c tomb=tombstone:v9:c])] q.vase)
       ?>  =(src.bowl ship.nest)
+      =.  cor  (emit (tell:plog %info ~['receiving tombstones' >nest<] ~))
       ?.  (~(has by v-channels) nest)  cor
       =.  v-channels
         %+  ~(jab by v-channels)  nest

--- a/desk/tests/app/channels.hoon
+++ b/desk/tests/app/channels.hoon
@@ -1,4 +1,4 @@
-/-  g=groups, c=channels
+/-  g=groups, gv=groups-ver, c=channels
 /+  *test-agent, s=subscriber, imp=import-aid
 /=  channels-agent  /app/channels
 |%
@@ -28,8 +28,9 @@
 ++  the-group  [~zod %test]
 ++  scry
   |=  =(pole knot)
-  ?+  pole  !!
+  ?+  pole  ~|(`path`pole !!)
     [%gu ship=@t %activity @ ~ ~]  `!>(|)
+    [%gx @ %groups @ %v2 %groups host=@ term=@ %noun ~]  `!>(*group:v7:gv)
   ==
 ++  test-checkpoint-sub
   %-  eval-mare
@@ -230,7 +231,7 @@
     ~2025.6.25..14.41.13..585b
   ++  overwrite-key
     ~2025.6.25..14.41.14..84fa
-  ++  sequence-fix-test-channel
+  ++  tombstone-fix-test-channel
     ^-  v-channel:c
     :-  ^-  global:v-channel:c
         :*  ^=  posts
@@ -269,7 +270,7 @@
       =;  chans=v-channels:c
         [%10 chans ~ ~ ~ *^subs:s *pimp:imp]
       =/  chan=v-channel:c
-        sequence-fix-test-channel
+        tombstone-fix-test-channel
       ::  client had just bunted tombstones
       ::
       =.  posts.chan
@@ -323,7 +324,7 @@
       =;  chans=v-channels:c
         [%10 chans ~ ~ ~ *^subs:s *pimp:imp]
       =/  chan=v-channel:c
-        sequence-fix-test-channel
+        tombstone-fix-test-channel
       (~(put by *v-channels:c) *nest:c chan)
     ::
     =.  save  (slot 3 save)           ::  lib discipline


### PR DESCRIPTION
## Summary

Ensure we fetch sequence numbers and tombstones, even if the channel host doesn't update as fast as we do.

## Changes

In #4889, we had made channels explicitly fetch sequence numbers from the host, to make sure we were in sync. In #4963, we made it do the same for tombstone data.

The logic for those two flows was/is identical, but had a serious flaw: when sending out the poke, we don't check whether lib negotiate thinks we match.  
This isn't a problem for the logic itself, it's robust against poke-nacks. But negotiate will crash the event, because sending a poke to a mismatching peer is considered an implementation error.  
That crash would kill the timer event and call `+on-fail`, which contains no recovery logic for this scenario (and couldn't even if it wanted to). As a result, some channels would never get their sequence numbers fetched.

Here, we resolve this problem by simply checking before we poke, and re-setting the timer if we don't match. Closes TLON-4701.

Because #4889 has already gone out to livenet, we must resolve the cases where ships hit this in practice. We move the sequence nr flow starting from the 8-to-9 migration into the 9-to-10 migration. This may result in duplicate timers for any given channel, but that's not the end of the world. Closes TLON-4702.

We also add `%request-seqs`/`%request-tombs` pokes for manual restarting of these flows, just in case. Please do not call out to that indiscriminately lest you end up with a bunch of identical refetching flows.

## How did I test?

Manually on a fakenet. We'll want to hit the same setup that led us to discover this the other day, too. cc @latter-bolden

## Risks and impact

- Technically safe to rollback without consulting PR author, but if we do we may start dropping timers again.
- Affects important code area:
  - [ ] Onboarding
  - [ ] State / providers
  - [x] Message sync
  - [ ] Channel display
  - [ ] Notifications

## Rollback plan

Consider keeping 70eae57 when rolling this back, it's the critical piece here.
