### PR TITLE
tlon-skill: add searchNotes to NOTES_V1_OPS mock assertion list

### DIFF
--- a/packages/tlon-skill/scripts/tloncorp-api-mock.ts
+++ b/packages/tlon-skill/scripts/tloncorp-api-mock.ts
@@ -31,6 +31,7 @@ export const NOTES_V1_OPS = [
   'createNotebook',
   'createGroupNotebook',
   'listNotes',
+  'searchNotes',
   'getNote',
   'createNote',
   'updateNoteBody',


### PR DESCRIPTION
## Summary

Fixes the `test-build` (Check Types) job, which is currently failing repo-wide for any branch containing latest develop:

```
scripts/tloncorp-api-mock.ts(65,34): error TS2344: Type '"searchNotes"' does not satisfy the constraint 'never'.
```

The notes search work added `searchNotes` to `NotesV1Api` in `@tloncorp/api`, but the hand-maintained `NOTES_V1_OPS` list in the tlon-skill test mock wasn't updated, so its compile-time exhaustiveness check (`AssertNever`) fails. The mock implementation is generated from the list, so the one entry is the whole fix.

## How did I test?

- `pnpm --filter @tloncorp/tlon-skill run tsc` clean against a freshly built `@tloncorp/api` dist (reproduces the CI error without the fix).
- tlon-skill unit suite: 423/423 passing.