### PR TITLE
tlon-skill: add a Hosted tlonbots section for the no-storage upload rule

### DIFF
--- a/packages/tlon-skill/SKILL.md
+++ b/packages/tlon-skill/SKILL.md
@@ -37,7 +37,9 @@ and `posts send` to a current chat/DM conversation (reply normally instead).
 Current-gallery `posts send` creates a new item and is allowed. Image sends
 (`--image`) are allowed anywhere,
 including the current conversation: `tlon upload <direct-image-url>`, then
-`posts send <target> [caption] --image <uploaded-url>`.
+`posts send <target> [caption] --image <uploaded-url>`. If you're a hosted
+tlonbot, that upload needs the owner config — see
+[Hosted tlonbots](#hosted-tlonbots).
 
 ## OpenClaw
 
@@ -45,23 +47,43 @@ When running as an OpenClaw skill, use the built-in `message` tool for sending o
 
 **Images are the exception: upload them first.** The `message` tool's `media=`
 parameter takes only an uploaded https URL — never a local file path, unlike
-other OpenClaw channels. `tlon upload` accepts a URL, a local file path, or
-stdin, and prints the uploaded URL:
+other OpenClaw channels. `upload` accepts a URL, a local file path, or stdin,
+and prints the uploaded URL:
 
 ```bash
 tlon upload ./generated-chart.png      # local file — prints the uploaded URL
 tlon upload https://example.com/x.png  # remote URL
 ```
 
-Pass that printed URL as `media=`. On hosted deployments the upload must run
-through the owner ship's config (the bot's own ship has no storage):
-`tlon --config "$TLON_OWNER_CONFIG_PATH" upload <path>`.
+Pass that printed URL as `media=`. If you're a hosted tlonbot, your own ship
+has no storage — see [Hosted tlonbots](#hosted-tlonbots) for the form to use.
 
 > **Deprecated: diary channels.** `%diary` is not managed by the CLI:
 > `tlon notebook`, `--kind diary`, and `diary/...` targets fail with guidance
 > toward `%notes`. Use the `tlon notes` family for Markdown notebooks. An owner
 > can preview a legacy diary with `tlon notes migrate-plan <diary-nest>` and
 > migrate it with `tlon notes migrate-apply <diary-nest> --yes`.
+
+## Hosted tlonbots
+
+Applies to bots provisioned by tlonbot's hosting entrypoint, under **either**
+runtime (OpenClaw or Hermes). It does not apply to a self-hosted OpenClaw or
+Hermes deployment running against a ship you control.
+
+A hosted tlonbot runs on a **moon**, and a moon has no storage of its own. Any
+upload authenticated as the bot fails; it has to authenticate as the owner
+ship, whose config path the entrypoint provides as `$TLON_OWNER_CONFIG_PATH`:
+
+```bash
+tlon --config "$TLON_OWNER_CONFIG_PATH" upload ./generated-chart.png
+tlon --config "$TLON_OWNER_CONFIG_PATH" upload https://example.com/x.png
+```
+
+This applies to every upload — `message` `media=` attachments, `posts send
+--image`, and `contacts update-profile --avatar` all take a URL that came back
+from one of these. A bare `tlon upload` is the most common mistake here, and it
+fails at the storage step rather than at auth, so read the whole error rather
+than the first line.
 
 ## Installation
 
@@ -526,6 +548,11 @@ notebook only.
 ### Upload
 
 Upload files to Tlon storage from a URL, local path, or stdin.
+
+Uploads go to the storage configured on the ship you authenticate as. A ship
+with no storage of its own can't upload — authenticate as one that does, with
+`--config`. Hosted tlonbots always fall in this category; see
+[Hosted tlonbots](#hosted-tlonbots).
 
 ```bash
 tlon upload https://example.com/image.png         # Upload from URL


### PR DESCRIPTION
Context: [TLON-6298](https://linear.app/tlon/issue/TLON-6298) (no auto-close — that issue tracks tlonbot e2e work; this is a spin-off finding).

A hosted tlonbot runs on a **moon**, and a moon has no storage of its own, so uploads have to authenticate as the owner ship. SKILL.md documented this only as a trailing sentence in the **OpenClaw** section — *after* two bare `tlon upload` examples — and the **Upload** reference section ~500 lines later didn't mention it at all.

But the rule isn't a property of OpenClaw. It's a property of *hosted tlonbots*, and applies equally under Hermes. So it gets its own section, and Hermes / OpenClaw / the Upload reference all link to it.

```
## Hermes            → link
## OpenClaw          → link
## Hosted tlonbots   ← the rule, and what it doesn't cover
## Installation
```

## Scope

Deliberately tight, because this is the **generic** skill doc — most people run the CLI against their own ship, which has storage:

- Upload reference examples stay **bare**; that's the correct default.
- Its new note states the constraint generically ("authenticate as a ship that has storage") without naming `$TLON_OWNER_CONFIG_PATH`.
- That variable is injected by tlonbot's `entrypoint/tlawn.py` and **is not defined anywhere in this repo** — the one pre-existing mention was the OpenClaw line. It now appears only in the Hosted tlonbots section, which also states what it does *not* cover: a self-hosted OpenClaw or Hermes deployment against a ship you control.

Earlier revisions of this PR pushed the owner-config form into the generic reference and the Hermes section; that was wrong for this reason and has been reverted.

## How it turned up

tlonbot's e2e nightly. On two of three `post-image` variants the bot called bare `tlon upload` first, got an error, then retried with `--config …/ships/<owner>.json` and succeeded:

| # | call | result | duration |
| --- | --- | --- | --- |
| 1 | `tlon upload <url>` | error | 433ms |
| 2 | `tlon --config …/ships/risref-hoplux.json upload <url>` | ok | 2925ms |

## Related — the misleading error, fixed but not shipped

That failure surfaced as `Error: Note: Credentials cached for <moon>` — the step that *succeeded*. The note is written to stderr during auth setup, so on failure stderr holds the note followed by the real error (`main.ts:222`), and a consumer surfacing the first stderr line reports the hint instead of the failure.

eeae99cb9 (2026-08-04) already gates that note on `process.stderr.isTTY`. It's on **`develop` but not `master`**, and unpublished: npm's latest `@tloncorp/tlon-skill` is 0.4.5 from 2026-07-29, and both branches still declare 0.4.5. Since `packages/openclaw` depends on `@tloncorp/tlon-skill: workspace:^` and plugin checkouts resolve that to a registry version, bots get the stale published build. Shipping it needs develop → master → version bump + publish; no code change.

Matching prompt fixes on the tlonbot side: tloncorp/tlonbot#168.

🤖 Generated with [Claude Code](https://claude.com/claude-code)