### PR TITLE
groups: restore create response in +go-u-create for group self-joins

### DIFF
--- a/desk/app/groups.hoon
+++ b/desk/app/groups.hoon
@@ -3079,10 +3079,7 @@
   ++  go-u-create
     |=  gr=group:g
     ^+  go-core
-    ::  nb: we don't send out a response here because
-    ::  a synthetic %create response is sent after
-    ::  the group log has been fully applied in +go-apply-log.
-    ::
+    =.  go-core  (go-response [%create gr])
     ?:  go-our-host  go-core
     ::
     ?>  ?=(%sub -.net)


### PR DESCRIPTION
## Summary

While testing the _other_ group channel init problem, it was discovered that the special case logic introduced in  `+go-u-create` to optimize group joins does not apply when running on the group host, which can't track its own group initialization status (group is always considered initialized, even though we might not be joined). This caused a `%create` response not to be emitted when self-joining a group. 

Note that this should not cause any visible issues, since the client eagerly populates a newly created group and does not rely on the `%create` event.

## Changes

1. Restore the original logic in `+go-u-create`. When a group is not initialized, a check in `+go-response` is going to prevent it from being sent out, so for a subscriber joining a group this change amounts to nothing. For a group host, however, this restores the proper response to be sent out when a group is first created. 

## How did I test?

Run a ship and observed the response being generated from a group host. 

## Risks and impact
This seems to have been masked by eager population of a created group by the client.

- Safe to rollback without consulting PR author? No
- Affects important code area:
  - [ ] Onboarding
  - [ ] State / providers
  - [ ] Message sync
  - [ ] Channel display
  - [ ] Notifications

## Rollback plan
Should not be reverted, since this corrects the logic when running on a group host.
