### PR TITLE
fix(openclaw): keep lens argumentDetail parseable for schema-padded tool calls

### DIFF
--- a/packages/openclaw/index.ts
+++ b/packages/openclaw/index.ts
@@ -13,6 +13,7 @@ import { publishContextLensEvent } from './src/context-lens-events.js';
 import { registerContextLensRoutes } from './src/context-lens-routes.js';
 import { initContextLensShipSync } from './src/context-lens-ship-sync.js';
 import { initContextLensStore } from './src/context-lens-store.js';
+import { detailToolParams } from './src/context-lens-tool-params.js';
 import {
   ensureBackgroundContextLensForSession,
   recordContextLensToolResultForSession,
@@ -120,27 +121,6 @@ function summarizeToolParams(params: unknown): string | undefined {
     return `${keys.length} key${keys.length === 1 ? '' : 's'}: ${shown}${suffix}`;
   }
   return typeof params;
-}
-
-const MAX_TOOL_PARAM_DETAIL_CHARS = 2000;
-
-function detailToolParams(params: unknown): string | undefined {
-  if (params === null || params === undefined) {
-    return undefined;
-  }
-  let serialized: string | undefined;
-  try {
-    serialized = JSON.stringify(params, null, 1);
-  } catch {
-    return undefined;
-  }
-  if (!serialized) {
-    return undefined;
-  }
-  if (serialized.length > MAX_TOOL_PARAM_DETAIL_CHARS) {
-    return `${serialized.slice(0, MAX_TOOL_PARAM_DETAIL_CHARS)}… [truncated]`;
-  }
-  return serialized;
 }
 
 function firstLine(value: string): string {

--- a/packages/openclaw/src/context-lens-tool-params.test.ts
+++ b/packages/openclaw/src/context-lens-tool-params.test.ts
@@ -1,0 +1,258 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  MAX_TOOL_PARAM_DETAIL_CHARS,
+  detailToolParams,
+  elideToolParamValues,
+  withoutEmptyToolParamValues,
+} from './context-lens-tool-params.js';
+
+// A `message action=send` call as gpt-5.6-luna actually issues it: every
+// optional parameter in the tool schema filled in with a default. Captured from
+// a tlonbot e2e run (108 keys); trimmed here to the shape that matters.
+function paddedMessageParams(): Record<string, unknown> {
+  const padding: Record<string, unknown> = {};
+  for (const key of [
+    'activityName',
+    'activityState',
+    'activityType',
+    'activityUrl',
+    'after',
+    'around',
+    'authorId',
+    'before',
+    'buffer',
+    'caption',
+    'categoryId',
+    'channelId',
+    'chatId',
+    'contentType',
+    'desc',
+    'effect',
+    'effectId',
+    'emoji',
+    'emojiName',
+    'endTime',
+    'eventName',
+    'eventType',
+    'fileId',
+    'filePath',
+    'filename',
+    'gatewayToken',
+    'gatewayUrl',
+    'groupId',
+    'guildId',
+    'image',
+    'kind',
+    'location',
+    'media',
+    'memberId',
+    'mimeType',
+    'name',
+    'openId',
+    'pageToken',
+    'parentId',
+    'participant',
+    'path',
+    'pollId',
+    'pollOptionId',
+    'pollQuestion',
+    'query',
+    'quoteText',
+    'reason',
+    'replyTo',
+    'roleId',
+    'scope',
+    'startTime',
+    'status',
+    'stickerDesc',
+    'stickerName',
+    'stickerTags',
+    'targetAuthor',
+    'threadId',
+    'threadName',
+    'topic',
+    'unionId',
+    'until',
+    'userId',
+  ]) {
+    padding[key] = '';
+  }
+  for (const key of [
+    'appliedTags',
+    'attachments',
+    'authorIds',
+    'channelIds',
+    'pollOption',
+    'roleIds',
+    'stickerId',
+    'targets',
+  ]) {
+    padding[key] = [];
+  }
+  for (const key of [
+    'asDocument',
+    'asVoice',
+    'clearParent',
+    'dryRun',
+    'forceDocument',
+    'fromMe',
+    'gifPlayback',
+    'includeArchived',
+    'includeMembers',
+    'members',
+    'nsfw',
+    'pollMulti',
+    'remove',
+    'silent',
+    'trackToolCalls',
+  ]) {
+    padding[key] = false;
+  }
+  for (const [key, value] of Object.entries({
+    autoArchiveMin: 1,
+    channelType: 0,
+    deleteDays: 0,
+    durationMin: 0,
+    limit: 1,
+    pageSize: 1,
+    pollDurationHours: 1,
+    pollOptionIndex: 1,
+    position: 0,
+    rateLimitPerUser: 0,
+    timeoutMs: 10_000,
+  })) {
+    padding[key] = value;
+  }
+  return {
+    action: 'send',
+    channel: 'tlon',
+    target: 'chat/~zod/gjkydolns-general',
+    accountId: 'default',
+    message: 'hello from the test suite',
+    ...padding,
+  };
+}
+
+function parsed(detail: string | undefined): Record<string, unknown> {
+  expect(detail).toBeTypeOf('string');
+  return JSON.parse(detail as string) as Record<string, unknown>;
+}
+
+describe('detailToolParams', () => {
+  it('returns undefined for nullish params', () => {
+    expect(detailToolParams(null)).toBeUndefined();
+    expect(detailToolParams(undefined)).toBeUndefined();
+  });
+
+  it('keeps a schema-padded call parseable, with its identifying args intact', () => {
+    // The regression this guards: pretty-printing pushed this payload over the
+    // budget, it was sliced mid-key, and consumers saw no arguments at all.
+    const detail = detailToolParams(paddedMessageParams());
+    expect(detail!.length).toBeLessThanOrEqual(MAX_TOOL_PARAM_DETAIL_CHARS);
+    const args = parsed(detail);
+    expect(args.action).toBe('send');
+    expect(args.target).toBe('chat/~zod/gjkydolns-general');
+    expect(args.message).toBe('hello from the test suite');
+  });
+
+  it('serializes compactly', () => {
+    expect(detailToolParams({ command: 'groups list' })).toBe(
+      '{"command":"groups list"}'
+    );
+  });
+
+  it('elides a long value instead of the document', () => {
+    const args = parsed(
+      detailToolParams({
+        action: 'send',
+        target: 'chat/~zod/x-general',
+        message: 'x'.repeat(5_000),
+      })
+    );
+    expect(args.action).toBe('send');
+    expect(args.target).toBe('chat/~zod/x-general');
+    expect(args.message).toMatch(/^x+… \[5000 chars\]$/);
+  });
+
+  it('caps long arrays and says how many were dropped', () => {
+    const args = parsed(
+      detailToolParams({
+        targets: Array.from({ length: 500 }, (_, i) => `~ship-${i}`),
+      })
+    );
+    expect(args.targets).toHaveLength(11);
+    expect((args.targets as unknown[])[10]).toBe('[+490 more items]');
+  });
+
+  it('drops empty padding when the elided document still overflows', () => {
+    const params = {
+      action: 'send',
+      target: 'chat/~zod/x-general',
+      ...Object.fromEntries(
+        Array.from({ length: 400 }, (_, i) => [`padKey${i}`, ''])
+      ),
+    };
+    const detail = detailToolParams(params);
+    expect(detail!.length).toBeLessThanOrEqual(MAX_TOOL_PARAM_DETAIL_CHARS);
+    const args = parsed(detail);
+    expect(args.action).toBe('send');
+    expect(args.target).toBe('chat/~zod/x-general');
+    expect(args.__emptyKeysOmitted__).toBe(400);
+  });
+
+  it('falls back to a shape summary when nothing fits, still as valid JSON', () => {
+    const params = Object.fromEntries(
+      Array.from({ length: 600 }, (_, i) => [`realKey${i}`, `value-${i}`])
+    );
+    const detail = detailToolParams(params);
+    expect(detail!.length).toBeLessThanOrEqual(MAX_TOOL_PARAM_DETAIL_CHARS);
+    const args = parsed(detail);
+    expect(args.__tooLarge__).toBeTypeOf('number');
+    expect(args.keys).toHaveLength(40);
+  });
+
+  it('survives a circular payload — the depth cap breaks the cycle', () => {
+    const circular: Record<string, unknown> = { action: 'send' };
+    circular.self = circular;
+    const args = parsed(detailToolParams(circular));
+    expect(args.action).toBe('send');
+    expect(JSON.stringify(args)).toContain('[object 2 keys]');
+  });
+
+  it('never emits unparseable JSON', () => {
+    for (const params of [
+      {},
+      { a: { b: { c: { d: { e: { f: 'deep' } } } } } },
+      { list: [{ nested: ['x', { deeper: true }] }] },
+      paddedMessageParams(),
+    ]) {
+      const detail = detailToolParams(params);
+      expect(() => JSON.parse(detail as string)).not.toThrow();
+    }
+  });
+});
+
+describe('withoutEmptyToolParamValues', () => {
+  it('drops "" / [] / null but keeps false and 0', () => {
+    expect(
+      withoutEmptyToolParamValues({
+        action: 'send',
+        caption: '',
+        targets: [],
+        replyTo: null,
+        dryRun: false,
+        limit: 0,
+      })
+    ).toEqual({ action: 'send', dryRun: false, limit: 0 });
+  });
+});
+
+describe('elideToolParamValues', () => {
+  it('summarizes past the depth limit rather than recursing forever', () => {
+    const deep = { a: { b: { c: { d: { e: { f: 'deep' } } } } } };
+    expect(JSON.stringify(elideToolParamValues(deep))).toContain(
+      '[object 1 keys]'
+    );
+  });
+});

