### PR TITLE
embeds/links: better youtube link descriptions, allow embeds to fill full width

### DIFF
--- a/packages/app/ui/components/Embed/EmbedContent.tsx
+++ b/packages/app/ui/components/Embed/EmbedContent.tsx
@@ -69,12 +69,14 @@ GenericEmbed.displayName = 'GenericEmbed';
 interface EmbedContentProps {
   url: string;
   content?: string;
+  height?: number;
   renderWrapper: (children: React.ReactNode) => React.ReactNode;
 }
 
 const EmbedContent = memo(function EmbedContent({
   url,
   content,
+  height,
   renderWrapper,
 }: EmbedContentProps) {
   const { embed } = useEmbed(
@@ -125,6 +127,7 @@ const EmbedContent = memo(function EmbedContent({
               url={embedUrl ?? url}
               provider={providerConfig}
               embedHtml={embedHtml}
+              embedHeight={height}
               onError={onEmbedError}
             />
           );

--- a/packages/app/ui/components/Embed/EmbedWebView.web.tsx
+++ b/packages/app/ui/components/Embed/EmbedWebView.web.tsx
@@ -194,13 +194,15 @@ export const EmbedWebView = memo<EmbedWebViewProps>(
     const loadingSpinner = isLoading && (
       <View
         width="100%"
-        height={calculatedHeight}
         backgroundColor="$secondaryBackground"
         justifyContent="center"
         alignItems="center"
         borderRadius="$s"
+        {...(provider.aspectRatio
+          ? { aspectRatio: provider.aspectRatio }
+          : { height: calculatedHeight })}
       >
-        <LoadingSpinner />
+        <LoadingSpinner color="$primaryText" />
       </View>
     );
 

--- a/packages/app/ui/components/Embed/providers.ts
+++ b/packages/app/ui/components/Embed/providers.ts
@@ -2,11 +2,13 @@ interface EmbedProviderConfig {
   name: string;
   defaultHeight: number;
   defaultWidth?: number;
+  aspectRatio?: number;
   generateHtml: (
     url: string,
     embedHtml?: string,
     isDark?: boolean,
-    constrainHeight?: boolean
+    constrainHeight?: boolean,
+    height?: number
   ) => string;
   extractId?: (url: string) => string | null;
   getCustomStyles?: () => string;
@@ -64,30 +66,38 @@ const youtubeConfig: EmbedProviderConfig = {
   name: 'YouTube',
   defaultHeight: 180,
   defaultWidth: 320,
+  aspectRatio: 16 / 9,
   extractId: extractYoutubeId,
-  generateHtml: (url: string) => {
+  generateHtml: (
+    url: string,
+    embedHtml?: string,
+    isDark?: boolean,
+    constrainHeight?: boolean,
+    height?: number
+  ) => {
     const videoId = extractYoutubeId(url);
+    const embedHeight = height || 180;
     return `
       <!DOCTYPE html>
       <html>
         <head>
           <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no" />
           <style>
-            html, body { 
-              margin: 0; 
-              padding: 0; 
+            html, body {
+              margin: 0;
+              padding: 0;
               background: transparent;
             }
             iframe {
               width: 100% !important;
-              height: 180px !important;
+              height: ${embedHeight}px !important;
               margin: 0 !important;
             }
           </style>
           <script>
             window.addEventListener('load', () => {
-              window.ReactNativeWebView.postMessage(JSON.stringify({ 
-                height: 180
+              window.ReactNativeWebView.postMessage(JSON.stringify({
+                height: ${embedHeight}
               }));
             });
           </script>

--- a/packages/app/ui/components/Embed/providers.ts
+++ b/packages/app/ui/components/Embed/providers.ts
@@ -109,6 +109,8 @@ const youtubeConfig: EmbedProviderConfig = {
             src="https://www.youtube.com/embed/${videoId}"
             frameborder="0"
             allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture"
+            // This is necessary to prevent periodic "Error code 153" errors
+            referrerpolicy="strict-origin-when-cross-origin"
             allowfullscreen>
           </iframe>
         </body>

--- a/packages/app/ui/components/GalleryPost/GalleryPost.tsx
+++ b/packages/app/ui/components/GalleryPost/GalleryPost.tsx
@@ -598,6 +598,9 @@ const LargeContentRenderer = createContentRenderer({
         aspectRatio: 1.5,
       },
     },
+    embed: {
+      ...noWrapperPadding,
+    },
   },
 });
 

--- a/packages/app/ui/components/PostContent/BlockRenderer.tsx
+++ b/packages/app/ui/components/PostContent/BlockRenderer.tsx
@@ -511,10 +511,15 @@ export function EmbedBlock({
     return null;
   }
 
+  // Extract height from props if available
+  const embedHeight =
+    typeof props.height === 'number' ? props.height : undefined;
+
   return (
     <EmbedContent
       url={block.url}
       content={block.content}
+      height={embedHeight}
       renderWrapper={(children) =>
         children ? (
           <View width="100%" {...props}>
@@ -609,10 +614,17 @@ export function BlockRenderer({ block }: { block: cn.BlockData }) {
 
   // Special handling for embed blocks - let EmbedContent decide if wrapper should render
   if (block.type === 'embed') {
+    // Extract height from wrapperProps if available
+    const embedHeight =
+      typeof wrapperProps?.height === 'number'
+        ? wrapperProps.height
+        : undefined;
+
     return (
       <EmbedContent
         url={block.url}
         content={block.content}
+        height={embedHeight}
         renderWrapper={(children) =>
           children ? (
             <Wrapper

--- a/packages/shared/src/store/metagrabActions.ts
+++ b/packages/shared/src/store/metagrabActions.ts
@@ -3,13 +3,29 @@ import { useQuery } from '@tanstack/react-query';
 import { getFallbackLinkMetadata, getLinkMetadata } from '../api';
 import * as db from '../db';
 import { createDevLogger } from '../debug';
-import { isTrustedEmbed, isValidUrl, trustedProviders } from '../logic';
+import {
+  fetchEmbed,
+  isTrustedEmbed,
+  isValidUrl,
+  trustedProviders,
+} from '../logic';
+
+// YouTube oEmbed response type based on https://www.youtube.com/oembed API
+interface YouTubeOEmbedResponse {
+  title?: string;
+  author_name?: string;
+  author_url?: string;
+  thumbnail_url?: string;
+  thumbnail_width?: number;
+  thumbnail_height?: number;
+  [key: string]: unknown; // Allow other fields we don't use
+}
 
 const logger = createDevLogger('metagrabActions', false);
 
 export async function getLinkMetaWithFallback(url: string) {
   logger.trackEvent('Attempting metagrab link preview');
-  const response = await getLinkMetadata(url);
+  let response = await getLinkMetadata(url);
 
   const failedToGetMeta =
     response.type === 'error' || response.type === 'redirect';
@@ -23,10 +39,47 @@ export async function getLinkMetaWithFallback(url: string) {
     (tp) => tp.name === 'Twitter'
   );
 
-  // for now, special case twitter links (metagrab is insufficient). Once we can proxy
+  const youtubeEmbedProvider = trustedProviders.find(
+    (tp) => tp.name === 'YouTube'
+  );
+
+  // special case twitter links (metagrab is insufficient). Once we can proxy
   // oembed, we should instead use that
   const isTwitterUrl =
     !!twitterEmbedProvider && isTrustedEmbed(url, [twitterEmbedProvider]);
+
+  // special case youtube links (metagrab is insufficient). Once we can proxy
+  // oembed, we should instead use that.
+  // Note: we can fetch oembed data on the client side for youtube links,
+  // but not for twitter links (because of CORS).
+  const isYouTubeUrl =
+    !!youtubeEmbedProvider && isTrustedEmbed(url, [youtubeEmbedProvider]);
+
+  if (isYouTubeUrl && response.type === 'page') {
+    try {
+      logger.trackEvent('Fetching YouTube oEmbed data', { url });
+      const oembedData = (await fetchEmbed(
+        url
+      )) as YouTubeOEmbedResponse | null;
+
+      if (oembedData?.title) {
+        response = {
+          ...response,
+          title: oembedData.title,
+          description: oembedData.author_name
+            ? `by ${oembedData.author_name}`
+            : response.description,
+          previewImageUrl: oembedData.thumbnail_url || response.previewImageUrl,
+        };
+        logger.trackEvent('Enhanced YouTube metadata with oEmbed', {
+          title: oembedData.title,
+          author: oembedData.author_name,
+        });
+      }
+    } catch (error) {
+      logger.trackError('Failed to fetch YouTube oEmbed data', error);
+    }
+  }
 
   if (failedToGetMeta || metaInsufficient || isTwitterUrl) {
     const settings = await db.getSettings();


### PR DESCRIPTION
## Summary

Fixes tlon-4644, missing link metadata in link previews for youtube links, by special casing youtube links in `getLinkMetaWithFallback` using the `fetchEmbed` function we already have, which fetches oembed data. Youtube doesn't provide title/description via opengraph, only via oembed.

Fixes tlon-4645, youtube (and other) embeds not filling the full width in gallery detail view, by removing the constraint that limited embeds to `provider.defaultWidth` (320px). Embeds now always use 100% width while maintaining aspect ratio. Also fixed some aspect ratio issues on web by removing conflicting height calculations and using CSS aspect-ratio format (`16/9` instead of decimal). Added `aspectRatio` property to provider configs to maintain correct proportions while filling the available width.

## How did I test?

Tested on iOS, Android, and web.

## Risks and impact

- Safe to rollback without consulting PR author? Yes
- Affects important code area:
  - [ ] Onboarding
  - [ ] State / providers
  - [ ] Message sync
  - [x] Channel display (kind of)
  - [ ] Notifications
  - [ ] Other:

## Rollback plan

Revert.

## Screenshots / videos

<img width="1080" height="2400" alt="Screenshot_1758712006" src="https://github.com/user-attachments/assets/d0e33081-20e5-47bd-a8b3-9e9c5e1e410d" />
<img width="1080" height="2400" alt="Screenshot_1758712037" src="https://github.com/user-attachments/assets/34146e09-56d3-4438-9c6c-009d0df870da" />

https://github.com/user-attachments/assets/e19d5046-3f40-457e-8f64-2bd9bea89fd6

(this video was made before the width changes, just demoing the link preview w/full description)

https://github.com/user-attachments/assets/3b98107d-dd51-47a5-91a3-8697e42c9350

<img width="1139" height="1356" alt="image" src="https://github.com/user-attachments/assets/1f0227f3-bddd-43fb-bd72-e30eaf84c0ff" />

Full-width tweet in gallery detail view:
<img width="1179" height="2556" alt="Simulator Screenshot - iPhone 15 - 2025-09-24 at 06 25 59" src="https://github.com/user-attachments/assets/617cb045-1de8-4c84-ae4a-c9fd262f2327" />


