### PR TITLE
misc: v6.2.2 fixes

### DIFF
--- a/packages/app/ui/components/InviteUsersWidget.tsx
+++ b/packages/app/ui/components/InviteUsersWidget.tsx
@@ -22,11 +22,6 @@ const InviteUsersWidgetComponent = ({
   const [loading, setLoading] = useState(false);
   const [invitees, setInvitees] = useState<string[]>([]);
 
-  // Extract existing group member IDs to mark them as immutable
-  const existingMemberIds = useMemo(() => {
-    return group.members?.map(member => member.contactId) ?? [];
-  }, [group.members]);
-
   const handleInviteGroupMembers = useCallback(async () => {
     setLoading(true);
     try {
@@ -66,7 +61,6 @@ const InviteUsersWidgetComponent = ({
           searchPlaceholder="Filter by nickname, @p"
           onSelectedChange={setInvitees}
           onScrollChange={onScrollChange}
-          immutableIds={existingMemberIds}
         />
       </ActionSheet.ContentBlock>
       <ActionSheet.ContentBlock>

--- a/packages/app/ui/contexts/chatOptions.tsx
+++ b/packages/app/ui/contexts/chatOptions.tsx
@@ -319,11 +319,14 @@ export const ChatOptionsProvider = ({
     if (groupId) {
       if (onPressInvite) {
         onPressInvite?.(groupId);
+        closeSheet();
       } else {
         // if not handled by the parent, open built in invite sheet
-        setInviteSheetOpen(true);
+        closeSheet();
+        setTimeout(() => {
+          setInviteSheetOpen(true);
+        }, 300);
       }
-      closeSheet();
     }
   }, [closeSheet, groupId, onPressInvite]);
 


### PR DESCRIPTION
## Summary

Addresses a few things we found during QA. Fixes TLON-4725

## Changes

- Reverts the change where we prevented the user from inviting other users who are already in the group. Unfortunately you do need to re-invite someone, sometimes.
- Adds a timeout between the group long-press menu and the "Invite people" sheet popping. Similar to the problem we found before, Expo 52 is much more strict about unmounting and remounting.

## How did I test?

Tested in iOS simulator.

## Risks and impact

- Safe to rollback without consulting PR author? Yes
- Affects important code area:
  - [ ] Onboarding
  - [ ] State / providers
  - [ ] Message sync
  - [ ] Channel display
  - [ ] Notifications
  - [x] Other (invite menu)

## Rollback plan

Revert