### PR TITLE
rework system notices

### DIFF
--- a/packages/app/contexts/ship.tsx
+++ b/packages/app/contexts/ship.tsx
@@ -56,9 +56,15 @@ const emptyShip: ShipInfo = {
   needsSplashSequence: false,
 };
 
-export const ShipProvider = ({ children }: { children: ReactNode }) => {
-  const [isLoading, setIsLoading] = useState(true);
-  const [shipInfo, setShipInfo] = useState(emptyShip);
+export const ShipProvider = ({
+  children,
+  initialShipInfo,
+}: {
+  children: ReactNode;
+  initialShipInfo?: ShipInfo;
+}) => {
+  const [isLoading, setIsLoading] = useState(!initialShipInfo);
+  const [shipInfo, setShipInfo] = useState(initialShipInfo ?? emptyShip);
 
   const setShip = useCallback(
     ({
@@ -151,6 +157,10 @@ export const ShipProvider = ({ children }: { children: ReactNode }) => {
   );
 
   useEffect(() => {
+    if (initialShipInfo) {
+      return;
+    }
+
     const loadConnection = async () => {
       try {
         const storedShipInfo = await storage.shipInfo.getValue();
@@ -168,7 +178,7 @@ export const ShipProvider = ({ children }: { children: ReactNode }) => {
     };
 
     loadConnection();
-  }, [setShip]);
+  }, [initialShipInfo, setShip]);
 
   const clearShip = useCallback(() => {
     setShipInfo(emptyShip);

--- a/packages/app/fixtures/Channel.fixture.tsx
+++ b/packages/app/fixtures/Channel.fixture.tsx
@@ -5,6 +5,7 @@ import { useCallback, useMemo, useRef, useState } from 'react';
 import { Button, SafeAreaView, Switch, View } from 'react-native';
 import { Label, XStack, YStack } from 'tamagui';
 
+import { ShipProvider } from '../contexts/ship';
 import { AppDataContextProvider, Channel, ChatOptionsProvider } from '../ui';
 import { FixtureWrapper } from './FixtureWrapper';
 import {
@@ -30,11 +31,21 @@ const ChannelFixtureWrapper = ({
   children,
 }: PropsWithChildren<{ theme?: 'light' | 'dark' }>) => {
   return (
-    <AppDataContextProvider contacts={initialContacts}>
-      <FixtureWrapper fillWidth fillHeight>
-        <ChatOptionsProvider {...noopProps()}>{children}</ChatOptionsProvider>
-      </FixtureWrapper>
-    </AppDataContextProvider>
+    <ShipProvider
+      initialShipInfo={{
+        authType: 'hosted',
+        ship: 'zod',
+        shipUrl: 'https://zod.test',
+        authCookie: 'fixture',
+        needsSplashSequence: false,
+      }}
+    >
+      <AppDataContextProvider currentUserId="~zod" contacts={initialContacts}>
+        <FixtureWrapper fillWidth fillHeight>
+          <ChatOptionsProvider {...noopProps()}>{children}</ChatOptionsProvider>
+        </FixtureWrapper>
+      </AppDataContextProvider>
+    </ShipProvider>
   );
 };
 

--- a/packages/app/fixtures/SystemNotices.fixture.tsx
+++ b/packages/app/fixtures/SystemNotices.fixture.tsx
@@ -1,48 +1,326 @@
-import { YStack } from 'tamagui';
+import * as db from '@tloncorp/shared/db';
+import { type ReactNode, useEffect, useMemo, useState } from 'react';
 
+import { ShipProvider } from '../contexts/ship';
+import { ChatList } from '../features/chat-list/ChatList';
+import { ChatListTabs } from '../features/chat-list/ChatListTabs';
+import {
+  ContactsScreenView,
+  GroupChannelsScreenView,
+  InlineScreenHeaderProvider,
+  ScreenHeader,
+  View,
+} from '../ui';
+import { CreateChannelSheet } from '../ui/components/ManageChannels/CreateChannelSheet';
 import SystemNotices from '../ui/components/SystemNotices';
+import { ChannelFixture } from './Channel.fixture';
 import { FixtureWrapper } from './FixtureWrapper';
+import {
+  group,
+  initialContacts,
+  tlonLocalBulletinBoard,
+  tlonLocalIntros,
+  tlonLocalWaterCooler,
+} from './fakeData';
 
-function NotificationsPromptFixture() {
+const noop = () => {};
+const currentUserId = '~zod';
+
+const groupWithRequests: db.Group = {
+  ...group,
+  joinRequests: [
+    {
+      groupId: group.id,
+      contactId: '~sampel-palnet',
+      requestedAt: Date.now(),
+    },
+  ],
+  pendingMembersDismissedAt: 0,
+};
+
+const singleChannelGroupWithRequests: db.Group = {
+  ...groupWithRequests,
+  channels: [tlonLocalIntros],
+  navSections: [],
+};
+
+const homeChats: db.Chat[] = [
+  {
+    id: group.id,
+    type: 'group',
+    group,
+    pin: null,
+    volumeSettings: null,
+    timestamp: Date.now(),
+    isPending: false,
+    unreadCount: 4,
+  },
+  {
+    id: tlonLocalWaterCooler.id,
+    type: 'channel',
+    channel: tlonLocalWaterCooler,
+    pin: null,
+    volumeSettings: null,
+    timestamp: Date.now() - 1,
+    isPending: false,
+    unreadCount: 2,
+  },
+  {
+    id: tlonLocalBulletinBoard.id,
+    type: 'channel',
+    channel: tlonLocalBulletinBoard,
+    pin: null,
+    volumeSettings: null,
+    timestamp: Date.now() - 2,
+    isPending: false,
+    unreadCount: 0,
+  },
+];
+
+function FullScreenFixture({ children }: { children: ReactNode }) {
   return (
-    <FixtureWrapper fillWidth safeArea={false}>
-      <YStack padding="$l">
-        <SystemNotices.NoticeFrame>
-          <YStack gap="$5xl">
-            <YStack gap="$xl">
-              <SystemNotices.NoticeTitle>
-                Enable notifications
-              </SystemNotices.NoticeTitle>
-              <SystemNotices.NoticeBody>
-                Tlon Messenger works best if you enable push notifications on
-                your device.
-              </SystemNotices.NoticeBody>
-            </YStack>
-            <SystemNotices.JoinRequestNotice
-              onViewRequests={() => console.log('View requests')}
-              onDismiss={() => console.log('Dismiss')}
-            />
-          </YStack>
-        </SystemNotices.NoticeFrame>
-      </YStack>
+    <FixtureWrapper
+      fillHeight
+      fillWidth
+      verticalAlign="top"
+      backgroundColor="$background"
+    >
+      <InlineScreenHeaderProvider value>
+        <View flex={1} backgroundColor="$background">
+          {children}
+        </View>
+      </InlineScreenHeaderProvider>
     </FixtureWrapper>
   );
 }
 
-function JoinRequestNoticeFixture() {
+function HomeNotificationsFixture() {
   return (
-    <FixtureWrapper fillWidth safeArea={false}>
-      <YStack padding="$l">
-        <SystemNotices.JoinRequestNotice
-          onViewRequests={() => console.log('View requests')}
-          onDismiss={() => console.log('Dismiss')}
+    <FullScreenFixture>
+      <View flex={1}>
+        <View flex={1}>
+          <ScreenHeader
+            title="Home"
+            placement="navigation"
+            rightActions={[
+              { id: 'search', icon: 'Search', label: 'Search', onPress: noop },
+              {
+                id: 'add-chat',
+                icon: 'Add',
+                label: 'Add a chat',
+                onPress: noop,
+              },
+            ]}
+          />
+          <ChatListTabs activeTab="home" onPressTab={noop} />
+          <ChatList
+            data={[{ title: 'All', data: homeChats }]}
+            allPinnedChats={[]}
+            onPressItem={noop}
+          />
+        </View>
+        <SystemNotices.NotificationsPromptView
+          primaryActionLabel="Settings"
+          onDismiss={noop}
+          onPrimaryAction={noop}
         />
-      </YStack>
-    </FixtureWrapper>
+      </View>
+    </FullScreenFixture>
+  );
+}
+
+function ContactsPromptFixture({
+  status,
+}: {
+  status: 'denied' | 'undetermined';
+}) {
+  return (
+    <FullScreenFixture>
+      <ScreenHeader
+        title="Contacts"
+        placement="navigation"
+        borderBottom
+        leftActions={[
+          {
+            id: 'add-contacts',
+            icon: 'Add',
+            label: 'Add contacts',
+            onPress: noop,
+          },
+        ]}
+        rightActions={[
+          {
+            id: 'contacts-settings',
+            icon: 'Settings',
+            label: 'Settings',
+            onPress: noop,
+          },
+        ]}
+      />
+      <SystemNotices.ContactBookPromptView
+        status={status}
+        onDismiss={noop}
+        onPrimaryAction={noop}
+      />
+      <ContactsScreenView
+        contacts={initialContacts}
+        systemContacts={[]}
+        suggestions={[]}
+        onContactPress={noop}
+        onAddContact={noop}
+        onContactLongPress={noop}
+        onInviteSystemContact={noop}
+      />
+    </FullScreenFixture>
+  );
+}
+
+function ChannelRequestsFixture() {
+  return (
+    <InlineScreenHeaderProvider value>
+      <ChannelFixture
+        theme="light"
+        negotiationMatch
+        passedProps={() => ({
+          channel: tlonLocalIntros,
+          group: singleChannelGroupWithRequests,
+        })}
+      />
+    </InlineScreenHeaderProvider>
+  );
+}
+
+function GroupChannelsRequestsFixture() {
+  return (
+    <FullScreenFixture>
+      <GroupChannelsScreenView
+        group={groupWithRequests}
+        onChannelPressed={noop}
+        onJoinChannel={noop}
+        onBackPressed={noop}
+        onGoToGroupMembers={noop}
+        onPressManageChannels={noop}
+      />
+    </FullScreenFixture>
+  );
+}
+
+function NonHostCreateChannelFixture() {
+  const adminGroup = useMemo<db.Group>(
+    () => ({
+      ...group,
+      currentUserIsHost: false,
+      members: [
+        ...(group.members ?? []),
+        {
+          contactId: currentUserId,
+          joinedAt: 0,
+          chatId: group.id,
+          membershipType: 'group',
+        },
+      ],
+    }),
+    []
+  );
+  const [ready, setReady] = useState(false);
+
+  useEffect(() => {
+    void (async () => {
+      await db.insertGroups({ groups: [adminGroup] });
+      await db.addGroupRole({ groupId: adminGroup.id, roleId: 'admin' });
+      await db.addMembersToRole({
+        groupId: adminGroup.id,
+        roleId: 'admin',
+        contactIds: [currentUserId],
+      });
+      setReady(true);
+    })();
+  }, [adminGroup]);
+
+  if (!ready) {
+    return null;
+  }
+
+  return (
+    <ShipProvider
+      initialShipInfo={{
+        authType: 'hosted',
+        ship: 'zod',
+        shipUrl: 'https://zod.test',
+        authCookie: 'fixture',
+        needsSplashSequence: false,
+      }}
+    >
+      <FixtureWrapper fillHeight fillWidth>
+        <CreateChannelSheet
+          group={adminGroup}
+          onOpenChange={noop}
+          sheetProps={{ snapPoints: [95], snapPointsMode: 'percent' }}
+        />
+      </FixtureWrapper>
+    </ShipProvider>
   );
 }
 
 export default {
-  'Join Request Notice': <JoinRequestNoticeFixture />,
-  'Notifications Prompt (Static)': <NotificationsPromptFixture />,
+  '01A Notifications — Expanded': (
+    <SystemNotices.PresentationProvider value="expanded">
+      <HomeNotificationsFixture />
+    </SystemNotices.PresentationProvider>
+  ),
+  '01B Notifications — Compact': (
+    <SystemNotices.PresentationProvider value="compact">
+      <HomeNotificationsFixture />
+    </SystemNotices.PresentationProvider>
+  ),
+  '02A Contacts ask — Expanded': (
+    <SystemNotices.PresentationProvider value="expanded">
+      <ContactsPromptFixture status="undetermined" />
+    </SystemNotices.PresentationProvider>
+  ),
+  '02B Contacts ask — Compact': (
+    <SystemNotices.PresentationProvider value="compact">
+      <ContactsPromptFixture status="undetermined" />
+    </SystemNotices.PresentationProvider>
+  ),
+  '03A Contacts settings — Expanded': (
+    <SystemNotices.PresentationProvider value="expanded">
+      <ContactsPromptFixture status="denied" />
+    </SystemNotices.PresentationProvider>
+  ),
+  '03B Contacts settings — Compact': (
+    <SystemNotices.PresentationProvider value="compact">
+      <ContactsPromptFixture status="denied" />
+    </SystemNotices.PresentationProvider>
+  ),
+  '04A New join requests channel — Expanded': (
+    <SystemNotices.PresentationProvider value="expanded">
+      <ChannelRequestsFixture />
+    </SystemNotices.PresentationProvider>
+  ),
+  '04B New join requests channel — Compact': (
+    <SystemNotices.PresentationProvider value="compact">
+      <ChannelRequestsFixture />
+    </SystemNotices.PresentationProvider>
+  ),
+  '05A New join requests list — Expanded': (
+    <SystemNotices.PresentationProvider value="expanded">
+      <GroupChannelsRequestsFixture />
+    </SystemNotices.PresentationProvider>
+  ),
+  '05B New join requests list — Compact': (
+    <SystemNotices.PresentationProvider value="compact">
+      <GroupChannelsRequestsFixture />
+    </SystemNotices.PresentationProvider>
+  ),
+  '06A Non-host admin — Expanded': (
+    <SystemNotices.PresentationProvider value="expanded">
+      <NonHostCreateChannelFixture />
+    </SystemNotices.PresentationProvider>
+  ),
+  '06B Non-host admin — Compact': (
+    <SystemNotices.PresentationProvider value="compact">
+      <NonHostCreateChannelFixture />
+    </SystemNotices.PresentationProvider>
+  ),
 };

--- a/packages/app/fixtures/SystemNotices.fixture.tsx
+++ b/packages/app/fixtures/SystemNotices.fixture.tsx
@@ -225,16 +225,37 @@ function NonHostCreateChannelFixture() {
   const [ready, setReady] = useState(false);
 
   useEffect(() => {
-    void (async () => {
-      await db.insertGroups({ groups: [adminGroup] });
-      await db.addGroupRole({ groupId: adminGroup.id, roleId: 'admin' });
-      await db.addMembersToRole({
-        groupId: adminGroup.id,
-        roleId: 'admin',
-        contactIds: [currentUserId],
-      });
-      setReady(true);
-    })();
+    const previousCurrentUserId = window.our;
+    let cancelled = false;
+    window.our = currentUserId;
+
+    const prepareFixture = async () => {
+      try {
+        await db.insertGroups({ groups: [adminGroup] });
+        await db.addGroupRole({ groupId: adminGroup.id, roleId: 'admin' });
+        await db.addMembersToRole({
+          groupId: adminGroup.id,
+          roleId: 'admin',
+          contactIds: [currentUserId],
+        });
+        if (!cancelled) {
+          setReady(true);
+        }
+      } catch (error) {
+        console.error('Failed to prepare non-host admin fixture', error);
+      }
+    };
+
+    void prepareFixture();
+
+    return () => {
+      cancelled = true;
+      if (previousCurrentUserId === undefined) {
+        Reflect.deleteProperty(window, 'our');
+      } else {
+        window.our = previousCurrentUserId;
+      }
+    };
   }, [adminGroup]);
 
   if (!ready) {

--- a/packages/app/ui/components/Channel/index.tsx
+++ b/packages/app/ui/components/Channel/index.tsx
@@ -861,6 +861,7 @@ export function Channel({
                                 <SystemNotices.ConnectedJoinRequestNotice
                                   group={group}
                                   onViewRequests={goToGroupSettings}
+                                  marginTop="$l"
                                 />
                               )}
                               <AnimatePresence>

--- a/packages/app/ui/components/GroupChannelsScreenView.tsx
+++ b/packages/app/ui/components/GroupChannelsScreenView.tsx
@@ -354,16 +354,22 @@ export const GroupChannelsScreenView = React.memo(
               getItemType={getItemType}
               {...screenScrollProps}
               ListHeaderComponent={
-                <>
+                <YStack width="100%" minWidth="100%" alignSelf="stretch">
                   {isPersonalGroup ? (
                     <WayfindingNotice.GroupChannels group={group} />
                   ) : null}
                   <SystemNotices.ConnectedJoinRequestNotice
                     group={group}
                     onViewRequests={onGoToGroupMembers}
+                    horizontalInset={false}
                   />
-                </>
+                </YStack>
               }
+              ListHeaderComponentStyle={{
+                width: '100%',
+                minWidth: '100%',
+                alignSelf: 'stretch',
+              }}
               contentContainerStyle={{
                 paddingTop: getTokenValue('$l'),
                 paddingHorizontal: getTokenValue('$l'),

--- a/packages/app/ui/components/ManageChannels/CreateChannelSheet.tsx
+++ b/packages/app/ui/components/ManageChannels/CreateChannelSheet.tsx
@@ -3,7 +3,7 @@ import { NativeStackNavigationProp } from '@react-navigation/native-stack';
 import { createChannel, useNotesDeskAvailable } from '@tloncorp/shared';
 import * as db from '@tloncorp/shared/db';
 import { Button } from '@tloncorp/ui';
-import { useCallback, useMemo } from 'react';
+import { type ComponentProps, useCallback, useMemo } from 'react';
 import { FormProvider, useForm, useWatch } from 'react-hook-form';
 import { YStack } from 'tamagui';
 
@@ -63,9 +63,14 @@ interface CreateChannelFormSchema {
 export function CreateChannelSheet({
   onOpenChange,
   group,
+  sheetProps,
 }: {
   onOpenChange: (open: boolean) => void;
   group: db.Group;
+  sheetProps?: Pick<
+    ComponentProps<typeof ActionSheet>,
+    'snapPoints' | 'snapPointsMode'
+  >;
 }) {
   const navigation =
     useNavigation<
@@ -134,7 +139,7 @@ export function CreateChannelSheet({
 
   return (
     <FormProvider {...form}>
-      <ActionSheet open onOpenChange={onOpenChange}>
+      <ActionSheet open onOpenChange={onOpenChange} {...sheetProps}>
         <ActionSheet.SimpleHeader title="Create a new channel" />
         <ActionSheet.Content>
           <ActionSheet.FormBlock>

--- a/packages/app/ui/components/ScreenHeader/ScreenHeader.tsx
+++ b/packages/app/ui/components/ScreenHeader/ScreenHeader.tsx
@@ -1,6 +1,14 @@
 import { useDebouncedValue } from '@tloncorp/shared';
 import { Icon, Text, View } from '@tloncorp/ui';
-import { Children, ReactNode, useEffect, useRef, useState } from 'react';
+import {
+  Children,
+  ReactNode,
+  createContext,
+  useContext,
+  useEffect,
+  useRef,
+  useState,
+} from 'react';
 import {
   ActivityIndicator,
   Platform,
@@ -69,6 +77,10 @@ type ScreenHeaderProps = SharedScreenHeaderProps &
       }
   );
 
+const InlineScreenHeaderContext = createContext(false);
+
+export const InlineScreenHeaderProvider = InlineScreenHeaderContext.Provider;
+
 export const ScreenHeaderComponent = ({
   children,
   title,
@@ -89,6 +101,7 @@ export const ScreenHeaderComponent = ({
   testID,
   placement = 'content',
 }: ScreenHeaderProps) => {
+  const forceInline = useContext(InlineScreenHeaderContext);
   const { top } = useSafeAreaInsets();
   const [headerWidth, setHeaderWidth] = useState(0);
   const [leftControlsWidth, setLeftControlsWidth] = useState(0);
@@ -281,7 +294,7 @@ export const ScreenHeaderComponent = ({
     isInteractive: onTitlePress != null,
   });
   const shouldUseNativeHeader = useNativeHeader({
-    enabled: placement === 'navigation',
+    enabled: placement === 'navigation' && !forceInline,
     title: typeof title === 'string' ? title : '',
     titleElement: interactiveTitleContent,
     titlePresentationKey,

--- a/packages/app/ui/components/ScreenHeader/index.ts
+++ b/packages/app/ui/components/ScreenHeader/index.ts
@@ -1,2 +1,2 @@
-export { ScreenHeader } from './ScreenHeader';
+export { InlineScreenHeaderProvider, ScreenHeader } from './ScreenHeader';
 export type { ScreenHeaderAction } from './actions';

--- a/packages/app/ui/components/SystemNotices.tsx
+++ b/packages/app/ui/components/SystemNotices.tsx
@@ -11,7 +11,7 @@ import {
   useMemo,
   useRef,
 } from 'react';
-import { Alert } from 'react-native';
+import { Alert, Platform } from 'react-native';
 import { View, XStack, YStack, isWeb, styled } from 'tamagui';
 
 import { useContactPermissions } from '../../hooks/useContactPermissions';
@@ -33,9 +33,8 @@ function useSystemNoticePresentation(
   presentation: SystemNoticePresentation | undefined,
   fallback: SystemNoticePresentation
 ) {
-  return (
-    useContext(SystemNoticePresentationContext) ?? presentation ?? fallback
-  );
+  const contextPresentation = useContext(SystemNoticePresentationContext);
+  return presentation ?? contextPresentation ?? fallback;
 }
 
 const NoticeContainer = styled(View, {
@@ -301,7 +300,9 @@ export function NotificationsPromptView({
   onPrimaryAction: () => void;
   presentation?: SystemNoticePresentation;
 }) {
-  const bottomContentInset = useTopLevelTabBarContentInset();
+  const tabBarContentInset = useTopLevelTabBarContentInset();
+  const bottomContentInset =
+    Platform.OS === 'ios' ? tabBarContentInset : undefined;
   const presentation = useSystemNoticePresentation(
     presentationOverride,
     'expanded'

--- a/packages/app/ui/components/SystemNotices.tsx
+++ b/packages/app/ui/components/SystemNotices.tsx
@@ -1,10 +1,18 @@
 import { AnalyticsEvent, createDevLogger, trackEvent } from '@tloncorp/shared';
 import * as db from '@tloncorp/shared/db';
 import * as store from '@tloncorp/shared/store';
-import { Button, Text } from '@tloncorp/ui';
-import { useCallback, useEffect, useMemo, useRef } from 'react';
-import { Alert, Platform } from 'react-native';
-import { XStack, YStack, isWeb, styled } from 'tamagui';
+import { Button, Icon, type IconType, Text } from '@tloncorp/ui';
+import {
+  type ReactNode,
+  createContext,
+  useCallback,
+  useContext,
+  useEffect,
+  useMemo,
+  useRef,
+} from 'react';
+import { Alert } from 'react-native';
+import { View, XStack, YStack, isWeb, styled } from 'tamagui';
 
 import { useContactPermissions } from '../../hooks/useContactPermissions';
 import { useNag } from '../../hooks/useNag';
@@ -13,34 +21,210 @@ import { useTopLevelTabBarContentInset } from '../../navigation/useTopLevelTabBa
 
 const logger = createDevLogger('SystemNotices', false);
 
-const NoticeFrame = styled(YStack, {
-  backgroundColor: '$systemNoticeBackground',
-  padding: '$2xl',
-  marginHorizontal: '$l',
-  borderRadius: '$l',
-  borderWidth: 1.6,
-  borderColor: '$systemNoticeBorder',
+export type SystemNoticePresentation = 'expanded' | 'compact';
+
+const SystemNoticePresentationContext =
+  createContext<SystemNoticePresentation | null>(null);
+
+export const SystemNoticePresentationProvider =
+  SystemNoticePresentationContext.Provider;
+
+function useSystemNoticePresentation(
+  presentation: SystemNoticePresentation | undefined,
+  fallback: SystemNoticePresentation
+) {
+  return (
+    useContext(SystemNoticePresentationContext) ?? presentation ?? fallback
+  );
+}
+
+const NoticeContainer = styled(View, {
+  width: '100%',
+  minWidth: '100%',
+  alignSelf: 'stretch',
+  variants: {
+    horizontalInset: {
+      true: {
+        paddingHorizontal: '$xl',
+      },
+    },
+  } as const,
+});
+
+const NoticeCardFrame = styled(YStack, {
+  width: '100%',
+  backgroundColor: '$background',
+  padding: 20,
+  borderRadius: '$2xl',
+  borderWidth: 1,
+  borderColor: '$border',
 });
 
 const NoticeBody = styled(Text, {
-  color: '$systemNoticeText',
-  opacity: 0.7,
-  size: '$label/l',
+  color: '$secondaryText',
+  size: '$label/m',
+  trimmed: false,
 });
 
 const NoticeTitle = styled(Text, {
-  color: '$systemNoticeText',
-  size: '$label/xl',
+  color: '$primaryText',
+  size: '$label/l',
   fontWeight: '600',
+  trimmed: false,
 });
+
+const NoticeIconFrame = styled(View, {
+  width: 40,
+  height: 40,
+  borderRadius: '$l',
+  backgroundColor: '$secondaryBackground',
+  alignItems: 'center',
+  justifyContent: 'center',
+});
+
+const NoticeBannerFrame = styled(XStack, {
+  width: '100%',
+  height: 56,
+  paddingHorizontal: '$xl',
+  borderRadius: '$xl',
+  backgroundColor: '$secondaryBackground',
+  alignItems: 'center',
+  gap: '$m',
+});
+
+function NoticeIcon({
+  type,
+  compact = false,
+}: {
+  type: IconType;
+  compact?: boolean;
+}) {
+  if (compact) {
+    return <Icon type={type} customSize={[24, 20]} color="$primaryText" />;
+  }
+
+  return (
+    <NoticeIconFrame>
+      <Icon type={type} customSize={[24, 22]} color="$primaryText" />
+    </NoticeIconFrame>
+  );
+}
+
+function NoticeCard({
+  icon,
+  title,
+  children,
+  actions,
+  horizontalInset = true,
+  ...frameProps
+}: {
+  icon: IconType;
+  title: string;
+  children: ReactNode;
+  actions?: ReactNode;
+  horizontalInset?: boolean;
+} & React.ComponentProps<typeof NoticeContainer>) {
+  return (
+    <NoticeContainer horizontalInset={horizontalInset} {...frameProps}>
+      <NoticeCardFrame>
+        <XStack gap="$l" alignItems="flex-start">
+          <NoticeIcon type={icon} />
+          <YStack flex={1}>
+            <NoticeTitle>{title}</NoticeTitle>
+            <NoticeBody>{children}</NoticeBody>
+          </YStack>
+        </XStack>
+        {actions ? <View marginTop="$xl">{actions}</View> : null}
+      </NoticeCardFrame>
+    </NoticeContainer>
+  );
+}
+
+function NoticeBanner({
+  icon,
+  title,
+  actionLabel,
+  onAction,
+  onDismiss,
+  horizontalInset = true,
+  ...containerProps
+}: {
+  icon: IconType;
+  title: string;
+  actionLabel?: string;
+  onAction?: () => void;
+  onDismiss?: () => void;
+  horizontalInset?: boolean;
+} & React.ComponentProps<typeof NoticeContainer>) {
+  return (
+    <NoticeContainer horizontalInset={horizontalInset} {...containerProps}>
+      <NoticeBannerFrame>
+        <NoticeIcon type={icon} compact />
+        <NoticeTitle flex={1} numberOfLines={1}>
+          {title}
+        </NoticeTitle>
+        {actionLabel && onAction ? (
+          <Button
+            preset="primary"
+            label={actionLabel}
+            size="small"
+            height={32}
+            minHeight={32}
+            paddingHorizontal="$l"
+            paddingVertical={0}
+            borderRadius="$l"
+            centered
+            onPress={onAction}
+          />
+        ) : null}
+        {onDismiss ? (
+          <Button
+            icon="Close"
+            size="small"
+            intent="secondary"
+            fill="text"
+            width={24}
+            minWidth={24}
+            height={24}
+            minHeight={24}
+            padding={0}
+            aria-label="Dismiss"
+            onPress={onDismiss}
+          />
+        ) : null}
+      </NoticeBannerFrame>
+    </NoticeContainer>
+  );
+}
+
+function NoticeActions({ children }: { children: ReactNode }) {
+  return (
+    <XStack width="100%" gap="$m">
+      {children}
+    </XStack>
+  );
+}
+
+const noticeActionProps = {
+  flex: 1,
+  height: 40,
+  minHeight: 40,
+  size: 'medium' as const,
+  paddingVertical: 0,
+  borderRadius: '$l' as const,
+  centered: true,
+};
 
 const SystemNotices = {
   ContactBookPrompt,
+  ContactBookPromptView,
   NotificationsPrompt,
+  NotificationsPromptView,
   JoinRequestNotice,
   ConnectedJoinRequestNotice,
   NonHostAdminChannelNotice,
-  NoticeFrame,
+  PresentationProvider: SystemNoticePresentationProvider,
+  NoticeFrame: NoticeCardFrame,
   NoticeBody,
   NoticeTitle,
 };
@@ -48,7 +232,6 @@ const SystemNotices = {
 export default SystemNotices;
 
 export function NotificationsPrompt() {
-  const tabBarContentInset = useTopLevelTabBarContentInset();
   const notifNag = useNag({
     key: 'notificationsPrompt',
     refreshInterval: 30 * 60 * 1000, // Nag every 30 minutes
@@ -99,36 +282,70 @@ export function NotificationsPrompt() {
   }
 
   return (
-    <NoticeFrame
-      // The iOS liquid-glass tab bar overlays content; Android's bar does not.
-      marginBottom={Platform.OS === 'ios' ? tabBarContentInset : undefined}
+    <NotificationsPromptView
+      primaryActionLabel={perms.canAskPermission ? 'Enable' : 'Settings'}
+      onDismiss={handleDismiss}
+      onPrimaryAction={handlePrimaryAction}
+    />
+  );
+}
+
+export function NotificationsPromptView({
+  primaryActionLabel,
+  onDismiss,
+  onPrimaryAction,
+  presentation: presentationOverride,
+}: {
+  primaryActionLabel: 'Enable' | 'Settings';
+  onDismiss: () => void;
+  onPrimaryAction: () => void;
+  presentation?: SystemNoticePresentation;
+}) {
+  const bottomContentInset = useTopLevelTabBarContentInset();
+  const presentation = useSystemNoticePresentation(
+    presentationOverride,
+    'expanded'
+  );
+
+  if (presentation === 'compact') {
+    return (
+      <NoticeBanner
+        icon="Notifications"
+        title="Turn on notifications"
+        actionLabel={primaryActionLabel}
+        onAction={onPrimaryAction}
+        onDismiss={onDismiss}
+        marginBottom={bottomContentInset}
+      />
+    );
+  }
+
+  return (
+    <NoticeCard
+      icon="Notifications"
+      title="Stay in the loop"
+      marginBottom={bottomContentInset}
+      actions={
+        <NoticeActions>
+          <Button
+            {...noticeActionProps}
+            intent="primary"
+            fill="ghost"
+            backgroundColor="$secondaryBackground"
+            label="Not now"
+            onPress={onDismiss}
+          />
+          <Button
+            {...noticeActionProps}
+            preset="primary"
+            label={primaryActionLabel}
+            onPress={onPrimaryAction}
+          />
+        </NoticeActions>
+      }
     >
-      <YStack gap="$5xl">
-        <YStack gap="$xl">
-          <NoticeTitle>Enable notifications</NoticeTitle>
-          <NoticeBody>
-            Tlon Messenger works best if you enable push notifications on your
-            device.
-          </NoticeBody>
-        </YStack>
-        <XStack gap="$m" justifyContent="flex-end">
-          <Button
-            type="notice"
-            fill="outline"
-            label="Not Now"
-            size="medium"
-            onPress={handleDismiss}
-          />
-          <Button
-            type="notice"
-            fill="solid"
-            size="medium"
-            label={perms.canAskPermission ? 'Enable' : 'Settings'}
-            onPress={handlePrimaryAction}
-          />
-        </XStack>
-      </YStack>
-    </NoticeFrame>
+      Turn on notifications for new messages, mentions, and invites.
+    </NoticeCard>
   );
 }
 
@@ -178,73 +395,152 @@ export function ContactBookPrompt(props: {
   }
 
   return (
-    <NoticeFrame marginTop="$xl">
-      <YStack gap="$5xl">
-        <YStack gap="$xl">
-          <NoticeTitle>Find Friends</NoticeTitle>
-          <NoticeBody>
-            Sync your contact book to easily find people you know on Tlon. Your
-            contacts are never uploaded — we only send anonymous, hashed
-            identifiers to our server to match you with people you know.
-          </NoticeBody>
-        </YStack>
-        {props.status === 'undetermined' && (
-          <XStack gap="$m" justifyContent="flex-end">
+    <ContactBookPromptView
+      status={props.status}
+      onDismiss={handleDismiss}
+      onPrimaryAction={handlePrimaryAction}
+    />
+  );
+}
+
+export function ContactBookPromptView({
+  status,
+  onDismiss,
+  onPrimaryAction,
+  presentation: presentationOverride,
+}: {
+  status: 'denied' | 'granted' | 'undetermined';
+  onDismiss: () => void;
+  onPrimaryAction: () => void;
+  presentation?: SystemNoticePresentation;
+}) {
+  const presentation = useSystemNoticePresentation(
+    presentationOverride,
+    'expanded'
+  );
+
+  if (presentation === 'compact') {
+    return (
+      <NoticeBanner
+        icon="AddPerson"
+        title="Find people you know"
+        actionLabel={status === 'denied' ? 'Settings' : 'Continue'}
+        onAction={onPrimaryAction}
+        onDismiss={onDismiss}
+        marginTop="$xl"
+      />
+    );
+  }
+
+  return (
+    <NoticeCard
+      icon="AddPerson"
+      title="Find people you know"
+      marginTop="$xl"
+      actions={
+        status === 'undetermined' ? (
+          <NoticeActions>
             <Button
-              type="notice"
-              fill="outline"
-              label="Not Now"
-              size="small"
-              onPress={handleDismiss}
+              {...noticeActionProps}
+              intent="primary"
+              fill="ghost"
+              backgroundColor="$secondaryBackground"
+              label="Not now"
+              onPress={onDismiss}
             />
             <Button
-              type="notice"
-              fill="solid"
+              {...noticeActionProps}
+              preset="primary"
               label="Continue"
-              size="small"
-              onPress={handlePrimaryAction}
+              onPress={onPrimaryAction}
             />
-          </XStack>
-        )}
-        {props.status === 'denied' && (
-          <Button preset="outline" label="Open Settings" />
-        )}
-      </YStack>
-    </NoticeFrame>
+          </NoticeActions>
+        ) : status === 'denied' ? (
+          <NoticeActions>
+            <Button
+              {...noticeActionProps}
+              preset="primary"
+              label="Open Settings"
+              onPress={onPrimaryAction}
+            />
+          </NoticeActions>
+        ) : null
+      }
+    >
+      Match with people in your contacts. We send anonymous hashes—not your
+      address book.
+    </NoticeCard>
   );
 }
 
 export function JoinRequestNotice(params: {
   onViewRequests: () => void;
   onDismiss: () => void;
+  horizontalInset?: boolean;
+  marginTop?: React.ComponentProps<typeof NoticeContainer>['marginTop'];
+  presentation?: SystemNoticePresentation;
 }) {
+  const presentation = useSystemNoticePresentation(
+    params.presentation,
+    'compact'
+  );
+
+  if (presentation === 'expanded') {
+    return (
+      <NoticeCard
+        icon="Profile"
+        title="New join requests"
+        horizontalInset={params.horizontalInset}
+        marginTop={params.marginTop}
+        actions={
+          <NoticeActions>
+            <Button
+              {...noticeActionProps}
+              intent="primary"
+              fill="ghost"
+              backgroundColor="$secondaryBackground"
+              label="Not now"
+              onPress={params.onDismiss}
+            />
+            <Button
+              {...noticeActionProps}
+              preset="primary"
+              label="Review"
+              onPress={params.onViewRequests}
+            />
+          </NoticeActions>
+        }
+      >
+        Review people waiting to join this group.
+      </NoticeCard>
+    );
+  }
+
   return (
-    <NoticeFrame gap="$2xl">
-      <NoticeTitle>Pending Member Requests</NoticeTitle>
-      <XStack gap="$m" justifyContent="flex-end">
-        <Button
-          type="notice"
-          fill="outline"
-          label="Dismiss"
-          onPress={params.onDismiss}
-        />
-        <Button
-          type="notice"
-          fill="solid"
-          label="View Requests"
-          onPress={params.onViewRequests}
-        />
-      </XStack>
-    </NoticeFrame>
+    <NoticeBanner
+      icon="Profile"
+      title="New join requests"
+      actionLabel="Review"
+      onAction={params.onViewRequests}
+      onDismiss={params.onDismiss}
+      horizontalInset={params.horizontalInset}
+      marginTop={params.marginTop}
+    />
   );
 }
 
 export function ConnectedJoinRequestNotice({
   group,
   onViewRequests,
+  horizontalInset,
+  marginTop,
+  presentation,
 }: {
   group?: db.Group | null;
   onViewRequests: () => void;
+  horizontalInset?: boolean;
+  marginTop?: React.ComponentProps<typeof NoticeContainer>['marginTop'];
+  presentation?: SystemNoticePresentation;
 }) {
   // see if we have any pending join requests that haven't been dismissed
   const hasRelevantJoinRequests = useMemo(() => {
@@ -283,17 +579,36 @@ export function ConnectedJoinRequestNotice({
     <SystemNotices.JoinRequestNotice
       onViewRequests={onViewRequests}
       onDismiss={handleDismissJoinRequests}
+      horizontalInset={horizontalInset}
+      marginTop={marginTop}
+      presentation={presentation}
     />
   );
 }
 
-export function NonHostAdminChannelNotice() {
+export function NonHostAdminChannelNotice({
+  presentation: presentationOverride,
+}: {
+  presentation?: SystemNoticePresentation;
+} = {}) {
+  const presentation = useSystemNoticePresentation(
+    presentationOverride,
+    'expanded'
+  );
+
+  if (presentation === 'compact') {
+    return (
+      <NoticeBanner
+        icon="Info"
+        title="Hosted on your node"
+        horizontalInset={false}
+      />
+    );
+  }
+
   return (
-    <NoticeFrame>
-      <NoticeBody>
-        Note: You are not the host of this group. Channels you create will be
-        hosted on your node and will operate independently of the group host.
-      </NoticeBody>
-    </NoticeFrame>
+    <NoticeCard icon="Info" title="Hosted on your node" horizontalInset={false}>
+      This channel will run independently from the group host.
+    </NoticeCard>
   );
 }

--- a/packages/app/ui/components/SystemNotices.tsx
+++ b/packages/app/ui/components/SystemNotices.tsx
@@ -55,7 +55,7 @@ const NoticeCardFrame = styled(YStack, {
   width: '100%',
   backgroundColor: '$background',
   padding: 20,
-  borderRadius: '$2xl',
+  borderRadius: '$xl',
   borderWidth: 1,
   borderColor: '$border',
 });

--- a/packages/app/ui/components/SystemNotices.tsx
+++ b/packages/app/ui/components/SystemNotices.tsx
@@ -253,21 +253,11 @@ export function NotificationsPrompt() {
     notifNag.dismiss();
   }, [notifNag]);
 
-  const handlePrimaryAction = useCallback(async () => {
-    if (perms.canAskPermission) {
-      await perms.requestPermissions();
-      if (perms.hasPermission) {
-        Alert.alert('Success', 'You will now receive notifications.');
-        notifNag.eliminate();
-      } else {
-        notifNag.dismiss();
-      }
-    } else {
-      logger.trackEvent(AnalyticsEvent.ActionNotifPermsSettingsOpened);
-      openedSettingsRef.current = true;
-      perms.openSettings();
-    }
-  }, [perms, notifNag]);
+  const handlePrimaryAction = useCallback(() => {
+    logger.trackEvent(AnalyticsEvent.ActionNotifPermsSettingsOpened);
+    openedSettingsRef.current = true;
+    perms.openSettings();
+  }, [perms]);
 
   if (
     isWeb ||
@@ -282,7 +272,7 @@ export function NotificationsPrompt() {
 
   return (
     <NotificationsPromptView
-      primaryActionLabel={perms.canAskPermission ? 'Enable' : 'Settings'}
+      primaryActionLabel="Settings"
       onDismiss={handleDismiss}
       onPrimaryAction={handlePrimaryAction}
     />


### PR DESCRIPTION
## Summary

Reworks system prompts into shared expanded cards and compact banners using the app design system. Notifications remain at the bottom with space for the native tab bar and safe area.

Fixes TLON-6340

## Changes

- Adds shared expanded and compact notice structures with consistent icons, type, actions, and spacing.
- Updates notification, contact access, join request, and non-host admin prompts.
- Renames member requests to “New join requests.”
- Fixes full-width layouts, button centering, screen headers, and floating notice spacing.
- Adds full-screen Cosmos fixtures for both structures at every placement.

## How did I test?

- `corepack pnpm --filter @tloncorp/app tsc`
- Targeted ESLint on all changed files
- Built, installed, and launched on an iPhone 17 Pro Simulator through the worktree-verified wrapper
- Checked expanded and compact fixtures for every placement
- Captured before and after screenshots on the same production screen backdrops
- Verified the radius update only changed the four outer card corners; compact notices remained pixel-identical

## Before / after

### Notifications

<table>
  <tr><th>Before</th><th>After</th></tr>
  <tr>
    <td><img width="390" alt="Notifications before" src="https://github.com/user-attachments/assets/5b0848ee-07ad-40d1-84f3-c4370b67571b" /></td>
    <td><img width="390" alt="Notifications after" src="https://github.com/user-attachments/assets/cf63a874-1de8-4139-bcfc-7c1796ac1e24" /></td>
  </tr>
</table>

### Contacts: ask

<table>
  <tr><th>Before</th><th>After</th></tr>
  <tr>
    <td><img width="390" alt="Contacts ask before" src="https://github.com/user-attachments/assets/55958534-4ee6-4399-a887-714fff79d824" /></td>
    <td><img width="390" alt="Contacts ask after" src="https://github.com/user-attachments/assets/0a025fde-0609-46d2-9064-df0252569690" /></td>
  </tr>
</table>

### Contacts: settings

<table>
  <tr><th>Before</th><th>After</th></tr>
  <tr>
    <td><img width="390" alt="Contacts settings before" src="https://github.com/user-attachments/assets/64780078-b186-4877-800d-76260b44e401" /></td>
    <td><img width="390" alt="Contacts settings after" src="https://github.com/user-attachments/assets/3321a7fc-4d90-49c8-b78d-a309c0e5483d" /></td>
  </tr>
</table>

### New join requests: channel

<table>
  <tr><th>Before</th><th>After</th></tr>
  <tr>
    <td><img width="390" alt="Join requests channel before" src="https://github.com/user-attachments/assets/929b017e-62ec-4923-9491-939e0ecd4c53" /></td>
    <td><img width="390" alt="Join requests channel after" src="https://github.com/user-attachments/assets/985bc471-448b-42b5-8829-fae14e03e656" /></td>
  </tr>
</table>

### New join requests: channel list

<table>
  <tr><th>Before</th><th>After</th></tr>
  <tr>
    <td><img width="390" alt="Join requests channel list before" src="https://github.com/user-attachments/assets/85153ee2-73ed-4b61-9c54-21a27e471e0b" /></td>
    <td><img width="390" alt="Join requests channel list after" src="https://github.com/user-attachments/assets/f400e626-c65c-47da-b24f-ecf48dcaea50" /></td>
  </tr>
</table>

### Non-host channel admin

<table>
  <tr><th>Before</th><th>After</th></tr>
  <tr>
    <td><img width="390" alt="Non-host channel admin before" src="https://github.com/user-attachments/assets/618c4e99-7f42-455d-ae1c-13ea9a283f42" /></td>
    <td><img width="390" alt="Non-host channel admin after" src="https://github.com/user-attachments/assets/81222060-521a-495f-bfc5-9fbcaff6d6a3" /></td>
  </tr>
</table>

## Risks and impact

- Safe to roll back: Yes
- Affects system prompts and their fixtures

## Rollback plan

Revert this commit.

