### PR TITLE
tests: easier testing of negotiate-wrapped agents

### DIFF
--- a/desk/lib/negotiate.hoon
+++ b/desk/lib/negotiate.hoon
@@ -732,6 +732,7 @@
       ?.  ?=(%x i.path)  [~ ~]
       ?+  t.t.t.path  [~ ~]
         [%version ~]  ``noun+!>(ours)
+        [%config ~]  ``noun+!>(know)
         [%state ~]  ``noun+!>(state)
       ::
           [%version @ @ @ ~]

--- a/desk/lib/test-agent.hoon
+++ b/desk/lib/test-agent.hoon
@@ -128,7 +128,6 @@
 ++  play-sign
   |=  [=bowl =wire =gill:gall =sign:agent:gall]
   ^+  bowl
-  =.  src.bowl  p.gill
   ?:  ?=(%poke-ack -.sign)  bowl
   =;  =_wex.bowl  bowl(wex wex)
   ?.  (~(has by wex.bowl) [wire gill])
@@ -277,7 +276,7 @@
   =.  bowl.s  (play-sign bowl.s wire gill sign)
   %.  s  %-  do
   |=  s=state
-  (~(on-agent agent.s bowl.s) wire sign)
+  (~(on-agent agent.s bowl.s(src p.gill)) wire sign)
 ::
 ++  do-arvo
   |=  [=wire sign=sign-arvo]

