### PR TITLE
Fix failing groups-ui scries

### DIFF
--- a/desk/app/channels.hoon
+++ b/desk/app/channels.hoon
@@ -1338,7 +1338,7 @@
     ::  /x/v/init: get unreads and unversioned channels
     ::
       [%x ?(%v0 %v1) %init ~]
-    ``noun+!>([unreads (uv-channels-1:utils v-channels)])
+    ``noun+!>([unreads (uv-channels:utils v-channels |)])
     ::
       [%x %v2 %init ~]
     ``noun+!>([unreads (uv-channels:utils v-channels |)])

--- a/desk/app/groups-ui.hoon
+++ b/desk/app/groups-ui.hoon
@@ -132,8 +132,8 @@
     ``ships+!>(get-suggested-contacts)
   ::
       [%x %init ~]
-    =+  .^([=groups-ui:v2:gv =gangs:v2:gv] (scry %gx %groups /v1/init/noun))
-    =+  .^([=unreads:d channels=channels-0:d] (scry %gx %channels /v1/init/noun))
+    =+  .^([=groups-ui:v2:gv =gangs:v2:gv] (scry %gx %groups /init/v1/noun))
+    =+  .^([=unreads:d channels=channels:v1:old:d] (scry %gx %channels /v1/init/noun))
     =+  .^(chat=chat-0:u (scry %gx %chat /init/noun))
     =+  .^(profile=? (scry %gx %profile /bound/loob))
     =/  init=init-0:u
@@ -147,8 +147,8 @@
       ==
     ``ui-init+!>(`init-0:u`init)
       [%x %v1 %init ~]
-    =+  .^([=groups-ui:v2:gv =gangs:v2:gv] (scry %gx %groups /v1/init/noun))
-    =+  .^([=unreads:d =channels:v7:old:d] (scry %gx %channels /v2/init/noun))
+    =+  .^([=groups-ui:v2:gv =gangs:v2:gv] (scry %gx %groups /init/v1/noun))
+    =+  .^([=unreads:d =channels:v1:old:d] (scry %gx %channels /v2/init/noun))
     =+  .^(chat=chat-0:u (scry %gx %chat /init/noun))
     =+  .^(profile=? (scry %gx %profile /bound/loob))
     =/  init=init-1:u
@@ -178,8 +178,8 @@
     ``ui-heads-3+!>(`mixed-heads-3:u`[chan chat])
   ::
       [%x %v2 %init ~]
-    =+  .^([=groups-ui:v2:gv =gangs:v2:gv] (scry %gx %groups /v1/init/noun))
-    =+  .^([* =channels:v7:old:d] (scry %gx %channels /v2/init/noun))
+    =+  .^([=groups-ui:v2:gv =gangs:v2:gv] (scry %gx %groups /init/v1/noun))
+    =+  .^([* =channels:v1:d] (scry %gx %channels /v2/init/noun))
     =+  .^(chat=chat-0:u (scry %gx %chat /init/noun))
     =+  .^(=activity:v2:old:a (scry %gx %activity /activity/noun))
     =+  .^(profile=? (scry %gx %profile /bound/loob))
@@ -196,7 +196,7 @@
   ::
       [%x %v3 %init ~]
     =+  .^([=groups-ui:v2:gv =gangs:v2:gv] (scry %gx %groups /init/v1/noun))
-    =+  .^([* =channels:v7:old:d] (scry %gx %channels /v2/init/noun))
+    =+  .^([* =channels:v1:d] (scry %gx %channels /v2/init/noun))
     =+  .^(chat=chat-0:u (scry %gx %chat /init/noun))
     =+  .^(=activity:v3:old:a (scry %gx %activity /v1/activity/noun))
     =+  .^(profile=? (scry %gx %profile /bound/loob))
@@ -227,6 +227,7 @@
           profile
       ==
     ``ui-init-4+!>(init)
+  ::
       [%x %v5 %init ~]
     =+  .^([=groups-ui:v7:gv =foreigns:v7:gv] (scry %gx %groups /v2/init/noun))
     =+  .^(=channel-8:u (scry %gx %channels /v4/init/noun))

--- a/desk/app/groups.hoon
+++ b/desk/app/groups.hoon
@@ -1891,11 +1891,11 @@
   ::  +se-c-entry-ban: execute an entry ban command
   ::
   ::  the entry ban command is used to forbid a ship or a class of
-  ::  ships of certain rank from joining the group, requesting to join
+  ::  ships of specified rank from joining the group, requesting to join
   ::  the group, or executing any commands on the group host.
   ::
   ::  the ship and rank blacklists do not affect the group host.
-  ::  it is illegal to execute any $c-ban commands that affects
+  ::  it is forbidden to execute any $c-ban commands that affect
   ::  the group host in any way.
   ::
   ::  the rank blacklist does not affect admins. it is illegal

--- a/desk/lib/test-agent.hoon
+++ b/desk/lib/test-agent.hoon
@@ -25,7 +25,6 @@
 ::      (ex-cards caz (ex-fact [/echo]~ %noun !>([~dev 123])) ~)
 ::
 /+  test
-!.
 ::
 =/  drop-verb=?  &
 ::
@@ -308,6 +307,17 @@
   |=  s=state
   &+[(~(on-peek agent.s bowl.s) path) s]
 ::
+++  get-full-peek
+  |=  =path
+  =/  m  (mare ,cage)
+  ^-  form:m
+  |=  s=state
+  =/  peek=(unit (unit cage))
+    (~(on-peek agent.s bowl.s) path)
+  ?.  ?=(^ peek)  |+~['invalid scry path' (spat path)]
+  ?.  ?=(^ u.peek)  |+~['unexpected empty result at scry path' (spat path)]
+  &+[u.u.peek s]
+::
 ++  get-agent
   =/  m  (mare agent)
   ^-  form:m
