### PR TITLE
message actions: hide actions that require a connection when we're not connected

### DIFF
--- a/packages/app/ui/components/ChatMessage/ChatMessageActions/MessageActions.tsx
+++ b/packages/app/ui/components/ChatMessage/ChatMessageActions/MessageActions.tsx
@@ -6,7 +6,7 @@ import * as logic from '@tloncorp/shared/logic';
 import * as store from '@tloncorp/shared/store';
 import { useCopy } from '@tloncorp/ui';
 import { memo, useMemo } from 'react';
-import { Alert, Platform } from 'react-native';
+import { Platform } from 'react-native';
 import { isWeb } from 'tamagui';
 
 import { useRenderCount } from '../../../../hooks/useRenderCount';
@@ -85,6 +85,10 @@ const ConnectedAction = memo(function ConnectedAction({
   );
 
   const visible = useMemo(() => {
+    if (action.isNetworkDependent && connectionStatus !== 'Connected') {
+      return false;
+    }
+
     switch (actionId) {
       case 'startThread':
         // only show start thread if
@@ -121,6 +125,8 @@ const ConnectedAction = memo(function ConnectedAction({
     currentUserId,
     channel.type,
     currentUserIsAdmin,
+    action.isNetworkDependent,
+    connectionStatus,
   ]);
 
   useRenderCount(`MessageAction-${actionId}`);
@@ -131,7 +137,6 @@ const ConnectedAction = memo(function ConnectedAction({
 
   return (
     <ActionList.Action
-      disabled={action.isNetworkDependent && connectionStatus !== 'Connected'}
       height="auto"
       onPress={() =>
         handleAction({
@@ -146,8 +151,6 @@ const ConnectedAction = memo(function ConnectedAction({
           onForward: forwardPost,
           onViewReactions,
           addAttachment,
-          isConnected: connectionStatus === 'Connected',
-          isNetworkDependent: action.isNetworkDependent,
         })
       }
       key={actionId}
@@ -183,8 +186,6 @@ export async function handleAction({
   onViewReactions,
   onForward,
   addAttachment,
-  isConnected,
-  isNetworkDependent,
 }: {
   id: ChannelAction.Id;
   post: db.Post;
@@ -197,17 +198,7 @@ export async function handleAction({
   onForward?: (post: db.Post) => void;
   onViewReactions?: (post: db.Post) => void;
   addAttachment: (attachment: Attachment) => void;
-  isConnected: boolean;
-  isNetworkDependent: boolean;
 }) {
-  if (isNetworkDependent && !isConnected) {
-    Alert.alert(
-      'App is disconnected',
-      'This action is unavailable while the app is in a disconnected state.'
-    );
-    return;
-  }
-
   const [path, reference] = logic.postToContentReference(post);
 
   switch (id) {


### PR DESCRIPTION
fixes tlon-4807

## Summary

OTT, if we're offline then we hide the "connected" actions.

## How did I test?

Tested in the sim and on web by pointing the app at a ship and shutting that ship down.

## Risks and impact

- Safe to rollback without consulting PR author? Yes
- Affects important code area: N/A

## Rollback plan

<!-- Describe the steps to revert these changes if needed. -->

## Screenshots / videos

<img width="1179" height="2556" alt="Simulator Screenshot - iPhone 15 - 2025-09-10 at 13 51 44" src="https://github.com/user-attachments/assets/894bd0b8-259c-4a53-b937-4a6cbbbec511" />