--- a/desk/lib/test-negotiate-agent.hoon
+++ b/desk/lib/test-negotiate-agent.hoon
@@ -1,0 +1,159 @@
+::  test-agent-negotiate: like /lib/test-agent, but negotiation transparency
+::
+::    use this as you would /lib/test-agent. this library will hide most
+::    /lib/negotiate behavior and side-effects, letting you write tests against
+::    your agent's logic without having to simulate version negotation.
+::
+::    caveats:
+::    - the bowl will still contain /~/negotiate wires
+::
+/+  *test-agent, negotiate
+::
+|%
++$  card  card:agent:gall
+::TODO  +get-bowl
+++  do
+  |=  call=$-(state [(list card) agent:gall])
+  =/  m  (mare ,(list card))
+  ::NOTE  ^do will play the cards with their negotiate wires
+  ;<  caz=(list card)  bind:m  (^do call)
+  ::  simulate immediate matching versions for everywhere we negotiate
+  ::
+  ;<  res=cage  bind:m  (got-peek /x/~/negotiate/config)
+  =+  !<(=config:negotiate q.res)
+  =|  cards=(list card)
+  |-  =*  loop  $
+  ?^  caz
+    ?.  ?=([%pass [%~.~ %negotiate %heed @ @ @ ~] *] i.caz)
+      loop(caz t.caz, cards (snoc cards i.caz))
+    =*  who  (slav %p i.t.t.t.p.i.caz)
+    =*  dud         i.t.t.t.t.p.i.caz
+    =*  pro       i.t.t.t.t.t.p.i.caz
+    ::NOTE  at time of writing, /lib/negotiate no-ops on watch acks,
+    ::      so we can get away with not processing the cards here.
+    ;<  *  bind:m  (^do-agent p.i.caz [who dud] %watch-ack ~)
+    ;<  c=(list card)  bind:m
+      %^  do-agent  p.i.caz
+        [who dud]
+      :+  %fact  %noun
+      !>((~(got by (~(got by config) dud)) pro))
+    loop(caz t.caz, cards (weld cards c))
+  ::  filter out /lib/negotiate internal effects,
+  ::  and clean up wrapped wires
+  ::
+  %-  pure:m
+  %+  murn  cards
+  |=  =card
+  ^-  (unit ^card)
+  ?+  card  `card
+      [%pass [%~.~ %negotiate %inner-watch @ @ *] *]
+    `card(p t.t.t.t.t.p.card)
+  ::
+    [%give ?(%kick %fact) [[%~.~ %negotiate *] ~] *]  ~
+    [%pass [%~.~ %negotiate *] *]  ~
+  ==
+::
+++  do-agent
+  |=  [=wire =gill:gall =sign:agent:gall]
+  =/  m  (mare ,(list card))
+  ^-  form:m
+  ::  if this is subscription-related, for a negotiated agent,
+  ::  put the lib negotiate wire on
+  ::
+  ;<  res=cage  bind:m  (got-peek /x/~/negotiate/config)
+  =+  !<(=config:negotiate q.res)
+  =?  wire  &((~(has by config) q.gill) !?=(%poke-ack -.sign) !?=([%~.~ %negotiate *] wire))
+    [%~.~ %negotiate %inner-watch (scot %p p.gill) q.gill wire]
+  |=  s=state
+  ^-  output:m
+  =.  bowl.s  (play-sign bowl.s wire gill sign)
+  %.  s  %-  do
+  |=  s=state
+  (~(on-agent agent.s bowl.s(src p.gill)) wire sign)
+::
+::NOTE  all of the below copied directly from /lib/test-agent
+::TODO  if test-agent was factored differently _maybe_ it'd be possible
+::      to wrap these as ++  do-poke  (cork poke do) or similar?
+::      but what would you do about the "pre and post logic" cases like +do-init?
+::
+++  do-init
+  =+  scry-warn=&
+  |=  [dap=term =agent]
+  =/  m  (mare ,(list card))
+  ^-  form:m
+  ;<  old-scry=scry  bind:m  |=(s=state &+[scry.s s])
+  ;<  ~              bind:m  %-  set-scry-gate
+                             |=  p=path
+                             ~?  >>  scry-warn
+                               ['scrying during +on-init... careful!' p]
+                             (old-scry p)
+  ;<  b=bowl         bind:m  get-bowl
+  ;<  ~              bind:m  (set-bowl %*(. *bowl dap dap, our our.b, src our.b))
+  ;<  c=(list card)  bind:m  (do |=(s=state ~(on-init agent bowl.s)))
+  ;<  ~              bind:m  (set-scry-gate old-scry)
+  (pure:m c)
+::
+++  do-load
+  =+  scry-warn=&
+  |=  [=agent vase=(unit vase)]
+  =/  m  (mare ,(list card))
+  ^-  form:m
+  ;<  old-scry=scry  bind:m  |=(s=state &+[scry.s s])
+  ;<  ~              bind:m  %-  set-scry-gate
+                             |=  p=path
+                             ~?  >>  scry-warn
+                               ['scrying during +on-load... careful!' p]
+                             (old-scry p)
+  ;<  c=(list card)  bind:m  %-  do  |=  s=state
+                             %-  ~(on-load agent bowl.s)
+                             ?^  vase  u.vase
+                             ~(on-save agent.s bowl.s)
+  ;<  ~              bind:m  (set-scry-gate old-scry)
+  (pure:m c)
+::
+++  do-poke
+  |=  [=mark =vase]
+  %-  do
+  |=  s=state
+  (~(on-poke agent.s bowl.s) mark vase)
+::
+++  do-watch
+  |=  =path
+  =/  m  (mare ,(list card))
+  ^-  form:m
+  |=  s=state
+  =.  sup.bowl.s
+    =/  =duct  [%test-sub (scot %p src.bowl.s) path]~
+    ~_  leaf+"sub on {(spud path)} already made by {(scow %p src.bowl.s)}"
+    ?<  (~(has by sup.bowl.s) duct)
+    (~(put by sup.bowl.s) duct [src.bowl.s path])
+  %.  s  %-  do
+  |=  s=state
+  (~(on-watch agent.s bowl.s) path)
+::
+++  do-leave
+  |=  =path
+  =/  m  (mare ,(list card))
+  ^-  form:m
+  |=  s=state
+  =.  sup.bowl.s
+    =/  =duct  [%test-sub (scot %p src.bowl.s) path]~
+    ~_  leaf+"sub on {(spud path)} not yet made by {(scow %p src.bowl.s)}"
+    ?>  (~(has by sup.bowl.s) duct)
+    (~(del by sup.bowl.s) duct [src.bowl.s path])
+  %.  s  %-  do
+  |=  s=state
+  (~(on-leave agent.s bowl.s) path)
+::
+++  do-arvo
+  |=  [=wire sign=sign-arvo]
+  %-  do
+  |=  s=state
+  (~(on-arvo agent.s bowl.s) wire sign)
+::
+++  do-fail
+  |=  [=term =tang]
+  %-  do
+  |=  s=state
+  (~(on-fail agent.s bowl.s) term tang)
+--

