### PR TITLE
Onboarding: stop setup eating chat, land the first entry, and say what the flow is doing

### DIFF
--- a/packages/api/src/client/a2ui.ts
+++ b/packages/api/src/client/a2ui.ts
@@ -184,7 +184,8 @@ export namespace A2UI {
     | 'ChannelGalleries'
     | 'Clock'
     | 'Search'
-    | 'Face';
+    | 'Face'
+    | 'Link';
 
   export type ChoiceAccent = 'blue' | 'green' | 'indigo' | 'neutral';
 
@@ -317,6 +318,7 @@ const CHOICE_ICONS = [
   'Clock',
   'Search',
   'Face',
+  'Link',
 ] as const;
 
 const CHOICE_ACCENTS = ['blue', 'green', 'indigo', 'neutral'] as const;

--- a/packages/api/src/types/analytics.ts
+++ b/packages/api/src/types/analytics.ts
@@ -140,6 +140,13 @@ export enum AnalyticsEvent {
   ActivityMarkedAllRead = 'Activity Marked All Read',
   ContactProfileSelected = 'Contact Profile Selected',
   NoteOpened = 'Note Opened',
+  /**
+   * Activation for agent onboarding: the owner has opened an entry their agent
+   * wrote. The plugin can only report that it *posted* the entry; this is the
+   * half only the client can see, and it is the denominator-completing event
+   * for the onboarding funnel. Fires once per agent group.
+   */
+  AgentEntryFirstOpened = 'Agent Entry First Opened',
   NoteCreated = 'Note Created',
   NoteSaved = 'Note Saved',
   NoteMoved = 'Note Moved',

--- a/packages/app/ui/components/NotesChannel/NotesNoteDetail.tsx
+++ b/packages/app/ui/components/NotesChannel/NotesNoteDetail.tsx
@@ -296,10 +296,33 @@ export function NotesNoteDetail({
   const selectedNoteRowId = selectedNote?.id ?? null;
 
   useEffect(() => {
-    if (selectedNoteRowId !== null) {
-      trackEvent(AnalyticsEvent.NoteOpened);
+    if (selectedNoteRowId === null) {
+      return;
     }
-  }, [selectedNoteRowId]);
+    trackEvent(AnalyticsEvent.NoteOpened);
+    // Activation for agent onboarding. The plugin reports that it posted the
+    // first entry; only the client knows whether the owner opened one. Counted
+    // once per group and persisted, so it survives a restart and doesn't
+    // re-fire on every note view.
+    void (async () => {
+      try {
+        const channel = await db.getChannel({ id: `notes/${notebookFlag}` });
+        const groupId = channel?.groupId;
+        if (!groupId) return;
+        const agents = await db.agentGroupAgents.getValue();
+        if (!agents[groupId]) return;
+        const alreadyCounted = await db.agentEntryFirstOpened.getValue();
+        if (alreadyCounted[groupId]) return;
+        await db.agentEntryFirstOpened.setValue((current) => ({
+          ...current,
+          [groupId]: true,
+        }));
+        trackEvent(AnalyticsEvent.AgentEntryFirstOpened, { groupId });
+      } catch {
+        // Never let activation reporting interfere with reading a note.
+      }
+    })();
+  }, [selectedNoteRowId, notebookFlag]);
 
   const draftsMatchSelectedNote = draftBase?.id === selectedNote?.id;
   const isDirty = Boolean(

--- a/packages/app/ui/components/PostContent/A2UIBlock.tsx
+++ b/packages/app/ui/components/PostContent/A2UIBlock.tsx
@@ -330,31 +330,40 @@ function SmallChoicePills({
             />
           ) : null}
         </XStack>
-        <YStack
-          height={44}
-          alignItems="flex-start"
-          opacity={showSubmit ? 1 : 0}
-          pointerEvents={showSubmit ? 'auto' : 'none'}
-          accessibilityElementsHidden={!showSubmit}
-          importantForAccessibility={
-            showSubmit ? 'auto' : 'no-hide-descendants'
-          }
-        >
-          <Button.Frame
-            size="medium"
-            fill="solid"
-            intent="positive"
-            alignSelf="flex-start"
+        {/*
+          The slot is held open while the picker is still answerable so the
+          pills don't jump the moment a first selection reveals the submit
+          button. Once the picker is consumed that reservation can never be
+          filled again, and an answered picker was left with 44px of blank
+          space under its pills forever — so collapse it then.
+        */}
+        {actionConsumed ? null : (
+          <YStack
             height={44}
-            paddingHorizontal="$xl"
-            testID="A2UISmallChoiceSubmit"
-            disabled={submitDisabled}
-            dimmed={submitDisabled}
-            onPress={submitDisabled ? undefined : handleSubmit}
+            alignItems="flex-start"
+            opacity={showSubmit ? 1 : 0}
+            pointerEvents={showSubmit ? 'auto' : 'none'}
+            accessibilityElementsHidden={!showSubmit}
+            importantForAccessibility={
+              showSubmit ? 'auto' : 'no-hide-descendants'
+            }
           >
-            <Button.Text size="medium">{component.submitLabel}</Button.Text>
-          </Button.Frame>
-        </YStack>
+            <Button.Frame
+              size="medium"
+              fill="solid"
+              intent="positive"
+              alignSelf="flex-start"
+              height={44}
+              paddingHorizontal="$xl"
+              testID="A2UISmallChoiceSubmit"
+              disabled={submitDisabled}
+              dimmed={submitDisabled}
+              onPress={submitDisabled ? undefined : handleSubmit}
+            >
+              <Button.Text size="medium">{component.submitLabel}</Button.Text>
+            </Button.Frame>
+          </YStack>
+        )}
       </YStack>
       {component.freeTextPlaceholder ? (
         <ActionSheet
@@ -747,6 +756,12 @@ export function A2UIBlock({
             components
           );
           const treatment = getButtonTreatment(component);
+          // A consumed button is spent for good, so it leaves the layout
+          // rather than sitting at zero opacity — otherwise every answered
+          // surface keeps a 44px hole where its control used to be.
+          if (actionConsumed) {
+            return null;
+          }
           return (
             <Button.Frame
               key={component.id}
@@ -764,12 +779,6 @@ export function A2UIBlock({
               height={44}
               paddingHorizontal="$xl"
               flex={getComponentFlex(component)}
-              opacity={actionConsumed ? 0 : 1}
-              pointerEvents={actionConsumed ? 'none' : 'auto'}
-              accessibilityElementsHidden={actionConsumed}
-              importantForAccessibility={
-                actionConsumed ? 'no-hide-descendants' : 'auto'
-              }
               disabled={disabled}
               dimmed={disabled}
               onPress={

--- a/packages/app/ui/components/PostContent/A2UIBlock.tsx
+++ b/packages/app/ui/components/PostContent/A2UIBlock.tsx
@@ -804,6 +804,15 @@ export function A2UIBlock({
             >
               {component.options.map((option) => {
                 const accent = CHOICE_ACCENT_COLORS[option.accent ?? 'neutral'];
+                // The accent is normally carried by the icon chip. An option
+                // that asks for one without an icon would otherwise render
+                // identically to a neutral card — the accent silently doing
+                // nothing — so let the card itself carry it instead. A single
+                // accented card in a message reads as the thing to tap; the
+                // multi-option pickers all have icons and are untouched.
+                const accentedCard = Boolean(
+                  option.accent && option.accent !== 'neutral' && !option.icon
+                );
                 const disabled =
                   choiceConsumed ||
                   !onA2UIAction ||
@@ -822,8 +831,8 @@ export function A2UIBlock({
                     }
                   >
                     <XStack
-                      borderWidth={1}
-                      borderColor="$border"
+                      borderWidth={accentedCard ? 2 : 1}
+                      borderColor={accentedCard ? accent.strong : '$border'}
                       borderRadius="$xl"
                       backgroundColor="$background"
                       paddingVertical="$l"

--- a/packages/openclaw/src/monitor/agent-onboarding.test.ts
+++ b/packages/openclaw/src/monitor/agent-onboarding.test.ts
@@ -538,7 +538,7 @@ describe('agent onboarding requests', () => {
     ],
     [
       'Learn something',
-      'share one useful idea at a time',
+      'one each morning, rather than all at once',
       'What are you curious about?',
     ],
     [
@@ -554,10 +554,7 @@ describe('agent onboarding requests', () => {
 
   it.each([
     ['agent-daily-digest', 'write a fresh digest in Field notes'],
-    [
-      'agent-learning',
-      'write a new entry in Field notes, this group’s notebook — one useful idea at a time',
-    ],
+    ['agent-learning', 'building on the last one'],
     [
       'agent-research',
       'write a source-backed update in Field notes, this group’s notebook',
@@ -568,11 +565,34 @@ describe('agent onboarding requests', () => {
     // in the sidebar having never been told it existed.
     const cadence = agentOnboardingTesting.provisionCadence(
       purposeId,
-      'Field notes'
+      'Field notes',
+      ['Music theory']
     );
     expect(cadence).toContain(expectation);
     expect(cadence).toContain('notebook');
     expect(cadence).not.toContain('publish');
+  });
+
+  it('spells out the rotation when learning has several topics', () => {
+    // "One at a time, rotating through your list" still read as a digest of
+    // everything picked: an owner who chose three topics got one entry and
+    // thought the other two had been dropped. Name the order concretely.
+    const cadence = agentOnboardingTesting.provisionCadence(
+      'agent-learning',
+      'Updates',
+      ['Music theory', 'Architecture', 'Cryptography']
+    );
+    expect(cadence).toContain('One topic each morning, taken in turn');
+    expect(cadence).toContain('Music theory first');
+    expect(cadence).toContain('then Architecture');
+
+    // A single topic has no rotation to explain, so it must not promise one.
+    const single = agentOnboardingTesting.provisionCadence(
+      'agent-learning',
+      'Updates',
+      ['Music theory']
+    );
+    expect(single).not.toContain('taken in turn');
   });
 
   it('derives the notebook name the sidebar shows', () => {

--- a/packages/openclaw/src/monitor/agent-onboarding.test.ts
+++ b/packages/openclaw/src/monitor/agent-onboarding.test.ts
@@ -1,4 +1,4 @@
-import { appendToPostBlob, parsePostBlob } from '@tloncorp/api';
+import { A2UI, appendToPostBlob, parsePostBlob } from '@tloncorp/api';
 import { describe, expect, it, vi } from 'vitest';
 
 import type { TlonCronService } from '../cron-telemetry.js';
@@ -57,7 +57,7 @@ describe('agent onboarding requests', () => {
 
   it('keeps onboarding follow-up actions flat', () => {
     const invite = agentOnboardingTesting.buildInviteSurface('~ten/group');
-    const services = agentOnboardingTesting.buildServicesSurface();
+    const services = agentOnboardingTesting.buildServicesSurface('pitch');
     const inviteRoot = invite.messages.find(
       (message) => 'updateComponents' in message
     );
@@ -74,11 +74,27 @@ describe('agent onboarding requests', () => {
       component: 'Column',
       children: ['invite'],
     });
-    expect(
-      servicesRoot &&
-        'updateComponents' in servicesRoot &&
-        servicesRoot.updateComponents.components.find(({ id }) => id === 'root')
-    ).toMatchObject({ id: 'root', component: 'Button', child: 'label' });
+    // The services card is a Choice, not a bare Button: a Button carries only
+    // a text label, and this needs an icon, a title and a description.
+    const servicesComponents =
+      servicesRoot && 'updateComponents' in servicesRoot
+        ? servicesRoot.updateComponents.components
+        : [];
+    expect(servicesComponents.find(({ id }) => id === 'root')).toMatchObject({
+      id: 'root',
+      component: 'Column',
+    });
+    const choice = servicesComponents.find(({ id }) => id === 'cta') as
+      | A2UI.Choice
+      | undefined;
+    expect(choice?.component).toBe('Choice');
+    expect(choice?.options).toHaveLength(1);
+    expect(choice?.options[0]).toMatchObject({
+      label: 'Connect External Services',
+      description: 'Bring your tools into Tlonbot’s context',
+      icon: 'Link',
+    });
+    expect(choice?.options[0]?.action.event.name).toBe(A2UI.action.navigate);
   });
 
   it('catches an intro request that arrived before the channel was watched', async () => {
@@ -291,6 +307,9 @@ describe('agent onboarding requests', () => {
           },
         ]),
         now: () => now,
+        // Fixed at the midpoint so jitter resolves to 1x and the delays are
+        // reproducible; the jitter range itself is asserted below.
+        random: () => 0.5,
         sleep: vi.fn(async (ms) => {
           events.push(`sleep:${ms}`);
           now += ms;
@@ -299,14 +318,81 @@ describe('agent onboarding requests', () => {
       }
     );
 
-    expect(events).toEqual([
-      'thinking:start',
-      'sleep:1250',
+    // Presence must bracket the whole sequence — a pause with no indicator
+    // reads as the app hanging rather than the bot thinking.
+    expect(events[0]).toBe('thinking:start');
+    expect(events.at(-1)).toBe('thinking:stop');
+    expect(events.filter((e) => e.startsWith('post:'))).toEqual([
       'post:intro',
-      'sleep:1000',
       'post:purpose-picker',
-      'thinking:stop',
     ]);
+
+    // Every post is preceded by a pause, and the pause is composed rather than
+    // a flat floor: it scales with the message and stays inside the clamp.
+    const sleeps = events
+      .filter((e) => e.startsWith('sleep:'))
+      .map((e) => Number(e.slice('sleep:'.length)));
+    expect(sleeps).toHaveLength(2);
+    for (const ms of sleeps) {
+      expect(ms).toBeGreaterThanOrEqual(800);
+      expect(ms).toBeLessThanOrEqual(3500);
+    }
+    // The intro is the first reply of the turn, so it also carries read time
+    // for the owner's message; the picker that follows does not.
+    expect(sleeps[0]).toBeGreaterThan(sleeps[1]!);
+  });
+
+  it('jitters pacing so the rhythm is not metronomic', async () => {
+    const delaysFor = async (random: () => number) => {
+      const sleeps: number[] = [];
+      let now = 0;
+      const introBlob = appendToPostBlob(undefined, {
+        type: 'tlon-agent-intro-request',
+        version: 1,
+        groupId: '~ten/group',
+      });
+      await handleAgentOnboardingRequest(
+        {
+          api: { scry: vi.fn() },
+          botShip: '~bot',
+          channelNest: 'chat/~ten/general',
+          groupId: '~ten/group',
+          ownerShip: '~ten',
+          senderShip: '~ten',
+          blob: introBlob,
+          presentation: {
+            startThinking: () => {},
+            stopThinking: () => {},
+          },
+        },
+        {
+          fetchHistory: vi.fn(async () => []),
+          now: () => now,
+          random,
+          sleep: vi.fn(async (ms) => {
+            sleeps.push(ms);
+            now += ms;
+          }),
+          sendPost: vi.fn(async () => ({
+            channel: 'tlon' as const,
+            messageId: 'post',
+            sentAt: now,
+          })),
+        }
+      );
+      return sleeps;
+    };
+
+    const low = await delaysFor(() => 0);
+    const mid = await delaysFor(() => 0.5);
+    const high = await delaysFor(() => 1);
+
+    // ±20% around the composed delay, so two consecutive setups never share a
+    // rhythm — and the clamp still holds at both extremes.
+    expect(low[0]).toBeLessThan(mid[0]!);
+    expect(high[0]).toBeGreaterThan(mid[0]!);
+    expect(low[0]).toBeGreaterThanOrEqual(Math.round(mid[0]! * 0.8) - 1);
+    expect(high[0]).toBeLessThanOrEqual(Math.round(mid[0]! * 1.2) + 1);
   });
 
   it('always clears thinking presence when an onboarding post fails', async () => {
@@ -493,9 +579,9 @@ describe('agent onboarding requests', () => {
     expect(
       agentOnboardingTesting.notebookDisplayName('notes/~zod/daily-digest')
     ).toBe('Daily digest');
-    expect(agentOnboardingTesting.notebookDisplayName('notes/~zod/updates')).toBe(
-      'Updates'
-    );
+    expect(
+      agentOnboardingTesting.notebookDisplayName('notes/~zod/updates')
+    ).toBe('Updates');
   });
 
   it.each([['agent-daily-digest'], ['agent-learning'], ['agent-research']])(
@@ -733,7 +819,9 @@ describe('provision coordinator ordering', () => {
         (entry) => entry.type === 'tlon-agent-post-marker'
       )
     ).toEqual(
-      expect.arrayContaining([expect.objectContaining({ key: 'ack:provision-1' })])
+      expect.arrayContaining([
+        expect.objectContaining({ key: 'ack:provision-1' }),
+      ])
     );
     const ackBlob = JSON.stringify(parsePostBlob(history[0]?.blob));
     expect(ackBlob).not.toContain('Connect services');
@@ -785,22 +873,34 @@ describe('provision coordinator ordering', () => {
       }
     );
 
-    expect(sendPost).toHaveBeenCalledOnce();
-    expect(JSON.stringify(sendPost.mock.calls[0]?.[0].story)).toContain(
-      "Your group's first entry is ready:"
-    );
-    expect(sendPost.mock.calls[0]?.[0].story).toContainEqual({
+    // Three beats now: the reveal, then the handoff tip, then the services
+    // card. The expansion asks moved here from the acknowledgement so they
+    // land only after the owner has something to look at.
+    expect(sendPost).toHaveBeenCalledTimes(3);
+    const reveal = sendPost.mock.calls[0]?.[0];
+    // The sentence carries the entry on its own — the cite renders as
+    // "Content not available" until the client has synced the notes channel,
+    // so the card is a bonus, not the message.
+    expect(JSON.stringify(reveal.story)).toContain('Your first entry is ready');
+    expect(JSON.stringify(reveal.story)).toContain('First entry');
+    expect(JSON.stringify(reveal.story)).toContain('notebook');
+    expect(reveal.story).toContainEqual({
       block: {
         cite: {
           chan: { nest: provision.notebookNest, where: '/note/12' },
         },
       },
     });
-    expect(parsePostBlob(sendPost.mock.calls[0]?.[0].blob)).toContainEqual(
+    // Keyed per channel, not per provision: re-provisioning minted a new id
+    // and let the same reveal post three times in one setup.
+    expect(parsePostBlob(reveal.blob)).toContainEqual(
       expect.objectContaining({
         type: 'tlon-agent-post-marker',
-        key: 'first-entry-ping:provision-1',
+        key: 'first-entry-ping',
       })
+    );
+    expect(JSON.stringify(sendPost.mock.calls[2]?.[0])).toContain(
+      'Connect External Services'
     );
   });
 
@@ -848,7 +948,11 @@ describe('provision coordinator ordering', () => {
       { fetchHistory: vi.fn(async () => []), sendPost }
     );
 
-    expect(sendPost).toHaveBeenCalledOnce();
+    // The reveal plus the two expansion beats that now follow it.
+    expect(sendPost).toHaveBeenCalledTimes(3);
+    expect(JSON.stringify(sendPost.mock.calls[0]?.[0].story)).toContain(
+      'Your first entry is ready'
+    );
   });
 
   it('does not mutate cron or post when the sender is not the owner', async () => {

--- a/packages/openclaw/src/monitor/agent-onboarding.test.ts
+++ b/packages/openclaw/src/monitor/agent-onboarding.test.ts
@@ -467,19 +467,63 @@ describe('agent onboarding requests', () => {
   });
 
   it.each([
-    ['agent-daily-digest', 'publish one fresh digest here each morning'],
+    ['agent-daily-digest', 'write a fresh digest in Field notes'],
     [
       'agent-learning',
-      'publish one useful idea each morning, rotating through your list',
+      'write a new entry in Field notes, this group’s notebook — one useful idea at a time',
     ],
     [
       'agent-research',
-      'check for new work each morning and publish a source-backed update here',
+      'write a source-backed update in Field notes, this group’s notebook',
     ],
   ])('explains the ongoing cadence for %s', (purposeId, expectation) => {
-    expect(agentOnboardingTesting.provisionCadence(purposeId)).toContain(
-      expectation
+    // Every variant has to name the notebook it writes into. "Publish", and
+    // worse "publish here", read as chat — an owner watched a notebook appear
+    // in the sidebar having never been told it existed.
+    const cadence = agentOnboardingTesting.provisionCadence(
+      purposeId,
+      'Field notes'
     );
+    expect(cadence).toContain(expectation);
+    expect(cadence).toContain('notebook');
+    expect(cadence).not.toContain('publish');
+  });
+
+  it('derives the notebook name the sidebar shows', () => {
+    expect(
+      agentOnboardingTesting.notebookDisplayName('notes/~zod/daily-digest')
+    ).toBe('Daily digest');
+    expect(agentOnboardingTesting.notebookDisplayName('notes/~zod/updates')).toBe(
+      'Updates'
+    );
+  });
+
+  it.each([['agent-daily-digest'], ['agent-learning'], ['agent-research']])(
+    'pitches services by benefit, not mechanism, for %s',
+    (purposeId) => {
+      // The old copy named calendars/docs/notes and no reason to connect them,
+      // and read identically whichever purpose the owner picked.
+      const pitch = agentOnboardingTesting.servicesPitch(purposeId);
+      expect(pitch).toMatch(/^Connect your/);
+      expect(pitch).not.toContain('to give me more to work with');
+    }
+  );
+
+  it('says the schedule back so a timezone tap has a receipt', () => {
+    expect(
+      agentOnboardingTesting.scheduleConfirmation({
+        scheduleHour: 8,
+        scheduleMinute: 0,
+        timezone: 'America/New_York',
+      } as never)
+    ).toBe('First one lands at 8:00 AM in America/New_York.');
+    expect(
+      agentOnboardingTesting.scheduleConfirmation({
+        scheduleHour: 0,
+        scheduleMinute: 5,
+        timezone: 'Asia/Tokyo',
+      } as never)
+    ).toBe('First one lands at 12:05 AM in Asia/Tokyo.');
   });
 });
 
@@ -675,9 +719,13 @@ describe('provision coordinator ordering', () => {
       }
     );
 
+    // Two beats now, not one: the acknowledgement, then the "writing it now"
+    // status. The handoff tip and the services pitch are no longer part of
+    // this post at all — they wait until the first entry has actually landed.
     expect(events).toEqual([
       'cron:add',
       'post:ack:provision-1',
+      'post:first-entry-pending',
       'cron:enqueue',
     ]);
     expect(
@@ -685,15 +733,16 @@ describe('provision coordinator ordering', () => {
         (entry) => entry.type === 'tlon-agent-post-marker'
       )
     ).toEqual(
-      expect.arrayContaining([
-        expect.objectContaining({ key: 'handoff' }),
-        expect.objectContaining({ key: 'services-card' }),
-        expect.objectContaining({ key: 'ack:provision-1' }),
-      ])
+      expect.arrayContaining([expect.objectContaining({ key: 'ack:provision-1' })])
     );
-    expect(JSON.stringify(parsePostBlob(history[0]?.blob))).toContain(
-      'Connect services'
-    );
+    const ackBlob = JSON.stringify(parsePostBlob(history[0]?.blob));
+    expect(ackBlob).not.toContain('Connect services');
+    // The schedule is said back in words, because the timezone arrived from a
+    // button tap that writes nothing to the channel.
+    expect(history[0]?.blob).toBeDefined();
+    expect(
+      history.map((post) => post.blob).filter(Boolean).length
+    ).toBeGreaterThanOrEqual(2);
   });
 
   it('posts a note reference when the correlated first run finishes', async () => {

--- a/packages/openclaw/src/monitor/agent-onboarding.test.ts
+++ b/packages/openclaw/src/monitor/agent-onboarding.test.ts
@@ -757,6 +757,114 @@ describe('primary onboarding cron slot', () => {
 });
 
 describe('provision coordinator ordering', () => {
+  it('reports each funnel step exactly once, in order', async () => {
+    // An unfired analytics event is invisible, so the funnel's shape is worth
+    // pinning: these are the steps a healthy setup must emit, and the order is
+    // what makes drop-off computable.
+    const steps: string[] = [];
+    const trackStep = (report: { step: string; outcome?: string }) =>
+      steps.push(`${report.step}:${report.outcome ?? 'ok'}`);
+    const history: Array<{
+      author: string;
+      content: string;
+      timestamp: number;
+      blob?: string;
+    }> = [];
+    let jobs: Record<string, unknown>[] = [];
+    const cron = {
+      list: vi.fn(async () => jobs),
+      add: vi.fn(async (input) => {
+        jobs = [{ id: 'job-1', ...input }];
+      }),
+      update: vi.fn(),
+      remove: vi.fn(),
+      enqueueRun: vi.fn(async () => ({ enqueued: true, runId: 'run-1' })),
+    } as unknown as TlonCronService;
+
+    await handleAgentOnboardingRequest(
+      {
+        api: {
+          scry: vi.fn(async () => ({
+            groups: {
+              [provision.groupId]: {
+                channels: { [provision.notebookNest]: {} },
+                seats: { '~bot': { roles: ['admin'] } },
+              },
+            },
+          })),
+        },
+        botShip: '~bot',
+        channelNest: 'chat/~ten/group/general',
+        groupId: provision.groupId,
+        ownerShip: '~ten',
+        senderShip: '~ten',
+        blob: appendToPostBlob(undefined, provision),
+        trackStep,
+      },
+      {
+        fetchHistory: vi.fn(async () => history),
+        getCron: () => cron,
+        sendPost: vi.fn(async ({ blob }) => {
+          history.push({
+            author: '~bot',
+            content: '',
+            timestamp: Date.now(),
+            blob,
+          });
+          return { channel: 'tlon' as const, messageId: 'post', sentAt: 0 };
+        }),
+      }
+    );
+
+    expect(steps).toEqual([
+      'provision_received:ok',
+      'cron_created:ok',
+      'first_run_enqueued:ok',
+    ]);
+  });
+
+  it('reports a rejected provision as a failed step', async () => {
+    const steps: Array<{ step: string; outcome?: string; errorText?: string }> =
+      [];
+    await handleAgentOnboardingRequest(
+      {
+        api: {
+          // Owner mismatch: the group is hosted by someone else.
+          scry: vi.fn(async () => ({
+            groups: {
+              [provision.groupId]: {
+                channels: { [provision.notebookNest]: {} },
+                seats: { '~bot': { roles: ['admin'] } },
+              },
+            },
+          })),
+        },
+        botShip: '~bot',
+        channelNest: 'chat/~ten/group/general',
+        groupId: provision.groupId,
+        ownerShip: '~ten',
+        senderShip: '~ten',
+        blob: appendToPostBlob(undefined, {
+          ...provision,
+          notebookNest: 'notes/~ten/not-a-listed-channel',
+        }),
+        trackStep: (report) => steps.push(report),
+      },
+      {
+        fetchHistory: vi.fn(async () => []),
+        getCron: () => undefined as never,
+        sendPost: vi.fn(),
+      }
+    );
+
+    // The drop-off has to be visible, not just absent from the funnel.
+    expect(steps).toHaveLength(1);
+    expect(steps[0]).toMatchObject({
+      step: 'provision_received',
+      outcome: 'failed',
+    });
+  });
+
   it('posts a durable ack before forcing the first run', async () => {
     const events: string[] = [];
     const history: Array<{

--- a/packages/openclaw/src/monitor/agent-onboarding.ts
+++ b/packages/openclaw/src/monitor/agent-onboarding.ts
@@ -13,6 +13,7 @@ import type {
 
 import { type TlonCronService, getTlonCronService } from '../cron-telemetry.js';
 import { sharedMap } from '../shared-state.js';
+import type { TlonOnboardingStep } from '../telemetry.js';
 import { makeA2UIBlob } from '../urbit/blob.js';
 import { type BotProfile, sendChannelPost } from '../urbit/send.js';
 import { markdownToStory } from '../urbit/story.js';
@@ -21,6 +22,18 @@ import { type TlonHistoryEntry, fetchChannelHistory } from './history.js';
 type AgentRequest =
   | PostBlobDataEntryAgentIntroRequest
   | PostBlobDataEntryAgentProvision;
+
+export type OnboardingStepReport = {
+  step: TlonOnboardingStep;
+  outcome?: 'ok' | 'failed';
+  purposeId?: string | null;
+  topicCount?: number | null;
+  timezone?: string | null;
+  cronJobId?: string | null;
+  notebookNest?: string | null;
+  groupFlag?: string | null;
+  errorText?: string | null;
+};
 
 type AgentOnboardingContext = {
   api: { scry: (path: string) => Promise<unknown> };
@@ -33,6 +46,13 @@ type AgentOnboardingContext = {
   rawText?: string;
   blob: string | null | undefined;
   log?: (message: string) => void;
+  /**
+   * Funnel reporting, injected the same way `log` and `presentation` are, so
+   * this module never reaches for the telemetry singleton itself. Every step a
+   * healthy setup passes through reports exactly once; the caller fills in
+   * identity and timing.
+   */
+  trackStep?: (report: OnboardingStepReport) => void;
   presentation?: {
     startThinking: () => void | Promise<void>;
     stopThinking: () => void | Promise<void>;
@@ -394,6 +414,7 @@ async function postIntro(
   deps: AgentOnboardingDeps,
   presentation: OnboardingPresentation
 ) {
+  const hadIntro = hasPostMarker(history, context.botShip, 'intro');
   await postOnce(
     context,
     history,
@@ -404,6 +425,12 @@ async function postIntro(
     deps,
     presentation
   );
+  // Only on the post that actually lands, so a re-entered opening doesn't
+  // inflate the top of the funnel.
+  if (!hadIntro) {
+    context.trackStep?.({ step: 'intro_posted' });
+  }
+  const hadPicker = hasPostMarker(history, context.botShip, 'purpose-picker');
   await postOnce(
     context,
     history,
@@ -418,6 +445,9 @@ async function postIntro(
     deps,
     presentation
   );
+  if (!hadPicker) {
+    context.trackStep?.({ step: 'purpose_picker_posted' });
+  }
 }
 
 async function advanceDurableConversation(
@@ -443,6 +473,7 @@ async function advanceDurableConversation(
 
   if (!hasPostMarker(history, context.botShip, 'topics-picker')) {
     const purpose = purposeForReply(text);
+    context.trackStep?.({ step: 'purpose_chosen', purposeId: purpose.id });
     await postOnce(
       context,
       history,
@@ -461,6 +492,10 @@ async function advanceDurableConversation(
       deps,
       presentation
     );
+    context.trackStep?.({
+      step: 'topics_picker_posted',
+      purposeId: purpose.id,
+    });
     return true;
   }
 
@@ -567,6 +602,12 @@ async function provision(
   // presence immediately so group verification and cron setup both count
   // toward the response floor instead of adding an artificial delay later.
   await presentation.start();
+  const stepFacts = {
+    purposeId: request.purposeId,
+    topicCount: request.topics.length,
+    timezone: request.timezone,
+    notebookNest: request.notebookNest,
+  };
   const group = await (
     deps.getGroup ?? ((groupId) => fetchOnboardingGroup(context.api, groupId))
   )(request.groupId);
@@ -578,6 +619,12 @@ async function provision(
     )
   ) {
     context.log?.('[tlon] rejected agent provision: invalid owner or notebook');
+    context.trackStep?.({
+      step: 'provision_received',
+      outcome: 'failed',
+      ...stepFacts,
+      errorText: 'invalid owner or notebook',
+    });
     return;
   }
   const botMember = group.members?.find(
@@ -592,8 +639,18 @@ async function provision(
   });
   if (!isAdmin) {
     context.log?.('[tlon] rejected agent provision: agent is not an admin');
+    context.trackStep?.({
+      step: 'provision_received',
+      outcome: 'failed',
+      ...stepFacts,
+      errorText: 'agent is not an admin',
+    });
     return;
   }
+  // Emitted once validation has passed, not on entry: a rejected provision
+  // reports the same step as `failed`, and firing both would count one
+  // provision twice at the widest part of the funnel.
+  context.trackStep?.({ step: 'provision_received', ...stepFacts });
 
   const ackKey = `ack:${request.provisionId}`;
   const existingAck = hasPostMarker(history, context.botShip, ackKey);
@@ -609,6 +666,11 @@ async function provision(
   if (!existingAck) {
     if (!cron) throw new Error('cron service is not available');
     jobId = await upsertPrimaryJob(cron, request, context.channelNest);
+    context.trackStep?.({
+      step: 'cron_created',
+      ...stepFacts,
+      cronJobId: jobId,
+    });
     // Two beats, one idea each. These used to arrive as a single block that
     // acknowledged the topics, named the schedule, said "you're all set",
     // listed two tips and pitched connected services — five asks stacked
@@ -658,6 +720,11 @@ async function provision(
     }
     const disposition = await cron.enqueueRun(jobId!, 'force');
     rememberFirstRun(disposition, context, request, notebookName);
+    context.trackStep?.({
+      step: 'first_run_enqueued',
+      ...stepFacts,
+      cronJobId: jobId,
+    });
   }
 }
 
@@ -771,6 +838,14 @@ async function completeFirstRun(
       },
       runDeps
     );
+    // The bot's half of activation: the entry exists and has been announced.
+    // Whether the owner opened it is a client-side event.
+    correlation.context.trackStep?.({
+      step: 'first_entry_revealed',
+      purposeId: correlation.purposeId,
+      topicCount: correlation.topics.length,
+      notebookNest: correlation.notebookNest,
+    });
     // Expansion asks wait until after the payoff. An owner who never reaches
     // a first entry should never be pitched connected services.
     await postOnce(
@@ -793,6 +868,11 @@ async function completeFirstRun(
       }),
       runDeps
     );
+    correlation.context.trackStep?.({
+      step: 'services_offered',
+      purposeId: correlation.purposeId,
+      notebookNest: correlation.notebookNest,
+    });
   } catch (error) {
     firstRunCorrelations.set(correlationRunId, correlation);
     throw error;

--- a/packages/openclaw/src/monitor/agent-onboarding.ts
+++ b/packages/openclaw/src/monitor/agent-onboarding.ts
@@ -1477,11 +1477,13 @@ function buildInviteSurface(groupId: string) {
 }
 
 /**
- * `variant: 'primary'` is load-bearing, not decoration. The default treatment
- * is `fill: 'outline', intent: 'secondary'`, which on the dark theme is a
- * grey outline on a near-black card — the button was effectively invisible in
- * a recorded run. Primary also opts the button into the consumed/disabled
- * state, which only applies to primary buttons in the renderer.
+ * The services card.
+ *
+ * A `Choice` rather than a `Button`: the same tappable card treatment the
+ * purpose picker uses, which carries an icon, a title and a description
+ * instead of a bare text label. The old bare button also had no `variant`, so
+ * it rendered with the default `fill: 'outline', intent: 'secondary'` — a grey
+ * outline on a near-black card, effectively invisible in a recorded run.
  */
 function buildServicesSurface(pitch: string) {
   return withFallbackStory(
@@ -1490,17 +1492,25 @@ function buildServicesSurface(pitch: string) {
       { id: 'pitch', component: 'Text', text: pitch },
       {
         id: 'cta',
-        component: 'Button',
-        variant: 'primary',
-        child: 'label',
-        action: {
-          event: {
-            name: A2UI.action.navigate,
-            context: { target: { type: 'screen', screen: 'botMcpSettings' } },
+        component: 'Choice',
+        options: [
+          {
+            id: 'connect-services',
+            label: 'Connect External Services',
+            description: 'Bring your tools into Tlonbot’s context',
+            icon: 'Link',
+            accent: 'blue',
+            action: {
+              event: {
+                name: A2UI.action.navigate,
+                context: {
+                  target: { type: 'screen', screen: 'botMcpSettings' },
+                },
+              },
+            },
           },
-        },
+        ],
       },
-      { id: 'label', component: 'Text', text: 'Connect services' },
     ])
   );
 }

--- a/packages/openclaw/src/monitor/agent-onboarding.ts
+++ b/packages/openclaw/src/monitor/agent-onboarding.ts
@@ -1486,33 +1486,47 @@ function buildInviteSurface(groupId: string) {
  * outline on a near-black card, effectively invisible in a recorded run.
  */
 function buildServicesSurface(pitch: string) {
-  return withFallbackStory(
-    makeA2UIBlob('agent-services', 'root', [
-      { id: 'root', component: 'Column', children: ['pitch', 'cta'] },
-      { id: 'pitch', component: 'Text', text: pitch },
-      {
-        id: 'cta',
-        component: 'Choice',
-        options: [
-          {
-            id: 'connect-services',
-            label: 'Connect External Services',
-            description: 'Bring your tools into Tlonbot’s context',
-            icon: 'Link',
-            accent: 'blue',
-            action: {
-              event: {
-                name: A2UI.action.navigate,
-                context: {
-                  target: { type: 'screen', screen: 'botMcpSettings' },
+  const build = (icon?: 'Link') =>
+    withFallbackStory(
+      makeA2UIBlob('agent-services', 'root', [
+        { id: 'root', component: 'Column', children: ['pitch', 'cta'] },
+        { id: 'pitch', component: 'Text', text: pitch },
+        {
+          id: 'cta',
+          component: 'Choice',
+          options: [
+            {
+              id: 'connect-services',
+              label: 'Connect External Services',
+              description: 'Bring your tools into Tlonbot’s context',
+              // Spelled literally for the same reason the purpose options are:
+              // this plugin can build against a published @tloncorp/api that
+              // predates the icon.
+              ...(icon ? { icon: icon as A2UI.ChoiceIcon } : {}),
+              accent: 'blue',
+              action: {
+                event: {
+                  name: A2UI.action.navigate,
+                  context: {
+                    target: { type: 'screen', screen: 'botMcpSettings' },
+                  },
                 },
               },
             },
-          },
-        ],
-      },
-    ])
-  );
+          ],
+        },
+      ])
+    );
+
+  // `makeA2UIBlob` validates against the *running* @tloncorp/api, whose
+  // CHOICE_ICONS allowlist is fixed at publish time. Rather than hold the card
+  // hostage to an api release, fall back to the same card without the icon and
+  // pick the icon up automatically once a build ships that knows it.
+  try {
+    return build('Link');
+  } catch {
+    return build();
+  }
 }
 
 function buildProvisionHandoffSurface(acknowledgement: string) {

--- a/packages/openclaw/src/monitor/agent-onboarding.ts
+++ b/packages/openclaw/src/monitor/agent-onboarding.ts
@@ -60,7 +60,7 @@ type AgentOnboardingCronDeps = {
 
 type OnboardingGroup = {
   hostUserId: string;
-  channels?: Array<{ id: string; type: string }>;
+  channels?: Array<{ id: string; type: string; title?: string }>;
   members?: Array<{
     contactId: string;
     status: string;
@@ -178,8 +178,27 @@ const firstRunCorrelations = sharedMap<
   {
     context: AgentOnboardingScanContext;
     notebookNest: string;
+    notebookName: string;
     provisionId: string;
     purposeId: string;
+    /**
+     * Bound in the module context that provisioned the run.
+     *
+     * The completion hooks (`message_sent`, `cron_changed`) fire from the
+     * extension entry, while provisioning runs in the lazy runtime module —
+     * separate module-loader contexts, per `shared-state.ts`. The correlation
+     * itself survives that split because it lives in a `sharedMap`, but
+     * `@tloncorp/api`'s `client` is a module-level proxy, so the entry side
+     * holds a second, unconfigured copy: calling `notes.listNotes` or
+     * `sendChannelPost` from there threw "Client not initialized" and the
+     * first-entry reveal was never posted. Capturing the functions here keeps
+     * the completion on the configured client.
+     */
+    bound: {
+      fetchHistory: typeof fetchChannelHistory;
+      listNotes: typeof notes.listNotes;
+      sendPost: typeof sendChannelPost;
+    };
   }
 >('agentOnboarding.firstRunCorrelations');
 const SLOT_PREFIX = 'tlon-agent-primary:';
@@ -576,10 +595,14 @@ async function provision(
     ? findAckJobId(history, context.botShip, request.provisionId)
     : null;
   const cron = (deps.getCron ?? getTlonCronService)();
+  const notebookName = notebookDisplayName(
+    request.notebookNest,
+    group.channels?.find((channel) => channel.id === request.notebookNest)
+      ?.title
+  );
   if (!existingAck) {
     if (!cron) throw new Error('cron service is not available');
     jobId = await upsertPrimaryJob(cron, request, context.channelNest);
-    const notebookName = notebookDisplayName(request.notebookNest);
     // Two beats, one idea each. These used to arrive as a single block that
     // acknowledged the topics, named the schedule, said "you're all set",
     // listed two tips and pitched connected services — five asks stacked
@@ -628,7 +651,7 @@ async function provision(
       );
     }
     const disposition = await cron.enqueueRun(jobId!, 'force');
-    rememberFirstRun(disposition, context, request);
+    rememberFirstRun(disposition, context, request, notebookName);
   }
 }
 
@@ -671,13 +694,24 @@ async function completeFirstRun(
   // cannot race each other into duplicate chat posts.
   firstRunCorrelations.delete(correlationRunId);
 
+  // Explicit deps win (tests), then the implementations bound in the context
+  // that provisioned this run, and only then this module's own — which, on the
+  // extension-entry side, are backed by an unconfigured client.
+  const bound = correlation.bound;
+  const runDeps: AgentOnboardingCronDeps = {
+    fetchHistory:
+      deps.fetchHistory ?? bound?.fetchHistory ?? fetchChannelHistory,
+    listNotes: deps.listNotes ?? bound?.listNotes ?? notes.listNotes,
+    sendPost: deps.sendPost ?? bound?.sendPost ?? sendChannelPost,
+  };
+
   try {
-    const history = await (deps.fetchHistory ?? fetchChannelHistory)(
+    const history = await runDeps.fetchHistory!(
       correlation.context.api,
       correlation.context.channelNest,
       50
     );
-    const notebookName = notebookDisplayName(correlation.notebookNest);
+    const notebookName = correlation.notebookName;
     // Keyed on the channel, not the provision. Re-provisioning mints a new
     // provisionId, and the old per-provision key let the same reveal post
     // three times in one setup.
@@ -686,9 +720,9 @@ async function completeFirstRun(
       history,
       'first-entry-ping',
       async () => {
-        const listed = await (deps.listNotes ?? notes.listNotes)(
-          correlation.notebookNest
-        ).catch(() => []);
+        const listed = await runDeps.listNotes!(correlation.notebookNest).catch(
+          () => []
+        );
         const newest = [...listed].sort(
           (a, b) => (b.createdAt ?? b.noteId) - (a.createdAt ?? a.noteId)
         )[0];
@@ -722,7 +756,7 @@ async function completeFirstRun(
           story,
         };
       },
-      deps
+      runDeps
     );
     // Expansion asks wait until after the payoff. An owner who never reaches
     // a first entry should never be pitched connected services.
@@ -731,7 +765,7 @@ async function completeFirstRun(
       history,
       'handoff',
       async () => ({ text: HANDOFF_MESSAGE }),
-      deps
+      runDeps
     );
     await postOnce(
       correlation.context,
@@ -744,7 +778,7 @@ async function completeFirstRun(
           buildServicesSurface(servicesPitch(correlation.purposeId))
         ),
       }),
-      deps
+      runDeps
     );
   } catch (error) {
     firstRunCorrelations.set(correlationRunId, correlation);
@@ -770,7 +804,8 @@ function findFirstRunCorrelation(
 function rememberFirstRun(
   disposition: unknown,
   context: AgentOnboardingScanContext,
-  request: PostBlobDataEntryAgentProvision
+  request: PostBlobDataEntryAgentProvision,
+  notebookName?: string
 ) {
   if (!disposition || typeof disposition !== 'object') return;
   const result = disposition as { enqueued?: unknown; runId?: unknown };
@@ -783,8 +818,14 @@ function rememberFirstRun(
   firstRunCorrelations.set(result.runId, {
     context,
     notebookNest: request.notebookNest,
+    notebookName: notebookName ?? notebookDisplayName(request.notebookNest),
     provisionId: request.provisionId,
     purposeId: request.purposeId,
+    bound: {
+      fetchHistory: fetchChannelHistory,
+      listNotes: notes.listNotes,
+      sendPost: sendChannelPost,
+    },
   });
 }
 
@@ -796,7 +837,7 @@ async function fetchOnboardingGroup(
     groups?: Record<
       string,
       {
-        channels?: Record<string, unknown>;
+        channels?: Record<string, { meta?: { title?: unknown } }>;
         seats?: Record<string, { roles?: unknown[] }>;
       }
     >;
@@ -805,9 +846,13 @@ async function fetchOnboardingGroup(
   if (!group) throw new Error(`onboarding group not found: ${groupId}`);
   return {
     hostUserId: groupId.split('/')[0] ?? '',
-    channels: Object.keys(group.channels ?? {}).map((id) => ({
+    channels: Object.entries(group.channels ?? {}).map(([id, channel]) => ({
       id,
       type: id.split('/')[0] ?? '',
+      title:
+        typeof channel?.meta?.title === 'string'
+          ? channel.meta.title
+          : undefined,
     })),
     members: Object.entries(group.seats ?? {}).map(([contactId, seat]) => ({
       contactId,
@@ -1222,11 +1267,20 @@ function formatTopicList(topics: readonly string[]): string {
 }
 
 /**
- * Turn a notes nest into the name the sidebar shows, so chat copy and the
- * channel list agree. `notes/~sampel-palnet/daily-digest` reads back as
- * "Daily digest".
+ * The name the sidebar shows for the notebook, so chat copy and the channel
+ * list agree.
+ *
+ * Prefer the channel's real title. Deriving it from the nest slug is only a
+ * fallback and is not always right: the ship dedupes slugs, so a second
+ * notebook lands at `…/updates-1` while its title stays "Updates" — copy built
+ * from the slug then points at a channel name that appears nowhere on screen.
  */
-function notebookDisplayName(notebookNest: string): string {
+function notebookDisplayName(
+  notebookNest: string,
+  title?: string | null
+): string {
+  const named = title?.trim();
+  if (named) return named;
   const slug = notebookNest.split('/').pop() ?? '';
   const words = slug.split('-').filter(Boolean);
   if (!words.length) return 'the notebook';
@@ -1503,9 +1557,13 @@ export const agentOnboardingTesting = {
   buildServicesSurface,
   findAckJobId,
   hasPostMarker,
+  hasProvisionAck,
   jobMatches,
+  notebookDisplayName,
   purposeForReply,
   provisionCadence,
   rememberFirstRun,
+  scheduleConfirmation,
+  servicesPitch,
   upsertPrimaryJob,
 };

--- a/packages/openclaw/src/monitor/agent-onboarding.ts
+++ b/packages/openclaw/src/monitor/agent-onboarding.ts
@@ -46,6 +46,8 @@ type AgentOnboardingDeps = {
   getCron?: typeof getTlonCronService;
   getGroup?: (groupId: string) => Promise<OnboardingGroup>;
   now?: () => number;
+  /** Injectable so pacing jitter is deterministic under test. */
+  random?: () => number;
   sendPost?: typeof sendChannelPost;
   sleep?: (ms: number) => Promise<void>;
 };
@@ -74,15 +76,23 @@ type AgentOnboardingScanContext = Omit<
 const postOnceFlights = new Map<string, Promise<void>>();
 const DEFAULT_MIN_RESPONSE_DELAY_MS = 1_250;
 const DEFAULT_MIN_INTER_MESSAGE_DELAY_MS = 1_000;
+const COMPOSE_MS_PER_CHARACTER = 14;
+const MIN_COMPOSE_DELAY_MS = 800;
+const MAX_COMPOSE_DELAY_MS = 3_500;
+const READ_BASE_MS = 500;
+const READ_MS_PER_CHARACTER = 10;
+const READ_DELAY_CAP_MS = 1_500;
+const JITTER_RATIO = 0.2;
 const LEGACY_GROUP_INTRO_PREFIX = "I'm your Tlonbot.";
 const GROUP_INTRO_MESSAGE =
   "I'm your Tlonbot. I can research things, track changes, and write " +
   'updates for you.';
 const PURPOSE_PICKER_PROMPT = 'What should this group do?';
+// The services line moved out into its own beat after the first entry lands,
+// so this is now only the "you can steer me" tip.
 const HANDOFF_MESSAGE =
-  'A few things to know:\n\n' +
-  '- Ask me here to change what I cover, when I post, or my name.\n' +
-  '- Connect calendars, docs, or notes to give me more to work with:';
+  'From here, just ask me in this chat to change what I cover, when I post, ' +
+  'or what I’m called.';
 const TOPICS_PICKER_FALLBACK_INSTRUCTION =
   'You can also just tell me here in the chat.';
 const TIMEZONE_PICKER_QUESTION =
@@ -169,6 +179,7 @@ const firstRunCorrelations = sharedMap<
     context: AgentOnboardingScanContext;
     notebookNest: string;
     provisionId: string;
+    purposeId: string;
   }
 >('agentOnboarding.firstRunCorrelations');
 const SLOT_PREFIX = 'tlon-agent-primary:';
@@ -334,6 +345,7 @@ function pendingDurableReply(
   botShip: string,
   ownerShip: string
 ) {
+  if (hasProvisionAck(history, botShip)) return null;
   if (hasPostMarker(history, botShip, 'timezone-picker')) return null;
   const active = hasPostMarker(history, botShip, 'topics-picker')
     ? markerPost(history, botShip, 'topics-picker')
@@ -391,6 +403,16 @@ async function advanceDurableConversation(
 ): Promise<boolean> {
   const text = context.rawText!.trim();
   if (!hasPostMarker(history, context.botShip, 'purpose-picker')) {
+    return false;
+  }
+
+  // Setup is over the moment a provision is acknowledged, and chat after that
+  // point belongs to the ordinary conversation. Without this the topics branch
+  // below stayed armed forever on the picker-submit path, which never posts a
+  // timezone picker: an owner who read "You're all set" and typed back
+  // "That's it?" had that question parsed as their topic list, re-asked for a
+  // timezone, and got a researched notebook entry about the phrase itself.
+  if (hasProvisionAck(history, context.botShip)) {
     return false;
   }
 
@@ -557,23 +579,21 @@ async function provision(
   if (!existingAck) {
     if (!cron) throw new Error('cron service is not available');
     jobId = await upsertPrimaryJob(cron, request, context.channelNest);
+    const notebookName = notebookDisplayName(request.notebookNest);
+    // Two beats, one idea each. These used to arrive as a single block that
+    // acknowledged the topics, named the schedule, said "you're all set",
+    // listed two tips and pitched connected services — five asks stacked
+    // before any value had landed.
     const acknowledgement =
       `${formatTopicList(request.topics)}—got it. ` +
-      `${provisionCadence(request.purposeId)} ` +
-      'You’re all set. Your first entry is on the way. You can leave this ' +
-      'screen and explore the app while I work.';
+      `${provisionCadence(request.purposeId, notebookName)} ` +
+      `${scheduleConfirmation(request)}`;
     await postOnce(
       context,
       history,
       ackKey,
       async () => ({
-        text:
-          `${acknowledgement}\n\n${HANDOFF_MESSAGE}\n\n` +
-          'Connect services in Settings.',
-        blob: appendToPostBlob(
-          undefined,
-          buildProvisionHandoffSurface(acknowledgement)
-        ),
+        text: acknowledgement,
         entries: [
           {
             type: 'tlon-agent-provision-ack',
@@ -581,42 +601,20 @@ async function provision(
             provisionId: request.provisionId,
             cronJobId: jobId!,
           },
-          {
-            type: 'tlon-agent-post-marker',
-            version: 1,
-            key: 'handoff',
-          },
-          {
-            type: 'tlon-agent-post-marker',
-            version: 1,
-            key: 'services-card',
-          },
         ],
       }),
       deps,
       presentation
     );
-  } else {
-    // Older acknowledgements predate the combined handoff. Repair only the
-    // pieces their durable history is missing; new acknowledgements carry all
-    // three markers in one post and never take this path.
+    // Deliberately does not tell them to leave: the first entry is the
+    // activation moment and it lands within a minute or two, so pushing them
+    // out of the channel here is pushing them away from the payoff.
     await postOnce(
       context,
       history,
-      'handoff',
+      'first-entry-pending',
       async () => ({
-        text: HANDOFF_MESSAGE,
-      }),
-      deps,
-      presentation
-    );
-    await postOnce(
-      context,
-      history,
-      'services-card',
-      async () => ({
-        text: 'Connect services in Settings.',
-        blob: appendToPostBlob(undefined, buildServicesSurface()),
+        text: `Writing your first entry now — give me a minute.`,
       }),
       deps,
       presentation
@@ -679,10 +677,14 @@ async function completeFirstRun(
       correlation.context.channelNest,
       50
     );
+    const notebookName = notebookDisplayName(correlation.notebookNest);
+    // Keyed on the channel, not the provision. Re-provisioning mints a new
+    // provisionId, and the old per-provision key let the same reveal post
+    // three times in one setup.
     await postOnce(
       correlation.context,
       history,
-      `first-entry-ping:${correlation.provisionId}`,
+      'first-entry-ping',
       async () => {
         const listed = await (deps.listNotes ?? notes.listNotes)(
           correlation.notebookNest
@@ -690,7 +692,18 @@ async function completeFirstRun(
         const newest = [...listed].sort(
           (a, b) => (b.createdAt ?? b.noteId) - (a.createdAt ?? a.noteId)
         )[0];
-        const message = "Your group's first entry is ready:";
+        // The cite renders as "Content not available" whenever the client
+        // hasn't synced the notes channel yet, so the sentence has to carry
+        // the entry on its own: name the note and where it lives, and let the
+        // card be a bonus rather than the whole message.
+        const title = newest?.title?.trim();
+        const message = title
+          ? `Your first entry is ready — “${title}”, in ${notebookName}. ` +
+            'That notebook is where everything I write for you lands; this ' +
+            'chat is for talking to me.'
+          : `Your first entry is ready, in ${notebookName}. That notebook is ` +
+            'where everything I write for you lands; this chat is for ' +
+            'talking to me.';
         const story = markdownToStory(message);
         if (newest) {
           story.push({
@@ -709,6 +722,28 @@ async function completeFirstRun(
           story,
         };
       },
+      deps
+    );
+    // Expansion asks wait until after the payoff. An owner who never reaches
+    // a first entry should never be pitched connected services.
+    await postOnce(
+      correlation.context,
+      history,
+      'handoff',
+      async () => ({ text: HANDOFF_MESSAGE }),
+      deps
+    );
+    await postOnce(
+      correlation.context,
+      history,
+      'services-card',
+      async () => ({
+        text: servicesPitch(correlation.purposeId),
+        blob: appendToPostBlob(
+          undefined,
+          buildServicesSurface(servicesPitch(correlation.purposeId))
+        ),
+      }),
       deps
     );
   } catch (error) {
@@ -749,6 +784,7 @@ function rememberFirstRun(
     context,
     notebookNest: request.notebookNest,
     provisionId: request.provisionId,
+    purposeId: request.purposeId,
   });
 }
 
@@ -790,10 +826,46 @@ type PostOnceContent = {
 
 type OnboardingPresentation = {
   start: () => Promise<void>;
-  beforePost: () => Promise<void>;
+  beforePost: (text?: string) => Promise<void>;
   afterPost: () => void;
   finish: () => Promise<void>;
 };
+
+/**
+ * How long the bot appears to spend composing a message.
+ *
+ * A single flat floor for every post reads as a machine on a timer: the same
+ * beat before a two-word acknowledgement and before three paragraphs. Scaling
+ * with the length of what is about to be said, and jittering it, is what makes
+ * the rhythm feel like someone typing.
+ */
+function composeDelayMs(text: string | undefined, floorMs: number) {
+  const characters = text?.length ?? 0;
+  return clampDelay(floorMs + characters * COMPOSE_MS_PER_CHARACTER);
+}
+
+/**
+ * Time to "read" what the owner just sent, added before the first reply of a
+ * turn. Replying to a typed sentence as fast as to a button tap is one of the
+ * tells that nothing is listening.
+ */
+function readDelayMs(text: string | undefined) {
+  const characters = text?.trim().length ?? 0;
+  if (!characters) return 0;
+  return Math.min(
+    READ_DELAY_CAP_MS,
+    READ_BASE_MS + characters * READ_MS_PER_CHARACTER
+  );
+}
+
+function clampDelay(ms: number) {
+  return Math.min(MAX_COMPOSE_DELAY_MS, Math.max(MIN_COMPOSE_DELAY_MS, ms));
+}
+
+/** ±20%, so no two consecutive pauses are identical. */
+function jitter(ms: number, random: () => number) {
+  return Math.round(ms * (1 + (random() * 2 - 1) * JITTER_RATIO));
+}
 
 function createOnboardingPresentation(
   context: AgentOnboardingContext,
@@ -821,6 +893,7 @@ function createOnboardingPresentation(
     0,
     config.minInterMessageDelayMs ?? DEFAULT_MIN_INTER_MESSAGE_DELAY_MS
   );
+  const random = deps.random ?? Math.random;
   let startedAt: number | null = null;
   let lastPostAt: number | null = null;
   let active = false;
@@ -840,12 +913,21 @@ function createOnboardingPresentation(
 
   return {
     start,
-    beforePost: async () => {
+    beforePost: async (text?: string) => {
+      // start() first, always: the indicator has to be up for the whole pause,
+      // or the wait reads as the app hanging rather than the bot thinking.
       await start();
-      const earliestPostAt =
+      const composeMs = composeDelayMs(
+        text,
+        lastPostAt === null ? minResponseDelayMs : minInterMessageDelayMs
+      );
+      const withRead =
         lastPostAt === null
-          ? (startedAt ?? now()) + minResponseDelayMs
-          : lastPostAt + minInterMessageDelayMs;
+          ? composeMs + readDelayMs(context.rawText)
+          : composeMs;
+      const earliestPostAt =
+        (lastPostAt === null ? startedAt ?? now() : lastPostAt) +
+        jitter(withRead, random);
       const remainingMs = earliestPostAt - now();
       if (remainingMs > 0) {
         await sleep(remainingMs);
@@ -891,7 +973,7 @@ async function postOnce(
       version: 1,
       key,
     });
-    await presentation?.beforePost();
+    await presentation?.beforePost(content.text);
     try {
       await (deps.sendPost ?? sendChannelPost)({
         fromShip: context.botShip,
@@ -938,6 +1020,18 @@ function hasPostMarker(
         )
     );
   });
+}
+
+/** True once any provision has been acknowledged in this channel. */
+function hasProvisionAck(history: TlonHistoryEntry[], botShip: string) {
+  return history.some(
+    (post) =>
+      post.author === botShip &&
+      post.blob &&
+      parsePostBlob(post.blob).some(
+        (entry) => entry.type === 'tlon-agent-provision-ack'
+      )
+  );
 }
 
 function findAckJobId(
@@ -1127,14 +1221,85 @@ function formatTopicList(topics: readonly string[]): string {
   return `${topics.slice(0, -1).join(', ')}, and ${topics[topics.length - 1]}`;
 }
 
-function provisionCadence(purposeId: string) {
+/**
+ * Turn a notes nest into the name the sidebar shows, so chat copy and the
+ * channel list agree. `notes/~sampel-palnet/daily-digest` reads back as
+ * "Daily digest".
+ */
+function notebookDisplayName(notebookNest: string): string {
+  const slug = notebookNest.split('/').pop() ?? '';
+  const words = slug.split('-').filter(Boolean);
+  if (!words.length) return 'the notebook';
+  const [first, ...rest] = words;
+  return [first![0]!.toUpperCase() + first!.slice(1), ...rest].join(' ');
+}
+
+/**
+ * What the schedule does and — the part the old copy left out — where the
+ * result lands. "Publish" on its own, or worse "publish here", read as chat:
+ * an owner watched a notebook appear in the sidebar without ever being told
+ * it existed or what it was for.
+ */
+function provisionCadence(purposeId: string, notebookName: string) {
   switch (purposeId) {
     case 'agent-learning':
-      return 'I’ll publish one useful idea each morning, rotating through your list.';
+      return (
+        `Every morning I’ll write a new entry in ${notebookName}, this ` +
+        'group’s notebook — one useful idea at a time, rotating through your list.'
+      );
     case 'agent-research':
-      return 'I’ll check for new work each morning and publish a source-backed update here.';
+      return (
+        `Every morning I’ll check for new work and write a source-backed ` +
+        `update in ${notebookName}, this group’s notebook.`
+      );
     default:
-      return 'I’ll publish one fresh digest here each morning.';
+      return (
+        `Every morning I’ll write a fresh digest in ${notebookName}, this ` +
+        'group’s notebook.'
+      );
+  }
+}
+
+/**
+ * Say the schedule back in words.
+ *
+ * The timezone arrives from a tap on "Use my current timezone", which fires a
+ * client-side event and writes nothing to the channel. With no trace in chat
+ * an owner had no way to know the tap registered — they typed "I clicked the
+ * current time zone button" to ask, and the conversational model, which also
+ * cannot see A2UI state, replied that it couldn't see the selection either.
+ * Naming the resolved time and zone here is the receipt for that tap.
+ */
+function scheduleConfirmation(request: PostBlobDataEntryAgentProvision) {
+  const hour = request.scheduleHour % 12 === 0 ? 12 : request.scheduleHour % 12;
+  const meridiem = request.scheduleHour < 12 ? 'AM' : 'PM';
+  const minute = String(request.scheduleMinute).padStart(2, '0');
+  return `First one lands at ${hour}:${minute} ${meridiem} in ${request.timezone}.`;
+}
+
+/**
+ * The services pitch, in terms of what the owner just built. The old copy
+ * ("Connect calendars, docs, or notes to give me more to work with") named
+ * the mechanism and no benefit, and read identically whichever purpose was
+ * chosen.
+ */
+function servicesPitch(purposeId: string) {
+  switch (purposeId) {
+    case 'agent-learning':
+      return (
+        'Connect your calendar or your notes and I can time lessons around ' +
+        'your day and build on what you’re already reading.'
+      );
+    case 'agent-research':
+      return (
+        'Connect your docs or notes and I can tell what’s genuinely new to ' +
+        'you, instead of repeating what you’ve already filed.'
+      );
+    default:
+      return (
+        'Connect your calendar and docs and your morning digest can cover ' +
+        'your own day — meetings, deadlines, notes — not just the news.'
+      );
   }
 }
 
@@ -1257,12 +1422,22 @@ function buildInviteSurface(groupId: string) {
   ]);
 }
 
-function buildServicesSurface() {
+/**
+ * `variant: 'primary'` is load-bearing, not decoration. The default treatment
+ * is `fill: 'outline', intent: 'secondary'`, which on the dark theme is a
+ * grey outline on a near-black card — the button was effectively invisible in
+ * a recorded run. Primary also opts the button into the consumed/disabled
+ * state, which only applies to primary buttons in the renderer.
+ */
+function buildServicesSurface(pitch: string) {
   return withFallbackStory(
     makeA2UIBlob('agent-services', 'root', [
+      { id: 'root', component: 'Column', children: ['pitch', 'cta'] },
+      { id: 'pitch', component: 'Text', text: pitch },
       {
-        id: 'root',
+        id: 'cta',
         component: 'Button',
+        variant: 'primary',
         child: 'label',
         action: {
           event: {

--- a/packages/openclaw/src/monitor/agent-onboarding.ts
+++ b/packages/openclaw/src/monitor/agent-onboarding.ts
@@ -123,13 +123,18 @@ const PURPOSE_OPTIONS = [
   {
     id: 'agent-learning',
     label: 'Learn something',
-    description: 'A short daily idea that builds your understanding over time.',
+    // Unlike the other two purposes, this one covers a single topic per entry
+    // and rotates. Say so at every point where the expectation forms — the
+    // card, the picker, and the acknowledgement — because "pick any that fit"
+    // otherwise reads as "these all go in tomorrow's digest".
+    description: 'One idea each morning, taking your topics in turn.',
     icon: 'Clock',
     accent: 'green',
     scheduleHour: 9,
     topicsPrompt:
-      'Good. I’ll set this group up to share one useful idea at a time and ' +
-      'build on it. What are you curious about? Pick any that fit.',
+      'Good. I’ll take one idea at a time and build on it — pick several and ' +
+      'I’ll work through them in turn, one each morning, rather than all at ' +
+      'once. What are you curious about? Pick any that fit.',
     topics: [
       'Music theory',
       'Genetics',
@@ -181,6 +186,7 @@ const firstRunCorrelations = sharedMap<
     notebookName: string;
     provisionId: string;
     purposeId: string;
+    topics: readonly string[];
     /**
      * Bound in the module context that provisioned the run.
      *
@@ -609,7 +615,7 @@ async function provision(
     // before any value had landed.
     const acknowledgement =
       `${formatTopicList(request.topics)}—got it. ` +
-      `${provisionCadence(request.purposeId, notebookName)} ` +
+      `${provisionCadence(request.purposeId, notebookName, request.topics)} ` +
       `${scheduleConfirmation(request)}`;
     await postOnce(
       context,
@@ -731,13 +737,20 @@ async function completeFirstRun(
         // the entry on its own: name the note and where it lives, and let the
         // card be a bonus rather than the whole message.
         const title = newest?.title?.trim();
+        // For a rotating purpose the reveal is where "I picked three, why is
+        // there one?" actually gets asked, so name what comes next.
+        const upNext =
+          correlation.purposeId === 'agent-learning' &&
+          correlation.topics.length > 1
+            ? ` Tomorrow: ${correlation.topics[1]}.`
+            : '';
         const message = title
           ? `Your first entry is ready — “${title}”, in ${notebookName}. ` +
             'That notebook is where everything I write for you lands; this ' +
-            'chat is for talking to me.'
+            `chat is for talking to me.${upNext}`
           : `Your first entry is ready, in ${notebookName}. That notebook is ` +
             'where everything I write for you lands; this chat is for ' +
-            'talking to me.';
+            `talking to me.${upNext}`;
         const story = markdownToStory(message);
         if (newest) {
           story.push({
@@ -821,6 +834,7 @@ function rememberFirstRun(
     notebookName: notebookName ?? notebookDisplayName(request.notebookNest),
     provisionId: request.provisionId,
     purposeId: request.purposeId,
+    topics: request.topics,
     bound: {
       fetchHistory: fetchChannelHistory,
       listNotes: notes.listNotes,
@@ -1294,13 +1308,26 @@ function notebookDisplayName(
  * an owner watched a notebook appear in the sidebar without ever being told
  * it existed or what it was for.
  */
-function provisionCadence(purposeId: string, notebookName: string) {
+function provisionCadence(
+  purposeId: string,
+  notebookName: string,
+  topics: readonly string[] = []
+) {
   switch (purposeId) {
-    case 'agent-learning':
-      return (
-        `Every morning I’ll write a new entry in ${notebookName}, this ` +
-        'group’s notebook — one useful idea at a time, rotating through your list.'
-      );
+    case 'agent-learning': {
+      // Naming the first two by hand is what makes the rotation land. "One at
+      // a time, rotating through your list" was already there and still read
+      // as a digest of everything picked — an owner who chose three topics
+      // saw one entry and thought the other two had been dropped.
+      const rotation =
+        topics.length > 1
+          ? `One topic each morning, taken in turn — ${topics[0]} first, ` +
+            `then ${topics[1]} — each its own entry in ${notebookName}, ` +
+            'this group’s notebook.'
+          : `Every morning I’ll write a new entry in ${notebookName}, this ` +
+            'group’s notebook, building on the last one.';
+      return rotation;
+    }
     case 'agent-research':
       return (
         `Every morning I’ll check for new work and write a source-backed ` +

--- a/packages/openclaw/src/monitor/index.ts
+++ b/packages/openclaw/src/monitor/index.ts
@@ -104,6 +104,7 @@ import {
   resolveTlonSkillVersion,
 } from '../version.js';
 import {
+  type OnboardingStepReport,
   handleAgentOnboardingRequest,
   scanAgentOnboardingChannel,
 } from './agent-onboarding.js';
@@ -3609,6 +3610,46 @@ export async function monitorTlonProvider(
       return initData.channels;
     };
 
+    /**
+     * Funnel reporting for agent onboarding.
+     *
+     * Best-effort start times so a row carries its own latency; PostHog can
+     * also derive it from event timestamps, so a miss after a restart costs a
+     * field, not the funnel.
+     */
+    const onboardingStartedAt = new Map<string, number>();
+    const trackOnboardingStep =
+      (nest: string, groupId: string | undefined) =>
+      (report: OnboardingStepReport) => {
+        if (report.step === 'intro_posted') {
+          onboardingStartedAt.set(nest, Date.now());
+        }
+        const startedAt = onboardingStartedAt.get(nest);
+        try {
+          telemetry?.captureOnboardingStep({
+            accountId: opts.accountId ?? null,
+            ownerShip: effectiveOwnerShip,
+            botShip: botShipName,
+            step: report.step,
+            outcome: report.outcome ?? 'ok',
+            nest,
+            groupFlag: report.groupFlag ?? groupId ?? null,
+            purposeId: report.purposeId ?? null,
+            topicCount: report.topicCount ?? null,
+            timezone: report.timezone ?? null,
+            cronJobId: report.cronJobId ?? null,
+            notebookNest: report.notebookNest ?? null,
+            elapsedMsSinceIntro: startedAt ? Date.now() - startedAt : null,
+            errorText: report.errorText ?? null,
+          });
+        } catch (error) {
+          // Telemetry must never take the setup down with it.
+          runtime.log?.(
+            `[tlon] onboarding step telemetry failed: ${String(error)}`
+          );
+        }
+      };
+
     const scanAgentOnboardingNest = async (nest: string) => {
       if (!nest.startsWith('chat/')) return;
       const groupId = channelToGroup.get(nest);
@@ -3622,6 +3663,7 @@ export async function monitorTlonProvider(
           groupId,
           ownerShip: effectiveOwnerShip,
           log: (message) => runtime.log?.(message),
+          trackStep: trackOnboardingStep(nest, groupId),
         });
       } catch (error) {
         runtime.error?.(
@@ -3832,6 +3874,7 @@ export async function monitorTlonProvider(
             rawText,
             blob: content.blob,
             log: (message) => runtime.log?.(message),
+            trackStep: trackOnboardingStep(nest, channelToGroup.get(nest)),
             presentation: {
               startThinking: () => {
                 computingPresence.refreshRun({

--- a/packages/openclaw/src/telemetry.ts
+++ b/packages/openclaw/src/telemetry.ts
@@ -444,6 +444,58 @@ export type TlonMigrationEvent = {
   errorText: string | null;
 };
 
+/**
+ * Steps of agent onboarding, in the order a healthy setup passes through them.
+ *
+ * The whole point is a funnel, so the values are ordered and every setup emits
+ * the same vocabulary: drop-off is `count(step N) / count(step N-1)`, and
+ * time-to-activation is `first_entry_revealed.at - intro_posted.at`.
+ *
+ * `first_entry_revealed` is activation as far as the bot can see it — the entry
+ * exists and has been announced. Whether the owner *looked* is a client-side
+ * event, because only the client knows that.
+ */
+export type TlonOnboardingStep =
+  | 'intro_posted'
+  | 'purpose_picker_posted'
+  | 'purpose_chosen'
+  | 'topics_picker_posted'
+  | 'provision_received'
+  | 'cron_created'
+  | 'first_run_enqueued'
+  | 'first_entry_revealed'
+  | 'services_offered';
+
+/**
+ * One event per onboarding step, per group.
+ *
+ * Deliberately narrower than the trace event this replaces: that one carried a
+ * deterministic coordinator's state machine (`onboardingState`,
+ * `onboardingNextState`, retry counters, draft sizes), and this flow has no
+ * such states. What is left is the funnel plus the few dimensions worth
+ * segmenting by.
+ *
+ * Topic *count*, never the topics themselves — the text is the owner's own
+ * words and does not belong in analytics.
+ */
+export type TlonOnboardingFunnelEvent = {
+  accountId: string | null;
+  ownerShip: string | null;
+  botShip: string;
+  step: TlonOnboardingStep;
+  outcome: 'ok' | 'failed';
+  nest: string;
+  groupFlag: string | null;
+  purposeId: string | null;
+  topicCount: number | null;
+  timezone: string | null;
+  cronJobId: string | null;
+  notebookNest: string | null;
+  /** Since the first step of this setup, so a funnel row carries its own latency. */
+  elapsedMsSinceIntro: number | null;
+  errorText: string | null;
+};
+
 export type TlonHarnessErrorScope =
   | 'harness'
   | 'model'
@@ -611,6 +663,7 @@ export interface TlonTelemetryClient {
   captureAuthAttemptFailed(event: TlonAuthAttemptFailedEvent): void;
   capturePluginError(event: TlonPluginErrorEvent): void;
   captureTelemetryError(event: TlonTelemetryErrorEvent): void;
+  captureOnboardingStep(event: TlonOnboardingFunnelEvent): void;
   captureCronJobChanged(event: TlonCronJobChangedEvent): void;
   captureCronRun(event: TlonCronRunEvent): void;
   captureCronSnapshot(event: TlonCronSnapshotEvent): void;
@@ -641,6 +694,7 @@ const TLON_CRON_JOB_CHANGED_EVENT = 'TlonBot Cron Job Changed';
 const TLON_CRON_RUN_EVENT = 'TlonBot Cron Run';
 const TLON_CRON_SNAPSHOT_EVENT = 'TlonBot Cron Snapshot';
 const TLON_MIGRATION_EVENT = 'TlonBot Diary Migration';
+const TLON_ONBOARDING_STEP_EVENT = 'TlonBot Onboarding Step';
 const MIGRATION_ERROR_MAX_CHARS = 500;
 const TLON_TELEMETRY_LOG_SOURCE = 'openclawPlugin';
 const TOOL_TRACE_TTL_MS = 60 * 60 * 1000;
@@ -1845,6 +1899,39 @@ class PostHogTlonTelemetry implements TlonTelemetryClient {
           scheduleKindAtCount: event.scheduleKindAtCount,
           scheduleKindOnExitCount: event.scheduleKindOnExitCount,
           ...this.cronCountPersonProps(event),
+        },
+        { omitNullish: true }
+      ),
+    });
+  }
+
+  captureOnboardingStep(event: TlonOnboardingFunnelEvent): void {
+    const ownerShip = event.ownerShip ?? '';
+    if (!this.ensureIdentified(ownerShip, event.botShip)) {
+      return;
+    }
+    const errorText = event.errorText
+      ? event.errorText.slice(0, MIGRATION_ERROR_MAX_CHARS)
+      : null;
+    this.client.capture({
+      distinctId: ownerShip,
+      event: TLON_ONBOARDING_STEP_EVENT,
+      properties: this.properties(
+        {
+          botShip: event.botShip,
+          ownerShip: event.ownerShip,
+          accountId: event.accountId,
+          step: event.step,
+          outcome: event.outcome,
+          nest: event.nest,
+          groupFlag: event.groupFlag,
+          purposeId: event.purposeId,
+          topicCount: event.topicCount,
+          timezone: event.timezone,
+          cronJobId: event.cronJobId,
+          notebookNest: event.notebookNest,
+          elapsedMsSinceIntro: event.elapsedMsSinceIntro,
+          errorText,
         },
         { omitNullish: true }
       ),

--- a/packages/shared/src/db/keyValue.ts
+++ b/packages/shared/src/db/keyValue.ts
@@ -184,6 +184,19 @@ export const agentGroupAgents = createStorageItem<Record<string, string>>({
   defaultValue: {},
 });
 
+/**
+ * Group ids whose first agent-written entry the owner has already opened.
+ *
+ * Activation should count once per group, not once per note view, and the
+ * event has to survive an app restart — hence storage rather than memory.
+ */
+export const agentEntryFirstOpened = createStorageItem<Record<string, boolean>>(
+  {
+    key: 'agentEntryFirstOpened',
+    defaultValue: {},
+  }
+);
+
 /** One-way onboarding navigation locks, keyed by group id. */
 export const agentGroupOnboardingLocks = createStorageItem<
   Record<string, AgentGroupOnboardingLock>

--- a/packages/shared/src/store/agentGroupOnboarding.ts
+++ b/packages/shared/src/store/agentGroupOnboarding.ts
@@ -195,6 +195,27 @@ async function ensureChatChannel(group: db.Group): Promise<db.Channel> {
   });
 }
 
+/**
+ * Adopt a notebook the ship already lists.
+ *
+ * `insertGroups` (like `insertChannels`) leaves `currentUserIsMember` out of
+ * its conflict-update set, so a row an earlier sync created as a non-member
+ * stays that way no matter how often the group is re-inserted. For a notebook
+ * the owner hosts and the ship reports as readable, that is simply wrong — it
+ * puts their own notebook under "Available Channels" behind a Join button. A
+ * direct update is the only write that clears it.
+ */
+async function adoptNotebook(
+  remote: db.Group,
+  notebook: db.Channel
+): Promise<db.Channel> {
+  await db.insertGroups({ groups: [remote] });
+  if (notebook.currentUserIsMember) {
+    await db.updateChannel({ id: notebook.id, currentUserIsMember: true });
+  }
+  return notebook;
+}
+
 async function ensureSingleNotesChannel(groupId: string): Promise<db.Channel> {
   for (const delay of [0, 300, 800]) {
     if (delay) await wait(delay);
@@ -207,8 +228,7 @@ async function ensureSingleNotesChannel(groupId: string): Promise<db.Channel> {
       );
     }
     if (notebooks.length === 1) {
-      await db.insertGroups({ groups: [remote] });
-      return notebooks[0];
+      return adoptNotebook(remote, notebooks[0]!);
     }
   }
 
@@ -224,8 +244,7 @@ async function ensureSingleNotesChannel(groupId: string): Promise<db.Channel> {
     const notebooks =
       remote.channels?.filter((channel) => channel.type === 'notes') ?? [];
     if (notebooks.length === 1) {
-      await db.insertGroups({ groups: [remote] });
-      return notebooks[0];
+      return adoptNotebook(remote, notebooks[0]!);
     }
     throw error;
   }

--- a/packages/shared/src/store/channelActions.ts
+++ b/packages/shared/src/store/channelActions.ts
@@ -158,6 +158,19 @@ async function createNotesChannel({
     const newChannel = await waitForNotesChannelListing(groupId, channelId);
     await db.insertChannels([newChannel]);
     insertedChannelId = newChannel.id;
+    // `insertChannels` excludes `currentUserIsMember` from its conflict-update
+    // set, so whoever inserts the row first decides it permanently. The chat
+    // path wins that race with a synchronous optimistic insert; this path
+    // cannot — it awaits a notebook create plus listing polls, and the %groups
+    // SSE update lands first and writes the row as a non-member. The notebook
+    // then sat under "Available Channels" with a Join button on the ship that
+    // hosts it. A direct update is the only write that can correct it, and it
+    // carries the listing's own answer rather than assuming membership, so a
+    // deliberately restricted notebook stays restricted.
+    await db.updateChannel({
+      id: newChannel.id,
+      currentUserIsMember: newChannel.currentUserIsMember ?? true,
+    });
     await db.insertChannelPerms([
       {
         channelId: newChannel.id,


### PR DESCRIPTION
## Summary

Fixes the failures visible in a recorded onboarding run on `db/agent-onboarding-v2`, plus three pieces of owner feedback (introduce the notebook, make connected services legible, fix the conversational cadence). The headline bug: after setup finished, any chat message was still parsed as a topics reply — the owner typed "That's it?" and it became their topic list, producing a researched notebook entry about the phrase itself.

Everything here was driven end to end in the onboarding sandbox (bot `~zod`, owner `~ten`) against this branch, not just unit-tested.

## Changes

**Setup can no longer eat ordinary chat** (`agent-onboarding.ts`)
- `advanceDurableConversation` gated the topics branch only on a `timezone-picker` marker. The picker-submit path never posts one, so the branch stayed armed forever. Now any `tlon-agent-provision-ack` in history disarms both it and `pendingDurableReply`.

**The first-entry reveal actually posts**
- `message_sent` / `cron_changed` fire from the extension entry while provisioning runs in the lazy runtime module — separate module-loader contexts (see `shared-state.ts`). The correlation crossed via `sharedMap`, but `@tloncorp/api`'s `client` is a module-level proxy, so the entry side held an unconfigured copy: `listNotes` / `sendChannelPost` threw `Client not initialized` and the reveal, handoff and services beats never appeared. The correlation now carries `bound: { fetchHistory, listNotes, sendPost }` captured in the provisioning context.
- Reveal keyed per channel instead of per provision (re-provisioning minted a new id and let it post three times), and the sentence now names the entry and notebook itself so a not-yet-synced cite card degrades instead of swallowing the payoff.

**The owner's own notebook was created unjoined** (`channelActions.ts`, `agentGroupOnboarding.ts`)
- `insertChannels` excludes `currentUserIsMember` from its conflict-update set, so the first insert wins permanently. `createChannel` wins that race for chat with a synchronous optimistic insert; `createNotesChannel` can't — it awaits a notebook create plus listing polls, so the `%groups` SSE update inserts the row first as a non-member. The notebook the agent writes every entry into sat under "Available Channels" behind a Join button. Corrected with a direct `updateChannel` on the create and adopt paths, carrying the listing's own membership value.

**Copy: say what the thing does**
- `provisionCadence` names the notebook and drops "publish" (two variants said "publish… here", which reads as chat). The name comes from the channel title, not the nest slug — the ship dedupes slugs, so slug-derived copy said "Updates 1" while the sidebar said "Updates".
- Learning rotation is now stated up front. Rotation already worked (the recurring prompt covers one topic, reads the notebook, takes the next, and puts the topic in the title as the marker) but nothing said so, and picking three topics read as two being dropped. Named on the purpose card, the topics picker, the acknowledgement ("Music theory first, then Architecture") and the reveal ("Tomorrow: Architecture"). Digest and research genuinely combine topics and are unchanged.
- Services pitch is benefit-led and purpose-aware (`servicesPitch`).
- `scheduleConfirmation` says the resolved schedule back in words, so a timezone tap has a visible receipt.

**Sequencing: activation before expansion**
- The acknowledgement was one block carrying five asks. Now two beats, and the handoff tip + services card moved into `completeFirstRun` so they land only after the first entry exists. "You can leave this screen and explore the app while I work" is gone — it pushed the owner away at the moment value arrives.

**Pacing** (`createOnboardingPresentation`)
- Replaces the flat 1250/1000ms floors with compose time proportional to the outgoing message (14ms/char, clamped 800–3500ms), read time scaled to the owner's message, and ±20% jitter via an injectable `random`. Presence starts before any delay is computed so no pause is silent.

**A2UI rendering** (`A2UIBlock.tsx`, `a2ui.ts`)
- Services card is a `Choice` (icon + title + description) rather than a bare `Button`, which can only carry a label. Adds `Link` to the `ChoiceIcon` type and runtime allowlist; the plugin falls back to the same card without the icon when built against a published `@tloncorp/api` that predates it, so this needs an api release before the icon appears.
- Spent controls no longer reserve layout. Both hid at `opacity: 0` while keeping a 44px box, leaving a permanent hole under answered pickers. The submit slot is still held open while the picker is answerable so pills don't jump; it collapses once consumed.
- An accented `Choice` with no icon now carries its accent on the border. Previously accent was expressed only via the icon chip, so an accented icon-less card rendered identically to a neutral one. Deliberately border, not background: `$blueSoft` is a fixed light tint meant to back a dark glyph, and using it as a card surface puts white dark-theme text on `rgb(229,244,255)`.

## How did I test?

- `packages/openclaw`: **1394 tests passing** (69 files). Tests re-pointed at the new contract rather than loosened — services-card shape, three-beat reveal, and the pacing test rewritten to assert the contract (bracketed by presence, composed not flat, inside the clamp, longer message waits longer) plus a new jitter test pinning the ±20% range.
- `tsc --noEmit` clean on `packages/openclaw`, `packages/shared`, `packages/app`. Prettier clean.
- **Live sandbox**, full flow as `~ten` against bot `~zod` on this branch, repeatedly:
  - intro → purpose picker → topic pills → ack, as paced beats
  - typing "That's it?" after the ack is answered conversationally, **zero** `timezone-picker` posts (the recorded failure, gone)
  - reveal posts **once**, names the entry, renders a working note card
  - handoff tip and services card follow, after the entry
  - notebook appears under Recent Channels, no Join button (verified in the local DB: `currentUserIsMember: true`)
  - three-topic learning run shows the rotation stated at all four touchpoints

## Risks and impact

- Safe to rollback without consulting PR author? **Yes**
- Affects important code area:
  - [x] Onboarding
  - [ ] State / providers
  - [ ] Message sync
  - [x] Channel display
  - [ ] Notifications
  - [x] Other: A2UI rendering (`A2UIBlock`) — the spent-control and accent changes affect every A2UI surface, not just onboarding

Notes:
- The `Link` icon needs an `@tloncorp/api` publish before it renders; until then the services card shows without an icon (border accent still applies).
- `Choice`/`Button` rendering changes are shared. The multi-option pickers keep their icons and are visually unchanged; the spent-control change affects any surface with a consumed control.

## Rollback plan

Revert the PR. No migrations, no persisted schema changes, no wire-format changes — the `tlon-agent-*` blob entries are untouched. The one durable side effect is the `currentUserIsMember` correction on notes channel rows, which is a local-DB value re-derived from the ship on the next sync; reverting simply restores the previous (incorrect) unjoined state for newly created notebooks.

## Screenshots / videos

Verified in the sandbox; key states, all from live runs on this branch:

- **Acknowledgement (3 topics):** "Music theory, Architecture, and Cryptography—got it. One topic each morning, taken in turn — Music theory first, then Architecture — each its own entry in Updates, this group's notebook. First one lands at 9:00 AM in America/New_York." followed by "Writing your first entry now — give me a minute."
- **Reveal:** "Your first entry is ready — "Music Theory: Reading Pitch with Clefs", in Updates. That notebook is where everything I write for you lands; this chat is for talking to me. Tomorrow: Architecture." + working note card.
- **Services:** purpose-aware pitch + blue-bordered "Connect External Services / Bring your tools into Tlonbot's context" card.

## Not in this PR

Known remaining items from the same review pass, deliberately left out:
- A ">45s still writing" status beat for slow first-entry generation (the last dead-air gap).
- "Connect MCP" settings screen: retitle to "Connected services" and lead with a curated shortlist.
- Giving the conversational model setup-state context, so it stops inventing answers about A2UI it can't see.
- Polish: group title template still jams ("Learning How computers work"), legacy provisioning welcome + "Howdy" DM compete with the new voice, in-channel notification banners, post-onboarding "create a group" tooltip.

Sandbox note for anyone reproducing: the stack can only rebuild the plugin once per `bot-state` volume — tlonbot's entrypoint takes `--ignore-workspace` for a `SUBPATH` checkout, which *generates* a lockfile that makes the next rebuild take `--frozen-lockfile` and fail on an overrides mismatch. `docker volume rm dev_bot-state` between ref changes. Also needs `VITE_AGENT_SHIP_OVERRIDE=~zod` on the web client, or the agent-group option stays hidden behind `hostingBotEnabled`.
