### PR TITLE
groups: let +fi-core only emit a single foreign update

### DIFF
--- a/desk/app/groups.hoon
+++ b/desk/app/groups.hoon
@@ -3935,6 +3935,7 @@
 ::
 ++  fi-core
   |_  [=flag:g foreign:g]
+  +*  foreign  +<+
   ::
   ++  fi-core  .
   ::  +fi-abed: init
@@ -3949,21 +3950,19 @@
   ::
   ++  fi-abet
     ^+  cor
-    =.  foreigns  (~(put by foreigns) flag +<+)
-    ::TODO figure out the foreign lifetime logic after designining
-    ::     new endpoints for the client
-    ::
+    =+  old-foreign=(~(get by foreigns) flag)
+    =.  foreigns  (~(put by foreigns) flag foreign)
     =?  foreigns  ?=([~ %done] progress)
       (~(del by foreigns) flag)
-    =.  fi-core  fi-give-update
+    =?  fi-core  |(?=(~ old-foreign) !=(u.old-foreign foreign))
+      fi-give-update
     cor
   ::  +fi-give-update: give foreigns update
   ::
   ++  fi-give-update
-    =/  foreigns  (~(put by foreigns) flag +<+)
-    =/  gangs-2
-      (~(run by foreigns) gang:v2:foreign:v7:gc)
-    =.  cor  (give %fact ~[/gangs/updates] gangs+!>(gangs-2))
+    =/  gang-2
+      (gang:v2:foreign:v7:gc foreign)
+    =.  cor  (give %fact ~[/gangs/updates] gangs+!>(`gangs:v2:gv`(my flag^gang-2 ~)))
     fi-core
   ::
   ++  fi-activity


### PR DESCRIPTION
## Summary

The bulk updating in +fi-core has been suspected of unnecessarily burdening the client. We change the updating logic to only emit a single update for the relevant foreign group.

## Changes

1. Adjust logic in `+fi-give-update` to only emit a single foreign group fact.

## How did I test?

Run the change on two ships. Verified that received group invitations show up.

## Risks and impact

- Safe to rollback without consulting PR author? Yes
- Affects important code area:
  - [ ] Onboarding
  - [ ] State / providers
  - [ ] Message sync
  - [ ] Channel display
  - [ ] Notifications
  - [ ] Other:

## Rollback plan

Rollback as needed.
