### PR TITLE
fix thread content not justifying to flex-end

### DIFF
--- a/packages/app/ui/components/Channel/PostList/PostList.web.tsx
+++ b/packages/app/ui/components/Channel/PostList/PostList.web.tsx
@@ -240,15 +240,7 @@ const PostListSingleColumn: PostListComponent = React.forwardRef(
               justifyContent: inverted ? 'flex-end' : 'flex-start',
             }}
           >
-            <View
-              style={[
-                {
-                  flex: 1,
-                  flexDirection: 'column',
-                },
-                contentContainerStyle,
-              ]}
-            >
+            <View style={[{ flexDirection: 'column' }, contentContainerStyle]}>
               {orderedData.map((item, index) => (
                 <PostListItem key={item.post.id} item={item} index={index}>
                   {renderItem({ item, index })}


### PR DESCRIPTION
## Summary
fixes TLON-4847

Fixes thread content not justifying to flex-end (and theoretically fixes chat channels not justifying to end – which I could not reliably reproduce).

## Changes
- We want the immediate parent of the post views to hug the post content so that we can position it at the top or bottom of the screen, based on whether the `PostList` is `inverted`.
- This view was incorrectly assigned the rule `flex: 1`, causing it to grow to fill its parent
- Since the post view parent fills its parent, it has no empty space to use to justify itself, causing all affected PostLists to appear to stick to the top (since we layout post views from top-to-bottom regardless of `inverted`).

Fixed by removing the unneeded `flex: 1`.

<details>

<summary>Why did I see the correct behavior when submitting #5141?</summary>

The `flex: 1` was not being consistently applied, and I don't know why – here are some investigation notes.

pasted from /1/chan/chat/~bitpyx-dildus/interface/msg/170141184507587055903478388481608122368

we're defining some containers for the list contents here – notably mixing ReactDOM and React Native (because we want to apply a RN ViewStyle in contentContainerStyle)

<img width="430" height="371" alt="Screenshot 2025-09-19 at 10 48 50 AM" src="https://github.com/user-attachments/assets/98fa6fad-c170-44ac-bff9-95da0a6ea8a6" />
 
that `flex: 1` is the actual bug here – since that View is growing to fill its container, justifyContent in the parent does nothing (the View will always stretch) 
but this wasn't happening for me on chat channel views – looking at the DOM, I see these elements corresponding to the code above: 

<img width="223" height="322" alt="Screenshot 2025-09-19 at 10 48 44 AM" src="https://github.com/user-attachments/assets/8c01a8b0-73a5-4fed-9ba1-bd613c8470c1" />

top is div, bottom is View. the padding-right / padding-left on the View are coming from contentContainerStyle. but where's the `flex: 1`? 
`flex: 1` does get rendered onto the corresponding node when in a thread; and it seems like sometimes tabbing back to a chat channel view, I see the justifyContent bug, so I'm guessing that `flex: 1` is being applied .. sometimes? 

</details>

## How did I test?
Tested only in Firefox – see screen recording.

## Risks and impact

- Safe to rollback without consulting PR author? Yes
- Affects important code area:
  - [ ] Onboarding
  - [ ] State / providers
  - [ ] Message sync
  - [x] Channel display
  - [ ] Notifications
  - [ ] Other:

## Rollback plan
git revert

## Screenshots / videos

https://github.com/user-attachments/assets/0a0a72ab-17d3-4668-9c79-5e0857464db4

