### PR TITLE
lure: make sure we set invite-type

### DIFF
--- a/packages/shared/src/store/inviteActions.ts
+++ b/packages/shared/src/store/inviteActions.ts
@@ -131,6 +131,7 @@ export async function createGroupInviteLink(groupId: string) {
     await createInviteLink(
       groupId,
       groupsDescribe({
+        inviteType: 'group',
         inviterUserId: currentUserId,
         inviterNickname: user?.nickname ?? '',
         inviterAvatarImage: user?.avatarImage ?? '',

--- a/packages/shared/src/store/lure.ts
+++ b/packages/shared/src/store/lure.ts
@@ -128,6 +128,7 @@ export const useLureState = create<LureState>((set, get) => ({
       const group = await db.getGroup({ id: flag });
       const user = await db.getContact({ id: currentUserId });
       const metadata: DeepLinkMetadata = {
+        inviteType: 'group',
         inviterUserId: currentUserId,
         inviterNickname: user?.nickname ?? undefined,
         inviterAvatarImage: user?.avatarImage ?? undefined,


### PR DESCRIPTION
## Summary

Fixes TLON-4882. New lure updates would like invite type to be set all the time.

## Changes

- Adds `inviteType: 'group'` to lure metadata

## How did I test?

<!-- Describe your testing process. -->

## Risks and impact

- Safe to rollback without consulting PR author? (Yes | No)
- Affects important code area:
  - [ ] Onboarding
  - [ ] State / providers
  - [ ] Message sync
  - [ ] Channel display
  - [ ] Notifications
  - [ ] Other:

## Rollback plan

<!-- Describe the steps to revert these changes if needed. -->

## Screenshots / videos

<!-- Attach any relevant media. -->