--- a/desk/tests/app/groups-server.hoon
+++ b/desk/tests/app/groups-server.hoon
@@ -1,7 +1,7 @@
 ::  groups unit tests
 ::
 /-  g=groups, gv=groups-ver, meta, s=story
-/+  *test, *test-agent, negotiate
+/+  *test, *test-negotiate-agent
 /+  gc=groups-conv
 /=  groups-agent  /app/groups
 |%
@@ -17,25 +17,6 @@
     [%gu ship=@ %activity now=@ rest=*]  `!>(|)
   ==
 ::
-++  do-negotiate
-  |=  [=gill:gall =protocol:negotiate =version:negotiate]
-  =/  m  (mare ,(list card))
-  ;<  caz=(list card)  bind:m
-    %^  do-agent  (heed-wire gill protocol)
-      gill
-    [%watch-ack ~]
-  ;<  cax=(list card)  bind:m
-    %^  do-agent  (heed-wire gill protocol)
-      gill
-    [%fact %noun !>(version)]
-  (pure:m (weld caz cax))
-::  +do-neg-agent: pass a sign on a negotiate inner-watch wire
-::
-++  do-neg-agent
-  |=  [=wire =gill:gall =sign:agent:gall]
-  =/  neg-wire=^wire
-    (weld /~/negotiate/inner-watch/(scot %p p.gill)/[q.gill] wire)
-  (do-agent neg-wire gill sign)
 ++  do-groups-init
   =/  m  (mare ,(list card))
   ^-  form:m
@@ -114,16 +95,6 @@
   ;<  caz=(list card)  bind:m  (do-poke group-command+!>([%join my-flag ~]))
   (pure:m caz)
 ::
-::
-++  heed-wire
-  |=  [=gill:gall =protocol:negotiate]
-  /~/negotiate/heed/(scot %p p.gill)/[q.gill]/[protocol]
-::
-++  ex-fact-negotiate
-  |=  [=gill:gall =protocol:negotiate]
-  %^  ex-task  (heed-wire gill protocol)
-    gill
-  [%watch /~/negotiate/version/[q.gill]]
 ::
 ++  ex-u-groups
   |=  [caz=(list card) us-groups=(list u-group:v7:gv)]
@@ -557,12 +528,10 @@
     :~  ::
         ::  invite ~dev
         (ex-poke (snoc dev-wire %old) [~dev my-agent] group-foreign-1+!>(a-foreigns-7-dev))
-        (ex-fact-negotiate [~dev my-agent] %groups)
         (ex-poke dev-wire [~dev my-agent] group-foreign-2+!>(a-foreigns-8-dev))
         ::
         ::  invite ~fun
         (ex-poke (snoc fun-wire %old) [~fun my-agent] group-foreign-1+!>(a-foreigns-7-fun))
-        (ex-fact-negotiate [~fun my-agent] %groups)
         (ex-poke fun-wire [~fun my-agent] group-foreign-2+!>(a-foreigns-8-fun))
         ::
         ::  self-join and foreigns update

--- a/desk/tests/app/groups.hoon
+++ b/desk/tests/app/groups.hoon
@@ -1,7 +1,7 @@
 ::  groups subscriber unit tests
 ::
 /-  g=groups, gv=groups-ver, meta, s=story
-/+  *test, *test-agent, negotiate
+/+  *test, *test-negotiate-agent
 /+  gc=groups-conv
 /=  groups-agent  /app/groups
 |%
@@ -61,9 +61,6 @@
   ?+    path  ~
     [%gu ship=@ %activity now=@ rest=*]  `!>(|)
   ==
