### PR TITLE
bot-e2e: stop glob bumps from defeating the unchanged-desk skip in Shared E2E

### DIFF
--- a/apps/tlon-web/e2e/shipManifest.json
+++ b/apps/tlon-web/e2e/shipManifest.json
@@ -1,7 +1,7 @@
 {
   "~zod": {
     "authFile": "e2e/.auth/zod.json",
-    "downloadUrl": "https://bootstrap.urbit.org/rube-zod29.tgz",
+    "downloadUrl": "https://bootstrap.urbit.org/rube-zod30.tgz",
     "url": "http://localhost:35453",
     "ship": "zod",
     "code": "lidlut-tabwed-pillex-ridrup",
@@ -28,7 +28,7 @@
   },
   "~ten": {
     "authFile": "e2e/.auth/ten.json",
-    "downloadUrl": "https://bootstrap.urbit.org/rube-ten29.tgz",
+    "downloadUrl": "https://bootstrap.urbit.org/rube-ten30.tgz",
     "url": "http://localhost:38473",
     "ship": "ten",
     "code": "lapseg-nolmel-riswen-hopryc",
@@ -41,7 +41,7 @@
   },
   "~mug": {
     "authFile": "e2e/.auth/mug.json",
-    "downloadUrl": "https://bootstrap.urbit.org/rube-mug29.tgz",
+    "downloadUrl": "https://bootstrap.urbit.org/rube-mug30.tgz",
     "url": "http://localhost:39983",
     "ship": "mug",
     "code": "ravsut-bolryd-hapsum-pastul",

--- a/apps/tlon-web/rube/Dockerfile
+++ b/apps/tlon-web/rube/Dockerfile
@@ -69,10 +69,10 @@ WORKDIR /workspace
 RUN mkdir -p /opt/ships && cd /opt/ships && \
     echo "Downloading ship archives and Urbit binary in parallel..." && \
     printf "%s\n" \
-        "https://bootstrap.urbit.org/rube-zod29.tgz zod.tgz" \
+        "https://bootstrap.urbit.org/rube-zod30.tgz zod.tgz" \
         "https://bootstrap.urbit.org/rube-bus9.tgz bus.tgz" \
-        "https://bootstrap.urbit.org/rube-ten29.tgz ten.tgz" \
-        "https://bootstrap.urbit.org/rube-mug29.tgz mug.tgz" \
+        "https://bootstrap.urbit.org/rube-ten30.tgz ten.tgz" \
+        "https://bootstrap.urbit.org/rube-mug30.tgz mug.tgz" \
         "https://github.com/urbit/vere/releases/latest/download/linux-x86_64.tgz urbit.tgz" \
     | xargs -P 5 -n 2 sh -c 'curl -fSL -o "$1" "$0" || exit 255' && \
     echo "All downloads complete, extracting..." && \

--- a/packages/tlon-bot-e2e/docker/docker-compose.base.yml
+++ b/packages/tlon-bot-e2e/docker/docker-compose.base.yml
@@ -29,7 +29,7 @@ services:
 
         echo "==> fake ships runtime pin"
         echo "    vere pin: vere-v4.5"
-        echo "    pier generation: 29"
+        echo "    pier generation: 30"
         echo "    zod code: lidlut-tabwed-pillex-ridrup"
         echo "    ten code: lapseg-nolmel-riswen-hopryc"
         echo "    mug code: ravsut-bolryd-hapsum-pastul"
@@ -130,23 +130,23 @@ services:
         }
 
         zod_archive="$$(artifact \
-          rube-zod29.tgz \
-          https://bootstrap.urbit.org/rube-zod29.tgz \
+          rube-zod30.tgz \
+          https://bootstrap.urbit.org/rube-zod30.tgz \
           md5 \
-          e44ffc39c21b530554e6e40511c0d5b1 \
-          337897864)"
+          c156c20f2f16754433711a2ab1aab234 \
+          347494585)"
         ten_archive="$$(artifact \
-          rube-ten29.tgz \
-          https://bootstrap.urbit.org/rube-ten29.tgz \
+          rube-ten30.tgz \
+          https://bootstrap.urbit.org/rube-ten30.tgz \
           md5 \
-          15a83ddd6fcc47ccae9e7e92389bbc2a \
-          337258886)"
+          833d91b522bab7ed1c28cc528b20ba46 \
+          346581323)"
         mug_archive="$$(artifact \
-          rube-mug29.tgz \
-          https://bootstrap.urbit.org/rube-mug29.tgz \
+          rube-mug30.tgz \
+          https://bootstrap.urbit.org/rube-mug30.tgz \
           md5 \
-          88df26690f14f38f562e7bac7dc49cc6 \
-          338125881)"
+          29b6004ce1f6dfcf67253375d13dab90 \
+          347375646)"
         vere_archive="$$(artifact \
           linux-x86_64-vere-v4.5.tgz \
           https://github.com/urbit/vere/releases/download/vere-v4.5/linux-x86_64.tgz \

