### PR TITLE
deps: use new aura-js

### DIFF
--- a/apps/tlon-web/src/logic/utils.ts
+++ b/apps/tlon-web/src/logic/utils.ts
@@ -33,7 +33,7 @@ import {
   Treaty,
   udToDec,
 } from '@urbit/api';
-import { formatUd, formatUv, unixToDa } from '@urbit/aura';
+import { render, unixToDa } from '@urbit/aura';
 import anyAscii from 'any-ascii';
 import bigInt, { BigInteger } from 'big-integer';
 import { hsla, parseToHsla, parseToRgba } from 'color2k';
@@ -358,7 +358,7 @@ export function preSig(ship: string): string {
 }
 
 export function newUv(seed = Date.now()) {
-  return formatUv(unixToDa(seed));
+  return render('uv', unixToDa(seed));
 }
 
 export function getSectTitle(cabals: Cabals, sect: string) {

--- a/packages/app/fixtures/fakeData.ts
+++ b/packages/app/fixtures/fakeData.ts
@@ -1,7 +1,7 @@
 import * as db from '@tloncorp/shared/db';
 import { PlaintextPreviewConfig, getTextContent } from '@tloncorp/shared/logic';
 import type { Story } from '@tloncorp/shared/urbit';
-import { formatUd, unixToDa } from '@urbit/aura';
+import { render, unixToDa } from '@urbit/aura';
 import seedrandom from 'seedrandom';
 
 const makeRandomGenerator = (seed: string = '') => {
@@ -686,7 +686,7 @@ export const createFakePost = (
   const fakeImage = image ? createImageContent(image) : null;
 
   const textContent = getTextContent(JSON.parse(contentOrFake)) ?? null;
-  const id = formatUd(unixToDa(randomSentAtSameDay));
+  const id = render('ud', unixToDa(randomSentAtSameDay));
   return {
     id: `${id}`,
     authorId: ship,

--- a/packages/app/ui/components/BareChatInput/useMentions.tsx
+++ b/packages/app/ui/components/BareChatInput/useMentions.tsx
@@ -1,5 +1,6 @@
 import { useQuery } from '@tanstack/react-query';
-import { ALL_MENTION_ID as allID, isValidPatp } from '@tloncorp/shared';
+import { slaw } from '@urbit/aura';
+import { ALL_MENTION_ID as allID } from '@tloncorp/shared';
 import * as db from '@tloncorp/shared/db';
 import { useMemo, useState } from 'react';
 
@@ -230,7 +231,7 @@ export const useMentions = ({
     if (mentionStartIndex === null) return;
 
     const display = option.title || option.id;
-    const mentionDisplay = isValidPatp(display) ? display : `@${display}`;
+    const mentionDisplay = slaw('p', display) !== null ? display : `@${display}`;
     const beforeMention = text.slice(0, mentionStartIndex);
     const afterMention = text.slice(
       mentionStartIndex + (mentionSearchText?.length || 0) + 1

--- a/packages/shared/src/api/apiUtils.ts
+++ b/packages/shared/src/api/apiUtils.ts
@@ -1,7 +1,7 @@
 import {
-  formatUd as baseFormatUd,
+  render,
   daToUnix,
-  parseUd,
+  parse,
   unixToDa,
 } from '@urbit/aura';
 import bigInt from 'big-integer';
@@ -57,17 +57,16 @@ export function fromClientMeta(meta: db.ClientMeta): ub.GroupMeta {
 }
 
 export function formatUd(ud: string) {
-  // @ts-expect-error string will get converted internally, so doesn't actually have to
-  //be a bigint
-  return baseFormatUd(ud);
+  //REVIEW  horrible signature
+  return render('ud', BigInt(ud));
 }
 
 export function udToDate(da: string) {
-  return daToUnix(parseUd(da));
+  return daToUnix(parse('ud', da));
 }
 
 export function formatDateParam(date: Date) {
-  return baseFormatUd(unixToDa(date!.getTime()));
+  return render('ud', unixToDa(date!.getTime()));
 }
 
 export function isDmChannelId(channelId: string) {

--- a/packages/shared/src/api/changesApi.ts
+++ b/packages/shared/src/api/changesApi.ts
@@ -1,4 +1,4 @@
-import { formatDa, unixToDa } from '@urbit/aura';
+import { render, unixToDa } from '@urbit/aura';
 
 import * as db from '../db';
 import * as ub from '../urbit';
@@ -14,7 +14,7 @@ export async function fetchChangesSince(
   db.ChangesResult & { nodeBusyStatus: 'available' | 'busy' | 'unknown' }
 > {
   const nodeIsBusy = checkIsNodeBusy();
-  const encodedTimestamp = formatDa(unixToDa(timestamp));
+  const encodedTimestamp = render('da', unixToDa(timestamp));
   const response = await scry<ub.Changes>({
     app: 'groups-ui',
     path: `/v5/changes/${encodedTimestamp}`,

--- a/packages/shared/src/api/channelsApi.ts
+++ b/packages/shared/src/api/channelsApi.ts
@@ -1,4 +1,4 @@
-import { formatUd, unixToDa } from '@urbit/aura';
+import { render, unixToDa } from '@urbit/aura';
 import { Poke } from '@urbit/http-api';
 
 import * as db from '../db';
@@ -461,7 +461,7 @@ export const searchChannel = async (params: {
     response = await scry<ub.ChannelScam>({
       app: 'channels',
       path: `/${params.channelId}/search/bounded/text/${
-        params.cursor ? formatUd(BigInt(params.cursor ?? 0)) : ''
+        params.cursor ? render('ud', BigInt(params.cursor ?? 0)) : ''
       }/${SINGLE_PAGE_SEARCH_DEPTH}/${encodedQuery}`,
     });
   } else {
@@ -470,7 +470,7 @@ export const searchChannel = async (params: {
     response = await scry<ub.ChatScam>({
       app: 'chat',
       path: `/${type}/${params.channelId}/search/bounded/text/${
-        params.cursor ? formatUd(BigInt(params.cursor ?? 0)) : ''
+        params.cursor ? render('ud', BigInt(params.cursor ?? 0)) : ''
       }/${SINGLE_PAGE_SEARCH_DEPTH}/${encodedQuery}`,
     });
   }

--- a/packages/shared/src/api/lanyardApi.ts
+++ b/packages/shared/src/api/lanyardApi.ts
@@ -1,4 +1,4 @@
-import { formatUv, parseUw } from '@urbit/aura';
+import { render, parse } from '@urbit/aura';
 import { Atom, Cell, Noun, dejs, dwim, enjs } from '@urbit/nockjs';
 
 import * as db from '../db';
@@ -31,12 +31,12 @@ export function subscribeToLanyardUpdates(
 
 export async function checkAttestedSignature(signData: string) {
   const nonce = Math.floor(Math.random() * 1000000);
-  const encodedNonce = formatUv(BigInt(nonce));
+  const encodedNonce = render('uv', BigInt(nonce));
 
   const query = [
     null,
     [null, nonce],
-    ['valid-jam', new Atom(parseUw(signData))],
+    ['valid-jam', new Atom(parse('uw', signData))],
   ];
   const noun = dwim(query);
 
@@ -71,7 +71,7 @@ export async function discoverContacts(
     const parsedLastSalt = storedLastSalt?.replaceAll('.', '') ?? '0x0';
     const lastSalt = BigInt(parsedLastSalt);
     const nonce = Math.floor(Math.random() * 1000000);
-    const encodedNonce = formatUv(BigInt(nonce));
+    const encodedNonce = render('uv', BigInt(nonce));
     const payload = [
       null,
       [null, nonce],

--- a/packages/shared/src/api/metagrabApi.ts
+++ b/packages/shared/src/api/metagrabApi.ts
@@ -1,4 +1,4 @@
-import { formatUw } from '@urbit/aura';
+import { render } from '@urbit/aura';
 import { Atom } from '@urbit/nockjs';
 
 import { createDevLogger } from '../debug';
@@ -13,7 +13,7 @@ export async function getLinkMetadata(
   url: string
 ): Promise<domain.LinkMetadata | domain.LinkMetadataError> {
   try {
-    const encodedUrl = formatUw(Atom.fromCord(url).number);
+    const encodedUrl = render('uw', Atom.fromCord(url).number);
     logger.log('encoded', { url, encodedUrl });
     const response = await request<ub.LinkMetadataResponse>(
       `/apps/groups/~/metagrab/${encodedUrl}`,

--- a/packages/shared/src/api/nounParsers.ts
+++ b/packages/shared/src/api/nounParsers.ts
@@ -1,4 +1,4 @@
-import { daToUnix, parseUw, patp } from '@urbit/aura';
+import { daToUnix, parse, render } from '@urbit/aura';
 import { Atom, Cell, Noun, cue, dwim, enjs, jam } from '@urbit/nockjs';
 import _ from 'lodash';
 
@@ -31,7 +31,7 @@ export type Sign = HalfSign | FullSign;
 
 export function parseSigned(sign: string): Sign | null {
   // the noun is @uw encoded, first we have to unwrap it
-  const uw = parseUw(sign);
+  const uw = parse('uw', sign);
   const at = new Atom(uw);
   const noun = cue(at); // (signed ?(half-sign-data full-sign-data))
 
@@ -43,7 +43,7 @@ export function parseSigned(sign: string): Sign | null {
   if (!(providerAtom instanceof Atom)) {
     throw new Error('Bad Sign: provider not an atom');
   }
-  const provider = patp(providerAtom.number);
+  const provider = render('p', providerAtom.number);
 
   const TARGET = 14; // TODO: mask instead of magic #
   const signedData = noun.at(Atom.fromInt(TARGET)) as Noun | null; // dat (signed-data)
@@ -176,7 +176,7 @@ function parseHalfSign(noun: Noun): HalfSign {
     throw new Error('Bad half Sign 3');
   }
 
-  const contactId = patp(b.head.number);
+  const contactId = render('p', b.head.number);
   const type = enjs.cord(b.tail) as db.AttestationType;
 
   return { signType: 'half', when, type, contactId };
@@ -198,7 +198,7 @@ function parseFullSign(noun: Noun): FullSign {
   if (!(b.head instanceof Atom)) {
     throw new Error('Bad full Sign 3');
   }
-  const contactId = patp(b.head.number);
+  const contactId = render('p', b.head.number);
 
   const c = b.tail;
   if (!(c instanceof Cell)) {

--- a/packages/shared/src/api/postsApi.ts
+++ b/packages/shared/src/api/postsApi.ts
@@ -1,4 +1,4 @@
-import { formatDa, unixToDa } from '@urbit/aura';
+import { render, unixToDa } from '@urbit/aura';
 import { Poke } from '@urbit/http-api';
 
 import * as db from '../db';
@@ -590,7 +590,7 @@ export const getChangedPosts = async ({
       `v1/${channelId}/posts/changes`,
       formatCursor(startCursor),
       formatCursor(endCursor),
-      formatDa(unixToDa(afterTime.valueOf()).toString())
+      render('da', unixToDa(afterTime.valueOf()).toString())
     ),
   });
   return toPagedPostsData(channelId, response);

--- a/packages/shared/src/http-api/Urbit.ts
+++ b/packages/shared/src/http-api/Urbit.ts
@@ -1,4 +1,4 @@
-import { formatUw, patp2bn, patp2dec } from '@urbit/aura';
+import { parse, render } from '@urbit/aura';
 import { Atom, Cell, Noun, dejs, enjs, jam } from '@urbit/nockjs';
 import { isBrowser } from 'browser-or-node';
 
@@ -580,7 +580,7 @@ export class Urbit {
   //      should result in a noun nesting inside of the xx $eyre-command type
   private async sendNounsToChannel(...args: (Noun | any)[]): Promise<void> {
     const options = this.fetchOptionsNoun('PUT', 'noun');
-    const body = formatUw(jam(dejs.list(args)).number.toString());
+    const body = render('uw', jam(dejs.list(args)).number.toString());
     this.validatePokeBodySize(body);
 
     const response = await this.fetchFn(this.channelUrl, {
@@ -719,7 +719,7 @@ export class Urbit {
     this.outstandingPokes.set(eventId, params);
 
     if (isNoun(noun)) {
-      const shipAtom = new Atom(BigInt(patp2bn(`~${ship}`).toString()));
+      const shipAtom = new Atom(BigInt(parse('p', `~${ship}`).toString()));
       const non = ['poke', eventId, shipAtom, app, mark, noun];
       await this.sendNounsToChannel(non);
     } else {

--- a/packages/shared/src/logic/branch.ts
+++ b/packages/shared/src/logic/branch.ts
@@ -1,4 +1,4 @@
-import { isValidPatp } from '@urbit/aura';
+import { slaw } from '@urbit/aura';
 
 import { getPostInfoFromWer } from '../api/harkApi';
 import { createDevLogger } from '../debug';
@@ -128,7 +128,7 @@ export function extractLureMetadata(branchParams: any) {
   ) {
     // fall back to v1 style lures where the id is a flag
     const [ship, _] = branchParams.lure.split('/');
-    if (isValidPatp(ship)) {
+    if (slaw('p', ship) !== null) {
       extracted.inviterUserId = ship;
       extracted.invitedGroupId = branchParams.lure;
     }
@@ -177,7 +177,7 @@ export const createDeepLink = async ({
   if (type === 'wer') {
     const parts = path.split('/');
     const isDMLure =
-      parts.length === 2 && parts[0] === 'dm' && isValidPatp(parts[1]);
+      parts.length === 2 && parts[0] === 'dm' && slaw('p', parts[1]) !== null;
     if (!isDMLure && !getPostInfoFromWer(path)) {
       logger.crumb(`Invalid path: ${path}`);
       return undefined;

--- a/packages/shared/src/logic/noun.ts
+++ b/packages/shared/src/logic/noun.ts
@@ -1,4 +1,4 @@
-import { daToUnix, formatUv, patp } from '@urbit/aura';
+import { daToUnix, render } from '@urbit/aura';
 import { Atom, Cell, Noun, enjs } from '@urbit/nockjs';
 
 // TODO: nockjs should export these
@@ -29,10 +29,10 @@ export const getPatp: EnjsFunction = (noun: Noun) => {
     throw new Error(`malformed patp ${noun.toString()}`);
   }
 
-  return patp(noun.number);
+  return render('p', noun.number);
 };
 
-export const getUv: EnjsFunction = runIfAtom((a) => formatUv(a.number));
+export const getUv: EnjsFunction = runIfAtom((a) => render('uv', a.number));
 
 export const time: EnjsFunction = runIfAtom((a) => daToUnix(a.number));
 

--- a/packages/shared/src/logic/references.ts
+++ b/packages/shared/src/logic/references.ts
@@ -1,10 +1,10 @@
-import { parseUd } from '@urbit/aura';
+import { parse } from '@urbit/aura';
 
 import * as db from '../db';
 import { ContentReference } from '../domain';
 
 function formatId(id: string) {
-  return parseUd(id).toString();
+  return parse('ud', id).toString();
 }
 
 export function getPostReferencePath(post: db.Post) {

--- a/packages/shared/src/logic/tiptap.ts
+++ b/packages/shared/src/logic/tiptap.ts
@@ -5,7 +5,7 @@ import {
   PasteRule,
 } from '@tiptap/core';
 import { JSONContent } from '@tiptap/react';
-import { deSig, isValidPatp } from '@urbit/aura';
+import { deSig, slaw } from '@urbit/aura';
 import { isEqual, reduce } from 'lodash';
 
 import { Story } from '../urbit/channel';
@@ -385,7 +385,7 @@ export function JSONToInlines(
     case 'at-mention': {
       const id = json.attrs?.id;
       const ship = preSig(id);
-      if (isValidPatp(ship)) {
+      if (slaw('p', ship) !== null) {
         return [{ ship }];
       }
 

--- a/packages/shared/src/logic/utils.ts
+++ b/packages/shared/src/logic/utils.ts
@@ -1,4 +1,4 @@
-import { formatUv } from '@urbit/aura';
+import { render } from '@urbit/aura';
 import anyAscii from 'any-ascii';
 import { differenceInDays, endOfToday, format } from 'date-fns';
 import emojiRegex from 'emoji-regex';
@@ -601,7 +601,7 @@ export const withRetry = <T>(fn: () => Promise<T>, config?: RetryConfig) => {
  * Random id value for group or channel, 4 bits of entropy, eg 0v2a.lmibb -> v2almibb
  */
 export function getRandomId() {
-  const id = formatUv(Math.floor(Math.random() * 0xffffffff).toString());
+  const id = render('uv', Math.floor(Math.random() * 0xffffffff).toString());
   return id.replace(/\./g, '').slice(1);
 }
 

--- a/packages/shared/src/store/storage/storageActions.ts
+++ b/packages/shared/src/store/storage/storageActions.ts
@@ -1,7 +1,6 @@
 import { PutObjectCommand, S3Client } from '@aws-sdk/client-s3';
 import { getSignedUrl } from '@aws-sdk/s3-request-presigner';
-import { deSig, unixToDa } from '@urbit/aura';
-import { formatDa } from '@urbit/aura';
+import { deSig, unixToDa, render } from '@urbit/aura';
 import * as FileSystem from 'expo-file-system';
 import { manipulateAsync } from 'expo-image-manipulator';
 import { ImagePickerAsset } from 'expo-image-picker';
@@ -84,7 +83,7 @@ export const performUpload = async (
 
   const contentType = file.type;
   const fileKey = `${deSig(getCurrentUserId())}/${deSig(
-    formatDa(unixToDa(new Date().getTime()))
+    render('da', unixToDa(new Date().getTime()))
   )}-${params.uri.split('/').pop()?.split('?')[0]}`;
   logger.log('asset key:', fileKey);
 

--- a/packages/shared/src/urbit/activity.ts
+++ b/packages/shared/src/urbit/activity.ts
@@ -1,4 +1,4 @@
-import { daToUnix, parseUd } from '@urbit/aura';
+import { daToUnix, parse } from '@urbit/aura';
 import _ from 'lodash';
 
 import { Kind, Story } from './channel';
@@ -767,7 +767,7 @@ export function getIdParts(id: string): { author: string; sent: number } {
   const [author, sentStr] = id.split('/');
   return {
     author,
-    sent: daToUnix(parseUd(sentStr)),
+    sent: daToUnix(parse('ud', sentStr)),
   };
 }
 

--- a/packages/shared/src/urbit/channel.ts
+++ b/packages/shared/src/urbit/channel.ts
@@ -1,4 +1,4 @@
-import { parseUd } from '@urbit/aura';
+import { parse } from '@urbit/aura';
 import bigInt, { BigInteger } from 'big-integer';
 import _ from 'lodash';
 import BTree from 'sorted-btree';
@@ -615,7 +615,7 @@ export function newPostTupleArray(
     data.pages
       .map((page) => {
         const pagePosts = Object.entries(page.posts).map(
-          ([k, v]) => [bigInt(parseUd(k)), v] as PostTuple
+          ([k, v]) => [bigInt(parse('ud', k)), v] as PostTuple
         );
 
         return pagePosts;

--- a/packages/shared/src/urbit/dms.ts
+++ b/packages/shared/src/urbit/dms.ts
@@ -1,4 +1,4 @@
-import { parseUd } from '@urbit/aura';
+import { parse } from '@urbit/aura';
 import bigInt, { BigInteger } from 'big-integer';
 import _ from 'lodash';
 import BTree from 'sorted-btree';
@@ -206,7 +206,7 @@ export function newWritTupleArray(
     data?.pages
       ?.map((page) => {
         const writPages = Object.entries(page.writs).map(
-          ([k, v]) => [bigInt(parseUd(k)), v] as WritTuple
+          ([k, v]) => [bigInt(parse('ud', k)), v] as WritTuple
         );
         return writPages;
       })

--- a/packages/shared/src/urbit/utils.ts
+++ b/packages/shared/src/urbit/utils.ts
@@ -1,4 +1,4 @@
-import { formatUv, isValidPatp, unixToDa } from '@urbit/aura';
+import { slaw, render, unixToDa } from '@urbit/aura';
 
 import { PostContent } from '../api';
 import { ChannelType } from '../db';
@@ -312,12 +312,12 @@ export function whomIsMultiDm(whom: string): boolean {
 // ship + term, term being a @tas: lower-case letters, numbers, and hyphens
 export function whomIsFlag(whom: string): boolean {
   return (
-    /^~[a-z-]+\/[a-z]+[a-z0-9-]*$/.test(whom) && isValidPatp(whom.split('/')[0])
+    /^~[a-z-]+\/[a-z]+[a-z0-9-]*$/.test(whom) && slaw('p', whom.split('/')[0]) !== null
   );
 }
 
 export function createMultiDmId(seed = Date.now()) {
-  return formatUv(unixToDa(seed));
+  return render('uv', unixToDa(seed));
 }
 
 export function getJoinStatusFromGang(gang: ubg.Gang): GroupJoinStatus | null {
@@ -365,7 +365,7 @@ export function extractGroupPrivacy(
 }
 
 export function createSectionId() {
-  const idParts = formatUv(BigInt(Date.now())).split('.');
+  const idParts = render('uv', BigInt(Date.now())).split('.');
   const newSectionId = `z${idParts[idParts.length - 1]}`;
 
   return newSectionId;


### PR DESCRIPTION
## Summary

Move to using the new aura-js from urbit/aura-js#8.

Opening this as an RFC. General questions/concerns/feedback welcome, see below for specific questions.

## Changes

Updates the usage of `@urbit/aura` in `/apps/tlon-web` and `/packages/shared`. I haven't done the rest yet, and the code here assumes you've `npm link`ed the aura-js PR, but the changes here should be sufficient to evaluate.

Questions:
1. I originally had `parse` aliased to `slaw` (returning `bigint | null`) rather than `slav` (returning `bigint` or throwing). iiuc old parsing logic tended to throw too, so we now maintain parity, but is that our ideal/desire?
    - Do you want a `parseMaybe` alias for `slaw`? Or a better/more standard name?
2. We don't expose any "is valid aura" helpers. So far it seems we only do that for `@p`s, and such checks are trivially implemented as checking `slaw` output for `null`. Thought? Do we want dedicated helpers?
   - Dedicated helpers _may_ be slightly faster by skipping the actual parsing logic, but for some auras (like `@p`) validating and parsing are basically the same step, and I haven't looked for or seen evidence that the whole is slow enough to matter, anyway.

## How did I test?

Compiles and passes basic smoke testing.

## Risks and impact

New aura-js includes bugfixes for some rendering and parsing edge cases, so doesn't have exact parity with the current one. This primarily affects rendering of `@uw`, `@q` for zero or leading-zero cases, and rendering & parsing of `@da`. I suspect that all cases that matter have parity, but we should keep an eye out regardless.

Particularly sensitive to that are cases where we store client-generated string representations of atoms in db/client state. Do we do any of that? Which ones?

- Sure, safe to rollback without consulting PR author.
- Affects important code area:
  - [ ] Onboarding
  - [ ] State / providers
  - [ ] Message sync
  - [ ] Channel display
  - [ ] Notifications
  - [x] Other: probably all of the above

## Rollback plan

Revert.