-++  is-negotiate-card
-  |=  =card
-  ?=([%pass [%~.~ %negotiate *] *] card)
 ++  do-groups-init
   =/  m  (mare ,(list card))
   ^-  form:m
@@ -96,48 +93,6 @@
     %-  gang:v2:foreign:v7:gc
     (v7:foreign:v8:gc foreign)
   (ex-fact ~[/gangs/updates] gangs+!>(`gangs:v2:gv`(my my-flag^gang ~)))
-::
-++  heed-wire
-  |=  [=gill:gall =protocol:negotiate]
-  /~/negotiate/heed/(scot %p p.gill)/[q.gill]/[protocol]
-::
-++  ex-fact-negotiate
-  |=  [=gill:gall =protocol:negotiate]
-  %^  ex-task  (heed-wire gill protocol)
-    gill
-  [%watch /~/negotiate/version/[q.gill]]
-::  +ex-cards: lib-negotiate compatible +ex-cards
-::
-++  ex-cards
-  |=  [caz=(list card) exe=(list $-(card tang))]
-  =.  caz
-    %+  turn  caz
-    |=  =card
-    ?.  ?=([%pass [%~.~ %negotiate %inner-watch @ @ *] *] card)
-      card
-    ?>  ?=([%pass * %agent ^ %watch *] card)
-    [%pass |5.p.card q.card]
-  (^ex-cards caz exe)
-::
-++  do-negotiate
-  |=  [=gill:gall =protocol:negotiate =version:negotiate]
-  =/  m  (mare ,(list card))
-  ;<  caz=(list card)  bind:m
-    %^  do-agent  (heed-wire gill protocol)
-      gill
-    [%watch-ack ~]
-  ;<  cax=(list card)  bind:m
-    %^  do-agent  (heed-wire gill protocol)
-      gill
-    [%fact %noun !>(version)]
-  (pure:m (weld caz cax))
-::  +do-neg-fact: pass a sign on a negotiate inner-watch wire
-::
-++  do-neg-agent
-  |=  [=wire =gill:gall =sign:agent:gall]
-  =/  neg-wire=^wire
-    (weld /~/negotiate/inner-watch/(scot %p p.gill)/[q.gill] wire)
-  (do-agent neg-wire gill sign)
 ::
 ++  do-a-groups
   |=  =a-groups:g
@@ -238,11 +193,9 @@
   ;<  caz=(list card)  bind:m  (do-a-foreigns [%foreign my-flag %join ~])
   ;<  ~  bind:m
     %+  ex-cards  caz