--- a/packages/tlon-bot-e2e/src/runtime/branch-desk.test.ts
+++ b/packages/tlon-bot-e2e/src/runtime/branch-desk.test.ts
@@ -69,6 +69,20 @@ describe('branch desk manifest', () => {
     await writeFile(path.join(root, 'z.hoon'), 'changed');
     expect(await createDeskManifest(root)).not.toBe(manifest);
   });
+
+  test('ignores glob-bot rewrites of desk.docket-0', async () => {
+    const root = await mkdtemp(path.join(os.tmpdir(), 'branch-desk-test-'));
+    tempDirs.push(root);
+    await writeFile(path.join(root, 'z.hoon'), 'z');
+    await writeFile(path.join(root, 'desk.docket-0'), 'glob-0v1.aaaaa');
+
+    const manifest = await createDeskManifest(root);
+    await writeFile(path.join(root, 'desk.docket-0'), 'glob-0v1.bbbbb');
+    expect(await createDeskManifest(root)).toBe(manifest);
+
+    await writeFile(path.join(root, 'z.hoon'), 'changed');
+    expect(await createDeskManifest(root)).not.toBe(manifest);
+  });
 });
 
 describe('applyBranchDesk control flow', () => {

--- a/packages/tlon-bot-e2e/src/runtime/branch-desk.ts
+++ b/packages/tlon-bot-e2e/src/runtime/branch-desk.ts
@@ -121,9 +121,13 @@ export async function createDeskManifest(deskDir: string): Promise<string> {
   const files = await listFiles(deskDir);
   const lines = await Promise.all(
     files
-      // assemble-desk.sh stamps HEAD, but frontend-only commits must not force
-      // an otherwise identical Hoon desk through an expensive |commit.
-      .filter((file) => file !== 'commit.txt')
+      // Frontend-only commits must not force an otherwise identical Hoon desk
+      // through an expensive |commit: assemble-desk.sh stamps HEAD into
+      // commit.txt, and the glob bot rewrites the glob hash in desk.docket-0
+      // (several times a day on develop). Neither affects anything the bot
+      // harness exercises, and the docket-only skip leaves the pier's
+      // archived docket in place.
+      .filter((file) => file !== 'commit.txt' && file !== 'desk.docket-0')
       .sort()
       .map(async (file) => {
         const digest = createHash('sha256')
@@ -279,7 +283,7 @@ async function readMountedDeskManifest(
     [
       'bash',
       '-c',
-      'set -euo pipefail; mount="$1"; test -d "$mount" && test -r "$mount" && test -x "$mount" || exit 20; cd "$mount"; find . -type f ! -path ./commit.txt -print0 | sort -z | xargs -0r sha256sum',
+      'set -euo pipefail; mount="$1"; test -d "$mount" && test -r "$mount" && test -x "$mount" || exit 20; cd "$mount"; find . -type f ! -path ./commit.txt ! -path ./desk.docket-0 -print0 | sort -z | xargs -0r sha256sum',
       'bash',
       `/data/${ship}/groups`,
     ]


### PR DESCRIPTION
## Summary

Fixes TLON-6357.

The Shared E2E job regressed from ~22 to ~42 minutes starting Aug 11-12. The cause is not test or harness growth: glob-bot commits ("update glob: [skip actions]") rewrite the glob hash in `desk.docket-0`, which defeats the unchanged-desk skip in `branch-desk.ts` — the manifest comparison excludes only `commit.txt`. Every stack the job boots (baseline partition, cron partition, package suite) then pays the full drifted desk apply (~8-9 minutes each) for a file the bot harness never serves. This PR excludes `desk.docket-0` from the drift manifest, the same rationale as the existing `commit.txt` exclusion: frontend-only commits must not force an otherwise identical Hoon desk through an expensive `|commit`. It also refreshes the pier archives to v30 (cut from current develop), clearing the real desk drift accumulated since the Aug 7 v29 archives — both halves are needed: the exclusion stops glob bumps from re-introducing drift, and the fresh archives erase the drift that already exists.

Measured Shared E2E durations: ~13 min (Aug 7, pre-desk-apply), ~22 min (Aug 11, applies added, piers fresh), ~38-52 min (Aug 12 onward, glob-drifted). **This PR's own CI demonstrates the fix: Shared E2E ran in 18 min (hermes-ci) and 22 min (openclaw-ci) on the final head, with the unchanged-desk skip firing against the v30 piers — back to the pre-regression baseline.** The web E2E job (Parallel, 4 shards) also benefits from the fresh archives: 14 min on this head vs 17-23 for recent runs on v29 piers — rube always applies the branch desk, so its cost scales with drift too, and the v30 refresh collapses that commit to a near-no-op.

## Changes

- `createDeskManifest` in `packages/tlon-bot-e2e/src/runtime/branch-desk.ts` filters `desk.docket-0` alongside `commit.txt`.
- The mounted-desk manifest command gains the matching `! -path ./desk.docket-0` exclusion.
- New unit test: manifests match when only `desk.docket-0` differs, and still diverge on a real Hoon change.
- Pier archives refreshed to v30 (`rube-{zod,ten,mug}30.tgz`, uploaded to `gs://bootstrap.urbit.org/`, ~bus intentionally left on its old archive): `shipManifest.json` and the rube `Dockerfile` updated by `archive-piers.sh`, and the bot-e2e compose pins (`docker-compose.base.yml`) bumped with the new md5/size values. The fake-ships CI cache key derives from `hashFiles` of that compose file, so it rolls automatically.

The docket is excluded from the comparison only: on a real apply it still rsyncs with the rest of the desk. On a docket-only drift the skip fires and the pier keeps its archived docket, which is fine because the bot harness never serves the web glob.

## How did I test?

- `pnpm --filter '@tloncorp/tlon-bot-e2e' tsc` clean; `test:unit` 151/151 passing including the new manifest case.
- Duration data above pulled from the last two weeks of Shared E2E job timings on hermes-ci.

## Risks and impact

- Safe to rollback without consulting PR author? Yes
- Affects important code area:
  - [x] Other: bot e2e harness only (`packages/tlon-bot-e2e`); no product code

A genuinely intentional docket change would no longer trigger an apply on its own in bot e2e; it rides along with any other desk change, and the web e2e suite still exercises the real docket path. The v30 archives change what every e2e job boots (web parallel e2e and prod smoke included) — this PR's own CI runs exercise them before merge. The old v29 archives remain in the bucket, so any in-flight branch pinned to them is unaffected until it rebases.

## Rollback plan

Revert the PR. No migrations, no persisted state, no product code.

## Screenshots / videos

N/A, CI harness change.
