### PR TITLE
WompWomp: add confirmation on web

### DIFF
--- a/packages/app/features/settings/UserBugReportScreen.tsx
+++ b/packages/app/features/settings/UserBugReportScreen.tsx
@@ -2,7 +2,7 @@ import { NativeStackScreenProps } from '@react-navigation/native-stack';
 import { createDevLogger } from '@tloncorp/shared';
 import { useCallback } from 'react';
 import { useForm } from 'react-hook-form';
-import { Alert, KeyboardAvoidingView } from 'react-native';
+import { Alert, KeyboardAvoidingView, Platform } from 'react-native';
 
 import { RootStackParamList } from '../../navigation/types';
 import {
@@ -19,6 +19,20 @@ type Props = NativeStackScreenProps<RootStackParamList, 'WompWomp'>;
 
 const logger = createDevLogger('bug-report', false);
 
+const showAlert = () => {
+  if (Platform.OS === 'web') {
+    window.alert(
+      'Bug report sent. Our team will investigate. Thank you for your feedback!'
+    );
+    return;
+  }
+  Alert.alert(
+    'Bug report sent',
+    'Our team will investigate. Thank you for your feedback!',
+    [{ text: 'OK' }]
+  );
+};
+
 export function UserBugReportScreen({ navigation }: Props) {
   const { control, handleSubmit } = useForm({
     defaultValues: {
@@ -33,13 +47,9 @@ export function UserBugReportScreen({ navigation }: Props) {
         logger.crumb(submission.additionalNotes);
       }
       logger.trackError('User manually submitted a bug report');
-      Alert.alert(
-        'Bug report sent',
-        'Our team will investigate. Thank you for your feedback!',
-        [{ text: 'OK', onPress: () => navigation.goBack() }]
-      );
+      showAlert();
     },
-    [navigation]
+    []
   );
 
   return (


### PR DESCRIPTION
## Summary

Fixes TLON-4549 by adding a `window.alert` confirmation on Web and preserves the React Native `Alert` on mobile. 

## Changes

Breaks the submission handler up and adds a `showAlert` function, which is platform-dependent.

## How did I test?

- Navigate to /settings/WompWomp on web
- Submit a testing bug
- Note the response from the Vercel ingestion point
- Navigate to personal icon -> gear icon -> Submit a Bug on mobile
- Submit a testing bug
- Verify that the confirmation alert pops

## Risks and impact

- Safe to rollback without consulting PR author? Yes
- Affects important code area:
  - [ ] Onboarding
  - [ ] State / providers
  - [ ] Message sync
  - [ ] Channel display
  - [ ] Notifications
  - [x] Other: Settings UI

## Rollback plan

git revert
