### PR TITLE
prevent openclaw api client races

### DIFF
--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tloncorp/api",
-  "version": "0.0.10",
+  "version": "0.0.12",
   "type": "module",
   "files": [
     "dist",

--- a/packages/api/src/__tests__/urbitClientResolver.test.ts
+++ b/packages/api/src/__tests__/urbitClientResolver.test.ts
@@ -1,0 +1,69 @@
+import { afterEach, describe, expect, test, vi } from 'vitest';
+
+import {
+  BadResponseError,
+  poke,
+  requestJson,
+  scry,
+  setClientResolver,
+} from '../client/urbit';
+import { AuthError, type Urbit } from '../http-api';
+
+afterEach(() => {
+  setClientResolver(null);
+});
+
+describe('client resolver', () => {
+  test('routes an operation through the resolved client', async () => {
+    const scopedClient = {
+      poke: vi.fn().mockResolvedValue(7),
+      requestJson: vi.fn().mockResolvedValue({ ok: true }),
+      scryWithInfo: vi.fn().mockResolvedValue({
+        result: { ship: '~zod' },
+        responseSizeInBytes: 0,
+        responseStatus: 200,
+      }),
+    };
+    setClientResolver(() => scopedClient as unknown as Urbit);
+
+    await expect(poke({ app: 'chat', mark: 'test', json: {} })).resolves.toBe(
+      7
+    );
+    await expect(scry({ app: 'contacts', path: '/v1/self' })).resolves.toEqual({
+      ship: '~zod',
+    });
+    await expect(requestJson('/notes', 'GET')).resolves.toEqual({ ok: true });
+  });
+
+  test('does not run singleton reauthentication for a scoped client', async () => {
+    const rejection = Object.assign(new Error('forbidden'), { status: 403 });
+    const scopedClient = {
+      requestJson: vi.fn().mockRejectedValue(rejection),
+    };
+    setClientResolver(() => scopedClient as unknown as Urbit);
+
+    await expect(requestJson('/notes', 'GET')).rejects.toEqual(
+      expect.objectContaining<Partial<BadResponseError>>({ status: 403 })
+    );
+    expect(scopedClient.requestJson).toHaveBeenCalledTimes(1);
+  });
+
+  test('does not run singleton reauthentication for a scoped poke', async () => {
+    const rejection = new AuthError('forbidden');
+    const scopedClient = { poke: vi.fn().mockRejectedValue(rejection) };
+    setClientResolver(() => scopedClient as unknown as Urbit);
+
+    await expect(poke({ app: 'chat', mark: 'test', json: {} })).rejects.toBe(
+      rejection
+    );
+    expect(scopedClient.poke).toHaveBeenCalledOnce();
+  });
+
+  test('an empty scope does not fall through to the configured client', async () => {
+    setClientResolver(() => null);
+
+    await expect(poke({ app: 'chat', mark: 'test', json: {} })).rejects.toThrow(
+      'Client not initialized'
+    );
+  });
+});

--- a/packages/api/src/client/urbit.ts
+++ b/packages/api/src/client/urbit.ts
@@ -5,7 +5,6 @@ import {
   AuthError,
   ChannelStatus,
   NounPokeInterface,
-  PokeInterface,
   Thread,
   Urbit,
 } from '../http-api';
@@ -124,6 +123,23 @@ const config: Config = {
   activitySupportsNotes: false,
 };
 
+type ClientResolver = () => Urbit | null | undefined;
+let clientResolver: ClientResolver | null = null;
+
+/**
+ * Let a server runtime provide an async-context-local client while preserving
+ * the configured singleton as the default for app clients. Returning
+ * `undefined` uses that default; `null` explicitly represents an empty scope.
+ */
+export function setClientResolver(resolver: ClientResolver | null): void {
+  clientResolver = resolver;
+}
+
+function resolveClient(): Urbit | null {
+  const resolved = clientResolver?.();
+  return resolved === undefined ? config.client : resolved;
+}
+
 // The capability flags below start false every boot and flip when app-info
 // sync resolves the backend version. Long-lived consumers that bake a
 // capability into something at call time (e.g. a subscription's stream
@@ -184,10 +200,11 @@ export const client = new Proxy(
   {},
   {
     get: function (target, prop, receiver) {
-      if (!config.client) {
+      const activeClient = resolveClient();
+      if (!activeClient) {
         throw new Error('Urbit client not set.');
       }
-      return Reflect.get(config.client, prop, receiver);
+      return Reflect.get(activeClient, prop, receiver);
     },
   }
 ) as Urbit;
@@ -508,26 +525,22 @@ export async function poke({ app, mark, json }: PokeParams) {
     app,
     mark,
   });
-  const doPoke = async (params?: Partial<PokeInterface<any>>) => {
-    if (!config.client) {
+  const activeClient = resolveClient();
+  const doPoke = async () => {
+    if (!activeClient) {
       throw new Error('Client not initialized');
     }
-    if (config.pendingAuth) {
+    if (activeClient === config.client && config.pendingAuth) {
       await config.pendingAuth;
     }
-    return config.client.poke({
-      ...params,
-      app,
-      mark,
-      json,
-    });
+    return activeClient.poke({ app, mark, json });
   };
   const retry = async (err: any) => {
     logger.trackError(`bad poke to ${app} with mark ${mark}`, {
       stack: err,
       body: json,
     });
-    if (!(err instanceof AuthError)) {
+    if (!(err instanceof AuthError) || activeClient !== config.client) {
       trackDuration('error');
       throw err;
     }
@@ -689,10 +702,11 @@ export async function scry<T>({
   path: string;
   timeout?: number;
 }) {
-  if (!config.client) {
+  const activeClient = resolveClient();
+  if (!activeClient) {
     throw new Error('Client not initialized');
   }
-  if (config.pendingAuth) {
+  if (activeClient === config.client && config.pendingAuth) {
     await config.pendingAuth;
   }
   logger.log('scry', app, path);
@@ -703,7 +717,7 @@ export async function scry<T>({
   });
   try {
     const { result, responseSizeInBytes, responseStatus } =
-      await config.client.scryWithInfo<T>({
+      await activeClient.scryWithInfo<T>({
         app,
         path,
         timeout: timeout ?? DEFAULT_SCRY_TIMEOUT,
@@ -712,11 +726,11 @@ export async function scry<T>({
     return result;
   } catch (res) {
     logger.log('bad scry', app, path, res.status);
-    if (res.status === 403) {
+    if (res.status === 403 && activeClient === config.client) {
       logger.log('scry failed with 403, authing to try again');
       await reauth();
       const { result, responseSizeInBytes, responseStatus } =
-        await config.client.scryWithInfo<T>({ app, path });
+        await activeClient.scryWithInfo<T>({ app, path });
       trackDuration('success', { responseSizeInBytes, responseStatus });
       return result;
     }
@@ -740,20 +754,24 @@ export async function requestJson<T = any>(
   body?: unknown,
   options: RequestJsonOptions = {}
 ): Promise<T> {
-  if (!config.client) {
+  const activeClient = resolveClient();
+  if (!activeClient) {
     throw new Error('Client not initialized');
   }
-  if (config.pendingAuth) {
+  if (activeClient === config.client && config.pendingAuth) {
     await config.pendingAuth;
   }
   const reauthStatuses = options.reauthStatuses ?? [403];
 
   try {
-    return await config.client.requestJson<T>(path, method, body);
+    return await activeClient.requestJson<T>(path, method, body);
   } catch (res) {
-    if (reauthStatuses.includes(res?.status)) {
+    if (
+      activeClient === config.client &&
+      reauthStatuses.includes(res?.status)
+    ) {
       await reauth();
-      return await config.client.requestJson<T>(path, method, body);
+      return await activeClient.requestJson<T>(path, method, body);
     }
     const errorBody = await responseErrorBody(res);
     throw new BadResponseError(res?.status ?? 0, errorBody);

--- a/packages/openclaw/src/context-lens-ship-sync.test.ts
+++ b/packages/openclaw/src/context-lens-ship-sync.test.ts
@@ -41,8 +41,6 @@ function makeParams(pokes: RecordedPoke[]): SharedApiClientParams {
       pokes.push(params as RecordedPoke);
       return Promise.resolve(undefined);
     },
-    shipName: '~zod',
-    shipUrl: 'http://localhost:8080',
   };
 }
 
@@ -328,8 +326,6 @@ describe('createContextLensShipSync', () => {
         pokes.push(params as RecordedPoke);
         return Promise.resolve(undefined);
       },
-      shipName: '~zod',
-      shipUrl: 'http://localhost:8080',
     };
     let current = flaky;
     const warnings: string[] = [];

--- a/packages/openclaw/src/gateway-status-registration.test.ts
+++ b/packages/openclaw/src/gateway-status-registration.test.ts
@@ -23,13 +23,13 @@ vi.mock('@tloncorp/api', () => ({
 }));
 
 vi.mock('./urbit/api-client.js', () => ({
-  configureTlonApiWithPoke: vi.fn(),
+  withTlonApiPoke: vi.fn(
+    (_poke: SharedApiClientParams['poke'], fn: () => Promise<unknown>) => fn()
+  ),
 }));
 
 const stubApiClientParams: SharedApiClientParams = {
   poke: vi.fn().mockResolvedValue(undefined),
-  shipName: 'test-bot',
-  shipUrl: 'http://localhost:8080',
 };
 
 /** A promise the test can settle on its own schedule. */

--- a/packages/openclaw/src/gateway-status.test.ts
+++ b/packages/openclaw/src/gateway-status.test.ts
@@ -23,7 +23,7 @@ import {
   startGatewayHeartbeatLoop,
 } from './gateway-status.js';
 import { sharedSlot } from './shared-state.js';
-import { configureTlonApiWithPoke } from './urbit/api-client.js';
+import { withTlonApiPoke } from './urbit/api-client.js';
 
 vi.mock('@tloncorp/api', () => ({
   configureStewardGateway: vi.fn().mockResolvedValue(undefined),
@@ -32,17 +32,14 @@ vi.mock('@tloncorp/api', () => ({
   gatewayStop: vi.fn().mockResolvedValue(undefined),
 }));
 
-// The heartbeat and sendGatewayStop paths call configureTlonApiWithPoke each
-// time to defeat OpenClaw plugin module isolation; in tests we stub it to a
-// no-op so the fake @tloncorp/api singleton stays as the vitest mock above.
 vi.mock('./urbit/api-client.js', () => ({
-  configureTlonApiWithPoke: vi.fn(),
+  withTlonApiPoke: vi.fn(
+    (_poke: SharedApiClientParams['poke'], fn: () => Promise<unknown>) => fn()
+  ),
 }));
 
 const stubApiClientParams: SharedApiClientParams = {
   poke: vi.fn().mockResolvedValue(undefined),
-  shipName: 'test-bot',
-  shipUrl: 'http://localhost:8080',
 };
 
 /** A promise the test can resolve/reject on its own schedule. */
@@ -103,7 +100,7 @@ beforeEach(() => {
   vi.mocked(gatewayStart).mockClear().mockResolvedValue(1);
   vi.mocked(gatewayHeartbeat).mockClear().mockResolvedValue(1);
   vi.mocked(gatewayStop).mockClear().mockResolvedValue(1);
-  vi.mocked(configureTlonApiWithPoke).mockClear();
+  vi.mocked(withTlonApiPoke).mockClear();
   sharedSlot<SharedApiClientParams>(API_CLIENT_PARAMS_SLOT).set(
     stubApiClientParams
   );
@@ -314,6 +311,10 @@ describe('gateway-status: startGatewayHeartbeatLoop', () => {
     await vi.advanceTimersByTimeAsync(30_000);
     expect(gatewayHeartbeat).toHaveBeenCalledTimes(1);
     expect(vi.mocked(gatewayHeartbeat).mock.calls[0][0].bootId).toBe('boot-1');
+    expect(withTlonApiPoke).toHaveBeenCalledWith(
+      stubApiClientParams.poke,
+      expect.any(Function)
+    );
     await vi.advanceTimersByTimeAsync(30_000);
     expect(gatewayHeartbeat).toHaveBeenCalledTimes(2);
     stop();
@@ -393,6 +394,35 @@ describe('gateway-status: runGatewayStatusActivation', () => {
     coordinator = createGatewayStatusCoordinator({ logger: undefined });
   });
 
+  it('reports a missing published poke and stops retrying when aborted', async () => {
+    const controller = new AbortController();
+    const errorObserved = deferred<void>();
+    const onActivationError = vi.fn((err: unknown, attempt: number) => {
+      expect(err).toEqual(
+        expect.objectContaining({ message: 'api-client params not published' })
+      );
+      expect(attempt).toBe(1);
+      errorObserved.resolve();
+    });
+    sharedSlot<SharedApiClientParams>(API_CLIENT_PARAMS_SLOT).set(null);
+    coordinator.beginGeneration();
+
+    const activation = runGatewayStatusActivation({
+      coordinator,
+      owner: '~zod',
+      signal: controller.signal,
+      isTornDown: () => false,
+      onActivationError,
+      registerHeartbeatStop: vi.fn(),
+    });
+
+    await expectSettled(errorObserved.promise, 'missing-published-poke');
+    expect(configureStewardGateway).not.toHaveBeenCalled();
+    controller.abort();
+    await expectSettled(activation, 'missing-published-poke:aborted');
+    expect(onActivationError).toHaveBeenCalledOnce();
+  });
+
   it('waits for the lifecycle, sends %configure + %gateway-start, then starts the heartbeat', async () => {
     const registerHeartbeatStop = vi.fn();
     const lc = coordinator.beginGeneration();
@@ -408,6 +438,13 @@ describe('gateway-status: runGatewayStatusActivation', () => {
     expect(vi.mocked(gatewayStart).mock.calls[0][0]).toMatchObject({
       bootId: lc.bootId,
     });
+    expect(withTlonApiPoke).toHaveBeenCalledTimes(2);
+    expect(vi.mocked(withTlonApiPoke).mock.calls[0][0]).toBe(
+      stubApiClientParams.poke
+    );
+    expect(vi.mocked(withTlonApiPoke).mock.calls[1][0]).toBe(
+      stubApiClientParams.poke
+    );
     expect(registerHeartbeatStop).toHaveBeenCalledTimes(1);
 
     // configure must precede gateway-start
@@ -822,11 +859,9 @@ describe('gateway-status: sendGatewayStop', () => {
     expect(gatewayStop).not.toHaveBeenCalled();
   });
 
-  it('configures the api client before sending the stop poke', async () => {
+  it('sends the stop through the published poke without reconfiguring the api client', async () => {
     const params: SharedApiClientParams = {
       poke: vi.fn().mockResolvedValue(undefined),
-      shipName: 'test-bot',
-      shipUrl: 'http://localhost:8080',
     };
     sharedSlot<SharedApiClientParams>(API_CLIENT_PARAMS_SLOT).set(params);
 
@@ -835,13 +870,10 @@ describe('gateway-status: sendGatewayStop', () => {
       reason: 'shutdown',
     });
     expect(sent).toBe(true);
-    expect(configureTlonApiWithPoke).toHaveBeenCalledTimes(1);
     expect(gatewayStop).toHaveBeenCalledTimes(1);
-    // configure must run before the poke so the stop reaches the SSE-bound
-    // client in this module's @tloncorp/api instance.
-    const configureOrder = vi.mocked(configureTlonApiWithPoke).mock
-      .invocationCallOrder[0];
-    const stopOrder = vi.mocked(gatewayStop).mock.invocationCallOrder[0];
-    expect(configureOrder).toBeLessThan(stopOrder);
+    expect(withTlonApiPoke).toHaveBeenCalledWith(
+      params.poke,
+      expect.any(Function)
+    );
   });
 });

--- a/packages/openclaw/src/gateway-status.ts
+++ b/packages/openclaw/src/gateway-status.ts
@@ -9,14 +9,11 @@ import type { OpenClawConfig } from 'openclaw/plugin-sdk/core';
 
 import { sharedSlot } from './shared-state.js';
 import { listTlonAccountIds } from './types.js';
-import { configureTlonApiWithPoke } from './urbit/api-client.js';
+import { withTlonApiPoke } from './urbit/api-client.js';
 
-// Shared-state slot for the @tloncorp/api client params. The monitor
-// publishes its SSE-bound poke + ship coords here; every other module
-// context (notably this one) reads them and configures its OWN local
-// @tloncorp/api singleton before any poke call. Storing a callback would
-// configure the publisher's @tloncorp/api instance, not the reader's, so
-// we deliberately move *data* through the slot, not behavior.
+// Shared-state slot for the monitor's latest SSE-bound poke. Gateway lifecycle
+// hooks run outside the monitor's async client scope, so they use this explicit
+// transport without mutating the process-global @tloncorp/api client.
 export const API_CLIENT_PARAMS_SLOT = '@tloncorp/openclaw.api-client-params';
 
 export interface SharedApiClientParams {
@@ -25,8 +22,6 @@ export interface SharedApiClientParams {
     mark: string;
     json: unknown;
   }) => Promise<unknown>;
-  shipName: string;
-  shipUrl: string;
 }
 
 const apiClientParamsSlot = sharedSlot<SharedApiClientParams>(
@@ -55,8 +50,7 @@ export function computeLeaseUntil(): number {
 }
 
 /** True iff exactly one Tlon account is configured. v1 requires exactly one
- * because the global @tloncorp/api client can't target multiple ships;
- * with >1 account, every eligible monitor would race the same client. */
+ * because the shared gateway-status slot can publish only one monitor poke. */
 export function isGatewayStatusEligible(cfg: OpenClawConfig): boolean {
   return listTlonAccountIds(cfg).length === 1;
 }
@@ -273,15 +267,9 @@ export function getGatewayStatusCoordinator(): GatewayStatusCoordinator | null {
   return coordinatorSlot.get();
 }
 
-// Configure THIS module's @tloncorp/api singleton against the
-// monitor-published params, then send the gateway-stop poke. Callers
-// (notably GatewayStatusCoordinator.markStopped) must go through this
-// helper instead of importing `gatewayStop` directly, because under
-// OpenClaw >=2026.4.27 plugin module isolation the entry module's
-// @tloncorp/api instance is never configured — only the monitor's is.
-// Routing through gateway-status.ts reuses the same configured instance
-// the heartbeat uses. Returns true if the poke was sent, false if the
-// params slot was empty.
+// Send through the monitor-published poke without reconfiguring the shared
+// @tloncorp/api client. Returns true if the poke was sent, false if the params
+// slot was empty.
 export async function sendGatewayStop(params: {
   bootId: string;
   reason: string;
@@ -290,12 +278,9 @@ export async function sendGatewayStop(params: {
   if (!apiParams) {
     return false;
   }
-  configureTlonApiWithPoke(
-    apiParams.poke,
-    apiParams.shipName,
-    apiParams.shipUrl
+  await withTlonApiPoke(apiParams.poke, () =>
+    gatewayStop({ bootId: params.bootId, reason: params.reason })
   );
-  await gatewayStop({ bootId: params.bootId, reason: params.reason });
   return true;
 }
 
@@ -327,13 +312,6 @@ export function startGatewayHeartbeatLoop(
       return;
     }
     try {
-      // Configure THIS module's @tloncorp/api instance against the
-      // monitor-published params every tick. Under OpenClaw plugin
-      // module isolation this code path can hold a separate
-      // @tloncorp/api instance from the monitor; outbound DMs via
-      // `withAuthenticatedTlonApi` can also rotate the global client
-      // between heartbeats. Reapplying here keeps the heartbeat poke
-      // pointed at the SSE-bound client.
       const params = apiClientParamsSlot.get();
       if (!params) {
         heartbeatOpts.logger?.error?.(
@@ -341,11 +319,12 @@ export function startGatewayHeartbeatLoop(
         );
         return;
       }
-      configureTlonApiWithPoke(params.poke, params.shipName, params.shipUrl);
-      await gatewayHeartbeat({
-        bootId: heartbeatOpts.bootId,
-        leaseUntil: computeLeaseUntil(),
-      });
+      await withTlonApiPoke(params.poke, () =>
+        gatewayHeartbeat({
+          bootId: heartbeatOpts.bootId,
+          leaseUntil: computeLeaseUntil(),
+        })
+      );
     } catch (err) {
       heartbeatOpts.onError?.(err);
       heartbeatOpts.logger?.error?.(
@@ -496,12 +475,21 @@ export async function runGatewayStatusActivation(
       return;
     }
     try {
+      const apiParams = apiClientParamsSlot.get();
+      if (!apiParams) {
+        throw new Error('api-client params not published');
+      }
+      // Pin one monitor transport across configure → start. Splitting this pair
+      // across a slot replacement could start a boot on a different SSE channel
+      // from the one that configured its owner and timing.
       await withActivationTimeout(
-        configureStewardGateway({
-          owner,
-          activeWindowSecs: ACTIVE_WINDOW_SECS,
-          offlineReplyCooldownSecs: OFFLINE_REPLY_COOLDOWN_SECS,
-        }),
+        withTlonApiPoke(apiParams.poke, () =>
+          configureStewardGateway({
+            owner,
+            activeWindowSecs: ACTIVE_WINDOW_SECS,
+            offlineReplyCooldownSecs: OFFLINE_REPLY_COOLDOWN_SECS,
+          })
+        ),
         '%configure',
         activationTimeoutMs
       );
@@ -513,7 +501,12 @@ export async function runGatewayStatusActivation(
       // matching %gateway-stop even if shutdown lands before markActivated().
       coordinator.markStarting(lc.generation);
       await withActivationTimeout(
-        gatewayStart({ bootId: lc.bootId, leaseUntil: computeLeaseUntil() }),
+        withTlonApiPoke(apiParams.poke, () =>
+          gatewayStart({
+            bootId: lc.bootId,
+            leaseUntil: computeLeaseUntil(),
+          })
+        ),
         '%gateway-start',
         activationTimeoutMs
       );

--- a/packages/openclaw/src/monitor/index.ts
+++ b/packages/openclaw/src/monitor/index.ts
@@ -84,7 +84,10 @@ import {
   startTlonAgentTurn,
 } from '../turn-recorder.js';
 import { resolveTlonAccount } from '../types.js';
-import { configureTlonApiWithPoke } from '../urbit/api-client.js';
+import {
+  runWithTlonApiScope,
+  setScopedTlonApiWithPoke,
+} from '../urbit/api-client.js';
 import {
   authenticate,
   isPermanentAuthenticationFailure,
@@ -254,9 +257,8 @@ function normalizeRunTimeoutMs(value: number | null | undefined): number {
     : DEFAULT_CONTEXT_LENS_RUN_TIMEOUT_MS;
 }
 
-// Holds the data needed for any module-loader context to (re)configure its
-// own @tloncorp/api singleton — see gateway-status.ts for why this is
-// necessary under OpenClaw >=2026.4.27 plugin module isolation.
+// Holds the latest monitor transport for gateway lifecycle hooks, which run
+// outside the monitor's async client scope. See gateway-status.ts.
 const apiClientParamsSlot = sharedSlot<SharedApiClientParams>(
   API_CLIENT_PARAMS_SLOT
 );
@@ -352,6 +354,10 @@ function resolveChannelAuthorization(
 export async function monitorTlonProvider(
   opts: MonitorTlonOpts = {}
 ): Promise<void> {
+  return runWithTlonApiScope(() => monitorTlonProviderScoped(opts));
+}
+
+async function monitorTlonProviderScoped(opts: MonitorTlonOpts): Promise<void> {
   const core = getTlonRuntime();
   // Prefer the channel-start config snapshot (Fix B) over an independent
   // load: see the MonitorTlonOpts.cfg doc comment.
@@ -649,21 +655,14 @@ export async function monitorTlonProvider(
     throw error;
   }
 
-  // Configure @tloncorp/api's global client to use the SSE client's poke for all send operations
-  configureTlonApiWithPoke(api.poke.bind(api), botShipName, account.url);
+  setScopedTlonApiWithPoke(api.poke.bind(api), botShipName, account.url);
 
-  // Publish the SSE-bound poke + ship coords so other module contexts (e.g.
-  // the gateway-status heartbeat) can configure their own @tloncorp/api
-  // singletons before pokeing. We store data here, not a closure, because
-  // closures capture their creating context's module imports.
-  // Capture the published object so the abort handler can do a
-  // reference-equality check before clearing — under a config-reload
-  // restart, a replacement monitor may publish fresh params before the
-  // old monitor's abort fires, and we must not clobber the new params.
+  // Publish the bound transport for consumers that do not need the global API
+  // client. Capture the published object so the abort handler can compare by
+  // reference: a config-reload restart may publish a replacement before the old
+  // monitor aborts, and the old cleanup must not clear the replacement.
   const myApiClientParams = {
     poke: api.poke.bind(api),
-    shipName: botShipName,
-    shipUrl: accountUrl,
   };
   apiClientParamsSlot.set(myApiClientParams);
 
@@ -1414,7 +1413,7 @@ export async function monitorTlonProvider(
       onMultiAccountSkip: (count) =>
         runtime.log?.(
           `[gateway-status] skipped: ${count} Tlon accounts configured, ` +
-            `but v1 only supports one (global @tloncorp/api client cannot target multiple ships)`
+            `but v1 only supports one shared gateway-status transport`
         ),
       registerHeartbeatStop: (stop) => {
         // A concurrent teardown may have already run cleanupGatewayStatus

--- a/packages/openclaw/src/monitor/nudge-runner.ts
+++ b/packages/openclaw/src/monitor/nudge-runner.ts
@@ -40,11 +40,9 @@ export type NudgeRunnerStartDecision =
  *  1. `channels.tlon.reengagement.enabled` must be explicitly `true`. The
  *     feature is default-off so self-hosted installs that configure
  *     `ownerShip` for approval DMs do not automatically get owner nudges.
- *  2. Exactly one Tlon account must be configured. The runner sends DMs
- *     through the global `@tloncorp/api` client configured by
- *     `configureTlonApiWithPoke`, and the last-started monitor wins that
- *     singleton — so multi-account mode is not safe until a per-account
- *     send path lands.
+ *  2. Exactly one Tlon account must be configured. Keep the existing product
+ *     constraint until multi-account reengagement behavior is validated; the
+ *     transport itself is now scoped per account.
  *
  * Pure helper; does not read process state.
  */
@@ -63,8 +61,7 @@ export function shouldStartNudgeRunner(
   }
   // Count *runnable* accounts (enabled + fully configured). Disabled or
   // half-configured stub entries should not trip the multi-account guard,
-  // since they would never start a monitor and so cannot race the global
-  // `@tloncorp/api` singleton with the active account.
+  // since they would never start a monitor.
   const accountIds = listRunnableTlonAccountIds(cfg);
   if (accountIds.length !== 1) {
     return {

--- a/packages/openclaw/src/urbit/api-client.test.ts
+++ b/packages/openclaw/src/urbit/api-client.test.ts
@@ -1,82 +1,136 @@
+import { getCurrentUserId, poke, requestJson, scry } from '@tloncorp/api';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
-const configureClient = vi.fn();
-const authenticate = vi.fn();
-const createHttpPokeApi = vi.fn();
-const urbitFetch = vi.fn();
-
-vi.mock('@tloncorp/api', () => ({
-  configureClient,
+const { authenticate, createHttpPokeApi, urbitFetch } = vi.hoisted(() => ({
+  authenticate: vi.fn(),
+  createHttpPokeApi: vi.fn(),
+  urbitFetch: vi.fn(),
 }));
 
-vi.mock('./auth.js', () => ({
-  authenticate,
-}));
+vi.mock('./auth.js', () => ({ authenticate }));
+vi.mock('./http-poke.js', () => ({ createHttpPokeApi }));
+vi.mock('./fetch.js', () => ({ urbitFetch }));
 
-vi.mock('./http-poke.js', () => ({
-  createHttpPokeApi,
-}));
-
-vi.mock('./fetch.js', () => ({
-  urbitFetch,
-}));
-
-describe('api client shim', () => {
+describe('scoped API client', () => {
   beforeEach(() => {
     vi.clearAllMocks();
   });
 
-  it('passes shipUrl through on the injected client shim', async () => {
-    const { configureTlonApiWithPoke } = await import('./api-client.js');
-
-    const poke = vi.fn();
-    configureTlonApiWithPoke(poke, '~zod', 'http://ships:8080');
-
-    expect(configureClient).toHaveBeenCalledWith(
-      expect.objectContaining({
-        shipName: 'zod',
-        shipUrl: 'http://ships:8080',
-        client: expect.objectContaining({
-          url: 'http://ships:8080',
-          nodeId: '',
-        }),
-      })
+  it('keeps concurrent monitor clients isolated', async () => {
+    const { runWithTlonApiScope, setScopedTlonApiWithPoke } = await import(
+      './api-client.js'
     );
+
+    const readShip = (ship: string) =>
+      runWithTlonApiScope(async () => {
+        setScopedTlonApiWithPoke(vi.fn(), ship, `http://${ship.slice(1)}`);
+        await Promise.resolve();
+        return getCurrentUserId();
+      });
+
+    await expect(
+      Promise.all([readShip('~zod'), readShip('~nec')])
+    ).resolves.toEqual(['~zod', '~nec']);
   });
 
-  it('configures the authenticated shim with url for server-side upload helpers', async () => {
-    authenticate.mockResolvedValue('cookie');
+  it('runs gateway pokes through the normal API path in a local scope', async () => {
+    const transport = vi.fn().mockResolvedValue(42);
+    const { withTlonApiPoke } = await import('./api-client.js');
+
+    await expect(
+      withTlonApiPoke(transport, () =>
+        poke({ app: 'steward', mark: 'gateway', json: {} })
+      )
+    ).resolves.toBe(42);
+    expect(transport).toHaveBeenCalledOnce();
+  });
+
+  it('fails unsupported gateway operations with descriptive shim errors', async () => {
+    const { withTlonApiPoke } = await import('./api-client.js');
+    const transport = vi.fn();
+
+    await expect(
+      withTlonApiPoke(transport, () => requestJson('/notes', 'GET'))
+    ).rejects.toThrow('JSON requests not supported on this client shim');
+    await expect(
+      withTlonApiPoke(transport, () => scry({ app: 'contacts', path: '/self' }))
+    ).rejects.toThrow('Scry not supported on this client shim');
+  });
+
+  it('runs an authenticated full client only inside its operation', async () => {
+    authenticate
+      .mockResolvedValueOnce('cookie-old')
+      .mockResolvedValueOnce('cookie-new');
     createHttpPokeApi.mockResolvedValue({
       poke: vi.fn(),
       delete: vi.fn().mockResolvedValue(undefined),
     });
-    urbitFetch.mockResolvedValue({
-      response: {
-        ok: true,
-        json: () => Promise.resolve({}),
-      },
-      release: vi.fn().mockResolvedValue(undefined),
-    });
+    urbitFetch
+      .mockResolvedValueOnce({
+        response: { ok: false, status: 401 },
+        release: vi.fn().mockResolvedValue(undefined),
+      })
+      .mockResolvedValueOnce({
+        response: {
+          ok: true,
+          status: 200,
+          text: vi.fn().mockResolvedValue('{"ok":true}'),
+        },
+        release: vi.fn().mockResolvedValue(undefined),
+      });
 
     const { withAuthenticatedTlonApi } = await import('./api-client.js');
 
-    await withAuthenticatedTlonApi(
+    const result = await withAuthenticatedTlonApi(
       {
         url: 'http://ships:8080',
         code: 'lidlut-tabwed-pillex-ridrup',
         ship: '~zod',
       },
-      async () => 'ok'
-    );
-
-    expect(configureClient).toHaveBeenCalledWith(
-      expect.objectContaining({
-        shipName: 'zod',
-        shipUrl: 'http://ships:8080',
-        client: expect.objectContaining({
-          url: 'http://ships:8080',
-        }),
+      async () => ({
+        ship: getCurrentUserId(),
+        response: await requestJson('/notes', 'GET'),
       })
     );
+
+    expect(result).toEqual({ ship: '~zod', response: { ok: true } });
+    expect(authenticate).toHaveBeenCalledTimes(2);
+    expect(urbitFetch).toHaveBeenNthCalledWith(
+      1,
+      expect.objectContaining({
+        init: expect.objectContaining({ headers: { Cookie: 'cookie-old' } }),
+      })
+    );
+    expect(urbitFetch).toHaveBeenNthCalledWith(
+      2,
+      expect.objectContaining({
+        init: expect.objectContaining({ headers: { Cookie: 'cookie-new' } }),
+      })
+    );
+  });
+
+  it('restores the monitor client after nested outbound work', async () => {
+    authenticate.mockResolvedValue('cookie');
+    createHttpPokeApi.mockResolvedValue({
+      poke: vi.fn(),
+      delete: vi.fn().mockResolvedValue(undefined),
+    });
+    const {
+      runWithTlonApiScope,
+      setScopedTlonApiWithPoke,
+      withAuthenticatedTlonApi,
+    } = await import('./api-client.js');
+
+    const ships = await runWithTlonApiScope(async () => {
+      setScopedTlonApiWithPoke(vi.fn(), '~zod', 'http://zod');
+      const before = getCurrentUserId();
+      const nested = await withAuthenticatedTlonApi(
+        { url: 'http://nec', code: 'lit', ship: '~nec' },
+        async () => getCurrentUserId()
+      );
+      return [before, nested, getCurrentUserId()];
+    });
+
+    expect(ships).toEqual(['~zod', '~nec', '~zod']);
   });
 });

--- a/packages/openclaw/src/urbit/api-client.ts
+++ b/packages/openclaw/src/urbit/api-client.ts
@@ -1,5 +1,7 @@
-import { configureClient } from '@tloncorp/api';
+import { type Urbit, setClientResolver } from '@tloncorp/api';
+import { AsyncLocalStorage } from 'node:async_hooks';
 
+import { sharedSlot } from '../shared-state.js';
 import { authenticate } from './auth.js';
 import { ssrfPolicyFromAllowPrivateNetwork } from './context.js';
 import { urbitFetch } from './fetch.js';
@@ -11,24 +13,25 @@ type PokeFn = (params: {
   json: unknown;
 }) => Promise<unknown>;
 type ScryFn = (params: { app: string; path: string }) => Promise<unknown>;
+type RequestJsonFn = <T>(
+  path: string,
+  method?: 'GET' | 'POST' | 'PUT' | 'DELETE',
+  body?: unknown
+) => Promise<T>;
 
 /**
- * Create a minimal Urbit-compatible shim that delegates poke() to the given function.
- * The @tloncorp/api configureClient accepts a `client` that looks like an Urbit instance.
- * Includes stubs for connect/eventSource/scryWithInfo so configureClient never crashes.
+ * Create the small Urbit-compatible surface used by OpenClaw's API helpers.
  */
-function createClientShim(pokeFn: PokeFn, shipUrl: string, scryFn?: ScryFn) {
+function createClientShim(
+  pokeFn: PokeFn,
+  ship: string,
+  shipUrl: string,
+  scryFn?: ScryFn,
+  requestJsonFn?: RequestJsonFn
+) {
   return {
     poke: (params: { app: string; mark: string; json: unknown }) =>
       pokeFn(params),
-    on: () => ({ on: () => ({}) }),
-    // connect/eventSource are called by configureClient when code is provided.
-    // Our shim should never hit that path (we always inject the client), but
-    // if another configureClient call happens without injecting, these no-ops
-    // prevent a TypeError crash.
-    connect: async () => {},
-    eventSource: async () => {},
-    // scryWithInfo is used by @tloncorp/api for scry operations (e.g., uploadFile).
     scryWithInfo: scryFn
       ? async <T>(params: { app: string; path: string }) => {
           const result = await scryFn(params);
@@ -41,33 +44,66 @@ function createClientShim(pokeFn: PokeFn, shipUrl: string, scryFn?: ScryFn) {
       : async () => {
           throw new Error('Scry not supported on this client shim');
         },
-    // Properties configureClient may access
-    verbose: false,
-    nodeId: '',
+    requestJson: requestJsonFn
+      ? <T>(
+          path: string,
+          method?: 'GET' | 'POST' | 'PUT' | 'DELETE',
+          body?: unknown
+        ) => requestJsonFn<T>(path, method, body)
+      : async () => {
+          throw new Error('JSON requests not supported on this client shim');
+        },
+    nodeId: ship ? (ship.startsWith('~') ? ship : `~${ship}`) : '',
     url: shipUrl,
-  } as any;
+  } as unknown as Urbit;
+}
+
+type ClientScope = { client: ReturnType<typeof createClientShim> | null };
+const clientScopeSlot = sharedSlot<AsyncLocalStorage<ClientScope>>(
+  'tlon-api-client-scope'
+);
+const clientScope =
+  clientScopeSlot.get() ?? new AsyncLocalStorage<ClientScope>();
+clientScopeSlot.set(clientScope);
+
+// Load-order invariant: every module context that calls @tloncorp/api must
+// transit this import side effect so its API copy resolves the shared scope.
+// Async context follows child work, not EventEmitter listeners invoked by an
+// emitter in another context; known lifecycle hooks re-enter explicitly below.
+setClientResolver(() => clientScope.getStore()?.client);
+
+/** Give one monitor its own async client slot before it creates background work. */
+export function runWithTlonApiScope<T>(fn: () => Promise<T>): Promise<T> {
+  return clientScope.run({ client: null }, fn);
+}
+
+/** Run a gateway API call through one explicit poke without changing globals. */
+export function withTlonApiPoke<T>(
+  pokeFn: PokeFn,
+  fn: () => Promise<T>
+): Promise<T> {
+  const client = createClientShim(pokeFn, '', '');
+  return clientScope.run({ client }, fn);
 }
 
 /**
- * Configure @tloncorp/api's global client with an existing poke function.
- * Use this when you already have an authenticated poke backend (e.g., SSE client in monitor).
+ * Install a monitor's authenticated SSE transport in its own async scope.
  */
-export function configureTlonApiWithPoke(
+export function setScopedTlonApiWithPoke(
   pokeFn: PokeFn,
   ship: string,
   shipUrl: string,
   scryFn?: ScryFn
 ): void {
-  const shim = createClientShim(pokeFn, shipUrl, scryFn);
-  configureClient({
-    shipName: ship.replace(/^~/, ''),
-    shipUrl,
-    client: shim,
-  });
+  const scope = clientScope.getStore();
+  if (!scope) {
+    throw new Error('Tlon API client scope not initialized');
+  }
+  scope.client = createClientShim(pokeFn, ship, shipUrl, scryFn);
 }
 
 /**
- * Create an authenticated HTTP-only client, configure @tloncorp/api, run fn, clean up.
+ * Create an authenticated HTTP-only client, run fn in its own scope, clean up.
  * Use this for one-shot outbound operations (channel.ts, actions.ts).
  * Supports both poke and scry (needed for uploadFile).
  */
@@ -83,7 +119,7 @@ export async function withAuthenticatedTlonApi<T>(
   const ssrfPolicy = ssrfPolicyFromAllowPrivateNetwork(
     params.allowPrivateNetwork
   );
-  const cookie = await authenticate(params.url, params.code, { ssrfPolicy });
+  let cookie = await authenticate(params.url, params.code, { ssrfPolicy });
 
   const api = await createHttpPokeApi({
     url: params.url,
@@ -92,23 +128,57 @@ export async function withAuthenticatedTlonApi<T>(
     allowPrivateNetwork: params.allowPrivateNetwork,
   });
 
-  // Build a scry function using the authenticated cookie
+  let pendingAuth: Promise<void> | null = null;
+  const reauthenticate = async () => {
+    if (!pendingAuth) {
+      pendingAuth = authenticate(params.url, params.code, { ssrfPolicy })
+        .then((nextCookie) => {
+          cookie = nextCookie;
+        })
+        .finally(() => {
+          pendingAuth = null;
+        });
+    }
+    await pendingAuth;
+  };
+
+  const fetchAuthenticated = async (
+    path: string,
+    init: RequestInit,
+    auditContext: string,
+    reauthStatuses: readonly number[] = [403]
+  ) => {
+    const request = () =>
+      urbitFetch({
+        baseUrl: params.url,
+        path,
+        init: { ...init, headers: { ...init.headers, Cookie: cookie } },
+        ssrfPolicy,
+        timeoutMs: 30_000,
+        auditContext,
+      });
+    let result = await request();
+    if (reauthStatuses.includes(result.response.status)) {
+      await result.release();
+      await reauthenticate();
+      result = await request();
+    }
+    return result;
+  };
+
   const scryFn: ScryFn = async ({ app, path }) => {
     const scryPath = `/~/scry/${app}${path}.json`;
-    const { response, release } = await urbitFetch({
-      baseUrl: params.url,
-      path: scryPath,
-      init: {
-        method: 'GET',
-        headers: { Cookie: cookie },
-      },
-      ssrfPolicy,
-      timeoutMs: 30_000,
-      auditContext: 'tlon-api-scry',
-    });
+    const { response, release } = await fetchAuthenticated(
+      scryPath,
+      { method: 'GET' },
+      'tlon-api-scry'
+    );
     try {
       if (!response.ok) {
-        throw new Error(`Scry failed: ${response.status} ${scryPath}`);
+        throw Object.assign(
+          new Error(`Scry failed: ${response.status} ${scryPath}`),
+          { status: response.status }
+        );
       }
       return await response.json();
     } finally {
@@ -116,16 +186,53 @@ export async function withAuthenticatedTlonApi<T>(
     }
   };
 
-  const shim = createClientShim(api.poke, params.url, scryFn);
-  configureClient({
-    shipName: params.ship.replace(/^~/, ''),
-    shipUrl: params.url,
-    client: shim,
-    getCode: async () => params.code,
-  });
+  const requestJsonFn: RequestJsonFn = async <T>(
+    path: string,
+    method = 'POST',
+    body?: unknown
+  ) => {
+    const headers: Record<string, string> = {};
+    if (body !== undefined) headers['Content-Type'] = 'application/json';
+    const { response, release } = await fetchAuthenticated(
+      path,
+      {
+        method,
+        headers,
+        ...(body === undefined ? {} : { body: JSON.stringify(body) }),
+      },
+      'tlon-api-request-json',
+      [401, 403]
+    );
+    try {
+      const responseText = await response.text();
+      if (!response.ok) {
+        throw Object.assign(
+          new Error(responseText || `HTTP ${response.status}`),
+          {
+            status: response.status,
+            body: responseText,
+            text: async () => responseText,
+          }
+        );
+      }
+      return responseText.trim()
+        ? (JSON.parse(responseText) as T)
+        : (undefined as T);
+    } finally {
+      await release();
+    }
+  };
+
+  const shim = createClientShim(
+    api.poke,
+    params.ship,
+    params.url,
+    scryFn,
+    requestJsonFn
+  );
 
   try {
-    return await fn();
+    return await clientScope.run({ client: shim }, fn);
   } finally {
     try {
       await api.delete();


### PR DESCRIPTION
## Summary

Prevents OpenClaw monitors, gateway heartbeats, and outbound operations from replacing one process-global Tlon API client while another operation is using it.

This fixes the production failure observed on `~dordev-ragsyn`: a cron-generated Notes entry completed successfully, but publishing failed with `JSON requests not supported on this client shim`. A gateway heartbeat installed the monitor's poke-only client between the authenticated setup and the later `notes.getNotebook()` / `notes.createNote()` JSON requests.

The generated content was not the cause.

## Changes

- Adds a small client-resolver hook to `@tloncorp/api`. App clients still use the existing configured singleton by default; server runtimes can resolve a client from their current async context.
- Gives each OpenClaw monitor its own async client scope before it creates SSE callbacks or background work.
- Runs each outbound send or action in a nested, full client scope containing `poke`, `scry`, and `requestJson`. Concurrent accounts cannot replace each other's client, and the previous monitor scope is restored automatically afterward.
- Keeps scoped authentication with the scoped client. Scry retries once after a 403, JSON requests retry once after a 401 or 403, and concurrent reauthentication is deduplicated within that operation.
- Runs gateway configure, start, heartbeat, and stop calls through the normal API `poke()` inside a short scope bound to the monitor's SSE transport. This keeps the existing API signatures and the generic poke logging, error reporting, and duration instrumentation.
- Shares the async scope through OpenClaw's existing cross-module registry so it survives OpenClaw's separate extension and runtime module-loader contexts.
- Removes every OpenClaw production call to `configureClient`; monitor restarts, heartbeats, and concurrent outbound operations no longer mutate the API package's singleton.

## Why this is safe

The underlying transports are unchanged. Monitor and gateway pokes still use the existing authenticated `UrbitSSEClient`; one-shot outbound work still uses the existing authenticated HTTP poke client and SSRF-guarded fetch path.

The client is selected once at the start of each `poke`, `scry`, or `requestJson` call, so another async scope cannot change the client midway through that request. Scoped clients own their own authentication and never enter the API singleton's reauthentication flow.

Gateway traffic uses the ordinary `@tloncorp/api` gateway helpers and `poke()` wrapper. There is no custom instrumentation path and no added transport parameter on the gateway API surface.

This is intentionally smaller than converting the entire API package to client factories. The API package keeps its existing singleton as the default for mobile, web, and other app clients. The resolver covers the client proxy plus `poke`, `scry`, and `requestJson`, which are the shared-client paths OpenClaw uses. Singleton-oriented subscription APIs are unchanged and are not routed through OpenClaw's scoped shim.

The existing single-account constraint for gateway-status and reengagement remains. It is now a product/shared-gateway-transport constraint, not a client-race constraint.

## Risks and impact

- Adds Node `AsyncLocalStorage` only inside the OpenClaw package; the shared API package has no Node dependency.
- A scoped client does not use the app singleton's auth callbacks; OpenClaw owns scoped auth and retry.
- There is no protocol, payload, database, or configuration change.
- Safe to roll back by reverting this PR.

## How did I test?

From a clean worktree based on current `origin/develop`:

- `packages/api`: TypeScript and package build passed
- `packages/api`: full unit suite — 35 files and 745 tests passed
- `packages/openclaw`: TypeScript and package build passed
- `packages/openclaw`: full unit suite — 68 files and 1,363 tests passed
- Temporary merge with current `db/agent-onboarding-v2`, including Notes publishing, after resolving the expected overlaps in `monitor/index.ts` and `urbit/api-client.ts`: OpenClaw build passed and 69 files / 1,403 tests passed
- Regression tests cover concurrent account scopes, normal gateway poke routing, descriptive failures for unsupported gateway operations, the empty activation slot, scoped `poke` / `scry` / `requestJson`, JSON reauthentication, and restoration after nested outbound work
- Targeted ESLint on changed files — no errors; existing warnings are unchanged
- `git diff --check`
