### PR TITLE
chat: fix DM sync across clients

### DIFF
--- a/desk/app/chat.hoon
+++ b/desk/app/chat.hoon
@@ -115,17 +115,17 @@
           [/epic %epic ~]
           [/unreads %chat-unread-update ~]
         ::
-          [/v1 %chat-club-action-1 %writ-response-1 ~]
+          [/v1 %chat-club-action-1 %writ-response-1 %ships ~]
           [/v1/club/$ %writ-response-1 ~]
           [/v1/clubs %chat-club-action-1 ~]
           [/v1/dm/$ %writ-response-1 ~]
         ::
-          [/v2 %chat-club-action-1 %writ-response-2 ~]
+          [/v2 %chat-club-action-1 %writ-response-2 %ships ~]
           [/v2/club/$ %writ-response-2 ~]
           [/v2/clubs %chat-club-action-1 ~]
           [/v2/dm/$ %writ-response-2 ~]
         ::
-          [/v3 %chat-club-action-1 %writ-response-3 ~]
+          [/v3 %chat-club-action-1 %writ-response-3 %ships ~]
           [/v3/club/$ %writ-response-3 ~]
           [/v3/clubs %chat-club-action-1 ~]
           [/v3/dm/$ %writ-response-3 ~]
@@ -702,7 +702,9 @@
   ::
       %chat-dm-rsvp
     =+  !<(=rsvp:dm:c vase)
-    di-abet:(di-rsvp:(di-abed:di-core ship.rsvp) ok.rsvp)
+    ::  use soft abed since user could be in a state where they need to accept/decline
+    ::  and the DM isn't actually in state
+    di-abet:(di-rsvp:(di-abed-soft:di-core ship.rsvp) ok.rsvp)
   ::
       %chat-blocked
     ?<  from-self
@@ -2148,12 +2150,12 @@
   (~(has in nets) net.dm)
 ::
 ++  give-invites
-  |=  =ship
+  |=  [s=@p n=@tas]
   =/  invites
-    ?:  (~(has by dms) ship)
-      ~(key by pending-dms)
-    (~(put in ~(key by pending-dms)) ship)
-  (give %fact ~[/ /dm/invited] ships+!>(invites))
+    ?:  =(n %invited)
+      (~(put in ~(key by pending-dms)) s)
+    ~(key by pending-dms)
+  (give %fact ~[/ /dm/invited /v1 /v2 /v3] ships+!>(invites))
 ::
 ++  verses-to-inlines  ::  for backcompat
   |=  l=(list verse:d)
@@ -2321,7 +2323,7 @@
       cor
     =.  pact.dm  (reduce:di-pact now.bowl from-self diff)
     =?  cor  &(=(net.dm %invited) !=(ship our.bowl))
-      (give-invites ship)
+      (give-invites ship net.dm)
     ?-  -.q.diff
         ?(%add-react %del-react)  (di-give-writs-diff diff)
     ::
@@ -2417,6 +2419,10 @@
     ?>  |(=(src.bowl ship) =(our src):bowl)
     ::  TODO hook into archive
     ?.  ok
+      ::  when declining/leaving a DM, send updated invite list to subscribers
+      ::  remove the current ship from the list since we're declining it
+      =/  updated-invites  (~(del in ~(key by pending-dms)) ship)
+      =.  cor  (give %fact ~[/ /dm/invited /v1 /v2 /v3] ships+!>(updated-invites))
       %-  (note:wood %odd leaf/"gone {<ship>}" ~)
       ?:  =(src.bowl ship)
         di-core
@@ -2424,6 +2430,11 @@
     =.  cor
       (emit [%pass /contacts/heed %agent [our.bowl %contacts] %poke contact-action-0+!>([%heed ~[ship]])])
     =.  net.dm  %done
+    ::  when accepting a DM, also send updated invite list to subscribers
+    ::  remove the accepted DM from the list since it's no longer an invite
+    =/  updated-invites  (~(del in ~(key by pending-dms)) ship)
+    =.  cor
+      (give %fact ~[/ /dm/invited /v1 /v2 /v3] ships+!>(updated-invites))
     (di-post-notice ' joined the chat')
   ::
   ++  di-watch

--- a/packages/shared/src/api/chatApi.ts
+++ b/packages/shared/src/api/chatApi.ts
@@ -94,7 +94,7 @@ export const updateDMMeta = async ({
 export type ChatEvent =
   | { type: 'showPost'; postId: string }
   | { type: 'hidePost'; postId: string }
-  | { type: 'addDmInvites'; channels: db.Channel[] }
+  | { type: 'syncDmInvites'; channels: db.Channel[] }
   | { type: 'groupDmsUpdate' }
   | { type: 'addPost'; post: db.Post; replyMeta?: db.ReplyMeta | null }
   | { type: 'deletePost'; postId: string }
@@ -127,11 +127,11 @@ export function subscribeToChatUpdates(
         return eventHandler({ type: 'hidePost', postId });
       }
 
-      // check for DM invites
+      // check for DM invites sync
       if (Array.isArray(event)) {
-        // dm invites
+        // dm invites - this is the complete list of pending invites
         return eventHandler({
-          type: 'addDmInvites',
+          type: 'syncDmInvites',
           channels: toClientDms(event, true),
         });
       }


### PR DESCRIPTION
## Summary

fixes tlon-4834

Fixes DM sync issue where DM invites remained stuck on some clients after being accepted or declined on other clients.

Before this change, the frontend only updated DM invites during init or re-init (triggered by connection resets, newly joined channels, or stale data). There was no real-time sync for DM invite state changes. This PR adds real-time sync via the chat agent's `/v3` wire, ensuring all clients immediately reflect when DM invites are accepted, declined, or when regular DMs are left.

We *did* expect an `addDmInvites` event on `/v3` in the frontend previously, but no event was ever sent on that path, and no events were ever emitted when we declined an invite or left a DM, so frontend state could be stale on clients. On the clients with stale state, the user also couldn't leave an existing invite because we were using `di-abed` rather than `di-abed-soft` in `%chat-dm-rsvp`.

## Changes

**Backend:**
- Updated `di-rsvp` to emit updated DM invite lists when accepting or declining DMs
- Modified `give-invites` to correctly handle DM state transitions
- Changed from `di-abed` to `di-abed-soft` in `%chat-dm-rsvp` to gracefully handle missing DMs (i.e., if the client thinks we still have a DM and the user tries to leave it, we allow it)
- Updated discipline so that we accept the `%ships` mark on the versioned paths.

**Frontend API:**
- Changed event type from `addDmInvites` to `syncDmInvites` to reflect the new full sync
- Updated event handler to properly parse DM invite sync events from backend

**Frontend Sync:**
- Implemented `handleSyncDmInvites()` function with DM invite state reconciliation
- Added logic to distinguish between accepted invites (convert to regular DMs) and declined invites (remove from local state)
- Cross-references backend DM state to ensure local state accuracy

## How did I test?

- Tested DM invite synchronization across multiple clients
- Verified that accepting DM invites on one client properly syncs to other clients
- Confirmed declining DM invites removes them from all connected clients
- Tested leaving regular DMs to ensure proper cleanup across clients

## Risks and impact

- Safe to rollback without consulting PR author? Yes
- Affects important code area:
  - [ ] Onboarding
  - [ ] State / providers
  - [x] Message sync
  - [ ] Channel display
  - [ ] Notifications
  - [ ] Other:

## Rollback plan

Revert.

## Screenshots / videos

N/A
