### PR TITLE
channels: prevent unsubscribing from groups updates

### DIFF
--- a/desk/app/channels-server.hoon
+++ b/desk/app/channels-server.hoon
@@ -684,9 +684,9 @@
         [%seat * %add *]
       (request-join flag.r-groups affected ships.r-group)
     ::
-      [%seat * %add-roles *]    (recheck-perms affected ~)
-      [%seat * %del-roles *]     (recheck-perms affected ~)
-      [%channel * %edit *]       (recheck-perms affected ~)
+      [%seat * %add-roles *]       (recheck-perms affected ~)
+      [%seat * %del-roles *]       (recheck-perms affected ~)
+      [%channel * %edit *]         (recheck-perms affected ~)
       [%channel * %add-readers *]  (recheck-perms affected ~)
       [%channel * %del-readers *]  (recheck-perms affected ~)
   ::

--- a/desk/app/channels.hoon
+++ b/desk/app/channels.hoon
@@ -595,7 +595,9 @@
     =.  cor  core
     =/  keep=?
       ?+    pole  |
-          [%groups *]  &(=(%groups dude) =(our.bowl ship) =(/groups path))
+          [%groups *]
+        &(=(%groups dude) =(our.bowl sub-ship) =(/v1/groups path))
+      ::
           [=kind:c ship=@ name=@ %updates ~]
         ?.  =(server dude)  |
         ?.  =((scot %p sub-ship) ship.pole)  |


### PR DESCRIPTION
## Summary

A bug was introduced 2 years ago that caused the channels agent to drop its group subscription on every other agent reload because of a faulty subscription cleanup logic. The problem was eventually discovered because of a group making heavy use of permissions that were not properly propagated to subscribers.

That this went unnoticed so long can be attributed to a few factors:

(1) Its proximate cause was a difficult to spot typo.
(2) The root cause is an unfortunate interplay of a subscription cleanup followed by the usual resubcription inflate pattern. If a subscription is deleted during cleanup, a subsequent `safe-subscribe` will fail to re-establish it because the subscription has not yet been left. Note this has _not_ been caused by `lib-suscriber`, but has been present much longer.
(3) The problem would "fix" itself on the next channels reload with the subscription being established, only to be broken on a subsequent channels reload, rinse and repeat.

The channels-server was not affected, because it did not employ the cleanup strategy as part of its `+inflate-io` routine.

The fix here is straightforward: we fix the typo, and also fix the wrong subscription path to reflect the use of the new groups endpoint.

Note that this does not address the deeper issue, which is the incompatibility between subscription cleanup and inflation, which requires a proper solution on its own.

## Changes

1. We fix the conditional that caused the groups subscription to be dropped.

## How did I test?

I run a ship off an old desk version, before the groups refactor. Observed the channels agent to drop subscription on every other agent reload. Used git blame to verify that this must have been happening for close to 2 years.

I then run a most recent desk version. Observed the faulty behavior again. Deployed the fix. Confirmed that after multiple reloads the subscription to groups is not dropped.

## Risks and impact

- Safe to rollback without consulting PR author? (Yes | No) No.
- Affects important code area:
  - [x] Onboarding
  - [x] State / providers
  - [x] Message sync
  - [x] Channel display
  - [x] Notifications

## Rollback plan

Should not be rolled back under any circumstances.

