### PR TITLE
channels/server: drop bad links from .meta too

### DIFF
--- a/desk/app/channels-server.hoon
+++ b/desk/app/channels-server.hoon
@@ -60,7 +60,7 @@
   |%
   +$  card  card:agent:gall
   +$  current-state
-    $:  %12
+    $:  %13
         =v-channels:v9:c
         =hooks:h
         =pimp:imp
@@ -156,12 +156,14 @@
   =?  old  ?=(%9 -.old)  (state-9-to-10 old)
   =?  old  ?=(%10 -.old)  (state-10-to-11 old)
   =?  old  ?=(%11 -.old)  (state-11-to-12 old)
-  ?>  ?=(%12 -.old)
+  =?  old  ?=(%12 -.old)  (state-12-to-13 old)
+  ?>  ?=(%13 -.old)
   =.  state  old
   inflate-io
   ::
   +$  versioned-state
-    $%  state-12
+    $%  state-13
+        state-12
         state-11
         state-10
         state-9
@@ -175,7 +177,8 @@
         state-1
         state-0
     ==
-  +$  state-12  current-state
+  +$  state-13  current-state
+  +$  state-12  _%*(. *state-13 - %12)
   +$  state-11  _%*(. *state-12 - %11)
   +$  state-10
     $:  %10
@@ -207,10 +210,15 @@
       =pimp:imp
     ==
   ::
+  ++  state-12-to-13
+    |=  s=state-12
+    ^-  state-13
+    s(- %13, v-channels (~(run by v-channels.s) channel:drop-bad-links:utils))
+  ::
   ++  state-11-to-12
     |=  s=state-11
     ^-  state-12
-    s(- %12, v-channels (~(run by v-channels.s) channel-drop-bad-links:utils))
+    s(- %12)
   ::
   ++  state-10-to-11
     |=  s=state-10

--- a/desk/app/channels.hoon
+++ b/desk/app/channels.hoon
@@ -210,7 +210,7 @@
   |%
   +$  card  card:agent:gall
   +$  current-state
-    $:  %14
+    $:  %15
         =v-channels:c
         voc=(map [nest:c plan:c] (unit said:c))
         hidden-posts=(set id-post:c)
@@ -354,7 +354,8 @@
     ==
   =.  cor  (emil caz-12)
   =?  old  ?=(%13 -.old)  (state-13-to-14 old)
-  ?>  ?=(%14 -.old)
+  =?  old  ?=(%14 -.old)  (state-14-to-15 old)
+  ?>  ?=(%15 -.old)
   ::  periodically clear .debounce to avoid space leak
   ::
   =.  debounce  ~
@@ -362,7 +363,8 @@
   inflate-io
   ::
   +$  versioned-state
-    $%  state-14
+    $%  state-15
+        state-14
         state-13
         state-12
         state-11
@@ -378,7 +380,8 @@
         state-1
         state-0
     ==
-  +$  state-14  current-state
+  +$  state-15  current-state
+  +$  state-14  _%*(. *state-15 - %14)
   +$  state-13  _%*(. *state-14 - %13)
   +$  state-12  _%*(. *state-13 - %12)
   +$  state-11  _%*(. *state-12 - %11)
@@ -448,22 +451,17 @@
         =pimp:imp
     ==
   ::
+  ++  state-14-to-15
+    |=  s=state-14
+    ^-  state-15
+    %=  s  -  %15
+      v-channels  (~(run by v-channels.s) channel:drop-bad-links:utils)
+      voc         (~(run by voc.s) (curr bind said:drop-bad-links:utils))
+    ==
+  ::
   ++  state-13-to-14
     |=  s=state-13
-    ^-  state-14
-    %=  s  -  %14
-      v-channels  (~(run by v-channels.s) channel-drop-bad-links:utils)
-    ::
-        voc
-      %-  ~(run by voc.s)
-      |=  s=(unit said:v9:c)
-      ^+  s
-      ?~  s  ~
-      ?+  q.u.s  s
-        [%post %& *]     s(content.post.q.u (drop-bad-links:utils content.post.q.u.s))
-        [%reply @ %& *]  s(content.reply.q.u (drop-bad-links:utils content.reply.q.u.s))
-      ==
-    ==
+    s(- %14)
   ::
   ++  state-12-to-13
     |=  s=state-12

--- a/desk/lib/channel-utils.hoon
+++ b/desk/lib/channel-utils.hoon
@@ -681,32 +681,52 @@
     (~(has in roles.u.seat) `role-id:v7:gv`p.inline)
   ==
 ::
-++  channel-drop-bad-links
-  |=  chan=v-channel:c
-  ^+  chan
-  %_  chan
-      posts
-    %+  run:on-v-posts:c
-      posts.chan
-    |=  post=(may:c v-post:c)
-    ?.  ?=(%& -.post)  post
-    post(content (drop-bad-links content.post))
-  ::
-      log
-    %+  run:log-on:c
-      log.chan
-    |=  upd=u-channel:c
-    ?.  ?=([%post * ?([%set %& *] [%essay *])] upd)  upd
-    ?-  -.u-post.upd
-      %set    upd(content.post.u-post (drop-bad-links content.post.u-post.upd))
-      %essay  upd(content.essay.u-post (drop-bad-links content.essay.u-post.upd))
-    ==
-  ==
 ++  drop-bad-links
