### PR TITLE
roles: don't allow editing of admin role

### DIFF
--- a/packages/app/features/groups/GroupRolesScreen.tsx
+++ b/packages/app/features/groups/GroupRolesScreen.tsx
@@ -149,8 +149,8 @@ function GroupRolesScreenView({
             borderWidth: 0,
           }}
         >
-          {groupRoles.map((role) => (
-            <Pressable key={role.id} onPress={() => handleSetEditRole(role)}>
+          {groupRoles.map((role) =>
+            role.title === 'Admin' ? (
               <ListItem
                 key={role.id}
                 paddingHorizontal="$2xl"
@@ -166,20 +166,39 @@ function GroupRolesScreenView({
                     <ListItem.Subtitle>{role.description}</ListItem.Subtitle>
                   )}
                 </ActionSheet.MainContent>
-
-                <ListItem.EndContent
-                  flexDirection="row"
-                  gap="$xl"
-                  alignItems="center"
-                >
-                  <ActionSheet.ActionIcon
-                    type="ChevronRight"
-                    color="$tertiaryText"
-                  />
-                </ListItem.EndContent>
               </ListItem>
-            </Pressable>
-          ))}
+            ) : (
+              <Pressable key={role.id} onPress={() => handleSetEditRole(role)}>
+                <ListItem
+                  key={role.id}
+                  paddingHorizontal="$2xl"
+                  backgroundColor={'$background'}
+                  borderRadius="$2xl"
+                  testID={`GroupRole-${role.title}`}
+                >
+                  <ActionSheet.MainContent>
+                    <ActionSheet.ActionTitle>
+                      {role.title}
+                    </ActionSheet.ActionTitle>
+                    {role.description && (
+                      <ListItem.Subtitle>{role.description}</ListItem.Subtitle>
+                    )}
+                  </ActionSheet.MainContent>
+
+                  <ListItem.EndContent
+                    flexDirection="row"
+                    gap="$xl"
+                    alignItems="center"
+                  >
+                    <ActionSheet.ActionIcon
+                      type="ChevronRight"
+                      color="$tertiaryText"
+                    />
+                  </ListItem.EndContent>
+                </ListItem>
+              </Pressable>
+            )
+          )}
           <Pressable onPress={() => setShowAddRole(true)}>
             <ListItem
               paddingHorizontal="$2xl"


### PR DESCRIPTION
## Summary

fixes tlon-4629 by not allowing Admin role to be edited (we render it separately from the other roles, without the Pressable).

Also adds an e2e test to make sure Admin is not editable.

## Changes

See above.

## How did I test?

Tested on web/ios, added an e2e test.

## Risks and impact

- Safe to rollback without consulting PR author? Yes
- Affects important code area: N/A

## Rollback plan

Revert

## Screenshots / videos

N/A
