### PR TITLE
logs: filter posthog logs

### DIFF
--- a/desk/app/logs.hoon
+++ b/desk/app/logs.hoon
@@ -8,7 +8,10 @@
 =>
   |%
   +$  card  card:agent:gall
-  +$  current-state  [%0 ~]
+  +$  current-state
+    $:  %1
+        posthog=(unit volume:l)
+    ==
   ::
   ++  commit  ?~(^commit 'unknown' i.^commit)
   --
@@ -22,8 +25,14 @@
       cor  ~(. +> [bowl ~])
   ::
   ++  on-init  on-init:def
-  ++  on-save  on-save:def
-  ++  on-load  on-load:def
+  ++  on-save  !>(state)
+  ++  on-load
+    |=  =vase
+    ^-  (quip card _this)
+    =^  cards  state
+      abet:(load:cor vase)
+    [cards this]
+  ::
   ++  on-poke
     |=  [=mark =vase]
     ^-  (quip card _this)
@@ -57,6 +66,21 @@
   ::
   (emit %pass /posthog [%arvo %k %fard fard])
 ::
+++  load
+  |^  |=  =vase
+  ^+  cor
+  =+  !<(old=any-state vase)
+  =?  old  ?=(~ old)  state-0-to-1
+  ?>  ?=(%1 -.old)
+  =.  state  old
+  cor
+  +$  any-state  ?(state-0 state-1)
+  +$  state-0  ~
+  +$  state-1  current-state
+  ++  state-0-to-1
+    [%1 `%info]
+  --
+::
 ++  poke
   |=  [=mark =vase]
   ^+  cor
@@ -66,8 +90,19 @@
     =+  !<(=a-log:l vase)
     ?-    -.a-log
         %log
+      ?~  posthog  cor
+      =/  level=@ud
+        ?-  -.event.a-log
+          %fail  (~(got by volume-level:l) %crit)
+          %tell  (~(got by volume-level:l) vol.event.a-log)
+        ==
+      ?.  (gte level (~(got by volume-level:l) u.posthog))
+        cor
       =.  data.a-log  ['commit'^s+commit data.a-log]
       (send-posthog-event sap.bowl now.bowl +.a-log)
+    ::
+        %set-posthog
+      cor(posthog vol.a-log)
     ==
   ==
 ::

--- a/desk/sur/logs.hoon
+++ b/desk/sur/logs.hoon
@@ -5,6 +5,14 @@
 +$  echo  (list tank)
 ::  $volume: echo volume
 +$  volume  ?(%dbug %info %warn %crit)
+++  volume-level
+  ^~  ^-  (map volume @ud)
+  %-  my
+  :~  [%dbug 0]
+      [%info 1]
+      [%warn 2]
+      [%crit 3]
+  ==
 ::  $log-event
 ::
 ::  %fail: agent failure (always considered critical)
@@ -21,5 +29,6 @@
 ::
 +$  a-log
   $%  [%log event=log-event data=log-data]
+      [%set-posthog vol=(unit volume)]
   ==
 --


### PR DESCRIPTION
## Summary

By default, only send logs with volume %info and higher into posthog, dropping the remainder on the floor.

## Changes

This is a partial revert of #5052's 89761bd. In that PR we introduced additional %dbug logs but ended up not including log submission control. The result is excessive log submission to posthog.

Here we reintroduce that log submission control.

My beef with #5052's terminal logging remains and as such I have excluded it from scope here.

## How did I test?

If it compiles, it works, right? (:

## Risks and impact

- Yes, safe to rollback without consulting PR author.
- Affects important code area: none

## Rollback plan

Can revert, old code's `+on-load` Just Works with any previous state.
