### PR TITLE
groups: delete the dead plural ui/groups scries

### DIFF
--- a/desk/app/groups.hoon
+++ b/desk/app/groups.hoon
@@ -108,6 +108,11 @@
       [/x/v2/groups/$/$/channels/$/$/$/writers %ships]
       [/x/groups/$/$/seats/$ %noun]
     ::
+      [/x/groups/light %groups]
+      [/x/v0/light/groups %groups]
+      [/x/v1/light/groups %groups-1]
+      [/x/v2/light/groups %groups-2]
+    ::
       [/x/v0/ui/groups/$/$ %group-ui]
       [/x/v1/ui/groups/$/$ %group-ui-1]
       [/x/v2/ui/groups/$/$ %group-ui-2]
@@ -1297,8 +1302,21 @@
         %v3  ``groups-3+groups-11
     ==
   ::
+      [%x ver=?(%v0 %v1 %v2) %light %groups ~]
+    =/  groups-9=groups:v9:gv
+      %-  ~(run by groups)
+      |=  [=net:g =group:g]
+      (v9:group:v11:gc (drop-seats:group:v11:gc group our.bowl))
+    ?-    ver.pole
+        %v0  ``groups+(~(run by groups-9) v2:group:v9:gc)
+        %v1  ``groups-1+(~(run by groups-9) v5:group:v9:gc)
+        %v2  ``groups-2+groups-9
+    ==
+  ::
     ::  deprecated
     [%x %groups ~]  $(pole /x/v0/groups)
+    ::  deprecated
+    [%x %groups %light ~]  $(pole /x/v0/light/groups)
   ::
       [%x %v1 %changes since=@ rest=*]
     =+  since=(slav %da since.pole)

--- a/desk/app/groups.hoon
+++ b/desk/app/groups.hoon
@@ -108,15 +108,6 @@
       [/x/v2/groups/$/$/channels/$/$/$/writers %ships]
       [/x/groups/$/$/seats/$ %noun]
     ::
-      [/x/groups/light %groups]
-      [/x/v0/light/groups %groups]
-      [/x/v1/light/groups %groups-1]
-      [/x/v2/light/groups %groups-2]
-    ::
-      [/x/v0/ui/groups %groups-ui]
-      [/x/v1/ui/groups %groups-ui-1]
-      [/x/v2/ui/groups %groups-ui-2]
-    ::
       [/x/v0/ui/groups/$/$ %group-ui]
       [/x/v1/ui/groups/$/$ %group-ui-1]
       [/x/v2/ui/groups/$/$ %group-ui-2]
@@ -1306,35 +1297,8 @@
         %v3  ``groups-3+groups-11
     ==
   ::
-      [%x ver=?(%v0 %v1 %v2) %light %groups ~]
-    =/  groups-9=groups:v9:gv
-      %-  ~(run by groups)
-      |=  [=net:g =group:g]
-      (v9:group:v11:gc (drop-seats:group:v11:gc group our.bowl))
-    ?-    ver.pole
-        %v0  ``groups+(~(run by groups-9) v2:group:v9:gc)
-        %v1  ``groups-1+(~(run by groups-9) v5:group:v9:gc)
-        %v2  ``groups-2+groups-9
-    ==
-  ::
-      [%x ver=?(%v0 %v1 %v2) %ui %groups ~]
-    ?-    ver.pole
-        %v0
-      =-  ``groups-ui+-
-      %-  ~(urn by groups)
-      |=  [=flag:g =net:g =group:g]
-      =/  =status:neg
-        (read-status:neg bowl [p.flag %groups])
-      (group-ui:v2:group:v11:gc status net group)
-    ::
-      %v1  ``groups-ui-1+(~(run by groups) group-ui:v5:group:v11:gc)
-      %v2  ``groups-ui-2+(~(run by groups) group-ui:v9:group:v11:gc)
-    ==
-  ::
     ::  deprecated
     [%x %groups ~]  $(pole /x/v0/groups)
-    ::  deprecated
-    [%x %groups %light ~]  $(pole /x/v0/light/groups)
   ::
       [%x %v1 %changes since=@ rest=*]
     =+  since=(slav %da since.pole)