-    :~  (ex-fact-negotiate [~zod my-agent] %groups)
-        (ex-poke (weld fi-area /join/public) [~zod my-agent] group-command+!>([%join my-flag ~]))
+    :~  (ex-poke (weld fi-area /join/public) [~zod my-agent] group-command+!>([%join my-flag ~]))
         (ex-foreign-response %*(. *foreign:g progress `%join))
     ==
-  ;<  *  bind:m  (do-negotiate [~zod my-agent] %groups %1)
   ;<  caz=(list card)  bind:m
     %-  (do-as ~zod)
     %^  do-agent  (weld fi-area /join/public)
@@ -259,7 +212,7 @@
     ==
   ;<  =bowl  bind:m  get-bowl
   ;<  *  bind:m
-    %^  do-neg-agent  (weld go-area /updates) 
+    %^  do-agent  (weld go-area /updates)
       [~zod my-agent]
     [%watch-ack ~]
   =/  init-log=log:g
@@ -268,7 +221,7 @@
     :~  now.bowl^[%create my-group]
     ==
   ;<  caz=(list card)  bind:m
-    %^  do-neg-agent  (weld go-area /updates) 
+    %^  do-agent  (weld go-area /updates)
       [~zod my-agent]
     [%fact group-log+!>(init-log)]
   (pure:m caz)
@@ -302,7 +255,7 @@
   ;<  ~  bind:m  (jab-bowl |=(=bowl bowl(src ~dev)))
   ::  invite ~fun to a public group
   ::
-  ;<  caz=(list card)  bind:m 
+  ;<  caz=(list card)  bind:m
     (do-a-groups [%invite my-flag ~fun ~ ~])
   ::  verify both old and new invites are sent
   ::
@@ -325,12 +278,11 @@
       [%invite invite]
     %+  ex-cards  caz
     :~  (ex-poke (weld go-area /invite/send/~fun/old) [~fun my-agent] group-foreign-1+!>(a-foreigns-7-fun))
-        (ex-fact-negotiate [~fun my-agent] %groups)
         (ex-poke (weld go-area /invite/send/~fun) [~fun my-agent] group-foreign-2+!>(a-foreigns-8-fun))
     ==
   ::  verify the invitee is recorded on the invited list
   ::
-  ;<  peek=cage  bind:m  
+  ;<  peek=cage  bind:m
     (got-peek /x/v2/groups/(scot %p p:my-flag)/[q:my-flag])
   =+  group=!<(group:g q.peek)
   ::  verify records on the invited list
@@ -340,7 +292,7 @@
     !>(`[now.bowl ~])
   ::  repeat the invite
   ::
-  ;<  caz=(list card)  bind:m 
+  ;<  caz=(list card)  bind:m
     (do-a-groups [%invite my-flag ~fun ~ ~])
   ;<  =^bowl  bind:m  get-bowl
   ;<  peek=cage  bind:m  (got-peek /x/groups/(scot %p p:my-flag)/[q:my-flag]/preview)
@@ -366,7 +318,7 @@
     ==
   ::  verify records on the invited list
   ::
-  ;<  peek=cage  bind:m  
+  ;<  peek=cage  bind:m
     (got-peek /x/v2/groups/(scot %p p:my-flag)/[q:my-flag])
   =+  group=!<(group:g q.peek)
   ;<  ~  bind:m


### PR DESCRIPTION
## Summary

Introduces /lib/test-negotiate-agent, which wraps around /lib/test-agent to augment it with transparent handling and hiding of /lib/negotiate behavior.

Simplifies the groups agent tests by making them use this as a drop-in replacement of /lib/test-agent.

## Changes

/lib/test-negotiate-agent overloads the original test-agent library, changing the behavior of `+do` to process negotiate cards appropriately, and re-defining every arm that calls `+do` to make sure that gets used.

When we see a version negotiation subscription we out, we simulate an instant watch-ack and matching version fact. This will "release" the underlying subscriptions, if any, and from the test writer's perspective they happen as if the negotiate wrapper wasn't even there.

## How did I test?

I, uh, ran the tests.

## Risks and impact

I'm not very happy with the amount of code duplication. There's probably some way to make /lib/test-agent "pluggable" to reduce this, but I fear that would increase its implementation complexity non-trivially.

This also continues /lib/negotiate's pattern of "just pretend it's not there", which is fine most of the time but has turned out a bit annoying at times wrt inspectability, or odd surprised where it isn't quite 100% invisible. One known case of that here, is that if you inspect the bowl from the test execution state directly, you'll find all the negotiate subs and wires in there.

b593ce7 doesn't _seem_ to affect any of our existing tests, they continue passing, but it _is_ a subtle behavioral change. You have been warned!

- Yes, safe to rollback without consulting PR author.

## Rollback plan

Revert.