### PR TITLE
onboarding: dont nag for notif permission until we need to

### DIFF
--- a/packages/app/hooks/nagLogic.test.ts
+++ b/packages/app/hooks/nagLogic.test.ts
@@ -2,12 +2,10 @@ import { NagState } from '@tloncorp/shared/domain';
 import { describe, expect, it } from 'vitest';
 
 import {
-  type NagConfig,
   createDefaultNagState,
   createDismissedState,
   createEliminatedState,
   shouldShowNag,
-  validateNagConfig,
 } from './nagLogic';
 
 describe('nagLogic', () => {
@@ -198,72 +196,6 @@ describe('nagLogic', () => {
         eliminated: false,
         firstEligibleTime: 0,
       });
-    });
-  });
-
-  describe('validateNagConfig', () => {
-    it('should pass validation for valid config', () => {
-      const config: NagConfig = {
-        key: 'test',
-        refreshInterval: 1000,
-        refreshCycle: 3,
-      };
-
-      const errors = validateNagConfig(config);
-      expect(errors).toEqual([]);
-    });
-
-    it('should fail validation for missing key', () => {
-      const config = {
-        key: '',
-      } as NagConfig;
-
-      const errors = validateNagConfig(config);
-      expect(errors).toContain('key must be a non-empty string');
-    });
-
-    it('should fail validation for invalid refreshInterval', () => {
-      const config: NagConfig = {
-        key: 'test',
-        refreshInterval: -1000,
-      };
-
-      const errors = validateNagConfig(config);
-      expect(errors).toContain('refreshInterval must be a positive number');
-    });
-
-    it('should fail validation for invalid refreshCycle', () => {
-      const config: NagConfig = {
-        key: 'test',
-        refreshCycle: -1,
-      };
-
-      const errors = validateNagConfig(config);
-      expect(errors).toContain('refreshCycle must be a positive integer');
-    });
-
-    it('should fail validation for non-integer refreshCycle', () => {
-      const config: NagConfig = {
-        key: 'test',
-        refreshCycle: 2.5,
-      };
-
-      const errors = validateNagConfig(config);
-      expect(errors).toContain('refreshCycle must be a positive integer');
-    });
-
-    it('should collect multiple validation errors', () => {
-      const config = {
-        key: '',
-        refreshInterval: -1000,
-        refreshCycle: -1,
-      } as NagConfig;
-
-      const errors = validateNagConfig(config);
-      expect(errors).toHaveLength(3);
-      expect(errors).toContain('key must be a non-empty string');
-      expect(errors).toContain('refreshInterval must be a positive number');
-      expect(errors).toContain('refreshCycle must be a positive integer');
     });
   });
 });

