### PR TITLE
web: remove 5s timeout for database loading to prevent empty chat list

### DIFF
--- a/packages/app/lib/splashscreen.ts
+++ b/packages/app/lib/splashscreen.ts
@@ -14,9 +14,13 @@ export const splashScreenProgress = (() => {
     web: [SplashScreenTask.loadTheme, SplashScreenTask.startDatabase],
     default: [SplashScreenTask.loadTheme],
   }).forEach((task) => {
-    // 5 seconds timeout for each task - this assumes that all of the tasks
-    // above are strictly "nice-to-haves" and should not block app load.
-    progressManager.add(task, 5000);
+    // Web needs actual data before showing UI, so no timeout for database task.
+    // Native uses 5 second timeout as a nice-to-have.
+    const timeout =
+      Platform.OS === 'web' && task === SplashScreenTask.startDatabase
+        ? undefined // No timeout - wait for actual data
+        : 5000; // Keep 5s timeout for other tasks/platforms
+    progressManager.add(task, timeout);
   });
 
   return progressManager;

--- a/packages/app/lib/splashscreen.ts
+++ b/packages/app/lib/splashscreen.ts
@@ -10,16 +10,18 @@ export const splashScreenProgress = (() => {
   const progressManager = new ProgressManager<SplashScreenTask>(new Set());
 
   // Setup tasks on progress manager
-  Platform.select({
-    web: [SplashScreenTask.loadTheme, SplashScreenTask.startDatabase],
-    default: [SplashScreenTask.loadTheme],
-  }).forEach((task) => {
-    // Web needs actual data before showing UI, so no timeout for database task.
-    // Native uses 5 second timeout as a nice-to-have.
-    const timeout =
-      Platform.OS === 'web' && task === SplashScreenTask.startDatabase
-        ? undefined // No timeout - wait for actual data
-        : 5000; // Keep 5s timeout for other tasks/platforms
+  const taskConfigs = Platform.select({
+    web: [
+      [SplashScreenTask.loadTheme, 5000],
+      // Web needs actual data before showing UI, so no timeout for database task
+      [SplashScreenTask.startDatabase, undefined],
+    ] as Array<[SplashScreenTask, number | undefined]>,
+    default: [[SplashScreenTask.loadTheme, 5000]] as Array<
+      [SplashScreenTask, number | undefined]
+    >,
+  });
+
+  taskConfigs?.forEach(([task, timeout]) => {
     progressManager.add(task, timeout);
   });
 


### PR DESCRIPTION
## Summary

Fixes empty chat list issue in web app where users would see "Welcome to Tlon" message immediately after loading before data had synced from the backend.

The `splashScreenProgress` system was added about a month ago to manage loading states across platforms. A few days after it was added, a 5-second timeout was added to all splash screen tasks. This timeout forced the UI to display after 5 seconds even if data hadn't synced yet. Since the web app creates a fresh database on every page load (unlike mobile which persists it), the timeout would expire before initial sync completed, resulting in users seeing an empty chat list until data arrived moments later. Prior to the `splashScreenProgress` system, the web app used a simple `dbIsLoaded` check with no timeout system.

## Changes

- Modified splash screen timeout logic in `packages/app/lib/splashscreen.ts` to exclude database task timeout on web platform
- Web platform with `startDatabase` task now waits for actual data instead of timing out after 5 seconds
- All other tasks and platforms retain the 5-second timeout behavior
- Updated timeout logic uses platform detection to differentiate between web and native behavior

## How did I test?
- Tested manually by running the dev server against my own ship.

## Risks and impact
- Safe to rollback without consulting PR author? Yes
- Affects important code area:
  - [ ] Onboarding
  - [x] State / providers
  - [x] Message sync
  - [ ] Channel display
  - [ ] Notifications
  
## Rollback plan

Revert

## Screenshots / videos

N/A