### PR TITLE
mobile: accurate badging and notifications

### DIFF
--- a/apps/tlon-mobile/eas.json
+++ b/apps/tlon-mobile/eas.json
@@ -51,7 +51,7 @@
       "autoIncrement": true,
       "env": {
         "APP_VARIANT": "preview",
-        "NOTIFY_PROVIDER": "wannec-dozzod-marnus",
+        "NOTIFY_PROVIDER": "wanmep-witnul-nocsyx-lassul",
         "NOTIFY_SERVICE": "tlon-preview-release"
       },
       "android": {

--- a/apps/tlon-mobile/eas.json
+++ b/apps/tlon-mobile/eas.json
@@ -51,7 +51,7 @@
       "autoIncrement": true,
       "env": {
         "APP_VARIANT": "preview",
-        "NOTIFY_PROVIDER": "wanmep-witnul-nocsyx-lassul",
+        "NOTIFY_PROVIDER": "wannec-dozzod-marnus",
         "NOTIFY_SERVICE": "tlon-preview-release"
       },
       "android": {

--- a/apps/tlon-mobile/ios/Landscape.xcodeproj/project.pbxproj
+++ b/apps/tlon-mobile/ios/Landscape.xcodeproj/project.pbxproj
@@ -17,6 +17,21 @@
 		5A1EB9552CAC451A00029EDC /* GroupStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5A1EB9522CAC451A00029EDC /* GroupStore.swift */; };
 		5A1EB9562CAC451A00029EDC /* GroupStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5A1EB9522CAC451A00029EDC /* GroupStore.swift */; };
 		5A1EB9572CAC451A00029EDC /* GroupStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5A1EB9522CAC451A00029EDC /* GroupStore.swift */; };
+		5A277C482E8B35F80030DB0E /* NotificationPreviewPayload.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5A277C472E8B35F80030DB0E /* NotificationPreviewPayload.swift */; };
+		5A277C492E8B35F80030DB0E /* NotificationPreviewPayload.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5A277C472E8B35F80030DB0E /* NotificationPreviewPayload.swift */; };
+		5A277C4A2E8B35F80030DB0E /* NotificationPreviewPayload.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5A277C472E8B35F80030DB0E /* NotificationPreviewPayload.swift */; };
+		5A277C4B2E8B35F80030DB0E /* NotificationPreviewPayload.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5A277C472E8B35F80030DB0E /* NotificationPreviewPayload.swift */; };
+		5A277C4C2E8B35F80030DB0E /* NotificationPreviewPayload.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5A277C472E8B35F80030DB0E /* NotificationPreviewPayload.swift */; };
+		5A277C4E2E8B36AA0030DB0E /* NotificationDismissHandler.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5A277C4D2E8B36AA0030DB0E /* NotificationDismissHandler.swift */; };
+		5A277C4F2E8B36AA0030DB0E /* NotificationDismissHandler.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5A277C4D2E8B36AA0030DB0E /* NotificationDismissHandler.swift */; };
+		5A277C502E8B36AA0030DB0E /* NotificationDismissHandler.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5A277C4D2E8B36AA0030DB0E /* NotificationDismissHandler.swift */; };
+		5A277C512E8B36AA0030DB0E /* NotificationDismissHandler.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5A277C4D2E8B36AA0030DB0E /* NotificationDismissHandler.swift */; };
+		5A277C522E8B36AA0030DB0E /* NotificationDismissHandler.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5A277C4D2E8B36AA0030DB0E /* NotificationDismissHandler.swift */; };
+		5A277C542E8B38320030DB0E /* JSValue+Extension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5A277C532E8B38320030DB0E /* JSValue+Extension.swift */; };
+		5A277C552E8B38320030DB0E /* JSValue+Extension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5A277C532E8B38320030DB0E /* JSValue+Extension.swift */; };
+		5A277C562E8B38320030DB0E /* JSValue+Extension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5A277C532E8B38320030DB0E /* JSValue+Extension.swift */; };
+		5A277C572E8B38320030DB0E /* JSValue+Extension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5A277C532E8B38320030DB0E /* JSValue+Extension.swift */; };
+		5A277C582E8B38320030DB0E /* JSValue+Extension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5A277C532E8B38320030DB0E /* JSValue+Extension.swift */; };
 		5A55792F2E7A16BC004DD85A /* NotificationLogging.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5A55792E2E7A16BC004DD85A /* NotificationLogging.swift */; };
 		5A5579302E7A16BC004DD85A /* NotificationLogging.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5A55792E2E7A16BC004DD85A /* NotificationLogging.swift */; };
 		5A5579312E7A16BC004DD85A /* NotificationLogging.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5A55792E2E7A16BC004DD85A /* NotificationLogging.swift */; };
@@ -29,8 +44,6 @@
 		5AA981102E68C91600FBE023 /* NotificationLogger.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5AA9810D2E68C91600FBE023 /* NotificationLogger.swift */; };
 		5AA981112E68C91600FBE023 /* NotificationLogger.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5AA9810D2E68C91600FBE023 /* NotificationLogger.swift */; };
 		5AA981122E68C91600FBE023 /* NotificationLogger.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5AA9810D2E68C91600FBE023 /* NotificationLogger.swift */; };
-		6303C7802DB17BC200A40B07 /* NotificationPreviewPayload.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6303C77F2DB17BC100A40B07 /* NotificationPreviewPayload.swift */; };
-		6303C7812DB17BC200A40B07 /* NotificationPreviewPayload.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6303C77F2DB17BC100A40B07 /* NotificationPreviewPayload.swift */; };
 		630DE0B72C51A0F80053603B /* Error+isAFTimeout.swift in Sources */ = {isa = PBXBuildFile; fileRef = 632793BD2C4AE4B500F942B1 /* Error+isAFTimeout.swift */; };
 		630DE0C52C51A8780053603B /* UIColor+Extension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 70D386702A60A3E600AFB46E /* UIColor+Extension.swift */; };
 		630DE0C62C51A8780053603B /* Contact.swift in Sources */ = {isa = PBXBuildFile; fileRef = 700B635C2A71DFE90017F40F /* Contact.swift */; };
@@ -182,8 +195,10 @@
 		70F99AAB2B2D337600D77256 /* UserDefaultsStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7036E3532ACD0FC90020A9FB /* UserDefaultsStore.swift */; };
 		70F99AAC2B2D338E00D77256 /* UrbitModule.swift in Sources */ = {isa = PBXBuildFile; fileRef = 70EAEAB42A57A99100FE96E4 /* UrbitModule.swift */; };
 		855125DEE814E6B0DFE6229D /* PrivacyInfo.xcprivacy in Resources */ = {isa = PBXBuildFile; fileRef = 9D6B23EFDEDD5888235A22BB /* PrivacyInfo.xcprivacy */; };
+		AA0FE320B86E4AD5A2E68DE9 /* bundle.js in Resources */ = {isa = PBXBuildFile; fileRef = 6354B01B2DA4510400A00356 /* bundle.js */; };
 		BB2F792D24A3F905000567C9 /* Expo.plist in Resources */ = {isa = PBXBuildFile; fileRef = BB2F792C24A3F905000567C9 /* Expo.plist */; };
 		C184662C2ABBDFF1008EA8C0 /* GoogleService-Info-io.tlon.groups.plist in Resources */ = {isa = PBXBuildFile; fileRef = C184662B2ABBDFF1008EA8C0 /* GoogleService-Info-io.tlon.groups.plist */; };
+		C5AA2DA09E0243819EFF88B6 /* bundle.js in Resources */ = {isa = PBXBuildFile; fileRef = 6354B01B2DA4510400A00356 /* bundle.js */; };
 		C83014822C7BA74C00D9A5CA /* UIFont+SystemDesign.m in Sources */ = {isa = PBXBuildFile; fileRef = C83014812C7BA74C00D9A5CA /* UIFont+SystemDesign.m */; };
 		C83014832C7BA74C00D9A5CA /* UIFont+SystemDesign.m in Sources */ = {isa = PBXBuildFile; fileRef = C83014812C7BA74C00D9A5CA /* UIFont+SystemDesign.m */; };
 		D0A57BA86BAF5327C2EECEE4 /* ExpoModulesProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = F61ADD28CFDBC6EFBD36E3DA /* ExpoModulesProvider.swift */; };
