### PR TITLE
tlon-skill: add searchNotes to the notes-v1 mock op list

### DIFF
--- a/packages/tlon-skill/scripts/tloncorp-api-mock.ts
+++ b/packages/tlon-skill/scripts/tloncorp-api-mock.ts
@@ -31,6 +31,7 @@ export const NOTES_V1_OPS = [
   'createNotebook',
   'createGroupNotebook',
   'listNotes',
+  'searchNotes',
   'getNote',
   'createNote',
   'updateNoteBody',


### PR DESCRIPTION
## Summary

Adds `searchNotes` to `NOTES_V1_OPS` in tlon-skill's `@tloncorp/api` test double, fixing a typecheck failure on `develop` that blocks every open PR.

#6228 added `searchNotes` to the `NotesV1Api` type without adding it to the hand-maintained op list that drives the mock. That list has a compile-time drift guard (`AssertNever<Exclude<keyof NotesV1Api, NotesV1Op>>`), which is exactly what caught this:

```
packages/tlon-skill/scripts/tloncorp-api-mock.ts(65,34): error TS2344:
Type '"searchNotes"' does not satisfy the constraint 'never'.
```

Both changes were green on their own branches and red together, and `ci.yml` does not run on pushes to `develop`, so nothing caught it at merge time.

## Changes

- `packages/tlon-skill/scripts/tloncorp-api-mock.ts`: one entry added to `NOTES_V1_OPS`, placed after `listNotes` to match the declaration order in `NotesV1Api`.

## How did I test?

- `pnpm typecheck` in `packages/tlon-skill` passes; removing the added line reproduces the CI error exactly (same file, line, column, and message).
- `pnpm test` in `packages/tlon-skill`: 423 unit and 356 hermetic tests pass.
- Verified `searchNotes` was the only drift in either direction: `NotesV1Api` has 22 keys, the op list had 21.

## Risks and impact

- Safe to rollback without consulting PR author? Yes
- Affects important code area:
  - [ ] Onboarding
  - [ ] State / providers
  - [ ] Message sync
  - [ ] Channel display
  - [ ] Notifications
  - [x] Other: test-only (tlon-skill's API test double)

Test-double surface only; no shipped behavior changes. The new mock op defaults to the same `async () => undefined` stub as every other entry, so existing tests are unaffected.

## Rollback plan

Revert.

## Screenshots / videos

N/A (test-only change).