--- a/packages/app/hooks/nagLogic.test.ts
+++ b/packages/app/hooks/nagLogic.test.ts
@@ -1,13 +1,13 @@
-import { describe, it, expect } from 'vitest';
+import { NagState } from '@tloncorp/shared/domain';
+import { describe, expect, it } from 'vitest';
 
 import {
-  shouldShowNag,
+  type NagConfig,
+  createDefaultNagState,
   createDismissedState,
   createEliminatedState,
-  createDefaultNagState,
+  shouldShowNag,
   validateNagConfig,
-  type NagState,
-  type NagConfig,
 } from './nagLogic';
 
 describe('nagLogic', () => {
@@ -68,7 +68,7 @@ describe('nagLogic', () => {
     });
 
     it('should show nag again after refresh interval passes', () => {
-      const oneDayAgo = fixedTime - (24 * 60 * 60 * 1000);
+      const oneDayAgo = fixedTime - 24 * 60 * 60 * 1000;
       const state: NagState = {
         lastDismissed: oneDayAgo,
         dismissCount: 1,
@@ -83,7 +83,7 @@ describe('nagLogic', () => {
     });
 
     it('should not show nag if refresh interval has not passed', () => {
-      const oneHourAgo = fixedTime - (1 * 60 * 60 * 1000);
+      const oneHourAgo = fixedTime - 1 * 60 * 60 * 1000;
       const state: NagState = {
         lastDismissed: oneHourAgo,
         dismissCount: 1,
@@ -98,7 +98,7 @@ describe('nagLogic', () => {
     });
 
     it('should not show nag after reaching refresh cycle limit', () => {
-      const oneDayAgo = fixedTime - (24 * 60 * 60 * 1000);
+      const oneDayAgo = fixedTime - 24 * 60 * 60 * 1000;
       const state: NagState = {
         lastDismissed: oneDayAgo,
         dismissCount: 3, // At limit
@@ -114,7 +114,7 @@ describe('nagLogic', () => {
     });
 
     it('should show nag if under refresh cycle limit', () => {
-      const oneDayAgo = fixedTime - (24 * 60 * 60 * 1000);
+      const oneDayAgo = fixedTime - 24 * 60 * 60 * 1000;
       const state: NagState = {
         lastDismissed: oneDayAgo,
         dismissCount: 2, // Under limit
@@ -200,7 +200,6 @@ describe('nagLogic', () => {
       });
     });
   });
-
 
   describe('validateNagConfig', () => {
     it('should pass validation for valid config', () => {

--- a/packages/app/hooks/nagLogic.test.ts
+++ b/packages/app/hooks/nagLogic.test.ts
@@ -11,14 +11,36 @@ import {
 } from './nagLogic';
 
 describe('nagLogic', () => {
-  const fixedTime = 1000000000000; // Fixed timestamp for testing
+  const fixedTime = 1000000000000;
 
   describe('shouldShowNag', () => {
-    it('should show nag initially when never dismissed', () => {
-      const state = createDefaultNagState();
+    it('should show nag initially when never dismissed and eligible time has passed', () => {
+      const state: NagState = {
+        ...createDefaultNagState(),
+        firstEligibleTime: fixedTime - 1000,
+      };
       const config = {};
 
       expect(shouldShowNag(state, config, fixedTime)).toBe(true);
+    });
+
+    it('should not show nag before initial delay has elapsed', () => {
+      const state: NagState = {
+        ...createDefaultNagState(),
+        firstEligibleTime: fixedTime + 1000,
+      };
+      const config = {
+        initialDelay: 2000,
+      };
+
+      expect(shouldShowNag(state, config, fixedTime)).toBe(false);
+    });
+
+    it('should not show nag if firstEligibleTime is not set (0)', () => {
+      const state = createDefaultNagState();
+      const config = {};
+
+      expect(shouldShowNag(state, config, fixedTime)).toBe(false);
     });
 
     it('should not show nag if eliminated', () => {
@@ -26,6 +48,7 @@ describe('nagLogic', () => {
         lastDismissed: 0,
         dismissCount: 0,
         eliminated: true,
+        firstEligibleTime: 0,
       };
       const config = {};
 
@@ -37,6 +60,7 @@ describe('nagLogic', () => {
         lastDismissed: fixedTime - 1000,
         dismissCount: 1,
         eliminated: false,
+        firstEligibleTime: 0,
       };
       const config = {};
 
@@ -49,6 +73,7 @@ describe('nagLogic', () => {
         lastDismissed: oneDayAgo,
         dismissCount: 1,
         eliminated: false,
+        firstEligibleTime: 0,
       };
       const config = {
         refreshInterval: 12 * 60 * 60 * 1000, // 12 hours
@@ -63,6 +88,7 @@ describe('nagLogic', () => {
         lastDismissed: oneHourAgo,
         dismissCount: 1,
         eliminated: false,
+        firstEligibleTime: 0,
       };
       const config = {
         refreshInterval: 12 * 60 * 60 * 1000, // 12 hours
@@ -77,6 +103,7 @@ describe('nagLogic', () => {
         lastDismissed: oneDayAgo,
         dismissCount: 3, // At limit
         eliminated: false,
+        firstEligibleTime: 0,
       };
       const config = {
         refreshInterval: 12 * 60 * 60 * 1000, // 12 hours
@@ -92,9 +119,10 @@ describe('nagLogic', () => {
         lastDismissed: oneDayAgo,
         dismissCount: 2, // Under limit
         eliminated: false,
+        firstEligibleTime: 0,
       };
       const config = {
-        refreshInterval: 12 * 60 * 60 * 1000, // 12 hours
+        refreshInterval: 12 * 60 * 60 * 1000,
         refreshCycle: 3,
       };
 
@@ -108,6 +136,7 @@ describe('nagLogic', () => {
         lastDismissed: 0,
         dismissCount: 0,
         eliminated: false,
+        firstEligibleTime: 0,
       };
 
       const result = createDismissedState(initialState, fixedTime);
@@ -116,6 +145,7 @@ describe('nagLogic', () => {
         lastDismissed: fixedTime,
         dismissCount: 1,
         eliminated: false,
+        firstEligibleTime: 0,
       });
     });
 
@@ -124,6 +154,7 @@ describe('nagLogic', () => {
         lastDismissed: fixedTime - 1000,
         dismissCount: 2,
         eliminated: false,
+        firstEligibleTime: 0,
       };
 
       const result = createDismissedState(initialState, fixedTime);
@@ -132,6 +163,7 @@ describe('nagLogic', () => {
         lastDismissed: fixedTime,
         dismissCount: 3,
         eliminated: false,
+        firstEligibleTime: 0,
       });
     });
   });
@@ -142,6 +174,7 @@ describe('nagLogic', () => {
         lastDismissed: fixedTime,
         dismissCount: 2,
         eliminated: false,
+        firstEligibleTime: 0,
       };
 
       const result = createEliminatedState(initialState);
@@ -150,6 +183,7 @@ describe('nagLogic', () => {
         lastDismissed: fixedTime,
         dismissCount: 2,
         eliminated: true,
+        firstEligibleTime: 0,
       });
     });
   });
@@ -162,6 +196,7 @@ describe('nagLogic', () => {
         lastDismissed: 0,
         dismissCount: 0,
         eliminated: false,
+        firstEligibleTime: 0,
       });
     });
   });

--- a/packages/app/hooks/nagLogic.ts
+++ b/packages/app/hooks/nagLogic.ts
@@ -1,9 +1,4 @@
-export interface NagState {
-  lastDismissed: number;
-  dismissCount: number;
-  eliminated: boolean;
-  firstEligibleTime: number;
-}
+import { NagState } from '@tloncorp/shared/domain';
 
 export interface NagBehaviorConfig {
   refreshInterval?: number;
@@ -36,7 +31,10 @@ export function shouldShowNag(
   }
 
   // If we have a refresh cycle limit and we've hit it, don't show
-  if (config.refreshCycle !== undefined && state.dismissCount >= config.refreshCycle) {
+  if (
+    config.refreshCycle !== undefined &&
+    state.dismissCount >= config.refreshCycle
+  ) {
     return false;
   }
 
@@ -85,13 +83,20 @@ export function validateNagConfig(config: NagConfig): string[] {
   }
 
   if (config.refreshInterval !== undefined) {
-    if (typeof config.refreshInterval !== 'number' || config.refreshInterval <= 0) {
+    if (
+      typeof config.refreshInterval !== 'number' ||
+      config.refreshInterval <= 0
+    ) {
       errors.push('refreshInterval must be a positive number');
     }
   }
 
   if (config.refreshCycle !== undefined) {
-    if (typeof config.refreshCycle !== 'number' || config.refreshCycle <= 0 || !Number.isInteger(config.refreshCycle)) {
+    if (
+      typeof config.refreshCycle !== 'number' ||
+      config.refreshCycle <= 0 ||
+      !Number.isInteger(config.refreshCycle)
+    ) {
       errors.push('refreshCycle must be a positive integer');
     }
   }

--- a/packages/app/hooks/nagLogic.ts
+++ b/packages/app/hooks/nagLogic.ts
@@ -74,32 +74,3 @@ export function createDefaultNagState(): NagState {
     firstEligibleTime: 0,
   };
 }
-
-export function validateNagConfig(config: NagConfig): string[] {
-  const errors: string[] = [];
-
-  if (!config.key || typeof config.key !== 'string') {
-    errors.push('key must be a non-empty string');
-  }
-
-  if (config.refreshInterval !== undefined) {
-    if (
-      typeof config.refreshInterval !== 'number' ||
-      config.refreshInterval <= 0
-    ) {
-      errors.push('refreshInterval must be a positive number');
-    }
-  }
-
-  if (config.refreshCycle !== undefined) {
-    if (
-      typeof config.refreshCycle !== 'number' ||
-      config.refreshCycle <= 0 ||
-      !Number.isInteger(config.refreshCycle)
-    ) {
-      errors.push('refreshCycle must be a positive integer');
-    }
-  }
-
-  return errors;
-}

--- a/packages/app/hooks/nagLogic.ts
+++ b/packages/app/hooks/nagLogic.ts
@@ -2,11 +2,13 @@ export interface NagState {
   lastDismissed: number;
   dismissCount: number;
   eliminated: boolean;
+  firstEligibleTime: number;
 }
 
 export interface NagBehaviorConfig {
   refreshInterval?: number;
   refreshCycle?: number;
+  initialDelay?: number;
 }
 
 export interface NagConfig extends NagBehaviorConfig {
@@ -23,9 +25,14 @@ export function shouldShowNag(
     return false;
   }
 
-  // If never dismissed, show it
+  // If never dismissed, check if initial delay has elapsed
   if (state.dismissCount === 0) {
-    return true;
+    // If firstEligibleTime is 0, initialize it now
+    if (state.firstEligibleTime === 0) {
+      return false; // Will be initialized in the hook
+    }
+    // Check if initial delay has elapsed
+    return currentTime >= state.firstEligibleTime;
   }
 
   // If we have a refresh cycle limit and we've hit it, don't show
@@ -66,6 +73,7 @@ export function createDefaultNagState(): NagState {
     lastDismissed: 0,
     dismissCount: 0,
     eliminated: false,
+    firstEligibleTime: 0,
   };
 }
 

--- a/packages/app/hooks/useNag.ts
+++ b/packages/app/hooks/useNag.ts
@@ -20,7 +20,6 @@ export {
   createDismissedState,
   createEliminatedState,
   createDefaultNagState,
-  validateNagConfig,
 } from './nagLogic';
 
 export interface NagHookReturn {

--- a/packages/app/ui/components/SystemNotices.tsx
+++ b/packages/app/ui/components/SystemNotices.tsx
@@ -65,6 +65,7 @@ export function NotificationsPrompt() {
     isWeb ||
     !perms.initialized ||
     perms.hasPermission ||
+    perms.canAskPermission ||
     notifNag.isLoading ||
     !notifNag.shouldShow
   ) {

--- a/packages/app/ui/components/SystemNotices.tsx
+++ b/packages/app/ui/components/SystemNotices.tsx
@@ -37,8 +37,9 @@ export default SystemNotices;
 export function NotificationsPrompt() {
   const notifNag = useNag({
     key: 'notificationsPrompt',
-    refreshInterval: 24 * 60 * 60 * 1000, // 24 hours
+    refreshInterval: 24 * 60 * 60 * 1000,
     refreshCycle: 3,
+    initialDelay: 3 * 24 * 60 * 60 * 1000,
   });
 
   const perms = useNotificationPermissions();

--- a/packages/shared/src/db/keyValue.ts
+++ b/packages/shared/src/db/keyValue.ts
@@ -344,12 +344,14 @@ export type NagState = {
   lastDismissed: number;
   dismissCount: number;
   eliminated: boolean;
+  firstEligibleTime: number;
 };
 
 const defaultNagState: NagState = {
   lastDismissed: 0,
   dismissCount: 0,
   eliminated: false,
+  firstEligibleTime: 0,
 };
 
 export const createNagStorageItem = (key: string) => {

--- a/packages/shared/src/domain/analytics.ts
+++ b/packages/shared/src/domain/analytics.ts
@@ -112,6 +112,8 @@ export enum AnalyticsEvent {
   ActionViewProfileGroup = 'Viewed Pinned Profile Group',
   ActionSelectActivityEvent = 'Tapped Activity Event',
   ActionsNotifPermsChecked = 'Checked Notification Permissions',
+  ActionNotifPermsSettingsOpened = 'Opened Notification Settings from Nag',
+  ActionNotifPermsGrantedFromNag = 'Granted Notification Permission from Nag',
   ActionInitiateTwitterAttest = 'Initiated Twitter Attestation',
   ActionConfirmTwitterAttest = 'Confirmed Twitter Attestation',
   ActionInitiatePhoneAttest = 'Initiated Phone Attestation',

--- a/packages/shared/src/domain/system.ts
+++ b/packages/shared/src/domain/system.ts
@@ -5,3 +5,10 @@ export interface NotifPerms {
   requestPermissions: () => Promise<void>;
   openSettings: () => void;
 }
+
+export interface NagState {
+  lastDismissed: number;
+  dismissCount: number;
+  eliminated: boolean;
+  firstEligibleTime: number;
+}


### PR DESCRIPTION
## Summary

Fixes TLON-4896 by not slamming the user with a notification permissions nag beneath the dialog already asking for the same thing. Also introduces a grace period of 3 days until we show the nag.

## Changes

- Only shows the notification permissions nag if explicitly denied, not just undetermined
- Adds an `initialDelay` prop to the `useNag` hook in ms
- Calculates the "first eligible time" for the nag to show
- Checks `Date.now()` on system notice mount to see if we are past the "first eligible time"
- Shows the nag if we are past it, does not if we are before it
- Logs events for people opening the system preferences from the nag and for enabling, then returning to the app

## How did I test?

- Set the notification perm nag grace period to 1 minute
- Launch the simulator w/ fresh install
- Deny notification permissions on first login
- Wait 1 minute
- Confirm nag appears

Also updated the logic tests to make sure our time-math is correct.

## Risks and impact

- Safe to rollback without consulting PR author? Yes
- Affects important code area:
  - [x] Onboarding
  - [ ] State / providers
  - [ ] Message sync
  - [ ] Channel display
  - [ ] Notifications
  - [ ] Other:

## Rollback plan

revert
