### PR TITLE
Add animated agent task rows

### DIFF
--- a/packages/app/fixtures/AgentTaskRows.fixture.tsx
+++ b/packages/app/fixtures/AgentTaskRows.fixture.tsx
@@ -2,12 +2,12 @@ import { Pressable } from '@tloncorp/ui';
 import { useEffect, useState } from 'react';
 import { SizableText, XStack, YStack } from 'tamagui';
 
+import { AgentTaskRows } from '../ui/components/AgentTaskRows';
 import {
   AGENT_TASK_DEMO_TICKS,
-  AgentTaskRows,
   buildAgentTaskDemoRows,
   getAgentTaskDemoAutoExpandedId,
-} from '../ui/components/AgentTaskRows';
+} from '../ui/components/AgentTaskRows/demo';
 import { FixtureWrapper } from './FixtureWrapper';
 
 function useDemoTick() {

--- a/packages/app/fixtures/AgentTaskRows.fixture.tsx
+++ b/packages/app/fixtures/AgentTaskRows.fixture.tsx
@@ -1,0 +1,120 @@
+import { Pressable } from '@tloncorp/ui';
+import { useEffect, useState } from 'react';
+import { SizableText, XStack, YStack } from 'tamagui';
+
+import {
+  AGENT_TASK_DEMO_TICKS,
+  AgentTaskRows,
+  buildAgentTaskDemoRows,
+  getAgentTaskDemoAutoExpandedId,
+} from '../ui/components/AgentTaskRows';
+import { FixtureWrapper } from './FixtureWrapper';
+
+function useDemoTick() {
+  const [tick, setTick] = useState(0);
+
+  useEffect(() => {
+    let currentTick = 0;
+    let timer: ReturnType<typeof setTimeout> | undefined;
+
+    const advance = () => {
+      if (currentTick >= AGENT_TASK_DEMO_TICKS.length) return;
+      timer = setTimeout(() => {
+        currentTick += 1;
+        setTick(currentTick);
+        advance();
+      }, AGENT_TASK_DEMO_TICKS[currentTick]);
+    };
+
+    advance();
+    return () => {
+      if (timer) clearTimeout(timer);
+    };
+  }, []);
+
+  return tick;
+}
+
+function VariantToggle({
+  value,
+  onChange,
+}: {
+  value: 'capsules' | 'list';
+  onChange: (value: 'capsules' | 'list') => void;
+}) {
+  return (
+    <XStack
+      alignSelf="flex-start"
+      padding="$2xs"
+      borderRadius="$xl"
+      backgroundColor="$secondaryBackground"
+      gap="$2xs"
+    >
+      {(['capsules', 'list'] as const).map((variant) => {
+        const active = value === variant;
+        return (
+          <Pressable
+            key={variant}
+            role="button"
+            aria-pressed={active}
+            accessibilityRole="button"
+            accessibilityState={{ selected: active }}
+            onPress={() => onChange(variant)}
+            cursor="pointer"
+            minHeight={44}
+            alignItems="center"
+            paddingHorizontal="$l"
+            borderRadius="$xl"
+            backgroundColor={active ? '$background' : 'transparent'}
+            hoverStyle={{ backgroundColor: '$background' }}
+            pressStyle={{ opacity: 0.7 }}
+          >
+            <SizableText
+              size="$xs"
+              color={active ? '$primaryText' : '$secondaryText'}
+              textTransform="capitalize"
+            >
+              {variant}
+            </SizableText>
+          </Pressable>
+        );
+      })}
+    </XStack>
+  );
+}
+
+function AgentTaskRowsFixture() {
+  const [variant, setVariant] = useState<'capsules' | 'list'>('capsules');
+  const tick = useDemoTick();
+
+  return (
+    <FixtureWrapper fillWidth fillHeight verticalAlign="top">
+      <YStack
+        width="100%"
+        maxWidth={520}
+        alignSelf="center"
+        padding="$xl"
+        gap="$xl"
+      >
+        <YStack gap="$xs">
+          <SizableText size="$l" color="$primaryText">
+            Agent turn activity
+          </SizableText>
+          <SizableText size="$s" color="$secondaryText">
+            Progress stays legible while the agent works. Open any row for the
+            underlying activity.
+          </SizableText>
+        </YStack>
+        <VariantToggle value={variant} onChange={setVariant} />
+        <AgentTaskRows
+          rows={buildAgentTaskDemoRows(tick)}
+          variant={variant}
+          autoExpandedId={getAgentTaskDemoAutoExpandedId(tick)}
+          testID="agent-task-rows"
+        />
+      </YStack>
+    </FixtureWrapper>
+  );
+}
+
+export default <AgentTaskRowsFixture />;

--- a/packages/app/ui/components/AgentTaskRows/AgentTaskRows.test.tsx
+++ b/packages/app/ui/components/AgentTaskRows/AgentTaskRows.test.tsx
@@ -1,0 +1,244 @@
+import React from 'react';
+import Animated from 'react-native-reanimated';
+import { ReactTestRenderer, act, create } from 'react-test-renderer';
+import {
+  afterAll,
+  beforeAll,
+  beforeEach,
+  describe,
+  expect,
+  it,
+  vi,
+} from 'vitest';
+
+import { AgentTaskRows } from './AgentTaskRows';
+
+const { darkMode } = vi.hoisted(() => ({
+  darkMode: { value: false },
+}));
+
+vi.mock('../../../hooks/useDarkMode', () => ({
+  useIsDarkMode: () => darkMode.value,
+}));
+
+vi.mock('@tloncorp/ui', () => ({
+  Icon: 'Icon',
+  Pressable: 'Pressable',
+}));
+
+vi.mock('react-native', () => ({
+  StyleSheet: { create: (styles: unknown) => styles },
+  View: 'NativeView',
+}));
+
+vi.mock('react-native-svg', () => ({
+  default: 'Svg',
+  Circle: 'SvgCircle',
+}));
+
+vi.mock('react-native-reanimated', () => {
+  const View = 'AnimatedView';
+  return {
+    default: {
+      View,
+      createAnimatedComponent: () => 'AnimatedSvgCircle',
+    },
+    Easing: {
+      cubic: 'cubic',
+      linear: 'linear',
+      out: (value: unknown) => value,
+      inOut: (value: unknown) => value,
+    },
+    FadeIn: {
+      duration: () => ({ easing: () => 'fade-in' }),
+    },
+    useAnimatedProps: (factory: () => unknown) => factory(),
+    useAnimatedStyle: (factory: () => unknown) => factory(),
+    useReducedMotion: () => true,
+    useSharedValue: (value: unknown) => ({ value }),
+    withRepeat: (value: unknown) => value,
+    withTiming: (value: unknown) => value,
+  };
+});
+
+vi.mock('tamagui', () => ({
+  Circle: 'Circle',
+  SizableText: 'SizableText',
+  View: 'View',
+  XStack: 'XStack',
+  YStack: 'YStack',
+  getVariableValue: (value: { val?: string } | string) =>
+    typeof value === 'string' ? value : value.val,
+  useTheme: () => ({
+    border: { val: '#ddd' },
+    secondaryText: { val: '#777' },
+    shadow: { val: '#000' },
+  }),
+}));
+
+describe('AgentTaskRows rendered states', () => {
+  beforeAll(() => {
+    Object.assign(globalThis, { IS_REACT_ACT_ENVIRONMENT: true });
+  });
+
+  beforeEach(() => {
+    darkMode.value = false;
+  });
+
+  afterAll(() => {
+    delete (globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean })
+      .IS_REACT_ACT_ENVIRONMENT;
+  });
+
+  it('renders waiting and determinate progress with explicit accessibility state', async () => {
+    let renderer: ReactTestRenderer;
+    await act(async () => {
+      renderer = create(
+        <AgentTaskRows
+          rows={[
+            {
+              id: 'waiting',
+              sequence: 1,
+              title: 'Confirm the group name',
+              subtitle: 'Waiting on you',
+              status: 'waiting',
+            },
+            {
+              id: 'running',
+              sequence: 2,
+              title: 'Create the group',
+              status: 'running',
+              progress: 0.4,
+            },
+            {
+              id: 'approval',
+              sequence: 3,
+              title: 'Approve publishing',
+              subtitle: 'Waiting for approval',
+              status: 'waiting',
+              waitingLabel: 'Waiting for approval',
+            },
+          ]}
+        />
+      );
+    });
+
+    expect(
+      renderer!.root.findByProps({
+        'aria-label': 'Confirm the group name, Waiting on you, Waiting on you',
+      })
+    ).toBeTruthy();
+    expect(
+      renderer!.root.findByProps({
+        'aria-label':
+          'Approve publishing, Waiting for approval, Waiting for approval',
+      })
+    ).toBeTruthy();
+    const progress = renderer!.root.findByProps({ role: 'progressbar' });
+    expect(progress.props['aria-valuemin']).toBe(0);
+    expect(progress.props['aria-valuemax']).toBe(100);
+    expect(progress.props['aria-valuenow']).toBe(40);
+
+    act(() => renderer!.unmount());
+  });
+
+  it('keeps a terminal row expandable after the run ends', async () => {
+    let renderer: ReactTestRenderer;
+    await act(async () => {
+      renderer = create(
+        <AgentTaskRows
+          rows={[
+            {
+              id: 'done',
+              sequence: 1,
+              title: 'Published the page',
+              subtitle: 'Completed',
+              status: 'completed',
+              details: [{ label: 'Outcome', value: 'Page is live.' }],
+            },
+          ]}
+        />
+      );
+    });
+
+    expect(JSON.stringify(renderer!.toJSON())).not.toContain('Page is live.');
+    const disclosure = renderer!.root.findByProps({
+      'aria-label': 'Published the page, Completed, Completed',
+    });
+    const preventDefault = vi.fn();
+    expect(disclosure.props.role).toBe('button');
+    expect(disclosure.props.tabIndex).toBe(0);
+    expect(disclosure.props.focusStyle).toBeUndefined();
+    expect(disclosure.props.focusVisibleStyle).toMatchObject({
+      outlineStyle: 'solid',
+      outlineWidth: 2,
+    });
+    await act(async () =>
+      disclosure.props.onKeyDown({ key: 'Enter', preventDefault })
+    );
+    expect(JSON.stringify(renderer!.toJSON())).toContain('Page is live.');
+    expect(disclosure.props['aria-expanded']).toBe(true);
+    expect(preventDefault).toHaveBeenCalledOnce();
+
+    act(() => renderer!.unmount());
+  });
+
+  it('does not advertise rows without details as interactive', async () => {
+    let renderer: ReactTestRenderer;
+    await act(async () => {
+      renderer = create(
+        <AgentTaskRows
+          rows={[
+            {
+              id: 'pending',
+              sequence: 1,
+              title: 'Wait for the next step',
+              status: 'pending',
+            },
+          ]}
+        />
+      );
+    });
+
+    const row = renderer!.root.findByProps({
+      'aria-label': 'Wait for the next step, Not started',
+    });
+    expect(row.props.disabled).toBe(true);
+    expect(row.props.cursor).toBe('default');
+    expect(row.props.role).toBeUndefined();
+    expect(row.props.tabIndex).toBeUndefined();
+    expect(row.props.onKeyDown).toBeUndefined();
+    expect(row.props.hoverStyle).toBeUndefined();
+
+    act(() => renderer!.unmount());
+  });
+
+  it('uses a crisp border instead of card shadows in dark themes', async () => {
+    darkMode.value = true;
+    let renderer: ReactTestRenderer;
+    await act(async () => {
+      renderer = create(
+        <AgentTaskRows
+          rows={[
+            {
+              id: 'dark-row',
+              sequence: 1,
+              title: 'Publish the result',
+              status: 'running',
+            },
+          ]}
+        />
+      );
+    });
+
+    const animatedViews = renderer!.root.findAllByType(Animated.View);
+    expect(animatedViews[0].props.style).toBeUndefined();
+    expect(animatedViews[1].props.style).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ borderColor: '#ddd', borderWidth: 1 }),
+      ])
+    );
+
+    act(() => renderer!.unmount());
+  });
+});

