### PR TITLE
trigger stick-to-scroll-start when viewport height changes

### DIFF
--- a/packages/app/ui/components/Channel/PostList/PostList.web.tsx
+++ b/packages/app/ui/components/Channel/PostList/PostList.web.tsx
@@ -152,8 +152,14 @@ const PostListSingleColumn: PostListComponent = React.forwardRef(
       insideScrolledToBottomBoundary,
     ]);
 
+    const viewportHeight =
+      useTrackContentRect(scrollerRef.current)?.height ?? 0;
+    const scrollerContentsKey = React.useMemo(
+      () => [orderedData, viewportHeight],
+      [orderedData, viewportHeight]
+    );
     useStickToScrollStart({
-      scrollerContentsKey: orderedData,
+      scrollerContentsKey,
       scrollerRef,
       inverted,
       hasNewerPosts,

--- a/packages/app/ui/components/Channel/PostList/PostList.web.tsx
+++ b/packages/app/ui/components/Channel/PostList/PostList.web.tsx
@@ -9,6 +9,7 @@ import { PostList as PostListNative } from './PostListFlatList';
 import { PostListComponent, PostWithNeighbors } from './shared';
 
 const FORCE_MANUAL_SCROLL_ANCHORING: boolean = false;
+const IS_FIREFOX = navigator.userAgent.includes('Firefox');
 
 export const PostList: PostListComponent = React.forwardRef((props, ref) => {
   const [webScrollerEnabled] = useFeatureFlag('webScroller');
@@ -155,7 +156,13 @@ const PostListSingleColumn: PostListComponent = React.forwardRef(
     const viewportHeight =
       useTrackContentRect(scrollerRef.current)?.height ?? 0;
     const scrollerContentsKey = React.useMemo(
-      () => [orderedData, viewportHeight],
+      () =>
+        // HACK: Firefox triggers a mysterious scroll on the next keypress after
+        // the viewport height changes, which causes the scroll to unstick from
+        // bottom. If we just don't try to stick to bottom while viewport is
+        // resizing, we keep stuck to the bottom _after_ the send (although the
+        // chat gets hidden during drafting), which is better than unsticking.
+        IS_FIREFOX ? orderedData : [orderedData, viewportHeight],
       [orderedData, viewportHeight]
     );
     useStickToScrollStart({


### PR DESCRIPTION
## Summary
towards TLON-4706

## Changes
`useStickToScrollStart` uses the opaque `scrollerContentsKey` param to trigger a "scroll-to-bottom if needed" action. This was previously only triggered when the post list data changed.
This PR changes `scrollerContentsKey` to also key off the viewport / window height into the post list – i.e. when the scroll view resizes (due to getting squeezed by the draft input growing), `useStickToScrollStart` triggers and sticks the scroll to bottom if needed.

This still doesn't work great on Firefox – I took some time but couldn't figure out why. See video below – there's a mysterious scroll that happens on the first input _after_ growing the draft input. My best guess is that it's a bug in the browser's native scroll anchoring implementation (although enabling the `FORCE_MANUAL_SCROLL_ANCHORING` flag did not fix).

## How did I test?
on Chrome, Safari, Firefox (FF has some bugs, visible in videos below):
- draft some messages that grow the input height, while locked to scroll bottom (see screen recording below)
- draft some messages that grow input while scrolled away from bottom - scroll does not stick to bottom
- scroll away from bottom, then back to bottom, then grow input height – scroll sticks to bottom

## Risks and impact

- Safe to rollback without consulting PR author? Yes
- Affects important code area:
  - [ ] Onboarding
  - [ ] State / providers
  - [ ] Message sync
  - [x] Channel display
  - [ ] Notifications
  - [ ] Other:

## Rollback plan
git revert

## Screenshots / videos
| Browser | Before | After |
| --- | --- | --- |
| Chrome | <video src="https://github.com/user-attachments/assets/eb7abc02-b2fb-4b08-82fa-0488de6768e4" /> | <video src="https://github.com/user-attachments/assets/2f709b36-50f6-4188-a97a-41edcfedc3c5" /> |
| Firefox (**reverted** - see below) | <video src="https://github.com/user-attachments/assets/497a4cf6-b7c4-427b-8e72-f1d290de05ab" /> | <video src="https://github.com/user-attachments/assets/923c890d-061a-445d-8e4f-331c85ae3d13" /> |


Safari not shown, but appears to act the same as Chrome