### PR TITLE
ActivityNavigator: add group Members screen to drawer

### DIFF
--- a/packages/app/navigation/desktop/ActivityNavigator.tsx
+++ b/packages/app/navigation/desktop/ActivityNavigator.tsx
@@ -11,6 +11,7 @@ import { useCallback, useMemo } from 'react';
 import { EditProfileScreen } from '../../features/settings/EditProfileScreen';
 import { UserProfileScreen } from '../../features/top/UserProfileScreen';
 import { useGroupActions } from '../../hooks/useGroupActions';
+import { GroupSettingsStack } from '../../navigation/GroupSettingsStack';
 import { ActivityScreenView, DESKTOP_SIDEBAR_WIDTH } from '../../ui';
 import { useRootNavigation } from '../utils';
 
@@ -104,6 +105,10 @@ export const ActivityNavigator = () => {
       <ActivityDrawer.Screen
         name="ActivityEmpty"
         component={EmptyActivityScreen}
+      />
+      <ActivityDrawer.Screen
+        name="GroupSettings"
+        component={GroupSettingsStack}
       />
       <ActivityDrawer.Screen name="UserProfile" component={UserProfileScreen} />
       <ActivityDrawer.Screen name="EditProfile" component={EditProfileScreen} />


### PR DESCRIPTION
## Summary

Fixes TLON-4839 where tapping an Activity item alerting you to someone asking to join your private group would lead you nowhere.

## Changes

Adds the group Members screen to the ActivityNavigator drawer so the user can navigate directly to the request to approve or deny.

## How did I test?

- Create a private group on ship A
- Send a reference to it in a DM to ship B
- On ship B, click the reference and ask to join
- On ship A, receive a notification
- Tap the notification and be routed to the group's Members screen
- Approve or deny the entrant

## Risks and impact

- Safe to rollback without consulting PR author? Yes
- Affects important code area:
  - [ ] Onboarding
  - [ ] State / providers
  - [ ] Message sync
  - [ ] Channel display
  - [ ] Notifications
  - [x] Other: desktop navigation

## Rollback plan

git revert

## Screenshots / videos


https://github.com/user-attachments/assets/38cf0b18-2f78-49ba-9f3a-7f36afb58ce5

