### PR TITLE
remove webScroller feature flag, defaulting to enabled

### DIFF
--- a/packages/app/fixtures/Channel.fixture.tsx
+++ b/packages/app/fixtures/Channel.fixture.tsx
@@ -32,7 +32,6 @@ import {
   tlonLocalGettingStarted,
   tlonLocalIntros,
 } from './fakeData';
-import { useFixtureFeatureFlag } from './useFixtureFeatureFlag';
 
 const posts = createFakePosts(100);
 const notebookPosts = createFakePosts(5, 'note');
@@ -58,8 +57,6 @@ function noopProps<T extends object>() {
 const ChannelFixtureWrapper = ({
   children,
 }: PropsWithChildren<{ theme?: 'light' | 'dark' }>) => {
-  useFixtureFeatureFlag('webScroller');
-
   return (
     <AppDataContextProvider contacts={initialContacts}>
       <FixtureWrapper fillWidth fillHeight>

--- a/packages/app/lib/featureFlags.ts
+++ b/packages/app/lib/featureFlags.ts
@@ -10,10 +10,6 @@ export const featureMeta = {
     default: false,
     label: 'Enable collecting and reporting performance data',
   },
-  webScroller: {
-    default: false,
-    label: 'Use web-native scroll implementation for chats',
-  },
   customChannelCreation: {
     default: false,
     label: 'Enable creating custom channels',

--- a/packages/app/ui/components/Channel/PostList/PostList.web.tsx
+++ b/packages/app/ui/components/Channel/PostList/PostList.web.tsx
@@ -3,7 +3,6 @@ import { isEqual } from 'lodash';
 import * as React from 'react';
 import { View } from 'react-native';
 
-import { useFeatureFlag } from '../../../../lib/featureFlags';
 import { ScrollAnchor } from '../Scroller';
 import { PostList as PostListNative } from './PostListFlatList';
 import { PostListComponent, PostWithNeighbors } from './shared';
@@ -11,9 +10,7 @@ import { PostListComponent, PostWithNeighbors } from './shared';
 const FORCE_MANUAL_SCROLL_ANCHORING: boolean = false;
 
 export const PostList: PostListComponent = React.forwardRef((props, ref) => {
-  const [webScrollerEnabled] = useFeatureFlag('webScroller');
-
-  if (webScrollerEnabled && props.numColumns === 1) {
+  if (props.numColumns === 1) {
     return <PostListSingleColumn {...props} ref={ref} />;
   } else {
     // Use the native implementation for multi-column lists


### PR DESCRIPTION
## Summary
fixes TLON-4664
Everyone gets the native web scroller introduced in https://github.com/tloncorp/tlon-apps/pull/4868

## Changes
Removes the `webScroller` feature flag, and changes the access to code equivalent to `webScroller = true`.

## How did I test?
Opened web app (Firefox) – flag doesn't show up in flags setting screen, and channel appears to be using web scroller (e.g. highlighting text works well).

## Risks and impact

- Safe to rollback without consulting PR author? Yes
- Affects important code area:
  - [ ] Onboarding
  - [ ] State / providers
  - [ ] Message sync
  - [x] Channel display
  - [ ] Notifications
  - [ ] Other:

## Rollback plan
git revert
