### PR TITLE
search: global full-text index agent for notes, channels and chat

### DIFF
--- a/desk/app/channels.hoon
+++ b/desk/app/channels.hoon
@@ -9,7 +9,8 @@
 ::    we can have resubscribe loop protection.
 ::
 /-  c=channels, cv=channels-ver, g=groups, gv=groups-ver, a=activity, av=activity-ver, story
-/-  meta
+/-  meta, se=search
+/+  sh=search
 /+  default-agent, verb, dbug,
     guard,
     neg=negotiate, discipline, logs,
@@ -263,6 +264,33 @@
 ++  emit  |=(=card cor(cards [card cards]))
 ++  emil  |=(caz=(list card) cor(cards (welp (flop caz) cards)))
 ++  give  |=(=gift:guard (emit %give gift))
+::  +search-running: is the local index agent installed?
+::
+++  search-running  .^(? %gu (scry-path %search /$))
+::  +submit-search: hand %search a reference to what changed
+::
+::    the poke names the change and stops there; %search tokenizes and
+::    indexes it in a later event, so a post never pays for indexing.
+::
+::    %search-action-1 isn't in /lib/rail's mark table, so the poke rides
+::    out as an unsafe cage; it arrives at %search as an ordinary poke.
+::
+++  submit-search
+  |=  =action:v1:se
+  ^+  cor
+  ?.  search-running  cor
+  (emit (unsafe:guard (submit:sh our.bowl action)))
+::  +search-rebuild: resubmit every post and reply we hold
+::
+++  search-rebuild
+  ^+  cor
+  ?.  search-running  cor
+  =/  nests=(list nest:c)  ~(tap in ~(key by v-channels))
+  |-  ^+  cor
+  ?~  nests  cor
+  =.  cor  ca-abet:ca-index-all:(ca-abed:ca-core i.nests)
+  $(nests t.nests)
+::
 ++  server  (cat 3 dap.bowl '-server')
 ++  log
   |=  msg=(trap tape)
@@ -1002,6 +1030,14 @@
   ::
       %unsafe
     ?+  p.cage.rail  ~|(bad-poke+mark !!)
+        %search-action-1
+      ::  %search asking us to resubmit everything we hold. it sends the
+      ::  whole action type; %rebuild is the only variant meant for us.
+      ?>  =(our src):bowl
+      =+  !<(act=action:v1:se q.cage.rail)
+      ?.  ?=(%rebuild -.act)  cor
+      search-rebuild
+    ::
         %channel-migration
       ?>  =(our src):bowl
       =+  !<(new-channels=v-channels:c q.cage.rail)
@@ -1754,6 +1790,113 @@
   ++  ca-sub-wire  (weld ca-area /updates)
   ++  ca-give-unread
     (give %fact ~[/unreads /v0/unreads /v1/unreads] channel-unread-update+[nest ca-unread])
