### PR TITLE
db: fix bug in NativeDB after reset

### DIFF
--- a/packages/app/lib/nativeDb.ts
+++ b/packages/app/lib/nativeDb.ts
@@ -96,6 +96,7 @@ export class NativeDb extends BaseDb {
       this.connection.delete();
       this.connection = null;
       this.client = null;
+      this.didMigrate = false;
 
       logger.trackEvent(AnalyticsEvent.NativeDbDebug, {
         context: 'purgeDb: closed the connection, cleared the client',


### PR DESCRIPTION
## Summary

After subsequent logins on the same app install, migrations were failing to run causing a cascade of errors and an empty ChatList.

We added a `didMigrate` flag to `NativeDB` in https://github.com/tloncorp/tlon-apps/pull/4988. During logout, we call `resetDb` which in turn runs `purgeDb` followed by `runMigrations`. The former was fully resetting the database, but leaving the `didMigrate` flag set. This meant the follow on migrations call was a no-op.

To resolve, we can just reset the flag when we reset all the other class instance properties in `purgeDb`.

Note, we attempted a previous spot fix [here](https://github.com/tloncorp/tlon-apps/pull/5035), but didn't find this.

Fixes TLON-4727

## Changes

<!-- Outline specific changes made in this PR. -->

## How did I test?

Log in, log out, log back in. 
Before the change: empty ChatList stuck in _Loading..._ 
After the change: normal behavior

## Risks and impact

- Safe to rollback without consulting PR author?  Yes
- Affects important code area:
  - [x] Onboarding