### PR TITLE
unreads: fix flickering unread badge on channels

### DIFF
--- a/packages/app/ui/components/Channel/index.tsx
+++ b/packages/app/ui/components/Channel/index.tsx
@@ -191,7 +191,7 @@ export const Channel = forwardRef<ChannelMethods, ChannelProps>(
 
     const inView = useIsFocused();
     const hasLoaded = !!(posts && channel);
-    const hasUnreads = (channel?.unread?.count ?? 0) > 0;
+    const hasUnreads = (channel?.unread?.countWithoutThreads ?? 0) > 0;
     useEffect(() => {
       if (hasUnreads && hasLoaded && inView) {
         markRead();


### PR DESCRIPTION
## Summary

fixes tlon-4804

Fixes unread count flickering that occurs when viewing channels with *only* thread unreads.

A feedback loop was causing unread indicators to flicker continuously when:
1. A channel had unread thread messages but no main channel unreads
2. The Channel component would see `unread.count > 0` (which includes thread unreads) and mark the channel as read
3. The server would continue sending updates because thread unreads still existed
4. This created an infinite loop of marking read → receiving updates → marking read

I'm not totally certain why this bubbled up now, the Channel component has worked this way since March. This issue emerged around September 5th when we made some backend changes to how thread unreads are filtered, I'm assuming that's related.

## Changes

- Updated the channel component to use `countWithoutThreads` instead of `count` when determining if a channel should be marked as read

## How did I test?

- Created a channel with thread-only unreads (no main channel messages unread)
- Verified the unread indicator no longer flickers when viewing the channel
- Confirmed main channel unreads still trigger read marking correctly
- Tested both group channels and DMs to ensure consistent behavior

## Risks and impact

- Safe to rollback without consulting PR author? Yes
- Affects important code area: N/A

## Rollback plan

Revert

## Screenshots / videos

N/A
