### PR TITLE
notify: gate pushes on client-declared capabilities

### DIFF
--- a/desk/app/notify.hoon
+++ b/desk/app/notify.hoon
@@ -18,12 +18,38 @@
   ==
 ++  clear-interval  ~d7
 ++  daily-stats-interval  ~d1
+::  +device-ttl: how long a registration counts toward the push capability gate
 ::
-+$  client-state
+::    Every app launch re-registers the device's push token, so a device that
+::    has been silent this long is either gone or reinstalled under a new
+::    token. Aging it out keeps a rotated-away token from pinning the gate shut
+::    forever; the cost is that a device that really is still reachable can
+::    receive one unrenderable notification, which is what it gets today.
+::
+++  device-ttl  ~d30
+::
++$  client-state-0
   $:  providers=(jug @p term)
   ==
 ::
+::  $device: a registered push target and what its app build can render
+::
++$  device
+  $:  caps=push-caps
+      last=@da
+  ==
+::
++$  client-state
+  $:  providers=(jug @p term)
+      devices=(map @t device)
+  ==
+::
 +$  base-state-0
+  $:  =provider-state
+      client-state=client-state-0
+  ==
+::
++$  base-state-9
   $:  =provider-state
       =client-state
   ==
@@ -86,6 +112,13 @@
       base-state-0
   ==
 ::
++$  state-9
+  $:  %9
+      last-timer=time
+      notifications=(map time-id:av event-8)
+      base-state-9
+  ==
+::
 +$  event-7
   $:  =event:v8:av
       ::TODO  if we poked the provider instead, we could track time-to-ack
@@ -108,9 +141,10 @@
       state-6
       state-7
       state-8
+      state-9
   ==
 ::
-+$  current-state  state-8
++$  current-state  state-9
 ::
 ++  migrate-state
   |=  old=versioned-state
@@ -124,7 +158,8 @@
     %5  $(old (migrate-5-to-6 old))
     %6  $(old (migrate-6-to-7 old))
     %7  $(old (migrate-7-to-8 old))
-    %8  old
+    %8  $(old (migrate-8-to-9 old))
+    %9  old
   ==
 ::
 ++  migrate-0-to-1
@@ -166,6 +201,17 @@
   |=  old=state-7
   ^-  state-8
   [%8 last-timer notifications |3]:old
+::
+++  migrate-8-to-9
+  |=  old=state-8
+  ^-  state-9
+  :*  %9
+      last-timer.old
+      notifications.old
+      provider-state.old
+      providers.client-state.old
+      ~
+  ==
 ::
 ::  +log: specialized wrapper for logging library
 ::
@@ -356,6 +402,10 @@
         =*  binding  'apn'
         =.  providers.client-state
           (~(put ju providers.client-state) who.act service.act)
+        =.  devices.client-state
+          %+  ~(put by (prune-devices:do devices.client-state))
+            address.act
+          [~ now.bowl]
         =/  pact=provider-action  [%client-join service.act address.act binding]
         :_  state
         [(poke:pass [who.act %notify] %notify-provider-action !>(pact))]~
@@ -363,6 +413,10 @@
           %connect-provider-with-binding
         =.  providers.client-state
           (~(put ju providers.client-state) who.act service.act)
+        =.  devices.client-state
+          %+  ~(put by (prune-devices:do devices.client-state))
+            address.act
+          [caps.act now.bowl]
         =/  pact=provider-action  [%client-join service.act address.act binding.act]
         :_  state
         [(poke:pass [who.act %notify] %notify-provider-action !>(pact))]~
@@ -504,6 +558,11 @@
     ::
         [%x %provider-state ~]  ``noun+!>(provider-state)
         [%x %client-state ~]    ``client-state+!>(client-state)
