### PR TITLE
fix stuck transaction

### DIFF
--- a/packages/shared/src/db/query.test.ts
+++ b/packages/shared/src/db/query.test.ts
@@ -1,0 +1,74 @@
+import { beforeEach, describe, expect, it } from 'vitest';
+
+import { setupDb } from '../test/helpers';
+import { client } from './client';
+import { QueryCtx, withTransactionCtx } from './query';
+
+describe('withTransactionCtx', () => {
+  let testCtx: QueryCtx;
+
+  beforeEach(() => {
+    testCtx = {
+      db: client,
+      pendingEffects: new Set(),
+      meta: {
+        label: 'test-transaction',
+        tableEffects: [],
+        tableDependencies: [],
+      },
+    };
+  });
+
+  // Test that running a transaction before setupDb doesn't permanently break transactions
+  it('should throw error before setupDb and succeed after setupDb', async () => {
+    const uninitializedCtx: QueryCtx = {
+      db: client, // This will throw when accessed since db is not yet set up
+      pendingEffects: new Set(),
+      meta: {
+        label: 'test-transaction-uninitialized',
+        tableEffects: [],
+        tableDependencies: [],
+      },
+    };
+
+    // Step 1: Attempt to run transaction before setupDb (should throw)
+    await expect(async () => {
+      await withTransactionCtx(uninitializedCtx, async (_tx) => {
+        return 'should not reach here';
+      });
+    }).rejects.toThrow('Database not set.');
+
+    // Step 2: Call setupDb (actual initialization)
+    setupDb();
+
+    // Step 3: Attempt to run transaction after setupDb (should succeed)
+    const workingCtx: QueryCtx = {
+      db: client,
+      pendingEffects: new Set(),
+      meta: {
+        label: 'test-transaction-working',
+        tableEffects: [],
+        tableDependencies: [],
+      },
+    };
+
+    const result = await withTransactionCtx(workingCtx, async (_tx) => {
+      return 'transaction successful';
+    });
+
+    expect(result).toBe('transaction successful');
+  });
+
+  it('should handle nested transactions correctly', async () => {
+    // Test that nested transactions work properly
+    const result = await withTransactionCtx(testCtx, async (outerTx) => {
+      // This should run in the same transaction context
+      return await withTransactionCtx(outerTx, async (innerTx) => {
+        expect(innerTx.meta.rootTransaction).toBe('test-transaction');
+        return 'nested transaction successful';
+      });
+    });
+
+    expect(result).toBe('nested transaction successful');
+  });
+});

--- a/packages/shared/src/db/query.ts
+++ b/packages/shared/src/db/query.ts
@@ -1,7 +1,7 @@
 import { sql } from 'drizzle-orm';
 
 import { queryClient } from '../api';
-import { createDevLogger, escapeLog, listDebugLabel, runIfDev } from '../debug';
+import { createDevLogger, escapeLog, listDebugLabel } from '../debug';
 import { AnalyticsEvent } from '../domain';
 import { startTrace } from '../perf';
 import * as changeListener from './changeListener';
@@ -300,13 +300,15 @@ export async function withTransactionCtx<T>(
           errorMessage: e.message,
           errorStack: e.stack,
         });
-        await ctx.db.run(sql`ROLLBACK`).catch((e) =>
+        try {
+          await ctx.db.run(sql`ROLLBACK`);
+        } catch (rollbackError) {
           txLogger.trackError('DB Transaction Rollback Error', {
             label: ctx.meta.label,
-            errorMessage: e.message,
-            errorStack: e.stack,
-          })
-        );
+            errorMessage: rollbackError.message,
+            errorStack: rollbackError.stack,
+          });
+        }
         ctx.meta.rootTransaction = null;
         reject(e);
       }


### PR DESCRIPTION
## Summary

Prevent uncaught errors from causing all transactions to hang indefinitely. 

## Changes

- Wraps full call to db rollback in a try/catch block.

## How did I test?

- Added automated test
- Tested on sim
