### PR TITLE
groups: clear out >3kb image metadata

### DIFF
--- a/desk/app/groups.hoon
+++ b/desk/app/groups.hoon
@@ -668,7 +668,11 @@
   ::
   %+  roll  ~(tap by groups)
   |=  [[=flag:g =net:g =group:g] =_cor]
-  ?.  (gth (met 3 image.meta.group) 3.000)  cor
+  ?:  ?|  =('' image.meta.group)
+          =('http' (end 3^4 image.meta.group))
+          =('#' (end 3 image.meta.group))
+      ==
+    cor
   ?:  =(p.flag our.bowl)
     ::  if it's our group, edit the metadata and send out updates about it
     ::

--- a/desk/app/groups.hoon
+++ b/desk/app/groups.hoon
@@ -672,7 +672,7 @@
   ?:  =(p.flag our.bowl)
     ::  if it's our group, edit the metadata and send out updates about it
     ::
-    se-abet:(se-c-group:(se-abed:se-core flag) %meta meta.group(image ''))
+    se-abet:(se-c-group:(se-abed:se-core:cor flag) %meta meta.group(image ''))
   ::  if it's not ours, just clean it up locally so it doesn't clog our pipes
   ::
   cor(groups (~(put by groups) flag net group(image.meta '')))

--- a/desk/app/groups.hoon
+++ b/desk/app/groups.hoon
@@ -661,7 +661,21 @@
   =?  cor  !=(~ caz-6-to-7)  (emil caz-6-to-7)
   ?>  ?=(%7 -.old)
   =.  state  old
-  inflate-io
+  =.  cor  inflate-io
+  ::  until client bugs are fixed and data validation happens on-ingress,
+  ::  always trawl our groups for raw image data (or really, metadata of a
+  ::  size that could be raw image data) and unset those.
+  ::
+  %+  roll  ~(tap by groups)
+  |=  [[=flag:g =net:g =group:g] =_cor]
+  ?.  (gth (met 3 image.meta.group) 3.000)  cor
+  ?:  =(p.flag our.bowl)
+    ::  if it's our group, edit the metadata and send out updates about it
+    ::
+    se-abet:(se-c-group:(se-abed:se-core flag) %meta meta.group(image ''))
+  ::  if it's not ours, just clean it up locally so it doesn't clog our pipes
+  ::
+  cor(groups (~(put by groups) flag net group(image.meta '')))
   ::
   +$  any-state
     $%  state-7


### PR DESCRIPTION
## Summary

Various bugs might lead to big data being injected into a group's metadata fields. Certainly, we don't do any data validation/sanitization right now. In practice, this means some groups have huge image metadata fields containing the raw image data.

Fixes TLON-4753

## Changes

Here, we modify agent load logic, so that we always do a quick pass over the groups we have in state. If a group we host is affected, run a command that clears it, ensuring updates get sent to subscribers informing them of the change. If it's a foreign group, just clear the data locally, but don't send any subscription updates.

## How did I test?

Tested on my fakezod with contrived group metadata setup.

## Risks and impact

Maybe the threshold is too low? I've seen links (in posts) as big as 2.7kb. That's kinda nuts honestly, imo if your groups image url is >3kb you had it coming. (;

Realizing now the big data probably ended up in the logs on group hosts. This data is mostly inert, all it really does it take up space in the loom, I don't think we ever send it out in practice. At least, not after the "flattened first update" change from #5017, which notably hasn't been merged yet.

- Yes, safe to rollback without consulting PR author.
- Affects important code area:
  - [ ] Onboarding
  - [ ] State / providers
  - [ ] Message sync
  - [ ] Channel display
  - [ ] Notifications
  - [ ] Other:

## Rollback plan

Can just `git revert`.