--- a/packages/openclaw/src/context-lens-tool-params.test.ts
+++ b/packages/openclaw/src/context-lens-tool-params.test.ts
@@ -176,6 +176,19 @@ describe('detailToolParams', () => {
     expect(args.message).toBe(message);
   });
 
+  it('drops padding before clamping a real value', () => {
+    // Over budget only because of the empty optional keys: the body must
+    // survive exactly, since dropping padding costs a consumer nothing and
+    // clamping the message costs it the predicate it matches on.
+    const message = 'y'.repeat(500);
+    const args = parsed(
+      detailToolParams({ ...paddedMessageParams(), message })
+    );
+    expect(args.message).toBe(message);
+    expect(args.action).toBe('send');
+    expect(args.__emptyKeysOmitted__).toBeTypeOf('number');
+  });
+
   it('elides a long value instead of the document', () => {
     const args = parsed(
       detailToolParams({

--- a/packages/openclaw/src/context-lens-tool-params.test.ts
+++ b/packages/openclaw/src/context-lens-tool-params.test.ts
@@ -162,6 +162,20 @@ describe('detailToolParams', () => {
     );
   });
 
+  it('keeps values verbatim when the real params already fit', () => {
+    // Eliding is a concession to the budget; paying it early would replace the
+    // exact `message` a fixture matches on with a placeholder.
+    const message = 'x'.repeat(300);
+    const args = parsed(
+      detailToolParams({
+        action: 'send',
+        target: 'chat/~zod/x-general',
+        message,
+      })
+    );
+    expect(args.message).toBe(message);
+  });
+
   it('elides a long value instead of the document', () => {
     const args = parsed(
       detailToolParams({
@@ -212,6 +226,22 @@ describe('detailToolParams', () => {
     expect(args.keys).toHaveLength(40);
   });
 
+  it('keeps the shape summary within budget when key names are huge', () => {
+    // An oversized summary would be sliced again downstream by ship-sync's own
+    // truncation, recreating the unparseable record this module prevents.
+    const params = Object.fromEntries(
+      Array.from({ length: 200 }, (_, i) => [
+        `absurdlyLongParameterName${'x'.repeat(300)}${i}`,
+        `value-${i}`,
+      ])
+    );
+    const detail = detailToolParams(params);
+    expect(detail!.length).toBeLessThanOrEqual(MAX_TOOL_PARAM_DETAIL_CHARS);
+    const args = parsed(detail);
+    expect(args.__tooLarge__).toBeTypeOf('number');
+    expect(args.keyCount).toBe(200);
+  });
+
   it('survives a circular payload — the depth cap breaks the cycle', () => {
     const circular: Record<string, unknown> = { action: 'send' };
     circular.self = circular;
@@ -226,9 +256,15 @@ describe('detailToolParams', () => {
       { a: { b: { c: { d: { e: { f: 'deep' } } } } } },
       { list: [{ nested: ['x', { deeper: true }] }] },
       paddedMessageParams(),
+      { message: 'x'.repeat(50_000) },
+      Object.fromEntries(
+        Array.from({ length: 300 }, (_, i) => [`k${'y'.repeat(200)}${i}`, 'v'])
+      ),
+      Array.from({ length: 400 }, (_, i) => `item-${i}`),
     ]) {
       const detail = detailToolParams(params);
       expect(() => JSON.parse(detail as string)).not.toThrow();
+      expect(detail!.length).toBeLessThanOrEqual(MAX_TOOL_PARAM_DETAIL_CHARS);
     }
   });
 });

--- a/packages/openclaw/src/context-lens-tool-params.ts
+++ b/packages/openclaw/src/context-lens-tool-params.ts
@@ -115,43 +115,62 @@ function shapeSummary(params: unknown, size: number): string | undefined {
   return safeStringify({ __tooLarge__: size, keyCount });
 }
 
+// Deliberately not a type predicate: narrowing the negative branch would make
+// the still-useful `serialized?.length` reads below unreachable-typed.
+function fits(serialized: string | undefined): boolean {
+  return (
+    serialized !== undefined && serialized.length <= MAX_TOOL_PARAM_DETAIL_CHARS
+  );
+}
+
+// Concessions in order of what they cost a consumer, cheapest first: keys the
+// model left empty carry no information beyond having been present, so drop
+// those before clamping any real value. Anything that fits is returned as-is.
 export function detailToolParams(params: unknown): string | undefined {
   if (params === null || params === undefined) {
     return undefined;
   }
 
-  // Verbatim first. Eliding is a concession to the budget, so paying for it
-  // when the real params already fit would throw away exactly what consumers
-  // match on — a 300-char message body would arrive as a 200-char placeholder.
+  // 1. Everything, exactly as passed.
   const verbatim = safeStringify(params);
-  if (verbatim && verbatim.length <= MAX_TOOL_PARAM_DETAIL_CHARS) {
+  if (fits(verbatim)) {
     return verbatim;
   }
 
-  // Over budget (or unserializable — elision also breaks reference cycles).
+  if (isPlainRecord(params)) {
+    const lean = withoutEmptyToolParamValues(params);
+    const omitted = Object.keys(params).length - Object.keys(lean).length;
+    const marked = (value: Record<string, unknown>) =>
+      omitted > 0 ? { ...value, __emptyKeysOmitted__: omitted } : value;
+
+    // 2. Padding dropped, every remaining value still exact. Only worth trying
+    //    when there was padding to drop — otherwise this is step 1 again.
+    if (omitted > 0) {
+      const leanVerbatim = safeStringify(marked(lean));
+      if (fits(leanVerbatim)) {
+        return leanVerbatim;
+      }
+    }
+
+    // 3. Padding dropped and long values clamped. Strictly better than eliding
+    //    with the padding still in place, so there is no all-keys elided step.
+    const leanElided = safeStringify(
+      marked(elideToolParamValues(lean) as Record<string, unknown>)
+    );
+    if (fits(leanElided)) {
+      return leanElided;
+    }
+    return shapeSummary(params, verbatim?.length ?? leanElided?.length ?? 0);
+  }
+
+  // Non-records (an array of params) have no padding to drop. Elision also
+  // breaks reference cycles, which is why this can succeed where step 1 threw.
   const elided = safeStringify(elideToolParamValues(params));
   if (!elided) {
     return undefined;
   }
-  if (elided.length <= MAX_TOOL_PARAM_DETAIL_CHARS) {
+  if (fits(elided)) {
     return elided;
   }
-
-  // Still over: drop the schema padding and record how much went missing.
-  if (isPlainRecord(params)) {
-    const lean = withoutEmptyToolParamValues(params);
-    const omitted = Object.keys(params).length - Object.keys(lean).length;
-    const leanSerialized = safeStringify({
-      ...(elideToolParamValues(lean) as Record<string, unknown>),
-      ...(omitted > 0 ? { __emptyKeysOmitted__: omitted } : {}),
-    });
-    if (
-      leanSerialized &&
-      leanSerialized.length <= MAX_TOOL_PARAM_DETAIL_CHARS
-    ) {
-      return leanSerialized;
-    }
-  }
-
   return shapeSummary(params, elided.length);
 }

--- a/packages/openclaw/src/context-lens-tool-params.ts
+++ b/packages/openclaw/src/context-lens-tool-params.ts
@@ -1,0 +1,121 @@
+// Serializes a tool call's params for the context lens's `argumentDetail`.
+//
+// Consumers parse this field back into structured arguments — the tlonbot e2e
+// harness evaluates fixture `args_match` predicates against it — so the one
+// invariant that matters is that the output is always valid JSON. It used to be
+// produced by pretty-printing the params and slicing the result at the budget,
+// which fails that invariant exactly when it matters: a model that fills in
+// every optional parameter (gpt-5.6-luna sends ~108 keys on a `message` call)
+// overflows the budget, the document is cut mid-key, and the consumer loses
+// every argument rather than the one long value that caused the overflow.
+//
+// Instead: serialize compactly, shrink individual values, and — if still over
+// budget — drop keys the model left empty and say how many were dropped. Every
+// path returns parseable JSON or undefined.
+
+export const MAX_TOOL_PARAM_DETAIL_CHARS = 2000;
+// Values longer than this are elided individually. Generous enough to keep the
+// identifying arguments a consumer matches on (channel ids, message bodies).
+export const MAX_TOOL_PARAM_VALUE_CHARS = 200;
+export const MAX_TOOL_PARAM_ARRAY_ITEMS = 10;
+const MAX_TOOL_PARAM_DEPTH = 4;
+const MAX_SHAPE_KEYS = 40;
+
+export function elideToolParamValues(value: unknown, depth = 0): unknown {
+  if (typeof value === 'string') {
+    return value.length > MAX_TOOL_PARAM_VALUE_CHARS
+      ? `${value.slice(0, MAX_TOOL_PARAM_VALUE_CHARS)}… [${value.length} chars]`
+      : value;
+  }
+  if (Array.isArray(value)) {
+    if (depth >= MAX_TOOL_PARAM_DEPTH) return `[array ${value.length}]`;
+    const items: unknown[] = value
+      .slice(0, MAX_TOOL_PARAM_ARRAY_ITEMS)
+      .map((item) => elideToolParamValues(item, depth + 1));
+    if (value.length > MAX_TOOL_PARAM_ARRAY_ITEMS) {
+      items.push(`[+${value.length - MAX_TOOL_PARAM_ARRAY_ITEMS} more items]`);
+    }
+    return items;
+  }
+  if (value && typeof value === 'object') {
+    const entries = Object.entries(value);
+    if (depth >= MAX_TOOL_PARAM_DEPTH) return `[object ${entries.length} keys]`;
+    const out: Record<string, unknown> = {};
+    for (const [key, nested] of entries) {
+      out[key] = elideToolParamValues(nested, depth + 1);
+    }
+    return out;
+  }
+  return value;
+}
+
+// Keys the model filled in with nothing. Dropping them takes a padded
+// `message` call from 108 keys to 32. `false` and `0` are kept — unlike "" and
+// [], those are values a consumer may legitimately assert on.
+export function withoutEmptyToolParamValues(
+  params: Record<string, unknown>
+): Record<string, unknown> {
+  const out: Record<string, unknown> = {};
+  for (const [key, value] of Object.entries(params)) {
+    if (value === undefined || value === null) continue;
+    if (typeof value === 'string' && value.length === 0) continue;
+    if (Array.isArray(value) && value.length === 0) continue;
+    out[key] = value;
+  }
+  return out;
+}
+
+function safeStringify(value: unknown): string | undefined {
+  try {
+    // Compact on purpose: the field is machine-read, and indentation costs
+    // roughly a third of the budget (2033 vs 1708 chars on a real padded call).
+    return JSON.stringify(value) || undefined;
+  } catch {
+    // Circular or otherwise unserializable.
+    return undefined;
+  }
+}
+
+function isPlainRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+export function detailToolParams(params: unknown): string | undefined {
+  if (params === null || params === undefined) {
+    return undefined;
+  }
+
+  const direct = safeStringify(elideToolParamValues(params));
+  if (!direct) {
+    return undefined;
+  }
+  if (direct.length <= MAX_TOOL_PARAM_DETAIL_CHARS) {
+    return direct;
+  }
+
+  // Over budget: drop the schema padding and record how much went missing.
+  if (isPlainRecord(params)) {
+    const lean = withoutEmptyToolParamValues(params);
+    const omitted = Object.keys(params).length - Object.keys(lean).length;
+    const leanSerialized = safeStringify({
+      ...(elideToolParamValues(lean) as Record<string, unknown>),
+      ...(omitted > 0 ? { __emptyKeysOmitted__: omitted } : {}),
+    });
+    if (
+      leanSerialized &&
+      leanSerialized.length <= MAX_TOOL_PARAM_DETAIL_CHARS
+    ) {
+      return leanSerialized;
+    }
+  }
+
+  // Last resort: describe the shape we could not fit, still as valid JSON.
+  return safeStringify(
+    isPlainRecord(params)
+      ? {
+          __tooLarge__: direct.length,
+          keys: Object.keys(params).slice(0, MAX_SHAPE_KEYS),
+        }
+      : { __tooLarge__: direct.length }
+  );
+}

--- a/packages/openclaw/src/context-lens-tool-params.ts
+++ b/packages/openclaw/src/context-lens-tool-params.ts
@@ -9,9 +9,10 @@
 // overflows the budget, the document is cut mid-key, and the consumer loses
 // every argument rather than the one long value that caused the overflow.
 //
-// Instead: serialize compactly, shrink individual values, and — if still over
-// budget — drop keys the model left empty and say how many were dropped. Every
-// path returns parseable JSON or undefined.
+// Instead, in order, stopping at the first result that fits: serialize the
+// params compactly and verbatim; shrink individual values; drop the keys the
+// model left empty, reporting how many; describe the shape. Every path returns
+// parseable JSON that is within budget, or undefined.
 
 export const MAX_TOOL_PARAM_DETAIL_CHARS = 2000;
 // Values longer than this are elided individually. Generous enough to keep the
@@ -20,6 +21,7 @@ export const MAX_TOOL_PARAM_VALUE_CHARS = 200;
 export const MAX_TOOL_PARAM_ARRAY_ITEMS = 10;
 const MAX_TOOL_PARAM_DEPTH = 4;
 const MAX_SHAPE_KEYS = 40;
+const MAX_SHAPE_KEY_NAME_CHARS = 40;
 
 export function elideToolParamValues(value: unknown, depth = 0): unknown {
   if (typeof value === 'string') {
@@ -80,20 +82,62 @@ function isPlainRecord(value: unknown): value is Record<string, unknown> {
   return typeof value === 'object' && value !== null && !Array.isArray(value);
 }
 
+// Describes params we could not fit, as JSON that is itself guaranteed to fit.
+// Key names can be arbitrarily long, so clamp each one and halve the list until
+// the document is within budget — an oversized summary would be sliced again by
+// the ship-sync layer, recreating the unparseable record this module exists to
+// prevent.
+function shapeSummary(params: unknown, size: number): string | undefined {
+  if (!isPlainRecord(params)) {
+    return safeStringify({ __tooLarge__: size });
+  }
+  const keyCount = Object.keys(params).length;
+  const names = Object.keys(params).map((key) =>
+    key.length > MAX_SHAPE_KEY_NAME_CHARS
+      ? `${key.slice(0, MAX_SHAPE_KEY_NAME_CHARS)}…`
+      : key
+  );
+  for (
+    let shown = Math.min(names.length, MAX_SHAPE_KEYS);
+    shown > 0;
+    shown = Math.floor(shown / 2)
+  ) {
+    const candidate = safeStringify({
+      __tooLarge__: size,
+      keyCount,
+      keys: names.slice(0, shown),
+    });
+    if (candidate && candidate.length <= MAX_TOOL_PARAM_DETAIL_CHARS) {
+      return candidate;
+    }
+  }
+  // Fixed-size floor: no key names at all.
+  return safeStringify({ __tooLarge__: size, keyCount });
+}
+
 export function detailToolParams(params: unknown): string | undefined {
   if (params === null || params === undefined) {
     return undefined;
   }
 
-  const direct = safeStringify(elideToolParamValues(params));
-  if (!direct) {
-    return undefined;
-  }
-  if (direct.length <= MAX_TOOL_PARAM_DETAIL_CHARS) {
-    return direct;
+  // Verbatim first. Eliding is a concession to the budget, so paying for it
+  // when the real params already fit would throw away exactly what consumers
+  // match on — a 300-char message body would arrive as a 200-char placeholder.
+  const verbatim = safeStringify(params);
+  if (verbatim && verbatim.length <= MAX_TOOL_PARAM_DETAIL_CHARS) {
+    return verbatim;
   }
 
-  // Over budget: drop the schema padding and record how much went missing.
+  // Over budget (or unserializable — elision also breaks reference cycles).
+  const elided = safeStringify(elideToolParamValues(params));
+  if (!elided) {
+    return undefined;
+  }
+  if (elided.length <= MAX_TOOL_PARAM_DETAIL_CHARS) {
+    return elided;
+  }
+
+  // Still over: drop the schema padding and record how much went missing.
   if (isPlainRecord(params)) {
     const lean = withoutEmptyToolParamValues(params);
     const omitted = Object.keys(params).length - Object.keys(lean).length;
@@ -109,13 +153,5 @@ export function detailToolParams(params: unknown): string | undefined {
     }
   }
 
-  // Last resort: describe the shape we could not fit, still as valid JSON.
-  return safeStringify(
-    isPlainRecord(params)
-      ? {
-          __tooLarge__: direct.length,
-          keys: Object.keys(params).slice(0, MAX_SHAPE_KEYS),
-        }
-      : { __tooLarge__: direct.length }
-  );
+  return shapeSummary(params, elided.length);
 }


### PR DESCRIPTION
Fixes TLON-6327

`argumentDetail` on a context-lens tool record is parsed back into structured arguments by consumers — the tlonbot e2e harness evaluates fixture `args_match` predicates against it — so the invariant that matters is that it's valid JSON. It wasn't: `detailToolParams` pretty-printed the params and sliced the result at 2000 chars, which cuts the document mid-key. The consumer then loses *every* argument, not just the one that overflowed.

## What made it break

Theoretical until the hosted bot moved from `minimax/minimax-m3` to `openai/gpt-5.6-luna` (tlonbot#165, Aug 7). luna fills in every optional parameter in the tool schema — 108 keys on a `message action=send` call — and the e2e nightly has failed since with:

```
FAIL luna/post-to-channel   reply: "done"
  assert: tool_calls[0]: expected 'message|tlon' — args mismatch on candidate 'message':
          arg 'action' = undefined did not match {"equals":"send"}
```

The bot was passing `action: "send"` correctly the whole time. Comparing the lens records either side of the swap:

```
Aug 7 (m3):    4 structured keys   ['action','channel','target','message']       → parsed, passed
Aug 8 (luna):  _raw len=2013, ends ' "activityUrl": "",\n "activ… [truncated]'   → unparseable
```

## Measured on that exact payload

```
keys sent by luna                     108
pretty (indent=1, as shipped)        2033 chars   → cut at 2000, unparseable
compact (no indent)                  1708 chars   → parses
compact + drop ""/[]/null             615 chars   (32 keys)
```

The indent alone was a third of the budget, on a field no human reads.

## The change

`detailToolParams` moves to `src/context-lens-tool-params.ts` (the unit suite runs `src/`) and now:

1. **Serializes compactly.** Fixes today's failure on its own.
2. **Elides values, not the document** — long strings clamped, long arrays capped, deep structures summarized. Whatever comes back parses, and the short identifying keys `args_match` needs (`action`, `target`, `message`) survive.
3. **Drops schema padding if still over budget** (`""`, `[]`, `null`) and reports the count as `__emptyKeysOmitted__`. `false` and `0` are kept — unlike empties, those are values a fixture may legitimately assert on.
4. **Last resort** is a shape summary (`__tooLarge__` plus key names), still valid JSON.

Note `context-lens-ship-sync.ts:89` (`truncateSummary`, 4096) slices the same way one layer up, so raising `MAX_TOOL_PARAM_DETAIL_CHARS` alone would only have moved the cliff — which is why the fix is structural rather than a bigger number.

## Verification

11 new tests driven by the real captured payload, plus each overflow path:

```
✓ keeps a schema-padded call parseable, with its identifying args intact
✓ serializes compactly
✓ elides a long value instead of the document
✓ caps long arrays and says how many were dropped
✓ drops empty padding when the elided document still overflows
✓ falls back to a shape summary when nothing fits, still as valid JSON
✓ survives a circular payload — the depth cap breaks the cycle
✓ never emits unparseable JSON
```

Full package suite green — 1360 tests, 68 files — plus typecheck and prettier clean.

One behavior change worth noting: a circular payload used to return `undefined` (the `JSON.stringify` throw). The depth cap now breaks the cycle first, so it returns a usable record instead. The `try/catch` stays for exotic cases (a throwing `toJSON`, `BigInt`).

The nightly won't go green on this alone — it needs a moon redeploy to pick up the plugin, and the harness half of TLON-6327 (tloncorp/tlonbot#173) makes a truncated record report as a source error rather than blaming the model.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
