### PR TITLE
desk: add channel-action spider threads

### DIFF
--- a/desk/ted/channel/action-1.hoon
+++ b/desk/ted/channel/action-1.hoon
@@ -1,8 +1,8 @@
-::  channel-action: send actions to %channels
+::  channel-action-1: send actions to %channels
 ::
 ::    thread for posting to a channel as this ship, used by the
 ::    alert bot and typically invoked through eyre's spider api.
-::    takes the v7 channel action (%channel-action mark) and
+::    takes the v9 channel action (%channel-action-1 mark) and
 ::    upconverts it before poking %channels.
 ::
 /-  spider, cv=channels-ver
@@ -13,9 +13,9 @@
 |=  arg=vase
 =/  m  (strand ,vase)
 ^-  form:m
-=+  !<(arg=(unit a-channels:v7:cv) arg)
+=+  !<(arg=(unit a-channels:v9:cv) arg)
 ?~  arg  (pure:m !>(~))
-=/  action  (v10:a-channels:v9:ccv (v9:a-channels:v7:ccv u.arg))
+=/  action  (v10:a-channels:v9:ccv u.arg)
 ?>  ?=([%channel ^ %post %add *] action)
 ;<  =bowl:strand  bind:m  get-bowl:io
 =.  sent.essay.c-post.a-channel.action  now.bowl

--- a/desk/ted/channel/action-1.hoon
+++ b/desk/ted/channel/action-1.hoon
@@ -1,12 +1,11 @@
-::  channel-action-1: send actions to %channels
+::  channel-action-1: poke %channels with a v9 channel action
 ::
-::    thread for posting to a channel as this ship, used by the
-::    alert bot and typically invoked through eyre's spider api.
-::    takes the v9 channel action (%channel-action-1 mark) and
-::    upconverts it before poking %channels.
+::    see /ted/channel/action for the general shape. this one takes the
+::    %channel-action-1 mark:
+::    /spider/groups/channel-action-1/channel-action-1/json
 ::
 /-  spider, cv=channels-ver
-/+  io=strandio, ccv=channel-conv
+/+  io=strandio
 =,  strand=strand:spider
 ::
 ^-  thread:spider
@@ -15,9 +14,9 @@
 ^-  form:m
 =+  !<(arg=(unit a-channels:v9:cv) arg)
 ?~  arg  (pure:m !>(~))
-=/  action  (v10:a-channels:v9:ccv u.arg)
-?>  ?=([%channel ^ %post %add *] action)
 ;<  =bowl:strand  bind:m  get-bowl:io
-=.  sent.essay.c-post.a-channel.action  now.bowl
-;<  ~  bind:m  (poke:io [our.bowl %channels] channel-action-2+!>(action))
+=/  action  u.arg
+=?  action  ?=([%channel ^ %post %add *] action)
+  action(sent.essay.c-post.a-channel now.bowl)
+;<  ~  bind:m  (poke:io [our.bowl %channels] channel-action-1+!>(action))
 (pure:m !>(~))

--- a/desk/ted/channel/action-2.hoon
+++ b/desk/ted/channel/action-2.hoon
@@ -1,8 +1,8 @@
-::  channel-action-2: send actions to %channels
+::  channel-action-2: poke %channels with a v10 channel action
 ::
-::    thread for posting to a channel as this ship, used by the
-::    alert bot and typically invoked through eyre's spider api.
-::    takes the v10 channel action (%channel-action-2 mark).
+::    see /ted/channel/action for the general shape. this one takes the
+::    %channel-action-2 mark:
+::    /spider/groups/channel-action-2/channel-action-2/json
 ::
 /-  spider, cv=channels-ver
 /+  io=strandio
@@ -14,9 +14,9 @@
 ^-  form:m
 =+  !<(arg=(unit a-channels:v10:cv) arg)
 ?~  arg  (pure:m !>(~))
-=/  action  u.arg
-?>  ?=([%channel ^ %post %add *] action)
 ;<  =bowl:strand  bind:m  get-bowl:io
-=.  sent.essay.c-post.a-channel.action  now.bowl
+=/  action  u.arg
+=?  action  ?=([%channel ^ %post %add *] action)
+  action(sent.essay.c-post.a-channel now.bowl)
 ;<  ~  bind:m  (poke:io [our.bowl %channels] channel-action-2+!>(action))
 (pure:m !>(~))

