### PR TITLE
web scroller: fix content justification for notebooks

### DIFF
--- a/packages/app/ui/components/Channel/PostList/PostList.web.tsx
+++ b/packages/app/ui/components/Channel/PostList/PostList.web.tsx
@@ -237,7 +237,7 @@ const PostListSingleColumn: PostListComponent = React.forwardRef(
               minHeight: '100%',
               flexDirection: 'column',
               alignItems: 'stretch',
-              justifyContent: 'flex-end',
+              justifyContent: inverted ? 'flex-end' : 'flex-start',
             }}
           >
             <View
@@ -245,7 +245,6 @@ const PostListSingleColumn: PostListComponent = React.forwardRef(
                 {
                   flex: 1,
                   flexDirection: 'column',
-                  justifyContent: inverted ? 'flex-end' : 'flex-start',
                 },
                 contentContainerStyle,
               ]}


### PR DESCRIPTION
## Summary
fixes TLON-4832
Without this fix, the deleted `justifyContent` would always have the content justified to flex-end, even in non-inverted contexts (e.g. notebooks).


## Changes
Switches `justifyContent` based on `inverted` when justifying the content container (which hugs the contents of the channel) instead of when justifying the content inside the container (which would do nothing, since the container hugs the content – so flex-start would look the same as flex-end). This bug was probably introduced when adding this container around the content.

## How did I test?
See screen recording – tested only on Firefox.

## Risks and impact

- Safe to rollback without consulting PR author? Yes
- Affects important code area:
  - [ ] Onboarding
  - [ ] State / providers
  - [ ] Message sync
  - [x] Channel display
  - [ ] Notifications
  - [ ] Other:

## Rollback plan
git revert

## Screenshots / videos

https://github.com/user-attachments/assets/48559532-b641-4076-98a6-a77517b0497d


