### PR TITLE
forwarding: fix issue with message forward hang on iOS

### DIFF
--- a/packages/app/ui/components/ChatMessage/ChatMessageActions/MessageActions.tsx
+++ b/packages/app/ui/components/ChatMessage/ChatMessageActions/MessageActions.tsx
@@ -6,7 +6,7 @@ import * as logic from '@tloncorp/shared/logic';
 import * as store from '@tloncorp/shared/store';
 import { useCopy } from '@tloncorp/ui';
 import { memo, useMemo } from 'react';
-import { Alert } from 'react-native';
+import { Alert, Platform } from 'react-native';
 import { isWeb } from 'tamagui';
 
 import { useRenderCount } from '../../../../hooks/useRenderCount';
@@ -257,8 +257,17 @@ export async function handleAction({
       post.hidden ? store.showPost({ post }) : store.hidePost({ post });
       break;
     case 'forward':
-      onForward?.(post);
-      break;
+      // On iOS, dismiss the current modal first, then open the forward sheet
+      // to avoid race condition between two modals
+      if (Platform.OS === 'ios') {
+        dismiss();
+        setTimeout(() => onForward?.(post), 300);
+      } else {
+        onForward?.(post);
+        dismiss();
+      }
+      triggerHaptic('success');
+      return; // Early return to avoid double dismiss
   }
 
   triggerHaptic('success');


### PR DESCRIPTION
## Summary

When users tapped "Forward post" on iOS, the app would completely freeze up. Turns out we had a a race condition with the modal, we were trying to open the forward sheet while simultaneously closing the message actions sheet, and iOS in particular didn't like that.

## Changes

- For iOS devices: we now dismiss the action sheet first, wait a bit (300ms), then open the forward sheet
- For Android/web: kept the original flow since they handle simultaneous modals just fine
- Added an early return to avoid calling dismiss twice and keep the haptic feedback working

## How did I test?

Tested on web and the sim.

## Risks and impact

- Safe to rollback without consulting PR author? Yes
- Affects important code area: N/A

## Rollback plan

Revert

## Screenshots / videos

N/A
