### PR TITLE
hermes: approval-card source links, hosted DM gating, /pending view buttons

### DIFF
--- a/packages/hermes-tlon-adapter/README.md
+++ b/packages/hermes-tlon-adapter/README.md
@@ -192,7 +192,9 @@ Unknown ships are not silently dropped — they queue for owner approval:
 -   an **unauthorized mention** in a restricted group channel queues a channel request; approval grants that ship access in that channel and replays the mention (with channel context)
 -   a **group invite** from an unapproved inviter queues a group request; approval joins the group (`tlon groups accept-invite`) and pulls the group's channels into the monitored set so the bot is addressable there. Invites are detected live via a `groups /v1/foreigns` subscription and caught up by scrying `/groups-ui/v7/init` at connect. The owner ship and `TLON_GROUP_INVITE_ALLOWLIST` (settings key `groupInviteAllowlist`) auto-accept; rejection leaves the invite untouched in Tlon.
 
-The owner is notified by DM with a plain-text summary plus an **A2UI approval card** (post-blob entry, rendered by current Tlon clients in DMs): Allow / Reject / Block buttons that type the matching command back into the DM via the `tlon.sendMessage` action, and a View-message button (`tlon.navigate`) when there is a source message. Old clients fall back to the text.
+The owner is notified by DM with a plain-text summary plus an **A2UI approval card** (post-blob entry, rendered by current Tlon clients in DMs): Allow / Reject / Block buttons that type the matching command back into the DM via the `tlon.sendMessage` action, and a View-message button (`tlon.navigate`) when there is a source message. `/pending` renders the same per-item View buttons on its card. Old clients fall back to the text, as does any card that fails validation — the notification itself always goes out.
+
+Channel requests always get the View button; **DM requests only get one when the owner ship is the bot ship**. A DM source message lives in the bot's own DM conversation, which a separate owner ship has no copy of, so the link would dead-end on the usual hosted setup (owner ≠ bot). Channel sources stay navigable for any owner who is a member of the group.
 
 Owner commands (deterministic, never wake the model):
 

