### PR TITLE
show a Bot badge wherever a contact or member is listed

### DIFF
--- a/packages/app/features/settings/BotChannelRuleSettingsScreen.tsx
+++ b/packages/app/features/settings/BotChannelRuleSettingsScreen.tsx
@@ -13,6 +13,7 @@ import { View, XStack, YStack } from 'tamagui';
 
 import { RootStackParamList } from '../../navigation/types';
 import { ScreenHeader, SettingsContentScrollView, TextInput } from '../../ui';
+import { BotBadge } from '../../ui/components/BotBadge';
 import {
   BotSettingsDivider,
   BotSettingsErrorText,
@@ -407,9 +408,23 @@ export function BotChannelRuleSettingsScreen(props: Props) {
                         justifyContent="space-between"
                         gap="$m"
                       >
-                        <Text size="$label/l" color="$primaryText">
-                          {ship}
-                        </Text>
+                        <XStack
+                          alignItems="center"
+                          gap="$s"
+                          flex={1}
+                          minWidth={0}
+                        >
+                          <Text
+                            size="$label/l"
+                            color="$primaryText"
+                            numberOfLines={1}
+                            flex={1}
+                            minWidth={0}
+                          >
+                            {ship}
+                          </Text>
+                          <BotBadge contactId={ship} />
+                        </XStack>
                         <Pressable
                           disabled={controlsDisabled}
                           onPress={() =>

--- a/packages/app/fixtures/ProfileBlock.fixture.tsx
+++ b/packages/app/fixtures/ProfileBlock.fixture.tsx
@@ -1,7 +1,7 @@
 import { AppDataContextProvider, View } from '../ui';
 import { ProfileBlock } from '../ui/components/ProfileBlock';
 import { FixtureWrapper } from './FixtureWrapper';
-import { brianContact } from './fakeData';
+import { brianContact, hostedBotContact } from './fakeData';
 
 const lightBg =
   'https://storage.googleapis.com/tlon-prod-memex-assets/solfer-magfed/solfer-magfed/2024.8.10..17.17.3..6624.dd2f.1a9f.be76-Untitled-3.png';
@@ -34,6 +34,15 @@ export default {
       >
         <View padding="$xl" width={'100%'}>
           <ProfileBlock contactId={brianContact.id} />
+        </View>
+      </AppDataContextProvider>
+    </FixtureWrapper>
+  ),
+  hostedBot: (
+    <FixtureWrapper fillWidth>
+      <AppDataContextProvider contacts={[hostedBotContact]}>
+        <View padding="$xl" width={'100%'}>
+          <ProfileBlock contactId={hostedBotContact.id} />
         </View>
       </AppDataContextProvider>
     </FixtureWrapper>

--- a/packages/app/fixtures/fakeData.ts
+++ b/packages/app/fixtures/fakeData.ts
@@ -206,6 +206,19 @@ export const edContact: db.Contact = {
   color: '#C0C3D8',
 };
 
+export const hostedBotContact: db.Contact = {
+  ...emptyContact,
+  id: '~pinser-botter-sampel-palnet',
+  nickname: 'Tlon Customer Support Assistant',
+};
+
+export const claimBotContact: db.Contact = {
+  ...emptyContact,
+  id: '~migsyl-fodtep',
+  nickname: 'claw',
+  botInfo: JSON.stringify({ v: 1, harness: 'openclaw', version: '1.2.3' }),
+};
+
 // Mock system contacts for fixtures
 export const emptySystemContact: db.SystemContact = {
   id: '',
@@ -328,6 +341,8 @@ export const initialSystemContacts: db.SystemContact[] = [
 ];
 
 export const initialContacts: db.Contact[] = [
+  hostedBotContact,
+  claimBotContact,
   galenContact,
   jamesContact,
   danContact,

--- a/packages/app/ui/components/BotBadge.tsx
+++ b/packages/app/ui/components/BotBadge.tsx
@@ -1,0 +1,12 @@
+import * as domain from '@tloncorp/shared/domain';
+
+import { useContact } from '../contexts/appDataContext';
+import { Badge } from './Badge';
+
+export function BotBadge({ contactId }: { contactId: string }) {
+  const contact = useContact(contactId);
+  if (!domain.isBotContact({ id: contactId, botInfo: contact?.botInfo })) {
+    return null;
+  }
+  return <Badge type="neutral" size="micro" text="Bot" flexShrink={0} />;
+}

--- a/packages/app/ui/components/ChannelMembersScreenView.tsx
+++ b/packages/app/ui/components/ChannelMembersScreenView.tsx
@@ -1,8 +1,9 @@
 import * as db from '@tloncorp/shared/db';
 import { useCallback } from 'react';
 import { FlatList, ListRenderItemInfo } from 'react-native';
-import { View, getTokenValue } from 'tamagui';
+import { View, XStack, getTokenValue } from 'tamagui';
 
+import { BotBadge } from './BotBadge';
 import ContactName from './ContactName';
 import { ListItem } from './ListItem';
 import { ScreenHeader } from './ScreenHeader';
@@ -21,10 +22,13 @@ export function ChannelMembersScreenView({
       return (
         <ListItem>
           <ListItem.ContactIcon contactId={item.contactId} />
-          <ListItem.MainContent>
-            <ListItem.Title>
-              <ContactName showNickname={true} userId={item.contactId} />
-            </ListItem.Title>
+          <ListItem.MainContent minWidth={0}>
+            <XStack alignItems="center" gap="$s">
+              <ListItem.Title flex={1} minWidth={0}>
+                <ContactName showNickname={true} userId={item.contactId} />
+              </ListItem.Title>
+              <BotBadge contactId={item.contactId} />
+            </XStack>
             <ListItem.Subtitle>{item.contactId}</ListItem.Subtitle>
           </ListItem.MainContent>
         </ListItem>

--- a/packages/app/ui/components/ContactRow.tsx
+++ b/packages/app/ui/components/ContactRow.tsx
@@ -6,6 +6,7 @@ import { ListItemProps } from 'tamagui';
 import { View, XStack } from 'tamagui';
 
 import { triggerHaptic } from '../utils';
+import { BotBadge } from './BotBadge';
 import { ContactName } from './ContactNameV2';
 import { ListItem } from './ListItem';
 
@@ -52,10 +53,13 @@ function ContactRowItemRaw({
     >
       <ListItem {...rest}>
         <ListItem.ContactIcon contactId={contact.id} />
-        <ListItem.MainContent>
-          <ListItem.Title>
-            <ContactName contactId={contact.id} mode="auto" />
-          </ListItem.Title>
+        <ListItem.MainContent minWidth={0}>
+          <XStack alignItems="center" gap="$s">
+            <ListItem.Title flex={1} minWidth={0}>
+              <ContactName contactId={contact.id} mode="auto" />
+            </ListItem.Title>
+            <BotBadge contactId={contact.id} />
+          </XStack>
           {disabled && disabledReason ? (
             <ListItem.Subtitle color="$negativeActionText">
               {disabledReason}

--- a/packages/app/ui/components/MentionPopup.tsx
+++ b/packages/app/ui/components/MentionPopup.tsx
@@ -7,8 +7,10 @@ import React, {
   useState,
 } from 'react';
 import { Platform } from 'react-native';
+import { XStack } from 'tamagui';
 
 import { MentionOption } from './BareChatInput/useMentions';
+import { BotBadge } from './BotBadge';
 import { ContactList } from './ContactList';
 import ContactName from './ContactName';
 import { ListItem } from './ListItem';
@@ -51,18 +53,21 @@ function MentionOptionItem({
         ) : (
           <ListItem.SystemIcon icon="Face" size={size} />
         )}
-        <ListItem.MainContent>
-          <ListItem.Title>
-            {isContact ? (
-              <ContactName
-                matchText={matchText}
-                showNickname
-                userId={option.id}
-              />
-            ) : (
-              option.title || option.id
-            )}
-          </ListItem.Title>
+        <ListItem.MainContent minWidth={0}>
+          <XStack alignItems="center" gap="$s">
+            <ListItem.Title flex={1} minWidth={0}>
+              {isContact ? (
+                <ContactName
+                  matchText={matchText}
+                  showNickname
+                  userId={option.id}
+                />
+              ) : (
+                option.title || option.id
+              )}
+            </ListItem.Title>
+            {isContact && <BotBadge contactId={option.id} />}
+          </XStack>
           {option.subtitle ? (
             <ListItem.Subtitle>{option.subtitle}</ListItem.Subtitle>
           ) : null}

--- a/packages/app/ui/components/ProfileRow.tsx
+++ b/packages/app/ui/components/ProfileRow.tsx
@@ -3,6 +3,7 @@ import { Text } from '@tloncorp/ui';
 import { XStack, YStack } from 'tamagui';
 
 import { ContactAvatar } from './Avatar';
+import { BotBadge } from './BotBadge';
 import { ContactName } from './ContactNameV2';
 
 export default function ProfileRow({
@@ -27,12 +28,21 @@ export default function ProfileRow({
       borderRadius={dark ? '$xl' : undefined}
     >
       <ContactAvatar size="$5xl" borderRadius={'$xl'} contactId={contactId} />
-      <YStack flex={1} gap="$l" justifyContent="center">
+      <YStack flex={1} minWidth={0} gap="$l" justifyContent="center">
         {hasNickname ? (
           <>
-            <Text color={color} size="$label/2xl">
-              <ContactName contactId={contactId} mode="nickname" />
-            </Text>
+            <XStack alignItems="center" gap="$s">
+              <Text
+                color={color}
+                size="$label/2xl"
+                numberOfLines={1}
+                flex={1}
+                minWidth={0}
+              >
+                <ContactName contactId={contactId} mode="nickname" />
+              </Text>
+              <BotBadge contactId={contactId} />
+            </XStack>
             <Text color={color} opacity={dark ? 0.5 : 0.7} size="$label/xl">
               <ContactName
                 contactId={contactId}
@@ -42,9 +52,22 @@ export default function ProfileRow({
             </Text>
           </>
         ) : (
-          <Text color={color} size="$label/3xl">
-            <ContactName contactId={contactId} mode="contactId" expandLongIds />
-          </Text>
+          <XStack alignItems="center" gap="$s">
+            <Text
+              color={color}
+              size="$label/3xl"
+              numberOfLines={1}
+              flex={1}
+              minWidth={0}
+            >
+              <ContactName
+                contactId={contactId}
+                mode="contactId"
+                expandLongIds
+              />
+            </Text>
+            <BotBadge contactId={contactId} />
+          </XStack>
         )}
       </YStack>
     </XStack>

--- a/packages/app/ui/components/UserProfileScreenView.tsx
+++ b/packages/app/ui/components/UserProfileScreenView.tsx
@@ -26,6 +26,7 @@ import { useContact, useCurrentUserId } from '../contexts/appDataContext';
 import { useNavigation as useContextNavigation } from '../contexts/navigation';
 import { useGroupTitle } from '../utils';
 import { ContactAvatar } from './Avatar';
+import { BotBadge } from './BotBadge';
 import { ContactName } from './ContactNameV2';
 import { GroupAvatar } from './GroupAvatar';
 import { ListItem } from './ListItem';
@@ -425,17 +426,22 @@ function UserInfoRow(props: { userId: string; hasNickname: boolean }) {
       <Pressable onPress={handleAvatarPress}>
         <ContactAvatar contactId={props.userId} size="$5xl" />
       </Pressable>
-      <Pressable width="100%" onPress={handleCopy}>
+      <Pressable flex={1} minWidth={0} onPress={handleCopy}>
         <YStack flex={1} justifyContent="center">
-          <ContactName
-            contactId={props.userId}
-            fontSize={24}
-            lineHeight={32}
-            maxWidth="100%"
-            numberOfLines={1}
-            color="$primaryText"
-            {...primaryNameProps}
-          />
+          <XStack alignItems="center" gap="$s">
+            <ContactName
+              contactId={props.userId}
+              fontSize={24}
+              lineHeight={32}
+              maxWidth="100%"
+              numberOfLines={1}
+              color="$primaryText"
+              flex={1}
+              minWidth={0}
+              {...primaryNameProps}
+            />
+            <BotBadge contactId={props.userId} />
+          </XStack>
           {props.hasNickname && (
             <XStack alignItems="center">
               <Text color="$secondaryText">

--- a/packages/app/ui/components/listItems/ContactListItem.tsx
+++ b/packages/app/ui/components/listItems/ContactListItem.tsx
@@ -1,8 +1,9 @@
 import { Pressable } from '@tloncorp/ui';
 import { ComponentProps } from 'react';
-import { isWeb } from 'tamagui';
+import { XStack, isWeb } from 'tamagui';
 
 import { AvatarProps } from '../Avatar';
+import { BotBadge } from '../BotBadge';
 import ContactName from '../ContactName';
 import { ContactName as ContactNameV2 } from '../ContactNameV2';
 import { ListItem } from '../ListItem';
@@ -49,26 +50,29 @@ export const ContactListItem = ({
     >
       <ListItem alignItems="center" justifyContent="flex-start" {...props}>
         {showIcon && <ListItem.ContactIcon size={size} contactId={contactId} />}
-        <ListItem.MainContent>
-          <ListItem.Title>
-            {matchText ? (
-              // Use old ContactName for search highlighting
-              <ContactName
-                matchText={matchText}
-                showNickname={showNickname}
-                showUserId={!showNickname && showUserId}
-                full={full}
-                userId={contactId}
-              />
-            ) : (
-              // Use ContactNameV2 for monospace styling
-              <ContactNameV2
-                contactId={contactId}
-                mode={showNickname ? 'auto' : 'contactId'}
-                expandLongIds={full}
-              />
-            )}
-          </ListItem.Title>
+        <ListItem.MainContent minWidth={0}>
+          <XStack alignItems="center" gap="$s">
+            <ListItem.Title flex={1} minWidth={0}>
+              {matchText ? (
+                // Use old ContactName for search highlighting
+                <ContactName
+                  matchText={matchText}
+                  showNickname={showNickname}
+                  showUserId={!showNickname && showUserId}
+                  full={full}
+                  userId={contactId}
+                />
+              ) : (
+                // Use ContactNameV2 for monospace styling
+                <ContactNameV2
+                  contactId={contactId}
+                  mode={showNickname ? 'auto' : 'contactId'}
+                  expandLongIds={full}
+                />
+              )}
+            </ListItem.Title>
+            <BotBadge contactId={contactId} />
+          </XStack>
           {showUserId && showNickname ? (
             <ListItem.Subtitle>
               <ContactNameV2

--- a/packages/shared/src/domain/botIdentity.test.ts
+++ b/packages/shared/src/domain/botIdentity.test.ts
@@ -1,0 +1,58 @@
+import { describe, expect, test } from 'vitest';
+
+import { isBotContact } from './botIdentity';
+
+const validClaim = JSON.stringify({
+  v: 1,
+  harness: 'openclaw',
+  version: '1.2.3',
+});
+
+describe('isBotContact', () => {
+  test('plain planet id is not a bot', () => {
+    expect(isBotContact({ id: '~sampel-palnet' })).toBe(false);
+  });
+
+  test('hosted bot moon prefix is a bot', () => {
+    expect(isBotContact({ id: '~pinser-botter-sampel-palnet' })).toBe(true);
+  });
+
+  test('valid bot-info claim is a bot', () => {
+    expect(isBotContact({ id: '~sampel-palnet', botInfo: validClaim })).toBe(
+      true
+    );
+  });
+
+  test('malformed bot-info claim alone is not a bot', () => {
+    expect(isBotContact({ id: '~sampel-palnet', botInfo: 'not json' })).toBe(
+      false
+    );
+  });
+
+  test('hosted prefix wins even with a malformed claim', () => {
+    expect(
+      isBotContact({ id: '~pinser-botter-sampel-palnet', botInfo: 'not json' })
+    ).toBe(true);
+  });
+
+  test('unknown harness in an otherwise valid claim is still a bot', () => {
+    expect(
+      isBotContact({
+        id: '~sampel-palnet',
+        botInfo: JSON.stringify({ v: 1, harness: 'xyz', version: '1.2.3' }),
+      })
+    ).toBe(true);
+  });
+
+  test('absent id is not a bot', () => {
+    expect(isBotContact({ id: null })).toBe(false);
+    expect(isBotContact({})).toBe(false);
+  });
+
+  // The two signals are independently sufficient: a claim alone is enough, with
+  // no id to fall back on. Without this, an implementation that gated the whole
+  // predicate on a truthy id would pass every other case here.
+  test('valid claim with no id is still a bot', () => {
+    expect(isBotContact({ botInfo: validClaim })).toBe(true);
+  });
+});

--- a/packages/shared/src/domain/botIdentity.ts
+++ b/packages/shared/src/domain/botIdentity.ts
@@ -1,0 +1,14 @@
+import { isBotUserId } from '@tloncorp/api/client/apiUtils';
+
+import { parseBotInfo } from './slashCommands';
+
+// A contact is a bot when either signal says so: its id carries the fixed
+// `~pinser-botter-` moon prefix that Tlon-hosted bots use, or it publishes a
+// parseable `bot-info` identity claim (docs/bot-info.md). The claim is
+// self-published and only shape-validated, so a third-party harness counts too.
+export function isBotContact(args: {
+  id?: string | null;
+  botInfo?: string | null;
+}): boolean {
+  return isBotUserId(args.id) || parseBotInfo(args.botInfo) !== null;
+}

--- a/packages/shared/src/domain/index.ts
+++ b/packages/shared/src/domain/index.ts
@@ -13,4 +13,5 @@ export * from '@tloncorp/api/types/systemContacts';
 export * from '@tloncorp/api/types/uploads';
 export * from '@tloncorp/api/types/wayfinding';
 export * from './botConfig';
+export * from './botIdentity';
 export * from './slashCommands';


### PR DESCRIPTION
> **Stacked PR — targets `patrick/tlon-6300-bots-advertise-their-slash-command-manifests` (#6252), not `develop`**, because it reads the `contacts.botInfo` column that PR introduces. #6252 is itself stacked on #6243. Retarget this to `develop` once both have merged.

## Summary

The `Bot` badge currently appears only next to a bot-authored post. This extends it to the surfaces that list _people_ — contacts, group and channel members, contact and mention pickers, and profile screens — so a bot is identifiable wherever you meet it, not only where it has posted.

## Changes

-   New `isBotContact` predicate in `packages/shared/src/domain/botIdentity.ts`: a contact counts as a bot if its id carries the `~pinser-botter-` moon prefix used by Tlon-hosted bots, or it publishes a parseable `bot-info` identity claim.
-   New `BotBadge` component in `packages/app/ui` renders the existing `Bot` badge (`Badge type="neutral" size="micro"`) or nothing.
-   Wired `BotBadge` into 7 components covering 18 surfaces. `ContactListItem` and `ContactRow` alone cover 13 of them: contacts screen, group members list, reactions pane, chat-details member preview, channel host row, role member picker, blocked contacts, the bot user allowlists in settings, and every contact-selection surface (add contacts, invite users, ship picker, create-chat sheet). The remaining 5 are individual edits: `ChannelMembersScreenView`, `MentionPopup`, `ProfileRow`, `UserProfileScreenView`, and `BotChannelRuleSettingsScreen`'s allowlist row.
-   Each updated row wraps name and badge in a bounded `XStack` (`minWidth={0}` on the container, `flex={1} minWidth={0}` on the name) so long names truncate instead of pushing the badge off-screen.
-   Added two bot contacts to shared test fixtures so badged rows are inspectable in Cosmos.

Out of scope: mentions rendered inside message bodies or the composer (only the mention picker is covered), chat-list rows / DM channel headers / activity rows (these render channel titles, not contacts), and the group join-request sheet (an ActionSheet action, not a row).

## How did I test?

-   `pnpm -r tsc` clean.
-   Prettier and eslint clean on all changed files.
-   New unit tests for `isBotContact` (8 cases, all passing), mutation-tested against six distinct wrong implementations, each caught.
-   `packages/app` test suite: 428 passing.
-   Cosmos visual pass over the `ContactList`, `BlockSectionList` and `ProfileBlock` fixtures, which are seeded with two bot contacts — one matching on the `~pinser-botter-` prefix, one on a `bot-info` claim. Confirmed: both signals badge, all other contacts are untouched, the badge does not collide with existing row end content (selection checkmarks, chevrons, remove controls), and narrowing the container to 340–360px truncates the name with an ellipsis while the badge stays fully visible. This last case is the one that matters — `ContactName` renders `white-space: nowrap`, so without an explicit line clamp a long name would run straight through the badge.
-   Still outstanding: a check against a live bot. The `bot-info` clause is exercised here only by a fixture; a real self-hosted bot publishing a claim is the only end-to-end proof of that path.

## Risks and impact

-   Safe to rollback without consulting PR author? Yes
-   Affects important code area:
    -   [ ] Onboarding
    -   [ ] State / providers
    -   [ ] Message sync
    -   [ ] Channel display
    -   [ ] Notifications
    -   [x] Other: contact/member list rendering

## Rollback plan

Revert.

## Screenshots / videos

From the Cosmos pass, in order:

1. **Contact list, IDs** — `~pinser-botter-sampel-palnet` and `~migsyl-fodtep` badged; the other seven contacts unchanged.
<img width="1280" height="900" alt="1-contact-list-ids" src="https://github.com/user-attachments/assets/e769963e-ad7c-470a-85b4-b148dc5ab57a" />

2. **Contact list, nicknames** — same rows with nicknames shown, including a deliberately long one.
<img width="1280" height="900" alt="2-contact-list-nicknames" src="https://github.com/user-attachments/assets/03ac4c86-e319-438f-a8dc-b084a9b8be89" />


3. **Contact row with selection** — badge sits between the name and the selection control, no collision.
<img width="1280" height="900" alt="3-contact-row-selectable" src="https://github.com/user-attachments/assets/34f3e675-cfba-473b-9729-73b89d68c9ca" />


4. **Profile block** — badge beside the nickname, full ID on the line below.
<img width="1280" height="900" alt="4-profile-block" src="https://github.com/user-attachments/assets/2e3c134d-303d-4a5d-9c5b-6ff217e10be7" />

5. **Truncation at 360px** — name ellipsizes, badge stays fully visible.
<img width="1280" height="800" alt="5-truncation-360px" src="https://github.com/user-attachments/assets/3ae2655a-37f9-46cf-a56c-9dad653dcc6e" />

6. **Contact list at 340px** — long moon ID and badge both fit; no clipping or overflow.
<img width="1280" height="800" alt="6-contact-list-340px" src="https://github.com/user-attachments/assets/e3e9ad5d-f6f6-4350-91c5-96aa329defbb" />

