### PR TITLE
mobile: prefill and validate ship login credentials in dev builds

### DIFF
--- a/apps/tlon-mobile/README.md
+++ b/apps/tlon-mobile/README.md
@@ -117,6 +117,13 @@ DEFAULT_SHIP_LOGIN_ACCESS_CODE=
 
 See `.env.sample` for other configurable env variables.
 
+In a dev build, setting both `DEFAULT_SHIP_LOGIN_URL` and
+`DEFAULT_SHIP_LOGIN_ACCESS_CODE` leaves the ship login screen ready to submit —
+press `Connect` and you are logged in, with no 2FA. Hosted (`*.tlon.network`)
+URLs are accepted there in dev builds too. Note this yields a self-hosted style
+session, so hosting-account flows (node status, revival, bot config) are not
+exercised.
+
 ### Notifications
 
 **Note:** dev mode push notifications are only sent to connected devices, not simulators.

--- a/apps/tlon-mobile/src/screens/Onboarding/ShipLoginScreen.tsx
+++ b/apps/tlon-mobile/src/screens/Onboarding/ShipLoginScreen.tsx
@@ -68,7 +68,8 @@ export const ShipLoginScreen = ({ navigation }: Props) => {
     if (!urlPattern.test(url)) {
       return false;
     }
-    if (hostedPattern.test(url)) {
+    // dev helper: allow logging in to hosted ships with their access code
+    if (hostedPattern.test(url) && !__DEV__) {
       return 'hosted';
     }
     return true;
@@ -130,6 +131,14 @@ export const ShipLoginScreen = ({ navigation }: Props) => {
       setValue('shipUrl', formattedShipUrl);
     }
   }, [errors.shipUrl, formattedShipUrl, setFocus, setValue]);
+
+  // dev helper: validate the env-prefilled credentials up front so Connect is
+  // enabled without having to visit each field first
+  useEffect(() => {
+    if (__DEV__ && DEFAULT_SHIP_LOGIN_URL && DEFAULT_SHIP_LOGIN_ACCESS_CODE) {
+      trigger();
+    }
+  }, [trigger]);
 
   return (
     <View flex={1} backgroundColor="$secondaryBackground">


### PR DESCRIPTION
## Summary

Signing a dev build in to a test ship means going through SMS/email 2FA every time, which agents and automated runs can't do unattended. `DEFAULT_SHIP_LOGIN_URL` + `DEFAULT_SHIP_LOGIN_ACCESS_CODE` already prefill the self-hosted login screen, but the prefill alone isn't usable — this makes it usable. Everything is behind `__DEV__`, so production onboarding is untouched.

**Note:** a `+code` login produces an `authType: 'self'` session, so hosting-account flows (node status, revival, bot config) aren't exercised on this path. It's for getting into the app quickly, not for testing hosted onboarding.

## Changes

Two things stopped the existing prefill from being useful:

- **`Connect` stayed disabled.** It's `disabled={!isValid}`, and the form validates on blur, so prefilled fields left the button dead until you visited each one. Now the prefilled values are validated on mount in dev, so `Connect` is ready as soon as the screen opens. Validation runs once and doesn't change how errors surface while typing.
- **Hosted URLs were rejected.** `*.tlon.network` is accepted in dev builds, so the flow works against a hosted test ship and not just a local one. The production guard steering hosted users to the hosting login ([d16bf74c](https://github.com/tloncorp/tlon-apps/commit/d16bf74cefae8a353b4a676c7cbc229e86aecda1)) is unchanged.

Nothing navigates or submits on its own. You still go `Log in` → `Or configure self hosted` → `Connect`, which keeps the signup, invite-link, and logged-out paths testable by hand while the env vars are set, and leaves the fields editable if you want to connect a different ship.

## How did I test?

Fresh install on the iOS simulator against a hosted test ship (`~pilwes-hosren`), both vars set in `apps/tlon-mobile/.env.local`:

- App opens on Welcome and stays there — `Sign up` and `Join with an invite` still reachable.
- `Log in` → `Or configure self hosted` shows both fields prefilled with `Connect` already enabled, no fields touched.
- One press of `Connect` lands on Usage Statistics, which only renders after a successful ship login. Chat list then loaded and synced.

## Risks and impact

- Safe to rollback without consulting PR author? **Yes**
- Affects important code area:
  - [x] Onboarding
  - [ ] State / providers
  - [ ] Message sync
  - [ ] Channel display
  - [ ] Notifications
  - [ ] Other:

Both gating conditions are false in production: `__DEV__`, and both env vars being non-empty (they default to `''`). A dev who doesn't set them sees no change.

One pre-existing thing worth knowing, unchanged by this PR: `app.config.ts` copies these vars into `extra` for any build, so a release built with them set would embed a real ship `+code`. This PR encourages putting a working code in `.env.local`, so it's worth keeping out of release builds.

## Rollback plan

Revert the commit. No migrations, no persisted state, no config to unwind.

## Screenshots / videos

No UI changes — the same screens render, with `Connect` enabled on arrival instead of disabled. Not attaching the logged-in screenshot from testing since it shows real DM content from a live ship.
