### PR TITLE
bot-e2e ci: move the desk dependency sync out of the 300s assemble cap

### DIFF
--- a/.github/workflows/hermes-ci.yml
+++ b/.github/workflows/hermes-ci.yml
@@ -23,12 +23,30 @@ jobs:
     # minutes per apply on native runners when the desk has drifted). The
     # previous budgets were exceeded at exactly that arithmetic.
     timeout-minutes: 60
+    env:
+      # assemble-desk.sh runs `peru sync` unless told otherwise, and
+      # branch-desk.ts caps an assemble at 300s — a cold sync has measured
+      # 277s. The step below syncs once, unbounded. See TLON-6338.
+      SKIP_SYNC: "true"
     steps:
       - name: Checkout
         uses: actions/checkout@v4
 
       - name: Install peru
         run: pipx install --force peru
+
+      - name: Cache vendored desk dependencies
+        id: desk-deps
+        uses: actions/cache@v4
+        with:
+          path: desk-deps
+          # The picked output is 25 files (~150K) and fully determined by
+          # peru.yaml's pins; peru's own .peru/ cache holds full clones (~800MB).
+          key: tlon-desk-deps-${{ hashFiles('peru.yaml') }}
+
+      - name: Sync desk dependencies
+        if: steps.desk-deps.outputs.cache-hit != 'true'
+        run: ./scripts/sync-deps.sh
 
       - name: Setup Node.js environment
         uses: actions/setup-node@v4

--- a/.github/workflows/openclaw-ci.yml
+++ b/.github/workflows/openclaw-ci.yml
@@ -65,12 +65,30 @@ jobs:
     defaults:
       run:
         working-directory: .
+    env:
+      # assemble-desk.sh runs `peru sync` unless told otherwise, and
+      # branch-desk.ts caps an assemble at 300s — a cold sync has measured
+      # 277s. The step below syncs once, unbounded. See TLON-6338.
+      SKIP_SYNC: "true"
     steps:
       - name: Checkout
         uses: actions/checkout@v4
 
       - name: Install peru
         run: pipx install --force peru
+
+      - name: Cache vendored desk dependencies
+        id: desk-deps
+        uses: actions/cache@v4
+        with:
+          path: desk-deps
+          # The picked output is 25 files (~150K) and fully determined by
+          # peru.yaml's pins; peru's own .peru/ cache holds full clones (~800MB).
+          key: tlon-desk-deps-${{ hashFiles('peru.yaml') }}
+
+      - name: Sync desk dependencies
+        if: steps.desk-deps.outputs.cache-hit != 'true'
+        run: ./scripts/sync-deps.sh
 
       - name: Setup Node.js environment
         uses: actions/setup-node@v4

--- a/apps/tlon-web/package.json
+++ b/apps/tlon-web/package.json
@@ -23,6 +23,7 @@
     "mock": "vite --mode mock",
     "serve-sw": "vite preview --mode sw",
     "tsc": "tsc --noEmit",
+    "test": "vitest --watch false",
     "cosmos": "cosmos",
     "rube:compile": "bash ./rube/compile-rube.sh",
     "rube": "./rube-runner.sh",