@@ -402,6 +412,31 @@
     (i.exes i.caz)
   $(exes t.exes, caz t.caz)
 ::
+++  ex-filter-cards
+  |=  [caz=(list card) fit=$-(card ?) exes=(list $-(card tang))]
+  =?  caz  drop-verb
+    ::  remove cards unconditionally emitted by /lib/verb
+    ::
+    %+  skip  caz
+    |=  =card
+    ?=([%give %fact [[%verb ?(%events %events-plus) ~] ~] *] card)
+  =.  caz  (skip caz fit)
+  =/  m  (mare ,~)
+  ^-  form:m
+  |=  s=state
+  =;  =tang
+    ?~(tang &+[~ s] |+tang)
+  |-  ^-  tang
+  ?~  exes
+    ?~  caz
+      ~
+    ['got more cards than expected' >caz< ~]
+  ?~  caz
+    ['expected more cards than got' ~]
+  %+  weld
+    (i.exes i.caz)
+  $(exes t.exes, caz t.caz)
+::
 ++  ex-card
   |=  caw=card
   |=  cav=card
@@ -421,6 +456,18 @@
   ?~  tang  ~
   ['in %fact vase,' tang]
 ::
+++  ex-fact-paths
+  |=  paths=(list path)
+  |=  car=card
+  ^-  tang
+  =*  nope
+    %-  expect-eq:test
+    [!>(`card`[%give %fact paths *mark *vase]) !>(`card`car)]
+  ?.  ?=([%give %fact *] car)  nope
+  =/  =tang  (expect-eq:test !>(paths) !>(paths.p.car))
+  ?~  tang  ~
+  ['in %fact paths,' tang]
+::
 ++  ex-poke
   |=  [=wire =gill:gall =mark =vase]
   |=  car=card
@@ -435,6 +482,18 @@
   =/  =tang  (expect-eq:test vase q.cage.task.q.car)
   ?~  tang  ~
   ['in %poke vase on ,' tang]
+::
+++  ex-poke-wire
+  |=  =wire
+  |=  car=card
+  ^-  tang
+  =*  fail
+    %-  expect-eq:test
+    [!>(`card`[%pass wire %agent *gill:gall %poke *mark *vase]) !>(`card`car)]
+  ?.  ?=([%pass * %agent * %poke *] car)  fail
+  =/  =tang  (expect-eq:test !>(wire) !>(p.car))
+  ?~  tang  ~
+  ['in %poke wire,' tang]
 ::
 ++  ex-task
   |=  [=wire =gill:gall =task:agent:gall]

--- a/desk/mar/ui/init-1.hoon
+++ b/desk/mar/ui/init-1.hoon
@@ -11,7 +11,7 @@
     %-  pairs
     :~  groups/(groups-ui:v2:enjs:gj groups.init)
         gangs/(gangs:v2:enjs:gj gangs.init)
-        channels/(channels:v7:enjs:dj channels.init)
+        channels/(channels:v1:enjs:dj channels.init)
         unreads/(unreads:enjs:dj unreads.init)
         pins/a/(turn pins.init whom:enjs:gj)
         profile/b/profile.init

--- a/desk/mar/ui/init-2.hoon
+++ b/desk/mar/ui/init-2.hoon
@@ -11,7 +11,7 @@
     %-  pairs
     :~  groups/(groups-ui:v2:enjs:gj groups.init)
         gangs/(gangs:v2:enjs:gj gangs.init)
-        channels/(channels:v7:enjs:dj channels.init)
+        channels/(channels:v1:enjs:dj channels.init)
         activity/(activity:v2:enjs:aj activity.init)
         pins/a/(turn pins.init whom:enjs:gj)
         profile/b/profile.init

--- a/desk/mar/ui/init-3.hoon
+++ b/desk/mar/ui/init-3.hoon
@@ -11,7 +11,7 @@
     %-  pairs
     :~  groups/(groups-ui:v2:enjs:gj groups.init)
         gangs/(gangs:v2:enjs:gj gangs.init)
-        channels/(channels:v7:enjs:dj channels.init)
+        channels/(channels:v1:enjs:dj channels.init)
         activity/(activity:v3:enjs:aj activity.init)
         pins/a/(turn pins.init whom:enjs:gj)
         profile/b/profile.init

--- a/desk/mar/ui/init-5.hoon
+++ b/desk/mar/ui/init-5.hoon
@@ -17,7 +17,7 @@
       ::
         :-  %channel
         %-  pairs
-        :~  channels/(channels:enjs:dj channels.channel.init)
+        :~  channels/(channels:v8:enjs:dj channels.channel.init)
             hidden-posts/(hidden-posts:enjs:dj hidden-posts.channel.init)
         ==
       ::

--- a/desk/mar/ui/init.hoon
+++ b/desk/mar/ui/init.hoon
@@ -12,7 +12,7 @@
     %-  pairs
     :~  groups/(groups-ui:v2:enjs:gj groups.init)
         gangs/(gangs:v2:enjs:gj gangs.init)
-        channels/(channels:v0:enjs:dj channels.init)
+        channels/(channels:v1:enjs:dj channels.init)
         unreads/(unreads:enjs:dj unreads.init)
         pins/a/(turn pins.init whom:enjs:gj)
         profile/b/profile.init

