### PR TITLE
e2e: fix issue with failures not being reported in ci workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -110,6 +110,9 @@ jobs:
                 -e CI=true \
                 docker.io/ubuntu:22.04 \
                 bash -c "
+                  # Exit on any error, undefined variable, or pipe failure
+                  set -euo pipefail
+                  
                   # Install dependencies
                   apt-get update && apt-get install -y curl git build-essential netcat-openbsd
                   
@@ -131,7 +134,6 @@ jobs:
                   cd apps/tlon-web
                   pnpm exec playwright install --with-deps chromium
                   
-                  # Run production smoke test
                   pnpm e2e:prod:smoke:force
                   
                   # Fix permissions on created files for host user
@@ -194,6 +196,9 @@ jobs:
               -e FORCE_EXTRACTION=true \
               docker.io/ubuntu:22.04 \
               bash -c "
+                # Exit on any error, undefined variable, or pipe failure
+                set -euo pipefail
+                
                 # Install dependencies
                 apt-get update && apt-get install -y curl git build-essential netcat-openbsd
                 
@@ -219,7 +224,6 @@ jobs:
                 cd apps/tlon-web
                 pnpm exec playwright install --with-deps chromium
                 
-                # Run tests
                 pnpm e2e:force
                 
                 # Fix permissions on all created files for host user


### PR DESCRIPTION
## Summary

Fixes CI incorrectly showing as passing when e2e test script execution fails in containers on our self-hosted Fedora runners.

When `pnpm e2e:force` failed inside the container (without running the tests yet), the bash script continued to the next command (`chmod -R 777 /workspace || true`) which succeeded. This success exit code masked the test failure, making the CI step appear green.

This PR adds `set -euo pipefail` to container bash scripts so they exit immediately on any command failure, preventing subsequent commands from masking the failure.

## How did I test?

- Testing by putting this PR up and letting it CI run a few times.

## Risks and impact

- Safe to rollback without consulting PR author? Yes
- Affects important code area: N/A

## Rollback plan

Revert.

## Screenshots / videos

N/A
