### PR TITLE
group joins: fix issue where we falsely report that users don't have access to any channels

### DIFF
--- a/desk/app/groups.hoon
+++ b/desk/app/groups.hoon
@@ -3531,6 +3531,9 @@
       =.  go-core  (go-response %channel nest [%section section.u-channel])
       ?:  go-our-host  go-core
       ::
+      ?.  (~(has by channels.group) nest)
+        ~&  >>  "groups: warning: section update for non-existent channel {<nest>} in group {<flag>} at {<now.bowl>}"
+        go-core
       =/  =channel:g  (got:by-ch nest)
       ?>  (~(has by sections.group) section.u-channel)
       =.  sections.group

--- a/desk/app/groups.hoon
+++ b/desk/app/groups.hoon
@@ -3531,9 +3531,6 @@
       =.  go-core  (go-response %channel nest [%section section.u-channel])
       ?:  go-our-host  go-core
       ::
-      ?.  (~(has by channels.group) nest)
-        ~&  >>  "groups: warning: section update for non-existent channel {<nest>} in group {<flag>} at {<now.bowl>}"
-        go-core
       =/  =channel:g  (got:by-ch nest)
       ?>  (~(has by sections.group) section.u-channel)
       =.  sections.group

--- a/packages/app/hooks/useGroupContext.ts
+++ b/packages/app/hooks/useGroupContext.ts
@@ -1,7 +1,7 @@
 import { sync, useUpdateChannel } from '@tloncorp/shared';
 import * as db from '@tloncorp/shared/db';
 import * as store from '@tloncorp/shared/store';
-import { useCallback, useEffect, useMemo, useState } from 'react';
+import { useCallback, useEffect, useMemo } from 'react';
 
 import { useCurrentUserId } from './useCurrentUser';
 
