### PR TITLE
tlonbot: add MCP connector icons on mobile

### DIFF
--- a/packages/api/src/types/hosting.ts
+++ b/packages/api/src/types/hosting.ts
@@ -225,6 +225,7 @@ export interface TlawnOAuthProvider {
   displayName: string;
   id: string;
   kind: TlawnOAuthProviderKind;
+  logoUrl?: string;
   revokeUrl?: string;
   scopes: string;
   suggestedUpstream: TlawnOAuthUpstream;

--- a/packages/app/features/settings/botMcpSettingsHelpers.test.ts
+++ b/packages/app/features/settings/botMcpSettingsHelpers.test.ts
@@ -1,0 +1,42 @@
+import type { TlawnOAuthProvider } from '@tloncorp/api';
+import { describe, expect, it } from 'vitest';
+import { vi } from 'vitest';
+
+import { buildProviderRows } from './botMcpSettingsHelpers';
+
+vi.mock('@tloncorp/shared', () => ({
+  AnalyticsEvent: {
+    TlonbotMcpConnected: 'connected',
+    TlonbotMcpDisconnected: 'disconnected',
+    TlonbotMcpError: 'error',
+    TlonbotMcpInitiatedOAuth: 'initiated',
+  },
+  createDevLogger: () => ({ trackEvent: vi.fn() }),
+}));
+
+describe('buildProviderRows', () => {
+  it('preserves Hosting-provided provider logos', () => {
+    const provider = {
+      displayName: 'Example',
+      id: 'example',
+      kind: 'mcp_remote',
+      logoUrl: 'https://assets.example.com/example.png',
+      scopes: '',
+      suggestedUpstream: {
+        mode: 'proxy',
+        name: 'Example',
+        url: 'https://mcp.example.com/mcp',
+      },
+      template: 'example',
+    } satisfies TlawnOAuthProvider;
+
+    expect(buildProviderRows([provider], [])).toEqual([
+      {
+        displayName: 'Example',
+        id: 'example',
+        logoUrl: 'https://assets.example.com/example.png',
+        status: 'not-connected',
+      },
+    ]);
+  });
+});

--- a/packages/app/features/settings/botMcpSettingsHelpers.ts
+++ b/packages/app/features/settings/botMcpSettingsHelpers.ts
@@ -44,6 +44,7 @@ export function buildProviderRows(
       return {
         displayName: provider.displayName,
         id: provider.id,
+        logoUrl: provider.logoUrl,
         status,
       };
     });

--- a/packages/app/ui/components/BotSettingsScreenView.tsx
+++ b/packages/app/ui/components/BotSettingsScreenView.tsx
@@ -24,6 +24,7 @@ export type BotSettingsProviderStatus =
 export interface BotSettingsProviderRow {
   displayName: string;
   id: string;
+  logoUrl?: string;
   status: BotSettingsProviderStatus;
 }
 
@@ -214,6 +215,7 @@ function ProviderListItem({
         >
           <McpProviderLogo
             displayName={provider.displayName}
+            logoUrl={provider.logoUrl}
             providerId={provider.id}
           />
           <ListItem.MainContent height="auto" minHeight="$4xl">

--- a/packages/app/ui/components/McpProviderLogo.tsx
+++ b/packages/app/ui/components/McpProviderLogo.tsx
@@ -23,6 +23,7 @@ type ImageLogo = {
 };
 
 const LOGO_SIZE = 28;
+const HOSTING_LOGO_SIZE = 48;
 
 const svgLogos: Partial<Record<string, SvgLogoComponent>> = {
   arena: ArenaLogo,
@@ -42,18 +43,35 @@ const imageLogos: Partial<Record<string, ImageLogo>> = {
 
 export function McpProviderLogo({
   displayName,
+  logoUrl,
   providerId,
 }: {
   displayName: string;
+  logoUrl?: string;
   providerId: string;
 }) {
   const SvgLogo = svgLogos[providerId];
   const imageLogo = imageLogos[providerId];
+  const fallbackLogo = SvgLogo ? (
+    <SvgLogo height={LOGO_SIZE} width={LOGO_SIZE} />
+  ) : imageLogo ? (
+    <Image
+      fallback={null}
+      height={LOGO_SIZE}
+      source={imageLogo.source}
+      width={LOGO_SIZE}
+      contentFit="contain"
+    />
+  ) : (
+    <Text color="$secondaryText" size="$label/l">
+      {displayName.slice(0, 1)}
+    </Text>
+  );
 
   return (
     <View
       alignItems="center"
-      backgroundColor="#FFFFFF"
+      backgroundColor="$secondaryBackground"
       borderColor="$border"
       borderRadius="$s"
       borderWidth={1}
@@ -62,20 +80,16 @@ export function McpProviderLogo({
       overflow="hidden"
       width="$4xl"
     >
-      {SvgLogo ? (
-        <SvgLogo height={LOGO_SIZE} width={LOGO_SIZE} />
-      ) : imageLogo ? (
+      {logoUrl ? (
         <Image
-          fallback={null}
-          height={LOGO_SIZE}
-          source={imageLogo.source}
-          width={LOGO_SIZE}
+          fallback={fallbackLogo}
+          height={HOSTING_LOGO_SIZE}
+          source={logoUrl}
+          width={HOSTING_LOGO_SIZE}
           contentFit="contain"
         />
       ) : (
-        <Text color="$secondaryText" size="$label/l">
-          {displayName.slice(0, 1)}
-        </Text>
+        fallbackLogo
       )}
     </View>
   );


### PR DESCRIPTION
## Summary

We added a ton more MCP options and now have icons available via the Hosting api. This just updates the client to use those.

## Changes

- Adds support for `logoUrl` in Hosting’s MCP provider response type and propagates it through the provider list
- MCP rows now display Hosting-provided logos, falling back to existing bundled icons or provider initials
- Made logo tile backgrounds theme-aware using `$secondaryBackground`
- Added a focused test confirming Hosting logo URLs reach the rendered provider rows

## How did I test?

iOS simulator

## Risks and impact

- Safe to rollback without consulting PR author? yes