+    ::
+    ::  would a push requiring this capability reach every live device?
+    ::
+        [%x %push-eligible cap=@t ~]
+      ``noun+!>((can-push:do `cap.pole))
     ==
   ::
   ++  on-agent
@@ -524,6 +583,14 @@
         ?.  ?=(%activity-event-1 p.cage.sign)
           `this
         =+  !<([=time-id:av =event:v9:av] q.cage.sign)
+        ::  a push we send is a push the device must display, so withhold it
+        ::  when this event's kind needs a capability some device lacks. the
+        ::  event is still recorded, for the note endpoint and in-app activity.
+        ::
+        ?.  (can-push:do (push-cap:do event))
+          %-  (tell:l %info 'notify: withheld push, device lacks capability' ~)
+          :_  this(notifications (~(put by notifications) time-id [event ~]))
+          ~
         =+  .^(=activity:v9:av %gx (scry:io %activity /v5/activity/activity-summary-5))
         =/  notify-count=@ud
           notify-count:(~(gut by activity) [%base ~] *activity-summary:v9:av)
@@ -727,6 +794,59 @@
     [(~(on-fail logs bowl /logs) term tang)]~
   --
 |_  bowl=bowl:gall
+::
+::  +gated-kinds: event kind -> the capability a device must declare for it
+::
+::    Empty means no kind is gated: every kind that exists today predates
+::    capability declarations, so it goes to every device exactly as before.
+::    Add an entry here when a new kind's notification cannot be rendered by
+::    already-released clients, and declare the same tag in the client's
+::    PUSH_CAPABILITIES. An entry can stay forever; it costs one lookup.
+::
+++  gated-kinds
+  ^-  (map @tas @t)
+  ~
+::
+::  +push-cap: the capability this event's notification needs, if any
+::
+++  push-cap
+  |=  =event:v9:av
+  ^-  (unit @t)
+  (~(get by gated-kinds) -<.event)
+::
+::  +can-push: may we push an event needing this capability?
+::
+::    All-or-nothing per ship, which is the granularity the provider gives us:
+::    it addresses the notification by identity and the push service fans it
+::    out to every binding the ship has. So one device that cannot render the
+::    kind withholds it from all of them.
+::
+++  can-push
+  |=  need=(unit @t)
+  ^-  ?
+  ?~  need  &
+  %-  ~(all by devices.client-state)
+  |=  =device
+  ?|  (stale-device device)
+      (~(has in caps.device) u.need)
+  ==
+::
+++  stale-device
+  |=  =device
+  ^-  ?
+  (lth (add last.device device-ttl) now.bowl)
+::
+::  +prune-devices: drop registrations that have aged out
+::
+::    Called when a device registers, which is the only time this map grows.
+::
+++  prune-devices
+  |=  devices=(map @t device)
+  ^-  (map @t device)
+  %-  ~(gas by *(map @t device))
+  %+  skip  ~(tap by devices)
+  |=  [@t =device]
+  (stale-device device)
 ::
 ++  is-whitelisted
   |=  [who=@p entry=provider-entry]

--- a/desk/mar/notify/client-action.hoon
+++ b/desk/mar/notify/client-action.hoon
@@ -26,12 +26,16 @@
           service+so
           address+so
       ==
+    ::  caps is optional: app builds older than push capability gating
+    ::  register without it, and declare nothing by omitting it
+    ::
     ++  connect-provider-with-binding
-      %-  ot
-      :~  who+(su fed:ag)
-          service+so
-          address+so
-          binding+so
+      %-  ou
+      :~  who+(un (su fed:ag))
+          service+(un so)
+          address+(un so)
+          binding+(un so)
+          caps+(uf ~ (as so))
       ==
     ++  remove-provider
       %-  ot

--- a/desk/sur/notify.hoon
+++ b/desk/sur/notify.hoon
@@ -15,9 +15,25 @@
       [%client-leave service=term]
   ==
 ::
+::  $push-caps: notification kinds a device's app build knows how to render
+::
+::    Declared by the client each time it registers its push token. %notify
+::    withholds a push whose kind requires a capability that any live device
+::    has not declared, because iOS cannot suppress an alert once APNs has
+::    delivered it. Kinds that predate this mechanism require nothing, so an
+::    old client declaring no capabilities keeps receiving what it does today.
+::
++$  push-caps  (set @t)
+::
 +$  client-action
   $%  [%connect-provider who=@p service=term address=@t]
-      [%connect-provider-with-binding who=@p service=term address=@t binding=@t]
+      $:  %connect-provider-with-binding
+          who=@p
+          service=term
+          address=@t
+          binding=@t
+          caps=push-caps
+      ==
       [%remove-provider who=@p service=term]
       [%send-message message=@t]
   ==

--- a/desk/tests/app/notify.hoon
+++ b/desk/tests/app/notify.hoon
@@ -1,0 +1,185 @@
+::  tests for %notify push capability gating
+::
+::    A push we send is a push the device has to display: iOS cannot suppress
+::    an alert once APNs has delivered it. So %notify withholds a push whose
+::    event kind requires a capability that any live device has not declared.
+::    The decision is all-or-nothing per ship, matching the provider, which
+::    addresses by identity and fans out to every binding the ship has.
+::
+::    No kind is gated yet (+gated-kinds is empty), so these drive the
+::    predicate itself through the /x/push-eligible scry.
+::
+/-  *notify, av=activity-ver
+/+  *test-agent
+/=  agent  /app/notify
+|%
+++  dap       %notify
+++  provider  ~bus
+++  service   %tlon
+::
+++  setup
+  =/  m  (mare ,~)
+  ^-  form:m
+  ;<  ~  bind:m  (jab-bowl |=(b=bowl b(our ~dev, src ~dev, now ~2024.1.1)))
+  ;<  *  bind:m  (do-init dap agent)
+  (pure:m ~)
+::
+::  +register: a device announcing its push token and what it can render
+::
+++  register
+  |=  [address=@t caps=push-caps]
+  =/  m  (mare ,~)
+  ^-  form:m
+  ;<  *  bind:m
+    %+  do-poke  %notify-client-action
+    !>  ^-  client-action
+    [%connect-provider-with-binding provider service address 'apn' caps]
+  (pure:m ~)
+::
+++  eligible
+  |=  cap=@ta
+  =/  m  (mare ,?)
+  ^-  form:m
+  ;<  =cage  bind:m  (got-peek /x/push-eligible/[cap])
+  (pure:m !<(? q.cage))
+::
+::  a ship with no registered device blocks nothing. there is nowhere to push
+::  in the first place, and we must not let an empty fleet read as "unable"
+::
+++  test-no-devices-are-eligible
+  %-  eval-mare
+  =/  m  (mare ,~)
+  ^-  form:m
+  ;<  ~  bind:m  setup
+  ;<  ok=?  bind:m  (eligible ~.react)
+  (ex-equal !>(ok) !>(&))
+::
+::  an app build old enough to predate capabilities registers without any,
+::  which is exactly how it reports that it cannot render a gated kind
+::
+++  test-device-without-capability-blocks
+  %-  eval-mare
+  =/  m  (mare ,~)
+  ^-  form:m
+  ;<  ~  bind:m  setup
+  ;<  ~  bind:m  (register 'tok-old' ~)
+  ;<  ok=?  bind:m  (eligible ~.react)
+  (ex-equal !>(ok) !>(|))
+::
+++  test-device-with-capability-is-eligible
+  %-  eval-mare
+  =/  m  (mare ,~)
+  ^-  form:m
+  ;<  ~  bind:m  setup
+  ;<  ~  bind:m  (register 'tok-new' (silt ~['react']))
+  ;<  ok=?  bind:m  (eligible ~.react)
+  (ex-equal !>(ok) !>(&))
+::
+::  a capability the device did not declare is still withheld from it
+::
+++  test-unrelated-capability-blocks
+  %-  eval-mare
+  =/  m  (mare ,~)
+  ^-  form:m
+  ;<  ~  bind:m  setup
+  ;<  ~  bind:m  (register 'tok-new' (silt ~['react']))
+  ;<  ok=?  bind:m  (eligible ~.flag)
+  (ex-equal !>(ok) !>(|))
+::
+::  one phone on an old build withholds the push from the new one too, since
+::  the provider fans out by identity and cannot address them separately
+::
+++  test-mixed-fleet-blocks
+  %-  eval-mare
+  =/  m  (mare ,~)
+  ^-  form:m
+  ;<  ~  bind:m  setup
+  ;<  ~  bind:m  (register 'tok-new' (silt ~['react']))
+  ;<  ~  bind:m  (register 'tok-old' ~)
+  ;<  ok=?  bind:m  (eligible ~.react)
+  (ex-equal !>(ok) !>(|))
+::
+::  re-registering the same token replaces its capabilities, so a device that
+::  updates its app stops blocking as soon as it launches
+::
+++  test-reregistration-replaces-capabilities
+  %-  eval-mare
+  =/  m  (mare ,~)
+  ^-  form:m
+  ;<  ~  bind:m  setup
+  ;<  ~  bind:m  (register 'tok' ~)
+  ;<  ~  bind:m  (register 'tok' (silt ~['react']))
+  ;<  ok=?  bind:m  (eligible ~.react)
+  (ex-equal !>(ok) !>(&))
+::
+::  every launch re-registers, so a registration this old is a token that
+::  rotated away or a device that is gone. it must stop pinning the gate shut
+::
+++  test-stale-device-is-ignored
+  %-  eval-mare
+  =/  m  (mare ,~)
+  ^-  form:m
+  ;<  ~  bind:m  setup
+  ;<  ~  bind:m  (register 'tok-old' ~)
+  ;<  ok=?  bind:m  (eligible ~.react)
+  ;<  ~  bind:m  (ex-equal !>(ok) !>(|))
+  ;<  ~  bind:m  (wait ~d31)
+  ;<  ok=?  bind:m  (eligible ~.react)
+  (ex-equal !>(ok) !>(&))
+::
+::  a device that keeps launching keeps counting, however old its token is
+::
+++  test-refreshed-device-still-blocks
+  %-  eval-mare
+  =/  m  (mare ,~)
+  ^-  form:m
+  ;<  ~  bind:m  setup
+  ;<  ~  bind:m  (register 'tok-old' ~)
+  ;<  ~  bind:m  (wait ~d20)
+  ;<  ~  bind:m  (register 'tok-old' ~)
+  ;<  ~  bind:m  (wait ~d20)
+  ;<  ok=?  bind:m  (eligible ~.react)
+  (ex-equal !>(ok) !>(|))
+::
+::  registration is the only point the map grows, so it is where aged-out
+::  entries get dropped rather than accumulating one per token rotation
+::
+++  test-registration-prunes-stale-devices
+  %-  eval-mare
+  =/  m  (mare ,~)
+  ^-  form:m
+  ;<  ~  bind:m  setup
+  ;<  ~  bind:m  (register 'tok-old' ~)
+  ;<  ~  bind:m  (wait ~d31)
+  ;<  ~  bind:m  (register 'tok-new' (silt ~['react']))
+  ;<  =cage  bind:m  (got-peek /x/client-state)
+  =+  !<([* devices=(map @t [caps=(set @t) last=@da])] q.cage)
+  (ex-equal !>(~(key by devices)) !>((silt ~['tok-new'])))
+::
+::  with no kind gated, an event still produces its provider fact — even for a
+::  device that declared nothing. this is the property that makes the mechanism
+::  safe to land: an empty +gated-kinds leaves push behavior exactly as it was
+::
+++  test-ungated-event-still-pushes
+  =/  sub=path  /v1/notify/(scot %p ~dev)/[service]
+  %-  eval-mare
+  =/  m  (mare ,~)
+  ^-  form:m
+  ;<  ~  bind:m  setup
+  ;<  ~  bind:m  (register 'tok-old' ~)
+  ;<  ~  bind:m
+    %-  set-scry-gate
+    |=  =path
+    ^-  (unit vase)
+    ?.  ?=([%gx *] path)  ~
+    `!>(*activity:v9:av)
+  ;<  *  bind:m  ((do-as provider) (do-watch sub))
+  =/  =time-id:av  `@da`~2024.1.2
+  =/  ev=event:v9:av  [[%group-join [~dev %test] ~bus] & |]
+  ;<  caz=(list card)  bind:m
+    (do-agent /activity [~dev %activity] [%fact %activity-event-1 !>([time-id ev])])
+  %+  ex-cards  caz
+  :~  %+  ex-fact  ~[sub]
+      [%notify-update-1 !>(`update`[0 `@`time-id %notify ~])]
+  ==
+--

--- a/packages/app/lib/notificationsApi.ts
+++ b/packages/app/lib/notificationsApi.ts
@@ -6,6 +6,18 @@ import { NOTIFY_PROVIDER, NOTIFY_SERVICE } from '../constants';
 
 const logger = createDevLogger('notificationsApi', true);
 
+/**
+ * Notification kinds this build knows how to render, declared to the ship on
+ * every registration. `%notify` withholds a push whose kind requires a
+ * capability the device hasn't declared, since iOS can't suppress an alert
+ * once APNs has delivered it — see `gated-kinds` in `desk/app/notify.hoon`.
+ *
+ * Empty because no kind is gated yet. When adding a kind that older clients
+ * can't render, add its tag here in the same change that teaches
+ * `renderActivityEventPreview` (packages/scripts) to handle it.
+ */
+export const PUSH_CAPABILITIES: string[] = [];
+
 export const connectNotifyProvider = async (address: string) => {
   await poke({
     app: 'notify',
@@ -16,6 +28,7 @@ export const connectNotifyProvider = async (address: string) => {
         service: NOTIFY_SERVICE,
         address,
         binding: Platform.OS === 'android' ? 'fcm' : 'apn',
+        caps: PUSH_CAPABILITIES,
       },
     },
   });
@@ -23,5 +36,6 @@ export const connectNotifyProvider = async (address: string) => {
     address,
     provider: NOTIFY_PROVIDER,
     service: NOTIFY_SERVICE,
+    caps: PUSH_CAPABILITIES,
   });
 };


### PR DESCRIPTION
## Summary

Lets the backend decide whether a push goes out, based on what the receiving device says it can render. New activity event kinds that generate pushes currently force a client-first release, because an old client that gets a push it can't render falls through to a generic alert and iOS can't suppress an alert once APNs has delivered it. This moves that decision to before the ship hands the notification to the provider.

Inert as merged: no event kind is gated, so behavior is identical to today. The first real user is the notes activity work (#6188 / #6200), which introduces `%note-create` / `%note-edit` as v10 kinds.

Fixes TLON-6314

## Changes

- `sur/notify.hoon` — `$push-caps`, and a `caps` field on `%connect-provider-with-binding`.
- `mar/notify/client-action.hoon` — that variant moves from `ot` to `ou`/`un` so `caps` is optional. An app build predating this registers exactly as before rather than crashing the poke; `ot` ignores unknown keys, so a newer client registering against an older ship also still works. No release-order constraint in either direction.
- `app/notify.hoon` — `$device` (declared caps + last-seen) in `client-state`, state-9 with an 8→9 migration, and `+gated-kinds` / `+push-cap` / `+can-push` / `+stale-device` / `+prune-devices` in the helper core. The gate sits in `on-agent [%activity ~]` ahead of the activity-summary scry; a withheld event is still recorded so the note endpoint and in-app activity are unaffected, and it logs at `%info`. Adds `/x/push-eligible/<cap>` for support debugging.
- `packages/app/lib/notificationsApi.ts` — `PUSH_CAPABILITIES`, declared on every registration (`connectNotifications()` already runs on each app mount, so the ship re-learns each device every launch).
- `tests/app/notify.hoon` — new, 10 cases.

Design notes:

- **Deny is opt-in per kind.** Every kind shipping today requires nothing, so a client that declares nothing — which is every build in the field — keeps receiving exactly what it does now. That's also what makes this work retroactively on already-released clients, which no client-side payload marker can.
- **All-or-nothing per ship.** That's the granularity the provider gives us: it addresses by identity and the push service fans out to every binding the ship has. So one device that can't render a kind withholds it from all of that ship's devices. Per-device precision would mean threading `requires` to the provider and dropping identity fan-out; deferred.
- **Registrations age out after 30 days.** Every launch re-registers, so an older entry is a rotated-away token or a device that's gone. Without the TTL such an entry would pin the gate shut for that user permanently and silently. The cost is that a device untouched for a month may receive one unrenderable notification — which is what it receives today.
- **An empty device map reads as permissive.** A ship whose app hasn't launched since the desk update has nothing recorded, so a gated kind would still reach it as the generic fallback. Bounded, closes on first launch, and the alternative would suppress a new kind for the whole userbase until everyone had opened the app once.
- **This does not retire the reactions shims.** `activitySupportsReactions` and the `activity-event` / `activity-event-1` mark choice solve the client-*ahead*-of-backend problem, which this doesn't touch — self-hosted ships will always lag.

## How did I test?

`./backend/run-tests.sh` — full Hoon unit suite green, including 10 new `%notify` tests:

- `test-ungated-event-still-pushes` drives a real `%activity-event-1` fact through `on-agent` with a device that declared nothing, and asserts the exact `notify-update-1` fact still reaches the provider subscription. This is the property that makes the change safe to land, so it's checked rather than argued.
- `test-no-devices-are-eligible`, `test-device-with(out)-capability-*`, `test-unrelated-capability-blocks`, `test-mixed-fleet-blocks` cover the predicate.
- `test-reregistration-replaces-capabilities`, `test-stale-device-is-ignored`, `test-refreshed-device-still-blocks`, `test-registration-prunes-stale-devices` cover the TTL and pruning.

Also confirmed `gall: reloading %notify` on a live ship, i.e. the 8→9 migration runs. Prettier clean on the changed TS. Aqua suite not run — it doesn't exercise `%notify`.

## Risks and impact

- Safe to rollback without consulting PR author? Yes
- Affects important code area:
  - [ ] Onboarding
  - [ ] State / providers
  - [ ] Message sync
  - [ ] Channel display
  - [x] Notifications
  - [ ] Other:

The state migration is the only non-inert part. `devices` starts empty, and with `+gated-kinds` empty the map is never read, so push behavior is unchanged on merge.

## Rollback plan

Revert the commit. `%notify` would load state-9 into the older `versioned-state`, so a revert needs the state-9 arm kept or the agent nuked; in practice reverting before any kind is gated has no user-visible effect, since the gate never fires and the only new state is an unread device map.

## Screenshots / videos

n/a — no UI.