@@ -250,10 +265,12 @@
 		13B07FB71A68108700A75B9A /* main.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = main.m; path = Landscape/main.m; sourceTree = "<group>"; };
 		3B0B210E999A7E0E1A345468 /* Pods-Landscape-preview.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Landscape-preview.release.xcconfig"; path = "Target Support Files/Pods-Landscape-preview/Pods-Landscape-preview.release.xcconfig"; sourceTree = "<group>"; };
 		5A1EB9522CAC451A00029EDC /* GroupStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GroupStore.swift; sourceTree = "<group>"; };
+		5A277C472E8B35F80030DB0E /* NotificationPreviewPayload.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = NotificationPreviewPayload.swift; sourceTree = "<group>"; };
+		5A277C4D2E8B36AA0030DB0E /* NotificationDismissHandler.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = NotificationDismissHandler.swift; path = Landscape/NotificationDismissHandler.swift; sourceTree = "<group>"; };
+		5A277C532E8B38320030DB0E /* JSValue+Extension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "JSValue+Extension.swift"; sourceTree = "<group>"; };
 		5A55792E2E7A16BC004DD85A /* NotificationLogging.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = NotificationLogging.swift; sourceTree = "<group>"; };
 		5A829AAF2E70CE0E0044507C /* NotificationLogProcessor.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = NotificationLogProcessor.swift; path = Landscape/NotificationLogProcessor.swift; sourceTree = "<group>"; };
 		5AA9810D2E68C91600FBE023 /* NotificationLogger.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = NotificationLogger.swift; sourceTree = "<group>"; };
-		6303C77F2DB17BC100A40B07 /* NotificationPreviewPayload.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NotificationPreviewPayload.swift; sourceTree = "<group>"; };
 		630DE0B82C51A1500053603B /* LandscapePreview-Bridging-Header.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = "LandscapePreview-Bridging-Header.h"; path = "Landscape/LandscapePreview-Bridging-Header.h"; sourceTree = "<group>"; };
 		630DE0E22C51A8790053603B /* Notifications-preview.appex */ = {isa = PBXFileReference; explicitFileType = "wrapper.app-extension"; includeInIndex = 0; path = "Notifications-preview.appex"; sourceTree = BUILT_PRODUCTS_DIR; };
 		630DE0EB2C51AC840053603B /* UserDefaults+appGroup.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UserDefaults+appGroup.swift"; sourceTree = "<group>"; };
@@ -372,6 +389,7 @@
 		13B07FAE1A68108700A75B9A /* Landscape */ = {
 			isa = PBXGroup;
 			children = (
+				5A277C4D2E8B36AA0030DB0E /* NotificationDismissHandler.swift */,
 				5A829AAF2E70CE0E0044507C /* NotificationLogProcessor.swift */,
 				63EC5CBF2CD049540098C343 /* SQLiteDB.swift */,
 				635BCB092CC6F954004D52AA /* Intents */,
@@ -429,7 +447,6 @@
 		6374ACE02C49DA9600E637C0 /* Notifications */ = {
 			isa = PBXGroup;
 			children = (
-				6303C77F2DB17BC100A40B07 /* NotificationPreviewPayload.swift */,
 				6354B01B2DA4510400A00356 /* bundle.js */,
 				6374ACEB2C49DAB600E637C0 /* Notifications.entitlements */,
 				636788082C90DC2600F5331E /* Notifications-preview.entitlements */,
@@ -460,6 +477,7 @@
 				70D386702A60A3E600AFB46E /* UIColor+Extension.swift */,
 				630DE0EB2C51AC840053603B /* UserDefaults+appGroup.swift */,
 				63E27E0A2C5AF26C008ACB45 /* Alamofire+sessionWithSharedCookieStorage.swift */,
+				5A277C532E8B38320030DB0E /* JSValue+Extension.swift */,
 			);
 			path = Extensions;
 			sourceTree = "<group>";
@@ -494,6 +512,7 @@
 		70D386522A609BFC00AFB46E /* Notifications */ = {
 			isa = PBXGroup;
 			children = (
+				5A277C472E8B35F80030DB0E /* NotificationPreviewPayload.swift */,
 				5AA9810D2E68C91600FBE023 /* NotificationLogger.swift */,
 				70D386532A609BFC00AFB46E /* PushNotificationManager.swift */,
 			);
@@ -620,6 +639,7 @@
 				FD10A7F022414F080027D42C /* Start Packager */,
 				E99812A83EA5B4CD5D501DE3 /* [Expo] Configure project */,
 				13B07F871A680F5B00A75B9A /* Sources */,
+				6354B0192DA44FB700A00356 /* Build JS bundle */,
 				13B07F8C1A680F5B00A75B9A /* Frameworks */,
 				13B07F8E1A680F5B00A75B9A /* Resources */,
 				70DBC01A2B7C61690021EA96 /* Copy GoogleService-Info.plist */,
@@ -696,6 +716,7 @@
 				70DBBFE72B7C60B50021EA96 /* Start Packager */,
 				70DBBFE82B7C60B50021EA96 /* [Expo] Configure project */,
 				70DBBFE92B7C60B50021EA96 /* Sources */,
+				6354B0192DA44FB700A00356 /* Build JS bundle */,
 				70DBC0022B7C60B50021EA96 /* Frameworks */,
 				70DBC0072B7C60B50021EA96 /* Resources */,
 				70DBC01B2B7C61A20021EA96 /* Copy GoogleService-Info.plist */,
@@ -796,6 +817,7 @@
 				C184662C2ABBDFF1008EA8C0 /* GoogleService-Info-io.tlon.groups.plist in Resources */,
 				3E461D99554A48A4959DE609 /* SplashScreen.storyboard in Resources */,
 				70D386722A61F2E400AFB46E /* main.jsbundle in Resources */,
+				C5AA2DA09E0243819EFF88B6 /* bundle.js in Resources */,
 				4ACCD7281520ED84DDC2759A /* PrivacyInfo.xcprivacy in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -825,6 +847,7 @@
 				70DBC00B2B7C60B50021EA96 /* SplashScreen.storyboard in Resources */,
 				70DBC0182B7C61130021EA96 /* GoogleService-Info-io.tlon.groups.preview.plist in Resources */,
 				70DBC00C2B7C60B50021EA96 /* main.jsbundle in Resources */,
+				AA0FE320B86E4AD5A2E68DE9 /* bundle.js in Resources */,
 				855125DEE814E6B0DFE6229D /* PrivacyInfo.xcprivacy in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -1305,6 +1328,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				5A277C4E2E8B36AA0030DB0E /* NotificationDismissHandler.swift in Sources */,
 				70D386592A609BFC00AFB46E /* UrbitAPI.swift in Sources */,
 				709FC0ED2AC1E25D00B0644D /* Club.swift in Sources */,
 				7083A16C2AFB01A30022404A /* TlonError.swift in Sources */,
@@ -1324,6 +1348,7 @@
 				63A5A04F2CD05CB900928EED /* ChannelEntity.swift in Sources */,
 				700B63602A71E0810017F40F /* SettingsStore.swift in Sources */,
 				5A55792F2E7A16BC004DD85A /* NotificationLogging.swift in Sources */,
+				5A277C542E8B38320030DB0E /* JSValue+Extension.swift in Sources */,
 				635BCB0B2CC6F969004D52AA /* OpenAppIntent.swift in Sources */,
 				70D386712A60A3E600AFB46E /* UIColor+Extension.swift in Sources */,
 				5A829AB02E70CE0E0044507C /* NotificationLogProcessor.swift in Sources */,
@@ -1340,6 +1365,7 @@
 				700B63622A71E0D70017F40F /* ContactStore.swift in Sources */,
 				63E27E132C5AF5B9008ACB45 /* HTTPCookieStorage+forwardChanges.swift in Sources */,
 				6374ACF92C4ACD5100E637C0 /* LoginStore.swift in Sources */,
+				5A277C482E8B35F80030DB0E /* NotificationPreviewPayload.swift in Sources */,
 				630DE0EC2C51AC840053603B /* UserDefaults+appGroup.swift in Sources */,
 				5AA9810E2E68C91600FBE023 /* NotificationLogger.swift in Sources */,
 				D0A57BA86BAF5327C2EECEE4 /* ExpoModulesProvider.swift in Sources */,
@@ -1353,7 +1379,6 @@
 				630DE0C52C51A8780053603B /* UIColor+Extension.swift in Sources */,
 				630DE0C62C51A8780053603B /* Contact.swift in Sources */,
 				630DE0C72C51A8780053603B /* Club.swift in Sources */,
-				6303C7812DB17BC200A40B07 /* NotificationPreviewPayload.swift in Sources */,
 				630DE0C82C51A8780053603B /* UrbitAPI.swift in Sources */,
 				630DE0C92C51A8780053603B /* Group.swift in Sources */,
 				630DE0CA2C51A8780053603B /* TlonError.swift in Sources */,
@@ -1363,10 +1388,12 @@
 				63E27E0E2C5AF26C008ACB45 /* Alamofire+sessionWithSharedCookieStorage.swift in Sources */,
 				630DE0CF2C51A8780053603B /* PocketUserAPI.swift in Sources */,
 				5A5579332E7A16BC004DD85A /* NotificationLogging.swift in Sources */,
+				5A277C522E8B36AA0030DB0E /* NotificationDismissHandler.swift in Sources */,
 				630DE0D02C51A8780053603B /* UserDefaultsStore.swift in Sources */,
 				5A1EB9572CAC451A00029EDC /* GroupStore.swift in Sources */,
 				5AA981122E68C91600FBE023 /* NotificationLogger.swift in Sources */,
 				630DE0D12C51A8780053603B /* ContactStore.swift in Sources */,
+				5A277C4C2E8B35F80030DB0E /* NotificationPreviewPayload.swift in Sources */,
 				630DE0D22C51A8780053603B /* NotificationService.swift in Sources */,
 				630DE0D32C51A8780053603B /* ClubStore.swift in Sources */,
 				63566D1D2C530A370048E3C4 /* INPerson+Extension.swift in Sources */,
@@ -1377,6 +1404,7 @@
 				630DE0D72C51A8780053603B /* Login.swift in Sources */,
 				630DE0D82C51A8780053603B /* PocketAPI.swift in Sources */,
 				630DE0D92C51A8780053603B /* PocketNotificationsAPI.swift in Sources */,
+				5A277C582E8B38320030DB0E /* JSValue+Extension.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -1387,7 +1415,6 @@
 				632793CE2C4AE81E00F942B1 /* UIColor+Extension.swift in Sources */,
 				632793C52C4AE56500F942B1 /* Contact.swift in Sources */,
 				632793CC2C4AE7E500F942B1 /* Club.swift in Sources */,
-				6303C7802DB17BC200A40B07 /* NotificationPreviewPayload.swift in Sources */,
 				632793BB2C4AE49600F942B1 /* UrbitAPI.swift in Sources */,
 				632793CD2C4AE7EC00F942B1 /* Group.swift in Sources */,
 				632793C82C4AE78400F942B1 /* TlonError.swift in Sources */,
@@ -1397,10 +1424,12 @@
 				63E27E0D2C5AF26C008ACB45 /* Alamofire+sessionWithSharedCookieStorage.swift in Sources */,
 				632793C62C4AE56F00F942B1 /* PocketUserAPI.swift in Sources */,
 				5A5579322E7A16BC004DD85A /* NotificationLogging.swift in Sources */,
+				5A277C512E8B36AA0030DB0E /* NotificationDismissHandler.swift in Sources */,
 				632793C42C4AE53A00F942B1 /* UserDefaultsStore.swift in Sources */,
 				5A1EB9562CAC451A00029EDC /* GroupStore.swift in Sources */,
 				5AA981112E68C91600FBE023 /* NotificationLogger.swift in Sources */,
 				632793C32C4AE53500F942B1 /* ContactStore.swift in Sources */,
+				5A277C4B2E8B35F80030DB0E /* NotificationPreviewPayload.swift in Sources */,
 				6374ACE22C49DA9600E637C0 /* NotificationService.swift in Sources */,
 				632793CB2C4AE7D900F942B1 /* ClubStore.swift in Sources */,
 				63566D1C2C530A370048E3C4 /* INPerson+Extension.swift in Sources */,
@@ -1411,6 +1440,7 @@
 				632793BA2C4AE01B00F942B1 /* Login.swift in Sources */,
 				632793B82C4ADEED00F942B1 /* PocketAPI.swift in Sources */,
 				632793B72C4ADEAC00F942B1 /* PocketNotificationsAPI.swift in Sources */,
+				5A277C572E8B38320030DB0E /* JSValue+Extension.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -1418,6 +1448,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				5A277C4F2E8B36AA0030DB0E /* NotificationDismissHandler.swift in Sources */,
 				70DBBFEA2B7C60B50021EA96 /* UrbitAPI.swift in Sources */,
 				70DBBFEB2B7C60B50021EA96 /* Club.swift in Sources */,
 				70DBBFEC2B7C60B50021EA96 /* TlonError.swift in Sources */,
@@ -1431,11 +1462,13 @@
 				70DBBFF12B7C60B50021EA96 /* Contact.swift in Sources */,
 				70DBBFF22B7C60B50021EA96 /* UrbitModule.m in Sources */,
 				70DBBFF32B7C60B50021EA96 /* INPerson+Extension.swift in Sources */,
+				5A277C492E8B35F80030DB0E /* NotificationPreviewPayload.swift in Sources */,
 				70DBBFF42B7C60B50021EA96 /* Error+logWithDomain.swift in Sources */,
 				70DBBFF52B7C60B50021EA96 /* Group.swift in Sources */,
 				70DBBFF62B7C60B50021EA96 /* SettingsStore.swift in Sources */,
 				63A5A04E2CD05CB900928EED /* ChannelEntity.swift in Sources */,
 				70DBBFF72B7C60B50021EA96 /* UIColor+Extension.swift in Sources */,
+				5A277C552E8B38320030DB0E /* JSValue+Extension.swift in Sources */,
 				5A5579302E7A16BC004DD85A /* NotificationLogging.swift in Sources */,
 				635BCB0C2CC6F969004D52AA /* OpenAppIntent.swift in Sources */,
 				70DBBFF82B7C60B50021EA96 /* PocketUserAPI.swift in Sources */,
@@ -1475,10 +1508,12 @@
 				632793C02C4AE4B500F942B1 /* Error+isAFTimeout.swift in Sources */,
 				70F99AA92B2D337600D77256 /* GroupChannelStore.swift in Sources */,
 				70F99A9F2B2D336800D77256 /* Group.swift in Sources */,
+				5A277C502E8B36AA0030DB0E /* NotificationDismissHandler.swift in Sources */,
 				70F99AA32B2D336E00D77256 /* PocketUserAPI.swift in Sources */,
 				5A1EB9552CAC451A00029EDC /* GroupStore.swift in Sources */,
 				70F99AA22B2D336E00D77256 /* UrbitAPI.swift in Sources */,
 				70F99AAA2B2D337600D77256 /* SettingsStore.swift in Sources */,
+				5A277C4A2E8B35F80030DB0E /* NotificationPreviewPayload.swift in Sources */,
 				70F99AA62B2D336E00D77256 /* PocketChatAPI.swift in Sources */,
 				70F99A9D2B2D336500D77256 /* Error+logWithDomain.swift in Sources */,
 				5AA981102E68C91600FBE023 /* NotificationLogger.swift in Sources */,
@@ -1489,6 +1524,7 @@
 				70F99A9C2B2D336500D77256 /* UIColor+Extension.swift in Sources */,
 				5A5579312E7A16BC004DD85A /* NotificationLogging.swift in Sources */,
 				70F99A9E2B2D336800D77256 /* Contact.swift in Sources */,
+				5A277C562E8B38320030DB0E /* JSValue+Extension.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/apps/tlon-mobile/ios/Landscape.xcodeproj/xcshareddata/xcschemes/Notifications-preview.xcscheme
+++ b/apps/tlon-mobile/ios/Landscape.xcodeproj/xcshareddata/xcschemes/Notifications-preview.xcscheme
@@ -40,7 +40,21 @@
       debugDocumentVersioning = "YES"
       debugServiceExtension = "internal"
       allowLocationSimulation = "YES"
-      launchAutomaticallySubstyle = "2">
+      launchAutomaticallySubstyle = "2"
+      consoleMode = "0"
+      structuredConsoleMode = "2">
+      <RemoteRunnable
+         runnableDebuggingMode = "0"
+         BundleIdentifier = "io.tlon.groups.preview"
+         RemotePath = "/var/containers/Bundle/Application/04E6C56E-53C2-465F-B709-97EF80BE32FD/Landscape-preview.app">
+      </RemoteRunnable>
+      <EnvironmentVariables>
+         <EnvironmentVariable
+            key = "OS_ACTIVITY_MODE"
+            value = "disable"
+            isEnabled = "YES">
+         </EnvironmentVariable>
+      </EnvironmentVariables>
    </LaunchAction>
    <ProfileAction
       buildConfiguration = "Release"

--- a/apps/tlon-mobile/ios/Landscape/AppDelegate.mm
+++ b/apps/tlon-mobile/ios/Landscape/AppDelegate.mm
@@ -91,4 +91,18 @@
   return [super application:application didFailToRegisterForRemoteNotificationsWithError:error];
 }
 
+// Handle remote notifications received while app is running
+- (void)application:(UIApplication *)application didReceiveRemoteNotification:(NSDictionary *)userInfo fetchCompletionHandler:(void (^)(UIBackgroundFetchResult))completionHandler
+{
+  // Handle notification dismiss actions using our Swift helper
+  [[NotificationDismissHandler shared] handleNotificationDismissWithUserInfo:userInfo];
+
+  // Call super to maintain existing functionality
+  if ([super respondsToSelector:@selector(application:didReceiveRemoteNotification:fetchCompletionHandler:)]) {
+    [super application:application didReceiveRemoteNotification:userInfo fetchCompletionHandler:completionHandler];
+  } else {
+    completionHandler(UIBackgroundFetchResultNoData);
+  }
+}
+
 @end

--- a/apps/tlon-mobile/ios/Landscape/NotificationDismissHandler.swift
+++ b/apps/tlon-mobile/ios/Landscape/NotificationDismissHandler.swift
@@ -26,12 +26,14 @@ import JavaScriptCore
         }
 
         guard let source = userInfo["dismissSource"] as? String,
-              let count = userInfo["notifyCount"] as? Int,
+              let notifyCount = userInfo["notifyCount"] as? String,
               let uid = userInfo["uid"] as? String,
               let id = userInfo["id"] as? String else {
             print("[dismisser] Missing required fields. dismissSource: \(userInfo["dismissSource"] ?? "nil"), notifyCount: \(userInfo["notifyCount"] ?? "nil"), uid: \(userInfo["uid"] ?? "nil"), id: \(userInfo["id"] ?? "nil")")
             return
         }
+        
+        let count = Int(notifyCount) ?? 0
 
         print("[dismisser] Dismissing notifications \(source) new count \(count) id \(id)")
         // Fetch the activity event to get grouping information
@@ -60,20 +62,16 @@ import JavaScriptCore
             guard let notificationId = notification.request.content.userInfo["id"] as? String else {
                 continue
             }
-            
-            print("[dismisser] notification: grouping \(threadIdentifier) id \(notificationId)")
 
             if threadIdentifier == source {
                 // Dismiss notifications with IDs that are less than the dismiss ID (older messages)
                 let comparison = notificationId.compare(dismissId)
-                print ("[dismisser] comparing ids \(dismissId) and \(notificationId) result: \(comparison)")
                 if comparison == .orderedAscending || comparison == .orderedSame {
                     identifiersToDismiss.append(notification.request.identifier)
                 }
             }
         }
 
-        print("[dismisser] ids to dismiss \(identifiersToDismiss)")
         if !identifiersToDismiss.isEmpty {
             center.removeDeliveredNotifications(withIdentifiers: identifiersToDismiss)
             print("[dismisser] Dismissed \(identifiersToDismiss.count) notifications for grouping: \(source)")

--- a/apps/tlon-mobile/ios/Landscape/NotificationDismissHandler.swift
+++ b/apps/tlon-mobile/ios/Landscape/NotificationDismissHandler.swift
@@ -1,0 +1,82 @@
+import Foundation
+import UserNotifications
+import JavaScriptCore
+
+@objc class NotificationDismissHandler: NSObject {
+
+    @objc static let shared = NotificationDismissHandler()
+
+    private override init() {
+        super.init()
+    }
+
+    @objc func handleNotificationDismiss(userInfo: [AnyHashable: Any]) {
+        print("[dismisser] handleNotificationDismiss called with userInfo: \(userInfo)")
+
+        guard let action = userInfo["action"] as? String else {
+            print("[dismisser] No action field found")
+            return
+        }
+
+        print("[dismisser] Action: \(action)")
+
+        guard action == "dismiss" else {
+            print("[dismisser] Action is not dismiss, ignoring")
+            return
+        }
+
+        guard let source = userInfo["dismissSource"] as? String,
+              let count = userInfo["notifyCount"] as? Int,
+              let uid = userInfo["uid"] as? String,
+              let id = userInfo["id"] as? String else {
+            print("[dismisser] Missing required fields. dismissSource: \(userInfo["dismissSource"] ?? "nil"), notifyCount: \(userInfo["notifyCount"] ?? "nil"), uid: \(userInfo["uid"] ?? "nil"), id: \(userInfo["id"] ?? "nil")")
+            return
+        }
+
+        print("[dismisser] Dismissing notifications \(source) new count \(count) id \(id)")
+        // Fetch the activity event to get grouping information
+        Task {
+            await dismissNotifications(forId: id, source: source, notifyCount: count, uid: uid)
+        }
+    }
+
+    @MainActor
+    private func dismissNotifications(forId dismissId: String, source: String, notifyCount: Int, uid: String) async {
+        let center = UNUserNotificationCenter.current()
+
+        // Set badge count
+        do {
+            try await center.setBadgeCount(notifyCount)
+        } catch {
+            print("[dismisser] Failed to set badge count: \(error)")
+        }
+
+        // Get delivered notifications and dismiss older ones
+        let notifications = await center.deliveredNotifications()
+        var identifiersToDismiss: [String] = []
+
+        for notification in notifications {
+            let threadIdentifier = notification.request.content.threadIdentifier
+            guard let notificationId = notification.request.content.userInfo["id"] as? String else {
+                continue
+            }
+            
+            print("[dismisser] notification: grouping \(threadIdentifier) id \(notificationId)")
+
+            if threadIdentifier == source {
+                // Dismiss notifications with IDs that are less than the dismiss ID (older messages)
+                let comparison = notificationId.compare(dismissId)
+                print ("[dismisser] comparing ids \(dismissId) and \(notificationId) result: \(comparison)")
+                if comparison == .orderedAscending || comparison == .orderedSame {
+                    identifiersToDismiss.append(notification.request.identifier)
+                }
+            }
+        }
+
+        print("[dismisser] ids to dismiss \(identifiersToDismiss)")
+        if !identifiersToDismiss.isEmpty {
+            center.removeDeliveredNotifications(withIdentifiers: identifiersToDismiss)
+            print("[dismisser] Dismissed \(identifiersToDismiss.count) notifications for grouping: \(source)")
+        }
+    }
+}

--- a/apps/tlon-mobile/ios/Notifications/NotificationService.swift
+++ b/apps/tlon-mobile/ios/Notifications/NotificationService.swift
@@ -6,15 +6,7 @@ class NotificationService: UNNotificationServiceExtension {
     var contentHandler: ((UNNotificationContent) -> Void)?
     var bestAttemptContent: UNMutableNotificationContent?
 
-    private func applyNotif(_ rawActivityEvent: Any, notification: UNMutableNotificationContent) async -> UNNotificationContent {
-        // Extract uid first - if we can't find it, we can't do proper error logging
-        guard let userInfo = notification.userInfo as? [String: Any],
-              let uid = userInfo["uid"] as? String else {
-            print("Cannot process notification: missing uid")
-            await NotificationLogger.logDelivery(properties: ["message": .string("Fallback notification delivered successfully")])
-            return notification
-        }
-
+    private func applyNotif(_ rawActivityEvent: Any, uid: String, badgeCount: Int, notification: UNMutableNotificationContent) async -> UNNotificationContent {
         do {
             return try await processRichNotification(rawActivityEvent, notification: notification, uid: uid)
         } catch {
@@ -23,7 +15,7 @@ class NotificationService: UNNotificationServiceExtension {
             } else {
                 NotificationError.unknown(uid: uid, underlyingError: error)
             }
-            
+
             await NotificationLogger.sendToPostHog(events: [
                 .error(err),
                 .delivery(["uid": .string(uid), "message": .string("Fallback notification delivered successfully")])
@@ -33,42 +25,18 @@ class NotificationService: UNNotificationServiceExtension {
     }
 
     private func processRichNotification(_ rawActivityEvent: Any, notification: UNMutableNotificationContent, uid: String) async throws -> UNNotificationContent {
-
         // Convert to JSON string first for error logging
         let activityEventJsonString = (try? JSONSerialization.jsonString(withJSONObject: rawActivityEvent)) ?? "Unknown"
-        
-        let context = JSContext()!
-        context.exceptionHandler = { context, exception in
-            print(exception?.toString() ?? "No exception found")
-        }
 
         // Store the JSON string in notification userInfo
         notification.userInfo["activityEventJsonString"] = activityEventJsonString
-
-        guard let scriptURL = Bundle.main.url(forResource: "bundle", withExtension: "js") else {
-            throw NotificationError.previewRenderFailed(uid: uid, activityEvent: activityEventJsonString)
-        }
-
-        guard let script = try? String(contentsOf: scriptURL) else {
-            throw NotificationError.previewRenderFailed(uid: uid, activityEvent: activityEventJsonString)
-        }
-
-        context.evaluateScript(script)
-
-        let previewRaw = context.objectForKeyedSubscript("tlon")
-            .invokeMethod("renderActivityEventPreview", withArguments: [
-                rawActivityEvent,
-            ])
-
-        guard let preview = try? previewRaw?.decode(as: NotificationPreviewPayload.self) else {
-            throw NotificationError.previewRenderFailed(uid: uid, activityEvent: activityEventJsonString)
-        }
 
         // If we have a preview, make sure to fully replace server-provided title / body.
         notification.title = ""
         notification.body = ""
 
         let renderer = NotificationPreviewContentNodeRenderer()
+        let preview = try getPreview(rawActivityEvent: rawActivityEvent, uid: uid, activityEventJsonString: activityEventJsonString)
         if let title = preview.notification.title {
             notification.title = await renderer.render(title)
         }
@@ -113,14 +81,87 @@ class NotificationService: UNNotificationServiceExtension {
             try await interaction.donate()
             let result = try notification.updating(from: intent)
 
-            // Log successful rich notification delivery
             await NotificationLogger.logDelivery(properties: ["uid": .string(uid), "message": .string("Rich notification delivered successfully")])
 
             return result
         } catch {
-            // Throw NotificationDisplayFailed instead of handling here
             throw NotificationError.notificationDisplayFailed(uid: uid, activityEvent: activityEventJsonString, underlyingError: error)
         }
+    }
+
+    private func dismissNotifs(id: String, source: String) {
+        let center = UNUserNotificationCenter.current()
+        center.getNotificationSettings { settings in
+            switch settings.authorizationStatus {
+            case .notDetermined:
+                // User hasn't been asked yet - good time to request
+                print("Not determined")
+            case .denied:
+                // User denied - need to direct to Settings
+                print("Denied")
+            case .authorized:
+                print("Authorized")
+            case .provisional:
+                print("Provisional authorization")
+            case .ephemeral:
+                print("Ephemeral authorization")
+            @unknown default:
+                print("Unknown status")
+            }
+        }
+        
+        center.getDeliveredNotifications { notifications in
+            // An array to hold the identifiers of delivered notifications you want to dismiss
+            var identifiersToDismiss: [String] = []
+
+            for notification in notifications {
+                // Implement your custom logic here to decide which notifications to dismiss
+                if notification.request.identifier.contains("some_criteria") {
+                    identifiersToDismiss.append(notification.request.identifier)
+                }
+
+                let grouping = notification.request.content.threadIdentifier
+                if let notifId = notification.request.content.userInfo["id"] as? String {
+                    if grouping == source {
+                        // ids are sortable as strings
+                        if notifId < id {
+                            identifiersToDismiss.append(notifId)
+                        }
+                    }
+                }
+            }
+
+            // Dismiss the selected notifications
+            center.removeDeliveredNotifications(withIdentifiers: identifiersToDismiss)
+        }
+    }
+
+    private func getPreview(rawActivityEvent: Any, uid: String, activityEventJsonString: String) throws -> NotificationPreviewPayload {
+        let context = JSContext()!
+        context.exceptionHandler = { context, exception in
+            print(exception?.toString() ?? "No exception found")
+        }
+        
+        guard let scriptURL = Bundle.main.url(forResource: "bundle", withExtension: "js") else {
+            throw NotificationError.previewRenderFailed(uid: uid, activityEvent: activityEventJsonString)
+        }
+
+        guard let script = try? String(contentsOf: scriptURL) else {
+            throw NotificationError.previewRenderFailed(uid: uid, activityEvent: activityEventJsonString)
+        }
+
+        context.evaluateScript(script)
+
+        let previewRaw = context.objectForKeyedSubscript("tlon")
+            .invokeMethod("renderActivityEventPreview", withArguments: [
+                rawActivityEvent,
+            ])
+
+        guard let preview = try? previewRaw?.decode(as: NotificationPreviewPayload.self) else {
+            throw NotificationError.previewRenderFailed(uid: uid, activityEvent: activityEventJsonString)
+        }
+
+        return preview
     }
 
     override func didReceive(_ request: UNNotificationRequest, withContentHandler contentHandler: @escaping (UNNotificationContent) -> Void) {
@@ -129,46 +170,66 @@ class NotificationService: UNNotificationServiceExtension {
 
       Task { [weak bestAttemptContent] in
         let parsedNotification = await PushNotificationManager.parseNotificationUserInfo(request.content.userInfo)
-        switch parsedNotification {
-        case let .activityEventJson(activityEventRaw):
-            var notifContent = bestAttemptContent ?? UNNotificationContent()
-
-          if let activityEventRaw {
-            notifContent = await applyNotif(
-                activityEventRaw,
+          switch parsedNotification {
+          case .notify(let uid, let notifyCount, let event):
+              var notifContent = bestAttemptContent ?? UNNotificationContent()
+              
+              notifContent = await applyNotif(
+                event,
+                uid: uid,
+                badgeCount: notifyCount,
                 notification: notifContent.mutableCopy() as! UNMutableNotificationContent
-            )
+              )
+              
+              contentHandler(notifContent)
+              return
+              
+          case .dismiss(let uid, let id, let notifyCount, let event):
+              let activityEventJsonString = (try? JSONSerialization.jsonString(withJSONObject: event)) ?? "Unknown"
+              do {
+                  let preview = try getPreview(rawActivityEvent: event, uid: uid, activityEventJsonString: activityEventJsonString)
+                  let renderer = NotificationPreviewContentNodeRenderer()
+                  
+                  if let groupingKey = preview.notification.groupingKey {
+                      let source = await renderer.render(groupingKey)
+                      dismissNotifs(id: id, source: source)
+                      try await UNUserNotificationCenter.current().setBadgeCount(notifyCount)
+                  }
+              } catch {
+                  print("Dismissal handling failed")
+                  await NotificationLogger.logError(NotificationError.notificationDismissalFailed(uid: uid, activityEvent: activityEventJsonString))
+              }
+              
+              if let bestAttemptContent = bestAttemptContent {
+                  bestAttemptContent.title = ""
+                  bestAttemptContent.subtitle = ""
+                  bestAttemptContent.body = ""
+                  contentHandler(bestAttemptContent)
+              }
+          case let .failedFetchContents(err):
+              // Extract uid for logging
+              if let uid = request.content.userInfo["uid"] as? String {
+                  await NotificationLogger.sendToPostHog(events: [
+                    .error(NotificationError.activityEventFetchFailed(uid: uid, underlyingError: err)),
+                    .delivery(["uid": .string(uid), "message": .string("Fallback notification delivered successfully")])
+                  ])
+                  print("Both logs completed for uid: \(uid)")
+              } else {
+                  print("No uid found in failed fetch contents case")
+              }
+              packErrorOnNotification(err)
+              contentHandler(bestAttemptContent!)
+              return
+              
+          case .invalid:
+              // Log invalid notification
+              if let uid = request.content.userInfo["uid"] as? String {
+                  await NotificationLogger.logError(NotificationError.unknown(uid: uid, message: "Invalid notification format"))
+              }
+              await NotificationLogger.logDelivery(properties: ["message": .string("Fallback notification delivered successfully")])
+              contentHandler(bestAttemptContent!)
+              return
           }
-
-          contentHandler(notifContent)
-          return
-
-        case let .failedFetchContents(err):
-          // Extract uid for logging
-          if let uid = request.content.userInfo["uid"] as? String {
-              await NotificationLogger.sendToPostHog(events: [
-                .error(NotificationError.activityEventFetchFailed(uid: uid, underlyingError: err)),
-                .delivery(["uid": .string(uid), "message": .string("Fallback notification delivered successfully")])
-              ])
-              print("Both logs completed for uid: \(uid)")
-          } else {
-              print("No uid found in failed fetch contents case")
-          }
-          packErrorOnNotification(err)
-          contentHandler(bestAttemptContent!)
-          return
-
-        case .invalid:
-          // Log invalid notification
-          if let uid = request.content.userInfo["uid"] as? String {
-              await NotificationLogger.logError(NotificationError.unknown(uid: uid, message: "Invalid notification format"))
-          }
-          fallthrough
-
-        case .dismiss:
-          contentHandler(bestAttemptContent!)
-          return
-        }
       }
     }
 

--- a/apps/tlon-mobile/ios/Notifications/NotificationService.swift
+++ b/apps/tlon-mobile/ios/Notifications/NotificationService.swift
@@ -126,12 +126,12 @@ class NotificationService: UNNotificationServiceExtension {
           switch parsedNotification {
           case .notify(let uid, let event):
               var notifContent = bestAttemptContent ?? UNNotificationContent()
-              
+              let notification = notifContent.mutableCopy() as! UNMutableNotificationContent
               print("[notifications] badge count \(notifContent.badge ?? NSNumber(0))")
               notifContent = await applyNotif(
                 event,
                 uid: uid,
-                notification: notifContent.mutableCopy() as! UNMutableNotificationContent
+                notification: notification
               )
               
               contentHandler(notifContent)

--- a/apps/tlon-mobile/ios/Shared/Extensions/JSValue+Extension.swift
+++ b/apps/tlon-mobile/ios/Shared/Extensions/JSValue+Extension.swift
@@ -1,0 +1,26 @@
+//
+//  JSValue+Extension.swift
+//  Landscape
+//
+//  Created by Hunter Miller on 9/29/25.
+//
+
+import Foundation
+import JavaScriptCore
+
+extension JSValue {
+    func decode<T: Decodable>(as type: T.Type) throws -> T {
+        guard
+            let object = self.toObject(),
+            JSONSerialization.isValidJSONObject(object)
+        else {
+            throw NSError(
+                domain: "JSValueError",
+                code: 1,
+                userInfo: [NSLocalizedDescriptionKey: "JSValue is not a valid JSON object"]
+            )
+        }
+        let jsonData = try JSONSerialization.data(withJSONObject: object, options: [])
+        return try JSONDecoder().decode(T.self, from: jsonData)
+    }
+}

--- a/apps/tlon-mobile/ios/Shared/Models/NotificationLogging.swift
+++ b/apps/tlon-mobile/ios/Shared/Models/NotificationLogging.swift
@@ -91,6 +91,7 @@ enum NotificationError: Error, LocalizedError {
     case previewRenderFailed(uid: String, activityEvent: String, underlyingError: Error? = nil)
     case previewEmpty(uid: String, activityEvent: String, underlyingError: Error? = nil)
     case notificationDisplayFailed(uid: String, activityEvent: String? = nil, underlyingError: Error? = nil)
+    case notificationDismissalFailed(uid: String, activityEvent: String?, underlyingError: Error? = nil)
     case unknown(uid: String, message: String = "Unknown notification processing error", underlyingError: Error? = nil)
     
     var message: String {
@@ -100,6 +101,7 @@ enum NotificationError: Error, LocalizedError {
         case .previewRenderFailed: return "Preview render failed"
         case .previewEmpty: return "Preview is empty"
         case .notificationDisplayFailed: return "Notification display failed"
+        case .notificationDismissalFailed: return "Notification dismissal failed"
         case .unknown(_, let message, _): return message
         }
     }
@@ -111,6 +113,7 @@ enum NotificationError: Error, LocalizedError {
              .previewRenderFailed(let uid, _, _),
              .previewEmpty(let uid, _, _),
              .notificationDisplayFailed(let uid, _, _),
+             .notificationDismissalFailed(let uid, _, _),
              .unknown(let uid, _, _):
             return uid
         }
@@ -123,6 +126,7 @@ enum NotificationError: Error, LocalizedError {
              .previewRenderFailed(_, _, let underlyingError),
              .previewEmpty(_, _, let underlyingError),
              .notificationDisplayFailed(_, _, let underlyingError),
+             .notificationDismissalFailed(_, _, let underlyingError),
              .unknown(_, _, let underlyingError):
             return underlyingError?.localizedDescription
         }

--- a/apps/tlon-mobile/ios/Shared/Notifications/NotificationPreviewPayload.swift
+++ b/apps/tlon-mobile/ios/Shared/Notifications/NotificationPreviewPayload.swift
@@ -1,7 +1,7 @@
 import Foundation
 
-struct NotificationPreviewPayload: Decodable {
-    indirect enum ContentNode: Decodable {
+public struct NotificationPreviewPayload: Decodable {
+    public indirect enum ContentNode: Decodable {
         case channelTitle(channelId: String)
         case gangTitle(gangId: String)
         case groupTitle(groupId: String)
@@ -31,7 +31,7 @@ struct NotificationPreviewPayload: Decodable {
             case postSource
         }
         
-        init(from decoder: Decoder) throws {
+        public init(from decoder: Decoder) throws {
             let container = try decoder.container(keyedBy: CodingKeys.self)
             let type = try container.decode(NodeType.self, forKey: .type)
             
@@ -91,8 +91,10 @@ struct NotificationPreviewPayload: Decodable {
     let message: Message?
 }
 
-struct NotificationPreviewContentNodeRenderer {
-    func render(_ node: NotificationPreviewPayload.ContentNode) async -> String {
+public struct NotificationPreviewContentNodeRenderer {
+    public init() {}
+
+    public func render(_ node: NotificationPreviewPayload.ContentNode) async -> String {
         switch node {
         case let .stringLiteral(content):
             return content

--- a/apps/tlon-mobile/ios/Shared/Notifications/PushNotificationManager.swift
+++ b/apps/tlon-mobile/ios/Shared/Notifications/PushNotificationManager.swift
@@ -19,8 +19,7 @@ import NotificationCenter
 
     static func parseNotificationUserInfo(_ userInfo: [AnyHashable: Any]) async -> ParseNotificationResult {
         guard let action = userInfo["action"] as? String,
-              let uid = userInfo["uid"] as? String,
-              let id = userInfo["id"] as? String
+              let uid = userInfo["uid"] as? String
         else {
             return .invalid
         }

--- a/apps/tlon-mobile/ios/Shared/Notifications/PushNotificationManager.swift
+++ b/apps/tlon-mobile/ios/Shared/Notifications/PushNotificationManager.swift
@@ -24,21 +24,21 @@ import NotificationCenter
             return .invalid
         }
 
-        do {
-            let aerData = try await PocketAPI.shared.fetchRawPushNotificationContents(uid)
-            let event = try JSONSerialization.jsonObject(with: aerData)
-            switch action {
-            case "notify":
-                return .notify(uid: uid, event: event)
-            case "dismiss":
-                return .dismiss
 
-            default:
-                return .invalid
+        switch action {
+        case "notify":
+            do {
+                let aerData = try await PocketAPI.shared.fetchRawPushNotificationContents(uid)
+                let event = try JSONSerialization.jsonObject(with: aerData)
+            } catch {
+                return .failedFetchContents(error)
             }
+            return .notify(uid: uid, event: event)
+        case "dismiss":
+            return .dismiss
 
-        } catch {
-            return .failedFetchContents(error)
+        default:
+            return .invalid
         }
     }
 }

--- a/apps/tlon-mobile/ios/Shared/Notifications/PushNotificationManager.swift
+++ b/apps/tlon-mobile/ios/Shared/Notifications/PushNotificationManager.swift
@@ -11,14 +11,13 @@ import NotificationCenter
 
 @objc final class PushNotificationManager: NSObject {
     enum ParseNotificationResult {
-        case notify(uid: String, notifyCount: Int, event: Any)
-        case dismiss(uid: String, id: String, notifyCount: Int, event: Any)
+        case notify(uid: String, event: Any)
+        case dismiss
         case invalid
         case failedFetchContents(Error)
     }
 
     static func parseNotificationUserInfo(_ userInfo: [AnyHashable: Any]) async -> ParseNotificationResult {
-        let notifyCount: Int = Int(userInfo["notify-count"] as? String ?? "0") ?? 0
         guard let action = userInfo["action"] as? String,
               let uid = userInfo["uid"] as? String,
               let id = userInfo["id"] as? String
@@ -31,9 +30,9 @@ import NotificationCenter
             let event = try JSONSerialization.jsonObject(with: aerData)
             switch action {
             case "notify":
-                return .notify(uid: uid, notifyCount: notifyCount, event: event)
+                return .notify(uid: uid, event: event)
             case "dismiss":
-                return .dismiss(uid: uid, id: id, notifyCount: notifyCount, event: event)
+                return .dismiss
 
             default:
                 return .invalid

--- a/desk/app/activity.hoon
+++ b/desk/app/activity.hoon
@@ -885,9 +885,7 @@
 ++  refresh-summary
   |=  =source:a
   =/  summary  (summarize-unreads source (get-index source))
-  =.  activity
-    (~(put by activity) source summary)
-  (give-unreads source)
+  cor(activity (~(put by activity) source summary))
 ::
 ++  refresh
   |=  =source:a
@@ -951,6 +949,7 @@
     ?:  from-parent
       (refresh-summary source)
     =.  cor  (refresh source)
+    =.  cor  (give-reads source)
     =/  new-activity=activity:a
       %+  roll
         :(weld (get-parents:src source) ~[source] ?:(deep.action children ~))
@@ -960,7 +959,7 @@
     (give-update [%activity new-activity] [%hose ~])
   ==
 ::
-++  give-unreads
+++  give-reads
   |=  =source:a
   ^+  cor
   =/  summary  (~(got by activity) source)

--- a/desk/app/notify.hoon
+++ b/desk/app/notify.hoon
@@ -191,7 +191,7 @@
         (~(wait pass:io /clear) (add now.bowl clear-interval))
         [%pass /eyre %arvo %e %connect [~ /apps/groups/~/notify] dap.bowl]
       ::
-        ?.  =(~wanmep-witnul-nocsyx-lassul our.bowl)  ~
+        ?.  =(~rivfur-livmet our.bowl)  ~
         [%pass / %agent [our.bowl %notify] %poke %provider-state-message !>(0)]~
     ==
   ::
@@ -209,7 +209,7 @@
       caz
     :*  (~(watch-our pass:io /activity) %activity /notifications)
         (~(watch-our pass:io /unreads) %activity /v4/unreads)
-        ?.  =(~wanmep-witnul-nocsyx-lassul our.bowl)  caz
+        ?.  =(~rivfur-livmet our.bowl)  caz
         [[%pass / %agent [our.bowl %notify] %poke %provider-state-message !>(0)] caz]
     ==
   ::
@@ -393,7 +393,7 @@
     ++  provider-state-message
       ^-  (quip card _state)
       ~&  "provider-state-message"
-      ?>  =(our.bowl ~wanmep-witnul-nocsyx-lassul)
+      ?>  =(our.bowl ~rivfur-livmet)
       =/  now  now.bowl
       =/  time-since-last  (sub `@`last-timer `@`now)
       ~&  ['time since last daily-stats-interval' time-since-last]

--- a/desk/app/notify.hoon
+++ b/desk/app/notify.hoon
@@ -187,10 +187,11 @@
   ++  on-init
     :_  this
     :*  (~(watch-our pass:io /activity) %activity /notifications)
+        (~(watch-our pass:io /unreads) %activity /v4/unreads)
         (~(wait pass:io /clear) (add now.bowl clear-interval))
         [%pass /eyre %arvo %e %connect [~ /apps/groups/~/notify] dap.bowl]
       ::
-        ?.  =(~rivfur-livmet our.bowl)  ~
+        ?.  =(~wanmep-witnul-nocsyx-lassul our.bowl)  ~
         [%pass / %agent [our.bowl %notify] %poke %provider-state-message !>(0)]~
     ==
   ::
@@ -206,9 +207,11 @@
     :_  this(state migrated)
     ?:  (~(has by wex.bowl) [/activity our.bowl %activity])
       caz
-    :-  (~(watch-our pass:io /activity) %activity /notifications)
-    ?.  =(~rivfur-livmet our.bowl)  caz
-    [[%pass / %agent [our.bowl %notify] %poke %provider-state-message !>(0)] caz]
+    :*  (~(watch-our pass:io /activity) %activity /notifications)
+        (~(watch-our pass:io /unreads) %activity /v4/unreads)
+        ?.  =(~wanmep-witnul-nocsyx-lassul our.bowl)  caz
+        [[%pass / %agent [our.bowl %notify] %poke %provider-state-message !>(0)] caz]
+    ==
   ::
   ++  on-poke
     |=  [=mark =vase]
@@ -281,12 +284,12 @@
               address.act
               binding.act
           ==
-        =/  =wire  /agentio-watch/notify/(scot %p src.bowl)/[service.act]
+        =/  =wire  /agentio-watch/v1/notify/(scot %p src.bowl)/[service.act]
         =?  cards  !(~(has by wex.bowl) wire src.bowl %notify)
           :_  cards
           %+  watch:pass
             [src.bowl %notify]
-          /notify/(scot %p src.bowl)/[service.act]
+          /v1/notify/(scot %p src.bowl)/[service.act]
         :-  cards
         state(provider-state (~(put by provider-state) service.act u.entry))
       ::
@@ -303,7 +306,7 @@
           :_  ~
           %+  leave-path:pass
             [src.bowl %notify]
-          /notify/(scot %p src.bowl)/[service.act]
+          /v1/notify/(scot %p src.bowl)/[service.act]
         :~  %:  remove-binding:do
                 service.act
                 u.entry
@@ -313,7 +316,7 @@
             ==
             %+  leave-path:pass
               [src.bowl %notify]
-            /notify/(scot %p src.bowl)/[service.act]
+            /v1/notify/(scot %p src.bowl)/[service.act]
         ==
       ==
     ::
@@ -390,7 +393,7 @@
     ++  provider-state-message
       ^-  (quip card _state)
       ~&  "provider-state-message"
-      ?>  =(our.bowl ~rivfur-livmet)
+      ?>  =(our.bowl ~wanmep-witnul-nocsyx-lassul)
       =/  now  now.bowl
       =/  time-since-last  (sub `@`last-timer `@`now)
       ~&  ['time since last daily-stats-interval' time-since-last]
@@ -425,6 +428,12 @@
     ::
         [%notify @ @ ~]
       =*  service  i.t.t.path
+      ?.  (~(has ju providers.client-state) src.bowl service)
+        ~|("permission denied" !!)
+      `this
+    ::
+        [%v1 %notify @ @ ~]
+      =*  service  i.t.t.t.path
       ?.  (~(has ju providers.client-state) src.bowl service)
         ~|("permission denied" !!)
       `this
@@ -470,10 +479,23 @@
         ?.  ?=(%activity-event p.cage.sign)
           `this
         =+  !<([=time-id:a =event:a] q.cage.sign)
+        =+  .^(=activity:a %gx (scry:io %activity /v4/activity/activity-summary-4))
+        =/  notify-count=@ud
+          notify-count:(~(gut by activity) [%base ~] *activity-summary:a)
+        =/  [v0-paths=(list path) v1-paths=(list path)]
+          %+  roll  ~(tap by sup.bowl)
+          |=  [[duct ship =path] v0=(list path) v1=(list path)]
+          ?:  ?=(%notify -.path)  [[path v0] v1]
+          [v0 [path v1]]
         :_  this(notifications (~(put by notifications) time-id [event ~]))
         =-  (zing (turn - drop))
         ^-  (list (unit card))
-        :_  [(fact-all:io %notify-update !>(`update`[`@`time-id %notify]))]~
+        =/  =update:v1
+          [notify-count `@`time-id %notify]
+        ~&  ['notify update' update +.update v0-paths v1-paths]
+        :_  :~  `(fact:io notify-update-1+!>(update) v1-paths)
+                `(fact:io notify-update+!>(`update:v0`+.update) v0-paths)
+            ==
         ::  if supported, convert the event to a hark notification (yarn) and
         ::  inject it into hark, so that old clients may continue retrieving
         ::  notifications from hark, using the id this agent gives them in the
@@ -492,6 +514,38 @@
         [%pass wire %agent [our.bowl %activity] %watch /notifications]~
       ==
     ::
+        [%unreads ~]
+      ?+  -.sign  (on-agent:def wire sign)
+          %fact
+        ?.  ?=(%activity-update-4 p.cage.sign)
+          `this
+        =+  !<(=update:a q.cage.sign)
+        ~&  ['unreads update' update]
+        ?.  ?=(%read -.update)
+          `this
+        ?^  unread.activity-summary.update
+          `this
+        =+  .^(=activity:a %gx (scry:io %activity /v4/activity/activity-summary-4))
+        =/  notify-count=@ud
+          notify-count:(~(gut by activity) [%base ~] *activity-summary:a)
+        :_  this
+        =/  v1-paths
+          %+  murn  ~(tap by sup.bowl)
+          |=  [duct ship =path]
+          ?:  ?=(%notify -.path)  ~
+          `path
+        =/  =update:v1
+          ::  the "newest" item in a recently read activity source
+          ::  is what we need to know which notifications to dismiss
+          [notify-count `@`newest.activity-summary.update %dismiss]
+        ~[(fact:io notify-update-1+!>(update) v1-paths)]
+      ::
+          %kick
+        %-  (tell:l %info 'notify unreads kick' ~)
+        :_  this
+        [%pass wire %agent [our.bowl %activity] %watch /v4/unreads]~
+      ==
+    ::
     ::  subscription from provider to client
     ::
         [%agentio-watch %notify @ @ ~]
@@ -500,12 +554,12 @@
       ?+  -.sign  (on-agent:def wire sign)
           %fact
         ?>  ?=(%notify-update p.cage.sign)
-        =+  !<(=update q.cage.sign)
+        =+  !<(=update:v0 q.cage.sign)
         :_  this
         =/  entry=(unit provider-entry)  (~(get by provider-state) service)
         ?~  entry
           ~
-        [(send-notification:do u.entry who update)]~
+        [(send-notification:do u.entry who [0 update])]~
       ::
           %kick
         %-  (tell:l %info 'notify client kick' ~)
@@ -518,6 +572,38 @@
         =/  =tang
           ['notify watch-nack' >wire< u.p.sign]
         ((tell:l %crit tang) ((slog tang) `this))
+      ==
+    ::
+    ::  subscription from provider to client
+    ::
+        [%agentio-watch %v1 %notify @ @ ~]
+      =/  who      (slav %p i.t.t.t.wire)
+      =*  service  i.t.t.t.t.wire
+      ?+  -.sign  (on-agent:def wire sign)
+          %fact
+        ?>  ?=(%notify-update-1 p.cage.sign)
+        =+  !<(=update:v1 q.cage.sign)
+        :_  this
+        =/  entry=(unit provider-entry)  (~(get by provider-state) service)
+        ?~  entry
+          ~
+        [(send-notification:do u.entry who update)]~
+      ::
+          %kick
+        %-  (tell:l %info 'notify client kick' ~)
+        :_  this
+        [(watch:pass [who %notify] /v1/notify/(scot %p who)/[service])]~
+      ::
+          %watch-ack
+        ?~  p.sign
+          `this
+        =/  =tang
+          ['notify watch-nack' >wire< u.p.sign]
+        %-  (tell:l %crit tang)
+        %-  (slog tang)
+        :_  this
+        ::  attempt watching old path for compatibility with old clients
+        [(watch:pass [who %notify] /notify/(scot %p who)/[service])]~
       ==
     ==
   ::
@@ -539,6 +625,7 @@
       ?>  ?=(%iris -.sign-arvo)
       ?>  ?=(%http-response +<.sign-arvo)
       ?>  ?=(%finished -.client-response.sign-arvo)
+      ~&  client-response.sign-arvo
       ?>  ?=(^ full-file.client-response.sign-arvo)
       =/  =mime-data:iris  u.full-file.client-response.sign-arvo
       ?>  =('application/json' type.mime-data)
@@ -563,6 +650,7 @@
         [%send-notification *]
       ?>  ?=(%iris -.sign-arvo)
       ?>  ?=(%http-response +<.sign-arvo)
+      ~&  client-response.sign-arvo
       =*  res  client-response.sign-arvo
       ?>  ?=(%finished -.res)
       =*  status  status-code.response-header.res
@@ -591,12 +679,6 @@
     ((fail:l term tang) `this)
   --
 |_  bowl=bowl:gall
-::
-++  filter-notifications
-  |=  =action:h
-  ^-  (unit update)
-  ?.  ?=(%add-yarn -.action)  ~
-  `[id.yarn.action %notify]
 ::
 ++  is-whitelisted
   |=  [who=@p entry=provider-entry]
@@ -674,7 +756,9 @@
     :~  identity+(rsh [3 1] (scot %p who))
         action+`@t`action.update
         uid+(scot %uv uid.update)
-        id+(scot %da uid.update)
+        ::  we use @ud here for string comparison on client dismissals
+        id+(scot %ud uid.update)
+        notify-count+(scot %ud notify-count.update)
     ==
   %:  post-form
       /send-notification/(scot %uv (sham eny.bowl))

--- a/desk/app/notify.hoon
+++ b/desk/app/notify.hoon
@@ -493,7 +493,6 @@
         =/  update-0=update:v0  [`@`time-id %notify]
         =/  =update:v1
           [notify-count `@`time-id %notify ~]
-        ~&  ['notify update' update +.update v0-paths v1-paths]
         :_  :~  `(fact:io notify-update-1+!>(update) v1-paths)
                 `(fact:io notify-update+!>(update-0) v0-paths)
             ==
@@ -521,7 +520,6 @@
         ?.  ?=(%activity-update-4 p.cage.sign)
           `this
         =+  !<(=update:a q.cage.sign)
-        ~&  ['unreads update' update]
         ?.  ?=(%read -.update)
           `this
         ?^  unread.activity-summary.update
@@ -633,7 +631,6 @@
       ?>  ?=(%iris -.sign-arvo)
       ?>  ?=(%http-response +<.sign-arvo)
       ?>  ?=(%finished -.client-response.sign-arvo)
-      ~&  client-response.sign-arvo
       ?>  ?=(^ full-file.client-response.sign-arvo)
       =/  =mime-data:iris  u.full-file.client-response.sign-arvo
       ?>  =('application/json' type.mime-data)
@@ -658,7 +655,6 @@
         [%send-notification *]
       ?>  ?=(%iris -.sign-arvo)
       ?>  ?=(%http-response +<.sign-arvo)
-      ~&  client-response.sign-arvo
       =*  res  client-response.sign-arvo
       ?>  ?=(%finished -.res)
       =*  status  status-code.response-header.res

--- a/desk/mar/notify/update-1.hoon
+++ b/desk/mar/notify/update-1.hoon
@@ -1,5 +1,5 @@
 /-  *notify
-|_  upd=update:v0
+|_  upd=update:v1
 ++  grad  %noun
 ++  grow
   |%
@@ -7,6 +7,6 @@
   --
 ++  grab
   |%
-  ++  noun  update:v0
+  ++  noun  update:v1
   --
 --

--- a/desk/sur/notify.hoon
+++ b/desk/sur/notify.hoon
@@ -40,13 +40,17 @@
       groups=(set resource:resource)
   ==
 ::
-+$  action  ?(%notify %dismiss)
++$  action
+  $%  [%notify ~]
+      [%dismiss source=@t]
+  ==
 ::
 +$  update
   [notify-count=@ud =uid =action]
 ++  v0
   |%
   ::
+  +$  action  ?(%notify %dismiss)
   +$  update
     [=uid =action]
   --

--- a/desk/sur/notify.hoon
+++ b/desk/sur/notify.hoon
@@ -43,5 +43,12 @@
 +$  action  ?(%notify %dismiss)
 ::
 +$  update
-  [=uid =action]
+  [notify-count=@ud =uid =action]
+++  v0
+  |%
+  ::
+  +$  update
+    [=uid =action]
+  --
+++  v1  .
 --

--- a/packages/scripts/src/index.ts
+++ b/packages/scripts/src/index.ts
@@ -111,7 +111,7 @@ export function renderActivityEventPreview({
     return {
       notification: {
         body: lit(contentSummary),
-        groupingKey: lit(sourceToString(source, true)),
+        groupingKey: lit(sourceToString(source)),
       },
       message: {
         timestamp: sent,


### PR DESCRIPTION
## Summary

Fixes TLON-4854. This PR adds support for badging app icons and dismissing notifications that have already been read. 

**NOTE:**
- this changes how the `/unreads` sub works in `%activity` but it is currently unused
- Also requires that the current function on Twilio preview get copied and deployed to the production environment. I think it should be safe to deploy ahead of time, but double check to confirm.

## Changes

- Changes %activity agent `/unreads` to only produce read notifications (open to renaming it lol)
- Adds handling to %notify agent to collect notification counts and respond to reads
- Sends new payload to Twilio
- Adds handling in iOS for both dismissals and badge count updates.
- Adds handling in Android for dismissals, badge count will automatically update based on current number of notifications so it didn't seem like we needed special handling here

## How did I test?

Running both Android and iOS in preview mode on a real device, sending notifications and then subsequently going read the channels where those notifications came from, and seeing the notification and badge count update appropriately.

## Risks and impact

- Safe to rollback without consulting PR author? Yes
- Affects important code area:
  - [ ] Onboarding
  - [ ] State / providers
  - [ ] Message sync
  - [ ] Channel display
  - [X] Notifications
  - [ ] Other:

## Rollback plan

Special handling will have to be added to restore the previous subscriptions in the %notify agent

## Screenshots / videos

<!-- Attach any relevant media. -->