--- a/desk/ted/channel/action-2.hoon
+++ b/desk/ted/channel/action-2.hoon
@@ -1,21 +1,20 @@
-::  channel-action: send actions to %channels
+::  channel-action-2: send actions to %channels
 ::
 ::    thread for posting to a channel as this ship, used by the
 ::    alert bot and typically invoked through eyre's spider api.
-::    takes the v7 channel action (%channel-action mark) and
-::    upconverts it before poking %channels.
+::    takes the v10 channel action (%channel-action-2 mark).
 ::
 /-  spider, cv=channels-ver
-/+  io=strandio, ccv=channel-conv
+/+  io=strandio
 =,  strand=strand:spider
 ::
 ^-  thread:spider
 |=  arg=vase
 =/  m  (strand ,vase)
 ^-  form:m
-=+  !<(arg=(unit a-channels:v7:cv) arg)
+=+  !<(arg=(unit a-channels:v10:cv) arg)
 ?~  arg  (pure:m !>(~))
-=/  action  (v10:a-channels:v9:ccv (v9:a-channels:v7:ccv u.arg))
+=/  action  u.arg
 ?>  ?=([%channel ^ %post %add *] action)
 ;<  =bowl:strand  bind:m  get-bowl:io
 =.  sent.essay.c-post.a-channel.action  now.bowl

--- a/desk/ted/channel/action.hoon
+++ b/desk/ted/channel/action.hoon
@@ -5,30 +5,27 @@
 ::    version of the channel action mark — the input-mark segment of the
 ::    spider url picks the json parser, e.g.
 ::    /spider/groups/channel-action-2/channel-action/json — and
-::    dispatches on the shape received, newest first.
+::    upconverts older shapes before poking %channels.
 ::
 /-  spider, cv=channels-ver
-/+  io=strandio
+/+  io=strandio, ccv=channel-conv
 =,  strand=strand:spider
 ::
 ^-  thread:spider
 |=  arg=vase
 =/  m  (strand ,vase)
 ^-  form:m
-;<  =bowl:strand  bind:m  get-bowl:io
 =/  new  ((soft (unit a-channels:v10:cv)) q.arg)