--- a/packages/app/ui/components/AgentTaskRows/AgentTaskRows.tsx
+++ b/packages/app/ui/components/AgentTaskRows/AgentTaskRows.tsx
@@ -1,14 +1,9 @@
 import { Icon, Pressable } from '@tloncorp/ui';
 import { useCallback, useEffect, useMemo, useState } from 'react';
-import {
-  type LayoutChangeEvent,
-  View as NativeView,
-  StyleSheet,
-} from 'react-native';
+import { View as NativeView, StyleSheet } from 'react-native';
 import Animated, {
   Easing,
   FadeIn,
-  FadeInUp,
   useAnimatedProps,
   useAnimatedStyle,
   useReducedMotion,
@@ -27,7 +22,15 @@ import {
   useTheme,
 } from 'tamagui';
 
-export type AgentTaskStatus = 'pending' | 'running' | 'completed' | 'failed';
+import { useIsDarkMode } from '../../../hooks/useDarkMode';
+import { activateAgentControlFromKeyboard } from './keyboardControl';
+
+export type AgentTaskStatus =
+  | 'pending'
+  | 'running'
+  | 'waiting'
+  | 'completed'
+  | 'failed';
 
 export type AgentTaskDetail = {
   label: string;
@@ -37,7 +40,11 @@ export type AgentTaskDetail = {
 export type AgentTaskRow = {
   id: string;
   title: string;
+  /** Concise user-facing progress that stays visible while details are closed. */
+  subtitle?: string;
   status: AgentTaskStatus;
+  /** Distinguishes requester input from an owner approval gate. */
+  waitingLabel?: 'Waiting on you' | 'Waiting for approval';
   sequence: number;
   meta?: string;
   details?: AgentTaskDetail[];
@@ -48,6 +55,7 @@ export type AgentTaskRow = {
 export type AgentTaskRowsProps = {
   rows: AgentTaskRow[];
   variant?: 'capsules' | 'list';
+  density?: 'default' | 'comfortable';
   /** Moves automatic disclosure to a row; manual choices take precedence. */
   autoExpandedId?: string;
   expandedIds?: readonly string[];
@@ -61,7 +69,22 @@ const RING_RADIUS = (RING_SIZE - RING_STROKE) / 2;
 const RING_CIRCUMFERENCE = 2 * Math.PI * RING_RADIUS;
 const AnimatedSvgCircle = Animated.createAnimatedComponent(SvgCircle);
 
-function statusLabel(status: AgentTaskStatus) {
+export function agentTaskStatusLabel(
+  status: AgentTaskStatus,
+  waitingLabel: AgentTaskRow['waitingLabel'] = 'Waiting on you'
+) {
+  if (status === 'pending') return 'Not started';
+  if (status === 'running') return 'In progress';
+  if (status === 'waiting') return waitingLabel;
+  if (status === 'completed') return 'Completed';
+  return 'Failed';
+}
+
+function statusPillLabel(
+  status: AgentTaskStatus,
+  waitingLabel: AgentTaskRow['waitingLabel'] = 'Waiting on you'
+) {
+  if (status === 'waiting') return waitingLabel;
   if (status === 'completed') return 'Completed';
   if (status === 'failed') return 'Failed';
   return null;
@@ -115,7 +138,17 @@ function ProgressRing({
   const trackColor = getVariableValue(theme.border);
 
   return (
-    <NativeView style={styles.ringFrame}>
+    <NativeView
+      style={styles.ringFrame}
+      role="progressbar"
+      aria-label={`Task ${sequence}, in progress`}
+      aria-valuemin={determinate ? 0 : undefined}
+      aria-valuemax={determinate ? 100 : undefined}
+      aria-valuenow={
+        determinate ? Math.round((progress ?? 0) * 100) : undefined
+      }
+      aria-valuetext={determinate ? undefined : 'In progress'}
+    >
       <Animated.View style={[styles.ringSvg, ringStyle]}>
         <Svg width={RING_SIZE} height={RING_SIZE}>
           <SvgCircle
@@ -155,31 +188,6 @@ function ProgressRing({
   );
 }
 
-function RotatingRetryIcon() {
-  const reducedMotion = useReducedMotion();
-  const rotation = useSharedValue(0);
-
-  useEffect(() => {
-    rotation.value = reducedMotion
-      ? 0
-      : withRepeat(
-          withTiming(360, { duration: 1100, easing: Easing.linear }),
-          -1,
-          false
-        );
-  }, [reducedMotion, rotation]);
-
-  const style = useAnimatedStyle(() => ({
-    transform: [{ rotate: `${rotation.value}deg` }],
-  }));
-
-  return (
-    <Animated.View style={style}>
-      <Icon type="Refresh" customSize={[16, 12]} color="$negativeActionText" />
-    </Animated.View>
-  );
-}
-
 function TaskStatus({ row }: { row: AgentTaskRow }) {
   const reducedMotion = useReducedMotion();
   const entering = reducedMotion
@@ -192,10 +200,15 @@ function TaskStatus({ row }: { row: AgentTaskRow }) {
 
   if (row.status === 'pending') {
     return (
-      <Circle size={RING_SIZE} borderWidth={1} borderColor="$border">
+      <Circle
+        size={RING_SIZE}
+        borderWidth={1}
+        borderColor="$border"
+        aria-label={`Task ${row.sequence}, not started`}
+      >
         <SizableText
           size="$xs"
-          color="$tertiaryText"
+          color="$secondaryText"
           lineHeight={14}
           fontVariant={['tabular-nums']}
         >
@@ -205,8 +218,32 @@ function TaskStatus({ row }: { row: AgentTaskRow }) {
     );
   }
 
+  if (row.status === 'waiting') {
+    return (
+      <Circle
+        size={RING_SIZE}
+        borderWidth={1}
+        borderColor="$secondaryText"
+        aria-label={`Task ${row.sequence}, ${agentTaskStatusLabel(
+          row.status,
+          row.waitingLabel
+        ).toLowerCase()}`}
+      >
+        <Icon
+          type="Clock"
+          customSize={[RING_SIZE, 14]}
+          color="$secondaryText"
+        />
+      </Circle>
+    );
+  }
+
   return (
-    <Animated.View key={row.status} entering={entering}>
+    <Animated.View
+      key={row.status}
+      entering={entering}
+      aria-label={`Task ${row.sequence}, ${agentTaskStatusLabel(row.status).toLowerCase()}`}
+    >
       <Circle
         size={RING_SIZE}
         backgroundColor={
@@ -225,8 +262,8 @@ function TaskStatus({ row }: { row: AgentTaskRow }) {
   );
 }
 
-function StatusPill({ status }: { status: AgentTaskStatus }) {
-  const label = statusLabel(status);
+function StatusPill({ row }: { row: AgentTaskRow }) {
+  const label = statusPillLabel(row.status, row.waitingLabel);
   if (!label) return null;
 
   return (
@@ -237,17 +274,14 @@ function StatusPill({ status }: { status: AgentTaskStatus }) {
       paddingHorizontal="$s"
       borderRadius="$xl"
       backgroundColor={
-        status === 'completed' ? '$positiveBackground' : '$negativeBackground'
+        row.status === 'completed'
+          ? '$positiveBackground'
+          : row.status === 'failed'
+            ? '$negativeBackground'
+            : '$secondaryBackground'
       }
     >
-      {status === 'failed' ? <RotatingRetryIcon /> : null}
-      <SizableText
-        size="$xs"
-        lineHeight={16}
-        color={
-          status === 'completed' ? '$positiveActionText' : '$negativeActionText'
-        }
-      >
+      <SizableText size="$xs" lineHeight={16} color="$primaryText">
         {label}
       </SizableText>
     </XStack>
@@ -271,14 +305,12 @@ function Chevron({ open }: { open: boolean }) {
 
   return (
     <Animated.View style={style}>
-      <Icon type="ChevronDown" customSize={[24, 15]} color="$tertiaryText" />
+      <Icon type="ChevronDown" customSize={[24, 15]} color="$secondaryText" />
     </Animated.View>
   );
 }
 
 function TaskDetails({ details }: { details: AgentTaskDetail[] }) {
-  const reducedMotion = useReducedMotion();
-
   return (
     <XStack
       gap="$m"
@@ -290,36 +322,19 @@ function TaskDetails({ details }: { details: AgentTaskDetail[] }) {
       <View width={1} backgroundColor="$border" />
       <YStack flex={1} gap="$m" minWidth={0}>
         {details.map((detail, index) => (
-          <Animated.View
-            key={`${detail.label}-${index}`}
-            entering={
-              reducedMotion
-                ? undefined
-                : FadeInUp.delay(120 + index * 100)
-                    .duration(300)
-                    .easing(Easing.out(Easing.cubic))
-            }
-          >
-            <XStack
-              justifyContent="space-between"
-              alignItems="flex-start"
-              gap="$l"
+          <YStack key={`${detail.label}-${index}`} gap="$2xs" minWidth={0}>
+            <SizableText size="$xs" color="$secondaryText">
+              {detail.label}
+            </SizableText>
+            <SizableText
+              size="$s"
+              lineHeight={20}
+              color="$secondaryText"
               minWidth={0}
             >
-              <SizableText size="$xs" color="$tertiaryText" flexShrink={0}>
-                {detail.label}
-              </SizableText>
-              <SizableText
-                size="$xs"
-                color="$secondaryText"
-                textAlign="right"
-                flex={1}
-                minWidth={0}
-              >
-                {detail.value}
-              </SizableText>
-            </XStack>
-          </Animated.View>
+              {detail.value}
+            </SizableText>
+          </YStack>
         ))}
       </YStack>
     </XStack>
@@ -333,81 +348,30 @@ function TaskDetailsDisclosure({
   open: boolean;
   details: AgentTaskDetail[];
 }) {
-  const reducedMotion = useReducedMotion();
-  const measuredHeight = useSharedValue(0);
-  const height = useSharedValue(0);
-  const opacity = useSharedValue(open ? 1 : 0);
-
-  const animateHeight = useCallback(
-    (nextHeight: number) => {
-      height.value = withTiming(nextHeight, {
-        duration: reducedMotion ? 1 : 300,
-        easing: Easing.inOut(Easing.cubic),
-      });
-    },
-    [height, reducedMotion]
-  );
-
-  const onContentLayout = useCallback(
-    (event: LayoutChangeEvent) => {
-      const nextHeight = event.nativeEvent.layout.height;
-      measuredHeight.value = nextHeight;
-      if (open) animateHeight(nextHeight);
-    },
-    [animateHeight, measuredHeight, open]
-  );
-
-  useEffect(() => {
-    animateHeight(open ? measuredHeight.value : 0);
-    opacity.value = withTiming(open ? 1 : 0, {
-      duration: reducedMotion ? 1 : open ? 220 : 160,
-      easing: Easing.out(Easing.cubic),
-    });
-  }, [animateHeight, measuredHeight, open, opacity, reducedMotion]);
-
-  const disclosureStyle = useAnimatedStyle(() => ({
-    height: height.value,
-    opacity: opacity.value,
-  }));
-
-  return (
-    <Animated.View
-      style={[styles.detailsDisclosure, disclosureStyle]}
-      pointerEvents={open ? 'auto' : 'none'}
-      accessibilityElementsHidden={!open}
-      importantForAccessibility={open ? 'auto' : 'no-hide-descendants'}
-    >
-      <NativeView onLayout={onContentLayout} collapsable={false}>
-        <TaskDetails details={details} />
-      </NativeView>
-    </Animated.View>
-  );
+  if (!open) return null;
+  return <TaskDetails details={details} />;
 }
 
 function TaskRow({
   row,
-  index,
   open,
   variant,
+  density,
   isLast,
   onToggle,
 }: {
   row: AgentTaskRow;
-  index: number;
   open: boolean;
   variant: 'capsules' | 'list';
+  density: 'default' | 'comfortable';
   isLast: boolean;
   onToggle: () => void;
 }) {
   const theme = useTheme();
+  const isDark = useIsDarkMode();
   const reducedMotion = useReducedMotion();
   const radius = useSharedValue(variant === 'list' ? 0 : open ? 14 : 22);
   const hasDetails = !!row.details?.length;
-  const entering = reducedMotion
-    ? undefined
-    : FadeInUp.delay(index * 80)
-        .duration(450)
-        .easing(Easing.out(Easing.cubic));
   const radiusStyle = useAnimatedStyle(() => ({
     borderRadius: radius.value,
   }));
@@ -421,20 +385,32 @@ function TaskRow({
 
   return (
     <Animated.View
-      entering={entering}
       style={
         variant === 'capsules'
-          ? {
-              elevation: 1,
-              shadowColor: getVariableValue(theme.shadow),
-              shadowOffset: { width: 0, height: 3 },
-              shadowOpacity: 0.7,
-              shadowRadius: 9,
-            }
+          ? isDark
+            ? undefined
+            : {
+                elevation: 1,
+                shadowColor: getVariableValue(theme.shadow),
+                shadowOffset: { width: 0, height: 3 },
+                shadowOpacity: 0.7,
+                shadowRadius: 9,
+              }
           : undefined
       }
     >
-      <Animated.View style={[styles.rowSurface, radiusStyle]}>
+      <Animated.View
+        style={[
+          styles.rowSurface,
+          radiusStyle,
+          variant === 'capsules' && isDark
+            ? {
+                borderColor: getVariableValue(theme.border),
+                borderWidth: 1,
+              }
+            : undefined,
+        ]}
+      >
         <YStack
           backgroundColor="$background"
           borderBottomWidth={variant === 'list' && !isLast ? 1 : 0}
@@ -442,41 +418,82 @@ function TaskRow({
         >
           <Pressable
             onPress={hasDetails ? onToggle : undefined}
+            onKeyDown={
+              hasDetails
+                ? (event) => activateAgentControlFromKeyboard(event, onToggle)
+                : undefined
+            }
             role={hasDetails ? 'button' : undefined}
             aria-expanded={hasDetails ? open : undefined}
-            accessibilityRole={hasDetails ? 'button' : undefined}
-            accessibilityLabel={`${row.title}${statusLabel(row.status) ? `, ${statusLabel(row.status)}` : ''}`}
-            accessibilityState={hasDetails ? { expanded: open } : undefined}
-            minHeight={44}
-            paddingHorizontal="$l"
-            hoverStyle={{ backgroundColor: '$secondaryBackground' }}
-            pressStyle={{
-              backgroundColor: '$secondaryBackground',
-              opacity: 0.82,
-            }}
-            focusStyle={{ outlineColor: '$primaryText', outlineWidth: 2 }}
+            aria-label={`${row.title}${row.subtitle ? `, ${row.subtitle}` : ''}, ${agentTaskStatusLabel(row.status, row.waitingLabel)}`}
+            disabled={!hasDetails}
+            tabIndex={hasDetails ? 0 : undefined}
+            cursor={hasDetails ? 'pointer' : 'default'}
+            minHeight={density === 'comfortable' ? 52 : 44}
+            paddingHorizontal={density === 'comfortable' ? '$xl' : '$l'}
+            paddingVertical={
+              density === 'comfortable' || row.subtitle ? '$s' : 0
+            }
+            hoverStyle={
+              hasDetails
+                ? { backgroundColor: '$secondaryBackground' }
+                : undefined
+            }
+            pressStyle={
+              hasDetails
+                ? {
+                    backgroundColor: '$secondaryBackground',
+                    opacity: 0.82,
+                  }
+                : undefined
+            }
+            focusVisibleStyle={
+              hasDetails
+                ? {
+                    outlineColor: '$primaryText',
+                    outlineOffset: 2,
+                    outlineStyle: 'solid',
+                    outlineWidth: 2,
+                  }
+                : undefined
+            }
           >
             <XStack minHeight={44} alignItems="center" gap="$m">
               <TaskStatus row={row} />
-              <SizableText
-                size="$s"
-                color="$primaryText"
-                flex={1}
-                minWidth={0}
-                numberOfLines={2}
-              >
-                {row.title}
-              </SizableText>
-              <StatusPill status={row.status} />
-              {row.meta ? (
+              <YStack flex={1} minWidth={0} gap="$2xs">
                 <SizableText
-                  size="$xs"
-                  color="$tertiaryText"
-                  flexShrink={0}
-                  fontVariant={['tabular-nums']}
+                  size="$s"
+                  color="$primaryText"
+                  minWidth={0}
+                  numberOfLines={2}
                 >
-                  {row.meta}
+                  {row.title}
                 </SizableText>
+                {row.subtitle ? (
+                  <SizableText
+                    size="$xs"
+                    lineHeight={16}
+                    color="$secondaryText"
+                    minWidth={0}
+                    numberOfLines={2}
+                  >
+                    {row.subtitle}
+                  </SizableText>
+                ) : null}
+              </YStack>
+              {statusPillLabel(row.status, row.waitingLabel) || row.meta ? (
+                <YStack flexShrink={0} alignItems="flex-end" gap="$2xs">
+                  <StatusPill row={row} />
+                  {row.meta ? (
+                    <SizableText
+                      size="$xs"
+                      color="$secondaryText"
+                      fontVariant={['tabular-nums']}
+                    >
+                      {row.meta}
+                    </SizableText>
+                  ) : null}
+                </YStack>
               ) : null}
               {hasDetails ? <Chevron open={open} /> : null}
             </XStack>
@@ -493,25 +510,20 @@ function TaskRow({
 export function AgentTaskRows({
   rows,
   variant = 'capsules',
+  density = 'default',
   autoExpandedId,
   expandedIds,
   onExpandedChange,
   testID,
 }: AgentTaskRowsProps) {
+  const isDark = useIsDarkMode();
   const [manualExpanded, setManualExpanded] = useState<
     Record<string, boolean | undefined>
   >({});
-  const [lastAutoExpandedId, setLastAutoExpandedId] = useState<
-    string | undefined
-  >();
   const controlledExpanded = useMemo(
     () => (expandedIds ? new Set(expandedIds) : null),
     [expandedIds]
   );
-
-  useEffect(() => {
-    if (autoExpandedId) setLastAutoExpandedId(autoExpandedId);
-  }, [autoExpandedId]);
 
   const toggle = useCallback(
     (id: string, currentlyOpen: boolean) => {
@@ -529,15 +541,15 @@ export function AgentTaskRows({
   const content = rows.map((row, index) => {
     const open = controlledExpanded
       ? controlledExpanded.has(row.id)
-      : manualExpanded[row.id] ?? row.id === lastAutoExpandedId;
+      : manualExpanded[row.id] ?? row.id === autoExpandedId;
 
     return (
       <TaskRow
         key={row.id}
         row={row}
-        index={index}
         open={open}
         variant={variant}
+        density={density}
         isLast={index === rows.length - 1}
         onToggle={() => toggle(row.id, open)}
       />
@@ -551,11 +563,13 @@ export function AgentTaskRows({
         borderRadius={22}
         overflow="hidden"
         backgroundColor="$background"
+        borderColor={isDark ? '$border' : undefined}
+        borderWidth={isDark ? 1 : 0}
         shadowColor="$shadow"
         shadowOffset={{ width: 0, height: 3 }}
-        shadowOpacity={0.7}
-        shadowRadius={9}
-        elevation={1}
+        shadowOpacity={isDark ? 0 : 0.7}
+        shadowRadius={isDark ? 0 : 9}
+        elevation={isDark ? 0 : 1}
       >
         {content}
       </YStack>
@@ -563,7 +577,7 @@ export function AgentTaskRows({
   }
 
   return (
-    <YStack testID={testID} gap="$m" minHeight={196}>
+    <YStack testID={testID} gap="$m">
       {content}
     </YStack>
   );
@@ -585,9 +599,6 @@ const styles = StyleSheet.create({
     width: RING_SIZE,
   },
   rowSurface: {
-    overflow: 'hidden',
-  },
-  detailsDisclosure: {
     overflow: 'hidden',
   },
 });

--- a/packages/app/ui/components/AgentTaskRows/AgentTaskRows.tsx
+++ b/packages/app/ui/components/AgentTaskRows/AgentTaskRows.tsx
@@ -1,0 +1,593 @@
+import { Icon, Pressable } from '@tloncorp/ui';
+import { useCallback, useEffect, useMemo, useState } from 'react';
+import {
+  type LayoutChangeEvent,
+  View as NativeView,
+  StyleSheet,
+} from 'react-native';
+import Animated, {
+  Easing,
+  FadeIn,
+  FadeInUp,
+  useAnimatedProps,
+  useAnimatedStyle,
+  useReducedMotion,
+  useSharedValue,
+  withRepeat,
+  withTiming,
+} from 'react-native-reanimated';
+import Svg, { Circle as SvgCircle } from 'react-native-svg';
+import {
+  Circle,
+  SizableText,
+  View,
+  XStack,
+  YStack,
+  getVariableValue,
+  useTheme,
+} from 'tamagui';
+
+export type AgentTaskStatus = 'pending' | 'running' | 'completed' | 'failed';
+
+export type AgentTaskDetail = {
+  label: string;
+  value: string;
+};
+
+export type AgentTaskRow = {
+  id: string;
+  title: string;
+  status: AgentTaskStatus;
+  sequence: number;
+  meta?: string;
+  details?: AgentTaskDetail[];
+  /** A determinate ring value from 0 to 1. Omit for an indeterminate ring. */
+  progress?: number;
+};
+
+export type AgentTaskRowsProps = {
+  rows: AgentTaskRow[];
+  variant?: 'capsules' | 'list';
+  /** Moves automatic disclosure to a row; manual choices take precedence. */
+  autoExpandedId?: string;
+  expandedIds?: readonly string[];
+  onExpandedChange?: (id: string, expanded: boolean) => void;
+  testID?: string;
+};
+
+const RING_SIZE = 24;
+const RING_STROKE = 2;
+const RING_RADIUS = (RING_SIZE - RING_STROKE) / 2;
+const RING_CIRCUMFERENCE = 2 * Math.PI * RING_RADIUS;
+const AnimatedSvgCircle = Animated.createAnimatedComponent(SvgCircle);
+
+function statusLabel(status: AgentTaskStatus) {
+  if (status === 'completed') return 'Completed';
+  if (status === 'failed') return 'Failed';
+  return null;
+}
+
+function ProgressRing({
+  sequence,
+  progress,
+}: {
+  sequence: number;
+  progress?: number;
+}) {
+  const theme = useTheme();
+  const reducedMotion = useReducedMotion();
+  const rotation = useSharedValue(-90);
+  const animatedProgress = useSharedValue(0);
+  const determinate = progress != null;
+
+  useEffect(() => {
+    if (determinate) {
+      rotation.value = -90;
+      animatedProgress.value = withTiming(Math.max(0, Math.min(progress, 1)), {
+        duration: reducedMotion ? 1 : 650,
+        easing: Easing.out(Easing.cubic),
+      });
+      return;
+    }
+
+    animatedProgress.value = 0.28;
+    rotation.value = reducedMotion
+      ? -90
+      : withRepeat(
+          withTiming(270, {
+            duration: 1100,
+            easing: Easing.linear,
+          }),
+          -1,
+          false
+        );
+  }, [animatedProgress, determinate, progress, reducedMotion, rotation]);
+
+  const ringStyle = useAnimatedStyle(() => ({
+    transform: [{ rotate: `${rotation.value}deg` }],
+  }));
+  const activeCircleProps = useAnimatedProps(() => ({
+    strokeDashoffset: determinate
+      ? RING_CIRCUMFERENCE * (1 - animatedProgress.value)
+      : 0,
+  }));
+  const activeColor = getVariableValue(theme.secondaryText);
+  const trackColor = getVariableValue(theme.border);
+
+  return (
+    <NativeView style={styles.ringFrame}>
+      <Animated.View style={[styles.ringSvg, ringStyle]}>
+        <Svg width={RING_SIZE} height={RING_SIZE}>
+          <SvgCircle
+            cx={RING_SIZE / 2}
+            cy={RING_SIZE / 2}
+            r={RING_RADIUS}
+            stroke={trackColor}
+            strokeWidth={RING_STROKE}
+            fill="none"
+          />
+          <AnimatedSvgCircle
+            animatedProps={activeCircleProps}
+            cx={RING_SIZE / 2}
+            cy={RING_SIZE / 2}
+            r={RING_RADIUS}
+            stroke={activeColor}
+            strokeWidth={RING_STROKE}
+            strokeDasharray={
+              determinate
+                ? `${RING_CIRCUMFERENCE} ${RING_CIRCUMFERENCE}`
+                : `${RING_CIRCUMFERENCE * 0.28} ${RING_CIRCUMFERENCE * 0.72}`
+            }
+            strokeLinecap="round"
+            fill="none"
+          />
+        </Svg>
+      </Animated.View>
+      <SizableText
+        size="$xs"
+        color="$secondaryText"
+        lineHeight={14}
+        fontVariant={['tabular-nums']}
+      >
+        {sequence}
+      </SizableText>
+    </NativeView>
+  );
+}
+
+function RotatingRetryIcon() {
+  const reducedMotion = useReducedMotion();
+  const rotation = useSharedValue(0);
+
+  useEffect(() => {
+    rotation.value = reducedMotion
+      ? 0
+      : withRepeat(
+          withTiming(360, { duration: 1100, easing: Easing.linear }),
+          -1,
+          false
+        );
+  }, [reducedMotion, rotation]);
+
+  const style = useAnimatedStyle(() => ({
+    transform: [{ rotate: `${rotation.value}deg` }],
+  }));
+
+  return (
+    <Animated.View style={style}>
+      <Icon type="Refresh" customSize={[16, 12]} color="$negativeActionText" />
+    </Animated.View>
+  );
+}
+
+function TaskStatus({ row }: { row: AgentTaskRow }) {
+  const reducedMotion = useReducedMotion();
+  const entering = reducedMotion
+    ? undefined
+    : FadeIn.duration(300).easing(Easing.out(Easing.cubic));
+
+  if (row.status === 'running') {
+    return <ProgressRing sequence={row.sequence} progress={row.progress} />;
+  }
+
+  if (row.status === 'pending') {
+    return (
+      <Circle size={RING_SIZE} borderWidth={1} borderColor="$border">
+        <SizableText
+          size="$xs"
+          color="$tertiaryText"
+          lineHeight={14}
+          fontVariant={['tabular-nums']}
+        >
+          {row.sequence}
+        </SizableText>
+      </Circle>
+    );
+  }
+
+  return (
+    <Animated.View key={row.status} entering={entering}>
+      <Circle
+        size={RING_SIZE}
+        backgroundColor={
+          row.status === 'completed'
+            ? '$positiveActionText'
+            : '$negativeActionText'
+        }
+      >
+        <Icon
+          type={row.status === 'completed' ? 'Checkmark' : 'Close'}
+          customSize={[RING_SIZE, 14]}
+          color="$background"
+        />
+      </Circle>
+    </Animated.View>
+  );
+}
+
+function StatusPill({ status }: { status: AgentTaskStatus }) {
+  const label = statusLabel(status);
+  if (!label) return null;
+
+  return (
+    <XStack
+      height={22}
+      alignItems="center"
+      gap="$2xs"
+      paddingHorizontal="$s"
+      borderRadius="$xl"
+      backgroundColor={
+        status === 'completed' ? '$positiveBackground' : '$negativeBackground'
+      }
+    >
+      {status === 'failed' ? <RotatingRetryIcon /> : null}
+      <SizableText
+        size="$xs"
+        lineHeight={16}
+        color={
+          status === 'completed' ? '$positiveActionText' : '$negativeActionText'
+        }
+      >
+        {label}
+      </SizableText>
+    </XStack>
+  );
+}
+
+function Chevron({ open }: { open: boolean }) {
+  const reducedMotion = useReducedMotion();
+  const rotation = useSharedValue(open ? 180 : 0);
+
+  useEffect(() => {
+    rotation.value = withTiming(open ? 180 : 0, {
+      duration: reducedMotion ? 1 : 300,
+      easing: Easing.inOut(Easing.cubic),
+    });
+  }, [open, reducedMotion, rotation]);
+
+  const style = useAnimatedStyle(() => ({
+    transform: [{ rotate: `${rotation.value}deg` }],
+  }));
+
+  return (
+    <Animated.View style={style}>
+      <Icon type="ChevronDown" customSize={[24, 15]} color="$tertiaryText" />
+    </Animated.View>
+  );
+}
+
+function TaskDetails({ details }: { details: AgentTaskDetail[] }) {
+  const reducedMotion = useReducedMotion();
+
+  return (
+    <XStack
+      gap="$m"
+      paddingLeft={22}
+      paddingRight="$l"
+      paddingVertical="$l"
+      alignItems="stretch"
+    >
+      <View width={1} backgroundColor="$border" />
+      <YStack flex={1} gap="$m" minWidth={0}>
+        {details.map((detail, index) => (
+          <Animated.View
+            key={`${detail.label}-${index}`}
+            entering={
+              reducedMotion
+                ? undefined
+                : FadeInUp.delay(120 + index * 100)
+                    .duration(300)
+                    .easing(Easing.out(Easing.cubic))
+            }
+          >
+            <XStack
+              justifyContent="space-between"
+              alignItems="flex-start"
+              gap="$l"
+              minWidth={0}
+            >
+              <SizableText size="$xs" color="$tertiaryText" flexShrink={0}>
+                {detail.label}
+              </SizableText>
+              <SizableText
+                size="$xs"
+                color="$secondaryText"
+                textAlign="right"
+                flex={1}
+                minWidth={0}
+              >
+                {detail.value}
+              </SizableText>
+            </XStack>
+          </Animated.View>
+        ))}
+      </YStack>
+    </XStack>
+  );
+}
+
+function TaskDetailsDisclosure({
+  open,
+  details,
+}: {
+  open: boolean;
+  details: AgentTaskDetail[];
+}) {
+  const reducedMotion = useReducedMotion();
+  const measuredHeight = useSharedValue(0);
+  const height = useSharedValue(0);
+  const opacity = useSharedValue(open ? 1 : 0);
+
+  const animateHeight = useCallback(
+    (nextHeight: number) => {
+      height.value = withTiming(nextHeight, {
+        duration: reducedMotion ? 1 : 300,
+        easing: Easing.inOut(Easing.cubic),
+      });
+    },
+    [height, reducedMotion]
+  );
+
+  const onContentLayout = useCallback(
+    (event: LayoutChangeEvent) => {
+      const nextHeight = event.nativeEvent.layout.height;
+      measuredHeight.value = nextHeight;
+      if (open) animateHeight(nextHeight);
+    },
+    [animateHeight, measuredHeight, open]
+  );
+
+  useEffect(() => {
+    animateHeight(open ? measuredHeight.value : 0);
+    opacity.value = withTiming(open ? 1 : 0, {
+      duration: reducedMotion ? 1 : open ? 220 : 160,
+      easing: Easing.out(Easing.cubic),
+    });
+  }, [animateHeight, measuredHeight, open, opacity, reducedMotion]);
+
+  const disclosureStyle = useAnimatedStyle(() => ({
+    height: height.value,
+    opacity: opacity.value,
+  }));
+
+  return (
+    <Animated.View
+      style={[styles.detailsDisclosure, disclosureStyle]}
+      pointerEvents={open ? 'auto' : 'none'}
+      accessibilityElementsHidden={!open}
+      importantForAccessibility={open ? 'auto' : 'no-hide-descendants'}
+    >
+      <NativeView onLayout={onContentLayout} collapsable={false}>
+        <TaskDetails details={details} />
+      </NativeView>
+    </Animated.View>
+  );
+}
+
+function TaskRow({
+  row,
+  index,
+  open,
+  variant,
+  isLast,
+  onToggle,
+}: {
+  row: AgentTaskRow;
+  index: number;
+  open: boolean;
+  variant: 'capsules' | 'list';
+  isLast: boolean;
+  onToggle: () => void;
+}) {
+  const theme = useTheme();
+  const reducedMotion = useReducedMotion();
+  const radius = useSharedValue(variant === 'list' ? 0 : open ? 14 : 22);
+  const hasDetails = !!row.details?.length;
+  const entering = reducedMotion
+    ? undefined
+    : FadeInUp.delay(index * 80)
+        .duration(450)
+        .easing(Easing.out(Easing.cubic));
+  const radiusStyle = useAnimatedStyle(() => ({
+    borderRadius: radius.value,
+  }));
+
+  useEffect(() => {
+    radius.value = withTiming(variant === 'list' ? 0 : open ? 14 : 22, {
+      duration: reducedMotion ? 1 : 300,
+      easing: Easing.inOut(Easing.cubic),
+    });
+  }, [open, radius, reducedMotion, variant]);
+
+  return (
+    <Animated.View
+      entering={entering}
+      style={
+        variant === 'capsules'
+          ? {
+              elevation: 1,
+              shadowColor: getVariableValue(theme.shadow),
+              shadowOffset: { width: 0, height: 3 },
+              shadowOpacity: 0.7,
+              shadowRadius: 9,
+            }
+          : undefined
+      }
+    >
+      <Animated.View style={[styles.rowSurface, radiusStyle]}>
+        <YStack
+          backgroundColor="$background"
+          borderBottomWidth={variant === 'list' && !isLast ? 1 : 0}
+          borderBottomColor="$border"
+        >
+          <Pressable
+            onPress={hasDetails ? onToggle : undefined}
+            role={hasDetails ? 'button' : undefined}
+            aria-expanded={hasDetails ? open : undefined}
+            accessibilityRole={hasDetails ? 'button' : undefined}
+            accessibilityLabel={`${row.title}${statusLabel(row.status) ? `, ${statusLabel(row.status)}` : ''}`}
+            accessibilityState={hasDetails ? { expanded: open } : undefined}
+            minHeight={44}
+            paddingHorizontal="$l"
+            hoverStyle={{ backgroundColor: '$secondaryBackground' }}
+            pressStyle={{
+              backgroundColor: '$secondaryBackground',
+              opacity: 0.82,
+            }}
+            focusStyle={{ outlineColor: '$primaryText', outlineWidth: 2 }}
+          >
+            <XStack minHeight={44} alignItems="center" gap="$m">
+              <TaskStatus row={row} />
+              <SizableText
+                size="$s"
+                color="$primaryText"
+                flex={1}
+                minWidth={0}
+                numberOfLines={2}
+              >
+                {row.title}
+              </SizableText>
+              <StatusPill status={row.status} />
+              {row.meta ? (
+                <SizableText
+                  size="$xs"
+                  color="$tertiaryText"
+                  flexShrink={0}
+                  fontVariant={['tabular-nums']}
+                >
+                  {row.meta}
+                </SizableText>
+              ) : null}
+              {hasDetails ? <Chevron open={open} /> : null}
+            </XStack>
+          </Pressable>
+          {row.details ? (
+            <TaskDetailsDisclosure open={open} details={row.details} />
+          ) : null}
+        </YStack>
+      </Animated.View>
+    </Animated.View>
+  );
+}
+
+export function AgentTaskRows({
+  rows,
+  variant = 'capsules',
+  autoExpandedId,
+  expandedIds,
+  onExpandedChange,
+  testID,
+}: AgentTaskRowsProps) {
+  const [manualExpanded, setManualExpanded] = useState<
+    Record<string, boolean | undefined>
+  >({});
+  const [lastAutoExpandedId, setLastAutoExpandedId] = useState<
+    string | undefined
+  >();
+  const controlledExpanded = useMemo(
+    () => (expandedIds ? new Set(expandedIds) : null),
+    [expandedIds]
+  );
+
+  useEffect(() => {
+    if (autoExpandedId) setLastAutoExpandedId(autoExpandedId);
+  }, [autoExpandedId]);
+
+  const toggle = useCallback(
+    (id: string, currentlyOpen: boolean) => {
+      const next = !currentlyOpen;
+      if (!controlledExpanded) {
+        setManualExpanded((current) => ({ ...current, [id]: next }));
+      }
+      onExpandedChange?.(id, next);
+    },
+    [controlledExpanded, onExpandedChange]
+  );
+
+  if (!rows.length) return null;
+
+  const content = rows.map((row, index) => {
+    const open = controlledExpanded
+      ? controlledExpanded.has(row.id)
+      : manualExpanded[row.id] ?? row.id === lastAutoExpandedId;
+
+    return (
+      <TaskRow
+        key={row.id}
+        row={row}
+        index={index}
+        open={open}
+        variant={variant}
+        isLast={index === rows.length - 1}
+        onToggle={() => toggle(row.id, open)}
+      />
+    );
+  });
+
+  if (variant === 'list') {
+    return (
+      <YStack
+        testID={testID}
+        borderRadius={22}
+        overflow="hidden"
+        backgroundColor="$background"
+        shadowColor="$shadow"
+        shadowOffset={{ width: 0, height: 3 }}
+        shadowOpacity={0.7}
+        shadowRadius={9}
+        elevation={1}
+      >
+        {content}
+      </YStack>
+    );
+  }
+
+  return (
+    <YStack testID={testID} gap="$m" minHeight={196}>
+      {content}
+    </YStack>
+  );
+}
+
+const styles = StyleSheet.create({
+  ringFrame: {
+    alignItems: 'center',
+    height: RING_SIZE,
+    justifyContent: 'center',
+    position: 'relative',
+    width: RING_SIZE,
+  },
+  ringSvg: {
+    height: RING_SIZE,
+    left: 0,
+    position: 'absolute',
+    top: 0,
+    width: RING_SIZE,
+  },
+  rowSurface: {
+    overflow: 'hidden',
+  },
+  detailsDisclosure: {
+    overflow: 'hidden',
+  },
+});

--- a/packages/app/ui/components/AgentTaskRows/demo.test.ts
+++ b/packages/app/ui/components/AgentTaskRows/demo.test.ts
@@ -1,0 +1,29 @@
+import { describe, expect, it } from 'vitest';
+
+import { buildAgentTaskDemoRows, getAgentTaskDemoAutoExpandedId } from './demo';
+
+describe('agent task row demo choreography', () => {
+  it('advances the progress ring before completing the first task', () => {
+    expect(buildAgentTaskDemoRows(0)[0]).toMatchObject({
+      status: 'running',
+      progress: 0,
+    });
+    expect(buildAgentTaskDemoRows(1)[0]).toMatchObject({
+      status: 'running',
+      progress: 0.66,
+    });
+    expect(buildAgentTaskDemoRows(2)[0].status).toBe('completed');
+  });
+
+  it('hints automatic disclosure only when a task becomes active', () => {
+    expect(getAgentTaskDemoAutoExpandedId(0)).toBe('map-events');
+    expect(getAgentTaskDemoAutoExpandedId(1)).toBeUndefined();
+    expect(getAgentTaskDemoAutoExpandedId(2)).toBe('shape-rows');
+    expect(getAgentTaskDemoAutoExpandedId(3)).toBeUndefined();
+  });
+
+  it('shows failure and recovery as distinct states', () => {
+    expect(buildAgentTaskDemoRows(4)[2].status).toBe('failed');
+    expect(buildAgentTaskDemoRows(5)[2].status).toBe('completed');
+  });
+});

--- a/packages/app/ui/components/AgentTaskRows/demo.ts
+++ b/packages/app/ui/components/AgentTaskRows/demo.ts
@@ -1,0 +1,54 @@
+import type { AgentTaskRow } from './AgentTaskRows';
+
+export const AGENT_TASK_DEMO_TICKS = [600, 900, 2400, 1400, 2400, 600];
+
+export function buildAgentTaskDemoRows(tick: number): AgentTaskRow[] {
+  const mapped = tick >= 2;
+  const fixtureFailed = tick === 4;
+  const fixtureDone = tick >= 5;
+
+  return [
+    {
+      id: 'map-events',
+      sequence: 1,
+      title: 'Map agent turn events',
+      status: mapped ? 'completed' : 'running',
+      progress: mapped ? undefined : tick >= 1 ? 0.66 : 0,
+      meta: '4 events',
+      details: [
+        { label: 'Commentary', value: 'Live progress narration' },
+        { label: 'Tools', value: 'Calls and command output' },
+        { label: 'Lifecycle', value: 'Started, waiting, completed' },
+      ],
+    },
+    {
+      id: 'shape-rows',
+      sequence: 2,
+      title: 'Shape Ochre task rows',
+      status: mapped ? 'running' : 'pending',
+      meta: '2 files',
+      details: [
+        { label: 'Presentation', value: 'Capsules and grouped list' },
+        { label: 'Interaction', value: 'Click any row to inspect details' },
+        { label: 'Motion', value: 'Stagger, expand, and state transitions' },
+      ],
+    },
+    {
+      id: 'messenger-fixture',
+      sequence: 3,
+      title: 'Prepare Messenger fixture',
+      status: fixtureDone ? 'completed' : fixtureFailed ? 'failed' : 'pending',
+      meta: 'fixture',
+      details: [
+        { label: 'Theme', value: 'Light and dark Ochre tokens' },
+        { label: 'Access', value: 'Keyboard focus and reduced motion' },
+      ],
+    },
+  ];
+}
+
+export function getAgentTaskDemoAutoExpandedId(tick: number) {
+  if (tick === 0) return 'map-events';
+  if (tick === 2) return 'shape-rows';
+  return undefined;
+}

--- a/packages/app/ui/components/AgentTaskRows/index.ts
+++ b/packages/app/ui/components/AgentTaskRows/index.ts
@@ -1,0 +1,2 @@
+export * from './AgentTaskRows';
+export * from './demo';

--- a/packages/app/ui/components/AgentTaskRows/keyboardControl.test.ts
+++ b/packages/app/ui/components/AgentTaskRows/keyboardControl.test.ts
@@ -1,0 +1,32 @@
+import { describe, expect, it, vi } from 'vitest';
+
+import { activateAgentControlFromKeyboard } from './keyboardControl';
+
+describe('activateAgentControlFromKeyboard', () => {
+  it.each(['Enter', ' '])('activates for %j', (key) => {
+    const preventDefault = vi.fn();
+    const activate = vi.fn();
+
+    activateAgentControlFromKeyboard({ key, preventDefault }, activate);
+
+    expect(preventDefault).toHaveBeenCalledOnce();
+    expect(activate).toHaveBeenCalledOnce();
+  });
+
+  it('ignores unrelated and repeated keys', () => {
+    const preventDefault = vi.fn();
+    const activate = vi.fn();
+
+    activateAgentControlFromKeyboard(
+      { key: 'ArrowDown', preventDefault },
+      activate
+    );
+    activateAgentControlFromKeyboard(
+      { key: 'Enter', repeat: true, preventDefault },
+      activate
+    );
+
+    expect(preventDefault).not.toHaveBeenCalled();
+    expect(activate).not.toHaveBeenCalled();
+  });
+});

--- a/packages/app/ui/components/AgentTaskRows/keyboardControl.ts
+++ b/packages/app/ui/components/AgentTaskRows/keyboardControl.ts
@@ -1,0 +1,18 @@
+export type KeyboardControlEvent = {
+  key: string;
+  repeat?: boolean;
+  preventDefault: () => void;
+};
+
+/** Give the cross-platform Pressable's web div native-button keyboard behavior. */
+export function activateAgentControlFromKeyboard(
+  event: KeyboardControlEvent,
+  activate: () => void
+) {
+  if (event.repeat || (event.key !== 'Enter' && event.key !== ' ')) {
+    return;
+  }
+
+  event.preventDefault();
+  activate();
+}

--- a/packages/app/ui/index.tsx
+++ b/packages/app/ui/index.tsx
@@ -1,4 +1,5 @@
 export * from './components/ActionSheet';
+export * from './components/AgentTaskRows';
 export * from './components/Activity/ActivityScreenView';
 export * from './components/AddContactsView';
 export * from './components/AppSetting';


### PR DESCRIPTION
## Summary

- add a reusable `AgentTaskRows` component with capsule and grouped-list presentations
- support pending, running, completed, and failed states with determinate or indeterminate progress
- add accessible expandable details, automatic disclosure for new work, reduced-motion behavior, and Ochre light/dark theme tokens
- add a Cosmos fixture with a sequenced agent-turn demo and focused demo-state tests
- export the component through the app UI package

## Why

Messenger needs a compact, legible way to show what an agent is doing during each turn. This recreates the interaction behavior from the Beautiful UI reference while keeping the visual language and spacing aligned with Ochre.

The expansion animation is scoped to the disclosure body so task headlines and status indicators do not stretch while rows open or close.

## Impact

This PR establishes the presentation component and fixture. Runtime, activity transport, privacy, and Messenger integration are isolated in follow-up PRs #6321, #6322, #6323, and #6324; this PR remains presentation-only.

## Stack

Review bottom-up; each PR is based on the branch above it.

1. **#6290 — reusable Ochre task-row UI (this PR)**
2. #6321 — OpenClaw 7.1 runtime
3. #6322 — private durable activity and lifecycle
4. #6323 — participant-safe group projection
5. #6324 — Messenger DM, group, and thread integration

## Validation

- `pnpm --filter @tloncorp/app test -- ui/components/AgentTaskRows/demo.test.ts` — 457 passed, 3 skipped
- `pnpm --filter @tloncorp/app exec eslint ui/components/AgentTaskRows/AgentTaskRows.tsx fixtures/AgentTaskRows.fixture.tsx`
- `pnpm prettier --check packages/app/ui/components/AgentTaskRows packages/app/fixtures/AgentTaskRows.fixture.tsx packages/app/ui/index.tsx`
- `pnpm --filter @tloncorp/editor build && pnpm --filter @tloncorp/app tsc`
- manual Cosmos review of capsule/list layouts, auto-expansion, headline stability, and detail spacing
