### PR TITLE
kits UI v1: kit card, detail sheet, install flow, group kit row

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -538,17 +538,17 @@ Uses Drizzle ORM with SQLite for local data storage:
 
 ## Adding a New Post Blob Entry Type
 
-See `docs/post-blobs.md` for the full post-blob spec: wire format, current entry types, read/write behavior, and integration rules.
+See `docs/tlon-apps/post-blobs.md` for the full post-blob spec: wire format, current entry types, read/write behavior, and integration rules.
 
 Use this section as a compact checklist when changing blob behavior.
 
 ### Checklist
 
-1. Add a named schema and inferred type in `packages/api/src/lib/content-helpers.ts`, then register it in `postBlobDataEntryDefinitions`.
+1. Add a named schema and inferred type in `packages/api/src/client/content-helpers.ts`, then register it in `postBlobDataEntryDefinitions`.
 2. Add an `appendXToPostBlob` helper if the new entry will be written from more than one place.
-3. Update the relevant attachment unions in `packages/api/src/types/attachment.ts`, then update `toPostData` in `packages/api/src/lib/content-helpers.ts` to write the new entry type.
+3. Update the relevant attachment unions in `packages/api/src/types/attachment.ts`, then update `toPostData` in `packages/api/src/client/content-helpers.ts` to write the new entry type.
 4. Do not add ad hoc `parsePostBlob` branches. Once the schema is in `postBlobDataEntryDefinitions`, the shared parser handles it.
-5. Update `convertContent` and the `PostContent` block types in `packages/api/src/lib/postContent.ts`.
+5. Update `convertContent` and the `PostContent` block types in `packages/api/src/client/postContent.ts`.
 6. If the new block renders in the app, register it in `packages/app/ui/components/PostContent/BlockRenderer.tsx`.
 7. Add tests for valid payloads and malformed payloads.
 8. Preserve graceful degradation. Unknown entries should continue to render the "Upgrade your app" blockquote.

