### PR TITLE
settings: volume options

### DIFF
--- a/.maestro/10-settings.yaml
+++ b/.maestro/10-settings.yaml
@@ -10,7 +10,7 @@ appId: io.tlon.groups
     id: 'ContactsSettingsButton'
 - assertVisible: 'Settings'
 - tapOn: 'Notification settings'
-- assertVisible: 'Push Notifications'
+- assertVisible: 'Notifications'
 - tapOn: 'All group activity'
 - tapOn:
     id: 'HeaderBackButton'

--- a/packages/app/features/settings/PushNotificationSettingsScreen.tsx
+++ b/packages/app/features/settings/PushNotificationSettingsScreen.tsx
@@ -21,7 +21,6 @@ import {
   TlonText,
   View,
   YStack,
-  useIsWindowNarrow,
 } from '../../ui';
 
 type Props = NativeStackScreenProps<RootStackParamList, 'AppSettings'>;
@@ -29,7 +28,6 @@ type Props = NativeStackScreenProps<RootStackParamList, 'AppSettings'>;
 export function PushNotificationSettingsScreen({ navigation }: Props) {
   const baseVolumeSetting = store.useBaseVolumeLevel();
   const { data: exceptions } = store.useVolumeExceptions();
-  const isWindowNarrow = useIsWindowNarrow();
   const isNative = Platform.OS === 'ios' || Platform.OS === 'android';
 
   const numExceptions = useMemo(
@@ -94,7 +92,12 @@ export function PushNotificationSettingsScreen({ navigation }: Props) {
           title="Notifications"
           backAction={() => navigation.goBack()}
         />
-        <ScrollView flex={1} paddingHorizontal={'$2xl'}>
+        <ScrollView
+          flex={1}
+          paddingHorizontal={'$xl'}
+          maxWidth={600}
+          marginHorizontal="auto"
+        >
           <TlonText.Text size={'$label/m'} marginVertical={'$l'}>
             Configure what kinds of messages will send you
             {isNative ? ` device push notifications and ` : ' '}in-app alerts.
@@ -103,7 +106,6 @@ export function PushNotificationSettingsScreen({ navigation }: Props) {
             options={notificationOptions}
             value={baseVolumeSetting}
             onChange={setLevel}
-            paddingRight={isWindowNarrow ? '$4xl' : undefined}
           />
           {numExceptions > 0 ? (
             <ExceptionsDisplay
@@ -128,13 +130,15 @@ export function ExceptionsDisplay({
   channels: db.Channel[];
   removeException: (exception: db.Group | db.Channel) => void;
 } & ComponentProps<typeof YStack>) {
+  const isNative = Platform.OS === 'ios' || Platform.OS === 'android';
   return (
     <YStack marginTop={'$l'} flex={1} {...rest}>
       <TlonText.Text size={'$label/2xl'} marginBottom={'$l'}>
         Overrides
       </TlonText.Text>
       <TlonText.Text size={'$label/m'} marginBottom={'$xl'}>
-        These groups, channels, and DMs have custom notification settings. Tap
+        These groups, channels, and DMs have custom notification settings.{' '}
+        {isNative ? 'Tap ' : 'Click '}
         the &quot;X&quot; to remove the override and return to the above
         setting.
       </TlonText.Text>

--- a/packages/app/features/settings/PushNotificationSettingsScreen.tsx
+++ b/packages/app/features/settings/PushNotificationSettingsScreen.tsx
@@ -135,7 +135,7 @@ export function ExceptionsDisplay({
       </TlonText.Text>
       <TlonText.Text size={'$label/m'} marginBottom={'$xl'}>
         These groups, channels, and DMs have custom notification settings. Tap
-        the &quot;X&quot; to remove the override and return to the default
+        the &quot;X&quot; to remove the override and return to the above
         setting.
       </TlonText.Text>
       {groups.map((group) => {

--- a/packages/app/ui/components/ChatOptionsSheet.tsx
+++ b/packages/app/ui/components/ChatOptionsSheet.tsx
@@ -266,6 +266,7 @@ export function GroupOptionsSheetContent({
   const canInvite = currentUserIsAdmin || group.privacy === 'public';
   const isPinned = group?.pin;
   const isErrored = group?.joinStatus === 'errored';
+  const baseVolumeLevel = store.useBaseVolumeLevel();
 
   const wrappedAction = useCallback(
     (action: () => void, clearChat = true) => {
@@ -291,13 +292,26 @@ export function GroupOptionsSheetContent({
     store.leaveGroup(group.id);
   }, [group]);
 
+  const notificationTitle = useMemo(() => {
+    const hasCustomSetting = !!group.volumeSettings?.level;
+
+    if (hasCustomSetting && group.volumeSettings) {
+      const levelName = ub.NotificationNamesShort[group.volumeSettings.level];
+      return `${levelName} (custom)`;
+    }
+
+    const defaultLevelName = ub.NotificationNamesShort[baseVolumeLevel];
+    return `${defaultLevelName} (app default)`;
+  }, [group.volumeSettings, baseVolumeLevel]);
+
   const actionGroups = useMemo(
     () =>
       createActionGroups(
         [
           'neutral',
           {
-            title: 'Notifications',
+            title: 'Group notifications',
+            description: notificationTitle,
             action: onPressNotifications,
             endIcon: 'ChevronRight',
           },
@@ -346,6 +360,7 @@ export function GroupOptionsSheetContent({
         ]
       ),
     [
+      notificationTitle,
       canInvite,
       canMarkRead,
       canSortChannels,
@@ -640,6 +655,7 @@ export function ChannelOptionsSheetContent({
   const isSingleChannelGroup = group?.channels?.length === 1;
   const canMarkRead = !(channel.unread?.count === 0);
   const enableCustomChannels = useCustomChannelsEnabled();
+  const baseVolumeLevel = store.useBaseVolumeLevel();
 
   const handlePressChatDetails = useCallback(() => {
     if (!group) {
@@ -656,13 +672,26 @@ export function ChannelOptionsSheetContent({
     [onOpenChange]
   );
 
+  const notificationTitle = useMemo(() => {
+    const hasCustomSetting = !!channel.volumeSettings?.level;
+
+    if (hasCustomSetting && channel.volumeSettings) {
+      const levelName = ub.NotificationNamesShort[channel.volumeSettings.level];
+      return `${levelName} (custom)`;
+    }
+
+    const defaultLevelName = ub.NotificationNamesShort[baseVolumeLevel];
+    return `${defaultLevelName} (app default)`;
+  }, [channel.volumeSettings, baseVolumeLevel]);
+
   const actionGroups: ActionGroup[] = useMemo(
     () =>
       createActionGroups(
         [
           'neutral',
           {
-            title: 'Notifications',
+            title: group ? 'Channel notifications' : 'Chat notifications',
+            description: notificationTitle,
             endIcon: 'ChevronRight',
             action: onPressNotifications,
           },
@@ -733,6 +762,7 @@ export function ChannelOptionsSheetContent({
         ]
       ),
     [
+      notificationTitle,
       onPressNotifications,
       channel?.pin,
       channel.type,

--- a/packages/app/ui/components/Form/inputs.tsx
+++ b/packages/app/ui/components/Form/inputs.tsx
@@ -538,7 +538,7 @@ export function RadioInputRow<T>({
         disabled={option.disabled}
         checked={checked}
       />
-      <YStack gap="$l">
+      <YStack gap="$l" flex={1}>
         <Text size="$label/xl" color="$primaryText">
           {option.title}
         </Text>

--- a/packages/shared/src/db/queries.ts
+++ b/packages/shared/src/db/queries.ts
@@ -1951,12 +1951,11 @@ export const getChannelVolumeSetting = createReadQuery(
 export const getVolumeExceptions = createReadQuery(
   'getVolumeExceptions',
   async (ctx: QueryCtx) => {
-    const base = await ctx.db.query.volumeSettings.findFirst({
-      where: eq($volumeSettings.itemType, 'base'),
-    });
-
     const exceptions = await ctx.db.query.volumeSettings.findMany({
-      where: not(eq($volumeSettings.level, base?.level || 'default')),
+      where: or(
+        eq($volumeSettings.itemType, 'group'),
+        eq($volumeSettings.itemType, 'channel')
+      ),
     });
 
     const groupIds = [];


### PR DESCRIPTION
## Summary

Fixes TLON-4855 where it's possible to have granted permissions for push notifications, yet have groups, DMs, or channels muted such that it produces no effect.

Rather than slapping a loud alert when the user has selected "Nothing," I opted to redesign the screen slightly with better language.

I also reflected the "exception" groups/DMs/channels' %volume states into the ChatOptionsSheet to aid usability.

## Changes

<!-- Outline specific changes made in this PR. -->

## How did I test?

<!-- Describe your testing process. -->

## Risks and impact

- Safe to rollback without consulting PR author? (Yes | No)
- Affects important code area:
  - [ ] Onboarding
  - [ ] State / providers
  - [ ] Message sync
  - [ ] Channel display
  - [x] Notifications
  - [ ] Other:

## Rollback plan

revert

## Screenshots / videos

<img width="1711" height="1158" alt="Screenshot 2025-10-07 at 4 05 53 PM" src="https://github.com/user-attachments/assets/dc6b9c95-aa04-44a4-94f4-a8f2804a2389" />

