### PR TITLE
sync: message preload client integration

### DIFF
--- a/apps/tlon-mobile/src/components/AuthenticatedApp.tsx
+++ b/apps/tlon-mobile/src/components/AuthenticatedApp.tsx
@@ -79,6 +79,8 @@ export default function ConnectedAuthenticatedApp() {
   useEffect(() => {
     async function setup() {
       configureClient();
+      // we store a flag to ensure this runs only once per login, not anytime
+      // the app is opened
       const didSyncInitialPosts = await db.didSyncInitialPosts.getValue();
       sync.syncStart().then(async () => {
         if (!didSyncInitialPosts) {

--- a/apps/tlon-mobile/src/components/AuthenticatedApp.tsx
+++ b/apps/tlon-mobile/src/components/AuthenticatedApp.tsx
@@ -1,3 +1,4 @@
+import NetInfo from '@react-native-community/netinfo';
 import {
   AppStatus,
   useAppStatusChange,
@@ -76,9 +77,25 @@ export default function ConnectedAuthenticatedApp() {
   const configureClient = useConfigureUrbitClient();
 
   useEffect(() => {
-    configureClient();
-    sync.syncStart();
-    setClientReady(true);
+    async function setup() {
+      configureClient();
+      const didSyncInitialPosts = await db.didSyncInitialPosts.getValue();
+      sync.syncStart().then(async () => {
+        if (!didSyncInitialPosts) {
+          const net = await NetInfo.fetch();
+          const syncSize =
+            net.isConnected &&
+            (net.type === 'wifi' ||
+              (net.type === 'cellular' &&
+                ['4g', '5g'].includes(net.details.cellularGeneration ?? '')))
+              ? 'heavy'
+              : 'light';
+          sync.syncInitialPosts({ syncSize });
+        }
+      });
+      setClientReady(true);
+    }
+    setup();
   }, [configureClient]);
 
   return (

--- a/apps/tlon-web/src/app.tsx
+++ b/apps/tlon-web/src/app.tsx
@@ -461,9 +461,7 @@ function ConnectedWebApp() {
         await db.headsSyncedAt.resetValue();
         sync
           .syncStart(false)
-          .then(() =>
-            sync.syncRelevantChannelPosts({ priority: sync.SyncPriority.Low })
-          );
+          .then(() => sync.syncInitialPosts({ syncSize: 'light' }));
         hasSyncedRef.current = true;
         telemetry.captureAppActive('web');
       }

--- a/packages/shared/src/api/postsApi.ts
+++ b/packages/shared/src/api/postsApi.ts
@@ -408,6 +408,25 @@ export interface GetChannelPostsResponse {
   totalPosts?: number;
 }
 
+export const getInitialPosts = async (config: {
+  channelCount: number;
+  postCount: number;
+}) => {
+  const response = await scry<ub.PostsInit>({
+    app: 'groups-ui',
+    path: `/v5/init-posts/${config.channelCount}/${config.postCount}`,
+  });
+
+  const channelPosts = Object.entries(response.channels).flatMap(
+    ([channelId, posts]) => (posts ? toPostsData(channelId, posts).posts : [])
+  );
+  const chatPosts = Object.entries(response.chat).flatMap(([chatId, posts]) =>
+    posts ? toPostsData(chatId, posts).posts : []
+  );
+
+  return [...channelPosts, ...chatPosts];
+};
+
 export const getChannelPosts = async ({
   channelId,
   cursor,

--- a/packages/shared/src/db/keyValue.ts
+++ b/packages/shared/src/db/keyValue.ts
@@ -315,7 +315,6 @@ export const wayfindingProgress = createStorageItem<WayfindingProgress>({
   },
 });
 
-
 export const lastLanyardSalt = createStorageItem<string | null>({
   key: 'lastLanyardSalt',
   defaultValue: null,
@@ -340,6 +339,12 @@ export const debugPermittedSchedulerId = createStorageItem<string | null>({
   persistAfterLogout: true,
 });
 
+export const didSyncInitialPosts = createStorageItem<boolean>({
+  key: 'didSyncInitialPosts',
+  defaultValue: false,
+  persistAfterLogout: false,
+});
+
 export type NagState = {
   lastDismissed: number;
   dismissCount: number;
@@ -358,4 +363,3 @@ export const createNagStorageItem = (key: string) => {
     defaultValue: defaultNagState,
   });
 };
-

--- a/packages/shared/src/db/queries.ts
+++ b/packages/shared/src/db/queries.ts
@@ -729,37 +729,6 @@ export const getAllChannels = createReadQuery(
   ['channels']
 );
 
-export const getChannelsForPredictiveSync = createReadQuery(
-  'getChannelsWithUncachedGap',
-  async (
-    opts: { session: Session; limit?: number },
-    ctx: QueryCtx
-  ): Promise<Channel[]> => {
-    const { session } = opts;
-    return await ctx.db.query.channels.findMany({
-      // where channel can fetch newer posts (i.e. has not cached newest posts)
-      where: not(
-        // logic ported from `hasChannelCachedNewestPosts`
-        // https://github.com/tloncorp/tlon-apps/blob/b967030abb33522964b7ca925c4c599bee489ae7/packages/shared/src/store/sync.ts#L1400
-        and(
-          isNotNull($channels.syncedAt),
-          or(
-            gte($channels.syncedAt, session.startTime ?? 0),
-            and(
-              isNotNull($channels.lastPostAt),
-              gt($channels.syncedAt, $channels.lastPostAt)
-            )
-          )
-        )!
-      ),
-
-      orderBy: [desc($channels.lastViewedAt), desc($channels.lastPostAt)],
-      limit: opts.limit,
-    });
-  },
-  ['channels']
-);
-
 export const getMentionCandidates = createReadQuery(
   'getMentionCandidates',
   async (

--- a/packages/shared/src/store/sync.ts
+++ b/packages/shared/src/store/sync.ts
@@ -1482,7 +1482,6 @@ export async function syncInitialPosts(config: {
       numPostsSynced: posts.length,
     });
   } catch (err) {
-    console.log(`bl: it threw?`, err);
     logger.trackError('Failed to sync initial posts', {
       errorMessage: err.toString(),
     });

--- a/packages/shared/src/store/sync.ts
+++ b/packages/shared/src/store/sync.ts
@@ -304,46 +304,6 @@ export const syncLatestPosts = async (
   }
 };
 
-/**
- * Syncs a subset of channels' latest posts; attempts to match the behavior of `useChannelPosts`.
- *
- * This is a best-effort attempt at preloading channels, and should only be
- * executed with a low priority `SyncCtx` to ensure that syncing a channel that
- * the user is looking at can interrupt this.
- * This function internally enqueues work on the sync queue; do not
- * explicitly enqueue this function, or else sync threads will get clogged up.
- */
-export const syncRelevantChannelPosts = async (
-  ctx?: SyncCtx,
-  queryCtx?: QueryCtx
-): Promise<void> => {
-  const session = getSession();
-  if (session == null) {
-    throw new Error('Missing session');
-  }
-  const channelsToSync = await db.getChannelsForPredictiveSync(
-    { session, limit: 20 },
-    queryCtx
-  );
-
-  const errors: { [channelId: string]: unknown } = {};
-  for (const channel of channelsToSync) {
-    try {
-      await fillChannelGap({
-        channelId: channel.id,
-        getSession,
-        syncCtx: ctx,
-      });
-    } catch (err) {
-      logger.error('error syncing channel', channel.id, err);
-      errors[channel.id] = err;
-    }
-  }
-  if (Object.keys(errors).length === channelsToSync.length) {
-    throw new Error('Failed predictive sync', errors);
-  }
-};
-
 export const syncSettings = async (ctx?: SyncCtx) => {
   const settings = await syncQueue.add('settings', ctx, () =>
     api.getSettings()
@@ -1496,6 +1456,39 @@ export async function syncSequencedPosts(
   return result;
 }
 
+export async function syncInitialPosts(config: {
+  syncSize: 'heavy' | 'light';
+}) {
+  try {
+    const params = {
+      // TODO: set defaults once we have perf data that's not
+      // tainted with base64
+      channelCount: config.syncSize === 'heavy' ? 30 : 10,
+      postCount: config.syncSize === 'heavy' ? 50 : 30,
+    };
+    const posts = await syncQueue.add(
+      'initialPosts',
+      { priority: SyncPriority.Medium },
+      () => api.getInitialPosts(params)
+    );
+    if (posts.length) {
+      await db.insertChannelPosts({ posts });
+    }
+
+    await db.didSyncInitialPosts.setValue(true);
+
+    logger.trackEvent('Synced Initial Posts', {
+      syncSize: config.syncSize,
+      numPostsSynced: posts.length,
+    });
+  } catch (err) {
+    console.log(`bl: it threw?`, err);
+    logger.trackError('Failed to sync initial posts', {
+      errorMessage: err.toString(),
+    });
+  }
+}
+
 export async function syncPosts(
   options: api.GetChannelPostsOptions,
   ctx?: SyncCtx
@@ -1909,180 +1902,3 @@ export const setupLowPrioritySubscriptions = async (ctx?: SyncCtx) => {
     ]);
   });
 };
-
-/**
- * Requires `channel` to be up-to-date from DB.
- */
-export function hasChannelCachedNewestPosts({
-  session,
-  channel,
-}: {
-  session: Session | null;
-  channel: db.Channel;
-}) {
-  if (session == null) {
-    return false;
-  }
-  const { syncedAt, lastPostAt } = channel;
-
-  if (syncedAt == null) {
-    return false;
-  }
-
-  // `syncedAt` is only set when sync endpoint reports that there are no newer posts.
-  // https://github.com/tloncorp/tlon-apps/blob/adde000f4330af7e0a2e19bdfcb295f5eb9fe3da/packages/shared/src/store/sync.ts#L905-L910
-  // We are guaranteed to have the most recent post before `syncedAt`; and
-  // we are guaranteed to have the most recent post after `session.startTime`.
-
-  // This case checks that we have overlap between sync backfill and session subscription.
-  //
-  //   ------------------------| syncedAt
-  //     session.startTime |---------------
-  if (syncedAt >= (session.startTime ?? 0)) {
-    return true;
-  }
-
-  // `lastPostAt` is set with the channel's latest post during session init:
-  // https://github.com/tloncorp/tlon-apps/blob/adde000f4330af7e0a2e19bdfcb295f5eb9fe3da/packages/shared/src/store/sync.ts#L1052
-  //
-  // Since we already checked that a session is active, this case checks
-  // that we've hit `syncedAt`'s "no newer posts" at some point _after_ the
-  // channel's most recent post's timestamp.
-  //
-  //          lastPostAt
-  //              v
-  //   ------------------------| syncedAt
-  //
-  // This check would fail if we first caught up via sync, and then later
-  // started a session: in that case, there could be missing posts between
-  // `syncedAt`'s "no newer posts" and the start of the session:
-  //
-  //                lastPostAt (post not received)
-  //                    v
-  //   ----| syncedAt
-  //         session.startTime |---------
-  //
-  // NB: In that case, we *do* have the single latest post for the channel,
-  // but we'd likely be missing all other posts in the gap. Wait until we
-  // filled in the gap to show posts.
-  if (lastPostAt && syncedAt > lastPostAt) {
-    return true;
-  }
-  return false;
-}
-
-/**
- * In the specified channel, fetch posts until we have cached all messages
- * between the channel's unread marker and "now". If we have no unread marker,
- * do nothing. This function does not fetch anything older than unread marker
- * (i.e. this should not fetch posts spanning to the start of the channel
- * timeline).
- */
-async function fillChannelGap(opts: {
-  channelId: db.Channel['id'];
-  getSession: () => Session | null;
-  syncCtx: SyncCtx | undefined;
-}) {
-  // How many syncs do we want to do before moving on to the next channel?
-  // This will be hit on any channel for which the user has an unread marker,
-  // and which has many unfetched newer posts in the corresponding post window
-  // for the unread.
-  // (example: If someone has visited a bunch of active channels in the past,
-  // left the network for a while, then installs this app fresh, they'll
-  // probably hit this max for every channel in the predictive sync set, since
-  // there are a lot of posts to fetch between their unread marker and the most
-  // recent post in each channel.)
-  let maxLoops = 2;
-
-  while (maxLoops > 0) {
-    const fillResult = await stepFillChannelGap(opts);
-    if (fillResult == null || fillResult.fetchedPosts.length === 0) {
-      break;
-    }
-    maxLoops--;
-  }
-  if (maxLoops <= 0) {
-    logger.info('Max fetches reached', opts.channelId);
-  }
-}
-
-/**
- * Performs one "step" of channel backfill. Run repeatedly to fully backfill.
- * Returns `true` if there may be more to fetch.
- */
-async function stepFillChannelGap({
-  channelId,
-  getSession,
-  syncCtx,
-}: {
-  channelId: db.Channel['id'];
-  getSession: () => Session | null;
-  syncCtx: SyncCtx | undefined;
-}): Promise<{
-  /** ordered by sent-at, desc */
-  fetchedPosts: db.Post[];
-} | null> {
-  const latestChannel = await db.getChannel({ id: channelId });
-  if (latestChannel == null) {
-    throw new Error('Missing channel');
-  }
-  const hasCachedNewestPosts = hasChannelCachedNewestPosts({
-    session: getSession(),
-    channel: latestChannel,
-  });
-  if (hasCachedNewestPosts) {
-    // nothing left to fetch
-    return null;
-  }
-
-  const baseSyncParams = {
-    channelId,
-    includeReplies: false,
-    count: 30,
-  } as const;
-
-  const syncParams: api.GetChannelPostsOptions | null = await (async () => {
-    const unread = await db.getChannelUnread({ channelId });
-    const unreadPostId = unread?.firstUnreadPostId;
-    if (unreadPostId == null) {
-      // no unread - we want to bring user to newest posts
-      return {
-        ...baseSyncParams,
-        mode: 'newest',
-      };
-    }
-
-    const backfillInfo = await db.checkUnreadChannelBackfill({
-      channelId,
-      postId: unreadPostId,
-    });
-    if (backfillInfo == null) {
-      // unread is outside a window - we want to show the unread to the user,
-      // so start fetching around the unread.
-      return {
-        ...baseSyncParams,
-        mode: 'around',
-        cursor: unreadPostId,
-      };
-    }
-
-    // if we already have a large set of posts after the unread, don't backfill more
-    if (backfillInfo.numberContiguous > 100) {
-      return null;
-    }
-
-    // we know what window we want to grow - fetch newer posts
-    return {
-      ...baseSyncParams,
-      mode: 'newer' as const,
-      cursor: backfillInfo.newestContiguousPostId,
-    };
-  })();
-
-  if (syncParams == null) {
-    return null;
-  }
-
-  const resp = await syncPosts(syncParams, syncCtx);
-  return { fetchedPosts: resp.posts };
-}

--- a/packages/shared/src/urbit/ui.ts
+++ b/packages/shared/src/urbit/ui.ts
@@ -38,3 +38,8 @@ export interface Changes {
   contacts: Record<string, ContactBookProfile>;
   activity: Activity;
 }
+
+export interface PostsInit {
+  channels: Record<string, Posts | null>;
+  chat: Record<string, Writs | null>;
+}


### PR DESCRIPTION
## Summary

Implements the client portion of our new `init-posts` endpoint for fetching initial message data after mobile login or web tab open. Previously on mobile we were not preloading messages and on web we were using a multi request "predictive sync" operation. This gives us a configurable single endpoint to fetch starting messages.

Uses adaptive loading on mobile where we first check the network characteristics before deciding how much data to sync. If you're on WiFi, it'll behave differently than if you're on 3G.

It's easy to switch the constants for num channels and num messages. We probably want to do a bit more perf testing to select the right constants there, but right now the base64 bug is complicating getting representative test data. I don't think that needs to block merge, but it should block deployment.

Fixes TLON-4901

## Changes
- add urbit types for `init-posts` result
- add `api` and `sync` methods for fetching the endpoint
- call it once on login for mobile
- call it on app open for web

## How did I test?

On simulator, I logged in and confirmed it synced messages successfully.

## Risks and impact

- Safe to rollback without consulting PR author? Yes
- Affects important code area:
  - [x] Onboarding
    - sort of, affects initial UX when you're dumped into ChatList
  - [x] Message sync
