### PR TITLE
hidden posts: fix race condition where hidden post ids arrive before posts exist

### DIFF
--- a/packages/shared/src/db/migrations/0000_sparkling_arclight.sql
+++ b/packages/shared/src/db/migrations/0000_sparkling_arclight.sql
@@ -363,7 +363,8 @@ CREATE TABLE `settings` (
 	`activity_seen_timestamp` integer,
 	`completed_wayfinding_splash` integer,
 	`completed_wayfinding_tutorial` integer,
-	`disable_tlon_infra_enhancement` integer
+	`disable_tlon_infra_enhancement` integer,
+	`pending_hidden_post_ids` text
 );
 --> statement-breakpoint
 CREATE TABLE `system_contact_sent_invites` (

--- a/packages/shared/src/db/migrations/meta/0000_snapshot.json
+++ b/packages/shared/src/db/migrations/meta/0000_snapshot.json
@@ -1,7 +1,7 @@
 {
   "version": "6",
   "dialect": "sqlite",
-  "id": "0f17c271-e1e5-49ef-aae0-666c3b66c643",
+  "id": "3d1380f9-1e43-47d3-ba20-fff21a63b788",
   "prevId": "00000000-0000-0000-0000-000000000000",
   "tables": {
     "activity_event_contact_group_pins": {
@@ -2421,6 +2421,13 @@
         "disable_tlon_infra_enhancement": {
           "name": "disable_tlon_infra_enhancement",
           "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "pending_hidden_post_ids": {
+          "name": "pending_hidden_post_ids",
+          "type": "text",
           "primaryKey": false,
           "notNull": false,
           "autoincrement": false

--- a/packages/shared/src/db/migrations/meta/_journal.json
+++ b/packages/shared/src/db/migrations/meta/_journal.json
@@ -5,8 +5,8 @@
     {
       "idx": 0,
       "version": "6",
-      "when": 1749833724434,
-      "tag": "0000_clean_nicolaos",
+      "when": 1756494637255,
+      "tag": "0000_sparkling_arclight",
       "breakpoints": true
     }
   ]

--- a/packages/shared/src/db/migrations/migrations.js
+++ b/packages/shared/src/db/migrations/migrations.js
@@ -1,7 +1,7 @@
 // This file is required for Expo/React Native SQLite migrations - https://orm.drizzle.team/quick-sqlite/expo
 
 import journal from './meta/_journal.json';
-import m0000 from './0000_clean_nicolaos.sql';
+import m0000 from './0000_sparkling_arclight.sql';
 
   export default {
     journal,

--- a/packages/shared/src/db/schema.ts
+++ b/packages/shared/src/db/schema.ts
@@ -58,6 +58,9 @@ export const settings = sqliteTable('settings', {
   completedWayfindingSplash: boolean('completed_wayfinding_splash'),
   completedWayfindingTutorial: boolean('completed_wayfinding_tutorial'),
   disableTlonInfraEnhancement: boolean('disable_tlon_infra_enhancement'),
+  pendingHiddenPostIds: text('pending_hidden_post_ids', { mode: 'json' }).$type<
+    string[]
+  >(),
 });
 
 export const systemContacts = sqliteTable('system_contacts', {


### PR DESCRIPTION
fixes tlon-4242

## Summary

Fixes issue where reported/hidden posts would reappear after any fresh database initialization due to a race condition between hidden post ID synchronization and post data synchronization.

When the database is initialized (web page refresh, mobile app install/reinstall or switching devices), hidden posts would not remain hidden:

1. Backend sends hidden post IDs during initialization
2. `resetHiddenPosts` tries to update posts that don't exist yet in the database
3. Posts are synced later, but don't get marked as hidden because the hidden IDs were already processed and discarded
4. Result: All previously hidden posts reappear

When I created the linear issue I had thought this was related to creating a new group, but I only thought that because at the time the e2e test was using a page.reload(). This actually effects hidden posts in any group, for any user.

This PR implements a pending queue for hidden post IDs:
1. Store pending IDs: When hidden post IDs arrive before posts exist, store them in the settings table
2. Apply on insert: When posts are inserted, check for pending hidden IDs and apply the hidden state
3. Clean up: Remove successfully applied IDs from the pending list to prevent memory growth

I'll also note that I think it would be more ideal if we include the hidden state on the posts themselves in the backend rather than as a separate piece of state, but that's a bigger change.

## Changes

- Added `pendingHiddenPostIds` field to settings table to temporarily store hidden post IDs that arrive before posts (open to suggestions on a better spot for this)
- Modified `resetHiddenPosts` to store pending hidden IDs in settings instead of attempting immediate database updates on non-existent posts
- Enhanced `insertPostsBatch` to check for pending hidden IDs and apply hidden state when posts are inserted
- Added cleanup logic to remove applied IDs from the pending list after successful application
- Improved error logging in `reportPost` and `hidePost` functions with structured error tracking

## Testing

- Web: Report posts, refresh page, verify they remain hidden
- Mobile sim: Clear database, reinitialize, verify hidden posts are restored
- Report multiple posts across different channels
- Verify all remain hidden after database reinitialization
- Tested cleanup logic ensures pending IDs are removed after application

## Risks and Impact

- Safe to rollback without consulting PR author? Yes
- Affects important code area:
  - [ ] Onboarding
  - [x] State / providers
  - [ ] Message sync
  - [ ] Channel display
  - [ ] Notifications

## Rollback Plan

Revert.