--- a/apps/tlon-mobile/src/screens/Onboarding/ReserveShipScreen.tsx
+++ b/apps/tlon-mobile/src/screens/Onboarding/ReserveShipScreen.tsx
@@ -53,6 +53,7 @@ export const ReserveShipScreen = ({ navigation }: Props) => {
         <BootStepDisplay
           bootPhase={signupContext.bootPhase}
           withInvites={Boolean(lureMeta)}
+          withKit={Boolean(lureMeta?.kit && !lureMeta?.invitedGroupId)}
         />
       </OnboardingTextBlock>
     </View>
@@ -68,6 +69,7 @@ interface DisplayStep {
 function BootStepDisplay(props: {
   bootPhase: NodeBootPhase;
   withInvites: boolean;
+  withKit: boolean;
 }) {
   const displaySteps = useMemo(() => {
     const steps: DisplayStep[] = [
@@ -92,8 +94,17 @@ function BootStepDisplay(props: {
       endInclusive: NodeBootPhase.ACCEPTING_INVITES,
     });
 
+    if (props.withKit) {
+      steps.push({
+        description: 'Installing your kit',
+        icon: 'SmushStar',
+        startExclusive: NodeBootPhase.ACCEPTING_INVITES,
+        endInclusive: NodeBootPhase.INSTALLING_KIT,
+      });
+    }
+
     return steps;
-  }, [props.withInvites]);
+  }, [props.withInvites, props.withKit]);
 
   return (
     <YStack width="100%">

--- a/packages/api/src/__tests__/content-helpers.test.ts
+++ b/packages/api/src/__tests__/content-helpers.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, test } from 'vitest';
 
 import {
   appendFileUploadToPostBlob,
+  appendKitToPostBlob,
   appendToPostBlob,
   appendVideoToPostBlob,
   contentToTextAndMentions,
@@ -102,6 +103,77 @@ describe('post blob helpers', () => {
     expect(
       parsePostBlob(
         JSON.stringify([{ type: 'tlon-context-lens', version: 1, lensId: '' }])
+      )
+    ).toEqual([{ type: 'unknown' }]);
+  });
+
+  test('parsePostBlob parses kit entries', () => {
+    const blob = appendKitToPostBlob(undefined, {
+      id: 'book-club',
+      publisher: '~sampel-palnet',
+      kitVersion: '0.1.0',
+      name: 'Book Club',
+      description: 'A monthly book club, batteries included',
+      image: 'https://cdn.example.com/book-club.png',
+    });
+
+    expect(parsePostBlob(blob)).toEqual([
+      {
+        type: 'kit',
+        version: 1,
+        id: 'book-club',
+        publisher: '~sampel-palnet',
+        kitVersion: '0.1.0',
+        name: 'Book Club',
+        description: 'A monthly book club, batteries included',
+        image: 'https://cdn.example.com/book-club.png',
+      },
+    ]);
+  });
+
+  test('parsePostBlob defaults kit description and tolerates absent image', () => {
+    expect(
+      parsePostBlob(
+        JSON.stringify([
+          {
+            type: 'kit',
+            version: 1,
+            id: 'book-club',
+            publisher: '~sampel-palnet',
+            kitVersion: '0.1.0',
+            name: 'Book Club',
+          },
+        ])
+      )
+    ).toEqual([
+      {
+        type: 'kit',
+        version: 1,
+        id: 'book-club',
+        publisher: '~sampel-palnet',
+        kitVersion: '0.1.0',
+        name: 'Book Club',
+        description: '',
+      },
+    ]);
+  });
+
+  test('parsePostBlob rejects malformed kit entries', () => {
+    expect(
+      parsePostBlob(JSON.stringify([{ type: 'kit', version: 1 }]))
+    ).toEqual([{ type: 'unknown' }]);
+    expect(
+      parsePostBlob(
+        JSON.stringify([
+          {
+            type: 'kit',
+            version: 1,
+            id: '',
+            publisher: '~sampel-palnet',
+            kitVersion: '0.1.0',
+            name: 'Book Club',
+          },
+        ])
       )
     ).toEqual([{ type: 'unknown' }]);
   });

--- a/packages/api/src/__tests__/groupKitConfig.test.ts
+++ b/packages/api/src/__tests__/groupKitConfig.test.ts
@@ -1,0 +1,54 @@
+import { describe, expect, test } from 'vitest';
+
+import { parseGroupKitConfig } from '../client/groupKitConfig';
+
+const validEntry = {
+  installId: 'book-club-0',
+  kit: {
+    id: 'book-club',
+    version: '0.1.0',
+    publisher: '~sampel-palnet',
+  },
+  places: {
+    discussion: 'chat/~host/book-club-discussion-1234',
+  },
+  schedules: [{ id: 'monthly-pick', cron: '0 17 1 * *' }],
+  agents: ['~sampel-palnet'],
+  setup: 'pending',
+  installedAt: 1786149333904,
+};
+
+describe('parseGroupKitConfig', () => {
+  test('parses a valid version-1 config', () => {
+    const blob = JSON.stringify({ version: 1, kits: [validEntry] });
+    expect(parseGroupKitConfig(blob)).toEqual({ kits: [validEntry] });
+  });
+
+  test('tolerates unknown keys', () => {
+    const blob = JSON.stringify({
+      version: 1,
+      future: true,
+      kits: [{ ...validEntry, extra: 'ignored' }],
+    });
+    expect(parseGroupKitConfig(blob)).toEqual({ kits: [validEntry] });
+  });
+
+  test('skips malformed kits[] entries', () => {
+    const blob = JSON.stringify({
+      version: 1,
+      kits: [{ installId: 'broken' }, validEntry, 'nonsense'],
+    });
+    expect(parseGroupKitConfig(blob)).toEqual({ kits: [validEntry] });
+  });
+
+  test('returns null for absent, non-JSON, or non-kit-config blobs', () => {
+    expect(parseGroupKitConfig(null)).toBeNull();
+    expect(parseGroupKitConfig(undefined)).toBeNull();
+    expect(parseGroupKitConfig('')).toBeNull();
+    expect(parseGroupKitConfig('not json')).toBeNull();
+    expect(
+      parseGroupKitConfig(JSON.stringify({ version: 2, kits: [] }))
+    ).toBeNull();
+    expect(parseGroupKitConfig(JSON.stringify({ hello: 'world' }))).toBeNull();
+  });
+});

--- a/packages/api/src/__tests__/postContent.kit.test.ts
+++ b/packages/api/src/__tests__/postContent.kit.test.ts
@@ -1,0 +1,48 @@
+import { expect, test } from 'vitest';
+
+import { convertContent } from '../client/postContent';
+
+test('convertContent renders kit blob entries as kit-card blocks before story content', () => {
+  const entry = {
+    type: 'kit',
+    version: 1,
+    id: 'book-club',
+    publisher: '~sampel-palnet',
+    kitVersion: '0.1.0',
+    name: 'Book Club',
+    description: 'A monthly book club, batteries included',
+    image: null,
+  };
+
+  const content = convertContent(
+    [{ inline: ['Book Club — A monthly book club, batteries included'] }],
+    JSON.stringify([entry])
+  );
+
+  expect(content[0]).toEqual({
+    type: 'kit-card',
+    kit: {
+      id: 'book-club',
+      publisher: '~sampel-palnet',
+      version: '0.1.0',
+      name: 'Book Club',
+      description: 'A monthly book club, batteries included',
+      image: null,
+    },
+  });
+  expect(content[1]).toMatchObject({ type: 'paragraph' });
+});
+
+test('convertContent degrades malformed kit blob entries to the upgrade notice', () => {
+  const content = convertContent(
+    null,
+    JSON.stringify([{ type: 'kit', version: 1 }])
+  );
+
+  expect(content).toEqual([
+    {
+      type: 'blockquote',
+      content: [{ type: 'text', text: 'Upgrade your app to see this post' }],
+    },
+  ]);
+});

--- a/packages/api/src/client/content-helpers.ts
+++ b/packages/api/src/client/content-helpers.ts
@@ -692,11 +692,29 @@ export type PostBlobDataEntryContextLens = z.infer<
   typeof PostBlobDataEntryContextLensSchema
 >;
 
+export const PostBlobDataEntryKitSchema = definePostBlobDataEntrySchema(
+  'kit',
+  1,
+  {
+    id: z.string().min(1),
+    /** publisher ship, e.g. `~sampel-palnet` */
+    publisher: z.string().min(1),
+    /** the kit's own semver, distinct from this entry's schema `version` */
+    kitVersion: z.string().min(1),
+    name: z.string().min(1),
+    description: z.string().optional().default(''),
+    image: z.string().nullish(),
+  }
+);
+
+export type PostBlobDataEntryKit = z.infer<typeof PostBlobDataEntryKitSchema>;
+
 const postBlobDataEntryDefinitions = [
   PostBlobDataEntryFileSchema,
   PostBlobDataEntryVoiceMemoSchema,
   PostBlobDataEntryVideoSchema,
   PostBlobDataEntryContextLensSchema,
+  PostBlobDataEntryKitSchema,
   A2UI.blobEntrySchema,
 ] as const;
 
@@ -803,6 +821,31 @@ export function appendVideoToPostBlob(
     height: opts.height,
     duration: opts.duration,
     posterUri: opts.posterUri,
+  });
+}
+
+export function appendKitToPostBlob(
+  blob: string | undefined,
+  opts: {
+    id: string;
+    /** publisher ship, e.g. `~sampel-palnet` */
+    publisher: string;
+    /** the kit's own semver, distinct from the entry schema version */
+    kitVersion: string;
+    name: string;
+    description?: string;
+    image?: string | null;
+  }
+) {
+  return appendToPostBlob(blob, {
+    type: 'kit',
+    version: 1,
+    id: opts.id,
+    publisher: opts.publisher,
+    kitVersion: opts.kitVersion,
+    name: opts.name,
+    description: opts.description ?? '',
+    image: opts.image,
   });
 }
 

--- a/packages/api/src/client/groupKitConfig.ts
+++ b/packages/api/src/client/groupKitConfig.ts
@@ -1,0 +1,81 @@
+import { z } from 'zod';
+
+import { createDevLogger } from '../lib/logger';
+
+const logger = createDevLogger('groupKitConfig', false);
+
+// Parsed representation of the kit install config the %kits agent writes
+// into a group's blob at install time. See kits/SCHEMA.md §2 for the source
+// of truth. Readers must tolerate unknown keys and skip malformed kits[]
+// entries rather than crash.
+
+const GroupKitScheduleSchema = z.object({
+  id: z.string().min(1),
+  cron: z.string().min(1),
+});
+
+export type GroupKitSchedule = z.infer<typeof GroupKitScheduleSchema>;
+
+const GroupKitEntrySchema = z.object({
+  installId: z.string().min(1),
+  kit: z.object({
+    id: z.string().min(1),
+    version: z.string().min(1),
+    publisher: z.string().min(1),
+  }),
+  /** abstract place name -> concrete channel nest */
+  places: z.record(z.string()).default({}),
+  schedules: z.array(GroupKitScheduleSchema).default([]),
+  /** ships whose bots are authorized to execute this kit here */
+  agents: z.array(z.string()).default([]),
+  setup: z.enum(['pending', 'done']).default('pending'),
+  installedAt: z.number().optional(),
+});
+
+export type GroupKitEntry = z.infer<typeof GroupKitEntrySchema>;
+
+export interface GroupKitConfig {
+  kits: GroupKitEntry[];
+}
+
+const GroupKitConfigEnvelopeSchema = z.object({
+  version: z.literal(1),
+  kits: z.array(z.unknown()),
+});
+
+/**
+ * Parse a group's blob into its kit install config. Returns null when the
+ * blob is absent, isn't JSON, or isn't a version-1 kit config. Malformed
+ * entries in `kits` are skipped.
+ */
+export function parseGroupKitConfig(
+  blob: string | null | undefined
+): GroupKitConfig | null {
+  if (!blob) {
+    return null;
+  }
+
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(blob);
+  } catch (error) {
+    logger.log('failed to parse group blob as JSON', { blob, error });
+    return null;
+  }
+
+  const envelope = GroupKitConfigEnvelopeSchema.safeParse(parsed);
+  if (!envelope.success) {
+    return null;
+  }
+
+  const kits = envelope.data.kits.flatMap((entry) => {
+    const result = GroupKitEntrySchema.safeParse(entry);
+    if (!result.success) {
+      logger.log('skipping malformed group kit entry', { entry });
+      return [];
+    }
+    return [result.data];
+  });
+
+  return { kits };
+}

--- a/packages/api/src/client/index.ts
+++ b/packages/api/src/client/index.ts
@@ -110,3 +110,4 @@ export * from './presenceApi';
 export * from './gatewayStatusApi';
 export * from './lensApi';
 export * from './kitsApi';
+export * from './groupKitConfig';

--- a/packages/api/src/client/postContent.ts
+++ b/packages/api/src/client/postContent.ts
@@ -124,6 +124,18 @@ export type A2UIBlockData = {
   a2ui: A2UI.BlobEntry;
 };
 