--- a/apps/tlon-web/rube/deskManifest.test.ts
+++ b/apps/tlon-web/rube/deskManifest.test.ts
@@ -1,0 +1,95 @@
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+
+import { desksMatch } from './deskManifest';
+
+describe('desksMatch', () => {
+  let stagingRoot: string;
+  let targetRoot: string;
+
+  const writeFile = (root: string, relativePath: string, content: string) => {
+    const fullPath = path.join(root, relativePath);
+    fs.mkdirSync(path.dirname(fullPath), { recursive: true });
+    fs.writeFileSync(fullPath, content);
+  };
+
+  beforeEach(() => {
+    stagingRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'desk-staging-'));
+    targetRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'desk-target-'));
+  });
+
+  afterEach(() => {
+    fs.rmSync(stagingRoot, { recursive: true, force: true });
+    fs.rmSync(targetRoot, { recursive: true, force: true });
+  });
+
+  it('matches identical trees, including nested directories', () => {
+    writeFile(stagingRoot, 'app/groups.hoon', 'groups-code');
+    writeFile(stagingRoot, 'lib/nested/test.hoon', 'lib-code');
+    writeFile(targetRoot, 'app/groups.hoon', 'groups-code');
+    writeFile(targetRoot, 'lib/nested/test.hoon', 'lib-code');
+
+    expect(desksMatch(stagingRoot, targetRoot)).toBe(true);
+  });
+
+  it('does not match when a file has different content', () => {
+    writeFile(stagingRoot, 'app/groups.hoon', 'groups-code');
+    writeFile(targetRoot, 'app/groups.hoon', 'stale-groups-code');
+
+    expect(desksMatch(stagingRoot, targetRoot)).toBe(false);
+  });
+
+  it('does not match when a file exists only in the target tree', () => {
+    writeFile(stagingRoot, 'app/groups.hoon', 'groups-code');
+    writeFile(targetRoot, 'app/groups.hoon', 'groups-code');
+    writeFile(targetRoot, 'app/deleted-from-desk.hoon', 'stale-file');
+
+    expect(desksMatch(stagingRoot, targetRoot)).toBe(false);
+  });
+
+  it('does not match when a file exists only in the staging tree', () => {
+    writeFile(stagingRoot, 'app/groups.hoon', 'groups-code');
+    writeFile(targetRoot, 'app/groups.hoon', 'groups-code');
+    writeFile(stagingRoot, 'lib/new-vendored-dep.hoon', 'new-dep-code');
+
+    expect(desksMatch(stagingRoot, targetRoot)).toBe(false);
+  });
+
+  it('ignores a top-level commit.txt whose content differs', () => {
+    writeFile(stagingRoot, 'app/groups.hoon', 'groups-code');
+    writeFile(stagingRoot, 'commit.txt', 'abc1234');
+    writeFile(targetRoot, 'app/groups.hoon', 'groups-code');
+    writeFile(targetRoot, 'commit.txt', 'development');
+
+    expect(desksMatch(stagingRoot, targetRoot)).toBe(true);
+  });
+
+  it('ignores a top-level commit.txt present in only one tree', () => {
+    writeFile(stagingRoot, 'app/groups.hoon', 'groups-code');
+    writeFile(stagingRoot, 'commit.txt', 'abc1234');
+    writeFile(targetRoot, 'app/groups.hoon', 'groups-code');
+
+    expect(desksMatch(stagingRoot, targetRoot)).toBe(true);
+  });
+
+  it('does not ignore a nested file named commit.txt', () => {
+    writeFile(stagingRoot, 'app/groups.hoon', 'groups-code');
+    writeFile(stagingRoot, 'lib/commit.txt', 'nested-a');
+    writeFile(targetRoot, 'app/groups.hoon', 'groups-code');
+    writeFile(targetRoot, 'lib/commit.txt', 'nested-b');
+
+    expect(desksMatch(stagingRoot, targetRoot)).toBe(false);
+  });
+
+  it('returns false when either directory does not exist', () => {
+    writeFile(stagingRoot, 'app/groups.hoon', 'groups-code');
+    const missingDir = fs.mkdtempSync(path.join(os.tmpdir(), 'desk-missing-'));
+    fs.rmSync(missingDir, { recursive: true });
+
+    expect(desksMatch(stagingRoot, missingDir)).toBe(false);
+    expect(desksMatch(missingDir, targetRoot)).toBe(false);
+    expect(desksMatch(missingDir, `${missingDir}-other`)).toBe(false);
+  });
+});

