### PR TITLE
Po/tlon 4719 activity screen crash

### DIFF
--- a/apps/tlon-mobile/ios/Podfile.lock
+++ b/apps/tlon-mobile/ios/Podfile.lock
@@ -2761,7 +2761,7 @@ SPEC CHECKSUMS:
   libdav1d: 23581a4d8ec811ff171ed5e2e05cd27bad64c39f
   libwebp: 02b23773aedb6ff1fd38cec7a77b81414c6842a8
   nanopb: 438bc412db1928dac798aa6fd75726007be04262
-  op-sqlite: 01b384f9c86809592fecda9465e5c9338ee0949e
+  op-sqlite: f800d2eeb9ca5c8931c612d4673f559fa23a5889
   PromisesObjC: f5707f49cb48b9636751c5b2e7d227e43fba9f47
   PromisesSwift: 9d77319bbe72ebf6d872900551f7eeba9bce2851
   RCT-Folly: ea9d9256ba7f9322ef911169a9f696e5857b9e17
@@ -2851,7 +2851,7 @@ SPEC CHECKSUMS:
   sqlite3: 83105acd294c9137c026e2da1931c30b4588ab81
   tentap: 1871a4fb2d150f4a031c154004d2b31a27fabee1
   UMAppLoader: 7e7e0eaa7854ffd652c00a68c443afb28c3bedba
-  Yoga: 8a9b4a239337975815ff5f0430a9cbd5957d00fd
+  Yoga: 1259c7a8cbaccf7b4c3ddf8ee36ca11be9dee407
 
 PODFILE CHECKSUM: cfdeceec80bf2f186cb06f550d3ae13ae1ed4571
 

--- a/apps/tlon-web/e2e/activity-gallery-missing-channel.spec.ts
+++ b/apps/tlon-web/e2e/activity-gallery-missing-channel.spec.ts
@@ -1,0 +1,57 @@
+import { expect } from '@playwright/test';
+
+import * as helpers from './helpers';
+import { test } from './test-fixtures';
+
+test('should handle gallery posts in activity without crashing', async ({
+  zodSetup,
+  tenSetup,
+}) => {
+  const zodPage = zodSetup.page;
+  const tenPage = tenSetup.page;
+
+  // Verify we're on Home
+  await expect(zodPage.getByText('Home')).toBeVisible();
+
+  // Create a group as ~zod
+  await helpers.createGroup(zodPage);
+  const groupName = '~ten, ~zod';
+
+  // Invite ~ten to the group immediately
+  await helpers.inviteMembersToGroup(zodPage, ['ten']);
+
+  // Navigate back to the group
+  await helpers.navigateBack(zodPage);
+  await expect(zodPage.getByText('Home')).toBeVisible();
+  await zodPage.getByText(groupName).first().click();
+
+  // Create a gallery channel
+  await helpers.openGroupSettings(zodPage);
+  await zodPage.getByTestId('GroupChannels').getByText('Channels').click();
+  await helpers.createChannel(zodPage, 'Gallery Test', 'gallery');
+
+  // Navigate to the gallery and create a post
+  await zodPage.getByTestId('ChannelListItem-Gallery Test').click();
+  await helpers.createGalleryPost(zodPage, 'Test gallery post content');
+
+  // Meanwhile, ~ten accepts the group invitation
+  await expect(tenPage.getByText('Home')).toBeVisible();
+  await helpers.acceptGroupInvite(tenPage, groupName);
+
+  // Create another gallery post to generate activity
+  await helpers.createGalleryPost(zodPage, 'Second gallery post for activity');
+
+  // Give time for the activity to propagate
+  await tenPage.waitForTimeout(5000);
+
+  // Navigate ~ten to the activity screen
+  await tenPage.getByTestId('ActivityNavIcon').click();
+
+  // Verify the activity screen loads without crashing
+  await expect(tenPage.getByText('Activity', { exact: true })).toBeVisible({
+    timeout: 10000,
+  });
+
+  // Verify the activity screen is functional by checking for the tabs
+  await expect(tenPage.getByText('All', { exact: true })).toBeVisible();
+});