--- a/packages/api/src/__tests__/urbitRequestTimeout.test.ts
+++ b/packages/api/src/__tests__/urbitRequestTimeout.test.ts
@@ -104,7 +104,7 @@ describe('Urbit request timeouts cover the response body read', () => {
   it('scry rejects when the response body stalls after headers', async () => {
     const client = new Urbit('', undefined, 'groups', stalledBodyFetch());
     await expect(
-      client.scry({ app: 'groups', path: '/v2/ui/groups', timeout: 50 })
+      client.scry({ app: 'groups', path: '/v3/groups', timeout: 50 })
     ).rejects.toThrow();
   });
 


### PR DESCRIPTION
## Summary

Removes the plural `ui/groups` `%groups` scry arm, which has no consumers, rather than carrying it forward to v3. Follow-up to #6209 (TLON-6274), stacked on it — review that one first.

Comes out of @mikolajpp's review, threads on the plural `ui/groups` ("we don't expose `v11` here") and on `light/groups` ("Is this endpoint in use by anything? If not, we should mark it for removal later. Otherwise it needs updating too").

**`light/groups` turned out to be in use, so it stays.** The first pass deleted it on a bad audit and broke CI — see below.

## Changes

- Delete the plural `ui/groups` peek arm and its three scry declarations — `/x/v0|v1|v2/ui/groups`
- Repoint `urbitRequestTimeout.test.ts` at `/v3/groups`; it used `/v2/ui/groups` as arbitrary filler against a stubbed fetch and would otherwise name a deleted endpoint

Net 18 lines removed from `app/groups.hoon`.

## Why `light/groups` stays

The first commit deleted it too, and both the parallel E2E job and the production build smoke test failed in "Setting up ships" with `~zod is not ready` / `~ten is not ready` until `Max attempts reached`. Cause: rube's own liveness probe reads it.

```
apps/tlon-web/rube/index.ts:1205
  http://localhost:${ship.httpPort}/~/scry/groups/groups/light.json
```

`checkGroupsAppHealth` 404s → `shipsAreReadyForTests` never returns true → 30 attempts → rube aborts before any test runs.

Three more live callers depend on the same deprecated alias:

| Caller | Path |
| --- | --- |
| `apps/tlon-mobile/ios/Shared/Networking/PocketChatAPI.swift:17` | `/~/scry/groups/groups/light` |
| `apps/tlon-mobile/android/app/src/main/java/io/tlon/landscape/api/TalkApi.java:137` | `/~/scry/groups/groups/light` |
| `api/openapi.yaml:42` | documented as `/groups/groups/light.json` |

The audit missed all four because it grepped the versioned spelling (`light/groups`); every real caller uses the alias spelling (`groups/light`). The arm and its four declarations are restored verbatim.

On @mikolajpp's "otherwise it needs updating too": every caller reads it through the unversioned alias, which resolves to `%v0` and the `%groups` mark. Nothing reads `%v1`/`%v2`, and nothing needs v11/blob from it — so there is nothing to update, just something not to delete.

## How did I test?

The plural `ui/groups` arm is dead: the only hit was the timeout test above. The two in-desk callers (`ted/group/create.hoon`, `ted/group/create-1.hoon`) read the **per-flag** path `/gx/groups/vN/ui/groups/<ship>/<name>`, a different arm that stays.

On a live moon: desk compiles and `%groups` loads, and the *surviving* per-flag arm still answers — `/v3/ui/groups/{flag}` and `/v3/groups` both return correctly. That was the real risk, since the deleted plural arm shared the `%ui %groups` prefix.

`./backend/run-tests.sh` green on the first pass: 319 OK, **Unit tests passed ✅** and **Aqua tests passed ✅**. Affected vitest file passes (6/6), Prettier clean. The restore commit only adds back code that compiled at the base, so re-running CI is the check that matters — specifically that E2E and the smoke test get past ship setup.

## Risks and impact

- Safe to rollback without consulting PR author? (Yes)
- Affects important code area:
  - [ ] Onboarding
  - [ ] State / providers
  - [ ] Message sync
  - [ ] Channel display
  - [ ] Notifications
  - [x] Other: removes one unused `%groups` scry endpoint

A third-party client scrying `/x/v0|v1|v2/ui/groups` would start getting no-match. These are unversioned-through-v2 legacy reads with no consumer in this repo, and the per-flag equivalents remain.

Note this orphans the `%groups-ui`, `%groups-ui-1`, and `%groups-ui-2` marks — nothing produces them now. I deliberately left the mark files and their strict-list entries alone, since dropping a strict mark is a one-way door (it can never go strict again without nest-failing legacy ships) and keeping them costs nothing.

Worth a separate look: rube's health probe hanging off a *deprecated* alias is fragile — it made a legacy-cleanup PR look like an infrastructure outage. Repointing it at a supported endpoint would make the next cleanup safer.

## Rollback plan

Revert the PR. No state, migration, or wire-format change.
