### PR TITLE
personal invite modal: fix padding/space issues

### DIFF
--- a/packages/app/ui/components/PersonalInviteSheet.tsx
+++ b/packages/app/ui/components/PersonalInviteSheet.tsx
@@ -25,7 +25,7 @@ export function PersonalInviteSheet({
 
   return (
     <ActionSheet open={open} onOpenChange={onOpenChange} snapPointsMode="fit">
-      <ActionSheet.SimpleHeader title="Invite Friends to Tlon" />
+      <ActionSheet.SimpleHeader title="Invite Friends to Tlon Messenger" />
       <ActionSheet.Content flex={1} paddingBottom={0}>
         <ActionSheet.ScrollableContent flex={1}>
           {hasOpenedRef.current && (

--- a/packages/app/ui/components/PersonalInviteSheet.tsx
+++ b/packages/app/ui/components/PersonalInviteSheet.tsx
@@ -54,7 +54,7 @@ const PersonalInviteSheetContent = ({
   }, [systemContacts]);
 
   return (
-    <View flex={1} paddingHorizontal={40}>
+    <YStack flex={1} paddingHorizontal={40} gap="$m">
       <Text size="$label/m" color="$secondaryText" marginBottom="$2xl">
         Anyone you invite will skip the waitlist and be added to your contacts.
         You&apos;ll receive a DM when they join.
@@ -69,7 +69,7 @@ const PersonalInviteSheetContent = ({
           />
         )}
       </View>
-      <YStack gap="$m">
+      <YStack paddingBottom="$l" gap="$m">
         <PersonalInviteButton />
         {hasSystemContacts && (
           <Pressable onPress={() => onPressInviteFriends()}>
@@ -85,6 +85,6 @@ const PersonalInviteSheetContent = ({
           </Pressable>
         )}
       </YStack>
-    </View>
+    </YStack>
   );
 };


### PR DESCRIPTION
## Summary

OTT, fixes tlon-4638. Looks like this:

<img width="578" height="440" alt="image" src="https://github.com/user-attachments/assets/009841ae-d8a2-4a77-a868-1470ebbd7da8" />


## Rollback plan

Revert
