### PR TITLE
OpenClaw: avoid overriding owner from %settings 

### DIFF
--- a/packages/openclaw/package.json
+++ b/packages/openclaw/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tloncorp/openclaw",
-  "version": "0.19.0",
+  "version": "0.20.0",
   "description": "OpenClaw Tlon/Urbit channel plugin",
   "license": "MIT",
   "repository": {

--- a/packages/openclaw/src/monitor/index.ts
+++ b/packages/openclaw/src/monitor/index.ts
@@ -390,7 +390,7 @@ export async function monitorTlonProvider(
     throw new Error('Tlon account ship is empty after normalization');
   }
   const tlonSkillVersion = await resolveTlonSkillVersion();
-  let effectiveOwnerShip: string | null = account.ownerShip
+  const effectiveOwnerShip: string | null = account.ownerShip
     ? normalizeShip(account.ownerShip)
     : null;
   setEffectiveOwnerShip(account.accountId, effectiveOwnerShip);
@@ -1149,11 +1149,6 @@ export async function monitorTlonProvider(
           fileValue: account.showModelSignature,
           settingsValue: currentSettings.showModelSig,
         },
-        {
-          key: 'ownerShip',
-          fileValue: account.ownerShip,
-          settingsValue: currentSettings.ownerShip,
-        },
       ];
 
       for (const { key, fileValue, settingsValue } of migrations) {
@@ -1259,13 +1254,6 @@ export async function monitorTlonProvider(
         effectiveGroupInviteAllowlist = currentSettings.groupInviteAllowlist;
         runtime.log?.(
           `[tlon] Using groupInviteAllowlist from settings store: ${effectiveGroupInviteAllowlist.join(', ')}`
-        );
-      }
-      if (currentSettings.ownerShip) {
-        effectiveOwnerShip = normalizeShip(currentSettings.ownerShip);
-        setEffectiveOwnerShip(account.accountId, effectiveOwnerShip);
-        runtime.log?.(
-          `[tlon] Using ownerShip from settings store: ${effectiveOwnerShip}`
         );
       }
       if (currentSettings.ownerListenEnabled !== undefined) {
@@ -4712,23 +4700,13 @@ export async function monitorTlonProvider(
           );
         }
 
-        // ownerShip is applied on both live subscription and refresh.
         // pendingNudge is only rehydrated from the store during startup load. Once the
         // monitor is running, the in-memory pending state is authoritative so refreshes
         // cannot clobber live state or resurrect stale store echoes.
         const sync = resolveSettingsMirrorSync({
           prevSettings,
           newSettings,
-          fileConfigOwnerShip: account.ownerShip
-            ? normalizeShip(account.ownerShip)
-            : null,
         });
-
-        if (sync.ownerShipChanged) {
-          effectiveOwnerShip = sync.effectiveOwnerShip;
-          runtime.log?.(`[tlon] Settings: ownerShip = ${effectiveOwnerShip}`);
-          setEffectiveOwnerShip(account.accountId, effectiveOwnerShip);
-        }
 
         // Reconcile the scheduler's owner-activity shadow with live settings
         // changes. Subscription events are authoritative (real-time ship echo

--- a/packages/openclaw/src/monitor/settings-sync.test.ts
+++ b/packages/openclaw/src/monitor/settings-sync.test.ts
@@ -15,64 +15,12 @@ function makeNudge(overrides?: Partial<PendingNudge>): PendingNudge {
 }
 
 describe('resolveSettingsMirrorSync', () => {
-  describe('ownerShip transitions', () => {
-    it('detects ownerShip set to new value', () => {
-      const result = resolveSettingsMirrorSync({
-        prevSettings: {},
-        newSettings: { ownerShip: 'sampel-palnet' },
-        fileConfigOwnerShip: '~file-owner',
-      });
-      expect(result.ownerShipChanged).toBe(true);
-      expect(result.effectiveOwnerShip).toBe('~sampel-palnet');
-    });
-
-    it('detects ownerShip changed to different value', () => {
-      const result = resolveSettingsMirrorSync({
-        prevSettings: { ownerShip: '~old-owner' },
-        newSettings: { ownerShip: '~new-owner' },
-        fileConfigOwnerShip: '~file-owner',
-      });
-      expect(result.ownerShipChanged).toBe(true);
-      expect(result.effectiveOwnerShip).toBe('~new-owner');
-    });
-
-    it('detects ownerShip set to falsy — falls back to file config', () => {
-      const result = resolveSettingsMirrorSync({
-        prevSettings: { ownerShip: '~old-owner' },
-        newSettings: { ownerShip: '' },
-        fileConfigOwnerShip: '~file-owner',
-      });
-      expect(result.ownerShipChanged).toBe(true);
-      expect(result.effectiveOwnerShip).toBe('~file-owner');
-    });
-
-    it('detects ownerShip deleted (undefined) — falls back to file config', () => {
-      const result = resolveSettingsMirrorSync({
-        prevSettings: { ownerShip: '~old-owner' },
-        newSettings: {},
-        fileConfigOwnerShip: '~file-owner',
-      });
-      expect(result.ownerShipChanged).toBe(true);
-      expect(result.effectiveOwnerShip).toBe('~file-owner');
-    });
-
-    it('unchanged ownerShip returns false', () => {
-      const result = resolveSettingsMirrorSync({
-        prevSettings: { ownerShip: '~same-owner' },
-        newSettings: { ownerShip: '~same-owner' },
-        fileConfigOwnerShip: '~file-owner',
-      });
-      expect(result.ownerShipChanged).toBe(false);
-    });
-  });
-
   describe('pendingNudge transitions', () => {
     it('detects pendingNudge added', () => {
       const nudge = makeNudge();
       const result = resolveSettingsMirrorSync({
         prevSettings: {},
         newSettings: { pendingNudge: nudge },
-        fileConfigOwnerShip: null,
       });
       expect(result.pendingNudgeChanged).toBe(true);
       expect(result.pendingNudge).toEqual(nudge);
@@ -83,7 +31,6 @@ describe('resolveSettingsMirrorSync', () => {
       const result = resolveSettingsMirrorSync({
         prevSettings: { pendingNudge: nudge },
         newSettings: {},
-        fileConfigOwnerShip: null,
       });
       expect(result.pendingNudgeChanged).toBe(true);
       expect(result.pendingNudge).toBeNull();
@@ -95,7 +42,6 @@ describe('resolveSettingsMirrorSync', () => {
       const result = resolveSettingsMirrorSync({
         prevSettings: settings,
         newSettings: settings,
-        fileConfigOwnerShip: null,
       });
       expect(result.pendingNudgeChanged).toBe(false);
     });
@@ -106,7 +52,6 @@ describe('resolveSettingsMirrorSync', () => {
       const result = resolveSettingsMirrorSync({
         prevSettings: { pendingNudge: old },
         newSettings: { pendingNudge: replacement },
-        fileConfigOwnerShip: null,
       });
       expect(result.pendingNudgeChanged).toBe(true);
       expect(result.pendingNudge).toEqual(replacement);
@@ -117,11 +62,14 @@ describe('resolveSettingsMirrorSync', () => {
     it('first onChange after startup with no new fields', () => {
       const result = resolveSettingsMirrorSync({
         prevSettings: {},
-        newSettings: { dmAllowlist: ['~ship'] },
-        fileConfigOwnerShip: null,
+        newSettings: {
+          dmAllowlist: ['~ship'],
+          ownerShip: '~stale-settings-owner',
+        },
       });
       expect(result.pendingNudgeChanged).toBe(false);
-      expect(result.ownerShipChanged).toBe(false);
+      expect(result).not.toHaveProperty('ownerShipChanged');
+      expect(result).not.toHaveProperty('effectiveOwnerShip');
     });
   });
 });

--- a/packages/openclaw/src/monitor/settings-sync.ts
+++ b/packages/openclaw/src/monitor/settings-sync.ts
@@ -1,17 +1,14 @@
 /**
  * Pure helper for settings mirror synchronization.
  *
- * Detects ownerShip and pendingNudge transitions from the settings mirror.
+ * Detects pendingNudge transitions from the settings mirror.
  * The scheduler no longer routes through this helper for lastNudgeStage —
  * the authoritative stage lives in a fresh scry plus a local shadow.
  */
 import type { PendingNudge } from '../pending-nudge.js';
 import type { TlonSettingsStore } from '../settings.js';
-import { normalizeShip } from '../targets.js';
 
 export type SettingsMirrorSyncResult = {
-  ownerShipChanged: boolean;
-  effectiveOwnerShip: string | null;
   pendingNudgeChanged: boolean;
   pendingNudge: PendingNudge | null;
 };
@@ -19,18 +16,8 @@ export type SettingsMirrorSyncResult = {
 export function resolveSettingsMirrorSync(params: {
   prevSettings: TlonSettingsStore;
   newSettings: TlonSettingsStore;
-  fileConfigOwnerShip: string | null;
 }): SettingsMirrorSyncResult {
-  const { prevSettings, newSettings, fileConfigOwnerShip } = params;
-
-  // ownerShip: compare string values (normalize for comparison)
-  const prevOwner = prevSettings.ownerShip;
-  const newOwner = newSettings.ownerShip;
-  const normalizedPrevOwner = prevOwner ? normalizeShip(prevOwner) : null;
-  const normalizedNewOwner = newOwner ? normalizeShip(newOwner) : null;
-  const ownerShipChanged = normalizedPrevOwner !== normalizedNewOwner;
-  const effectiveOwnerShip: string | null =
-    normalizedNewOwner ?? fileConfigOwnerShip;
+  const { prevSettings, newSettings } = params;
 
   // pendingNudge: reference equality since applySettingsUpdate uses shallow spread
   const pendingNudgeChanged =
@@ -38,8 +25,6 @@ export function resolveSettingsMirrorSync(params: {
   const pendingNudge: PendingNudge | null = newSettings.pendingNudge ?? null;
 
   return {
-    ownerShipChanged,
-    effectiveOwnerShip,
     pendingNudgeChanged,
     pendingNudge,
   };


### PR DESCRIPTION
## Summary

Part of Part of TLON-6280

We want to avoid letting stale `%settings` configurations override the configured owner ship.

## Changes

- Stop migrating `ownerShip` from config into `%settings`
- Ignore stale `%settings.ownerShip` values at startup and during live updates.
- Keep the environment-generated OpenClaw configuration authoritative

## How did I test?

Settings sync tests updated.

## Risks and impact

- Safe to rollback without consulting PR author? Yes