--- a/desk/sur/ui.hoon
+++ b/desk/sur/ui.hoon
@@ -21,7 +21,7 @@
 +$  init-3
   $:  groups=groups-ui:v2:gv
       =gangs:v2:gv
-      =channels:v7:old:d
+      =channels:v1:old:d
       =activity:v3:old:a
       pins=(list whom)
       chat=chat-1
@@ -30,7 +30,7 @@
 +$  init-2
   $:  groups=groups-ui:v2:gv
       =gangs:v2:gv
-      =channels:v7:old:d
+      =channels:v1:old:d
       activity=activity:v2:old:a
       pins=(list whom)
       chat=chat-1
@@ -40,7 +40,7 @@
 +$  init-1
   $:  groups=groups-ui:v2:gv
       =gangs:v2:gv
-      =channels:v7:old:d
+      =channels:v1:old:d
       =unreads:d
       pins=(list whom)
       chat=chat-0
@@ -50,7 +50,7 @@
 +$  init-0
   $:  groups=groups-ui:v2:gv
       =gangs:v2:gv
-      channels=channels-0:d
+      channels=channels:v1:old:d
       =unreads:d
       pins=(list whom)
       chat=chat-0
@@ -62,7 +62,7 @@
 +$  mixed-heads-3  [chan=channel-heads:v9:d chat=chat-heads:v6:cv]
 ::
 +$  channel-8
-  $:  =channels:d
+  $:  =channels:v8:d
       hidden-posts=(set id-post:d)
   ==
 +$  channel-0

--- a/desk/tests/app/activity.hoon
+++ b/desk/tests/app/activity.hoon
@@ -29,8 +29,8 @@
   ;<  *  bind:m  (ex-equal !>(~(wyt by pre)) !>(count))
   ;<  new=vase  bind:m  get-save
   =/  want-indices  post
-  =+  !<(=new-state new)
-  =/  new-indices  indices.new-state
+  =+  !<(=state-8 new)
+  =/  new-indices  indices.state-8
   (ex-equal !>(new-indices) !>(want-indices))
 ::
 ++  test-fix-init
