### PR TITLE
chat: /changes tweaks

### DIFF
--- a/desk/app/chat.hoon
+++ b/desk/app/chat.hoon
@@ -1098,19 +1098,21 @@
   ::
       [%x %v3 %changes since=@ rest=*]
     =+  since=(slav %da i.t.t.t.path)
-    =/  changes=(map whom:c (unit writs:c))
-      %-  ~(gas by *(map whom:c (unit writs:c)))
+    =/  changes=(map whom:c writs:c)
+      %-  ~(gas by *(map whom:c writs:c))
       %+  weld
-        %+  turn  ~(tap by dms)
+        %+  murn  ~(tap by dms)
         |=  [who=ship =dm:c]
-        ^-  [whom:c (unit writs:c)]
-        :-  [%ship who]
-        (~(changes pac pact.dm) since)
-      %+  turn  ~(tap by clubs)
+        ^-  (unit [whom:c writs:c])
+        %+  bind
+          (~(changes pac pact.dm) since)
+        (lead [%ship who])
+      %+  murn  ~(tap by clubs)
       |=  [=id:club:c =club:c]
-      ^-  [whom:c (unit writs:c)]
-      :-  [%club id]
-      (~(changes pac pact.club) since)
+      ^-  (unit [whom:c writs:c])
+      %+  bind
+        (~(changes pac pact.club) since)
+      (lead [%club id])
     ?+  t.t.t.t.path  [~ ~]
       ~  ``chat-changed-writs+!>(changes)
     ::
@@ -1119,9 +1121,8 @@
       !>  ^-  json
       %-  numb:enjs:format
       %-  ~(rep by changes)
-      |=  [[* w=(unit writs:c)] sum=@ud]
-      %+  add  sum
-      ?~(w 0 (wyt:on:writs:c u.w))
+      |=  [[* w=writs:c] sum=@ud]
+      (add sum (wyt:on:writs:c w))
     ==
   ::
       [%x %dm ~]

--- a/desk/app/groups-ui.hoon
+++ b/desk/app/groups-ui.hoon
@@ -246,11 +246,16 @@
   ::
       [%x %v5 %changes since=@ ~]
     =+  .^(channels=json (scry %gx %channels /v5/changes/[since.pole]/json))
+    =+  .^(chat=json (scry %gx %chat /v3/changes/[since.pole]/json))
     =+  .^(groups=json (scry %gx %groups /v2/changes/[since.pole]/json))
     =+  .^(contacts=json (scry %gx %contacts /v1/changes/[since.pole]/json))
     :^  ~  ~  %json
     !>  %-  pairs:enjs:format
-    ~['channels'^channels 'groups'^groups 'contacts'^contacts]
+    :~  'channels'^channels
+        'chat'^chat
+        'groups'^groups
+        'contacts'^contacts
+    ==
   ==
 ::
 ++  poke

--- a/desk/mar/chat/changed-writs.hoon
+++ b/desk/mar/chat/changed-writs.hoon
@@ -1,6 +1,6 @@
 /-  cv=chat-ver
 /+  j=chat-json
-|_  changes=(map whom:v6:cv (unit writs:v6:cv))
+|_  changes=(map whom:v6:cv writs:v6:cv)
 ++  grad  %noun
 ++  grow
   |%
@@ -10,13 +10,12 @@
     %-  pairs:enjs:format
     =,  enjs:j
     %+  turn  ~(tap by changes)
-    |=  [=whom:v6:cv writs=(unit writs:v6:cv)]
+    |=  [=whom:v6:cv writs=writs:v6:cv]
     ^-  [@t json]
-    :-  (^whom whom)
-    ?~(writs ~ (^writs u.writs))
+    [(^whom whom) (^writs writs)]
   --
 ++  grab
   |%
-  ++  noun  (map whom:v6:cv (unit writs:v6:cv))
+  ++  noun  (map whom:v6:cv writs:v6:cv)
   --
 --


### PR DESCRIPTION
## Summary

Make chat's /changes mirror channel's by omitting `null`s (a la 0ec40d1), and include it in the groups-ui global /changes scry.

## Changes

That's it, those are the changes. Note that this changes the type of the `%chat-changed-writs` mark, which test ships that had the integration branch already might get upset about.

## How did I test?

Manually invoking the scry endpoints.

## Risks and impact

- Safe to rollback without consulting PR author, sure.
- Affects important code area:
  - [ ] Onboarding
  - [ ] State / providers
  - [x] Message sync
  - [ ] Channel display
  - [ ] Notifications

## Rollback plan

Can just revert, though again beware of the mark type change.
