### PR TITLE
client: fix group preview loading

### DIFF
--- a/packages/shared/src/store/dbHooks.ts
+++ b/packages/shared/src/store/dbHooks.ts
@@ -13,11 +13,7 @@ import { getConstants } from '../domain/constants';
 import * as logic from '../logic';
 import * as ub from '../urbit';
 import { hasCustomS3Creds, hasHostingUploadCreds } from './storage';
-import {
-  syncChannelPreivews,
-  syncGroupPreviews,
-  syncPostReference,
-} from './sync';
+import { syncChannelPreivews, syncPostReference } from './sync';
 import { keyFromQueryDeps, useKeyFromQueryDeps } from './useKeyFromQueryDeps';
 
 export * from './useChannelSearch';

--- a/packages/shared/src/store/hostingActions.ts
+++ b/packages/shared/src/store/hostingActions.ts
@@ -5,7 +5,6 @@ import * as domain from '../domain';
 import { AnalyticsEvent } from '../domain';
 import * as logic from '../logic';
 import { withRetry } from '../logic';
-import { syncGroupPreviews } from './sync';
 
 const logger = createDevLogger('hostingActions', true);
 

--- a/packages/shared/src/store/sync.ts
+++ b/packages/shared/src/store/sync.ts
@@ -1260,6 +1260,7 @@ export const handleChatUpdate = async (
       }
 
       await db.insertPostReactions(
+
         {
           reactions: [
             {
@@ -1706,6 +1707,11 @@ export const syncStart = async (alreadySubscribed?: boolean) => {
     updateSession({ phase: 'ready' });
 
     await failEnqueuedPosts();
+
+    // fire off relevant channel posts sync, but don't wait for it
+    syncRelevantChannelPosts({ priority: SyncPriority.Low }).then(() => {
+      logger.crumb(`finished channel predictive sync`);
+    });
 
     // post sync initialization work
     await verifyUserInviteLink();

--- a/packages/shared/src/store/sync.ts
+++ b/packages/shared/src/store/sync.ts
@@ -1260,7 +1260,6 @@ export const handleChatUpdate = async (
       }
 
       await db.insertPostReactions(
-
         {
           reactions: [
             {
@@ -1707,11 +1706,6 @@ export const syncStart = async (alreadySubscribed?: boolean) => {
     updateSession({ phase: 'ready' });
 
     await failEnqueuedPosts();
-
-    // fire off relevant channel posts sync, but don't wait for it
-    syncRelevantChannelPosts({ priority: SyncPriority.Low }).then(() => {
-      logger.crumb(`finished channel predictive sync`);
-    });
 
     // post sync initialization work
     await verifyUserInviteLink();


### PR DESCRIPTION
## Summary

Fixes TLON-4795. We were seeing what looked like looping when loading a group preview. It turns out the first time you load a group preview and for as long as the `useGroupPreview` hook is active, the query will fetch and modify the DB for groups, which will then trigger an invalidation, which then triggers the query to fire again. This separates the DB insertion to happen only once if we don't have the group in the DB originally.

## Changes

- removed unused imports
- changed flow of `useGroupPreview` to prevent query loops

## How did I test?

On my main ship, navigated to a channel with a group preview and observed only one preview call instead of constant fetches

## Risks and impact

- Safe to rollback without consulting PR author? Yes
- Affects important code area:
  - [ ] Onboarding
  - [ ] State / providers
  - [ ] Message sync
  - [ ] Channel display
  - [ ] Notifications
  - [ ] Other:

## Rollback plan

<!-- Describe the steps to revert these changes if needed. -->

## Screenshots / videos

<!-- Attach any relevant media. -->
