### PR TITLE
GroupMembersScreenView: add filter input

### DIFF
--- a/packages/app/ui/components/GroupMembersScreenView.tsx
+++ b/packages/app/ui/components/GroupMembersScreenView.tsx
@@ -273,7 +273,7 @@ export function GroupMembersScreenView({
         <View paddingHorizontal="$l" paddingBottom="$s">
           <TextInput
             icon="Search"
-            placeholder="Search by name or @p handle"
+            placeholder="Search by name or ID"
             value={searchQuery}
             onChangeText={setSearchQuery}
             spellCheck={false}

--- a/packages/app/ui/components/GroupMembersScreenView.tsx
+++ b/packages/app/ui/components/GroupMembersScreenView.tsx
@@ -1,6 +1,7 @@
 import { parseGroupId } from '@tloncorp/shared/api';
 import * as db from '@tloncorp/shared/db';
 import { SectionListHeader } from '@tloncorp/ui';
+import Fuse from 'fuse.js';
 import { useCallback, useMemo, useState } from 'react';
 import { SectionList } from 'react-native';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
@@ -8,6 +9,7 @@ import { View, getTokenValue } from 'tamagui';
 
 import { useIsAdmin } from '../utils';
 import { ContactList } from './ContactList';
+import { TextInput } from './Form';
 import { GroupJoinRequestSheet } from './GroupJoinRequestSheet';
 import { ProfileSheet } from './ProfileSheet';
 import { ScreenHeader } from './ScreenHeader';
@@ -51,6 +53,7 @@ export function GroupMembersScreenView({
 }) {
   const { bottom } = useSafeAreaInsets();
   const [selectedContact, setSelectedContact] = useState<string | null>(null);
+  const [searchQuery, setSearchQuery] = useState('');
   const currentUserIsAdmin = useIsAdmin(groupId, currentUserId);
   const contacts = useMemo(
     () =>
@@ -60,9 +63,32 @@ export function GroupMembersScreenView({
     [members]
   );
 
+  const fuse = useMemo(() => {
+    return new Fuse(members, {
+      keys: [
+        {
+          name: 'contact.nickname',
+          getFn: (member) => member.contact?.nickname || '',
+        },
+        {
+          name: 'contact.id',
+          getFn: (member) => member.contact?.id || member.contactId,
+        },
+      ],
+      threshold: 0.4,
+    });
+  }, [members]);
+
+  const filteredMembers = useMemo(() => {
+    if (!searchQuery.trim()) {
+      return members;
+    }
+    return fuse.search(searchQuery).map((result) => result.item);
+  }, [members, searchQuery, fuse]);
+
   const membersByRole = useMemo(
     () =>
-      members.reduce<Record<string, db.ChatMember[]>>((acc, m) => {
+      filteredMembers.reduce<Record<string, db.ChatMember[]>>((acc, m) => {
         if (m.roles !== undefined && m.roles !== null) {
           m.roles.forEach((role) => {
             if (acc[role.roleId] === undefined) {
@@ -73,36 +99,72 @@ export function GroupMembersScreenView({
         }
         return acc;
       }, {}),
-    [members]
+    [filteredMembers]
   );
 
-  const membersWithoutRoles = members
+  const membersWithoutRoles = filteredMembers
     .filter((m) => m.status !== 'invited')
     .filter((m) => m.roles?.length === 0 || m.roles === null);
 
-  const invitedMembers = members.filter((m) => m.status === 'invited');
+  const invitedMembers = filteredMembers.filter((m) => m.status === 'invited');
 
-  const bannedUserData: db.ChatMember[] = useMemo(
-    () =>
-      bannedUsers.map((b) => ({
-        contactId: b.contactId,
-        roles: null,
-        contact: contacts.find((c) => c.id === b.contactId),
-        membershipType: 'group',
-      })),
-    [bannedUsers, contacts]
-  );
+  const bannedUserData: db.ChatMember[] = useMemo(() => {
+    const bannedData = bannedUsers.map((b) => ({
+      contactId: b.contactId,
+      roles: null,
+      contact: contacts.find((c) => c.id === b.contactId),
+      membershipType: 'group' as const,
+    }));
 
-  const joinRequestData: db.ChatMember[] = useMemo(
-    () =>
-      joinRequests.map((r) => ({
-        contactId: r.contactId,
-        roles: null,
-        contact: contacts.find((c) => c.id === r.contactId),
-        membershipType: 'group',
-      })),
-    [joinRequests, contacts]
-  );
+    if (!searchQuery.trim()) {
+      return bannedData;
+    }
+
+    const bannedFuse = new Fuse(bannedData, {
+      keys: [
+        {
+          name: 'contact.nickname',
+          getFn: (member) => member.contact?.nickname || '',
+        },
+        {
+          name: 'contact.id',
+          getFn: (member) => member.contact?.id || member.contactId,
+        },
+      ],
+      threshold: 0.4,
+    });
+
+    return bannedFuse.search(searchQuery).map((result) => result.item);
+  }, [bannedUsers, contacts, searchQuery]);
+
+  const joinRequestData: db.ChatMember[] = useMemo(() => {
+    const requestData = joinRequests.map((r) => ({
+      contactId: r.contactId,
+      roles: null,
+      contact: contacts.find((c) => c.id === r.contactId),
+      membershipType: 'group' as const,
+    }));
+
+    if (!searchQuery.trim()) {
+      return requestData;
+    }
+
+    const requestFuse = new Fuse(requestData, {
+      keys: [
+        {
+          name: 'contact.nickname',
+          getFn: (member) => member.contact?.nickname || '',
+        },
+        {
+          name: 'contact.id',
+          getFn: (member) => member.contact?.id || member.contactId,
+        },
+      ],
+      threshold: 0.4,
+    });
+
+    return requestFuse.search(searchQuery).map((result) => result.item);
+  }, [joinRequests, contacts, searchQuery]);
   const selectedIsRequest = joinRequests.some(
     (request) => request.contactId === selectedContact
   );
@@ -200,10 +262,33 @@ export function GroupMembersScreenView({
 
   const { host: groupHostId } = parseGroupId(groupId);
 
+  const handlePressClear = useCallback(() => {
+    setSearchQuery('');
+  }, []);
+
   return (
     <>
       <View backgroundColor="$background" flex={1}>
         <ScreenHeader title="Members" backAction={goBack} />
+        <View paddingHorizontal="$l" paddingBottom="$s">
+          <TextInput
+            icon="Search"
+            placeholder="Search by name or @p handle"
+            value={searchQuery}
+            onChangeText={setSearchQuery}
+            spellCheck={false}
+            autoCorrect={false}
+            autoCapitalize="none"
+            rightControls={
+              searchQuery !== '' ? (
+                <TextInput.InnerButton
+                  label="Clear"
+                  onPress={handlePressClear}
+                />
+              ) : undefined
+            }
+          />
+        </View>
         <SectionList
           sections={sectionedData}
           keyExtractor={keyExtractor}


### PR DESCRIPTION
## Summary

I ran into TLON-4639 while attempting to give ~wittyr-witbes admin control of Tlon Studio, which has some 6K members. Scrolling through the entire list was not fun. Therefore, this fixes TLON-4639 by adding a filter input to the group members screen view. 

## Changes

- Creates Fuse.js objects for members, banned users, invited users, and users asking for entry
- Adds an input box to the top of the members list screen to allow for filtering by name or @p
- Allows the user to clear the input and reset the filter

## How did I test?

- Open a group with lots of members (Tlon Studio)
- Search for a known @p far down in the alphabet (I used ~wittyr-witbes)
- Verify that the exact match shows at the top of the list
- Enter a known nickname
- Verify that the exact match(es) show at the the top of the list
- Enter a partial @p or partial nickname
- Verify that the results make sense

## Risks and impact

- Safe to rollback without consulting PR author? Yes
- Affects important code area:
  - [ ] Onboarding
  - [ ] State / providers
  - [ ] Message sync
  - [ ] Channel display
  - [ ] Notifications
  - [x] Other: group settings

## Rollback plan

Revert

## Screenshots / videos

https://github.com/user-attachments/assets/fa40c75a-6585-4206-add6-36d164347cc7

