### PR TITLE
threads: fix issue with reply messages delivered to main chat

### DIFF
--- a/packages/shared/src/store/useChannelPosts.ts
+++ b/packages/shared/src/store/useChannelPosts.ts
@@ -181,7 +181,7 @@ export const useChannelPosts = (options: UseChannelPostsParams) => {
   const [newPosts, setNewPosts] = useState<db.Post[]>([]);
   const handleNewPost = useCallback(
     (post: db.Post) => {
-      if (post.channelId === options.channelId) {
+      if (post.channelId === options.channelId && post.type !== 'reply') {
         setNewPosts((posts) => addPostToNewPosts(post, posts));
       }
     },


### PR DESCRIPTION
fixes tlon-4705

Two thread-related bugs:

1. Thread replies were being delivered to main channels when messages failed and you hit retry
2. Thread replies would briefly appear in main channel view (if you quickly navigated out of the thread) due to missing filtering in useChannelPosts

The retry problem was that `retrySendPost()` always called the regular post API without checking if it was originally a thread message. The UI problem was that subscriptions weren't filtering out reply posts like database queries do, thread replies would appear briefly in the main chat channel until the next database query update removed them via deduplication logic.

## Changes

1. Updated `retrySendPost()` to check if a failed message has a `parentId` (indicating it was originally a thread reply). If it does, it fetches the parent post to get the `parentAuthor` and routes the retry to the thread reply API instead of the regular post API.

2. Added reply type filter to `useChannelPosts` subscription handler so thread replies don't appear in main channel views via subscription updates.

## How did I test?

- Retry bug: Made thread messages fail on purpose, hit retry, verified they stayed in the thread
- UI bug: Sent thread replies and immediately navigated to main channel, verified replies don't appear there briefly
- Double-checked that regular main channel messages still work fine
- Tested on both web and iOS sim

## Risks and impact

- Safe to rollback without consulting PR author? Yes
- Affects important code area:
  - [ ] Onboarding
  - [ ] State / providers
  - [ ] Message sync
  - [ ] Channel display
  - [ ] Notifications

## Rollback plan

Revert

## Screenshots / videos

N/A