@@ -13,8 +13,6 @@ export const useGroupContext = ({
   isFocused?: boolean;
 }) => {
   const currentUserId = useCurrentUserId();
-  const [syncRetryCount, setSyncRetryCount] = useState(0);
-  const MAX_SYNC_RETRIES = 3;
   
   const groupQuery = store.useGroup({
     id: groupId,
@@ -27,44 +25,6 @@ export const useGroupContext = ({
   }, [groupId]);
 
   const group = groupQuery.data ?? null;
-
-  // Reset retry count when group successfully syncs (channels load)
-  useEffect(() => {
-    if (group && group.channels && group.channels.length > 0) {
-      setSyncRetryCount(0);
-    }
-  }, [group]);
-
-  // Retry sync if we detect a likely sync failure
-  // (nav sections exist but channels haven't loaded)
-  useEffect(() => {
-    if (
-      groupId &&
-      group &&
-      group.channels?.length === 0 &&
-      group.navSections &&
-      group.navSections.length > 0 &&
-      group.navSections.some((s) => s.channels && s.channels.length > 0) &&
-      syncRetryCount < MAX_SYNC_RETRIES
-    ) {
-      // Nav sections reference channels but channels array is empty
-      // This indicates a likely sync failure - retry after delay with exponential backoff
-      const delay = 5000 * Math.pow(2, syncRetryCount); // 5s, 10s, 20s
-      const timer = setTimeout(() => {
-        console.log(
-          `Retrying sync for group ${groupId} - attempt ${syncRetryCount + 1}/${MAX_SYNC_RETRIES} (delay: ${delay}ms)`
-        );
-        sync.syncGroup(
-          groupId,
-          { priority: store.SyncPriority.High },
-          { force: true }
-        );
-        setSyncRetryCount(prev => prev + 1);
-      }, delay);
-
-      return () => clearTimeout(timer);
-    }
-  }, [groupId, group, syncRetryCount]);
 
   const currentUserIsAdmin = useMemo(() => {
     return group?.members.some(

--- a/packages/app/ui/components/ActionSheet.tsx
+++ b/packages/app/ui/components/ActionSheet.tsx
@@ -673,7 +673,7 @@ export const SimpleActionSheetHeader = ({
       {icon ? icon : null}
       <ListItem.MainContent>
         <ListItem.Title>{title}</ListItem.Title>
-        {subtitle && <ListItem.Subtitle>{subtitle}</ListItem.Subtitle>}
+        {subtitle ? <ListItem.Subtitle>{subtitle}</ListItem.Subtitle> : null}
       </ListItem.MainContent>
     </ActionSheet.Header>
   );

--- a/packages/app/ui/components/GroupChannelsScreenView.tsx
+++ b/packages/app/ui/components/GroupChannelsScreenView.tsx
@@ -313,10 +313,12 @@ export const GroupChannelsScreenView = React.memo(
             padding="$m"
           >
             <Text color="$primaryText" fontSize="$m" textAlign="center">
-              You don&apos;t have access to any channels in this group.
+              No channels available in this group yet.
             </Text>
             <Text color="$primaryText" fontSize="$m" textAlign="center">
-              Please contact the group host to request access.
+              {isGroupAdmin
+                ? 'Create a channel to get started.'
+                : 'The group host can create channels or grant you access to existing ones.'}
             </Text>
           </YStack>
         ) : (

--- a/packages/app/ui/components/GroupChannelsScreenView.tsx
+++ b/packages/app/ui/components/GroupChannelsScreenView.tsx
@@ -299,7 +299,12 @@ export const GroupChannelsScreenView = React.memo(
               paddingBottom: insets.bottom,
             }}
           />
-        ) : group && group.channels && group.channels.length === 0 ? (
+        ) : group &&
+          group.channels &&
+          group.channels.length === 0 &&
+          !group.joinStatus ? (
+          // Only show "no access" if we're certain the group has fully synced
+          // and there are truly no channels available
           <YStack
             flex={1}
             justifyContent="center"
@@ -315,6 +320,7 @@ export const GroupChannelsScreenView = React.memo(
             </Text>
           </YStack>
         ) : (
+          // Show loading spinner while channels are syncing
           <YStack flex={1} justifyContent="center" alignItems="center">
             <LoadingSpinner />
           </YStack>

--- a/packages/app/ui/components/GroupChannelsScreenView.tsx
+++ b/packages/app/ui/components/GroupChannelsScreenView.tsx
@@ -285,7 +285,12 @@ export const GroupChannelsScreenView = React.memo(
         {isPersonalGroup && group && (
           <WayfindingNotice.GroupChannels group={group} />
         )}
-        {group && group.channels && group.channels.length ? (
+        {group && group.joinStatus === 'joining' ? (
+          // Show loading spinner while group is syncing
+          <YStack flex={1} justifyContent="center" alignItems="center">
+            <LoadingSpinner />
+          </YStack>
+        ) : group && group.channels && group.channels.length > 0 ? (
           <FlashList
             data={listItems}
             renderItem={renderItem}
@@ -299,12 +304,8 @@ export const GroupChannelsScreenView = React.memo(
               paddingBottom: insets.bottom,
             }}
           />
-        ) : group &&
-          group.channels &&
-          group.channels.length === 0 &&
-          !group.joinStatus ? (
-          // Only show "no access" if we're certain the group has fully synced
-          // and there are truly no channels available
+        ) : group && group.channels && group.channels.length === 0 ? (
+          // Only show "no channels" message when we're certain the group has fully synced
           <YStack
             flex={1}
             justifyContent="center"
@@ -322,7 +323,7 @@ export const GroupChannelsScreenView = React.memo(
             </Text>
           </YStack>
         ) : (
-          // Show loading spinner while channels are syncing
+          // Show loading spinner while waiting for group data
           <YStack flex={1} justifyContent="center" alignItems="center">
             <LoadingSpinner />
           </YStack>

--- a/packages/app/ui/components/GroupPreviewSheet.tsx
+++ b/packages/app/ui/components/GroupPreviewSheet.tsx
@@ -4,9 +4,8 @@ import * as logic from '@tloncorp/shared/logic';
 import * as store from '@tloncorp/shared/store';
 import { LoadingSpinner } from '@tloncorp/ui';
 import React, { useCallback, useEffect, useMemo, useState } from 'react';
-import { Spinner, YStack } from 'tamagui';
+import { YStack } from 'tamagui';
 
-import { useStore } from '../contexts';
 import { triggerHaptic, useGroupTitle } from '../utils';
 import {
   ActionGroup,
@@ -203,15 +202,9 @@ export function getActionGroups(
     cancelJoin: () => void;
   }
 ): ActionGroup[] {
-  if (status.isMember) {
-    return createActionGroups([
-      'positive',
-      {
-        title: 'Go to group',
-        action: actions.goToGroup,
-      },
-    ]);
-  } else if (status.isJoining) {
+  if (status.isJoining) {
+    // Check isJoining first, even if isMember is true
+    // This handles the case where group is still syncing
     return createActionGroups(
       [
         'disabled',
@@ -228,6 +221,15 @@ export function getActionGroups(
         },
       ]
     );
+  } else if (status.isMember) {
+    // Only show "Go to group" if NOT joining (fully synced)
+    return createActionGroups([
+      'positive',
+      {
+        title: 'Go to group',
+        action: actions.goToGroup,
+      },
+    ]);
   } else if (status.isErrored) {
     return createActionGroups([
       'negative',

--- a/packages/app/ui/components/GroupPreviewSheet.tsx
+++ b/packages/app/ui/components/GroupPreviewSheet.tsx
@@ -202,9 +202,18 @@ export function getActionGroups(
     cancelJoin: () => void;
   }
 ): ActionGroup[] {
-  if (status.isJoining) {
-    // Check isJoining first, even if isMember is true
-    // This handles the case where group is still syncing
+  if (status.isMember) {
+    // If user is a member, always allow navigation to the group
+    // The group view will handle showing appropriate loading states
+    return createActionGroups([
+      'positive',
+      {
+        title: 'Go to group',
+        action: actions.goToGroup,
+      },
+    ]);
+  } else if (status.isJoining) {
+    // Only show "Joining" state when not yet a member
     return createActionGroups(
       [
         'disabled',
@@ -221,15 +230,6 @@ export function getActionGroups(
         },
       ]
     );
-  } else if (status.isMember) {
-    // Only show "Go to group" if NOT joining (fully synced)
-    return createActionGroups([
-      'positive',
-      {
-        title: 'Go to group',
-        action: actions.goToGroup,
-      },
-    ]);
   } else if (status.isErrored) {
     return createActionGroups([
       'negative',

--- a/packages/app/ui/components/ListItem/listItemUtils.tsx
+++ b/packages/app/ui/components/ListItem/listItemUtils.tsx
@@ -26,12 +26,12 @@ export function getGroupStatus(group: db.Group) {
   const isRequested = group.haveRequestedInvite;
   const isInvite = group.haveInvite;
 
-  const state = isNew
-    ? 'new'
+  const state = isJoining
+    ? 'joining'
     : isErrored
       ? 'errored'
-      : isJoining
-        ? 'joining'
+      : isNew
+        ? 'new'
         : isRequested
           ? 'requested'
           : isInvite


### PR DESCRIPTION
## Summary

Fixes issue where "You don't have access to any channels in this group" incorrectly appears after joining a group. The issue occurred when group metadata synced before channels, causing the UI to show an access error instead of a loading state during the join process.

Users were seeing "You don't have access to any channels" immediately after joining groups, even when they had full access. This was caused by:
1. Backend subscription crashes when processing section updates for non-existent channels
2. Frontend incorrectly detecting sync completion when channels hadn't loaded yet  
3. UI showing wrong states based on incomplete data

The subscription was crashing because section update operations were attempting to access channels that didn't exist in the local state. Without the defensive check, the code would crash at line 3537 when trying to get a non-existent channel. I'm not exactly sure *why* the channels wouldn't yet be in local state, but the defensive changes here prevent crashing completely when this happens.

**Note:** The backend fix addresses one specific crash scenario. The frontend changes provide a more comprehensive solution by ensuring groups aren't shown as "joined" until all data has finished syncing, preventing the misleading "no access" message in various partial-sync scenarios.

## Changes

Backend (desk/app/groups.hoon):
- Added defensive programming at line 3534-3536 to prevent subscription crashes when processing section updates for non-existent channels
- Added detailed warning message with group flag and timestamp for debugging: `"groups: warning: section update for non-existent channel {<nest>} in group {<flag>} at {<now.bowl>}"`
- This handles cases where section updates arrive before channel creation or for channels the user doesn't have permission to access

Frontend (packages/app/ui/components/GroupChannelsScreenView.tsx):
- Shows loading spinner while `joinStatus` indicates group is still syncing
- Only shows "no channels" message when sync is complete (`!group.joinStatus`)
- Updated empty state message from "You don't have access" to "No channels available in this group yet"
- Provides contextual guidance: admins see "Create a channel to get started", non-admins see guidance about the group host

UI State Fixes:
- **listItemUtils.tsx**: Fixed badge priority to show "Joining" before "NEW" 
- **GroupPreviewSheet.tsx**: Checks `isJoining` state first, even when `isMember` is true, to handle cases where group is still syncing
- **ActionSheet.tsx**: Minor cleanup for subtitle null handling

## Testing

- Tested locally with local moons + my main planet on the latest develop.

## Risks and Impact

- Safe to rollback without consulting PR author? Yes
- Affects important code area:
  - [ ] Onboarding
  - [x] State / providers
  - [ ] Message sync
  - [ ] Channel display
  - [ ] Notifications

## Rollback Plan

Revert.