### PR TITLE
openclaw: honor groupInviteAllowlist when auto-accepting invites

### DIFF
--- a/packages/openclaw/README.md
+++ b/packages/openclaw/README.md
@@ -49,7 +49,11 @@ channels:
 
         # Auto-accept settings
         autoAcceptDmInvites: true # Accept DMs from ships in dmAllowlist
-        autoAcceptGroupInvites: false # Require approval for group invites
+        autoAcceptGroupInvites: false # Legacy: no longer governs group-invite authorization (groupInviteAllowlist does); controls channel persistence
+
+        # Ships allowed to invite the bot to groups (auto-accepted unless blocked)
+        groupInviteAllowlist:
+            - '~trusted-friend'
 
         # Channel discovery
         autoDiscoverChannels: true # Monitor all channels in joined groups
@@ -98,7 +102,7 @@ The approval system lets you control who can interact with your bot. When `owner
 
 -   **DM requests** from ships not on your `dmAllowlist`
 -   **Channel mentions** from ships not authorized for that channel
--   **Group invites** (if `autoAcceptGroupInvites` is false)
+-   **Group invites** from ships not on your `groupInviteAllowlist` (owner invites and allowlisted, non-blocked ships are auto-accepted)
 
 ### Usage
 

--- a/packages/openclaw/SECURITY.md
+++ b/packages/openclaw/SECURITY.md
@@ -53,19 +53,34 @@ If no mode is specified, default to "restricted" — NEVER "open"
 
 ## 3. Group Invite Authorization
 
-**Principle:** When auto-accepting invites, validate the inviter.
+**Principle:** Validate the inviter before auto-accepting; auto-accept requires positive confirmation.
 
-| Scenario                                                      | Expected Behavior                |
-| ------------------------------------------------------------- | -------------------------------- |
-| `autoAcceptGroupInvites` = false                              | ❌ Don't auto-accept any invites |
-| `autoAcceptGroupInvites` = true, `groupInviteAllowlist` empty | ❌ Reject all (fail-safe)        |
-| `autoAcceptGroupInvites` = true, inviter ON allowlist         | ✅ Accept invite                 |
-| `autoAcceptGroupInvites` = true, inviter NOT on allowlist     | ❌ Reject invite                 |
+Evaluated in this order per unprocessed valid invite:
 
-**Critical Invariant:**
+| #   | Condition                                          | Action                                    | Blocked lookup?     |
+| --- | -------------------------------------------------- | ----------------------------------------- | ------------------- |
+| 1   | Inviter is owner                                   | ✅ Auto-accept                            | no                  |
+| 2   | Not on `groupInviteAllowlist`, owner configured    | Queue approval card                       | no                  |
+| 3   | Not on allowlist, no owner configured              | Log + ignore                              | no                  |
+| 4   | On allowlist, **confirmed not blocked**            | ✅ Auto-accept                            | yes                 |
+| 5   | On allowlist, **confirmed blocked**                | Silent ignore (no card), mark processed   | yes                 |
+| 6   | On allowlist, lookup failed/timed out (_unknown_)  | Fall through to row 2/3 (card, or ignore) | yes (attempted)     |
+
+The `autoAcceptGroupInvites` flag no longer governs invite authorization; it
+remains a persistence input (auto-detected channels are persisted to
+`groupChannels` only when it is true).
+
+**Critical Invariants:**
 
 ```
