### PR TITLE
groups: fix subscriber-side channel section update

### DIFF
--- a/desk/app/groups.hoon
+++ b/desk/app/groups.hoon
@@ -3495,6 +3495,9 @@
       ::
       =/  =channel:g  (got:by-ch nest)
       ?>  (~(has by sections.group) section.u-channel)
+      =.  sections.group
+        %+  ~(jab by sections.group)  section.channel
+        |=(=section:g section(order (~(del of order.section) nest)))
       =.  section.channel   section.u-channel
       =.  channels.group  (put:by-ch nest channel)
       =.  sections.group


### PR DESCRIPTION
## Summary

This fixes a bug where the channel section update was not applied correctly at the subscriber side. At the group host the logic would correctly remove the channel from the old section when moving between sections. At the subscriber side, we did not properly clean up the entry in the old section before assigning the channel to a new section.

## Changes

Adds logic to clean up old channel section when moving a channel between sections.

## How did I test?

Setup up a group with two ships, and observed channel sections being messed up at the subscriber after moving channels back and forth. 

## Risks and impact
This problem would trigger at any group member in a group where channels have been moved between sections _after_ the user joined. While this fixes the logic, the bad state will persist. There are the following ways to fix this currently:
1. Manually rectify the situation by deleting and then restoring a section.
2. Rejoining the group, which would download the correct group state.

As a last resort, if this has been found to affect more than a few users, we could always deploy a migration to fix this.

- Safe to rollback without consulting PR author? No, would introduce a bug.
- Affects important code area:
  - [ ] Onboarding
  - [x] State / providers
  - [ ] Message sync
  - [x] Channel display
  - [ ] Notifications
