### PR TITLE
openclaw, api: honor TLON_HOSTING on media sends; overridable memex base URL (cherry-pick #6244)

### DIFF
--- a/packages/api/src/__tests__/storageApi.test.ts
+++ b/packages/api/src/__tests__/storageApi.test.ts
@@ -243,6 +243,99 @@ describe('uploadFile assume-hosted override (TLON_HOSTING)', () => {
   });
 });
 
+describe('uploadFile TLON_MEMEX_URL override', () => {
+  const forced = { hostedDetection: 'assume-hosted' as const };
+
+  afterEach(() => {
+    vi.unstubAllEnvs();
+  });
+
+  test('TLON_MEMEX_URL custom endpoint is used for memex token request', async () => {
+    vi.stubEnv('TLON_MEMEX_URL', 'https://memex.test.tlon.systems');
+    isHostedMock.mockReturnValue(false);
+    mockShip({ service: 'presigned-url' });
+
+    fetchMock.mockImplementation(async (url: string) => {
+      if (String(url).startsWith('https://memex.test.tlon.systems/')) {
+        return {
+          ok: true,
+          json: async () => ({
+            url: 'https://presigned-put.example.com/upload-here',
+            filePath: 'https://storage.tlon.network/~zod/file.png',
+          }),
+        };
+      }
+      return { ok: true, json: async () => ({}) };
+    });
+
+    const result = await uploadFile({ blob, ...forced });
+
+    expect(result.url).toBe('https://storage.tlon.network/~zod/file.png');
+    const memexCall = fetchMock.mock.calls.find((c) =>
+      String(c[0]).startsWith('https://memex.test.tlon.systems/')
+    );
+    expect(memexCall).toBeDefined();
+    expect(memexCall![0]).toBe('https://memex.test.tlon.systems/v1/zod/upload');
+  });
+
+  test('trailing slash on TLON_MEMEX_URL is normalized', async () => {
+    vi.stubEnv('TLON_MEMEX_URL', 'https://memex.test.tlon.systems/');
+    isHostedMock.mockReturnValue(false);
+    mockShip({ service: 'presigned-url' });
+
+    fetchMock.mockImplementation(async (url: string) => {
+      if (String(url).startsWith('https://memex.test.tlon.systems/')) {
+        return {
+          ok: true,
+          json: async () => ({
+            url: 'https://presigned-put.example.com/upload-here',
+            filePath: 'https://storage.tlon.network/~zod/file.png',
+          }),
+        };
+      }
+      return { ok: true, json: async () => ({}) };
+    });
+
+    const result = await uploadFile({ blob, ...forced });
+
+    expect(result.url).toBe('https://storage.tlon.network/~zod/file.png');
+    const memexCall = fetchMock.mock.calls.find((c) =>
+      String(c[0]).startsWith('https://memex.test.tlon.systems/')
+    );
+    expect(memexCall).toBeDefined();
+    // Should be /v1/ not //v1/
+    expect(memexCall![0]).toBe('https://memex.test.tlon.systems/v1/zod/upload');
+  });
+
+  test('unset TLON_MEMEX_URL falls back to default memex.tlon.network', async () => {
+    isHostedMock.mockReturnValue(false);
+    mockShip({ service: 'presigned-url' });
+    mockMemexResponse();
+
+    const result = await uploadFile({ blob, ...forced });
+
+    expect(result.url).toBe('https://storage.tlon.network/~zod/file.png');
+    const memexCall = fetchMock.mock.calls.find((c) =>
+      String(c[0]).startsWith('https://memex.tlon.network/')
+    );
+    expect(memexCall).toBeDefined();
+  });
+
+  test('blank/whitespace TLON_MEMEX_URL falls back to default', async () => {
+    vi.stubEnv('TLON_MEMEX_URL', '   ');
+    isHostedMock.mockReturnValue(false);
+    mockShip({ service: 'presigned-url' });
+    mockMemexResponse();
+
+    const result = await uploadFile({ blob, ...forced });
+
+    expect(result.url).toBe('https://storage.tlon.network/~zod/file.png');
+    const memexCall = fetchMock.mock.calls.find((c) =>
+      String(c[0]).startsWith('https://memex.tlon.network/')
+    );
+    expect(memexCall).toBeDefined();
+  });
+});
 describe('uploadFile custom-S3 ACL retry', () => {
   function setupCustomS3() {
     isHostedMock.mockReturnValue(false);

--- a/packages/api/src/client/storageApi.ts
+++ b/packages/api/src/client/storageApi.ts
@@ -138,6 +138,14 @@ export const getStorageCredentials = async (): Promise<StorageCredentials> => {
 
 const MEMEX_BASE_URL = 'https://memex.tlon.network';
 
+function memexBaseUrl(): string {
+  if (typeof process !== 'undefined') {
+    const override = process.env?.TLON_MEMEX_URL?.trim();
+    if (override) return override.replace(/\/+$/, '');
+  }
+  return MEMEX_BASE_URL;
+}
+
 const mimeToExt: Record<string, string> = {
   'image/jpeg': '.jpg',
   'image/jpg': '.jpg',
@@ -334,7 +342,7 @@ async function getMemexUploadUrl(params: {
     path: '/secret',
   });
 
-  const endpoint = `${MEMEX_BASE_URL}/v1/${desig(currentUser)}/upload`;
+  const endpoint = `${memexBaseUrl()}/v1/${desig(currentUser)}/upload`;
   const response = await fetch(endpoint, {
     method: 'PUT',
     headers: { 'Content-Type': 'application/json' },

--- a/packages/openclaw/src/urbit/upload.test.ts
+++ b/packages/openclaw/src/urbit/upload.test.ts
@@ -175,9 +175,10 @@ describe('prepareOutboundMedia', () => {
 
   /**
    * A bot moon as actually deployed: reached over localhost/proxy (so not a
-   * hosted node by URL), no credentials, and `service` at its bunted default of
-   * `presigned-url`. `uploadFile` would throw for this ship, so we must not
-   * call it.
+   * hosted node by URL), no credentials. Fresh ships bunt `service` to
+   * `%credentials`; the mock sets `presigned-url` to model a moon that has
+   * been poked by the hosted entrypoint. `uploadFile` would throw for this
+   * ship, so we must not call it.
    */
   function mockMoonShaped() {
     mockIsHosted.mockReturnValue(false);
@@ -251,7 +252,7 @@ describe('prepareOutboundMedia', () => {
       'throws LOCAL_MEDIA_ERROR for %s without fetching',
       async (input) => {
         await expect(prepareOutboundMedia(input)).rejects.toThrow(
-          "Local file paths are not supported on this channel — upload the file first (e.g. `tlon upload <path>` using your owner ship's credentials), then resend with the returned https URL."
+          'Local file paths are not supported on this channel — upload the file first (e.g. `tlon upload <path>`) and resend with the returned https URL.'
         );
         expect(mockFetchGuard).not.toHaveBeenCalled();
       }
@@ -607,7 +608,7 @@ describe('prepareOutboundMedia', () => {
       vi.unstubAllEnvs();
     });
 
-    it('does not call uploadFile, hotlinks', async () => {
+    it('uploads via uploadFile with assume-hosted', async () => {
       vi.stubEnv('TLON_HOSTING', 'true');
       mockImageFetch();
       mockScry.mockImplementation(async ({ path }: { path: string }) => {
@@ -624,16 +625,61 @@ describe('prepareOutboundMedia', () => {
         }
         return {
           'storage-update': {
-            configuration: { currentBucket: '' },
+            configuration: { service: 'presigned-url', currentBucket: '' },
           },
         };
+      });
+      mockUploadFile.mockResolvedValue({
+        url: 'https://storage.example.com/uploaded.png',
       });
 
       const result = await prepareOutboundMedia(
         'https://example.com/image.png'
       );
-      expect(mockUploadFile).not.toHaveBeenCalled();
-      expect(result.url).toBe('https://example.com/image.png');
+      expect(mockUploadFile).toHaveBeenCalledTimes(1);
+      expect(mockUploadFile).toHaveBeenCalledWith(
+        expect.objectContaining({
+          hostedDetection: 'assume-hosted',
+        })
+      );
+      expect(result.url).toBe('https://storage.example.com/uploaded.png');
+    });
+
+    it('TLON_HOSTING=1 + moon-shaped scries (service credentials, no creds) → uploads', async () => {
+      vi.stubEnv('TLON_HOSTING', '1');
+      mockImageFetch();
+      mockScry.mockImplementation(async ({ path }: { path: string }) => {
+        if (path === '/credentials') {
+          return {
+            'storage-update': {
+              credentials: {
+                accessKeyId: '',
+                endpoint: '',
+                secretAccessKey: '',
+              },
+            },
+          };
+        }
+        return {
+          'storage-update': {
+            configuration: { service: 'credentials', currentBucket: '' },
+          },
+        };
+      });
+      mockUploadFile.mockResolvedValue({
+        url: 'https://storage.example.com/moon-uploaded.png',
+      });
+
+      const result = await prepareOutboundMedia(
+        'https://example.com/image.png'
+      );
+      expect(mockUploadFile).toHaveBeenCalledTimes(1);
+      expect(mockUploadFile).toHaveBeenCalledWith(
+        expect.objectContaining({
+          hostedDetection: 'assume-hosted',
+        })
+      );
+      expect(result.url).toBe('https://storage.example.com/moon-uploaded.png');
     });
   });
 
@@ -665,7 +711,7 @@ describe('prepareOutboundMedia', () => {
       expect(result.url).toBe('https://example.com/image.png');
     });
 
-    it('moon-shaped (not hosted, default presigned service, no creds) → hotlink, no uploadFile', async () => {
+    it('moon-shaped (not hosted, poked to presigned-url, no creds) → hotlink, no uploadFile', async () => {
       mockImageFetch();
       mockMoonShaped();
 

--- a/packages/openclaw/src/urbit/upload.ts
+++ b/packages/openclaw/src/urbit/upload.ts
@@ -14,7 +14,7 @@ const MAX_MEDIA_BYTES = 10 * 1024 * 1024;
 const FETCH_DEADLINE_MS = 30_000;
 
 const LOCAL_MEDIA_ERROR =
-  "Local file paths are not supported on this channel — upload the file first (e.g. `tlon upload <path>` using your owner ship's credentials), then resend with the returned https URL.";
+  'Local file paths are not supported on this channel — upload the file first (e.g. `tlon upload <path>`) and resend with the returned https URL.';
 const HTTPS_ONLY_ERROR = 'Only https media URLs are supported.';
 const USERINFO_ERROR =
   'Media URLs with embedded credentials are not supported.';
@@ -105,6 +105,11 @@ function strictPostableUrl(u: string): string | null {
   return parsed.href;
 }
 
+function isTlonHostingForced(): boolean {
+  const raw = (process.env.TLON_HOSTING ?? '').trim().toLowerCase();
+  return raw === '1' || raw === 'true' || raw === 'yes' || raw === 'on';
+}
+
 /**
  * Whether `uploadFile` could actually store bytes for this ship.
  *
@@ -144,8 +149,9 @@ async function shipCanStoreUploads(): Promise<boolean> {
       creds.accessKeyId && creds.endpoint && creds.secretAccessKey
     );
 
-    // A fresh ship bunts `service` to %presigned-url, so this arm turns on
-    // only for clients whose URL is a hosted node.
+    // A fresh ship bunts `service` to `%credentials`; hosted infra (tlonbot's
+    // entrypoint) pokes bot moons to `%presigned-url`; the `|| !hasCustomS3`
+    // disjunct is what actually routes creds-less hosted ships to memex.
     if (
       isHostedClient() &&
       (config.service === 'presigned-url' || !hasCustomS3)
@@ -161,7 +167,7 @@ async function shipCanStoreUploads(): Promise<boolean> {
 
 function isHostedClient(): boolean {
   try {
-    return getCurrentUserIsHosted();
+    return isTlonHostingForced() || getCurrentUserIsHosted();
   } catch {
     return false;
   }
@@ -254,6 +260,9 @@ export async function prepareOutboundMedia(
       blob,
       fileName,
       contentType: effectiveMime,
+      ...(isTlonHostingForced()
+        ? { hostedDetection: 'assume-hosted' as const }
+        : {}),
     });
     const postable = strictPostableUrl(result.url);
     if (postable) {

--- a/packages/openclaw/test/cases/06-media.test.ts
+++ b/packages/openclaw/test/cases/06-media.test.ts
@@ -12,7 +12,7 @@ const SOURCE_IMAGE_URL =
   'https://storage.googleapis.com/tlon-test-ci-shared/test-images/openclaw-image.png';
 
 const LOCAL_MEDIA_ERROR_TEXT =
-  "Local file paths are not supported on this channel — upload the file first (e.g. `tlon upload <path>` using your owner ship's credentials), then resend with the returned https URL.";
+  'Local file paths are not supported on this channel — upload the file first (e.g. `tlon upload <path>`) and resend with the returned https URL.';
 
 // Poke mark verified against fakezod — see plan §1b.
 // JSON keys must be kebab-case (storage-json/hoon), not camelCase.

--- a/packages/tlon-skill/SKILL.md
+++ b/packages/tlon-skill/SKILL.md
@@ -53,8 +53,10 @@ tlon upload ./generated-chart.png      # local file — prints the uploaded URL
 tlon upload https://example.com/x.png  # remote URL
 ```
 
-Pass that printed URL as `media=`. On hosted deployments the upload must run
-through the owner ship's config (the bot's own ship has no storage):
+Pass that printed URL as `media=`. On Tlon-hosted deployments (where
+`TLON_HOSTING` is set) the bot's own ship uploads through Tlon file hosting.
+If the upload fails (e.g. self-hosted moons, which have no storage), retry
+through the owner ship's config:
 `tlon --config "$TLON_OWNER_CONFIG_PATH" upload <path>`.
 
 > **Deprecated: diary channels.** `%diary` is not managed by the CLI:


### PR DESCRIPTION
## Summary

Cherry-pick of #6244 (merged to develop) onto staging, so hosted bot-moon direct uploads make the release. Applied clean — the touched files are identical between staging and #6244's merge base.

The tlon-apps half of bot-moon direct uploads — pairs with tloncorp/tlonbot#169, which configures moon `%storage` and exports `TLON_HOSTING=1` into the bot environment. In practice this gets us three things:

- **Test-env coverage for the feature.** The `tlon` CLI uploads through `@tloncorp/api`, which had memex hard-coded to prod: on the test env, own-ship uploads 403 (staging token, prod feds) and silently fall back to the owner config — so nightly could never actually exercise direct uploads. The new `TLON_MEMEX_URL` override points test-env ships at staging memex.
- **Consistent model-facing instructions.** SKILL.md still said the bot's own ship has no storage and mandated the owner config, contradicting the TOOLS.md that tlonbot now deploys. Which instruction won on a given turn was a coin flip.
- **A safety net on `media=` sends.** Bots only upload deliberately via the CLI, but every media send flows through the plugin's `prepareOutboundMedia`, which hotlinked whatever URL the model passed whenever it skipped the upload step — leaving posts pointing at third-party URLs that can expire or die. With `TLON_HOSTING` honored there, any https URL passed to `media=` gets re-hosted on memex. This also opens the door to a one-step prompt flow for URL media later.

Known wart: in the prompted flow (CLI upload, then `media=` with the memex URL), the plugin now re-fetches and re-uploads the already-hosted URL — one duplicate object per send. Follow-up options: skip re-hosting URLs already on our storage, or simplify the prompts to one step.

## Changes

- `shipCanStoreUploads` / `isHostedClient` in `packages/openclaw/src/urbit/upload.ts` now treat `TLON_HOSTING` as forcing hosted, and `prepareOutboundMedia` passes `hostedDetection: 'assume-hosted'` through to `uploadFile` (which recomputes hostedness independently).
- Added the `TLON_MEMEX_URL` env override for the memex base URL in `packages/api/src/client/storageApi.ts`. Trailing slashes are normalized; unset or blank falls back to the default.
- Dropped the owner-ship-credentials wording from the local-media error string, updating both test copies that assert on it.
- Fixed the stale storage guidance in `packages/tlon-skill/SKILL.md`, and corrected comments that claimed `%storage` bunts `service` to `%presigned-url` (Hoon `?()` bunts to the last branch, `%credentials`).

With `TLON_HOSTING` unset, self-hosted behavior is unchanged and covered by existing tests.

## How did I test?

Re-run on this branch (staging base), not just inherited from #6244:

- OpenClaw unit suite: 1345/1345 passing, including the new `TLON_HOSTING` + moon-shaped cases.
- `packages/api` storageApi tests: 14/14 passing, including 4 new `TLON_MEMEX_URL` cases.
- `pnpm -r tsc` scope for openclaw/api/tlon-skill clean; Prettier clean.
- `packages/openclaw/test/cases/06-media.test.ts` was updated for the new error string but not executed; it needs a live model/gateway.

## Risks and impact

- Safe to rollback without consulting PR author? Yes
- Affects important code area:
  - [ ] Onboarding
  - [ ] State / providers
  - [ ] Message sync
  - [ ] Channel display
  - [ ] Notifications
  - [x] Other: media upload path for hosted bot moons

## Rollback plan

Revert.
