### PR TITLE
channels: check log and post integrity

### DIFF
--- a/desk/app/channels-server.hoon
+++ b/desk/app/channels-server.hoon
@@ -692,6 +692,8 @@
   =?  +.pole  !?=([%v0 *] +.pole)
     [%v0 +.pole]
   ?+  pole  [~ ~]
+      [%x %v0 %v-channels ~]
+    ``noun+!>(v-channels)
       [%x %v0 %hooks ~]
     ``hook-full+!>(hooks)
   ==

--- a/desk/ted/channel/check-log-integrity.hoon
+++ b/desk/ted/channel/check-log-integrity.hoon
@@ -1,0 +1,99 @@
+/-  spider, c=channels
+/+  s=strandio
+=,  strand=strand:spider
+^-  thread:spider
+|=  arg=vase
+=/  m  (strand ,vase)
+^-  form:m
+|^
+=/  =nest:c  (need !<((unit nest:c) arg))
+~&  "getting channel for {<nest>}"
+;<  =v-channels:c  bind:m
+  (scry:s v-channels:c /gx/channels-server/v0/v-channels/noun)
+~&  "got channels"
+?~  channel=(~(get by v-channels) nest)
+  ~&  "channel not found"
+  (pure:m !>(~))
+~&  "got channel"
+=*  chan  u.channel
+=/  =log:c  log.chan
+=/  [=state *]
+  %^  (dip:log-on:c state)  log
+    *state
+  |=  [=state =time update=u-channel:v9:c]
+  ?+  update  [~ | state]
+      [%post * %set %& *]
+    :-  ~  :-  |
+    =*  post  post.u-post.update
+    ?:  =(0 rev.post)  :: new post
+      state(adds (~(put by adds.state) id.post [time seq.post]))
+    state(edits (~(put by edits.state) id.post rev.post))
+  ::
+      [%post * %set %| *]
+    :-  ~  :-  |
+    =*  post  post.u-post.update
+    state(dels (~(put by dels.state) id.post [time seq.post]))
+  ==
+::  compare dels vs adds, both in existence of add and time ordering
+=/  missing-adds=(set id-post:c)
+  (~(dif in ~(key by dels.state)) ~(key by adds.state))
+~&  [%missing-adds missing-adds]
+=/  order-issues=(list id-post:c)
+  %+  murn
+    ~(tap by adds.state)
+  |=  [id=id-post:c time=@da seq=@ud]
+  ::  ignore if not found we already know missing from above
+  ?~  del=(~(get by dels.state) id)  ~
+  ::  if the add time is less than the delete time, we're good
+  ?:  (lte time log-time.u.del)  ~
+  ::  otherwise return this id
+  `id
+~&  [%order-issues order-issues]
+=/  disagreed-seqs=(list id-post:c)
+  %+  murn
+    ~(tap by dels.state)
+  |=  [id=id-post:c time=@da seq=@ud]
+  ::  ignore if not found we already know missing from above
+  ?~  add=(~(get by adds.state) id)  ~
+  ::  if the seqs match, we're good
+  ?:  =(seq seq.u.add)  ~
+  `id
+~&  [%disagreeing-add-del disagreed-seqs]
+=/  [* duplicates=(map id-post:c @ud)]
+  %+  roll
+    ~(tap by adds.state)
+  |=  [[id=id-post:c time=@da seq=@ud] [seen=(set @ud) dupes=(map id-post:c @ud)]]
+  ?.  (~(has in seen) seq)  [(~(put in seen) seq) dupes]
+  [seen (~(put by dupes) id seq)]
+~&  [%duplicate-sequences duplicates]
+=/  merged-seqs=(set @ud)
+  %-  sy
+  %+  turn
+    (weld ~(tap by adds.state) ~(tap by dels.state))
+  |=([* * seq=@ud] seq)
+:: this should equal last sequence number
+=/  total=@ud  ~(wyt in merged-seqs)
+~&  [%total-sequences total]
+=/  seq-range=(set @ud)  ?.((gth total 0) ~ (sy (gulf 1 total)))
+=/  missing-nos=(set @ud)  (~(dif in seq-range) merged-seqs)
+~&  [%missing-sequence-numbers missing-nos]
+=/  disagreeing-sequences=(list id-post:c)
+  %+  murn
+    ~(tap by (~(uni by adds.state) dels.state))
+  |=  [id=id-post:c time=@da seq=@ud]
+  ?~  post=(get:on-v-posts:c posts.chan id)  ~
+  =/  post-seq
+    ?-  -.u.post
+      %&  seq.u.post
+      %|  seq.u.post
+    ==
+  ?:  =(seq post-seq)  ~
+  `id
+~&  [%disagreeing-sequences disagreeing-sequences]
+(pure:m !>(~))
++$  state
+  $:  adds=(map id-post:c [log-time=@da seq=@ud])
+      dels=(map id-post:c [log-time=@da seq=@ud])
+      edits=(map id-post:c count=@ud)
+  ==
+--

--- a/desk/ted/channel/check-posts-integrity.hoon
+++ b/desk/ted/channel/check-posts-integrity.hoon
@@ -1,0 +1,52 @@
+/-  spider, c=channels
+/+  s=strandio
+=,  strand=strand:spider
+^-  thread:spider
+|=  arg=vase
+=/  m  (strand ,vase)
+^-  form:m
+|^
+=/  agent=?(%channels %channels-server)
+  (need !<((unit ?(%channels %channels-server)) arg))
+;<  =v-channels:c  bind:m
+  %+  scry:s  v-channels:c
+  ?:  ?=(%channels agent)
+    /gx/channels/v4/v-channels/noun
+  /gx/channels-server/v0/v-channels/noun
+=;  [problematic-channels=(set nest:c)]
+  =/  has-problems  !=(0 ~(wyt in problematic-channels))
+  ~?  >>>  has-problems
+    [%problematic-channels problematic-channels]
+  ~?  >   !has-problems
+    'posts integrity verified'
+  (pure:m !>(~))
+%+  roll
+  ~(tap by v-channels)
+|=  [[=nest:c =v-channel:c] probs=(set nest:c)]
+=/  remaining=(set @ud)
+  ?:  =(0 (wyt:on-v-posts:c posts.v-channel))  ~
+  (sy (gulf 1 count.v-channel))
+=;  [seen=(set @ud) remaining=(set @ud) dupes=(set @ud)]
+  =/  has-dupes  !=(0 ~(wyt in dupes))
+  =/  unseen     !=(0 ~(wyt in remaining))
+  ~?  >>>  has-dupes  [%dupes nest dupes]
+  ~?  >>>  unseen     [%unseen nest remaining]
+  ::  if we don't have any duplicates or unseen sequence numbers we're good
+  ?.  |(has-dupes unseen)  probs
+  (~(put in probs) nest)
+%+  roll
+  (tap:on-v-posts:c posts.v-channel)
+|=  [[id=id-post:c post=(may:c v-post:c)] seen=(set @ud) =_remaining dupes=(set @ud)]
+=/  seq=@ud
+  ?-  -.post
+    %&  seq.post
+    %|  seq.post
+  ==
+?:  (~(has in seen) seq)
+  ~&  >>>  [%duplicate-seq seq id nest]
+  [seen remaining (~(put in dupes) seq)]
+?.  (~(has in remaining) seq)
+  ~&  >>>  [%seq-out-of-range seq nest]
+  [(~(put in seen) seq) remaining dupes]
+[(~(put in seen) seq) (~(del in remaining) seq) dupes]
+--


### PR DESCRIPTION
## Summary

These threads iterate over all channels and checks the integrity of either their logs or posts. The post checker takes an arg, either %channels or %channels-server, which allows you to check all channels you know about or just the ones you host.

## Changes

- added scry to get channels-server channels out as nouns
- added thread to check log integrity from channels-server
- added thread to check post integrity from either channels or channels-server

## How did I test?

Ran each thread on local copy of ~dabben-larbet and presented results as expected

## Risks and impact

- Safe to rollback without consulting PR author? Yes
- Affects important code area:
  - [ ] Onboarding
  - [ ] State / providers
  - [ ] Message sync
  - [ ] Channel display
  - [ ] Notifications

## Rollback plan

<!-- Describe the steps to revert these changes if needed. -->

## Screenshots / videos

<!-- Attach any relevant media. -->