@@ -44,17 +44,19 @@
   =/  start-state  [%6 %some indices pre-fix volumes]
   ;<  caz=(list card:agent:gall)  bind:m  (do-load activity-agent `!>(start-state))
   ;<  *  bind:m  (ex-equal !>(~(wyt by pre-fix)) !>(11))
-  =/  cage  noun+!>(%fix-init-unreads)
   ;<  bowl  bind:m  get-bowl
   ;<  *  bind:m
     %+  ex-cards  caz
-    ~[(ex-poke /fix-init-unreads [~zod dap] cage)]
-  ;<  *  bind:m  (do-poke cage)
+    :~  (ex-poke /adjust-old-default [~zod dap] noun+!>(%adjust-old-default))
+        (ex-poke /fix-init-unreads [~zod dap] noun+!>(%fix-init-unreads))
+    ==
+  ;<  *  bind:m  (do-poke noun+!>(%adjust-old-default))
+  ;<  *  bind:m  (do-poke noun+!>(%fix-init-unreads))
   ;<  new=vase  bind:m  get-save
-  =+  !<(=new-state new)
-  (ex-equal !>(activity.new-state) !>(post-fix))
-+$  new-state
-  $:  %6
+  =+  !<(=state-8 new)
+  (ex-equal !>(activity.state-8) !>(post-fix))
++$  state-8
+  $:  %8
       allowed=notifications-allowed:a
       =indices:a
       =activity:a

--- a/desk/tests/app/channels-server.hoon
+++ b/desk/tests/app/channels-server.hoon
@@ -6,9 +6,20 @@
 ++  dap  %channels-server
 ::
 +$  current-state
-  [%10 =v-channels:c =hooks:h =pimp:imp]
+  [%11 =v-channels:v9:c =hooks:h =pimp:imp]
+  :: [%10 =v-channels:c =hooks:h =pimp:imp]
 +$  state-8
   [%8 =v-channels:v8:c =hooks:h =pimp:imp]
+::
+++  skip-poke-wire
+  |=  wire=path
+  |=  =card
+  ?.  ?=([%pass * %agent * %poke *] card)  |
+  =(wire p.card)
+::
+++  ex-cards
+  |=  [caz=(list card) exes=(list $-(card tang))]
+  (ex-filter-cards caz (skip-poke-wire /logs) exes)
 --
 ::
 |%
@@ -58,9 +69,9 @@
   %+  ex-cards  caz
   =/  =vase
     !>  :^  %sequence-numbers  *nest:c
-      333
+      1
     ^-  (list [id-post:c (unit @ud)])
-    :~  [~2025.8.4 `777]
+    :~  [~2025.8.4 `1]
     ==
   :~  (ex-poke /numbers [~fun %channels] %noun vase)
   ==
@@ -288,7 +299,7 @@
     ;<  save=vase  bind:m  get-save
     =/  fixed-state=current-state
       =;  chans=v-channels:c
-        [%10 chans *hooks:h *pimp:imp]
+        [%11 chans *hooks:h *pimp:imp]
       =/  chan=v-channel:c
         tombstone-rescue-test-channel-new
       (~(put by *v-channels:c) *nest:c chan)

--- a/desk/tests/app/channels.hoon
+++ b/desk/tests/app/channels.hoon
@@ -3,11 +3,11 @@
 /=  channels-agent  /app/channels
 |%
 +$  current-state
-  $:  %11
+  $:  %13
       =v-channels:c
       voc=(map [nest:c plan:c] (unit said:c))
       hidden-posts=(set id-post:c)
-      debounce=(jug nest:c @da)
+      debounce=(jug nest:c @da)  ::  temporary bandaid
     ::
       ::  .pending-ref-edits: for migration, see also +poke %negotiate-notif
       ::
@@ -33,6 +33,15 @@
     [%gu ship=@t %activity @ ~ ~]  `!>(|)
     [%gx @ %groups @ %v2 %groups host=@ term=@ %noun ~]  `!>(*group:v7:gv)
   ==
+++  skip-poke-wire
+  |=  wire=path
+  |=  =card
+  ?.  ?=([%pass * %agent * %poke *] card)  |
+  =(wire p.card)
+++  ex-cards
+  |=  [caz=(list card) exes=(list $-(card tang))]
+  (ex-filter-cards caz (skip-poke-wire /logs) exes)
+::
 ++  test-checkpoint-sub
   %-  eval-mare
   =/  m  (mare ,~)
@@ -202,7 +211,7 @@
     =/  m  (mare ,~)
     =/  bad-state=current-state
       =;  chans=v-channels:c
-        [%11 chans ~ ~ ~ ~ *^subs:s *pimp:imp]
+        [%13 chans ~ ~ ~ ~ *^subs:s *pimp:imp]
       =/  chan=v-channel:c
         sequence-fix-test-channel
       ::  bad 7->8 migration in old code had dropped the tombstone
@@ -239,7 +248,7 @@
     ;<  save=vase  bind:m  get-save
     =/  fixed-state=current-state
       =;  chans=v-channels:c
-        [%11 chans ~ ~ ~ ~ *^subs:s *pimp:imp]
+        [%13 chans ~ ~ ~ ~ *^subs:s *pimp:imp]
       =/  chan=v-channel:c
         sequence-fix-test-channel
       ::  missing message will not have magically recovered,
@@ -308,7 +317,7 @@
     =/  m  (mare ,~)
     =/  bad-state=current-state
       =;  chans=v-channels:c
-        [%11 chans ~ ~ ~ ~ *^subs:s *pimp:imp]
+        [%13 chans ~ ~ ~ ~ *^subs:s *pimp:imp]
       =/  chan=v-channel:c
         tombstone-fix-test-channel
       ::  client had just bunted tombstones
@@ -362,7 +371,7 @@
     ;<  save=vase  bind:m  get-save
     =/  fixed-state=current-state
       =;  chans=v-channels:c
-        [%11 chans ~ ~ ~ ~ *^subs:s *pimp:imp]
+        [%13 chans ~ ~ ~ ~ *^subs:s *pimp:imp]
       =/  chan=v-channel:c
         tombstone-fix-test-channel
       (~(put by *v-channels:c) *nest:c chan)

--- a/desk/tests/app/chat.hoon
+++ b/desk/tests/app/chat.hoon
@@ -1,5 +1,5 @@
-/-  c=chat, ch=channels, h=hark, contacts
-/+  *test-agent
+/-  c=chat, cv=chat-ver, ch=channels, h=hark, contacts, activity
+/+  *test-agent, cc=chat-conv
 /=  agent  /app/chat
 |%
 ++  dap  %chat-test
@@ -14,7 +14,7 @@
   =/  =diff:dm:c  (dm-message ~zod now.bw verse)
   ::  start a dm from zod
   :: ~&  'starting dm from zod'
-  ;<  *  bind:m  (do-poke %chat-dm-diff !>(diff))
+  ;<  *  bind:m  (do-poke %chat-dm-diff-1 !>(diff))
   ;<  *  bind:m  (set-src ~dev)
   ::  accept the dm and set read
   :: ~&  'accepting dm from zod'
@@ -28,22 +28,36 @@
   ;<  *  bind:m  (wait ~s1)
   ;<  bw=bowl  bind:m  get-bowl
   =/  =diff:dm:c  (dm-message ~zod now.bw verse)
-  ;<  caz=(list card)  bind:m  (do-poke %chat-dm-diff !>(diff))
+  ;<  caz=(list card)  bind:m  (do-poke %chat-dm-diff-1 !>(diff))
   ::  expect a notification and an unread dm
   =/  =whom:c  [%ship ~zod]
   =/  =unread:unreads:c  [now.bw 1 `[[[~zod now.bw] now.bw] 1] ~]
   =/  =unreads:c  (malt [whom unread] ~)
-  =/  =response:writs:c  [[~zod now.bw] %add [~[verse] ~zod now.bw] now.bw]
+  =/  =essay:c
+    [[~[verse] ~zod now.bw] chat+/ ~ ~]
+  =/  =response:writs:c  [[~zod now.bw] %add essay 3 now.bw]
+  =/  old-response-3=[whom:v3:cv response:writs:v3:cv]
+    :-  whom
+    %-  v3:response-writs:v5:cc
+    (v5:response-writs:v6:cc response)
+  =/  old-response-4=[whom:v4:cv response:writs:v4:cv]
+    [whom (v4:response-writs:v6:cc response)]
+  =/  old-response-5=[whom:v5:cv response:writs:v5:cv]
+    [whom (v5:response-writs:v6:cc response)]
   =/  =new-yarn:h  [& & rope content /dm/~zod ~]
+  =/  activity-action=action:activity
+    [%add %dm-post [[~zod now.bw] now.bw] [%ship ~zod] ~[verse] &]
   ;<  *  bind:m  (ex-scry-result /x/unreads !>(unreads))
   :: ~&  'have unreads'
   ;<  *  bind:m
     %+  ex-cards  caz
