### PR TITLE
mobile: prevent locking on splash screen

### DIFF
--- a/apps/tlon-mobile/src/App.main.tsx
+++ b/apps/tlon-mobile/src/App.main.tsx
@@ -63,6 +63,12 @@ const useSplashHider = () => {
       }
     };
 
+    // check if progress completed before mounting
+    if (splashScreenProgress.finished) {
+      onComplete();
+      return;
+    }
+
     splashScreenProgress.emitter.on('complete', onComplete);
 
     return () => {

--- a/apps/tlon-mobile/src/App.main.tsx
+++ b/apps/tlon-mobile/src/App.main.tsx
@@ -45,21 +45,29 @@ SplashScreen.preventAutoHideAsync().catch((err) => {
 });
 
 const useSplashHider = () => {
-  const [splashHidden, setSplashHidden] = useState(false);
+  const [splashHidden, setSplashHidden] = useState(
+    splashScreenProgress.finished
+  );
 
   useEffect(() => {
-    splashScreenProgress.emitter.on('complete', async () => {
+    const onComplete = () => {
       try {
         withRetry(async () => {
           await SplashScreen.hideAsync();
           setSplashHidden(true);
         });
-      } catch (error) {
+      } catch (err) {
         splashscreenLogger.trackError('Failed to hide splash screen', {
-          error,
+          errorMessage: err.message,
         });
       }
-    });
+    };
+
+    splashScreenProgress.emitter.on('complete', onComplete);
+
+    return () => {
+      splashScreenProgress.emitter.off('complete', onComplete);
+    };
   }, []);
 
   return splashHidden;

--- a/apps/tlon-mobile/src/App.main.tsx
+++ b/apps/tlon-mobile/src/App.main.tsx
@@ -78,6 +78,14 @@ const App = () => {
   usePreloadedEmojis();
 
   useEffect(() => {
+    // if not logged in, we never want to show the splash screen
+    // after the app initializes
+    if (!isAuthenticated) {
+      SplashScreen.hideAsync();
+    }
+  }, [isAuthenticated]);
+
+  useEffect(() => {
     const unsubscribeFromNetInfo = NetInfo.addEventListener(
       ({ isConnected }) => {
         setConnected(isConnected ?? true);


### PR DESCRIPTION
`expo-splash-screen` has a bug in the native implementation for `SplashScreen.hideAsync`. To actually close it, it needs to target the splash view and uses a heuristic to find it. If a modal view is popped before the splash is hidden, it finds that modal instead and fails to remove the actual splash view.

This happened when you hit `GettingNodeReady` on a fresh install because it immediately pops a notification permission prompt for letting you know when your ship is booted. There are probably other circumstances where this can get hit that we didn't know about. For example, deeplink click while authenticated will immediately pop a group preview sheet.

To avoid this condition, we gate rendering `<App />` until the splash has been successfully hidden. We shouldn't be popping modals any higher up in the stack than there.