### PR TITLE
chore(mobile): experiment with reanimated worklets bundle mode

### DIFF
--- a/apps/tlon-mobile/babel.config.js
+++ b/apps/tlon-mobile/babel.config.js
@@ -51,7 +51,13 @@ module.exports = function (api) {
           experimentalFlattenThemesOnNative: true,
         },
       ],
-      'react-native-worklets/plugin',
+      [
+        'react-native-worklets/plugin',
+        {
+          bundleMode: true,
+          strictGlobal: true,
+        },
+      ],
     ].filter(Boolean),
   };
 };

--- a/apps/tlon-mobile/metro.config.js
+++ b/apps/tlon-mobile/metro.config.js
@@ -6,6 +6,9 @@ const connect = require('connect');
 const { spawn } = require('child_process');
 const { getSentryExpoConfig } = require('@sentry/react-native/metro');
 const { FileStore } = require('metro-cache');
+const {
+  getBundleModeMetroConfig,
+} = require('react-native-worklets/bundleMode');
 
 const nonInlinedRequires = require('./metro-non-inlined-requires');
 
@@ -181,4 +184,7 @@ function openDrizzleStudio(dbPath) {
   );
 }
 
-module.exports = mergeConfig(baseConfig, config);
+// Wrap the fully-merged config: getBundleModeMetroConfig mutates
+// serializer/resolver/transformer in place (composing with the existing
+// resolveRequest and getTransformOptions), so it must run after mergeConfig.
+module.exports = getBundleModeMetroConfig(mergeConfig(baseConfig, config));


### PR DESCRIPTION
## Summary

Experiment: enables `react-native-worklets` **bundle mode** on the mobile app. Stacked on the Expo SDK 57 upgrade (#6045) because the bundle-mode API only exists in the worklets 0.10.0 that branch pulls in. Opening as a **draft to shelve** — it boots and runs cleanly, but I want release-build and Sentry-symbolication checks before taking it further.

Bundle mode gives worklets access to the whole JS bundle instead of serializing each `'worklet'` function to a string that the UI runtime `eval`s. Upside: third-party libs work in worklets with no `'worklet'` patching, worklets ship as Hermes bytecode, and it's slated to become the worklets default. It's still experimental upstream.

## Changes

JS-only, no native changes:

- `babel.config.js` — worklets plugin → `{ bundleMode: true, strictGlobal: true }` (`strictGlobal` is the documented companion; stops implicit global capture into worklet closures).
- `metro.config.js` — wrap the fully-merged config with `getBundleModeMetroConfig(...)`. It mutates `serializer`/`resolver`/`transformer` in place and *composes* (doesn't clobber) our existing `resolveRequest`/`getTransformOptions`, so it has to run after `mergeConfig`.

## How did I test?

iOS simulator, dev build:

- `expo export` (iOS): whole graph bundles clean — 23MB `.hbc`, 0 errors, no unresolved worklets.
- Native build (0 errors) + boot: app renders, remote images load, data syncs, list scrolling (reanimated scroll worklets) is smooth. Metro log confirms the mechanism: `[Worklets] Bundle mode initialization: Downloaded the bundle for Worklet Runtimes.`
- Fast Refresh of a worklet module (edited a `useAnimatedStyle` in `InteractableChatListItem`): incremental 1-module update, scroll state preserved, no "Unable to resolve worklet", no redbox — so the two "recommended" Metro patches aren't needed for basic worklet HMR here.

**Not tested (why it's shelved):** release/embedded build (no Metro), Android, and Sentry stack-trace symbolication.

## Risks and impact

- Safe to rollback without consulting PR author? **Yes** — revert the two config edits.
- Affects important code area:
  - [x] Other: Metro/Babel build config — touches how *all* reanimated worklets are transformed and run.

Notable unknowns for a reviewer: bundle mode overrides `createModuleIdFactory` (changes module IDs), so **Sentry source-map symbolication needs verifying** before this could ship. The worklet runtime also logs benign `console.warn`s at boot (`ExpoImage`/`FileSystem`/… "Cannot read properties of undefined") from eagerly evaluating native modules against bundle mode's `TurboModuleRegistry` shim — cosmetic, cleanable later via the plugin's `importForwarding`.

## Rollback plan

Revert the commit (or the two config edits). No native, state, or migration changes.

## Screenshots / videos

App running on iOS under bundle mode — fully rendered, remote images loading, worklet runtime initialized:

![Tlon booted under worklets bundle mode](https://github.com/user-attachments/assets/f8d6faf4-0194-4e71-98a6-29a5a052f108)

---

Related: #6045 (Expo SDK 57) is the base of this branch.
