### PR TITLE
render conversations upright

### DIFF
--- a/packages/app/features/top/ChannelScreen.tsx
+++ b/packages/app/features/top/ChannelScreen.tsx
@@ -120,8 +120,8 @@ export default function ChannelScreen(props: Props) {
     }
   }, [channelIsPending, channelId]);
 
-  // for the unread channel divider, we care about the unread state when you enter but don't want it to update over
-  // time
+  // Snapshot unread state once per focused entry so the divider does not move
+  // as the channel is marked read.
   const [initialChannelUnreadSnapshot, setInitialChannelUnreadSnapshot] =
     React.useState<{
       channelId: string;
@@ -132,7 +132,13 @@ export default function ChannelScreen(props: Props) {
     let isCurrent = true;
 
     async function initializeChannelUnread() {
-      const unread = await db.getChannelUnread({ channelId: currentChannelId });
+      let unread: db.ChannelUnread | null | undefined;
+      try {
+        unread = await db.getChannelUnread({ channelId: currentChannelId });
+      } catch (error) {
+        logger.trackError('failed to initialize channel unread', error);
+      }
+
       if (isCurrent) {
         setInitialChannelUnreadSnapshot({
           channelId: currentChannelId,
@@ -212,8 +218,7 @@ export default function ChannelScreen(props: Props) {
   } = store.useChannelPosts({
     // Capture the unread cursor before loading posts or mounting Channel,
     // which can mark the channel read as soon as cached posts are available.
-    enabled:
-      unreadDidInitialize && !!channel && !channel?.isPendingChannel,
+    enabled: unreadDidInitialize && !!channel && !channel?.isPendingChannel,
     channelId: currentChannelId,
     count: 30,
     filterDeleted: !channelConfiguration?.includeDeletedPosts,

--- a/packages/app/features/top/ChannelScreen.tsx
+++ b/packages/app/features/top/ChannelScreen.tsx
@@ -210,16 +210,25 @@ export default function ChannelScreen(props: Props) {
     }
   }, [channel?.id, cursor]);
 
-  // If scroll to bottom is pressed, it's most straighforward to ignore
-  // existing cursor
-  // A selected post or channel navigation establishes a new cursor scope.
+  // Channel navigation establishes a new cursor scope.
   useEffect(() => {
     setClearedCursor(false);
-  }, [currentChannelId, selectedPostId]);
+  }, [currentChannelId]);
+
+  // A newly selected post establishes a new cursor scope. Clearing an existing
+  // selection below must not immediately restore the cursor we just retired.
+  useEffect(() => {
+    if (selectedPostId) {
+      setClearedCursor(false);
+    }
+  }, [selectedPostId]);
 
   const handleScrollToBottom = useCallback(() => {
     setClearedCursor(true);
-  }, []);
+    if (selectedPostId) {
+      props.navigation.setParams({ selectedPostId: undefined });
+    }
+  }, [props.navigation, selectedPostId]);
 
   const channelConfiguration = useMemo(
     () => configurationFromChannel(channel),
@@ -479,7 +488,7 @@ export default function ChannelScreen(props: Props) {
           group={group}
           groupIsLoading={groupIsLoading}
           posts={filteredPosts ?? null}
-          selectedPostId={selectedPostId}
+          selectedPostId={clearedCursor ? undefined : selectedPostId}
           goBack={navigationRef.current.goBack}
           goToPost={navigateToPost}
           goToMediaViewer={navigateToImage}

--- a/packages/app/features/top/ChannelScreen.tsx
+++ b/packages/app/features/top/ChannelScreen.tsx
@@ -129,10 +129,12 @@ export default function ChannelScreen(props: Props) {
     } | null>(null);
   const [unreadSnapshotIsFresh, setUnreadSnapshotIsFresh] =
     React.useState(false);
+  const [clearedCursor, setClearedCursor] = React.useState(false);
   const isFocused = useIsFocused();
   useFocusEffect(
     useCallback(() => {
       let isCurrent = true;
+      setClearedCursor(false);
       setUnreadSnapshotIsFresh(false);
 
       async function initializeChannelUnread() {
@@ -204,8 +206,6 @@ export default function ChannelScreen(props: Props) {
 
   // If scroll to bottom is pressed, it's most straighforward to ignore
   // existing cursor
-  const [clearedCursor, setClearedCursor] = React.useState(false);
-
   // A selected post or channel navigation establishes a new cursor scope.
   useEffect(() => {
     setClearedCursor(false);

--- a/packages/app/features/top/ChannelScreen.tsx
+++ b/packages/app/features/top/ChannelScreen.tsx
@@ -122,21 +122,39 @@ export default function ChannelScreen(props: Props) {
 
   // for the unread channel divider, we care about the unread state when you enter but don't want it to update over
   // time
-  const [initialChannelUnread, setInitialChannelUnread] =
-    React.useState<db.ChannelUnread | null>(null);
-  const [unreadDidInitialize, setUnreadDidInitialize] = React.useState(false);
+  const [initialChannelUnreadSnapshot, setInitialChannelUnreadSnapshot] =
+    React.useState<{
+      channelId: string;
+      unread: db.ChannelUnread | null;
+    } | null>(null);
   const isFocused = useIsFocused();
   useEffect(() => {
+    let isCurrent = true;
+
     async function initializeChannelUnread() {
       const unread = await db.getChannelUnread({ channelId: currentChannelId });
-      setInitialChannelUnread(unread ?? null);
-      setUnreadDidInitialize(true);
+      if (isCurrent) {
+        setInitialChannelUnreadSnapshot({
+          channelId: currentChannelId,
+          unread: unread ?? null,
+        });
+      }
     }
 
     if (isFocused) {
-      initializeChannelUnread();
+      void initializeChannelUnread();
     }
+
+    return () => {
+      isCurrent = false;
+    };
   }, [currentChannelId, isFocused]);
+
+  const unreadDidInitialize =
+    initialChannelUnreadSnapshot?.channelId === currentChannelId;
+  const initialChannelUnread = unreadDidInitialize
+    ? initialChannelUnreadSnapshot.unread
+    : null;
 
   const {
     navigateToImage,
@@ -153,19 +171,12 @@ export default function ChannelScreen(props: Props) {
 
   const { performGroupAction } = useGroupActions();
 
-  const unreadCursor = useMemo(() => {
-    if (!channel) {
-      return undefined;
-    }
-    return (
-      initialChannelUnread &&
-      (initialChannelUnread.countWithoutThreads ?? 0) > 0 &&
-      initialChannelUnread.firstUnreadPostId
-    );
-    // We only want this to rerun when the channel is loaded for the first time OR if
-    // the initial unread state changes
-    // eslint-disable-next-line
-  }, [!!channel, initialChannelUnread]);
+  const unreadCursor =
+    channel &&
+    initialChannelUnread &&
+    (initialChannelUnread.countWithoutThreads ?? 0) > 0
+      ? initialChannelUnread.firstUnreadPostId
+      : undefined;
   const cursor = selectedPostId || unreadCursor;
 
   useEffect(() => {
@@ -199,7 +210,10 @@ export default function ChannelScreen(props: Props) {
     loadOlder,
     isLoading: isLoadingPosts,
   } = store.useChannelPosts({
-    enabled: !!channel && !channel?.isPendingChannel,
+    // Capture the unread cursor before loading posts or mounting Channel,
+    // which can mark the channel read as soon as cached posts are available.
+    enabled:
+      unreadDidInitialize && !!channel && !channel?.isPendingChannel,
     channelId: currentChannelId,
     count: 30,
     filterDeleted: !channelConfiguration?.includeDeletedPosts,
@@ -414,7 +428,7 @@ export default function ChannelScreen(props: Props) {
     [currentChannelId, routeGroupId, channel?.groupId]
   );
 
-  if (!channel) {
+  if (!channel || !unreadDidInitialize) {
     return null;
   }
 

--- a/packages/app/features/top/ChannelScreen.tsx
+++ b/packages/app/features/top/ChannelScreen.tsx
@@ -134,7 +134,6 @@ export default function ChannelScreen(props: Props) {
   useFocusEffect(
     useCallback(() => {
       let isCurrent = true;
-      setClearedCursor(false);
       setUnreadSnapshotIsFresh(false);
 
       async function initializeChannelUnread() {
@@ -167,6 +166,13 @@ export default function ChannelScreen(props: Props) {
     isFocused &&
     unreadSnapshotIsFresh &&
     initialChannelUnreadSnapshot?.channelId === currentChannelId;
+  useEffect(() => {
+    if (unreadDidInitialize) {
+      // Keep the retained visit's query mode stable while its replacement
+      // unread snapshot loads, then allow the fresh cursor to take over.
+      setClearedCursor(false);
+    }
+  }, [unreadDidInitialize]);
   // Retain the prior focused entry's snapshot while its replacement loads.
   // This preserves Channel-local draft state without enabling unread work
   // until the new snapshot is ready.

--- a/packages/app/features/top/ChannelScreen.tsx
+++ b/packages/app/features/top/ChannelScreen.tsx
@@ -235,6 +235,8 @@ export default function ChannelScreen(props: Props) {
   });
 
   useEffect(() => {
+    // This recovers a failed around-cursor query by issuing a newest query.
+    // Successful queries that temporarily omit the anchor recover in PostList.
     if (
       unreadCursor &&
       !selectedPostId &&

--- a/packages/app/features/top/ChannelScreen.tsx
+++ b/packages/app/features/top/ChannelScreen.tsx
@@ -153,19 +153,20 @@ export default function ChannelScreen(props: Props) {
 
   const { performGroupAction } = useGroupActions();
 
-  const cursor = useMemo(() => {
+  const unreadCursor = useMemo(() => {
     if (!channel) {
       return undefined;
     }
-    const firstUnreadId =
+    return (
       initialChannelUnread &&
       (initialChannelUnread.countWithoutThreads ?? 0) > 0 &&
-      initialChannelUnread?.firstUnreadPostId;
-    return selectedPostId || firstUnreadId;
+      initialChannelUnread.firstUnreadPostId
+    );
     // We only want this to rerun when the channel is loaded for the first time OR if
-    // the selected post route param changes
+    // the initial unread state changes
     // eslint-disable-next-line
-  }, [!!channel, initialChannelUnread, selectedPostId]);
+  }, [!!channel, initialChannelUnread]);
+  const cursor = selectedPostId || unreadCursor;
 
   useEffect(() => {
     if (channel?.id) {
@@ -177,11 +178,10 @@ export default function ChannelScreen(props: Props) {
   // existing cursor
   const [clearedCursor, setClearedCursor] = React.useState(false);
 
-  // But if a new post is selected, we should mark the cursor
-  // as uncleared
+  // A selected post or channel navigation establishes a new cursor scope.
   useEffect(() => {
     setClearedCursor(false);
-  }, [selectedPostId]);
+  }, [currentChannelId, selectedPostId]);
 
   const handleScrollToBottom = useCallback(() => {
     setClearedCursor(true);
@@ -216,8 +216,31 @@ export default function ChannelScreen(props: Props) {
   });
 
   useEffect(() => {
-    // make sure we always load enough posts to fill the screen or
-    // onScrollEndReached might not fire properly
+    if (
+      unreadCursor &&
+      !selectedPostId &&
+      !clearedCursor &&
+      postsQuery.isError &&
+      !isLoadingPosts
+    ) {
+      logger.log('unread cursor failed; falling back to newest posts', {
+        channelId: currentChannelId,
+        unreadCursor,
+      });
+      setClearedCursor(true);
+    }
+  }, [
+    clearedCursor,
+    currentChannelId,
+    isLoadingPosts,
+    postsQuery.isError,
+    selectedPostId,
+    unreadCursor,
+  ]);
+
+  useEffect(() => {
+    // Make sure the initial page can fill the screen; otherwise the visual
+    // start boundary may never move far enough to request another older page.
     const ENOUGH_POSTS_TO_FILL_SCREEN = 20;
     if (
       !postsQuery.isFetching &&
@@ -426,8 +449,8 @@ export default function ChannelScreen(props: Props) {
           goToDm={handleGoToDm}
           goToUserProfile={handleGoToUserProfile}
           goToGroupSettings={handleGoToGroupSettings}
-          onScrollEndReached={loadOlder}
-          onScrollStartReached={loadNewer}
+          onLoadNewerPosts={loadNewer}
+          onLoadOlderPosts={loadOlder}
           onPressRef={navigateToRef}
           markRead={handleMarkRead}
           onGroupAction={performGroupAction}

--- a/packages/app/features/top/ChannelScreen.tsx
+++ b/packages/app/features/top/ChannelScreen.tsx
@@ -128,36 +128,38 @@ export default function ChannelScreen(props: Props) {
       unread: db.ChannelUnread | null;
     } | null>(null);
   const isFocused = useIsFocused();
-  useEffect(() => {
-    let isCurrent = true;
+  useFocusEffect(
+    useCallback(() => {
+      let isCurrent = true;
+      setInitialChannelUnreadSnapshot(null);
 
-    async function initializeChannelUnread() {
-      let unread: db.ChannelUnread | null | undefined;
-      try {
-        unread = await db.getChannelUnread({ channelId: currentChannelId });
-      } catch (error) {
-        logger.trackError('failed to initialize channel unread', error);
+      async function initializeChannelUnread() {
+        let unread: db.ChannelUnread | null | undefined;
+        try {
+          unread = await db.getChannelUnread({ channelId: currentChannelId });
+        } catch (error) {
+          logger.trackError('failed to initialize channel unread', error);
+        }
+
+        if (isCurrent) {
+          setInitialChannelUnreadSnapshot({
+            channelId: currentChannelId,
+            unread: unread ?? null,
+          });
+        }
       }
 
-      if (isCurrent) {
-        setInitialChannelUnreadSnapshot({
-          channelId: currentChannelId,
-          unread: unread ?? null,
-        });
-      }
-    }
-
-    if (isFocused) {
       void initializeChannelUnread();
-    }
 
-    return () => {
-      isCurrent = false;
-    };
-  }, [currentChannelId, isFocused]);
+      return () => {
+        isCurrent = false;
+        setInitialChannelUnreadSnapshot(null);
+      };
+    }, [currentChannelId])
+  );
 
   const unreadDidInitialize =
-    initialChannelUnreadSnapshot?.channelId === currentChannelId;
+    isFocused && initialChannelUnreadSnapshot?.channelId === currentChannelId;
   const initialChannelUnread = unreadDidInitialize
     ? initialChannelUnreadSnapshot.unread
     : null;

--- a/packages/app/features/top/ChannelScreen.tsx
+++ b/packages/app/features/top/ChannelScreen.tsx
@@ -127,11 +127,13 @@ export default function ChannelScreen(props: Props) {
       channelId: string;
       unread: db.ChannelUnread | null;
     } | null>(null);
+  const [unreadSnapshotIsFresh, setUnreadSnapshotIsFresh] =
+    React.useState(false);
   const isFocused = useIsFocused();
   useFocusEffect(
     useCallback(() => {
       let isCurrent = true;
-      setInitialChannelUnreadSnapshot(null);
+      setUnreadSnapshotIsFresh(false);
 
       async function initializeChannelUnread() {
         let unread: db.ChannelUnread | null | undefined;
@@ -146,6 +148,7 @@ export default function ChannelScreen(props: Props) {
             channelId: currentChannelId,
             unread: unread ?? null,
           });
+          setUnreadSnapshotIsFresh(true);
         }
       }
 
@@ -153,16 +156,22 @@ export default function ChannelScreen(props: Props) {
 
       return () => {
         isCurrent = false;
-        setInitialChannelUnreadSnapshot(null);
+        setUnreadSnapshotIsFresh(false);
       };
     }, [currentChannelId])
   );
 
   const unreadDidInitialize =
-    isFocused && initialChannelUnreadSnapshot?.channelId === currentChannelId;
-  const initialChannelUnread = unreadDidInitialize
-    ? initialChannelUnreadSnapshot.unread
-    : null;
+    isFocused &&
+    unreadSnapshotIsFresh &&
+    initialChannelUnreadSnapshot?.channelId === currentChannelId;
+  // Retain the prior focused entry's snapshot while its replacement loads.
+  // This preserves Channel-local draft state without enabling unread work
+  // until the new snapshot is ready.
+  const initialChannelUnread =
+    initialChannelUnreadSnapshot?.channelId === currentChannelId
+      ? initialChannelUnreadSnapshot.unread
+      : null;
 
   const {
     navigateToImage,
@@ -380,13 +389,13 @@ export default function ChannelScreen(props: Props) {
   );
 
   const handleMarkRead = useCallback(async () => {
-    if (channel && !channel.isPendingChannel) {
+    if (unreadDidInitialize && channel && !channel.isPendingChannel) {
       store.markChannelRead({
         id: channel.id,
         groupId: channel.groupId ?? undefined,
       });
     }
-  }, [channel?.type, channel?.id, channel?.groupId]);
+  }, [channel?.type, channel?.id, channel?.groupId, unreadDidInitialize]);
 
   const handlePressInvite = useCallback(
     (groupId: string) => {
@@ -437,7 +446,10 @@ export default function ChannelScreen(props: Props) {
     [currentChannelId, routeGroupId, channel?.groupId]
   );
 
-  if (!channel || !unreadDidInitialize) {
+  if (
+    !channel ||
+    initialChannelUnreadSnapshot?.channelId !== currentChannelId
+  ) {
     return null;
   }
 

--- a/packages/app/fixtures/Channel.fixture.tsx
+++ b/packages/app/fixtures/Channel.fixture.tsx
@@ -218,14 +218,14 @@ function ChannelWithControlledPostLoading() {
 
   const [shouldLoadOnScrollBoundaries, setShouldLoadOnScrollBoundaries] =
     useState(false);
-  const onScrollStartReached = useMemo(
+  const onLoadNewerPosts = useMemo(
     () =>
       shouldLoadOnScrollBoundaries
         ? () => loadMore({ limit: 5, insertionPoint: 'start' })
         : undefined,
     [shouldLoadOnScrollBoundaries, loadMore]
   );
-  const onScrollEndReached = useMemo(
+  const onLoadOlderPosts = useMemo(
     () =>
       shouldLoadOnScrollBoundaries
         ? () => loadMore({ limit: 5, insertionPoint: 'end' })
@@ -246,8 +246,8 @@ function ChannelWithControlledPostLoading() {
             post: anchorPost,
           }),
           hasNewerPosts: true,
-          onScrollStartReached,
-          onScrollEndReached,
+          onLoadNewerPosts,
+          onLoadOlderPosts,
         })}
       />
       <FixtureToolbar>

--- a/packages/app/package.json
+++ b/packages/app/package.json
@@ -12,6 +12,7 @@
   },
   "dependencies": {
     "@emoji-mart/data": "^1.1.2",
+    "@legendapp/list": "3.3.3",
     "@mattermost/react-native-paste-input": "2.0.1",
     "@tloncorp/api": "workspace:*",
     "@tloncorp/editor": "workspace:*",

--- a/packages/app/ui/components/Channel/PostList/PostList.tsx
+++ b/packages/app/ui/components/Channel/PostList/PostList.tsx
@@ -130,13 +130,13 @@ const ConversationPostList: PostListComponent = React.forwardRef(
       isLoading,
     });
 
-    const previousAnchorKeyRef = React.useRef(anchorKey);
+    const currentAnchorKeyRef = React.useRef(anchorKey);
     React.useLayoutEffect(() => {
-      if (previousAnchorKeyRef.current === anchorKey) {
+      if (currentAnchorKeyRef.current === anchorKey) {
         return;
       }
 
-      previousAnchorKeyRef.current = anchorKey;
+      currentAnchorKeyRef.current = anchorKey;
       didStartInitialScrollRef.current = false;
       if (initialScrollFrameRef.current !== undefined) {
         cancelAnimationFrame(initialScrollFrameRef.current);
@@ -207,6 +207,10 @@ const ConversationPostList: PostListComponent = React.forwardRef(
       onScrolledToBottom,
       onScrolledAwayFromBottom,
     });
+    const finishInitialScroll = React.useCallback(() => {
+      setDidFinishInitialScroll(true);
+      onInitialScrollCompleted?.();
+    }, [onInitialScrollCompleted]);
     const completeInitialScroll = React.useCallback(() => {
       if (!isInitialAnchorReady || didStartInitialScrollRef.current) {
         return;
@@ -215,11 +219,10 @@ const ConversationPostList: PostListComponent = React.forwardRef(
       const loadedAnchorKey = anchorKey;
       void applyAnchorPosition()
         .then(() => {
-          if (previousAnchorKeyRef.current !== loadedAnchorKey) {
+          if (currentAnchorKeyRef.current !== loadedAnchorKey) {
             return;
           }
-          setDidFinishInitialScroll(true);
-          onInitialScrollCompleted?.();
+          finishInitialScroll();
         })
         .catch(() => {
           // Navigation can cancel the scroll while the list is unmounting.
@@ -227,8 +230,8 @@ const ConversationPostList: PostListComponent = React.forwardRef(
     }, [
       anchorKey,
       applyAnchorPosition,
+      finishInitialScroll,
       isInitialAnchorReady,
-      onInitialScrollCompleted,
     ]);
     // onLoad fires before LegendList's post-load buffer expansion has laid out.
     // Wait through that expansion so the exact target uses settled row sizes.
@@ -251,13 +254,26 @@ const ConversationPostList: PostListComponent = React.forwardRef(
       },
       []
     );
-    const handleLoad = React.useCallback(() => {
-      if (anchor?.type === 'unread') {
-        scheduleInitialScroll();
-      } else {
-        completeInitialScroll();
+    React.useEffect(() => {
+      if (
+        !isInitialAnchorReady ||
+        isLoading ||
+        postsWithNeighbors.length !== 0 ||
+        didStartInitialScrollRef.current
+      ) {
+        return;
       }
-    }, [anchor?.type, completeInitialScroll, scheduleInitialScroll]);
+
+      // LegendList defers onLoad when initialScrollAtEnd has no data to target.
+      // A settled empty conversation has no position to reconcile, so reveal it.
+      didStartInitialScrollRef.current = true;
+      finishInitialScroll();
+    }, [
+      finishInitialScroll,
+      isInitialAnchorReady,
+      isLoading,
+      postsWithNeighbors.length,
+    ]);
 
     React.useEffect(() => {
       if (
@@ -347,7 +363,7 @@ const ConversationPostList: PostListComponent = React.forwardRef(
             ? undefined
             : { opacity: 0 },
         ]}
-        onLoad={handleLoad}
+        onLoad={scheduleInitialScroll}
         onScroll={handleScroll}
         onScrollBeginDrag={() => {
           userHasScrolledRef.current = true;

--- a/packages/app/ui/components/Channel/PostList/PostList.tsx
+++ b/packages/app/ui/components/Channel/PostList/PostList.tsx
@@ -10,6 +10,7 @@ import { PostList as PostListFlatList } from './PostListFlatList';
 import {
   getPostListAnchorKey,
   getPostListInitialization,
+  getPostListScopeKey,
 } from './postListInitialization';
 import {
   PostListComponent,
@@ -69,7 +70,11 @@ PostList.displayName = 'PostList';
 const ConversationPostList: PostListComponent = React.forwardRef(
   (props, forwardedRef) => {
     const initialization = useConversationListInitialization(props);
+    const { onInitialScrollPending } = props;
     const attemptRef = React.useRef<PostListMethods>(null);
+    React.useLayoutEffect(() => {
+      onInitialScrollPending?.();
+    }, [initialization.mountKey, onInitialScrollPending]);
     React.useImperativeHandle(
       forwardedRef,
       () => ({
@@ -120,7 +125,7 @@ function useConversationListInitialization({
     );
   }, [anchor?.postId, postsWithNeighbors]);
   const anchorKey = getPostListAnchorKey(anchor);
-  const anchorScopeKey = `${channel.id}:${anchorKey ?? 'latest'}`;
+  const anchorScopeKey = getPostListScopeKey(channel.id, anchor);
   const [timedOutAnchorScopeKey, setTimedOutAnchorScopeKey] = React.useState<
     string | null
   >(null);
@@ -149,6 +154,10 @@ function useConversationListInitialization({
     }, ANCHOR_RESOLUTION_TIMEOUT_MS);
     return () => clearTimeout(timeout);
   }, [anchorScopeKey, shouldStartAnchorTimeout]);
+
+  React.useLayoutEffect(() => {
+    setTimedOutAnchorScopeKey(null);
+  }, [anchorScopeKey]);
 
   return {
     anchorIndex,
@@ -202,8 +211,8 @@ function useConversationAnchorTarget({
   const applyAnchorPosition = React.useCallback(async () => {
     const target = latestAnchorPositionRef.current;
     if (target === 'end') {
-      appliedAnchorPositionRef.current = target;
       await listRef.current?.scrollToEnd({ animated: false });
+      appliedAnchorPositionRef.current = target;
       return true;
     }
 
@@ -211,8 +220,8 @@ function useConversationAnchorTarget({
       return false;
     }
 
-    appliedAnchorPositionRef.current = target;
     await listRef.current?.scrollToIndex({ ...target, animated: false });
+    appliedAnchorPositionRef.current = target;
     return true;
   }, [listRef]);
 
@@ -262,7 +271,11 @@ function useInitialConversationScroll({
         }
       })
       .catch(() => {
-        // Navigation can cancel the scroll while the list is unmounting.
+        // A same-mount measurement race must not leave the list hidden. Reveal
+        // the estimated position; the correction effect gets one exact retry.
+        if (attemptIsActiveRef.current) {
+          finishInitialScroll();
+        }
       });
   }, [applyAnchorPosition, finishInitialScroll, isInitialAnchorReady]);
 

--- a/packages/app/ui/components/Channel/PostList/PostList.tsx
+++ b/packages/app/ui/components/Channel/PostList/PostList.tsx
@@ -71,7 +71,13 @@ export const PostList: PostListComponent = React.forwardRef(
     return usesConversationPostList(props) ? (
       <ConversationPostList {...props} ref={forwardedRef} />
     ) : (
-      <PostListFlatList {...props} ref={forwardedRef} />
+      <PostListFlatList
+        // FlatList rows may retain their layouts when selection changes, so a
+        // fresh selected anchor needs a fresh measurement/scroll attempt.
+        key={props.anchor?.type === 'selected' ? props.anchor.postId : undefined}
+        {...props}
+        ref={forwardedRef}
+      />
     );
   }
 );

--- a/packages/app/ui/components/Channel/PostList/PostList.tsx
+++ b/packages/app/ui/components/Channel/PostList/PostList.tsx
@@ -61,7 +61,9 @@ PostList.displayName = 'PostList';
 /**
  * LegendList-backed implementation for upright native conversations. Callers
  * provide posts in visual order so every renderer shares one coordinate
- * system.
+ * system. Initial positioning has three phases: use estimates at mount, apply
+ * the exact position after initial layout, then correct for content changes
+ * until the user scrolls.
  */
 const ConversationPostList: PostListComponent = React.forwardRef(
   (
@@ -163,6 +165,9 @@ const ConversationPostList: PostListComponent = React.forwardRef(
         return;
       }
 
+      // Query failures switch ChannelScreen back to newest mode. A cache-backed
+      // query can appear settled while its around-cursor fetch and cache updates
+      // are still arriving, so wait briefly before falling back here.
       const timeout = setTimeout(() => {
         setTimedOutAnchorId(anchorId);
       }, ANCHOR_RESOLUTION_TIMEOUT_MS);
@@ -242,8 +247,9 @@ const ConversationPostList: PostListComponent = React.forwardRef(
       isInitialAnchorReady,
       listMountKey,
     ]);
-    // onLoad fires before LegendList's post-load buffer expansion has laid out.
-    // Wait through that expansion so the exact target uses settled row sizes.
+    // LegendList has no settled-layout callback: onLoad fires before its
+    // next-frame buffer expansion, so wait through two layout opportunities
+    // before applying the exact target from measured row sizes.
     const scheduleInitialScroll = React.useCallback(() => {
       if (initialScrollFrameRef.current !== undefined) {
         cancelAnimationFrame(initialScrollFrameRef.current);

--- a/packages/app/ui/components/Channel/PostList/PostList.tsx
+++ b/packages/app/ui/components/Channel/PostList/PostList.tsx
@@ -19,18 +19,8 @@ import {
   usesConversationPostList,
 } from './shared';
 
-// V1 uses bounded wall-clock fallbacks because LegendList does not expose a
-// single "all requested rows are measured" signal. Replace these with an
-// event-driven quiescence check when the list provides one.
 const ANCHOR_RESOLUTION_TIMEOUT_MS = 2_000;
 const ESTIMATED_ITEM_SIZE = 120;
-/**
- * How long after the initial scroll we keep re-applying the anchor position as
- * items report their real sizes. Item sizes only settle after measurement, and
- * the first scroll is computed from `ESTIMATED_ITEM_SIZE`, so without this the
- * list keeps whatever position the estimate produced.
- */
-const ANCHOR_SETTLE_WINDOW_MS = 1_000;
 
 function getPostId({ post }: PostWithNeighbors) {
   return post.id;
@@ -102,17 +92,12 @@ const ConversationPostList: PostListComponent = React.forwardRef(
   ) => {
     const listRef = React.useRef<LegendListRef>(null);
     const didStartInitialScrollRef = React.useRef(false);
-    const anchorGenerationRef = React.useRef(0);
     const userHasScrolledRef = React.useRef(false);
     const appliedAnchorPositionRef = React.useRef<AnchorPosition | undefined>(
       undefined
     );
     const [didFinishInitialScroll, setDidFinishInitialScroll] =
       React.useState(false);
-    const anchorSettledRef = React.useRef(false);
-    const settleTimerRef = React.useRef<ReturnType<typeof setTimeout> | null>(
-      null
-    );
     const insets = useSafeAreaInsets();
     const collectionLayout = React.useMemo(
       () => layoutForType(collectionLayoutType),
@@ -151,17 +136,11 @@ const ConversationPostList: PostListComponent = React.forwardRef(
       }
 
       previousAnchorKeyRef.current = anchorKey;
-      anchorGenerationRef.current += 1;
       didStartInitialScrollRef.current = false;
       setDidFinishInitialScroll(false);
       userHasScrolledRef.current = false;
       appliedAnchorPositionRef.current = undefined;
-      anchorSettledRef.current = false;
       setTimedOutAnchorId(null);
-      if (settleTimerRef.current) {
-        clearTimeout(settleTimerRef.current);
-        settleTimerRef.current = null;
-      }
     }, [anchorKey]);
 
     React.useEffect(() => {
@@ -197,16 +176,13 @@ const ConversationPostList: PostListComponent = React.forwardRef(
       latestAnchorPositionRef.current = anchorPosition;
     }, [anchorPosition]);
 
-    /**
-     * Applies the resolved anchor position, choosing between the anchor target
-     * and the list end. Every path that positions the list on initial load goes
-     * through here so they cannot disagree.
-     */
-    const applyAnchorPosition = React.useCallback(async () => {
+    // LegendList owns the initial position through initialScrollIndex. This is
+    // only for a target that changes after the list has finished loading.
+    const applyAnchorPosition = React.useCallback(() => {
       const target = latestAnchorPositionRef.current;
       if (target === 'end') {
         appliedAnchorPositionRef.current = target;
-        await listRef.current?.scrollToEnd({ animated: false });
+        listRef.current?.scrollToEnd({ animated: false });
         return true;
       }
 
@@ -215,7 +191,7 @@ const ConversationPostList: PostListComponent = React.forwardRef(
       }
 
       appliedAnchorPositionRef.current = target;
-      await listRef.current?.scrollToIndex({ ...target, animated: false });
+      listRef.current?.scrollToIndex({ ...target, animated: false });
       return true;
     }, []);
     const { onScroll: handleScroll, isAtBottom } = useScrollDirectionTracker({
@@ -231,50 +207,10 @@ const ConversationPostList: PostListComponent = React.forwardRef(
         return;
       }
       didStartInitialScrollRef.current = true;
-      const anchorGeneration = anchorGenerationRef.current;
-
-      const completeInitialScroll = async () => {
-        try {
-          if (anchorGeneration !== anchorGenerationRef.current) {
-            return;
-          }
-
-          // The around-anchor query can prepend cached history while
-          // LegendList is bootstrapping. Re-resolve the current anchor index
-          // before releasing queued edge events.
-          await applyAnchorPosition();
-
-          if (anchorGeneration !== anchorGenerationRef.current) {
-            return;
-          }
-
-          const updatedTarget = latestAnchorPositionRef.current;
-          if (
-            updatedTarget &&
-            !isSameAnchorPosition(
-              updatedTarget,
-              appliedAnchorPositionRef.current
-            )
-          ) {
-            await applyAnchorPosition();
-          }
-        } catch {
-          // Navigation can cancel the imperative scroll while unmounting.
-        } finally {
-          if (anchorGeneration === anchorGenerationRef.current) {
-            setDidFinishInitialScroll(true);
-            onInitialScrollCompleted?.();
-            settleTimerRef.current = setTimeout(() => {
-              if (anchorGeneration === anchorGenerationRef.current) {
-                anchorSettledRef.current = true;
-              }
-            }, ANCHOR_SETTLE_WINDOW_MS);
-          }
-        }
-      };
-
-      void completeInitialScroll();
-    }, [applyAnchorPosition, isInitialAnchorReady, onInitialScrollCompleted]);
+      appliedAnchorPositionRef.current = latestAnchorPositionRef.current;
+      setDidFinishInitialScroll(true);
+      onInitialScrollCompleted?.();
+    }, [isInitialAnchorReady, onInitialScrollCompleted]);
 
     React.useEffect(() => {
       if (
@@ -286,53 +222,8 @@ const ConversationPostList: PostListComponent = React.forwardRef(
         return;
       }
 
-      void applyAnchorPosition().catch(() => {
-        // The list may unmount while the inset correction is in flight.
-      });
+      applyAnchorPosition();
     }, [anchorPosition, applyAnchorPosition, didFinishInitialScroll]);
-
-    // The initial scroll offset is derived from `ESTIMATED_ITEM_SIZE`. Real rows
-    // routinely differ (author row, media, reactions), so re-apply the target
-    // while the rows at or above it settle. Native visible-content preservation
-    // keeps the target locked when rows below it change size.
-    const handleItemSizeChanged = React.useCallback(
-      ({
-        index,
-        size,
-        previous,
-      }: {
-        index: number;
-        size: number;
-        previous: number;
-      }) => {
-        if (
-          anchorSettledRef.current ||
-          userHasScrolledRef.current ||
-          !didStartInitialScrollRef.current ||
-          size === previous
-        ) {
-          return;
-        }
-
-        const target = latestAnchorPositionRef.current;
-        if (!target || target === 'end' || index > target.index) {
-          return;
-        }
-
-        void applyAnchorPosition().catch(() => {
-          // The list can unmount while a correction is in flight.
-        });
-      },
-      [applyAnchorPosition]
-    );
-
-    React.useEffect(() => {
-      return () => {
-        if (settleTimerRef.current) {
-          clearTimeout(settleTimerRef.current);
-        }
-      };
-    }, []);
 
     React.useImperativeHandle(
       forwardedRef,
@@ -406,11 +297,9 @@ const ConversationPostList: PostListComponent = React.forwardRef(
           isInitialAnchorReady ? undefined : { opacity: 0 },
         ]}
         onLoad={handleLoad}
-        onItemSizeChanged={handleItemSizeChanged}
         onScroll={handleScroll}
         onScrollBeginDrag={() => {
           userHasScrolledRef.current = true;
-          anchorSettledRef.current = true;
         }}
         onStartReached={onStartReached}
         onStartReachedThreshold={onStartReachedThreshold}

--- a/packages/app/ui/components/Channel/PostList/PostList.tsx
+++ b/packages/app/ui/components/Channel/PostList/PostList.tsx
@@ -10,7 +10,6 @@ import { PostList as PostListFlatList } from './PostListFlatList';
 import {
   getPostListAnchorKey,
   getPostListInitialization,
-  shouldSnapUnreadAnchorToEnd,
 } from './postListInitialization';
 import {
   PostListComponent,
@@ -89,7 +88,6 @@ const ConversationPostList: PostListComponent = React.forwardRef(
       onEndReached,
       onEndReachedThreshold,
       anchor,
-      hasNewerPosts,
       channel,
       collectionLayoutType,
       onInitialScrollCompleted,
@@ -115,7 +113,6 @@ const ConversationPostList: PostListComponent = React.forwardRef(
     const settleTimerRef = React.useRef<ReturnType<typeof setTimeout> | null>(
       null
     );
-    const [viewportHeight, setViewportHeight] = React.useState(0);
     const insets = useSafeAreaInsets();
     const collectionLayout = React.useMemo(
       () => layoutForType(collectionLayoutType),
@@ -189,30 +186,8 @@ const ConversationPostList: PostListComponent = React.forwardRef(
             },
       [anchor?.type, anchorIndex, didTimeoutWaitingForAnchor]
     );
-    // Top-aligning the first unread is right when there is a run of unreads to
-    // read down through. When the messages after the anchor cannot fill a
-    // viewport, there is nothing below it, so
-    // top-aligning strands the view above the natural bottom - the user lands
-    // short with content still to scroll. Land at the end instead.
-    //
-    // Defaults to false until the viewport is measured, so an unmeasured first
-    // pass keeps the ordinary anchor behaviour rather than jumping to the end.
-    // Rich media can exceed the estimate; the settle corrections below repair
-    // the landing as real row sizes arrive.
-    const estimatedAnchorExtent =
-      anchorIndex === -1
-        ? undefined
-        : (postsWithNeighbors.length - anchorIndex) * ESTIMATED_ITEM_SIZE;
-    const shouldSnapAnchorToEnd = shouldSnapUnreadAnchorToEnd({
-      anchorType: anchor?.type,
-      estimatedAnchorExtent,
-      hasNewerPosts,
-      anchorToEnd,
-      viewportHeight,
-    });
     const anchorPosition: AnchorPosition | undefined =
-      shouldSnapAnchorToEnd ||
-      (anchorToEnd && (!anchor?.postId || didTimeoutWaitingForAnchor))
+      anchorToEnd && (!anchor?.postId || didTimeoutWaitingForAnchor)
         ? 'end'
         : initialScrollIndex;
     const latestAnchorPositionRef = React.useRef<AnchorPosition | undefined>(
@@ -317,11 +292,11 @@ const ConversationPostList: PostListComponent = React.forwardRef(
     }, [anchorPosition, applyAnchorPosition, didFinishInitialScroll]);
 
     // The initial scroll offset is derived from `ESTIMATED_ITEM_SIZE`. Real rows
-    // routinely differ (author row, media, reactions), so the first landing can
-    // sit short of the anchor. Re-apply the target while items above it are
-    // still being measured - nothing else re-issues the scroll, because the
-    // correction effect above only reacts to `viewOffset` changing, not to
-    // measurement.
+    // routinely differ (author row, media, reactions), so re-apply the target
+    // while they settle. For unread anchors this includes the rows below the
+    // target: LegendList naturally clamps the divider below the top when that
+    // tail is too short, and its measured height determines whether the clamp
+    // is needed. Selected anchors only depend on sizes at or above the target.
     const handleItemSizeChanged = React.useCallback(
       ({
         index,
@@ -342,8 +317,11 @@ const ConversationPostList: PostListComponent = React.forwardRef(
         }
 
         const target = latestAnchorPositionRef.current;
-        // Only sizes at or above the anchor move its offset.
-        if (!target || target === 'end' || index > target.index) {
+        if (
+          !target ||
+          target === 'end' ||
+          (anchor?.type !== 'unread' && index > target.index)
+        ) {
           return;
         }
 
@@ -351,7 +329,7 @@ const ConversationPostList: PostListComponent = React.forwardRef(
           // The list can unmount while a correction is in flight.
         });
       },
-      [applyAnchorPosition]
+      [anchor?.type, applyAnchorPosition]
     );
 
     React.useEffect(() => {
@@ -433,9 +411,6 @@ const ConversationPostList: PostListComponent = React.forwardRef(
           style,
           isInitialAnchorReady ? undefined : { opacity: 0 },
         ]}
-        onLayout={(event) => {
-          setViewportHeight(event.nativeEvent.layout.height);
-        }}
         onLoad={handleLoad}
         onItemSizeChanged={handleItemSizeChanged}
         onScroll={handleScroll}

--- a/packages/app/ui/components/Channel/PostList/PostList.tsx
+++ b/packages/app/ui/components/Channel/PostList/PostList.tsx
@@ -267,6 +267,7 @@ function useInitialConversationScroll({
   const didStartInitialScrollRef = React.useRef(false);
   const initialScrollFrameRef = React.useRef<number | undefined>(undefined);
   const userHasScrolledRef = React.useRef(false);
+  const [hasUserScrolled, setHasUserScrolled] = React.useState(false);
   const [didFinishInitialScroll, setDidFinishInitialScroll] =
     React.useState(false);
   const { anchorPosition, appliedAnchorPositionRef, applyAnchorPosition } =
@@ -359,10 +360,12 @@ function useInitialConversationScroll({
 
   const markUserScrolled = React.useCallback(() => {
     userHasScrolledRef.current = true;
+    setHasUserScrolled(true);
   }, []);
 
   return {
     didFinishInitialScroll,
+    hasUserScrolled,
     markUserScrolled,
     scheduleInitialScroll,
   };
@@ -415,26 +418,37 @@ const ConversationPostListAttempt = React.forwardRef<
       didTimeoutWaitingForAnchor,
       listRef,
     });
-    const { didFinishInitialScroll, markUserScrolled, scheduleInitialScroll } =
-      useInitialConversationScroll({
-        anchorTarget,
-        isInitialAnchorReady,
-        isLoading,
-        itemCount: postsWithNeighbors.length,
-        onInitialScrollCompleted,
-      });
-    const { initialScrollIndex } = anchorTarget;
-    const { onScroll: handleScroll } = useScrollDirectionTracker({
-      atBottomThreshold: onScrolledToBottomThreshold,
-      bottomAtEnd: true,
+    const {
+      didFinishInitialScroll,
+      hasUserScrolled,
+      markUserScrolled,
+      scheduleInitialScroll,
+    } = useInitialConversationScroll({
+      anchorTarget,
+      isInitialAnchorReady,
+      isLoading,
+      itemCount: postsWithNeighbors.length,
+      onInitialScrollCompleted,
     });
+    const { initialScrollIndex } = anchorTarget;
+    const { onScroll: handleScroll, isAtBottom: isWithinBottomThreshold } =
+      useScrollDirectionTracker({
+        atBottomThreshold: onScrolledToBottomThreshold,
+        bottomAtEnd: true,
+      });
     // LegendList recalculates this when scrolling, content, or row measurements
     // change. React Native onScroll can retain an intermediate value while the
     // initial anchor settles, briefly showing the scroll-to-bottom control.
-    const isAtBottom = useLegendListIsNearEnd(listRef);
+    const isNearEnd = useLegendListIsNearEnd(listRef);
     // The list is hidden while its initial anchor settles, so do not publish
-    // transient geometry that could show external scroll chrome first.
-    usePostListBottomCallbacks(!didFinishInitialScroll || isAtBottom, {
+    // transient geometry that could show external scroll chrome first. Until
+    // the first user-driven navigation, LegendList's settled state also guards
+    // against a stale intermediate React Native scroll event.
+    const isAtBottom =
+      !didFinishInitialScroll ||
+      (!hasUserScrolled && isNearEnd) ||
+      isWithinBottomThreshold;
+    usePostListBottomCallbacks(isAtBottom, {
       onScrolledToBottom,
       onScrolledAwayFromBottom,
     });
@@ -442,13 +456,17 @@ const ConversationPostListAttempt = React.forwardRef<
     React.useImperativeHandle(
       forwardedRef,
       (): PostListMethods => ({
-        scrollToStart: (opts) =>
+        scrollToStart: (opts) => {
+          markUserScrolled();
           void listRef.current?.scrollToOffset({
             offset: 0,
             animated: opts.animated,
-          }),
-        scrollToEnd: (opts) =>
-          void listRef.current?.scrollToEnd({ animated: opts.animated }),
+          });
+        },
+        scrollToEnd: (opts) => {
+          markUserScrolled();
+          void listRef.current?.scrollToEnd({ animated: opts.animated });
+        },
         scrollToPost: ({ postId, animated, viewPosition }) => {
           const index = postsWithNeighbors.findIndex(
             ({ post }) => post.id === postId
@@ -457,6 +475,7 @@ const ConversationPostListAttempt = React.forwardRef<
             return;
           }
 
+          markUserScrolled();
           void listRef.current?.scrollToIndex({
             index,
             animated,
@@ -464,7 +483,7 @@ const ConversationPostListAttempt = React.forwardRef<
           });
         },
       }),
-      [postsWithNeighbors]
+      [markUserScrolled, postsWithNeighbors]
     );
 
     return (

--- a/packages/app/ui/components/Channel/PostList/PostList.tsx
+++ b/packages/app/ui/components/Channel/PostList/PostList.tsx
@@ -122,7 +122,7 @@ const ConversationPostList: PostListComponent = React.forwardRef(
       !!anchor?.postId && timedOutAnchorId === anchor.postId;
     const anchorKey = getPostListAnchorKey(anchor);
     const {
-      mountKey: listMountKey,
+      mountKey: anchorResolutionMountKey,
       isAnchorReady: isInitialAnchorReady,
       shouldStartAnchorTimeout,
     } = getPostListInitialization({
@@ -131,16 +131,18 @@ const ConversationPostList: PostListComponent = React.forwardRef(
       didTimeoutWaitingForAnchor,
       isLoading,
     });
+    const anchorScopeKey = `${channel.id}:${anchorKey ?? 'latest'}`;
+    const listMountKey = `${channel.id}:${anchorResolutionMountKey}`;
 
-    const currentAnchorKeyRef = React.useRef(anchorKey);
+    const currentAnchorScopeKeyRef = React.useRef(anchorScopeKey);
     React.useLayoutEffect(() => {
-      if (currentAnchorKeyRef.current === anchorKey) {
+      if (currentAnchorScopeKeyRef.current === anchorScopeKey) {
         return;
       }
 
-      currentAnchorKeyRef.current = anchorKey;
+      currentAnchorScopeKeyRef.current = anchorScopeKey;
       setTimedOutAnchorId(null);
-    }, [anchorKey]);
+    }, [anchorScopeKey]);
 
     const currentListMountKeyRef = React.useRef(listMountKey);
     React.useLayoutEffect(() => {

--- a/packages/app/ui/components/Channel/PostList/PostList.tsx
+++ b/packages/app/ui/components/Channel/PostList/PostList.tsx
@@ -395,6 +395,7 @@ const ConversationPostListAttempt = React.forwardRef<
       listHeaderComponent,
       listBottomComponent,
       isLoading = false,
+      hasNewerPosts = false,
       anchorIndex,
       didTimeoutWaitingForAnchor,
       isInitialAnchorReady,
@@ -485,8 +486,10 @@ const ConversationPostListAttempt = React.forwardRef<
           initialScrollIndex === undefined
         }
         initialScrollIndex={initialScrollIndex}
-        maintainScrollAtEnd={anchorToEnd}
-        maintainScrollAtEndThreshold={anchorToEnd ? 0.1 : undefined}
+        maintainScrollAtEnd={anchorToEnd && !hasNewerPosts}
+        maintainScrollAtEndThreshold={
+          anchorToEnd && !hasNewerPosts ? 0.1 : undefined
+        }
         maintainVisibleContentPosition={
           collectionLayout.shouldMaintainVisibleContentPosition || undefined
         }
@@ -504,7 +507,9 @@ const ConversationPostListAttempt = React.forwardRef<
         style={[
           { flex: 1 },
           style,
-          isInitialAnchorReady && didFinishInitialScroll
+          isInitialAnchorReady &&
+          (didFinishInitialScroll ||
+            (isLoading && postsWithNeighbors.length === 0))
             ? undefined
             : { opacity: 0 },
         ]}

--- a/packages/app/ui/components/Channel/PostList/PostList.tsx
+++ b/packages/app/ui/components/Channel/PostList/PostList.tsx
@@ -45,6 +45,24 @@ function getPostId({ post }: PostWithNeighbors) {
   return post.id;
 }
 
+function runImperativeScroll(scroll: () => Promise<void> | undefined) {
+  const attempt = () => {
+    try {
+      return scroll() ?? Promise.resolve();
+    } catch (error) {
+      return Promise.reject(error);
+    }
+  };
+
+  void attempt().catch(() => {
+    // LegendList can reject while data or measurements are changing. Retry
+    // once after the next layout opportunity and contain a second failure.
+    requestAnimationFrame(() => {
+      void attempt().catch(() => {});
+    });
+  });
+}
+
 type IndexedAnchorPosition = {
   index: number;
   viewPosition: number;
@@ -414,6 +432,7 @@ const ConversationPostListAttempt = React.forwardRef<
     forwardedRef
   ) => {
     const listRef = React.useRef<LegendListRef>(null);
+    const postsWithNeighborsRef = React.useRef(postsWithNeighbors);
     const insets = useSafeAreaInsets();
     const collectionLayout = React.useMemo(
       () => layoutForType(collectionLayoutType),
@@ -439,6 +458,9 @@ const ConversationPostListAttempt = React.forwardRef<
       onInitialScrollCompleted,
     });
     const { initialScrollIndex } = anchorTarget;
+    React.useLayoutEffect(() => {
+      postsWithNeighborsRef.current = postsWithNeighbors;
+    }, [postsWithNeighbors]);
     const { onScroll: handleScroll, isAtBottom: isWithinBottomThreshold } =
       useScrollDirectionTracker({
         atBottomThreshold: onScrolledToBottomThreshold,
@@ -466,32 +488,37 @@ const ConversationPostListAttempt = React.forwardRef<
       (): PostListMethods => ({
         scrollToStart: (opts) => {
           markUserScrolled();
-          void listRef.current?.scrollToOffset({
-            offset: 0,
-            animated: opts.animated,
-          });
+          runImperativeScroll(() =>
+            listRef.current?.scrollToOffset({
+              offset: 0,
+              animated: opts.animated,
+            })
+          );
         },
         scrollToEnd: (opts) => {
           markUserScrolled();
-          void listRef.current?.scrollToEnd({ animated: opts.animated });
+          runImperativeScroll(() =>
+            listRef.current?.scrollToEnd({ animated: opts.animated })
+          );
         },
         scrollToPost: ({ postId, animated, viewPosition }) => {
-          const index = postsWithNeighbors.findIndex(
-            ({ post }) => post.id === postId
-          );
-          if (index === -1) {
-            return;
-          }
-
           markUserScrolled();
-          void listRef.current?.scrollToIndex({
-            index,
-            animated,
-            viewPosition,
+          runImperativeScroll(() => {
+            const index = postsWithNeighborsRef.current.findIndex(
+              ({ post }) => post.id === postId
+            );
+            if (index === -1) {
+              return undefined;
+            }
+            return listRef.current?.scrollToIndex({
+              index,
+              animated,
+              viewPosition,
+            });
           });
         },
       }),
-      [markUserScrolled, postsWithNeighbors]
+      [markUserScrolled]
     );
 
     return (

--- a/packages/app/ui/components/Channel/PostList/PostList.tsx
+++ b/packages/app/ui/components/Channel/PostList/PostList.tsx
@@ -137,6 +137,16 @@ const ConversationPostList: PostListComponent = React.forwardRef(
       }
 
       currentAnchorKeyRef.current = anchorKey;
+      setTimedOutAnchorId(null);
+    }, [anchorKey]);
+
+    const currentListMountKeyRef = React.useRef(listMountKey);
+    React.useLayoutEffect(() => {
+      if (currentListMountKeyRef.current === listMountKey) {
+        return;
+      }
+
+      currentListMountKeyRef.current = listMountKey;
       didStartInitialScrollRef.current = false;
       if (initialScrollFrameRef.current !== undefined) {
         cancelAnimationFrame(initialScrollFrameRef.current);
@@ -145,8 +155,7 @@ const ConversationPostList: PostListComponent = React.forwardRef(
       setDidFinishInitialScroll(false);
       userHasScrolledRef.current = false;
       appliedAnchorPositionRef.current = undefined;
-      setTimedOutAnchorId(null);
-    }, [anchorKey]);
+    }, [listMountKey]);
 
     React.useEffect(() => {
       const anchorId = anchor?.postId;
@@ -216,10 +225,10 @@ const ConversationPostList: PostListComponent = React.forwardRef(
         return;
       }
       didStartInitialScrollRef.current = true;
-      const loadedAnchorKey = anchorKey;
+      const loadedListMountKey = listMountKey;
       void applyAnchorPosition()
         .then(() => {
-          if (currentAnchorKeyRef.current !== loadedAnchorKey) {
+          if (currentListMountKeyRef.current !== loadedListMountKey) {
             return;
           }
           finishInitialScroll();
@@ -228,10 +237,10 @@ const ConversationPostList: PostListComponent = React.forwardRef(
           // Navigation can cancel the scroll while the list is unmounting.
         });
     }, [
-      anchorKey,
       applyAnchorPosition,
       finishInitialScroll,
       isInitialAnchorReady,
+      listMountKey,
     ]);
     // onLoad fires before LegendList's post-load buffer expansion has laid out.
     // Wait through that expansion so the exact target uses settled row sizes.

--- a/packages/app/ui/components/Channel/PostList/PostList.tsx
+++ b/packages/app/ui/components/Channel/PostList/PostList.tsx
@@ -13,6 +13,7 @@ import {
 } from './postListInitialization';
 import {
   PostListComponent,
+  PostListComponentProps,
   PostListMethods,
   PostWithNeighbors,
   usePostListBottomCallbacks,
@@ -66,6 +67,281 @@ PostList.displayName = 'PostList';
  * until the user scrolls.
  */
 const ConversationPostList: PostListComponent = React.forwardRef(
+  (props, forwardedRef) => {
+    const initialization = useConversationListInitialization(props);
+    const attemptRef = React.useRef<PostListMethods>(null);
+    React.useImperativeHandle(
+      forwardedRef,
+      () => ({
+        scrollToStart: (options) => attemptRef.current?.scrollToStart(options),
+        scrollToEnd: (options) => attemptRef.current?.scrollToEnd(options),
+        scrollToPost: (options) => attemptRef.current?.scrollToPost(options),
+      }),
+      []
+    );
+
+    return (
+      <ConversationPostListAttempt
+        // Each resolution gets a fresh positioning attempt. This keeps its
+        // refs and reveal state scoped to the same key that remounts the list.
+        key={initialization.mountKey}
+        {...props}
+        {...initialization}
+        ref={attemptRef}
+      />
+    );
+  }
+);
+ConversationPostList.displayName = 'ConversationPostList';
+
+type ConversationListInitialization = {
+  anchorIndex: number;
+  didTimeoutWaitingForAnchor: boolean;
+  isInitialAnchorReady: boolean;
+  mountKey: string;
+};
+
+function useConversationListInitialization({
+  anchor,
+  channel,
+  isLoading = false,
+  postsWithNeighbors,
+}: Pick<
+  PostListComponentProps,
+  'anchor' | 'channel' | 'isLoading' | 'postsWithNeighbors'
+>): ConversationListInitialization {
+  const anchorIndex = React.useMemo(() => {
+    if (!anchor?.postId) {
+      return -1;
+    }
+
+    return postsWithNeighbors.findIndex(
+      ({ post }) => post.id === anchor.postId
+    );
+  }, [anchor?.postId, postsWithNeighbors]);
+  const anchorKey = getPostListAnchorKey(anchor);
+  const anchorScopeKey = `${channel.id}:${anchorKey ?? 'latest'}`;
+  const [timedOutAnchorScopeKey, setTimedOutAnchorScopeKey] = React.useState<
+    string | null
+  >(null);
+  const didTimeoutWaitingForAnchor = timedOutAnchorScopeKey === anchorScopeKey;
+  const {
+    mountKey: anchorResolutionMountKey,
+    isAnchorReady: isInitialAnchorReady,
+    shouldStartAnchorTimeout,
+  } = getPostListInitialization({
+    anchorKey,
+    anchorIndex,
+    didTimeoutWaitingForAnchor,
+    isLoading,
+  });
+
+  React.useEffect(() => {
+    if (!shouldStartAnchorTimeout) {
+      return;
+    }
+
+    // Query failures switch ChannelScreen back to newest mode. A cache-backed
+    // query can appear settled while its around-cursor fetch and cache updates
+    // are still arriving, so wait briefly before falling back here.
+    const timeout = setTimeout(() => {
+      setTimedOutAnchorScopeKey(anchorScopeKey);
+    }, ANCHOR_RESOLUTION_TIMEOUT_MS);
+    return () => clearTimeout(timeout);
+  }, [anchorScopeKey, shouldStartAnchorTimeout]);
+
+  return {
+    anchorIndex,
+    didTimeoutWaitingForAnchor,
+    isInitialAnchorReady,
+    mountKey: `${channel.id}:${anchorResolutionMountKey}`,
+  };
+}
+
+type ConversationPostListAttemptProps = PostListComponentProps &
+  ConversationListInitialization;
+
+function useConversationAnchorTarget({
+  anchor,
+  anchorIndex,
+  anchorToEnd,
+  didTimeoutWaitingForAnchor,
+  listRef,
+}: Pick<
+  ConversationPostListAttemptProps,
+  'anchor' | 'anchorIndex' | 'anchorToEnd' | 'didTimeoutWaitingForAnchor'
+> & {
+  listRef: React.RefObject<LegendListRef | null>;
+}) {
+  const initialScrollIndex = React.useMemo<IndexedAnchorPosition | undefined>(
+    () =>
+      anchorIndex === -1 || didTimeoutWaitingForAnchor
+        ? undefined
+        : {
+            index: anchorIndex,
+            viewPosition: anchor?.type === 'unread' ? 0 : 0.5,
+            viewOffset: 0,
+          },
+    [anchor?.type, anchorIndex, didTimeoutWaitingForAnchor]
+  );
+  const anchorPosition: AnchorPosition | undefined =
+    anchorToEnd && (!anchor?.postId || didTimeoutWaitingForAnchor)
+      ? 'end'
+      : initialScrollIndex;
+  const latestAnchorPositionRef = React.useRef(anchorPosition);
+  const appliedAnchorPositionRef = React.useRef<AnchorPosition | undefined>(
+    undefined
+  );
+
+  React.useLayoutEffect(() => {
+    latestAnchorPositionRef.current = anchorPosition;
+  }, [anchorPosition]);
+
+  // LegendList uses initialScrollIndex to get near the target from estimates.
+  // Once it has measured the initial rows, this applies the exact position.
+  const applyAnchorPosition = React.useCallback(async () => {
+    const target = latestAnchorPositionRef.current;
+    if (target === 'end') {
+      appliedAnchorPositionRef.current = target;
+      await listRef.current?.scrollToEnd({ animated: false });
+      return true;
+    }
+
+    if (!target) {
+      return false;
+    }
+
+    appliedAnchorPositionRef.current = target;
+    await listRef.current?.scrollToIndex({ ...target, animated: false });
+    return true;
+  }, [listRef]);
+
+  return {
+    anchorPosition,
+    appliedAnchorPositionRef,
+    applyAnchorPosition,
+    initialScrollIndex,
+  };
+}
+
+function useInitialConversationScroll({
+  anchorTarget,
+  isInitialAnchorReady,
+  isLoading,
+  itemCount,
+  onInitialScrollCompleted,
+}: {
+  anchorTarget: ReturnType<typeof useConversationAnchorTarget>;
+  isInitialAnchorReady: boolean;
+  isLoading: boolean;
+  itemCount: number;
+  onInitialScrollCompleted?: () => void;
+}) {
+  const attemptIsActiveRef = React.useRef(true);
+  const didStartInitialScrollRef = React.useRef(false);
+  const initialScrollFrameRef = React.useRef<number | undefined>(undefined);
+  const userHasScrolledRef = React.useRef(false);
+  const [didFinishInitialScroll, setDidFinishInitialScroll] =
+    React.useState(false);
+  const { anchorPosition, appliedAnchorPositionRef, applyAnchorPosition } =
+    anchorTarget;
+
+  const finishInitialScroll = React.useCallback(() => {
+    setDidFinishInitialScroll(true);
+    onInitialScrollCompleted?.();
+  }, [onInitialScrollCompleted]);
+  const completeInitialScroll = React.useCallback(() => {
+    if (!isInitialAnchorReady || didStartInitialScrollRef.current) {
+      return;
+    }
+    didStartInitialScrollRef.current = true;
+    void applyAnchorPosition()
+      .then(() => {
+        if (attemptIsActiveRef.current) {
+          finishInitialScroll();
+        }
+      })
+      .catch(() => {
+        // Navigation can cancel the scroll while the list is unmounting.
+      });
+  }, [applyAnchorPosition, finishInitialScroll, isInitialAnchorReady]);
+
+  // LegendList has no settled-layout callback: onLoad fires before its
+  // next-frame buffer expansion, so wait through two layout opportunities
+  // before applying the exact target from measured row sizes.
+  const scheduleInitialScroll = React.useCallback(() => {
+    if (initialScrollFrameRef.current !== undefined) {
+      cancelAnimationFrame(initialScrollFrameRef.current);
+    }
+    initialScrollFrameRef.current = requestAnimationFrame(() => {
+      initialScrollFrameRef.current = requestAnimationFrame(() => {
+        initialScrollFrameRef.current = undefined;
+        completeInitialScroll();
+      });
+    });
+  }, [completeInitialScroll]);
+
+  React.useLayoutEffect(() => {
+    attemptIsActiveRef.current = true;
+    return () => {
+      attemptIsActiveRef.current = false;
+      if (initialScrollFrameRef.current !== undefined) {
+        cancelAnimationFrame(initialScrollFrameRef.current);
+      }
+    };
+  }, []);
+
+  React.useEffect(() => {
+    if (
+      !isInitialAnchorReady ||
+      isLoading ||
+      itemCount !== 0 ||
+      didStartInitialScrollRef.current
+    ) {
+      return;
+    }
+
+    // LegendList defers onLoad when initialScrollAtEnd has no data to target.
+    // A settled empty conversation has no position to reconcile, so reveal it.
+    didStartInitialScrollRef.current = true;
+    finishInitialScroll();
+  }, [finishInitialScroll, isInitialAnchorReady, isLoading, itemCount]);
+
+  React.useEffect(() => {
+    if (
+      !didFinishInitialScroll ||
+      userHasScrolledRef.current ||
+      !anchorPosition ||
+      isSameAnchorPosition(anchorPosition, appliedAnchorPositionRef.current)
+    ) {
+      return;
+    }
+
+    void applyAnchorPosition().catch(() => {
+      // The list may unmount while a later anchor correction is in flight.
+    });
+  }, [
+    anchorPosition,
+    appliedAnchorPositionRef,
+    applyAnchorPosition,
+    didFinishInitialScroll,
+  ]);
+
+  const markUserScrolled = React.useCallback(() => {
+    userHasScrolledRef.current = true;
+  }, []);
+
+  return {
+    didFinishInitialScroll,
+    markUserScrolled,
+    scheduleInitialScroll,
+  };
+}
+
+const ConversationPostListAttempt = React.forwardRef<
+  PostListMethods,
+  ConversationPostListAttemptProps
+>(
   (
     {
       postsWithNeighbors,
@@ -89,132 +365,34 @@ const ConversationPostList: PostListComponent = React.forwardRef(
       listHeaderComponent,
       listBottomComponent,
       isLoading = false,
+      anchorIndex,
+      didTimeoutWaitingForAnchor,
+      isInitialAnchorReady,
     },
     forwardedRef
   ) => {
     const listRef = React.useRef<LegendListRef>(null);
-    const didStartInitialScrollRef = React.useRef(false);
-    const initialScrollFrameRef = React.useRef<number | undefined>(undefined);
-    const userHasScrolledRef = React.useRef(false);
-    const appliedAnchorPositionRef = React.useRef<AnchorPosition | undefined>(
-      undefined
-    );
-    const [didFinishInitialScroll, setDidFinishInitialScroll] =
-      React.useState(false);
     const insets = useSafeAreaInsets();
     const collectionLayout = React.useMemo(
       () => layoutForType(collectionLayoutType),
       [collectionLayoutType]
     );
-    const anchorIndex = React.useMemo(() => {
-      if (!anchor?.postId) {
-        return -1;
-      }
-
-      return postsWithNeighbors.findIndex(
-        ({ post }) => post.id === anchor.postId
-      );
-    }, [anchor?.postId, postsWithNeighbors]);
-    const [timedOutAnchorId, setTimedOutAnchorId] = React.useState<
-      string | null
-    >(null);
-    const didTimeoutWaitingForAnchor =
-      !!anchor?.postId && timedOutAnchorId === anchor.postId;
-    const anchorKey = getPostListAnchorKey(anchor);
-    const {
-      mountKey: anchorResolutionMountKey,
-      isAnchorReady: isInitialAnchorReady,
-      shouldStartAnchorTimeout,
-    } = getPostListInitialization({
-      anchorKey,
+    const anchorTarget = useConversationAnchorTarget({
+      anchor,
       anchorIndex,
+      anchorToEnd,
       didTimeoutWaitingForAnchor,
-      isLoading,
+      listRef,
     });
-    const anchorScopeKey = `${channel.id}:${anchorKey ?? 'latest'}`;
-    const listMountKey = `${channel.id}:${anchorResolutionMountKey}`;
-
-    const currentAnchorScopeKeyRef = React.useRef(anchorScopeKey);
-    React.useLayoutEffect(() => {
-      if (currentAnchorScopeKeyRef.current === anchorScopeKey) {
-        return;
-      }
-
-      currentAnchorScopeKeyRef.current = anchorScopeKey;
-      setTimedOutAnchorId(null);
-    }, [anchorScopeKey]);
-
-    const currentListMountKeyRef = React.useRef(listMountKey);
-    React.useLayoutEffect(() => {
-      if (currentListMountKeyRef.current === listMountKey) {
-        return;
-      }
-
-      currentListMountKeyRef.current = listMountKey;
-      didStartInitialScrollRef.current = false;
-      if (initialScrollFrameRef.current !== undefined) {
-        cancelAnimationFrame(initialScrollFrameRef.current);
-        initialScrollFrameRef.current = undefined;
-      }
-      setDidFinishInitialScroll(false);
-      userHasScrolledRef.current = false;
-      appliedAnchorPositionRef.current = undefined;
-    }, [listMountKey]);
-
-    React.useEffect(() => {
-      const anchorId = anchor?.postId;
-      if (!shouldStartAnchorTimeout || !anchorId) {
-        return;
-      }
-
-      // Query failures switch ChannelScreen back to newest mode. A cache-backed
-      // query can appear settled while its around-cursor fetch and cache updates
-      // are still arriving, so wait briefly before falling back here.
-      const timeout = setTimeout(() => {
-        setTimedOutAnchorId(anchorId);
-      }, ANCHOR_RESOLUTION_TIMEOUT_MS);
-      return () => clearTimeout(timeout);
-    }, [anchor?.postId, shouldStartAnchorTimeout]);
-    const initialScrollIndex = React.useMemo<IndexedAnchorPosition | undefined>(
-      () =>
-        anchorIndex === -1 || didTimeoutWaitingForAnchor
-          ? undefined
-          : {
-              index: anchorIndex,
-              viewPosition: anchor?.type === 'unread' ? 0 : 0.5,
-              viewOffset: 0,
-            },
-      [anchor?.type, anchorIndex, didTimeoutWaitingForAnchor]
-    );
-    const anchorPosition: AnchorPosition | undefined =
-      anchorToEnd && (!anchor?.postId || didTimeoutWaitingForAnchor)
-        ? 'end'
-        : initialScrollIndex;
-    const latestAnchorPositionRef = React.useRef<AnchorPosition | undefined>(
-      anchorPosition
-    );
-    React.useLayoutEffect(() => {
-      latestAnchorPositionRef.current = anchorPosition;
-    }, [anchorPosition]);
-
-    // LegendList uses initialScrollIndex to get near the target from estimates.
-    // Once it has measured the initial rows, this applies the exact position.
-    const applyAnchorPosition = React.useCallback(async () => {
-      const target = latestAnchorPositionRef.current;
-      if (target === 'end') {
-        appliedAnchorPositionRef.current = target;
-        await listRef.current?.scrollToEnd({ animated: false });
-        return true;
-      }
-
-      if (!target) {
-        return false;
-      }
-
-      appliedAnchorPositionRef.current = target;
-      await listRef.current?.scrollToIndex({ ...target, animated: false });
-      return true;
-    }, []);
+    const { didFinishInitialScroll, markUserScrolled, scheduleInitialScroll } =
+      useInitialConversationScroll({
+        anchorTarget,
+        isInitialAnchorReady,
+        isLoading,
+        itemCount: postsWithNeighbors.length,
+        onInitialScrollCompleted,
+      });
+    const { initialScrollIndex } = anchorTarget;
     const { onScroll: handleScroll, isAtBottom } = useScrollDirectionTracker({
       atBottomThreshold: onScrolledToBottomThreshold,
       bottomAtEnd: true,
@@ -223,89 +401,6 @@ const ConversationPostList: PostListComponent = React.forwardRef(
       onScrolledToBottom,
       onScrolledAwayFromBottom,
     });
-    const finishInitialScroll = React.useCallback(() => {
-      setDidFinishInitialScroll(true);
-      onInitialScrollCompleted?.();
-    }, [onInitialScrollCompleted]);
-    const completeInitialScroll = React.useCallback(() => {
-      if (!isInitialAnchorReady || didStartInitialScrollRef.current) {
-        return;
-      }
-      didStartInitialScrollRef.current = true;
-      const loadedListMountKey = listMountKey;
-      void applyAnchorPosition()
-        .then(() => {
-          if (currentListMountKeyRef.current !== loadedListMountKey) {
-            return;
-          }
-          finishInitialScroll();
-        })
-        .catch(() => {
-          // Navigation can cancel the scroll while the list is unmounting.
-        });
-    }, [
-      applyAnchorPosition,
-      finishInitialScroll,
-      isInitialAnchorReady,
-      listMountKey,
-    ]);
-    // LegendList has no settled-layout callback: onLoad fires before its
-    // next-frame buffer expansion, so wait through two layout opportunities
-    // before applying the exact target from measured row sizes.
-    const scheduleInitialScroll = React.useCallback(() => {
-      if (initialScrollFrameRef.current !== undefined) {
-        cancelAnimationFrame(initialScrollFrameRef.current);
-      }
-      initialScrollFrameRef.current = requestAnimationFrame(() => {
-        initialScrollFrameRef.current = requestAnimationFrame(() => {
-          initialScrollFrameRef.current = undefined;
-          completeInitialScroll();
-        });
-      });
-    }, [completeInitialScroll]);
-    React.useEffect(
-      () => () => {
-        if (initialScrollFrameRef.current !== undefined) {
-          cancelAnimationFrame(initialScrollFrameRef.current);
-        }
-      },
-      []
-    );
-    React.useEffect(() => {
-      if (
-        !isInitialAnchorReady ||
-        isLoading ||
-        postsWithNeighbors.length !== 0 ||
-        didStartInitialScrollRef.current
-      ) {
-        return;
-      }
-
-      // LegendList defers onLoad when initialScrollAtEnd has no data to target.
-      // A settled empty conversation has no position to reconcile, so reveal it.
-      didStartInitialScrollRef.current = true;
-      finishInitialScroll();
-    }, [
-      finishInitialScroll,
-      isInitialAnchorReady,
-      isLoading,
-      postsWithNeighbors.length,
-    ]);
-
-    React.useEffect(() => {
-      if (
-        !didFinishInitialScroll ||
-        userHasScrolledRef.current ||
-        !anchorPosition ||
-        isSameAnchorPosition(anchorPosition, appliedAnchorPositionRef.current)
-      ) {
-        return;
-      }
-
-      void applyAnchorPosition().catch(() => {
-        // The list may unmount while a later anchor correction is in flight.
-      });
-    }, [anchorPosition, applyAnchorPosition, didFinishInitialScroll]);
 
     React.useImperativeHandle(
       forwardedRef,
@@ -337,9 +432,6 @@ const ConversationPostList: PostListComponent = React.forwardRef(
 
     return (
       <AnimatedLegendList<PostWithNeighbors>
-        // Explicit anchors intentionally remount when they resolve because
-        // LegendList only honors its initial target during mount.
-        key={listMountKey}
         ref={listRef}
         dataKey={channel.id}
         data={postsWithNeighbors}
@@ -382,9 +474,7 @@ const ConversationPostList: PostListComponent = React.forwardRef(
         ]}
         onLoad={scheduleInitialScroll}
         onScroll={handleScroll}
-        onScrollBeginDrag={() => {
-          userHasScrolledRef.current = true;
-        }}
+        onScrollBeginDrag={markUserScrolled}
         onStartReached={onStartReached}
         onStartReachedThreshold={onStartReachedThreshold}
         onEndReached={onEndReached}
@@ -394,4 +484,4 @@ const ConversationPostList: PostListComponent = React.forwardRef(
   }
 );
 
-ConversationPostList.displayName = 'ConversationPostList';
+ConversationPostListAttempt.displayName = 'ConversationPostListAttempt';

--- a/packages/app/ui/components/Channel/PostList/PostList.tsx
+++ b/packages/app/ui/components/Channel/PostList/PostList.tsx
@@ -2,7 +2,7 @@ import { type LegendListRef } from '@legendapp/list/react-native';
 import { AnimatedLegendList } from '@legendapp/list/reanimated';
 import { layoutForType } from '@tloncorp/shared';
 import * as React from 'react';
-import { Platform } from 'react-native';
+import { Platform, useWindowDimensions } from 'react-native';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
 
 import { useScrollDirectionTracker } from '../../../contexts/scroll';
@@ -109,11 +109,14 @@ const ConversationPostList: PostListComponent = React.forwardRef(
     );
     const [didFinishInitialScroll, setDidFinishInitialScroll] =
       React.useState(false);
+    const [didSettleInitialAnchor, setDidSettleInitialAnchor] =
+      React.useState(false);
     const anchorSettledRef = React.useRef(false);
     const settleTimerRef = React.useRef<ReturnType<typeof setTimeout> | null>(
       null
     );
     const insets = useSafeAreaInsets();
+    const { height: windowHeight } = useWindowDimensions();
     const collectionLayout = React.useMemo(
       () => layoutForType(collectionLayoutType),
       [collectionLayoutType]
@@ -154,6 +157,7 @@ const ConversationPostList: PostListComponent = React.forwardRef(
       anchorGenerationRef.current += 1;
       didStartInitialScrollRef.current = false;
       setDidFinishInitialScroll(false);
+      setDidSettleInitialAnchor(false);
       userHasScrolledRef.current = false;
       appliedAnchorPositionRef.current = undefined;
       anchorSettledRef.current = false;
@@ -267,6 +271,7 @@ const ConversationPostList: PostListComponent = React.forwardRef(
             settleTimerRef.current = setTimeout(() => {
               if (anchorGeneration === anchorGenerationRef.current) {
                 anchorSettledRef.current = true;
+                setDidSettleInitialAnchor(true);
               }
             }, ANCHOR_SETTLE_WINDOW_MS);
           }
@@ -293,10 +298,8 @@ const ConversationPostList: PostListComponent = React.forwardRef(
 
     // The initial scroll offset is derived from `ESTIMATED_ITEM_SIZE`. Real rows
     // routinely differ (author row, media, reactions), so re-apply the target
-    // while they settle. For unread anchors this includes the rows below the
-    // target: LegendList naturally clamps the divider below the top when that
-    // tail is too short, and its measured height determines whether the clamp
-    // is needed. Selected anchors only depend on sizes at or above the target.
+    // while the rows at or above it settle. Native visible-content preservation
+    // keeps the target locked when rows below it change size.
     const handleItemSizeChanged = React.useCallback(
       ({
         index,
@@ -317,11 +320,7 @@ const ConversationPostList: PostListComponent = React.forwardRef(
         }
 
         const target = latestAnchorPositionRef.current;
-        if (
-          !target ||
-          target === 'end' ||
-          (anchor?.type !== 'unread' && index > target.index)
-        ) {
+        if (!target || target === 'end' || index > target.index) {
           return;
         }
 
@@ -329,8 +328,17 @@ const ConversationPostList: PostListComponent = React.forwardRef(
           // The list can unmount while a correction is in flight.
         });
       },
-      [anchor?.type, applyAnchorPosition]
+      [applyAnchorPosition]
     );
+
+    // Estimates can make the unread tail appear too short and clamp the marker
+    // below the top. Reserve enough temporary scroll range to establish the
+    // target immediately; remove it after measurements settle. If the real tail
+    // is genuinely short, the list then clamps to its correct lower position.
+    const shouldReserveUnreadAnchorEndSpace =
+      anchor?.type === 'unread' &&
+      anchorIndex !== -1 &&
+      !didSettleInitialAnchor;
 
     React.useEffect(() => {
       return () => {
@@ -398,7 +406,12 @@ const ConversationPostList: PostListComponent = React.forwardRef(
         ListEmptyComponent={renderEmptyComponent}
         ListHeaderComponent={listHeaderComponent}
         ListFooterComponent={listBottomComponent}
-        contentContainerStyle={contentContainerStyle}
+        contentContainerStyle={[
+          contentContainerStyle,
+          shouldReserveUnreadAnchorEndSpace
+            ? { paddingBottom: windowHeight }
+            : undefined,
+        ]}
         contentInsetAdjustmentBehavior={
           Platform.OS === 'ios' ? 'never' : undefined
         }

--- a/packages/app/ui/components/Channel/PostList/PostList.tsx
+++ b/packages/app/ui/components/Channel/PostList/PostList.tsx
@@ -74,7 +74,9 @@ export const PostList: PostListComponent = React.forwardRef(
       <PostListFlatList
         // FlatList rows may retain their layouts when selection changes, so a
         // fresh selected anchor needs a fresh measurement/scroll attempt.
-        key={props.anchor?.type === 'selected' ? props.anchor.postId : undefined}
+        key={
+          props.anchor?.type === 'selected' ? props.anchor.postId : undefined
+        }
         {...props}
         ref={forwardedRef}
       />

--- a/packages/app/ui/components/Channel/PostList/PostList.tsx
+++ b/packages/app/ui/components/Channel/PostList/PostList.tsx
@@ -431,7 +431,9 @@ const ConversationPostListAttempt = React.forwardRef<
     // change. React Native onScroll can retain an intermediate value while the
     // initial anchor settles, briefly showing the scroll-to-bottom control.
     const isAtBottom = useLegendListIsNearEnd(listRef);
-    usePostListBottomCallbacks(isAtBottom, {
+    // The list is hidden while its initial anchor settles, so do not publish
+    // transient geometry that could show external scroll chrome first.
+    usePostListBottomCallbacks(!didFinishInitialScroll || isAtBottom, {
       onScrolledToBottom,
       onScrolledAwayFromBottom,
     });

--- a/packages/app/ui/components/Channel/PostList/PostList.tsx
+++ b/packages/app/ui/components/Channel/PostList/PostList.tsx
@@ -176,13 +176,13 @@ const ConversationPostList: PostListComponent = React.forwardRef(
       latestAnchorPositionRef.current = anchorPosition;
     }, [anchorPosition]);
 
-    // LegendList owns the initial position through initialScrollIndex. This is
-    // only for a target that changes after the list has finished loading.
-    const applyAnchorPosition = React.useCallback(() => {
+    // LegendList uses initialScrollIndex to get near the target from estimates.
+    // Once it has measured the initial rows, this applies the exact position.
+    const applyAnchorPosition = React.useCallback(async () => {
       const target = latestAnchorPositionRef.current;
       if (target === 'end') {
         appliedAnchorPositionRef.current = target;
-        listRef.current?.scrollToEnd({ animated: false });
+        await listRef.current?.scrollToEnd({ animated: false });
         return true;
       }
 
@@ -191,7 +191,7 @@ const ConversationPostList: PostListComponent = React.forwardRef(
       }
 
       appliedAnchorPositionRef.current = target;
-      listRef.current?.scrollToIndex({ ...target, animated: false });
+      await listRef.current?.scrollToIndex({ ...target, animated: false });
       return true;
     }, []);
     const { onScroll: handleScroll, isAtBottom } = useScrollDirectionTracker({
@@ -207,10 +207,24 @@ const ConversationPostList: PostListComponent = React.forwardRef(
         return;
       }
       didStartInitialScrollRef.current = true;
-      appliedAnchorPositionRef.current = latestAnchorPositionRef.current;
-      setDidFinishInitialScroll(true);
-      onInitialScrollCompleted?.();
-    }, [isInitialAnchorReady, onInitialScrollCompleted]);
+      const loadedAnchorKey = anchorKey;
+      void applyAnchorPosition()
+        .then(() => {
+          if (previousAnchorKeyRef.current !== loadedAnchorKey) {
+            return;
+          }
+          setDidFinishInitialScroll(true);
+          onInitialScrollCompleted?.();
+        })
+        .catch(() => {
+          // Navigation can cancel the scroll while the list is unmounting.
+        });
+    }, [
+      anchorKey,
+      applyAnchorPosition,
+      isInitialAnchorReady,
+      onInitialScrollCompleted,
+    ]);
 
     React.useEffect(() => {
       if (
@@ -222,7 +236,9 @@ const ConversationPostList: PostListComponent = React.forwardRef(
         return;
       }
 
-      applyAnchorPosition();
+      void applyAnchorPosition().catch(() => {
+        // The list may unmount while a later anchor correction is in flight.
+      });
     }, [anchorPosition, applyAnchorPosition, didFinishInitialScroll]);
 
     React.useImperativeHandle(
@@ -294,7 +310,9 @@ const ConversationPostList: PostListComponent = React.forwardRef(
         style={[
           { flex: 1 },
           style,
-          isInitialAnchorReady ? undefined : { opacity: 0 },
+          isInitialAnchorReady && didFinishInitialScroll
+            ? undefined
+            : { opacity: 0 },
         ]}
         onLoad={handleLoad}
         onScroll={handleScroll}

--- a/packages/app/ui/components/Channel/PostList/PostList.tsx
+++ b/packages/app/ui/components/Channel/PostList/PostList.tsx
@@ -2,7 +2,7 @@ import { type LegendListRef } from '@legendapp/list/react-native';
 import { AnimatedLegendList } from '@legendapp/list/reanimated';
 import { layoutForType } from '@tloncorp/shared';
 import * as React from 'react';
-import { Platform, useWindowDimensions } from 'react-native';
+import { Platform } from 'react-native';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
 
 import { useScrollDirectionTracker } from '../../../contexts/scroll';
@@ -109,14 +109,11 @@ const ConversationPostList: PostListComponent = React.forwardRef(
     );
     const [didFinishInitialScroll, setDidFinishInitialScroll] =
       React.useState(false);
-    const [didSettleInitialAnchor, setDidSettleInitialAnchor] =
-      React.useState(false);
     const anchorSettledRef = React.useRef(false);
     const settleTimerRef = React.useRef<ReturnType<typeof setTimeout> | null>(
       null
     );
     const insets = useSafeAreaInsets();
-    const { height: windowHeight } = useWindowDimensions();
     const collectionLayout = React.useMemo(
       () => layoutForType(collectionLayoutType),
       [collectionLayoutType]
@@ -157,7 +154,6 @@ const ConversationPostList: PostListComponent = React.forwardRef(
       anchorGenerationRef.current += 1;
       didStartInitialScrollRef.current = false;
       setDidFinishInitialScroll(false);
-      setDidSettleInitialAnchor(false);
       userHasScrolledRef.current = false;
       appliedAnchorPositionRef.current = undefined;
       anchorSettledRef.current = false;
@@ -271,7 +267,6 @@ const ConversationPostList: PostListComponent = React.forwardRef(
             settleTimerRef.current = setTimeout(() => {
               if (anchorGeneration === anchorGenerationRef.current) {
                 anchorSettledRef.current = true;
-                setDidSettleInitialAnchor(true);
               }
             }, ANCHOR_SETTLE_WINDOW_MS);
           }
@@ -330,15 +325,6 @@ const ConversationPostList: PostListComponent = React.forwardRef(
       },
       [applyAnchorPosition]
     );
-
-    // Estimates can make the unread tail appear too short and clamp the marker
-    // below the top. Reserve enough temporary scroll range to establish the
-    // target immediately; remove it after measurements settle. If the real tail
-    // is genuinely short, the list then clamps to its correct lower position.
-    const shouldReserveUnreadAnchorEndSpace =
-      anchor?.type === 'unread' &&
-      anchorIndex !== -1 &&
-      !didSettleInitialAnchor;
 
     React.useEffect(() => {
       return () => {
@@ -406,12 +392,7 @@ const ConversationPostList: PostListComponent = React.forwardRef(
         ListEmptyComponent={renderEmptyComponent}
         ListHeaderComponent={listHeaderComponent}
         ListFooterComponent={listBottomComponent}
-        contentContainerStyle={[
-          contentContainerStyle,
-          shouldReserveUnreadAnchorEndSpace
-            ? { paddingBottom: windowHeight }
-            : undefined,
-        ]}
+        contentContainerStyle={contentContainerStyle}
         contentInsetAdjustmentBehavior={
           Platform.OS === 'ios' ? 'never' : undefined
         }

--- a/packages/app/ui/components/Channel/PostList/PostList.tsx
+++ b/packages/app/ui/components/Channel/PostList/PostList.tsx
@@ -24,6 +24,23 @@ import {
 const ANCHOR_RESOLUTION_TIMEOUT_MS = 2_000;
 const ESTIMATED_ITEM_SIZE = 120;
 
+function useLegendListIsNearEnd(
+  listRef: React.RefObject<LegendListRef | null>
+) {
+  const subscribe = React.useCallback(
+    (onStoreChange: () => void) =>
+      listRef.current?.getState().listen('isNearEnd', onStoreChange) ??
+      (() => {}),
+    [listRef]
+  );
+  const getSnapshot = React.useCallback(
+    () => listRef.current?.getState().isNearEnd ?? true,
+    [listRef]
+  );
+
+  return React.useSyncExternalStore(subscribe, getSnapshot, getSnapshot);
+}
+
 function getPostId({ post }: PostWithNeighbors) {
   return post.id;
 }
@@ -406,10 +423,14 @@ const ConversationPostListAttempt = React.forwardRef<
         onInitialScrollCompleted,
       });
     const { initialScrollIndex } = anchorTarget;
-    const { onScroll: handleScroll, isAtBottom } = useScrollDirectionTracker({
+    const { onScroll: handleScroll } = useScrollDirectionTracker({
       atBottomThreshold: onScrolledToBottomThreshold,
       bottomAtEnd: true,
     });
+    // LegendList recalculates this when scrolling, content, or row measurements
+    // change. React Native onScroll can retain an intermediate value while the
+    // initial anchor settles, briefly showing the scroll-to-bottom control.
+    const isAtBottom = useLegendListIsNearEnd(listRef);
     usePostListBottomCallbacks(isAtBottom, {
       onScrolledToBottom,
       onScrolledAwayFromBottom,

--- a/packages/app/ui/components/Channel/PostList/PostList.tsx
+++ b/packages/app/ui/components/Channel/PostList/PostList.tsx
@@ -1,1 +1,455 @@
-export { PostList } from './PostListFlatList';
+import { type LegendListRef } from '@legendapp/list/react-native';
+import { AnimatedLegendList } from '@legendapp/list/reanimated';
+import { layoutForType } from '@tloncorp/shared';
+import * as React from 'react';
+import { Platform } from 'react-native';
+import { useSafeAreaInsets } from 'react-native-safe-area-context';
+
+import { useScrollDirectionTracker } from '../../../contexts/scroll';
+import { PostList as PostListFlatList } from './PostListFlatList';
+import {
+  getPostListAnchorKey,
+  getPostListInitialization,
+  shouldSnapUnreadAnchorToEnd,
+} from './postListInitialization';
+import {
+  PostListComponent,
+  PostListMethods,
+  PostWithNeighbors,
+  usePostListBottomCallbacks,
+  usesConversationPostList,
+} from './shared';
+
+// V1 uses bounded wall-clock fallbacks because LegendList does not expose a
+// single "all requested rows are measured" signal. Replace these with an
+// event-driven quiescence check when the list provides one.
+const ANCHOR_RESOLUTION_TIMEOUT_MS = 2_000;
+const ESTIMATED_ITEM_SIZE = 120;
+/**
+ * How long after the initial scroll we keep re-applying the anchor position as
+ * items report their real sizes. Item sizes only settle after measurement, and
+ * the first scroll is computed from `ESTIMATED_ITEM_SIZE`, so without this the
+ * list keeps whatever position the estimate produced.
+ */
+const ANCHOR_SETTLE_WINDOW_MS = 1_000;
+
+function getPostId({ post }: PostWithNeighbors) {
+  return post.id;
+}
+
+type IndexedAnchorPosition = {
+  index: number;
+  viewPosition: number;
+  viewOffset: number;
+};
+type AnchorPosition = 'end' | IndexedAnchorPosition;
+
+function isSameAnchorPosition(
+  left: AnchorPosition | undefined,
+  right: AnchorPosition | undefined
+) {
+  return (
+    left === right ||
+    (typeof left === 'object' &&
+      typeof right === 'object' &&
+      left.index === right.index &&
+      left.viewPosition === right.viewPosition &&
+      left.viewOffset === right.viewOffset)
+  );
+}
+
+export const PostList: PostListComponent = React.forwardRef(
+  (props, forwardedRef) => {
+    return usesConversationPostList(props) ? (
+      <ConversationPostList {...props} ref={forwardedRef} />
+    ) : (
+      <PostListFlatList {...props} ref={forwardedRef} />
+    );
+  }
+);
+PostList.displayName = 'PostList';
+
+/**
+ * LegendList-backed implementation for upright native conversations. Callers
+ * provide posts in visual order so every renderer shares one coordinate
+ * system.
+ */
+const ConversationPostList: PostListComponent = React.forwardRef(
+  (
+    {
+      postsWithNeighbors,
+      scrollEnabled = true,
+      anchorToEnd = false,
+      contentContainerStyle,
+      style,
+      renderItem,
+      renderEmptyComponent,
+      onStartReached,
+      onStartReachedThreshold,
+      onEndReached,
+      onEndReachedThreshold,
+      anchor,
+      hasNewerPosts,
+      channel,
+      collectionLayoutType,
+      onInitialScrollCompleted,
+      onScrolledToBottom,
+      onScrolledToBottomThreshold = 1,
+      onScrolledAwayFromBottom,
+      listHeaderComponent,
+      listBottomComponent,
+      isLoading = false,
+    },
+    forwardedRef
+  ) => {
+    const listRef = React.useRef<LegendListRef>(null);
+    const didStartInitialScrollRef = React.useRef(false);
+    const anchorGenerationRef = React.useRef(0);
+    const userHasScrolledRef = React.useRef(false);
+    const appliedAnchorPositionRef = React.useRef<AnchorPosition | undefined>(
+      undefined
+    );
+    const [didFinishInitialScroll, setDidFinishInitialScroll] =
+      React.useState(false);
+    const anchorSettledRef = React.useRef(false);
+    const settleTimerRef = React.useRef<ReturnType<typeof setTimeout> | null>(
+      null
+    );
+    const [viewportHeight, setViewportHeight] = React.useState(0);
+    const insets = useSafeAreaInsets();
+    const collectionLayout = React.useMemo(
+      () => layoutForType(collectionLayoutType),
+      [collectionLayoutType]
+    );
+    const anchorIndex = React.useMemo(() => {
+      if (!anchor?.postId) {
+        return -1;
+      }
+
+      return postsWithNeighbors.findIndex(
+        ({ post }) => post.id === anchor.postId
+      );
+    }, [anchor?.postId, postsWithNeighbors]);
+    const [timedOutAnchorId, setTimedOutAnchorId] = React.useState<
+      string | null
+    >(null);
+    const didTimeoutWaitingForAnchor =
+      !!anchor?.postId && timedOutAnchorId === anchor.postId;
+    const anchorKey = getPostListAnchorKey(anchor);
+    const {
+      mountKey: listMountKey,
+      isAnchorReady: isInitialAnchorReady,
+      shouldStartAnchorTimeout,
+    } = getPostListInitialization({
+      anchorKey,
+      anchorIndex,
+      didTimeoutWaitingForAnchor,
+      isLoading,
+    });
+
+    const previousAnchorKeyRef = React.useRef(anchorKey);
+    React.useLayoutEffect(() => {
+      if (previousAnchorKeyRef.current === anchorKey) {
+        return;
+      }
+
+      previousAnchorKeyRef.current = anchorKey;
+      anchorGenerationRef.current += 1;
+      didStartInitialScrollRef.current = false;
+      setDidFinishInitialScroll(false);
+      userHasScrolledRef.current = false;
+      appliedAnchorPositionRef.current = undefined;
+      anchorSettledRef.current = false;
+      setTimedOutAnchorId(null);
+      if (settleTimerRef.current) {
+        clearTimeout(settleTimerRef.current);
+        settleTimerRef.current = null;
+      }
+    }, [anchorKey]);
+
+    React.useEffect(() => {
+      const anchorId = anchor?.postId;
+      if (!shouldStartAnchorTimeout || !anchorId) {
+        return;
+      }
+
+      const timeout = setTimeout(() => {
+        setTimedOutAnchorId(anchorId);
+      }, ANCHOR_RESOLUTION_TIMEOUT_MS);
+      return () => clearTimeout(timeout);
+    }, [anchor?.postId, shouldStartAnchorTimeout]);
+    const initialScrollIndex = React.useMemo<IndexedAnchorPosition | undefined>(
+      () =>
+        anchorIndex === -1 || didTimeoutWaitingForAnchor
+          ? undefined
+          : {
+              index: anchorIndex,
+              viewPosition: anchor?.type === 'unread' ? 0 : 0.5,
+              viewOffset: 0,
+            },
+      [anchor?.type, anchorIndex, didTimeoutWaitingForAnchor]
+    );
+    // Top-aligning the first unread is right when there is a run of unreads to
+    // read down through. When the messages after the anchor cannot fill a
+    // viewport, there is nothing below it, so
+    // top-aligning strands the view above the natural bottom - the user lands
+    // short with content still to scroll. Land at the end instead.
+    //
+    // Defaults to false until the viewport is measured, so an unmeasured first
+    // pass keeps the ordinary anchor behaviour rather than jumping to the end.
+    // Rich media can exceed the estimate; the settle corrections below repair
+    // the landing as real row sizes arrive.
+    const estimatedAnchorExtent =
+      anchorIndex === -1
+        ? undefined
+        : (postsWithNeighbors.length - anchorIndex) * ESTIMATED_ITEM_SIZE;
+    const shouldSnapAnchorToEnd = shouldSnapUnreadAnchorToEnd({
+      anchorType: anchor?.type,
+      estimatedAnchorExtent,
+      hasNewerPosts,
+      anchorToEnd,
+      viewportHeight,
+    });
+    const anchorPosition: AnchorPosition | undefined =
+      shouldSnapAnchorToEnd ||
+      (anchorToEnd && (!anchor?.postId || didTimeoutWaitingForAnchor))
+        ? 'end'
+        : initialScrollIndex;
+    const latestAnchorPositionRef = React.useRef<AnchorPosition | undefined>(
+      anchorPosition
+    );
+    React.useLayoutEffect(() => {
+      latestAnchorPositionRef.current = anchorPosition;
+    }, [anchorPosition]);
+
+    /**
+     * Applies the resolved anchor position, choosing between the anchor target
+     * and the list end. Every path that positions the list on initial load goes
+     * through here so they cannot disagree.
+     */
+    const applyAnchorPosition = React.useCallback(async () => {
+      const target = latestAnchorPositionRef.current;
+      if (target === 'end') {
+        appliedAnchorPositionRef.current = target;
+        await listRef.current?.scrollToEnd({ animated: false });
+        return true;
+      }
+
+      if (!target) {
+        return false;
+      }
+
+      appliedAnchorPositionRef.current = target;
+      await listRef.current?.scrollToIndex({ ...target, animated: false });
+      return true;
+    }, []);
+    const { onScroll: handleScroll, isAtBottom } = useScrollDirectionTracker({
+      atBottomThreshold: onScrolledToBottomThreshold,
+      bottomAtEnd: true,
+    });
+    usePostListBottomCallbacks(isAtBottom, {
+      onScrolledToBottom,
+      onScrolledAwayFromBottom,
+    });
+    const handleLoad = React.useCallback(() => {
+      if (!isInitialAnchorReady || didStartInitialScrollRef.current) {
+        return;
+      }
+      didStartInitialScrollRef.current = true;
+      const anchorGeneration = anchorGenerationRef.current;
+
+      const completeInitialScroll = async () => {
+        try {
+          if (anchorGeneration !== anchorGenerationRef.current) {
+            return;
+          }
+
+          // The around-anchor query can prepend cached history while
+          // LegendList is bootstrapping. Re-resolve the current anchor index
+          // before releasing queued edge events.
+          await applyAnchorPosition();
+
+          if (anchorGeneration !== anchorGenerationRef.current) {
+            return;
+          }
+
+          const updatedTarget = latestAnchorPositionRef.current;
+          if (
+            updatedTarget &&
+            !isSameAnchorPosition(
+              updatedTarget,
+              appliedAnchorPositionRef.current
+            )
+          ) {
+            await applyAnchorPosition();
+          }
+        } catch {
+          // Navigation can cancel the imperative scroll while unmounting.
+        } finally {
+          if (anchorGeneration === anchorGenerationRef.current) {
+            setDidFinishInitialScroll(true);
+            onInitialScrollCompleted?.();
+            settleTimerRef.current = setTimeout(() => {
+              if (anchorGeneration === anchorGenerationRef.current) {
+                anchorSettledRef.current = true;
+              }
+            }, ANCHOR_SETTLE_WINDOW_MS);
+          }
+        }
+      };
+
+      void completeInitialScroll();
+    }, [applyAnchorPosition, isInitialAnchorReady, onInitialScrollCompleted]);
+
+    React.useEffect(() => {
+      if (
+        !didFinishInitialScroll ||
+        userHasScrolledRef.current ||
+        !anchorPosition ||
+        isSameAnchorPosition(anchorPosition, appliedAnchorPositionRef.current)
+      ) {
+        return;
+      }
+
+      void applyAnchorPosition().catch(() => {
+        // The list may unmount while the inset correction is in flight.
+      });
+    }, [anchorPosition, applyAnchorPosition, didFinishInitialScroll]);
+
+    // The initial scroll offset is derived from `ESTIMATED_ITEM_SIZE`. Real rows
+    // routinely differ (author row, media, reactions), so the first landing can
+    // sit short of the anchor. Re-apply the target while items above it are
+    // still being measured - nothing else re-issues the scroll, because the
+    // correction effect above only reacts to `viewOffset` changing, not to
+    // measurement.
+    const handleItemSizeChanged = React.useCallback(
+      ({
+        index,
+        size,
+        previous,
+      }: {
+        index: number;
+        size: number;
+        previous: number;
+      }) => {
+        if (
+          anchorSettledRef.current ||
+          userHasScrolledRef.current ||
+          !didStartInitialScrollRef.current ||
+          size === previous
+        ) {
+          return;
+        }
+
+        const target = latestAnchorPositionRef.current;
+        // Only sizes at or above the anchor move its offset.
+        if (!target || target === 'end' || index > target.index) {
+          return;
+        }
+
+        void applyAnchorPosition().catch(() => {
+          // The list can unmount while a correction is in flight.
+        });
+      },
+      [applyAnchorPosition]
+    );
+
+    React.useEffect(() => {
+      return () => {
+        if (settleTimerRef.current) {
+          clearTimeout(settleTimerRef.current);
+        }
+      };
+    }, []);
+
+    React.useImperativeHandle(
+      forwardedRef,
+      (): PostListMethods => ({
+        scrollToStart: (opts) =>
+          void listRef.current?.scrollToOffset({
+            offset: 0,
+            animated: opts.animated,
+          }),
+        scrollToEnd: (opts) =>
+          void listRef.current?.scrollToEnd({ animated: opts.animated }),
+        scrollToPost: ({ postId, animated, viewPosition }) => {
+          const index = postsWithNeighbors.findIndex(
+            ({ post }) => post.id === postId
+          );
+          if (index === -1) {
+            return;
+          }
+
+          void listRef.current?.scrollToIndex({
+            index,
+            animated,
+            viewPosition,
+          });
+        },
+      }),
+      [postsWithNeighbors]
+    );
+
+    return (
+      <AnimatedLegendList<PostWithNeighbors>
+        // Explicit anchors intentionally remount when they resolve because
+        // LegendList only honors its initial target during mount.
+        key={listMountKey}
+        ref={listRef}
+        dataKey={channel.id}
+        data={postsWithNeighbors}
+        keyExtractor={getPostId}
+        renderItem={renderItem}
+        getItemType={({ post }) => post.type}
+        estimatedItemSize={ESTIMATED_ITEM_SIZE}
+        // Chat rows are stateful and highly variable-height; recycling them can
+        // briefly reuse stale row state and measurements for another post.
+        recycleItems={!anchorToEnd}
+        alignItemsAtEnd={anchorToEnd}
+        initialScrollAtEnd={
+          anchorToEnd &&
+          isInitialAnchorReady &&
+          initialScrollIndex === undefined
+        }
+        initialScrollIndex={initialScrollIndex}
+        maintainScrollAtEnd={anchorToEnd}
+        maintainScrollAtEndThreshold={anchorToEnd ? 0.1 : undefined}
+        maintainVisibleContentPosition={
+          collectionLayout.shouldMaintainVisibleContentPosition || undefined
+        }
+        ListEmptyComponent={renderEmptyComponent}
+        ListHeaderComponent={listHeaderComponent}
+        ListFooterComponent={listBottomComponent}
+        contentContainerStyle={contentContainerStyle}
+        contentInsetAdjustmentBehavior={
+          Platform.OS === 'ios' ? 'never' : undefined
+        }
+        scrollIndicatorInsets={{ top: 0, bottom: insets.bottom }}
+        automaticallyAdjustsScrollIndicatorInsets={false}
+        keyboardDismissMode="on-drag"
+        scrollEnabled={scrollEnabled}
+        style={[
+          { flex: 1 },
+          style,
+          isInitialAnchorReady ? undefined : { opacity: 0 },
+        ]}
+        onLayout={(event) => {
+          setViewportHeight(event.nativeEvent.layout.height);
+        }}
+        onLoad={handleLoad}
+        onItemSizeChanged={handleItemSizeChanged}
+        onScroll={handleScroll}
+        onScrollBeginDrag={() => {
+          userHasScrolledRef.current = true;
+          anchorSettledRef.current = true;
+        }}
+        onStartReached={onStartReached}
+        onStartReachedThreshold={onStartReachedThreshold}
+        onEndReached={onEndReached}
+        onEndReachedThreshold={onEndReachedThreshold}
+      />
+    );
+  }
+);
+
+ConversationPostList.displayName = 'ConversationPostList';

--- a/packages/app/ui/components/Channel/PostList/PostList.tsx
+++ b/packages/app/ui/components/Channel/PostList/PostList.tsx
@@ -92,6 +92,7 @@ const ConversationPostList: PostListComponent = React.forwardRef(
   ) => {
     const listRef = React.useRef<LegendListRef>(null);
     const didStartInitialScrollRef = React.useRef(false);
+    const initialScrollFrameRef = React.useRef<number | undefined>(undefined);
     const userHasScrolledRef = React.useRef(false);
     const appliedAnchorPositionRef = React.useRef<AnchorPosition | undefined>(
       undefined
@@ -137,6 +138,10 @@ const ConversationPostList: PostListComponent = React.forwardRef(
 
       previousAnchorKeyRef.current = anchorKey;
       didStartInitialScrollRef.current = false;
+      if (initialScrollFrameRef.current !== undefined) {
+        cancelAnimationFrame(initialScrollFrameRef.current);
+        initialScrollFrameRef.current = undefined;
+      }
       setDidFinishInitialScroll(false);
       userHasScrolledRef.current = false;
       appliedAnchorPositionRef.current = undefined;
@@ -202,7 +207,7 @@ const ConversationPostList: PostListComponent = React.forwardRef(
       onScrolledToBottom,
       onScrolledAwayFromBottom,
     });
-    const handleLoad = React.useCallback(() => {
+    const completeInitialScroll = React.useCallback(() => {
       if (!isInitialAnchorReady || didStartInitialScrollRef.current) {
         return;
       }
@@ -225,6 +230,34 @@ const ConversationPostList: PostListComponent = React.forwardRef(
       isInitialAnchorReady,
       onInitialScrollCompleted,
     ]);
+    // onLoad fires before LegendList's post-load buffer expansion has laid out.
+    // Wait through that expansion so the exact target uses settled row sizes.
+    const scheduleInitialScroll = React.useCallback(() => {
+      if (initialScrollFrameRef.current !== undefined) {
+        cancelAnimationFrame(initialScrollFrameRef.current);
+      }
+      initialScrollFrameRef.current = requestAnimationFrame(() => {
+        initialScrollFrameRef.current = requestAnimationFrame(() => {
+          initialScrollFrameRef.current = undefined;
+          completeInitialScroll();
+        });
+      });
+    }, [completeInitialScroll]);
+    React.useEffect(
+      () => () => {
+        if (initialScrollFrameRef.current !== undefined) {
+          cancelAnimationFrame(initialScrollFrameRef.current);
+        }
+      },
+      []
+    );
+    const handleLoad = React.useCallback(() => {
+      if (anchor?.type === 'unread') {
+        scheduleInitialScroll();
+      } else {
+        completeInitialScroll();
+      }
+    }, [anchor?.type, completeInitialScroll, scheduleInitialScroll]);
 
     React.useEffect(() => {
       if (

--- a/packages/app/ui/components/Channel/PostList/PostList.web.tsx
+++ b/packages/app/ui/components/Channel/PostList/PostList.web.tsx
@@ -11,7 +11,6 @@ import {
   PostListComponent,
   PostWithNeighbors,
   usePostListBottomCallbacks,
-  usesConversationPostList,
 } from './shared';
 
 const FORCE_MANUAL_SCROLL_ANCHORING: boolean = false;
@@ -19,8 +18,8 @@ const IS_FIREFOX = navigator.userAgent.includes('Firefox');
 
 export const PostList: PostListComponent = React.forwardRef(
   (props, forwardedRef) => {
-    return usesConversationPostList(props) ? (
-      <WebConversationPostList {...props} ref={forwardedRef} />
+    return props.numColumns === 1 ? (
+      <PostListSingleColumn {...props} ref={forwardedRef} />
     ) : (
       <PostListFlatList {...props} ref={forwardedRef} />
     );
@@ -28,7 +27,7 @@ export const PostList: PostListComponent = React.forwardRef(
 );
 PostList.displayName = 'PostList';
 
-const WebConversationPostList: PostListComponent = React.forwardRef(
+const PostListSingleColumn: PostListComponent = React.forwardRef(
   (
     {
       anchor,
@@ -267,7 +266,7 @@ const WebConversationPostList: PostListComponent = React.forwardRef(
     );
   }
 );
-WebConversationPostList.displayName = 'WebConversationPostList';
+PostListSingleColumn.displayName = 'PostListSingleColumn';
 
 function PostListItem({
   item,

--- a/packages/app/ui/components/Channel/PostList/PostList.web.tsx
+++ b/packages/app/ui/components/Channel/PostList/PostList.web.tsx
@@ -34,11 +34,9 @@ const WebConversationPostList: PostListComponent = React.forwardRef(
       anchor,
       // channel,
       // collectionLayoutType,
-      columnWrapperStyle,
       contentContainerStyle,
       hasNewerPosts = false,
       anchorToEnd = false,
-      numColumns,
       onEndReached,
       onEndReachedThreshold = 1,
       onInitialScrollCompleted,
@@ -250,16 +248,7 @@ const WebConversationPostList: PostListComponent = React.forwardRef(
               justifyContent: anchorToEnd ? 'flex-end' : 'flex-start',
             }}
           >
-            <View
-              style={[
-                {
-                  flexDirection: numColumns === 1 ? 'column' : 'row',
-                  flexWrap: numColumns === 1 ? undefined : 'wrap',
-                },
-                contentContainerStyle,
-                numColumns > 1 ? columnWrapperStyle : undefined,
-              ]}
-            >
+            <View style={contentContainerStyle}>
               {listHeaderComponent}
               {orderedData.map((item, index) => (
                 <PostListItem key={item.post.id} item={item} index={index}>

--- a/packages/app/ui/components/Channel/PostList/PostList.web.tsx
+++ b/packages/app/ui/components/Channel/PostList/PostList.web.tsx
@@ -5,33 +5,40 @@ import { useEffect, useLayoutEffect, useRef } from 'react';
 import { View } from 'react-native';
 
 import { ScrollAnchor } from '../Scroller';
-import { PostList as PostListNative } from './PostListFlatList';
-import { PostListComponent, PostWithNeighbors } from './shared';
+import { PostList as PostListFlatList } from './PostListFlatList';
+import { getPostListAnchorKey } from './postListInitialization';
+import {
+  PostListComponent,
+  PostWithNeighbors,
+  usePostListBottomCallbacks,
+  usesConversationPostList,
+} from './shared';
 
 const FORCE_MANUAL_SCROLL_ANCHORING: boolean = false;
 const IS_FIREFOX = navigator.userAgent.includes('Firefox');
 
-export const PostList: PostListComponent = React.forwardRef((props, ref) => {
-  if (props.numColumns === 1) {
-    return <PostListSingleColumn {...props} ref={ref} />;
-  } else {
-    // Use the native implementation for multi-column lists
-    return <PostListNative {...props} ref={ref} />;
+export const PostList: PostListComponent = React.forwardRef(
+  (props, forwardedRef) => {
+    return usesConversationPostList(props) ? (
+      <WebConversationPostList {...props} ref={forwardedRef} />
+    ) : (
+      <PostListFlatList {...props} ref={forwardedRef} />
+    );
   }
-});
+);
 PostList.displayName = 'PostList';
 
-const PostListSingleColumn: PostListComponent = React.forwardRef(
+const WebConversationPostList: PostListComponent = React.forwardRef(
   (
     {
       anchor,
       // channel,
       // collectionLayoutType,
-      // columnWrapperStyle,
+      columnWrapperStyle,
       contentContainerStyle,
       hasNewerPosts = false,
-      inverted = false,
-      // numColumns,
+      anchorToEnd = false,
+      numColumns,
       onEndReached,
       onEndReachedThreshold = 1,
       onInitialScrollCompleted,
@@ -53,15 +60,12 @@ const PostListSingleColumn: PostListComponent = React.forwardRef(
     const scrollerRef = useRef<HTMLDivElement | null>(null);
     const scrollerContentContainerRef = useRef<HTMLDivElement>(null);
 
-    const orderedData = React.useMemo(
-      () => (inverted ? [...postsWithNeighbors].reverse() : postsWithNeighbors),
-      [inverted, postsWithNeighbors]
-    );
+    const orderedData = postsWithNeighbors;
 
     useScrollToAnchorOnMount({
       anchor,
       scrollerRef,
-      inverted,
+      anchorToEnd,
       onScrollCompleted: onInitialScrollCompleted,
       contentKey: `${orderedData.length}:${orderedData[0]?.post.id ?? ''}:${orderedData[orderedData.length - 1]?.post.id ?? ''}`,
     });
@@ -130,7 +134,6 @@ const PostListSingleColumn: PostListComponent = React.forwardRef(
       useTrackContentRect(scrollerContentContainerRef.current)?.height ?? 0;
     useBoundaryCallbacks({
       element: scrollerRef.current,
-      inverted,
       onEndReached,
       onEndReachedThreshold,
       onStartReached,
@@ -147,17 +150,10 @@ const PostListSingleColumn: PostListComponent = React.forwardRef(
         side: 'bottom',
       }
     );
-    useEffect(() => {
-      if (insideScrolledToBottomBoundary) {
-        onScrolledToBottom?.();
-      } else {
-        onScrolledAwayFromBottom?.();
-      }
-    }, [
-      onScrolledAwayFromBottom,
+    usePostListBottomCallbacks(insideScrolledToBottomBoundary, {
       onScrolledToBottom,
-      insideScrolledToBottomBoundary,
-    ]);
+      onScrolledAwayFromBottom,
+    });
 
     const viewportHeight =
       useTrackContentRect(scrollerRef.current)?.height ?? 0;
@@ -168,7 +164,7 @@ const PostListSingleColumn: PostListComponent = React.forwardRef(
       // HACK: When the viewport shrinks in height, the browser prioritizes
       // anchoring the content at the top of the viewport - so the content at
       // the bottom of the viewport gets hidden "under the fold." To avoid
-      // this, we want to trigger "stick-to-scroll-start" when the viewport
+      // this, we want to trigger "stick-to-anchor-edge" when the viewport
       // height changes. This works for Chrome and Safari.
       //
       // Firefox triggers a mysterious scroll on the next keypress after
@@ -188,10 +184,10 @@ const PostListSingleColumn: PostListComponent = React.forwardRef(
         ),
       [postsWithNeighbors]
     );
-    useStickToScrollStart({
+    useStickToAnchorEdge({
       scrollerContentsKey,
       scrollerRef,
-      inverted,
+      anchorToEnd,
       // - If we don't have all the newest posts, we want to wait to autoscroll
       //   to the newer messages until we've loaded everything - otherwise, we'll
       //   scroll on each page that comes in, which is jarring.
@@ -208,7 +204,7 @@ const PostListSingleColumn: PostListComponent = React.forwardRef(
       scrollToStart: ({ animated = true }) => {
         if (scrollerRef.current) {
           scrollerRef.current.scrollTo({
-            top: inverted ? scrollerRef.current.scrollHeight : 0,
+            top: 0,
             behavior: animated ? 'smooth' : 'instant',
           });
         }
@@ -216,24 +212,20 @@ const PostListSingleColumn: PostListComponent = React.forwardRef(
       scrollToEnd: ({ animated = true }) => {
         if (scrollerRef.current) {
           scrollerRef.current.scrollTo({
-            top: inverted ? 0 : scrollerRef.current.scrollHeight,
+            top: scrollerRef.current.scrollHeight,
             behavior: animated ? 'smooth' : 'instant',
           });
         }
       },
-      scrollToIndex: ({ index, animated = true }) => {
-        const resolvedIndex = inverted ? orderedData.length - 1 - index : index;
-        const item = orderedData[resolvedIndex];
-        if (item) {
-          const element = scrollerContentContainerRef.current?.querySelector(
-            `[data-postid="${item.post.id}"]`
-          ) as HTMLElement | null;
-          if (element) {
-            element.scrollIntoView({
-              block: 'center',
-              behavior: animated ? 'smooth' : 'instant',
-            });
-          }
+      scrollToPost: ({ postId, animated = true }) => {
+        const element = scrollerContentContainerRef.current?.querySelector(
+          `[data-postid="${postId}"]`
+        ) as HTMLElement | null;
+        if (element) {
+          element.scrollIntoView({
+            block: 'center',
+            behavior: animated ? 'smooth' : 'instant',
+          });
         }
       },
     }));
@@ -255,10 +247,19 @@ const PostListSingleColumn: PostListComponent = React.forwardRef(
               minHeight: '100%',
               flexDirection: 'column',
               alignItems: 'stretch',
-              justifyContent: inverted ? 'flex-end' : 'flex-start',
+              justifyContent: anchorToEnd ? 'flex-end' : 'flex-start',
             }}
           >
-            <View style={[{ flexDirection: 'column' }, contentContainerStyle]}>
+            <View
+              style={[
+                {
+                  flexDirection: numColumns === 1 ? 'column' : 'row',
+                  flexWrap: numColumns === 1 ? undefined : 'wrap',
+                },
+                contentContainerStyle,
+                numColumns > 1 ? columnWrapperStyle : undefined,
+              ]}
+            >
               {listHeaderComponent}
               {orderedData.map((item, index) => (
                 <PostListItem key={item.post.id} item={item} index={index}>
@@ -277,7 +278,7 @@ const PostListSingleColumn: PostListComponent = React.forwardRef(
     );
   }
 );
-PostListSingleColumn.displayName = 'PostListSingleColumn';
+WebConversationPostList.displayName = 'WebConversationPostList';
 
 function PostListItem({
   item,
@@ -557,29 +558,29 @@ function useManualScrollAnchoring<Data>({
   coordinator.current?.setContentKey(scrollerContentsKey);
 }
 
-function useStickToScrollStart({
-  inverted,
+function useStickToAnchorEdge({
+  anchorToEnd,
   scrollerContentsKey,
   scrollerRef,
   disable,
-  maxDistanceForStickToStart = 100,
+  maxDistanceForAnchor = 100,
 }: {
-  inverted: boolean;
+  anchorToEnd: boolean;
   /** This value must change when the scroll height of the scroller changes */
   scrollerContentsKey: unknown;
   scrollerRef: React.RefObject<HTMLDivElement | null>;
   disable: boolean;
   /** If the distance from viewport boundary to scroll boundary is less than this, perform sticking */
-  maxDistanceForStickToStart?: number;
+  maxDistanceForAnchor?: number;
 }) {
-  const shouldStickToStartRef = useRef(false);
+  const shouldStickToAnchorRef = useRef(false);
 
-  const [isAtStart] = useScrollBoundary(scrollerRef.current, {
+  const [isAtAnchor] = useScrollBoundary(scrollerRef.current, {
     isNearBoundary: React.useCallback(
-      (distance: number) => distance < maxDistanceForStickToStart,
-      [maxDistanceForStickToStart]
+      (distance: number) => distance < maxDistanceForAnchor,
+      [maxDistanceForAnchor]
     ),
-    side: inverted ? 'bottom' : 'top',
+    side: anchorToEnd ? 'bottom' : 'top',
   });
 
   // Use useLayoutEffect (not useEffect) so the sticky flag is updated
@@ -587,33 +588,38 @@ function useStickToScrollStart({
   // With useEffect, the flag could be set to false between renders during
   // a message burst, causing the scroll to stop tracking.
   useLayoutEffect(() => {
-    shouldStickToStartRef.current = !disable && isAtStart;
-  }, [isAtStart, disable]);
+    shouldStickToAnchorRef.current = !disable && isAtAnchor;
+  }, [isAtAnchor, disable]);
 
   useLayoutEffect(() => {
     const scroller = scrollerRef.current;
-    if (!shouldStickToStartRef.current || scroller == null) {
+    if (!shouldStickToAnchorRef.current || scroller == null) {
       return;
     }
-    scroller.scrollTo({ top: inverted ? scroller.scrollHeight : 0 });
-  }, [scrollerRef, scrollerContentsKey, inverted]);
+    scroller.scrollTo({ top: anchorToEnd ? scroller.scrollHeight : 0 });
+  }, [anchorToEnd, scrollerRef, scrollerContentsKey]);
 }
 
 function useScrollToAnchorOnMount({
   anchor,
   scrollerRef,
-  inverted,
+  anchorToEnd,
   onScrollCompleted,
   contentKey,
 }: {
   anchor: ScrollAnchor | null | undefined;
   scrollerRef: React.RefObject<HTMLDivElement | null>;
-  inverted: boolean;
+  anchorToEnd: boolean;
   onScrollCompleted?: () => void;
   contentKey: string | number;
 }) {
   const needsInitialScrollRef = useRef(true);
   const timeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const anchorKey = getPostListAnchorKey(anchor) ?? 'latest';
+
+  useLayoutEffect(() => {
+    needsInitialScrollRef.current = true;
+  }, [anchorKey]);
 
   // Timeout fallback: give up after 5s if anchor element never appears
   useEffect(() => {
@@ -631,7 +637,7 @@ function useScrollToAnchorOnMount({
     return () => {
       if (timeoutRef.current) clearTimeout(timeoutRef.current);
     };
-  }, [anchor?.postId]); // eslint-disable-line react-hooks/exhaustive-deps
+  }, [anchor?.postId, anchorKey, onScrollCompleted]);
 
   // Main scroll effect — re-runs when contentKey changes (as new posts render)
   useLayoutEffect(() => {
@@ -640,7 +646,7 @@ function useScrollToAnchorOnMount({
     if (!scroller) return;
 
     if (!anchor) {
-      if (inverted) {
+      if (anchorToEnd) {
         scroller.scrollTo({ top: scroller.scrollHeight });
       }
       needsInitialScrollRef.current = false;
@@ -658,7 +664,7 @@ function useScrollToAnchorOnMount({
       onScrollCompleted?.();
     }
     // else: element not in DOM yet — do nothing, wait for next contentKey change
-  }, [scrollerRef, anchor, inverted, onScrollCompleted, contentKey]);
+  }, [scrollerRef, anchor, anchorToEnd, onScrollCompleted, contentKey]);
 }
 
 // Pass this to useDeduplicateInvocationBy().resetDeduplicateInvocation() to
@@ -675,7 +681,6 @@ const KEY_TO_PASSTHROUGH_NEXT_INVOCATION = Symbol();
  */
 function useBoundaryCallbacks({
   element,
-  inverted,
   onEndReached,
   onEndReachedThreshold,
   onStartReached,
@@ -683,7 +688,6 @@ function useBoundaryCallbacks({
   scrollerContentKey,
 }: {
   element: HTMLElement | null;
-  inverted: boolean;
   onEndReached?: () => void;
   onEndReachedThreshold: number;
   onStartReached?: () => void;
@@ -700,7 +704,7 @@ function useBoundaryCallbacks({
   );
   const [reachedStart, getReachedStart] = useScrollBoundary(element, {
     isNearBoundary: withinViewportRatioOfBoundary(onStartReachedThreshold),
-    side: inverted ? 'bottom' : 'top',
+    side: 'top',
   });
   useEffect(() => {
     if (getReachedStart() ?? false) {
@@ -739,7 +743,7 @@ function useBoundaryCallbacks({
   );
   const [reachedEnd, getReachedEnd] = useScrollBoundary(element, {
     isNearBoundary: withinViewportRatioOfBoundary(onEndReachedThreshold),
-    side: inverted ? 'top' : 'bottom',
+    side: 'bottom',
   });
   useEffect(() => {
     if (getReachedEnd() ?? false) {

--- a/packages/app/ui/components/Channel/PostList/PostList.web.tsx
+++ b/packages/app/ui/components/Channel/PostList/PostList.web.tsx
@@ -21,7 +21,13 @@ export const PostList: PostListComponent = React.forwardRef(
     return props.numColumns === 1 ? (
       <PostListSingleColumn {...props} ref={forwardedRef} />
     ) : (
-      <PostListFlatList {...props} ref={forwardedRef} />
+      <PostListFlatList
+        key={
+          props.anchor?.type === 'selected' ? props.anchor.postId : undefined
+        }
+        {...props}
+        ref={forwardedRef}
+      />
     );
   }
 );

--- a/packages/app/ui/components/Channel/PostList/PostList.web.tsx
+++ b/packages/app/ui/components/Channel/PostList/PostList.web.tsx
@@ -6,7 +6,7 @@ import { View } from 'react-native';
 
 import { ScrollAnchor } from '../Scroller';
 import { PostList as PostListFlatList } from './PostListFlatList';
-import { getPostListAnchorKey } from './postListInitialization';
+import { getPostListScopeKey } from './postListInitialization';
 import {
   PostListComponent,
   PostWithNeighbors,
@@ -31,13 +31,14 @@ const PostListSingleColumn: PostListComponent = React.forwardRef(
   (
     {
       anchor,
-      // channel,
+      channel,
       // collectionLayoutType,
       contentContainerStyle,
       hasNewerPosts = false,
       anchorToEnd = false,
       onEndReached,
       onEndReachedThreshold = 1,
+      onInitialScrollPending,
       onInitialScrollCompleted,
       onScrolledToBottom,
       onScrolledToBottomThreshold = 1,
@@ -64,7 +65,9 @@ const PostListSingleColumn: PostListComponent = React.forwardRef(
       scrollerRef,
       anchorToEnd,
       onScrollCompleted: onInitialScrollCompleted,
+      onScrollPending: onInitialScrollPending,
       contentKey: `${orderedData.length}:${orderedData[0]?.post.id ?? ''}:${orderedData[orderedData.length - 1]?.post.id ?? ''}`,
+      initializationKey: getPostListScopeKey(channel.id, anchor),
     });
 
     useManualScrollAnchoring({
@@ -593,21 +596,25 @@ function useScrollToAnchorOnMount({
   scrollerRef,
   anchorToEnd,
   onScrollCompleted,
+  onScrollPending,
   contentKey,
+  initializationKey,
 }: {
   anchor: ScrollAnchor | null | undefined;
   scrollerRef: React.RefObject<HTMLDivElement | null>;
   anchorToEnd: boolean;
   onScrollCompleted?: () => void;
+  onScrollPending?: () => void;
   contentKey: string | number;
+  initializationKey: string;
 }) {
   const needsInitialScrollRef = useRef(true);
   const timeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
-  const anchorKey = getPostListAnchorKey(anchor) ?? 'latest';
 
   useLayoutEffect(() => {
     needsInitialScrollRef.current = true;
-  }, [anchorKey]);
+    onScrollPending?.();
+  }, [initializationKey, onScrollPending]);
 
   // Timeout fallback: give up after 5s if anchor element never appears
   useEffect(() => {
@@ -625,7 +632,7 @@ function useScrollToAnchorOnMount({
     return () => {
       if (timeoutRef.current) clearTimeout(timeoutRef.current);
     };
-  }, [anchor?.postId, anchorKey, onScrollCompleted]);
+  }, [anchor?.postId, initializationKey, onScrollCompleted]);
 
   // Main scroll effect — re-runs when contentKey changes (as new posts render)
   useLayoutEffect(() => {

--- a/packages/app/ui/components/Channel/PostList/PostListFlatList.tsx
+++ b/packages/app/ui/components/Channel/PostList/PostListFlatList.tsx
@@ -1,4 +1,3 @@
-import { layoutForType } from '@tloncorp/shared';
 import * as React from 'react';
 import { useMemo } from 'react';
 import Animated from 'react-native-reanimated';
@@ -10,6 +9,7 @@ import {
   PostListComponent,
   PostListMethods,
   PostWithNeighbors,
+  usePostListBottomCallbacks,
 } from './shared';
 
 function getPostId({ post }: PostWithNeighbors) {
@@ -22,7 +22,6 @@ export const PostList: PostListComponent = React.forwardRef(
       postsWithNeighbors,
       scrollEnabled = true,
       numColumns,
-      inverted,
       contentContainerStyle,
       columnWrapperStyle,
       style,
@@ -33,8 +32,6 @@ export const PostList: PostListComponent = React.forwardRef(
       onEndReached,
       onEndReachedThreshold,
       anchor,
-      hasNewerPosts,
-      collectionLayoutType,
       onInitialScrollCompleted,
       onScrolledToBottom,
       onScrolledToBottomThreshold = 1,
@@ -44,12 +41,9 @@ export const PostList: PostListComponent = React.forwardRef(
     },
     forwardedRef
   ) => {
-    const collectionLayout = React.useMemo(
-      () => layoutForType(collectionLayoutType),
-      [collectionLayoutType]
-    );
     const listRef =
       React.useRef<React.ElementRef<typeof Animated.FlatList>>(null);
+    const selectedAnchor = anchor?.type === 'selected' ? anchor : null;
     const insets = useSafeAreaInsets();
     const scrollIndicatorInsets = React.useMemo(() => {
       return {
@@ -66,12 +60,8 @@ export const PostList: PostListComponent = React.forwardRef(
       flatlistProps: anchorScrollLockFlatlistProps,
     } = useAnchorScrollLock({
       posts: postsWithNeighbors.map((x) => x.post),
-      anchor,
+      anchor: selectedAnchor,
       flatListRef: listRef,
-      hasNewerPosts,
-      shouldMaintainVisibleContentPosition:
-        collectionLayout.shouldMaintainVisibleContentPosition,
-      collectionLayoutType,
       columnsCount: numColumns,
     });
 
@@ -84,13 +74,10 @@ export const PostList: PostListComponent = React.forwardRef(
     const { onScroll: handleScroll, isAtBottom } = useScrollDirectionTracker({
       atBottomThreshold: onScrolledToBottomThreshold,
     });
-    React.useEffect(() => {
-      if (isAtBottom) {
-        onScrolledToBottom?.();
-      } else {
-        onScrolledAwayFromBottom?.();
-      }
-    }, [onScrolledToBottom, onScrolledAwayFromBottom, isAtBottom]);
+    usePostListBottomCallbacks(isAtBottom, {
+      onScrolledToBottom,
+      onScrolledAwayFromBottom,
+    });
 
     const renderItemWithExtraProps = React.useCallback<typeof renderItem>(
       ({ item, index }) =>
@@ -120,9 +107,17 @@ export const PostList: PostListComponent = React.forwardRef(
             listRef.current.scrollToEnd({ animated: opts.animated });
           }
         },
-        scrollToIndex: ({ index, animated, viewPosition }) => {
-          if (listRef.current) {
-            listRef.current.scrollToIndex({ index, animated, viewPosition });
+        scrollToPost: ({ postId, animated, viewPosition }) => {
+          const rawIndex = postsWithNeighbors.findIndex(
+            ({ post }) => post.id === postId
+          );
+          if (listRef.current && rawIndex !== -1) {
+            listRef.current.scrollToIndex({
+              index:
+                numColumns > 1 ? Math.floor(rawIndex / numColumns) : rawIndex,
+              animated,
+              viewPosition,
+            });
           }
         },
       })
@@ -131,11 +126,6 @@ export const PostList: PostListComponent = React.forwardRef(
     const listStyle = useMemo(() => {
       return [style, readyToDisplayPosts ? null : { opacity: 0 }];
     }, [readyToDisplayPosts, style]);
-
-    // https://github.com/facebook/react-native/issues/21196
-    // Disable `inverted` when list is empty to avoid RN rendering bugs.
-    const effectiveInverted =
-      (postsWithNeighbors?.length || 0) === 0 ? false : inverted;
 
     return (
       <Animated.FlatList<PostWithNeighbors>
@@ -154,13 +144,8 @@ export const PostList: PostListComponent = React.forwardRef(
             ? undefined
             : columnWrapperStyle
         }
-        inverted={effectiveInverted}
-        ListFooterComponent={
-          effectiveInverted ? listHeaderComponent : listBottomComponent
-        }
-        ListHeaderComponent={
-          effectiveInverted ? listBottomComponent : listHeaderComponent
-        }
+        ListFooterComponent={listBottomComponent}
+        ListHeaderComponent={listHeaderComponent}
         maxToRenderPerBatch={15}
         windowSize={11}
         numColumns={numColumns}

--- a/packages/app/ui/components/Channel/PostList/index.ts
+++ b/packages/app/ui/components/Channel/PostList/index.ts
@@ -1,2 +1,2 @@
 export { PostList } from './PostList';
-export type { PostListMethods } from './shared';
+export type { PostListMethods, PostWithNeighbors } from './shared';

--- a/packages/app/ui/components/Channel/PostList/postListInitialization.test.ts
+++ b/packages/app/ui/components/Channel/PostList/postListInitialization.test.ts
@@ -1,0 +1,141 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  getPostListAnchorKey,
+  getPostListInitialization,
+  shouldSnapUnreadAnchorToEnd,
+} from './postListInitialization';
+
+describe('getPostListAnchorKey', () => {
+  it('distinguishes anchor intent when the post stays the same', () => {
+    expect(
+      getPostListAnchorKey({ type: 'unread', postId: 'same-post' })
+    ).not.toBe(getPostListAnchorKey({ type: 'selected', postId: 'same-post' }));
+  });
+});
+
+describe('getPostListInitialization', () => {
+  it.each([
+    {
+      name: 'keeps the latest list stable while data arrives',
+      input: { anchorIndex: -1 },
+      expected: {
+        isAnchorReady: true,
+        mountKey: 'latest',
+        shouldStartAnchorTimeout: false,
+      },
+    },
+    {
+      name: 'waits for anchor data before starting the timeout',
+      input: {
+        anchorKey: 'unread:unread-post',
+        anchorIndex: -1,
+        isLoading: true,
+      },
+      expected: {
+        isAnchorReady: false,
+        mountKey: 'anchor:unread:unread-post:waiting',
+        shouldStartAnchorTimeout: false,
+      },
+    },
+    {
+      name: 'starts fallback after an empty initial page settles',
+      input: {
+        anchorKey: 'unread:deleted-unread-post',
+        anchorIndex: -1,
+        isLoading: false,
+      },
+      expected: {
+        isAnchorReady: false,
+        mountKey: 'anchor:unread:deleted-unread-post:waiting',
+        shouldStartAnchorTimeout: true,
+      },
+    },
+    {
+      name: 'waits for an explicit anchor',
+      input: {
+        anchorKey: 'unread:unread-post',
+        anchorIndex: -1,
+      },
+      expected: {
+        isAnchorReady: false,
+        mountKey: 'anchor:unread:unread-post:waiting',
+        shouldStartAnchorTimeout: true,
+      },
+    },
+    {
+      name: 'remounts when the explicit anchor arrives',
+      input: {
+        anchorKey: 'unread:unread-post',
+        anchorIndex: 4,
+      },
+      expected: {
+        isAnchorReady: true,
+        mountKey: 'anchor:unread:unread-post:ready',
+        shouldStartAnchorTimeout: false,
+      },
+    },
+    {
+      name: 'falls back when the explicit anchor never arrives',
+      input: {
+        anchorKey: 'unread:deleted-unread-post',
+        anchorIndex: -1,
+        didTimeoutWaitingForAnchor: true,
+      },
+      expected: {
+        isAnchorReady: true,
+        mountKey: 'anchor:unread:deleted-unread-post:fallback',
+        shouldStartAnchorTimeout: false,
+      },
+    },
+  ])('$name', ({ input, expected }) => {
+    expect(getPostListInitialization(input)).toEqual(expected);
+  });
+});
+
+describe('shouldSnapUnreadAnchorToEnd', () => {
+  it('snaps a near-end unread anchor only when the newest page is loaded', () => {
+    expect(
+      shouldSnapUnreadAnchorToEnd({
+        anchorType: 'unread',
+        estimatedAnchorExtent: 720,
+        hasNewerPosts: false,
+        anchorToEnd: true,
+        viewportHeight: 800,
+      })
+    ).toBe(true);
+    expect(
+      shouldSnapUnreadAnchorToEnd({
+        anchorType: 'unread',
+        estimatedAnchorExtent: 720,
+        hasNewerPosts: true,
+        anchorToEnd: true,
+        viewportHeight: 800,
+      })
+    ).toBe(false);
+  });
+
+  it('includes the anchor row and footer before snapping to the end', () => {
+    expect(
+      shouldSnapUnreadAnchorToEnd({
+        anchorType: 'unread',
+        estimatedAnchorExtent: 920,
+        hasNewerPosts: false,
+        anchorToEnd: true,
+        viewportHeight: 800,
+      })
+    ).toBe(false);
+  });
+
+  it('keeps selected anchors centered even when they are near the end', () => {
+    expect(
+      shouldSnapUnreadAnchorToEnd({
+        anchorType: 'selected',
+        estimatedAnchorExtent: 720,
+        hasNewerPosts: false,
+        anchorToEnd: true,
+        viewportHeight: 800,
+      })
+    ).toBe(false);
+  });
+});

--- a/packages/app/ui/components/Channel/PostList/postListInitialization.test.ts
+++ b/packages/app/ui/components/Channel/PostList/postListInitialization.test.ts
@@ -3,7 +3,6 @@ import { describe, expect, it } from 'vitest';
 import {
   getPostListAnchorKey,
   getPostListInitialization,
-  shouldSnapUnreadAnchorToEnd,
 } from './postListInitialization';
 
 describe('getPostListAnchorKey', () => {
@@ -90,52 +89,5 @@ describe('getPostListInitialization', () => {
     },
   ])('$name', ({ input, expected }) => {
     expect(getPostListInitialization(input)).toEqual(expected);
-  });
-});
-
-describe('shouldSnapUnreadAnchorToEnd', () => {
-  it('snaps a near-end unread anchor only when the newest page is loaded', () => {
-    expect(
-      shouldSnapUnreadAnchorToEnd({
-        anchorType: 'unread',
-        estimatedAnchorExtent: 720,
-        hasNewerPosts: false,
-        anchorToEnd: true,
-        viewportHeight: 800,
-      })
-    ).toBe(true);
-    expect(
-      shouldSnapUnreadAnchorToEnd({
-        anchorType: 'unread',
-        estimatedAnchorExtent: 720,
-        hasNewerPosts: true,
-        anchorToEnd: true,
-        viewportHeight: 800,
-      })
-    ).toBe(false);
-  });
-
-  it('includes the anchor row and footer before snapping to the end', () => {
-    expect(
-      shouldSnapUnreadAnchorToEnd({
-        anchorType: 'unread',
-        estimatedAnchorExtent: 920,
-        hasNewerPosts: false,
-        anchorToEnd: true,
-        viewportHeight: 800,
-      })
-    ).toBe(false);
-  });
-
-  it('keeps selected anchors centered even when they are near the end', () => {
-    expect(
-      shouldSnapUnreadAnchorToEnd({
-        anchorType: 'selected',
-        estimatedAnchorExtent: 720,
-        hasNewerPosts: false,
-        anchorToEnd: true,
-        viewportHeight: 800,
-      })
-    ).toBe(false);
   });
 });

--- a/packages/app/ui/components/Channel/PostList/postListInitialization.test.ts
+++ b/packages/app/ui/components/Channel/PostList/postListInitialization.test.ts
@@ -3,6 +3,7 @@ import { describe, expect, it } from 'vitest';
 import {
   getPostListAnchorKey,
   getPostListInitialization,
+  getPostListScopeKey,
 } from './postListInitialization';
 
 describe('getPostListAnchorKey', () => {
@@ -10,6 +11,16 @@ describe('getPostListAnchorKey', () => {
     expect(
       getPostListAnchorKey({ type: 'unread', postId: 'same-post' })
     ).not.toBe(getPostListAnchorKey({ type: 'selected', postId: 'same-post' }));
+  });
+});
+
+describe('getPostListScopeKey', () => {
+  it('distinguishes the same anchor intent across channels', () => {
+    const anchor = { type: 'unread' as const, postId: 'same-post' };
+
+    expect(getPostListScopeKey('channel-a', anchor)).not.toBe(
+      getPostListScopeKey('channel-b', anchor)
+    );
   });
 });
 

--- a/packages/app/ui/components/Channel/PostList/postListInitialization.ts
+++ b/packages/app/ui/components/Channel/PostList/postListInitialization.ts
@@ -4,6 +4,13 @@ export function getPostListAnchorKey(anchor?: ScrollAnchor | null) {
   return anchor ? `${anchor.type}:${anchor.postId}` : undefined;
 }
 
+export function getPostListScopeKey(
+  channelId: string,
+  anchor?: ScrollAnchor | null
+) {
+  return `${channelId}:${getPostListAnchorKey(anchor) ?? 'latest'}`;
+}
+
 export function getPostListInitialization({
   anchorKey,
   anchorIndex,

--- a/packages/app/ui/components/Channel/PostList/postListInitialization.ts
+++ b/packages/app/ui/components/Channel/PostList/postListInitialization.ts
@@ -37,26 +37,3 @@ export function getPostListInitialization({
     shouldStartAnchorTimeout: resolution === 'waiting' && !isLoading,
   };
 }
-
-export function shouldSnapUnreadAnchorToEnd({
-  anchorType,
-  estimatedAnchorExtent,
-  hasNewerPosts,
-  anchorToEnd,
-  viewportHeight,
-}: {
-  anchorType?: 'unread' | 'selected';
-  estimatedAnchorExtent?: number;
-  hasNewerPosts?: boolean;
-  anchorToEnd: boolean;
-  viewportHeight: number;
-}) {
-  return (
-    anchorType === 'unread' &&
-    estimatedAnchorExtent !== undefined &&
-    viewportHeight > 0 &&
-    estimatedAnchorExtent <= viewportHeight &&
-    !hasNewerPosts &&
-    anchorToEnd
-  );
-}

--- a/packages/app/ui/components/Channel/PostList/postListInitialization.ts
+++ b/packages/app/ui/components/Channel/PostList/postListInitialization.ts
@@ -1,0 +1,62 @@
+import type { ScrollAnchor } from '../scrollerTypes';
+
+export function getPostListAnchorKey(anchor?: ScrollAnchor | null) {
+  return anchor ? `${anchor.type}:${anchor.postId}` : undefined;
+}
+
+export function getPostListInitialization({
+  anchorKey,
+  anchorIndex,
+  didTimeoutWaitingForAnchor = false,
+  isLoading = false,
+}: {
+  anchorKey?: string;
+  anchorIndex: number;
+  didTimeoutWaitingForAnchor?: boolean;
+  isLoading?: boolean;
+}) {
+  // LegendList reads its initial scroll target only during mount, so the key
+  // advances when an awaited anchor resolves (or falls back). This is a v1
+  // bridge until readiness can be driven by measured-row quiescence.
+  if (!anchorKey) {
+    return {
+      isAnchorReady: true,
+      mountKey: 'latest',
+      shouldStartAnchorTimeout: false,
+    };
+  }
+
+  const resolution = didTimeoutWaitingForAnchor
+    ? 'fallback'
+    : anchorIndex !== -1
+      ? 'ready'
+      : 'waiting';
+  return {
+    isAnchorReady: resolution !== 'waiting',
+    mountKey: `anchor:${anchorKey}:${resolution}`,
+    shouldStartAnchorTimeout: resolution === 'waiting' && !isLoading,
+  };
+}
+
+export function shouldSnapUnreadAnchorToEnd({
+  anchorType,
+  estimatedAnchorExtent,
+  hasNewerPosts,
+  anchorToEnd,
+  viewportHeight,
+}: {
+  anchorType?: 'unread' | 'selected';
+  estimatedAnchorExtent?: number;
+  hasNewerPosts?: boolean;
+  anchorToEnd: boolean;
+  viewportHeight: number;
+}) {
+  return (
+    anchorType === 'unread' &&
+    estimatedAnchorExtent !== undefined &&
+    viewportHeight > 0 &&
+    estimatedAnchorExtent <= viewportHeight &&
+    !hasNewerPosts &&
+    anchorToEnd
+  );
+}

--- a/packages/app/ui/components/Channel/PostList/shared.ts
+++ b/packages/app/ui/components/Channel/PostList/shared.ts
@@ -7,15 +7,15 @@ import type { ScrollAnchor } from '../scrollerTypes';
 
 export interface PostWithNeighbors {
   post: db.Post;
-  newer: db.Post | null;
-  older: db.Post | null;
+  previous: db.Post | null;
+  next: db.Post | null;
 }
 
 export interface PostListMethods {
   scrollToStart: (opts: { animated?: boolean }) => void;
   scrollToEnd: (opts: { animated?: boolean }) => void;
-  scrollToIndex: (opts: {
-    index: number;
+  scrollToPost: (opts: {
+    postId: string;
     animated?: boolean;
     viewPosition?: number;
   }) => void;
@@ -28,15 +28,17 @@ export type PostListComponentProps = {
   columnWrapperStyle?: StyleProp<ViewStyle>;
   contentContainerStyle?: StyleProp<ViewStyle>;
   hasNewerPosts?: boolean;
-  inverted?: boolean;
+  isLoading?: boolean;
+  /** Pins short content and new items to the visual end of the list. */
+  anchorToEnd?: boolean;
   // This should take precedence over the `collectionLayoutType`'s intrinsic column count
   numColumns: number;
   onEndReached?: () => void;
   onEndReachedThreshold?: number;
   onInitialScrollCompleted?: () => void;
   /**
-   * Called once each time the list is scrolled to the start. This is different
-   * from `onStartReached` which prevents itself from firing until the scroll's
+   * Called once each time the list is scrolled to the visual bottom. This is
+   * different from `onEndReached`, which prevents itself from firing until the scroll's
    * content height has changed.
    */
   onScrolledToBottom?: () => void;
@@ -62,8 +64,6 @@ export type PostListComponentProps = {
    * Content to display at the visual top of the list (above all items).
    * Used to render gallery/notebook headers inside the PostList, avoiding
    * nested FlatLists which break on Android.
-   *
-   * Mapped to ListFooterComponent when inverted, ListHeaderComponent otherwise.
    */
   listHeaderComponent?: React.ReactElement;
   /**
@@ -75,3 +75,28 @@ export type PostListComponentProps = {
 export type PostListComponent = ReturnType<
   typeof React.forwardRef<PostListMethods, PostListComponentProps>
 >;
+
+export function usesConversationPostList({
+  collectionLayoutType,
+}: Pick<PostListComponentProps, 'collectionLayoutType'>) {
+  return collectionLayoutType === 'compact-list-bottom-to-top';
+}
+
+export function usePostListBottomCallbacks(
+  isAtBottom: boolean,
+  {
+    onScrolledToBottom,
+    onScrolledAwayFromBottom,
+  }: Pick<
+    PostListComponentProps,
+    'onScrolledToBottom' | 'onScrolledAwayFromBottom'
+  >
+) {
+  React.useEffect(() => {
+    if (isAtBottom) {
+      onScrolledToBottom?.();
+    } else {
+      onScrolledAwayFromBottom?.();
+    }
+  }, [isAtBottom, onScrolledAwayFromBottom, onScrolledToBottom]);
+}

--- a/packages/app/ui/components/Channel/PostList/shared.ts
+++ b/packages/app/ui/components/Channel/PostList/shared.ts
@@ -35,6 +35,7 @@ export type PostListComponentProps = {
   numColumns: number;
   onEndReached?: () => void;
   onEndReachedThreshold?: number;
+  onInitialScrollPending?: () => void;
   onInitialScrollCompleted?: () => void;
   /**
    * Called once each time the list is scrolled to the visual bottom. This is

--- a/packages/app/ui/components/Channel/Scroller.tsx
+++ b/packages/app/ui/components/Channel/Scroller.tsx
@@ -571,7 +571,7 @@ const Scroller = forwardRef(
               inset={0}
               alignItems="center"
               justifyContent="center"
-              pointerEvents="none"
+              pointerEvents="auto"
             >
               <LoadingSpinner size="small" />
             </View>

--- a/packages/app/ui/components/Channel/Scroller.tsx
+++ b/packages/app/ui/components/Channel/Scroller.tsx
@@ -27,6 +27,7 @@ import React, {
   useCallback,
   useEffect,
   useImperativeHandle,
+  useLayoutEffect,
   useMemo,
   useRef,
   useState,
@@ -50,14 +51,9 @@ import { ViewReactionsSheet } from '../ChatMessage/ViewReactionsSheet';
 import { EmojiPickerSheet } from '../Emoji';
 import { ChannelDivider } from './ChannelDivider';
 import { ContextLensRunSheet } from './ContextLens/ContextLensRunSheet';
-import { PostList, PostListMethods } from './PostList';
+import { PostList, PostListMethods, PostWithNeighbors } from './PostList';
+import { getPostListAnchorKey } from './PostList/postListInitialization';
 import type { ScrollAnchor } from './scrollerTypes';
-
-interface PostWithNeighbors {
-  post: db.Post;
-  newer: db.Post | null;
-  older: db.Post | null;
-}
 
 const logger = createDevLogger('scroller', false);
 
@@ -66,7 +62,7 @@ export type { ScrollAnchor } from './scrollerTypes';
 /**
  * This scroller makes some assumptions you should not break!
  * - Posts and unread state should be be loaded before the scroller is rendered
- * - Posts should be sorted in descending order
+ * - Posts should be supplied in their visual top-to-bottom order
  * - If we're scrolling to an anchor, that anchor should be in the first page of posts
  */
 const Scroller = forwardRef(
@@ -74,7 +70,7 @@ const Scroller = forwardRef(
     {
       anchor,
       showDividers = true,
-      inverted,
+      anchorToEnd,
       renderItem,
       renderEmptyComponent,
       posts,
@@ -106,7 +102,7 @@ const Scroller = forwardRef(
     }: {
       anchor?: ScrollAnchor | null;
       showDividers?: boolean;
-      inverted: boolean;
+      anchorToEnd: boolean;
       renderItem: RenderItemType;
       renderEmptyComponent?: () => ReactElement;
       posts: db.Post[] | null;
@@ -128,8 +124,8 @@ const Scroller = forwardRef(
       activeMessage: db.Post | null;
       setActiveMessage: (post: db.Post | null) => void;
       ref?: RefObject<{
-        scrollToIndex: (params: {
-          index: number;
+        scrollToPost: (params: {
+          postId: string;
           animated?: boolean;
           viewPosition?: number;
         }) => void;
@@ -199,31 +195,27 @@ const Scroller = forwardRef(
     const listRef = useRef<PostListMethods>(null);
 
     useImperativeHandle(ref, () => ({
-      scrollToIndex: (params: {
-        index: number;
+      scrollToPost: (params: {
+        postId: string;
         animated?: boolean;
         viewPosition?: number;
-      }) => listRef.current?.scrollToIndex(params),
+      }) => listRef.current?.scrollToPost(params),
       scrollToStart: (params: { animated?: boolean }) =>
         listRef.current?.scrollToStart(params),
       scrollToEnd: (params: { animated?: boolean }) =>
         listRef.current?.scrollToEnd(params),
     }));
 
-    const pressedGoToBottom = () => {
+    const pressedGoToBottom = useCallback(() => {
       setHasPressedGoToBottom(true);
       onPressScrollToBottom?.();
 
       if (listRef.current && !isLoading) {
         requestAnimationFrame(() => {
-          if (inverted) {
-            listRef.current?.scrollToStart({ animated: true });
-          } else {
-            listRef.current?.scrollToEnd({ animated: true });
-          }
+          listRef.current?.scrollToEnd({ animated: true });
         });
       }
-    };
+    }, [isLoading, onPressScrollToBottom]);
 
     const activeMessageRefs = useRef<Record<string, RefObject<RNView | null>>>(
       {}
@@ -250,15 +242,10 @@ const Scroller = forwardRef(
     const postsWithNeighbors: PostWithNeighbors[] | undefined = useMemo(
       () =>
         posts?.map((post, postIndex, posts) => {
-          const newerIndex = postIndex - 1;
-          const olderIndex = postIndex + 1;
-          const newerPost = newerIndex >= 0 ? posts[newerIndex] : null;
-          const olderPost =
-            olderIndex < posts.length ? posts[olderIndex] : null;
           return {
             post,
-            newer: newerPost,
-            older: olderPost,
+            previous: postIndex > 0 ? posts[postIndex - 1] : null,
+            next: postIndex + 1 < posts.length ? posts[postIndex + 1] : null,
           };
         }),
       [posts]
@@ -271,26 +258,24 @@ const Scroller = forwardRef(
     }, [theme.background.val]);
 
     const listRenderItem: ListRenderItem<PostWithNeighbors> = useCallback(
-      ({ item: { post, newer, older, ...rest }, index }) => {
-        const previousItem = inverted ? older : newer;
-        const nextItem = inverted ? newer : older;
+      ({ item: { post, previous, next, ...rest }, index }) => {
         const isFirstPostOfDay = !isSameDay(
           post.receivedAt ?? 0,
-          previousItem?.receivedAt ?? 0
+          previous?.receivedAt ?? 0
         );
         const isLastPostOfBlock =
           post.type !== 'notice' &&
           (post.type === 'chat' || post.type === 'reply') &&
-          nextItem != null &&
-          (nextItem.authorId !== post.authorId ||
-            !isSameDay(post.receivedAt ?? 0, nextItem.receivedAt ?? 0));
+          next != null &&
+          (next.authorId !== post.authorId ||
+            !isSameDay(post.receivedAt ?? 0, next.receivedAt ?? 0));
         const showAuthor =
           post.type === 'note' ||
           post.type === 'block' ||
-          !previousItem ||
-          previousItem?.authorId !== post.authorId ||
-          previousItem?.type === 'notice' ||
-          previousItem?.isDeleted === true ||
+          !previous ||
+          previous?.authorId !== post.authorId ||
+          previous?.type === 'notice' ||
+          previous?.isDeleted === true ||
           isFirstPostOfDay;
         const isFirstUnread = post.id === firstUnreadId;
         const isSelected =
@@ -334,7 +319,7 @@ const Scroller = forwardRef(
             itemAspectRatio={collectionLayout.itemAspectRatio ?? undefined}
             itemWidth={itemWidth}
             columnCount={columns}
-            previousPost={previousItem}
+            previousPost={previous}
             {...rest}
           />
         );
@@ -345,7 +330,6 @@ const Scroller = forwardRef(
         highlightPostId,
         contextLensSelectedPostId,
         firstUnreadId,
-        inverted,
         renderItem,
         unreadCount,
         showReplies,
@@ -370,7 +354,6 @@ const Scroller = forwardRef(
 
     const insets = useSafeAreaInsets();
     const rootVerticalPadding = getTokens().space.l.val;
-
     const contentContainerStyle = useStyle(
       useMemo(() => {
         if (!posts?.length) {
@@ -435,6 +418,13 @@ const Scroller = forwardRef(
     });
 
     const [readyToDisplayPosts, setReadyToDisplayPosts] = useState(false);
+    const anchorKey = getPostListAnchorKey(anchor);
+
+    useLayoutEffect(() => {
+      pendingEvents.current.onEndReached = false;
+      pendingEvents.current.onStartReached = false;
+      setReadyToDisplayPosts(false);
+    }, [anchorKey]);
 
     // We don't want to trigger onEndReached or onStartReached until we've found
     // the anchor as additional page loads during the initial render can wreak
@@ -482,12 +472,12 @@ const Scroller = forwardRef(
 
       const shouldShowForUnreads =
         collectionLayoutType === 'compact-list-bottom-to-top' &&
-        inverted &&
+        anchorToEnd &&
         unreadCount &&
         !isAtBottom;
       const shouldShowForScroll =
         collectionLayoutType === 'compact-list-bottom-to-top' &&
-        inverted &&
+        anchorToEnd &&
         !isAtBottom &&
         (!hasPressedGoToBottom || isLoading || hasNewerPosts);
 
@@ -496,7 +486,7 @@ const Scroller = forwardRef(
       isAtBottom,
       hasPressedGoToBottom,
       collectionLayoutType,
-      inverted,
+      anchorToEnd,
       unreadCount,
       isLoading,
       hasNewerPosts,
@@ -515,11 +505,12 @@ const Scroller = forwardRef(
     const onInitialScrollCompleted = useCallback(() => {
       setReadyToDisplayPosts(true);
     }, []);
+    const showScrollButton = Boolean(shouldShowScrollButton());
 
     return (
       <View flex={1}>
-        {shouldShowScrollButton() && (
-          <View position="absolute" bottom={'$m'} right={'$l'} zIndex={1000}>
+        {showScrollButton && (
+          <View position="absolute" bottom="$m" right="$l" zIndex={1000}>
             <FloatingActionButton
               icon={
                 isLoading && hasPressedGoToBottom ? (
@@ -540,7 +531,8 @@ const Scroller = forwardRef(
             columnWrapperStyle={columnWrapperStyle}
             contentContainerStyle={contentContainerStyle}
             hasNewerPosts={hasNewerPosts}
-            inverted={inverted}
+            isLoading={isLoading}
+            anchorToEnd={anchorToEnd}
             // This is needed so that we can force a refresh of the list when
             // we need to switch from 1 to 2 columns or vice versa.
             key={channel.type + '-' + columns}
@@ -565,6 +557,19 @@ const Scroller = forwardRef(
             listBottomComponent={listBottomComponent}
           />
         )}
+        {postsWithNeighbors != null &&
+          postsWithNeighbors.length > 0 &&
+          !readyToDisplayPosts && (
+            <View
+              position="absolute"
+              inset={0}
+              alignItems="center"
+              justifyContent="center"
+              pointerEvents="none"
+            >
+              <LoadingSpinner size="small" />
+            </View>
+          )}
         {activeMessage !== null && !emojiPickerOpen && (
           <Modal
             visible={activeMessage !== null && !emojiPickerOpen}

--- a/packages/app/ui/components/Channel/Scroller.tsx
+++ b/packages/app/ui/components/Channel/Scroller.tsx
@@ -52,7 +52,7 @@ import { EmojiPickerSheet } from '../Emoji';
 import { ChannelDivider } from './ChannelDivider';
 import { ContextLensRunSheet } from './ContextLens/ContextLensRunSheet';
 import { PostList, PostListMethods, PostWithNeighbors } from './PostList';
-import { getPostListAnchorKey } from './PostList/postListInitialization';
+import { getPostListScopeKey } from './PostList/postListInitialization';
 import type { ScrollAnchor } from './scrollerTypes';
 
 const logger = createDevLogger('scroller', false);
@@ -418,7 +418,7 @@ const Scroller = forwardRef(
       onStartReached: false,
     });
 
-    const anchorKey = `${channel.id}:${getPostListAnchorKey(anchor) ?? 'latest'}`;
+    const anchorKey = getPostListScopeKey(channel.id, anchor);
     const [completedAnchorKey, setCompletedAnchorKey] = useState<string | null>(
       null
     );
@@ -508,6 +508,9 @@ const Scroller = forwardRef(
     const onInitialScrollCompleted = useCallback(() => {
       setCompletedAnchorKey(anchorKey);
     }, [anchorKey]);
+    const onInitialScrollPending = useCallback(() => {
+      setCompletedAnchorKey(null);
+    }, []);
 
     return (
       <View flex={1}>
@@ -541,6 +544,7 @@ const Scroller = forwardRef(
             numColumns={columns}
             onEndReached={handleEndReached}
             onEndReachedThreshold={1}
+            onInitialScrollPending={onInitialScrollPending}
             onInitialScrollCompleted={onInitialScrollCompleted}
             onScrolledAwayFromBottom={onScrolledAwayFromBottom}
             onScrolledToBottom={onScrolledToBottom}

--- a/packages/app/ui/components/Channel/Scroller.tsx
+++ b/packages/app/ui/components/Channel/Scroller.tsx
@@ -206,7 +206,7 @@ const Scroller = forwardRef(
         listRef.current?.scrollToEnd(params),
     }));
 
-    const pressedGoToBottom = useCallback(() => {
+    const pressedGoToBottom = () => {
       setHasPressedGoToBottom(true);
       onPressScrollToBottom?.();
 
@@ -215,7 +215,7 @@ const Scroller = forwardRef(
           listRef.current?.scrollToEnd({ animated: true });
         });
       }
-    }, [isLoading, onPressScrollToBottom]);
+    };
 
     const activeMessageRefs = useRef<Record<string, RefObject<RNView | null>>>(
       {}
@@ -354,6 +354,7 @@ const Scroller = forwardRef(
 
     const insets = useSafeAreaInsets();
     const rootVerticalPadding = getTokens().space.l.val;
+
     const contentContainerStyle = useStyle(
       useMemo(() => {
         if (!posts?.length) {
@@ -507,12 +508,11 @@ const Scroller = forwardRef(
     const onInitialScrollCompleted = useCallback(() => {
       setCompletedAnchorKey(anchorKey);
     }, [anchorKey]);
-    const showScrollButton = Boolean(shouldShowScrollButton());
 
     return (
       <View flex={1}>
-        {showScrollButton && (
-          <View position="absolute" bottom="$m" right="$l" zIndex={1000}>
+        {shouldShowScrollButton() && (
+          <View position="absolute" bottom={'$m'} right={'$l'} zIndex={1000}>
             <FloatingActionButton
               icon={
                 isLoading && hasPressedGoToBottom ? (

--- a/packages/app/ui/components/Channel/Scroller.tsx
+++ b/packages/app/ui/components/Channel/Scroller.tsx
@@ -417,13 +417,15 @@ const Scroller = forwardRef(
       onStartReached: false,
     });
 
-    const [readyToDisplayPosts, setReadyToDisplayPosts] = useState(false);
-    const anchorKey = getPostListAnchorKey(anchor);
+    const anchorKey = `${channel.id}:${getPostListAnchorKey(anchor) ?? 'latest'}`;
+    const [completedAnchorKey, setCompletedAnchorKey] = useState<string | null>(
+      null
+    );
+    const readyToDisplayPosts = completedAnchorKey === anchorKey;
 
     useLayoutEffect(() => {
       pendingEvents.current.onEndReached = false;
       pendingEvents.current.onStartReached = false;
-      setReadyToDisplayPosts(false);
     }, [anchorKey]);
 
     // We don't want to trigger onEndReached or onStartReached until we've found
@@ -503,8 +505,8 @@ const Scroller = forwardRef(
       setIsAtBottom(false);
     }, []);
     const onInitialScrollCompleted = useCallback(() => {
-      setReadyToDisplayPosts(true);
-    }, []);
+      setCompletedAnchorKey(anchorKey);
+    }, [anchorKey]);
     const showScrollButton = Boolean(shouldShowScrollButton());
 
     return (

--- a/packages/app/ui/components/Channel/index.tsx
+++ b/packages/app/ui/components/Channel/index.tsx
@@ -267,8 +267,8 @@ interface ChannelProps {
   goToContextLensRuns?: () => void;
   goToContextLensRun?: (params: { botShip: string; lensId: string }) => void;
   goToUserProfile: (userId: string) => void;
-  onScrollEndReached?: () => void;
-  onScrollStartReached?: () => void;
+  onLoadNewerPosts?: () => void;
+  onLoadOlderPosts?: () => void;
   isLoadingPosts?: boolean;
   loadPostsError?: Error | null;
   onPressRef: (channel: db.Channel, post: db.Post) => void;
@@ -309,8 +309,8 @@ export function Channel({
   goToDm,
   goToUserProfile,
   goToGroupSettings,
-  onScrollEndReached,
-  onScrollStartReached,
+  onLoadNewerPosts,
+  onLoadOlderPosts,
   isLoadingPosts,
   loadPostsError,
   markRead,
@@ -481,15 +481,17 @@ export function Channel({
 
   const handleRefPress = useCallback(
     (refChannel: db.Channel, post: db.Post) => {
-      const anchorIndex = posts?.findIndex((p) => p.id === post.id) ?? -1;
+      const postIsLoaded = posts?.some(
+        (loadedPost) => loadedPost.id === post.id
+      );
 
       if (
         refChannel.id === channel.id &&
-        anchorIndex !== -1 &&
+        postIsLoaded &&
         collectionRef.current
       ) {
         // If the post is already loaded, scroll to it and highlight
-        collectionRef.current?.scrollToPostAtIndex?.(anchorIndex, 0.5);
+        collectionRef.current?.scrollToPost?.(post.id, 0.5);
         collectionRef.current?.highlightPost?.(post.id);
         return;
       }
@@ -556,7 +558,7 @@ export function Channel({
   // Helper to scroll to new message - shared by sendPost and sendPostFromDraft
   const scrollToNewMessage = useCallback(() => {
     requestAnimationFrame(() => {
-      collectionRef.current?.scrollToStart?.({ animated: true });
+      collectionRef.current?.scrollToLatest?.({ animated: true });
     });
   }, []);
 
@@ -811,8 +813,8 @@ export function Channel({
                                     onPressDelete,
                                     onPressRetrySend,
                                     onPressRetryLoad,
-                                    onScrollEndReached,
-                                    onScrollStartReached,
+                                    onLoadNewerPosts,
+                                    onLoadOlderPosts,
                                     posts: posts ?? undefined,
                                     scrollToBottom: onPressScrollToBottom,
                                     selectedPostId,

--- a/packages/app/ui/components/Channel/useAnchorScrollLock.ts
+++ b/packages/app/ui/components/Channel/useAnchorScrollLock.ts
@@ -17,8 +17,8 @@ const logger = createDevLogger('useAnchorScrollLock', false);
 /**
  * useAnchorScrollLock
  *
- * Manages scrolling to an anchor post (selected post or unread marker)
- * in a virtualized FlatList where the target item may not be measured yet.
+ * Manages scrolling to a selected post in a virtualized notebook or gallery
+ * FlatList where the target item may not be measured yet.
  *
  * Scroll phase state machine (`scrollPhaseRef`):
  *
@@ -57,17 +57,11 @@ export function useAnchorScrollLock({
   flatListRef,
   posts,
   anchor,
-  hasNewerPosts,
-  shouldMaintainVisibleContentPosition,
-  collectionLayoutType,
   columnsCount,
 }: {
   flatListRef: RefObject<FlatList<db.Post> | null>;
   posts: db.Post[] | null;
-  anchor: ScrollAnchor | null | undefined;
-  hasNewerPosts?: boolean;
-  shouldMaintainVisibleContentPosition: boolean;
-  collectionLayoutType: string;
+  anchor: Pick<ScrollAnchor, 'postId'> | null | undefined;
   columnsCount: number;
 }) {
   const MAX_FAILURE_RETRIES = 3;
@@ -107,14 +101,12 @@ export function useAnchorScrollLock({
   const anchorIndexRef = useRef(anchorIndex);
   anchorIndexRef.current = anchorIndex;
 
-  // For grid layouts, FlatList indexes by row, not by item. Centralize
-  // the raw-item-index → row-index conversion to avoid inconsistencies.
+  // A multi-column FlatList indexes by row, not by item. Centralize the
+  // raw-item-index → row-index conversion to avoid inconsistencies.
   const getEffectiveIndex = useCallback(
     (rawIndex: number) =>
-      collectionLayoutType === 'grid'
-        ? Math.floor(rawIndex / columnsCount)
-        : rawIndex,
-    [collectionLayoutType, columnsCount]
+      columnsCount > 1 ? Math.floor(rawIndex / columnsCount) : rawIndex,
+    [columnsCount]
   );
 
   const handleScrollBeginDrag = useCallback(() => {
@@ -156,7 +148,6 @@ export function useAnchorScrollLock({
             anchor?.postId === currentAnchorId.current
           ) {
             const retryEffectiveIndex = getEffectiveIndex(idx);
-            const viewPos = anchor?.type === 'unread' ? 1 : 0.5;
             logger.log('retrying scroll after failure', {
               index: retryEffectiveIndex,
               attempt: failureRetryCountRef.current,
@@ -165,7 +156,7 @@ export function useAnchorScrollLock({
               const countBefore = failureRetryCountRef.current;
               flatListRef.current.scrollToIndex({
                 index: retryEffectiveIndex,
-                viewPosition: viewPos,
+                viewPosition: 0.5,
                 animated: false,
               });
               // Only start a done-timeout if onScrollToIndexFailed did not
@@ -207,7 +198,6 @@ export function useAnchorScrollLock({
         scrollPhaseRef.current !== 'done'
       ) {
         const effectiveIndex = getEffectiveIndex(index);
-        const viewPosition = anchor.type === 'unread' ? 1 : 0.5;
         const isCorrection = scrollPhaseRef.current === 'scrolled';
 
         logger.log(
@@ -217,7 +207,7 @@ export function useAnchorScrollLock({
           { id: post.id, index }
         );
 
-        if (collectionLayoutType === 'grid') {
+        if (columnsCount > 1) {
           logger.log('Using grid-adjusted index for scrollToIndex:', {
             originalIndex: index,
             gridAdjustedIndex: effectiveIndex,
@@ -228,7 +218,7 @@ export function useAnchorScrollLock({
         try {
           flatListRef.current.scrollToIndex({
             index: effectiveIndex,
-            viewPosition,
+            viewPosition: 0.5,
             animated: false,
           });
         } catch (e) {
@@ -274,17 +264,6 @@ export function useAnchorScrollLock({
     }
   );
 
-  const maintainVisibleContentPositionConfig = useMemo(() => {
-    if (!shouldMaintainVisibleContentPosition) {
-      return undefined;
-    }
-
-    return {
-      minIndexForVisible: 0,
-      autoscrollToTopThreshold: hasNewerPosts ? undefined : 0,
-    };
-  }, [hasNewerPosts, shouldMaintainVisibleContentPosition]);
-
   // Clean up timers on unmount
   useEffect(() => {
     return () => {
@@ -324,13 +303,8 @@ export function useAnchorScrollLock({
     () => ({
       onScrollBeginDrag: handleScrollBeginDrag,
       onScrollToIndexFailed: handleScrollToIndexFailed,
-      maintainVisibleContentPosition: maintainVisibleContentPositionConfig,
     }),
-    [
-      handleScrollBeginDrag,
-      handleScrollToIndexFailed,
-      maintainVisibleContentPositionConfig,
-    ]
+    [handleScrollBeginDrag, handleScrollToIndexFailed]
   );
 
   return useMemo(

--- a/packages/app/ui/components/DetailView.tsx
+++ b/packages/app/ui/components/DetailView.tsx
@@ -33,6 +33,7 @@ export interface DetailViewProps {
     scrollToStart: (opts: { animated?: boolean }) => void;
     scrollToEnd: (opts: { animated?: boolean }) => void;
   } | null>;
+  isLoading?: boolean;
 }
 
 export const DetailView = ({
@@ -53,12 +54,13 @@ export const DetailView = ({
   anchor,
   highlightPostId,
   scrollerRef,
+  isLoading,
 }: DetailViewProps) => {
   const channelType = channel.type;
   const isChat = channelType !== 'notebook' && channelType !== 'gallery';
   const resolvedPosts = useMemo(() => {
     if (isChat) {
-      return posts ? [...posts, post] : posts;
+      return posts ? [post, ...[...posts].reverse()] : posts;
     }
     return posts ? [...posts].reverse() : posts;
   }, [posts, post, isChat]);
@@ -118,7 +120,7 @@ export const DetailView = ({
       <Scroller
         ref={scrollerRef}
         anchor={anchor}
-        inverted={isChat}
+        anchorToEnd={isChat}
         renderItem={ChatMessage}
         channel={channel}
         collectionLayoutType="compact-list-bottom-to-top"
@@ -145,6 +147,7 @@ export const DetailView = ({
         setActiveMessage={setActiveMessage}
         listHeaderComponent={listHeaderComponent}
         listBottomComponent={listBottomComponent}
+        isLoading={isLoading}
       />
     </View>
   );

--- a/packages/app/ui/components/PostScreenView.tsx
+++ b/packages/app/ui/components/PostScreenView.tsx
@@ -34,6 +34,7 @@ import { useCurrentUserId } from '../contexts/appDataContext';
 import { useAttachmentContext } from '../contexts/attachment';
 import { ChannelProvider } from '../contexts/channel';
 import { NavigationProvider } from '../contexts/navigation';
+import { ScrollContextProvider } from '../contexts/scroll';
 import * as utils from '../utils';
 import BareChatInput from './BareChatInput';
 import { BigInput } from './BigInput';
@@ -62,7 +63,7 @@ const HIGHLIGHT_DURATION_MS = 5000;
 
 interface ChatThreadHandle {
   posts: db.Post[];
-  scrollToPostAtIndex: (index: number, viewPosition?: number) => void;
+  scrollToPost: (postId: string, viewPosition?: number) => void;
   highlightPost: (postId: string) => void;
 }
 
@@ -338,11 +339,9 @@ export function PostScreenView({
         const isSameThread =
           post.parentId === parentPost?.id || post.id === parentPost?.id;
         if (isSameChannel && isSameThread) {
-          const anchorIndex = threadHandle.posts.findIndex(
-            (p) => p.id === post.id
-          );
-          if (anchorIndex !== -1) {
-            threadHandle.scrollToPostAtIndex(anchorIndex, 0.5);
+          const hasPost = threadHandle.posts.some((p) => p.id === post.id);
+          if (hasPost) {
+            threadHandle.scrollToPost(post.id, 0.5);
             threadHandle.highlightPost(post.id);
             return;
           }
@@ -421,35 +420,37 @@ export function PostScreenView({
                             />
                           </YStack>
                         ) : mode === 'single' ? (
-                          <SinglePostView
-                            {...{
-                              channel,
-                              chatThreadHandleRef,
-                              editingPost,
-                              goBack,
-                              group,
-                              handleGoToImage,
-                              inspectContextLensPost:
-                                contextLensAvailable && contextLensOpen
-                                  ? inspectContextLensPost
-                                  : undefined,
-                              openContextLensForPost:
-                                contextLensAvailable && !isWindowNarrow
-                                  ? openContextLensForPost
-                                  : undefined,
-                              onGoToBotRun:
-                                contextLensAvailable && isWindowNarrow
-                                  ? goToContextLensRun
-                                  : undefined,
-                              negotiationMatch,
-                              onPressDelete,
-                              onPressRetry,
-                              parentEditDraftCallbacks,
-                              parentPost,
-                              selectedPostId,
-                              setEditingPost,
-                            }}
-                          />
+                          <ScrollContextProvider>
+                            <SinglePostView
+                              {...{
+                                channel,
+                                chatThreadHandleRef,
+                                editingPost,
+                                goBack,
+                                group,
+                                handleGoToImage,
+                                inspectContextLensPost:
+                                  contextLensAvailable && contextLensOpen
+                                    ? inspectContextLensPost
+                                    : undefined,
+                                openContextLensForPost:
+                                  contextLensAvailable && !isWindowNarrow
+                                    ? openContextLensForPost
+                                    : undefined,
+                                onGoToBotRun:
+                                  contextLensAvailable && isWindowNarrow
+                                    ? goToContextLensRun
+                                    : undefined,
+                                negotiationMatch,
+                                onPressDelete,
+                                onPressRetry,
+                                parentEditDraftCallbacks,
+                                parentPost,
+                                selectedPostId,
+                                setEditingPost,
+                              }}
+                            />
+                          </ScrollContextProvider>
                         ) : (
                           <CarouselPostScreenContent
                             flex={1}
@@ -627,8 +628,8 @@ function SinglePostView({
   const scrollerRef = useRef<{
     scrollToStart: (opts: { animated?: boolean }) => void;
     scrollToEnd: (opts: { animated?: boolean }) => void;
-    scrollToIndex: (params: {
-      index: number;
+    scrollToPost: (params: {
+      postId: string;
       animated?: boolean;
       viewPosition?: number;
     }) => void;
@@ -656,11 +657,12 @@ function SinglePostView({
   );
   const hasThreadUnreadActivity = hasUnreadActivity(liveThreadUnread);
 
-  const { data: threadPosts } = store.useThreadPosts({
-    postId: parentPost.id,
-    authorId: parentPost.authorId,
-    channelId: channel.id,
-  });
+  const { data: threadPosts, isLoading: isLoadingThreadPosts } =
+    store.useThreadPosts({
+      postId: parentPost.id,
+      authorId: parentPost.authorId,
+      channelId: channel.id,
+    });
 
   const posts = useMemo(() => {
     return parentPost ? [...(threadPosts ?? []), parentPost] : null;
@@ -703,9 +705,9 @@ function SinglePostView({
     if (isChatChannel && posts) {
       chatThreadHandleRef.current = {
         posts,
-        scrollToPostAtIndex: (index: number, viewPosition?: number) => {
-          scrollerRef.current?.scrollToIndex({
-            index,
+        scrollToPost: (postId: string, viewPosition?: number) => {
+          scrollerRef.current?.scrollToPost({
+            postId,
             animated: true,
             viewPosition,
           });
@@ -731,8 +733,8 @@ function SinglePostView({
   }, []);
 
   // Compute a ScrollAnchor from selectedPostId for chat threads.
-  // This wires into useAnchorScrollLock via Scroller, giving us retry/recovery
-  // for unmeasured items instead of a one-shot scrollToIndex.
+  // This wires into Scroller's anchor initialization, giving us retry/recovery
+  // for unmeasured items instead of a one-shot imperative scroll.
   const threadAnchor: ScrollAnchor | null = useMemo(() => {
     if (isChatChannel && selectedPostId) {
       return { type: 'selected', postId: selectedPostId };
@@ -761,13 +763,9 @@ function SinglePostView({
   }, [isChatChannel]);
   const scrollToNewReply = useCallback(() => {
     requestAnimationFrame(() => {
-      if (isChatChannel) {
-        scrollerRef.current?.scrollToStart({ animated: true });
-      } else {
-        scrollerRef.current?.scrollToEnd({ animated: true });
-      }
+      scrollerRef.current?.scrollToEnd({ animated: true });
     });
-  }, [isChatChannel]);
+  }, []);
 
   const hasLoadedReplies = !!(posts && channel && parentPost);
   // Only mark thread as read when user is actively using the app (not idle)
@@ -875,6 +873,7 @@ function SinglePostView({
             inspectContextLensPost={inspectContextLensPost}
             onOpenContextLens={openContextLensForPost}
             onGoToBotRun={onGoToBotRun}
+            isLoading={isLoadingThreadPosts}
           />
         ) : null}
 
@@ -1096,13 +1095,15 @@ function _CarouselPost({
 }: { channel: db.Channel; parentPost: db.Post } & ChannelContext) {
   return (
     <Carousel.Item flex={1}>
-      <SinglePostView
-        {...{
-          channel,
-          ...channelContext,
-          parentPost,
-        }}
-      />
+      <ScrollContextProvider>
+        <SinglePostView
+          {...{
+            channel,
+            ...channelContext,
+            parentPost,
+          }}
+        />
+      </ScrollContextProvider>
     </Carousel.Item>
   );
 }

--- a/packages/app/ui/components/postCollectionViews/ListPostCollectionView.tsx
+++ b/packages/app/ui/components/postCollectionViews/ListPostCollectionView.tsx
@@ -23,12 +23,13 @@ import { useShouldShowThinkingState } from '../Channel/useShouldShowThinkingStat
 import { IPostCollectionView } from './shared';
 
 interface ScrollerHandle {
-  scrollToIndex: (params: {
-    index: number;
+  scrollToPost: (params: {
+    postId: string;
     animated?: boolean;
     viewPosition?: number;
   }) => void;
   scrollToStart: (params: { animated?: boolean }) => void;
+  scrollToEnd: (params: { animated?: boolean }) => void;
 }
 
 export const ListPostCollection: IPostCollectionView = forwardRef(
@@ -45,6 +46,12 @@ export const ListPostCollection: IPostCollectionView = forwardRef(
     const collectionLayout = useMemo(
       () => layoutForType(collectionLayoutType),
       [collectionLayoutType]
+    );
+    const anchorToEnd = collectionLayout.scrollDirection === 'bottom-to-top';
+    const renderOrderedPosts = useMemo(
+      () =>
+        ctx.posts && anchorToEnd ? [...ctx.posts].reverse() : ctx.posts ?? null,
+      [anchorToEnd, ctx.posts]
     );
     const listBottomComponent = useMemo(
       () =>
@@ -104,15 +111,22 @@ export const ListPostCollection: IPostCollectionView = forwardRef(
     }, []);
 
     useImperativeHandle(forwardedRef, () => ({
-      scrollToPostAtIndex(index: number, viewPosition?: number) {
-        scrollerRef.current?.scrollToIndex({
-          index,
+      scrollToPost(postId: string, viewPosition?: number) {
+        scrollerRef.current?.scrollToPost({
+          postId,
           animated: false,
           viewPosition,
         });
       },
       scrollToStart(opts: { animated?: boolean }) {
         scrollerRef.current?.scrollToStart(opts);
+      },
+      scrollToLatest(opts: { animated?: boolean }) {
+        if (anchorToEnd) {
+          scrollerRef.current?.scrollToEnd(opts);
+        } else {
+          scrollerRef.current?.scrollToStart(opts);
+        }
       },
       highlightPost(postId: string) {
         if (highlightTimerRef.current) clearTimeout(highlightTimerRef.current);
@@ -150,12 +164,11 @@ export const ListPostCollection: IPostCollectionView = forwardRef(
     ]);
     return (
       <Scroller
-        key={scrollerAnchor?.postId}
-        inverted={collectionLayout.scrollDirection === 'bottom-to-top'}
+        anchorToEnd={anchorToEnd}
         renderItem={ctx.LegacyPostView}
         renderEmptyComponent={renderEmptyComponent}
         anchor={scrollerAnchor}
-        posts={ctx.posts ?? null}
+        posts={renderOrderedPosts}
         hasNewerPosts={ctx.hasNewerPosts}
         hasOlderPosts={ctx.hasOlderPosts}
         editingPost={ctx.editingPost}
@@ -175,8 +188,10 @@ export const ListPostCollection: IPostCollectionView = forwardRef(
         }
         onPressReplies={ctx.goToPost}
         onPressImage={ctx.goToMediaViewer}
-        onEndReached={ctx.onScrollEndReached}
-        onStartReached={ctx.onScrollStartReached}
+        onEndReached={anchorToEnd ? ctx.onLoadNewerPosts : ctx.onLoadOlderPosts}
+        onStartReached={
+          anchorToEnd ? ctx.onLoadOlderPosts : ctx.onLoadNewerPosts
+        }
         onPressRetry={ctx.onPressRetrySend}
         onPressDelete={ctx.onPressDelete}
         activeMessage={activeMessage}

--- a/packages/app/ui/components/postCollectionViews/types.ts
+++ b/packages/app/ui/components/postCollectionViews/types.ts
@@ -1,6 +1,7 @@
 export interface PostCollectionHandle {
-  scrollToPostAtIndex?: (index: number, viewPosition?: number) => void;
+  scrollToPost?: (postId: string, viewPosition?: number) => void;
   scrollToStart?: (opts: { animated?: boolean }) => void;
+  scrollToLatest?: (opts: { animated?: boolean }) => void;
   highlightPost?: (postId: string) => void;
 }
 

--- a/packages/app/ui/contexts/postCollection.ts
+++ b/packages/app/ui/contexts/postCollection.ts
@@ -22,8 +22,8 @@ export interface PostCollectionContextValue {
   onPressDelete: (post: db.Post) => void;
   onPressRetryLoad: () => void;
   onPressRetrySend: (post: db.Post) => Promise<void>;
-  onScrollEndReached?: () => void;
-  onScrollStartReached?: () => void;
+  onLoadNewerPosts?: () => void;
+  onLoadOlderPosts?: () => void;
   posts?: db.Post[];
   scrollToBottom?: () => void;
   selectedPostId?: string | null;

--- a/packages/app/ui/contexts/scroll.tsx
+++ b/packages/app/ui/contexts/scroll.tsx
@@ -29,9 +29,11 @@ export const useScrollContext = () => useContext(ScrollContext);
 export const useScrollDirectionTracker = ({
   setIsAtBottom: setIsAtBottomProp,
   atBottomThreshold = 1, // multiple of screen/viewport height
+  bottomAtEnd = false,
 }: {
   setIsAtBottom?: (isAtBottom: boolean) => void;
   atBottomThreshold?: number;
+  bottomAtEnd?: boolean;
 } = {}) => {
   const [scrollValue] = useScrollContext();
   const previousScrollValue = useSharedValue(0);
@@ -50,20 +52,31 @@ export const useScrollDirectionTracker = ({
 
   const scrollHandler = useAnimatedScrollHandler((event) => {
     const { y } = event.contentOffset;
+    const maxOffset = Math.max(
+      0,
+      event.contentSize.height -
+        event.layoutMeasurement.height +
+        (event.contentInset?.bottom ?? 0)
+    );
+    const distanceFromBottom = bottomAtEnd ? maxOffset - y : y;
 
-    if (y < 0 || y > event.contentSize.height) {
+    if (
+      distanceFromBottom < 0 ||
+      distanceFromBottom > event.contentSize.height
+    ) {
       return;
     }
 
     scrollValue.value = clamp(
-      scrollValue.value + (y - previousScrollValue.value) / 200,
+      scrollValue.value +
+        (distanceFromBottom - previousScrollValue.value) / 200,
       0,
       1
     );
 
-    previousScrollValue.value = y;
+    previousScrollValue.value = distanceFromBottom;
 
-    const atBottom = y <= AT_BOTTOM_THRESHOLD;
+    const atBottom = distanceFromBottom <= AT_BOTTOM_THRESHOLD;
 
     if (previousAtBottom.value !== atBottom) {
       previousAtBottom.value = atBottom;

--- a/packages/shared/src/store/useChannelPosts/queries.test.ts
+++ b/packages/shared/src/store/useChannelPosts/queries.test.ts
@@ -3,7 +3,7 @@ import { afterEach, describe, expect, it } from 'vitest';
 import * as db from '../../db';
 import { getLatestChannelPostsInitialPage, queryKeyPrefix } from './queries';
 
-type TestPageParam = { mode: string; cursorPostId?: string };
+type TestPageParam = { mode: string; cursorPostId?: string; count?: number };
 
 const data = (...entries: [string, TestPageParam][]) => ({
   pages: entries.map(([page]) => page),
@@ -17,15 +17,46 @@ describe('getLatestChannelPostsInitialPage', () => {
     db.queryClient.clear();
   });
 
-  it('returns data from the newest completed mount', () => {
+  it('returns the most recently completed matching data', () => {
     const queryKey = [...queryKeyPrefix, 'channel', undefined, false];
 
-    db.queryClient.setQueryData([...queryKey, 10], data(['older', newest]));
-    db.queryClient.setQueryData([...queryKey, 30], data(['newer', newest]));
-    db.queryClient.setQueryData([...queryKey, 20], data(['middle', newest]));
+    db.queryClient.setQueryData([...queryKey, 30], data(['older', newest]), {
+      updatedAt: 10,
+    });
+    db.queryClient.setQueryData([...queryKey, 10], data(['newer', newest]), {
+      updatedAt: 30,
+    });
+    db.queryClient.setQueryData([...queryKey, 20], data(['middle', newest]), {
+      updatedAt: 20,
+    });
 
     expect(getLatestChannelPostsInitialPage(queryKey, newest)).toEqual(
       data(['newer', newest])
+    );
+  });
+
+  it('does not reuse an initial page with a different requested count', () => {
+    const queryKey = [...queryKeyPrefix, 'channel', 'first-unread', false];
+    const thirtyPosts = {
+      mode: 'around',
+      cursorPostId: 'first-unread',
+      count: 30,
+    };
+    const fiftyPosts = { ...thirtyPosts, count: 50 };
+
+    db.queryClient.setQueryData(
+      [...queryKey, 10],
+      data(['thirty', thirtyPosts]),
+      { updatedAt: 20 }
+    );
+    db.queryClient.setQueryData(
+      [...queryKey, 20],
+      data(['fifty', fiftyPosts]),
+      { updatedAt: 30 }
+    );
+
+    expect(getLatestChannelPostsInitialPage(queryKey, thirtyPosts)).toEqual(
+      data(['thirty', thirtyPosts])
     );
   });
 

--- a/packages/shared/src/store/useChannelPosts/queries.test.ts
+++ b/packages/shared/src/store/useChannelPosts/queries.test.ts
@@ -5,8 +5,11 @@ import { getLatestChannelPostsInitialPage, queryKeyPrefix } from './queries';
 
 type TestPageParam = { mode: string; cursorPostId?: string; count?: number };
 
-const data = (...entries: [string, TestPageParam][]) => ({
-  pages: entries.map(([page]) => page),
+const data = (...entries: [string, TestPageParam, number?][]) => ({
+  pages: entries.map(([label, _pageParam, fetchedAt = 0]) => ({
+    label,
+    fetchedAt,
+  })),
   pageParams: entries.map(([, pageParam]) => pageParam),
 });
 
@@ -20,18 +23,15 @@ describe('getLatestChannelPostsInitialPage', () => {
   it('returns the most recently completed matching data', () => {
     const queryKey = [...queryKeyPrefix, 'channel', undefined, false];
 
-    db.queryClient.setQueryData([...queryKey, 30], data(['older', newest]), {
-      updatedAt: 10,
-    });
-    db.queryClient.setQueryData([...queryKey, 10], data(['newer', newest]), {
-      updatedAt: 30,
-    });
-    db.queryClient.setQueryData([...queryKey, 20], data(['middle', newest]), {
-      updatedAt: 20,
-    });
+    db.queryClient.setQueryData([...queryKey, 30], data(['older', newest, 10]));
+    db.queryClient.setQueryData([...queryKey, 10], data(['newer', newest, 30]));
+    db.queryClient.setQueryData(
+      [...queryKey, 20],
+      data(['middle', newest, 20])
+    );
 
     expect(getLatestChannelPostsInitialPage(queryKey, newest)).toEqual(
-      data(['newer', newest])
+      data(['newer', newest, 30])
     );
   });
 
@@ -46,17 +46,37 @@ describe('getLatestChannelPostsInitialPage', () => {
 
     db.queryClient.setQueryData(
       [...queryKey, 10],
-      data(['thirty', thirtyPosts]),
+      data(['thirty', thirtyPosts, 20]),
       { updatedAt: 20 }
     );
     db.queryClient.setQueryData(
       [...queryKey, 20],
-      data(['fifty', fiftyPosts]),
+      data(['fifty', fiftyPosts, 30]),
       { updatedAt: 30 }
     );
 
     expect(getLatestChannelPostsInitialPage(queryKey, thirtyPosts)).toEqual(
-      data(['thirty', thirtyPosts])
+      data(['thirty', thirtyPosts, 20])
+    );
+  });
+
+  it('does not treat pagination as a fresher initial page', () => {
+    const queryKey = [...queryKeyPrefix, 'channel', undefined, false];
+    const older = { mode: 'older' };
+
+    db.queryClient.setQueryData(
+      [...queryKey, 10],
+      data(['stale-initial', newest, 10], ['fresh-pagination', older, 40]),
+      { updatedAt: 40 }
+    );
+    db.queryClient.setQueryData(
+      [...queryKey, 20],
+      data(['fresh-initial', newest, 30]),
+      { updatedAt: 30 }
+    );
+
+    expect(getLatestChannelPostsInitialPage(queryKey, newest)).toEqual(
+      data(['fresh-initial', newest, 30])
     );
   });
 

--- a/packages/shared/src/store/useChannelPosts/queries.test.ts
+++ b/packages/shared/src/store/useChannelPosts/queries.test.ts
@@ -1,9 +1,14 @@
 import { afterEach, describe, expect, it } from 'vitest';
 
 import * as db from '../../db';
-import { getLatestChannelPostsQueryData, queryKeyPrefix } from './queries';
+import { getLatestChannelPostsFirstPage, queryKeyPrefix } from './queries';
 
-describe('getLatestChannelPostsQueryData', () => {
+const data = (...pages: string[]) => ({
+  pages,
+  pageParams: pages.map((_, index) => index),
+});
+
+describe('getLatestChannelPostsFirstPage', () => {
   afterEach(() => {
     db.queryClient.clear();
   });
@@ -11,11 +16,19 @@ describe('getLatestChannelPostsQueryData', () => {
   it('returns data from the newest completed mount', () => {
     const queryKey = [...queryKeyPrefix, 'channel', undefined, false];
 
-    db.queryClient.setQueryData([...queryKey, 10], 'older');
-    db.queryClient.setQueryData([...queryKey, 30], 'newer');
-    db.queryClient.setQueryData([...queryKey, 20], 'middle');
+    db.queryClient.setQueryData([...queryKey, 10], data('older'));
+    db.queryClient.setQueryData([...queryKey, 30], data('newer'));
+    db.queryClient.setQueryData([...queryKey, 20], data('middle'));
 
-    expect(getLatestChannelPostsQueryData(queryKey)).toBe('newer');
+    expect(getLatestChannelPostsFirstPage(queryKey)).toEqual(data('newer'));
+  });
+
+  it('only reuses the first page', () => {
+    const queryKey = [...queryKeyPrefix, 'channel', undefined, false];
+
+    db.queryClient.setQueryData([...queryKey, 10], data('initial', 'older'));
+
+    expect(getLatestChannelPostsFirstPage(queryKey)).toEqual(data('initial'));
   });
 
   it('does not reuse data from another cursor', () => {
@@ -28,22 +41,24 @@ describe('getLatestChannelPostsQueryData', () => {
 
     db.queryClient.setQueryData(
       [...queryKeyPrefix, 'channel', undefined, false, 30],
-      'latest'
+      data('latest')
     );
-    db.queryClient.setQueryData([...unreadQueryKey, 20], 'unread');
+    db.queryClient.setQueryData([...unreadQueryKey, 20], data('unread'));
 
-    expect(getLatestChannelPostsQueryData(unreadQueryKey)).toBe('unread');
+    expect(getLatestChannelPostsFirstPage(unreadQueryKey)).toEqual(
+      data('unread')
+    );
   });
 
   it('ignores incomplete mounts and non-mount descendants', () => {
     const queryKey = [...queryKeyPrefix, 'channel', undefined, false];
 
-    db.queryClient.setQueryData([...queryKey, 10], 'complete');
+    db.queryClient.setQueryData([...queryKey, 10], data('complete'));
     db.queryClient
       .getQueryCache()
       .build(db.queryClient, { queryKey: [...queryKey, 30] });
-    db.queryClient.setQueryData([...queryKey, 40, 'extra'], 'nested');
+    db.queryClient.setQueryData([...queryKey, 40, 'extra'], data('nested'));
 
-    expect(getLatestChannelPostsQueryData(queryKey)).toBe('complete');
+    expect(getLatestChannelPostsFirstPage(queryKey)).toEqual(data('complete'));
   });
 });

--- a/packages/shared/src/store/useChannelPosts/queries.test.ts
+++ b/packages/shared/src/store/useChannelPosts/queries.test.ts
@@ -1,0 +1,49 @@
+import { afterEach, describe, expect, it } from 'vitest';
+
+import * as db from '../../db';
+import { getLatestChannelPostsQueryData, queryKeyPrefix } from './queries';
+
+describe('getLatestChannelPostsQueryData', () => {
+  afterEach(() => {
+    db.queryClient.clear();
+  });
+
+  it('returns data from the newest completed mount', () => {
+    const queryKey = [...queryKeyPrefix, 'channel', undefined, false];
+
+    db.queryClient.setQueryData([...queryKey, 10], 'older');
+    db.queryClient.setQueryData([...queryKey, 30], 'newer');
+    db.queryClient.setQueryData([...queryKey, 20], 'middle');
+
+    expect(getLatestChannelPostsQueryData(queryKey)).toBe('newer');
+  });
+
+  it('does not reuse data from another cursor', () => {
+    const unreadQueryKey = [
+      ...queryKeyPrefix,
+      'channel',
+      'first-unread',
+      false,
+    ];
+
+    db.queryClient.setQueryData(
+      [...queryKeyPrefix, 'channel', undefined, false, 30],
+      'latest'
+    );
+    db.queryClient.setQueryData([...unreadQueryKey, 20], 'unread');
+
+    expect(getLatestChannelPostsQueryData(unreadQueryKey)).toBe('unread');
+  });
+
+  it('ignores incomplete mounts and non-mount descendants', () => {
+    const queryKey = [...queryKeyPrefix, 'channel', undefined, false];
+
+    db.queryClient.setQueryData([...queryKey, 10], 'complete');
+    db.queryClient
+      .getQueryCache()
+      .build(db.queryClient, { queryKey: [...queryKey, 30] });
+    db.queryClient.setQueryData([...queryKey, 40, 'extra'], 'nested');
+
+    expect(getLatestChannelPostsQueryData(queryKey)).toBe('complete');
+  });
+});

--- a/packages/shared/src/store/useChannelPosts/queries.test.ts
+++ b/packages/shared/src/store/useChannelPosts/queries.test.ts
@@ -1,14 +1,18 @@
 import { afterEach, describe, expect, it } from 'vitest';
 
 import * as db from '../../db';
-import { getLatestChannelPostsFirstPage, queryKeyPrefix } from './queries';
+import { getLatestChannelPostsInitialPage, queryKeyPrefix } from './queries';
 
-const data = (...pages: string[]) => ({
-  pages,
-  pageParams: pages.map((_, index) => index),
+type TestPageParam = { mode: string; cursorPostId?: string };
+
+const data = (...entries: [string, TestPageParam][]) => ({
+  pages: entries.map(([page]) => page),
+  pageParams: entries.map(([, pageParam]) => pageParam),
 });
 
-describe('getLatestChannelPostsFirstPage', () => {
+const newest = { mode: 'newest' };
+
+describe('getLatestChannelPostsInitialPage', () => {
   afterEach(() => {
     db.queryClient.clear();
   });
@@ -16,19 +20,28 @@ describe('getLatestChannelPostsFirstPage', () => {
   it('returns data from the newest completed mount', () => {
     const queryKey = [...queryKeyPrefix, 'channel', undefined, false];
 
-    db.queryClient.setQueryData([...queryKey, 10], data('older'));
-    db.queryClient.setQueryData([...queryKey, 30], data('newer'));
-    db.queryClient.setQueryData([...queryKey, 20], data('middle'));
+    db.queryClient.setQueryData([...queryKey, 10], data(['older', newest]));
+    db.queryClient.setQueryData([...queryKey, 30], data(['newer', newest]));
+    db.queryClient.setQueryData([...queryKey, 20], data(['middle', newest]));
 
-    expect(getLatestChannelPostsFirstPage(queryKey)).toEqual(data('newer'));
+    expect(getLatestChannelPostsInitialPage(queryKey, newest)).toEqual(
+      data(['newer', newest])
+    );
   });
 
-  it('only reuses the first page', () => {
+  it('reuses the original newest page after newer pages are prepended', () => {
     const queryKey = [...queryKeyPrefix, 'channel', undefined, false];
+    const newer = { mode: 'newer' };
+    const older = { mode: 'older' };
 
-    db.queryClient.setQueryData([...queryKey, 10], data('initial', 'older'));
+    db.queryClient.setQueryData(
+      [...queryKey, 10],
+      data(['newer', newer], ['initial', newest], ['older', older])
+    );
 
-    expect(getLatestChannelPostsFirstPage(queryKey)).toEqual(data('initial'));
+    expect(getLatestChannelPostsInitialPage(queryKey, newest)).toEqual(
+      data(['initial', newest])
+    );
   });
 
   it('does not reuse data from another cursor', () => {
@@ -39,26 +52,59 @@ describe('getLatestChannelPostsFirstPage', () => {
       false,
     ];
 
+    const unread = { mode: 'around', cursorPostId: 'first-unread' };
     db.queryClient.setQueryData(
       [...queryKeyPrefix, 'channel', undefined, false, 30],
-      data('latest')
+      data(['latest', newest])
     );
-    db.queryClient.setQueryData([...unreadQueryKey, 20], data('unread'));
+    db.queryClient.setQueryData(
+      [...unreadQueryKey, 20],
+      data(['unread', unread])
+    );
 
-    expect(getLatestChannelPostsFirstPage(unreadQueryKey)).toEqual(
-      data('unread')
+    expect(getLatestChannelPostsInitialPage(unreadQueryKey, unread)).toEqual(
+      data(['unread', unread])
+    );
+  });
+
+  it('preserves an around-cursor page after newer pages are prepended', () => {
+    const queryKey = [...queryKeyPrefix, 'channel', 'first-unread', false];
+    const newer = { mode: 'newer' };
+    const unread = { mode: 'around', cursorPostId: 'first-unread' };
+
+    db.queryClient.setQueryData(
+      [...queryKey, 10],
+      data(['newer', newer], ['unread', unread])
+    );
+
+    expect(getLatestChannelPostsInitialPage(queryKey, unread)).toEqual(
+      data(['unread', unread])
     );
   });
 
   it('ignores incomplete mounts and non-mount descendants', () => {
     const queryKey = [...queryKeyPrefix, 'channel', undefined, false];
 
-    db.queryClient.setQueryData([...queryKey, 10], data('complete'));
+    db.queryClient.setQueryData([...queryKey, 10], data(['complete', newest]));
     db.queryClient
       .getQueryCache()
       .build(db.queryClient, { queryKey: [...queryKey, 30] });
-    db.queryClient.setQueryData([...queryKey, 40, 'extra'], data('nested'));
+    db.queryClient.setQueryData(
+      [...queryKey, 40, 'extra'],
+      data(['nested', newest])
+    );
 
-    expect(getLatestChannelPostsFirstPage(queryKey)).toEqual(data('complete'));
+    expect(getLatestChannelPostsInitialPage(queryKey, newest)).toEqual(
+      data(['complete', newest])
+    );
+  });
+
+  it('does not substitute a different page when the initial page is absent', () => {
+    const queryKey = [...queryKeyPrefix, 'channel', undefined, false];
+    const newer = { mode: 'newer' };
+
+    db.queryClient.setQueryData([...queryKey, 10], data(['newer', newer]));
+
+    expect(getLatestChannelPostsInitialPage(queryKey, newest)).toBeUndefined();
   });
 });

--- a/packages/shared/src/store/useChannelPosts/queries.ts
+++ b/packages/shared/src/store/useChannelPosts/queries.ts
@@ -4,8 +4,12 @@ import * as db from '../../db';
 
 export const queryKeyPrefix = ['channelPosts'];
 
-export function getLatestChannelPostsFirstPage<TPage, TPageParam = unknown>(
-  queryKey: readonly unknown[]
+export function getLatestChannelPostsInitialPage<
+  TPage,
+  TPageParam extends { mode?: unknown; cursorPostId?: unknown },
+>(
+  queryKey: readonly unknown[],
+  initialPageParam: TPageParam
 ): InfiniteData<TPage, TPageParam> | undefined {
   let latestMountTime = -1;
   let latestData: InfiniteData<TPage, TPageParam> | undefined;
@@ -28,13 +32,27 @@ export function getLatestChannelPostsFirstPage<TPage, TPageParam = unknown>(
     }
   }
 
-  return latestData
-    ? {
-        ...latestData,
-        pages: latestData.pages.slice(0, 1),
-        pageParams: latestData.pageParams.slice(0, 1),
-      }
-    : undefined;
+  if (!latestData) {
+    return undefined;
+  }
+
+  const initialPageIndex = latestData.pageParams.findIndex(
+    (pageParam) =>
+      pageParam.mode === initialPageParam.mode &&
+      pageParam.cursorPostId === initialPageParam.cursorPostId
+  );
+  if (initialPageIndex === -1) {
+    return undefined;
+  }
+
+  return {
+    ...latestData,
+    pages: latestData.pages.slice(initialPageIndex, initialPageIndex + 1),
+    pageParams: latestData.pageParams.slice(
+      initialPageIndex,
+      initialPageIndex + 1
+    ),
+  };
 }
 
 export const clearChannelPostsQueries = () => {

--- a/packages/shared/src/store/useChannelPosts/queries.ts
+++ b/packages/shared/src/store/useChannelPosts/queries.ts
@@ -2,6 +2,33 @@ import * as db from '../../db';
 
 export const queryKeyPrefix = ['channelPosts'];
 
+export function getLatestChannelPostsQueryData<T>(
+  queryKey: readonly unknown[]
+): T | undefined {
+  let latestMountTime = -1;
+  let latestData: T | undefined;
+
+  for (const query of db.queryClient
+    .getQueryCache()
+    .findAll({ queryKey, exact: false })) {
+    if (query.queryKey.length !== queryKey.length + 1) {
+      continue;
+    }
+
+    const mountTime = query.queryKey.at(-1);
+    if (
+      typeof mountTime === 'number' &&
+      mountTime > latestMountTime &&
+      query.state.data !== undefined
+    ) {
+      latestMountTime = mountTime;
+      latestData = query.state.data as T;
+    }
+  }
+
+  return latestData;
+}
+
 export const clearChannelPostsQueries = () => {
   db.queryClient.invalidateQueries({ queryKey: queryKeyPrefix });
 };

--- a/packages/shared/src/store/useChannelPosts/queries.ts
+++ b/packages/shared/src/store/useChannelPosts/queries.ts
@@ -5,7 +5,7 @@ import * as db from '../../db';
 export const queryKeyPrefix = ['channelPosts'];
 
 export function getLatestChannelPostsInitialPage<
-  TPage,
+  TPage extends { fetchedAt: number },
   TPageParam extends {
     mode?: unknown;
     cursorPostId?: unknown;
@@ -15,7 +15,7 @@ export function getLatestChannelPostsInitialPage<
   queryKey: readonly unknown[],
   initialPageParam: TPageParam
 ): InfiniteData<TPage, TPageParam> | undefined {
-  let latestDataUpdatedAt = -1;
+  let latestPageFetchedAt = -1;
   let latestData: InfiniteData<TPage, TPageParam> | undefined;
   let latestInitialPageIndex = -1;
 
@@ -39,9 +39,9 @@ export function getLatestChannelPostsInitialPage<
     );
     if (
       initialPageIndex !== -1 &&
-      query.state.dataUpdatedAt > latestDataUpdatedAt
+      data.pages[initialPageIndex].fetchedAt > latestPageFetchedAt
     ) {
-      latestDataUpdatedAt = query.state.dataUpdatedAt;
+      latestPageFetchedAt = data.pages[initialPageIndex].fetchedAt;
       latestData = data;
       latestInitialPageIndex = initialPageIndex;
     }

--- a/packages/shared/src/store/useChannelPosts/queries.ts
+++ b/packages/shared/src/store/useChannelPosts/queries.ts
@@ -6,13 +6,18 @@ export const queryKeyPrefix = ['channelPosts'];
 
 export function getLatestChannelPostsInitialPage<
   TPage,
-  TPageParam extends { mode?: unknown; cursorPostId?: unknown },
+  TPageParam extends {
+    mode?: unknown;
+    cursorPostId?: unknown;
+    count?: unknown;
+  },
 >(
   queryKey: readonly unknown[],
   initialPageParam: TPageParam
 ): InfiniteData<TPage, TPageParam> | undefined {
-  let latestMountTime = -1;
+  let latestDataUpdatedAt = -1;
   let latestData: InfiniteData<TPage, TPageParam> | undefined;
+  let latestInitialPageIndex = -1;
 
   for (const query of db.queryClient
     .getQueryCache()
@@ -21,14 +26,24 @@ export function getLatestChannelPostsInitialPage<
       continue;
     }
 
-    const mountTime = query.queryKey.at(-1);
+    if (query.state.data === undefined) {
+      continue;
+    }
+
+    const data = query.state.data as InfiniteData<TPage, TPageParam>;
+    const initialPageIndex = data.pageParams.findIndex(
+      (pageParam) =>
+        pageParam.mode === initialPageParam.mode &&
+        pageParam.cursorPostId === initialPageParam.cursorPostId &&
+        pageParam.count === initialPageParam.count
+    );
     if (
-      typeof mountTime === 'number' &&
-      mountTime > latestMountTime &&
-      query.state.data !== undefined
+      initialPageIndex !== -1 &&
+      query.state.dataUpdatedAt > latestDataUpdatedAt
     ) {
-      latestMountTime = mountTime;
-      latestData = query.state.data as InfiniteData<TPage, TPageParam>;
+      latestDataUpdatedAt = query.state.dataUpdatedAt;
+      latestData = data;
+      latestInitialPageIndex = initialPageIndex;
     }
   }
 
@@ -36,21 +51,15 @@ export function getLatestChannelPostsInitialPage<
     return undefined;
   }
 
-  const initialPageIndex = latestData.pageParams.findIndex(
-    (pageParam) =>
-      pageParam.mode === initialPageParam.mode &&
-      pageParam.cursorPostId === initialPageParam.cursorPostId
-  );
-  if (initialPageIndex === -1) {
-    return undefined;
-  }
-
   return {
     ...latestData,
-    pages: latestData.pages.slice(initialPageIndex, initialPageIndex + 1),
+    pages: latestData.pages.slice(
+      latestInitialPageIndex,
+      latestInitialPageIndex + 1
+    ),
     pageParams: latestData.pageParams.slice(
-      initialPageIndex,
-      initialPageIndex + 1
+      latestInitialPageIndex,
+      latestInitialPageIndex + 1
     ),
   };
 }

--- a/packages/shared/src/store/useChannelPosts/queries.ts
+++ b/packages/shared/src/store/useChannelPosts/queries.ts
@@ -1,12 +1,14 @@
+import type { InfiniteData } from '@tanstack/react-query';
+
 import * as db from '../../db';
 
 export const queryKeyPrefix = ['channelPosts'];
 
-export function getLatestChannelPostsQueryData<T>(
+export function getLatestChannelPostsFirstPage<TPage, TPageParam = unknown>(
   queryKey: readonly unknown[]
-): T | undefined {
+): InfiniteData<TPage, TPageParam> | undefined {
   let latestMountTime = -1;
-  let latestData: T | undefined;
+  let latestData: InfiniteData<TPage, TPageParam> | undefined;
 
   for (const query of db.queryClient
     .getQueryCache()
@@ -22,11 +24,17 @@ export function getLatestChannelPostsQueryData<T>(
       query.state.data !== undefined
     ) {
       latestMountTime = mountTime;
-      latestData = query.state.data as T;
+      latestData = query.state.data as InfiniteData<TPage, TPageParam>;
     }
   }
 
-  return latestData;
+  return latestData
+    ? {
+        ...latestData,
+        pages: latestData.pages.slice(0, 1),
+        pageParams: latestData.pageParams.slice(0, 1),
+      }
+    : undefined;
 }
 
 export const clearChannelPostsQueries = () => {

--- a/packages/shared/src/store/useChannelPosts/useChannelPosts.ts
+++ b/packages/shared/src/store/useChannelPosts/useChannelPosts.ts
@@ -16,7 +16,7 @@ import * as sync from '../sync';
 import { SyncPriority } from '../syncQueue';
 import { useDetectSequenceRegression } from '../useDetectSequenceRegression';
 import { mergePendingPosts } from '../useMergePendingPosts';
-import { queryKeyPrefix } from './queries';
+import { getLatestChannelPostsQueryData, queryKeyPrefix } from './queries';
 import { useDeletedPosts, useNewPostListener } from './subscriptions';
 
 const postsLogger = createDevLogger('useChannelPosts', false);
@@ -49,15 +49,25 @@ export const useChannelPosts = (options: UseChannelPostsParams) => {
 
   const { enabled } = options;
 
-  const queryKey = useMemo(
+  const queryKeyWithoutMountTime = useMemo(
     () => [
       ...queryKeyPrefix,
       options.channelId,
       options.cursorPostId,
       options.filterDeleted,
-      mountTime,
     ],
-    [options.channelId, options.cursorPostId, options.filterDeleted, mountTime]
+    [options.channelId, options.cursorPostId, options.filterDeleted]
+  );
+
+  const queryKey = useMemo(
+    () => [...queryKeyWithoutMountTime, mountTime],
+    [queryKeyWithoutMountTime, mountTime]
+  );
+
+  const placeholderData = useMemo(
+    () =>
+      getLatestChannelPostsQueryData<PostQueryData>(queryKeyWithoutMountTime),
+    [queryKeyWithoutMountTime]
   );
 
   const initialPageParam = useMemo(() => {
@@ -86,6 +96,7 @@ export const useChannelPosts = (options: UseChannelPostsParams) => {
   const query = useInfiniteQuery({
     enabled,
     initialPageParam,
+    placeholderData,
     refetchOnMount: false,
     retry(failureCount, error) {
       postsLogger.trackError('failed to load posts', error);
@@ -97,7 +108,8 @@ export const useChannelPosts = (options: UseChannelPostsParams) => {
     retryDelay: () => 500,
     queryFn: async (ctx): Promise<PostQueryPage> => {
       const queryOptions = await normalizeCursor(
-        ctx.pageParam || initialPageParam
+        (ctx.pageParam as UseChannelPostsPageParams | undefined) ??
+          initialPageParam
       );
 
       const posts = await getLocalFirstPosts(queryOptions);
@@ -391,9 +403,14 @@ function useTrackReady(
   const hasEnoughPosts = postsLength > 30;
   const isLoading = query.isLoading || query.isPending;
   const canLoadMore = query.hasNextPage || query.hasPreviousPage;
+  const hasResolvedCurrentQuery = !query.isPlaceholderData;
 
   useEffect(() => {
-    if (!alreadyTracked && (hasEnoughPosts || (!isLoading && !canLoadMore))) {
+    if (
+      !alreadyTracked &&
+      hasResolvedCurrentQuery &&
+      (hasEnoughPosts || (!isLoading && !canLoadMore))
+    ) {
       loadTracked.current = true;
       postsLogger.trackEvent(AnalyticsEvent.ChannelLoadComplete, {
         channelType: getChannelIdType(channelId),
@@ -405,6 +422,7 @@ function useTrackReady(
     canLoadMore,
     channelId,
     hasEnoughPosts,
+    hasResolvedCurrentQuery,
     isLoading,
     postsLength,
   ]);

--- a/packages/shared/src/store/useChannelPosts/useChannelPosts.ts
+++ b/packages/shared/src/store/useChannelPosts/useChannelPosts.ts
@@ -72,7 +72,13 @@ export const useChannelPosts = (options: UseChannelPostsParams) => {
       mode: options.mode ?? 'newest',
       filterDeleted: options.filterDeleted ?? false,
     } as UseChannelPostsPageParams;
-  }, [options]);
+  }, [
+    options.channelId,
+    options.cursorPostId,
+    options.filterDeleted,
+    options.firstPageCount,
+    options.mode,
+  ]);
 
   const placeholderData = useMemo(
     () =>

--- a/packages/shared/src/store/useChannelPosts/useChannelPosts.ts
+++ b/packages/shared/src/store/useChannelPosts/useChannelPosts.ts
@@ -23,6 +23,8 @@ const postsLogger = createDevLogger('useChannelPosts', false);
 
 type PostQueryPage = {
   posts: db.Post[];
+  /** Completion time for this page, independent of later pagination. */
+  fetchedAt: number;
   /**
    * False when a sync page reports that there are no more newer posts.
    * Obviously, new posts can be made after this is set: in practice, we
@@ -129,6 +131,7 @@ export const useChannelPosts = (options: UseChannelPostsParams) => {
 
       return {
         posts,
+        fetchedAt: Date.now(),
         canFetchNewerPosts,
       };
     },

--- a/packages/shared/src/store/useChannelPosts/useChannelPosts.ts
+++ b/packages/shared/src/store/useChannelPosts/useChannelPosts.ts
@@ -16,7 +16,7 @@ import * as sync from '../sync';
 import { SyncPriority } from '../syncQueue';
 import { useDetectSequenceRegression } from '../useDetectSequenceRegression';
 import { mergePendingPosts } from '../useMergePendingPosts';
-import { getLatestChannelPostsFirstPage, queryKeyPrefix } from './queries';
+import { getLatestChannelPostsInitialPage, queryKeyPrefix } from './queries';
 import { useDeletedPosts, useNewPostListener } from './subscriptions';
 
 const postsLogger = createDevLogger('useChannelPosts', false);
@@ -64,12 +64,6 @@ export const useChannelPosts = (options: UseChannelPostsParams) => {
     [queryKeyWithoutMountTime, mountTime]
   );
 
-  const placeholderData = useMemo(
-    () =>
-      getLatestChannelPostsFirstPage<PostQueryPage>(queryKeyWithoutMountTime),
-    [queryKeyWithoutMountTime]
-  );
-
   const initialPageParam = useMemo(() => {
     return {
       count: options.firstPageCount,
@@ -79,6 +73,15 @@ export const useChannelPosts = (options: UseChannelPostsParams) => {
       filterDeleted: options.filterDeleted ?? false,
     } as UseChannelPostsPageParams;
   }, [options]);
+
+  const placeholderData = useMemo(
+    () =>
+      getLatestChannelPostsInitialPage<PostQueryPage, PageParam>(
+        queryKeyWithoutMountTime,
+        initialPageParam
+      ),
+    [initialPageParam, queryKeyWithoutMountTime]
+  );
 
   const abortControllerRef = useRef<AbortController | null>(
     new AbortController()

--- a/packages/shared/src/store/useChannelPosts/useChannelPosts.ts
+++ b/packages/shared/src/store/useChannelPosts/useChannelPosts.ts
@@ -16,7 +16,7 @@ import * as sync from '../sync';
 import { SyncPriority } from '../syncQueue';
 import { useDetectSequenceRegression } from '../useDetectSequenceRegression';
 import { mergePendingPosts } from '../useMergePendingPosts';
-import { getLatestChannelPostsQueryData, queryKeyPrefix } from './queries';
+import { getLatestChannelPostsFirstPage, queryKeyPrefix } from './queries';
 import { useDeletedPosts, useNewPostListener } from './subscriptions';
 
 const postsLogger = createDevLogger('useChannelPosts', false);
@@ -66,7 +66,7 @@ export const useChannelPosts = (options: UseChannelPostsParams) => {
 
   const placeholderData = useMemo(
     () =>
-      getLatestChannelPostsQueryData<PostQueryData>(queryKeyWithoutMountTime),
+      getLatestChannelPostsFirstPage<PostQueryPage>(queryKeyWithoutMountTime),
     [queryKeyWithoutMountTime]
   );
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1028,6 +1028,9 @@ importers:
       '@emoji-mart/data':
         specifier: ^1.1.2
         version: 1.1.2
+      '@legendapp/list':
+        specifier: 3.3.3
+        version: 3.3.3(react-dom@19.2.3(react@19.2.3))(react-native@0.86.0(@react-native/jest-preset@0.86.0(@babel/core@7.29.0)(react@19.2.3))(@react-native/metro-config@0.86.0)(@types/react@19.2.17)(react@19.2.3))(react@19.2.3)
       '@mattermost/react-native-paste-input':
         specifier: 2.0.1
         version: 2.0.1(patch_hash=313cd7a4e43eaaa79e0a2d2c03a592d1814b7ca83b5f8d6fec9c4603c4ac323d)(react-native@0.86.0(@react-native/jest-preset@0.86.0(@babel/core@7.29.0)(react@19.2.3))(@react-native/metro-config@0.86.0)(@types/react@19.2.17)(react@19.2.3))(react@19.2.3)
@@ -3390,6 +3393,18 @@ packages:
 
   '@jridgewell/trace-mapping@0.3.31':
     resolution: {integrity: sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==}
+
+  '@legendapp/list@3.3.3':
+    resolution: {integrity: sha512-p3g4xG6f//s4XQKhuus2189GCQgOHEIbJXHePqeDxj+6UQQQyij4YBjyArNSCgqoP0c03sxDPSOuCFB128Ql6g==}
+    peerDependencies:
+      react: 19.2.3
+      react-dom: '*'
+      react-native: '*'
+    peerDependenciesMeta:
+      react-dom:
+        optional: true
+      react-native:
+        optional: true
 
   '@lydell/node-pty-darwin-arm64@1.2.0-beta.12':
     resolution: {integrity: sha512-tqaifcY9Cr41SblO1+FLzh8oxxtkNhuW9Dhl22lKme9BreYvKvxEZcdPIXTuqkJc5tagOEC4QHShKmJjLyLXLQ==}
@@ -16682,6 +16697,14 @@ snapshots:
     dependencies:
       '@jridgewell/resolve-uri': 3.1.2
       '@jridgewell/sourcemap-codec': 1.5.5
+
+  '@legendapp/list@3.3.3(react-dom@19.2.3(react@19.2.3))(react-native@0.86.0(@react-native/jest-preset@0.86.0(@babel/core@7.29.0)(react@19.2.3))(@react-native/metro-config@0.86.0)(@types/react@19.2.17)(react@19.2.3))(react@19.2.3)':
+    dependencies:
+      react: 19.2.3
+      use-sync-external-store: 1.6.0(react@19.2.3)
+    optionalDependencies:
+      react-dom: 19.2.3(react@19.2.3)
+      react-native: 0.86.0(@react-native/jest-preset@0.86.0(@babel/core@7.29.0)(react@19.2.3))(@react-native/metro-config@0.86.0)(@types/react@19.2.17)(react@19.2.3)
 
   '@lydell/node-pty-darwin-arm64@1.2.0-beta.12':
     optional: true


### PR DESCRIPTION
## Summary

Builds on #6215 to render conversation data in visual top-to-bottom order and use LegendList for native conversations. This removes inverted-scroll coordinates while preserving the existing conversation header, composer, and other chrome.

Web and non-conversation collection layouts keep their existing renderers and scroll behavior.

## Changes

### Platform and layout split

| Condition | Renderer |
| --- | --- |
| Native conversation | LegendList |
| Web single-column view | DOM scroller |
| Everything else | Shared FlatList |

All renderers stay behind the same PostList interface. Scroller now supplies posts in visual order and uses visual start/end terms consistently: older posts load above and newer posts load below.

### Scroll initialization

- snapshot unread state before loading posts so marking a channel read cannot move its initial divider
- prefer an explicitly selected post, then the first unread post, then the latest position
- keep the last matching initial query page visible while an around-cursor query remounts
- model anchor resolution as waiting, ready, or fallback; channel and resolution changes create a fresh positioning attempt
- mount near the target from estimated row sizes, then apply the exact non-animated position after LegendList has had two layout frames to measure rows
- place unread markers at the visual top below the header, center selected posts, and pin latest/short conversations to the visual bottom
- keep correcting for late row-size changes until the user starts scrolling, then stop moving the viewport
- hide the list and pause boundary pagination until initial positioning completes
- fall back to newest posts only when the around-cursor query fails or a settled query still cannot resolve its anchor

### Supporting changes

- preserve the correct initial query page after older or newer pagination has changed page order
- expose scroll-to-post by post ID so callers do not depend on renderer-specific indices
- make scroll-to-bottom and pagination use visual coordinates instead of inverted-list coordinates
- reveal settled empty conversations without creating a fake scroll target

## How did I test?

- app TypeScript
- shared TypeScript
- ESLint on the touched app files: 0 errors
- post-list initialization tests: 8 passed
- channel-post query tests: 3 passed
- iOS device and simulator: unread entry and re-entry, selected/latest entry, constrained unread placement, dynamic row sizing, true top/bottom boundaries, and switching between unread channels
- Android emulator: varied content types and unread counts, initial anchoring, pagination, and content-size changes near the anchor
