### PR TITLE
groups: robustly handle invalid seat updates

### DIFF
--- a/desk/app/groups.hoon
+++ b/desk/app/groups.hoon
@@ -3292,7 +3292,8 @@
       =.  seats.group
         %-  ~(rep in ships)
         |=  [=ship =_seats.group]
-        =+  seat=(~(got by seats) ship)
+        ?~  tea=(~(get by seats.group) ship)  seats
+        =*  seat  u.tea
         =.  seat
           seat(roles (~(uni in roles.seat) roles.u-seat))
         (~(put by seats) ship seat)
@@ -3312,7 +3313,8 @@
       =.  seats.group
         %-  ~(rep in ships)
         |=  [=ship =_seats.group]
-        =+  seat=(~(got by seats) ship)
+        ?~  tea=(~(get by seats.group) ship)  seats
+        =*  seat  u.tea
         =.  seat
           seat(roles (~(dif in roles.seat) roles.u-seat))
         (~(put by seats) ship seat)


### PR DESCRIPTION
## Summary

There are group hosts of the network with the group log containing inconsistent updates, when replayed from the beginning. This is an inheritance from old groups, and little can be done about it, short of attempting to sanitize logs to make sure they apply cleanly. For now, however, we simply restore the robust behavior of old groups which does not result in a crash prevent group join on some hosts.

Fixes TLON-4739.

## Changes

1. Prevent crashes in`+go-u-seat` by defaulting to no-op when a seat is not found.
 
## How did I test?
Run on a test moon. Verified that a group join fails prior to this fix with the same cause. After the fix was deployed, the group was successfully joined.

## Risks and impact

- Safe to rollback without consulting PR author? No.
- Affects important code area:
  - [x] Onboarding
  - [x] State / providers
  - [x] Message sync
  - [x] Channel display
  - [x] Notifications

## Rollback plan

Revert, at the risk of breaking some group joins.