-?^  new
-  ?~  u.new  (pure:m !>(~))
-  =/  a-channels  u.u.new
-  ?>  ?=([%channel ^ %post %add *] a-channels)
-  =.  sent.essay.c-post.a-channel.a-channels  now.bowl
-  ;<  ~  bind:m  (poke:io [our.bowl %channels] channel-action-2+!>(a-channels))
-  (pure:m !>(~))
-=/  old  ((soft (unit a-channels:v7:cv)) q.arg)
-?~  old  ~|(%unknown-channel-action-version !!)
-?~  u.old  (pure:m !>(~))
-=/  a-channels  u.u.old
-?>  ?=([%channel ^ %post %add *] a-channels)
-=.  sent.essay.c-post.a-channel.a-channels  now.bowl
-;<  ~  bind:m  (poke:io [our.bowl %channels] channel-action+!>(a-channels))
+=/  a-channels=(unit a-channels:v10:cv)
+  ?^  new  u.new
+  =/  old  ((soft (unit a-channels:v7:cv)) q.arg)
+  ?~  old  ~|(%unknown-channel-action-version !!)
+  ?~  u.old  ~
+  `(v10:a-channels:v9:ccv (v9:a-channels:v7:ccv u.u.old))
+?~  a-channels  (pure:m !>(~))
+=/  action  u.a-channels
+?>  ?=([%channel ^ %post %add *] action)
+;<  =bowl:strand  bind:m  get-bowl:io
+=.  sent.essay.c-post.a-channel.action  now.bowl
+;<  ~  bind:m  (poke:io [our.bowl %channels] channel-action-2+!>(action))
 (pure:m !>(~))

--- a/desk/ted/channel/action.hoon
+++ b/desk/ted/channel/action.hoon
@@ -1,0 +1,22 @@
+::  channel-action: send actions to %channels
+::
+::    HTTP endpoint for posting to a channel as this ship, used by the
+::    alert bot (serverless-infra /api/sendAlertBotMessage). Takes a
+::    %channel-action mark (json or noun) and pokes our %channels.
+::
+/-  spider, cv=channels-ver
+/+  io=strandio
+=,  strand=strand:spider
+::
+^-  thread:spider
+|=  arg=vase
+=/  m  (strand ,vase)
+^-  form:m
+=+  !<(arg-a-channels=(unit a-channels:v7:cv) arg)
+?~  arg-a-channels  (pure:m !>(~))
+=*  a-channels  u.arg-a-channels
+?>  ?=([%channel ^ %post %add *] a-channels)
+;<  =bowl:strand  bind:m  get-bowl:io
+=.  sent.essay.c-post.a-channel.a-channels  now.bowl
+;<  ~  bind:m  (poke:io [our.bowl %channels] channel-action+!>(a-channels))
+(pure:m !>(~))

--- a/desk/ted/channel/action.hoon
+++ b/desk/ted/channel/action.hoon
@@ -1,8 +1,11 @@
 ::  channel-action: send actions to %channels
 ::
 ::    HTTP endpoint for posting to a channel as this ship, used by the
-::    alert bot (serverless-infra /api/sendAlertBotMessage). Takes a
-::    %channel-action mark (json or noun) and pokes our %channels.
+::    alert bot (serverless-infra /api/sendAlertBotMessage). Takes any
+::    version of the channel action mark — the input-mark segment of the
+::    spider url picks the json parser, e.g.
+::    /spider/groups/channel-action-2/channel-action/json — and
+::    dispatches on the shape received, newest first.
 ::
 /-  spider, cv=channels-ver
 /+  io=strandio
@@ -12,11 +15,20 @@
 |=  arg=vase
 =/  m  (strand ,vase)
 ^-  form:m
-=+  !<(arg-a-channels=(unit a-channels:v7:cv) arg)
-?~  arg-a-channels  (pure:m !>(~))
-=*  a-channels  u.arg-a-channels
-?>  ?=([%channel ^ %post %add *] a-channels)
 ;<  =bowl:strand  bind:m  get-bowl:io
+=/  new  ((soft (unit a-channels:v10:cv)) q.arg)
+?^  new
+  ?~  u.new  (pure:m !>(~))
+  =/  a-channels  u.u.new
+  ?>  ?=([%channel ^ %post %add *] a-channels)
+  =.  sent.essay.c-post.a-channel.a-channels  now.bowl
+  ;<  ~  bind:m  (poke:io [our.bowl %channels] channel-action-2+!>(a-channels))
+  (pure:m !>(~))
+=/  old  ((soft (unit a-channels:v7:cv)) q.arg)
+?~  old  ~|(%unknown-channel-action-version !!)
+?~  u.old  (pure:m !>(~))
+=/  a-channels  u.u.old
+?>  ?=([%channel ^ %post %add *] a-channels)
 =.  sent.essay.c-post.a-channel.a-channels  now.bowl
 ;<  ~  bind:m  (poke:io [our.bowl %channels] channel-action+!>(a-channels))
 (pure:m !>(~))

--- a/desk/ted/channel/action.hoon
+++ b/desk/ted/channel/action.hoon
@@ -2,8 +2,8 @@
 ::
 ::    HTTP endpoint for posting to a channel as this ship, used by the
 ::    alert bot (serverless-infra /api/sendAlertBotMessage). Takes any
-::    version of the channel action mark — the input-mark segment of the
-::    spider url picks the json parser, e.g.
+::    version of the channel action mark (v7, v9, or v10) — the
+::    input-mark segment of the spider url picks the json parser, e.g.
 ::    /spider/groups/channel-action-2/channel-action/json — and
 ::    upconverts older shapes before poking %channels.
 ::
@@ -15,9 +15,13 @@
 |=  arg=vase
 =/  m  (strand ,vase)
 ^-  form:m
-=/  new  ((soft (unit a-channels:v10:cv)) q.arg)
 =/  a-channels=(unit a-channels:v10:cv)
+  =/  new  ((soft (unit a-channels:v10:cv)) q.arg)
   ?^  new  u.new
+  =/  mid  ((soft (unit a-channels:v9:cv)) q.arg)
+  ?^  mid
+    ?~  u.mid  ~
+    `(v10:a-channels:v9:ccv u.u.mid)
   =/  old  ((soft (unit a-channels:v7:cv)) q.arg)
   ?~  old  ~|(%unknown-channel-action-version !!)
   ?~  u.old  ~

