### PR TITLE
web: fix notes overwriting each other as you swap around

### DIFF
--- a/packages/app/ui/components/NotesChannel/NotesNativeChannel.tsx
+++ b/packages/app/ui/components/NotesChannel/NotesNativeChannel.tsx
@@ -1093,7 +1093,6 @@ export function NotesNativeChannel({
         />
       ) : (
         <NotesNoteDetail
-          key={`${notebookFlag}/${selectedNoteId}`}
           autoFocusTitle={focusTitleNoteId === selectedNoteId}
           headerActionsPlacement="channel-header"
           noteId={selectedNoteId}

--- a/packages/app/ui/components/NotesChannel/NotesNativeChannel.tsx
+++ b/packages/app/ui/components/NotesChannel/NotesNativeChannel.tsx
@@ -1093,6 +1093,7 @@ export function NotesNativeChannel({
         />
       ) : (
         <NotesNoteDetail
+          key={`${notebookFlag}/${selectedNoteId}`}
           autoFocusTitle={focusTitleNoteId === selectedNoteId}
           headerActionsPlacement="channel-header"
           noteId={selectedNoteId}

--- a/packages/app/ui/components/NotesChannel/NotesNoteDetail.test.tsx
+++ b/packages/app/ui/components/NotesChannel/NotesNoteDetail.test.tsx
@@ -17,9 +17,11 @@ import {
 } from './NotesNoteDetail';
 
 const mocks = vi.hoisted(() => ({
+  draftStashes: {} as Record<string, Record<string, unknown>>,
   getDraftStashes: vi.fn(),
   notes: [] as Array<Record<string, unknown>>,
   saveNotebookNote: vi.fn(),
+  setDraftStashes: vi.fn(),
   useNotebookData: vi.fn(),
 }));
 
@@ -43,7 +45,7 @@ vi.mock('@tloncorp/shared', () => ({
 vi.mock('@tloncorp/shared/db', () => ({
   notesNoteDrafts: {
     getValue: mocks.getDraftStashes,
-    setValue: vi.fn(async () => undefined),
+    setValue: mocks.setDraftStashes,
   },
 }));
 
@@ -184,7 +186,9 @@ describe('NotesNoteDetail note switching', () => {
 
   beforeEach(() => {
     vi.clearAllMocks();
+    mocks.draftStashes = {};
     mocks.getDraftStashes.mockResolvedValue({});
+    mocks.setDraftStashes.mockResolvedValue(undefined);
     mocks.notes = [note(1, 'Original A'), note(2, 'Original B')];
     mocks.useNotebookData.mockImplementation(() => ({
       folders: [],
@@ -215,7 +219,7 @@ describe('NotesNoteDetail note switching', () => {
           revision: base.revision + 1,
         })
       );
-    let renderer: ReactTestRenderer;
+    let renderer!: ReactTestRenderer;
 
     await act(async () => {
       renderer = create(
@@ -388,6 +392,16 @@ describe('NotesNoteDetail note switching', () => {
 
   it('preserves an authoritative title through a deep body-save queue', async () => {
     const firstSave = deferred<Record<string, unknown>>();
+    mocks.getDraftStashes.mockImplementation(async () => mocks.draftStashes);
+    mocks.setDraftStashes.mockImplementation(
+      async (
+        update: (
+          stashes: Record<string, Record<string, unknown>>
+        ) => Record<string, Record<string, unknown>>
+      ) => {
+        mocks.draftStashes = update(mocks.draftStashes);
+      }
+    );
     mocks.saveNotebookNote
       .mockReturnValueOnce(firstSave.promise)
       .mockImplementation(
@@ -503,6 +517,148 @@ describe('NotesNoteDetail note switching', () => {
         body: 'Newest body',
       })
     );
+    expect(mocks.draftStashes['~zod/notebook/1']).toBeUndefined();
+  });
+
+  it('preserves a title revert made after an intermediate adoption', async () => {
+    const firstSave = deferred<Record<string, unknown>>();
+    const secondSave = deferred<Record<string, unknown>>();
+    mocks.saveNotebookNote
+      .mockReturnValueOnce(firstSave.promise)
+      .mockReturnValueOnce(secondSave.promise)
+      .mockImplementation(
+        async ({
+          note: base,
+          title,
+          body,
+        }: {
+          note: ReturnType<typeof note>;
+          title: string;
+          body: string;
+        }) => ({
+          ...base,
+          title,
+          bodyMd: body,
+          revision: base.revision + 1,
+        })
+      );
+    mocks.notes = [
+      note(1, 'Original A', 1, 'Original title'),
+      note(2, 'Original B'),
+    ];
+    let renderer!: ReactTestRenderer;
+
+    await act(async () => {
+      renderer = create(
+        <NotesNoteDetail
+          headerActionsPlacement="none"
+          noteId={1}
+          notebookFlag="~zod/notebook"
+          startInEdit
+        />
+      );
+    });
+    await act(async () => {
+      renderer.root
+        .findByProps({ testID: 'NotesBodyInput' })
+        .props.onChangeText('Older body');
+    });
+    await act(async () => {
+      renderer.update(
+        <NotesNoteDetail
+          headerActionsPlacement="none"
+          noteId={2}
+          notebookFlag="~zod/notebook"
+          startInEdit
+        />
+      );
+    });
+    await act(async () => {
+      renderer.update(
+        <NotesNoteDetail
+          headerActionsPlacement="none"
+          noteId={1}
+          notebookFlag="~zod/notebook"
+          startInEdit
+        />
+      );
+    });
+    await act(async () => {
+      renderer.root
+        .findByProps({ testID: 'NotesBodyInput' })
+        .props.onChangeText('Latest body');
+    });
+    await act(async () => {
+      renderer.update(
+        <NotesNoteDetail
+          headerActionsPlacement="none"
+          noteId={2}
+          notebookFlag="~zod/notebook"
+          startInEdit
+        />
+      );
+    });
+    await act(async () => {
+      renderer.update(
+        <NotesNoteDetail
+          headerActionsPlacement="none"
+          noteId={1}
+          notebookFlag="~zod/notebook"
+          startInEdit
+        />
+      );
+    });
+
+    await act(async () => {
+      firstSave.resolve(note(1, 'Older body', 2, 'Remote title'));
+      await firstSave.promise;
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+    expect(
+      renderer.root.findByProps({ testID: 'NotesTitleInput' }).props.value
+    ).toBe('Remote title');
+    expect(
+      renderer.root.findByProps({ testID: 'NotesBodyInput' }).props.value
+    ).toBe('Latest body');
+
+    await act(async () => {
+      renderer.root
+        .findByProps({ testID: 'NotesTitleInput' })
+        .props.onChangeText('Original title');
+    });
+    await act(async () => {
+      secondSave.resolve(note(1, 'Latest body', 3, 'Remote title'));
+      await secondSave.promise;
+      await Promise.resolve();
+    });
+    expect(
+      renderer.root.findByProps({ testID: 'NotesTitleInput' }).props.value
+    ).toBe('Original title');
+
+    await act(async () => {
+      renderer.update(
+        <NotesNoteDetail
+          headerActionsPlacement="none"
+          noteId={2}
+          notebookFlag="~zod/notebook"
+          startInEdit
+        />
+      );
+    });
+    expect(mocks.saveNotebookNote).toHaveBeenNthCalledWith(
+      3,
+      expect.objectContaining({
+        note: expect.objectContaining({
+          revision: 3,
+          title: 'Remote title',
+        }),
+        title: 'Original title',
+        body: 'Latest body',
+      })
+    );
+
+    act(() => renderer.unmount());
   });
 
   it('keeps an older sibling body edit when the predecessor captured only a newer title edit', async () => {
@@ -1384,6 +1540,77 @@ describe('NotesNoteDetail note switching', () => {
         .props.onChangeText('Original A');
     });
     act(() => recoveredRenderer!.unmount());
+  });
+
+  it('advances a restored draft base when the settled row already matches', async () => {
+    const firstSave = deferred<Record<string, unknown>>();
+    mocks.saveNotebookNote.mockReturnValueOnce(firstSave.promise);
+    let renderer!: ReactTestRenderer;
+
+    await act(async () => {
+      renderer = create(
+        <NotesNoteDetail
+          headerActionsPlacement="none"
+          noteId={1}
+          notebookFlag="~zod/notebook"
+          startInEdit
+        />
+      );
+    });
+    await act(async () => {
+      renderer.root
+        .findByProps({ testID: 'NotesBodyInput' })
+        .props.onChangeText('Edited A');
+    });
+    await act(async () => {
+      renderer.unmount();
+      await Promise.resolve();
+    });
+
+    await act(async () => {
+      renderer = create(
+        <NotesNoteDetail
+          headerActionsPlacement="none"
+          noteId={1}
+          notebookFlag="~zod/notebook"
+          startInEdit
+        />
+      );
+    });
+    expect(
+      renderer.root.findByProps({ testID: 'NotesBodyInput' }).props.value
+    ).toBe('Edited A');
+
+    const savedRow = note(1, 'Edited A', 2);
+    mocks.notes = [savedRow, note(2, 'Original B')];
+    await act(async () => {
+      renderer.update(
+        <NotesNoteDetail
+          headerActionsPlacement="none"
+          noteId={1}
+          notebookFlag="~zod/notebook"
+          startInEdit
+        />
+      );
+      firstSave.resolve(savedRow);
+      await firstSave.promise;
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    await act(async () => {
+      renderer.update(
+        <NotesNoteDetail
+          headerActionsPlacement="none"
+          noteId={2}
+          notebookFlag="~zod/notebook"
+          startInEdit
+        />
+      );
+    });
+    expect(mocks.saveNotebookNote).toHaveBeenCalledTimes(1);
+
+    act(() => renderer.unmount());
   });
 
   it('reconsiders a skipped row when a previous editor instance settles', async () => {

--- a/packages/app/ui/components/NotesChannel/NotesNoteDetail.test.tsx
+++ b/packages/app/ui/components/NotesChannel/NotesNoteDetail.test.tsx
@@ -261,6 +261,82 @@ describe('NotesNoteDetail note switching', () => {
     act(() => renderer!.unmount());
   });
 
+  it('keeps a restored draft on its stale revision when the row advanced remotely', async () => {
+    const firstSave = deferred<Record<string, unknown>>();
+    mocks.saveNotebookNote
+      .mockReturnValueOnce(firstSave.promise)
+      .mockRejectedValueOnce(new Error('revision conflict'));
+    let renderer: ReactTestRenderer;
+
+    await act(async () => {
+      renderer = create(
+        <NotesNoteDetail
+          headerActionsPlacement="none"
+          noteId={1}
+          notebookFlag="~zod/notebook"
+          startInEdit
+        />
+      );
+    });
+    await act(async () => {
+      renderer!.root
+        .findByProps({ testID: 'NotesBodyInput' })
+        .props.onChangeText('Edited A');
+    });
+    await act(async () => {
+      renderer!.update(
+        <NotesNoteDetail
+          headerActionsPlacement="none"
+          noteId={2}
+          notebookFlag="~zod/notebook"
+          startInEdit
+        />
+      );
+    });
+
+    mocks.notes = [note(1, 'Remote A', 2), note(2, 'Original B')];
+    await act(async () => {
+      renderer!.update(
+        <NotesNoteDetail
+          headerActionsPlacement="none"
+          noteId={1}
+          notebookFlag="~zod/notebook"
+          startInEdit
+        />
+      );
+    });
+    expect(
+      renderer!.root.findByProps({ testID: 'NotesBodyInput' }).props.value
+    ).toBe('Edited A');
+
+    await act(async () => {
+      renderer!.update(
+        <NotesNoteDetail
+          headerActionsPlacement="none"
+          noteId={2}
+          notebookFlag="~zod/notebook"
+          startInEdit
+        />
+      );
+    });
+    await act(async () => {
+      firstSave.reject(new Error('revision conflict'));
+      await Promise.resolve();
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    expect(mocks.saveNotebookNote).toHaveBeenNthCalledWith(
+      2,
+      expect.objectContaining({
+        note: expect.objectContaining({ noteId: 1, revision: 1 }),
+        body: 'Edited A',
+      })
+    );
+
+    act(() => renderer!.unmount());
+  });
+
   it('rebases an earlier save without resurrecting an explicitly reverted draft', async () => {
     const firstSave = deferred<Record<string, unknown>>();
     mocks.saveNotebookNote
@@ -471,7 +547,7 @@ describe('NotesNoteDetail note switching', () => {
     act(() => renderer!.unmount());
   });
 
-  it('adopts an authoritative title when the reopened title is untouched', async () => {
+  it('adopts an authoritative title after a semantic title revert', async () => {
     const firstSave = deferred<Record<string, unknown>>();
     mocks.saveNotebookNote.mockReturnValueOnce(firstSave.promise);
     mocks.notes = [
@@ -515,6 +591,13 @@ describe('NotesNoteDetail note switching', () => {
         />
       );
     });
+    await act(async () => {
+      const titleInput = renderer!.root.findByProps({
+        testID: 'NotesTitleInput',
+      });
+      titleInput.props.onChangeText('Original title ');
+      titleInput.props.onChangeText('Original title');
+    });
 
     const savedRow = note(1, 'Edited A', 2, 'Remote title');
     mocks.notes = [savedRow, note(2, 'Original B')];
@@ -547,6 +630,68 @@ describe('NotesNoteDetail note switching', () => {
     expect(mocks.saveNotebookNote).toHaveBeenCalledTimes(1);
 
     act(() => renderer!.unmount());
+  });
+
+  it('does not let a clean sibling editor replace dirty recovery data', async () => {
+    const firstSave = deferred<Record<string, unknown>>();
+    mocks.saveNotebookNote.mockReturnValueOnce(firstSave.promise);
+    let dirtyRenderer: ReactTestRenderer;
+    let cleanRenderer: ReactTestRenderer;
+
+    await act(async () => {
+      dirtyRenderer = create(
+        <NotesNoteDetail
+          headerActionsPlacement="none"
+          noteId={1}
+          notebookFlag="~zod/notebook"
+          startInEdit
+        />
+      );
+      cleanRenderer = create(
+        <NotesNoteDetail
+          headerActionsPlacement="none"
+          noteId={1}
+          notebookFlag="~zod/notebook"
+          startInEdit
+        />
+      );
+    });
+    await act(async () => {
+      dirtyRenderer!.root
+        .findByProps({ testID: 'NotesBodyInput' })
+        .props.onChangeText('Edited A');
+    });
+    act(() => dirtyRenderer!.unmount());
+
+    await act(async () => {
+      firstSave.reject(new Error('save failed'));
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+    act(() => cleanRenderer!.unmount());
+
+    let recoveredRenderer: ReactTestRenderer;
+    await act(async () => {
+      recoveredRenderer = create(
+        <NotesNoteDetail
+          headerActionsPlacement="none"
+          noteId={1}
+          notebookFlag="~zod/notebook"
+          startInEdit
+        />
+      );
+    });
+    expect(
+      recoveredRenderer!.root.findByProps({ testID: 'NotesBodyInput' }).props
+        .value
+    ).toBe('Edited A');
+
+    await act(async () => {
+      recoveredRenderer!.root
+        .findByProps({ testID: 'NotesBodyInput' })
+        .props.onChangeText('Original A');
+    });
+    act(() => recoveredRenderer!.unmount());
   });
 
   it('reconsiders a skipped row when a previous editor instance settles', async () => {

--- a/packages/app/ui/components/NotesChannel/NotesNoteDetail.test.tsx
+++ b/packages/app/ui/components/NotesChannel/NotesNoteDetail.test.tsx
@@ -2,6 +2,7 @@ import React from 'react';
 import { ReactTestRenderer, act, create } from 'react-test-renderer';
 import {
   afterAll,
+  afterEach,
   beforeAll,
   beforeEach,
   describe,
@@ -13,6 +14,7 @@ import {
 import { NotesNoteDetail } from './NotesNoteDetail';
 
 const mocks = vi.hoisted(() => ({
+  getDraftStashes: vi.fn(),
   notes: [] as Array<Record<string, unknown>>,
   saveNotebookNote: vi.fn(),
   useNotebookData: vi.fn(),
@@ -37,7 +39,7 @@ vi.mock('@tloncorp/shared', () => ({
 
 vi.mock('@tloncorp/shared/db', () => ({
   notesNoteDrafts: {
-    getValue: vi.fn(async () => ({})),
+    getValue: mocks.getDraftStashes,
     setValue: vi.fn(async () => undefined),
   },
 }));
@@ -90,10 +92,12 @@ vi.mock('./notesTree', () => ({
 
 function deferred<T>() {
   let resolve!: (value: T) => void;
-  const promise = new Promise<T>((resolvePromise) => {
+  let reject!: (reason?: unknown) => void;
+  const promise = new Promise<T>((resolvePromise, rejectPromise) => {
     resolve = resolvePromise;
+    reject = rejectPromise;
   });
-  return { promise, resolve };
+  return { promise, reject, resolve };
 }
 
 function note(noteId: number, bodyMd: string, revision = 1) {
@@ -131,8 +135,13 @@ describe('NotesNoteDetail note switching', () => {
     ).requestAnimationFrame;
   });
 
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
   beforeEach(() => {
     vi.clearAllMocks();
+    mocks.getDraftStashes.mockResolvedValue({});
     mocks.notes = [note(1, 'Original A'), note(2, 'Original B')];
     mocks.useNotebookData.mockImplementation(() => ({
       folders: [],
@@ -301,6 +310,9 @@ describe('NotesNoteDetail note switching', () => {
         />
       );
     });
+    expect(
+      renderer!.root.findByProps({ testID: 'NotesBodyInput' }).props.value
+    ).toBe('Edited A');
 
     // Make the user's intent explicit: change the new visit, then revert it
     // to the original text while the previous visit's save is still pending.
@@ -351,6 +363,168 @@ describe('NotesNoteDetail note switching', () => {
         body: 'Original A',
       })
     );
+
+    act(() => renderer!.unmount());
+  });
+
+  it('waits for a reopened note stash before applying an earlier save base', async () => {
+    const firstSave = deferred<Record<string, unknown>>();
+    const reopenedStashRead = deferred<Record<string, unknown>>();
+    mocks.saveNotebookNote.mockReturnValueOnce(firstSave.promise);
+    let renderer: ReactTestRenderer;
+
+    await act(async () => {
+      renderer = create(
+        <NotesNoteDetail
+          headerActionsPlacement="none"
+          noteId={1}
+          notebookFlag="~zod/notebook"
+          startInEdit
+        />
+      );
+    });
+    await act(async () => {
+      renderer!.root
+        .findByProps({ testID: 'NotesBodyInput' })
+        .props.onChangeText('Edited A');
+    });
+    await act(async () => {
+      renderer!.update(
+        <NotesNoteDetail
+          headerActionsPlacement="none"
+          noteId={2}
+          notebookFlag="~zod/notebook"
+          startInEdit
+        />
+      );
+    });
+
+    vi.spyOn(Date, 'now').mockReturnValue(Date.now() + 121_000);
+    mocks.getDraftStashes.mockReturnValueOnce(reopenedStashRead.promise);
+    await act(async () => {
+      renderer!.update(
+        <NotesNoteDetail
+          headerActionsPlacement="none"
+          noteId={1}
+          notebookFlag="~zod/notebook"
+          startInEdit
+        />
+      );
+    });
+
+    const earlierSavedRow = note(1, 'Edited A', 2);
+    mocks.notes = [earlierSavedRow, note(2, 'Original B')];
+    await act(async () => {
+      renderer!.update(
+        <NotesNoteDetail
+          headerActionsPlacement="none"
+          noteId={1}
+          notebookFlag="~zod/notebook"
+          startInEdit
+        />
+      );
+      firstSave.resolve(earlierSavedRow);
+      await firstSave.promise;
+    });
+    expect(
+      renderer!.root.findByProps({ testID: 'NotesBodyInput' }).props.value
+    ).toBe('Original A');
+
+    await act(async () => {
+      reopenedStashRead.resolve({
+        '~zod/notebook/1': {
+          title: 'Note 1',
+          body: 'Edited A',
+          baseRevision: 1,
+          stashedAt: Date.now(),
+        },
+      });
+      await reopenedStashRead.promise;
+    });
+    expect(
+      renderer!.root.findByProps({ testID: 'NotesBodyInput' }).props.value
+    ).toBe('Edited A');
+
+    await act(async () => {
+      renderer!.update(
+        <NotesNoteDetail
+          headerActionsPlacement="none"
+          noteId={2}
+          notebookFlag="~zod/notebook"
+          startInEdit
+        />
+      );
+    });
+    expect(mocks.saveNotebookNote).toHaveBeenCalledTimes(1);
+
+    act(() => renderer!.unmount());
+  });
+
+  it('reconsiders a skipped row after an earlier save rejects', async () => {
+    const firstSave = deferred<Record<string, unknown>>();
+    mocks.saveNotebookNote.mockReturnValueOnce(firstSave.promise);
+    let renderer: ReactTestRenderer;
+
+    await act(async () => {
+      renderer = create(
+        <NotesNoteDetail
+          headerActionsPlacement="none"
+          noteId={1}
+          notebookFlag="~zod/notebook"
+          startInEdit
+        />
+      );
+    });
+    await act(async () => {
+      renderer!.root
+        .findByProps({ testID: 'NotesBodyInput' })
+        .props.onChangeText('Edited A');
+    });
+    await act(async () => {
+      renderer!.update(
+        <NotesNoteDetail
+          headerActionsPlacement="none"
+          noteId={2}
+          notebookFlag="~zod/notebook"
+          startInEdit
+        />
+      );
+    });
+    vi.spyOn(Date, 'now').mockReturnValue(Date.now() + 121_000);
+    await act(async () => {
+      renderer!.update(
+        <NotesNoteDetail
+          headerActionsPlacement="none"
+          noteId={1}
+          notebookFlag="~zod/notebook"
+          startInEdit
+        />
+      );
+    });
+
+    mocks.notes = [note(1, 'Remote A', 2), note(2, 'Original B')];
+    await act(async () => {
+      renderer!.update(
+        <NotesNoteDetail
+          headerActionsPlacement="none"
+          noteId={1}
+          notebookFlag="~zod/notebook"
+          startInEdit
+        />
+      );
+    });
+    expect(
+      renderer!.root.findByProps({ testID: 'NotesBodyInput' }).props.value
+    ).toBe('Original A');
+
+    await act(async () => {
+      firstSave.reject(new Error('save failed'));
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+    expect(
+      renderer!.root.findByProps({ testID: 'NotesBodyInput' }).props.value
+    ).toBe('Remote A');
 
     act(() => renderer!.unmount());
   });

--- a/packages/app/ui/components/NotesChannel/NotesNoteDetail.test.tsx
+++ b/packages/app/ui/components/NotesChannel/NotesNoteDetail.test.tsx
@@ -632,6 +632,112 @@ describe('NotesNoteDetail note switching', () => {
     act(() => renderer!.unmount());
   });
 
+  it('preserves a title revert made while its rename save is pending', async () => {
+    const firstSave = deferred<Record<string, unknown>>();
+    mocks.saveNotebookNote
+      .mockReturnValueOnce(firstSave.promise)
+      .mockImplementation(
+        async ({
+          note: base,
+          title,
+          body,
+        }: {
+          note: ReturnType<typeof note>;
+          title: string;
+          body: string;
+        }) => ({
+          ...base,
+          title,
+          bodyMd: body,
+          revision: base.revision + 1,
+        })
+      );
+    mocks.notes = [
+      note(1, 'Original A', 1, 'Original title'),
+      note(2, 'Original B'),
+    ];
+    let renderer: ReactTestRenderer;
+
+    await act(async () => {
+      renderer = create(
+        <NotesNoteDetail
+          headerActionsPlacement="none"
+          noteId={1}
+          notebookFlag="~zod/notebook"
+          startInEdit
+        />
+      );
+    });
+    await act(async () => {
+      renderer!.root
+        .findByProps({ testID: 'NotesTitleInput' })
+        .props.onChangeText('Renamed title');
+    });
+    await act(async () => {
+      renderer!.update(
+        <NotesNoteDetail
+          headerActionsPlacement="none"
+          noteId={2}
+          notebookFlag="~zod/notebook"
+          startInEdit
+        />
+      );
+    });
+    await act(async () => {
+      renderer!.update(
+        <NotesNoteDetail
+          headerActionsPlacement="none"
+          noteId={1}
+          notebookFlag="~zod/notebook"
+          startInEdit
+        />
+      );
+    });
+    await act(async () => {
+      renderer!.root
+        .findByProps({ testID: 'NotesTitleInput' })
+        .props.onChangeText('Original title');
+    });
+
+    const savedRow = note(1, 'Original A', 2, 'Renamed title');
+    mocks.notes = [savedRow, note(2, 'Original B')];
+    await act(async () => {
+      renderer!.update(
+        <NotesNoteDetail
+          headerActionsPlacement="none"
+          noteId={1}
+          notebookFlag="~zod/notebook"
+          startInEdit
+        />
+      );
+      firstSave.resolve(savedRow);
+      await firstSave.promise;
+    });
+    expect(
+      renderer!.root.findByProps({ testID: 'NotesTitleInput' }).props.value
+    ).toBe('Original title');
+
+    await act(async () => {
+      renderer!.update(
+        <NotesNoteDetail
+          headerActionsPlacement="none"
+          noteId={2}
+          notebookFlag="~zod/notebook"
+          startInEdit
+        />
+      );
+    });
+    expect(mocks.saveNotebookNote).toHaveBeenNthCalledWith(
+      2,
+      expect.objectContaining({
+        note: expect.objectContaining({ noteId: 1, revision: 2 }),
+        title: 'Original title',
+      })
+    );
+
+    act(() => renderer!.unmount());
+  });
+
   it('does not let a clean sibling editor replace dirty recovery data', async () => {
     const firstSave = deferred<Record<string, unknown>>();
     mocks.saveNotebookNote.mockReturnValueOnce(firstSave.promise);

--- a/packages/app/ui/components/NotesChannel/NotesNoteDetail.test.tsx
+++ b/packages/app/ui/components/NotesChannel/NotesNoteDetail.test.tsx
@@ -100,13 +100,18 @@ function deferred<T>() {
   return { promise, reject, resolve };
 }
 
-function note(noteId: number, bodyMd: string, revision = 1) {
+function note(
+  noteId: number,
+  bodyMd: string,
+  revision = 1,
+  title = `Note ${noteId}`
+) {
   return {
     id: `~zod/notebook/${noteId}`,
     notebookFlag: '~zod/notebook',
     noteId,
     folderId: 0,
-    title: `Note ${noteId}`,
+    title,
     bodyMd,
     revision,
     createdAt: Date.now(),
@@ -249,6 +254,9 @@ describe('NotesNoteDetail note switching', () => {
         body: 'Latest A edit',
       })
     );
+    expect(
+      renderer!.root.findByProps({ testID: 'NotesBodyInput' }).props.value
+    ).toBe('Original B');
 
     act(() => renderer!.unmount());
   });
@@ -367,7 +375,7 @@ describe('NotesNoteDetail note switching', () => {
     act(() => renderer!.unmount());
   });
 
-  it('waits for a reopened note stash before applying an earlier save base', async () => {
+  it('restores a reopened draft synchronously while its save is pending', async () => {
     const firstSave = deferred<Record<string, unknown>>();
     const reopenedStashRead = deferred<Record<string, unknown>>();
     mocks.saveNotebookNote.mockReturnValueOnce(firstSave.promise);
@@ -411,6 +419,9 @@ describe('NotesNoteDetail note switching', () => {
         />
       );
     });
+    expect(
+      renderer!.root.findByProps({ testID: 'NotesBodyInput' }).props.value
+    ).toBe('Edited A');
 
     const earlierSavedRow = note(1, 'Edited A', 2);
     mocks.notes = [earlierSavedRow, note(2, 'Original B')];
@@ -428,7 +439,7 @@ describe('NotesNoteDetail note switching', () => {
     });
     expect(
       renderer!.root.findByProps({ testID: 'NotesBodyInput' }).props.value
-    ).toBe('Original A');
+    ).toBe('Edited A');
 
     await act(async () => {
       reopenedStashRead.resolve({
@@ -460,9 +471,13 @@ describe('NotesNoteDetail note switching', () => {
     act(() => renderer!.unmount());
   });
 
-  it('reconsiders a skipped row after an earlier save rejects', async () => {
+  it('adopts an authoritative title when the reopened title is untouched', async () => {
     const firstSave = deferred<Record<string, unknown>>();
     mocks.saveNotebookNote.mockReturnValueOnce(firstSave.promise);
+    mocks.notes = [
+      note(1, 'Original A', 1, 'Original title'),
+      note(2, 'Original B'),
+    ];
     let renderer: ReactTestRenderer;
 
     await act(async () => {
@@ -490,7 +505,6 @@ describe('NotesNoteDetail note switching', () => {
         />
       );
     });
-    vi.spyOn(Date, 'now').mockReturnValue(Date.now() + 121_000);
     await act(async () => {
       renderer!.update(
         <NotesNoteDetail
@@ -500,6 +514,81 @@ describe('NotesNoteDetail note switching', () => {
           startInEdit
         />
       );
+    });
+
+    const savedRow = note(1, 'Edited A', 2, 'Remote title');
+    mocks.notes = [savedRow, note(2, 'Original B')];
+    await act(async () => {
+      renderer!.update(
+        <NotesNoteDetail
+          headerActionsPlacement="none"
+          noteId={1}
+          notebookFlag="~zod/notebook"
+          startInEdit
+        />
+      );
+      firstSave.resolve(savedRow);
+      await firstSave.promise;
+    });
+
+    expect(
+      renderer!.root.findByProps({ testID: 'NotesTitleInput' }).props.value
+    ).toBe('Remote title');
+    await act(async () => {
+      renderer!.update(
+        <NotesNoteDetail
+          headerActionsPlacement="none"
+          noteId={2}
+          notebookFlag="~zod/notebook"
+          startInEdit
+        />
+      );
+    });
+    expect(mocks.saveNotebookNote).toHaveBeenCalledTimes(1);
+
+    act(() => renderer!.unmount());
+  });
+
+  it('reconsiders a skipped row when a previous editor instance settles', async () => {
+    const firstSave = deferred<Record<string, unknown>>();
+    mocks.saveNotebookNote.mockReturnValueOnce(firstSave.promise);
+    let renderer: ReactTestRenderer;
+
+    await act(async () => {
+      renderer = create(
+        <NotesNoteDetail
+          headerActionsPlacement="none"
+          noteId={1}
+          notebookFlag="~zod/notebook"
+          startInEdit
+        />
+      );
+    });
+    await act(async () => {
+      renderer!.root
+        .findByProps({ testID: 'NotesBodyInput' })
+        .props.onChangeText('Edited A');
+    });
+    act(() => renderer!.unmount());
+    vi.spyOn(Date, 'now').mockReturnValue(Date.now() + 121_000);
+    await act(async () => {
+      renderer = create(
+        <NotesNoteDetail
+          headerActionsPlacement="none"
+          noteId={1}
+          notebookFlag="~zod/notebook"
+          startInEdit
+        />
+      );
+    });
+    expect(
+      renderer!.root.findByProps({ testID: 'NotesBodyInput' }).props.value
+    ).toBe('Edited A');
+
+    await act(async () => {
+      renderer!.root
+        .findByProps({ testID: 'NotesBodyInput' })
+        .props.onChangeText('Original A');
     });
 
     mocks.notes = [note(1, 'Remote A', 2), note(2, 'Original B')];

--- a/packages/app/ui/components/NotesChannel/NotesNoteDetail.test.tsx
+++ b/packages/app/ui/components/NotesChannel/NotesNoteDetail.test.tsx
@@ -1,0 +1,215 @@
+import React from 'react';
+import { ReactTestRenderer, act, create } from 'react-test-renderer';
+import {
+  afterAll,
+  beforeAll,
+  beforeEach,
+  describe,
+  expect,
+  it,
+  vi,
+} from 'vitest';
+
+import { NotesNoteDetail } from './NotesNoteDetail';
+
+const mocks = vi.hoisted(() => ({
+  notes: [] as Array<Record<string, unknown>>,
+  saveNotebookNote: vi.fn(),
+  useNotebookData: vi.fn(),
+}));
+
+vi.mock('@tloncorp/api', () => ({
+  getActivityCapabilitiesEpoch: () => 0,
+  onActivityCapabilitiesChange: () => () => undefined,
+}));
+
+vi.mock('@tloncorp/shared', () => ({
+  AnalyticsEvent: { NoteOpened: 'NoteOpened' },
+  NotesNoteConflictError: class NotesNoteConflictError extends Error {},
+  adoptNotebookNoteRemote: vi.fn(),
+  convertContent: () => [],
+  markNoteRead: vi.fn(),
+  markdownToStory: () => [],
+  normalizeNotebookNoteTitle: (title: string) => title.trim() || 'Untitled',
+  saveNotebookNote: mocks.saveNotebookNote,
+  trackEvent: vi.fn(),
+}));
+
+vi.mock('@tloncorp/shared/db', () => ({
+  notesNoteDrafts: {
+    getValue: vi.fn(async () => ({})),
+    setValue: vi.fn(async () => undefined),
+  },
+}));
+
+vi.mock('@tloncorp/ui', () => ({ Text: 'Text' }));
+
+vi.mock('react-native', () => ({
+  AppState: {
+    addEventListener: vi.fn(() => ({ remove: vi.fn() })),
+  },
+}));
+
+vi.mock('tamagui', () => ({
+  Input: 'Input',
+  ScrollView: 'ScrollView',
+  TextArea: 'TextArea',
+  XStack: 'XStack',
+  YStack: 'YStack',
+  getTokenValue: () => 16,
+  isWeb: true,
+}));
+
+vi.mock('../Channel/ChannelHeader', () => ({
+  useRegisterChannelHeaderItem: vi.fn(),
+  useRegisterChannelHeaderLoadingSubtitle: vi.fn(),
+}));
+
+vi.mock('../Form', () => ({ TextInput: 'TextInput' }));
+vi.mock('../NotebookPost/NotebookPost', () => ({
+  NotebookContentRenderer: () => null,
+}));
+vi.mock('../ScreenHeader', () => ({
+  ScreenHeader: { TextButton: 'TextButton' },
+}));
+vi.mock('./NotesData', () => ({
+  NotebookGateMessage: () => null,
+  NotesMessage: () => null,
+  useNotebookData: mocks.useNotebookData,
+}));
+vi.mock('./NotesFeedback', () => ({
+  NotesBanner: () => null,
+  errorMessage: (error: unknown, fallback: string) =>
+    error instanceof Error ? error.message : fallback,
+}));
+vi.mock('./notesTelemetry', () => ({ trackNotesActionError: vi.fn() }));
+vi.mock('./notesTree', () => ({
+  formatNoteDate: () => 'Today',
+  getFolderPath: () => null,
+}));
+
+function deferred<T>() {
+  let resolve!: (value: T) => void;
+  const promise = new Promise<T>((resolvePromise) => {
+    resolve = resolvePromise;
+  });
+  return { promise, resolve };
+}
+
+function note(noteId: number, bodyMd: string, revision = 1) {
+  return {
+    id: `~zod/notebook/${noteId}`,
+    notebookFlag: '~zod/notebook',
+    noteId,
+    folderId: 0,
+    title: `Note ${noteId}`,
+    bodyMd,
+    revision,
+    createdAt: Date.now(),
+    updatedAt: Date.now(),
+  };
+}
+
+describe('NotesNoteDetail note switching', () => {
+  beforeAll(() => {
+    Object.assign(globalThis, {
+      IS_REACT_ACT_ENVIRONMENT: true,
+      requestAnimationFrame: (callback: FrameRequestCallback) => {
+        callback(0);
+        return 0;
+      },
+    });
+  });
+
+  afterAll(() => {
+    delete (globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean })
+      .IS_REACT_ACT_ENVIRONMENT;
+    delete (
+      globalThis as unknown as {
+        requestAnimationFrame?: typeof requestAnimationFrame;
+      }
+    ).requestAnimationFrame;
+  });
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mocks.notes = [note(1, 'Original A'), note(2, 'Original B')];
+    mocks.useNotebookData.mockImplementation(() => ({
+      folders: [],
+      notes: mocks.notes,
+      canEdit: true,
+      rootFolderId: 0,
+      gate: null,
+    }));
+  });
+
+  it('ignores a save completion from an earlier A visit after switching A → B → A', async () => {
+    const firstSave = deferred<Record<string, unknown>>();
+    mocks.saveNotebookNote.mockReturnValueOnce(firstSave.promise);
+    let renderer: ReactTestRenderer;
+
+    await act(async () => {
+      renderer = create(
+        <NotesNoteDetail
+          headerActionsPlacement="none"
+          noteId={1}
+          notebookFlag="~zod/notebook"
+          startInEdit
+        />
+      );
+    });
+
+    await act(async () => {
+      renderer!.root
+        .findByProps({ testID: 'NotesBodyInput' })
+        .props.onChangeText('Edited A');
+    });
+
+    await act(async () => {
+      renderer!.update(
+        <NotesNoteDetail
+          headerActionsPlacement="none"
+          noteId={2}
+          notebookFlag="~zod/notebook"
+          startInEdit
+        />
+      );
+    });
+    expect(mocks.saveNotebookNote).toHaveBeenCalledWith(
+      expect.objectContaining({
+        note: expect.objectContaining({ noteId: 1 }),
+        body: 'Edited A',
+      })
+    );
+
+    await act(async () => {
+      renderer!.update(
+        <NotesNoteDetail
+          headerActionsPlacement="none"
+          noteId={1}
+          notebookFlag="~zod/notebook"
+          startInEdit
+        />
+      );
+    });
+    expect(
+      renderer!.root.findByProps({ testID: 'NotesBodyInput' }).props.value
+    ).toBe('Original A');
+    const renderCountBeforeStaleCompletion =
+      mocks.useNotebookData.mock.calls.length;
+
+    await act(async () => {
+      firstSave.resolve(note(1, 'Edited A', 2));
+      await firstSave.promise;
+    });
+
+    expect(mocks.useNotebookData).toHaveBeenCalledTimes(
+      renderCountBeforeStaleCompletion
+    );
+    expect(
+      renderer!.root.findByProps({ testID: 'NotesBodyInput' }).props.value
+    ).toBe('Original A');
+
+    act(() => renderer!.unmount());
+  });
+});

--- a/packages/app/ui/components/NotesChannel/NotesNoteDetail.test.tsx
+++ b/packages/app/ui/components/NotesChannel/NotesNoteDetail.test.tsx
@@ -11,7 +11,10 @@ import {
   vi,
 } from 'vitest';
 
-import { NotesNoteDetail } from './NotesNoteDetail';
+import {
+  NotesNoteDetail,
+  deriveNotesNoteSaveFieldIntent,
+} from './NotesNoteDetail';
 
 const mocks = vi.hoisted(() => ({
   getDraftStashes: vi.fn(),
@@ -118,6 +121,41 @@ function note(
     updatedAt: Date.now(),
   };
 }
+
+describe('deriveNotesNoteSaveFieldIntent', () => {
+  it.each([
+    {
+      name: 'preserves an untouched field with no predecessor',
+      hasPredecessor: false,
+      matchesPredecessorRequest: false,
+      differsFromBase: false,
+      expected: 'preserve',
+    },
+    {
+      name: 'sets a dirty field with no predecessor',
+      hasPredecessor: false,
+      matchesPredecessorRequest: false,
+      differsFromBase: true,
+      expected: 'set',
+    },
+    {
+      name: 'preserves a field matching the predecessor request',
+      hasPredecessor: true,
+      matchesPredecessorRequest: true,
+      differsFromBase: true,
+      expected: 'preserve',
+    },
+    {
+      name: 'sets a field that changes the predecessor request',
+      hasPredecessor: true,
+      matchesPredecessorRequest: false,
+      differsFromBase: false,
+      expected: 'set',
+    },
+  ])('$name', ({ expected, name: _name, ...input }) => {
+    expect(deriveNotesNoteSaveFieldIntent(input)).toBe(expected);
+  });
+});
 
 describe('NotesNoteDetail note switching', () => {
   beforeAll(() => {
@@ -344,6 +382,467 @@ describe('NotesNoteDetail note switching', () => {
       expect.objectContaining({
         note: expect.objectContaining({ noteId: 1, revision: 2 }),
         body: 'Latest A edit',
+      })
+    );
+  });
+
+  it('preserves an authoritative title through a deep body-save queue', async () => {
+    const firstSave = deferred<Record<string, unknown>>();
+    mocks.saveNotebookNote
+      .mockReturnValueOnce(firstSave.promise)
+      .mockImplementation(
+        async ({
+          note: base,
+          title,
+          body,
+        }: {
+          note: ReturnType<typeof note>;
+          title: string;
+          body: string;
+        }) => ({
+          ...base,
+          title,
+          bodyMd: body,
+          revision: base.revision + 1,
+        })
+      );
+    mocks.notes = [
+      note(1, 'Original A', 1, 'Original title'),
+      note(2, 'Original B'),
+    ];
+    let firstRenderer: ReactTestRenderer;
+    let secondRenderer: ReactTestRenderer;
+    let thirdRenderer: ReactTestRenderer;
+
+    await act(async () => {
+      firstRenderer = create(
+        <NotesNoteDetail
+          headerActionsPlacement="none"
+          noteId={1}
+          notebookFlag="~zod/notebook"
+          startInEdit
+        />
+      );
+    });
+    await act(async () => {
+      firstRenderer.root
+        .findByProps({ testID: 'NotesBodyInput' })
+        .props.onChangeText('Older body');
+    });
+    await act(async () => {
+      firstRenderer.unmount();
+      await Promise.resolve();
+    });
+
+    await act(async () => {
+      secondRenderer = create(
+        <NotesNoteDetail
+          headerActionsPlacement="none"
+          noteId={1}
+          notebookFlag="~zod/notebook"
+          startInEdit
+        />
+      );
+    });
+    await act(async () => {
+      secondRenderer.root
+        .findByProps({ testID: 'NotesBodyInput' })
+        .props.onChangeText('Latest body');
+    });
+    await act(async () => {
+      secondRenderer.unmount();
+      await Promise.resolve();
+    });
+
+    await act(async () => {
+      thirdRenderer = create(
+        <NotesNoteDetail
+          headerActionsPlacement="none"
+          noteId={1}
+          notebookFlag="~zod/notebook"
+          startInEdit
+        />
+      );
+    });
+    await act(async () => {
+      thirdRenderer.root
+        .findByProps({ testID: 'NotesBodyInput' })
+        .props.onChangeText('Newest body');
+    });
+    await act(async () => {
+      thirdRenderer.unmount();
+      await Promise.resolve();
+    });
+
+    await act(async () => {
+      firstSave.resolve(note(1, 'Older body', 2, 'Remote title'));
+      await firstSave.promise;
+      await Promise.resolve();
+      await Promise.resolve();
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    expect(mocks.saveNotebookNote).toHaveBeenNthCalledWith(
+      2,
+      expect.objectContaining({
+        note: expect.objectContaining({ revision: 2, title: 'Remote title' }),
+        title: 'Remote title',
+        body: 'Latest body',
+      })
+    );
+    expect(mocks.saveNotebookNote).toHaveBeenNthCalledWith(
+      3,
+      expect.objectContaining({
+        note: expect.objectContaining({
+          revision: 3,
+          title: 'Remote title',
+          bodyMd: 'Latest body',
+        }),
+        title: 'Remote title',
+        body: 'Newest body',
+      })
+    );
+  });
+
+  it('keeps an older sibling body edit when the predecessor captured only a newer title edit', async () => {
+    const firstSave = deferred<Record<string, unknown>>();
+    mocks.saveNotebookNote
+      .mockReturnValueOnce(firstSave.promise)
+      .mockImplementation(
+        async ({
+          note: base,
+          title,
+          body,
+        }: {
+          note: ReturnType<typeof note>;
+          title: string;
+          body: string;
+        }) => ({
+          ...base,
+          title,
+          bodyMd: body,
+          revision: base.revision + 1,
+        })
+      );
+    mocks.notes = [
+      note(1, 'Original A', 1, 'Original title'),
+      note(2, 'Original B'),
+    ];
+    let titleRenderer: ReactTestRenderer;
+    let bodyRenderer: ReactTestRenderer;
+
+    await act(async () => {
+      titleRenderer = create(
+        <NotesNoteDetail
+          headerActionsPlacement="none"
+          noteId={1}
+          notebookFlag="~zod/notebook"
+          startInEdit
+        />
+      );
+      bodyRenderer = create(
+        <NotesNoteDetail
+          headerActionsPlacement="none"
+          noteId={1}
+          notebookFlag="~zod/notebook"
+          startInEdit
+        />
+      );
+    });
+    await act(async () => {
+      bodyRenderer.root
+        .findByProps({ testID: 'NotesBodyInput' })
+        .props.onChangeText('Latest body');
+      titleRenderer.root
+        .findByProps({ testID: 'NotesTitleInput' })
+        .props.onChangeText('Sibling title');
+    });
+    await act(async () => {
+      titleRenderer.unmount();
+      await Promise.resolve();
+    });
+    await act(async () => {
+      bodyRenderer.unmount();
+      await Promise.resolve();
+    });
+
+    await act(async () => {
+      firstSave.resolve(note(1, 'Original A', 1, 'Sibling title'));
+      await firstSave.promise;
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    expect(mocks.saveNotebookNote).toHaveBeenNthCalledWith(
+      2,
+      expect.objectContaining({
+        // Queue-relative intent deliberately retains HEAD's last-flusher
+        // behavior for conflicting sibling titles while protecting the
+        // independently edited body from being dropped.
+        title: 'Original title',
+        body: 'Latest body',
+      })
+    );
+  });
+
+  it('preserves a title revert queued with a body edit', async () => {
+    const firstSave = deferred<Record<string, unknown>>();
+    mocks.saveNotebookNote
+      .mockReturnValueOnce(firstSave.promise)
+      .mockImplementation(
+        async ({
+          note: base,
+          title,
+          body,
+        }: {
+          note: ReturnType<typeof note>;
+          title: string;
+          body: string;
+        }) => ({
+          ...base,
+          title,
+          bodyMd: body,
+          revision: base.revision + 1,
+        })
+      );
+    mocks.notes = [
+      note(1, 'Original A', 1, 'Original title'),
+      note(2, 'Original B'),
+    ];
+    let firstRenderer: ReactTestRenderer;
+    let secondRenderer: ReactTestRenderer;
+
+    await act(async () => {
+      firstRenderer = create(
+        <NotesNoteDetail
+          headerActionsPlacement="none"
+          noteId={1}
+          notebookFlag="~zod/notebook"
+          startInEdit
+        />
+      );
+    });
+    await act(async () => {
+      firstRenderer.root
+        .findByProps({ testID: 'NotesTitleInput' })
+        .props.onChangeText('Renamed title');
+    });
+    await act(async () => {
+      firstRenderer.unmount();
+      await Promise.resolve();
+    });
+
+    await act(async () => {
+      secondRenderer = create(
+        <NotesNoteDetail
+          headerActionsPlacement="none"
+          noteId={1}
+          notebookFlag="~zod/notebook"
+          startInEdit
+        />
+      );
+    });
+    await act(async () => {
+      secondRenderer.root
+        .findByProps({ testID: 'NotesTitleInput' })
+        .props.onChangeText('Original title');
+      secondRenderer.root
+        .findByProps({ testID: 'NotesBodyInput' })
+        .props.onChangeText('Edited body');
+    });
+    await act(async () => {
+      secondRenderer.unmount();
+      await Promise.resolve();
+    });
+
+    await act(async () => {
+      firstSave.resolve(note(1, 'Original A', 1, 'Renamed title'));
+      await firstSave.promise;
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    expect(mocks.saveNotebookNote).toHaveBeenNthCalledWith(
+      2,
+      expect.objectContaining({
+        note: expect.objectContaining({ title: 'Renamed title' }),
+        title: 'Original title',
+        body: 'Edited body',
+      })
+    );
+  });
+
+  it('preserves a body revert queued with a title edit', async () => {
+    const firstSave = deferred<Record<string, unknown>>();
+    mocks.saveNotebookNote
+      .mockReturnValueOnce(firstSave.promise)
+      .mockImplementation(
+        async ({
+          note: base,
+          title,
+          body,
+        }: {
+          note: ReturnType<typeof note>;
+          title: string;
+          body: string;
+        }) => ({
+          ...base,
+          title,
+          bodyMd: body,
+          revision: base.revision + 1,
+        })
+      );
+    mocks.notes = [
+      note(1, 'Original A', 1, 'Original title'),
+      note(2, 'Original B'),
+    ];
+    let firstRenderer: ReactTestRenderer;
+    let secondRenderer: ReactTestRenderer;
+
+    await act(async () => {
+      firstRenderer = create(
+        <NotesNoteDetail
+          headerActionsPlacement="none"
+          noteId={1}
+          notebookFlag="~zod/notebook"
+          startInEdit
+        />
+      );
+    });
+    await act(async () => {
+      firstRenderer.root
+        .findByProps({ testID: 'NotesBodyInput' })
+        .props.onChangeText('Edited body');
+    });
+    await act(async () => {
+      firstRenderer.unmount();
+      await Promise.resolve();
+    });
+
+    await act(async () => {
+      secondRenderer = create(
+        <NotesNoteDetail
+          headerActionsPlacement="none"
+          noteId={1}
+          notebookFlag="~zod/notebook"
+          startInEdit
+        />
+      );
+    });
+    await act(async () => {
+      secondRenderer.root
+        .findByProps({ testID: 'NotesBodyInput' })
+        .props.onChangeText('Original A');
+      secondRenderer.root
+        .findByProps({ testID: 'NotesTitleInput' })
+        .props.onChangeText('Renamed title');
+    });
+    await act(async () => {
+      secondRenderer.unmount();
+      await Promise.resolve();
+    });
+
+    await act(async () => {
+      firstSave.resolve(note(1, 'Edited body', 2, 'Original title'));
+      await firstSave.promise;
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    expect(mocks.saveNotebookNote).toHaveBeenNthCalledWith(
+      2,
+      expect.objectContaining({
+        note: expect.objectContaining({ revision: 2, bodyMd: 'Edited body' }),
+        title: 'Renamed title',
+        body: 'Original A',
+      })
+    );
+  });
+
+  it('retries inherited intent when a queued predecessor fails', async () => {
+    const firstSave = deferred<Record<string, unknown>>();
+    mocks.saveNotebookNote
+      .mockReturnValueOnce(firstSave.promise)
+      .mockImplementation(
+        async ({
+          note: base,
+          title,
+          body,
+        }: {
+          note: ReturnType<typeof note>;
+          title: string;
+          body: string;
+        }) => ({
+          ...base,
+          title,
+          bodyMd: body,
+          revision: base.revision + 1,
+        })
+      );
+    mocks.notes = [
+      note(1, 'Original A', 1, 'Original title'),
+      note(2, 'Original B'),
+    ];
+    let firstRenderer: ReactTestRenderer;
+    let secondRenderer: ReactTestRenderer;
+
+    await act(async () => {
+      firstRenderer = create(
+        <NotesNoteDetail
+          headerActionsPlacement="none"
+          noteId={1}
+          notebookFlag="~zod/notebook"
+          startInEdit
+        />
+      );
+    });
+    await act(async () => {
+      firstRenderer.root
+        .findByProps({ testID: 'NotesTitleInput' })
+        .props.onChangeText('Renamed title');
+    });
+    await act(async () => {
+      firstRenderer.unmount();
+      await Promise.resolve();
+    });
+
+    await act(async () => {
+      secondRenderer = create(
+        <NotesNoteDetail
+          headerActionsPlacement="none"
+          noteId={1}
+          notebookFlag="~zod/notebook"
+          startInEdit
+        />
+      );
+    });
+    await act(async () => {
+      secondRenderer.root
+        .findByProps({ testID: 'NotesBodyInput' })
+        .props.onChangeText('Edited body');
+    });
+    await act(async () => {
+      secondRenderer.unmount();
+      await Promise.resolve();
+    });
+
+    await act(async () => {
+      firstSave.reject(new Error('save failed'));
+      await Promise.resolve();
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    expect(mocks.saveNotebookNote).toHaveBeenNthCalledWith(
+      2,
+      expect.objectContaining({
+        note: expect.objectContaining({
+          revision: 1,
+          title: 'Original title',
+        }),
+        title: 'Renamed title',
+        body: 'Edited body',
       })
     );
   });

--- a/packages/app/ui/components/NotesChannel/NotesNoteDetail.test.tsx
+++ b/packages/app/ui/components/NotesChannel/NotesNoteDetail.test.tsx
@@ -143,9 +143,26 @@ describe('NotesNoteDetail note switching', () => {
     }));
   });
 
-  it('ignores a save completion from an earlier A visit after switching A → B → A', async () => {
+  it('keeps same-note saves FIFO across A → B → A visits', async () => {
     const firstSave = deferred<Record<string, unknown>>();
-    mocks.saveNotebookNote.mockReturnValueOnce(firstSave.promise);
+    mocks.saveNotebookNote
+      .mockReturnValueOnce(firstSave.promise)
+      .mockImplementation(
+        async ({
+          note: base,
+          title,
+          body,
+        }: {
+          note: ReturnType<typeof note>;
+          title: string;
+          body: string;
+        }) => ({
+          ...base,
+          title,
+          bodyMd: body,
+          revision: base.revision + 1,
+        })
+      );
     let renderer: ReactTestRenderer;
 
     await act(async () => {
@@ -162,7 +179,7 @@ describe('NotesNoteDetail note switching', () => {
     await act(async () => {
       renderer!.root
         .findByProps({ testID: 'NotesBodyInput' })
-        .props.onChangeText('Edited A');
+        .props.onChangeText('Older A edit');
     });
 
     await act(async () => {
@@ -178,7 +195,7 @@ describe('NotesNoteDetail note switching', () => {
     expect(mocks.saveNotebookNote).toHaveBeenCalledWith(
       expect.objectContaining({
         note: expect.objectContaining({ noteId: 1 }),
-        body: 'Edited A',
+        body: 'Older A edit',
       })
     );
 
@@ -192,23 +209,148 @@ describe('NotesNoteDetail note switching', () => {
         />
       );
     });
-    expect(
-      renderer!.root.findByProps({ testID: 'NotesBodyInput' }).props.value
-    ).toBe('Original A');
-    const renderCountBeforeStaleCompletion =
-      mocks.useNotebookData.mock.calls.length;
 
     await act(async () => {
-      firstSave.resolve(note(1, 'Edited A', 2));
+      renderer!.root
+        .findByProps({ testID: 'NotesBodyInput' })
+        .props.onChangeText('Latest A edit');
+    });
+
+    await act(async () => {
+      renderer!.update(
+        <NotesNoteDetail
+          headerActionsPlacement="none"
+          noteId={2}
+          notebookFlag="~zod/notebook"
+          startInEdit
+        />
+      );
+    });
+    expect(mocks.saveNotebookNote).toHaveBeenCalledTimes(1);
+
+    await act(async () => {
+      firstSave.resolve(note(1, 'Older A edit', 2));
       await firstSave.promise;
     });
 
-    expect(mocks.useNotebookData).toHaveBeenCalledTimes(
-      renderCountBeforeStaleCompletion
+    expect(mocks.saveNotebookNote).toHaveBeenNthCalledWith(
+      2,
+      expect.objectContaining({
+        note: expect.objectContaining({ noteId: 1, revision: 2 }),
+        body: 'Latest A edit',
+      })
     );
+
+    act(() => renderer!.unmount());
+  });
+
+  it('rebases an earlier save without resurrecting an explicitly reverted draft', async () => {
+    const firstSave = deferred<Record<string, unknown>>();
+    mocks.saveNotebookNote
+      .mockReturnValueOnce(firstSave.promise)
+      .mockImplementation(
+        async ({
+          note: base,
+          title,
+          body,
+        }: {
+          note: ReturnType<typeof note>;
+          title: string;
+          body: string;
+        }) => ({
+          ...base,
+          title,
+          bodyMd: body,
+          revision: base.revision + 1,
+        })
+      );
+    let renderer: ReactTestRenderer;
+
+    await act(async () => {
+      renderer = create(
+        <NotesNoteDetail
+          headerActionsPlacement="none"
+          noteId={1}
+          notebookFlag="~zod/notebook"
+          startInEdit
+        />
+      );
+    });
+    await act(async () => {
+      renderer!.root
+        .findByProps({ testID: 'NotesBodyInput' })
+        .props.onChangeText('Edited A');
+    });
+    await act(async () => {
+      renderer!.update(
+        <NotesNoteDetail
+          headerActionsPlacement="none"
+          noteId={2}
+          notebookFlag="~zod/notebook"
+          startInEdit
+        />
+      );
+    });
+    await act(async () => {
+      renderer!.update(
+        <NotesNoteDetail
+          headerActionsPlacement="none"
+          noteId={1}
+          notebookFlag="~zod/notebook"
+          startInEdit
+        />
+      );
+    });
+
+    // Make the user's intent explicit: change the new visit, then revert it
+    // to the original text while the previous visit's save is still pending.
+    await act(async () => {
+      const input = renderer!.root.findByProps({ testID: 'NotesBodyInput' });
+      input.props.onChangeText('Temporary new edit');
+      input.props.onChangeText('Original A');
+    });
+
+    const earlierSavedRow = note(1, 'Edited A', 2);
+    mocks.notes = [earlierSavedRow, note(2, 'Original B')];
+    await act(async () => {
+      renderer!.update(
+        <NotesNoteDetail
+          headerActionsPlacement="none"
+          noteId={1}
+          notebookFlag="~zod/notebook"
+          startInEdit
+        />
+      );
+    });
     expect(
       renderer!.root.findByProps({ testID: 'NotesBodyInput' }).props.value
     ).toBe('Original A');
+
+    await act(async () => {
+      firstSave.resolve(earlierSavedRow);
+      await firstSave.promise;
+    });
+    expect(
+      renderer!.root.findByProps({ testID: 'NotesBodyInput' }).props.value
+    ).toBe('Original A');
+
+    await act(async () => {
+      renderer!.update(
+        <NotesNoteDetail
+          headerActionsPlacement="none"
+          noteId={2}
+          notebookFlag="~zod/notebook"
+          startInEdit
+        />
+      );
+    });
+    expect(mocks.saveNotebookNote).toHaveBeenNthCalledWith(
+      2,
+      expect.objectContaining({
+        note: expect.objectContaining({ noteId: 1, revision: 2 }),
+        body: 'Original A',
+      })
+    );
 
     act(() => renderer!.unmount());
   });

--- a/packages/app/ui/components/NotesChannel/NotesNoteDetail.test.tsx
+++ b/packages/app/ui/components/NotesChannel/NotesNoteDetail.test.tsx
@@ -261,6 +261,93 @@ describe('NotesNoteDetail note switching', () => {
     act(() => renderer!.unmount());
   });
 
+  it('keeps same-note saves FIFO across editor remounts', async () => {
+    const firstSave = deferred<Record<string, unknown>>();
+    mocks.saveNotebookNote
+      .mockReturnValueOnce(firstSave.promise)
+      .mockImplementation(
+        async ({
+          note: base,
+          title,
+          body,
+        }: {
+          note: ReturnType<typeof note>;
+          title: string;
+          body: string;
+        }) => ({
+          ...base,
+          title,
+          bodyMd: body,
+          revision: base.revision + 1,
+        })
+      );
+    let firstRenderer: ReactTestRenderer;
+    let secondRenderer: ReactTestRenderer;
+
+    await act(async () => {
+      firstRenderer = create(
+        <NotesNoteDetail
+          headerActionsPlacement="none"
+          noteId={1}
+          notebookFlag="~zod/notebook"
+          startInEdit
+        />
+      );
+    });
+    await act(async () => {
+      firstRenderer.root
+        .findByProps({ testID: 'NotesBodyInput' })
+        .props.onChangeText('Older A edit');
+    });
+    await act(async () => {
+      firstRenderer.unmount();
+      await Promise.resolve();
+    });
+
+    expect(mocks.saveNotebookNote).toHaveBeenCalledTimes(1);
+
+    await act(async () => {
+      secondRenderer = create(
+        <NotesNoteDetail
+          headerActionsPlacement="none"
+          noteId={1}
+          notebookFlag="~zod/notebook"
+          startInEdit
+        />
+      );
+    });
+    expect(
+      secondRenderer!.root.findByProps({ testID: 'NotesBodyInput' }).props.value
+    ).toBe('Older A edit');
+
+    await act(async () => {
+      secondRenderer.root
+        .findByProps({ testID: 'NotesBodyInput' })
+        .props.onChangeText('Latest A edit');
+    });
+    await act(async () => {
+      secondRenderer.unmount();
+      await Promise.resolve();
+    });
+
+    expect(mocks.saveNotebookNote).toHaveBeenCalledTimes(1);
+
+    await act(async () => {
+      firstSave.resolve(note(1, 'Older A edit', 2));
+      await firstSave.promise;
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    expect(mocks.saveNotebookNote).toHaveBeenNthCalledWith(
+      2,
+      expect.objectContaining({
+        note: expect.objectContaining({ noteId: 1, revision: 2 }),
+        body: 'Latest A edit',
+      })
+    );
+  });
+
   it('keeps a restored draft on its stale revision when the row advanced remotely', async () => {
     const firstSave = deferred<Record<string, unknown>>();
     mocks.saveNotebookNote

--- a/packages/app/ui/components/NotesChannel/NotesNoteDetail.tsx
+++ b/packages/app/ui/components/NotesChannel/NotesNoteDetail.tsx
@@ -287,6 +287,53 @@ export function NotesNoteDetail({
     (session: NotesEditorSession) => editorSessionRef.current === session,
     []
   );
+  const isCurrentEditorNote = useCallback(
+    (flag: string, targetNoteId: number) =>
+      editorSessionRef.current.key === draftStashKey(flag, targetNoteId),
+    []
+  );
+  const pendingSaveSessionsRef = useRef(
+    new Map<string, Map<NotesEditorSession, number>>()
+  );
+  const markPendingSave = useCallback(
+    (flag: string, targetNoteId: number, session: NotesEditorSession) => {
+      const key = draftStashKey(flag, targetNoteId);
+      const sessions = pendingSaveSessionsRef.current.get(key) ?? new Map();
+      sessions.set(session, (sessions.get(session) ?? 0) + 1);
+      pendingSaveSessionsRef.current.set(key, sessions);
+    },
+    []
+  );
+  const finishPendingSave = useCallback(
+    (flag: string, targetNoteId: number, session: NotesEditorSession) => {
+      const key = draftStashKey(flag, targetNoteId);
+      const sessions = pendingSaveSessionsRef.current.get(key);
+      if (!sessions) return;
+      const remaining = (sessions.get(session) ?? 0) - 1;
+      if (remaining > 0) {
+        sessions.set(session, remaining);
+      } else {
+        sessions.delete(session);
+      }
+      if (sessions.size === 0) {
+        pendingSaveSessionsRef.current.delete(key);
+      }
+    },
+    []
+  );
+  const hasPendingSaveFromEarlierSession = useCallback(
+    (flag: string, targetNoteId: number) => {
+      const sessions = pendingSaveSessionsRef.current.get(
+        draftStashKey(flag, targetNoteId)
+      );
+      if (!sessions) return false;
+      const currentSession = editorSessionRef.current;
+      return Array.from(sessions).some(
+        ([session, count]) => session !== currentSession && count > 0
+      );
+    },
+    []
+  );
   const titleInputRef = useRef<TextInputRef>(null);
   const autoFocusedTitleNoteIdRef = useRef<string | null>(null);
   const bodyInputRef = useRef<ElementRef<typeof TextArea>>(null);
@@ -492,7 +539,22 @@ export function NotesNoteDetail({
       selectedNote != null &&
       draftBase != null &&
       selectedNote.revision < draftBase.revision;
-    if (sameNote && (isDirty || selectedNote === draftBase || rowTrailsBase)) {
+    // A save from an earlier visit can update the reactive row while the
+    // current visit is clean against its old base. Do not adopt that row into
+    // the current drafts: the save completion advances only the base below,
+    // making an explicit revert dirty and therefore eligible for its own save.
+    const earlierVisitSavePending =
+      sameNote &&
+      notebookFlag != null &&
+      selectedNote != null &&
+      hasPendingSaveFromEarlierSession(notebookFlag, selectedNote.noteId);
+    if (
+      sameNote &&
+      (isDirty ||
+        selectedNote === draftBase ||
+        rowTrailsBase ||
+        earlierVisitSavePending)
+    ) {
       return;
     }
     if (sameNote) {
@@ -506,7 +568,14 @@ export function NotesNoteDetail({
       setError(null);
       setConflictNote(null);
     }
-  }, [draftBase, isDirty, preserveScrollOffset, selectedNote]);
+  }, [
+    draftBase,
+    hasPendingSaveFromEarlierSession,
+    isDirty,
+    notebookFlag,
+    preserveScrollOffset,
+    selectedNote,
+  ]);
 
   useEffect(() => {
     if (!autoFocusTitle) {
@@ -551,7 +620,14 @@ export function NotesNoteDetail({
     Promise.resolve(null)
   );
   const runSave = useCallback(
-    (flag: string, base: db.NotesNote, title: string, body: string) => {
+    (
+      flag: string,
+      base: db.NotesNote,
+      title: string,
+      body: string,
+      session: NotesEditorSession
+    ) => {
+      markPendingSave(flag, base.noteId, session);
       const next = saveChainRef.current
         .catch(() => null)
         .then((prevSaved) =>
@@ -568,7 +644,7 @@ export function NotesNoteDetail({
       );
       return next;
     },
-    []
+    [markPendingSave]
   );
 
   // Save target for flushes that run outside the React data flow (unmount
@@ -659,11 +735,16 @@ export function NotesNoteDetail({
           notebookFlag,
           base,
           titleDraft,
-          bodyToSave
+          bodyToSave,
+          session
         );
         // Rebase onto the saved revision; keystrokes typed during the save
         // leave the drafts dirty against it, so the next cycle saves them.
-        if (updated && isCurrentEditorSession(session)) {
+        const currentSession = isCurrentEditorSession(session);
+        const currentNoteDraftIsReady =
+          isCurrentEditorNote(notebookFlag, base.noteId) &&
+          draftSessionRef.current === editorSessionRef.current;
+        if (updated && (currentSession || currentNoteDraftIsReady)) {
           setDraftBase(updated);
           // A save we did NOT rename in can come back with a different
           // title: another client renamed, and the response payload's
@@ -674,6 +755,7 @@ export function NotesNoteDetail({
           // but only when the user had no rename in flight (title matched
           // the base going in) and didn't touch it during the save.
           if (
+            currentSession &&
             normalizeNotebookNoteTitle(titleDraft) === base.title &&
             titleDraftRef.current === titleDraft &&
             updated.title !== titleDraft
@@ -718,13 +800,17 @@ export function NotesNoteDetail({
           setError(message);
         }
         return false;
+      } finally {
+        finishPendingSave(notebookFlag, base.noteId, session);
       }
     },
     [
       canEdit,
       clearConflict,
       draftBase,
+      finishPendingSave,
       isCurrentEditorSession,
+      isCurrentEditorNote,
       notebookFlag,
       preserveScrollOffset,
       reportConflict,
@@ -855,7 +941,7 @@ export function NotesNoteDetail({
       isDirty: true,
       updatedAt: Date.now(),
     });
-    runSave(flag, base, titleToSave, bodyToSave)
+    runSave(flag, base, titleToSave, bodyToSave, session)
       .then((updated) => {
         clearDraftStash(flag, base.noteId, {
           title: titleToSave,
@@ -869,12 +955,17 @@ export function NotesNoteDetail({
         });
         // No-ops after unmount; while mounted (background flush) rebase so
         // the next cycle doesn't re-send a stale revision.
-        if (updated && isCurrentEditorSession(session)) {
+        const currentSession = isCurrentEditorSession(session);
+        const currentNoteDraftIsReady =
+          isCurrentEditorNote(flag, base.noteId) &&
+          draftSessionRef.current === editorSessionRef.current;
+        if (updated && (currentSession || currentNoteDraftIsReady)) {
           setDraftBase(updated);
           // Same untouched-title rebase as the foreground save path: a
           // remote rename carried back by the payload must not leave the
           // stale title draft looking like a local edit.
           if (
+            currentSession &&
             normalizeNotebookNoteTitle(titleToSave) === base.title &&
             titleDraftRef.current === titleToSave &&
             updated.title !== titleToSave
@@ -908,10 +999,13 @@ export function NotesNoteDetail({
           setSaveState('error');
           setError(errorMessage(e, 'Failed to save note'));
         }
-      });
+      })
+      .finally(() => finishPendingSave(flag, base.noteId, session));
   }, [
     clearConflict,
+    finishPendingSave,
     isCurrentEditorSession,
+    isCurrentEditorNote,
     preserveScrollOffset,
     reportConflict,
     runSave,

--- a/packages/app/ui/components/NotesChannel/NotesNoteDetail.tsx
+++ b/packages/app/ui/components/NotesChannel/NotesNoteDetail.tsx
@@ -70,6 +70,7 @@ const DRAFT_SNAPSHOT_TTL_MS = 120_000;
 export type NotesNoteDraftSnapshot = {
   notebookFlag: string;
   noteId: number;
+  baseRevision: number;
   title: string;
   body: string;
   isDirty: boolean;
@@ -249,6 +250,7 @@ export function NotesNoteDetail({
   const [bodyInputWidth, setBodyInputWidth] = useState(0);
   const [saveState, setSaveState] = useState<SaveState>('idle');
   const [error, setError] = useState<string | null>(null);
+  const [pendingSaveEpoch, setPendingSaveEpoch] = useState(0);
   // The host's copy of the note after a save hit a genuine revision
   // conflict. While set, autosave is suspended and the banner offers the
   // user the resolution (keep mine / use theirs) — a blind retry can never
@@ -287,13 +289,14 @@ export function NotesNoteDetail({
     (session: NotesEditorSession) => editorSessionRef.current === session,
     []
   );
-  const isCurrentEditorNote = useCallback(
-    (flag: string, targetNoteId: number) =>
-      editorSessionRef.current.key === draftStashKey(flag, targetNoteId),
-    []
-  );
   const pendingSaveSessionsRef = useRef(
     new Map<string, Map<NotesEditorSession, number>>()
+  );
+  const stashRestoreCompletedSessionsRef = useRef(
+    new WeakSet<NotesEditorSession>()
+  );
+  const deferredBaseRebasesRef = useRef(
+    new Map<NotesEditorSession, db.NotesNote>()
   );
   const markPendingSave = useCallback(
     (flag: string, targetNoteId: number, session: NotesEditorSession) => {
@@ -318,6 +321,13 @@ export function NotesNoteDetail({
       if (sessions.size === 0) {
         pendingSaveSessionsRef.current.delete(key);
       }
+      // Pending saves live in a ref so queue bookkeeping itself does not
+      // perturb the editor. Settlement is different: row adoption may have
+      // skipped an already-received row while this save was pending, so wake
+      // the current note and let that effect reconsider it.
+      if (editorSessionRef.current.key === key) {
+        setPendingSaveEpoch((epoch) => epoch + 1);
+      }
     },
     []
   );
@@ -331,6 +341,25 @@ export function NotesNoteDetail({
       return Array.from(sessions).some(
         ([session, count]) => session !== currentSession && count > 0
       );
+    },
+    []
+  );
+  const rebaseCurrentNoteFromEarlierSession = useCallback(
+    (flag: string, targetNoteId: number, updated: db.NotesNote) => {
+      const currentSession = editorSessionRef.current;
+      if (currentSession.key !== draftStashKey(flag, targetNoteId)) return;
+      if (
+        draftSessionRef.current === currentSession &&
+        stashRestoreCompletedSessionsRef.current.has(currentSession)
+      ) {
+        setDraftBase(updated);
+        return;
+      }
+      // The reopened note has not finished consulting its durable stash yet.
+      // Hold only the new base revision; once restoration finishes, applying
+      // it alongside the restored/current drafts makes their true dirtiness
+      // visible without replacing them.
+      deferredBaseRebasesRef.current.set(currentSession, updated);
     },
     []
   );
@@ -464,6 +493,7 @@ export function NotesNoteDetail({
       const snapshot: NotesNoteDraftSnapshot = {
         notebookFlag,
         noteId: selectedNote.noteId,
+        baseRevision: draftBase.revision,
         title: titleDraft,
         body,
         isDirty: dirty,
@@ -548,21 +578,40 @@ export function NotesNoteDetail({
       notebookFlag != null &&
       selectedNote != null &&
       hasPendingSaveFromEarlierSession(notebookFlag, selectedNote.noteId);
+    const earlierVisitRebaseDeferred =
+      sameNote && deferredBaseRebasesRef.current.has(editorSessionRef.current);
     if (
       sameNote &&
       (isDirty ||
         selectedNote === draftBase ||
         rowTrailsBase ||
-        earlierVisitSavePending)
+        earlierVisitSavePending ||
+        earlierVisitRebaseDeferred)
     ) {
       return;
     }
     if (sameNote) {
       preserveScrollOffset();
     }
-    setDraftBase(selectedNote ?? null);
-    setTitleDraft(selectedNote?.title ?? '');
-    setBodyDraft(selectedNote?.bodyMd ?? '');
+    const inMemoryDraft =
+      !sameNote && notebookFlag && selectedNote
+        ? getNotesNoteDraftSnapshot(notebookFlag, selectedNote.noteId)
+        : null;
+    const canRestoreInMemoryDraft =
+      inMemoryDraft?.baseRevision === selectedNote?.revision;
+    if (canRestoreInMemoryDraft && inMemoryDraft && selectedNote) {
+      const currentSession = editorSessionRef.current;
+      stashRestoreCompletedSessionsRef.current.add(currentSession);
+      const deferredBase = deferredBaseRebasesRef.current.get(currentSession);
+      deferredBaseRebasesRef.current.delete(currentSession);
+      setDraftBase(deferredBase ?? selectedNote);
+      setTitleDraft(inMemoryDraft.title);
+      setBodyDraft(inMemoryDraft.body);
+    } else {
+      setDraftBase(selectedNote ?? null);
+      setTitleDraft(selectedNote?.title ?? '');
+      setBodyDraft(selectedNote?.bodyMd ?? '');
+    }
     if (!sameNote) {
       setSaveState('idle');
       setError(null);
@@ -573,6 +622,7 @@ export function NotesNoteDetail({
     hasPendingSaveFromEarlierSession,
     isDirty,
     notebookFlag,
+    pendingSaveEpoch,
     preserveScrollOffset,
     selectedNote,
   ]);
@@ -725,6 +775,7 @@ export function NotesNoteDetail({
       rememberNotesNoteDraftSnapshot({
         notebookFlag,
         noteId: base.noteId,
+        baseRevision: base.revision,
         title: titleDraft,
         body: bodyToSave,
         isDirty: true,
@@ -741,10 +792,7 @@ export function NotesNoteDetail({
         // Rebase onto the saved revision; keystrokes typed during the save
         // leave the drafts dirty against it, so the next cycle saves them.
         const currentSession = isCurrentEditorSession(session);
-        const currentNoteDraftIsReady =
-          isCurrentEditorNote(notebookFlag, base.noteId) &&
-          draftSessionRef.current === editorSessionRef.current;
-        if (updated && (currentSession || currentNoteDraftIsReady)) {
+        if (updated && currentSession) {
           setDraftBase(updated);
           // A save we did NOT rename in can come back with a different
           // title: another client renamed, and the response payload's
@@ -763,6 +811,12 @@ export function NotesNoteDetail({
             setTitleDraft(updated.title);
             titleDraftRef.current = updated.title;
           }
+        } else if (updated) {
+          rebaseCurrentNoteFromEarlierSession(
+            notebookFlag,
+            base.noteId,
+            updated
+          );
         }
         clearDraftStash(notebookFlag, base.noteId, {
           title: titleDraft,
@@ -810,9 +864,9 @@ export function NotesNoteDetail({
       draftBase,
       finishPendingSave,
       isCurrentEditorSession,
-      isCurrentEditorNote,
       notebookFlag,
       preserveScrollOffset,
+      rebaseCurrentNoteFromEarlierSession,
       reportConflict,
       runSave,
       titleDraft,
@@ -936,6 +990,7 @@ export function NotesNoteDetail({
     rememberNotesNoteDraftSnapshot({
       notebookFlag: flag,
       noteId: base.noteId,
+      baseRevision: base.revision,
       title: titleToSave,
       body: bodyToSave,
       isDirty: true,
@@ -956,10 +1011,7 @@ export function NotesNoteDetail({
         // No-ops after unmount; while mounted (background flush) rebase so
         // the next cycle doesn't re-send a stale revision.
         const currentSession = isCurrentEditorSession(session);
-        const currentNoteDraftIsReady =
-          isCurrentEditorNote(flag, base.noteId) &&
-          draftSessionRef.current === editorSessionRef.current;
-        if (updated && (currentSession || currentNoteDraftIsReady)) {
+        if (updated && currentSession) {
           setDraftBase(updated);
           // Same untouched-title rebase as the foreground save path: a
           // remote rename carried back by the payload must not leave the
@@ -973,6 +1025,8 @@ export function NotesNoteDetail({
             setTitleDraft(updated.title);
             titleDraftRef.current = updated.title;
           }
+        } else if (updated) {
+          rebaseCurrentNoteFromEarlierSession(flag, base.noteId, updated);
         }
         if (isCurrentEditorSession(session)) {
           setSaveState('saved');
@@ -1005,8 +1059,8 @@ export function NotesNoteDetail({
     clearConflict,
     finishPendingSave,
     isCurrentEditorSession,
-    isCurrentEditorNote,
     preserveScrollOffset,
+    rebaseCurrentNoteFromEarlierSession,
     reportConflict,
     runSave,
   ]);
@@ -1027,12 +1081,16 @@ export function NotesNoteDetail({
     return () => subscription.remove();
   }, [flushPendingSave]);
 
-  // Guard so the stash restore below runs once per loaded note revision.
+  // Guard so the stash restore below runs once per editor visit + loaded note
+  // revision. A single global key is insufficient: A → B → A can revisit the
+  // same revision while A's previous async stash read is still relevant.
   // Without it, any edit that brings the content back to the saved state
   // (type a char, then delete it) flips the editor clean again and the
   // restore effect re-applies the stash — resurrecting the deleted edit
   // and destroying the caret position.
-  const stashRestoreCheckedRef = useRef<string | null>(null);
+  const stashRestoreStartedKeysRef = useRef(
+    new WeakMap<NotesEditorSession, string>()
+  );
   const stashRestoreKey =
     notebookFlag && draftBase
       ? `${draftStashKey(notebookFlag, draftBase.noteId)}/${draftBase.revision}`
@@ -1052,7 +1110,11 @@ export function NotesNoteDetail({
     // the remote work the conflict was protecting.
     if (conflictNote) return;
     if (!isDirty) {
-      if (stashRestoreCheckedRef.current === stashRestoreKey) {
+      const currentSession = editorSessionRef.current;
+      if (
+        draftSessionRef.current === currentSession &&
+        stashRestoreCompletedSessionsRef.current.has(currentSession)
+      ) {
         clearDraftStash(notebookFlag, draftBase.noteId);
       }
       return;
@@ -1081,47 +1143,71 @@ export function NotesNoteDetail({
   // then pushing the restored draft can't clobber anyone's newer work.
   useEffect(() => {
     if (!notebookFlag || !draftBase || isDirty || !stashRestoreKey) return;
-    if (stashRestoreCheckedRef.current === stashRestoreKey) return;
-    stashRestoreCheckedRef.current = stashRestoreKey;
+    const session = draftSessionRef.current;
+    if (session !== editorSessionRef.current) return;
+    if (stashRestoreCompletedSessionsRef.current.has(session)) return;
+    if (stashRestoreStartedKeysRef.current.get(session) === stashRestoreKey) {
+      return;
+    }
+    stashRestoreStartedKeysRef.current.set(session, stashRestoreKey);
+    const deferredBaseRebases = deferredBaseRebasesRef.current;
     let cancelled = false;
     void db.notesNoteDrafts.getValue().then((stashes) => {
       const stash = stashes[draftStashKey(notebookFlag, draftBase.noteId)];
-      if (cancelled || !stash) return;
-      if (stash.baseRevision !== draftBase.revision) {
-        if (
-          stash.title === draftBase.title &&
-          stash.body === draftBase.bodyMd
+      if (cancelled) return;
+      if (stash) {
+        if (stash.baseRevision !== draftBase.revision) {
+          if (
+            stash.title === draftBase.title &&
+            stash.body === draftBase.bodyMd
+          ) {
+            // The stashed content is exactly what the row now holds — the
+            // save landed (e.g. a late flush succeeded). Nothing to recover.
+            clearDraftStash(notebookFlag, draftBase.noteId);
+          } else {
+            // The stashed edits never landed and the note moved on (a flush
+            // hit a conflict and the session ended before recovery could run).
+            // Restoring them as plain drafts would be worse than dropping
+            // them: their base revision is now current, so the next autosave
+            // would silently overwrite the newer remote work. Surface it as
+            // the standing conflict it is — row as "theirs", stash as "mine" —
+            // which also suspends autosave until the user picks a side.
+            setTitleDraft(stash.title);
+            setBodyDraft(stash.body);
+            setConflictNote(draftBase);
+            setError(
+              'This note was changed elsewhere. Your unsaved changes are kept.'
+            );
+            setSaveState('error');
+          }
+        } else if (
+          stash.title !== draftBase.title ||
+          stash.body !== draftBase.bodyMd
         ) {
-          // The stashed content is exactly what the row now holds — the
-          // save landed (e.g. a late flush succeeded). Nothing to recover.
-          clearDraftStash(notebookFlag, draftBase.noteId);
-          return;
+          setTitleDraft(stash.title);
+          setBodyDraft(stash.body);
         }
-        // The stashed edits never landed and the note moved on (a flush
-        // hit a conflict and the session ended before recovery could run).
-        // Restoring them as plain drafts would be worse than dropping
-        // them: their base revision is now current, so the next autosave
-        // would silently overwrite the newer remote work. Surface it as
-        // the standing conflict it is — row as "theirs", stash as "mine" —
-        // which also suspends autosave until the user picks a side.
-        setTitleDraft(stash.title);
-        setBodyDraft(stash.body);
-        setConflictNote(draftBase);
-        setError(
-          'This note was changed elsewhere. Your unsaved changes are kept.'
-        );
-        setSaveState('error');
-        return;
       }
-      if (stash.title !== draftBase.title || stash.body !== draftBase.bodyMd) {
-        setTitleDraft(stash.title);
-        setBodyDraft(stash.body);
+
+      // Mark readiness only after the durable read has been considered. If an
+      // earlier visit saved while this read was pending, advance the base in
+      // the same batch as the restored drafts so neither can cancel the other.
+      stashRestoreCompletedSessionsRef.current.add(session);
+      const deferredBase = deferredBaseRebases.get(session);
+      if (
+        deferredBase &&
+        editorSessionRef.current === session &&
+        draftSessionRef.current === session
+      ) {
+        deferredBaseRebases.delete(session);
+        setDraftBase(deferredBase);
       }
     });
     return () => {
       cancelled = true;
+      deferredBaseRebases.delete(session);
     };
-  }, [draftBase, isDirty, notebookFlag, stashRestoreKey]);
+  }, [draftBase, editorSession, isDirty, notebookFlag, stashRestoreKey]);
 
   const togglePreview = useCallback(() => {
     setPreviewMode(!isPreviewing);

--- a/packages/app/ui/components/NotesChannel/NotesNoteDetail.tsx
+++ b/packages/app/ui/components/NotesChannel/NotesNoteDetail.tsx
@@ -54,6 +54,21 @@ import { trackNotesActionError } from './notesTelemetry';
 import { formatNoteDate, getFolderPath } from './notesTree';
 
 type SaveState = 'idle' | 'dirty' | 'saving' | 'saved' | 'error';
+export type NotesNoteSaveFieldIntent = 'preserve' | 'set';
+
+type NotesNoteQueuedSaveResult = {
+  updated: db.NotesNote | null | undefined;
+  requestedTitle: string;
+  requestedBody: string;
+  titleIntent: NotesNoteSaveFieldIntent;
+  bodyIntent: NotesNoteSaveFieldIntent;
+};
+
+type NotesNoteSaveChain = {
+  promise: Promise<NotesNoteQueuedSaveResult | null>;
+  requestedTitle: string;
+  requestedBody: string;
+};
 
 // Long enough that we don't fire a save on every typing pause; exits are
 // covered by the flush paths and the draft stash either way.
@@ -88,10 +103,25 @@ const notePreviewModes = new Map<string, boolean>();
 const notesNoteDraftSnapshots = new Map<string, NotesNoteDraftSnapshot>();
 const notesNoteDraftSnapshotOwners = new Map<string, NotesNoteDraftOwner>();
 const notesNoteDraftStashOwners = new Map<string, NotesNoteDraftOwner>();
-const notesNoteSaveChains = new Map<string, Promise<db.NotesNote | null>>();
+const notesNoteSaveChains = new Map<string, NotesNoteSaveChain>();
 const pendingNotesNoteSaveCounts = new Map<string, number>();
 const pendingNotesNoteSaveListeners = new Set<() => void>();
 let pendingNotesNoteSaveEpoch = 0;
+
+export function deriveNotesNoteSaveFieldIntent({
+  hasPredecessor,
+  matchesPredecessorRequest,
+  differsFromBase,
+}: {
+  hasPredecessor: boolean;
+  matchesPredecessorRequest: boolean;
+  differsFromBase: boolean;
+}): NotesNoteSaveFieldIntent {
+  if (hasPredecessor) {
+    return matchesPredecessorRequest ? 'preserve' : 'set';
+  }
+  return differsFromBase ? 'set' : 'preserve';
+}
 
 function emitPendingNotesNoteSaveChange() {
   pendingNotesNoteSaveEpoch += 1;
@@ -200,26 +230,42 @@ function clearMatchingNotesNoteDraftSnapshot({
 function rebaseNotesNoteDraftSnapshot(
   notebookFlag: string,
   noteId: number,
-  base: db.NotesNote,
-  savedTitle: string,
-  updated: db.NotesNote
+  result: NotesNoteQueuedSaveResult
 ) {
   const key = draftSnapshotKey(notebookFlag, noteId);
   const snapshot = notesNoteDraftSnapshots.get(key);
   if (!snapshot) return;
 
-  notesNoteDraftSnapshots.set(key, {
+  const nextTitle =
+    result.titleIntent === 'preserve' &&
+    normalizeNotebookNoteTitle(snapshot.title) ===
+      normalizeNotebookNoteTitle(result.requestedTitle)
+      ? result.updated?.title ?? snapshot.title
+      : snapshot.title;
+  const nextBody =
+    result.bodyIntent === 'preserve' && snapshot.body === result.requestedBody
+      ? result.updated?.bodyMd ?? snapshot.body
+      : snapshot.body;
+  const nextSnapshot = {
     ...snapshot,
-    baseRevision: updated.revision,
-    baseTitle: updated.title,
-    baseBody: updated.bodyMd,
-    title:
-      normalizeNotebookNoteTitle(savedTitle) === base.title &&
-      normalizeNotebookNoteTitle(snapshot.title) === base.title
-        ? updated.title
-        : snapshot.title,
+    baseRevision: result.updated?.revision ?? snapshot.baseRevision,
+    baseTitle: result.updated?.title ?? snapshot.baseTitle,
+    baseBody: result.updated?.bodyMd ?? snapshot.baseBody,
+    title: nextTitle,
+    body: nextBody,
+    isDirty: Boolean(
+      result.updated &&
+        (normalizeNotebookNoteTitle(nextTitle) !== result.updated.title ||
+          nextBody !== result.updated.bodyMd)
+    ),
     updatedAt: Date.now(),
-  });
+  };
+  if (!nextSnapshot.isDirty) {
+    notesNoteDraftSnapshots.delete(key);
+    notesNoteDraftSnapshotOwners.delete(key);
+    return;
+  }
+  notesNoteDraftSnapshots.set(key, nextSnapshot);
 }
 
 export function getNotesNoteDraftSnapshot(
@@ -727,24 +773,71 @@ export function NotesNoteDetail({
     (flag: string, base: db.NotesNote, title: string, body: string) => {
       markPendingNotesNoteSave(flag, base.noteId);
       const key = draftSnapshotKey(flag, base.noteId);
-      const previous = notesNoteSaveChains.get(key) ?? Promise.resolve(null);
-      const next = previous
-        .catch(() => null)
-        .then((prevSaved) =>
-          saveNotebookNote({
+      const predecessor = notesNoteSaveChains.get(key) ?? null;
+      // A queued request only reasserts a field when it changes what the
+      // chain already wants. Comparing requested values preserves a remote
+      // authoritative field without mistaking a revert of our own pending
+      // edit for an untouched field.
+      const titleIntent = deriveNotesNoteSaveFieldIntent({
+        hasPredecessor: predecessor !== null,
+        matchesPredecessorRequest: Boolean(
+          predecessor &&
+            normalizeNotebookNoteTitle(title) ===
+              normalizeNotebookNoteTitle(predecessor.requestedTitle)
+        ),
+        differsFromBase: normalizeNotebookNoteTitle(title) !== base.title,
+      });
+      const bodyIntent = deriveNotesNoteSaveFieldIntent({
+        hasPredecessor: predecessor !== null,
+        matchesPredecessorRequest: Boolean(
+          predecessor && body === predecessor.requestedBody
+        ),
+        differsFromBase: body !== base.bodyMd,
+      });
+
+      const next = (predecessor?.promise ?? Promise.resolve(null)).then(
+        (previousResult) => {
+          const prevSaved = previousResult?.updated;
+          const authoritativeBase =
+            prevSaved && prevSaved.id === base.id ? prevSaved : null;
+          const effectiveTitle =
+            titleIntent === 'preserve' && authoritativeBase
+              ? authoritativeBase.title
+              : title;
+          const effectiveBody =
+            bodyIntent === 'preserve' && authoritativeBase
+              ? authoritativeBase.bodyMd
+              : body;
+          return saveNotebookNote({
             notebookFlag: flag,
-            note: prevSaved && prevSaved.id === base.id ? prevSaved : base,
-            title,
-            body,
-          })
-        );
+            note: authoritativeBase ?? base,
+            title: effectiveTitle,
+            body: effectiveBody,
+          }).then((updated) => ({
+            updated,
+            requestedTitle: title,
+            requestedBody: body,
+            titleIntent,
+            bodyIntent,
+          }));
+        }
+      );
       const settled = next.then(
-        (updated) => updated ?? null,
+        (result) => result,
         () => null
       );
-      notesNoteSaveChains.set(key, settled);
+      const chain: NotesNoteSaveChain = {
+        promise: settled,
+        // Keep the request rather than the effective payload: the next
+        // request should describe a new desired state relative to what this
+        // request asked for, even when this one preserved an authoritative
+        // value from its predecessor.
+        requestedTitle: title,
+        requestedBody: body,
+      };
+      notesNoteSaveChains.set(key, chain);
       void settled.then(() => {
-        if (notesNoteSaveChains.get(key) === settled) {
+        if (notesNoteSaveChains.get(key) === chain) {
           notesNoteSaveChains.delete(key);
         }
       });
@@ -810,39 +903,48 @@ export function NotesNoteDetail({
     ({
       flag,
       base,
-      title,
-      body,
-      updated,
+      result,
     }: {
       flag: string;
       base: db.NotesNote;
-      title: string;
-      body: string;
-      updated: db.NotesNote | null | undefined;
+      result: NotesNoteQueuedSaveResult;
     }) => {
-      clearDraftStash(flag, base.noteId, { title, body });
+      clearDraftStash(flag, base.noteId, {
+        title: result.requestedTitle,
+        body: result.requestedBody,
+      });
       clearMatchingNotesNoteDraftSnapshot({
         notebookFlag: flag,
         noteId: base.noteId,
-        title,
-        body,
+        title: result.requestedTitle,
+        body: result.requestedBody,
       });
-      if (updated) {
-        rebaseNotesNoteDraftSnapshot(flag, base.noteId, base, title, updated);
+      if (result.updated) {
+        rebaseNotesNoteDraftSnapshot(flag, base.noteId, result);
       }
-      if (!updated || !isCurrentNote(flag, base.noteId)) return;
+      if (!result.updated || !isCurrentNote(flag, base.noteId)) return;
 
-      // Same-note completions advance the base without replacing newer
-      // drafts. Adopt an authoritative title when the current draft has no
-      // semantic rename relative to the base that was saved.
-      setDraftBase(updated);
+      // Same-note completions advance the base without replacing edits made
+      // after this request was captured. Untouched fields adopt the
+      // authoritative result, including concurrent changes returned by the
+      // preceding save in the queue.
+      setDraftBase(result.updated);
       if (
-        normalizeNotebookNoteTitle(title) === base.title &&
-        normalizeNotebookNoteTitle(titleDraftRef.current) === base.title &&
-        updated.title !== titleDraftRef.current
+        result.titleIntent === 'preserve' &&
+        normalizeNotebookNoteTitle(titleDraftRef.current) ===
+          normalizeNotebookNoteTitle(result.requestedTitle) &&
+        result.updated.title !== titleDraftRef.current
       ) {
-        setTitleDraft(updated.title);
-        titleDraftRef.current = updated.title;
+        setTitleDraft(result.updated.title);
+        titleDraftRef.current = result.updated.title;
+      }
+      if (
+        result.bodyIntent === 'preserve' &&
+        bodyDraftRef.current === result.requestedBody &&
+        result.updated.bodyMd !== bodyDraftRef.current
+      ) {
+        setBodyDraft(result.updated.bodyMd);
+        bodyDraftRef.current = result.updated.bodyMd;
       }
       setSaveState('saved');
       clearConflict(flag, base.noteId);
@@ -877,7 +979,7 @@ export function NotesNoteDetail({
         draftOwnerRef.current
       );
       try {
-        const updated = await runSave(
+        const result = await runSave(
           notebookFlag,
           base,
           titleDraft,
@@ -886,9 +988,7 @@ export function NotesNoteDetail({
         handleSuccessfulSave({
           flag: notebookFlag,
           base,
-          title: titleDraft,
-          body: bodyToSave,
-          updated,
+          result,
         });
         return true;
       } catch (e) {
@@ -1055,13 +1155,11 @@ export function NotesNoteDetail({
       draftOwnerRef.current
     );
     runSave(flag, base, titleToSave, bodyToSave)
-      .then((updated) => {
+      .then((result) => {
         handleSuccessfulSave({
           flag,
           base,
-          title: titleToSave,
-          body: bodyToSave,
-          updated,
+          result,
         });
       })
       .catch((e) => {

--- a/packages/app/ui/components/NotesChannel/NotesNoteDetail.tsx
+++ b/packages/app/ui/components/NotesChannel/NotesNoteDetail.tsx
@@ -54,6 +54,7 @@ import { trackNotesActionError } from './notesTelemetry';
 import { formatNoteDate, getFolderPath } from './notesTree';
 
 type SaveState = 'idle' | 'dirty' | 'saving' | 'saved' | 'error';
+type NotesEditorSession = { key: string | null };
 
 // Long enough that we don't fire a save on every typing pause; exits are
 // covered by the flush paths and the draft stash either way.
@@ -262,6 +263,30 @@ export function NotesNoteDetail({
   );
   const titleDraftRef = useRef(titleDraft);
   const bodyDraftRef = useRef(bodyDraft);
+  // A note can be selected, left, and selected again while an earlier save is
+  // still in flight. Give each visit its own identity so that a completion
+  // from the first visit cannot rebase the later editor session, even when
+  // both visits point at the same note id.
+  const editorSessionKey =
+    notebookFlag && noteId !== null
+      ? draftStashKey(notebookFlag, noteId)
+      : null;
+  const editorSession = useMemo<NotesEditorSession>(
+    () => ({ key: editorSessionKey }),
+    [editorSessionKey]
+  );
+  const editorSessionRef = useRef(editorSession);
+  useLayoutEffect(() => {
+    editorSessionRef.current = editorSession;
+  }, [editorSession]);
+  // The selected note changes one render before the draft base and draft refs
+  // catch up. Keep the session attached to the base so a selection-change
+  // cleanup still captures the session that owns those drafts.
+  const draftSessionRef = useRef(editorSession);
+  const isCurrentEditorSession = useCallback(
+    (session: NotesEditorSession) => editorSessionRef.current === session,
+    []
+  );
   const titleInputRef = useRef<TextInputRef>(null);
   const autoFocusedTitleNoteIdRef = useRef<string | null>(null);
   const bodyInputRef = useRef<ElementRef<typeof TextArea>>(null);
@@ -554,12 +579,21 @@ export function NotesNoteDetail({
     flag: string | null | undefined;
     base: db.NotesNote | null;
     canEdit: boolean;
+    session: NotesEditorSession;
   } | null>(null);
   useEffect(() => {
+    if (
+      notebookFlag &&
+      draftBase &&
+      draftStashKey(notebookFlag, draftBase.noteId) === editorSessionKey
+    ) {
+      draftSessionRef.current = editorSession;
+    }
     flushCtxRef.current = {
       flag: notebookFlag,
       base: draftBase,
       canEdit,
+      session: draftSessionRef.current,
     };
   });
 
@@ -603,6 +637,7 @@ export function NotesNoteDetail({
     async (baseOverride?: db.NotesNote) => {
       const base = baseOverride ?? draftBase;
       if (!notebookFlag || !base || !canEdit) return false;
+      const session = draftSessionRef.current;
       const bodyToSave = bodyDraftRef.current;
       const dirty =
         normalizeNotebookNoteTitle(titleDraft) !== base.title ||
@@ -628,7 +663,7 @@ export function NotesNoteDetail({
         );
         // Rebase onto the saved revision; keystrokes typed during the save
         // leave the drafts dirty against it, so the next cycle saves them.
-        if (updated) {
+        if (updated && isCurrentEditorSession(session)) {
           setDraftBase(updated);
           // A save we did NOT rename in can come back with a different
           // title: another client renamed, and the response payload's
@@ -657,15 +692,20 @@ export function NotesNoteDetail({
           title: titleDraft,
           body: bodyToSave,
         });
-        setSaveState('saved');
-        clearConflict(notebookFlag, base.noteId);
+        if (isCurrentEditorSession(session)) {
+          setSaveState('saved');
+          clearConflict(notebookFlag, base.noteId);
+        }
         return true;
       } catch (e) {
         const message = errorMessage(e, 'Failed to save note');
         trackNotesActionError('save note', e, message, {
           noteId: base.noteId,
         });
-        if (e instanceof NotesNoteConflictError) {
+        if (
+          e instanceof NotesNoteConflictError &&
+          isCurrentEditorSession(session)
+        ) {
           reportConflict(notebookFlag, e);
           return false;
         }
@@ -673,8 +713,7 @@ export function NotesNoteDetail({
         // an autosave that rejects after the user switched notes must not
         // mark the newly-selected note as failed. (reportConflict applies
         // the same guard for conflicts.)
-        const ctx = flushCtxRef.current;
-        if (ctx?.flag === notebookFlag && ctx.base?.noteId === base.noteId) {
+        if (isCurrentEditorSession(session)) {
           setSaveState('error');
           setError(message);
         }
@@ -685,6 +724,7 @@ export function NotesNoteDetail({
       canEdit,
       clearConflict,
       draftBase,
+      isCurrentEditorSession,
       notebookFlag,
       preserveScrollOffset,
       reportConflict,
@@ -755,7 +795,12 @@ export function NotesNoteDetail({
     // very content the user just chose to throw away.
     titleDraftRef.current = adopted.title;
     bodyDraftRef.current = adopted.bodyMd;
-    flushCtxRef.current = { flag: notebookFlag, base: adopted, canEdit };
+    flushCtxRef.current = {
+      flag: notebookFlag,
+      base: adopted,
+      canEdit,
+      session: draftSessionRef.current,
+    };
     // Persist the host's copy locally so the reactive row catches up with
     // the adoption instead of reloading the stale pre-conflict content
     // over it. (The draft-loading effect also skips rows that trail the
@@ -800,7 +845,7 @@ export function NotesNoteDetail({
       normalizeNotebookNoteTitle(titleToSave) !== ctx.base.title ||
       bodyToSave !== ctx.base.bodyMd;
     if (!dirty) return;
-    const { flag, base } = ctx;
+    const { flag, base, session } = ctx;
     preserveScrollOffset();
     rememberNotesNoteDraftSnapshot({
       notebookFlag: flag,
@@ -824,7 +869,7 @@ export function NotesNoteDetail({
         });
         // No-ops after unmount; while mounted (background flush) rebase so
         // the next cycle doesn't re-send a stale revision.
-        if (updated) {
+        if (updated && isCurrentEditorSession(session)) {
           setDraftBase(updated);
           // Same untouched-title rebase as the foreground save path: a
           // remote rename carried back by the payload must not leave the
@@ -838,14 +883,19 @@ export function NotesNoteDetail({
             titleDraftRef.current = updated.title;
           }
         }
-        setSaveState('saved');
-        clearConflict(flag, base.noteId);
+        if (isCurrentEditorSession(session)) {
+          setSaveState('saved');
+          clearConflict(flag, base.noteId);
+        }
       })
       .catch((e) => {
         // No-ops after unmount; while mounted, surface a conflict so the
         // resolution banner appears instead of a silently-failed flush.
         // reportConflict drops it if the selection has since moved on.
-        if (e instanceof NotesNoteConflictError) {
+        if (
+          e instanceof NotesNoteConflictError &&
+          isCurrentEditorSession(session)
+        ) {
           reportConflict(flag, e);
           return;
         }
@@ -854,13 +904,18 @@ export function NotesNoteDetail({
         // is still in the editor, show the error so autosave/user retries.
         // After unmount the durable stash carries the edits, and the
         // stash-restore pass surfaces a conflict if the note moved on.
-        const ctx = flushCtxRef.current;
-        if (ctx?.flag === flag && ctx.base?.noteId === base.noteId) {
+        if (isCurrentEditorSession(session)) {
           setSaveState('error');
           setError(errorMessage(e, 'Failed to save note'));
         }
       });
-  }, [clearConflict, preserveScrollOffset, reportConflict, runSave]);
+  }, [
+    clearConflict,
+    isCurrentEditorSession,
+    preserveScrollOffset,
+    reportConflict,
+    runSave,
+  ]);
 
   // Flush unsaved work when switching notes or unmounting — the poke
   // outlives the component.

--- a/packages/app/ui/components/NotesChannel/NotesNoteDetail.tsx
+++ b/packages/app/ui/components/NotesChannel/NotesNoteDetail.tsx
@@ -54,7 +54,6 @@ import { trackNotesActionError } from './notesTelemetry';
 import { formatNoteDate, getFolderPath } from './notesTree';
 
 type SaveState = 'idle' | 'dirty' | 'saving' | 'saved' | 'error';
-type NotesEditorSession = { key: string | null };
 
 // Long enough that we don't fire a save on every typing pause; exits are
 // covered by the flush paths and the draft stash either way.
@@ -74,6 +73,7 @@ export type NotesNoteDraftSnapshot = {
   title: string;
   body: string;
   isDirty: boolean;
+  titleTouched: boolean;
   updatedAt: number;
 };
 
@@ -83,6 +83,54 @@ const draftSnapshotKey = (notebookFlag: string, noteId: number) =>
   `${notebookFlag}/${noteId}`;
 const notePreviewModes = new Map<string, boolean>();
 const notesNoteDraftSnapshots = new Map<string, NotesNoteDraftSnapshot>();
+const pendingNotesNoteSaveCounts = new Map<string, number>();
+const pendingNotesNoteSaveListeners = new Set<() => void>();
+let pendingNotesNoteSaveEpoch = 0;
+
+function emitPendingNotesNoteSaveChange() {
+  pendingNotesNoteSaveEpoch += 1;
+  pendingNotesNoteSaveListeners.forEach((listener) => listener());
+}
+
+function subscribeToPendingNotesNoteSaves(listener: () => void) {
+  pendingNotesNoteSaveListeners.add(listener);
+  return () => pendingNotesNoteSaveListeners.delete(listener);
+}
+
+function getPendingNotesNoteSaveEpoch() {
+  return pendingNotesNoteSaveEpoch;
+}
+
+function hasPendingNotesNoteSave(notebookFlag: string, noteId: number) {
+  return (
+    (pendingNotesNoteSaveCounts.get(draftSnapshotKey(notebookFlag, noteId)) ??
+      0) > 0
+  );
+}
+
+function markPendingNotesNoteSave(notebookFlag: string, noteId: number) {
+  const key = draftSnapshotKey(notebookFlag, noteId);
+  pendingNotesNoteSaveCounts.set(
+    key,
+    (pendingNotesNoteSaveCounts.get(key) ?? 0) + 1
+  );
+  emitPendingNotesNoteSaveChange();
+}
+
+function finishPendingNotesNoteSave(notebookFlag: string, noteId: number) {
+  const key = draftSnapshotKey(notebookFlag, noteId);
+  const snapshot = notesNoteDraftSnapshots.get(key);
+  if (snapshot) {
+    notesNoteDraftSnapshots.set(key, { ...snapshot, updatedAt: Date.now() });
+  }
+  const remaining = (pendingNotesNoteSaveCounts.get(key) ?? 1) - 1;
+  if (remaining > 0) {
+    pendingNotesNoteSaveCounts.set(key, remaining);
+  } else {
+    pendingNotesNoteSaveCounts.delete(key);
+  }
+  emitPendingNotesNoteSaveChange();
+}
 
 function rememberNotesNoteDraftSnapshot(snapshot: NotesNoteDraftSnapshot) {
   notesNoteDraftSnapshots.set(
@@ -115,6 +163,23 @@ function clearMatchingNotesNoteDraftSnapshot({
   notesNoteDraftSnapshots.delete(key);
 }
 
+function rebaseNotesNoteDraftSnapshot(
+  notebookFlag: string,
+  noteId: number,
+  updated: db.NotesNote
+) {
+  const key = draftSnapshotKey(notebookFlag, noteId);
+  const snapshot = notesNoteDraftSnapshots.get(key);
+  if (!snapshot) return;
+
+  notesNoteDraftSnapshots.set(key, {
+    ...snapshot,
+    baseRevision: updated.revision,
+    title: snapshot.titleTouched ? snapshot.title : updated.title,
+    updatedAt: Date.now(),
+  });
+}
+
 export function getNotesNoteDraftSnapshot(
   notebookFlag: string,
   noteId: number
@@ -122,7 +187,10 @@ export function getNotesNoteDraftSnapshot(
   const key = draftSnapshotKey(notebookFlag, noteId);
   const snapshot = notesNoteDraftSnapshots.get(key);
   if (!snapshot) return null;
-  if (Date.now() - snapshot.updatedAt > DRAFT_SNAPSHOT_TTL_MS) {
+  if (
+    !hasPendingNotesNoteSave(notebookFlag, noteId) &&
+    Date.now() - snapshot.updatedAt > DRAFT_SNAPSHOT_TTL_MS
+  ) {
     notesNoteDraftSnapshots.delete(key);
     return null;
   }
@@ -250,7 +318,11 @@ export function NotesNoteDetail({
   const [bodyInputWidth, setBodyInputWidth] = useState(0);
   const [saveState, setSaveState] = useState<SaveState>('idle');
   const [error, setError] = useState<string | null>(null);
-  const [pendingSaveEpoch, setPendingSaveEpoch] = useState(0);
+  useSyncExternalStore(
+    subscribeToPendingNotesNoteSaves,
+    getPendingNotesNoteSaveEpoch,
+    getPendingNotesNoteSaveEpoch
+  );
   // The host's copy of the note after a save hit a genuine revision
   // conflict. While set, autosave is suspended and the banner offers the
   // user the resolution (keep mine / use theirs) — a blind retry can never
@@ -265,104 +337,17 @@ export function NotesNoteDetail({
   );
   const titleDraftRef = useRef(titleDraft);
   const bodyDraftRef = useRef(bodyDraft);
-  // A note can be selected, left, and selected again while an earlier save is
-  // still in flight. Give each visit its own identity so that a completion
-  // from the first visit cannot rebase the later editor session, even when
-  // both visits point at the same note id.
-  const editorSessionKey =
+  const selectedNoteKey =
     notebookFlag && noteId !== null
-      ? draftStashKey(notebookFlag, noteId)
+      ? draftSnapshotKey(notebookFlag, noteId)
       : null;
-  const editorSession = useMemo<NotesEditorSession>(
-    () => ({ key: editorSessionKey }),
-    [editorSessionKey]
-  );
-  const editorSessionRef = useRef(editorSession);
+  const selectedNoteKeyRef = useRef(selectedNoteKey);
+  const titleTouchedRef = useRef(false);
   useLayoutEffect(() => {
-    editorSessionRef.current = editorSession;
-  }, [editorSession]);
-  // The selected note changes one render before the draft base and draft refs
-  // catch up. Keep the session attached to the base so a selection-change
-  // cleanup still captures the session that owns those drafts.
-  const draftSessionRef = useRef(editorSession);
-  const isCurrentEditorSession = useCallback(
-    (session: NotesEditorSession) => editorSessionRef.current === session,
-    []
-  );
-  const pendingSaveSessionsRef = useRef(
-    new Map<string, Map<NotesEditorSession, number>>()
-  );
-  const stashRestoreCompletedSessionsRef = useRef(
-    new WeakSet<NotesEditorSession>()
-  );
-  const deferredBaseRebasesRef = useRef(
-    new Map<NotesEditorSession, db.NotesNote>()
-  );
-  const markPendingSave = useCallback(
-    (flag: string, targetNoteId: number, session: NotesEditorSession) => {
-      const key = draftStashKey(flag, targetNoteId);
-      const sessions = pendingSaveSessionsRef.current.get(key) ?? new Map();
-      sessions.set(session, (sessions.get(session) ?? 0) + 1);
-      pendingSaveSessionsRef.current.set(key, sessions);
-    },
-    []
-  );
-  const finishPendingSave = useCallback(
-    (flag: string, targetNoteId: number, session: NotesEditorSession) => {
-      const key = draftStashKey(flag, targetNoteId);
-      const sessions = pendingSaveSessionsRef.current.get(key);
-      if (!sessions) return;
-      const remaining = (sessions.get(session) ?? 0) - 1;
-      if (remaining > 0) {
-        sessions.set(session, remaining);
-      } else {
-        sessions.delete(session);
-      }
-      if (sessions.size === 0) {
-        pendingSaveSessionsRef.current.delete(key);
-      }
-      // Pending saves live in a ref so queue bookkeeping itself does not
-      // perturb the editor. Settlement is different: row adoption may have
-      // skipped an already-received row while this save was pending, so wake
-      // the current note and let that effect reconsider it.
-      if (editorSessionRef.current.key === key) {
-        setPendingSaveEpoch((epoch) => epoch + 1);
-      }
-    },
-    []
-  );
-  const hasPendingSaveFromEarlierSession = useCallback(
-    (flag: string, targetNoteId: number) => {
-      const sessions = pendingSaveSessionsRef.current.get(
-        draftStashKey(flag, targetNoteId)
-      );
-      if (!sessions) return false;
-      const currentSession = editorSessionRef.current;
-      return Array.from(sessions).some(
-        ([session, count]) => session !== currentSession && count > 0
-      );
-    },
-    []
-  );
-  const rebaseCurrentNoteFromEarlierSession = useCallback(
-    (flag: string, targetNoteId: number, updated: db.NotesNote) => {
-      const currentSession = editorSessionRef.current;
-      if (currentSession.key !== draftStashKey(flag, targetNoteId)) return;
-      if (
-        draftSessionRef.current === currentSession &&
-        stashRestoreCompletedSessionsRef.current.has(currentSession)
-      ) {
-        setDraftBase(updated);
-        return;
-      }
-      // The reopened note has not finished consulting its durable stash yet.
-      // Hold only the new base revision; once restoration finishes, applying
-      // it alongside the restored/current drafts makes their true dirtiness
-      // visible without replacing them.
-      deferredBaseRebasesRef.current.set(currentSession, updated);
-    },
-    []
-  );
+    if (selectedNoteKeyRef.current === selectedNoteKey) return;
+    selectedNoteKeyRef.current = selectedNoteKey;
+    titleTouchedRef.current = false;
+  }, [selectedNoteKey]);
   const titleInputRef = useRef<TextInputRef>(null);
   const autoFocusedTitleNoteIdRef = useRef<string | null>(null);
   const bodyInputRef = useRef<ElementRef<typeof TextArea>>(null);
@@ -396,6 +381,16 @@ export function NotesNoteDetail({
       ? null
       : notes.find((note) => note.noteId === noteId) ?? null;
   const selectedNoteRowId = selectedNote?.id ?? null;
+  const selectedNoteSavePending = Boolean(
+    notebookFlag &&
+      selectedNote &&
+      hasPendingNotesNoteSave(notebookFlag, selectedNote.noteId)
+  );
+  const isCurrentNote = useCallback(
+    (flag: string, targetNoteId: number) =>
+      selectedNoteKeyRef.current === draftSnapshotKey(flag, targetNoteId),
+    []
+  );
 
   useEffect(() => {
     if (selectedNoteRowId !== null) {
@@ -497,10 +492,11 @@ export function NotesNoteDetail({
         title: titleDraft,
         body,
         isDirty: dirty,
+        titleTouched: titleTouchedRef.current,
         updatedAt: Date.now(),
       };
 
-      if (dirty) {
+      if (dirty || selectedNoteSavePending) {
         rememberNotesNoteDraftSnapshot(snapshot);
       } else {
         clearNotesNoteDraftSnapshot(notebookFlag, selectedNote.noteId);
@@ -513,6 +509,7 @@ export function NotesNoteDetail({
       notebookFlag,
       onDraftChange,
       selectedNote,
+      selectedNoteSavePending,
       titleDraft,
     ]
   );
@@ -558,7 +555,7 @@ export function NotesNoteDetail({
   // was in flight. A remote edit that lands while dirty keeps the stale base
   // revision, so the next save fails the revision check instead of silently
   // overwriting the remote work.
-  useEffect(() => {
+  useLayoutEffect(() => {
     const sameNote = (selectedNote?.id ?? null) === (draftBase?.id ?? null);
     // Never adopt a row that trails the base's revision: right after a save
     // or a conflict resolution the reactive row lags the persisted write by
@@ -569,62 +566,51 @@ export function NotesNoteDetail({
       selectedNote != null &&
       draftBase != null &&
       selectedNote.revision < draftBase.revision;
-    // A save from an earlier visit can update the reactive row while the
-    // current visit is clean against its old base. Do not adopt that row into
-    // the current drafts: the save completion advances only the base below,
-    // making an explicit revert dirty and therefore eligible for its own save.
-    const earlierVisitSavePending =
-      sameNote &&
-      notebookFlag != null &&
-      selectedNote != null &&
-      hasPendingSaveFromEarlierSession(notebookFlag, selectedNote.noteId);
-    const earlierVisitRebaseDeferred =
-      sameNote && deferredBaseRebasesRef.current.has(editorSessionRef.current);
     if (
       sameNote &&
       (isDirty ||
         selectedNote === draftBase ||
         rowTrailsBase ||
-        earlierVisitSavePending ||
-        earlierVisitRebaseDeferred)
+        selectedNoteSavePending ||
+        conflictNote)
     ) {
       return;
     }
     if (sameNote) {
       preserveScrollOffset();
     }
-    const inMemoryDraft =
+    const snapshot =
       !sameNote && notebookFlag && selectedNote
         ? getNotesNoteDraftSnapshot(notebookFlag, selectedNote.noteId)
         : null;
-    const canRestoreInMemoryDraft =
-      inMemoryDraft?.baseRevision === selectedNote?.revision;
-    if (canRestoreInMemoryDraft && inMemoryDraft && selectedNote) {
-      const currentSession = editorSessionRef.current;
-      stashRestoreCompletedSessionsRef.current.add(currentSession);
-      const deferredBase = deferredBaseRebasesRef.current.get(currentSession);
-      deferredBaseRebasesRef.current.delete(currentSession);
-      setDraftBase(deferredBase ?? selectedNote);
-      setTitleDraft(inMemoryDraft.title);
-      setBodyDraft(inMemoryDraft.body);
-    } else {
-      setDraftBase(selectedNote ?? null);
-      setTitleDraft(selectedNote?.title ?? '');
-      setBodyDraft(selectedNote?.bodyMd ?? '');
-    }
+    const restoreSnapshot = Boolean(
+      snapshot &&
+        selectedNote &&
+        (snapshot.baseRevision === selectedNote.revision ||
+          selectedNoteSavePending)
+    );
+    setDraftBase(selectedNote ?? null);
+    setTitleDraft(
+      restoreSnapshot && snapshot ? snapshot.title : selectedNote?.title ?? ''
+    );
+    setBodyDraft(
+      restoreSnapshot && snapshot ? snapshot.body : selectedNote?.bodyMd ?? ''
+    );
+    titleTouchedRef.current =
+      restoreSnapshot && snapshot ? snapshot.titleTouched : false;
     if (!sameNote) {
       setSaveState('idle');
       setError(null);
       setConflictNote(null);
     }
   }, [
+    conflictNote,
     draftBase,
-    hasPendingSaveFromEarlierSession,
     isDirty,
     notebookFlag,
-    pendingSaveEpoch,
     preserveScrollOffset,
     selectedNote,
+    selectedNoteSavePending,
   ]);
 
   useEffect(() => {
@@ -670,14 +656,8 @@ export function NotesNoteDetail({
     Promise.resolve(null)
   );
   const runSave = useCallback(
-    (
-      flag: string,
-      base: db.NotesNote,
-      title: string,
-      body: string,
-      session: NotesEditorSession
-    ) => {
-      markPendingSave(flag, base.noteId, session);
+    (flag: string, base: db.NotesNote, title: string, body: string) => {
+      markPendingNotesNoteSave(flag, base.noteId);
       const next = saveChainRef.current
         .catch(() => null)
         .then((prevSaved) =>
@@ -694,8 +674,11 @@ export function NotesNoteDetail({
       );
       return next;
     },
-    [markPendingSave]
+    []
   );
+  const finishSave = useCallback((flag: string, targetNoteId: number) => {
+    finishPendingNotesNoteSave(flag, targetNoteId);
+  }, []);
 
   // Save target for flushes that run outside the React data flow (unmount
   // cleanup, AppState changes). Synced in an effect so a selection-change
@@ -705,21 +688,14 @@ export function NotesNoteDetail({
     flag: string | null | undefined;
     base: db.NotesNote | null;
     canEdit: boolean;
-    session: NotesEditorSession;
+    titleTouched: boolean;
   } | null>(null);
   useEffect(() => {
-    if (
-      notebookFlag &&
-      draftBase &&
-      draftStashKey(notebookFlag, draftBase.noteId) === editorSessionKey
-    ) {
-      draftSessionRef.current = editorSession;
-    }
     flushCtxRef.current = {
       flag: notebookFlag,
       base: draftBase,
       canEdit,
-      session: draftSessionRef.current,
+      titleTouched: titleTouchedRef.current,
     };
   });
 
@@ -729,19 +705,14 @@ export function NotesNoteDetail({
   // newly-selected note with the old note's content, so drop it instead.
   const reportConflict = useCallback(
     (flag: string, conflict: NotesNoteConflictError) => {
-      const ctx = flushCtxRef.current;
-      if (
-        !ctx ||
-        ctx.flag !== flag ||
-        ctx.base?.noteId !== conflict.remoteNote.noteId
-      ) {
+      if (!isCurrentNote(flag, conflict.remoteNote.noteId)) {
         return;
       }
       setConflictNote(conflict.remoteNote);
       setError(conflict.message);
       setSaveState('error');
     },
-    []
+    [isCurrentNote]
   );
 
   // Counterpart to reportConflict: a save that SUCCEEDS for the current
@@ -750,20 +721,65 @@ export function NotesNoteDetail({
   // resolution) can reject and re-arm the banner after the resolution
   // cleared it; without this, the banner sticks and autosave stays
   // suspended even though the rebased save landed.
-  const clearConflict = useCallback((flag: string, noteId: number) => {
-    const ctx = flushCtxRef.current;
-    if (!ctx || ctx.flag !== flag || ctx.base?.noteId !== noteId) {
-      return;
-    }
-    setConflictNote(null);
-    setError(null);
-  }, []);
+  const clearConflict = useCallback(
+    (flag: string, noteId: number) => {
+      if (!isCurrentNote(flag, noteId)) {
+        return;
+      }
+      setConflictNote(null);
+      setError(null);
+    },
+    [isCurrentNote]
+  );
+
+  const handleSuccessfulSave = useCallback(
+    ({
+      flag,
+      base,
+      title,
+      body,
+      updated,
+    }: {
+      flag: string;
+      base: db.NotesNote;
+      title: string;
+      body: string;
+      updated: db.NotesNote | null | undefined;
+    }) => {
+      clearDraftStash(flag, base.noteId, { title, body });
+      clearMatchingNotesNoteDraftSnapshot({
+        notebookFlag: flag,
+        noteId: base.noteId,
+        title,
+        body,
+      });
+      if (updated) {
+        rebaseNotesNoteDraftSnapshot(flag, base.noteId, updated);
+      }
+      if (!updated || !isCurrentNote(flag, base.noteId)) return;
+
+      // Same-note completions advance the base without replacing newer
+      // drafts. An authoritative title is adopted only when this visit has
+      // not touched it.
+      setDraftBase(updated);
+      if (!titleTouchedRef.current && updated.title !== titleDraftRef.current) {
+        setTitleDraft(updated.title);
+        titleDraftRef.current = updated.title;
+      } else if (
+        normalizeNotebookNoteTitle(titleDraftRef.current) === updated.title
+      ) {
+        titleTouchedRef.current = false;
+      }
+      setSaveState('saved');
+      clearConflict(flag, base.noteId);
+    },
+    [clearConflict, isCurrentNote]
+  );
 
   const saveSelectedNote = useCallback(
     async (baseOverride?: db.NotesNote) => {
       const base = baseOverride ?? draftBase;
       if (!notebookFlag || !base || !canEdit) return false;
-      const session = draftSessionRef.current;
       const bodyToSave = bodyDraftRef.current;
       const dirty =
         normalizeNotebookNoteTitle(titleDraft) !== base.title ||
@@ -779,6 +795,7 @@ export function NotesNoteDetail({
         title: titleDraft,
         body: bodyToSave,
         isDirty: true,
+        titleTouched: titleTouchedRef.current,
         updatedAt: Date.now(),
       });
       try {
@@ -786,62 +803,22 @@ export function NotesNoteDetail({
           notebookFlag,
           base,
           titleDraft,
-          bodyToSave,
-          session
+          bodyToSave
         );
-        // Rebase onto the saved revision; keystrokes typed during the save
-        // leave the drafts dirty against it, so the next cycle saves them.
-        const currentSession = isCurrentEditorSession(session);
-        if (updated && currentSession) {
-          setDraftBase(updated);
-          // A save we did NOT rename in can come back with a different
-          // title: another client renamed, and the response payload's
-          // authoritative note carried it into `updated`. The untouched
-          // title draft still holds the old title — left alone it reads as
-          // a local edit and the next autosave would rename the host note
-          // BACK, silently undoing the other client's rename. Rebase it,
-          // but only when the user had no rename in flight (title matched
-          // the base going in) and didn't touch it during the save.
-          if (
-            currentSession &&
-            normalizeNotebookNoteTitle(titleDraft) === base.title &&
-            titleDraftRef.current === titleDraft &&
-            updated.title !== titleDraft
-          ) {
-            setTitleDraft(updated.title);
-            titleDraftRef.current = updated.title;
-          }
-        } else if (updated) {
-          rebaseCurrentNoteFromEarlierSession(
-            notebookFlag,
-            base.noteId,
-            updated
-          );
-        }
-        clearDraftStash(notebookFlag, base.noteId, {
+        handleSuccessfulSave({
+          flag: notebookFlag,
+          base,
           title: titleDraft,
           body: bodyToSave,
+          updated,
         });
-        clearMatchingNotesNoteDraftSnapshot({
-          notebookFlag,
-          noteId: base.noteId,
-          title: titleDraft,
-          body: bodyToSave,
-        });
-        if (isCurrentEditorSession(session)) {
-          setSaveState('saved');
-          clearConflict(notebookFlag, base.noteId);
-        }
         return true;
       } catch (e) {
         const message = errorMessage(e, 'Failed to save note');
         trackNotesActionError('save note', e, message, {
           noteId: base.noteId,
         });
-        if (
-          e instanceof NotesNoteConflictError &&
-          isCurrentEditorSession(session)
-        ) {
+        if (e instanceof NotesNoteConflictError) {
           reportConflict(notebookFlag, e);
           return false;
         }
@@ -849,24 +826,23 @@ export function NotesNoteDetail({
         // an autosave that rejects after the user switched notes must not
         // mark the newly-selected note as failed. (reportConflict applies
         // the same guard for conflicts.)
-        if (isCurrentEditorSession(session)) {
+        if (isCurrentNote(notebookFlag, base.noteId)) {
           setSaveState('error');
           setError(message);
         }
         return false;
       } finally {
-        finishPendingSave(notebookFlag, base.noteId, session);
+        finishSave(notebookFlag, base.noteId);
       }
     },
     [
       canEdit,
-      clearConflict,
       draftBase,
-      finishPendingSave,
-      isCurrentEditorSession,
+      finishSave,
+      handleSuccessfulSave,
+      isCurrentNote,
       notebookFlag,
       preserveScrollOffset,
-      rebaseCurrentNoteFromEarlierSession,
       reportConflict,
       runSave,
       titleDraft,
@@ -928,6 +904,7 @@ export function NotesNoteDetail({
     setDraftBase(adopted);
     setTitleDraft(adopted.title);
     setBodyDraft(adopted.bodyMd);
+    titleTouchedRef.current = false;
     // Sync the out-of-band flush inputs in the same tick. The draft refs
     // and flush context normally catch up in post-commit effects; a
     // background/unmount flush firing inside that gap would pair the
@@ -939,7 +916,7 @@ export function NotesNoteDetail({
       flag: notebookFlag,
       base: adopted,
       canEdit,
-      session: draftSessionRef.current,
+      titleTouched: false,
     };
     // Persist the host's copy locally so the reactive row catches up with
     // the adoption instead of reloading the stale pre-conflict content
@@ -985,7 +962,7 @@ export function NotesNoteDetail({
       normalizeNotebookNoteTitle(titleToSave) !== ctx.base.title ||
       bodyToSave !== ctx.base.bodyMd;
     if (!dirty) return;
-    const { flag, base, session } = ctx;
+    const { flag, base, titleTouched } = ctx;
     preserveScrollOffset();
     rememberNotesNoteDraftSnapshot({
       notebookFlag: flag,
@@ -994,53 +971,24 @@ export function NotesNoteDetail({
       title: titleToSave,
       body: bodyToSave,
       isDirty: true,
+      titleTouched,
       updatedAt: Date.now(),
     });
-    runSave(flag, base, titleToSave, bodyToSave, session)
+    runSave(flag, base, titleToSave, bodyToSave)
       .then((updated) => {
-        clearDraftStash(flag, base.noteId, {
+        handleSuccessfulSave({
+          flag,
+          base,
           title: titleToSave,
           body: bodyToSave,
+          updated,
         });
-        clearMatchingNotesNoteDraftSnapshot({
-          notebookFlag: flag,
-          noteId: base.noteId,
-          title: titleToSave,
-          body: bodyToSave,
-        });
-        // No-ops after unmount; while mounted (background flush) rebase so
-        // the next cycle doesn't re-send a stale revision.
-        const currentSession = isCurrentEditorSession(session);
-        if (updated && currentSession) {
-          setDraftBase(updated);
-          // Same untouched-title rebase as the foreground save path: a
-          // remote rename carried back by the payload must not leave the
-          // stale title draft looking like a local edit.
-          if (
-            currentSession &&
-            normalizeNotebookNoteTitle(titleToSave) === base.title &&
-            titleDraftRef.current === titleToSave &&
-            updated.title !== titleToSave
-          ) {
-            setTitleDraft(updated.title);
-            titleDraftRef.current = updated.title;
-          }
-        } else if (updated) {
-          rebaseCurrentNoteFromEarlierSession(flag, base.noteId, updated);
-        }
-        if (isCurrentEditorSession(session)) {
-          setSaveState('saved');
-          clearConflict(flag, base.noteId);
-        }
       })
       .catch((e) => {
         // No-ops after unmount; while mounted, surface a conflict so the
         // resolution banner appears instead of a silently-failed flush.
         // reportConflict drops it if the selection has since moved on.
-        if (
-          e instanceof NotesNoteConflictError &&
-          isCurrentEditorSession(session)
-        ) {
+        if (e instanceof NotesNoteConflictError) {
           reportConflict(flag, e);
           return;
         }
@@ -1049,18 +997,17 @@ export function NotesNoteDetail({
         // is still in the editor, show the error so autosave/user retries.
         // After unmount the durable stash carries the edits, and the
         // stash-restore pass surfaces a conflict if the note moved on.
-        if (isCurrentEditorSession(session)) {
+        if (isCurrentNote(flag, base.noteId)) {
           setSaveState('error');
           setError(errorMessage(e, 'Failed to save note'));
         }
       })
-      .finally(() => finishPendingSave(flag, base.noteId, session));
+      .finally(() => finishSave(flag, base.noteId));
   }, [
-    clearConflict,
-    finishPendingSave,
-    isCurrentEditorSession,
+    finishSave,
+    handleSuccessfulSave,
+    isCurrentNote,
     preserveScrollOffset,
-    rebaseCurrentNoteFromEarlierSession,
     reportConflict,
     runSave,
   ]);
@@ -1081,16 +1028,12 @@ export function NotesNoteDetail({
     return () => subscription.remove();
   }, [flushPendingSave]);
 
-  // Guard so the stash restore below runs once per editor visit + loaded note
-  // revision. A single global key is insufficient: A → B → A can revisit the
-  // same revision while A's previous async stash read is still relevant.
+  // Guard so the stash restore below runs once per loaded note revision.
   // Without it, any edit that brings the content back to the saved state
   // (type a char, then delete it) flips the editor clean again and the
   // restore effect re-applies the stash — resurrecting the deleted edit
   // and destroying the caret position.
-  const stashRestoreStartedKeysRef = useRef(
-    new WeakMap<NotesEditorSession, string>()
-  );
+  const stashRestoreCheckedRef = useRef<string | null>(null);
   const stashRestoreKey =
     notebookFlag && draftBase
       ? `${draftStashKey(notebookFlag, draftBase.noteId)}/${draftBase.revision}`
@@ -1109,12 +1052,8 @@ export function NotesNoteDetail({
     // restore them as ordinary drafts whose autosave silently overwrites
     // the remote work the conflict was protecting.
     if (conflictNote) return;
-    if (!isDirty) {
-      const currentSession = editorSessionRef.current;
-      if (
-        draftSessionRef.current === currentSession &&
-        stashRestoreCompletedSessionsRef.current.has(currentSession)
-      ) {
+    if (!isDirty && !selectedNoteSavePending) {
+      if (stashRestoreCheckedRef.current === stashRestoreKey) {
         clearDraftStash(notebookFlag, draftBase.noteId);
       }
       return;
@@ -1134,6 +1073,7 @@ export function NotesNoteDetail({
     draftBase,
     isDirty,
     notebookFlag,
+    selectedNoteSavePending,
     stashRestoreKey,
     titleDraft,
   ]);
@@ -1142,72 +1082,62 @@ export function NotesNoteDetail({
   // editor is clean and the row is still at the stash's base revision —
   // then pushing the restored draft can't clobber anyone's newer work.
   useEffect(() => {
-    if (!notebookFlag || !draftBase || isDirty || !stashRestoreKey) return;
-    const session = draftSessionRef.current;
-    if (session !== editorSessionRef.current) return;
-    if (stashRestoreCompletedSessionsRef.current.has(session)) return;
-    if (stashRestoreStartedKeysRef.current.get(session) === stashRestoreKey) {
+    if (
+      !notebookFlag ||
+      !draftBase ||
+      isDirty ||
+      selectedNoteSavePending ||
+      !stashRestoreKey
+    ) {
       return;
     }
-    stashRestoreStartedKeysRef.current.set(session, stashRestoreKey);
-    const deferredBaseRebases = deferredBaseRebasesRef.current;
+    if (stashRestoreCheckedRef.current === stashRestoreKey) return;
+    stashRestoreCheckedRef.current = stashRestoreKey;
     let cancelled = false;
     void db.notesNoteDrafts.getValue().then((stashes) => {
       const stash = stashes[draftStashKey(notebookFlag, draftBase.noteId)];
-      if (cancelled) return;
-      if (stash) {
-        if (stash.baseRevision !== draftBase.revision) {
-          if (
-            stash.title === draftBase.title &&
-            stash.body === draftBase.bodyMd
-          ) {
-            // The stashed content is exactly what the row now holds — the
-            // save landed (e.g. a late flush succeeded). Nothing to recover.
-            clearDraftStash(notebookFlag, draftBase.noteId);
-          } else {
-            // The stashed edits never landed and the note moved on (a flush
-            // hit a conflict and the session ended before recovery could run).
-            // Restoring them as plain drafts would be worse than dropping
-            // them: their base revision is now current, so the next autosave
-            // would silently overwrite the newer remote work. Surface it as
-            // the standing conflict it is — row as "theirs", stash as "mine" —
-            // which also suspends autosave until the user picks a side.
-            setTitleDraft(stash.title);
-            setBodyDraft(stash.body);
-            setConflictNote(draftBase);
-            setError(
-              'This note was changed elsewhere. Your unsaved changes are kept.'
-            );
-            setSaveState('error');
-          }
-        } else if (
-          stash.title !== draftBase.title ||
-          stash.body !== draftBase.bodyMd
+      if (cancelled || !stash) return;
+      if (stash.baseRevision !== draftBase.revision) {
+        if (
+          stash.title === draftBase.title &&
+          stash.body === draftBase.bodyMd
         ) {
-          setTitleDraft(stash.title);
-          setBodyDraft(stash.body);
+          // The stashed content is exactly what the row now holds — the
+          // save landed (e.g. a late flush succeeded). Nothing to recover.
+          clearDraftStash(notebookFlag, draftBase.noteId);
+          return;
         }
+        // The stashed edits never landed and the note moved on (a flush
+        // hit a conflict and the session ended before recovery could run).
+        // Restoring them as plain drafts would be worse than dropping
+        // them: their base revision is now current, so the next autosave
+        // would silently overwrite the newer remote work. Surface it as
+        // the standing conflict it is — row as "theirs", stash as "mine" —
+        // which also suspends autosave until the user picks a side.
+        setTitleDraft(stash.title);
+        setBodyDraft(stash.body);
+        setConflictNote(draftBase);
+        setError(
+          'This note was changed elsewhere. Your unsaved changes are kept.'
+        );
+        setSaveState('error');
+        return;
       }
-
-      // Mark readiness only after the durable read has been considered. If an
-      // earlier visit saved while this read was pending, advance the base in
-      // the same batch as the restored drafts so neither can cancel the other.
-      stashRestoreCompletedSessionsRef.current.add(session);
-      const deferredBase = deferredBaseRebases.get(session);
-      if (
-        deferredBase &&
-        editorSessionRef.current === session &&
-        draftSessionRef.current === session
-      ) {
-        deferredBaseRebases.delete(session);
-        setDraftBase(deferredBase);
+      if (stash.title !== draftBase.title || stash.body !== draftBase.bodyMd) {
+        setTitleDraft(stash.title);
+        setBodyDraft(stash.body);
       }
     });
     return () => {
       cancelled = true;
-      deferredBaseRebases.delete(session);
     };
-  }, [draftBase, editorSession, isDirty, notebookFlag, stashRestoreKey]);
+  }, [
+    draftBase,
+    isDirty,
+    notebookFlag,
+    selectedNoteSavePending,
+    stashRestoreKey,
+  ]);
 
   const togglePreview = useCallback(() => {
     setPreviewMode(!isPreviewing);
@@ -1246,6 +1176,10 @@ export function NotesNoteDetail({
   );
 
   const handleTitleDraftChange = useCallback((nextTitle: string) => {
+    titleTouchedRef.current = true;
+    if (flushCtxRef.current) {
+      flushCtxRef.current.titleTouched = true;
+    }
     titleDraftRef.current = nextTitle;
     setTitleDraft(nextTitle);
   }, []);

--- a/packages/app/ui/components/NotesChannel/NotesNoteDetail.tsx
+++ b/packages/app/ui/components/NotesChannel/NotesNoteDetail.tsx
@@ -88,6 +88,7 @@ const notePreviewModes = new Map<string, boolean>();
 const notesNoteDraftSnapshots = new Map<string, NotesNoteDraftSnapshot>();
 const notesNoteDraftSnapshotOwners = new Map<string, NotesNoteDraftOwner>();
 const notesNoteDraftStashOwners = new Map<string, NotesNoteDraftOwner>();
+const notesNoteSaveChains = new Map<string, Promise<db.NotesNote | null>>();
 const pendingNotesNoteSaveCounts = new Map<string, number>();
 const pendingNotesNoteSaveListeners = new Set<() => void>();
 let pendingNotesNoteSaveEpoch = 0;
@@ -720,15 +721,14 @@ export function NotesNoteDetail({
     setPreviewMode,
   ]);
 
-  // All saves go through one chain so each rebases onto the revision the
-  // previous save produced instead of racing the backend revision check.
-  const saveChainRef = useRef<Promise<db.NotesNote | null>>(
-    Promise.resolve(null)
-  );
+  // Saves are queued per note outside the component so unmounting and rapidly
+  // reopening an editor cannot start a concurrent write from the same base.
   const runSave = useCallback(
     (flag: string, base: db.NotesNote, title: string, body: string) => {
       markPendingNotesNoteSave(flag, base.noteId);
-      const next = saveChainRef.current
+      const key = draftSnapshotKey(flag, base.noteId);
+      const previous = notesNoteSaveChains.get(key) ?? Promise.resolve(null);
+      const next = previous
         .catch(() => null)
         .then((prevSaved) =>
           saveNotebookNote({
@@ -738,10 +738,16 @@ export function NotesNoteDetail({
             body,
           })
         );
-      saveChainRef.current = next.then(
+      const settled = next.then(
         (updated) => updated ?? null,
         () => null
       );
+      notesNoteSaveChains.set(key, settled);
+      void settled.then(() => {
+        if (notesNoteSaveChains.get(key) === settled) {
+          notesNoteSaveChains.delete(key);
+        }
+      });
       return next;
     },
     []

--- a/packages/app/ui/components/NotesChannel/NotesNoteDetail.tsx
+++ b/packages/app/ui/components/NotesChannel/NotesNoteDetail.tsx
@@ -70,12 +70,15 @@ export type NotesNoteDraftSnapshot = {
   notebookFlag: string;
   noteId: number;
   baseRevision: number;
+  baseTitle: string;
+  baseBody: string;
   title: string;
   body: string;
   isDirty: boolean;
-  titleTouched: boolean;
   updatedAt: number;
 };
+
+type NotesNoteDraftOwner = object;
 
 const draftStashKey = (notebookFlag: string, noteId: number) =>
   `${notebookFlag}/${noteId}`;
@@ -83,6 +86,8 @@ const draftSnapshotKey = (notebookFlag: string, noteId: number) =>
   `${notebookFlag}/${noteId}`;
 const notePreviewModes = new Map<string, boolean>();
 const notesNoteDraftSnapshots = new Map<string, NotesNoteDraftSnapshot>();
+const notesNoteDraftSnapshotOwners = new Map<string, NotesNoteDraftOwner>();
+const notesNoteDraftStashOwners = new Map<string, NotesNoteDraftOwner>();
 const pendingNotesNoteSaveCounts = new Map<string, number>();
 const pendingNotesNoteSaveListeners = new Set<() => void>();
 let pendingNotesNoteSaveEpoch = 0;
@@ -132,15 +137,42 @@ function finishPendingNotesNoteSave(notebookFlag: string, noteId: number) {
   emitPendingNotesNoteSaveChange();
 }
 
-function rememberNotesNoteDraftSnapshot(snapshot: NotesNoteDraftSnapshot) {
-  notesNoteDraftSnapshots.set(
-    draftSnapshotKey(snapshot.notebookFlag, snapshot.noteId),
-    snapshot
-  );
+function rememberNotesNoteDraftSnapshot(
+  snapshot: NotesNoteDraftSnapshot,
+  owner: NotesNoteDraftOwner
+) {
+  const key = draftSnapshotKey(snapshot.notebookFlag, snapshot.noteId);
+  const existing = notesNoteDraftSnapshots.get(key);
+  if (
+    !snapshot.isDirty &&
+    existing &&
+    notesNoteDraftSnapshotOwners.get(key) !== owner
+  ) {
+    return;
+  }
+  notesNoteDraftSnapshots.set(key, snapshot);
+  notesNoteDraftSnapshotOwners.set(key, owner);
 }
 
-function clearNotesNoteDraftSnapshot(notebookFlag: string, noteId: number) {
-  notesNoteDraftSnapshots.delete(draftSnapshotKey(notebookFlag, noteId));
+function claimNotesNoteDraftRecovery(
+  notebookFlag: string,
+  noteId: number,
+  owner: NotesNoteDraftOwner
+) {
+  const key = draftSnapshotKey(notebookFlag, noteId);
+  notesNoteDraftSnapshotOwners.set(key, owner);
+  notesNoteDraftStashOwners.set(key, owner);
+}
+
+function clearNotesNoteDraftSnapshot(
+  notebookFlag: string,
+  noteId: number,
+  owner?: NotesNoteDraftOwner
+) {
+  const key = draftSnapshotKey(notebookFlag, noteId);
+  if (owner && notesNoteDraftSnapshotOwners.get(key) !== owner) return;
+  notesNoteDraftSnapshots.delete(key);
+  notesNoteDraftSnapshotOwners.delete(key);
 }
 
 function clearMatchingNotesNoteDraftSnapshot({
@@ -161,11 +193,13 @@ function clearMatchingNotesNoteDraftSnapshot({
   }
 
   notesNoteDraftSnapshots.delete(key);
+  notesNoteDraftSnapshotOwners.delete(key);
 }
 
 function rebaseNotesNoteDraftSnapshot(
   notebookFlag: string,
   noteId: number,
+  base: db.NotesNote,
   updated: db.NotesNote
 ) {
   const key = draftSnapshotKey(notebookFlag, noteId);
@@ -175,7 +209,12 @@ function rebaseNotesNoteDraftSnapshot(
   notesNoteDraftSnapshots.set(key, {
     ...snapshot,
     baseRevision: updated.revision,
-    title: snapshot.titleTouched ? snapshot.title : updated.title,
+    baseTitle: updated.title,
+    baseBody: updated.bodyMd,
+    title:
+      normalizeNotebookNoteTitle(snapshot.title) === base.title
+        ? updated.title
+        : snapshot.title,
     updatedAt: Date.now(),
   });
 }
@@ -192,6 +231,7 @@ export function getNotesNoteDraftSnapshot(
     Date.now() - snapshot.updatedAt > DRAFT_SNAPSHOT_TTL_MS
   ) {
     notesNoteDraftSnapshots.delete(key);
+    notesNoteDraftSnapshotOwners.delete(key);
     return null;
   }
   return snapshot;
@@ -272,12 +312,14 @@ function estimateBodyInputHeight(body: string, inputWidth: number) {
 function clearDraftStash(
   notebookFlag: string,
   noteId: number,
-  ifMatches?: { title: string; body: string }
+  ifMatches?: { title: string; body: string },
+  owner?: NotesNoteDraftOwner
 ) {
   void db.notesNoteDrafts.setValue((stashes) => {
     const key = draftStashKey(notebookFlag, noteId);
     const stash = stashes[key];
     if (!stash) return stashes;
+    if (owner && notesNoteDraftStashOwners.get(key) !== owner) return stashes;
     if (
       ifMatches &&
       (stash.title !== ifMatches.title || stash.body !== ifMatches.body)
@@ -286,6 +328,7 @@ function clearDraftStash(
     }
     const next = { ...stashes };
     delete next[key];
+    notesNoteDraftStashOwners.delete(key);
     return next;
   });
 }
@@ -342,11 +385,10 @@ export function NotesNoteDetail({
       ? draftSnapshotKey(notebookFlag, noteId)
       : null;
   const selectedNoteKeyRef = useRef(selectedNoteKey);
-  const titleTouchedRef = useRef(false);
+  const draftOwnerRef = useRef<NotesNoteDraftOwner>({});
   useLayoutEffect(() => {
     if (selectedNoteKeyRef.current === selectedNoteKey) return;
     selectedNoteKeyRef.current = selectedNoteKey;
-    titleTouchedRef.current = false;
   }, [selectedNoteKey]);
   const titleInputRef = useRef<TextInputRef>(null);
   const autoFocusedTitleNoteIdRef = useRef<string | null>(null);
@@ -476,7 +518,11 @@ export function NotesNoteDetail({
         !draftsMatchSelectedNote
       ) {
         if (notebookFlag && selectedNote) {
-          clearNotesNoteDraftSnapshot(notebookFlag, selectedNote.noteId);
+          clearNotesNoteDraftSnapshot(
+            notebookFlag,
+            selectedNote.noteId,
+            draftOwnerRef.current
+          );
         }
         onDraftChange?.(null);
         return;
@@ -489,17 +535,22 @@ export function NotesNoteDetail({
         notebookFlag,
         noteId: selectedNote.noteId,
         baseRevision: draftBase.revision,
+        baseTitle: draftBase.title,
+        baseBody: draftBase.bodyMd,
         title: titleDraft,
         body,
         isDirty: dirty,
-        titleTouched: titleTouchedRef.current,
         updatedAt: Date.now(),
       };
 
       if (dirty || selectedNoteSavePending) {
-        rememberNotesNoteDraftSnapshot(snapshot);
+        rememberNotesNoteDraftSnapshot(snapshot, draftOwnerRef.current);
       } else {
-        clearNotesNoteDraftSnapshot(notebookFlag, selectedNote.noteId);
+        clearNotesNoteDraftSnapshot(
+          notebookFlag,
+          selectedNote.noteId,
+          draftOwnerRef.current
+        );
       }
       onDraftChange?.(snapshot);
     },
@@ -589,15 +640,32 @@ export function NotesNoteDetail({
         (snapshot.baseRevision === selectedNote.revision ||
           selectedNoteSavePending)
     );
-    setDraftBase(selectedNote ?? null);
+    const restoredBase =
+      restoreSnapshot &&
+      snapshot &&
+      selectedNote &&
+      snapshot.baseRevision !== selectedNote.revision
+        ? {
+            ...selectedNote,
+            revision: snapshot.baseRevision,
+            title: snapshot.baseTitle,
+            bodyMd: snapshot.baseBody,
+          }
+        : selectedNote;
+    setDraftBase(restoredBase ?? null);
     setTitleDraft(
       restoreSnapshot && snapshot ? snapshot.title : selectedNote?.title ?? ''
     );
     setBodyDraft(
       restoreSnapshot && snapshot ? snapshot.body : selectedNote?.bodyMd ?? ''
     );
-    titleTouchedRef.current =
-      restoreSnapshot && snapshot ? snapshot.titleTouched : false;
+    if (restoreSnapshot && snapshot && notebookFlag && selectedNote) {
+      claimNotesNoteDraftRecovery(
+        notebookFlag,
+        selectedNote.noteId,
+        draftOwnerRef.current
+      );
+    }
     if (!sameNote) {
       setSaveState('idle');
       setError(null);
@@ -688,14 +756,12 @@ export function NotesNoteDetail({
     flag: string | null | undefined;
     base: db.NotesNote | null;
     canEdit: boolean;
-    titleTouched: boolean;
   } | null>(null);
   useEffect(() => {
     flushCtxRef.current = {
       flag: notebookFlag,
       base: draftBase,
       canEdit,
-      titleTouched: titleTouchedRef.current,
     };
   });
 
@@ -754,21 +820,20 @@ export function NotesNoteDetail({
         body,
       });
       if (updated) {
-        rebaseNotesNoteDraftSnapshot(flag, base.noteId, updated);
+        rebaseNotesNoteDraftSnapshot(flag, base.noteId, base, updated);
       }
       if (!updated || !isCurrentNote(flag, base.noteId)) return;
 
       // Same-note completions advance the base without replacing newer
-      // drafts. An authoritative title is adopted only when this visit has
-      // not touched it.
+      // drafts. Adopt an authoritative title when the current draft has no
+      // semantic rename relative to the base that was saved.
       setDraftBase(updated);
-      if (!titleTouchedRef.current && updated.title !== titleDraftRef.current) {
+      if (
+        normalizeNotebookNoteTitle(titleDraftRef.current) === base.title &&
+        updated.title !== titleDraftRef.current
+      ) {
         setTitleDraft(updated.title);
         titleDraftRef.current = updated.title;
-      } else if (
-        normalizeNotebookNoteTitle(titleDraftRef.current) === updated.title
-      ) {
-        titleTouchedRef.current = false;
       }
       setSaveState('saved');
       clearConflict(flag, base.noteId);
@@ -788,16 +853,20 @@ export function NotesNoteDetail({
       preserveScrollOffset();
       setSaveState('saving');
       setError(null);
-      rememberNotesNoteDraftSnapshot({
-        notebookFlag,
-        noteId: base.noteId,
-        baseRevision: base.revision,
-        title: titleDraft,
-        body: bodyToSave,
-        isDirty: true,
-        titleTouched: titleTouchedRef.current,
-        updatedAt: Date.now(),
-      });
+      rememberNotesNoteDraftSnapshot(
+        {
+          notebookFlag,
+          noteId: base.noteId,
+          baseRevision: base.revision,
+          baseTitle: base.title,
+          baseBody: base.bodyMd,
+          title: titleDraft,
+          body: bodyToSave,
+          isDirty: true,
+          updatedAt: Date.now(),
+        },
+        draftOwnerRef.current
+      );
       try {
         const updated = await runSave(
           notebookFlag,
@@ -904,7 +973,6 @@ export function NotesNoteDetail({
     setDraftBase(adopted);
     setTitleDraft(adopted.title);
     setBodyDraft(adopted.bodyMd);
-    titleTouchedRef.current = false;
     // Sync the out-of-band flush inputs in the same tick. The draft refs
     // and flush context normally catch up in post-commit effects; a
     // background/unmount flush firing inside that gap would pair the
@@ -916,7 +984,6 @@ export function NotesNoteDetail({
       flag: notebookFlag,
       base: adopted,
       canEdit,
-      titleTouched: false,
     };
     // Persist the host's copy locally so the reactive row catches up with
     // the adoption instead of reloading the stale pre-conflict content
@@ -962,18 +1029,22 @@ export function NotesNoteDetail({
       normalizeNotebookNoteTitle(titleToSave) !== ctx.base.title ||
       bodyToSave !== ctx.base.bodyMd;
     if (!dirty) return;
-    const { flag, base, titleTouched } = ctx;
+    const { flag, base } = ctx;
     preserveScrollOffset();
-    rememberNotesNoteDraftSnapshot({
-      notebookFlag: flag,
-      noteId: base.noteId,
-      baseRevision: base.revision,
-      title: titleToSave,
-      body: bodyToSave,
-      isDirty: true,
-      titleTouched,
-      updatedAt: Date.now(),
-    });
+    rememberNotesNoteDraftSnapshot(
+      {
+        notebookFlag: flag,
+        noteId: base.noteId,
+        baseRevision: base.revision,
+        baseTitle: base.title,
+        baseBody: base.bodyMd,
+        title: titleToSave,
+        body: bodyToSave,
+        isDirty: true,
+        updatedAt: Date.now(),
+      },
+      draftOwnerRef.current
+    );
     runSave(flag, base, titleToSave, bodyToSave)
       .then((updated) => {
         handleSuccessfulSave({
@@ -1054,19 +1125,37 @@ export function NotesNoteDetail({
     if (conflictNote) return;
     if (!isDirty && !selectedNoteSavePending) {
       if (stashRestoreCheckedRef.current === stashRestoreKey) {
-        clearDraftStash(notebookFlag, draftBase.noteId);
+        clearDraftStash(
+          notebookFlag,
+          draftBase.noteId,
+          undefined,
+          draftOwnerRef.current
+        );
       }
       return;
     }
-    void db.notesNoteDrafts.setValue((stashes) => ({
-      ...stashes,
-      [draftStashKey(notebookFlag, draftBase.noteId)]: {
-        title: titleDraft,
-        body: bodyDraft,
-        baseRevision: draftBase.revision,
-        stashedAt: Date.now(),
-      },
-    }));
+    const key = draftStashKey(notebookFlag, draftBase.noteId);
+    const owner = draftOwnerRef.current;
+    void db.notesNoteDrafts.setValue((stashes) => {
+      if (
+        !isDirty &&
+        selectedNoteSavePending &&
+        stashes[key] &&
+        notesNoteDraftStashOwners.get(key) !== owner
+      ) {
+        return stashes;
+      }
+      notesNoteDraftStashOwners.set(key, owner);
+      return {
+        ...stashes,
+        [key]: {
+          title: titleDraft,
+          body: bodyDraft,
+          baseRevision: draftBase.revision,
+          stashedAt: Date.now(),
+        },
+      };
+    });
   }, [
     bodyDraft,
     conflictNote,
@@ -1095,8 +1184,10 @@ export function NotesNoteDetail({
     stashRestoreCheckedRef.current = stashRestoreKey;
     let cancelled = false;
     void db.notesNoteDrafts.getValue().then((stashes) => {
-      const stash = stashes[draftStashKey(notebookFlag, draftBase.noteId)];
+      const key = draftStashKey(notebookFlag, draftBase.noteId);
+      const stash = stashes[key];
       if (cancelled || !stash) return;
+      notesNoteDraftStashOwners.set(key, draftOwnerRef.current);
       if (stash.baseRevision !== draftBase.revision) {
         if (
           stash.title === draftBase.title &&
@@ -1176,10 +1267,6 @@ export function NotesNoteDetail({
   );
 
   const handleTitleDraftChange = useCallback((nextTitle: string) => {
-    titleTouchedRef.current = true;
-    if (flushCtxRef.current) {
-      flushCtxRef.current.titleTouched = true;
-    }
     titleDraftRef.current = nextTitle;
     setTitleDraft(nextTitle);
   }, []);

--- a/packages/app/ui/components/NotesChannel/NotesNoteDetail.tsx
+++ b/packages/app/ui/components/NotesChannel/NotesNoteDetail.tsx
@@ -58,8 +58,8 @@ export type NotesNoteSaveFieldIntent = 'preserve' | 'set';
 
 type NotesNoteQueuedSaveResult = {
   updated: db.NotesNote | null | undefined;
-  requestedTitle: string;
-  requestedBody: string;
+  effectiveTitle: string;
+  effectiveBody: string;
   titleIntent: NotesNoteSaveFieldIntent;
   bodyIntent: NotesNoteSaveFieldIntent;
 };
@@ -206,27 +206,6 @@ function clearNotesNoteDraftSnapshot(
   notesNoteDraftSnapshotOwners.delete(key);
 }
 
-function clearMatchingNotesNoteDraftSnapshot({
-  notebookFlag,
-  noteId,
-  title,
-  body,
-}: {
-  notebookFlag: string;
-  noteId: number;
-  title: string;
-  body: string;
-}) {
-  const key = draftSnapshotKey(notebookFlag, noteId);
-  const snapshot = notesNoteDraftSnapshots.get(key);
-  if (!snapshot || snapshot.title !== title || snapshot.body !== body) {
-    return;
-  }
-
-  notesNoteDraftSnapshots.delete(key);
-  notesNoteDraftSnapshotOwners.delete(key);
-}
-
 function rebaseNotesNoteDraftSnapshot(
   notebookFlag: string,
   noteId: number,
@@ -239,11 +218,11 @@ function rebaseNotesNoteDraftSnapshot(
   const nextTitle =
     result.titleIntent === 'preserve' &&
     normalizeNotebookNoteTitle(snapshot.title) ===
-      normalizeNotebookNoteTitle(result.requestedTitle)
+      normalizeNotebookNoteTitle(result.effectiveTitle)
       ? result.updated?.title ?? snapshot.title
       : snapshot.title;
   const nextBody =
-    result.bodyIntent === 'preserve' && snapshot.body === result.requestedBody
+    result.bodyIntent === 'preserve' && snapshot.body === result.effectiveBody
       ? result.updated?.bodyMd ?? snapshot.body
       : snapshot.body;
   const nextSnapshot = {
@@ -379,6 +358,51 @@ function clearDraftStash(
     delete next[key];
     notesNoteDraftStashOwners.delete(key);
     return next;
+  });
+}
+
+// Advance durable recovery data using the payload this queued request
+// actually executed with. A field changed after execution began no longer
+// matches that effective payload and is therefore preserved as a new draft.
+function rebaseNotesNoteDraftStash(
+  notebookFlag: string,
+  noteId: number,
+  result: NotesNoteQueuedSaveResult
+) {
+  if (!result.updated) return;
+  const updated = result.updated;
+  void db.notesNoteDrafts.setValue((stashes) => {
+    const key = draftStashKey(notebookFlag, noteId);
+    const stash = stashes[key];
+    if (!stash) return stashes;
+    const nextTitle =
+      result.titleIntent === 'preserve' &&
+      normalizeNotebookNoteTitle(stash.title) ===
+        normalizeNotebookNoteTitle(result.effectiveTitle)
+        ? updated.title
+        : stash.title;
+    const nextBody =
+      result.bodyIntent === 'preserve' && stash.body === result.effectiveBody
+        ? updated.bodyMd
+        : stash.body;
+    if (
+      normalizeNotebookNoteTitle(nextTitle) === updated.title &&
+      nextBody === updated.bodyMd
+    ) {
+      const next = { ...stashes };
+      delete next[key];
+      notesNoteDraftStashOwners.delete(key);
+      return next;
+    }
+    return {
+      ...stashes,
+      [key]: {
+        ...stash,
+        title: nextTitle,
+        body: nextBody,
+        baseRevision: updated.revision,
+      },
+    };
   });
 }
 
@@ -666,6 +690,38 @@ export function NotesNoteDetail({
       selectedNote != null &&
       draftBase != null &&
       selectedNote.revision < draftBase.revision;
+    const draftsMatchSelectedRow = Boolean(
+      sameNote &&
+        selectedNote &&
+        normalizeNotebookNoteTitle(titleDraft) === selectedNote.title &&
+        bodyDraft === selectedNote.bodyMd
+    );
+    if (
+      sameNote &&
+      isDirty &&
+      draftsMatchSelectedRow &&
+      !rowTrailsBase &&
+      !selectedNoteSavePending &&
+      !conflictNote &&
+      notebookFlag &&
+      selectedNote
+    ) {
+      preserveScrollOffset();
+      setDraftBase(selectedNote);
+      setSaveState('saved');
+      clearNotesNoteDraftSnapshot(
+        notebookFlag,
+        selectedNote.noteId,
+        draftOwnerRef.current
+      );
+      clearDraftStash(
+        notebookFlag,
+        selectedNote.noteId,
+        { title: titleDraft, body: bodyDraft },
+        draftOwnerRef.current
+      );
+      return;
+    }
     if (
       sameNote &&
       (isDirty ||
@@ -721,6 +777,7 @@ export function NotesNoteDetail({
       setConflictNote(null);
     }
   }, [
+    bodyDraft,
     conflictNote,
     draftBase,
     isDirty,
@@ -728,6 +785,7 @@ export function NotesNoteDetail({
     preserveScrollOffset,
     selectedNote,
     selectedNoteSavePending,
+    titleDraft,
   ]);
 
   useEffect(() => {
@@ -815,8 +873,8 @@ export function NotesNoteDetail({
             body: effectiveBody,
           }).then((updated) => ({
             updated,
-            requestedTitle: title,
-            requestedBody: body,
+            effectiveTitle,
+            effectiveBody,
             titleIntent,
             bodyIntent,
           }));
@@ -909,18 +967,9 @@ export function NotesNoteDetail({
       base: db.NotesNote;
       result: NotesNoteQueuedSaveResult;
     }) => {
-      clearDraftStash(flag, base.noteId, {
-        title: result.requestedTitle,
-        body: result.requestedBody,
-      });
-      clearMatchingNotesNoteDraftSnapshot({
-        notebookFlag: flag,
-        noteId: base.noteId,
-        title: result.requestedTitle,
-        body: result.requestedBody,
-      });
       if (result.updated) {
         rebaseNotesNoteDraftSnapshot(flag, base.noteId, result);
+        rebaseNotesNoteDraftStash(flag, base.noteId, result);
       }
       if (!result.updated || !isCurrentNote(flag, base.noteId)) return;
 
@@ -932,7 +981,7 @@ export function NotesNoteDetail({
       if (
         result.titleIntent === 'preserve' &&
         normalizeNotebookNoteTitle(titleDraftRef.current) ===
-          normalizeNotebookNoteTitle(result.requestedTitle) &&
+          normalizeNotebookNoteTitle(result.effectiveTitle) &&
         result.updated.title !== titleDraftRef.current
       ) {
         setTitleDraft(result.updated.title);
@@ -940,7 +989,7 @@ export function NotesNoteDetail({
       }
       if (
         result.bodyIntent === 'preserve' &&
-        bodyDraftRef.current === result.requestedBody &&
+        bodyDraftRef.current === result.effectiveBody &&
         result.updated.bodyMd !== bodyDraftRef.current
       ) {
         setBodyDraft(result.updated.bodyMd);

--- a/packages/app/ui/components/NotesChannel/NotesNoteDetail.tsx
+++ b/packages/app/ui/components/NotesChannel/NotesNoteDetail.tsx
@@ -200,6 +200,7 @@ function rebaseNotesNoteDraftSnapshot(
   notebookFlag: string,
   noteId: number,
   base: db.NotesNote,
+  savedTitle: string,
   updated: db.NotesNote
 ) {
   const key = draftSnapshotKey(notebookFlag, noteId);
@@ -212,6 +213,7 @@ function rebaseNotesNoteDraftSnapshot(
     baseTitle: updated.title,
     baseBody: updated.bodyMd,
     title:
+      normalizeNotebookNoteTitle(savedTitle) === base.title &&
       normalizeNotebookNoteTitle(snapshot.title) === base.title
         ? updated.title
         : snapshot.title,
@@ -820,7 +822,7 @@ export function NotesNoteDetail({
         body,
       });
       if (updated) {
-        rebaseNotesNoteDraftSnapshot(flag, base.noteId, base, updated);
+        rebaseNotesNoteDraftSnapshot(flag, base.noteId, base, title, updated);
       }
       if (!updated || !isCurrentNote(flag, base.noteId)) return;
 
@@ -829,6 +831,7 @@ export function NotesNoteDetail({
       // semantic rename relative to the base that was saved.
       setDraftBase(updated);
       if (
+        normalizeNotebookNoteTitle(title) === base.title &&
         normalizeNotebookNoteTitle(titleDraftRef.current) === base.title &&
         updated.title !== titleDraftRef.current
       ) {

--- a/packages/app/ui/components/Wayfinding/botProviderOptions.test.ts
+++ b/packages/app/ui/components/Wayfinding/botProviderOptions.test.ts
@@ -52,7 +52,7 @@ describe('bot credential choices', () => {
       }),
       expect.objectContaining({
         id: 'xai:api-key',
-        label: 'xAI (Grok) — API key',
+        label: 'xAI (Grok)',
         credentialMode: 'api-key',
         requiresKey: true,
       }),


### PR DESCRIPTION
## Summary

Unsaved notebook edits could overwrite another note when rapidly switching between notes. The shared editor retained draft state while delayed save callbacks continued updating it, allowing one note’s content to become associated with another note’s save target.

The fix prevents asynchronous saves from one note from mutating another note’s editor state. Saves remain ordered in the background, while note switching stays immediate and drafts are safely restored and rebased.

## Changes

- Guarded save completions using note identity.
- Preserved one FIFO save chain across note switches.
- Restored pending drafts synchronously from memory.
- Added observable per-note pending-save tracking across component remounts.

## Risks and impact

- Safe to rollback without consulting PR author? Yes
- Affects important code area:
  - [x] State / providers
  
Fixes TLON-6356
