### PR TITLE
app: render a bullet for plain items in mixed task lists

### DIFF
--- a/packages/app/ui/components/PostContent/BlockRenderer.tsx
+++ b/packages/app/ui/components/PostContent/BlockRenderer.tsx
@@ -99,6 +99,20 @@ export function ListBlock({
   return <ListNode node={block.list} {...props} />;
 }
 
+// Contract: a tasklist list's children MAY lack a task inline — GFM permits
+// mixing plain and task items, the converter preserves that faithfully, and
+// remark re-merges adjacent lists so the wire cannot avoid the mixed shape.
+// Such children get a plain bullet; task items draw their own checkbox via
+// InlineTask, so their outer marker stays suppressed.
+export function listItemMarkerType(
+  listType: 'ordered' | 'unordered' | 'tasklist',
+  child: cn.ListData
+): 'ordered' | 'unordered' | 'tasklist' {
+  if (listType !== 'tasklist') return listType;
+  const hasTask = child.content.some((inline) => inline.type === 'task');
+  return hasTask ? 'tasklist' : 'unordered';
+}
+
 function ListNode({
   node,
 }: {
@@ -111,7 +125,10 @@ function ListNode({
       ) : null}
       {node.children?.map((childNode, i) => (
         <XStack key={i} gap="$m">
-          <ListItemMarker index={i} type={node.type ?? 'unordered'} />
+          <ListItemMarker
+            index={i}
+            type={listItemMarkerType(node.type ?? 'unordered', childNode)}
+          />
           <ListNode key={i} node={childNode} />
         </XStack>
       ))}

--- a/packages/app/ui/components/PostContent/listItemMarker.test.ts
+++ b/packages/app/ui/components/PostContent/listItemMarker.test.ts
@@ -1,0 +1,104 @@
+import { convertContent, markdownToStory } from '@tloncorp/shared/logic';
+import { expect, test, vi } from 'vitest';
+
+import { listItemMarkerType } from './BlockRenderer';
+
+// BlockRenderer pulls in the native/expo rendering stack. Stub the leaf
+// native modules and the component subtrees so the module graph loads
+// without rendering anything.
+vi.mock('@tloncorp/shared', () => ({
+  AnalyticsEvent: {},
+  trackEvent: vi.fn(),
+  useMutableCallback: (cb: unknown) => cb,
+  useMutableRef: () => ({ current: null }),
+}));
+
+vi.mock('@tloncorp/ui', () => ({
+  Button: () => null,
+  GestureTrigger: () => null,
+  Icon: () => null,
+  Image: () => null,
+  Pressable: () => null,
+  Text: () => null,
+  useCopy: () => ({ doCopy: () => {}, didCopy: false }),
+}));
+
+vi.mock('expo-image', () => ({}));
+vi.mock('react-native-gesture-handler', () => ({
+  Gesture: {},
+  GestureDetector: () => null,
+  ScrollView: () => null,
+}));
+vi.mock('tamagui', () => {
+  const styledComponent: any = () => null;
+  styledComponent.styleable = () => styledComponent;
+  return {
+    ScrollView: () => null,
+    Text: () => null,
+    View: () => null,
+    XStack: () => null,
+    YStack: () => null,
+    createStyledContext: () => ({ Provider: () => null }),
+    styled: () => styledComponent,
+    withStaticProperties: (component: any, statics: any) =>
+      Object.assign(component, statics),
+  };
+});
+
+vi.mock('../../contexts/nowPlaying', () => ({
+  useNowPlayingController: () => ({}),
+}));
+vi.mock('../AudioRecorder/Waveform', () => ({ Waveform: () => null }));
+vi.mock('../FileUploadPreview', () => ({ FileUploadPreview: () => null }));
+vi.mock('../VideoPreview', () => ({ VideoPreview: () => null }));
+vi.mock('./InlineRenderer', () => ({ InlineRenderer: () => null }));
+
+function firstList(markdown: string) {
+  const block = convertContent(markdownToStory(markdown), null).find(
+    (b) => b.type === 'list'
+  );
+  if (!block || block.type !== 'list') {
+    throw new Error('expected a list block');
+  }
+  return block.list;
+}
+
+function childMarkerTypes(markdown: string) {
+  const list = firstList(markdown);
+  return (list.children ?? []).map((child) =>
+    listItemMarkerType(list.type ?? 'unordered', child)
+  );
+}
+
+// Task item first, deliberately: this branch's base converter classifies a list by its first item, while the incoming #6216 converter classifies by any task item; task-first produces the mixed tasklist shape under both rules, so this fixture stays stable across that merge (plain-first would classify unordered here and even lose the checkbox).
+const mixedList = firstList('- [x] done\n- plain');
+
+test('mixed list converts to a tasklist with two children', () => {
+  expect(mixedList.type).toBe('tasklist');
+  expect(mixedList.children).toHaveLength(2);
+});
+
+test('task item in a mixed list keeps its suppressed marker', () => {
+  const children = mixedList.children ?? [];
+  expect(listItemMarkerType('tasklist', children[0])).toBe('tasklist');
+});
+
+test('plain item in a mixed list gets a bullet', () => {
+  const children = mixedList.children ?? [];
+  expect(listItemMarkerType('tasklist', children[1])).toBe('unordered');
+});
+
+test('homogeneous tasklist children all keep their suppressed markers', () => {
+  expect(childMarkerTypes('- [ ] a\n- [x] b')).toEqual([
+    'tasklist',
+    'tasklist',
+  ]);
+});
+
+test('homogeneous unordered children all get bullets', () => {
+  expect(childMarkerTypes('- a\n- b')).toEqual(['unordered', 'unordered']);
+});
+
+test('homogeneous ordered children all keep their numbers', () => {
+  expect(childMarkerTypes('1. a\n2. b')).toEqual(['ordered', 'ordered']);
+});


### PR DESCRIPTION
## Summary

Fixes TLON-6306: a plain item in a mixed GFM task list renders with neither a bullet nor a checkbox. The renderer suppresses the outer marker for every `tasklist` child, relying on each item's `task` inline to draw its checkbox — but GFM permits mixing plain and task items, the converter carries that shape faithfully, and remark re-merges adjacent lists so the wire cannot avoid producing it (a converter-side split would re-collapse on the next parse, breaking Markdown↔Story round-trip idempotence).

This makes the mixed shape legal by contract: **a `tasklist` list's children MAY lack a `task` inline; the renderer draws a plain bullet for those.**

## Example

This GFM input (legal per spec — task and plain items mixed in one list):

```markdown
- [x] done
- plain
```

carries on the wire as one `tasklist` whose second child has no `task` inline:

```json
{"list":{"type":"tasklist","contents":[],"items":[
  {"item":[{"task":{"checked":true,"content":["done"]}}]},
  {"item":["plain"]}]}}
```

| | rendered |
|---|---|
| **before** | ☑ done<br>&nbsp;&nbsp;&nbsp;&nbsp;plain &nbsp;&nbsp;*(no bullet, no checkbox — floats unmarked)* |
| **after** | ☑ done<br>•&nbsp;plain |

## Changes

- `BlockRenderer.tsx`: exported pure helper `listItemMarkerType(listType, child)` carrying the contract comment — `tasklist` children with a `task` inline keep their suppressed marker (checkbox comes from `InlineTask`), children without one get a bullet; other list types pass through unchanged. `ListNode` passes the helper's result to `ListItemMarker`.
- `listItemMarker.test.ts` (new): fixtures generated from `convertContent(markdownToStory(...))` rather than hand-written, so they can't drift from the converter. The mixed fixture uses task-first ordering (`- [x] done\n- plain`), which classifies `tasklist` under both develop's first-item rule and #6216's any-item rule, keeping the test stable across that merge. Homogeneous controls cover all three list types.

## How did I test?

- New test: 6/6 pass. Full packages/app suite: 346 passed, 3 skipped (baseline), 0 failed. `tsc` and prettier clean.
- Mutation-tested the helper in both semantic directions: reverting to unconditional suppression (the original bug) and to unconditional bullets each kill exactly the intended tests. Honest limit: the one-line JSX wiring (`ListNode` → helper) is not pinned — bypassing the helper at the call site survives the pure-function tests; pinning it would need component rendering, which this package's vitest setup deliberately avoids.
- Mixed-shape wire behavior and the impossibility of a converter-side fix were verified on the #6216 side (round-trip idempotence enforced by its property suite; a forced generator case for the mixed shape is being added there).

## Risks and impact

- Safe to rollback without consulting PR author? Yes
- Affects important code area:
  - [x] Channel display
- Homogeneous ordered/unordered/task lists render exactly as before; only the previously marker-less mixed-list children change (they gain a bullet). Also protects any mixed-list content already stored.

## Rollback plan

Revert.

## Screenshots / videos

N/A — marker logic covered by unit tests; no layout changes to existing content.