--- a/apps/tlon-web/rube/deskManifest.ts
+++ b/apps/tlon-web/rube/deskManifest.ts
@@ -1,0 +1,74 @@
+import * as crypto from 'crypto';
+import * as fs from 'fs';
+import * as path from 'path';
+
+// Files written into an assembled desk by the build, not source. Compared
+// trees may legitimately differ here.
+export const GENERATED_DESK_FILES: ReadonlySet<string> = new Set([
+  'commit.txt',
+]);
+
+const hashFile = (filePath: string): string => {
+  const content = fs.readFileSync(filePath);
+  return crypto
+    .createHash('md5')
+    .update(content as any)
+    .digest('hex');
+};
+
+// relative path -> md5 of contents, for every file under `root`, excluding
+// GENERATED_DESK_FILES. Returns an empty Map if `root` does not exist.
+export function buildDeskManifest(root: string): Map<string, string> {
+  const manifest = new Map<string, string>();
+
+  if (!fs.existsSync(root)) {
+    return manifest;
+  }
+
+  const walk = (dir: string) => {
+    const items = fs.readdirSync(dir);
+    for (const item of items) {
+      const fullPath = path.join(dir, item);
+      const stat = fs.statSync(fullPath);
+      if (stat.isDirectory()) {
+        walk(fullPath);
+      } else {
+        const relativePath = path
+          .relative(root, fullPath)
+          .split(path.sep)
+          .join('/');
+        if (GENERATED_DESK_FILES.has(relativePath)) {
+          continue;
+        }
+        manifest.set(relativePath, hashFile(fullPath));
+      }
+    }
+  };
+
+  walk(root);
+
+  return manifest;
+}
+
+// True when two desk trees are byte-identical apart from generated files.
+// MUST be symmetric: differing key sets in EITHER direction mean no match.
+export function desksMatch(aRoot: string, bRoot: string): boolean {
+  if (!fs.existsSync(aRoot) || !fs.existsSync(bRoot)) {
+    return false;
+  }
+
+  const aManifest = buildDeskManifest(aRoot);
+  const bManifest = buildDeskManifest(bRoot);
+
+  if (aManifest.size !== bManifest.size) {
+    return false;
+  }
+
+  for (const [relativePath, hash] of aManifest) {
+    if (bManifest.get(relativePath) !== hash) {
+      return false;
+    }
+  }
+
+  return true;
+}

--- a/apps/tlon-web/rube/index.ts
+++ b/apps/tlon-web/rube/index.ts
@@ -6,13 +6,18 @@
 
 /* eslint no-console: 0 */
 import * as childProcess from 'child_process';
-import * as crypto from 'crypto';
 import * as fs from 'fs';
 import fetch from 'node-fetch';
 import * as os from 'os';
 import * as path from 'path';
+import * as stream from 'stream';
 import * as tar from 'tar-fs';
+import { promisify } from 'util';
 import * as zlib from 'zlib';
+
+import { desksMatch } from './deskManifest';
+
+const pipeline = promisify(stream.pipeline);
 
 // Load .env.test file if it exists
 const envTestPath = path.join(__dirname, '..', '..', '.env.test');
@@ -41,6 +46,8 @@ const childrenFile = path.join(rubeDir, '.rube-children.json');
 // Use RUBE_WORKSPACE if set (for container environments with limited disk space)
 const WORKSPACE_DIR = process.env.RUBE_WORKSPACE || __dirname;
 console.log(`Using workspace directory: ${WORKSPACE_DIR}`);
+
+const DESK_STAGING_DIR = path.join(WORKSPACE_DIR, 'desk-staging');
 
 const manifestPath = path.join(
   __dirname,
@@ -340,14 +347,17 @@ const downloadFile = async (url: string, savePath: string) => {
   });
 };
 