--- a/packages/hermes-tlon-adapter/adapter.py
+++ b/packages/hermes-tlon-adapter/adapter.py
@@ -37,6 +37,7 @@ from .approval import (
     SETTINGS_KEY_DEFAULT_AUTHORIZED_SHIPS,
     SETTINGS_KEY_DM_ALLOWLIST,
     SETTINGS_KEY_GROUP_INVITE_ALLOWLIST,
+    MAX_PENDING_APPROVALS_A2UI,
     SETTINGS_KEY_PENDING_APPROVALS,
     approval_group_flag,
     approval_id,
@@ -60,6 +61,7 @@ from .approval import (
     remove_approval,
     serialize_blob,
     settings_bool,
+    validate_a2ui_card,
 )
 from .attention import AttentionFacts, resolve_attention
 from .channel_access import (
@@ -80,6 +82,7 @@ from .history import (
     build_thread_context,
     fetch_channel_history,
     fetch_post,
+    fetch_post_author,
     fetch_reply,
     fetch_thread_context,
 )
@@ -945,6 +948,9 @@ class TlonAdapter(BasePlatformAdapter):
         self._seen_order: list[str] = []
         self._reaction_state = ReactionState()
         self._message_cache = MessageCache()
+        # Channel nest -> owning group flag, rebuilt from `/groups-ui/v7/init`
+        # the first time an approval card needs a `groupId` and on every miss.
+        self._nest_to_group: dict[str, str] = {}
         self._pending_reaction_notes: OrderedDict[str, deque[str]] = OrderedDict()
         # Maps a top-level own-post reaction's synthetic `react/…` dispatch
         # id to the real reactable post it was about, so send()'s
@@ -1169,6 +1175,7 @@ class TlonAdapter(BasePlatformAdapter):
         self._executed_block_directives.clear()
         self._reaction_state.clear()
         self._message_cache.clear()
+        self._nest_to_group.clear()
         self._pending_reaction_notes.clear()
         self._reaction_reply_targets.clear()
         self._processed_dm_invites.clear()
@@ -1659,6 +1666,40 @@ class TlonAdapter(BasePlatformAdapter):
         preview = strip_block_directives(preview).strip()
         return preview or "[attachment]"
 
+    async def _parent_author_for(
+        self, message: TlonIncomingMessage, *, allow_scry: bool
+    ) -> Optional[str]:
+        """Author of the thread parent an approval request replied to.
+
+        Without it a View-message button on a thread reply silently no-ops
+        whenever the owner's client has not already synced the parent post.
+        Cache first (the ``"unknown"`` sentinel is not an author); the exact
+        post scry is the channel-side fallback only — DM parents are in the
+        bot's own recent cache.
+        """
+        parent_id = message.reply_to_message_id
+        if not parent_id:
+            return None
+        cached = self._message_cache.lookup(message.chat_id, parent_id)
+        if cached is not None and cached.author and cached.author != "unknown":
+            return normalize_ship(cached.author) or None
+        if not allow_scry or self._sse is None:
+            return None
+        author = await fetch_post_author(self._sse.scry, message.chat_id, parent_id)
+        return normalize_ship(author or "") or None
+
+    def _recipient_sees_bot_dms(self) -> bool:
+        """Whether the notified owner can open the bot's own DM conversations.
+
+        Only when the owner *is* the bot ship: on a hosted deployment the
+        owner is a separate ship whose client has no copy of the bot's DM
+        channel, so a DM source link would dead-end. Sender-side heuristic,
+        matching OpenClaw — no permission scry.
+        """
+        return normalize_ship(self.tlon_config.owner_ship) == normalize_ship(
+            self.tlon_config.ship_name
+        )
+
     async def _queue_dm_approval(
         self, message: TlonIncomingMessage, clean_text: str
     ) -> None:
@@ -1672,6 +1713,9 @@ class TlonAdapter(BasePlatformAdapter):
             return
         original = self._original_message_payload(message)
         original["messageText"] = clean_text
+        parent_author = await self._parent_author_for(message, allow_scry=False)
+        if parent_author:
+            original["parentAuthorId"] = parent_author
         await self._queue_approval(
             approval_kind="dm",
             requesting_ship=message.user_id,
@@ -1692,6 +1736,9 @@ class TlonAdapter(BasePlatformAdapter):
             return
         original = self._original_message_payload(message)
         original["messageText"] = clean_text
+        parent_author = await self._parent_author_for(message, allow_scry=True)
+        if parent_author:
+            original["parentAuthorId"] = parent_author
         if normalize_ship(message.user_id) in self._known_bot_ships:
             # The triggering message may carry a plain-string author even
             # though the ship was already learned as a bot, and the learned
@@ -1785,12 +1832,38 @@ class TlonAdapter(BasePlatformAdapter):
         owner = self.tlon_config.owner_ship
         if not owner:
             return
-        text = format_approval_request(approval)
-        blob = serialize_blob(build_approval_card(approval))
-        with cli_context("owner_notification"):
-            result = await self._cli.run_command(
-                ("posts", "send", owner, text, "--blob", blob)
+        text = format_approval_request(approval)[:MAX_MESSAGE_LENGTH]
+        # The text notification is self-sufficient, so a card that cannot be
+        # built or does not validate costs the owner the buttons, never the
+        # request itself.
+        blob: Optional[str] = None
+        card_error: Any = None
+        try:
+            card = build_approval_card(
+                approval,
+                recipient_sees_bot_dms=self._recipient_sees_bot_dms(),
+                channel_groups=await self._channel_groups_for([approval]),
             )
+            if validate_a2ui_card(card):
+                blob = serialize_blob(card)
+            else:
+                card_error = "approval card failed validation"
+        except Exception as exc:
+            card_error = exc
+        if card_error is not None:
+            logger.warning(
+                "[tlon] approval card unavailable for %s: %s",
+                approval_id(approval),
+                card_error,
+            )
+            self._telemetry.error(
+                "approval", card_error, requestType=approval_type(approval)
+            )
+        args: list[str] = ["posts", "send", owner, text]
+        if blob:
+            args.extend(["--blob", blob])
+        with cli_context("owner_notification"):
+            result = await self._cli.run_command(args)
         if not result.success:
             logger.warning(
                 "[tlon] approval notification to %s failed: %s", owner, result.error
@@ -1964,9 +2037,23 @@ class TlonAdapter(BasePlatformAdapter):
 
         blob_fields: tuple[str | None, ...] = ()
         if action == "pending":
+            is_dm_reply = _is_dm_chat_id(reply_chat_id)
+            # Group flags only decorate the card, so don't scry for them when
+            # no card will be built (non-DM reply, or outside the 1..4 item
+            # card budget — the list is already pruned above).
+            wants_card = (
+                is_dm_reply
+                and 0 < len(self._pending_approvals) <= MAX_PENDING_APPROVALS_A2UI
+            )
             reply, pending_blob = build_pending_approvals_response(
                 self._pending_approvals,
-                is_dm=_is_dm_chat_id(reply_chat_id),
+                is_dm=is_dm_reply,
+                recipient_sees_bot_dms=self._recipient_sees_bot_dms(),
+                channel_groups=(
+                    await self._channel_groups_for(self._pending_approvals)
+                    if wants_card
+                    else {}
+                ),
             )
             if pending_blob is not None:
                 blob_fields = (pending_blob,)
@@ -3422,6 +3509,61 @@ class TlonAdapter(BasePlatformAdapter):
             for nest in channels
             if isinstance(nest, str)
             and nest.split("/", 1)[0] in ("chat", "heap", "diary")
+        }
+
+    async def _refresh_nest_to_group(self) -> None:
+        """Rebuild the nest -> group-flag map from `/groups-ui/v7/init`.
+
+        The same payload the group lookups above walk. On failure the previous
+        map is kept — a stale flag beats none, and the next render retries.
+        """
+        if self._sse is None:
+            return
+        try:
+            init = await self._sse.scry("/groups-ui/v7/init")
+        except Exception as exc:
+            logger.debug("[tlon] could not scry nest-to-group map: %s", exc)
+            return
+        groups = init.get("groups") if isinstance(init, Mapping) else None
+        if not isinstance(groups, Mapping):
+            return
+        resolved: dict[str, str] = {}
+        for flag, group in groups.items():
+            if not isinstance(flag, str) or not isinstance(group, Mapping):
+                continue
+            channels = group.get("channels")
+            if not isinstance(channels, Mapping):
+                continue
+            for channel_nest in channels:
+                if isinstance(channel_nest, str) and channel_nest:
+                    resolved[channel_nest] = flag
+        self._nest_to_group = resolved
+
+    async def _channel_groups_for(
+        self, approvals: Iterable[Mapping[str, Any]]
+    ) -> dict[str, str]:
+        """nest -> group flag for the channel approvals about to be rendered.
+
+        Resolved at render time rather than stored on the approval record, so
+        the `pendingApprovals` schema OpenClaw shares stays unchanged and
+        already-persisted approvals gain the link too. At most one scry per
+        render: the map is rebuilt once when any nest is missing from it, and
+        nests still unresolved after that are omitted (a nest whose group the
+        bot has left has no navigable group anyway).
+        """
+        nests: list[str] = []
+        for approval in approvals:
+            nest = approval_nest(approval)
+            if approval_type(approval) == "channel" and nest and nest not in nests:
+                nests.append(nest)
+        if not nests:
+            return {}
+        if any(nest not in self._nest_to_group for nest in nests):
+            await self._refresh_nest_to_group()
+        return {
+            nest: self._nest_to_group[nest]
+            for nest in nests
+            if self._nest_to_group.get(nest)
         }
 
     async def _lookup_diary_channel_title(self, nest: str) -> Optional[str]:

--- a/packages/hermes-tlon-adapter/approval.py
+++ b/packages/hermes-tlon-adapter/approval.py
@@ -33,11 +33,13 @@ SETTINGS_KEY_AUTO_ACCEPT_DM_INVITES = "autoAcceptDmInvites"
 APPROVAL_TTL_MS = 48 * 60 * 60 * 1000
 DM_INVITE_PREVIEW = "(DM invite - no message yet)"
 PREVIEW_MAX_CHARS = 100
-# Derived from the client's component budget, not a taste choice: each
-# pending item with a preview line costs ~9 components (row + title +
-# context + preview + actions row + 3 buttons + divider), so 4 items already
-# renders a 43-component card and a 5th would push it past 50 — the a2ui
-# validator's maxComponents (packages/api/src/client/a2ui.ts LIMITS).
+# Derived from the client's component budget, not a taste choice: the card
+# header plus the four shared button labels costs 9 components, each fully
+# loaded item costs 9 more (column + title + context + preview + actions row
+# + Allow/Reject/Block/View buttons), and 3 dividers separate 4 items —
+# 9 + 4*9 + 3 = 48 of the 50 the a2ui validator allows (maxComponents in
+# packages/api/src/client/a2ui.ts LIMITS). A 5th item would blow the budget,
+# and so would giving each item's View button its own Row (52).
 MAX_PENDING_APPROVALS_A2UI = 4
 MAX_PENDING_APPROVALS_TEXT = 25
 
@@ -549,6 +551,31 @@ def _send_message_button(
     return [button, {"id": f"{button_id}Label", "component": "Text", "text": label}]
 
 
+def _navigate_button(
+    button_id: str,
+    label_id: str,
+    target: Mapping[str, Any],
+    *,
+    variant: Optional[str] = None,
+) -> dict[str, Any]:
+    """A ``tlon.navigate`` button; the label node is supplied by the caller so
+    a multi-item card can share one across every button."""
+    button: dict[str, Any] = {
+        "id": button_id,
+        "component": "Button",
+        "child": label_id,
+        "action": {
+            "event": {
+                "name": A2UI_ACTION_NAVIGATE,
+                "context": {"target": target},
+            }
+        },
+    }
+    if variant is not None:
+        button["variant"] = variant
+    return button
+
+
 def _truncate_migrate_card_text(text: str, max_chars: int) -> str:
     if len(text) <= max_chars:
         return text
@@ -670,7 +697,22 @@ def build_migrate_card(command: str, title: Optional[str] = None) -> str:
     return serialize_blob(card)
 
 
-def _approval_nav_target(approval: Mapping[str, Any]) -> Optional[dict[str, Any]]:
+def _approval_nav_target(
+    approval: Mapping[str, Any],
+    *,
+    recipient_sees_bot_dms: bool = True,
+    channel_groups: Optional[Mapping[str, str]] = None,
+) -> Optional[dict[str, Any]]:
+    """Navigation target for the source message, or None when there is none.
+
+    A DM source lives in the bot's own DM history, so it is only reachable
+    when the notified owner is the bot ship itself; channel sources stay
+    navigable for any owner. Optional target fields must be non-empty or the
+    validator rejects the whole card, so every one of them is gated.
+    """
+    kind = approval_type(approval)
+    if kind == "dm" and not recipient_sees_bot_dms:
+        return None
     original = approval.get("originalMessage")
     if not isinstance(original, Mapping):
         return None
@@ -685,11 +727,17 @@ def _approval_nav_target(approval: Mapping[str, Any]) -> Optional[dict[str, Any]
     parent_id = str(original.get("parentId") or "")
     if parent_id:
         target["parentId"] = parent_id
-    kind = approval_type(approval)
+    parent_author = str(original.get("parentAuthorId") or "").strip()
+    if parent_author:
+        target["parentAuthorId"] = parent_author
     if kind == "dm":
         target["channelId"] = approval_ship(approval)
     elif kind == "channel" and approval_nest(approval):
-        target["channelId"] = approval_nest(approval)
+        nest = approval_nest(approval)
+        target["channelId"] = nest
+        group_flag = str((channel_groups or {}).get(nest) or "").strip()
+        if group_flag:
+            target["groupId"] = group_flag
     else:
         return None
     return target
@@ -740,11 +788,20 @@ def _approval_card_context_lines(approval: Mapping[str, Any]) -> list[str]:
     return lines
 
 
-def build_approval_card(approval: Mapping[str, Any]) -> dict[str, Any]:
+def build_approval_card(
+    approval: Mapping[str, Any],
+    *,
+    recipient_sees_bot_dms: bool = True,
+    channel_groups: Optional[Mapping[str, str]] = None,
+) -> dict[str, Any]:
     request_id = approval_id(approval)
     context_lines = _approval_card_context_lines(approval)
     preview = str(approval.get("messagePreview") or "")
-    nav_target = _approval_nav_target(approval)
+    nav_target = _approval_nav_target(
+        approval,
+        recipient_sees_bot_dms=recipient_sees_bot_dms,
+        channel_groups=channel_groups,
+    )
 
     body_children = [
         "eyebrow",
@@ -813,17 +870,7 @@ def build_approval_card(approval: Mapping[str, Any]) -> dict[str, Any]:
     if nav_target:
         components.extend(
             [
-                {
-                    "id": "viewMessage",
-                    "component": "Button",
-                    "child": "viewMessageLabel",
-                    "action": {
-                        "event": {
-                            "name": A2UI_ACTION_NAVIGATE,
-                            "context": {"target": nav_target},
-                        }
-                    },
-                },
+                _navigate_button("viewMessage", "viewMessageLabel", nav_target),
                 {"id": "viewMessageLabel", "component": "Text", "text": "View message"},
             ]
         )
@@ -892,6 +939,9 @@ def _pending_button(
 
 def build_pending_approvals_card(
     approvals: Iterable[Mapping[str, Any]],
+    *,
+    recipient_sees_bot_dms: bool = True,
+    channel_groups: Optional[Mapping[str, str]] = None,
 ) -> Optional[dict[str, Any]]:
     """Build the bounded pending-approvals card from OpenClaw #5939.
 
@@ -923,12 +973,18 @@ def build_pending_approvals_card(
         _pending_text_component("allowLabel", "Allow"),
         _pending_text_component("rejectLabel", "Reject"),
         _pending_text_component("blockLabel", "Block"),
+        _pending_text_component("viewMessageLabel", "View message"),
     ]
 
     for index, approval in enumerate(active):
         prefix = f"item{index}"
         title, context, preview = _pending_item_fields(approval)
         request_id = approval_id(approval)
+        nav_target = _approval_nav_target(
+            approval,
+            recipient_sees_bot_dms=recipient_sees_bot_dms,
+            channel_groups=channel_groups,
+        )
         if index:
             divider_id = f"{prefix}Divider"
             body_children.append(divider_id)
@@ -951,10 +1007,14 @@ def build_pending_approvals_card(
                 {
                     "id": f"{prefix}Actions",
                     "component": "Row",
+                    # The View button shares the item's actions row instead of
+                    # getting a row of its own: at 4 items that fold is the
+                    # difference between 48 and 52 components.
                     "children": [
                         f"{prefix}Allow",
                         f"{prefix}Reject",
                         f"{prefix}Block",
+                        *([f"{prefix}View"] if nav_target else []),
                     ],
                 },
                 _pending_button(
@@ -971,6 +1031,18 @@ def build_pending_approvals_card(
                     "blockLabel",
                     f"/ban {request_id}",
                     variant="borderless",
+                ),
+                *(
+                    [
+                        _navigate_button(
+                            f"{prefix}View",
+                            "viewMessageLabel",
+                            nav_target,
+                            variant="secondary",
+                        )
+                    ]
+                    if nav_target
+                    else []
                 ),
             ]
         )
@@ -1179,17 +1251,30 @@ def validate_a2ui_card(entry: Any) -> bool:
 
 
 def build_pending_approvals_response(
-    approvals: Iterable[Mapping[str, Any]], *, is_dm: bool
+    approvals: Iterable[Mapping[str, Any]],
+    *,
+    is_dm: bool,
+    recipient_sees_bot_dms: bool = True,
+    channel_groups: Optional[Mapping[str, str]] = None,
 ) -> tuple[str, Optional[str]]:
-    """Return the self-sufficient text fallback and optional pending-card blob."""
+    """Return the self-sufficient text fallback and optional pending-card blob.
+
+    Building, validating, and serializing are all guarded: the text reply is
+    always usable on its own, so no builder failure should cost the owner the
+    answer to `/pending`.
+    """
     active = list(approvals)
     text = format_pending_list(active)
     if not is_dm:
         return text, None
-    card = build_pending_approvals_card(active)
-    if card is None or not validate_a2ui_card(card):
-        return text, None
     try:
+        card = build_pending_approvals_card(
+            active,
+            recipient_sees_bot_dms=recipient_sees_bot_dms,
+            channel_groups=channel_groups,
+        )
+        if card is None or not validate_a2ui_card(card):
+            return text, None
         return text, serialize_blob(card)
-    except (TypeError, ValueError):
+    except Exception:
         return text, None

--- a/packages/hermes-tlon-adapter/history.py
+++ b/packages/hermes-tlon-adapter/history.py
@@ -217,6 +217,29 @@ def parse_parent_post(
     )
 
 
+def parse_post_author(payload: Any) -> Optional[str]:
+    """Author of a single post, without ``parse_parent_post``'s content gate.
+
+    ``_entry_from_content`` drops contentless posts entirely and stamps the
+    ``"unknown"`` sentinel on the rest, so it cannot answer "who wrote this
+    post" for a thread parent that is an image, a poll, or a deleted body —
+    which is exactly what an approval card's navigation target needs.
+    """
+    if not isinstance(payload, dict):
+        return None
+    post = payload.get("post") if isinstance(payload.get("post"), dict) else payload
+    post_set = post.get("r-post", {}).get("set") if isinstance(post.get("r-post"), dict) else None
+    content = (
+        post.get("essay")
+        or post.get("memo")
+        or (post_set or {}).get("essay")
+        or (post_set or {}).get("memo")
+    )
+    if not isinstance(content, dict):
+        return None
+    return extract_author_ship(content.get("author")) or None
+
+
 def parse_exact_reply(
     payload: Any,
     reply_id: str,
@@ -253,6 +276,20 @@ async def fetch_post(
         logger.debug("[tlon] exact post fetch failed for %s: %s", post_id, exc)
         return None
     return parse_parent_post(payload, post_id, nest)
+
+
+async def fetch_post_author(
+    scry: ScryFn,
+    nest: str,
+    post_id: str,
+) -> Optional[str]:
+    """Author of one top-level post, tolerating posts with no readable body."""
+    try:
+        payload = await scry(f"/channels/v4/{nest}/posts/post/{format_ud(post_id)}")
+    except Exception as exc:
+        logger.debug("[tlon] post author fetch failed for %s: %s", post_id, exc)
+        return None
+    return parse_post_author(payload)
 
 
 async def fetch_thread_context(

--- a/packages/hermes-tlon-adapter/test_adapter_approvals.py
+++ b/packages/hermes-tlon-adapter/test_adapter_approvals.py
@@ -217,6 +217,9 @@ class FakeSSE:
         self.pokes.append((app, mark, json_payload))
         return 1
 
+    async def close(self, graceful=True):
+        pass
+
     def pokes_for(self, mark):
         return [poke for poke in self.pokes if poke[1] == mark]
 
@@ -1391,6 +1394,343 @@ class AdapterApprovalTests(unittest.TestCase):
         self.assertIn(f"#{first_id}", text)
         self.assertIn(f"#{second_id}", text)
         self.assertIsNone(blob)
+
+    # ── source-message navigation targets ───────────────────────────────
+
+    @staticmethod
+    def card_components(blob):
+        entry = json.loads(blob)[0]
+        return {
+            component["id"]: component
+            for component in entry["messages"][1]["updateComponents"]["components"]
+        }
+
+    def notification_target(self, adapter):
+        """Nav target on the last owner-notification card, or None."""
+        notification = adapter._cli.notifications()[-1]
+        self.assertIn("--blob", notification)
+        components = self.card_components(notification[notification.index("--blob") + 1])
+        view = components.get("viewMessage")
+        return view["action"]["event"]["context"]["target"] if view else None
+
+    @staticmethod
+    def post_scries(adapter):
+        return [path for path in adapter._sse.scries if "/posts/post/" in path]
+
+    @staticmethod
+    def init_scries(adapter):
+        return [path for path in adapter._sse.scries if path == "/groups-ui/v7/init"]
+
+    def test_channel_approval_takes_parent_author_from_cache(self):
+        adapter = self.make_adapter()
+        # the parent arrives through the normal channel path, which is what
+        # populates the cache under the key the lookup reads
+        self.dispatches(
+            adapter, channel_event("root post", author="~bus", post_id="170.100")
+        )
+
+        self.dispatches(adapter, channel_event("~pen replying", parent_id="170.100"))
+
+        pending = adapter._pending_approvals[0]
+        self.assertEqual(pending["originalMessage"]["parentAuthorId"], "~bus")
+        self.assertEqual(self.notification_target(adapter)["parentAuthorId"], "~bus")
+        self.assertEqual(self.post_scries(adapter), [])
+
+    def test_channel_approval_scries_parent_author_on_cache_miss(self):
+        adapter = self.make_adapter()
+        path = "/channels/v4/chat/~pen/general/posts/post/170.100"
+        # a parent with no readable body still has an author
+        adapter._sse.payloads[path] = {
+            "post": {
+                "essay": {"author": "~bus", "sent": 500, "content": []},
+                "seal": {"id": "170100"},
+            }
+        }
+
+        self.dispatches(adapter, channel_event("~pen replying", parent_id="170.100"))
+
+        pending = adapter._pending_approvals[0]
+        self.assertEqual(pending["originalMessage"]["parentAuthorId"], "~bus")
+        self.assertEqual(self.post_scries(adapter), [path])
+
+    def test_channel_approval_scries_past_unknown_cache_sentinel(self):
+        adapter = self.make_adapter()
+        adapter._message_cache.record("chat/~pen/general", "170.100", "", "root post")
+        self.assertEqual(
+            adapter._message_cache.lookup("chat/~pen/general", "170.100").author,
+            "unknown",
+        )
+        path = "/channels/v4/chat/~pen/general/posts/post/170.100"
+        adapter._sse.payloads[path] = {
+            "post": {
+                "essay": {"author": "~bus", "sent": 500, "content": []},
+                "seal": {"id": "170100"},
+            }
+        }
+
+        self.dispatches(adapter, channel_event("~pen replying", parent_id="170.100"))
+
+        pending = adapter._pending_approvals[0]
+        self.assertEqual(pending["originalMessage"]["parentAuthorId"], "~bus")
+        self.assertEqual(self.post_scries(adapter), [path])
+
+    def test_channel_approval_queues_when_parent_author_is_unresolvable(self):
+        adapter = self.make_adapter()
+
+        self.dispatches(adapter, channel_event("~pen replying", parent_id="170.100"))
+
+        pending = adapter._pending_approvals[0]
+        self.assertEqual(pending["type"], "channel")
+        self.assertEqual(pending["originalMessage"]["parentId"], "170.100")
+        self.assertNotIn("parentAuthorId", pending["originalMessage"])
+        self.assertNotIn("parentAuthorId", self.notification_target(adapter))
+
+    def test_channel_approval_card_carries_group_id_from_init_scry(self):
+        adapter = self.make_adapter()
+        adapter._sse.payloads["/groups-ui/v7/init"] = {
+            "groups": {
+                "~host/projects": {
+                    "channels": {"chat/~pen/general": {}, "heap/~pen/gallery": {}}
+                }
+            }
+        }
+
+        self.dispatches(adapter, channel_event("~pen are you there?"))
+
+        target = self.notification_target(adapter)
+        self.assertEqual(target["channelId"], "chat/~pen/general")
+        self.assertEqual(target["groupId"], "~host/projects")
+        self.assertEqual(adapter._nest_to_group["heap/~pen/gallery"], "~host/projects")
+
+    def test_channel_approval_card_omits_group_id_when_init_scry_fails(self):
+        adapter = self.make_adapter()
+
+        self.dispatches(adapter, channel_event("~pen are you there?"))
+
+        target = self.notification_target(adapter)
+        self.assertEqual(target["channelId"], "chat/~pen/general")
+        self.assertNotIn("groupId", target)
+        self.assertEqual(len(adapter._pending_approvals), 1)
+
+    def test_out_of_budget_pending_skips_group_scries(self):
+        adapter = self.make_adapter()
+        adapter._pending_approvals = [
+            {
+                "id": f"c{index}",
+                "type": "channel",
+                "requestingShip": f"~ship{index}",
+                "channelNest": f"chat/~pen/room{index}",
+                "timestamp": int(time.time() * 1000),
+            }
+            for index in range(5)
+        ]
+
+        self.dispatches(
+            adapter,
+            dm_event("/pending", author="~mug", whom="~mug", msg_id="cmd-1"),
+            dm=True,
+        )
+
+        self.assertIsNone(adapter._cli.message_blobs[-1][0])
+        self.assertEqual(self.init_scries(adapter), [])
+
+    def test_pending_resolves_group_ids_with_one_init_scry(self):
+        adapter = self.make_adapter()
+        adapter._sse.payloads["/groups-ui/v7/init"] = {
+            "groups": {
+                "~host/projects": {"channels": {"chat/~pen/general": {}}},
+                "~host/garden": {"channels": {"chat/~bus/plants": {}}},
+            }
+        }
+        adapter._pending_approvals = [
+            {
+                "id": f"c{index}",
+                "type": "channel",
+                "requestingShip": "~ten",
+                "channelNest": nest,
+                "timestamp": int(time.time() * 1000),
+                "originalMessage": {"messageId": f"170.{index}"},
+            }
+            for index, nest in enumerate(["chat/~pen/general", "chat/~bus/plants"])
+        ]
+
+        self.dispatches(
+            adapter,
+            dm_event("/pending", author="~mug", whom="~mug", msg_id="cmd-1"),
+            dm=True,
+        )
+
+        components = self.card_components(adapter._cli.message_blobs[-1][0])
+        target0 = components["item0View"]["action"]["event"]["context"]["target"]
+        target1 = components["item1View"]["action"]["event"]["context"]["target"]
+        self.assertEqual(target0["groupId"], "~host/projects")
+        self.assertEqual(target1["groupId"], "~host/garden")
+        self.assertEqual(len(self.init_scries(adapter)), 1)
+
+    def test_disconnect_clears_the_nest_to_group_cache(self):
+        adapter = self.make_adapter()
+        adapter._sse.payloads["/groups-ui/v7/init"] = {
+            "groups": {"~host/projects": {"channels": {"chat/~pen/general": {}}}}
+        }
+        self.dispatches(adapter, channel_event("~pen are you there?"))
+        self.assertEqual(
+            adapter._nest_to_group["chat/~pen/general"], "~host/projects"
+        )
+
+        asyncio.run(adapter.disconnect())
+
+        self.assertEqual(adapter._nest_to_group, {})
+
+    def test_dm_approval_takes_parent_author_from_cache(self):
+        adapter = self.make_adapter()
+        # same as the channel case: record through the real inbound path so
+        # the test pins the cache key the DM lookup actually uses
+        self.dispatches(adapter, dm_event("root message", msg_id="dm-parent"), dm=True)
+
+        self.dispatches(
+            adapter,
+            dm_event("replying", parent_id="dm-parent", msg_id="dm-2"),
+            dm=True,
+        )
+
+        pending = adapter._pending_approvals[0]
+        self.assertEqual(pending["originalMessage"]["parentId"], "dm-parent")
+        self.assertEqual(pending["originalMessage"]["parentAuthorId"], "~ten")
+        self.assertEqual(self.post_scries(adapter), [])
+
+    def test_dm_approval_never_scries_for_an_uncached_parent(self):
+        adapter = self.make_adapter()
+
+        self.dispatches(
+            adapter,
+            dm_event("replying", parent_id="dm-parent", msg_id="dm-2"),
+            dm=True,
+        )
+
+        pending = adapter._pending_approvals[0]
+        self.assertEqual(pending["originalMessage"]["parentId"], "dm-parent")
+        self.assertNotIn("parentAuthorId", pending["originalMessage"])
+        self.assertEqual(self.post_scries(adapter), [])
+
+    def test_hosted_owner_gets_no_dm_source_link_but_keeps_channel_links(self):
+        # owner ~mug ≠ bot ~pen: the bot's DM conversation does not exist in
+        # the owner's client, so a DM source link would dead-end.
+        dm_adapter = self.make_adapter()
+        self.dispatches(dm_adapter, dm_event("hi bot"), dm=True)
+        self.assertIsNone(self.notification_target(dm_adapter))
+
+        channel_adapter = self.make_adapter()
+        self.dispatches(channel_adapter, channel_event("~pen are you there?"))
+        self.assertEqual(
+            self.notification_target(channel_adapter)["channelId"],
+            "chat/~pen/general",
+        )
+
+    def test_self_owned_bot_keeps_the_dm_source_link(self):
+        adapter = self.make_adapter({"owner_ship": "~pen"})
+
+        self.dispatches(adapter, dm_event("hi bot"), dm=True)
+
+        target = self.notification_target(adapter)
+        self.assertEqual(target["channelId"], "~ten")
+        self.assertEqual(target["postId"], "dm-1")
+
+    def test_pending_card_hides_dm_source_for_a_hosted_owner(self):
+        adapter = self.make_adapter()
+        self.dispatches(adapter, dm_event("hi bot"), dm=True)
+        self.dispatches(
+            adapter, channel_event("~pen help", author="~bus", post_id="170.9")
+        )
+
+        self.dispatches(
+            adapter,
+            dm_event("/pending", author="~mug", whom="~mug", msg_id="cmd-1"),
+            dm=True,
+        )
+
+        components = self.card_components(adapter._cli.message_blobs[-1][0])
+        self.assertNotIn("item0View", components)
+        self.assertEqual(
+            components["item0Actions"]["children"],
+            ["item0Allow", "item0Reject", "item0Block"],
+        )
+        self.assertIn("item1View", components["item1Actions"]["children"])
+        self.assertEqual(
+            components["item1View"]["action"]["event"]["context"]["target"][
+                "channelId"
+            ],
+            "chat/~pen/general",
+        )
+
+    def test_pending_card_keeps_dm_source_for_a_self_owned_bot(self):
+        # the owner ship is the bot ship, so /pending arrives on the bot's own
+        # DM surface rather than through an inbound DM event
+        adapter = self.make_adapter({"owner_ship": "~pen"})
+        self.dispatches(adapter, dm_event("hi bot"), dm=True)
+
+        asyncio.run(
+            adapter._handle_approval_command(
+                "pending", "", reply_chat_id="~pen", reply_parent_id=None
+            )
+        )
+
+        components = self.card_components(adapter._cli.message_blobs[-1][0])
+        self.assertIn("item0View", components["item0Actions"]["children"])
+        self.assertEqual(
+            components["item0View"]["action"]["event"]["context"]["target"][
+                "channelId"
+            ],
+            "~ten",
+        )
+
+    # ── owner notification fallback ─────────────────────────────────────
+
+    def test_owner_notification_drops_blob_when_card_fails_validation(self):
+        adapter, fake = self.make_instrumented_adapter()
+
+        with patch.object(adapter_mod, "validate_a2ui_card", lambda _card: False):
+            self.dispatches(adapter, dm_event("hi bot"), dm=True)
+
+        notification = adapter._cli.notifications()[-1]
+        self.assertNotIn("--blob", notification)
+        self.assertIn("DM request", notification[3])
+        self.assertEqual(len(adapter._pending_approvals), 1)
+        errors = [
+            props
+            for name, props in fake.captures
+            if name == "TlonBot Error" and props.get("component") == "approval"
+        ]
+        self.assertEqual(len(errors), 1)
+        self.assertEqual(errors[0]["requestType"], "dm")
+
+    def test_owner_notification_survives_a_raising_card_builder(self):
+        adapter = self.make_adapter()
+
+        def explode(*_args, **_kwargs):
+            raise RuntimeError("card builder regression")
+
+        with patch.object(adapter_mod, "build_approval_card", explode):
+            self.dispatches(adapter, dm_event("hi bot"), dm=True)
+
+        notification = adapter._cli.notifications()[-1]
+        self.assertNotIn("--blob", notification)
+        self.assertIn("DM request", notification[3])
+        self.assertEqual(len(adapter._pending_approvals), 1)
+
+    def test_owner_notification_text_is_clamped_to_max_message_length(self):
+        adapter = self.make_adapter()
+        approval = {
+            "id": "c1a2b",
+            "type": "channel",
+            "requestingShip": "~ten",
+            "timestamp": int(time.time() * 1000),
+            "channelNest": "n" * (tlon_api.MAX_MESSAGE_LENGTH + 500),
+        }
+
+        asyncio.run(adapter._notify_owner_approval(approval))
+
+        text = adapter._cli.notifications()[-1][3]
+        self.assertEqual(len(text), tlon_api.MAX_MESSAGE_LENGTH)
 
     def test_control_reply_truncates_to_max_message_length(self):
         adapter = self.make_adapter()

--- a/packages/hermes-tlon-adapter/test_approval.py
+++ b/packages/hermes-tlon-adapter/test_approval.py
@@ -472,6 +472,76 @@ class A2UICardTests(unittest.TestCase):
         self.assertEqual(target["channelId"], "chat/~pen/general")
         self.assertEqual(target["parentId"], "170.0")
 
+    def test_card_navigation_carries_parent_author_and_group(self):
+        card = approval.build_approval_card(
+            make_approval(
+                type="channel",
+                channelNest="chat/~pen/general",
+                originalMessage={
+                    "messageId": "170.1",
+                    "messageText": "hi",
+                    "timestamp": 1,
+                    "parentId": "170.0",
+                    "parentAuthorId": "~mug",
+                },
+            ),
+            channel_groups={"chat/~pen/general": "~host/projects"},
+        )
+        components, _ = self.card_components(card)
+        target = components["viewMessage"]["action"]["event"]["context"]["target"]
+        self.assertEqual(target["parentId"], "170.0")
+        self.assertEqual(target["parentAuthorId"], "~mug")
+        self.assertEqual(target["groupId"], "~host/projects")
+        self.assertTrue(approval.validate_a2ui_card(card))
+
+    def test_card_navigation_omits_unresolved_optional_fields(self):
+        """An empty optional field invalidates the whole blob, so absent data
+        must stay absent rather than render as ''."""
+        card = approval.build_approval_card(
+            make_approval(
+                type="channel",
+                channelNest="chat/~pen/general",
+                originalMessage={
+                    "messageId": "170.1",
+                    "messageText": "hi",
+                    "timestamp": 1,
+                    "parentAuthorId": "   ",
+                },
+            ),
+            channel_groups={"chat/~other/general": "~host/projects"},
+        )
+        components, _ = self.card_components(card)
+        target = components["viewMessage"]["action"]["event"]["context"]["target"]
+        for field in ("parentId", "parentAuthorId", "groupId"):
+            self.assertNotIn(field, target)
+        self.assertTrue(approval.validate_a2ui_card(card))
+
+    def test_dm_source_hidden_when_recipient_does_not_see_bot_dms(self):
+        dm = make_approval(
+            originalMessage={"messageId": "170.1", "messageText": "hi", "timestamp": 1}
+        )
+        channel = make_approval(
+            id="c1a2b",
+            type="channel",
+            channelNest="chat/~pen/general",
+            originalMessage={"messageId": "170.2", "messageText": "hi", "timestamp": 1},
+        )
+
+        gated_dm, _ = self.card_components(
+            approval.build_approval_card(dm, recipient_sees_bot_dms=False)
+        )
+        self.assertNotIn("viewMessage", gated_dm)
+        self.assertNotIn("viewMessage", gated_dm["actions"]["children"])
+
+        # channel sources stay navigable for a separate owner ship
+        gated_channel, _ = self.card_components(
+            approval.build_approval_card(channel, recipient_sees_bot_dms=False)
+        )
+        self.assertIn("viewMessage", gated_channel["actions"]["children"])
+
+        default_dm, _ = self.card_components(approval.build_approval_card(dm))
+        self.assertIn("viewMessage", default_dm["actions"]["children"])
+
     def test_invite_card_has_no_view_button(self):
         card = approval.build_approval_card(make_approval(messagePreview=approval.DM_INVITE_PREVIEW))
         components, _ = self.card_components(card)
@@ -544,11 +614,19 @@ class A2UICardTests(unittest.TestCase):
 
 class PendingApprovalsA2UITests(unittest.TestCase):
     def approvals(self, count):
+        """Fully loaded items: preview line plus a navigable source message."""
         return [
             make_approval(
                 id=f"d{index}",
                 messagePreview=f"request {index}",
                 requestingShip=f"~ship{index}",
+                originalMessage={
+                    "messageId": f"170.14{index}",
+                    "messageText": f"request {index}",
+                    "timestamp": 1,
+                    "parentId": "170.100",
+                    "parentAuthorId": "~mug",
+                },
             )
             for index in range(count)
         ]
@@ -556,6 +634,9 @@ class PendingApprovalsA2UITests(unittest.TestCase):
     @staticmethod
     def components(card):
         return card["messages"][1]["updateComponents"]["components"]
+
+    def component_map(self, card):
+        return {component["id"]: component for component in self.components(card)}
 
     def test_pending_card_is_valid_for_one_and_four_items(self):
         for count in (1, 4):
@@ -568,6 +649,82 @@ class PendingApprovalsA2UITests(unittest.TestCase):
             self.assertIn(f"/allow d{count - 1}", json.dumps(card))
             self.assertIn(f"/reject d{count - 1}", json.dumps(card))
             self.assertIn(f"/ban d{count - 1}", json.dumps(card))
+            self.assertIn(f"item{count - 1}View", ids)
+        # the budget the MAX_PENDING_APPROVALS_A2UI comment is derived from:
+        # 9 shared + 9 per fully loaded item + 3 dividers
+        four_items = approval.build_pending_approvals_card(self.approvals(4))
+        self.assertEqual(len(self.components(four_items)), 48)
+
+    def test_pending_card_items_carry_their_own_source_links(self):
+        items = [
+            *self.approvals(1),
+            make_approval(
+                id="c1a2b",
+                type="channel",
+                channelNest="chat/~pen/general",
+                requestingShip="~bus",
+                messagePreview="mention",
+                originalMessage={
+                    "messageId": "170.9",
+                    "messageText": "mention",
+                    "timestamp": 1,
+                },
+            ),
+        ]
+
+        card = approval.build_pending_approvals_card(
+            items, channel_groups={"chat/~pen/general": "~host/projects"}
+        )
+        components = self.component_map(card)
+
+        self.assertTrue(approval.validate_a2ui_card(card))
+        # the view button rides in the item's actions row, not a row of its own
+        self.assertEqual(
+            components["item0Actions"]["children"],
+            ["item0Allow", "item0Reject", "item0Block", "item0View"],
+        )
+        self.assertEqual(components["item0View"]["child"], "viewMessageLabel")
+        self.assertEqual(components["item1View"]["child"], "viewMessageLabel")
+        first = components["item0View"]["action"]["event"]
+        second = components["item1View"]["action"]["event"]
+        self.assertEqual(first["name"], approval.A2UI_ACTION_NAVIGATE)
+        self.assertEqual(first["context"]["target"]["postId"], "170.140")
+        self.assertEqual(first["context"]["target"]["channelId"], "~ship0")
+        self.assertEqual(first["context"]["target"]["parentAuthorId"], "~mug")
+        self.assertEqual(second["context"]["target"]["postId"], "170.9")
+        self.assertEqual(
+            second["context"]["target"]["channelId"], "chat/~pen/general"
+        )
+        self.assertEqual(second["context"]["target"]["groupId"], "~host/projects")
+
+    def test_pending_card_gate_hides_dm_sources_and_keeps_channel_sources(self):
+        items = [
+            *self.approvals(1),
+            make_approval(
+                id="c1a2b",
+                type="channel",
+                channelNest="chat/~pen/general",
+                requestingShip="~bus",
+                originalMessage={
+                    "messageId": "170.9",
+                    "messageText": "mention",
+                    "timestamp": 1,
+                },
+            ),
+        ]
+
+        card = approval.build_pending_approvals_card(
+            items, recipient_sees_bot_dms=False
+        )
+        components = self.component_map(card)
+
+        self.assertTrue(approval.validate_a2ui_card(card))
+        self.assertNotIn("item0View", components)
+        self.assertEqual(
+            components["item0Actions"]["children"],
+            ["item0Allow", "item0Reject", "item0Block"],
+        )
+        self.assertIn("item1View", components["item1Actions"]["children"])
 
     def test_pending_card_falls_back_outside_dm_card_budget_or_with_bad_id(self):
         self.assertIsNone(approval.build_pending_approvals_card([]))
@@ -607,6 +764,33 @@ class PendingApprovalsA2UITests(unittest.TestCase):
         text, blob = approval.build_pending_approvals_response(approvals, is_dm=True)
         self.assertEqual(text, approval.format_pending_list(approvals))
         self.assertIsNone(blob)
+
+    def test_pending_response_falls_back_when_any_card_stage_raises(self):
+        """Build, validate, and serialize are all inside the guard, and the
+        guard is not limited to (TypeError, ValueError)."""
+        approvals = self.approvals(2)
+        for stage, error in (
+            ("build_pending_approvals_card", RuntimeError("builder regression")),
+            ("validate_a2ui_card", KeyError("component")),
+            ("serialize_blob", RuntimeError("not serializable")),
+        ):
+            with self.subTest(stage=stage):
+                original = getattr(approval, stage)
+
+                def raise_error(*_args, _error=error, **_kwargs):
+                    raise _error
+
+                setattr(approval, stage, raise_error)
+                self.addCleanup(setattr, approval, stage, original)
+                try:
+                    text, blob = approval.build_pending_approvals_response(
+                        approvals, is_dm=True
+                    )
+                finally:
+                    setattr(approval, stage, original)
+
+                self.assertEqual(text, approval.format_pending_list(approvals))
+                self.assertIsNone(blob)
 
     def test_validator_rejects_duplicate_dangling_and_cyclic_components(self):
         card = approval.build_pending_approvals_card(self.approvals(1))

--- a/packages/hermes-tlon-adapter/test_history.py
+++ b/packages/hermes-tlon-adapter/test_history.py
@@ -419,6 +419,87 @@ class ParseThreadTests(unittest.TestCase):
         self.assertEqual([entry.content for entry in entries], ["reply"])
 
 
+class ParsePostAuthorTests(unittest.TestCase):
+    """A thread parent's author must resolve even when the parent has no
+    readable body — `parse_parent_post` drops those posts entirely."""
+
+    def test_string_author_in_bare_envelope(self):
+        payload = {"essay": essay("~mug", "root", 500), "seal": {"id": "7"}}
+        self.assertEqual(history.parse_post_author(payload), "~mug")
+
+    def test_profile_author_in_wrapped_envelope(self):
+        payload = {
+            "post": {
+                "essay": {
+                    "author": {"ship": "ten", "nickname": "Ten"},
+                    "sent": 500,
+                    "content": [{"inline": ["root"]}],
+                },
+                "seal": {"id": "7"},
+            }
+        }
+        self.assertEqual(history.parse_post_author(payload), "~ten")
+
+    def test_contentless_post_in_r_post_set_envelope_keeps_author(self):
+        payload = {
+            "post": {
+                "r-post": {
+                    "set": {
+                        "essay": {"author": "~bus", "sent": 500, "content": []},
+                        "seal": {"id": "7"},
+                    }
+                }
+            }
+        }
+        self.assertEqual(history.parse_post_author(payload), "~bus")
+        # the content gate this helper exists to bypass
+        self.assertIsNone(history.parse_parent_post(payload, "7"))
+
+    def test_memo_content_key_is_accepted(self):
+        self.assertEqual(
+            history.parse_post_author({"post": {"memo": essay("~mug", "reply", 500)}}),
+            "~mug",
+        )
+
+    def test_authorless_and_junk_payloads_return_none(self):
+        for payload in (
+            {"essay": {"sent": 500, "content": []}},
+            {"post": {"essay": {"author": "", "sent": 500}}},
+            {"post": {"r-post": {"set": {}}}},
+            {},
+            None,
+            "junk",
+            [{"essay": essay("~mug", "root", 500)}],
+        ):
+            self.assertIsNone(history.parse_post_author(payload), payload)
+
+    def test_fetch_post_author_uses_exact_post_route(self):
+        nest = "chat/~pen/general"
+        path = f"/channels/v4/{nest}/posts/post/170.141"
+        scry = make_scry(
+            {
+                path: {
+                    "post": {
+                        "essay": {"author": "~mug", "sent": 500, "content": []},
+                        "seal": {"id": "170141"},
+                    }
+                }
+            }
+        )
+
+        author = asyncio.run(history.fetch_post_author(scry, nest, "170141"))
+
+        self.assertEqual(author, "~mug")
+        self.assertEqual(scry.calls, [path])
+
+    def test_fetch_post_author_returns_none_when_scry_fails(self):
+        self.assertIsNone(
+            asyncio.run(
+                history.fetch_post_author(make_scry({}), "chat/~pen/general", "170141")
+            )
+        )
+
+
 class BuildContextTests(unittest.TestCase):
     def entries(self):
         return [


### PR DESCRIPTION
## Summary

Brings the Hermes adapter's owner-approval flow to parity with the OpenClaw runtime (TLON-6321): approval-card navigation targets now carry the `parentAuthorId` and `groupId` the Tlon client's A2UI navigation hook needs, DM source links are hidden when the owner cannot see the bot's DMs, and `/pending` gains a per-item View-message button. The notification path also falls back to plain text when a card can't be built or validated.

Fixes TLON-6321

## Changes

-   `_approval_nav_target` in `approval.py` now emits `parentAuthorId` and, for channel approvals, `groupId`; every optional field stays gated on a non-empty value so the validator doesn't reject the card.
-   Added `_parent_author_for` in `adapter.py`, resolving a thread parent's author cache-first (skipping the `"unknown"` sentinel) with a `/channels/v4` exact-post scry fallback for channel approvals and cache-only lookup for DMs.
-   Added `_refresh_nest_to_group` / `_channel_groups_for`, which build a lazily-cached nest to group-flag map from the existing `/groups-ui/v7/init` scry and resolve it at render time — at most one scry per render, skipped for `/pending` when no card will be built, and the cache is dropped on disconnect. The persisted `pendingApprovals` shape is unchanged and already-queued approvals pick up the link.
-   DM source links are now gated on the owner ship being the bot ship (`_recipient_sees_bot_dms`); on hosted setups the owner's client has no copy of the bot's DM conversation, so those links dead-ended. Channel links stay for any owner.
-   `/pending` renders a View button per item, folded into that item's existing actions row and sharing one label node, keeping the card at 48 of the a2ui validator's 50-component budget at the 4-item maximum.
-   Single-approval notification is now fault-tolerant: text clamped to `MAX_MESSAGE_LENGTH`, card build and validation under a catch-all that logs and reports telemetry, `--blob` attached only when the card is valid. Previously a bad card meant the owner got no notification at all.
-   Widened the `build_pending_approvals_response` guard to cover build, validate, and serialize with `except Exception`.
-   Added `parse_post_author` / `fetch_post_author` in `history.py`, which extract a post's author without the content gate that made the existing helpers drop contentless posts (images, polls, deleted bodies).
-   README documents the `/pending` View buttons, the card-validation fallback, and the hosted DM-link caveat.

## How did I test?

-   Full adapter suite locally: 987 tests passing, including 31 new tests across `test_history.py`, `test_approval.py`, and `test_adapter_approvals.py` (cache/scry parent-author resolution, groupId resolution incl. single-scry and out-of-budget-skip behavior, cache invalidation on disconnect, the DM gate on both card builders, notification fallback paths, and a `48` component-count assertion at the 4-item maximum).
-   Ran the suite under docker `python:3.10` (CI's version): 987 run, 1 failure in `test_version`'s git-repo detection, environmental (the container mounts only the package directory) and unrelated to these changes.
-   Mutation-checked the new coverage: 19 targeted mutations (dropped target fields, hardcoded DM gate, unfolded component layout, narrowed exception guards, unwired call sites, weakened scry gating) were each caught by the new tests.
-   Prettier check passes on the README.

## Risks and impact

-   Safe to rollback without consulting PR author? Yes
-   Affects important code area:
    -   [x] Other: Hermes bot runtime owner-approval flow

Card rendering regressions are bounded by the validator plus the text fallback, so a malformed card degrades to the plain-text notification rather than dropping it. `groupId` resolution adds at most one `/groups-ui/v7/init` scry per approval render — new-approval notifications are requester-triggered, so this sits on that path — bounded by the single-flight rebuild, skipped entirely when `/pending` won't build a card, and invalidated on disconnect so a stale map doesn't outlive a session.

## Rollback plan

Revert