--- a/packages/app/navigation/desktop/TopLevelDrawer.tsx
+++ b/packages/app/navigation/desktop/TopLevelDrawer.tsx
@@ -116,6 +116,7 @@ const DrawerContent = (props: DrawerContentComponentProps) => {
           activeType="NotificationsFilled"
           hasUnreads={haveUnreadUnseenActivity}
           isActive={isRouteActive('Activity')}
+          testID="ActivityNavIcon"
           onPress={() => {
             saveHomeState();
             props.navigation.reset({

--- a/packages/app/ui/components/ChatMessage/ChatMessageActions/Component.tsx
+++ b/packages/app/ui/components/ChatMessage/ChatMessageActions/Component.tsx
@@ -43,7 +43,7 @@ export function ChatMessageActions({
 }: ChatMessageActionsProps) {
   const currentUserId = useCurrentUserId();
   const channel = store.useChannel({ id: post.channelId });
-  const canWrite = useCanWrite(channel.data!, currentUserId);
+  const canWrite = useCanWrite(channel.data, currentUserId);
   const insets = useSafeAreaInsets();
   const PADDING_THRESHOLD = 40;
 

--- a/packages/app/ui/components/ChatMessage/ReactionsDisplay.tsx
+++ b/packages/app/ui/components/ChatMessage/ReactionsDisplay.tsx
@@ -25,7 +25,7 @@ export function ReactionsDisplay({
   const currentUserId = useCurrentUserId();
   const [sheetOpen, setSheetOpen] = useState(false);
   const channel = store.useChannel({ id: post.channelId });
-  const canWrite = useCanWrite(channel.data!, currentUserId);
+  const canWrite = useCanWrite(channel.data, currentUserId);
 
   const handleSelectEmoji = useOnEmojiSelect(post, () => setSheetOpen(false));
 

--- a/packages/app/ui/utils/channelUtils.tsx
+++ b/packages/app/ui/utils/channelUtils.tsx
@@ -157,12 +157,15 @@ export function useIsAdmin(chatId: string, userId: string): boolean {
   return isAdmin;
 }
 
-export function useCanWrite(channel: db.Channel, userId: string): boolean {
+export function useCanWrite(
+  channel: db.Channel | null | undefined,
+  userId: string
+): boolean {
   const writers = useMemo(
-    () => channel.writerRoles?.map((role) => role.roleId) ?? [],
-    [channel.writerRoles]
+    () => channel?.writerRoles?.map((role) => role.roleId) ?? [],
+    [channel?.writerRoles]
   );
-  const memberRoles = useMemberRoles(channel.groupId ?? '', userId);
+  const memberRoles = useMemberRoles(channel?.groupId ?? '', userId);
   const canWrite = useMemo(
     () =>
       writers.length === 0 ||


### PR DESCRIPTION
## Summary

fixes tlon-4719

Fixes crash in Activity screen when rendering gallery posts where channel data is unavailable in the local database.

The Activity screen uniquely renders gallery and notebook posts directly using `GalleryPost` and `PostReference` components (unlike chat posts which only show text previews). These components expect channel context that may not be available when channel data hasn't synced yet, the channel was deleted, or the user left the group/channel but still has old activity events.

Issue originally identified (and fixed) by @alecananian with gallery `heap/~ripwen-sabrup/max-zoom-photos-jpg-1371`.

## Changes

- Updated `useCanWrite` function in `packages/app/ui/utils/channelUtils.tsx` to accept `null` or `undefined` channels and use optional chaining for safe
   property access
- Removed non-null assertions (`!`) in `ChatMessageActions/Component.tsx` when calling `useCanWrite` with `channel.data`
- Removed non-null assertions (`!`) in `ReactionsDisplay.tsx` when calling `useCanWrite` with `channel.data`

## How did I test?
I added a specific e2e test that addresses this situation

## Risks and impact

- Safe to rollback without consulting PR author? Yes
- Affects important code area:
  - [ ] Onboarding
  - [ ] State / providers
  - [ ] Message sync
  - [ ] Channel display
  - [ ] Notifications

## Rollback plan

Revert