-    :~  (ex-poke /contacts/~zod [~dev %contacts] act:mar:contacts !>([%heed ~[~zod]]))
+    :~  (ex-poke /contacts/~zod [~dev %contacts] contact-action+!>([%heed ~[~zod]]))
         (ex-fact ~[/unreads] %chat-unread-update !>([whom unread]))
-        (ex-poke /hark [~dev %hark] %hark-action-1 !>([%new-yarn new-yarn]))
-        (ex-fact ~[/dm/~zod] %writ-response !>([[%ship ~zod] response]))
-        (ex-fact ~[/dm/~zod/writs] %writ-response !>([[%ship ~zod] response]))
+        (ex-poke /activity/submit [~dev %activity] activity-action+!>(activity-action))
+        (ex-fact ~[/ /dm/~zod /dm/~zod/writs] writ-response+!>(old-response-3))
+        (ex-fact ~[/v1 /v1/dm/~zod /v1/dm/~zod/writs] writ-response-1+!>(old-response-4))
+        (ex-fact ~[/v2 /v2/dm/~zod /v2/dm/~zod/writs] writ-response-2+!>(old-response-5))
+        (ex-fact ~[/v3 /v3/dm/~zod /v3/dm/~zod/writs] writ-response-3+!>([whom response]))
     ==
   ;<  *  bind:m  (wait ~s1)
   ;<  bw=bowl  bind:m  get-bowl
@@ -54,14 +68,17 @@
   :~  (ex-poke /hark [~dev %hark] %hark-action-1 !>([%saw-rope rope]))
       (ex-fact ~[/unreads] %chat-unread-update !>([whom unread]))
   ==
-::++  test-club-notification-clearing
 ++  scries
   |=  =path
   ^-  (unit vase)
-  ?+  path  ~
-    [%gu @ %groups @ *]           `!>(%.y)
+  ?+    path  ~
+    [%gu @ %activity @ %$ ~]         `!>(&)
+    [%gu @ %groups @ *]           `!>(&)
     [%gx @ %groups @ %volume *]   `!>(%soft)
     [%gx @ %hark @ *]             `!>(carpet)
+  ::
+      [%gx @ %chat-test @ %~.~ %negotiate %status %~.~zod %chat-test *]
+    `!>(%match)
   ==
 ++  rope  `rope:h`[~ ~ %groups /dm/~zod]
 ++  content  `(list content:h)`~[[%ship ~zod] ': ' 'hi ~dev']
@@ -76,6 +93,7 @@
 ++  dm-message
   |=  [author=ship =time =verse:ch]
   ^-  diff:dm:c
