### PR TITLE
notes: bump notebook recency for our own note changes

### DIFF
--- a/desk/app/notes.hoon
+++ b/desk/app/notes.hoon
@@ -28,7 +28,7 @@
 |_  =bowl:gall
 +*  this  .
     def   ~(. (default-agent this %|) bowl)
-    cor   ~(. +> [bowl ~])
+    cor   ~(. +> [bowl ~ ~])
 ::
 ++  on-init
   ^-  (quip card _this)
@@ -88,7 +88,11 @@
 --
 ::  helper core
 ::
-|_  [=bowl:gall cards=(list card)]
+|_  $:  =bowl:gall
+        cards=(list card)
+        ::  notebooks already bumped this event, see +notebook-activity-bump
+        bumped=(set [=flag:n group=(unit flag:n)])
+    ==
 ++  dummy  'freeze-requests-13-snapshot-v1'
 ++  abet  [(flop cards) state]
 ++  cor   .
@@ -1257,9 +1261,16 @@
 ::  +notebook-activity-bump: move a notebook's recency without adding an
 ::  event. %activity's +bump creates the source if absent, so this inits it.
 ::
+::  A bump sets the source's time to now.bowl, which is fixed for the whole
+::  event, so repeats within one event are redundant — collapse them. A
+::  batch import calls +se-update once per note, and would otherwise poke
+::  %activity (and re-fan-out its summaries) once per imported file.
+::
 ++  notebook-activity-bump
   |=  [=flag:n group=(unit flag:n)]
   ^+  cor
+  ?:  (~(has in bumped) [flag group])  cor
+  =.  bumped  (~(put in bumped) [flag group])
   %-  submit-activity
   :+  %bump  %notebook
   :-  flag
@@ -2725,13 +2736,18 @@
     ^+  no-core
     ?-  -.response
         %snapshot
+      ::  a rewatch re-sends the whole snapshot, and bumping on those would
+      ::  promote the notebook on every reconnect. +join-remote-v1's
+      ::  placeholder has notebook id 0; a resubscribe already has the host's.
+      =/  first-snapshot=?  =(0 id.notebook.notebook-state)
       =.  notebook-state  notebook-state.response
       ?>  ?=(%sub -.net)
       =.  net  net(init &)
       =.  cards  [notebooks-changed-card cards]
       ::  the snapshot carries the host's notebook-state, so group is now
       ::  known — report active to %groups (no-op if not a group channel).
-      =.  cor  (notebook-activity-bump flag group.notebook-state)
+      =?  cor  first-snapshot
+        (notebook-activity-bump flag group.notebook-state)
       =/  stream=card
         :*  %give  %fact  [/v0/notes/(scot %p ship.flag)/[name.flag]/stream]~
             notes-response+!>(response)

--- a/desk/app/notes.hoon
+++ b/desk/app/notes.hoon
@@ -1191,11 +1191,12 @@
   ==
 ::  +note-activity: translate an applied u-note into %activity actions.
 ::
-::    %created / %updated -> (re)arm the trailing debounce timer; the
-::                 event is submitted by +note-activity-wake once the
-::                 change settles. Creates debounce too: the client
-::                 creates a note and immediately titles/edits it, which
-::                 would otherwise notify twice in quick succession.
+::    %created / %updated -> ours just bump the notebook's recency;
+::                 anyone else's (re)arm the trailing debounce timer and
+::                 +note-activity-wake submits the event once the change
+::                 settles. Creates debounce too: the client creates a
+::                 note and immediately titles/edits it, which would
+::                 otherwise notify twice in quick succession.
 ::    %deleted  -> %del the note source (regardless of author)
 ::
 ++  note-activity
@@ -1203,7 +1204,8 @@
   ^+  cor
   ?-  -.upd
       ?(%created %updated)
-    ?:  =(our.bowl updated-by.note.upd)  cor
+    ?:  =(our.bowl updated-by.note.upd)
+      (notebook-activity-bump flag group)
     ::  the wire carries the updated-at this timer was armed against, so
     ::  +note-activity-wake can tell whether it is the note's latest
     ::  change — no timer bookkeeping needed, stale timers just no-op
@@ -1252,6 +1254,16 @@
   ?:  =(created-at.u.note updated-at.u.note)
     [%add %note-create ev]
   [%add %note-edit ev]
