### PR TITLE
groups: robustly handle a missing channel section & other fixes

### DIFF
--- a/desk/app/groups.hoon
+++ b/desk/app/groups.hoon
@@ -3684,9 +3684,10 @@
       =/  =channel:g  (got:by-ch nest)
       ?.  (~(has by sections.group) section.u-channel)
         (go-restart-updates `'missing channel updated section')
-      =.  sections.group
-        %+  ~(jab by sections.group)  section.channel
-        |=(=section:g section(order (~(del of order.section) nest)))
+      =+  section=(~(get by sections.group) section.channel)
+      =?  sections.group  ?=(^ section)
+        %+  ~(put by sections.group)  section.channel
+        u.section(order (~(del of order.u.section) nest))
       =.  section.channel   section.u-channel
       =.  channels.group  (put:by-ch nest channel)
       =.  sections.group

--- a/desk/app/groups.hoon
+++ b/desk/app/groups.hoon
@@ -1275,6 +1275,7 @@
         %-  silt
         %+  skim  nests
         |=  =nest:g
+        ?.  ?=(kind:d p.nest)  |
         .^(? %gu (channels-scry nest))
       ==
     cor

--- a/desk/app/logs.hoon
+++ b/desk/app/logs.hoon
@@ -24,7 +24,9 @@
       def  ~(. (default-agent this %|) bowl)
       cor  ~(. +> [bowl ~])
   ::
-  ++  on-init  on-init:def
+  ++  on-init
+    ^-  (quip card _this)
+    `this(posthog `%info)
   ++  on-save  !>(state)
   ++  on-load
     |=  =vase

--- a/desk/tests/app/logs.hoon
+++ b/desk/tests/app/logs.hoon
@@ -2,7 +2,7 @@
 /+  *test-agent
 /=  agent  /app/logs
 |%
-++  dap  %logs-test
+++  dap  %logs
 ++  test-log-fail
   %-  eval-mare
   =/  m  (mare ,~)


### PR DESCRIPTION
## Summary

Some group subscribers have a corrupted state where a channel is placed in a non-existent section. This prevent a channel section update from going through. We fix this by robustly handling a current missing channel section.

Another instance of invalid channel nests inserted by third-party developers was caught and fixed.

We also drive-by-fix the logs agent to pass the unit tests broken by recently merged changes: the default volume was not initialized.

## Changes

1. We avoid a `+jab` crash and replace it with a two step get, put to update a channel section.
2. Ignore channels with invalid nest kinds during active-channels loading.
3. Fix the logs agent to initialize its logging volume to `%info` by default.

## How did I test?

Compiled and run the unit tests.

## Risks and impact

- Safe to rollback without consulting PR author? No
- Affects important code area:
  - [ ] Onboarding
  - [ ] State / providers
  - [ ] Message sync
  - [ ] Channel display
  - [ ] Notifications
  - [ ] Other:

## Rollback plan

Can be reverted at the cost of triggering desync on some ships.
