### PR TITLE
ImageInput: show errors on upload, don't let users without configs attempt to upload

### DIFF
--- a/apps/tlon-web/e2e/group-customization.spec.ts
+++ b/apps/tlon-web/e2e/group-customization.spec.ts
@@ -50,13 +50,13 @@ test('should customize group name, icon, and description', async ({
     await page.getByText('My Group').click();
   }
 
-  // Change the group icon/picture
+  // Change the group icon/picture. TODO: Implement image upload functionality in e2e tests. e2e ships don't have a storage config.
   await helpers.openGroupCustomization(page);
-  await helpers.changeGroupIcon(page); // No image path provided, so it will just test the interface
+  // await helpers.changeGroupIcon(page); // No image path provided, so it will just test the interface
 
   // close the modal
   // not clear why we need to click the first one, but it works
-  await page.getByTestId('AttachmentSheetCloseButton').first().click();
+  // await page.getByTestId('AttachmentSheetCloseButton').first().click();
 
   // Change the group description
   await helpers.changeGroupDescription(page, 'This is a test group');
@@ -69,4 +69,3 @@ test('should customize group name, icon, and description', async ({
   }
   await page.getByText('Cancel').click();
 });
-

--- a/packages/app/ui/components/Form/inputs.tsx
+++ b/packages/app/ui/components/Form/inputs.tsx
@@ -16,7 +16,7 @@ import {
   useState,
 } from 'react';
 import React from 'react';
-import { Alert, TextInput as RNTextInput } from 'react-native';
+import { TextInput as RNTextInput } from 'react-native';
 import {
   ScrollView,
   Spinner,
@@ -205,10 +205,14 @@ export const ImageInput = XStack.styleable<{
 
   const handleSheetToggled = useCallback(() => {
     if (!canUpload) {
-      Alert.alert('Configure storage to upload images');
+      showToast({
+        message: 'Please configure storage settings to upload images',
+        duration: 3000,
+      });
+      return; // Don't open the sheet
     }
     setSheetOpen((open) => !open);
-  }, [canUpload]);
+  }, [canUpload, showToast]);
 
   const { attachment } = useMappedImageAttachments(
     assetUri ? { attachment: assetUri } : {}
@@ -236,15 +240,22 @@ export const ImageInput = XStack.styleable<{
 
   return (
     <>
-      <XStack gap="$m" ref={ref}>
-        <ImageInputButtonFrame group onPress={handleSheetToggled}>
-          <ImageInputButtonText>{buttonLabel}</ImageInputButtonText>
+      <XStack gap="$m" ref={ref} opacity={canUpload ? 1 : 0.5}>
+        <ImageInputButtonFrame
+          group
+          onPress={handleSheetToggled}
+          disabled={!canUpload}
+        >
+          <ImageInputButtonText disabled={!canUpload}>
+            {!canUpload ? 'Storage not configured' : buttonLabel}
+          </ImageInputButtonText>
         </ImageInputButtonFrame>
         <ImageInputPreviewFrame
           height={isWindowNarrow ? undefined : '100%'}
           onPress={handleSheetToggled}
+          disabled={!canUpload}
         >
-          <Icon type="Camera" color="$tertiaryText" />
+          <Icon type="Camera" color={canUpload ? '$tertiaryText' : '$border'} />
           {placeholderUri ? (
             <ImageInputPreviewImage source={{ uri: placeholderUri }} />
           ) : null}
@@ -275,6 +286,14 @@ const ImageInputButtonFrame = styled(InputFrame, {
   padding: '$xl',
   flex: 1,
   pressStyle: { backgroundColor: '$border' },
+  variants: {
+    disabled: {
+      true: {
+        cursor: 'not-allowed',
+        pressStyle: { backgroundColor: 'transparent' },
+      },
+    },
+  },
 });
 
 const ImageInputButtonText = styled(Text, {
@@ -283,6 +302,14 @@ const ImageInputButtonText = styled(Text, {
   color: '$secondaryText',
   lineHeight: '$s',
   '$group-press': { color: '$tertiaryText' },
+  variants: {
+    disabled: {
+      true: {
+        color: '$tertiaryText',
+        '$group-press': { color: '$tertiaryText' },
+      },
+    },
+  },
 });
 
 const ImageInputPreviewFrame = styled(View, {
@@ -293,6 +320,14 @@ const ImageInputPreviewFrame = styled(View, {
   alignItems: 'center',
   justifyContent: 'center',
   pressStyle: { opacity: 0.5 },
+  variants: {
+    disabled: {
+      true: {
+        cursor: 'not-allowed',
+        pressStyle: { opacity: 1 },
+      },
+    },
+  },
 });
 
 const ImageInputPreviewImage = styled(Image, {

--- a/packages/app/ui/components/Form/inputs.tsx
+++ b/packages/app/ui/components/Form/inputs.tsx
@@ -1,4 +1,4 @@
-import { VariantsFromValues, useIsWindowNarrow } from '@tloncorp/ui';
+import { VariantsFromValues, useIsWindowNarrow, useToast } from '@tloncorp/ui';
 import { Button } from '@tloncorp/ui';
 import { Icon, IconType } from '@tloncorp/ui';
 import { Image } from '@tloncorp/ui';
@@ -189,6 +189,7 @@ export const ImageInput = XStack.styleable<{
   );
   const { canUpload } = useAttachmentContext();
   const isWindowNarrow = useIsWindowNarrow();
+  const showToast = useToast();
 
   useEffect(() => {
     if (assetUri !== value) {
@@ -216,8 +217,18 @@ export const ImageInput = XStack.styleable<{
   useEffect(() => {
     if (attachment && attachment.uploadState?.status === 'success') {
       setAssetUri?.(attachment.uploadState.remoteUri);
+    } else if (attachment && attachment.uploadState?.status === 'error') {
+      // Show toast with error message
+      const errorMessage =
+        attachment.uploadState.errorMessage || 'Upload failed';
+      showToast({
+        message: `Failed to upload image: ${errorMessage}`,
+        duration: 5000,
+      });
+      // Clear the failed upload so user can try again
+      setAssetUri(undefined);
     }
-  }, [attachment]);
+  }, [attachment, showToast]);
 
   const handleImageRemoved = useCallback(() => {
     setAssetUri(undefined);

--- a/packages/app/ui/components/Form/inputs.tsx
+++ b/packages/app/ui/components/Form/inputs.tsx
@@ -240,11 +240,12 @@ export const ImageInput = XStack.styleable<{
 
   return (
     <>
-      <XStack gap="$m" ref={ref} opacity={canUpload ? 1 : 0.5}>
+      <XStack gap="$m" ref={ref}>
         <ImageInputButtonFrame
           group
           onPress={handleSheetToggled}
           disabled={!canUpload}
+          opacity={canUpload ? 1 : 0.5}
         >
           <ImageInputButtonText disabled={!canUpload}>
             {!canUpload ? 'Storage not configured' : buttonLabel}
@@ -254,6 +255,7 @@ export const ImageInput = XStack.styleable<{
           height={isWindowNarrow ? undefined : '100%'}
           onPress={handleSheetToggled}
           disabled={!canUpload}
+          opacity={!canUpload && !assetUri ? 0.5 : 1}
         >
           <Icon type="Camera" color={canUpload ? '$tertiaryText' : '$border'} />
           {placeholderUri ? (


### PR DESCRIPTION
## Summary

1) show error messages from uploads in ImageInput as a toast to the user
2) don't allow users who can't upload to even attempt to upload


## How did I test?

Tested on web and iOS sim, with ships that do and do not have a storage config.

## Risks and impact

- Safe to rollback without consulting PR author? Yes
- Affects important code area: N/A

## Rollback plan

Revert