+export type KitCardBlockData = {
+  type: 'kit-card';
+  kit: {
+    id: string;
+    publisher: string;
+    version: string;
+    name: string;
+    description: string;
+    image?: string | null;
+  };
+};
+
 export type LinkBlockData = {
   type: 'link';
   url: string;
@@ -187,6 +199,7 @@ export type BlockData =
   | ParagraphBlockData
   | ImageBlockData
   | A2UIBlockData
+  | KitCardBlockData
   | VideoBlockData
   | FileUploadBlockData
   | VoiceMemoBlockData
@@ -304,6 +317,8 @@ export function plaintextPreviewOf(
           return plaintextPreviewOfListData(block.list, config);
         case 'bigEmoji':
           return block.emoji;
+        case 'kit-card':
+          return '(Kit)';
         case 'table': {
           const headerText = block.header.cells
             .map((cell) => plaintextPreviewOfInlineString(cell.content, config))
@@ -449,6 +464,21 @@ export function convertContent(
           out.push({
             type: 'a2ui',
             a2ui: entry,
+          });
+          break;
+        }
+
+        case 'kit': {
+          out.push({
+            type: 'kit-card',
+            kit: {
+              id: entry.id,
+              publisher: entry.publisher,
+              version: entry.kitVersion,
+              name: entry.name,
+              description: entry.description,
+              image: entry.image,
+            },
           });
           break;
         }

--- a/packages/api/src/index.ts
+++ b/packages/api/src/index.ts
@@ -62,6 +62,7 @@ export {
 } from './urbit';
 export {
   appendFileUploadToPostBlob,
+  appendKitToPostBlob,
   appendToPostBlob,
   appendVideoToPostBlob,
   contentToTextAndMentions,
@@ -71,6 +72,7 @@ export {
   type ClientPostBlobData,
   type Mention,
   type PostBlobDataEntry,
+  type PostBlobDataEntryKit,
 } from './client/content-helpers';
 export { getTextContent } from './client/postContent';
 export { preSig } from './lib/urbit';

--- a/packages/app/features/top/chatDetails.tsx
+++ b/packages/app/features/top/chatDetails.tsx
@@ -16,6 +16,7 @@ import {
   ContactListItem,
   GroupMemberProfileSheet,
   Icon,
+  KitDetailSheet,
   ListItem,
   PaddedBlock,
   Pressable,
@@ -378,6 +379,9 @@ export function SettingsSection({
 
   const baseVolumeLevel = store.useBaseVolumeLevel();
 
+  const groupKit = store.useGroupKit(entityType === 'group' ? group : null);
+  const [kitSheetOpen, setKitSheetOpen] = useState(false);
+
   const connectionStatus = useShipConnectionStatus(group?.hostUserId ?? '', {
     enabled: entityType === 'group' && !!group,
   });
@@ -436,8 +440,20 @@ export function SettingsSection({
       onPress: handlePressNotificationSettings,
     };
 
+    // visible to all members, not just admins: any member can inspect the
+    // kit powering their group
+    const kitAction: SettingsActionProps | null = groupKit
+      ? {
+          title: 'Kit',
+          endValue: groupKit.kit.id,
+          testID: 'GroupKit',
+          disabled: false,
+          onPress: () => setKitSheetOpen(true),
+        }
+      : null;
+
     if (!currentUserIsAdmin) {
-      return [notificationAction];
+      return [...(kitAction ? [kitAction] : []), notificationAction];
     }
 
     if (entityType === 'group' && group) {
@@ -464,6 +480,7 @@ export function SettingsSection({
           disabled: !actionsEnabled,
           onPress: handlePressManageChannels,
         },
+        ...(kitAction ? [kitAction] : []),
         notificationAction,
       ];
     }
@@ -498,6 +515,7 @@ export function SettingsSection({
     handlePressManageChannels,
     handlePressEditChannelPrivacy,
     groupRoles,
+    groupKit,
   ]);
 
   return (
@@ -523,6 +541,18 @@ export function SettingsSection({
           />
         ))}
       </ActionSheet.ActionGroup>
+      {groupKit && group ? (
+        <KitDetailSheet
+          open={kitSheetOpen}
+          onOpenChange={setKitSheetOpen}
+          kit={{
+            id: groupKit.kit.id,
+            publisher: groupKit.kit.publisher,
+            version: groupKit.kit.version,
+          }}
+          contextGroup={group}
+        />
+      ) : null}
     </View>
   );
 }

--- a/packages/app/fixtures/ActionSheet/KitDetailSheet.fixture.tsx
+++ b/packages/app/fixtures/ActionSheet/KitDetailSheet.fixture.tsx
@@ -1,0 +1,67 @@
+import * as db from '@tloncorp/shared/db';
+
+import { KitDetailSheet, KitDetailSheetKit } from '../../ui';
+import { FixtureWrapper } from '../FixtureWrapper';
+import { group } from '../fakeData';
+
+const bookClub: KitDetailSheetKit = {
+  id: 'book-club',
+  publisher: '~sampel-palnet',
+  version: '0.1.0',
+  name: 'Book Club',
+  description: 'A monthly book club with scheduled picks and reminders',
+  image: null,
+};
+
+const kitGroupBlob = JSON.stringify({
+  version: 1,
+  kits: [
+    {
+      installId: 'book-club-0',
+      kit: {
+        id: 'book-club',
+        version: '0.1.0',
+        publisher: '~sampel-palnet',
+      },
+      places: { discussion: 'chat/~host/book-club-discussion-1234' },
+      schedules: [{ id: 'monthly-pick', cron: '0 17 1 * *' }],
+      agents: ['~sampel-palnet'],
+      setup: 'done',
+      installedAt: 1786149333904,
+    },
+  ],
+});
+
+const kitGroup: db.Group = {
+  ...group,
+  blob: kitGroupBlob,
+};
+
+const sheetFixtures: Record<
+  string,
+  { kit: KitDetailSheetKit; contextGroup?: db.Group }
+> = {
+  // manifest/install queries have no live ship in cosmos, so the CTA
+  // renders the not-installed "Get this kit" state
+  notInstalled: { kit: bookClub },
+  // opened from a kit-made group's details row: "Get your own" (+ "Remove
+  // kit" when the viewer is a group admin)
+  fromKitGroup: { kit: bookClub, contextGroup: kitGroup },
+  sparseCardData: {
+    kit: { id: 'book-club', publisher: '~sampel-palnet' },
+  },
+};
+
+export default Object.fromEntries(
+  Object.entries(sheetFixtures).map(([key, { kit, contextGroup }]) => [
+    key,
+    <FixtureWrapper key={key}>
+      <KitDetailSheet
+        open={true}
+        onOpenChange={() => {}}
+        kit={kit}
+        contextGroup={contextGroup}
+      />
+    </FixtureWrapper>,
+  ])
+);

--- a/packages/app/fixtures/KitCard.fixture.tsx
+++ b/packages/app/fixtures/KitCard.fixture.tsx
@@ -1,0 +1,40 @@
+import { KitCard, KitCardData } from '../ui';
+import { FixtureWrapper } from './FixtureWrapper';
+
+const bookClub: KitCardData = {
+  id: 'book-club',
+  publisher: '~sampel-palnet',
+  version: '0.1.0',
+  name: 'Book Club',
+  description: 'A monthly book club with scheduled picks and reminders',
+  image: null,
+};
+
+const kitFixtures: Record<string, KitCardData> = {
+  // installs/manifest queries have no live ship in cosmos, so the button
+  // renders the not-installed "Get" state
+  notInstalled: bookClub,
+  withImage: {
+    ...bookClub,
+    image: 'https://bwyci9wowl3jgy4d.public.blob.vercel-storage.com/groups.png',
+  },
+  noDescription: {
+    ...bookClub,
+    description: '',
+  },
+  longText: {
+    ...bookClub,
+    name: 'A Kit With A Very Long Name That Should Truncate',
+    description:
+      'A very long description that goes on and on and should be clamped to a single line inside the card body',
+  },
+};
+
+export default Object.fromEntries(
+  Object.entries(kitFixtures).map(([key, kit]) => [
+    key,
+    <FixtureWrapper key={key} fillWidth>
+      <KitCard kit={kit} margin="$l" />
+    </FixtureWrapper>,
+  ])
+);

--- a/packages/app/hooks/useBootSequence.ts
+++ b/packages/app/hooks/useBootSequence.ts
@@ -337,7 +337,12 @@ export function useBootSequence() {
         }
       }, 5000);
 
-      return lureMeta?.kit ? NodeBootPhase.INSTALLING_KIT : NodeBootPhase.READY;
+      // only install a personal copy for kit-flavored links that don't point
+      // at an existing group — joining a kit-made group must not also
+      // instantiate one of your own
+      return lureMeta?.kit && !lureMeta.invitedGroupId
+        ? NodeBootPhase.INSTALLING_KIT
+        : NodeBootPhase.READY;
     }
 
     //
@@ -345,7 +350,7 @@ export function useBootSequence() {
     // invite link. Non-fatal: any failure or timeout continues to READY.
     //
     if (bootPhase === NodeBootPhase.INSTALLING_KIT) {
-      if (!lureMeta?.kit) {
+      if (!lureMeta?.kit || lureMeta.invitedGroupId) {
         return NodeBootPhase.READY;
       }
 

--- a/packages/app/ui/components/InviteFriendsToTlonButton.tsx
+++ b/packages/app/ui/components/InviteFriendsToTlonButton.tsx
@@ -34,10 +34,17 @@ export function InviteFriendsToTlonButton({
   const userId = useCurrentUserId();
   const isGroupAdmin = useIsAdmin(group?.id ?? '', userId);
   const inviteService = useInviteService();
+  // kit-made groups mint kit-flavored invite links so new signups get the
+  // kit threaded through onboarding
+  const groupKit = store.useGroupKit(group);
+  const kit = groupKit
+    ? `${groupKit.kit.publisher}/${groupKit.kit.id}`
+    : undefined;
   const { status, shareUrl } = store.useLure({
     flag: group?.id ?? '',
     inviteServiceEndpoint: inviteService.endpoint,
     inviteServiceIsDev: inviteService.isDev,
+    kit,
   });
   const { doCopy, didCopy } = useCopy(shareUrl || '');
 

--- a/packages/app/ui/components/KitCard/index.tsx
+++ b/packages/app/ui/components/KitCard/index.tsx
@@ -1,0 +1,144 @@
+import type * as cn from '@tloncorp/shared/logic';
+import * as store from '@tloncorp/shared/store';
+import { Button, Icon, Image, Text } from '@tloncorp/ui';
+import { ComponentProps, useCallback, useMemo, useState } from 'react';
+import { View, XStack, YStack } from 'tamagui';
+
+import { useRootNavigation } from '../../../navigation/utils';
+import { useMaybeChannelContext } from '../../contexts/channel';
+import { ContactName as ContactNameV2 } from '../ContactNameV2';
+import { Reference } from '../ContentReference/Reference';
+import { KitDetailSheet } from '../KitDetailSheet';
+
+export type KitCardData = cn.KitCardBlockData['kit'];
+
+/**
+ * Reference-style card for a `kit-card` post block. Tapping anywhere opens
+ * the kit detail sheet; the trailing button reflects the viewer's state
+ * (Get / Open / Runs here).
+ *
+ * Note: unlike GroupReference, which delegates presses to the navigation
+ * context, this card renders its own KitDetailSheet so it stays
+ * self-contained wherever the block appears.
+ */
+export function KitCard({
+  kit,
+  ...props
+}: { kit: KitCardData } & ComponentProps<typeof Reference.Frame>) {
+  const [detailOpen, setDetailOpen] = useState(false);
+  const { data: installs } = store.useKitInstalls();
+  const channel = useMaybeChannelContext();
+  const { data: currentGroup } = store.useGroup({
+    id: channel?.groupId ?? undefined,
+  });
+  const currentGroupKit = store.useGroupKit(currentGroup);
+  const { navigateToGroup } = useRootNavigation();
+
+  const installedFlag = useMemo(() => {
+    if (!installs) {
+      return null;
+    }
+    const match = Object.entries(installs).find(
+      ([, install]) =>
+        install.id === kit.id && install.publisher === kit.publisher
+    );
+    return match?.[0] ?? null;
+  }, [installs, kit.id, kit.publisher]);
+
+  const runsHere =
+    currentGroupKit != null &&
+    currentGroupKit.kit.id === kit.id &&
+    currentGroupKit.kit.publisher === kit.publisher;
+
+  const openDetail = useCallback(() => setDetailOpen(true), []);
+
+  const openGroup = useCallback(() => {
+    if (installedFlag) {
+      navigateToGroup(installedFlag);
+    }
+  }, [installedFlag, navigateToGroup]);
+
+  return (
+    <>
+      <Reference.Frame pressable {...props} onPress={openDetail}>
+        <Reference.Header>
+          <Reference.Title>
+            <Reference.TitleIcon type="Gift" />
+            <Reference.TitleText>Kit</Reference.TitleText>
+          </Reference.Title>
+          <Reference.ActionIcon />
+        </Reference.Header>
+        <Reference.Body pointerEvents="auto">
+          <XStack padding="$l" gap="$l" alignItems="center">
+            <KitCardIcon image={kit.image ?? null} />
+            <YStack flex={1} gap="$2xs">
+              <Text size="$label/l" numberOfLines={1}>
+                {kit.name}
+              </Text>
+              {kit.description ? (
+                <Text size="$label/m" color="$secondaryText" numberOfLines={1}>
+                  {kit.description}
+                </Text>
+              ) : null}
+              <Text size="$label/s" color="$tertiaryText">
+                <ContactNameV2 contactId={kit.publisher} mode="contactId" />
+              </Text>
+            </YStack>
+            {runsHere ? (
+              <Text size="$label/m" color="$tertiaryText">
+                Runs here
+              </Text>
+            ) : installedFlag ? (
+              <Button
+                fill="outline"
+                type="primary"
+                label="Open"
+                onPress={openGroup}
+                testID="ActionButton-OpenKitGroup"
+              />
+            ) : (
+              <Button
+                fill="solid"
+                type="primary"
+                label="Get"
+                onPress={openDetail}
+                testID="ActionButton-GetKit"
+              />
+            )}
+          </XStack>
+        </Reference.Body>
+      </Reference.Frame>
+      <KitDetailSheet
+        open={detailOpen}
+        onOpenChange={setDetailOpen}
+        kit={kit}
+      />
+    </>
+  );
+}
+
+function KitCardIcon({ image }: { image: string | null }) {
+  if (image) {
+    return (
+      <Image
+        source={image}
+        width="$4xl"
+        height="$4xl"
+        borderRadius="$s"
+        contentFit="cover"
+      />
+    );
+  }
+  return (
+    <View
+      width="$4xl"
+      height="$4xl"
+      borderRadius="$s"
+      backgroundColor="$secondaryBackground"
+      alignItems="center"
+      justifyContent="center"
+    >
+      <Icon type="Gift" color="$secondaryText" size="$m" />
+    </View>
+  );
+}

--- a/packages/app/ui/components/KitDetailSheet.tsx
+++ b/packages/app/ui/components/KitDetailSheet.tsx
@@ -1,0 +1,634 @@
+import * as api from '@tloncorp/api';
+import { createDevLogger } from '@tloncorp/shared';
+import * as db from '@tloncorp/shared/db';
+import * as store from '@tloncorp/shared/store';
+import {
+  Button,
+  Icon,
+  IconType,
+  Image,
+  LoadingSpinner,
+  Text,
+} from '@tloncorp/ui';
+import React, { useCallback, useEffect, useMemo, useState } from 'react';
+import { Alert } from 'react-native';
+import { View, XStack, YStack } from 'tamagui';
+
+import { useRootNavigation } from '../../navigation/utils';
+import { useCurrentUserId } from '../contexts/appDataContext';
+import { triggerHaptic, useIsAdmin } from '../utils';
+import { ActionSheet } from './ActionSheet';
+import { Badge } from './Badge';
+import { ContactName as ContactNameV2 } from './ContactNameV2';
+import { TextInput } from './Form';
+import { ListItem } from './ListItem';
+
+const logger = createDevLogger('KitDetailSheet', true);
+
+const INSTALL_STEPS = [
+  'Creating group',
+  'Setting up channels',
+  'Waking the agent',
+];
+const INSTALL_TIMEOUT = 30 * 1000;
+const KIT_NAME_ALPHABET = 'abcdefghijklmnopqrstuvwxyz0123456789';
+
+const PLACE_ICONS: Record<api.KitPlace['kind'], IconType> = {
+  chat: 'ChannelTalk',
+  notebook: 'ChannelNotebooks',
+  gallery: 'ChannelGalleries',
+};
+
+const wait = (ms: number) => new Promise((resolve) => setTimeout(resolve, ms));
+
+/** The kit reference a detail sheet is opened with. Display fields are
+ * optional; the sheet fills them in from the manifest once it loads. */
+export interface KitDetailSheetKit {
+  id: string;
+  publisher: string;
+  version?: string;
+  name?: string;
+  description?: string;
+  image?: string | null;
+}
+
+type InstallFlow =
+  | { phase: 'idle' }
+  | { phase: 'naming' }
+  | { phase: 'installing'; step: number; title: string }
+  | { phase: 'error'; message: string; retry: () => void };
+
+type KitActionButton = {
+  title: string;
+  accent?: 'hero' | 'heroPositive' | 'negative' | 'secondary' | 'minimal';
+  onPress?: () => void;
+  description?: string;
+  disabled?: boolean;
+  testID?: string;
+};
+
+interface KitDetailSheetProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  kit: KitDetailSheetKit;
+  /** set when the sheet is opened from within a group whose blob carries a
+   * kit (e.g. the group details "Kit" row) */
+  contextGroup?: db.Group | null;
+}
+
+function KitDetailSheetComponent({
+  open,
+  onOpenChange,
+  kit,
+  contextGroup,
+}: KitDetailSheetProps) {
+  useEffect(() => {
+    if (open) {
+      triggerHaptic('sheetOpen');
+    }
+  }, [open]);
+
+  return (
+    <ActionSheet open={open} onOpenChange={onOpenChange}>
+      {open ? (
+        <KitDetailPane
+          kit={kit}
+          contextGroup={contextGroup}
+          onClose={() => onOpenChange(false)}
+        />
+      ) : null}
+    </ActionSheet>
+  );
+}
+
+export const KitDetailSheet = React.memo(KitDetailSheetComponent);
+
+export function KitDetailPane({
+  kit,
+  contextGroup,
+  onClose,
+}: {
+  kit: KitDetailSheetKit;
+  contextGroup?: db.Group | null;
+  onClose: () => void;
+}) {
+  const { data: manifest, isLoading: isManifestLoading } = store.useKitManifest(
+    kit.publisher,
+    kit.id
+  );
+  const { data: installs } = store.useKitInstalls();
+  const contextGroupKit = store.useGroupKit(contextGroup);
+  const currentUserId = useCurrentUserId();
+  const isContextAdmin = useIsAdmin(contextGroup?.id ?? '', currentUserId);
+  const { navigateToGroup } = useRootNavigation();
+
+  const [flow, setFlow] = useState<InstallFlow>({ phase: 'idle' });
+  const [draftTitle, setDraftTitle] = useState('');
+
+  const name = manifest?.name ?? kit.name ?? kit.id;
+  const description = manifest?.description ?? kit.description ?? '';
+  const image = manifest?.image ?? kit.image ?? null;
+  const version = manifest?.version ?? kit.version;
+
+  const installedFlag = useMemo(() => {
+    if (!installs) {
+      return null;
+    }
+    const match = Object.entries(installs).find(
+      ([, install]) =>
+        install.id === kit.id && install.publisher === kit.publisher
+    );
+    return match?.[0] ?? null;
+  }, [installs, kit.id, kit.publisher]);
+
+  const isContextInstall =
+    contextGroupKit != null &&
+    contextGroupKit.kit.id === kit.id &&
+    contextGroupKit.kit.publisher === kit.publisher;
+  const isOwnContextInstall =
+    isContextInstall &&
+    installedFlag != null &&
+    installedFlag === contextGroup?.id;
+
+  const closeAndNavigate = useCallback(
+    (groupId: string) => {
+      onClose();
+      // let the sheet finish closing before navigating (see GroupPreviewSheet)
+      setTimeout(() => navigateToGroup(groupId), 100);
+    },
+    [onClose, navigateToGroup]
+  );
+
+  const runInstall = useCallback(
+    async (title: string) => {
+      setFlow({ phase: 'installing', step: 0, title });
+      try {
+        const preexistingFlags = new Set(
+          Object.keys(await api.getInstalls().catch(() => ({})))
+        );
+        await api.installKit({
+          id: kit.id,
+          name: kitGroupName(title, kit.id),
+          meta: { title, description: '', image: '', cover: '' },
+        });
+        setFlow({ phase: 'installing', step: 1, title });
+
+        // wait for the install ledger entry (group + channels created)
+        const deadline = Date.now() + INSTALL_TIMEOUT;
+        let flag: string | null = null;
+        while (!flag && Date.now() < deadline) {
+          await wait(1000);
+          const current = await api.getInstalls().catch(() => null);
+          if (current) {
+            const found = Object.entries(current).find(
+              ([installFlag, install]) =>
+                !preexistingFlags.has(installFlag) &&
+                install.id === kit.id &&
+                install.publisher === kit.publisher
+            );
+            if (found) {
+              flag = found[0];
+            }
+          }
+        }
+        if (!flag) {
+          throw new Error('Timed out while creating the group.');
+        }
+        setFlow({ phase: 'installing', step: 2, title });
+
+        // wait for the group row to sync locally so navigation lands on a
+        // hydrated screen; if it doesn't arrive in budget, navigate anyway
+        // and let sync catch up
+        let group: db.Group | null = null;
+        while (!group && Date.now() < deadline) {
+          group = (await db.getGroup({ id: flag })) ?? null;
+          if (!group) {
+            await wait(1000);
+          }
+        }
+        closeAndNavigate(flag);
+      } catch (e) {
+        logger.trackError('kit install failed', {
+          kit: `${kit.publisher}/${kit.id}`,
+          errorMessage: e?.message,
+        });
+        setFlow({
+          phase: 'error',
+          message: e?.message ?? 'Something went wrong.',
+          retry: () => runInstall(title),
+        });
+      }
+    },
+    [kit.id, kit.publisher, closeAndNavigate]
+  );
+
+  const startInstall = useCallback(() => {
+    setDraftTitle(name);
+    setFlow({ phase: 'naming' });
+  }, [name]);
+
+  const openGroup = useCallback(() => {
+    if (installedFlag) {
+      closeAndNavigate(installedFlag);
+    }
+  }, [installedFlag, closeAndNavigate]);
+
+  const removeKit = useCallback(() => {
+    if (!contextGroup) {
+      return;
+    }
+    const doRemove = async () => {
+      try {
+        await api.uninstallKit(contextGroup.id);
+        onClose();
+      } catch (e) {
+        logger.trackError('kit uninstall failed', {
+          kit: `${kit.publisher}/${kit.id}`,
+          groupId: contextGroup.id,
+          errorMessage: e?.message,
+        });
+        setFlow({
+          phase: 'error',
+          message: e?.message ?? 'Something went wrong.',
+          retry: doRemove,
+        });
+      }
+    };
+    Alert.alert(
+      'Remove kit?',
+      `The group will remain, but ${name}'s automation will stop.`,
+      [
+        { text: 'Cancel', style: 'cancel' },
+        { text: 'Remove kit', style: 'destructive', onPress: doRemove },
+      ]
+    );
+  }, [contextGroup, kit.id, kit.publisher, name, onClose]);
+
+  const actionButtons = useMemo(
+    () =>
+      getKitDetailActions(
+        {
+          installedFlag,
+          isContextInstall,
+          isOwnContextInstall,
+          isContextAdmin,
+        },
+        { startInstall, openGroup, removeKit }
+      ),
+    [
+      installedFlag,
+      isContextInstall,
+      isOwnContextInstall,
+      isContextAdmin,
+      startInstall,
+      openGroup,
+      removeKit,
+    ]
+  );
+
+  return (
+    <ActionSheet.Content>
+      <YStack paddingHorizontal="$xl" paddingVertical="$xl" gap="$xl">
+        <YStack
+          alignItems="center"
+          padding="$xl"
+          borderRadius="$xl"
+          borderWidth={1}
+          borderColor="$border"
+          backgroundColor="$background"
+          gap="$xl"
+        >
+          <KitHeroIcon image={image} />
+          <Text size="$label/3xl" textAlign="center">
+            {name}
+          </Text>
+          <Text size="$label/m" color="$tertiaryText">
+            <ContactNameV2 contactId={kit.publisher} mode="contactId" />
+          </Text>
+          {version ? <Badge text={`v${version}`} type="neutral" /> : null}
+        </YStack>
+
+        {description ? (
+          <YStack
+            padding="$xl"
+            borderRadius="$xl"
+            borderWidth={1}
+            borderColor="$border"
+            backgroundColor="$background"
+            gap="$xl"
+          >
+            <Text size="$label/m" color="$tertiaryText">
+              Description
+            </Text>
+            <Text size="$body">{description}</Text>
+          </YStack>
+        ) : null}
+
+        <YStack
+          padding="$xl"
+          borderRadius="$xl"
+          borderWidth={1}
+          borderColor="$border"
+          backgroundColor="$background"
+          gap="$l"
+        >
+          <Text size="$label/m" color="$tertiaryText">
+            What it makes
+          </Text>
+          {manifest ? (
+            manifest.places.length > 0 ? (
+              manifest.places.map((place) => (
+                <ListItem
+                  key={place.name}
+                  backgroundColor="unset"
+                  paddingHorizontal={0}
+                >
+                  <ListItem.SystemIcon
+                    icon={PLACE_ICONS[place.kind] ?? 'ChannelTalk'}
+                  />
+                  <ListItem.MainContent>
+                    <ListItem.Title>{place.title}</ListItem.Title>
+                    {place.description ? (
+                      <ListItem.Subtitle>{place.description}</ListItem.Subtitle>
+                    ) : null}
+                  </ListItem.MainContent>
+                </ListItem>
+              ))
+            ) : (
+              <Text size="$body" color="$secondaryText">
+                This kit doesn&rsquo;t create any channels.
+              </Text>
+            )
+          ) : isManifestLoading ? (
+            <XStack justifyContent="center" padding="$l">
+              <LoadingSpinner size="small" />
+            </XStack>
+          ) : (
+            <Text size="$body" color="$secondaryText">
+              Couldn&rsquo;t load the kit&rsquo;s details from{' '}
+              <ContactNameV2 contactId={kit.publisher} mode="contactId" />.
+            </Text>
+          )}
+        </YStack>
+
+        {manifest && manifest.schedules.length > 0 ? (
+          <YStack
+            padding="$xl"
+            borderRadius="$xl"
+            borderWidth={1}
+            borderColor="$border"
+            backgroundColor="$background"
+            gap="$l"
+          >
+            <Text size="$label/m" color="$tertiaryText">
+              What it does
+            </Text>
+            {manifest.schedules.map((schedule) => (
+              <Text key={schedule.id} size="$body">
+                {schedule.description}
+              </Text>
+            ))}
+          </YStack>
+        ) : null}
+
+        <Text size="$label/m" color="$tertiaryText" textAlign="center">
+          Published by{' '}
+          <ContactNameV2 contactId={kit.publisher} mode="contactId" />
+          {version ? ` · v${version}` : ''}
+        </Text>
+
+        {flow.phase === 'idle' ? (
+          <YStack gap="$m">
+            {actionButtons.map((action) => (
+              <YStack key={action.title} gap="$xs">
+                <Button
+                  {...buttonPropsForAccent(action.accent)}
+                  disabled={action.disabled}
+                  onPress={action.onPress}
+                  testID={action.testID ?? `ActionButton-${action.title}`}
+                  alignSelf="stretch"
+                  label={action.title}
+                  centered
+                />
+                {action.description ? (
+                  <Text
+                    size="$label/m"
+                    color="$tertiaryText"
+                    textAlign="center"
+                  >
+                    {action.description}
+                  </Text>
+                ) : null}
+              </YStack>
+            ))}
+          </YStack>
+        ) : flow.phase === 'naming' ? (
+          <YStack gap="$l">
+            <Text size="$label/m" color="$tertiaryText">
+              Name your group
+            </Text>
+            <TextInput
+              placeholder="Group name"
+              value={draftTitle}
+              onChangeText={setDraftTitle}
+              onSubmitEditing={() =>
+                draftTitle.trim() && runInstall(draftTitle.trim())
+              }
+              returnKeyType="go"
+              testID="KitGroupNameInput"
+            />
+            <Button
+              fill="solid"
+              type="primary"
+              disabled={!draftTitle.trim()}
+              onPress={() => runInstall(draftTitle.trim())}
+              testID="ActionButton-CreateKitGroup"
+              alignSelf="stretch"
+              label="Create group"
+              centered
+            />
+            <Button
+              fill="text"
+              type="primary"
+              onPress={() => setFlow({ phase: 'idle' })}
+              testID="ActionButton-CancelKitInstall"
+              alignSelf="stretch"
+              label="Cancel"
+              centered
+            />
+          </YStack>
+        ) : flow.phase === 'installing' ? (
+          <InstallProgress step={flow.step} />
+        ) : (
+          <YStack gap="$m">
+            <Text
+              size="$label/m"
+              color="$negativeActionText"
+              textAlign="center"
+            >
+              {flow.message}
+            </Text>
+            <Button
+              fill="solid"
+              type="primary"
+              onPress={flow.retry}
+              testID="ActionButton-RetryKitAction"
+              alignSelf="stretch"
+              label="Retry"
+              centered
+            />
+            <Button
+              fill="text"
+              type="primary"
+              onPress={() => setFlow({ phase: 'idle' })}
+              testID="ActionButton-DismissKitError"
+              alignSelf="stretch"
+              label="Cancel"
+              centered
+            />
+          </YStack>
+        )}
+      </YStack>
+    </ActionSheet.Content>
+  );
+}
+
+/** Pure mapping from viewer state to the sheet's CTA stack. */
+export function getKitDetailActions(
+  status: {
+    installedFlag: string | null;
+    isContextInstall: boolean;
+    isOwnContextInstall: boolean;
+    isContextAdmin: boolean;
+  },
+  actions: {
+    startInstall: () => void;
+    openGroup: () => void;
+    removeKit: () => void;
+  }
+): KitActionButton[] {
+  if (status.isContextInstall) {
+    const buttons: KitActionButton[] = [];
+    if (!status.isOwnContextInstall) {
+      buttons.push({
+        title: 'Get your own',
+        accent: 'hero',
+        onPress: actions.startInstall,
+        testID: 'ActionButton-GetYourOwnKit',
+      });
+    }
+    if (status.isContextAdmin) {
+      buttons.push({
+        title: 'Remove kit',
+        accent: 'negative',
+        onPress: actions.removeKit,
+        description: 'The group stays — the kit’s automation stops.',
+        testID: 'ActionButton-RemoveKit',
+      });
+    }
+    return buttons;
+  }
+  if (status.installedFlag) {
+    return [
+      {
+        title: 'Open group',
+        accent: 'heroPositive',
+        onPress: actions.openGroup,
+        testID: 'ActionButton-OpenKitGroup',
+      },
+    ];
+  }
+  return [
+    {
+      title: 'Get this kit',
+      accent: 'hero',
+      onPress: actions.startInstall,
+      testID: 'ActionButton-GetKit',
+    },
+  ];
+}
+
+// Map v1 accent to v2 fill/type (same mapping as GroupPreviewSheet)
+function buttonPropsForAccent(accent: KitActionButton['accent']) {
+  switch (accent) {
+    case 'hero':
+      return { fill: 'solid' as const, type: 'primary' as const };
+    case 'heroPositive':
+      return { fill: 'solid' as const, type: 'positive' as const };
+    case 'negative':
+      return { fill: 'outline' as const, type: 'negative' as const };
+    case 'secondary':
+      return { fill: 'outline' as const, type: 'secondary' as const };
+    case 'minimal':
+      return { fill: 'text' as const, type: 'primary' as const };
+    default:
+      return { fill: 'outline' as const, type: 'primary' as const };
+  }
+}
+
+function InstallProgress({ step }: { step: number }) {
+  return (
+    <YStack width="100%">
+      {INSTALL_STEPS.map((description, index) => (
+        <ListItem backgroundColor="unset" key={index}>
+          <ListItem.MainContent>
+            <ListItem.Title color={index > step ? '$tertiaryText' : undefined}>
+              {description}
+            </ListItem.Title>
+          </ListItem.MainContent>
+          <ListItem.EndContent width="$3xl" alignItems="center">
+            {index === step && <LoadingSpinner size="small" />}
+            {index < step && <ListItem.SystemIcon icon="Checkmark" />}
+          </ListItem.EndContent>
+        </ListItem>
+      ))}
+    </YStack>
+  );
+}
+
+function KitHeroIcon({ image }: { image: string | null }) {
+  if (image) {
+    return (
+      <Image
+        source={image}
+        width="$9xl"
+        height="$9xl"
+        borderRadius="$xl"
+        contentFit="cover"
+      />
+    );
+  }
+  return (
+    <View
+      width="$9xl"
+      height="$9xl"
+      borderRadius="$xl"
+      backgroundColor="$secondaryBackground"
+      alignItems="center"
+      justifyContent="center"
+    >
+      <Icon type="Gift" color="$secondaryText" />
+    </View>
+  );
+}
+
+/** Derive a valid @tas group name from a chosen title: kebab-cased title
+ * stem (falling back to the kit id) plus 4 random lowercase alphanumerics. */
+export function kitGroupName(title: string, kitId: string): string {
+  const base = title
+    .toLowerCase()
+    .replace(/['’]/g, '')
+    .replace(/[^a-z0-9-]+/g, '-')
+    .replace(/-+/g, '-')
+    .replace(/^-+|-+$/g, '');
+  const stem = (/^[a-z]/.test(base) ? base.slice(0, 40) : kitId).replace(
+    /-+$/,
+    ''
+  );
+  const suffix = Array.from(
+    { length: 4 },
+    () =>
+      KIT_NAME_ALPHABET[Math.floor(Math.random() * KIT_NAME_ALPHABET.length)]
+  ).join('');
+  return `${stem}-${suffix}`;
+}

--- a/packages/app/ui/components/PostContent/BlockRenderer.tsx
+++ b/packages/app/ui/components/PostContent/BlockRenderer.tsx
@@ -51,6 +51,7 @@ import {
 } from '../ContentReference/types';
 import { FileUploadPreview } from '../FileUploadPreview';
 import { HighlightedCode } from '../HighlightedCode';
+import { KitCard } from '../KitCard';
 import { VideoPreview } from '../VideoPreview';
 import { A2UIBlock } from './A2UIBlock';
 import { BlockquoteSideBorder } from './BlockquoteSideBorder';
@@ -474,6 +475,13 @@ export function FileUploadBlock({
   'file'
 >) {
   return <FileUploadPreview file={block.file} {...passedProps} />;
+}
+
+export function KitCardBlock({
+  block,
+  ...passedProps
+}: ForwardingProps<typeof KitCard, { block: cn.KitCardBlockData }, 'kit'>) {
+  return <KitCard kit={block.kit} {...passedProps} />;
 }
 
 export function BigEmojiBlock({
@@ -973,6 +981,7 @@ export const defaultBlockRenderers: BlockRendererConfig = {
   file: FileUploadBlock,
   voicememo: VoiceMemoBlock,
   table: TableBlock,
+  'kit-card': KitCardBlock,
 };
 
 type BlockSettings<T extends ComponentType> = Partial<ComponentProps<T>> & {
@@ -997,6 +1006,7 @@ export type DefaultRendererProps = {
   file: BlockSettings<typeof FileUploadBlock>;
   voicememo: BlockSettings<typeof VoiceMemoBlock>;
   table: BlockSettings<typeof TableBlock>;
+  'kit-card': BlockSettings<typeof KitCardBlock>;
 };
 
 interface BlockRendererContextValue {

--- a/packages/app/ui/contexts/channel.tsx
+++ b/packages/app/ui/contexts/channel.tsx
@@ -19,6 +19,16 @@ export const useChannelContext = () => {
   return context.channel;
 };
 
+/**
+ * Like `useChannelContext`, but returns null instead of throwing when no
+ * `ChannelProvider` is present. For components that can render both inside
+ * and outside a channel.
+ */
+export const useMaybeChannelContext = () => {
+  const context = useContext(Context);
+  return context?.channel ?? null;
+};
+
 export const ChannelProvider = ({
   children,
   value,

--- a/packages/app/ui/index.tsx
+++ b/packages/app/ui/index.tsx
@@ -44,6 +44,8 @@ export * from './components/GroupMembersScreenView';
 export * from './components/GroupPreviewSheet';
 export * from './components/InviteUsersSheet';
 export * from './components/InviteUsersWidget';
+export * from './components/KitCard';
+export * from './components/KitDetailSheet';
 export * from './components/ListItem';
 export * from './components/listItems';
 export * from './components/LongPressDisclosure';

--- a/packages/shared/src/logic/notesPublish.ts
+++ b/packages/shared/src/logic/notesPublish.ts
@@ -133,6 +133,7 @@ function renderBlockToHtml(block: BlockData): string {
     case 'file':
     case 'voicememo':
     case 'a2ui':
+    case 'kit-card':
       return '';
   }
 }

--- a/packages/shared/src/store/dbHooks.ts
+++ b/packages/shared/src/store/dbHooks.ts
@@ -8,7 +8,7 @@ import { getMessagesFilter } from '@tloncorp/api';
 import { referenceLookupId } from '@tloncorp/api/client/references';
 import * as ub from '@tloncorp/api/urbit';
 import { isMatch, pick } from 'lodash';
-import { useEffect, useMemo } from 'react';
+import { useEffect, useMemo, useRef } from 'react';
 
 import * as db from '../db';
 import { GroupedChats } from '../db/types';
@@ -124,6 +124,77 @@ export const useContextLensBotShips = () => {
   return useQuery({
     queryKey: ['contextLensBotShips', deps],
     queryFn: () => db.getContextLensBotShips(),
+  });
+};
+
+/**
+ * The first kit entry from a group's blob install config, or null when the
+ * group wasn't made by (or no longer carries) a kit.
+ */
+export const useGroupKit = (
+  group: db.Group | null | undefined
+): api.GroupKitEntry | null => {
+  const blob = group?.blob;
+  return useMemo(() => {
+    const config = api.parseGroupKitConfig(blob);
+    return config?.kits[0] ?? null;
+  }, [blob]);
+};
+
+/** The %kits install ledger, keyed by group flag. */
+export const useKitInstalls = () => {
+  return useQuery({
+    queryKey: ['kitInstalls'],
+    queryFn: () => api.getInstalls(),
+  });
+};
+
+const KIT_MANIFEST_FETCH_BUDGET = 20 * 1000;
+
+/**
+ * A kit's manifest from the local %kits library. If the kit isn't in the
+ * library yet, asks the publisher for it once and polls (with backoff) for
+ * its arrival for up to ~20s.
+ */
+export const useKitManifest = (
+  publisher?: string | null,
+  id?: string | null
+) => {
+  const requestedFetchAt = useRef<number | null>(null);
+  return useQuery({
+    enabled: Boolean(publisher && id),
+    queryKey: ['kitManifest', publisher, id],
+    queryFn: async (): Promise<api.KitManifest | null> => {
+      if (!publisher || !id) {
+        return null;
+      }
+      const kit = await api.getKit(id);
+      if (kit) {
+        return kit.manifest;
+      }
+      if (requestedFetchAt.current == null) {
+        requestedFetchAt.current = Date.now();
+        await api.fetchKit(publisher, id);
+      }
+      return null;
+    },
+    refetchInterval: (query) => {
+      if (query.state.data) {
+        return false;
+      }
+      const startedAt = requestedFetchAt.current;
+      if (
+        startedAt == null ||
+        Date.now() - startedAt > KIT_MANIFEST_FETCH_BUDGET
+      ) {
+        return false;
+      }
+      // 1s, 2s, 4s, ... capped at 5s between polls
+      return Math.min(
+        1000 * 2 ** Math.max(query.state.dataUpdateCount - 1, 0),
+        5000
+      );
+    },
   });
 };
 

--- a/packages/shared/src/store/lure.ts
+++ b/packages/shared/src/store/lure.ts
@@ -182,11 +182,14 @@ export function useLure({
   flag,
   inviteServiceEndpoint,
   inviteServiceIsDev,
+  kit,
   disableLoading = false,
 }: {
   flag: string;
   inviteServiceEndpoint: string;
   inviteServiceIsDev: boolean;
+  /** kit reference ("<publisher>/<id>") to carry on the invite link */
+  kit?: string;
   disableLoading?: boolean;
 }) {
   const [lastLoggedStatus, setLastLoggedStatus] = useState('');
@@ -202,7 +205,7 @@ export function useLure({
 
   lureLogger.crumb('lure fetcher', canCheckForUpdate);
   useQuery({
-    queryKey: ['lureFetcher', flag],
+    queryKey: ['lureFetcher', flag, kit],
     queryFn: async () => {
       lureLogger.crumb(
         'fetching',
@@ -210,7 +213,7 @@ export function useLure({
         inviteServiceEndpoint,
         inviteServiceIsDev
       );
-      await fetchLure(flag, inviteServiceEndpoint, inviteServiceIsDev);
+      await fetchLure(flag, inviteServiceEndpoint, inviteServiceIsDev, kit);
       return true;
     },
     enabled: canCheckForUpdate,

--- a/packages/tlon-skill/scripts/kits.ts
+++ b/packages/tlon-skill/scripts/kits.ts
@@ -11,8 +11,16 @@
  *   tlon kits install <id> [--name <term>] [--title <title>]
  *   tlon kits installs
  *   tlon kits uninstall <flag>
+ *   tlon kits card <id> <nest>
  */
-import { poke, scry } from '@tloncorp/api';
+import {
+  type Story,
+  appendKitToPostBlob,
+  getCurrentUserId,
+  poke,
+  scry,
+  sendPost,
+} from '@tloncorp/api';
 import { loadKit, toWireKit } from '@tloncorp/tlon-kits';
 import type { WireKit, WireManifest } from '@tloncorp/tlon-kits';
 
@@ -39,6 +47,7 @@ Commands:
                                              Instantiate a kit: create a group + places
   installs                                   List installed kits by group flag
   uninstall <flag>                           Uninstall from a group (~ship/name)
+  card <id> <nest>                           Post a shareable kit card to a chat channel
 
 Examples:
   tlon kits list
@@ -46,7 +55,8 @@ Examples:
   tlon kits add ./kits/book-club
   tlon kits fetch ~sampel-palnet book-club
   tlon kits install book-club --name book-club-1 --title "Book Club"
-  tlon kits uninstall ~sampel-palnet/book-club-1`;
+  tlon kits uninstall ~sampel-palnet/book-club-1
+  tlon kits card book-club chat/~sampel-palnet/general`;
 
 const KITS_COMMAND_HELP: Record<string, string> = {
   list: 'Usage: tlon kits list',
@@ -59,6 +69,7 @@ const KITS_COMMAND_HELP: Record<string, string> = {
   installs: 'Usage: tlon kits installs',
   uninstall:
     'Usage: tlon kits uninstall <flag>\nExample: tlon kits uninstall ~sampel-palnet/book-club-1',
+  card: 'Usage: tlon kits card <id> <nest>\nPosts a chat message carrying the kit as a shareable card.\nExample: tlon kits card book-club chat/~sampel-palnet/general',
 };
 
 type KitInstall = {
@@ -87,6 +98,7 @@ function validateKitsArgs(args: string[]): void {
     fetch: 2,
     install: 1,
     uninstall: 1,
+    card: 2,
   };
   const needed = required[command] ?? 0;
   for (let i = 1; i <= needed; i += 1) {
@@ -308,6 +320,40 @@ async function main() {
           json: { uninstall: { flag } },
         });
         console.log(`✓ Uninstall requested for ${flag}`);
+        break;
+      }
+
+      case 'card': {
+        const nest = args[2];
+        if (!nest.startsWith('chat/')) {
+          throw new Error(
+            `Kit cards can only be posted to chat channels (got ${nest})`
+          );
+        }
+        const kit = await fetchLibraryKit(args[1]);
+        const manifest = kit.manifest;
+        // post blob wire format: a JSON array of typed, versioned entries
+        // (see docs/tlon-apps/post-blobs.md)
+        const blob = appendKitToPostBlob(undefined, {
+          id: manifest.id,
+          publisher: manifest.publisher,
+          kitVersion: manifest.version,
+          name: manifest.name,
+          description: manifest.description,
+          image: manifest.image,
+        });
+        const text = manifest.description
+          ? `${manifest.name} — ${manifest.description}`
+          : manifest.name;
+        const content: Story = [{ inline: [text] }];
+        await sendPost({
+          channelId: nest,
+          authorId: getCurrentUserId(),
+          sentAt: Date.now(),
+          content,
+          blob,
+        });
+        console.log(`✓ Posted kit card for ${manifest.id} to ${nest}`);
         break;
       }
 


### PR DESCRIPTION
# Summary

Client UI v1 for kits (TLON-6323), stacked on the kits backend PR (#6241). Design principle: a kit share and an invite link are the same object, and the card is a *reference* (typed post-blob entry, viewer-state rendering), not an agent composition.

- **`kit` post-blob entry + kit-card block** — pointer entry (no attachment machinery), rendered through BlockRenderer with the standard unknown-entry upgrade notice for old clients.
- **KitCard** — reference-style card with state-aware CTA: Get (not installed), Open (installed — jumps to the group), Runs here (inside a kit-made group).
- **KitDetailSheet** — GroupPreviewSheet pattern: what the kit makes (places), what it does (schedules), provenance; Get → name the group → staged install progress (create group / set up channels / wake the agent) → land in the group where the setup conversation starts. Admin Remove-kit behind a confirm.
- **Group details "Kit" row** — visible to all members of a kit-made group (parsed from the group blob, no new state); opens the detail sheet with Get-your-own.
- **Share threading** — kit-made groups automatically mint kit-flavored invite links (`useLure` accepts `kit`, InviteFriendsToTlonButton supplies it from the group blob).
- **Signup** — the INSTALLING_KIT boot phase now narrates ("Installing your kit" step) and is gated to personal kit links only, fixing a latent double-install when joining an existing kit group via invite.
- **`tlon kits card <id> <nest>`** — posts the card into a chat, so cards exist in the world before any in-app authoring surface.

UI spec: kits/SCHEMA.md + the kits design notes (§UI).

# How did I test?

- tsc clean across api, shared, app, tlon-skill, tlon-mobile, tlon-web.
- vitest: api 327/327 (incl. new kit entry/parser/block tests), shared 382/382, app 282/282; tlon-skill 270 unit + 362 hermetic CLI.
- Cosmos fixtures for KitCard states and KitDetailSheet.
- Not yet exercised against a live ship end-to-end (backend branch was: install/blob verified on ~lagrev); a scripted e2e needs the pier regen noted on #6241.

# Risks and impact

- New entry type is additive; old clients render the standard upgrade notice.
- Boot-sequence change narrows when kit install runs (kit && !invitedGroup) — strictly safer than before.
- No new tables/migrations: installed-kit state reads the already-synced group blob and %kits scries.

# Rollback plan

Revert; the entry type degrades gracefully and nothing else depends on the new components.

Fixes TLON-6323

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01K32JNc3ZZZQyeKHnCtB4Re