-  =/  =memo:ch  [~[verse] author time]
-  [[author time] %add memo ~ ~]
+  =/  =essay:c
+    [[~[verse] ~zod time] chat+/ ~ ~]
+  [[author time] %add essay `time]
 --

--- a/desk/tests/app/groups.hoon
+++ b/desk/tests/app/groups.hoon
@@ -5,17 +5,6 @@
 /+  gc=groups-conv
 /=  groups-agent  /app/groups
 |%
-++  get-full-peek
-  |=  =path
-  =/  m  (mare ,cage)
-  ^-  form:m
-  |=  s=state
-  =/  peek=(unit (unit cage))
-    (~(on-peek agent.s bowl.s) path)
-  ?.  ?=(^ peek)  |+~['invalid scry path' (spat path)]
-  ?.  ?=(^ u.peek)  |+~['unexpected empty result at scry path' (spat path)]
-  &+[u.u.peek s]
-::
 ++  my-agent  %groups-test
 ++  my-flag  [~zod %my-test-group]
 ++  my-area  `path`/groups/~zod/my-test-group
@@ -54,21 +43,18 @@
   ;<  =bowl:gall  bind:m  get-bowl
   (pure:m caz)
 ::
-++  do-poke-c-groups
-  |=  [src=ship =c-groups:g]
+++  do-c-groups
+  |=  =c-groups:g
   =/  m  (mare ,(list card))
   ^-  form:m
-  ::  bump time to avoid flickers in update time
   ;<  ~  bind:m  (wait ~m1)
-  ;<  ~  bind:m  (set-src src)
   (do-poke group-command+!>(c-groups))
-++  do-poke-c-group
-  |=  [src=ship =c-group:g]
+::
+++  do-c-group
+  |=  =c-group:g
   =/  m  (mare ,(list card))
   ^-  form:m
-  ::  bump time to avoid flickers in update time
   ;<  ~  bind:m  (wait ~m1)
-  ;<  ~  bind:m  (set-src src)
   =/  =c-groups:g  [%group my-flag c-group]
   (do-poke group-command+!>(c-groups))
 ::
@@ -76,7 +62,7 @@
   |=  =privacy:g
   =/  m  (mare ,(list card))
   ^-  form:m
-  (do-poke-c-group ~zod [%entry %privacy privacy])
+  ((do-as ~zod) (do-c-group [%entry %privacy privacy]))
 ::
 ++  do-join-group
   |=  =ship
@@ -100,17 +86,6 @@
   %+  ex-fact
     ~[/server/groups/~zod/my-test-group/updates/~zod/(scot %da *@da)]
   group-update+!>(`update:g`[time u-group])
-::
-++  ex-skip-fact
-  |=  paths=(list path)
-  |=  car=card
-  ^-  tang
-  =*  nope
-    %-  expect-eq
-    [!>(`card`[%give %fact paths *mark *vase]) !>(`card`car)]
-  ?.  ?=([%give %fact *] car)  nope
-  ?.  =(paths paths.p.car)     nope
-  ~
 ::
 :: ++  ex-r-groups
 ::   |=  [caz=(list card) rs-groups=(list r-groups:v7:gv)]
@@ -194,7 +169,7 @@
           [~zod my-agent]
         group-command+!>(`c-groups:g`[%join my-flag ~])
       ::
-        (ex-skip-fact ~[/gangs/updates])
+        (ex-fact-paths ~[/gangs/updates])
     ==
   (ex-fail (do-create-group %secret))
 ::  +test-c-join-public: test public group join
@@ -210,7 +185,7 @@
   ;<  *  bind:m  (do-create-group %public)
   ::  a ship can join a public group without a token
   ::
-  ;<  caz=(list card)  bind:m  (do-poke-c-groups ~dev [%join my-flag ~])
+  ;<  caz=(list card)  bind:m  ((do-as ~dev) (do-c-groups [%join my-flag ~]))
   ;<  =bowl:gall  bind:m  get-bowl
   =/  =seat:v7:gv  [~ now.bowl]
   ;<  ~  bind:m
@@ -218,7 +193,7 @@
   ::  re-joining is a vacuous operation
   ::
   ;<  caz=(list card)  bind:m
-    (do-poke-c-groups ~dev [%join my-flag ~])
+    ((do-as ~dev) (do-c-groups [%join my-flag ~]))
   (ex-cards caz ~)
 ::  +test-c-groups-join-private: test private group join
 ::
@@ -232,21 +207,22 @@
   ^-  form:m
   ;<  *  bind:m  do-groups-init
   ;<  *  bind:m  (do-create-group %private)
+  ;<  *  bind:m  (jab-bowl |=(=bowl bowl(eny 0v123)))
   ::  joining a private group without a valid token fails
   ::
   ;<  *  bind:m
-    (ex-fail (do-poke-c-groups ~fed [%join my-flag ~]))
+    (ex-fail ((do-as ~fed) (do-c-groups [%join my-flag ~])))
   ;<  caz=(list card)  bind:m
     =/  =c-token-add:g
       [[%personal ~dev] ~ ~ |]
     ::  the token generated is going to be 0v0, as we haven't
     ::  set entropy.
     ::
-    (do-poke-c-group ~zod [%entry %token %add c-token-add])
-  ::  joining a private group with a valid token works
+    ((do-as ~zod) (do-c-group [%entry %token %add c-token-add]))
+  ::  a private group can be joined with a valid token
   ::
   ;<  caz=(list card)  bind:m
-    (do-poke-c-groups ~dev [%join my-flag `0v0])
+    ((do-as ~dev) (do-c-groups [%join my-flag `0v123]))
   ;<  =bowl  bind:m  get-bowl
   =/  =seat:v7:gv  [~ now.bowl]
   ;<  ~  bind:m
@@ -254,7 +230,11 @@
   ::  trying to reuse the token fails
   ::
   ;<  caz=(list card)  bind:m
-    (ex-fail (do-poke-c-groups ~fed [%join my-flag `0v0]))
+    (ex-fail ((do-as ~fed) (do-c-groups [%join my-flag `0v123])))
+  ::  as does using a non-existent token
+  ::
+  ;<  caz=(list card)  bind:m
+    (ex-fail ((do-as ~fed) (do-c-groups [%join my-flag `0v321])))
   (pure:m ~)
 ::  +test-c-groups-ask-public: test public group ask request
 ::
@@ -278,7 +258,7 @@
   ::  one man's path is another man's wire
   =/  ask-path=path  (weld `path`[%server my-area] /ask/~dev)
   ;<  caz=(list card)  bind:m
-    (do-watch ask-path)
+    ((do-as ~dev) (do-watch ask-path))
   ::  the request is immediately approved and an (empty) invite
   ::  token is sent.
   ::
@@ -289,7 +269,7 @@
     ==
   ::  a banned ship can't ask to join the group
   ::