+  ::  +ca-entry: an index submission for one post or reply
+  ::
+  ::    .context is the channel slug; the target already carries the nest,
+  ::    so this only has to be good enough to label a result.
+  ::
+  ++  ca-entry
+    |=  $:  id=id-post:c
+            reply=(unit id-reply:c)
+            title=@t
+            =story:c
+            =author:c
+            sent=time
+        ==
+    ^-  entry:v1:se
+    :*  `target:v1:se`[%channel nest id reply]
+        title
+        name.nest
+        (flatten:utils story)
+        `?@(author author ship.author)
+        sent
+    ==
+  ::
+  ++  ca-title
+    |=  meta=(unit data:meta)
+    ^-  @t
+    ?~(meta '' title.u.meta)
+  ::  +ca-index: mirror a channel change into the search index
+  ::
+  ++  ca-index
+    |=  =r-channel:c
+    ^+  ca-core
+    ?.  search-running  ca-core
+    =/  acts=(list action:v1:se)  (ca-index-acts r-channel)
+    ?~  acts  ca-core
+    %-  emil
+    (turn acts |=(a=action:v1:se (unsafe:guard (submit:sh our.bowl a))))
+  ::  +ca-index-acts: which submissions a response implies
+  ::
+  ::    a tombstone retracts the document; anything else (re)indexes it.
+  ::    reacts and metadata changes carry no text, so they are ignored.
+  ::
+  ++  ca-index-acts
+    |=  =r-channel:c
+    ^-  (list action:v1:se)
+    ?+    r-channel  ~
+        [%post * %set *]
+      =*  m  post.r-post.r-channel
+      ?:  ?=(%| -.m)
+        ~[[%erase ~[`target:v1:se`[%channel nest id.r-channel ~]]]]
+      =*  p  +.m
+      ~[[%touch ~[(ca-entry id.p ~ (ca-title meta.p) content.p author.p sent.p)]]]
+    ::
+        [%post * %essay *]
+      =*  e  essay.r-post.r-channel
+      :_  ~
+      :-  %touch
+      ~[(ca-entry id.r-channel ~ (ca-title meta.e) content.e author.e sent.e)]
+    ::
+        [%post * %reply * * %set *]
+      =*  m  reply.r-reply.r-post.r-channel
+      =/  rid  id.r-post.r-channel
+      ?:  ?=(%| -.m)
+        ~[[%erase ~[`target:v1:se`[%channel nest id.r-channel `rid]]]]
+      =*  r  +.m
+      :_  ~
+      :-  %touch
+      ~[(ca-entry id.r-channel `rid '' content.r author.r sent.r)]
+    ::
+        [%posts *]
+      =/  pl  (tap:on-posts:c posts.r-channel)
+      =/  live=(list entry:v1:se)
+        %+  murn  pl
+        |=  [id=id-post:c m=(may:c post:c)]
+        ^-  (unit entry:v1:se)
+        ?:  ?=(%| -.m)  ~
+        =*  p  +.m
+        `(ca-entry id.p ~ (ca-title meta.p) content.p author.p sent.p)
+      =/  dead=(list target:v1:se)
+        %+  murn  pl
+        |=  [id=id-post:c m=(may:c post:c)]
+        ^-  (unit target:v1:se)
+        ?:(?=(%& -.m) ~ ``target:v1:se`[%channel nest id ~])
+      ;:  weld
+        ?~(live ~ ~[`action:v1:se`[%touch live]])
+        ?~(dead ~ ~[`action:v1:se`[%erase dead]])
+      ==
+    ==
+  ::  +ca-index-all: submit every post and reply in this channel
+  ::
+  ++  ca-index-all
+    ^+  ca-core
+    =/  entries=(list entry:v1:se)
+      %-  zing
+      %+  turn  (tap:on-v-posts:c posts.channel)
+      |=  [id=id-post:c m=(may:c v-post:c)]
+      ^-  (list entry:v1:se)
+      ?:  ?=(%| -.m)  ~
+      =*  p  +.m
+      :-  (ca-entry id.p ~ (ca-title meta.p) content.p author.p sent.p)
+      %+  murn  (tap:on-v-replies:c replies.p)
+      |=  [rid=id-reply:c mr=(may:c v-reply:c)]
+      ^-  (unit entry:v1:se)
+      ?:  ?=(%| -.mr)  ~
+      =*  r  +.mr
+      `(ca-entry id.p `id.r '' content.r author.r sent.r)
+    ?~  entries  ca-core
+    (emit (unsafe:guard (submit:sh our.bowl [%touch entries])))
   ::
   ++  ca-activity
     =,  v9:av
@@ -2704,6 +2847,10 @@
   ++  ca-response
     |=  =r-channel:c
     ~>  %spin.['ca-response']
+    ::  every content change funnels through here, so this is the one
+    ::  place the index has to be told about
+    ::
+    =.  ca-core  (ca-index r-channel)
     =/  r-channels-10=r-channels:v10:cv
       [nest r-channel]
     =.  ca-core

--- a/desk/app/chat.hoon
+++ b/desk/app/chat.hoon
@@ -1,5 +1,5 @@
 /-  c=chat, cv=chat-ver, d=channels, dv=channels-ver, g=groups
-/-  u=ui, e=epic, a=activity, av=activity-ver, s=story, meta
+/-  u=ui, e=epic, a=activity, av=activity-ver, s=story, meta, se=search
 /-  contacts
 /+  default-agent, verb, dbug,
     guard,
@@ -12,6 +12,7 @@
 /+  wood-lib=wood
 ::  performance, keep warm
 /+  chat-json
+/+  sh=search
 ::
 /*  desk-bill  %bill  /desk/bill  ::  keep warm
 ::
@@ -268,6 +269,119 @@
 ++  emil  |=(caz=(list card) cor(cards (welp (flop caz) cards)))
 ++  give  |=(=gift:guard (emit %give gift))
 ++  now-id   `id:c`[our now]:bowl
+::  +search-running: is the local index agent installed?
+::
+++  search-running  .^(? %gu (scry-path %search /$))
+::  +submit-search-list: hand %search references to what changed
+::
+::    the pokes name the changes and stop there; %search tokenizes and
+::    indexes them in a later event, so sending a message never pays for
+::    indexing.
+::
+::    %search-action-1 isn't in /lib/rail's mark table, so the poke rides
+::    out as an unsafe cage; it arrives at %search as an ordinary poke.
+::
+++  submit-search-list
+  |=  acts=(list action:v1:se)
+  ^+  cor
+  ?~  acts  cor
+  ?.  search-running  cor
+  %-  emil
+  %+  turn  acts
+  |=(a=action:v1:se (unsafe:guard (submit:sh our.bowl a)))
+::  +chat-entry: an index submission for one message or reply
+::
+++  chat-entry
+  |=  $:  =whom:c
+          id=id:c
+          reply=(unit id:c)
+          context=@t
+          =story:d
+          =author:c
+          sent=time
+      ==
+  ^-  entry:v1:se
+  :*  `target:v1:se`[%chat whom id reply]
+      ''
+      context
+      (flatten:utils story)
+      `?@(author author ship.author)
+      sent
+  ==
+::  +chat-index-acts: which submissions a writ response implies
+::
+::    reactions carry no text, so they produce nothing.
+::
+++  chat-index-acts
+  |=  [=whom:c context=@t =response:writs:c]
+  ^-  (list action:v1:se)
+  =*  id   id.response
+  =*  del  response.response
+  ?-    -.del
+      %add
+    =*  e  essay.del
+    ~[[%touch ~[(chat-entry whom id ~ context content.e author.e sent.e)]]]
+  ::
+      %del
+    ~[[%erase ~[`target:v1:se`[%chat whom id ~]]]]
+  ::
+      %reply
+    =*  rid  id.del
+    ?-    -.delta.del
+        %add
+      =*  re  reply-essay.delta.del
+      :_  ~
+      :-  %touch
+      ~[(chat-entry whom id `rid context content.re author.re sent.re)]
+    ::
+        %del
+      ~[[%erase ~[`target:v1:se`[%chat whom id `rid]]]]
+    ::
+        ?(%add-react %del-react)
+      ~
+    ==
+  ::
+      ?(%add-react %del-react)
+    ~
+  ==
+::  +submit-writs: submit every message and reply in one conversation
+::
+++  submit-writs
+  |=  [=whom:c context=@t =writs:c]
+  ^+  cor
+  =/  entries=(list entry:v1:se)
+    %-  zing
+    %+  turn  (tap:on:writs:c writs)
+    |=  [=time m=(may:c writ:c)]
+    ^-  (list entry:v1:se)
+    ?:  ?=(%| -.m)  ~
+    =*  w  +.m
+    :-  (chat-entry whom id.w ~ context content.w author.w sent.w)
+    %+  murn  (tap:on:replies:c replies.w)
+    |=  [rt=^time mr=(may:c reply:c)]
+    ^-  (unit entry:v1:se)
+    ?:  ?=(%| -.mr)  ~
+    =*  r  +.mr
+    `(chat-entry whom id.w `id.r context content.r author.r sent.r)
+  ?~  entries  cor
+  (submit-search-list ~[[%touch entries]])
+::  +search-rebuild: resubmit every message we hold
+::
+++  search-rebuild
+  ^+  cor
+  ?.  search-running  cor
+  =.  cor
+    =/  dl  ~(tap by dms)
+    |-  ^+  cor
+    ?~  dl  cor
+    =.  cor  (submit-writs [%ship p.i.dl] (scot %p p.i.dl) wit.pact.q.i.dl)
+    $(dl t.dl)
+  =/  cl  ~(tap by clubs)
+  |-  ^+  cor
+  ?~  cl  cor
+  =.  cor  (submit-writs [%club p.i.cl] title.met.crew.q.i.cl wit.pact.q.i.cl)
+  $(cl t.cl)
+::
 ++  scry-path
   |=  [agent=term =path]
   ~>  %spin.['scry-path']
@@ -821,6 +935,14 @@
         %chat-trim
       ?>  from-self
       trim:migrate
+    ::
+        %search-action-1
+      ::  %search asking us to resubmit everything we hold. it sends the
+      ::  whole action type; %rebuild is the only variant meant for us.
+      ?>  from-self
+      =+  !<(act=action:v1:se q.cage.rail)
+      ?.  ?=(%rebuild -.act)  cor
+      search-rebuild
     ==
   ?+    -.rail  ~|(bad-poke/-.rail !!)
       %chat-negotiate
@@ -2079,6 +2201,8 @@
     ?~  response
       =.  cor  (emit (tell-log %error ~['+diff-to-response miss (cu)'] ~))
       cu-core
+    =.  cor
+      (submit-search-list (chat-index-acts whom title.met.crew.club u.response))
     =/  old-response-3=[whom:v3:cv response:writs:v3:cv]
       :-  whom
       %-  v3:response-writs:v5:cc
@@ -2600,6 +2724,8 @@
     ?~  response
       =.  cor  (emit (tell-log %error ~['+diff-to-response miss (di)'] ~))
       di-core
+    =.  cor
+      (submit-search-list (chat-index-acts whom (scot %p ship) u.response))
     =/  old-response-3=[whom:v3:cv response:writs:v3:cv]
       :-  whom
       %-  v3:response-writs:v5:cc

--- a/desk/app/notes.hoon
+++ b/desk/app/notes.hoon
@@ -1,7 +1,8 @@
 ::  notes: shared notebook Gall agent (dual-mode host/subscriber)
 ::
-/-  n=notes, mcp-proxy, av=activity-ver
+/-  n=notes, mcp-proxy, av=activity-ver, se=search
 /+  default-agent, dbug, verb, server, logs, notes-json
+/+  sh=search
 ::  static web assets, imported straight from files and served as-is. The
 ::  agent sets each response's content-type explicitly (see below), so the
 ::  import marks only need to carry the raw bytes.
@@ -198,6 +199,14 @@
       ?>  (~(has by books) flag)
       se-abet:(se-poke-v1:(se-abed:se-core flag) rid c-notebook.cmd)
     ==
+  ::
+      %search-action-1
+    ::  %search asking us to resubmit everything we hold. it sends the
+    ::  whole action type; %rebuild is the only variant meant for us.
+    ?>  =(our.bowl src.bowl)
+    =+  !<(act=action:v1:se vase)
+    ?.  ?=(%rebuild -.act)  cor
+    search-rebuild
   ::
       %group-channel-join
     ::  channel-host convention: %groups auto-joins this notes nest as the
@@ -1189,6 +1198,81 @@
       %agent  [our.bowl %activity]
       %poke  activity-action-2+!>(action)
   ==
+::  +search-running: is the local index agent installed?
+::
+++  search-running
+  =/  base=path  /(scot %p our.bowl)/search/(scot %da now.bowl)
+  .^(? %gu (weld base /$))
+::
+++  submit-search
+  |=  =action:v1:se
+  ^+  cor
+  ?.  search-running  cor
+  (emit (submit:sh our.bowl action))
+::  +note-search: translate an applied u-note into an index submission.
+::
+::    the poke only names what changed; %search tokenizes it later on its
+::    own timer, so this costs the write event one card and nothing else.
+::
+++  note-search
+  |=  [=flag:n context=@t id=@ud upd=u-note:n]
+  ^+  cor
+  ?-  -.upd
+      ?(%created %updated)
+    %-  submit-search
+    :-  %touch
+    :_  ~
+    :*  `target:v1:se`[%note flag id]
+        title.note.upd
+        context
+        body-md.note.upd
+        `updated-by.note.upd
+        updated-at.note.upd
+    ==
+  ::
+      %deleted
+    (submit-search [%erase ~[`target:v1:se`[%note flag id]]])
+  ::
+      ?(%published %unpublished %history-archived)
+    cor
+  ==
+::  +notebook-search-gone: a notebook went away; drop its notes from the index
+::
+++  notebook-search-gone
+  |=  [=flag:n ids=(list @ud)]
+  ^+  cor
+  ?~  ids  cor
+  %-  submit-search
+  :-  %erase
+  %+  turn  ids
+  |=(id=@ud `target:v1:se`[%note flag id])
+::  +search-rebuild: resubmit every note we hold
+::
+::    one poke per notebook rather than one per note: %search drains its
+::    queue in small batches regardless, and this keeps the rebuild event
+::    itself down to a card per notebook.
+::
+++  search-rebuild
+  ^+  cor
+  ?.  search-running  cor
+  =/  bl  ~(tap by books)
+  |-  ^+  cor
+  ?~  bl  cor
+  =/  =flag:n  p.i.bl
+  =/  nbs=notebook-state:n  notebook-state.q.i.bl
+  =/  entries=(list entry:v1:se)
+    %+  turn  ~(val by notes.nbs)
+    |=  =note:n
+    ^-  entry:v1:se
+    :*  `target:v1:se`[%note flag id.note]
+        title.note
+        title.notebook.nbs
+        body-md.note
+        `updated-by.note
+        updated-at.note
+    ==
+  =?  cor  ?=(^ entries)  (submit-search [%touch entries])
+  $(bl t.bl)
 ::  +note-activity: translate an applied u-note into %activity actions.
 ::
 ::    %created / %updated -> (re)arm the trailing debounce timer; the
@@ -1746,6 +1830,8 @@
     ^+  cor
     =?  cor  gone
       (notebook-activity-gone flag group.notebook-state)
+    =?  cor  gone
+      (notebook-search-gone flag ~(tap in ~(key by notes.notebook-state)))
     =.  books
       ?:  gone
         (~(del by books) flag)
@@ -1772,6 +1858,8 @@
     =.  last-update  `[ts upd]
     =?  cor  ?=(%note -.upd)
       (note-activity flag group.notebook-state [id u-note]:upd)
+    =?  cor  ?=(%note -.upd)
+      (note-search flag title.notebook.notebook-state [id u-note]:upd)
     %-  give
     :+  %fact  ~[se-sub-path (weld se-area /stream)]
     notes-response+!>(`response:n`[%update flag [ts upd]])
@@ -2472,6 +2560,8 @@
     ^+  cor
     =?  cor  gone
       (notebook-activity-gone flag group.notebook-state)
+    =?  cor  gone
+      (notebook-search-gone flag ~(tap in ~(key by notes.notebook-state)))
     =.  books
       ?:  gone
         (~(del by books) flag)

--- a/desk/app/search.hoon
+++ b/desk/app/search.hoon
@@ -1,0 +1,277 @@
+::  search: global full-text index over this ship's content
+::
+::    %search owns one inverted index covering %channels, %chat and %notes.
+::    producing agents don't index anything themselves; when their content
+::    changes they submit a flat $entry naming the change and %search does
+::    the tokenizing and index work later, on its own timer.
+::
+::    that deferral is the point. indexing a message costs far more than
+::    writing it, and a chat event should not pay for it. +poke therefore
+::    does nothing but push onto .queue and arm a behn wake, so the work
+::    lands in a separate arvo event and the producing agent's event stays
+::    as cheap as it was before. +drain then handles a bounded batch per
+::    wake, re-arming while the queue is non-empty, so a large backfill is
+::    spread across many small events instead of one enormous one.
+::
+::    the index is local and covers only content this ship already holds,
+::    so there is no permission model here beyond refusing foreign pokes:
+::    everything indexed is something our own client could already read.
+::
+/-  se=search
+/+  sl=search, search-json
+/+  default-agent, verb, dbug
+|%
++$  card  card:agent:gall
+::
++$  state-0
+  $:  %0
+      =index:v1:se
+      queue=(qeu job:v1:se)
+      ::  .pending tracks queue depth; $qeu has no size arm and counting
+      ::  it per submission would be the one expensive thing on the hot path
+      ::
+      pending=@ud
+      armed=_|
+      last-indexed=@da
+  ==
++$  versioned-state  $%(state-0)
+--
+=|  state-0
+=*  state  -
+%-  agent:dbug
+%^  verb  |  %warn
+^-  agent:gall
+=<
+  |_  =bowl:gall
+  +*  this  .
+      def   ~(. (default-agent this %.n) bowl)
+      cor   ~(. +> [bowl ~])
+  ++  on-init
+    ^-  (quip card _this)
+    =^  cards  state  abet:init:cor
+    [cards this]
+  ++  on-save  !>(state)
+  ++  on-load
+    |=  ole=vase
+    ^-  (quip card _this)
+    =/  attempt  (mule |.(!<(versioned-state ole)))
+    ?:  ?=(%& -.attempt)
+      [~ this(state p.attempt)]
+    ::  an unreadable index is not worth a migration: it is entirely
+    ::  derived data, so drop it and rebuild from the producing agents
+    ::
+    %-  (slog 'search: unreadable state, rebuilding index' ~)
+    =^  cards  state  abet:init:cor
+    [cards this]
+  ++  on-poke
+    |=  [=mark =vase]
+    ^-  (quip card _this)
+    =^  cards  state  abet:(poke:cor mark vase)
+    [cards this]
+  ++  on-watch  |=(=path (on-watch:def path))
+  ++  on-leave  |=(path `this)
+  ++  on-peek   peek:cor
+  ++  on-agent
+    |=  [=wire =sign:agent:gall]
+    ^-  (quip card _this)
+    =^  cards  state  abet:(agent:cor wire sign)
+    [cards this]
+  ++  on-arvo
+    |=  [=wire sign=sign-arvo]
+    ^-  (quip card _this)
+    ?.  ?=([%behn %wake *] sign)
+      (on-arvo:def wire sign)
+    =^  cards  state  abet:(wake:cor wire error.sign)
+    [cards this]
+  ++  on-fail
+    |=  [=term =tang]
+    ^-  (quip card _this)
+    %-  (slog 'search: on-fail' >term< tang)
+    [~ this]
+  --
+|_  [=bowl:gall cards=(list card)]
+++  cor   .
+++  abet  [(flop cards) state]
+++  emit  |=(=card cor(cards [card cards]))
+::  +batch-size: jobs indexed per wake
+::
+::    small enough that one event stays short, large enough that a
+::    backfill of a busy ship doesn't take all day.
+::
+++  batch-size  64
+::  +queue-cap: refuse further submissions past this depth
+::
+::    the drain runs an event per batch, so it outpaces any realistic
+::    write rate; the cap only exists so a pathological producer can't
+::    grow state without bound.
+::
+++  queue-cap   50.000
+::
+++  sources
+  ^-  (set source:v1:se)
+  (silt `(list source:v1:se)`~[%channels %chat %notes])
+::  +init: index what already exists
+::
+::    deferred to a timer rather than done inline: at install time the
+::    producing agents may not have come up yet.
+::
+++  init
+  ^+  cor
+  (emit %pass /init %arvo %b %wait now.bowl)
+::
+++  poke
+  |=  [=mark =vase]
+  ^+  cor
+  ?>  =(src our):bowl
+  ?>  =(%search-action-1 mark)
+  =+  !<(=action:v1:se vase)
+  ?-  -.action
+      %touch
+    (enqueue (turn entries.action |=(e=entry:v1:se `job:v1:se`[%touch e])))
+  ::
+      %erase
+    (enqueue (turn targets.action |=(t=target:v1:se `job:v1:se`[%erase t])))
+  ::
+      %rebuild
+    (rebuild sources.action)
+  ::
+      %wipe
+    cor(index (~(purge dex:sl index) source.action))
+  ::
+      %reset
+    =.  index    *index:v1:se
+    =.  queue    *(qeu job:v1:se)
+    =.  pending  0
+    cor
+  ==
+::  +enqueue: accept work without doing any of it
+::
+++  enqueue
+  |=  jobs=(list job:v1:se)
+  ^+  cor
+  =.  cor
+    |-  ^+  cor
+    ?~  jobs  cor
+    ?:  (gte pending queue-cap)
+      =/  =tank
+        leaf+"search: queue at capacity, dropping {<(lent jobs)>} jobs"
+      ((slog tank ~) cor)
+    =.  queue    (~(put to queue) i.jobs)
+    =.  pending  +(pending)
+    $(jobs t.jobs)
+  arm
+::  +arm: schedule a drain, unless one is already scheduled
+::
+++  arm
+  ^+  cor
+  ?:  armed  cor
+  ?:  =(0 pending)  cor
+  =.  armed  &
+  (emit %pass /drain %arvo %b %wait now.bowl)
+::
+++  wake
+  |=  [=wire error=(unit tang)]
+  ^+  cor
+  ?^  error
+    ((slog leaf+"search: timer failed on {<wire>}" u.error) cor)
+  ?+    wire  cor
+      [%init ~]
+    (rebuild sources)
+  ::
+      [%drain ~]
+    =.  armed  |
+    =.  cor    (drain batch-size)
+    arm
+  ==
+::  +drain: index a bounded batch of queued jobs
+::
+++  drain
+  |=  n=@ud
+  ^+  cor
+  ?:  =(0 n)  cor
+  ::  guarded through a local: narrowing .queue in place would change the
+  ::  core's type and fight the +cor cast below
+  ::
+  =/  q  queue
+  ?~  q  cor
+  =^  =job:v1:se  queue  ~(get to q)
+  =.  pending       (dec pending)
+  =.  last-indexed  now.bowl
+  =.  index
+    ?-  -.job
+      %touch  (~(catalog dex:sl index) entry.job)
+      %erase  (~(erase dex:sl index) target.job)
+    ==
+  $(n (dec n))
+::  +rebuild: ask producers to resubmit everything they own
+::
+::    each source is purged first so content deleted while %search was
+::    down or absent doesn't survive as an orphaned result.
+::
+++  rebuild
+  |=  want=(set source:v1:se)
+  ^+  cor
+  =/  todo=(list source:v1:se)  ~(tap in (~(int in want) sources))
+  |-  ^+  cor
+  ?~  todo  cor
+  =/  dap=@tas  i.todo
+  ?.  .^(? %gu /(scot %p our.bowl)/[dap]/(scot %da now.bowl)/$)
+    $(todo t.todo)
+  =.  index  (~(purge dex:sl index) i.todo)
+  =.  cor
+    %-  emit
+    :*  %pass  /rebuild/[dap]
+        %agent  [our.bowl dap]
+        %poke   %search-action-1
+        !>(`action:v1:se`[%rebuild (silt `(list source:v1:se)`~[i.todo])])
+    ==
+  $(todo t.todo)
+::
+++  agent
+  |=  [=wire =sign:agent:gall]
+  ^+  cor
+  ?+  wire  cor
+      [%rebuild @ ~]
+    ?.  ?=(%poke-ack -.sign)  cor
+    ?~  p.sign  cor
+    ((slog leaf+"search: rebuild refused by %{(trip i.t.wire)}" u.p.sign) cor)
+  ==
+::
+++  peek
+  |=  =(pole knot)
+  ^-  (unit (unit cage))
+  ?+    pole  [~ ~]
+      [%x %v1 %hits skip=@ count=@ nedl=@ ~]
+    =/  =result:v1:se
+      %^  page  (needle nedl.pole)  ~
+      [(slav %ud skip.pole) (slav %ud count.pole)]
+    ``search-result-1+!>(result)
+  ::
+      [%x %v1 %hits %source src=?(%channels %chat %notes) skip=@ count=@ nedl=@ ~]
+    =/  =result:v1:se
+      %^  page  (needle nedl.pole)  `src.pole
+      [(slav %ud skip.pole) (slav %ud count.pole)]
+    ``search-result-1+!>(result)
+  ::
+      [%x %v1 %status ~]
+    =/  =status:v1:se
+      :*  ~(wyt by docs.index)
+          ~(wyt by terms.index)
+          pending
+          last-indexed
+      ==
+    ``search-status-1+!>(status)
+  ==
+::  +needle: a query term arrives either knot-encoded or bare
+::
+++  needle
+  |=  nedl=@t
+  ^-  @t
+  (fall (slaw %t nedl) nedl)
+::
+++  page
+  |=  [query=@t src=(unit source:v1:se) skip=@ud count=@ud]
+  ^-  result:v1:se
+  =/  hits=(list hit:v1:se)  (~(seek dex:sl index) query src)
+  [query (scag count (slag skip hits)) (lent hits) skip]
+--

--- a/desk/desk.bill
+++ b/desk/desk.bill
@@ -21,4 +21,5 @@
     %gateway-status
     %presence
     %steward
+    %search
 ==

--- a/desk/lib/search-json.hoon
+++ b/desk/lib/search-json.hoon
@@ -1,0 +1,162 @@
+::  search-json: json conversions for the %search agent
+::
+::    identity fields are spelled the way clients already spell them —
+::    "chat/~zod/general" for a nest, "~zod/notebook" for a notebook —
+::    so a result can be routed without re-deriving anything.
+::
+/-  sr=search
+/+  sl=search
+|%
+++  enjs
+  =,  enjs:format
+  |%
+  ++  nest
+    |=  n=nest:v1:sr
+    ^-  json
+    s+(rap 3 kind.n '/' (scot %p host.n) '/' name.n ~)
+  ::
+  ++  book
+    |=  b=book:v1:sr
+    ^-  json
+    s+(rap 3 (scot %p ship.b) '/' name.b ~)
+  ::
+  ++  whom
+    |=  w=whom:v1:sr
+    ^-  json
+    ?-  -.w
+      %ship  s+(scot %p p.w)
+      %club  s+(scot %uv p.w)
+    ==
+  ::
+  ++  mid
+    |=  m=mid:v1:sr
+    ^-  json
+    (pairs ~[['ship' s+(scot %p ship.m)] ['time' s+(scot %da time.m)]])
+  ::
+  ++  target
+    |=  t=target:v1:sr
+    ^-  json
+    ?-  -.t
+        %channel
+      %+  frond  'channel'
+      %-  pairs
+      :~  ['nest' (nest nest.t)]
+          ['post' s+(scot %da post.t)]
+          ['reply' ?~(reply.t ~ s+(scot %da u.reply.t))]
+      ==
+    ::
+        %chat
+      %+  frond  'chat'
+      %-  pairs
+      :~  ['whom' (whom whom.t)]
+          ['id' (mid id.t)]
+          ['reply' ?~(reply.t ~ (mid u.reply.t))]
+      ==
+    ::
+        %note
+      %+  frond  'note'
+      (pairs ~[['book' (book book.t)] ['id' (numb id.t)]])
+    ==
+  ::
+  ++  source
+    |=  s=source:v1:sr
+    ^-  json
+    s+s
+  ::
+  ++  doc
+    |=  d=doc:v1:sr
+    ^-  json
+    %-  pairs
+    :~  ['target' (target target.d)]
+        ['source' (source (owner:sl target.d))]
+        ['title' s+title.d]
+        ['context' s+context.d]
+        ['snippet' s+snippet.d]
+        ['author' ?~(author.d ~ s+(scot %p u.author.d))]
+        ['time' s+(scot %da time.d)]
+    ==
+  ::
+  ++  hit
+    |=  h=hit:v1:sr
+    ^-  json
+    (pairs ~[['doc' (doc doc.h)] ['score' (numb score.h)]])
+  ::
+  ++  result
+    |=  r=result:v1:sr
+    ^-  json
+    %-  pairs
+    :~  ['query' s+query.r]
+        ['hits' a+(turn hits.r hit)]
+        ['total' (numb total.r)]
+        ['skip' (numb skip.r)]
+    ==
+  ::
+  ++  status
+    |=  s=status:v1:sr
+    ^-  json
+    %-  pairs
+    :~  ['docs' (numb docs.s)]
+        ['keys' (numb keys.s)]
+        ['pending' (numb pending.s)]
+        ['lastIndexed' s+(scot %da last-indexed.s)]
+    ==
+  --
+::
+++  dejs
+  =,  dejs:format
+  |%
+  ++  ship-rule  ;~(pfix sig fed:ag)
+  ++  club-rule  (cook |=(@ `@uv`+<) ;~(pfix (jest '0v') viz:ag))
+  ::
+  ++  nest  `$-(json nest:v1:sr)`(su ;~((glue fas) sym ship-rule sym))
+  ++  book  `$-(json book:v1:sr)`(su ;~((glue fas) ship-rule sym))
+  ::
+  ++  whom
+    ^-  $-(json whom:v1:sr)
+    %-  su
+    ;~  pose
+      (stag %ship ship-rule)
+      (stag %club club-rule)
+    ==
+  ::
+  ++  mid
+    ^-  $-(json mid:v1:sr)
+    (ot ~[[%ship (se %p)] [%time (se %da)]])
+  ::
+  ++  target
+    ^-  $-(json target:v1:sr)
+    %-  of
+    :~  :-  %channel
+        (ot ~[[%nest nest] [%post (se %da)] [%reply (mu (se %da))]])
+        :-  %chat
+        (ot ~[[%whom whom] [%id mid] [%reply (mu mid)]])
+        :-  %note
+        (ot ~[[%book book] [%id ni]])
+    ==
+  ::
+  ++  entry
+    ^-  $-(json entry:v1:sr)
+    %-  ot
+    :~  [%target target]
+        [%title so]
+        [%context so]
+        [%text so]
+        [%author (mu (se %p))]
+        [%time (se %da)]
+    ==
+  ::
+  ++  source
+    ^-  $-(json source:v1:sr)
+    (su (perk %channels %chat %notes ~))
+  ::
+  ++  action
+    ^-  $-(json action:v1:sr)
+    %-  of
+    :~  [%touch (ot ~[[%entries (ar entry)]])]
+        [%erase (ot ~[[%targets (ar target)]])]
+        [%rebuild (ot ~[[%sources (as source)]])]
+        [%wipe (ot ~[[%source source]])]
+        [%reset ul]
+    ==
+  --
+--

--- a/desk/lib/search.hoon
+++ b/desk/lib/search.hoon
@@ -131,6 +131,16 @@
   |=  txt=@t
   ^-  @t
   (clip snippet-len txt)
+::  +parent-of: the post or message a reply hangs off, if this is one
+::
+++  parent-of
+  |=  =target:v1:se
+  ^-  (unit target:v1:se)
+  ?-  -.target
+    %channel  ?~(reply.target ~ `target(reply ~))
+    %chat     ?~(reply.target ~ `target(reply ~))
+    %note     ~
+  ==
 ::  +digest: a target's index key
 ::
 ++  digest
@@ -242,6 +252,8 @@
       ==
     =.  docs.ix   (~(put by docs.ix) tid doc)
     =.  trail.ix  (~(put by trail.ix) tid ks)
+    =/  par=(unit target:v1:se)  (parent-of target.entry)
+    =?  kids.ix  ?=(^ par)  (~(put ju kids.ix) (digest u.par) tid)
     =.  terms.ix
       =/  wl=(list [k=key:v1:se r=rank:v1:se])  ~(tap by weights)
       =/  ts  terms.ix
@@ -251,12 +263,32 @@
       $(wl t.wl, ts (~(put by ts) k.i.wl (~(put by ps) tid r.i.wl)))
     =.  grams.ix  (sow fresh)
     ix
+  ::  +retract: remove a document and every reply hanging off it
+  ::
+  ::    +strip alone is what a re-index wants — an edited message keeps
+  ::    its replies. a deletion wants this, so the replies don't survive
+  ::    as results pointing at a message that no longer exists.
+  ::
+  ++  retract
+    |=  =tid:v1:se
+    ^+  ix
+    =/  par=(unit tid:v1:se)
+      ?~  d=(~(get by docs.ix) tid)  ~
+      ?~  p=(parent-of target.u.d)  ~
+      `(digest u.p)
+    =/  children=(list tid:v1:se)  ~(tap in (~(get ju kids.ix) tid))
+    =.  ix       (strip tid)
+    =.  kids.ix  (~(del by kids.ix) tid)
+    =?  kids.ix  ?=(^ par)  (~(del ju kids.ix) u.par tid)
+    |-  ^+  ix
+    ?~  children  ix
+    $(children t.children, ix (retract i.children))
   ::  +erase: retract a document by target
   ::
   ++  erase
     |=  =target:v1:se
     ^+  ix
-    (strip (digest target))
+    (retract (digest target))
   ::  +purge: retract every document owned by one source
   ::
   ++  purge
@@ -269,7 +301,7 @@
       ?.(=(source (owner target.doc)) ~ `tid)
     |-  ^+  ix
     ?~  tl  ix
-    $(tl t.tl, ix (strip i.tl))
+    $(tl t.tl, ix (retract i.tl))
   ::  +nearby: stored terms sharing enough trigrams with .term
   ::
   ++  nearby

--- a/desk/lib/search.hoon
+++ b/desk/lib/search.hoon
@@ -1,0 +1,400 @@
+::  search: tokenizer and inverted-index core for the %search agent
+::
+::    the index is a plain inverted map from normalized term to the
+::    documents containing it, with a trigram side-index that supplies
+::    prefix and typo tolerance. it holds no document text beyond a
+::    display snippet, so it stays a fraction of the size of the corpus
+::    it covers.
+::
+::    scoring is deliberately simple: a term's weight in a document comes
+::    from where it appeared (title beats body) and how often, a match's
+::    contribution comes from how it matched (exact beats substring beats
+::    trigram-only), and a document that matches more of the query's
+::    distinct terms always outranks one that matches fewer.
+::
+/-  se=search
+|%
++$  card  card:agent:gall
+::  weights: a term's worth inside a document
+::
+++  rank-title  8
+++  rank-body   2
+::  .rank-cap bounds repetition, so a word repeated 500 times in one
+::  message can't outweigh every other document
+::
+++  rank-cap    64
+::  weights: how much a match is worth, by how it matched
+::
+++  weight-exact  4
+++  weight-part   2
+++  weight-fuzzy  1
+::  matching more of the query's distinct terms always wins, whatever the
+::  per-term weights add up to
+::
+++  term-bonus   10.000
+::  bounds on work done per query term and per stored term
+::
+++  fuzzy-cap    32
+++  max-term     32
+++  snippet-len  256
+::  +owner: which agent owns a target
+::
+++  owner
+  |=  =target:v1:se
+  ^-  source:v1:se
+  ?-  -.target
+    %channel  %channels
+    %chat     %chat
+    %note     %notes
+  ==
+::  +word-char: does this byte continue a word?
+::
+::    bytes at or above 128 are utf-8 continuation or lead bytes; we keep
+::    them so non-latin text survives tokenization as whole runs, which
+::    the trigram index can still match into.
+::
+++  word-char
+  |=  c=@
+  ^-  ?
+  ?|  &((gte c 'a') (lte c 'z'))
+      &((gte c 'A') (lte c 'Z'))
+      &((gte c '0') (lte c '9'))
+      =(c '-')
+      =(c '_')
+      =(c '\'')
+      (gte c 128)
+  ==
+::  +tokens: split text into normalized terms, in order, stopwords dropped
+::
+++  tokens
+  |=  txt=@t
+  ^-  (list key:v1:se)
+  =/  cs=tape  (cass (trip txt))
+  =|  cur=tape
+  =|  out=(list @t)
+  |-  ^-  (list @t)
+  ?~  cs
+    (flop (close cur out))
+  ?:  (word-char i.cs)
+    $(cs t.cs, cur [i.cs cur])
+  $(cs t.cs, cur ~, out (close cur out))
+::  +close: finish the term being accumulated, if it is worth keeping
+::
+++  close
+  |=  [cur=tape out=(list @t)]
+  ^-  (list @t)
+  ?~  cur  out
+  =/  term=@t  (crip (scag max-term (flop cur)))
+  ?:  (~(has in stopwords) term)  out
+  [term out]
+::  +grams: a term's ordered trigrams
+::
+::    terms under three bytes have none; they are still reachable by
+::    exact match, they just don't participate in fuzzy matching.
+::
+++  grams
+  |=  term=@t
+  ^-  (list gram:v1:se)
+  =/  t=tape  (trip term)
+  =/  len  (lent t)
+  ?:  (lth len 3)  ~
+  %+  turn  (gulf 0 (sub len 3))
+  |=(i=@ud (crip (swag [i 3] t)))
+::  +contains: is .nedl a substring of .hay?
+::
+++  contains
+  |=  [nedl=@t hay=@t]
+  ^-  ?
+  !=(~ (find (trip nedl) (trip hay)))
+::  +clip: truncate to .len bytes without splitting a utf-8 sequence
+::
+++  clip
+  |=  [len=@ud txt=@t]
+  ^-  @t
+  =/  t=tape  (trip txt)
+  ?:  (lte (lent t) len)  txt
+  =/  cut=@ud
+    =|  i=@ud
+    |-  ^-  @ud
+    ?~  t  i
+    =/  wid=@ud
+      ?:  (lth i.t 128)  1
+      ?:  (lth i.t 224)  2
+      ?:  (lth i.t 240)  3
+      4
+    ?:  (gth (add i wid) len)  i
+    $(i (add i wid), t (slag (dec wid) t.t))
+  (crip (scag cut (trip txt)))
+::  +snippet: the stored display slice of a document body
+::
+++  snippet
+  |=  txt=@t
+  ^-  @t
+  (clip snippet-len txt)
+::  +digest: a target's index key
+::
+++  digest
+  |=  =target:v1:se
+  ^-  tid:v1:se
+  (shaf %sear (jam target))
+::  +dex: index operations
+::
+++  dex
+  |_  ix=index:v1:se
+  ::  +strip: retract a document and every posting that points at it
+  ::
+  ++  strip
+    |=  =tid:v1:se
+    ^+  ix
+    ?~  ks=(~(get by trail.ix) tid)
+      ix(docs (~(del by docs.ix) tid))
+    ::  a term whose last posting just went away is dropped outright, and
+    ::  its trigrams with it, so vocabulary doesn't leak as content churns
+    ::
+    =/  res
+      =/  kl=(list key:v1:se)  ~(tap in u.ks)
+      =/  ts=(map key:v1:se postings:v1:se)  terms.ix
+      =/  dead=(set key:v1:se)  ~
+      |-  ^-  [(map key:v1:se postings:v1:se) (set key:v1:se)]
+      ?~  kl  [ts dead]
+      ?~  ps=(~(get by ts) i.kl)  $(kl t.kl)
+      =/  rest=postings:v1:se  (~(del by u.ps) tid)
+      ?~  rest
+        $(kl t.kl, ts (~(del by ts) i.kl), dead (~(put in dead) i.kl))
+      $(kl t.kl, ts (~(put by ts) i.kl rest))
+    =.  terms.ix  -.res
+    =.  grams.ix  (shed +.res)
+    =.  trail.ix  (~(del by trail.ix) tid)
+    =.  docs.ix   (~(del by docs.ix) tid)
+    ix
+  ::  +shed: drop trigram entries for terms that no longer exist
+  ::
+  ++  shed
+    |=  dead=(set key:v1:se)
+    ^-  (jug gram:v1:se key:v1:se)
+    =/  kl=(list key:v1:se)  ~(tap in dead)
+    =/  gg  grams.ix
+    |-  ^-  (jug gram:v1:se key:v1:se)
+    ?~  kl  gg
+    =/  gs=(list gram:v1:se)  (grams i.kl)
+    =.  gg
+      |-  ^-  (jug gram:v1:se key:v1:se)
+      ?~  gs  gg
+      =/  s=(set key:v1:se)  (~(del in (~(get ju gg) i.gs)) i.kl)
+      ?~  s  $(gs t.gs, gg (~(del by gg) i.gs))
+      $(gs t.gs, gg (~(put by gg) i.gs s))
+    $(kl t.kl)
+  ::  +sow: add trigram entries for newly seen terms
+  ::
+  ++  sow
+    |=  fresh=(set key:v1:se)
+    ^-  (jug gram:v1:se key:v1:se)
+    =/  kl=(list key:v1:se)  ~(tap in fresh)
+    =/  gg  grams.ix
+    |-  ^-  (jug gram:v1:se key:v1:se)
+    ?~  kl  gg
+    =/  gs=(list gram:v1:se)  (grams i.kl)
+    =.  gg
+      |-  ^-  (jug gram:v1:se key:v1:se)
+      ?~  gs  gg
+      $(gs t.gs, gg (~(put ju gg) i.gs i.kl))
+    $(kl t.kl)
+  ::  +weigh: a document's per-term weights
+  ::
+  ++  weigh
+    |=  [title=@t text=@t]
+    ^-  (map key:v1:se rank:v1:se)
+    =/  out  (tally ~ (tokens title) rank-title)
+    (tally out (tokens text) rank-body)
+  ::
+  ++  tally
+    |=  [out=(map key:v1:se rank:v1:se) ks=(list key:v1:se) w=rank:v1:se]
+    ^-  (map key:v1:se rank:v1:se)
+    |-
+    ?~  ks  out
+    =/  cur  (~(gut by out) i.ks 0)
+    =/  new  ?:((gte cur rank-cap) cur (add cur w))
+    $(ks t.ks, out (~(put by out) i.ks new))
+  ::  +catalog: index a document, replacing any earlier version of it
+  ::
+  ::    a document with no indexable terms (only stopwords, punctuation or
+  ::    emoji) is retracted rather than stored: nothing could ever match it.
+  ::
+  ++  catalog
+    |=  =entry:v1:se
+    ^+  ix
+    =/  =tid:v1:se  (digest target.entry)
+    =.  ix  (strip tid)
+    =/  weights  (weigh title.entry text.entry)
+    ?:  =(~ weights)  ix
+    =/  ks=(set key:v1:se)  ~(key by weights)
+    =/  fresh=(set key:v1:se)
+      %-  silt
+      %+  skim  ~(tap in ks)
+      |=(k=key:v1:se !(~(has by terms.ix) k))
+    =/  =doc:v1:se
+      :*  target.entry
+          title.entry
+          context.entry
+          (snippet text.entry)
+          author.entry
+          time.entry
+      ==
+    =.  docs.ix   (~(put by docs.ix) tid doc)
+    =.  trail.ix  (~(put by trail.ix) tid ks)
+    =.  terms.ix
+      =/  wl=(list [k=key:v1:se r=rank:v1:se])  ~(tap by weights)
+      =/  ts  terms.ix
+      |-  ^-  (map key:v1:se postings:v1:se)
+      ?~  wl  ts
+      =/  ps=postings:v1:se  (~(gut by ts) k.i.wl ~)
+      $(wl t.wl, ts (~(put by ts) k.i.wl (~(put by ps) tid r.i.wl)))
+    =.  grams.ix  (sow fresh)
+    ix
+  ::  +erase: retract a document by target
+  ::
+  ++  erase
+    |=  =target:v1:se
+    ^+  ix
+    (strip (digest target))
+  ::  +purge: retract every document owned by one source
+  ::
+  ++  purge
+    |=  =source:v1:se
+    ^+  ix
+    =/  tl=(list tid:v1:se)
+      %+  murn  ~(tap by docs.ix)
+      |=  [=tid:v1:se =doc:v1:se]
+      ^-  (unit tid:v1:se)
+      ?.(=(source (owner target.doc)) ~ `tid)
+    |-  ^+  ix
+    ?~  tl  ix
+    $(tl t.tl, ix (strip i.tl))
+  ::  +nearby: stored terms sharing enough trigrams with .term
+  ::
+  ++  nearby
+    |=  term=key:v1:se
+    ^-  (list key:v1:se)
+    =/  gs=(list gram:v1:se)  (grams term)
+    =/  total  (lent gs)
+    ?:  =(0 total)  ~
+    =/  counts=(map key:v1:se @ud)
+      =/  counts=(map key:v1:se @ud)  ~
+      |-  ^+  counts
+      ?~  gs  counts
+      =/  ks=(list key:v1:se)  ~(tap in (~(get ju grams.ix) i.gs))
+      =.  counts
+        |-  ^+  counts
+        ?~  ks  counts
+        $(ks t.ks, counts (~(put by counts) i.ks +((~(gut by counts) i.ks 0))))
+      $(gs t.gs)
+    ::  a 60% trigram overlap keeps "chanel" reaching "channel" without
+    ::  dragging in every term that happens to share one slice
+    ::
+    =/  kept=(list [k=key:v1:se n=@ud])
+      %+  skim  ~(tap by counts)
+      |=  [k=key:v1:se n=@ud]
+      &(!=(k term) (gte (mul 10 n) (mul 6 total)))
+    %+  scag  fuzzy-cap
+    %+  turn
+      %+  sort  kept
+      |=([a=[k=key:v1:se n=@ud] b=[k=key:v1:se n=@ud]] (gth n.a n.b))
+    |=([k=key:v1:se n=@ud] k)
+  ::  +candidates: per-document score contribution for one query term
+  ::
+  ++  candidates
+    |=  term=key:v1:se
+    ^-  (map tid:v1:se @ud)
+    =/  out=(map tid:v1:se @ud)
+      %-  ~(run by (~(gut by terms.ix) term ~))
+      |=(r=rank:v1:se (mul r weight-exact))
+    =/  near=(list key:v1:se)  (nearby term)
+    |-  ^-  (map tid:v1:se @ud)
+    ?~  near  out
+    =/  w=@ud  ?:((contains term i.near) weight-part weight-fuzzy)
+    =/  pl=(list [p=tid:v1:se q=rank:v1:se])
+      ~(tap by (~(gut by terms.ix) i.near ~))
+    =.  out
+      |-  ^-  (map tid:v1:se @ud)
+      ?~  pl  out
+      =/  cur  (~(gut by out) p.i.pl 0)
+      $(pl t.pl, out (~(put by out) p.i.pl (max cur (mul q.i.pl w))))
+    $(near t.near)
+  ::  +seek: score every document matching .query
+  ::
+  ::    results are ranked by how many of the query's distinct terms the
+  ::    document matched, then by score, then by recency.
+  ::
+  ++  seek
+    |=  [query=@t src=(unit source:v1:se)]
+    ^-  (list hit:v1:se)
+    =/  qs=(list key:v1:se)  ~(tap in (silt (tokens query)))
+    =/  acc=(map tid:v1:se [hits=@ud score=@ud])
+      =/  acc=(map tid:v1:se [hits=@ud score=@ud])  ~
+      |-  ^+  acc
+      ?~  qs  acc
+      =/  cl=(list [p=tid:v1:se q=@ud])  ~(tap by (candidates i.qs))
+      =.  acc
+        |-  ^+  acc
+        ?~  cl  acc
+        =/  cur=[hits=@ud score=@ud]  (~(gut by acc) p.i.cl [0 0])
+        %=  $
+          cl   t.cl
+          acc  (~(put by acc) p.i.cl [+(hits.cur) (add score.cur q.i.cl)])
+        ==
+      $(qs t.qs)
+    =/  hits=(list hit:v1:se)
+      %+  murn  ~(tap by acc)
+      |=  [=tid:v1:se v=[hits=@ud score=@ud]]
+      ^-  (unit hit:v1:se)
+      ?~  d=(~(get by docs.ix) tid)  ~
+      =/  wanted=?
+        ?~  src  &
+        =(u.src (owner target.u.d))
+      ?.  wanted  ~
+      `[u.d (add (mul hits.v term-bonus) score.v)]
+    %+  sort  hits
+    |=  [a=hit:v1:se b=hit:v1:se]
+    ?.  =(score.a score.b)  (gth score.a score.b)
+    (gth time.doc.a time.doc.b)
+  --
+::  producer helpers
+::
+::    +running lets a producing agent stay quiet on ships where %search
+::    isn't installed, the same way they guard their %activity pokes.
+::
+++  running
+  |=  [our=ship now=@da]
+  ^-  ?
+  .^(? %gu /(scot %p our)/search/(scot %da now)/$)
+::
+++  submit
+  |=  [our=ship =action:v1:se]
+  ^-  card
+  [%pass /search/submit %agent [our %search] %poke %search-action-1 !>(action)]
+::
+::  +stopwords: terms too common to be worth an inverted-index posting
+::
+::    kept as one space-separated cord rather than a list literal purely
+::    for legibility; +tokens consults this once per word, so the parse
+::    is memoized rather than re-run on every lookup.
+::
+++  stopwords
+  ~+
+  ^-  (set @t)
+  %-  silt
+  %+  rash
+    ^-  @t
+    %-  crip
+    ;:  weld
+      "a about after again all also am an and any are as at be been "
+      "being both but by can could did do does doing don't down each "
+      "for from had has have he her here hers him his how i if in into "
+      "is it it's its just me more most my no nor not of off ok on once "
+      "only or other ought our ours out over own same she should so "
+      "some such than that the their them then there these they this "
+      "those to too under until up very was we were what when where "
+      "which while who whom why will with would yes yet you your yours"
+    ==
+  (more ace (cook crip (plus ;~(less ace prn))))
+--

--- a/desk/mar/search/action-1.hoon
+++ b/desk/mar/search/action-1.hoon
@@ -1,0 +1,59 @@
+::  search-action-1: mark for %search inbound actions
+::
+::    also the mark producing agents accept, so %search can ask them to
+::    resubmit their content with a %rebuild.
+::
+/-  se=search
+/+  sj=search-json
+|_  =action:v1:se
+++  grad  %noun
+++  grow
+  |%
+  ++  noun  action
+  ++  json
+    =,  enjs:format
+    ^-  ^json
+    ?-  -.action
+        %touch
+      %+  frond  'touch'
+      %-  pairs
+      :~  :-  'entries'
+          :-  %a
+          %+  turn  entries.action
+          |=  e=entry:v1:se
+          ^-  ^json
+          %-  pairs
+          :~  ['target' (target:enjs:sj target.e)]
+              ['title' s+title.e]
+              ['context' s+context.e]
+              ['text' s+text.e]
+              ['author' ?~(author.e ~ s+(scot %p u.author.e))]
+              ['time' s+(scot %da time.e)]
+          ==
+      ==
+    ::
+        %erase
+      %+  frond  'erase'
+      %-  pairs
+      :~  ['targets' a+(turn targets.action target:enjs:sj)]
+      ==
+    ::
+        %rebuild
+      %+  frond  'rebuild'
+      %-  pairs
+      :~  ['sources' a+(turn ~(tap in sources.action) source:enjs:sj)]
+      ==
+    ::
+        %wipe
+      (frond 'wipe' (pairs ~[['source' (source:enjs:sj source.action)]]))
+    ::
+        %reset
+      (frond 'reset' ~)
+    ==
+  --
+++  grab
+  |%
+  ++  noun  action:v1:se
+  ++  json  action:dejs:sj
+  --
+--

--- a/desk/mar/search/result-1.hoon
+++ b/desk/mar/search/result-1.hoon
@@ -1,0 +1,16 @@
+::  search-result-1: mark for a page of %search results
+::
+/-  se=search
+/+  sj=search-json
+|_  =result:v1:se
+++  grad  %noun
+++  grow
+  |%
+  ++  noun  result
+  ++  json  (result:enjs:sj result)
+  --
+++  grab
+  |%
+  ++  noun  result:v1:se
+  --
+--

--- a/desk/mar/search/status-1.hoon
+++ b/desk/mar/search/status-1.hoon
@@ -1,0 +1,16 @@
+::  search-status-1: mark for %search index health
+::
+/-  se=search
+/+  sj=search-json
+|_  =status:v1:se
+++  grad  %noun
+++  grow
+  |%
+  ++  noun  status
+  ++  json  (status:enjs:sj status)
+  --
+++  grab
+  |%
+  ++  noun  status:v1:se
+  --
+--

--- a/desk/sur/search.hoon
+++ b/desk/sur/search.hoon
@@ -1,0 +1,136 @@
+::  search: shared types for the global full-text index
+::
+::    %search keeps one inverted index over content owned by other agents
+::    in this desk. producing agents (%channels, %chat, %notes) never hand
+::    over their own data structures — they submit flat $entry records and
+::    identify content with a $target built only from stable identity
+::    fields. that keeps the index decoupled from the heavily-versioned
+::    content types those agents pass over the network.
+::
+|%
+::  $source: the agent that owns a document
+::
++$  source  ?(%channels %chat %notes)
+::  identity fields, structurally identical to their owners' types
+::
+::    they are restated here rather than imported so a kelvin bump in
+::    $nest:channels or $whom:chat can't force an index migration. the
+::    owners' types nest under these, so producers pass theirs directly.
+::
++$  nest  [kind=@tas host=ship name=@tas]
++$  whom  $%([%ship p=ship] [%club p=@uvH])
++$  book  [=ship name=@tas]
++$  mid   [=ship =time]
+::  $target: a pointer to one indexed document
+::
+::    .reply is the reply's own id when the document is a reply; the
+::    post/message id stays in the parent field so a client can route to
+::    the thread either way.
+::
++$  target
+  $%  [%channel =nest post=@da reply=(unit @da)]
+      [%chat =whom id=mid reply=(unit mid)]
+      [%note =book id=@ud]
+  ==
+::  $tid: target digest, the index's internal document key
+::
++$  tid  @uvH
+::  $key: a normalized search term
+::
++$  key  @t
+::  $gram: a three-character slice of a $key
+::
++$  gram  @t
+::  $rank: a term's weight within one document
+::
++$  rank  @ud
+::  $doc: what the index retains about a document
+::
+::    the index stores no full text. .snippet is a leading slice kept for
+::    result display; clients resolve .target against the owning agent
+::    for anything richer.
+::
++$  doc
+  $:  =target
+      title=@t
+      context=@t
+      snippet=@t
+      author=(unit ship)
+      time=@da
+  ==
+::  $entry: an indexing submission from a producing agent
+::
+::    .title is the document's own headline — a note's or diary post's
+::    title, empty for a chat message — and is indexed at high weight.
+::    .context is the container it lives in (channel, notebook, dm) and is
+::    kept for display only: indexing it would make every message in a
+::    channel called "design" a strong match for "design".
+::
+::    .text is the flattened body. producers flatten their own content so
+::    %search never learns their content formats.
+::
++$  entry
+  $:  =target
+      title=@t
+      context=@t
+      text=@t
+      author=(unit ship)
+      time=@da
+  ==
+::  $postings: documents containing a term, and that term's weight in each
+::
++$  postings  (map tid rank)
+::  $index: the inverted index
+::
+::    .terms  term -> documents containing it
+::    .grams  trigram -> terms containing it, for fuzzy and prefix matching
+::    .trail  document -> its terms, so a document can be fully retracted
+::    .docs   document -> its stored record
+::
++$  index
+  $:  terms=(map key postings)
+      grams=(jug gram key)
+      trail=(map tid (set key))
+      docs=(map tid doc)
+  ==
+::  $job: one queued unit of deferred index work
+::
++$  job
+  $%  [%touch =entry]
+      [%erase =target]
+  ==
+::  $action: inbound poke protocol
+::
+::    %touch and %erase are the hot path and do no work beyond queueing.
+::    %rebuild asks producers to resubmit everything they own; %wipe drops
+::    one source's documents; %reset empties the index.
+::
++$  action
+  $%  [%touch entries=(list entry)]
+      [%erase targets=(list target)]
+      [%rebuild sources=(set source)]
+      [%wipe =source]
+      [%reset ~]
+  ==
+::  $hit: a scored result
+::
++$  hit  [=doc score=@ud]
+::  $result: a page of results
+::
++$  result
+  $:  query=@t
+      hits=(list hit)
+      total=@ud
+      skip=@ud
+  ==
+::  $status: index health, for clients and debugging
+::
++$  status
+  $:  docs=@ud
+      keys=@ud
+      pending=@ud
+      last-indexed=@da
+  ==
+::
+++  v1  .
+--

--- a/desk/sur/search.hoon
+++ b/desk/sur/search.hoon
@@ -86,12 +86,16 @@
 ::    .grams  trigram -> terms containing it, for fuzzy and prefix matching
 ::    .trail  document -> its terms, so a document can be fully retracted
 ::    .docs   document -> its stored record
+::    .kids   post/message -> its replies, which are documents in their own
+::            right; deleting the parent has to take them with it, or a
+::            delete leaves results pointing at nothing
 ::
 +$  index
   $:  terms=(map key postings)
       grams=(jug gram key)
       trail=(map tid (set key))
       docs=(map tid doc)
+      kids=(jug tid tid)
   ==
 ::  $job: one queued unit of deferred index work
 ::

--- a/desk/tests/app/channels.hoon
+++ b/desk/tests/app/channels.hoon
@@ -32,6 +32,7 @@
   |=  =(pole knot)
   ?+  pole  ~|(`path`pole !!)
     [%gu ship=@t %activity @ ~ ~]  `!>(|)
+    [%gu ship=@t %search @ ~ ~]  `!>(|)
     [%gx @ %groups @ %v2 %groups host=@ term=@ %noun ~]  `!>(*group:v9:gv)
   ==
 ::

--- a/desk/tests/app/chat.hoon
+++ b/desk/tests/app/chat.hoon
@@ -74,6 +74,7 @@
   ^-  (unit vase)
   ?+    path  ~
     [%gu @ %activity @ %$ ~]         `!>(&)
+    [%gu @ %search @ %$ ~]           `!>(|)
     [%gu @ %groups @ *]           `!>(&)
     [%gx @ %groups @ %volume *]   `!>(%soft)
   ::

--- a/desk/tests/app/notes.hoon
+++ b/desk/tests/app/notes.hoon
@@ -306,6 +306,8 @@
   |=  pax=path
   ?:  ?=([%gu @ %activity @ %$ ~] pax)
     `!>(|)
+  ?:  ?=([%gu @ %search @ %$ ~] pax)
+    `!>(|)
   ~
 ::  +activity-scry: %activity is running; used by activity-submission tests.
 ::
@@ -314,6 +316,8 @@
   |=  pax=path
   ?:  ?=([%gu @ %activity @ %$ ~] pax)
     `!>(&)
+  ?:  ?=([%gu @ %search @ %$ ~] pax)
+    `!>(|)
   ~
 ::  +nb-flag: flag for notebook with title+nid under ship who
 ::  Applies the same slug algorithm as ++slugify in app/notes.hoon.
@@ -625,12 +629,14 @@
   =/  can-read-allow=scry
     |=  pax=path
     ?:  ?=([%gu @ %activity @ %$ ~] pax)  `!>(|)
+    ?:  ?=([%gu @ %search @ %$ ~] pax)  `!>(|)
     ?.  ?=([%gx @ %groups @ %v2 %groups @ @ %channels %can-read %noun ~] pax)  ~
     `!>(|=([who=ship =nest:n] =(who ~bus)))
   ::  revoked: can-read denies everyone (host self-shortcuts in group-can-read).
   =/  can-read-deny=scry
     |=  pax=path
     ?:  ?=([%gu @ %activity @ %$ ~] pax)  `!>(|)
+    ?:  ?=([%gu @ %search @ %$ ~] pax)  `!>(|)
     ?.  ?=([%gx @ %groups @ %v2 %groups @ @ %channels %can-read %noun ~] pax)  ~
     `!>(|=([who=ship =nest:n] |))
   ;<  ~  b  init-zod
@@ -2882,6 +2888,8 @@
   |=  pax=path
   ?:  ?=([%gu @ %groups @ %groups @ @ ~] pax)
     `!>(synced)
+  ?:  ?=([%gu @ %search @ %$ ~] pax)
+    `!>(|)
   ?.  ?=([%gx @ %groups @ %v2 %groups @ @ %channels %can-read %noun ~] pax)
     ~
   `!>(|=([who=ship =nest:n] allowed))

--- a/desk/tests/app/search.hoon
+++ b/desk/tests/app/search.hoon
@@ -1,0 +1,191 @@
+::  tests for the %search agent
+::
+::    the agent's contract is that submitting work is cheap and doing it
+::    is deferred: a %touch must produce a timer and nothing else, and the
+::    index must only change once that timer fires.
+::
+/-  se=search
+/+  sl=search
+/+  *test-agent
+/=  agent  /app/search
+|%
+++  dap  %search
+++  sid  ~sidwyn-nimnev-nocsyx-lassul
+::
+++  bt
+  |=  id=@ud
+  ^-  target:v1:se
+  [%note [sid %notebook] id]
+::
+++  ent
+  |=  [id=@ud title=@t text=@t]
+  ^-  entry:v1:se
+  [(bt id) title 'Notebook' text `sid ~2026.1.1]
+::
+++  act
+  |=  =action:v1:se
+  ^-  cage
+  search-action-1+!>(action)
+::  +producers-up: the agents %search backfills from are all running
+::
+++  producers-up
+  ^-  scry
+  |=  pax=path
+  ?:(?=([%gu @ @ @ %$ ~] pax) `!>(&) ~)
+::  +setup: init, then swallow the /init rebuild timer +on-init arms
+::
+++  setup
+  =/  m  (mare ,~)
+  ^-  form:m
+  ;<  ~  bind:m  (jab-bowl |=(b=bowl b(our sid, src sid)))
+  ;<  *  bind:m  (do-init dap agent)
+  ;<  ~  bind:m  (set-scry-gate producers-up)
+  ;<  ~  bind:m  (jab-bowl |=(b=bowl b(now ~2026.1.1)))
+  (pure:m ~)
+::  +hits: query the agent's own scry surface
+::
+++  hits
+  |=  query=@t
+  =/  m  (mare ,(list @ud))
+  ^-  form:m
+  ;<  =cage  bind:m  (got-peek /x/v1/hits/0/50/[query])
+  =+  !<(=result:v1:se q.cage)
+  %-  pure:m
+  %+  turn  hits.result
+  |=  h=hit:v1:se
+  ?>(?=([%note *] target.doc.h) id.target.doc.h)
+::
+++  docs-indexed
+  =/  m  (mare ,@ud)
+  ^-  form:m
+  ;<  =cage  bind:m  (got-peek /x/v1/status)
+  =+  !<(=status:v1:se q.cage)
+  (pure:m docs.status)
+::
+::  on-init must not index anything inline — it defers the backfill to a
+::  timer so the producing agents have come up by the time we ask them
+::
+++  test-init-defers-rebuild
+  %-  eval-mare
+  =/  m  (mare ,~)
+  ^-  form:m
+  ;<  ~  bind:m  (jab-bowl |=(b=bowl b(our sid, src sid)))
+  ;<  caz=(list card)  bind:m  (do-init dap agent)
+  ;<  b=bowl  bind:m  get-bowl
+  (ex-cards caz ~[(ex-arvo /init [%b %wait now.b])])
+::
+::  the whole point of the agent: a submission costs one timer and leaves
+::  the index untouched until that timer fires
+::
+++  test-touch-defers-indexing
+  %-  eval-mare
+  =/  m  (mare ,~)
+  ^-  form:m
+  ;<  ~  bind:m  setup
+  ;<  caz=(list card)  bind:m
+    (do-poke (act [%touch ~[(ent 1 'Freeze plan' 'verify the sunrise order')]]))
+  ;<  ~  bind:m  (ex-cards caz ~[(ex-arvo /drain [%b %wait ~2026.1.1])])
+  ::  nothing indexed yet
+  ;<  n=@ud  bind:m  docs-indexed
+  ;<  ~  bind:m  (ex-equal !>(n) !>(0))
+  ;<  ids=(list @ud)  bind:m  (hits 'sunrise')
+  (ex-equal !>(ids) !>(`(list @ud)`~))
+::
+::  ...and once it does fire, the document is searchable
+::
+++  test-drain-indexes-queued-work
+  %-  eval-mare
+  =/  m  (mare ,~)
+  ^-  form:m
+  ;<  ~  bind:m  setup
+  ;<  *  bind:m
+    (do-poke (act [%touch ~[(ent 1 'Freeze plan' 'verify the sunrise order')]]))
+  ;<  caz=(list card)  bind:m  (do-arvo /drain [%behn %wake ~])
+  ::  queue drained, so no follow-up timer
+  ;<  ~  bind:m  (ex-cards caz ~)
+  ;<  n=@ud  bind:m  docs-indexed
+  ;<  ~  bind:m  (ex-equal !>(n) !>(1))
+  ;<  ids=(list @ud)  bind:m  (hits 'sunrise')
+  (ex-equal !>(ids) !>(`(list @ud)`~[1]))
+::
+::  a second submission while a drain is already scheduled must not arm a
+::  second timer — one drain event handles the whole queue
+::
+++  test-touch-arms-one-timer
+  %-  eval-mare
+  =/  m  (mare ,~)
+  ^-  form:m
+  ;<  ~  bind:m  setup
+  ;<  *  bind:m  (do-poke (act [%touch ~[(ent 1 '' 'first message')]]))
+  ;<  caz=(list card)  bind:m
+    (do-poke (act [%touch ~[(ent 2 '' 'second message')]]))
+  ;<  ~  bind:m  (ex-cards caz ~)
+  ;<  *  bind:m  (do-arvo /drain [%behn %wake ~])
+  ;<  n=@ud  bind:m  docs-indexed
+  (ex-equal !>(n) !>(2))
+::
+::  an erase submitted after a touch retracts the document
+::
+++  test-erase-retracts
+  %-  eval-mare
+  =/  m  (mare ,~)
+  ^-  form:m
+  ;<  ~  bind:m  setup
+  ;<  *  bind:m  (do-poke (act [%touch ~[(ent 1 '' 'transient wording')]]))
+  ;<  *  bind:m  (do-arvo /drain [%behn %wake ~])
+  ;<  *  bind:m  (do-poke (act [%erase ~[(bt 1)]]))
+  ;<  *  bind:m  (do-arvo /drain [%behn %wake ~])
+  ;<  n=@ud  bind:m  docs-indexed
+  ;<  ~  bind:m  (ex-equal !>(n) !>(0))
+  ;<  ids=(list @ud)  bind:m  (hits 'transient')
+  (ex-equal !>(ids) !>(`(list @ud)`~))
+::
+::  %rebuild purges the named source and asks its owner to resubmit
+::
+++  test-rebuild-pokes-owner
+  %-  eval-mare
+  =/  m  (mare ,~)
+  ^-  form:m
+  ;<  ~  bind:m  setup
+  ;<  *  bind:m  (do-poke (act [%touch ~[(ent 1 '' 'stale wording')]]))
+  ;<  *  bind:m  (do-arvo /drain [%behn %wake ~])
+  ;<  caz=(list card)  bind:m
+    (do-poke (act [%rebuild (silt `(list source:v1:se)`~[%notes])]))
+  ;<  ~  bind:m
+    %+  ex-cards  caz
+    :~  %-  ex-poke
+        :*  /rebuild/notes
+            [sid %notes]
+            %search-action-1
+            !>(`action:v1:se`[%rebuild (silt `(list source:v1:se)`~[%notes])])
+        ==
+    ==
+  ::  the stale documents are gone; %notes will resubmit what still exists
+  ;<  n=@ud  bind:m  docs-indexed
+  (ex-equal !>(n) !>(0))
+::
+::  %reset empties the index outright
+::
+++  test-reset-clears-index
+  %-  eval-mare
+  =/  m  (mare ,~)
+  ^-  form:m
+  ;<  ~  bind:m  setup
+  ;<  *  bind:m  (do-poke (act [%touch ~[(ent 1 '' 'some wording')]]))
+  ;<  *  bind:m  (do-arvo /drain [%behn %wake ~])
+  ;<  *  bind:m  (do-poke (act [%reset ~]))
+  ;<  n=@ud  bind:m  docs-indexed
+  (ex-equal !>(n) !>(0))
+::
+::  the index is local: a foreign ship can't submit into it
+::
+++  test-foreign-poke-rejected
+  %-  eval-mare
+  =/  m  (mare ,~)
+  ^-  form:m
+  ;<  ~  bind:m  setup
+  ;<  ~  bind:m  (jab-bowl |=(b=bowl b(src ~bus)))
+  ;<  ~  bind:m
+    (ex-fail (do-poke (act [%touch ~[(ent 1 '' 'injected wording')]])))
+  (pure:m ~)
+--

--- a/desk/tests/lib/search.hoon
+++ b/desk/tests/lib/search.hoon
@@ -1,0 +1,261 @@
+::  tests for the %search tokenizer and index core
+::
+/-  se=search
+/+  sl=search, *test
+|%
+++  sid  ~sidwyn-nimnev-nocsyx-lassul
+::  +book-target: a note target, the cheapest shape to build in tests
+::
+++  bt
+  |=  id=@ud
+  ^-  target:v1:se
+  [%note [sid %notebook] id]
+::
+++  ent
+  |=  [id=@ud title=@t text=@t]
+  ^-  entry:v1:se
+  [(bt id) title 'Notebook' text `sid ~2026.1.1]
+::  +msg: a chat entry, for tests that need a second source
+::
+++  msg
+  |=  [t=@da text=@t]
+  ^-  entry:v1:se
+  [[%chat [%ship sid] [sid t] ~] '' 'DM' text `sid t]
+::  +rep: a chat reply hanging off the message sent at .t
+::
+++  rep
+  |=  [t=@da r=@da text=@t]
+  ^-  entry:v1:se
+  [[%chat [%ship sid] [sid t] `[sid r]] '' 'DM' text `sid r]
+::  +index-of: an index holding the given entries
+::
+++  index-of
+  |=  entries=(list entry:v1:se)
+  ^-  index:v1:se
+  =|  ix=index:v1:se
+  |-  ^-  index:v1:se
+  ?~  entries  ix
+  $(entries t.entries, ix (~(catalog dex:sl ix) i.entries))
+::
+++  hit-ids
+  |=  hits=(list hit:v1:se)
+  ^-  (list @ud)
+  %+  turn  hits
+  |=  h=hit:v1:se
+  ?>(?=([%note *] target.doc.h) id.target.doc.h)
+::
+++  seek-ids
+  |=  [ix=index:v1:se query=@t]
+  ^-  (list @ud)
+  (hit-ids (~(seek dex:sl ix) query ~))
+::
+++  test-tokens-splits-and-lowercases
+  %+  expect-eq
+    !>(`(list @t)`~['freeze' 'checklist' 'kelvin-9'])
+  !>((tokens:sl 'Freeze, CHECKLIST kelvin-9!'))
+::
+++  test-tokens-drops-stopwords
+  %+  expect-eq
+    !>(`(list @t)`~['quick' 'brown' 'fox'])
+  !>((tokens:sl 'the quick and a brown fox'))
+::
+::  a message of nothing but stopwords and punctuation has no terms at all
+::
+++  test-tokens-empty
+  %+  expect-eq
+    !>(`(list @t)`~)
+  !>((tokens:sl 'the and of !!! ...'))
+::
+++  test-grams-ordered-slices
+  ;:  weld
+    %+  expect-eq
+      !>(`(list @t)`~['cha' 'han' 'ann' 'nne' 'nel'])
+    !>((grams:sl 'channel'))
+  ::
+    ::  terms under three bytes have no trigrams; exact match still finds them
+    %+  expect-eq
+      !>(`(list @t)`~)
+    !>((grams:sl 'ok'))
+  ==
+::
+::  +clip must not split a utf-8 sequence: cutting "héllo" at 3 bytes has to
+::  stop before the two-byte "é" rather than halfway through it
+::
+++  test-clip-respects-utf8
+  ;:  weld
+    %+  expect-eq  !>('h')  !>((clip:sl 2 'héllo'))
+    %+  expect-eq  !>('hé')  !>((clip:sl 3 'héllo'))
+    %+  expect-eq  !>('héllo')  !>((clip:sl 99 'héllo'))
+  ==
+::
+++  test-catalog-and-exact-match
+  =/  ix  (index-of ~[(ent 1 'Freeze plan' 'verify the sunrise ordering')])
+  ;:  weld
+    %+  expect-eq  !>(`(list @ud)`~[1])  !>((seek-ids ix 'sunrise'))
+    %+  expect-eq  !>(`(list @ud)`~[1])  !>((seek-ids ix 'freeze'))
+    %+  expect-eq  !>(`(list @ud)`~)     !>((seek-ids ix 'wombat'))
+  ==
+::
+::  a title match must outrank a body match for the same term
+::
+++  test-title-outranks-body
+  =/  ix
+    %-  index-of
+    :~  (ent 1 'unrelated' 'kelvin appears in the body only')
+        (ent 2 'kelvin' 'unrelated body text here')
+    ==
+  %+  expect-eq  !>(`(list @ud)`~[2 1])  !>((seek-ids ix 'kelvin'))
+::
+::  matching more of the query's distinct terms wins regardless of weights
+::
+++  test-more-terms-matched-wins
+  =/  ix
+    %-  index-of
+    :~  (ent 1 '' 'kelvin kelvin kelvin kelvin kelvin')
+        (ent 2 '' 'kelvin freeze')
+    ==
+  %+  expect-eq  !>(`(list @ud)`~[2 1])  !>((seek-ids ix 'kelvin freeze'))
+::
+::  a prefix reaches the full term through the trigram index
+::
+++  test-prefix-match
+  =/  ix  (index-of ~[(ent 1 '' 'the migration plan')])
+  %+  expect-eq  !>(`(list @ud)`~[1])  !>((seek-ids ix 'migrat'))
+::
+::  and so does a typo, at 60% trigram overlap
+::
+++  test-fuzzy-match
+  =/  ix  (index-of ~[(ent 1 '' 'the channel is busy')])
+  %+  expect-eq  !>(`(list @ud)`~[1])  !>((seek-ids ix 'chanel'))
+::
+::  re-cataloging the same target replaces it rather than accumulating:
+::  the old text stops matching and the document is still counted once
+::
+++  test-recatalog-replaces
+  =/  ix  (index-of ~[(ent 1 '' 'the original wording')])
+  =.  ix  (~(catalog dex:sl ix) (ent 1 '' 'the replacement wording'))
+  ;:  weld
+    %+  expect-eq  !>(`(list @ud)`~)     !>((seek-ids ix 'original'))
+    %+  expect-eq  !>(`(list @ud)`~[1])  !>((seek-ids ix 'replacement'))
+    %+  expect-eq  !>(1)  !>(~(wyt by docs.ix))
+  ==
+::
+::  erasing retracts the document and, with it, every term only it used —
+::  otherwise vocabulary would leak as content churns
+::
+++  test-erase-retracts-terms
+  =/  ix  (index-of ~[(ent 1 '' 'solitary vocabulary')])
+  =.  ix  (~(erase dex:sl ix) (bt 1))
+  ;:  weld
+    %+  expect-eq  !>(`(list @ud)`~)  !>((seek-ids ix 'solitary'))
+    %+  expect-eq  !>(0)  !>(~(wyt by docs.ix))
+    %+  expect-eq  !>(0)  !>(~(wyt by terms.ix))
+    %+  expect-eq  !>(0)  !>(~(wyt by grams.ix))
+    %+  expect-eq  !>(0)  !>(~(wyt by trail.ix))
+  ==
+::
+::  a term shared with a surviving document must not be dropped with it
+::
+++  test-erase-keeps-shared-terms
+  =/  ix
+    %-  index-of
+    ~[(ent 1 '' 'shared wording') (ent 2 '' 'shared phrasing')]
+  =.  ix  (~(erase dex:sl ix) (bt 1))
+  ;:  weld
+    %+  expect-eq  !>(`(list @ud)`~[2])  !>((seek-ids ix 'shared'))
+    %+  expect-eq  !>(`(list @ud)`~)     !>((seek-ids ix 'wording'))
+  ==
+::
+::  deleting a message takes its replies with it — a reply is its own
+::  document, and leaving it behind means a hit pointing at nothing
+::
+++  test-erase-cascades-to-replies
+  =/  ix
+    %-  index-of
+    :~  (msg ~2026.1.1 'parent wording')
+        (rep ~2026.1.1 ~2026.1.2 'reply wording')
+    ==
+  ;:  weld
+    %+  expect-eq  !>(2)  !>(~(wyt by docs.ix))
+    ::
+    =.  ix  (~(erase dex:sl ix) [%chat [%ship sid] [sid ~2026.1.1] ~])
+    ;:  weld
+      %+  expect-eq  !>(0)  !>(~(wyt by docs.ix))
+      %+  expect-eq  !>(0)  !>(~(wyt by terms.ix))
+      %+  expect-eq  !>(0)  !>(~(wyt by kids.ix))
+    ==
+  ==
+::
+::  editing a message must not: a re-index keeps the replies in place
+::
+++  test-recatalog-keeps-replies
+  =/  ix
+    %-  index-of
+    :~  (msg ~2026.1.1 'parent wording')
+        (rep ~2026.1.1 ~2026.1.2 'reply wording')
+    ==
+  =.  ix  (~(catalog dex:sl ix) (msg ~2026.1.1 'edited parent wording'))
+  ;:  weld
+    %+  expect-eq  !>(2)  !>(~(wyt by docs.ix))
+    %+  expect-eq  !>(1)  !>((lent (~(seek dex:sl ix) 'reply' ~)))
+    %+  expect-eq  !>(1)  !>((lent (~(seek dex:sl ix) 'edited' ~)))
+  ==
+::
+::  erasing a reply on its own leaves the parent alone
+::
+++  test-erase-reply-keeps-parent
+  =/  ix
+    %-  index-of
+    :~  (msg ~2026.1.1 'parent wording')
+        (rep ~2026.1.1 ~2026.1.2 'reply wording')
+    ==
+  =.  ix  (~(erase dex:sl ix) [%chat [%ship sid] [sid ~2026.1.1] `[sid ~2026.1.2]])
+  ;:  weld
+    %+  expect-eq  !>(1)  !>(~(wyt by docs.ix))
+    %+  expect-eq  !>(1)  !>((lent (~(seek dex:sl ix) 'parent' ~)))
+    %+  expect-eq  !>(0)  !>((lent (~(seek dex:sl ix) 'reply' ~)))
+    %+  expect-eq  !>(0)  !>(~(wyt by kids.ix))
+  ==
+::
+::  a document with no indexable terms is dropped rather than stored:
+::  nothing could ever match it
+::
+++  test-textless-document-not-stored
+  =/  ix  (index-of ~[(ent 1 '' 'the and of')])
+  %+  expect-eq  !>(0)  !>(~(wyt by docs.ix))
+::
+::  a stopword-only query matches nothing rather than everything
+::
+++  test-stopword-query-matches-nothing
+  =/  ix  (index-of ~[(ent 1 '' 'the quick brown fox')])
+  %+  expect-eq  !>(`(list @ud)`~)  !>((seek-ids ix 'the and of'))
+::
+::  +purge drops one source and leaves the others intact
+::
+++  test-purge-by-source
+  =/  ix
+    %-  index-of
+    :~  (ent 1 '' 'kelvin in a note')
+        (msg ~2026.1.1 'kelvin in a message')
+    ==
+  =.  ix  (~(purge dex:sl ix) %notes)
+  ;:  weld
+    %+  expect-eq  !>(1)  !>(~(wyt by docs.ix))
+    %+  expect-eq  !>(`(list @ud)`~)  !>((seek-ids ix 'note'))
+  ==
+::
+::  the source filter restricts results without changing the index
+::
+++  test-seek-source-filter
+  =/  ix
+    %-  index-of
+    :~  (ent 1 '' 'kelvin in a note')
+        (msg ~2026.1.1 'kelvin in a message')
+    ==
+  ;:  weld
+    %+  expect-eq  !>(2)  !>((lent (~(seek dex:sl ix) 'kelvin' ~)))
+    %+  expect-eq  !>(1)  !>((lent (~(seek dex:sl ix) 'kelvin' `%notes)))
+    %+  expect-eq  !>(1)  !>((lent (~(seek dex:sl ix) 'kelvin' `%chat)))
+    %+  expect-eq  !>(0)  !>((lent (~(seek dex:sl ix) 'kelvin' `%channels)))
+  ==
+--

--- a/docs/search.md
+++ b/docs/search.md
@@ -1,0 +1,135 @@
+# %search
+
+One global full-text index over this ship's own content. Producing agents submit references to what changed; `%search` does the tokenizing and index work later, on its own timer, so the producing agent's event never pays for indexing.
+
+Prior art: [arthyn/sphinx](https://github.com/arthyn/sphinx), which built an inverted index with trigram and phonetic fallbacks for a public app directory. `%search` keeps the inverted-index-plus-trigrams shape and drops the rest: this index is local, private, and covers message-shaped content rather than directory listings.
+
+## why an index
+
+Today each agent answers search by scanning. `%channels` and `%chat` both expose `/search/text/…` scries that walk a channel's or DM's message store from newest to oldest, bounded by a "how many did you look at" cursor so a single scry can't run away. That is linear in the size of the conversation, per conversation, per keystroke — and it cannot answer "where did anyone say this" across the ship at all.
+
+`%search` inverts it. One map from term to the documents containing it, built once as content arrives, so a query costs a handful of map lookups regardless of how much history the ship holds.
+
+## deferral
+
+This is the part worth being careful about. Indexing a message costs far more than writing one: tokenize the body, compute trigrams for every fresh term, then touch a posting list per term. A chat event should not pay for that.
+
+So the protocol is split:
+
+-   **producers** emit one poke naming what changed — a `$target` plus already-flattened text. Building that costs a `+flatten` over content the agent just parsed anyway, and one card. Nothing else.
+-   **`%search`** does no work in `+on-poke` beyond pushing onto `queue` and arming a behn wake if one isn't already armed. All the real work happens in `+drain`, in a later arvo event.
+
+`+drain` handles a bounded batch (`+batch-size`, 64) per wake and re-arms while the queue is non-empty. A large backfill therefore spreads across many small events instead of one enormous one, and the drain outpaces any realistic write rate because each batch gets its own event. `queue-cap` (50k) is a backstop against a pathological producer, not an expected condition.
+
+The producer's poke carries flattened text rather than the agent's own content type on purpose: `%search` never learns what a `$story` or a `$reply-essay` is, so a kelvin bump in those types can't force an index migration.
+
+## state model
+
+```
+state-0
+  index         index    the inverted index (below)
+  queue         (qeu job)  submitted-but-not-yet-indexed work
+  pending       @ud      queue depth ($qeu has no size arm; counting per submission
+                         would be the one expensive thing on the hot path)
+  armed         ?        whether a drain wake is already scheduled
+  last-indexed  @da      when the last batch drained
+```
+
+`index` (in `sur/search.hoon`):
+
+```
+terms  (map key postings)   term -> documents containing it, with each term's weight
+grams  (jug gram key)       trigram -> terms containing it, for prefix and typo matching
+trail  (map tid (set key))  document -> its terms, so a document can be fully retracted
+docs   (map tid doc)        document -> its stored record
+kids   (jug tid tid)        post/message -> its replies
+```
+
+`tid` is `(shaf %sear (jam target))` — a digest rather than the target itself, because a target appears in one posting list per term it uses.
+
+The index is derived data. `+on-load` does not migrate it: an unreadable state resets and rebuilds from the producing agents.
+
+## what is stored
+
+No full text. A `$doc` keeps the target, the document's own title (a note or diary-post title; empty for a chat message), the container it lives in for display (`context`), a leading `snippet` capped at 256 bytes, the author, and the time. Clients resolve `target` against the owning agent for anything richer.
+
+`+clip` truncates the snippet on a utf-8 character boundary, so a snippet never ends mid-sequence.
+
+## targets
+
+A `$target` is built only from identity fields that don't churn — restated in `sur/search.hoon` rather than imported, so the owners' types nest under them but a version bump in `$nest:channels` or `$whom:chat` doesn't reach the index:
+
+```
+[%channel =nest post=@da reply=(unit @da)]      post or reply in a %channels channel
+[%chat =whom id=mid reply=(unit mid)]           message or reply in a DM or club
+[%note =book id=@ud]                            note in a %notes notebook
+```
+
+`reply` is the reply's own id; the parent stays in `post`/`id`, so a client can route to the thread either way. The owning agent is derived from the target's head (`+owner`), which is what the `%source` scry filter and `%wipe` key on.
+
+## scoring
+
+Deliberately simple, and in this order:
+
+1. **How many of the query's distinct terms the document matched.** `+term-bonus` (10,000) dominates every per-term weight, so a document matching two query terms always outranks one matching one. This gives AND-preference without excluding partial matches.
+2. **Summed per-term score.** A term's weight in a document comes from where it appeared — `rank-title` 8, `rank-body` 2, summed per occurrence and capped at `rank-cap` 64 so a word repeated 500 times can't drown out everything else. A match's multiplier comes from how it matched: exact 4, substring 2, trigram-only 1.
+3. **Recency.**
+
+Fuzzy matching goes through the trigram index: a query term's trigrams pick out stored terms sharing at least 60% of them (capped at `fuzzy-cap` 32 candidates), which covers both prefixes as typed (`migrat` → `migration`) and transpositions (`chanel` → `channel`). Terms under three bytes have no trigrams and are reachable by exact match only.
+
+Stopwords are dropped at both index and query time, so a stopword-only query matches nothing rather than everything, and a message of only stopwords is never stored — nothing could match it.
+
+## poke surface
+
+`%search-action-1`, `src == our` only. The index is local and covers only content this ship already holds, so there is no permission model beyond refusing foreign pokes: everything indexed is something our own client could already read.
+
+| Action                            | Effect                                                   |
+| --------------------------------- | -------------------------------------------------------- |
+| `[%touch entries=(list entry)]`   | queue for indexing                                       |
+| `[%erase targets=(list target)]`  | queue for retraction                                     |
+| `[%rebuild sources=(set source)]` | purge each named source, then poke its owner to resubmit |
+| `[%wipe =source]`                 | drop one source's documents                              |
+| `[%reset ~]`                      | empty the index and the queue                            |
+
+`%touch` replaces any earlier version of the same target rather than accumulating, so an edit is just another `%touch`.
+
+Producing agents also **accept** `%search-action-1` and act on `%rebuild` alone; every other variant is ignored by them. `%channels` and `%chat` route through `/lib/guard`, so the mark arrives in their `%unsafe` rail branch (`%search-action-1` is not in `/lib/rail`'s mark table) and the outgoing pokes go out via `+unsafe:guard`.
+
+## scry surface
+
+| Path                                               | Returns                                                                  |
+| -------------------------------------------------- | ------------------------------------------------------------------------ |
+| `/x/v1/hits/[skip]/[count]/[nedl]`                 | `%search-result-1` — a scored page across all sources                    |
+| `/x/v1/hits/source/[source]/[skip]/[count]/[nedl]` | same, restricted to one source                                           |
+| `/x/v1/status`                                     | `%search-status-1` — document count, term count, queue depth, last drain |
+
+`nedl` is accepted knot-encoded or bare, matching the existing `%chat` and `%channels` search scries. Both marks carry a `json` grow arm, so a client can hit them with a `.json` scry.
+
+## rebuild and backfill
+
+Incremental submission only covers content written while `%search` is up. `%rebuild` covers the rest: it purges the named source (so content deleted while `%search` was absent doesn't survive as an orphaned result) and pokes that source's owner, which walks its own store and resubmits.
+
+Producers batch by container — one poke per channel, DM, club, or notebook rather than one per message — so the rebuild event costs a card per container while the per-message indexing still spreads across `%search`'s drains.
+
+`+on-init` schedules a rebuild of all three sources on a timer rather than doing it inline, since the producing agents may not have come up yet at install time. Each source is skipped if `.^(? %gu …)` says its agent isn't running.
+
+## producer integration
+
+| Agent       | Hook                                                                          | Rebuild source                                          |
+| ----------- | ----------------------------------------------------------------------------- | ------------------------------------------------------- |
+| `%channels` | `+ca-response` — every content change funnels through it                      | `+ca-index-all` per nest, driven from `+search-rebuild` |
+| `%chat`     | `+di-give-writs-diff` and `+cu-give-writs-diff`                               | `+submit-writs` per DM and club                         |
+| `%notes`    | `+se-update` on `%note` updates; `+notebook-search-gone` when a notebook goes | `+search-rebuild` per notebook                          |
+
+Each guards on `+search-running` (`.^(? %gu …/search/…/$)`) so a ship without the agent installed stays quiet, the same way they guard their `%activity` pokes. Reactions and metadata-only changes carry no text and produce nothing.
+
+Agent test harnesses must answer that liveness probe: the mocked scry gates in `tests/app/{channels,chat,notes}.hoon` return `|` for `[%gu @ %search @ %$ ~]`, which keeps existing card expectations intact.
+
+## invariants
+
+-   Submitting never indexes. `+on-poke` touches `queue`, `pending` and `armed` and nothing else.
+-   A drain is scheduled at most once at a time; `+arm` is a no-op while `armed` is set or the queue is empty.
+-   `+catalog` on an existing target fully retracts the old version first, so re-indexing is idempotent and posting lists never accumulate duplicates.
+-   A term whose last posting is retracted is dropped from `terms` **and** `grams`, so vocabulary doesn't leak as content churns.
+-   Deleting a post or message retracts its replies too — `+retract` cascades through `kids` — so a delete can't leave hits pointing at content that no longer exists. Re-indexing an edit uses `+strip`, which does not cascade, so an edited message keeps its replies.
+-   The index holds nothing this ship can't already read, and refuses pokes from anyone but ourselves.


### PR DESCRIPTION
## Summary

Adds `%search`, a new Gall agent that maintains one global full-text index over this ship's own content. Producing agents (`%channels`, `%chat`, `%notes`) submit a reference to what changed; `%search` does the tokenizing and index work later, on its own behn timer, so the producing agent's event never pays for indexing.

Modeled on the prior art in [arthyn/sphinx](https://github.com/arthyn/sphinx) — same inverted-index-plus-trigrams shape, minus the parts specific to a public app directory.

Fixes TLON-6330

## Changes

**New agent** (`desk/app/search.hoon`, `sur/search.hoon`, `lib/search.hoon`, `lib/search-json.hoon`, `mar/search/{action-1,result-1,status-1}.hoon`, registered in `desk.bill`):

- `+on-poke` does no indexing. It pushes onto a queue, arms a wake if one isn't already armed, and returns. `+drain` handles a bounded batch (64) per wake and re-arms while the queue is non-empty, so a large backfill spreads across many small events rather than one enormous one.
- Inverted index (term → documents) with a trigram side-index giving prefix and typo tolerance (`migrat` → `migration`, `chanel` → `channel`). Ranking is: how many of the query's distinct terms matched, then weighted score (title beats body, exact beats substring beats trigram-only), then recency.
- Stores no full text — a target, title, container, 256-byte snippet, author and time. Clients resolve the target against the owning agent.
- Scries: `/x/v1/hits/[skip]/[count]/[nedl]`, the same filtered by source, and `/x/v1/status`. Both result marks carry `json` grow arms.

**Producer wiring** — a hook at each agent's existing change funnel (`+ca-response`, `+di-give-writs-diff`/`+cu-give-writs-diff`, `+se-update`), plus a `%rebuild` handler that resubmits everything the agent holds, batched one poke per channel/DM/club/notebook. Each guards on `%search` liveness the way they already guard `%activity` pokes, so a ship without the agent stays quiet.

**Decoupling** — targets are built only from stable identity fields (restated in `sur/search.hoon` rather than imported), and producers flatten their own content, so `%search` never learns what a `$story` is. A kelvin bump in `$nest:channels` or `$whom:chat` can't force an index migration.

Spec doc in `docs/search.md`.

## How did I test?

**Automated** — 28 new tests, all passing on ~sidwyn via `mcp/run-tests`:

- `tests/lib/search.hoon` (20): tokenizing, stopwords, trigrams, UTF-8-safe snippet truncation, ranking order, re-index replacement, term/trigram cleanup on erase, reply cascade on delete, source filtering, purge.
- `tests/app/search.hoon` (8): the deferral contract specifically — a `%touch` must produce a timer and leave the index untouched; the index only changes once that timer fires; a second submission doesn't arm a second timer. Plus rebuild, reset, and foreign-poke rejection.

Existing `%notes` (110), `%channels` (7), `%chat` and `%channels-server` suites all pass. Their mocked scry gates needed a `|` answer for the new `%search` liveness probe; that's the only change to those test files.

**Manual, on ~sidwyn** — committed the desk and exercised the whole pipeline end to end:

- Backfill across all three producers: 73 documents, 495 terms, queue fully drained.
- Incremental indexing for each source — created a note, posted to a channel, sent a DM; each was searchable immediately afterward without a rebuild.
- Deletion: deleted the note, confirmed the hit disappeared and its terms were dropped.
- Query behavior: exact match, prefix match (`migrat` → the `migration` message), and the `source` filter returning correctly scoped results.

## Risks and impact

- Safe to rollback without consulting PR author? **Yes**
- Affects important code area:
  - [x] Other: adds hooks to the change funnels in `%channels`, `%chat` and `%notes`

The index itself is derived data and entirely local — nothing is sent off-ship, and it holds only content the ship already had. The producer hooks add one card per content change, guarded on `%search` being installed. `%search` has no state migration: an unreadable state resets and rebuilds from the producers.

The main risk is the added hook in three hot write paths. Each is a guard plus a card, with all real work deferred, and the existing suites for all three agents pass unchanged.

## Rollback plan

Revert the two commits. `%search` disappears from `desk.bill` and the producer hooks go with it; no other agent's state or protocol is touched, so nothing needs cleanup. To disable without reverting, `|nuke %search` — the producers' liveness guards then make their hooks no-ops.

## Screenshots / videos

n/a — backend only. No client changes; the scry surface is in place for a client to adopt.

🤖 Generated with [Claude Code](https://claude.com/claude-code)