### PR TITLE
notes: hide the context lens toggle in notes channels

### DIFF
--- a/packages/app/ui/components/Channel/ContextLens/useContextLensStore.ts
+++ b/packages/app/ui/components/Channel/ContextLens/useContextLensStore.ts
@@ -193,6 +193,11 @@ export function useContextLensAvailable(channel?: db.Channel | null) {
   if (!channel) {
     return true;
   }
+  // Notes channels have no per-post surface for a run to attach to, so the
+  // header toggle would open a panel with nothing to show.
+  if (channel.type === 'notes') {
+    return false;
+  }
   if (isDm) {
     return (botShips ?? []).includes(preSig(channel.id));
   }


### PR DESCRIPTION
## Summary

The context lens header toggle — the "bot run" icon — appears in notes channels whenever the group has a bot attached. Notes has no per-post surface for a run to attach to, so the toggle opens a panel with nothing in it. This gates context lens availability on channel type so notes channels don't offer it.

Fixes TLON-6329

## Changes

- `useContextLensAvailable` now returns `false` for `channel.type === 'notes'`.

Gating at the availability hook rather than at the header render site means the `⟐ Bot run` badge, the run panel, and the narrow-screen `goToContextLensRuns` navigation all drop out for notes as well — one gate instead of four call sites.

## How did I test?

- `pnpm run build:packages` succeeds.
- `pnpm --filter @tloncorp/app exec tsc --noEmit` is clean.
- `npx prettier --check` passes on the changed file.
- No unit or e2e tests reference `useContextLensAvailable` or `ContextLensHeaderButton`, so nothing needed updating.

I have not exercised this against a running ship with a bot-enabled group — the change is a single type check on an existing hook, and the reviewer's eye on the notes header is probably worth more than my screenshot here.

## Risks and impact

- Safe to rollback without consulting PR author? Yes
- Affects important code area:
  - [ ] Onboarding
  - [ ] State / providers
  - [ ] Message sync
  - [x] Channel display
  - [ ] Notifications
  - [ ] Other:

This is client-side only. Bot runs can still target a notes channel from the backend; this removes the entry point from the notes header, not the capability.

## Rollback plan

Revert the commit. The hook returns to its prior behavior and the toggle reappears in notes channels.

## Screenshots / videos

None — the change removes an icon rather than adding UI.
