### PR TITLE
openclaw: reply as a comment when triggered by a top-level gallery post

### DIFF
--- a/packages/openclaw/src/channel.ts
+++ b/packages/openclaw/src/channel.ts
@@ -152,6 +152,7 @@ export const tlonPlugin = createChatChannelPlugin({
         hints.push(
           '',
           'Tlon gallery channels (heap/~host/name) are for collecting images, links, and media.',
+          '- When you were triggered from a gallery post, your normal reply is posted as a comment on that post. Use action=send only when you intend to create a separate NEW top-level gallery item.',
           '- To post to a gallery: use action=send, to=heap/~host/name, message=<text or URL>',
           '- For image posts, include media=<imageUrl> with an optional message=<caption>',
           '- To react to a gallery comment: use action=react, to=heap/~host/name, messageId=<commentId>, parentId=<postId>, emoji=<emoji>',

--- a/packages/openclaw/src/context-lens.test.ts
+++ b/packages/openclaw/src/context-lens.test.ts
@@ -906,6 +906,37 @@ describe('retry seed and dispatch', () => {
     }
   });
 
+  it('keeps degraded provenance across retry chains', () => {
+    // A retry of a degraded run seeds a new lens; its threading metadata is
+    // still untrustworthy, so a second retry must stay degraded.
+    const registry = createContextLensRegistry();
+    const lens = registry.create({
+      messageId: 'react-170.141-~nec-1',
+      chatType: 'channel',
+      trigger: 'retry',
+      sessionKey: 'session-retry-5',
+      senderShip: '~ten',
+      conversationId: 'heap/~ten/gallery',
+      preview: 'preview text',
+      retrySeed: {
+        messageText: 'full original text',
+        blobField: null,
+        parentId: null,
+        isThreadReply: false,
+        replyParentId: null,
+        cachesHistory: true,
+        degraded: true,
+      },
+    });
+    const failed = registry.setStatus(lens.lensId, 'error', new Error('boom'));
+
+    const result = buildRetryDispatch(failed!);
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.dispatch.degraded).toBe(true);
+    }
+  });
+
   it('refuses non-retryable, internal, and incomplete runs', () => {
     const registry = createContextLensRegistry();
 

--- a/packages/openclaw/src/context-lens.ts
+++ b/packages/openclaw/src/context-lens.ts
@@ -65,6 +65,9 @@ export type ContextLensRetrySeed = {
   isThreadReply?: boolean;
   replyParentId?: string | null;
   cachesHistory?: boolean;
+  // Degraded provenance survives retry chains: a retry of a degraded run
+  // seeds a new lens, but its threading metadata is still untrustworthy.
+  degraded?: boolean;
 };
 
 export type ContextLensSourceKind =
@@ -321,7 +324,8 @@ export type RetryDispatch = {
   isThreadReply?: boolean;
   replyParentId?: string | null;
   cachesHistory?: boolean;
-  /** True when dispatching from the truncated preview because the run predates retrySeed. */
+  /** True when threading metadata is untrustworthy: the run predates
+   *  retrySeed, or it retries a run that was itself degraded. */
   degraded: boolean;
 };
 
@@ -380,7 +384,7 @@ export function buildRetryDispatch(lens: ContextLens): RetryDispatchResult {
       isThreadReply: seed?.isThreadReply ?? false,
       replyParentId: seed?.replyParentId ?? null,
       cachesHistory: seed?.cachesHistory ?? true,
-      degraded: !seed,
+      degraded: seed?.degraded ?? !seed,
     },
   };
 }

--- a/packages/openclaw/src/monitor/channel-reactions.test.ts
+++ b/packages/openclaw/src/monitor/channel-reactions.test.ts
@@ -34,6 +34,55 @@ describe('handleChannelReaction', () => {
     );
   });
 
