### PR TITLE
fix: hide stale note search results when query changes

### DIFF
--- a/packages/app/features/top/NotesSearchScreen.tsx
+++ b/packages/app/features/top/NotesSearchScreen.tsx
@@ -8,6 +8,7 @@ import {
   useNotesSearch,
   useNotesSearchSupported,
 } from '@tloncorp/shared';
+import { noteSearchQueryIsCurrent } from '@tloncorp/shared/logic';
 import { useCallback, useEffect, useMemo, useState } from 'react';
 import { SizableText, XStack, YStack } from 'tamagui';
 
@@ -27,6 +28,7 @@ export function NotesSearchScreen(props: Props) {
   // The header hides its search button on an older backend, but a deep link or
   // a route restored from a previous session can still land here.
   const searchSupported = useNotesSearchSupported();
+  const [inputValue, setInputValue] = useState('');
   const [query, setQuery] = useState('');
   const { notes, loading, errored, hasMore, loadMore, searchComplete } =
     useNotesSearch(notebookFlag, query);
@@ -35,6 +37,20 @@ export function NotesSearchScreen(props: Props) {
   const search = useMemo(
     () => ({ loading, errored, hasMore, loadMore, searchComplete }),
     [loading, errored, hasMore, loadMore, searchComplete]
+  );
+  const queryIsCurrent = noteSearchQueryIsCurrent(inputValue, query);
+  const visibleSearch = useMemo(
+    () =>
+      queryIsCurrent
+        ? search
+        : {
+            ...search,
+            loading: true,
+            errored: false,
+            hasMore: false,
+            searchComplete: false,
+          },
+    [queryIsCurrent, search]
   );
 
   // Local reads, only for labeling which folder a hit lives in — the search
@@ -79,6 +95,7 @@ export function NotesSearchScreen(props: Props) {
           <XStack marginHorizontal="$m">
             <SearchBar
               onChangeQuery={setQuery}
+              onChangeValue={setInputValue}
               placeholder="Search notes"
               inputProps={{ autoFocus: true }}
               onPressCancel={() => props.navigation.pop()}
@@ -86,9 +103,9 @@ export function NotesSearchScreen(props: Props) {
           </XStack>
           <NotesSearchResults
             getFolderPath={getFolderPath}
-            notes={notes}
-            query={query}
-            search={search}
+            notes={queryIsCurrent ? notes : []}
+            query={inputValue.trim()}
+            search={visibleSearch}
             onPressNote={handlePressNote}
           />
         </View>

--- a/packages/app/ui/components/NotesChannel/NotesSearchModal.tsx
+++ b/packages/app/ui/components/NotesChannel/NotesSearchModal.tsx
@@ -1,4 +1,5 @@
 import { useNotesSearch } from '@tloncorp/shared';
+import { noteSearchQueryIsCurrent } from '@tloncorp/shared/logic';
 import { Pressable, TlonText } from '@tloncorp/ui';
 import { debounce } from 'lodash';
 import { useCallback, useEffect, useMemo, useState } from 'react';
@@ -65,7 +66,7 @@ export function NotesSearchModal({
 
   // What's typed hasn't been searched yet, so `notes` still belongs to the
   // previous term.
-  const queryIsStale = inputValue.trim() !== query;
+  const queryIsCurrent = noteSearchQueryIsCurrent(inputValue, query);
 
   const { notes, loading, errored, hasMore, loadMore, searchComplete } =
     useNotesSearch(open ? notebookFlag : null, open ? query : '');
@@ -73,6 +74,23 @@ export function NotesSearchModal({
   const search = useMemo(
     () => ({ loading, errored, hasMore, loadMore, searchComplete }),
     [loading, errored, hasMore, loadMore, searchComplete]
+  );
+  const visibleNotes = useMemo(
+    () => (queryIsCurrent ? notes : []),
+    [notes, queryIsCurrent]
+  );
+  const visibleSearch = useMemo(
+    () =>
+      queryIsCurrent
+        ? search
+        : {
+            ...search,
+            loading: true,
+            errored: false,
+            hasMore: false,
+            searchComplete: false,
+          },
+    [queryIsCurrent, search]
   );
 
   // Cleared on close rather than on open: the input remounts empty, and a query
@@ -89,16 +107,16 @@ export function NotesSearchModal({
   // Keep the highlight on the first result as pages stream in, and drop it if
   // the note it pointed at is no longer in the list.
   useEffect(() => {
-    if (notes.length === 0) {
+    if (visibleNotes.length === 0) {
       setSelectedNoteId(null);
       return;
     }
     setSelectedNoteId((current) =>
-      current !== null && notes.some((note) => note.noteId === current)
+      current !== null && visibleNotes.some((note) => note.noteId === current)
         ? current
-        : notes[0].noteId
+        : visibleNotes[0].noteId
     );
-  }, [notes]);
+  }, [visibleNotes]);
 
   const close = useCallback(() => onOpenChange(false), [onOpenChange]);
 
@@ -112,22 +130,22 @@ export function NotesSearchModal({
 
   const moveSelection = useCallback(
     (delta: number) => {
-      if (notes.length === 0) return;
-      const currentIndex = notes.findIndex(
+      if (visibleNotes.length === 0) return;
+      const currentIndex = visibleNotes.findIndex(
         (note) => note.noteId === selectedNoteId
       );
       const nextIndex = Math.min(
-        notes.length - 1,
+        visibleNotes.length - 1,
         Math.max(0, (currentIndex === -1 ? 0 : currentIndex) + delta)
       );
-      setSelectedNoteId(notes[nextIndex].noteId);
+      setSelectedNoteId(visibleNotes[nextIndex].noteId);
       // Arrowing to the end is the same "give me more" signal as scrolling to
       // it, and the list's own onEndReached can't see keyboard movement.
-      if (nextIndex === notes.length - 1 && hasMore && !loading) {
+      if (nextIndex === visibleNotes.length - 1 && hasMore && !loading) {
         loadMore();
       }
     },
-    [hasMore, loadMore, loading, notes, selectedNoteId]
+    [hasMore, loadMore, loading, selectedNoteId, visibleNotes]
   );
 
   const handleNavigationKey = useCallback(
@@ -143,14 +161,16 @@ export function NotesSearchModal({
           close();
           break;
         case 'Enter': {
-          if (queryIsStale) {
-            // Mid-debounce the visible results belong to the previous term, so
-            // Enter searches what's typed instead of opening a hit from it.
+          if (!queryIsCurrent) {
+            // Mid-debounce the current results are hidden because they belong
+            // to the previous term. Enter commits what's typed immediately.
             commitQuery.cancel();
             setQuery(inputValue.trim());
             break;
           }
-          const selected = notes.find((note) => note.noteId === selectedNoteId);
+          const selected = visibleNotes.find(
+            (note) => note.noteId === selectedNoteId
+          );
           if (selected) {
             selectNote(selected);
           }
@@ -163,10 +183,10 @@ export function NotesSearchModal({
       commitQuery,
       inputValue,
       moveSelection,
-      notes,
-      queryIsStale,
+      queryIsCurrent,
       selectNote,
       selectedNoteId,
+      visibleNotes,
     ]
   );
 
@@ -254,9 +274,9 @@ export function NotesSearchModal({
           <YStack flex={1} minHeight={0}>
             <NotesSearchResults
               getFolderPath={getFolderPath}
-              notes={notes}
-              query={query}
-              search={search}
+              notes={visibleNotes}
+              query={inputValue.trim()}
+              search={visibleSearch}
               selectedNoteId={selectedNoteId}
               onPressNote={selectNote}
             />

--- a/packages/app/ui/components/SearchBar.tsx
+++ b/packages/app/ui/components/SearchBar.tsx
@@ -16,6 +16,7 @@ export function SearchBar({
   autoFocus = false,
   placeholder,
   onChangeQuery,
+  onChangeValue,
   debounceTime = 300,
   onPressCancel,
   inputProps,
@@ -24,6 +25,10 @@ export function SearchBar({
   autoFocus?: boolean;
   placeholder?: string;
   onChangeQuery: (query: string) => void;
+  // Receives the input's raw value immediately, before onChangeQuery's
+  // debounce. Consumers can use it to hide results belonging to an older
+  // committed query.
+  onChangeValue?: (value: string) => void;
   debounceTime?: number;
   onPressCancel?: () => void;
   inputProps?: ComponentProps<typeof TextInput>;
@@ -57,6 +62,7 @@ export function SearchBar({
       // we update the input display immediately, but debounce for consumers
       // of the search bar
       setValue(text);
+      onChangeValue?.(text);
       const newValue = text.trim();
       if (newValue === '') {
         // if value was cleared, update immediately
@@ -71,7 +77,7 @@ export function SearchBar({
         debouncedOnChangeQuery(newValue);
       }
     },
-    [debounceTime, debouncedOnChangeQuery, onChangeQuery]
+    [debounceTime, debouncedOnChangeQuery, onChangeQuery, onChangeValue]
   );
 
   return (

--- a/packages/shared/src/logic/notesSearch.test.ts
+++ b/packages/shared/src/logic/notesSearch.test.ts
@@ -4,6 +4,7 @@ import {
   buildNoteSnippet,
   buildNoteTitleSegments,
   noteSearchListState,
+  noteSearchQueryIsCurrent,
 } from './notesSearch';
 
 function render(segments: { text: string; match: boolean }[]): string {
@@ -150,5 +151,16 @@ describe('noteSearchListState', () => {
     expect(
       noteSearchListState({ ...base, resultCount: 3, errored: true })
     ).toBe('results');
+  });
+});
+
+describe('noteSearchQueryIsCurrent', () => {
+  test('accepts the committed query and ignores surrounding input whitespace', () => {
+    expect(noteSearchQueryIsCurrent('needle', 'needle')).toBe(true);
+    expect(noteSearchQueryIsCurrent('  needle  ', 'needle')).toBe(true);
+  });
+
+  test('rejects results from the previous debounced query', () => {
+    expect(noteSearchQueryIsCurrent('new query', 'old query')).toBe(false);
   });
 });

--- a/packages/shared/src/logic/notesSearch.ts
+++ b/packages/shared/src/logic/notesSearch.ts
@@ -24,6 +24,18 @@ const SNIPPET_CONTEXT = 80;
 // Cap for a snippet with no match to anchor on (title-only hits).
 const SNIPPET_LEAD = 160;
 
+/**
+ * Whether the visible input is the query that produced the current results.
+ * Search inputs keep their raw value while the backend query is trimmed, so
+ * surrounding whitespace does not make an otherwise-current result stale.
+ */
+export function noteSearchQueryIsCurrent(
+  inputValue: string,
+  query: string
+): boolean {
+  return inputValue.trim() === query;
+}
+
 function findMatches(haystack: string, needle: string): [number, number][] {
   if (!needle) return [];
   const lowerHaystack = haystack.toLowerCase();

--- a/packages/tlon-skill/scripts/tloncorp-api-mock.ts
+++ b/packages/tlon-skill/scripts/tloncorp-api-mock.ts
@@ -31,6 +31,7 @@ export const NOTES_V1_OPS = [
   'createNotebook',
   'createGroupNotebook',
   'listNotes',
+  'searchNotes',
   'getNote',
   'createNote',
   'updateNoteBody',


### PR DESCRIPTION
OTT

Small fix I was going to tack onto https://github.com/tloncorp/tlon-apps/pull/6228 before it got merged.