### PR TITLE
openclaw: history author parsing, abortable cli commands, cron accessor guard

### DIFF
--- a/packages/openclaw/src/cron-telemetry.test.ts
+++ b/packages/openclaw/src/cron-telemetry.test.ts
@@ -495,6 +495,23 @@ describe('cron telemetry hook handling', () => {
     expect(reports).toEqual([]);
   });
 
+  it('does not let a stale gateway clear a replacement accessor', async () => {
+    const staleService = makeCronService([{ ...makeJob(), id: 'stale-job' }]);
+    const replacementService = makeCronService([
+      { ...makeJob(), id: 'replacement-job' },
+    ]);
+    const staleAccessor = () => staleService;
+    const replacementAccessor = () => replacementService;
+    setCronServiceAccessor(staleAccessor);
+    setCronServiceAccessor(replacementAccessor);
+
+    clearCronServiceAccessor(staleAccessor);
+
+    await expect(emitCronSnapshot()).resolves.toBe(true);
+    expect(staleService.list).not.toHaveBeenCalled();
+    expect(replacementService.list).toHaveBeenCalledOnce();
+  });
+
   it('retries the boot snapshot once the accessor appears', async () => {
     vi.useFakeTimers();
     scheduleCronSnapshot();

--- a/packages/openclaw/src/cron-telemetry.ts
+++ b/packages/openclaw/src/cron-telemetry.ts
@@ -79,7 +79,10 @@ export function setCronServiceAccessor(
   cronServiceAccessorSlot.set(accessor);
 }
 
-export function clearCronServiceAccessor(): void {
+export function clearCronServiceAccessor(expected?: CronServiceAccessor): void {
+  if (expected && cronServiceAccessorSlot.get() !== expected) {
+    return;
+  }
   cronServiceAccessorSlot.set(null);
 }
 

--- a/packages/openclaw/src/monitor/history.ts
+++ b/packages/openclaw/src/monitor/history.ts
@@ -288,8 +288,15 @@ export async function fetchChannelHistory(
         const essay = item.essay || item['r-post']?.set?.essay;
         const seal = item.seal || item['r-post']?.set?.seal;
 
+        // A bot posting with a profile carries an author *object*; every
+        // consumer compares ships, so unwrap here or the bot never
+        // recognizes its own posts in history.
+        const rawAuthor = essay?.author;
         return {
-          author: essay?.author || 'unknown',
+          author:
+            typeof rawAuthor === 'string'
+              ? rawAuthor
+              : rawAuthor?.ship || 'unknown',
           content: extractMessageText(essay?.content || []),
           timestamp: essay?.sent || Date.now(),
           id: seal?.id,

--- a/packages/openclaw/src/tlon-command-runner.test.ts
+++ b/packages/openclaw/src/tlon-command-runner.test.ts
@@ -44,6 +44,19 @@ afterEach(() => {
 });
 
 describe('runTlonCommand timeout output capture', () => {
+  it('terminates and rejects when its abort signal fires', async () => {
+    const controller = new AbortController();
+    const command = runTlonCommand(
+      process.execPath,
+      ['-e', 'setTimeout(() => process.exit(0), 5000)'],
+      undefined,
+      { timeoutMs: 10_000, abortSignal: controller.signal }
+    );
+    setTimeout(() => controller.abort(), 50);
+
+    await expect(command).rejects.toThrow('tlon command aborted');
+  });
+
   it('terminates and rejects near the timeout when no deadline callback is supplied', async () => {
     const timeoutMs = 300;
     const script = [

--- a/packages/openclaw/src/tlon-command-runner.ts
+++ b/packages/openclaw/src/tlon-command-runner.ts
@@ -34,6 +34,7 @@ export type TlonCommandDeadlineOutput = {
 export type TlonCommandRunnerOptions = {
   timeoutMs?: number;
   onDeadline?: (output: TlonCommandDeadlineOutput) => void;
+  abortSignal?: AbortSignal;
 };
 
 /**
@@ -45,6 +46,9 @@ export function runTlonCommand(
   credentials?: { url: string; ship: string; code: string },
   options?: TlonCommandRunnerOptions
 ): Promise<string> {
+  if (options?.abortSignal?.aborted) {
+    return Promise.reject(new TlonCommandError('tlon command aborted'));
+  }
   return new Promise((resolve, reject) => {
     const env = { ...process.env };
     if (credentials) {
@@ -76,6 +80,18 @@ export function runTlonCommand(
     const onChildError = (error: Error) => {
       spawnError = error;
     };
+    const terminateChild = () => {
+      child.kill('SIGTERM');
+      killTimer = setTimeout(() => child.kill('SIGKILL'), 2_000);
+    };
+    const onAbort = () => {
+      if (completionSettled) {
+        return;
+      }
+      completionSettled = true;
+      terminateChild();
+      reject(new TlonCommandError('tlon command aborted', { stdout, stderr }));
+    };
     const teardownAfterClose = () => {
       if (timeout) {
         clearTimeout(timeout);
@@ -89,6 +105,7 @@ export function runTlonCommand(
       child.stderr.removeListener('data', onStderrData);
       child.removeListener('error', onChildError);
       child.removeListener('close', onChildClose);
+      options?.abortSignal?.removeEventListener('abort', onAbort);
       stdout = '';
       stderr = '';
     };
@@ -126,6 +143,11 @@ export function runTlonCommand(
     child.stderr.on('data', onStderrData);
     child.on('error', onChildError);
     child.on('close', onChildClose);
+    options?.abortSignal?.addEventListener('abort', onAbort, { once: true });
+    // Close the tiny race between the pre-spawn check and listener install.
+    if (options?.abortSignal?.aborted) {
+      onAbort();
+    }
 
     if (timeoutMs > 0) {
       timeout = setTimeout(() => {
@@ -138,8 +160,7 @@ export function runTlonCommand(
           return;
         }
         completionSettled = true;
-        child.kill('SIGTERM');
-        killTimer = setTimeout(() => child.kill('SIGKILL'), 2_000);
+        terminateChild();
         reject(
           new TlonCommandError(`tlon command timed out after ${timeoutMs}ms`, {
             stdout,


### PR DESCRIPTION
## Summary

Wave 0 of splitting up #6221: three self-contained `packages/openclaw` fixes that don't depend on the agent-onboarding feature. Each fixes a real gap in plugin infrastructure that exists on develop today; extracting them shrinks the feature PR.

## Changes

- **Channel history author parsing**: a bot posting with a profile carries an author *object* in the channel scry, so `fetchChannelHistory` returned `[object Object]`-style authors and the bot could never recognize its own posts in history. Unwrap to `.ship` when the author isn't a plain string. This is a latent bug for every history consumer, not just onboarding.
- **Abortable `tlon` CLI commands**: `runTlonCommand` gains an optional `abortSignal`. On abort it terminates the child (SIGTERM, escalating to SIGKILL after 2s) and rejects, with the listener installed race-free (pre-spawn check, install, post-install re-check) and removed on teardown. Previously a shutdown could leave CLI children running to completion. The SIGTERM→SIGKILL escalation is shared with the existing timeout path via a `terminateChild` helper.
- **Cron service accessor guard**: `clearCronServiceAccessor` now accepts the expected accessor and refuses to null out a *replacement* accessor — a stale gateway's stop event could previously clear the slot registered by its successor, silently killing cron snapshot telemetry until the next restart.

## How did I test?

- `pnpm tsc --noEmit` clean in `packages/openclaw`
- `pnpm test` — 67 files, 1,347 unit tests pass, including a new regression test for each of the abort and stale-clear behaviors
- Prettier check clean
- Integration tests (`pnpm test:integration`) not run — these changes don't alter any inbound/outbound message path
- The hunks are lifted from the onboarding branch, where they've been exercised against production hosting

## Risks and impact

- Safe to rollback without consulting PR author? Yes
- Affects important code area:
  - [ ] Onboarding
  - [ ] State / providers
  - [ ] Message sync
  - [ ] Channel display
  - [ ] Notifications
  - [x] Other: `@tloncorp/openclaw` plugin infrastructure (history parsing, CLI runner, cron telemetry)

All three changes are backward compatible: `abortSignal` and the `expected` accessor parameter are optional, and the author unwrap only changes behavior for author values that were previously garbage.

## Rollback plan

Revert the merge. No state, schema, or wire-format changes; the plugin redeploys cleanly at the previous commit.

## Screenshots / videos

n/a