+  it('dispatches a top-level reaction on a bot post anchored to the post', async () => {
+    const log = vi.fn();
+    const dispatchAgent = vi.fn(async () => {});
+    const enqueueSystemEvent = vi.fn();
+
+    await handleChannelReaction({
+      botShip: '~bot',
+      emoji: '👍',
+      formatShip: (ship) => ship,
+      nest: 'heap/~zod/gallery',
+      postId: '170141184507123',
+      reactor: '~nec',
+      target: { author: '~bot', content: 'bot post' },
+      log,
+      dispatchAgent,
+      enqueueSystemEvent,
+    });
+
+    expect(dispatchAgent).toHaveBeenCalledWith(
+      expect.objectContaining({ replyParentId: '170141184507123' })
+    );
+    expect(enqueueSystemEvent).not.toHaveBeenCalled();
+  });
+
+  it('dispatches a reply reaction anchored to the root post', async () => {
+    const log = vi.fn();
+    const dispatchAgent = vi.fn(async () => {});
+    const enqueueSystemEvent = vi.fn();
+
+    await handleChannelReaction({
+      botShip: '~bot',
+      emoji: '👍',
+      formatShip: (ship) => ship,
+      nest: 'heap/~zod/gallery',
+      postId: '170141184507456',
+      rootPostId: '170141184507123',
+      reactor: '~nec',
+      target: { author: '~bot', content: 'bot comment' },
+      log,
+      dispatchAgent,
+      enqueueSystemEvent,
+    });
+
+    expect(dispatchAgent).toHaveBeenCalledWith(
+      expect.objectContaining({ replyParentId: '170141184507123' })
+    );
+    expect(enqueueSystemEvent).not.toHaveBeenCalled();
+  });
+
   it('resolves a target once for two reactors', async () => {
     const target = { author: '~bot', content: 'bot message', timestamp: 1 };
     const resolveTarget = vi.fn(async () => target);

--- a/packages/openclaw/src/monitor/deliver-parent.test.ts
+++ b/packages/openclaw/src/monitor/deliver-parent.test.ts
@@ -1,0 +1,139 @@
+import { describe, expect, it } from 'vitest';
+
+import { resolveDeliverParentId } from './deliver-parent.js';
+
+describe('resolveDeliverParentId', () => {
+  it('keeps chat top-level replies top-level', () => {
+    expect(
+      resolveDeliverParentId({
+        isGroup: true,
+        channelNest: 'chat/~zod/general',
+        messageId: '170141184507123',
+      })
+    ).toBeNull();
+  });
+
+  it('anchors chat thread replies to the thread parent', () => {
+    expect(
+      resolveDeliverParentId({
+        isGroup: true,
+        channelNest: 'chat/~zod/general',
+        messageId: '170141184507456',
+        parentId: '170141184507123',
+        isThreadReply: true,
+      })
+    ).toBe('170141184507123');
+  });
+
+  it('anchors top-level heap replies to the triggering post', () => {
+    expect(
+      resolveDeliverParentId({
+        isGroup: true,
+        channelNest: 'heap/~zod/gallery',
+        messageId: '170141184507123',
+      })
+    ).toBe('170141184507123');
+  });
+
+  it('keeps heap comment-thread replies anchored to the comment parent', () => {
+    expect(
+      resolveDeliverParentId({
+        isGroup: true,
+        channelNest: 'heap/~zod/gallery',
+        messageId: '170141184507456',
+        parentId: '170141184507123',
+        isThreadReply: true,
+      })
+    ).toBe('170141184507123');
+  });
+
+  it('lets the reaction replyParentId win over the heap fallback', () => {
+    expect(
+      resolveDeliverParentId({
+        isGroup: true,
+        channelNest: 'heap/~zod/gallery',
+        messageId: 'react-170141184507123',
+        replyParentId: '170141184507123',
+      })
+    ).toBe('170141184507123');
+  });
+
+  it('prefers replyParentId when both replyParentId and parentId are set', () => {
+    expect(
+      resolveDeliverParentId({
+        isGroup: true,
+        channelNest: 'heap/~zod/gallery',
+        messageId: '170141184507789',
+        parentId: '170141184507123',
+        replyParentId: '170141184507456',
+      })
+    ).toBe('170141184507456');
+  });
+
+  it('does not synthesize a heap anchor when messageId is empty', () => {
+    expect(
+      resolveDeliverParentId({
+        isGroup: true,
+        channelNest: 'heap/~zod/gallery',
+        messageId: '',
+      })
+    ).toBeNull();
+  });
+
+  it('does not synthesize a heap anchor for degraded retries', () => {
+    expect(
+      resolveDeliverParentId({
+        isGroup: true,
+        channelNest: 'heap/~zod/gallery',
+        messageId: 'react-170141184507123',
+        degraded: true,
+      })
+    ).toBeNull();
+  });
+
+  it('does not synthesize an anchor for a thread reply without a parent', () => {
+    expect(
+      resolveDeliverParentId({
+        isGroup: true,
+        channelNest: 'heap/~zod/gallery',
+        messageId: '170141184507456',
+        parentId: null,
+        isThreadReply: true,
+      })
+    ).toBeNull();
+  });
+
+  it('keeps diary top-level replies top-level', () => {
+    expect(
+      resolveDeliverParentId({
+        isGroup: true,
+        channelNest: 'diary/~zod/notes',
+        messageId: '170141184507123',
+      })
+    ).toBeNull();
+  });
+
+  it('preserves DM anchoring with and without replyParentId', () => {
+    expect(
+      resolveDeliverParentId({
+        isGroup: false,
+        messageId: '170141184507123',
+      })
+    ).toBeNull();
+    // isGroup gates the fallback even if a heap-shaped nest is present.
+    expect(
+      resolveDeliverParentId({
+        isGroup: false,
+        channelNest: 'heap/~zod/gallery',
+        messageId: '170141184507123',
+      })
+    ).toBeNull();
+    expect(
+      resolveDeliverParentId({
+        isGroup: false,
+        messageId: '170141184507456',
+        replyParentId: '~bot/170.141.184.507.123',
+      })
+    ).toBe('~bot/170.141.184.507.123');
+  });
+});

--- a/packages/openclaw/src/monitor/deliver-parent.ts
+++ b/packages/openclaw/src/monitor/deliver-parent.ts
@@ -1,0 +1,30 @@
+export function resolveDeliverParentId(params: {
+  isGroup: boolean;
+  channelNest?: string;
+  /** Trigger's own id ('' when unknown). */
+  messageId: string;
+  parentId?: string | null;
+  isThreadReply?: boolean;
+  replyParentId?: string | null;
+  /** Retry dispatch reconstructed without a retrySeed — threading metadata
+   *  defaulted, messageId may be synthetic; never synthesize an anchor. */
+  degraded?: boolean;
+}): string | null {
+  const explicit = params.replyParentId ?? params.parentId ?? null;
+  if (explicit != null) {
+    return explicit;
+  }
+  // A top-level heap post is a separate gallery item, not a conversational
+  // reply — anchor reactive replies to the triggering post as a comment.
+  // Chat keeps linear top-level replies.
+  if (
+    params.isGroup &&
+    !params.isThreadReply &&
+    !params.degraded &&
+    Boolean(params.channelNest?.startsWith('heap/')) &&
+    params.messageId
+  ) {
+    return params.messageId;
+  }
+  return null;
+}

--- a/packages/openclaw/src/monitor/index.ts
+++ b/packages/openclaw/src/monitor/index.ts
@@ -130,6 +130,7 @@ import {
   setBridge,
 } from './command-bridge.js';
 import { createComputingPresenceTracker } from './computing-presence.js';
+import { resolveDeliverParentId } from './deliver-parent.js';
 import { fetchAllChannels, fetchInitData } from './discovery.js';
 import { dmReactionReplyParentId } from './dm-reactions.js';
 import {
@@ -2286,6 +2287,7 @@ export async function monitorTlonProvider(
       parentId?: string | null;
       isThreadReply?: boolean;
       replyParentId?: string | null; // Override parentId for delivery only (not in ctx payload)
+      degraded?: boolean;
       retryOf?: string; // lensId of the failed run this dispatch retries
     }) => {
       const {
@@ -2303,8 +2305,18 @@ export async function monitorTlonProvider(
       // replyParentId overrides parentId for the deliver callback (thread reply routing)
       // but doesn't affect the ctx payload (MessageThreadId/ReplyToId).
       // Used for reactions: agent sees no thread context (so it responds), but
-      // the reply is still delivered as a thread reply.
-      const deliverParentId = params.replyParentId ?? parentId;
+      // the reply is still delivered as a thread reply. Top-level heap triggers
+      // fall back to the triggering post itself so gallery replies land as
+      // comments, not new items.
+      const deliverParentId = resolveDeliverParentId({
+        isGroup,
+        channelNest,
+        messageId,
+        parentId,
+        isThreadReply,
+        replyParentId: params.replyParentId,
+        degraded: params.degraded,
+      });
       const groupChannel = channelNest; // For compatibility
       const rawMessageText = sanitizeMessageText(params.messageText);
       let currentMessageText = rawMessageText;
@@ -2388,6 +2400,7 @@ export async function monitorTlonProvider(
           isThreadReply: Boolean(isThreadReply),
           replyParentId: params.replyParentId ?? null,
           cachesHistory: Boolean(params.cachesHistory),
+          degraded: Boolean(params.degraded),
         },
       });
       contextLenses.recordPersistence(lens.lensId, {
@@ -2757,6 +2770,7 @@ export async function monitorTlonProvider(
                 fromShip: botShipName,
                 nest: groupChannel,
                 story: markdownToStory(noHistoryMsg),
+                replyToId: deliverParentId ?? undefined,
                 blob: contextLensBlob,
               });
               outputMessageId = result.messageId;
@@ -2825,6 +2839,7 @@ export async function monitorTlonProvider(
               fromShip: botShipName,
               nest: groupChannel,
               story: markdownToStory(errorMsg),
+              replyToId: deliverParentId ?? undefined,
               blob: contextLensBlob,
             });
             outputMessageId = result.messageId;
@@ -3809,7 +3824,14 @@ export async function monitorTlonProvider(
             fromShip: botShipName,
             nest,
             story: markdownToStory(replyText),
-            replyToId: parentId ?? undefined,
+            replyToId:
+              resolveDeliverParentId({
+                isGroup: true,
+                channelNest: nest,
+                messageId: messageId ?? '',
+                parentId,
+                isThreadReply,
+              }) ?? undefined,
           });
           return;
         }
@@ -4538,6 +4560,7 @@ export async function monitorTlonProvider(
             parentId: dispatch.parentId,
             isThreadReply: dispatch.isThreadReply,
             replyParentId: dispatch.replyParentId,
+            degraded: dispatch.degraded,
             cachesHistory: dispatch.cachesHistory,
             trigger: 'retry',
             retryOf: lensId,

--- a/packages/openclaw/src/urbit/send.test.ts
+++ b/packages/openclaw/src/urbit/send.test.ts
@@ -94,6 +94,73 @@ describe('sendDm', () => {
     expect(result.messageId).toBe('~zod/mocked-ud');
   });
 
+  it('posts heap replies with a replyToId via sendReply anchored to the parent', async () => {
+    const sendPost = vi.fn(async () => ({}));
+    const sendReply = vi.fn(async () => ({}));
+
+    vi.doMock('@tloncorp/api', () => ({
+      sendPost,
+      sendReply,
+      addReaction: vi.fn(),
+      removeReaction: vi.fn(),
+      deletePost: vi.fn(),
+      configureClient: vi.fn(),
+    }));
+
+    const { sendChannelPost } = await import('./send.js');
+    const aura = await import('@urbit/aura');
+    vi.mocked(aura.scot).mockImplementation((_aura, atom) =>
+      atom === 170141184507123n ? '170.141.184.507.123' : 'mocked-ud'
+    );
+
+    await sendChannelPost({
+      fromShip: '~zod',
+      nest: 'heap/~zod/gallery',
+      story: [{ inline: ['a comment'] }],
+      replyToId: '170141184507123',
+    });
+
+    expect(sendReply).toHaveBeenCalledTimes(1);
+    expect(sendReply).toHaveBeenCalledWith(
+      expect.objectContaining({
+        channelId: 'heap/~zod/gallery',
+        parentId: '170.141.184.507.123',
+      })
+    );
+    expect(sendPost).not.toHaveBeenCalled();
+  });
+
+  it('posts a new heap item via sendPost when replyToId is absent', async () => {
+    const sendPost = vi.fn(async () => ({}));
+    const sendReply = vi.fn(async () => ({}));
+
+    vi.doMock('@tloncorp/api', () => ({
+      sendPost,
+      sendReply,
+      addReaction: vi.fn(),
+      removeReaction: vi.fn(),
+      deletePost: vi.fn(),
+      configureClient: vi.fn(),
+    }));
+
+    const { sendChannelPost } = await import('./send.js');
+
+    await sendChannelPost({
+      fromShip: '~zod',
+      nest: 'heap/~zod/gallery',
+      story: [{ inline: ['a new gallery item'] }],
+    });
+
+    expect(sendPost).toHaveBeenCalledTimes(1);
+    expect(sendPost).toHaveBeenCalledWith(
+      expect.objectContaining({
+        channelId: 'heap/~zod/gallery',
+        authorId: '~zod',
+      })
+    );
+    expect(sendReply).not.toHaveBeenCalled();
+  });
+
   it.each([
     ['a bare target id', '170.141.184.507.123'],
     ['a full /v4 target id', '~bot/170.141.184.507.123'],


### PR DESCRIPTION
## Summary

Fixes [TLON-6177](https://linear.app/tlon/issue/TLON-6177): when an OpenClaw bot is triggered by a top-level gallery (`heap/`) post, its reply now lands as a comment on that post instead of creating a new top-level gallery item. Chat channels, DMs, thread replies, and reaction dispatches keep their current behavior, apart from one small summarization-fallback alignment noted under risks. This is the OpenClaw counterpart to the Hermes fix in #6151 (TLON-6095).

## Changes

-   Added `resolveDeliverParentId()` in `packages/openclaw/src/monitor/deliver-parent.ts`, a pure helper that computes the delivery anchor. Explicit anchors win in order (`replyParentId`, then `parentId`); when there is none, it falls back to the triggering post's id, guarded on group + `heap/` nest + non-thread + non-degraded + non-empty message id. Everything else resolves to `null` (top-level), including `chat/` and `diary/`.
-   Wired the helper into the monitor's `deliverParentId` computation in `packages/openclaw/src/monitor/index.ts`, which feeds delivery, `participatedThreads`, the session route's `threadId`, and seeded retries.
-   Anchored the `/owner-listen` control-command reply through the same helper, so the confirmation lands as a comment when the command was typed as a top-level gallery post.
-   Anchored the two summarization fallback replies (no history available, history fetch error) to `deliverParentId`, matching the successful-summary path. This applies to all group channels: a fallback for a thread-triggered summary request now lands in that thread (chat, heap, or diary), and a heap top-level trigger gets a comment.
-   Added a `degraded` flag to the dispatch params and forwarded `dispatch.degraded` from the retry call site, so retries reconstructed without a `retrySeed` (possibly synthetic message id, defaulted threading metadata) never synthesize an anchor. The flag is also captured into the `retrySeed` (`packages/openclaw/src/context-lens.ts`), so degraded provenance survives retry chains — a retry of a degraded run stays degraded on subsequent retries.
-   Added one agent-guidance line in `packages/openclaw/src/channel.ts` teaching that a normal reply becomes a comment on the triggering gallery post, and that `action=send` is the way to create a separate new gallery item.

## How did I test?

-   `pnpm tsc --noEmit` clean in `packages/openclaw`.
-   `pnpm test`: 69 files / 1375 tests passing, including 16 new tests:
    -   11 `resolveDeliverParentId` tests covering chat top-level and thread, heap top-level and comment-thread, reaction `replyParentId` precedence (including both anchors set), empty message id, degraded retry, thread reply with no parent, diary top-level, and DMs with and without `replyParentId` (including with a heap-shaped nest)
    -   two `sendChannelPost` cases: a heap post with `replyToId` goes through `sendReply` with the dotted parent id, and one without `replyToId` still creates a new item via `sendPost`
    -   two `handleChannelReaction` cases pinning the `replyParentId` values the helper's precedence relies on (post id for a top-level reaction, root post id for a reply reaction)
    -   a `buildRetryDispatch` case pinning that degraded provenance survives retry chains
-   Prettier clean on the changed files.
-   Not yet manually verified against a live ship. No end-to-end or manual run has been performed, so the wiring of the helper into the monitor closure, `/owner-listen`, and the summarization fallbacks is covered by review only.

## Risks and impact

-   Safe to rollback without consulting PR author? Yes
-   Affects important code area:
    -   [x] Other: OpenClaw bot reply delivery (`packages/openclaw` monitor)

Deliberate side effects of anchoring heap replies:

-   After a normal agent reply, `participatedThreads` tracks the triggering heap post, so later comments under that gallery post engage the bot without an explicit mention. This matches existing chat-thread semantics and stays bounded by the existing bot-loop limits. (Direct sends — `/owner-listen` confirmations and summarization fallbacks — return before participation tracking and route persistence, so they anchor without these effects.)
-   For normal agent delivery, the session route's `threadId` becomes the heap post id (where existing session-route policy persists a route), so route-based system and background sends for that session default to commenting on the triggering post rather than creating a new item.
-   Summarization fallback replies for thread-triggered requests now land in-thread in all group channels (previously they were always top-level). This aligns the fallbacks with the successful-summary path, which already threads.

Unchanged: chat top-level replies stay top-level; DMs, reactions, and agent replies to thread triggers resolve exactly as before (the summarization-fallback alignment above is the one thread-placement change); degraded retries keep the current top-level behavior instead of anchoring to a possibly synthetic id, including across retry chains.

## Rollback plan

Revert
