### PR TITLE
desk: add -gen-moon thread

### DIFF
--- a/desk/ted/gen-moon.hoon
+++ b/desk/ted/gen-moon.hoon
@@ -1,0 +1,38 @@
+/-  spider
+/+  strandio
+=,  strand=strand:spider
+^-  thread:spider
+|=  arg=vase
+=/  m  (strand ,vase)
+^-  form:m
+=+  !<(arg=(unit json) arg)
+?>  ?=(^ arg)
+?>  ?=(%~ u.arg)
+;<  =bowl:spider  bind:m  get-bowl:strandio
+=/  ran  (clan:title our.bowl)
+?:  ?=([?(%earl %pawn)] ran)
+  %+  strand-fail:strand  %invalid-parent-rank
+  :_  ~
+  :-  %leaf
+  "can't create a moon from a {?:(?=(%earl ran) "moon" "comet")}"
+=/  mon=ship
+  (add our.bowl (lsh 5 (end 5 (shaz eny.bowl))))
+;<  ryf=(unit rift)  bind:m
+  (scry:strandio (unit rift) /j/ryft/(scot %p mon))
+?^  ryf
+  %+  strand-fail:strand  %moon-already-exists
+  :~  leaf+"can't create {(scow %p mon)}, it already exists."
+      leaf+"use |moon-breach and/or |moon-cycle-keys instead."
+  ==
+=/  cic  (pit:nu:cric:crypto 512 (shaz (jam mon life=1 eny.bowl)) %b ~)
+=/  =feed:jael
+  [[%2 ~] mon rift=0 [life=1 sec:ex:cic]~]
+;<  ~  bind:m
+  %-  send-raw-card:strandio
+  [%pass /ted/gen-moon %arvo %j %moon mon *id:block:jael %keys [1 1 pub:ex:cic] %.n]
+=/  result=json
+  %-  pairs:enjs:format
+  :~  ship+s+(scot %p mon)
+      key+s+(scot %uw (jam feed))
+  ==
+(pure:m !>(result))


### PR DESCRIPTION
Splits the `-gen-moon` thread out of `mp/steward-crons` so it can land on its own — the rest of that branch isn't needed for it, and downstream tooling only wants the thread.

Targeting `staging` rather than `develop` to get it into the next release. Cherry-picked from 467791c10; @mikolajp is the author and authorship is preserved.

## What it does

Mints a moon under the running ship and returns it over spider:

```
POST /spider/groups/json/gen-moon/json   body: null
-> {"ship": "~doznec-doznec-sampel-palnet", "key": "0w..."}
```

It refuses on a moon or comet (`%invalid-parent-rank`), and refuses if the derived moon already exists (`%moon-already-exists`), pointing at `|moon-breach` / `|moon-cycle-keys`.

## Why a thread rather than `|moon`

`|moon` can't be driven remotely. It emits the moon's name and key through `slog` — the ship's own terminal — rather than returning them; its actual return value carries only the public key. And no Clay write is reachable over Eyre (`%kiln-info` has no mark with a JSON grab), so code can't be pushed to a ship over HTTP either. A thread on a desk is the only way to get the secret key back over the network.

## Risk

Additive: one new file, no existing behaviour touched. `/- spider` and `/+ strandio` match the imports of the pre-existing `desk/ted/moon.hoon`, and `sur/spider.hoon` arrives via `scripts/assemble-desk.sh` — both confirmed present on `staging`, so no new dependencies.

Draft until it's been exercised against a live planet.

Fixes TLON-6335