### PR TITLE
chat: resequence chats to restore missing numbers

### DIFF
--- a/desk/app/chat.hoon
+++ b/desk/app/chat.hoon
@@ -453,14 +453,15 @@
   ++  pact-9-to-10
     |=  pact:v5:cv
     ^-  pact:v6:cv
-    =;  nu-wit
-      [num nu-wit dex upd=~]
-    %+  gas:on:writs:v6:cv  *writs:v6:cv
-    %+  turn
-      (tap:on:writs:v5:cv wit)
-    |=  [=time =writ:v5:cv]
-    :-  time
-    [%& (v6:writ:v5:cc writ)]
+    =;  [num=@ud writs=(list [time (may:v6:cv writ:v6:cv)])]
+      [num (gas:on:writs:v6:cv ~ writs) dex upd=~]
+    %+  roll  (tap:on:writs:v5:cv wit)
+    |=  [[=time =writ:v5:cv] num=@ud writs=(list [time (may:v6:cv writ:v6:cv)])]
+    ^+  [num writs]
+    =.  num  +(num)
+    :-  num
+    =/  new-writ  (v6:writ:v5:cc writ)
+    [[time %& new-writ(seq num)] writs]
   ++  state-8-to-9
     |=  state-8
     ^-  state-9
@@ -486,19 +487,18 @@
   ++  pact-8-to-9
     |=  =pact:v4:cv
     ^-  pact:v5:cv
-    =;  [num=@ud writs=(list [time writ:v5:cv])]
-      [num (gas:on:writs:v5:cv ~ writs) dex.pact]
-    %+  roll  (tap:on:writs:v4:cv wit.pact)
-    |=  [[=time =writ:v4:cv] num=@ud writs=(list [time writ:v5:cv])]
-    ^+  [num writs]
-    =.  num  +(num)
-    :-  num
-    [[time (writ-8-to-9 num writ)] writs]
+    =;  writs=(list [time writ:v5:cv])
+      ::  default num here because it will be numbered above
+      [0 (gas:on:writs:v5:cv ~ writs) dex.pact]
+    %+  turn  (tap:on:writs:v4:cv wit.pact)
+    |=  [=time =writ:v4:cv]
+    [time (writ-8-to-9 writ)]
   ++  writ-8-to-9
-    |=  [seq=@ud =writ:v4:cv]
+    |=  =writ:v4:cv
     ^-  writ:v5:cv
     =,  -.writ
-    [[id seq time reacts replies reply-meta] +.writ]
+    ::  default seq here because it will be numbered above
+    [[id 0 time reacts replies reply-meta] +.writ]
   ::
   ++  state-7-to-8
     |=  state-7


### PR DESCRIPTION
## Summary

Fixes TLON-4703. We found this when testing the tombstones migration. Because chats were sequenced before the tombstone work, any deletes that have happened since will create gaps in the sequence. This runs the same sequencing logic as the previous update, but now that we have tombstones we should never drop a number.

## Changes

<!-- Outline specific changes made in this PR. -->

## How did I test?

<!-- Describe your testing process. -->

## Risks and impact

- Safe to rollback without consulting PR author? (Yes | No)
- Affects important code area:
  - [ ] Onboarding
  - [ ] State / providers
  - [ ] Message sync
  - [ ] Channel display
  - [ ] Notifications

## Rollback plan

<!-- Describe the steps to revert these changes if needed. -->

## Screenshots / videos

<!-- Attach any relevant media. -->