-  ;<  *  bind:m  (do-poke-c-group ~zod [%entry %ban %add-ships (sy ~fed ~)])
+  ;<  *  bind:m  ((do-as ~zod) (do-c-group [%entry %ban %add-ships (sy ~fed ~)]))
   ;<  ~  bind:m  (set-src ~fed)
   ;<  ~  bind:m
     (ex-fail (do-poke group-command+!>([%ask my-flag `story])))
@@ -307,15 +287,15 @@
   ;<  *  bind:m  do-groups-init
   ;<  *  bind:m  (do-create-group %private)
   ::  a ship can ask to join the group. the request is recorded and
-  ::  broadcasted, but no gifts are emitted.
+  ::  broadcasted.
   ::
   =/  =story:s
     [inline+['an appeal to host']~]~
   =/  ask-path=path  (weld `path`[%server my-area] /ask/~dev)
   ;<  caz=(list card)  bind:m
-    (do-poke-c-groups ~dev [%ask my-flag `story])
+    ((do-as ~dev) (do-c-groups [%ask my-flag `story]))
   ;<  *  bind:m
-    (do-watch ask-path)
+    ((do-as ~dev) (do-watch ask-path))
   ;<  ~  bind:m
     (ex-u-groups caz [%entry %ask [%add ~dev `story]]~)
   ;<  peek=cage  bind:m  (get-full-peek /x/v2/groups/~zod/my-test-group)
@@ -327,7 +307,7 @@
   ::  an admin can approve or deny the request
   ::
   ;<  caz=(list card)  bind:m
-    (do-poke-c-groups ~zod [%group my-flag %entry %ask (sy ~dev ~) %approve])
+    ((do-as ~zod) (do-c-group [%entry %ask (sy ~dev ~) %approve]))
   ::  when a request is approved, the host generates a new token and
   ::  sends it to the requester. the request is then deleted from the
   ::  record.
@@ -342,7 +322,7 @@
     ==
   ::  an ask request originating from a banned ship fails
   ::
-  ;<  *  bind:m  (do-poke-c-group ~zod [%entry %ban %add-ships (sy ~fed ~)])
+  ;<  *  bind:m  ((do-as ~zod) (do-c-group [%entry %ban %add-ships (sy ~fed ~)]))
   ;<  ~  bind:m  (set-src ~fed)
   ;<  ~  bind:m
     (ex-fail (do-poke group-command+!>([%ask my-flag `story])))
@@ -368,7 +348,7 @@
   ;<  *  bind:m  (do-create-group %public)
   ::  a ship can join a public group without a token
   ::
-  ;<  caz=(list card)  bind:m  (do-poke-c-groups ~dev [%join my-flag ~])
+  ;<  caz=(list card)  bind:m  ((do-as ~dev) (do-c-groups [%join my-flag ~]))
   ;<  =bowl:gall  bind:m  get-bowl
   =/  =seat:v7:gv  [~ now.bowl]
   ;<  ~  bind:m
@@ -376,7 +356,7 @@
   ::  leaving the group then deletes the seat
   ::
   ;<  caz=(list card)  bind:m
-    (do-poke-c-groups ~dev [%leave my-flag])
+    ((do-as ~dev) (do-c-groups [%leave my-flag]))
   ;<  ~  bind:m
     (ex-u-groups caz [%seat (sy ~dev ~) [%del ~]]~)
   ::  a ship can ask to join the private group. the request is recorded and
@@ -387,9 +367,9 @@
     [inline+['an appeal to host']~]~
   =/  ask-path=path  (weld `path`[%server my-area] /ask/~dev)
   ;<  caz=(list card)  bind:m
-    (do-poke-c-groups ~dev [%ask my-flag `story])
+    ((do-as ~dev) (do-c-groups [%ask my-flag `story]))
   ;<  *  bind:m
-    (do-watch ask-path)
+    ((do-as ~dev) (do-watch ask-path))
   ;<  ~  bind:m
     (ex-u-groups caz [%entry %ask [%add ~dev `story]]~)
   ;<  peek=cage  bind:m  (get-full-peek /x/v2/groups/~zod/my-test-group)
@@ -402,7 +382,7 @@
   ::  the group host delets the request and kicks the subscription.
   ::
   ;<  caz=(list card)  bind:m
-    (do-poke-c-groups ~dev [%leave my-flag])
+    ((do-as ~dev) (do-c-groups [%leave my-flag]))
   ;<  =bowl:gall  bind:m  get-bowl
   ;<  ~  bind:m
     %+  ex-cards  caz
@@ -425,7 +405,7 @@
   =/  meta=data:meta:g
     ['New Title' 'New description' '' '']
   ;<  caz=(list card)  bind:m
-    (do-poke-c-group ~zod [%meta meta])
+    ((do-as ~zod) (do-c-group [%meta meta]))
   ;<  peek=cage  bind:m  (get-full-peek /x/v2/groups/~zod/my-test-group)
   =+  !<(=group:g q.peek)
   ;<  ~  bind:m
@@ -435,8 +415,49 @@
   ::  non-admin members can't update metadata
   ::
   ;<  *  bind:m  (do-join-group ~dev)
-  ;<  ~  bind:m  (ex-fail (do-poke-c-group ~dev [%meta meta]))
+  ;<  ~  bind:m  (ex-fail ((do-as ~dev) (do-c-group [%meta meta])))
   ::  non-members can't update metadata
-  ;<  ~  bind:m  (ex-fail (do-poke-c-group ~fed [%meta meta]))
+  ;<  ~  bind:m  (ex-fail ((do-as ~fed) (do-c-group [%meta meta])))
+  (pure:m ~)
+::  +test-c-group-entry-privacy: test group privacy update
+::
+::  group privacy can only be updated by a group host or an admin.
+::
+++  test-c-group-entry-privacy
+  %-  eval-mare
+  =/  m  (mare ,~)
+  ^-  form:m
+  ;<  *  bind:m  do-groups-init
+  ;<  *  bind:m  (do-create-group %public)
+  ::  the group host can update the group privacy
+  ::
+  ;<  caz=(list card)  bind:m
+    ((do-as ~zod) (do-c-group [%entry %privacy %secret]))
+  ;<  ~  bind:m
+    (ex-u-groups caz [%entry %privacy %secret]~)
+  ;<  peek=cage  bind:m  (get-full-peek /x/v2/groups/~zod/my-test-group)
+  =+  !<(=group:g q.peek)
+  ;<  ~  bind:m
+    (ex-equal !>(privacy.admissions.group) !>(%secret))
+  ::  a non-member, or ordinary group member can't update the group privacy
+  ::
+  ;<  *  bind:m
+    ((do-as ~zod) (do-c-group [%entry %privacy %public]))
+  ;<  *  bind:m
+    (ex-fail ((do-as ~dev) (do-c-group [%entry %privacy %secret])))
+  ;<  *  bind:m
+    (do-join-group ~dev)
+  ;<  *  bind:m
+    (ex-fail ((do-as ~dev) (do-c-group [%entry %privacy %secret])))
+  ::  an admin member can update the group privacy
+  ::
+  ;<  *  bind:m
+    ((do-as ~zod) (do-c-group [%seat (sy ~dev ~) %add-roles (sy %admin ~)]))
+  ;<  *  bind:m
+    ((do-as ~dev) (do-c-group [%entry %privacy %secret]))
+  ;<  peek=cage  bind:m  (get-full-peek /x/v2/groups/~zod/my-test-group)
+  =+  !<(=group:g q.peek)
+  ;<  ~  bind:m
+    (ex-equal !>(privacy.admissions.group) !>(%secret))
   (pure:m ~)
 --

--- a/desk/tests/app/logs.hoon
+++ b/desk/tests/app/logs.hoon
@@ -7,15 +7,18 @@
   %-  eval-mare
   =/  m  (mare ,~)
   ;<  *  bind:m  (do-init dap agent)
-  :: ;<  *  bind:m  (set-scry-gate ,~)
   ;<  *  bind:m  (jab-bowl |=(b=bowl b(sap /gall/test)))
   ;<  =bowl:gall  bind:m  get-bowl
-  =/  ev-fail=log-event:l
-    [%fail %test-fail leaf+"test stacktrace" ~]
+  =/  fail=log-event:l
+    [%fail %test-fail leaf+"test stacktrace"]
   ;<  caz=(list card)  bind:m
-    (do-poke log-action+!>([%log ev-fail]))
+    (do-poke log-action+!>(`a-log:l`[%log fail ~]))
+  =/  =log-item:l
+    [now.bowl fail]
+  =/  =log-data:l
+    ~['commit'^s+'development']
   =/  fard=(fyrd:khan cage)
-    [q.byk.bowl %posthog noun+!>(`[`path`/gall/test [now.bowl ev-fail]])]
+    [q.byk.bowl %posthog noun+!>(`[`path`/gall/test log-item log-data])]
   ::  expect log submission -posthog
   ::
   ?>  ?=([[%pass *] ~] caz)
@@ -31,5 +34,5 @@
   ::
   %+  ex-equal
     !>((~(nest ut p.q.args.fard) | p.q.args.p.q.card))
-    !>(&)
+  !>(&)
 --

--- a/desk/tests/app/verifier.hoon
+++ b/desk/tests/app/verifier.hoon
@@ -19,12 +19,15 @@
 ++  twitter-api-bearer  'someBearerToken'
 ++  attempt-timeout     ~h1
 ::
-++  ex-cards  ::NOTE  custom version that ignores logging-related cards
+++  skip-poke-wire
+  |=  wire=path
+  |=  =card
+  ?.  ?=([%pass * %agent * %poke *] card)  |
+  =(wire p.card)
+::
+++  ex-cards
   |=  [caz=(list card) exes=(list $-(card tang))]
-  =-  (^ex-cards - exes)
-  %+  skip  caz
-  |=  c=card
-  ?=([%pass [%logs ~] *] c)
+  (ex-filter-cards caz (skip-poke-wire /logs) exes)
 ::
 ++  ex-verifier-update
   =/  initial=?  |
@@ -156,7 +159,7 @@
   =/  m  (mare state:v)
   ;<  =vase  bind:m  get-save
   =+  !<([[%negotiate *] =^vase] vase)
-  =+  !<([%0 =state:v] vase)
+  =+  !<([%1 =state:v] vase)
   (pure:m state)
 ::
 ++  user-does
@@ -784,7 +787,7 @@
       twitter-api  [bearer=twitter-api-bearer]
       domain       `'http://sampel.net'
     ==
-  ;<  *  bind:m  (do-load agent `!>([%0 state]))
+  ;<  *  bind:m  (do-load agent `!>([%1 state]))
   (pure:m ~)
 ::
 ++  test-duplicate
@@ -967,7 +970,7 @@
       %+  ~(put by records)  this-id
       [this-ship wen config %done at]
     $(i +(i))
-  ;<  *  bind:m  (do-load agent `!>([%0 (state-from-records records)]))
+  ;<  *  bind:m  (do-load agent `!>([%1 (state-from-records records)]))
   (pure:m ~)
 ::
 ++  expect-query-response

--- a/desk/tests/lib/negotiate.hoon
+++ b/desk/tests/lib/negotiate.hoon
@@ -112,6 +112,15 @@
   =/  git=@t  (rap 3 (scot %p p.gill) '/' q.gill ~)
   !>(`json`o+(~(gas by *(map @t json)) 'match'^b+match 'gill'^s+git ~))
 ::
+++  skip-poke-wire
+  |=  wire=path
+  |=  =card
+  ?.  ?=([%pass * %agent * %poke *] card)  |
+  =(wire p.card)
+::
+++  ex-cards
+  |=  [caz=(list card) exes=(list $-(card tang))]
+  (ex-filter-cards caz (skip-poke-wire /~/negotiate/logs) exes)
 --
 ::
 |%


### PR DESCRIPTION
## Summary

Wrong scry types were introduced by mistake to old unused endpoints during channels custom type changes, which involved changes to conversion functions, introduced last year. We fix both the types expected by the groups-ui agent and the types returned from some channels scries that were wrongly modified at the time.

Additionally, we also fix the most recent scry endpoint `v5`, which was failing due to an unnoticed change in the JSON conversion function.

**Note: you should only look at the last commit when reviewing. Github needlessly repeats the changes that are already in `mp/backend-unit-tests` branch.**

## Changes

1. Adjust the expected scry types, and init types in the groups-ui agent.
2. Fix a channels scry endpoint to return the correct type.

## How did I test?

Queried all modified endpoints.

## Risks and impact

- Safe to rollback without consulting PR author? No, risks breaking old scries.
- Affects important code area:
  - [ ] Onboarding
  - [ ] State / providers
  - [ ] Message sync
  - [ ] Channel display
  - [ ] Notifications
  - [ ] Other:

## Rollback plan

Can be rolled back, at the cost of breaking both the `v5` (most recent) scry, as well as old unused scries.