--- a/desk/ted/channel/action.hoon
+++ b/desk/ted/channel/action.hoon
@@ -1,12 +1,16 @@
-::  channel-action: send actions to %channels
+::  channel-action: poke %channels with a v7 channel action
 ::
-::    thread for posting to a channel as this ship, used by the
-::    alert bot and typically invoked through eyre's spider api.
-::    takes the v7 channel action (%channel-action mark) and
-::    upconverts it before poking %channels.
+::    exposes the %channels action poke over spider's json api, for
+::    callers that can't hold an eyre channel open:
+::    /spider/groups/channel-action/channel-action/json
+::
+::    %channels accepts every action mark version it has ever shipped,
+::    so the action is poked through as-is. only .sent is filled in:
+::    it's the client id %channels dedupes posts on, and an http caller
+::    has no way to pick one.
 ::
 /-  spider, cv=channels-ver
-/+  io=strandio, ccv=channel-conv
+/+  io=strandio
 =,  strand=strand:spider
 ::
 ^-  thread:spider
@@ -15,9 +19,9 @@
 ^-  form:m
 =+  !<(arg=(unit a-channels:v7:cv) arg)
 ?~  arg  (pure:m !>(~))
-=/  action  (v10:a-channels:v9:ccv (v9:a-channels:v7:ccv u.arg))
-?>  ?=([%channel ^ %post %add *] action)
 ;<  =bowl:strand  bind:m  get-bowl:io
-=.  sent.essay.c-post.a-channel.action  now.bowl
-;<  ~  bind:m  (poke:io [our.bowl %channels] channel-action-2+!>(action))
+=/  action  u.arg
+=?  action  ?=([%channel ^ %post %add *] action)
+  action(sent.essay.c-post.a-channel now.bowl)
+;<  ~  bind:m  (poke:io [our.bowl %channels] channel-action+!>(action))
 (pure:m !>(~))


### PR DESCRIPTION
## Summary

Adds spider threads that expose the `%channels` action poke over an HTTP JSON endpoint, so external services can post to a channel with a plain authenticated `POST` instead of holding an eyre channel open. Living in the groups desk means they stay in sync with `sur`/`mar` changes rather than rotting in a frozen snapshot desk.

## Changes

Following the existing versioned-thread pattern (`ted/group/create.hoon` / `create-1.hoon`), there is one thread per channel-action mark version, each typed to exactly one input:

- `%channel-action` — v7 payloads: `/spider/groups/channel-action/channel-action/json`
- `%channel-action-1` — v9 payloads: `/spider/groups/channel-action-1/channel-action-1/json`
- `%channel-action-2` — v10 payloads: `/spider/groups/channel-action-2/channel-action-2/json`

Each thread `!<`s its input at exactly its own version, then pokes `%channels` with the mark it was given. No version sniffing happens inside a thread, and no conversion happens either — `app/channels` already accepts every action mark version it has shipped and runs the `channel-conv` chain itself.

The one thing a thread does touch is `.sent`, and only for post adds: it's the client id `%channels` dedupes posts on, and an HTTP caller has no way to pick a good one (callers commonly send `0`, which would make every post after the first a silent duplicate). Every other action passes through untouched.

## How did I test?

Assembled the desk onto a 408-kelvin dev ship and committed it.

- All three threads build (`-build-file`).
- Posted through all three endpoints over HTTP with `sent: 0`; each message landed in the channel with a distinct, non-zero `.sent`, confirming the stamp works and dedupe doesn't swallow repeats.
- Deleted those test posts through the same endpoint, confirming a non-post-add action passes through unmodified.
- A malformed arg is rejected by the typed `!<` (nest-fail → `%false-start`) instead of being mis-parsed.

## Risks and impact

- Safe to rollback without consulting PR author? Yes
- Affects important code area:
  - [ ] Onboarding
  - [ ] State / providers
  - [ ] Message sync
  - [ ] Channel display
  - [ ] Notifications
  - [x] Other: new spider threads only; no existing code paths touched

## Rollback plan

Revert the PR. The threads are additive — nothing else in the desk references them, and no agent, mark, or type changed.

## Screenshots / videos

N/A

Fixes TLON-6172
