### PR TITLE
groups: prevent unjoined channels from sticking in UI when leaving

### DIFF
--- a/packages/shared/src/db/queries.ts
+++ b/packages/shared/src/db/queries.ts
@@ -2212,9 +2212,14 @@ export const updateChannel = createWriteQuery(
         );
       }
 
+      // Filter out undefined values to avoid clearing fields unintentionally
+      const filteredUpdate = Object.fromEntries(
+        Object.entries(update).filter(([_, value]) => value !== undefined)
+      );
+
       return txCtx.db
         .update($channels)
-        .set(update)
+        .set(filteredUpdate)
         .where(eq($channels.id, update.id));
     });
   },


### PR DESCRIPTION
## Summary

Users attempting to leave a channel would see it flash and immediately reappear in the channel list, making it impossible to leave. 

When leaving multiple channels rapidly, some would appear to rejoin after a few seconds, and refreshing the page would show inconsistent state where channels appeared left or rejoined unpredictably. 

With some careful tracing, I found that (1) sync events were overwriting local membership state and (2) we were timing out on rapidly successive leave operations, which would cause a state rollback (even if the leave was successful -- just not _immediately_).

## Changes

- Filter out undefined values before updating channels to prevent backend metadata sync events from accidentally clearing the `currentUserIsMember` field.
- Don't rollback the optimistic leave update when requests timeout, since the backend may have successfully processed the leave even if the confirmation response didn't arrive in time.

## How did I test?

- Join a group with lots of channels
- Rapidly leave 5-8 channels from the sidebar
- Observe the channels you left flashing back into "joined" state
- Apply fixes, refresh browser
- Rejoin left channels
- Refresh again for good measure
- Rapidly leave 5-8 channels from the sidebar
- Observe that they stay left and do not change position, even if you see timeout errors in the browser console
- Refresh the page and confirm the channels are unjoined

## Risks and impact

- Safe to rollback without consulting PR author? Yes
- Affects important code area:
  - [ ] Onboarding
  - [x] State / providers
  - [ ] Message sync
  - [ ] Channel display
  - [ ] Notifications
  - [ ] Other:

## Rollback plan

git revert