+::  +notebook-activity-bump: move a notebook's recency without adding an
+::  event. %activity's +bump creates the source if absent, so this inits it.
+::
+++  notebook-activity-bump
+  |=  [=flag:n group=(unit flag:n)]
+  ^+  cor
+  %-  submit-activity
+  :+  %bump  %notebook
+  :-  flag
+  (bind group |=(f=flag:n [ship.f name.f]))
 ::  +notebook-activity-gone: a notebook was deleted or left; drop its
 ::  %activity source (note children included).
 ::
@@ -1908,6 +1920,7 @@
       =/  =wire    /notes/(scot %p ship.flag)/[name.flag]/create
       (emit %pass wire %agent dock %poke group-action-4+!>(action))
     =.  se-core  (emit notebooks-changed-card)
+    =.  cor  (notebook-activity-bump flag group)
     (se-update [%created notebook %private])
   ::  +se-poke: dispatch a c-notes command to the right handler
   ::
@@ -2718,6 +2731,7 @@
       =.  cards  [notebooks-changed-card cards]
       ::  the snapshot carries the host's notebook-state, so group is now
       ::  known — report active to %groups (no-op if not a group channel).
+      =.  cor  (notebook-activity-bump flag group.notebook-state)
       =/  stream=card
         :*  %give  %fact  [/v0/notes/(scot %p ship.flag)/[name.flag]/stream]~
             notes-response+!>(response)

--- a/desk/tests/app/notes.hoon
+++ b/desk/tests/app/notes.hoon
@@ -2446,9 +2446,10 @@
   ?.  =([ship.f name.f] notebook.ev)
     |+['expected event notebook flag']~
   &+[~ s]
-::  self-authored changes submit nothing
+::  self-authored changes don't notify, they just bump the notebook's
+::  recency — immediately, since a bump adds no event and can't notify
 ::
-++  test-activity-self-note-silent
+++  test-activity-self-note-bumps
   %-  eval-mare
   =/  m  (mare ,~)
   =*  b  bind:m
@@ -2464,10 +2465,90 @@
   =/  acts  (weld (activity-actions caz) (activity-actions caz2))
   =/  timers  (weld (edit-timer-wires caz) (edit-timer-wires caz2))
   |=  s=state
-  ?.  =(~ acts)
-    |+['expected no activity submissions for self-authored changes']~
+  ?.  =(2 (lent acts))
+    |+['expected a bump for each self-authored change']~
   ?.  =(~ timers)
     |+['expected no debounce timers for self-authored changes']~
+  |-
+  ?~  acts  &+[~ s]
+  =/  act  i.acts
+  ?.  ?=(%bump -.act)
+    |+['expected self-authored changes to submit a %bump']~
+  ?.  ?=(%notebook -.source.act)
+    |+['expected the bump to name the notebook source']~
+  ?.  =([ship.f name.f] flag.source.act)
+    |+['expected the bumped notebook flag']~
+  ?.  =(~ group.source.act)
+    |+['expected no group on a solo notebook source']~
+  $(acts t.acts)
+::  creating a notebook gives it an %activity source right away, so its
+::  notes have a parent to hang off and roll their unreads up into
+::
+++  test-activity-notebook-create-inits-source
+  %-  eval-mare
+  =/  m  (mare ,~)
+  =*  b  bind:m
+  ^-  form:m
+  ;<  ~  b  init-zod
+  ;<  =bowl:gall  b  get-bowl
+  ;<  ~  b  (set-scry-gate activity-scry)
+  ;<  caz=(list card)  b  (poke-a [%create-notebook 'NB'])
+  =/  f=flag:n  (nb-flag our.bowl 'NB' 1)
+  =/  acts  (activity-actions caz)
+  |=  s=state
+  ?.  =(1 (lent acts))
+    |+['expected exactly one activity submission on notebook create']~
+  =/  act  (snag 0 acts)
+  ?.  ?=(%bump -.act)
+    |+['expected a %bump to init the notebook source']~
+  ?.  ?=(%notebook -.source.act)
+    |+['expected the bump to name the notebook source']~
+  ?.  =([ship.f name.f] flag.source.act)
+    |+['expected the created notebook flag']~
+  &+[~ s]
+::  joining someone else's notebook inits its source too — the snapshot is
+::  the first point the group (and so the source) is known
+::
+++  test-activity-join-inits-source
+  %-  eval-mare
+  =/  m  (mare ,~)
+  =*  b  bind:m
+  ^-  form:m
+  ;<  ~  b  init-zod
+  ;<  ~  b  (set-scry-gate activity-scry)
+  =/  f=flag:n  [~bus %shared]
+  ;<  caz0=(list card)  b  (poke-a [%join f])
+  =/  req-watch=(unit wire)  (find-watch-wire caz0)
+  ~|  %no-join-request-watch-wire
+  ?>  ?=(^ req-watch)
+  ;<  *  b
+    %+  do-agent-drain  u.req-watch
+    :-  [~bus %notes]
+    :+  %fact  %notes-response-update-1
+    !>(`response-update:v1:n`[`@uv`0v0 [%ok *@da [%member-joined ~zod %viewer]]])
+  =/  nb=notebook:n  [1 'NB' ~bus *@da *@da ~bus]
+  =/  root=folder:n  [1 1 'root' ~ ~bus *@da *@da ~bus]
+  =/  nb-state=notebook-state:n
+    :*  nb
+        (~(gas by *members:n) ~[[~bus %owner] [~zod %viewer]])
+        %public
+        (~(gas by *(map @ud folder:n)) ~[[1 root]])
+        ~  ~  ~
+    ==
+  ;<  caz=(list card)  b
+    %+  do-agent  /notes/sub/(scot %p ~bus)/shared
+    [[~bus %notes] [%fact %notes-response !>(`response:n`[%snapshot f %public nb-state])]]
+  =/  acts  (activity-actions caz)
+  |=  s=state
+  ?.  =(1 (lent acts))
+    |+['expected exactly one activity submission on join snapshot']~
+  =/  act  (snag 0 acts)
+  ?.  ?=(%bump -.act)
+    |+['expected a %bump to init the joined notebook source']~
+  ?.  ?=(%notebook -.source.act)
+    |+['expected the bump to name the notebook source']~
+  ?.  =([ship.f name.f] flag.source.act)
+    |+['expected the joined notebook flag']~
   &+[~ s]
 ::  changes don't submit immediately: each one (re)arms a debounce timer,
 ::  and only the timer armed against the note's latest change submits