-If groupInviteAllowlist is empty/undefined, fail-safe to DENY — NEVER accept
+If groupInviteAllowlist is empty/undefined, fail-safe to DENY — only the owner auto-accepts.
+
+Auto-accept requires a positive "not blocked" confirmation (fail-closed):
+every non-confirmation lands somewhere that is not a join.
+
+Confirmed-blocked and lookup-unknown are DISTINCT outcomes: a confirmed-blocked
+inviter is silently ignored directly (never carded); only an unknown lookup
+falls through to the approval path.
 ```
 
 **Why This Matters:**

--- a/packages/openclaw/src/config-schema.ts
+++ b/packages/openclaw/src/config-schema.ts
@@ -115,7 +115,7 @@ export const TlonAccountSchema = z.object({
   showModelSignature: z.boolean().optional(),
   // Auto-accept settings
   autoAcceptDmInvites: z.boolean().optional(), // Auto-accept DMs from ships in dmAllowlist
-  autoAcceptGroupInvites: z.boolean().optional(), // Auto-accept all group invites
+  autoAcceptGroupInvites: z.boolean().optional(), // No longer governs group-invite authorization (groupInviteAllowlist does); retained for channel persistence and back-compat
   // Owner ship for approval system
   ownerShip: ShipSchema.optional(), // Ship that receives approval requests and can approve/deny
   // Reaction level: off (no reactions), ack (notify only), minimal (react sparingly), extensive (react freely)
@@ -153,7 +153,7 @@ export const TlonConfigSchema = z.object({
   accounts: z.record(z.string(), TlonAccountSchema).optional(),
   // Auto-accept settings
   autoAcceptDmInvites: z.boolean().optional(), // Auto-accept DMs from ships in dmAllowlist
-  autoAcceptGroupInvites: z.boolean().optional(), // Auto-accept all group invites
+  autoAcceptGroupInvites: z.boolean().optional(), // No longer governs group-invite authorization (groupInviteAllowlist does); retained for channel persistence and back-compat
   // Owner ship for approval system
   ownerShip: ShipSchema.optional(), // Ship that receives approval requests and can approve/deny
   // Reaction level: off (no reactions), ack (notify only), minimal (react sparingly), extensive (react freely)

--- a/packages/openclaw/src/monitor/index.ts
+++ b/packages/openclaw/src/monitor/index.ts
@@ -181,7 +181,9 @@ import {
   isDmAllowed,
   isOwnerListenSlashCommand,
   isSummarizationRequest,
+  parseBlockedShips,
   prepareInboundText,
+  resolveGroupInviteAction,
   sanitizeMessageText,
   shouldEngageInGroup,
   stripBotMentionOutsidePlaceholders,
@@ -1243,11 +1245,13 @@ export async function monitorTlonProvider(
       // An explicit empty settings list is authoritative (the admin cleared the
       // allowlist), not a signal to fall back to the file config — otherwise
       // clearing it in the form would keep auto-accepting invites from the old
-      // file list. Only `undefined` (never set) defers to the file value.
+      // file list. Only `undefined` (never set / deleted) defers to the file
+      // value; see the matching re-derivation in the settings subscription.
+      effectiveGroupInviteAllowlist =
+        currentSettings.groupInviteAllowlist ?? account.groupInviteAllowlist;
       if (currentSettings.groupInviteAllowlist !== undefined) {
-        effectiveGroupInviteAllowlist = currentSettings.groupInviteAllowlist;
         runtime.log?.(
-          `[tlon] Using groupInviteAllowlist from settings store: ${effectiveGroupInviteAllowlist.join(', ')}`
+          `[tlon] Using groupInviteAllowlist from settings store: ${effectiveGroupInviteAllowlist.length > 0 ? effectiveGroupInviteAllowlist.join(', ') : '(empty)'}`
         );
       }
       if (currentSettings.ownerShip) {
@@ -1432,7 +1436,9 @@ export async function monitorTlonProvider(
       effectiveAutoDiscoverChannels ||
       account.groupChannels.length > 0 ||
       Boolean(currentSettings.groupChannels?.length) ||
-      effectiveAutoAcceptGroupInvites;
+      effectiveAutoAcceptGroupInvites ||
+      Boolean(effectiveOwnerShip) ||
+      effectiveGroupInviteAllowlist.length > 0;
     if (shouldFetchGroupMetadata) {
       try {
         const initData = await fetchInitData(api, runtime);
@@ -1649,7 +1655,7 @@ export async function monitorTlonProvider(
     const SCRY_TIMEOUT_MS = 15_000;
 
     async function scryBlockedShips(): Promise<string[]> {
-      const blocked = (await Promise.race([
+      const blocked = await Promise.race([
         api!.scry('/chat/blocked.json'),
         new Promise<never>((_, reject) =>
           setTimeout(
@@ -1657,8 +1663,13 @@ export async function monitorTlonProvider(
             SCRY_TIMEOUT_MS
           )
         ),
-      ])) as string[] | undefined;
-      return Array.isArray(blocked) ? blocked : [];
+      ]);
+      // Throws on a malformed payload rather than coercing it to "nobody is
+      // blocked" — resolveGroupInviteAction treats a successful result as a
+      // positive not-blocked confirmation and would otherwise auto-accept an
+      // allowlisted ship on a garbled response. Callers that only display or
+      // fail open (isShipBlocked, getBlockedShips) already catch.
+      return parseBlockedShips(blocked);
     }
 
     // Check if a ship is blocked using Tlon's native block list
@@ -4646,14 +4657,28 @@ export async function monitorTlonProvider(
           );
         }
 
-        // Update group invite allowlist. An explicit empty list is authoritative
-        // (the admin cleared it) — don't fall back to the file list, or clearing
-        // the allowlist would keep auto-accepting invites from the old entries.
-        if (newSettings.groupInviteAllowlist !== undefined) {
-          effectiveGroupInviteAllowlist = newSettings.groupInviteAllowlist;
-          runtime.log?.(
-            `[tlon] Settings: groupInviteAllowlist updated to ${effectiveGroupInviteAllowlist.join(', ')}`
-          );
+        // Re-derive the allowlist from every snapshot rather than only when the
+        // key is present. An explicit empty list is authoritative (the admin
+        // cleared it) so it must not fall back to the file list; but `undefined`
+        // — a del-entry, or a malformed value that `applySettingsUpdate`
+        // normalizes away — must fall back to the file config rather than
+        // leaving the previous in-memory list in place. Keeping the stale list
+        // would let a ship removed from the allowlist go on auto-joining groups
+        // until the gateway restarted.
+        {
+          const nextAllowlist =
+            newSettings.groupInviteAllowlist ?? account.groupInviteAllowlist;
+          const changed =
+            nextAllowlist.length !== effectiveGroupInviteAllowlist.length ||
+            nextAllowlist.some(
+              (ship, i) => ship !== effectiveGroupInviteAllowlist[i]
+            );
+          effectiveGroupInviteAllowlist = nextAllowlist;
+          if (changed) {
+            runtime.log?.(
+              `[tlon] Settings: groupInviteAllowlist updated to ${effectiveGroupInviteAllowlist.length > 0 ? effectiveGroupInviteAllowlist.join(', ') : '(empty)'}`
+            );
+          }
         }
 
         if (newSettings.defaultAuthorizedShips !== undefined) {
@@ -4996,6 +5021,15 @@ export async function monitorTlonProvider(
             return;
           }
 
+          // One block-list scry per batch, shared by every invite in it and
+          // fetched lazily so a batch with no allowlisted inviter costs none.
+          // Without this a startup backlog of N allowlisted invites would issue
+          // N sequential scries — up to 15s each — before the foreigns
+          // subscription is even established.
+          let blockedShipsOnce: Promise<string[]> | null = null;
+          const fetchBlockedShips = () =>
+            (blockedShipsOnce ??= scryBlockedShips());
+
           for (const [groupFlag, foreign] of Object.entries(foreigns)) {
             if (processedGroupInvites.has(groupFlag)) {
               continue;
@@ -5010,10 +5044,24 @@ export async function monitorTlonProvider(
             }
 
             const inviterShip = validInvite.from;
-            const normalizedInviter = normalizeShip(inviterShip);
 
-            // Owner invites are always accepted
-            if (isOwner(inviterShip)) {
+            const decision = await resolveGroupInviteAction(
+              {
+                inviterShip,
+                ownerShip: effectiveOwnerShip,
+                allowlist: effectiveGroupInviteAllowlist,
+              },
+              {
+                // SECURITY: pass the scryBlockedShips-backed fetcher (rejects
+                // on failure or a malformed payload), NOT isShipBlocked (which
+                // swallows errors to "not blocked"). A rejection means
+                // "unknown" and must never auto-accept — see
+                // resolveGroupInviteAction.
+                fetchBlockedShips,
+              }
+            );
+
+            if (decision.action === 'accept') {
               try {
                 await api.poke({
                   app: 'groups',
@@ -5023,87 +5071,51 @@ export async function monitorTlonProvider(
                     'join-all': true,
                   },
                 });
+                // Mark processed only on success — failure retries on the
+                // next foreigns event.
                 processedGroupInvites.add(groupFlag);
                 runtime.log?.(
-                  `[tlon] Auto-accepted group invite from owner: ${groupFlag}`
+                  `[tlon] Auto-accepted group invite (${decision.reason}): ${groupFlag} (from ${inviterShip})`
                 );
               } catch (err) {
                 runtime.error?.(
-                  `[tlon] Failed to accept group invite from owner: ${String(err)}`
+                  `[tlon] Failed to accept group invite (${decision.reason}) ${groupFlag}: ${String(err)}`
                 );
               }
               continue;
             }
 
-            // Skip if auto-accept is disabled
-            if (!effectiveAutoAcceptGroupInvites) {
-              // If owner is configured, queue approval
-              if (effectiveOwnerShip) {
-                const approval = createPendingApproval(
-                  {
-                    type: 'group',
-                    requestingShip: inviterShip,
-                    groupFlag,
-                    groupTitle: validInvite.preview?.meta?.title,
-                  },
-                  pendingApprovals.map((a) => a.id)
-                );
-                await queueApprovalRequest(approval);
-                processedGroupInvites.add(groupFlag);
-              }
-              continue;
-            }
-
-            // Check if inviter is on allowlist
-            const isAllowed =
-              effectiveGroupInviteAllowlist.length > 0
-                ? effectiveGroupInviteAllowlist
-                    .map((s) => normalizeShip(s))
-                    .some((s) => s === normalizedInviter)
-                : false; // Fail-safe: empty allowlist means deny
-
-            if (!isAllowed) {
-              // If owner is configured, queue approval
-              if (effectiveOwnerShip) {
-                const approval = createPendingApproval(
-                  {
-                    type: 'group',
-                    requestingShip: inviterShip,
-                    groupFlag,
-                    groupTitle: validInvite.preview?.meta?.title,
-                  },
-                  pendingApprovals.map((a) => a.id)
-                );
-                await queueApprovalRequest(approval);
-                processedGroupInvites.add(groupFlag);
-              } else {
-                runtime.log?.(
-                  `[tlon] Rejected group invite from ${inviterShip} (not in groupInviteAllowlist): ${groupFlag}`
-                );
-                processedGroupInvites.add(groupFlag);
-              }
-              continue;
-            }
-
-            // Inviter is on allowlist - accept the invite
-            try {
-              await api.poke({
-                app: 'groups',
-                mark: 'group-join',
-                json: {
-                  flag: groupFlag,
-                  'join-all': true,
+            if (decision.action === 'queue') {
+              const approval = createPendingApproval(
+                {
+                  type: 'group',
+                  requestingShip: inviterShip,
+                  groupFlag,
+                  groupTitle: validInvite.preview?.meta?.title,
                 },
-              });
+                pendingApprovals.map((a) => a.id)
+              );
+              await queueApprovalRequest(approval);
               processedGroupInvites.add(groupFlag);
-              runtime.log?.(
-                `[tlon] Auto-accepted group invite: ${groupFlag} (from ${validInvite.from})`
-              );
-            } catch (err) {
-              runtime.error?.(
-                `[tlon] Failed to auto-accept group ${groupFlag}: ${String(err)}`
-              );
+              continue;
             }
+
+            if (decision.reason === 'blocked') {
+              // Confirmed blocked: silent ignore, no approval card. Routing
+              // this through queueApprovalRequest would re-ask the fail-open
+              // isShipBlocked and could card a ship known to be blocked.
+              runtime.log?.(
+                `[tlon] Ignoring group invite from blocked ship ${inviterShip}: ${groupFlag}`
+              );
+              processedGroupInvites.add(groupFlag);
+              continue;
+            }
+
+            // ignore/no-owner: log but leave unprocessed so a later allowlist
+            // edit can pick the invite up on the next foreigns event.
+            runtime.log?.(
+              `[tlon] Ignoring group invite from ${inviterShip} (not in groupInviteAllowlist, no owner configured): ${groupFlag}`
+            );
           }
         };
 

--- a/packages/openclaw/src/monitor/utils.ts
+++ b/packages/openclaw/src/monitor/utils.ts
@@ -309,11 +309,15 @@ export function isDmAllowed(
 }
 
 /**
- * Check if a group invite from a ship should be auto-accepted.
+ * Check if a ship is on the group-invite allowlist.
+ *
+ * Used by resolveGroupInviteAction: allowlist membership (plus a positive
+ * "not blocked" confirmation) is sufficient for auto-accept. The
+ * autoAcceptGroupInvites flag no longer governs invite authorization.
  *
  * SECURITY: Fail-safe to deny. If allowlist is empty or undefined,
- * ALL invites are rejected - even if autoAcceptGroupInvites is enabled.
- * This prevents misconfigured bots from accepting malicious invites.
+ * ALL invites are rejected. This prevents misconfigured bots from
+ * accepting malicious invites.
  */
 export function isGroupInviteAllowed(
   inviterShip: string,
@@ -327,6 +331,117 @@ export function isGroupInviteAllowed(
   return allowlist
     .map((ship) => normalizeShip(ship))
     .some((ship) => ship === normalizedInviter);
+}
+
+/**
+ * Parse a `/chat/blocked.json` scry payload into a ship list.
+ *
+ * SECURITY: throws when the payload is not an array. The block list decides
+ * whether an allowlisted ship may auto-join, so "we could not understand the
+ * response" must stay distinguishable from "nobody is blocked" — coercing a
+ * malformed payload to `[]` would read as positive confirmation that the
+ * inviter is not blocked and auto-accept them.
+ *
+ * Individual non-string entries are dropped rather than failing the whole
+ * array. Throwing on a partially-malformed list would be *less* safe than the
+ * lenient behavior it replaced: callers that fail open (`isShipBlocked`,
+ * `getBlockedShips`) would catch the throw and report "not blocked", so one
+ * bad element could unblock every genuinely blocked ship in the list.
+ * Dropping bad elements keeps every ship we can actually read.
+ *
+ * The %ships mark serializes an empty block list as `[]`, so a well-formed
+ * empty response is a valid array and is NOT an error.
+ */
+export function parseBlockedShips(raw: unknown): string[] {
+  if (!Array.isArray(raw)) {
+    throw new Error(
+      `blocked list scry returned ${raw === null ? 'null' : typeof raw}, expected an array`
+    );
+  }
+  return raw.filter((ship): ship is string => typeof ship === 'string');
+}
+
+/**
+ * The action to take for a pending group invite.
+ *
+ * - `accept/owner`: inviter is the configured owner — auto-accept.
+ * - `accept/allowlisted`: inviter is on `groupInviteAllowlist` and a
+ *   block-list lookup positively confirmed they are not blocked — auto-accept.
+ * - `queue`: inviter is not authorized (or authorization could not be
+ *   confirmed) and an owner is configured — send an approval card.
+ * - `ignore/blocked`: a block-list lookup positively confirmed the inviter
+ *   is blocked — silently drop, no card.
+ * - `ignore/no-owner`: inviter is not authorized and no owner is
+ *   configured — silently drop.
+ */
+export type GroupInviteAction =
+  | { action: 'accept'; reason: 'owner' | 'allowlisted' }
+  | { action: 'queue' }
+  | { action: 'ignore'; reason: 'blocked' | 'no-owner' };
+
+/**
+ * Resolve what to do with a group invite, fail-closed.
+ *
+ * SECURITY: auto-accept requires a positive "not blocked" confirmation.
+ * `deps.fetchBlockedShips` must reject (not swallow) on failure — a
+ * rejection means "unknown", which falls through to the queue/no-owner
+ * path and must never auto-accept. The gate passes `scryBlockedShips`
+ * (rejects on failure), not `isShipBlocked` (swallows errors to
+ * "not blocked").
+ *
+ * Confirmed-blocked and lookup-unknown are distinct outcomes: a
+ * confirmed-blocked inviter dispatches straight to silent ignore (routing
+ * it through the queue path would re-ask a fail-open blocked lookup and
+ * could card a ship already known to be blocked); only unknown falls
+ * through to the queue path, where that second lookup is a genuine
+ * recovery attempt.
+ */
+export async function resolveGroupInviteAction(
+  params: {
+    inviterShip: string;
+    ownerShip: string | null; // normalized effective owner; null ⇒ no owner
+    allowlist: string[];
+  },
+  deps: {
+    /** Resolves the block list. MUST reject (not swallow) on failure —
+     *  a rejection means "unknown", which must never auto-accept. */
+    fetchBlockedShips: () => Promise<string[]>;
+  }
+): Promise<GroupInviteAction> {
+  const { inviterShip, ownerShip, allowlist } = params;
+  const hasOwner = ownerShip !== null;
+
+  // Owner invites are always accepted, without consulting the block list
+  // (keeps the owner path scry-free and preserves the existing ordering).
+  if (hasOwner && normalizeShip(inviterShip) === ownerShip) {
+    return { action: 'accept', reason: 'owner' };
+  }
+
+  const queueOrIgnore: GroupInviteAction = hasOwner
+    ? { action: 'queue' }
+    : { action: 'ignore', reason: 'no-owner' };
+
+  if (!isGroupInviteAllowed(inviterShip, allowlist)) {
+    return queueOrIgnore;
+  }
+
+  // Allowlisted: auto-accept only on a positive "not blocked" confirmation.
+  let blockedShips: string[];
+  try {
+    blockedShips = await deps.fetchBlockedShips();
+  } catch {
+    // Lookup failed or timed out — unknown. Fall through to queue/no-owner;
+    // never auto-accept on an unconfirmed lookup.
+    return queueOrIgnore;
+  }
+
+  const normalizedInviter = normalizeShip(inviterShip);
+  if (blockedShips.some((s) => normalizeShip(s) === normalizedInviter)) {
+    // Confirmed blocked — silent ignore directly, not the queue path.
+    return { action: 'ignore', reason: 'blocked' };
+  }
+
+  return { action: 'accept', reason: 'allowlisted' };
 }
 
 /**

--- a/packages/openclaw/src/security.test.ts
+++ b/packages/openclaw/src/security.test.ts
@@ -7,7 +7,7 @@
  * - Ship normalization consistency
  * - Bot mention detection boundaries
  */
-import { describe, expect, it } from 'vitest';
+import { describe, expect, it, vi } from 'vitest';
 
 import {
   extractMessageText,
@@ -15,6 +15,8 @@ import {
   isChannelRestricted,
   isDmAllowed,
   isGroupInviteAllowed,
+  parseBlockedShips,
+  resolveGroupInviteAction,
   sanitizeMessageText,
 } from './monitor/utils.js';
 import { normalizeShip } from './targets.js';
@@ -145,6 +147,146 @@ describe('Security: Group Invite Allowlist', () => {
     it('handles whitespace in allowlist entries', () => {
       const allowlist = [' ~nocsyx-lassul ', '~malmur-halmex'];
       expect(isGroupInviteAllowed('~nocsyx-lassul', allowlist)).toBe(true);
+    });
+  });
+
+  describe('resolveGroupInviteAction', () => {
+    const owner = '~nocsyx-lassul';
+    const inviter = '~sampel-palnet';
+
+    function makeFetchBlockedShips(blocked: string[] = []) {
+      return vi.fn().mockResolvedValue(blocked);
+    }
+
+    it('auto-accepts the owner without consulting the block list', async () => {
+      const fetchBlockedShips = makeFetchBlockedShips();
+      const result = await resolveGroupInviteAction(
+        { inviterShip: owner, ownerShip: owner, allowlist: [] },
+        { fetchBlockedShips }
+      );
+      expect(result).toEqual({ action: 'accept', reason: 'owner' });
+      // Owner path must stay scry-free
+      expect(fetchBlockedShips).not.toHaveBeenCalled();
+    });
+
+    it('auto-accepts an allowlisted ship when the block list confirms it clean', async () => {
+      const fetchBlockedShips = makeFetchBlockedShips(['~malicious-actor']);
+      const result = await resolveGroupInviteAction(
+        { inviterShip: inviter, ownerShip: owner, allowlist: [inviter] },
+        { fetchBlockedShips }
+      );
+      expect(result).toEqual({ action: 'accept', reason: 'allowlisted' });
+      expect(fetchBlockedShips).toHaveBeenCalledTimes(1);
+    });
+
+    it('silently ignores an allowlisted ship the block list confirms blocked (not queue)', async () => {
+      const fetchBlockedShips = makeFetchBlockedShips([inviter]);
+      const result = await resolveGroupInviteAction(
+        { inviterShip: inviter, ownerShip: owner, allowlist: [inviter] },
+        { fetchBlockedShips }
+      );
+      // Confirmed-blocked is a distinct outcome: silent ignore, never a card
+      expect(result).toEqual({ action: 'ignore', reason: 'blocked' });
+      expect(result.action).not.toBe('queue');
+      expect(fetchBlockedShips).toHaveBeenCalledTimes(1);
+    });
+
+    it('falls through to queue when the block-list lookup rejects — never accept', async () => {
+      // CRITICAL (fail-closed): a failed/timed-out scry means "unknown",
+      // which must never become an auto-join.
+      const fetchBlockedShips = vi
+        .fn()
+        .mockRejectedValue(new Error('blocked list scry timeout'));
+      const result = await resolveGroupInviteAction(
+        { inviterShip: inviter, ownerShip: owner, allowlist: [inviter] },
+        { fetchBlockedShips }
+      );
+      expect(result.action).toBe('queue');
+      expect(result).not.toEqual(expect.objectContaining({ action: 'accept' }));
+      expect(fetchBlockedShips).toHaveBeenCalledTimes(1);
+    });
+
+    it('matches allowlist entries via normalization (delegates to isGroupInviteAllowed)', async () => {
+      const fetchBlockedShips = makeFetchBlockedShips();
+      const result = await resolveGroupInviteAction(
+        // Entry spelled without the leading ~
+        {
+          inviterShip: inviter,
+          ownerShip: owner,
+          allowlist: ['sampel-palnet'],
+        },
+        { fetchBlockedShips }
+      );
+      expect(result).toEqual({ action: 'accept', reason: 'allowlisted' });
+    });
+
+    it('queues an unknown inviter when an owner is configured, without a block-list lookup', async () => {
+      const fetchBlockedShips = makeFetchBlockedShips();
+      const result = await resolveGroupInviteAction(
+        {
+          inviterShip: inviter,
+          ownerShip: owner,
+          allowlist: ['~someone-else'],
+        },
+        { fetchBlockedShips }
+      );
+      expect(result).toEqual({ action: 'queue' });
+      // Non-allowlisted path must stay scry-free (queue does its own lookup)
+      expect(fetchBlockedShips).not.toHaveBeenCalled();
+    });
+
+    it('ignores an unknown inviter when no owner is configured, without a block-list lookup', async () => {
+      const fetchBlockedShips = makeFetchBlockedShips();
+      const result = await resolveGroupInviteAction(
+        { inviterShip: inviter, ownerShip: null, allowlist: ['~someone-else'] },
+        { fetchBlockedShips }
+      );
+      expect(result).toEqual({ action: 'ignore', reason: 'no-owner' });
+      expect(fetchBlockedShips).not.toHaveBeenCalled();
+    });
+
+    it('queues a non-owner invite when the allowlist is empty (fail-safe)', async () => {
+      const fetchBlockedShips = makeFetchBlockedShips();
+      const result = await resolveGroupInviteAction(
+        { inviterShip: inviter, ownerShip: owner, allowlist: [] },
+        { fetchBlockedShips }
+      );
+      // Empty allowlist must deny everyone but the owner — never accept-all
+      expect(result).toEqual({ action: 'queue' });
+      expect(fetchBlockedShips).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('parseBlockedShips', () => {
+    // The block list decides whether an allowlisted ship may auto-join, so a
+    // payload we cannot understand must throw (=> "unknown" => approval card)
+    // rather than coerce to [] (=> "nobody blocked" => auto-join).
+    it('accepts a well-formed ship array', () => {
+      expect(parseBlockedShips(['~zod', '~sampel-palnet'])).toEqual([
+        '~zod',
+        '~sampel-palnet',
+      ]);
+    });
+
+    it('accepts an empty array — a genuinely empty block list is not an error', () => {
+      expect(parseBlockedShips([])).toEqual([]);
+    });
+
+    it.each([
+      ['null', null],
+      ['undefined', undefined],
+      ['an object', { blocked: ['~zod'] }],
+      ['a string', '~zod'],
+      ['a number', 0],
+    ])('throws on %s rather than reporting "nobody blocked"', (_label, raw) => {
+      expect(() => parseBlockedShips(raw)).toThrow();
+    });
+
+    it('keeps readable ships and drops a non-string entry, rather than failing the whole list', () => {
+      // Throwing here would be worse than the lenient behavior this replaced:
+      // isShipBlocked/getBlockedShips catch and fail open, so one bad element
+      // would report every genuinely blocked ship as unblocked.
+      expect(parseBlockedShips(['~zod', 42, '~bus'])).toEqual(['~zod', '~bus']);
     });
   });
 });

--- a/packages/openclaw/src/settings.ts
+++ b/packages/openclaw/src/settings.ts
@@ -44,8 +44,9 @@ export type TlonSettingsStore = {
   showModelSig?: boolean;
   autoAcceptDmInvites?: boolean;
   autoDiscoverChannels?: boolean;
+  /** No longer governs group-invite authorization (groupInviteAllowlist does); retained for channel persistence and back-compat */
   autoAcceptGroupInvites?: boolean;
-  /** Ships allowed to invite us to groups (when autoAcceptGroupInvites is true) */
+  /** Ships allowed to invite us to groups (allowlist membership is sufficient for auto-accept) */
   groupInviteAllowlist?: string[];
   channelRules?: Record<
     string,


### PR DESCRIPTION
## Summary

`groupInviteAllowlist` was inert on openclaw. The foreigns handler only consulted it when `autoAcceptGroupInvites` was true, and nothing in the hosted stack enables that flag — plugin default is `false`, tlawn never sets it, the self-host script writes `false`, and no settings UI exposes it. So an allowlisted ship's invite produced an owner approval card identical to a stranger's.

This makes the allowlist load-bearing, matching hermes's owner/allowlist semantics with one deliberate divergence: openclaw consults the block list before joining, hermes doesn't.

## Changes

The decision moves into `resolveGroupInviteAction` (pure, async, no side effects); `processPendingInvites` dispatches on its result:

| Inviter                                   | Action                       |
| ----------------------------------------- | ---------------------------- |
| Owner                                     | accept, no block-list lookup |
| Allowlisted, confirmed not blocked        | accept — the fix             |
| Allowlisted, confirmed blocked            | ignore silently, no card     |
| Allowlisted, lookup rejected or timed out | approval path                |
| Not allowlisted                           | approval path                |

Approval path is `queueApprovalRequest`; with no `ownerShip` configured the invite is left unprocessed rather than marked, so a later allowlist edit picks it up on the next foreigns event. Empty allowlist authorizes only the owner.

Rows three and four are distinct on purpose. Accepting requires positive confirmation of _not blocked_, so a rejected lookup can't become a join. A confirmed-blocked inviter is dropped directly instead of going through `queueApprovalRequest`, which re-checks via the fail-open `isShipBlocked` and would card a ship we already know is blocked. The resolver is therefore handed `scryBlockedShips` (rejects) rather than `isShipBlocked` (swallows to `false`).

Supporting changes:

-   **`parseBlockedShips`** replaces `scryBlockedShips`'s `Array.isArray(x) ? x : []` coercion. Non-array payloads now throw — coercing them read as positive confirmation of an empty block list. Non-string elements _within_ an array are filtered rather than throwing: `isShipBlocked` and `getBlockedShips` catch and fail open, so all-or-nothing rejection would report every genuinely blocked ship as unblocked. Empty lists are valid; the `%ships` mark emits `[]`.

-   **Allowlist re-derived per settings snapshot** as `settings ?? file`, not gated on `!== undefined`. A `del-entry` (or a value `applySettingsUpdate` normalizes to `undefined`) previously left the prior list live in memory, so a removed ship kept authorization until restart. Explicit `[]` remains authoritative.

-   **`shouldFetchGroupMetadata` gains `ownerShip` / non-empty-allowlist terms.** The flag no longer signals "we care about invites", and this predicate gates the `fetchInitData` that populates `initForeigns`. The existing flag term is kept, so nothing that fetched before stops fetching.

-   **Block-list lookup memoized per `processPendingInvites` batch**, lazily. Startup drains the backlog before subscribing, so per-invite lookups would serialize at up to 15s each on a ship where the scry is timing out.

`autoAcceptGroupInvites` is retained deliberately: it still gates the two channel-persistence sites (`index.ts` ~4890, ~4948) and stays in the Zod schema so the generated `openclaw.plugin.json` keeps the key. Ungating that persistence and giving `groupChannels` a coherent lifecycle is [TLON-6297](https://linear.app/tlon/issue/TLON-6297/groupchannels-persistence-is-gated-on-the-vestigial). Docs, schema comments and `SECURITY.md` updated.

## How did I test?

16 unit tests in `security.test.ts` across the resolver and parser — owner, allowlisted-clear, confirmed-blocked, rejected lookup, unknown inviter, no-owner, empty allowlist, normalization delegation, and malformed payload shapes. Owner and unknown-inviter cases assert the lookup is never called.

Suite green at 1216/63, `tsc --noEmit` and Prettier clean, and `pnpm build` leaves `openclaw.plugin.json` byte-identical (which is what preserves host back-compat for the retained key).

Not covered: the allowlist re-derivation and the batch memo both live in the monitor closure, and reintroducing each bug leaves the suite green. Covering them needs monitor-level tests with injected scry/poke deps, which the closure doesn't admit today. No cross-ship invite fixture exists either.

## Risks and impact

-   Safe to rollback without consulting PR author? Yes
-   Affects important code area:
    -   [x] Other: openclaw bot group-invite authorization

Behavior delta is row two: allowlisted, non-blocked ships auto-join where they previously carded — what the field always promised in the ylem settings page and `BotSettingsScreen`.

Latency: at most one 15s-timeout lookup per batch containing an allowlisted inviter. This doesn't cap total lookups — `queueApprovalRequest` still does its own per-invite check, as before.

Self-hosters with `autoAcceptGroupInvites: false` _and_ a populated allowlist will see those ships start auto-joining. Intended semantics, but upgrade-visible, so worth a release-note line.

Two known issues left out of scope. The detached foreigns callbacks race (dedup set is written after the awaits, so two rapid snapshots can double-process) predates this PR and is marginally widened by the added lookup; closing it needs an in-flight reservation or serialized processing. And the stale-on-delete pattern fixed here for `groupInviteAllowlist` applies to other keys too — `dmAllowlist` most importantly, since it gates DM handling and DM-invite auto-accept. Separate PR; noted because it surfaced here.

## Rollback plan

Revert.