-const extractFile = async (filePath: string, extractPath: string) =>
-  new Promise<string>((resolve, reject) => {
-    fs.createReadStream(filePath)
-      .pipe(zlib.createGunzip())
-      .pipe(tar.extract(extractPath))
-      .on('finish', () => resolve(extractPath))
-      .on('error', reject);
-  });
+// pipeline (not .pipe()) so a failure anywhere in the chain rejects — .pipe()
+// does not forward errors, so a truncated archive would surface as an
+// uncaught exception and skip the caller's cleanup of the partial directory.
+const extractFile = async (filePath: string, extractPath: string) => {
+  await pipeline(
+    fs.createReadStream(filePath),
+    zlib.createGunzip(),
+    tar.extract(extractPath)
+  );
+  return extractPath;
+};
 
 const execPromise = (command: string): Promise<string> =>
   new Promise((resolve, reject) => {
@@ -465,11 +475,28 @@ const getPiers = async () => {
 
     // Only extract if ship needs extraction or force extraction is enabled
     if (forceExtraction || shipNeedsExtraction(shipConfig)) {
-      if (fs.existsSync(extractPath)) {
-        fs.rmSync(extractPath, { recursive: true });
-        console.log(`Removed existing ${extractPath}`);
+      // Extract into a sibling temp dir and rename it into place at the end,
+      // so an interrupted extraction never leaves a partial tree at
+      // extractPath that a later run would accept as valid.
+      const tmpExtractPath = `${extractPath}.incomplete`;
+      if (fs.existsSync(tmpExtractPath)) {
+        fs.rmSync(tmpExtractPath, { recursive: true });
       }
-      await extractFile(savePath, extractPath);
+      try {
+        await extractFile(savePath, tmpExtractPath);
+        if (fs.existsSync(extractPath)) {
+          fs.rmSync(extractPath, { recursive: true });
+          console.log(`Removed existing ${extractPath}`);
+        }
+        fs.renameSync(tmpExtractPath, extractPath);
+      } catch (e) {
+        try {
+          fs.rmSync(tmpExtractPath, { recursive: true, force: true });
+        } catch {
+          // best-effort cleanup only; the original error is what matters
+        }
+        throw e;
+      }
       console.log(
         `Extracted ${ship} to ${extractPath}${forceExtraction ? ' (force extraction enabled)' : ''}`
       );
@@ -685,33 +712,63 @@ const syncDeskDeps = () => {
 const copyDesks = async (): Promise<string[]> => {
   const shipsNeedingUpdates: string[] = [];
 
-  // Populate desk-deps/ once before assembling each ship's desk.
+  // Populate desk-deps/ once; the staging assembly below layers it into the
+  // assembled desk.
   syncDeskDeps();
 
+  // Assemble the canonical desk once into a staging dir. assemble-desk.sh
+  // stamps staging's commit.txt with the current HEAD when git metadata is
+  // available; the rsync below copies it onto each ship, so provenance on the
+  // ship matches what a deploy would produce. We synced once above, so skip
+  // the script's own sync.
+  childProcess.execSync(
+    `bash "${REPO_ROOT}/scripts/assemble-desk.sh" "${DESK_STAGING_DIR}"`,
+    { env: { ...process.env, SKIP_SYNC: 'true' }, stdio: 'inherit' }
+  );
+
+  // A ship whose desk we failed to update would silently run the archived
+  // Hoon — exactly the stale-desk failure this comparison exists to prevent.
+  // Collect failures so every selected ship is still attempted, then fail the
+  // run rather than letting tests report against the wrong code.
+  const failures: string[] = [];
+
   for (const ship of Object.values(ships) as Ship[]) {
-    if (targetShip && targetShip !== ship.ship) {
+    // Match the mount/commit/readiness loops below: a skipCommit ship (~bus is
+    // deliberately kept on old Hoon) never runs |commit, so nothing we rsync
+    // reaches its clay and a copy failure there must not fail the run.
+    if ((targetShip && targetShip !== ship.ship) || ship.skipCommit === true) {
       continue;
     }
 
-    if (needsDeskUpdate(ship)) {
-      const groupsDir = IN_CONTAINER
-        ? path.join(ship.extractPath, 'groups')
-        : path.join(ship.extractPath, ship.ship, 'groups');
+    const groupsDir = IN_CONTAINER
+      ? path.join(ship.extractPath, 'groups')
+      : path.join(ship.extractPath, ship.ship, 'groups');
 
-      try {
-        console.log(`Copying desk changes to ${ship.ship}`);
-        // assemble-desk.sh layers desk-deps/ (--delete) then desk/ on top, so
-        // the result is exactly the assembled desk with stale files cleared.
-        // We synced once above, so skip the per-ship sync.
-        childProcess.execSync(
-          `bash "${REPO_ROOT}/scripts/assemble-desk.sh" "${groupsDir}"`,
-          { env: { ...process.env, SKIP_SYNC: 'true' }, stdio: 'inherit' }
-        );
-        shipsNeedingUpdates.push(ship.ship);
-      } catch (e) {
-        console.error('Error copying desks', e);
+    try {
+      if (desksMatch(DESK_STAGING_DIR, groupsDir)) {
+        continue;
       }
+
+      console.log(`Copying desk changes to ${ship.ship}`);
+      // --checksum because we got here on a CONTENT mismatch: rsync's default
+      // quick check skips files whose size and mtime match, so a same-size,
+      // same-mtime edit would be detected by desksMatch and then silently not
+      // transferred, and the |commit below would publish stale Hoon.
+      childProcess.execSync(
+        `rsync -aL --delete --checksum "${DESK_STAGING_DIR}/" "${groupsDir}/"`,
+        { stdio: 'inherit' }
+      );
+      shipsNeedingUpdates.push(ship.ship);
+    } catch (e) {
+      console.error(`Error copying desk to ${ship.ship}`, e);
+      failures.push(ship.ship);
     }
+  }
+
+  if (failures.length > 0) {
+    throw new Error(
+      `Failed to copy the assembled desk to: ${failures.join(', ')}`
+    );
   }
 
   if (shipsNeedingUpdates.length === 0) {
@@ -1582,81 +1639,6 @@ process.on('uncaughtException', (err) => {
   process.exit(1);
 });
 
-const getFileHash = (filePath: string): string => {
-  if (!fs.existsSync(filePath)) {
-    return '';
-  }
-  // Read as binary to handle all file types correctly
-  const content = fs.readFileSync(filePath);
-  return crypto
-    .createHash('md5')
-    .update(content as any)
-    .digest('hex');
-};
-
-const compareSourceToTarget = (
-  sourceDirPath: string,
-  targetDirPath: string
-): boolean => {
-  if (!fs.existsSync(sourceDirPath) || !fs.existsSync(targetDirPath)) {
-    return false;
-  }
-
-  const sourceFiles: string[] = [];
-  const walk = (dir: string, basePath: string) => {
-    const items = fs.readdirSync(dir);
-    for (const item of items) {
-      const fullPath = path.join(dir, item);
-      const stat = fs.statSync(fullPath);
-      if (stat.isDirectory()) {
-        walk(fullPath, basePath);
-      } else {
-        const relativePath = path.relative(basePath, fullPath);
-        sourceFiles.push(relativePath);
-      }
-    }
-  };
-
-  walk(sourceDirPath, sourceDirPath);
-
-  // For each file in source, check if it exists in target and has same hash
-  for (const relativeFilePath of sourceFiles) {
-    const sourceFilePath = path.join(sourceDirPath, relativeFilePath);
-    const targetFilePath = path.join(targetDirPath, relativeFilePath);
-
-    // If target file doesn't exist, directories don't match
-    if (!fs.existsSync(targetFilePath)) {
-      return false;
-    }
-
-    // If file contents don't match, directories don't match
-    const sourceHash = getFileHash(sourceFilePath);
-    const targetHash = getFileHash(targetFilePath);
-    if (sourceHash !== targetHash) {
-      return false;
-    }
-  }
-
-  return true;
-};
-
-const needsDeskUpdate = (ship: Ship): boolean => {
-  const sourceDeskPath = path.resolve(__dirname, '../../../../desk');
-  const targetGroupsPath = IN_CONTAINER
-    ? path.join(ship.extractPath, 'groups')
-    : path.join(ship.extractPath, ship.ship, 'groups');
-
-  // If target doesn't exist, we need to update
-  if (!fs.existsSync(targetGroupsPath)) {
-    return true;
-  }
-
-  // Compare only source files (ignore generated files in target)
-  const sourcesMatch = compareSourceToTarget(sourceDeskPath, targetGroupsPath);
-
-  return !sourcesMatch;
-};
-
 const shipNeedsExtraction = (ship: Ship): boolean => {
   const shipPath = IN_CONTAINER
     ? ship.extractPath
@@ -1667,8 +1649,10 @@ const shipNeedsExtraction = (ship: Ship): boolean => {
     return true;
   }
 
-  // Check if the ship directory looks valid (has expected structure)
-  const expectedFiles = ['.urb', '.bin', '.run', 'groups'];
+  // Check if the ship directory looks valid (has expected structure).
+  // archive-piers.sh excludes .run and .bin/* from the tarballs, so no
+  // published archive can ever contain them.
+  const expectedFiles = ['.urb', 'groups'];
   const hasValidStructure = expectedFiles.every((file) =>
     fs.existsSync(path.join(shipPath, file))
   );
@@ -1691,19 +1675,7 @@ const shipNeedsExtraction = (ship: Ship): boolean => {
     }
   }
 
-  // Check if the groups directory matches the desk directory
-  const sourceDeskPath = path.resolve(__dirname, '../../../../desk');
-  const targetGroupsPath = path.join(shipPath, 'groups');
-
-  // If groups directory doesn't exist, we need to extract
-  if (!fs.existsSync(targetGroupsPath)) {
-    return true;
-  }
-
-  // Compare only source files (ignore generated files in target)
-  const sourcesMatch = compareSourceToTarget(sourceDeskPath, targetGroupsPath);
-
-  return !sourcesMatch;
+  return false;
 };
 
 const executeClickCommand = async (

--- a/apps/tlon-web/vitest.config.ts
+++ b/apps/tlon-web/vitest.config.ts
@@ -1,0 +1,12 @@
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  test: {
+    environment: 'node',
+    // Only rube unit tests — apps/tlon-web/e2e/*.spec.ts are Playwright
+    // specs and must never be collected by vitest.
+    // No passWithNoTests: this package owns these tests now, so a broken
+    // include should fail CI rather than silently collecting nothing.
+    include: ['rube/**/*.test.ts'],
+  },
+});

--- a/scripts/assemble-desk.sh
+++ b/scripts/assemble-desk.sh
@@ -43,7 +43,14 @@ rsync -aL --delete --delete-excluded --exclude=.DS_Store desk-deps/ "$target/"
 # 2. our own source on top (wins on overlap)
 rsync -aL --exclude=.DS_Store desk/ "$target/"
 
-# stamp the build commit, like the deploy pipeline does
-git rev-parse --short HEAD > "$target/commit.txt" 2>/dev/null || true
+# Stamp the build commit, like the deploy pipeline does. Redirecting straight
+# into the file would truncate it before git ran, so a checkout without git
+# metadata (e.g. a Docker build context that .dockerignore strips .git from)
+# left an EMPTY stamp and %groups/%logs then compiled provenance as unknown.
+# Capture first and only overwrite the copied desk/commit.txt on success.
+commit="$(git rev-parse --short HEAD 2>/dev/null || true)"
+if [ -n "$commit" ]; then
+  printf '%s\n' "$commit" > "$target/commit.txt"
+fi
 
 echo "Assembled desk into $target"


### PR DESCRIPTION
## Summary

Two fixes to the desk-assembly path, both aimed at `staging`:

1. **The `peru sync` inside bot-e2e's 300s assemble cap is moved out of it**, and its output cached. This is the intermittent `Shared E2E` failure that's been red across unrelated branches.
2. **A cherry-pick of #6272**, which merged to `develop` but not `staging` — the two branches have been running different `assemble-desk.sh`.

Fixes TLON-6338

## 1. The assemble cap

`branch-desk.ts:20` bounds `scripts/assemble-desk.sh` at `ASSEMBLE_DESK_TIMEOUT_MS = 300_000` with `killTree: true`. That script runs `peru sync` first unless `SKIP_SYNC` is set, so a cold clone of the vendored upstream deps sat inside the bound — ~800MB of history across `urbit/urbit`, `landscape` and `mcp`.

Measured both ends of that:

| | cold sync | assemble |
|---|---|---|
| Fast runner (from a passing CI run) | 32.6s | — |
| Ordinary connection (local) | **277.2s** — 92% of the cap | — |
| Warm (`desk-deps/` already present) | — | 0.17s |

So it wasn't a marginal budget, it was a coin flip. When it lost:

```
Error: assemble branch desk failed with exit 143: bash .../assemble-desk.sh
  /tmp/tlon-bot-e2e-desk-CFQ2wG/groups timed out after 300000ms
```

Exit 143 is SIGTERM from the harness itself, and `killTree` discarded peru's output — so the log showed 300 seconds of silence with all three ships reporting healthy (`status=200 ok=true urbauth=true`) and no other clue. It reads like a hang in the desk apply; it's a large download that didn't finish.

Frequency on 2026-08-13, ~3 runs in 22 for each workflow, across unrelated branches:

- OpenClaw Shared E2E: 18:56, 19:23, 20:37
- Hermes Shared E2E: 14:22, 19:23, 20:37

**bot-e2e is the only caller that bounds this script.** `backend/run-tests.sh:165`, `backend/update-pill.sh:397`, `.github/helpers/deploy.sh:44` and rube (`rube/index.ts:682`, `construct-desk.sh:112`) all run it unbounded, so for them a slow sync is just a slower job — which is why nothing outside bot-e2e ever flaked. rube additionally syncs once up front and assembles each pier with `--skip-sync`; this change brings bot-e2e in line with that.

**The fix:** set `SKIP_SYNC` at the job level and populate `desk-deps/` in its own unbounded step, so the 300s cap bounds only the two rsyncs. Then cache `desk-deps/` keyed on `peru.yaml` so the fetch is usually skipped outright.

Caching the *picked output* rather than `.peru/` is deliberate: `desk-deps/` is 25 files / ~150K and fully determined by peru.yaml's pinned revs, where peru's own cache holds full clones and runs ~800MB.

## 2. Cherry-pick of #6272

`cf81b1291` is an ancestor of `develop` but not `staging`, so staging still ran the old stamp line that #6272 fixed:

```bash
git rev-parse --short HEAD > "$target/commit.txt" 2>/dev/null || true
```

In CI with `.git` present this is benign, so it is **not** the cause of the failures above — but it means staging and develop have been running different assemble scripts, and staging is missing the rube manifest fix too. Authorship and the original commit reference are preserved.

`sync-dev.yml` merges staging into develop on every push, so basing on staging propagates both fixes to develop automatically.

## How did I test?

Against `origin/staging` + these commits:

- **Cache miss with no sync fails loudly, not silently** — `SKIP_SYNC=true` with no `desk-deps/` exits 1 with `desk-deps/ not found — run scripts/sync-deps.sh (peru sync) first`.
- **`SKIP_SYNC=true` produces an identical desk** — assembled with and without the sync and diffed the trees: byte-identical, 639 files. The skip path ran in 0.17s vs 0.71s.
- **The 6272 stamp fix is live** — `commit.txt` in the assembled desk holds `cec997fb5`, matching `HEAD`, rather than the `development` literal or an empty file.
- **Both workflows parse**, with `SKIP_SYNC: "true"` at job level and the sync step correctly gated on `steps.desk-deps.outputs.cache-hit != 'true'`.
- Cold-sync timing reproduced independently in a clean directory with staging's `peru.yaml`: `real 277.20`, 798MB of `.peru/`, 152K of `desk-deps/`.

Neither prettier check in `ci.yml` covers YAML (both are scoped to `*.{ts,tsx}`), so the workflow edits aren't format-gated; added lines are ≤79 chars to match the surrounding file.

This PR touches `peru.yaml`-adjacent paths and both workflow files, so it triggers both Shared E2E workflows and exercises the change on itself.

## Known gap

Local `pnpm test:e2e:*` runs still take the capped path, since only CI sets `SKIP_SYNC`. Closing that means hoisting the sync into `branch-desk.ts` itself, which touches `branch-desk.test.ts`; left as follow-up to keep this diff on the failing surface.

🤖 Generated with [Claude Code](https://claude.com/claude-code)