### PR TITLE
tlon-skill: subscribe to /v2/groups so group mutations resolve

### DIFF
--- a/packages/tlon-skill/scripts/api-client.ts
+++ b/packages/tlon-skill/scripts/api-client.ts
@@ -162,6 +162,18 @@ async function setupSubscriptions(subs: SubscriptionApp[]): Promise<void> {
     await subscribe({ app: 'groups', path: '/v1/groups' }, (e) =>
       logSubscriptionUpdate('groups', e)
     );
+    // Group mutations in @tloncorp/api are tracked against /v2/groups. Keep
+    // the v1 subscription for older ships, but also feed the endpoint whose
+    // watcher must resolve before updateGroupMeta and related calls return.
+    try {
+      await subscribe({ app: 'groups', path: '/v2/groups' }, (e) =>
+        logSubscriptionUpdate('groups v2', e)
+      );
+    } catch (err) {
+      if (isVerbose()) {
+        console.error('groups /v2 subscription unavailable:', err);
+      }
+    }
   }
 
   if (subs.includes('channels')) {


### PR DESCRIPTION
## Summary

Wave 0 of splitting up #6221: subscribe the tlon-skill CLI to `/v2/groups` alongside `/v1/groups`. Group mutations in `@tloncorp/api` track completion against the `/v2/groups` subscription, so with only the v1 subscription every successful `updateGroupMeta`-style poke waited the full 20 seconds and then reported `TimeoutError: active` — the write landed on the ship, but the CLI could never observe its own confirmation.

## Changes

- `setupSubscriptions` in `packages/tlon-skill/scripts/api-client.ts` also subscribes to `{ app: 'groups', path: '/v2/groups' }` when groups subscriptions are requested. The v1 subscription is kept for older ships, and a v2 subscription failure is tolerated (logged in verbose mode) rather than fatal, so the CLI still works against ships that predate the v2 path.

## How did I test?

- `pnpm typecheck` clean in `packages/tlon-skill` (both `tsconfig.json` and `tsconfig.test.json` projects)
- Prettier check clean
- Lifted from the onboarding branch, where the fix was verified against production hosting: group meta updates went from a guaranteed 20s timeout-per-write to resolving normally

Note: this is a source-only change; the bundled CLI shipped inside the OpenClaw plugin picks it up on the plugin's next rebuild.

## Risks and impact

- Safe to rollback without consulting PR author? Yes
- Affects important code area:
  - [ ] Onboarding
  - [ ] State / providers
  - [ ] Message sync
  - [ ] Channel display
  - [ ] Notifications
  - [x] Other: bundled tlon-skill CLI

Strictly additive subscription; failure to establish it degrades to today's behavior.

## Rollback plan

Revert the merge.

## Screenshots / videos

n/a
