### PR TITLE
fix nested notes folder back navigation

### DIFF
--- a/packages/app/ui/components/GroupChannelsScreenView.tsx
+++ b/packages/app/ui/components/GroupChannelsScreenView.tsx
@@ -293,7 +293,9 @@ export const GroupChannelsScreenView = React.memo(
             title={notebookSidebarContent.title}
             testID="NotebookSidebarBackHeader"
             borderBottom
-            backAction={handleDismissNotebookSidebar}
+            backAction={
+              notebookSidebarContent.backAction ?? handleDismissNotebookSidebar
+            }
             rightControls={notebookSidebarContent.actions}
           />
           <YStack flex={1} minHeight={0}>

--- a/packages/app/ui/components/NotesChannel/NotesNativeChannel.tsx
+++ b/packages/app/ui/components/NotesChannel/NotesNativeChannel.tsx
@@ -76,6 +76,7 @@ import {
   getFolderLabel,
   getNextNoteIdAfterDelete,
   getNextNoteIdAfterFolderDelete,
+  getNotesSidebarParentFolderId,
   makeNotesFolderPathLabeler,
 } from './notesTree';
 import { useNotesImportController } from './useNotesImportController';
@@ -146,6 +147,9 @@ export function NotesNativeChannel({
   const showToast = useToast();
   const useDesktopSplit = Platform.OS === 'web' && !isWindowNarrow;
   const notebookSidebarSourceId = `${channelId}/${folderId ?? 'root'}`;
+  const [desktopFolderId, setDesktopFolderId] = useState<number | null>(
+    folderId ?? null
+  );
   const [selectedNoteId, setSelectedNoteId] = useState<number | null>(
     initialNoteId ?? null
   );
@@ -202,6 +206,12 @@ export function NotesNativeChannel({
       enabled: Boolean(notebookFlag),
     });
 
+  useEffect(() => {
+    if (useDesktopSplit) {
+      setDesktopFolderId(folderId ?? null);
+    }
+  }, [folderId, useDesktopSplit]);
+
   // Derived, never stored: the selected folder is the folder of the note
   // selected in the split pane — the only selection the tree makes visible.
   // Storing it separately let side effects (folder opens, moves) leave stale
@@ -242,10 +252,14 @@ export function NotesNativeChannel({
     () => buildFolderUnreadCounts(folders, notes, unreadNoteIds),
     [folders, notes, unreadNoteIds]
   );
-  const activeFolderId = folderId ?? rootFolderId;
+  const activeFolderId = useDesktopSplit
+    ? desktopFolderId ?? rootFolderId
+    : folderId ?? rootFolderId;
   const displayedFolderId =
-    folderId != null && folders.some((folder) => folder.folderId === folderId)
-      ? folderId
+    activeFolderId != null &&
+    activeFolderId !== rootFolderId &&
+    folders.some((folder) => folder.folderId === activeFolderId)
+      ? activeFolderId
       : null;
   useEffect(() => {
     if (displayedFolderId !== null) {
@@ -317,8 +331,16 @@ export function NotesNativeChannel({
     setSelectedNoteId(noteId);
   });
 
+  const didAutoSelectInitialNoteRef = useRef(false);
   useEffect(() => {
-    if (!useDesktopSplit || selectedNoteId !== null) return;
+    if (
+      !useDesktopSplit ||
+      gate ||
+      selectedNoteId !== null ||
+      didAutoSelectInitialNoteRef.current
+    ) {
+      return;
+    }
     // a notification/activity target that hasn't synced yet takes
     // precedence — auto-selecting the first note here would mark an
     // unrelated note read before the target appears
@@ -328,6 +350,7 @@ export function NotesNativeChannel({
     ) {
       return;
     }
+    didAutoSelectInitialNoteRef.current = true;
     const firstNote = treeRows.find((row) => row.type === 'note')?.note;
     if (!firstNote) return;
     selectNoteInPane(firstNote.noteId);
@@ -337,6 +360,7 @@ export function NotesNativeChannel({
     treeRows,
     useDesktopSplit,
     initialNoteId,
+    gate,
   ]);
 
   useEffect(() => {
@@ -425,9 +449,8 @@ export function NotesNativeChannel({
   // opened by id — the note may not be in `notes` yet on a thin client.
   //
   // The tree shows one folder's contents, so a hit from a different folder
-  // would otherwise be selected somewhere the sidebar can't show. Open that
-  // folder instead, carrying the note along, so the sidebar matches the note
-  // and its header still walks back the way folder navigation does.
+  // also moves the desktop sidebar there. The detail pane stays mounted and
+  // changes only because the user explicitly selected this search result.
   const handleSelectSearchResult = useMutableCallback(
     (note: NotesSearchResultNote) => {
       trackEvent(AnalyticsEvent.NotesSearchResultSelected);
@@ -442,21 +465,8 @@ export function NotesNativeChannel({
         return;
       }
 
-      const folder = folders.find(
-        (candidate) => candidate.folderId === noteFolderId
-      );
-      navigation.dispatch(
-        StackActions.push('NotesFolder', {
-          channelId,
-          folderId: noteFolderId,
-          folderTitle:
-            noteFolderId === rootFolderId
-              ? channelTitle ?? 'Notebook'
-              : getFolderLabel(folder),
-          groupId: groupId ?? undefined,
-          noteId: note.noteId,
-        })
-      );
+      setDesktopFolderId(noteFolderId === rootFolderId ? null : noteFolderId);
+      openNoteId(note.noteId);
     }
   );
 
@@ -492,12 +502,32 @@ export function NotesNativeChannel({
   }, [isFocused, openSearch, searchOpen, searchSupported, useDesktopSplit]);
 
   const openFolder = useMutableCallback((folder: db.NotesFolder) => {
+    if (useDesktopSplit) {
+      setDesktopFolderId(folder.folderId);
+      return;
+    }
+
     navigation.dispatch(
       StackActions.push('NotesFolder', {
         channelId,
         folderId: folder.folderId,
         folderTitle: getFolderLabel(folder),
         groupId: groupId ?? undefined,
+      })
+    );
+  });
+
+  const activeSidebarFolder = folders.find(
+    (folder) => folder.folderId === activeFolderId
+  );
+  const sidebarIsNested =
+    activeFolderId != null && activeFolderId !== rootFolderId;
+  const handleSidebarBack = useMutableCallback(() => {
+    setDesktopFolderId(
+      getNotesSidebarParentFolderId({
+        folderId: activeFolderId,
+        folders,
+        rootFolderId,
       })
     );
   });
@@ -1020,9 +1050,12 @@ export function NotesNativeChannel({
       ? {
           channelId,
           actions: headerActions,
+          backAction: sidebarIsNested ? handleSidebarBack : undefined,
           content: notesTreePane,
           groupId,
-          title: channelTitle ?? 'Notebook',
+          title: sidebarIsNested
+            ? getFolderLabel(activeSidebarFolder)
+            : channelTitle ?? 'Notebook',
         }
       : null,
     notebookSidebarSourceId

--- a/packages/app/ui/components/NotesChannel/NotesNativeChannel.tsx
+++ b/packages/app/ui/components/NotesChannel/NotesNativeChannel.tsx
@@ -163,6 +163,9 @@ export function NotesNativeChannel({
   const [isCreatingFolder, setIsCreatingFolder] = useState(false);
   const [newActionSheetOpen, setNewActionSheetOpen] = useState(false);
   const [searchOpen, setSearchOpen] = useState(false);
+  const [pendingDesktopNoteId, setPendingDesktopNoteId] = useState<
+    number | null
+  >(null);
   const [publishingAction, setPublishingAction] =
     useState<PublishingAction>(null);
   const [renameFolderName, setRenameFolderName] = useState('');
@@ -207,10 +210,8 @@ export function NotesNativeChannel({
     });
 
   useEffect(() => {
-    if (useDesktopSplit) {
-      setDesktopFolderId(folderId ?? null);
-    }
-  }, [folderId, useDesktopSplit]);
+    setDesktopFolderId(folderId ?? null);
+  }, [folderId]);
 
   // Derived, never stored: the selected folder is the folder of the note
   // selected in the split pane — the only selection the tree makes visible.
@@ -388,6 +389,7 @@ export function NotesNativeChannel({
         setStartEditNoteId(noteId);
       }
 
+      setPendingDesktopNoteId(null);
       if (useDesktopSplit) {
         selectNoteInPane(noteId);
         return;
@@ -409,6 +411,13 @@ export function NotesNativeChannel({
       options?: { focusTitle?: boolean; startInEdit?: boolean }
     ) => openNoteId(note.noteId, options)
   );
+
+  useEffect(() => {
+    if (pendingDesktopNoteId == null) return;
+    if (!notes.some((note) => note.noteId === pendingDesktopNoteId)) return;
+
+    openNoteId(pendingDesktopNoteId);
+  }, [notes, openNoteId, pendingDesktopNoteId]);
 
   // a notification or activity press targets a specific note; open it once
   // its record has synced (the notes dep keeps this retrying until the note
@@ -456,17 +465,20 @@ export function NotesNativeChannel({
       trackEvent(AnalyticsEvent.NotesSearchResultSelected);
 
       const noteFolderId = note.folderId ?? rootFolderId;
-      if (
-        !useDesktopSplit ||
-        noteFolderId == null ||
-        noteFolderId === activeFolderId
-      ) {
+      if (!useDesktopSplit) {
         openNoteId(note.noteId);
         return;
       }
 
-      setDesktopFolderId(noteFolderId === rootFolderId ? null : noteFolderId);
-      openNoteId(note.noteId);
+      if (noteFolderId != null && noteFolderId !== activeFolderId) {
+        setDesktopFolderId(noteFolderId === rootFolderId ? null : noteFolderId);
+      }
+
+      if (notes.some((candidate) => candidate.noteId === note.noteId)) {
+        openNoteId(note.noteId);
+      } else {
+        setPendingDesktopNoteId(note.noteId);
+      }
     }
   );
 
@@ -621,7 +633,7 @@ export function NotesNativeChannel({
     isDragImportActive,
     isImportingNotes,
   } = useNotesImportController({
-    activeFolderId: folderId ?? null,
+    activeFolderId,
     canDropImportNotes,
     canEdit,
     folders,

--- a/packages/app/ui/components/NotesChannel/notesTree.test.ts
+++ b/packages/app/ui/components/NotesChannel/notesTree.test.ts
@@ -11,6 +11,7 @@ import {
   getFolderPath,
   getNextNoteIdAfterDelete,
   getNextNoteIdAfterFolderDelete,
+  getNotesSidebarParentFolderId,
   makeNotesFolderPathLabeler,
 } from './notesTree';
 
@@ -98,6 +99,25 @@ describe('makeNotesFolderPathLabeler', () => {
 });
 
 describe('notes tree helpers', () => {
+  test('walks the sidebar back one folder at a time before reaching root', () => {
+    const folders = [root, projects, backlog];
+
+    expect(
+      getNotesSidebarParentFolderId({
+        folderId: backlog.folderId,
+        folders,
+        rootFolderId: root.folderId,
+      })
+    ).toBe(projects.folderId);
+    expect(
+      getNotesSidebarParentFolderId({
+        folderId: projects.folderId,
+        folders,
+        rootFolderId: root.folderId,
+      })
+    ).toBeNull();
+  });
+
   test('builds a folder path for note metadata', () => {
     expect(getFolderPath([root, projects, backlog], 4, 1)).toBe(
       'Root / Projects / Backlog'

--- a/packages/app/ui/components/NotesChannel/notesTree.ts
+++ b/packages/app/ui/components/NotesChannel/notesTree.ts
@@ -387,6 +387,26 @@ export function getFolderLabel(folder: db.NotesFolder | null | undefined) {
   return folder.name === '/' ? 'Root' : folder.name;
 }
 
+export function getNotesSidebarParentFolderId({
+  folderId,
+  folders,
+  rootFolderId,
+}: {
+  folderId: number | null;
+  folders: db.NotesFolder[];
+  rootFolderId: number | null;
+}) {
+  if (folderId == null || folderId === rootFolderId) return null;
+
+  const parentFolderId = folders.find(
+    (folder) => folder.folderId === folderId
+  )?.parentFolderId;
+
+  return parentFolderId == null || parentFolderId === rootFolderId
+    ? null
+    : parentFolderId;
+}
+
 /**
  * Label a search hit with the path of folders holding it ("Specs / Wire
  * formats"), for the results list. Two notes named the same in sibling folders

--- a/packages/app/ui/contexts/notebookSidebar.tsx
+++ b/packages/app/ui/contexts/notebookSidebar.tsx
@@ -9,6 +9,7 @@ import React, {
 
 export type NotebookSidebarContent = {
   actions?: ReactNode;
+  backAction?: () => void;
   channelId: string;
   content: ReactNode;
   groupId?: string | null;


### PR DESCRIPTION
## Summary

Keep the displayed desktop note independent from notes sidebar folder navigation. Sidebar back now returns to the immediate parent folder instead of dismissing the notebook and jumping to the group channel list.

## Changes

- keep the active desktop folder as local sidebar state instead of pushing a new navigation screen
- let the notebook sidebar supply a folder-specific back action and title
- preserve the mounted note pane and current note while entering or leaving folders
- only dismiss the notebook sidebar when back is pressed at its root
- keep mobile folder navigation unchanged
- add regression coverage for walking nested folders back to root

## How did I test?

- notes tree tests: 20 passed
- app TypeScript
- ESLint on changed files
- Prettier check on changed files
- `git diff --check`