### PR TITLE
lure: stop refreshing links from client and including deprecated fields

### DIFF
--- a/packages/app/features/groups/GroupMetaScreen.tsx
+++ b/packages/app/features/groups/GroupMetaScreen.tsx
@@ -61,8 +61,6 @@ export function GroupMetaScreen(props: Props) {
       } else {
         onPressChatDetails({ type: 'group', id: groupId });
       }
-
-      store.createGroupInviteLink(groupId);
     },
     [
       setGroupMetadata,

--- a/packages/shared/src/api/inviteApi.ts
+++ b/packages/shared/src/api/inviteApi.ts
@@ -10,7 +10,7 @@ const ID_LINK_TIMEOUT = 3 * 1000;
 // 2. Must be flag shaped for %grouper not to crash
 const SELF_INVITE_KEY = '~zod/personal-invite-link';
 
-export function groupsDescribe(meta: GroupMeta & InviteLinkMetadata) {
+export function groupsDescribe(meta: InviteLinkMetadata) {
   return {
     tag: 'groups-0',
     fields: { ...meta }, // makes typescript happy
@@ -77,13 +77,6 @@ export async function createPersonalInviteLink(
   await createInviteLink(
     SELF_INVITE_KEY,
     groupsDescribe({
-      // legacy keys
-      title: 'Personal Invite',
-      description: '',
-      cover: '',
-      image: '',
-
-      // new-style metadata keys
       inviterUserId: currentUserId,
       inviterNickname: currentUser?.nickname ?? '',
       inviterAvatarImage: currentUser?.avatarImage ?? '',

--- a/packages/shared/src/store/inviteActions.ts
+++ b/packages/shared/src/store/inviteActions.ts
@@ -131,13 +131,6 @@ export async function createGroupInviteLink(groupId: string) {
     await createInviteLink(
       groupId,
       groupsDescribe({
-        // legacy keys
-        title: group?.title ?? '',
-        description: group?.description ?? '',
-        cover: group?.coverImage ?? '',
-        image: group?.iconImage ?? '',
-
-        // new-style metadata keys
         inviterUserId: currentUserId,
         inviterNickname: user?.nickname ?? '',
         inviterAvatarImage: user?.avatarImage ?? '',


### PR DESCRIPTION
## Summary

OTT, This fixes TLON-4763 and TLON-4761. 

## Changes

- removed call to update group metadata when editing a group
- removed deprecated metadata fields

## How did I test?

Manually on web editing group metadata and watching network requests.

## Risks and impact

- Safe to rollback without consulting PR author? Yes
- Affects important code area:
  - [X] Onboarding
  - [ ] State / providers
  - [ ] Message sync
  - [ ] Channel display
  - [ ] Notifications
  - [ ] Other:

## Rollback plan

<!-- Describe the steps to revert these changes if needed. -->

## Screenshots / videos

<!-- Attach any relevant media. -->
