### PR TITLE
groups: better %group-join poke compatibility

### DIFF
--- a/desk/app/groups.hoon
+++ b/desk/app/groups.hoon
@@ -449,11 +449,11 @@
         %group-join
       ?>  from-self
       =+  !<(=join:v0:gv vase)
-      ~|  f=flag.join
-      =/  =foreign:v7:gv  (~(got by foreigns) flag.join)
+      =/  far=(unit foreign:v7:gv)  (~(get by foreigns) flag.join)
       =/  tok=(unit token:g)
-        ?~  invites.foreign  ~
-        token.i.invites.foreign
+        ?~  far  ~
+        ?~  invites.u.far  ~
+        token.i.invites.u.far
       fi-abet:(fi-join:(fi-abed:fi-core flag.join) tok)
     ::
         %group-knock


### PR DESCRIPTION
## Summary

Old %group-join poke was implemented in a way that required
an entry in foreigns to work. This was never a problem at the client,
because it would always preview groups before joining. However,
it caused crashes at hosting, who were issuing group join pokes to
public groups without previewing first.

We improve this by defaulting to a join without token when a foreign
group entry is not found.

## Changes
1. Fix the handling of the %group-join poke to never crash, but rather use an empty join token when none is available.

## How did I test?

1. Unit tests pass.
2. Group join works from the client.

## Risks and impact

- Safe to rollback without consulting PR author? (Yes | No)
- Affects important code area:
  - [ ] Onboarding
  - [ ] State / providers
  - [ ] Message sync
  - [ ] Channel display
  - [ ] Notifications
  - [ ] Other:

## Rollback plan

Can be reverted.