### PR TITLE
fix web db row mapping, storage item updates, and settings back navigation

### DIFF
--- a/packages/api/src/client/computingStatus.ts
+++ b/packages/api/src/client/computingStatus.ts
@@ -2,8 +2,10 @@ const COMPUTING_STATUS_PROTOCOL = 'tlon.computing-status.v1' as const;
 
 const TOOL_LABELS: Record<string, string> = {
   exec: 'Running a command',
+  image: 'Generating an image',
   read: 'Reading files',
   web_fetch: 'Checking the web',
+  web_search: 'Searching the web',
 };
 
 export interface ComputingToolCall {

--- a/packages/app/features/settings/BotApiKeySettingsScreen.tsx
+++ b/packages/app/features/settings/BotApiKeySettingsScreen.tsx
@@ -8,6 +8,7 @@ import {
   useIsWindowNarrow,
 } from '@tloncorp/ui';
 import { useCallback, useEffect, useMemo, useState } from 'react';
+import { Platform } from 'react-native';
 import { View, XStack, YStack } from 'tamagui';
 
 import { RootStackParamList } from '../../navigation/types';
@@ -179,9 +180,10 @@ export function BotApiKeySettingsScreen(props: Props) {
     <View flex={1} backgroundColor="$secondaryBackground">
       <ScreenHeader
         borderBottom
-        backAction={isWindowNarrow ? handleBack : undefined}
+        backAction={
+          Platform.OS !== 'web' || isWindowNarrow ? handleBack : undefined
+        }
         title={`${provider.label} API key`}
-        placement="navigation"
       />
       <SettingsContentScrollView
         paddingHorizontal="$l"

--- a/packages/app/features/settings/BotChannelRuleSettingsScreen.tsx
+++ b/packages/app/features/settings/BotChannelRuleSettingsScreen.tsx
@@ -9,6 +9,7 @@ import {
 } from '@tloncorp/ui';
 import { valid } from '@urbit/aura';
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import { Platform } from 'react-native';
 import { View, XStack, YStack } from 'tamagui';
 
 import { RootStackParamList } from '../../navigation/types';
@@ -302,9 +303,10 @@ export function BotChannelRuleSettingsScreen(props: Props) {
     <View flex={1} backgroundColor="$secondaryBackground">
       <ScreenHeader
         borderBottom
-        backAction={isWindowNarrow ? handleBack : undefined}
+        backAction={
+          Platform.OS !== 'web' || isWindowNarrow ? handleBack : undefined
+        }
         title={channelLabel || 'Channel'}
-        placement="navigation"
       />
       {!ready ? (
         <View flex={1} alignItems="center" justifyContent="center">

--- a/packages/app/features/settings/BotModelSettingsScreen.tsx
+++ b/packages/app/features/settings/BotModelSettingsScreen.tsx
@@ -8,6 +8,7 @@ import {
   useIsWindowNarrow,
 } from '@tloncorp/ui';
 import { useCallback, useEffect, useMemo, useState } from 'react';
+import { Platform } from 'react-native';
 import { View, XStack, YStack } from 'tamagui';
 
 import { RootStackParamList } from '../../navigation/types';
@@ -213,9 +214,10 @@ export function BotModelSettingsScreen(props: Props) {
     <View flex={1} backgroundColor="$secondaryBackground">
       <ScreenHeader
         borderBottom
-        backAction={isWindowNarrow ? handleBack : undefined}
+        backAction={
+          Platform.OS !== 'web' || isWindowNarrow ? handleBack : undefined
+        }
         title={mode === 'default' ? 'Default model' : 'Fallback models'}
-        placement="navigation"
       />
       {!ready ? (
         <View flex={1} alignItems="center" justifyContent="center">

--- a/packages/app/features/settings/BotSettingsScreen.tsx
+++ b/packages/app/features/settings/BotSettingsScreen.tsx
@@ -4,7 +4,7 @@ import * as db from '@tloncorp/shared/db';
 import { Text, pluralize, useIsWindowNarrow } from '@tloncorp/ui';
 import { ConfirmDialog } from '@tloncorp/ui';
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
-import { Alert } from 'react-native';
+import { Alert, Platform } from 'react-native';
 import { View, YStack } from 'tamagui';
 
 import { useHandleLogout } from '../../hooks/useHandleLogout';
@@ -166,9 +166,10 @@ export function BotSettingsScreen(props: Props) {
     <View flex={1} backgroundColor="$secondaryBackground">
       <ScreenHeader
         borderBottom
-        backAction={isWindowNarrow ? handleBack : undefined}
+        backAction={
+          Platform.OS !== 'web' || isWindowNarrow ? handleBack : undefined
+        }
         title="Bot settings"
-        placement="navigation"
       />
       <SettingsContentScrollView
         paddingHorizontal="$l"

--- a/packages/app/features/settings/BotShipListSettingsScreen.tsx
+++ b/packages/app/features/settings/BotShipListSettingsScreen.tsx
@@ -1,6 +1,7 @@
 import { NativeStackScreenProps } from '@react-navigation/native-stack';
 import { LoadingSpinner, Text, useIsWindowNarrow } from '@tloncorp/ui';
 import { useCallback, useEffect, useMemo, useState } from 'react';
+import { Platform } from 'react-native';
 import { View, YStack } from 'tamagui';
 
 import { RootStackParamList } from '../../navigation/types';
@@ -134,18 +135,18 @@ export function BotShipListSettingsScreen(props: Props) {
     <View flex={1} backgroundColor="$background">
       <ScreenHeader
         borderBottom
-        backAction={isWindowNarrow ? handleBack : undefined}
+        backAction={
+          Platform.OS !== 'web' || isWindowNarrow ? handleBack : undefined
+        }
         title={meta.title}
-        rightActions={[
-          {
-            id: 'add-ship',
-            icon: 'Add',
-            label: `Add ${meta.title.toLowerCase()}`,
-            onPress: () => setPickerOpen(true),
-            visible: ready,
-          },
-        ]}
-        placement="navigation"
+        rightControls={
+          ready ? (
+            <ScreenHeader.IconButton
+              type="Add"
+              onPress={() => setPickerOpen(true)}
+            />
+          ) : undefined
+        }
       />
       {!ready ? (
         <View flex={1} alignItems="center" justifyContent="center">

--- a/packages/app/lib/webDb.ts
+++ b/packages/app/lib/webDb.ts
@@ -74,7 +74,27 @@ export class WebDb extends BaseDb {
       this.sqlocal = sqlocal;
 
       const { driver } = sqlocal;
-      this.client = drizzle(driver, { schema });
+      // SQLocal answers a `get` with no result as `{ rows: [] }`, but
+      // drizzle's sqlite-proxy contract wants a falsy `rows` for "no row"
+      // (`mapGetResult` only short-circuits on `!row`). An empty array is
+      // truthy, so without this shim every single-row lookup that misses
+      // maps `[]` as if it were a row: plain queries fabricate a phantom
+      // object with every field undefined, and relational queries crash in
+      // `mapRelationalRow` ("Cannot read properties of undefined (reading
+      // 'map')"). Native drivers return undefined here — this makes web
+      // match them.
+      const proxyDriver: typeof driver = async (sql, params, method) => {
+        const result = await driver(sql, params, method);
+        if (
+          method === 'get' &&
+          Array.isArray(result.rows) &&
+          result.rows.length === 0
+        ) {
+          result.rows = undefined as unknown as typeof result.rows;
+        }
+        return result;
+      };
+      this.client = drizzle(proxyDriver, { schema });
 
       // Immediately try to load DB from persisted file.
       // If successful, this will `overwriteDatabaseFile` which will reset the

--- a/packages/app/navigation/TopLevelTabNavigator.tsx
+++ b/packages/app/navigation/TopLevelTabNavigator.tsx
@@ -3,13 +3,16 @@ import {
   createBottomTabNavigator,
 } from '@react-navigation/bottom-tabs';
 import { useIsWindowNarrow } from '@tloncorp/ui';
+import { useState } from 'react';
 
 import { ActivityScreen } from '../features/top/ActivityScreen';
 import ChatListScreen from '../features/top/ChatListScreen';
 import ContactsScreen from '../features/top/ContactsScreen';
+import { useShowWebSplashModal } from '../hooks/useShowWebSplashModal';
 import { useTopLevelTabController } from '../hooks/useTopLevelTabController';
 import { AvatarNavIcon, NavBar, NavIcon } from '../ui/components/NavBar';
 import ProfileStatusSheet from '../ui/components/ProfileStatusSheet';
+import { SplashModal } from '../ui/components/Wayfinding/SplashModal';
 import { TopLevelTabName, trackTopLevelTabSelection } from './topLevelTabs';
 import type { TopLevelTabParamList } from './types';
 
@@ -95,16 +98,28 @@ function WebTopLevelTabBar({ state, navigation }: BottomTabBarProps) {
 }
 
 export function TopLevelTabNavigator() {
+  const showSplash = useShowWebSplashModal();
+  const [splashDismissed, setSplashDismissed] = useState(false);
   return (
-    <Tabs.Navigator
-      initialRouteName="ChatList"
-      backBehavior="history"
-      screenOptions={{ headerShown: false }}
-      tabBar={WebTopLevelTabBar}
-    >
-      <Tabs.Screen name="ChatList" component={ChatListScreen} />
-      <Tabs.Screen name="Activity" component={ActivityScreen} />
-      <Tabs.Screen name="Contacts" component={ContactsScreen} />
-    </Tabs.Navigator>
+    <>
+      <Tabs.Navigator
+        initialRouteName="ChatList"
+        backBehavior="history"
+        screenOptions={{ headerShown: false }}
+        tabBar={WebTopLevelTabBar}
+      >
+        <Tabs.Screen name="ChatList" component={ChatListScreen} />
+        <Tabs.Screen name="Activity" component={ActivityScreen} />
+        <Tabs.Screen name="Contacts" component={ContactsScreen} />
+      </Tabs.Navigator>
+      <SplashModal
+        open={showSplash && !splashDismissed}
+        setOpen={(open) => {
+          if (!open) {
+            setSplashDismissed(true);
+          }
+        }}
+      />
+    </>
   );
 }

--- a/packages/app/navigation/utils.ts
+++ b/packages/app/navigation/utils.ts
@@ -12,6 +12,7 @@ import * as logic from '@tloncorp/shared/logic';
 import * as store from '@tloncorp/shared/store';
 import { useGlobalSearch, useIsWindowNarrow } from '@tloncorp/ui';
 import { useCallback, useMemo } from 'react';
+import { Platform } from 'react-native';
 
 import type {
   DesktopBasePathStackParamList,
@@ -483,8 +484,9 @@ export function useRootNavigation() {
     navigationRef.current.goBack();
   }, [navigationRef]);
 
+  const useNestedSettings = Platform.OS === 'web' && !isWindowNarrow;
   const navigateToBotSettings = useCallback(() => {
-    if (isWindowNarrow) {
+    if (!useNestedSettings) {
       navigationRef.current.navigate('BotSettings');
       return;
     }
@@ -496,7 +498,7 @@ export function useRootNavigation() {
     navigateToNestedSettings('Settings', {
       screen: 'BotSettings',
     });
-  }, [isWindowNarrow, navigationRef]);
+  }, [useNestedSettings, navigationRef]);
 
   const resetToChannel = useResetToChannel();
   const navigateToChannel = useNavigateToChannel();
@@ -583,13 +585,10 @@ export async function getMainGroupRoute(
   groupId: string,
   isWindowNarrow: boolean
 ) {
-  // This route decision already needs the full group. Populate the same query
-  // cache used by GroupChannels so its first render does not repeat the DB read
-  // during the native push animation.
-  const [group, lastVisitedChannelId] = await Promise.all([
-    store.fetchGroup(groupId),
-    isWindowNarrow ? null : db.lastVisitedChannelId(groupId).getValue(),
-  ]);
+  const group = await db.getGroup({ id: groupId });
+  const lastVisitedChannelId = await db
+    .lastVisitedChannelId(groupId)
+    .getValue();
   if (
     group &&
     group.channels &&

--- a/packages/app/ui/components/BotSettingsScreenView.tsx
+++ b/packages/app/ui/components/BotSettingsScreenView.tsx
@@ -8,6 +8,7 @@ import {
   triggerHaptic,
 } from '@tloncorp/ui';
 import { useState } from 'react';
+import { Platform } from 'react-native';
 import { View, XStack, YStack } from 'tamagui';
 
 import { useIsWindowNarrow } from '../utils';
@@ -64,18 +65,14 @@ export function BotSettingsScreenView({
     <View flex={1} backgroundColor="$background">
       <ScreenHeader
         borderBottom
-        backAction={isWindowNarrow ? onBackPressed : undefined}
+        backAction={
+          Platform.OS !== 'web' || isWindowNarrow ? onBackPressed : undefined
+        }
         loadingSubtitle={refreshing && !initialLoading ? 'Refreshing' : null}
-        rightActions={[
-          {
-            id: 'refresh-providers',
-            icon: 'Refresh',
-            label: 'Refresh providers',
-            onPress: onRefresh,
-          },
-        ]}
+        rightControls={
+          <ScreenHeader.IconButton type="Refresh" onPress={onRefresh} />
+        }
         title="Connect MCP"
-        placement="navigation"
       />
       {initialLoading ? (
         <YStack flex={1} alignItems="center" justifyContent="center">

--- a/packages/shared/src/db/storageItem.test.ts
+++ b/packages/shared/src/db/storageItem.test.ts
@@ -1,0 +1,36 @@
+import { beforeEach, describe, expect, test, vi } from 'vitest';
+
+import { createStorageItem } from './storageItem';
+
+const storage = vi.hoisted(() => ({
+  getItem: vi.fn(),
+  setItem: vi.fn(),
+  removeItem: vi.fn(),
+}));
+
+vi.mock('./getStorageMethods', () => ({
+  getStorageMethods: () => storage,
+}));
+
+describe('createStorageItem update queue', () => {
+  beforeEach(() => {
+    storage.getItem.mockReset();
+    storage.setItem.mockReset();
+    storage.removeItem.mockReset();
+  });
+
+  test('allows a reset to retry after an earlier write rejects', async () => {
+    const item = createStorageItem({
+      key: 'retry-after-rejection',
+      defaultValue: null,
+    });
+    storage.setItem
+      .mockRejectedValueOnce(new Error('storage unavailable'))
+      .mockResolvedValueOnce(undefined);
+
+    await expect(item.resetValue()).rejects.toThrow('storage unavailable');
+    await expect(item.resetValue()).resolves.toBeNull();
+
+    expect(storage.setItem).toHaveBeenCalledTimes(2);
+  });
+});

--- a/packages/shared/src/db/storageItem.ts
+++ b/packages/shared/src/db/storageItem.ts
@@ -26,6 +26,10 @@ export type StorageItem<T> = {
   useValue: () => T;
   useStorageItem: () => {
     value: T;
+    /** True until the stored value has hydrated; `value` is the default. */
+    isLoading: boolean;
+    /** True when hydration failed and `value` is only the default. */
+    isError: boolean;
     setValue: (value: T | ((curr: T) => T)) => Promise<void>;
     resetValue: () => Promise<T>;
   };
@@ -57,7 +61,19 @@ export const createStorageItem = <T>(config: StorageItemConfig<T>) => {
     deserialize = JSON.parse,
   } = config;
   const storage = getStorageMethods(config);
-  let updateLock = Promise.resolve();
+  let updateLock: Promise<void> = Promise.resolve();
+
+  const enqueueUpdate = <R>(operation: () => Promise<R>): Promise<R> => {
+    const result = updateLock.then(operation);
+    // Keep the queue tail fulfilled even when this caller's operation fails.
+    // The caller still receives `result` and its rejection, while a later
+    // write gets a fresh attempt instead of inheriting a poisoned lock.
+    updateLock = result.then(
+      () => undefined,
+      () => undefined
+    );
+    return result;
+  };
 
   const getValue = async (waitForLock = false): Promise<T> => {
     if (waitForLock) {
@@ -101,7 +117,7 @@ export const createStorageItem = <T>(config: StorageItemConfig<T>) => {
   };
 
   const resetValue = async (): Promise<T> => {
-    updateLock = updateLock.then(async () => {
+    await enqueueUpdate(async () => {
       await storage.setItem(key, serialize(defaultValue));
       queryClient.invalidateQueries({ queryKey: [key] });
       storageItemListeners.get(key)?.forEach((listener) => {
@@ -109,12 +125,11 @@ export const createStorageItem = <T>(config: StorageItemConfig<T>) => {
       });
       logger.log(`reset value ${key}`);
     });
-    await updateLock;
     return defaultValue;
   };
 
   const setValue = async (valueInput: T | ((curr: T) => T)): Promise<void> => {
-    updateLock = updateLock.then(async () => {
+    await enqueueUpdate(async () => {
       let newValue: T;
       if (valueInput instanceof Function) {
         const currValue = await getValue();
@@ -132,7 +147,6 @@ export const createStorageItem = <T>(config: StorageItemConfig<T>) => {
       });
       logger.log(`set value ${key}`, newValue);
     });
-    await updateLock;
   };
 
   function useValue() {
@@ -144,15 +158,23 @@ export const createStorageItem = <T>(config: StorageItemConfig<T>) => {
   }
 
   function useStorageItem() {
-    const { data: value, isLoading: queryIsLoading } = useQuery({
+    const {
+      data: value,
+      isLoading: queryIsLoading,
+      isError,
+    } = useQuery({
       queryKey: [key],
       queryFn: () => getValue(),
     });
-    // Treat undefined data as still loading to prevent brief flashes of default value
-    const isLoading = queryIsLoading || value === undefined;
+    // Treat undefined data as still loading to prevent brief flashes of the
+    // default value — but never past a failed read: `data` stays undefined
+    // on error, and callers that hold UI (or a lock) while loading must not
+    // hold it forever because storage misbehaved once.
+    const isLoading = !isError && (queryIsLoading || value === undefined);
     return {
       value: value === undefined ? defaultValue : value,
       isLoading,
+      isError,
       setValue,
       resetValue,
     };


### PR DESCRIPTION
## Summary

Wave 0 of splitting up #6221: five standalone client fixes that don't depend on the agent-onboarding feature, extracted verbatim so the feature PR can shrink. All were found while exercising that flow, but each fixes behavior that is wrong on develop today.

## Changes

- **Web DB row mapping**: shim SQLocal's `{ rows: [] }` "no result" shape to the falsy `rows` that drizzle's sqlite-proxy contract expects. Without it, every single-row lookup that misses fabricates a phantom object with every field undefined on web, and relational queries crash in `mapRelationalRow`.
- **Storage item updates**: a failed write no longer poisons the serialized update queue — previously one rejection made every later `setValue`/`resetValue` on that key fail immediately. `useStorageItem().isLoading` also no longer sticks true forever after a read error, and the hook now exposes `isError`.
- **Bot settings back controls**: nested-drawer settings only exist on wide web, but the back button was keyed on window width alone. Native tablets sat on flat RootStack routes with `headerBackVisible: false` and gestures disabled — wide enough to hide the back button, with no drawer to fall back on. Back controls now show everywhere except nested web settings. (Extracted minus the feature-only `navigateToBotMcpSettings`.)
- **Web splash**: mount `SplashModal` in the narrow-web tab navigator. `useShowWebSplashModal` requires a ≤767px viewport, but the only existing mount was in the wide-only desktop sidebar, so the web splash could never appear.
- **Computing status**: display labels for `image` and `web_search` tool calls.

## How did I test?

- `tsc --noEmit` clean for `packages/api`, `packages/shared`, `packages/app`
- `vitest run src/db/storageItem.test.ts` passes (new regression test for the queue fix)
- Prettier check and `git diff --check` clean on all changed files
- The hunks are lifted unchanged from the onboarding branch, where they have been exercised manually against production hosting

## Risks and impact

- Safe to rollback without consulting PR author? Yes
- Affects important code area:
  - [ ] Onboarding
  - [x] State / providers
  - [ ] Message sync
  - [ ] Channel display
  - [ ] Notifications
  - [x] Other: settings navigation, web splash mount, web db driver

Behavior notes: web-mobile users will see the wayfinding splash for the first time (it was dead on that surface); `useStorageItem().isLoading` now settles false when a storage read errors instead of staying true forever.

## Rollback plan

Revert the merge. No migrations, schema changes, or persisted-format changes.

## Screenshots / videos

n/a
