### PR TITLE
fix(hermes-tlon-adapter): accept the optional kwarg in two SSE test doubles so the suite passes with Context Lens on

### DIFF
--- a/packages/hermes-tlon-adapter/test_adapter_attention.py
+++ b/packages/hermes-tlon-adapter/test_adapter_attention.py
@@ -1783,7 +1783,7 @@ class AdapterAttentionTests(unittest.TestCase):
             async def open(self):
                 return None
 
-            async def subscribe(self, app, path):
+            async def subscribe(self, app, path, *, optional=False):
                 subscriptions.append((app, path))
                 return len(subscriptions)
 

--- a/packages/hermes-tlon-adapter/test_adapter_nudge.py
+++ b/packages/hermes-tlon-adapter/test_adapter_nudge.py
@@ -147,7 +147,7 @@ class SlowAuthenticateSSE:
     async def open(self):
         assert self.ready
 
-    async def subscribe(self, _app, _path):
+    async def subscribe(self, _app, _path, *, optional=False):
         assert self.ready
 
     async def poke(self, app, mark, payload):


### PR DESCRIPTION
## Problem

`TlonSSEClient.subscribe` gained a keyword-only `optional` parameter in ead5a945f. `_connect_sse` uses it for the one subscription that is allowed to fail:

```python
if self._lens.enabled:
    await sse.subscribe("steward", "/v1/lens", optional=True)
```

Nine test doubles were updated to match the new signature. Two were not:

- `test_adapter_nudge.py` — `async def subscribe(self, _app, _path)`
- `test_adapter_attention.py` — `async def subscribe(self, app, path)`

A double that does not match the real signature raises `TypeError: subscribe() got an unexpected keyword argument 'optional'`.

## Why CI does not catch this

The steward subscription sits behind a guard on `self._lens.enabled`, which reads `context_lens_enabled` from the config. CI runs with Context Lens off. The branch never runs, so both doubles look correct.

A developer who enables Context Lens gets an error in `test_retained_queue_head_waits_for_fully_authenticated_sse`. The failure looks like a broken adapter. The adapter is correct.

## Change

Add `*, optional=False` to both doubles. No production code changes.

## Verification

Full adapter suite, 956 tests:

| Config | Before | After |
| --- | --- | --- |
| `TLON_CONTEXT_LENS=true` | 1 error | OK |
| variable unset (CI state) | OK | OK |

Command:

```bash
python -m unittest discover . -p 'test_*.py'
```
