### PR TITLE
feat(lens): copy a bot run's raw payload

### DIFF
--- a/packages/app/features/lens/ContextLensRunScreen.tsx
+++ b/packages/app/features/lens/ContextLensRunScreen.tsx
@@ -6,7 +6,14 @@ import { useCallback, useEffect, useMemo, useState } from 'react';
 
 import { useA2UINavigation } from '../../hooks/useA2UINavigation';
 import type { RootStackParamList } from '../../navigation/types';
-import { ScreenHeader, ScreenScrollView, SizableText, YStack } from '../../ui';
+import {
+  ScreenHeader,
+  ScreenScrollView,
+  SizableText,
+  XStack,
+  YStack,
+} from '../../ui';
+import { CopyRawPayloadButton } from '../../ui/components/Channel/ContextLens/CopyRawPayloadButton';
 import {
   type LensMessageTarget,
   RunInspector,
@@ -90,6 +97,18 @@ export function ContextLensRunScreen(props: Props) {
         borderBottom
         placement="navigation"
       />
+      {/* Outside the `lens` branch on purpose: the stored envelope is worth
+          copying precisely when `lensFromRunPayload` rejects it and the
+          inspector below cannot render. */}
+      {runQuery.data?.payload != null ? (
+        <XStack
+          justifyContent="flex-end"
+          paddingHorizontal="$l"
+          paddingTop="$l"
+        >
+          <CopyRawPayloadButton payload={runQuery.data.payload} />
+        </XStack>
+      ) : null}
       {lens ? (
         <ScreenScrollView showsVerticalScrollIndicator={false}>
           <YStack gap="$m" padding="$l" paddingBottom="$2xl">

--- a/packages/app/ui/components/Channel/ContextLens/ContextLensPanel.tsx
+++ b/packages/app/ui/components/Channel/ContextLens/ContextLensPanel.tsx
@@ -4,6 +4,7 @@ import { Icon, Pressable } from '@tloncorp/ui';
 import { useEffect, useMemo, useState } from 'react';
 import { ScrollView, SizableText, View, XStack, YStack } from 'tamagui';
 
+import { CopyRawPayloadButton } from './CopyRawPayloadButton';
 import { RecentRunList } from './RecentRunList';
 import { RunInspector } from './RunInspector';
 import { RunSummary } from './RunSummary';
@@ -396,32 +397,35 @@ export function ContextLensPanel({
                   : 'Run inspector'}
           </SizableText>
         </YStack>
-        {streamStatus !== 'disabled' ? (
-          <XStack
-            alignItems="center"
-            gap="$xs"
-            borderWidth={1}
-            borderColor="$border"
-            borderRadius="$s"
-            paddingHorizontal="$s"
-            paddingVertical="$2xs"
-            backgroundColor="$secondaryBackground"
-          >
-            <View
-              width={6}
-              height={6}
-              borderRadius={999}
-              backgroundColor={
-                streamStatus === 'connected'
-                  ? TONE_COLORS.positive
-                  : TONE_COLORS.warning
-              }
-            />
-            <SizableText size="$s" color="$secondaryText">
-              {streamStatus}
-            </SizableText>
-          </XStack>
-        ) : null}
+        <XStack alignItems="center" gap="$xs" flexShrink={0}>
+          {streamStatus !== 'disabled' ? (
+            <XStack
+              alignItems="center"
+              gap="$xs"
+              borderWidth={1}
+              borderColor="$border"
+              borderRadius="$s"
+              paddingHorizontal="$s"
+              paddingVertical="$2xs"
+              backgroundColor="$secondaryBackground"
+            >
+              <View
+                width={6}
+                height={6}
+                borderRadius={999}
+                backgroundColor={
+                  streamStatus === 'connected'
+                    ? TONE_COLORS.positive
+                    : TONE_COLORS.warning
+                }
+              />
+              <SizableText size="$s" color="$secondaryText">
+                {streamStatus}
+              </SizableText>
+            </XStack>
+          ) : null}
+          <CopyRawPayloadButton payload={latest} />
+        </XStack>
       </XStack>
 
       {panelMode === 'selected' ? (

--- a/packages/app/ui/components/Channel/ContextLens/CopyRawPayloadButton.tsx
+++ b/packages/app/ui/components/Channel/ContextLens/CopyRawPayloadButton.tsx
@@ -1,0 +1,51 @@
+import { Icon, Pressable, useCopy } from '@tloncorp/ui';
+import { useMemo } from 'react';
+import { SizableText, XStack } from 'tamagui';
+
+/**
+ * Copies a run exactly as the client received it. The inspector renders a
+ * narrowed view of a lens, so any field it doesn't surface is otherwise
+ * invisible; the raw envelope is what makes a run diffable against what the bot
+ * actually reported.
+ *
+ * Takes `unknown` because the two surfaces hold different envelopes — the run
+ * screen has the stored `{schemaVersion, lens}` record, the panel has the live
+ * gateway event. Renders nothing without a payload, so callers can place it
+ * unconditionally.
+ */
+export function CopyRawPayloadButton({ payload }: { payload: unknown }) {
+  const raw = useMemo(
+    () => (payload == null ? null : JSON.stringify(payload, null, 2)),
+    [payload]
+  );
+  const { doCopy, didCopy } = useCopy(raw ?? '');
+
+  if (raw === null) {
+    return null;
+  }
+
+  return (
+    <Pressable
+      onPress={doCopy}
+      cursor="pointer"
+      borderWidth={1}
+      borderColor="$border"
+      borderRadius="$s"
+      paddingHorizontal="$s"
+      paddingVertical="$2xs"
+      backgroundColor="$background"
+      testID="LensCopyRawPayloadButton"
+    >
+      <XStack alignItems="center" gap="$2xs">
+        <Icon
+          type={didCopy ? 'Checkmark' : 'Copy'}
+          color="$secondaryText"
+          customSize={[12, 12]}
+        />
+        <SizableText size="$s" color="$secondaryText">
+          {didCopy ? 'Copied' : 'Copy raw'}
+        </SizableText>
+      </XStack>
+    </Pressable>
+  );
+}


### PR DESCRIPTION
## Summary

Adds a "Copy raw" control to the Context Lens run views that copies the payload the client received, verbatim. The inspector renders a narrowed view of a lens, so any field it doesn't surface is invisible when comparing a run against what the bot actually reported.

This came out of debugging a hosted bot that claimed it couldn't read an attached image. The lens summary showed nothing useful; the raw payload's `tools.runs` array contained the actual failure (`No image model is configured`), which is what led to the root cause.

## Changes

- `CopyRawPayloadButton` (new, the only new file) — shared control used by both surfaces. Clipboard and copied-state handling come from the existing `useCopy` hook in `@tloncorp/ui`; the button only serializes with `JSON.stringify(payload, null, 2)` and swaps `Copy` → `Checkmark` with a "Copied" label. Renders `null` when there is no payload, so callers place it unconditionally. Chrome matches the existing "Show"/"Latest" controls in `RecentRunList` (1px `$border`, `$s` radius, `$s`/`$2xs` padding, 12px icon) so the lens UI reads as one set of affordances.
- `ContextLensPanel` — button in the panel header, right-aligned alongside the stream-status chip.
- `ContextLensRunScreen` — button top-right of the content area.

It takes `unknown` because the two surfaces hold different envelopes: the run screen has the stored `{schemaVersion, lens}` record, the panel has the live gateway event.

Two placement decisions worth flagging for review:

- **The run screen's button sits outside the `lens` branch on purpose.** When `lensFromRunPayload` rejects a payload the inspector can't render at all, and that's exactly when the raw record is worth having. The row is separately gated on `payload != null` so it doesn't leave dead space above the "Looking for Lens metadata" state.
- **It's in the content area on mobile, not the header.** That screen uses `placement="navigation"`, so `ScreenHeader` returns `null` and the native navigation header takes over. Native headers only accept typed `ScreenHeaderAction`s drawn from the 9 icons in `ScreenHeader/icons.json`, which has no `Copy` or `Checkmark`. Matching desktop's button there would mean taking the screen off the native header entirely — too much for one control, so it went into content instead.

Copy rather than a file download: `packages/app` is shared across mobile/web/desktop and a download has no native equivalent. Clipboard is already this repo's cross-platform text-export mechanism. A web-only `.web.ts` download variant would be a small follow-up if wanted.

## How did I test?

- `npx tsc --noEmit` in `packages/app` — clean.
- Prettier clean on all changed files.
- Verified the payload shape the button copies by reading it out of a real bot run end to end (context lens store → `runQuery.data.payload`), which is how the `tools.runs` error above was found.

Not yet exercised in a running client — the desktop panel placement and the mobile content placement are both unverified visually. Worth an eyeball before merge; if the mobile control reads better inside the scroll content (scrolling away with `RunSummary`) rather than pinned below the header, that's a one-line move.

## Risks and impact

- Safe to rollback without consulting PR author? **Yes**
- Affects important code area:
  - [ ] Onboarding
  - [ ] State / providers
  - [ ] Message sync
  - [ ] Channel display
  - [ ] Notifications
  - [x] Other: Context Lens run inspector (owner-only debug UI)

Additive and read-only. No new network calls, no writes, no changes to how runs are fetched or stored — it serializes data already in hand. Scoped to the lens views, which are owner-visibility only.

## Rollback plan

Revert the commit. The one new file is only referenced by the two modified ones, so nothing else depends on it.

## Screenshots / videos

None yet — see the note in "How did I test?".

Fixes TLON-6346

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QRsdaPHXCHwZgUkj3n8ftT