### PR TITLE
mobile: move ErrorBoundary below BaseProviderStack

### DIFF
--- a/apps/tlon-mobile/src/App.main.tsx
+++ b/apps/tlon-mobile/src/App.main.tsx
@@ -155,13 +155,13 @@ export default function ConnectedApp() {
   const migrationState = useMigrations();
 
   return (
-    <ErrorBoundary>
-      <FeatureFlagConnectedInstrumentationProvider>
-        <NavigationContainer
-          theme={isDarkMode ? DarkTheme : DefaultTheme}
-          ref={navigationContainerRef}
-        >
-          <BaseProviderStack migrationState={migrationState}>
+    <FeatureFlagConnectedInstrumentationProvider>
+      <NavigationContainer
+        theme={isDarkMode ? DarkTheme : DefaultTheme}
+        ref={navigationContainerRef}
+      >
+        <BaseProviderStack migrationState={migrationState}>
+          <ErrorBoundary>
             <BranchProvider>
               <GestureHandlerRootView style={{ flex: 1 }}>
                 <SignupProvider>
@@ -173,10 +173,10 @@ export default function ConnectedApp() {
                 </SignupProvider>
               </GestureHandlerRootView>
             </BranchProvider>
-          </BaseProviderStack>
-        </NavigationContainer>
-      </FeatureFlagConnectedInstrumentationProvider>
-    </ErrorBoundary>
+          </ErrorBoundary>
+        </BaseProviderStack>
+      </NavigationContainer>
+    </FeatureFlagConnectedInstrumentationProvider>
   );
 }
 


### PR DESCRIPTION
## Summary

We were seeing crashes related to Tamagui tamagui theme. In the warning it says "99% of the time this is due to mismatched @tamagui packages" but all of ours are on the same version.

Inspecting the trace, the error gets emitted from the app's top level `ErrorBoundary` component. We mount it above the Tamagui provider, so it blows up when rendering since it uses Tamagui components for the error screen visual. Since the error boundary component itself crashes, the underlying issue gets swallowed.

## Changes

- Move the root `ErrorBoundary` below the `BaseProviderStack` (the component that mounts Tamagui theme)

## How did I test?

in `<App />`, I threw an error. Confirmed before the change all that shows up is the Tamagui theme. After the change, the error screen is shown and the actual thrown error is logged.

## Risks and impact

- Safe to rollback without consulting PR author? Yes