@@ -2880,6 +2961,10 @@
   |=  [synced=? allowed=?]
   ^-  scry
   |=  pax=path
+  ::  creating the notebook probes %activity liveness; answer it like
+  ::  +base-scry so these tests see no activity cards
+  ?:  ?=([%gu @ %activity @ %$ ~] pax)
+    `!>(|)
   ?:  ?=([%gu @ %groups @ %groups @ @ ~] pax)
     `!>(synced)
   ?.  ?=([%gx @ %groups @ %v2 %groups @ @ %channels %can-read %noun ~] pax)

--- a/desk/tests/app/notes.hoon
+++ b/desk/tests/app/notes.hoon
@@ -2535,13 +2535,21 @@
         (~(gas by *(map @ud folder:n)) ~[[1 root]])
         ~  ~  ~
     ==
+  =/  =response:n  [%snapshot f %public nb-state]
   ;<  caz=(list card)  b
     %+  do-agent  /notes/sub/(scot %p ~bus)/shared
-    [[~bus %notes] [%fact %notes-response !>(`response:n`[%snapshot f %public nb-state])]]
+    [[~bus %notes] [%fact %notes-response !>(response)]]
+  ::  a rewatch re-sends the same snapshot; it must not bump again
+  ;<  caz2=(list card)  b
+    %+  do-agent  /notes/sub/(scot %p ~bus)/shared
+    [[~bus %notes] [%fact %notes-response !>(response)]]
   =/  acts  (activity-actions caz)
+  =/  acts2  (activity-actions caz2)
   |=  s=state
   ?.  =(1 (lent acts))
     |+['expected exactly one activity submission on join snapshot']~
+  ?.  =(~ acts2)
+    |+['expected no activity submission on a resubscribe snapshot']~
   =/  act  (snag 0 acts)
   ?.  ?=(%bump -.act)
     |+['expected a %bump to init the joined notebook source']~
@@ -2549,6 +2557,33 @@
     |+['expected the bump to name the notebook source']~
   ?.  =([ship.f name.f] flag.source.act)
     |+['expected the joined notebook flag']~
+  &+[~ s]
+::  a batch import calls +se-update per note; the redundant per-note bumps
+::  collapse into one for the whole event
+::
+++  test-activity-batch-import-bumps-once
+  %-  eval-mare
+  =/  m  (mare ,~)
+  =*  b  bind:m
+  ^-  form:m
+  ;<  ~  b  init-zod
+  ;<  =bowl:gall  b  get-bowl
+  ;<  ~  b  (set-scry-gate activity-scry)
+  ;<  *  b  (poke-a [%create-notebook 'NB'])
+  =/  f=flag:n  (nb-flag our.bowl 'NB' 1)
+  ;<  caz=(list card)  b
+    %^  poke-a  %notebook  f
+    :-  %batch-import
+    [2 ~[['A' 'a'] ['B' 'b'] ['C' 'c']]]
+  =/  acts  (activity-actions caz)
+  |=  s=state
+  ?.  =(1 (lent acts))
+    |+['expected one bump for the whole import, not one per note']~
+  =/  act  (snag 0 acts)
+  ?.  ?=(%bump -.act)
+    |+['expected the import to submit a %bump']~
+  ?.  ?=(%notebook -.source.act)
+    |+['expected the bump to name the notebook source']~
   &+[~ s]
 ::  changes don't submit immediately: each one (re)arms a debounce timer,
 ::  and only the timer armed against the note's latest change submits