-  |^  |=  content=story:c
-      ^+  content
-      (turn content strip)
-  ++  strip
+  |%
+  ++  channel
+    |=  chan=v-channel:c
+    ^+  chan
+    %_  chan
+        posts
+      %+  run:on-v-posts:c
+        posts.chan
+      |=  post=(may:c v-post:c)
+      ?.  ?=(%& -.post)  post
+      post(+>+ (essay +>+.post))
+    ::
+        log
+      %+  run:log-on:c
+        log.chan
+      |=  upd=u-channel:c
+      ?.  ?=([%post * ?([%set %& *] [%essay *])] upd)  upd
+      ?-  -.u-post.upd
+        %set    upd(+>+.post.u-post (essay +>+.post.u-post.upd))
+        %essay  upd(essay.u-post (essay essay.u-post.upd))
+      ==
+    ==
+  ++  said
+    |=  =said:c
+    ?+  q.said  said
+      [%post %& *]     said(+>.post.q (essay +>.post.q.said))
+      [%reply @ %& *]  said(content.reply.q (story content.reply.q.said))
+    ==
+  ++  essay
+    |=  =essay:c
+    %_  essay
+      content  (story content.essay)
+      meta     (bind meta.essay meta)
+    ==
+  ++  meta
+    |=  =data:m
+    %_  data
+      image  ?:((is-good-link image.data) image.data '')
+      cover  ?:((is-good-link cover.data) cover.data '')
+    ==
+  ++  story
+    |=  content=story:c
+    ^+  content
+    (turn content verse)
+  ++  verse
     |=  =verse:s
     ^+  verse
     ?-  -.verse

--- a/desk/tests/app/channels.hoon
+++ b/desk/tests/app/channels.hoon
@@ -3,7 +3,7 @@
 /=  channels-agent  /app/channels
 |%
 +$  current-state
-  $:  %13
+  $:  %15
       =v-channels:c
       voc=(map [nest:c plan:c] (unit said:c))
       hidden-posts=(set id-post:c)
@@ -203,7 +203,7 @@
     =/  m  (mare ,~)
     =/  bad-state=current-state
       =;  chans=v-channels:c
-        [%13 chans ~ ~ ~ ~ *^subs:s *pimp:imp]
+        [%15 chans ~ ~ ~ ~ *^subs:s *pimp:imp]
       =/  chan=v-channel:c
         sequence-fix-test-channel
       ::  bad 7->8 migration in old code had dropped the tombstone
@@ -240,7 +240,7 @@
     ;<  save=vase  bind:m  get-save
     =/  fixed-state=current-state
       =;  chans=v-channels:c
-        [%13 chans ~ ~ ~ ~ *^subs:s *pimp:imp]
+        [%15 chans ~ ~ ~ ~ *^subs:s *pimp:imp]
       =/  chan=v-channel:c
         sequence-fix-test-channel
       ::  missing message will not have magically recovered,
@@ -309,7 +309,7 @@
     =/  m  (mare ,~)
     =/  bad-state=current-state
       =;  chans=v-channels:c
-        [%13 chans ~ ~ ~ ~ *^subs:s *pimp:imp]
+        [%15 chans ~ ~ ~ ~ *^subs:s *pimp:imp]
       =/  chan=v-channel:c
         tombstone-fix-test-channel
       ::  client had just bunted tombstones
@@ -363,7 +363,7 @@
     ;<  save=vase  bind:m  get-save
     =/  fixed-state=current-state
       =;  chans=v-channels:c
-        [%13 chans ~ ~ ~ ~ *^subs:s *pimp:imp]
+        [%15 chans ~ ~ ~ ~ *^subs:s *pimp:imp]
       =/  chan=v-channel:c
         tombstone-fix-test-channel
       (~(put by *v-channels:c) *nest:c chan)
@@ -399,5 +399,5 @@
             [%link '/good' 'txt']
         ==
     ==
-  !>((drop-bad-links:utils story))
+  !>((story:drop-bad-links:utils story))
 --


### PR DESCRIPTION


## Summary

In #5119 we had cleaned up "bad" links (usually: base64 blobs) from post and log contents. However, we neglected to check the meta.essay, which may have similar troubles in its image and cover fields.

## Changes

We lightly restructure the existing utilities, to be a core with multiple entry-points based on what type you want to drop bad links from.

We update the callsites as appropriate, and _move_ the cleanup logic into a new state transition to avoid duplicating effort for not-yet-up-to-date ships.

Lastly we update the tests to match.

## How did I test?

It compiles!

## Risks and impact

The core link cleaning/detection logic hasn't changed, so should be derisked by virtue of #5119 being out and fine.

- Yes, safe to rollback without consulting PR author, but runs up against state migration stuff.
- Affects important code area:
  - [ ] Onboarding
  - [ ] State / providers
  - [ ] Message sync
  - [ ] Channel display
  - [ ] Notifications
  - [ ] Other:

## Rollback plan

Revert logic w/o reverting state transition.