### PR DESCRIPTION
## Summary

A notebook never moved up a recency-sorted list when you were the one writing in it. `%channels` and `%chat` both poke `[%bump source]` for self-authored messages; `%notes` submitted nothing at all. Fixing that also closes a second gap: nothing ever created the `%notebook` `%activity` source, so note unreads didn't roll up into the group/base summaries.

Fixes TLON-6325

## Changes

`desk/app/notes.hoon`:

- Added `+notebook-activity-bump`, poking `[%bump [%notebook flag group]]`.
- `+note-activity` now bumps on self-authored `%created`/`%updated` instead of early-returning. Not debounced: a bump adds no stream event and cannot notify, so the reason `+edit-activity-window` exists doesn't apply, and debouncing would leave your own notebook mis-sorted for two minutes after you write in it.
- Notebook create (`+se-create-notebook`) and join (the `%snapshot` branch of `+no-response`) bump too, which inits the source — the `%chan-init` analogue.

**Why no new event type, and so no migration.** `%activity`'s `+bump` reads through `+get-index`, so it materialises a missing index rather than dropping the poke, and `+summarize-unreads` folds `bump.index` straight into `newest` (`lib/activity.hoon:312`). One bump therefore both creates the source and sets recency — no `$incoming-event` variant, no `activity-json` work, no volume defaults, no frontend types, no version bump.

**Why the source needed initialising at all.** `+add-event` only built the `%notebook` index as a side effect of a *remote* note event (`activity.hoon:1126-1130`). `+get-parent` requires the parent to be present in `.indices`, not just in `.activity` (`lib/activity.hoon:47`) — `+refresh-summary` only writes the `.activity` map. So in a notebook only you wrote in, note sources had no resolvable parent (`%drop-orphans` would delete them) and `+get-children` for `%base`/`%group` skipped the notebook entirely, so its notes' unreads never rolled up.

`desk/tests/app/notes.hoon`:

- `test-activity-self-note-silent` → `test-activity-self-note-bumps`; it asserted the old submit-nothing behaviour.
- New `test-activity-notebook-create-inits-source` and `test-activity-join-inits-source`.
- `+said-group-scry` now answers the `%activity` liveness probe like `+base-scry`. Notebook creation now performs that scry, and three `/v0/said` group tests were failing with `blocking on scry /gu/~zod/activity/...`.

## How did I test?

Built and committed the assembled desk on a dev ship (`~sidwyn-nimnev-nocsyx-lassul`), confirming the `%groups` `%cz` hash moved (`0x18f00507…` → `0xfb682766…`) so it actually compiled and the agents reloaded rather than silently rolling back.

- `/tests/app/notes` — 113 arms, 0 failures
- `/tests/app/activity` — 12 arms, 0 failures

Not exercised in a client: the recency change is only observable as notebook sort order, and I didn't have a two-ship UI setup up. Worth a look from someone with one running.

## Risks and impact

- Safe to rollback without consulting PR author? (Yes)
- Affects important code area:
  - [ ] Onboarding
  - [ ] State / providers
  - [ ] Message sync
  - [ ] Channel display
  - [x] Notifications
  - [x] Other: `%notes` ↔ `%activity` integration, unread rollup

Backend-only, and no state type changed, so there is nothing to migrate. Notes `%activity` has only shipped to devs. The one behavioural cost is an `%activity` poke per editor autosave while you are typing in a note (the editor autosaves every few seconds); each is a `+get-index`, a put, and a summary refresh for the source plus parents. If that shows up in practice, routing `%updated` through the existing `+edit-activity-window` debounce is a one-line follow-up.

## Rollback plan

Revert the commit. No state migration, no new marks or event types, so nothing persists that a revert wouldn't undo. Existing `%notebook` sources created by these bumps are ordinary sources and are cleaned up by the existing `+notebook-activity-gone` path.

## Screenshots / videos

n/a — backend only.
