### PR TITLE
feat(openclaw): publish participant-safe group activity

### DIFF
--- a/packages/api/src/__tests__/participantAgentActivity.test.ts
+++ b/packages/api/src/__tests__/participantAgentActivity.test.ts
@@ -1,0 +1,163 @@
+import { describe, expect, it } from 'vitest';
+
+import { appendToPostBlob, parsePostBlob } from '../client/content-helpers';
+import {
+  MAX_PARTICIPANT_AGENT_ACTIVITY_STEPS,
+  MAX_PARTICIPANT_AGENT_ACTIVITY_TITLE_CHARS,
+  type ParticipantAgentActivityProjectionV1,
+  ParticipantAgentActivityProjectionV1Schema,
+} from '../client/participantAgentActivity';
+
+function projection(): ParticipantAgentActivityProjectionV1 {
+  return {
+    schemaVersion: 1,
+    surface: 'final',
+    publicRunId: 'run_abcdefghijklmnopqrstuvwxyz',
+    revision: 4,
+    triggerPostId: '~sampel-palnet/170.141.184.507.123',
+    threadRootId: '~sampel-palnet/170.141.184.500.100',
+    retryOf: 'run_zyxwvutsrqponmlkjihgfedcba',
+    continuation: {
+      kind: 'request_input',
+      parentPublicRunId: 'run_parentabcdefghijklmnopq',
+    },
+    state: 'completed',
+    createdAt: 1_000,
+    updatedAt: 2_000,
+    completedAt: 2_000,
+    steps: [
+      {
+        id: 'step_abcdefghijklmnopqrstuvwxyz',
+        title: 'Compare the records',
+        status: 'completed',
+        update: 'Matched every requested city.',
+        actions: { total: 12, completed: 12 },
+      },
+    ],
+  };
+}
+
+describe('ParticipantAgentActivityProjectionV1Schema', () => {
+  it('parses the bounded public contract', () => {
+    expect(
+      ParticipantAgentActivityProjectionV1Schema.parse(projection())
+    ).toEqual(projection());
+  });
+
+  it('keeps continuation lineage opaque and rejects owner Lens identifiers', () => {
+    expect(projection().continuation).toEqual({
+      kind: 'request_input',
+      parentPublicRunId: 'run_parentabcdefghijklmnopq',
+    });
+    expect(
+      ParticipantAgentActivityProjectionV1Schema.safeParse({
+        ...projection(),
+        continuation: {
+          kind: 'request_input',
+          parentPublicRunId: 'run_parentabcdefghijklmnopq',
+          parentLensId: 'owner-lens-secret',
+        },
+      }).success
+    ).toBe(false);
+  });
+
+  it('rejects identity, private detail, and unknown nested fields', () => {
+    expect(
+      ParticipantAgentActivityProjectionV1Schema.safeParse({
+        ...projection(),
+        botShip: '~zod',
+      }).success
+    ).toBe(false);
+    expect(
+      ParticipantAgentActivityProjectionV1Schema.safeParse({
+        ...projection(),
+        channelId: 'chat/~zod/private',
+      }).success
+    ).toBe(false);
+    expect(
+      ParticipantAgentActivityProjectionV1Schema.safeParse({
+        ...projection(),
+        steps: [
+          {
+            ...projection().steps[0],
+            toolArguments: '--token very-secret',
+          },
+        ],
+      }).success
+    ).toBe(false);
+  });
+
+  it('enforces text, count, chronology, and aggregate bounds', () => {
+    expect(
+      ParticipantAgentActivityProjectionV1Schema.safeParse({
+        ...projection(),
+        steps: [
+          {
+            ...projection().steps[0],
+            title: 'x'.repeat(MAX_PARTICIPANT_AGENT_ACTIVITY_TITLE_CHARS + 1),
+          },
+        ],
+      }).success
+    ).toBe(false);
+    expect(
+      ParticipantAgentActivityProjectionV1Schema.safeParse({
+        ...projection(),
+        steps: Array.from(
+          { length: MAX_PARTICIPANT_AGENT_ACTIVITY_STEPS + 1 },
+          (_, index) => ({
+            id: `step_${index}`,
+            title: `Step ${index}`,
+            status: 'pending',
+          })
+        ),
+      }).success
+    ).toBe(false);
+    expect(
+      ParticipantAgentActivityProjectionV1Schema.safeParse({
+        ...projection(),
+        updatedAt: 999,
+      }).success
+    ).toBe(false);
+    expect(
+      ParticipantAgentActivityProjectionV1Schema.safeParse({
+        ...projection(),
+        steps: [
+          {
+            ...projection().steps[0],
+            actions: { total: 1, completed: 2 },
+          },
+        ],
+      }).success
+    ).toBe(false);
+  });
+
+  it('does not allow terminal metadata on an active projection', () => {
+    expect(
+      ParticipantAgentActivityProjectionV1Schema.safeParse({
+        ...projection(),
+        state: 'working',
+      }).success
+    ).toBe(false);
+  });
+
+  it('round-trips as an optional field on the existing Lens v1 blob entry', () => {
+    const participantActivity = projection();
+    const blob = appendToPostBlob(undefined, {
+      type: 'tlon-context-lens',
+      version: 1,
+      lensId: 'owner-lens-123',
+      delivery: 'final',
+      participantActivity,
+    });
+
+    expect(parsePostBlob(blob)).toEqual([
+      {
+        type: 'tlon-context-lens',
+        version: 1,
+        lensId: 'owner-lens-123',
+        delivery: 'final',
+        participantActivity,
+      },
+    ]);
+  });
+});

--- a/packages/api/src/client/content-helpers.ts
+++ b/packages/api/src/client/content-helpers.ts
@@ -21,6 +21,7 @@ import {
   pathToCite,
 } from '../urbit';
 import { A2UI } from './a2ui';
+import { ParticipantAgentActivityProjectionV1Schema } from './participantAgentActivity';
 
 export * from './a2ui';
 
@@ -689,6 +690,8 @@ export const PostBlobDataEntryContextLensSchema = definePostBlobDataEntrySchema(
     delivery: z.enum(['final', 'intermediate']).optional(),
     /** lets chat close the run truthfully before the durable final snapshot */
     outcome: z.enum(['completed', 'failed']).optional(),
+    /** Sanitized channel-visible task state; full Lens data remains owner-only. */
+    participantActivity: ParticipantAgentActivityProjectionV1Schema.optional(),
   }
 );
 

--- a/packages/api/src/client/index.ts
+++ b/packages/api/src/client/index.ts
@@ -117,6 +117,7 @@ export * from './apiUtils';
 export * from './metagrabApi';
 export * from './changesApi';
 export * from './computingStatus';
+export * from './participantAgentActivity';
 export * from './presenceApi';
 export * from './stewardGatewayApi';
 export * from './lensApi';

--- a/packages/api/src/client/participantAgentActivity.ts
+++ b/packages/api/src/client/participantAgentActivity.ts
@@ -1,0 +1,209 @@
+import { z } from 'zod';
+
+/**
+ * Public, channel-visible projection of an agent run.
+ *
+ * Bot and channel identity deliberately do not live in this payload. Consumers
+ * must derive both from the authenticated post envelope that carries it.
+ */
+export const PARTICIPANT_AGENT_ACTIVITY_SCHEMA_VERSION = 1 as const;
+export const MAX_PARTICIPANT_AGENT_ACTIVITY_STEPS = 24;
+export const MAX_PARTICIPANT_AGENT_ACTIVITY_BYTES = 24 * 1024;
+export const MAX_PARTICIPANT_AGENT_ACTIVITY_TITLE_CHARS = 240;
+export const MAX_PARTICIPANT_AGENT_ACTIVITY_UPDATE_CHARS = 1_000;
+
+const opaqueIdSchema = z
+  .string()
+  .min(1)
+  .max(96)
+  .regex(/^[A-Za-z0-9_-]+$/);
+
+function containsControlCharacters(value: string): boolean {
+  return Array.from(value).some((character) => {
+    const codePoint = character.codePointAt(0) ?? 0;
+    return codePoint <= 0x1f || codePoint === 0x7f;
+  });
+}
+
+const correlationIdSchema = z
+  .string()
+  .trim()
+  .min(1)
+  .max(320)
+  .refine((value) => !containsControlCharacters(value), {
+    message: 'correlation ids may not contain control characters',
+  });
+
+const stepIdSchema = z
+  .string()
+  .min(1)
+  .max(128)
+  .regex(/^[A-Za-z0-9_-]+$/);
+
+const publicTextSchema = (max: number) =>
+  z
+    .string()
+    .trim()
+    .min(1)
+    .max(max)
+    .refine((value) => !containsControlCharacters(value), {
+      message: 'public text may not contain control characters',
+    });
+
+const timestampSchema = z
+  .number()
+  .int()
+  .nonnegative()
+  .max(Number.MAX_SAFE_INTEGER);
+
+export const ParticipantAgentActivityStateSchema = z.enum([
+  'working',
+  'waiting_requester',
+  'waiting_owner',
+  'completed',
+  'incomplete',
+  'failed',
+  'timed_out',
+  'cancelled',
+]);
+
+export const ParticipantAgentActivityStepStatusSchema = z.enum([
+  'pending',
+  'running',
+  'waiting',
+  'completed',
+  'failed',
+  'cancelled',
+]);
+
+export const ParticipantAgentActivityActionsSchema = z
+  .object({
+    total: z.number().int().nonnegative().max(10_000),
+    completed: z.number().int().nonnegative().max(10_000),
+  })
+  .strict()
+  .refine((actions) => actions.completed <= actions.total, {
+    message: 'completed actions may not exceed total actions',
+    path: ['completed'],
+  });
+
+export const ParticipantAgentActivityStepSchema = z
+  .object({
+    id: stepIdSchema,
+    title: publicTextSchema(MAX_PARTICIPANT_AGENT_ACTIVITY_TITLE_CHARS),
+    status: ParticipantAgentActivityStepStatusSchema,
+    update: publicTextSchema(
+      MAX_PARTICIPANT_AGENT_ACTIVITY_UPDATE_CHARS
+    ).optional(),
+    actions: ParticipantAgentActivityActionsSchema.optional(),
+  })
+  .strict();
+
+function serializedByteLength(value: unknown): number {
+  try {
+    return new TextEncoder().encode(JSON.stringify(value)).byteLength;
+  } catch {
+    return Number.POSITIVE_INFINITY;
+  }
+}
+
+const TERMINAL_STATES = new Set([
+  'completed',
+  'incomplete',
+  'failed',
+  'timed_out',
+  'cancelled',
+]);
+
+export const ParticipantAgentActivityProjectionV1Schema = z
+  .object({
+    schemaVersion: z.literal(PARTICIPANT_AGENT_ACTIVITY_SCHEMA_VERSION),
+    /** Carrier posts are synthetic progress surfaces; final posts are replies. */
+    surface: z.enum(['carrier', 'final']),
+    /** Stable opaque identity. This must not be a Context Lens id. */
+    publicRunId: opaqueIdSchema,
+    /** Monotonic publisher revision used to ignore stale post edits. */
+    revision: z.number().int().nonnegative().max(Number.MAX_SAFE_INTEGER),
+    /** The real user post that triggered this run. */
+    triggerPostId: correlationIdSchema,
+    /** Present only when the trigger belongs to a thread. */
+    threadRootId: correlationIdSchema.optional(),
+    /** Opaque publicRunId of the run this run retries. */
+    retryOf: opaqueIdSchema.optional(),
+    /** Safe public lineage for a typed requester-input continuation. */
+    continuation: z
+      .object({
+        kind: z.literal('request_input'),
+        parentPublicRunId: opaqueIdSchema,
+      })
+      .strict()
+      .optional(),
+    state: ParticipantAgentActivityStateSchema,
+    createdAt: timestampSchema,
+    updatedAt: timestampSchema,
+    completedAt: timestampSchema.optional(),
+    steps: z
+      .array(ParticipantAgentActivityStepSchema)
+      .min(1)
+      .max(MAX_PARTICIPANT_AGENT_ACTIVITY_STEPS),
+    terminalReason: z
+      .enum(['timeout', 'denied', 'interrupted', 'failed'])
+      .optional(),
+  })
+  .strict()
+  .superRefine((projection, ctx) => {
+    if (projection.updatedAt < projection.createdAt) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        message: 'updatedAt may not precede createdAt',
+        path: ['updatedAt'],
+      });
+    }
+    if (
+      projection.completedAt !== undefined &&
+      (projection.completedAt < projection.createdAt ||
+        projection.completedAt > projection.updatedAt)
+    ) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        message: 'completedAt must fall within the projection lifetime',
+        path: ['completedAt'],
+      });
+    }
+    const isTerminal = TERMINAL_STATES.has(projection.state);
+    if (!isTerminal && projection.completedAt !== undefined) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        message: 'active or waiting projections may not be completed',
+        path: ['completedAt'],
+      });
+    }
+    if (!isTerminal && projection.terminalReason !== undefined) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        message: 'active or waiting projections may not have a terminal reason',
+        path: ['terminalReason'],
+      });
+    }
+    if (
+      serializedByteLength(projection) > MAX_PARTICIPANT_AGENT_ACTIVITY_BYTES
+    ) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        message: 'participant activity projection is too large',
+      });
+    }
+  });
+
+export type ParticipantAgentActivityState = z.infer<
+  typeof ParticipantAgentActivityStateSchema
+>;
+export type ParticipantAgentActivityStepStatus = z.infer<
+  typeof ParticipantAgentActivityStepStatusSchema
+>;
+export type ParticipantAgentActivityStep = z.infer<
+  typeof ParticipantAgentActivityStepSchema
+>;
+export type ParticipantAgentActivityProjectionV1 = z.infer<
+  typeof ParticipantAgentActivityProjectionV1Schema
+>;

--- a/packages/openclaw/.env.example
+++ b/packages/openclaw/.env.example
@@ -29,6 +29,10 @@ TLON_OWNER_SHIP=~ten
 # Enable durable agent activity/task rows through the ship-side %steward app.
 TLON_CONTEXT_LENS_ENABLED=true
 
+# Experimental: publish only the safe task projection to group participants.
+# Raw Context Lens data remains owner-only.
+TLON_PARTICIPANT_AGENT_ACTIVITY_ENABLED=true
+
 # Maximum time for one Tlon agent turn. Defaults to fifteen minutes.
 TLON_RUN_TIMEOUT_MS=900000
 

--- a/packages/openclaw/README.md
+++ b/packages/openclaw/README.md
@@ -78,9 +78,13 @@ channels:
         # Show model info in responses
         showModelSignature: false
 
-        # Enable owner-only durable agent activity and run history.
+        # Owner-only run history and the experimental participant-safe group
+        # activity projection are separate opt-ins. The latter publishes only
+        # plan titles, commentary, statuses, and aggregate action counts into
+        # the normal channel; raw Lens/tool data remains owner-only.
         contextLens:
             enabled: true
+            participantActivityEnabled: false
 
         # Optional PostHog telemetry. Disabled unless explicitly enabled.
         telemetry:

--- a/packages/openclaw/dev/docker-compose.yml
+++ b/packages/openclaw/dev/docker-compose.yml
@@ -16,6 +16,9 @@ services:
       # packages/api, and @urbit/* hoisted to the monorepo root node_modules.
       # Must point inside the /workspace/tlon-apps mount, not a standalone one.
       - TLON_SKILL_DIR=/workspace/tlon-apps/packages/tlon-skill
+      # Explicit opt-in: publish only the participant-safe task projection to
+      # normal group-channel posts. Raw Context Lens remains owner-only.
+      - TLON_PARTICIPANT_AGENT_ACTIVITY_ENABLED=${TLON_PARTICIPANT_AGENT_ACTIVITY_ENABLED:-false}
     ports:
       - "${OPENCLAW_GATEWAY_PORT:-18789}:18789"
     volumes:

--- a/packages/openclaw/dev/entrypoint.sh
+++ b/packages/openclaw/dev/entrypoint.sh
@@ -121,6 +121,13 @@ if [ -f "/workspace/tlonbot/openclaw.json" ]; then
       "$CONFIG_PATH" > "$CONFIG_PATH.tmp" && mv "$CONFIG_PATH.tmp" "$CONFIG_PATH"
   fi
 
+  if [ "${TLON_PARTICIPANT_AGENT_ACTIVITY_ENABLED:-false}" = "true" ]; then
+    echo "==> Enabling participant-safe group agent activity..."
+    jq '.channels.tlon.contextLens = (.channels.tlon.contextLens // {})
+      | .channels.tlon.contextLens.participantActivityEnabled = true' \
+      "$CONFIG_PATH" > "$CONFIG_PATH.tmp" && mv "$CONFIG_PATH.tmp" "$CONFIG_PATH"
+  fi
+
   # Fifteen minutes by default: tool-heavy turns can spend several minutes on
   # remote uploads and verification. Override for shorter local test cases.
   tlon_run_timeout_ms="${TLON_RUN_TIMEOUT_MS:-900000}"

--- a/packages/openclaw/openclaw.plugin.json
+++ b/packages/openclaw/openclaw.plugin.json
@@ -244,6 +244,9 @@
                     "enabled": {
                       "type": "boolean"
                     },
+                    "participantActivityEnabled": {
+                      "type": "boolean"
+                    },
                     "ttlMs": {
                       "type": "integer",
                       "minimum": 60000,
@@ -378,6 +381,9 @@
             "type": "object",
             "properties": {
               "enabled": {
+                "type": "boolean"
+              },
+              "participantActivityEnabled": {
                 "type": "boolean"
               },
               "ttlMs": {

--- a/packages/openclaw/src/config-schema.test.ts
+++ b/packages/openclaw/src/config-schema.test.ts
@@ -90,6 +90,7 @@ describe('Tlon config schema', () => {
     const parsed = TlonConfigSchema.parse({
       contextLens: {
         enabled: true,
+        participantActivityEnabled: true,
         ttlMs: 600_000,
         maxEntries: 500,
         visibilityDefault: 'owner',
@@ -109,6 +110,7 @@ describe('Tlon config schema', () => {
     });
 
     expect(parsed.contextLens?.enabled).toBe(true);
+    expect(parsed.contextLens?.participantActivityEnabled).toBe(true);
     expect(parsed.contextLens?.allowedOrigins).toEqual([
       'https://app.tlon.network',
     ]);

--- a/packages/openclaw/src/config-schema.ts
+++ b/packages/openclaw/src/config-schema.ts
@@ -49,6 +49,9 @@ export const TlonContextLensStoreSchema = z.object({
 
 export const TlonContextLensSchema = z.object({
   enabled: z.boolean().optional(),
+  // Explicit, default-off opt-in for publishing an allowlisted task
+  // projection into group-channel posts. Raw Lens data remains owner-only.
+  participantActivityEnabled: z.boolean().optional(),
   ttlMs: z.number().int().min(60_000).optional(),
   maxEntries: z.number().int().min(1).optional(),
   visibilityDefault: z.enum(['owner', 'participants', 'internal']).optional(),

--- a/packages/openclaw/src/context-lens-card-eligibility.test.ts
+++ b/packages/openclaw/src/context-lens-card-eligibility.test.ts
@@ -1,0 +1,199 @@
+import { describe, expect, it } from 'vitest';
+
+import { isContextLensCardEligible } from './context-lens-card-eligibility.js';
+import type { ContextLens } from './context-lens.js';
+
+function lens(overrides: Partial<ContextLens> = {}): ContextLens {
+  return {
+    lensId: 'lens-1',
+    botShip: '~zod',
+    runId: 'run-1',
+    messageId: 'message-1',
+    sessionKeyHash: null,
+    chatType: 'dm',
+    runKind: 'conversation',
+    visibility: 'owner',
+    trigger: 'dm',
+    triggerDetails: {
+      type: 'dm',
+      messageId: 'message-1',
+      conversationKind: 'dm',
+    },
+    model: null,
+    provider: null,
+    context: {
+      currentMessage: true,
+      threadMessages: 0,
+      channelMessages: 0,
+      citedPosts: 0,
+      attachments: 0,
+      pendingNudge: false,
+      sources: [],
+    },
+    persistence: {
+      postsReply: false,
+      updatesSettings: false,
+      writesMedia: false,
+      emitsTelemetry: false,
+      cachesHistory: false,
+      events: [],
+    },
+    tools: {
+      ownerOnlyAvailable: [],
+      called: [],
+      callCount: 0,
+      lastStartedAt: null,
+      runs: [],
+    },
+    outputs: [],
+    activity: {
+      schemaVersion: 1,
+      eventCount: 0,
+      lastEventAt: null,
+      truncated: false,
+      plan: null,
+      items: [],
+    },
+    lifecycle: {
+      queuedAt: null,
+      queuedMs: 0,
+      dispatchStartedAt: null,
+      firstToolStartedAt: null,
+      completedAt: null,
+      durationMs: null,
+      timeoutMs: null,
+      timedOut: false,
+      deliveredMessageCount: 0,
+      queuedFinal: false,
+      queuedFinalCount: 0,
+      queuedBlockCount: 0,
+    },
+    status: 'dispatching',
+    error: null,
+    createdAt: 1,
+    updatedAt: 1,
+    expiresAt: 10,
+    ...overrides,
+  };
+}
+
+describe('isContextLensCardEligible', () => {
+  it('keeps a lifecycle-only conversational turn out of task cards', () => {
+    expect(isContextLensCardEligible(lens())).toBe(false);
+    expect(
+      isContextLensCardEligible(
+        lens({
+          status: 'completed',
+          lifecycle: { ...lens().lifecycle, durationMs: 4_000 },
+        })
+      )
+    ).toBe(false);
+  });
+
+  it('does not qualify a plan and update_plan accounting alone', () => {
+    const planned = lens();
+    planned.activity.plan = {
+      updatedAt: 2,
+      steps: [{ id: 'step-1', title: 'Do the work', status: 'running' }],
+    };
+    planned.tools = {
+      ...planned.tools,
+      called: ['update_plan'],
+      callCount: 3,
+      runs: [
+        {
+          id: 'plan-call-1',
+          callIndex: 1,
+          name: 'update_plan',
+          startedAt: 1,
+          completedAt: 2,
+          durationMs: 1,
+          status: 'completed',
+        },
+      ],
+    };
+    expect(isContextLensCardEligible(planned)).toBe(false);
+
+    planned.activity.items = [
+      {
+        id: 'commentary-with-plan',
+        kind: 'commentary',
+        title: 'Checking now.',
+        status: 'running',
+        startedAt: 2,
+        updatedAt: 2,
+        completedAt: null,
+      },
+    ];
+    expect(isContextLensCardEligible(planned)).toBe(true);
+  });
+
+  it('qualifies a typed requester-input continuation without prose heuristics', () => {
+    expect(
+      isContextLensCardEligible(
+        lens({
+          continuation: {
+            kind: 'request_input',
+            parentLensId: 'parent-lens',
+            requestInputId: 'request-input:call-1',
+            workflowId: 'parent-lens',
+            linkedAt: 2,
+          },
+        })
+      )
+    ).toBe(true);
+  });
+
+  it('qualifies user-facing commentary and real recorded tool calls', () => {
+    const commentary = lens();
+    commentary.activity.items = [
+      {
+        id: 'commentary-1',
+        kind: 'commentary',
+        title: 'Progress',
+        status: 'running',
+        startedAt: 1,
+        updatedAt: 2,
+        completedAt: null,
+      },
+    ];
+    expect(isContextLensCardEligible(commentary)).toBe(true);
+
+    expect(
+      isContextLensCardEligible(
+        lens({
+          tools: {
+            ...lens().tools,
+            called: ['web_search'],
+            callCount: 1,
+          },
+        })
+      )
+    ).toBe(true);
+  });
+
+  it('qualifies unsuccessful terminal runs but not generic reasoning items', () => {
+    const generic = lens();
+    generic.activity.items = [
+      {
+        id: 'reasoning-1',
+        kind: 'item',
+        title: 'Reasoning',
+        status: 'completed',
+        startedAt: 1,
+        updatedAt: 2,
+        completedAt: 2,
+      },
+    ];
+    expect(isContextLensCardEligible(generic)).toBe(false);
+
+    for (const status of [
+      'no_reply',
+      'timed_out',
+      'aborted',
+      'error',
+    ] as const) {
+      expect(isContextLensCardEligible(lens({ status }))).toBe(true);
+    }
+  });
+});

--- a/packages/openclaw/src/context-lens-card-eligibility.ts
+++ b/packages/openclaw/src/context-lens-card-eligibility.ts
@@ -1,13 +1,6 @@
 import { hasContextLensActivityCardContent } from '@tloncorp/api/urbit/lens';
 
-import type { ContextLens } from './context-lens.js';
-
-const UNSUCCESSFUL_TERMINAL_STATUSES = new Set<ContextLens['status']>([
-  'no_reply',
-  'timed_out',
-  'aborted',
-  'error',
-]);
+import { type ContextLens, RETRYABLE_STATUSES } from './context-lens.js';
 
 function hasNonPlanToolCall(lens: ContextLens): boolean {
   const names = [
@@ -30,6 +23,6 @@ export function isContextLensCardEligible(lens: ContextLens): boolean {
     lens.continuation?.kind === 'request_input' ||
     hasContextLensActivityCardContent(lens.activity) ||
     hasNonPlanToolCall(lens) ||
-    UNSUCCESSFUL_TERMINAL_STATUSES.has(lens.status)
+    RETRYABLE_STATUSES.has(lens.status)
   );
 }

--- a/packages/openclaw/src/context-lens-card-eligibility.ts
+++ b/packages/openclaw/src/context-lens-card-eligibility.ts
@@ -1,0 +1,35 @@
+import { hasContextLensActivityCardContent } from '@tloncorp/api/urbit/lens';
+
+import type { ContextLens } from './context-lens.js';
+
+const UNSUCCESSFUL_TERMINAL_STATUSES = new Set<ContextLens['status']>([
+  'no_reply',
+  'timed_out',
+  'aborted',
+  'error',
+]);
+
+function hasNonPlanToolCall(lens: ContextLens): boolean {
+  const names = [
+    ...lens.tools.called,
+    ...lens.tools.runs.map((run) => run.name),
+  ].filter(Boolean);
+  if (names.length > 0) {
+    return names.some((name) => name !== 'update_plan');
+  }
+  // Older persisted snapshots can retain a count without tool names.
+  return lens.tools.callCount > 0;
+}
+
+/**
+ * Deterministic producer-side card gate. This intentionally never examines
+ * assistant prose, plan titles, elapsed time, or provider-generic items.
+ */
+export function isContextLensCardEligible(lens: ContextLens): boolean {
+  return (
+    lens.continuation?.kind === 'request_input' ||
+    hasContextLensActivityCardContent(lens.activity) ||
+    hasNonPlanToolCall(lens) ||
+    UNSUCCESSFUL_TERMINAL_STATUSES.has(lens.status)
+  );
+}

--- a/packages/openclaw/src/group-agent-activity-publisher.test.ts
+++ b/packages/openclaw/src/group-agent-activity-publisher.test.ts
@@ -4,6 +4,7 @@ import { beforeEach, describe, expect, test, vi } from 'vitest';
 import type { ContextLens } from './context-lens.js';
 import { createGroupAgentActivityPublisher } from './group-agent-activity-publisher.js';
 import type { GroupAgentActivityTransport } from './group-agent-activity-transport.js';
+import { buildParticipantAgentActivityProjection } from './participant-agent-activity.js';
 
 function makeLens(overrides: Partial<ContextLens> = {}): ContextLens {
   const now = 1_000;
@@ -597,6 +598,64 @@ describe('group participant agent activity publisher', () => {
         }),
       })
     );
+  });
+
+  test('terminalizes an aborted Lens as a cancelled participant receipt', async () => {
+    const transport = makeTransport();
+    const publisher = createGroupAgentActivityPublisher({
+      transport,
+      botShip: '~bot',
+      getBotProfile: () => undefined,
+      project: (lens, options) =>
+        buildParticipantAgentActivityProjection({
+          lens,
+          surface: options.surface,
+          revision: options.revision,
+          outcome: options.outcome,
+        }),
+      serializeReferenceBlob: ({ participantActivity }) =>
+        JSON.stringify(participantActivity),
+      replaceParticipantActivity: (_blob, _lensId, activity) =>
+        JSON.stringify(activity),
+      storyFromText: (text) => [{ inline: [text] }],
+      minUpdateIntervalMs: 0,
+    });
+    const active = makeLens();
+
+    publisher.handleEvent({
+      seq: 1,
+      at: 1_000,
+      phase: 'plan',
+      lens: active,
+    });
+    await publisher.flush();
+    publisher.handleEvent({
+      seq: 2,
+      at: 2_000,
+      phase: 'final',
+      lens: {
+        ...active,
+        status: 'aborted',
+        updatedAt: 2_000,
+        lifecycle: {
+          ...active.lifecycle,
+          completedAt: 2_000,
+          durationMs: 1_000,
+        },
+      },
+    });
+    await publisher.flush();
+
+    expect(transport.update).toHaveBeenLastCalledWith(
+      { postId: 'carrier-1', sentAt: 1_100 },
+      expect.objectContaining({
+        participantActivity: expect.objectContaining({
+          state: 'cancelled',
+          terminalReason: 'interrupted',
+        }),
+      })
+    );
+    await publisher.stop();
   });
 
   test('retries a failed terminal carrier edit with bounded backoff', async () => {

--- a/packages/openclaw/src/group-agent-activity-publisher.test.ts
+++ b/packages/openclaw/src/group-agent-activity-publisher.test.ts
@@ -1,0 +1,1068 @@
+import type { ParticipantAgentActivityProjectionV1 } from '@tloncorp/api/client/participantAgentActivity';
+import { beforeEach, describe, expect, test, vi } from 'vitest';
+
+import type { ContextLens } from './context-lens.js';
+import { createGroupAgentActivityPublisher } from './group-agent-activity-publisher.js';
+import type { GroupAgentActivityTransport } from './group-agent-activity-transport.js';
+
+function makeLens(overrides: Partial<ContextLens> = {}): ContextLens {
+  const now = 1_000;
+  return {
+    lensId: 'private-lens-id',
+    botShip: '~bot',
+    runId: 'run-1',
+    messageId: '123456',
+    sessionKeyHash: 'private-session',
+    chatType: 'channel',
+    runKind: 'conversation',
+    visibility: 'owner',
+    trigger: 'mention',
+    triggerDetails: {
+      type: 'mention',
+      messageId: '123456',
+      authorShip: '~requester',
+      conversationId: 'chat/~host/general',
+      conversationKind: 'channel',
+    },
+    retrySeed: {
+      messageText: 'private original text',
+      parentId: null,
+      isThreadReply: false,
+      replyParentId: null,
+    },
+    model: 'private-model',
+    provider: 'private-provider',
+    context: {
+      currentMessage: true,
+      threadMessages: 0,
+      channelMessages: 0,
+      citedPosts: 0,
+      attachments: 0,
+      pendingNudge: false,
+      sources: [],
+    },
+    persistence: {
+      postsReply: false,
+      updatesSettings: false,
+      writesMedia: false,
+      emitsTelemetry: false,
+      cachesHistory: false,
+      events: [],
+    },
+    tools: {
+      ownerOnlyAvailable: [],
+      called: [],
+      callCount: 0,
+      lastStartedAt: null,
+      runs: [],
+    },
+    outputs: [],
+    activity: {
+      schemaVersion: 1,
+      eventCount: 1,
+      lastEventAt: now,
+      truncated: false,
+      plan: {
+        updatedAt: now,
+        steps: [
+          { id: 'step-1', title: 'Check the records', status: 'running' },
+        ],
+      },
+      items: [
+        {
+          id: 'commentary-1',
+          kind: 'commentary',
+          title: 'Checking the records now.',
+          status: 'running',
+          startedAt: now,
+          updatedAt: now,
+          completedAt: null,
+        },
+      ],
+    },
+    lifecycle: {
+      queuedAt: now,
+      queuedMs: 0,
+      dispatchStartedAt: now,
+      firstToolStartedAt: null,
+      completedAt: null,
+      durationMs: null,
+      timeoutMs: 900_000,
+      timedOut: false,
+      deliveredMessageCount: 0,
+      queuedFinal: false,
+      queuedFinalCount: 0,
+      queuedBlockCount: 0,
+    },
+    status: 'dispatching',
+    error: null,
+    createdAt: now,
+    updatedAt: now,
+    expiresAt: now + 900_000,
+    ...overrides,
+  };
+}
+
+function projection(
+  lens: ContextLens,
+  surface: 'carrier' | 'final',
+  finalReplyDelivered = false,
+  revision = 1,
+  outcome?: 'completed' | 'failed' | 'cancelled'
+): ParticipantAgentActivityProjectionV1 {
+  const sourceStep = lens.activity.plan?.steps[0];
+  const timedOut = lens.status === 'timed_out';
+  const state =
+    outcome === 'cancelled'
+      ? ('cancelled' as const)
+      : outcome === 'failed'
+        ? ('failed' as const)
+        : timedOut
+          ? ('timed_out' as const)
+          : finalReplyDelivered || outcome === 'completed'
+            ? sourceStep?.status === 'completed'
+              ? ('completed' as const)
+              : ('incomplete' as const)
+            : ('working' as const);
+  const stepStatus =
+    state === 'cancelled'
+      ? ('cancelled' as const)
+      : state === 'failed' || state === 'timed_out'
+        ? ('failed' as const)
+        : state === 'incomplete'
+          ? ('pending' as const)
+          : sourceStep?.status === 'completed'
+            ? ('completed' as const)
+            : ('running' as const);
+  return {
+    schemaVersion: 1,
+    publicRunId: 'public-run-1',
+    surface,
+    revision,
+    triggerPostId: '123456',
+    state,
+    createdAt: lens.createdAt,
+    updatedAt: lens.updatedAt,
+    ...(state === 'working' ? {} : { completedAt: lens.updatedAt }),
+    steps: [
+      {
+        id: 'public-step-1',
+        title: sourceStep?.title ?? 'Check the records',
+        status: stepStatus,
+      },
+    ],
+    ...(timedOut
+      ? { terminalReason: 'timeout' as const }
+      : state === 'cancelled'
+        ? { terminalReason: 'interrupted' as const }
+        : state === 'failed'
+          ? { terminalReason: 'failed' as const }
+          : {}),
+  };
+}
+
+function makeTransport(): GroupAgentActivityTransport {
+  return {
+    create: vi.fn(async () => ({ postId: 'carrier-1', sentAt: 1_100 })),
+    update: vi.fn(async () => {}),
+    resolve: vi.fn(async (sentAt, draft) => ({
+      postId: 'final-1',
+      sentAt,
+      ...(draft.parentId ? { parentId: draft.parentId } : {}),
+    })),
+  };
+}
+
+function deferred<T>() {
+  let resolve!: (value: T | PromiseLike<T>) => void;
+  let reject!: (reason?: unknown) => void;
+  const promise = new Promise<T>((resolvePromise, rejectPromise) => {
+    resolve = resolvePromise;
+    reject = rejectPromise;
+  });
+  return { promise, resolve, reject };
+}
+
+function makePublisher(
+  transport: GroupAgentActivityTransport,
+  options: {
+    retryDelaysMs?: readonly number[];
+    retentionMs?: number;
+  } = {}
+) {
+  return createGroupAgentActivityPublisher({
+    transport,
+    botShip: '~bot',
+    getBotProfile: () => undefined,
+    project: (lens, projectOptions) =>
+      projection(
+        lens,
+        projectOptions.surface,
+        projectOptions.finalReplyDelivered,
+        projectOptions.revision,
+        projectOptions.outcome
+      ),
+    serializeReferenceBlob: ({ participantActivity }) =>
+      JSON.stringify(participantActivity),
+    replaceParticipantActivity: (_blob, _lensId, activity) =>
+      JSON.stringify(activity),
+    storyFromText: (text) => [{ inline: [text] }],
+    minUpdateIntervalMs: 0,
+    ...options,
+  });
+}
+
+function lensWithStep(
+  lens: ContextLens,
+  params: {
+    status: ContextLens['status'];
+    stepStatus: NonNullable<
+      ContextLens['activity']['plan']
+    >['steps'][number]['status'];
+    title?: string;
+    updatedAt: number;
+  }
+): ContextLens {
+  return {
+    ...lens,
+    status: params.status,
+    updatedAt: params.updatedAt,
+    activity: {
+      ...lens.activity,
+      plan: {
+        updatedAt: params.updatedAt,
+        steps: [
+          {
+            id: 'step-1',
+            title: params.title ?? 'Check the records',
+            status: params.stepStatus,
+          },
+        ],
+      },
+    },
+    lifecycle: {
+      ...lens.lifecycle,
+      ...(params.status === 'timed_out'
+        ? {
+            timedOut: true,
+            completedAt: params.updatedAt,
+            durationMs: params.updatedAt - lens.createdAt,
+          }
+        : params.status === 'completed'
+          ? {
+              completedAt: params.updatedAt,
+              durationMs: params.updatedAt - lens.createdAt,
+            }
+          : {}),
+    },
+  };
+}
+
+describe('group participant agent activity publisher', () => {
+  beforeEach(() => {
+    vi.useRealTimers();
+  });
+
+  test('publishes only structurally eligible channel conversation runs', async () => {
+    const transport = makeTransport();
+    const publisher = createGroupAgentActivityPublisher({
+      transport,
+      botShip: '~bot',
+      getBotProfile: () => undefined,
+      project: (lens, options) =>
+        projection(
+          lens,
+          options.surface,
+          options.finalReplyDelivered,
+          options.revision,
+          options.outcome
+        ),
+      serializeReferenceBlob: ({ participantActivity }) =>
+        JSON.stringify(participantActivity),
+      replaceParticipantActivity: (_blob, _lensId, activity) =>
+        JSON.stringify(activity),
+      storyFromText: (text) => [{ inline: [text] }],
+      minUpdateIntervalMs: 0,
+    });
+
+    publisher.handleEvent({
+      seq: 1,
+      at: 1_000,
+      phase: 'activity',
+      lens: makeLens({ chatType: 'dm' }),
+    });
+    publisher.handleEvent({
+      seq: 2,
+      at: 1_000,
+      phase: 'activity',
+      lens: makeLens({
+        activity: {
+          schemaVersion: 1,
+          eventCount: 0,
+          lastEventAt: null,
+          truncated: false,
+          plan: null,
+          items: [],
+        },
+      }),
+    });
+    publisher.handleEvent({
+      seq: 3,
+      at: 1_000,
+      phase: 'activity',
+      lens: makeLens({
+        tools: {
+          ...makeLens().tools,
+          called: ['update_plan'],
+          callCount: 3,
+        },
+        activity: {
+          schemaVersion: 1,
+          eventCount: 1,
+          lastEventAt: 1_000,
+          truncated: false,
+          plan: {
+            updatedAt: 1_000,
+            steps: [
+              { id: 'step-1', title: 'Answer the greeting', status: 'running' },
+            ],
+          },
+          items: [],
+        },
+      }),
+    });
+    publisher.handleEvent({
+      seq: 4,
+      at: 1_000,
+      phase: 'activity',
+      lens: makeLens({
+        activity: {
+          schemaVersion: 1,
+          eventCount: 1,
+          lastEventAt: 1_000,
+          truncated: false,
+          plan: null,
+          items: [
+            {
+              id: 'generic-reasoning',
+              kind: 'item',
+              title: 'Reasoning',
+              status: 'running',
+              startedAt: 1_000,
+              updatedAt: 1_000,
+              completedAt: null,
+            },
+          ],
+        },
+      }),
+    });
+    await publisher.flush();
+    expect(transport.create).not.toHaveBeenCalled();
+
+    publisher.handleEvent({
+      seq: 5,
+      at: 1_000,
+      phase: 'activity',
+      lens: makeLens({
+        activity: {
+          schemaVersion: 1,
+          eventCount: 1,
+          lastEventAt: 1_000,
+          truncated: false,
+          plan: null,
+          items: [
+            {
+              id: 'commentary-1',
+              kind: 'commentary',
+              title: 'Checking the records now.',
+              status: 'running',
+              startedAt: 1_000,
+              updatedAt: 1_000,
+              completedAt: null,
+            },
+          ],
+        },
+      }),
+    });
+    await publisher.flush();
+    expect(transport.create).toHaveBeenCalledTimes(1);
+    expect(transport.create).toHaveBeenCalledWith(
+      expect.objectContaining({
+        conversationId: 'chat/~host/general',
+        authorId: '~bot',
+        story: [{ inline: ['Working…'] }],
+      })
+    );
+  });
+
+  test('keeps an existing public run eligible after its structural seed is cleared', async () => {
+    const transport = makeTransport();
+    const publisher = makePublisher(transport);
+    const active = makeLens();
+    publisher.handleEvent({ seq: 1, at: 1_000, phase: 'plan', lens: active });
+    await publisher.flush();
+
+    const cleared: ContextLens = {
+      ...active,
+      updatedAt: 2_000,
+      activity: {
+        schemaVersion: 1,
+        eventCount: 0,
+        lastEventAt: null,
+        truncated: false,
+        plan: null,
+        items: [],
+      },
+    };
+    expect(publisher.buildFinalProjection(cleared, 'completed')).not.toBeNull();
+    await publisher.stop();
+  });
+
+  test('updates one carrier and keeps a thread carrier in its exact thread', async () => {
+    const transport = makeTransport();
+    const publisher = createGroupAgentActivityPublisher({
+      transport,
+      botShip: '~bot',
+      getBotProfile: () => undefined,
+      project: (lens, options) =>
+        projection(
+          lens,
+          options.surface,
+          options.finalReplyDelivered,
+          options.revision,
+          options.outcome
+        ),
+      serializeReferenceBlob: ({ participantActivity }) =>
+        JSON.stringify(participantActivity),
+      replaceParticipantActivity: (_blob, _lensId, activity) =>
+        JSON.stringify(activity),
+      storyFromText: (text) => [{ inline: [text] }],
+      minUpdateIntervalMs: 0,
+    });
+    const threadLens = makeLens({
+      retrySeed: {
+        messageText: 'private',
+        parentId: 'thread-root',
+        isThreadReply: true,
+        replyParentId: 'thread-root',
+      },
+    });
+
+    publisher.handleEvent({
+      seq: 1,
+      at: 1_000,
+      phase: 'plan',
+      lens: threadLens,
+    });
+    await publisher.flush();
+    expect(transport.create).toHaveBeenCalledWith(
+      expect.objectContaining({ parentId: 'thread-root' })
+    );
+
+    publisher.handleEvent({
+      seq: 2,
+      at: 2_000,
+      phase: 'activity',
+      lens: { ...threadLens, updatedAt: 2_000 },
+    });
+    await publisher.flush();
+    expect(transport.create).toHaveBeenCalledTimes(1);
+    // Private/timing-only Lens churn does not edit the public carrier.
+    expect(transport.update).not.toHaveBeenCalled();
+
+    publisher.handleEvent({
+      seq: 3,
+      at: 3_000,
+      phase: 'plan',
+      lens: {
+        ...threadLens,
+        updatedAt: 3_000,
+        activity: {
+          ...threadLens.activity,
+          plan: {
+            updatedAt: 3_000,
+            steps: [
+              {
+                id: 'step-1',
+                title: 'Verify the records',
+                status: 'running',
+              },
+            ],
+          },
+        },
+      },
+    });
+    await publisher.flush();
+    expect(transport.update).toHaveBeenCalledTimes(1);
+    expect(transport.update).toHaveBeenCalledWith(
+      { postId: 'carrier-1', sentAt: 1_100 },
+      expect.objectContaining({
+        parentId: 'thread-root',
+        participantActivity: expect.objectContaining({
+          steps: [expect.objectContaining({ title: 'Verify the records' })],
+        }),
+      })
+    );
+  });
+
+  test('publishes a liveness heartbeat for long silent work', async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(1_000);
+    const transport = makeTransport();
+    const publisher = createGroupAgentActivityPublisher({
+      transport,
+      botShip: '~bot',
+      getBotProfile: () => undefined,
+      project: (lens, options) =>
+        projection(
+          lens,
+          options.surface,
+          options.finalReplyDelivered,
+          options.revision,
+          options.outcome
+        ),
+      serializeReferenceBlob: ({ participantActivity }) =>
+        JSON.stringify(participantActivity),
+      replaceParticipantActivity: (_blob, _lensId, activity) =>
+        JSON.stringify(activity),
+      storyFromText: (text) => [{ inline: [text] }],
+      minUpdateIntervalMs: 0,
+      heartbeatIntervalMs: 60_000,
+    });
+
+    publisher.handleEvent({
+      seq: 1,
+      at: 1_000,
+      phase: 'plan',
+      lens: makeLens(),
+    });
+    await publisher.flush();
+    expect(transport.update).not.toHaveBeenCalled();
+
+    await vi.advanceTimersByTimeAsync(60_000);
+    await publisher.flush();
+    expect(transport.update).toHaveBeenCalledTimes(1);
+    expect(transport.update).toHaveBeenCalledWith(
+      { postId: 'carrier-1', sentAt: 1_100 },
+      expect.objectContaining({
+        participantActivity: expect.objectContaining({
+          state: 'working',
+          revision: 2,
+          updatedAt: 61_000,
+        }),
+      })
+    );
+    await publisher.stop();
+  });
+
+  test('terminalizes an active carrier instead of deleting it on stop', async () => {
+    const transport = makeTransport();
+    const publisher = createGroupAgentActivityPublisher({
+      transport,
+      botShip: '~bot',
+      getBotProfile: () => undefined,
+      project: (lens, options) =>
+        projection(
+          lens,
+          options.surface,
+          options.finalReplyDelivered,
+          options.revision,
+          options.outcome
+        ),
+      serializeReferenceBlob: ({ participantActivity }) =>
+        JSON.stringify(participantActivity),
+      replaceParticipantActivity: (_blob, _lensId, activity) =>
+        JSON.stringify(activity),
+      storyFromText: (text) => [{ inline: [text] }],
+      minUpdateIntervalMs: 0,
+    });
+
+    publisher.handleEvent({
+      seq: 1,
+      at: 1_000,
+      phase: 'plan',
+      lens: makeLens(),
+    });
+    await publisher.flush();
+    await publisher.stop();
+
+    expect(transport.update).toHaveBeenLastCalledWith(
+      { postId: 'carrier-1', sentAt: 1_100 },
+      expect.objectContaining({
+        story: [{ inline: ['The agent run was cancelled.'] }],
+        participantActivity: expect.objectContaining({
+          surface: 'carrier',
+          state: 'cancelled',
+          terminalReason: 'interrupted',
+        }),
+      })
+    );
+  });
+
+  test('retries a failed terminal carrier edit with bounded backoff', async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(1_000);
+    const transport = makeTransport();
+    const publisher = createGroupAgentActivityPublisher({
+      transport,
+      botShip: '~bot',
+      getBotProfile: () => undefined,
+      project: (lens, options) =>
+        projection(
+          lens,
+          options.surface,
+          options.finalReplyDelivered,
+          options.revision,
+          options.outcome
+        ),
+      serializeReferenceBlob: ({ participantActivity }) =>
+        JSON.stringify(participantActivity),
+      replaceParticipantActivity: (_blob, _lensId, activity) =>
+        JSON.stringify(activity),
+      storyFromText: (text) => [{ inline: [text] }],
+      minUpdateIntervalMs: 0,
+      retryDelaysMs: [10],
+    });
+
+    publisher.handleEvent({
+      seq: 1,
+      at: 1_000,
+      phase: 'plan',
+      lens: makeLens(),
+    });
+    await publisher.flush();
+    vi.mocked(transport.update)
+      .mockRejectedValueOnce(new Error('host echo delayed'))
+      .mockResolvedValue(undefined);
+
+    const terminal = makeLens({
+      status: 'timed_out',
+      updatedAt: 2_000,
+      lifecycle: {
+        ...makeLens().lifecycle,
+        timedOut: true,
+        completedAt: 2_000,
+        durationMs: 1_000,
+      },
+    });
+    publisher.handleEvent({
+      seq: 2,
+      at: 2_000,
+      phase: 'final',
+      lens: terminal,
+    });
+    await publisher.flush();
+    expect(transport.update).toHaveBeenCalledTimes(1);
+
+    await vi.advanceTimersByTimeAsync(10);
+    await publisher.flush();
+    expect(transport.update).toHaveBeenCalledTimes(2);
+    expect(transport.update).toHaveBeenLastCalledWith(
+      { postId: 'carrier-1', sentAt: 1_100 },
+      expect.objectContaining({
+        participantActivity: expect.objectContaining({ state: 'timed_out' }),
+      })
+    );
+    await publisher.stop();
+  });
+
+  test('moves to the normal final reply and terminally reconciles its blob', async () => {
+    const transport = makeTransport();
+    const publisher = createGroupAgentActivityPublisher({
+      transport,
+      botShip: '~bot',
+      getBotProfile: () => undefined,
+      project: (lens, options) =>
+        projection(
+          lens,
+          options.surface,
+          options.finalReplyDelivered,
+          options.revision,
+          options.outcome
+        ),
+      serializeReferenceBlob: ({ participantActivity }) =>
+        JSON.stringify(participantActivity),
+      replaceParticipantActivity: (_blob, _lensId, activity) =>
+        JSON.stringify(activity),
+      storyFromText: (text) => [{ inline: [text] }],
+      minUpdateIntervalMs: 0,
+    });
+    const active = makeLens();
+    publisher.handleEvent({ seq: 1, at: 1_000, phase: 'plan', lens: active });
+    await publisher.flush();
+
+    const finalProjection = publisher.buildFinalProjection(
+      active,
+      'completed'
+    )!;
+    publisher.registerFinalReply({
+      lens: active,
+      sentAt: 2_000,
+      story: [{ inline: ['Here is the answer.'] }],
+      blob: JSON.stringify(finalProjection),
+      participantActivity: finalProjection,
+      outcome: 'completed',
+    });
+    await publisher.flush();
+    // Keep the real carrier post (and any replies/reactions on it), but settle
+    // its projection. Modern clients hide it in favor of the final reply.
+    expect(transport.update).toHaveBeenCalledWith(
+      { postId: 'carrier-1', sentAt: 1_100 },
+      expect.objectContaining({
+        story: [{ inline: ['Finished with incomplete steps.'] }],
+        participantActivity: expect.objectContaining({
+          surface: 'carrier',
+          state: 'incomplete',
+        }),
+      })
+    );
+    // The final reply already contains this semantic snapshot, so do not
+    // immediately edit it merely to advance timing metadata.
+    expect(transport.resolve).not.toHaveBeenCalled();
+
+    const terminal = makeLens({
+      status: 'timed_out',
+      updatedAt: 3_000,
+      lifecycle: {
+        ...active.lifecycle,
+        timedOut: true,
+        completedAt: 3_000,
+        durationMs: 2_000,
+      },
+    });
+    publisher.handleEvent({
+      seq: 2,
+      at: 3_000,
+      phase: 'final',
+      lens: terminal,
+    });
+    await publisher.flush();
+    expect(transport.resolve).toHaveBeenCalledTimes(1);
+    expect(transport.update).toHaveBeenCalledWith(
+      { postId: 'final-1', sentAt: 2_000 },
+      expect.objectContaining({
+        story: [{ inline: ['Here is the answer.'] }],
+        blob: expect.stringContaining('timed_out'),
+        participantActivity: expect.objectContaining({
+          surface: 'final',
+          state: 'timed_out',
+        }),
+      })
+    );
+  });
+
+  test('does not let an older final edit erase a newer terminal Lens event', async () => {
+    const transport = makeTransport();
+    const publisher = makePublisher(transport);
+    const active = makeLens();
+    publisher.handleEvent({ seq: 1, at: 1_000, phase: 'plan', lens: active });
+    await publisher.flush();
+
+    const initialFinal = publisher.buildFinalProjection(active, 'completed')!;
+    publisher.registerFinalReply({
+      lens: active,
+      sentAt: 2_000,
+      story: [{ inline: ['Here is the answer.'] }],
+      blob: JSON.stringify(initialFinal),
+      participantActivity: initialFinal,
+      outcome: 'completed',
+    });
+    await publisher.flush();
+
+    const firstFinalEditStarted = deferred<void>();
+    const releaseFirstFinalEdit = deferred<void>();
+    let deferFinalEdit = true;
+    vi.mocked(transport.update).mockImplementation(async (post) => {
+      if (post.postId === 'final-1' && deferFinalEdit) {
+        deferFinalEdit = false;
+        firstFinalEditStarted.resolve(undefined);
+        await releaseFirstFinalEdit.promise;
+      }
+    });
+
+    const timedOut = lensWithStep(active, {
+      status: 'timed_out',
+      stepStatus: 'running',
+      updatedAt: 3_000,
+    });
+    publisher.handleEvent({
+      seq: 2,
+      at: 3_000,
+      phase: 'final',
+      lens: timedOut,
+    });
+    const flushing = publisher.flush();
+    await firstFinalEditStarted.promise;
+
+    const completed = lensWithStep(active, {
+      status: 'completed',
+      stepStatus: 'completed',
+      title: 'Verified the records',
+      updatedAt: 4_000,
+    });
+    publisher.handleEvent({
+      seq: 3,
+      at: 4_000,
+      phase: 'final',
+      lens: completed,
+    });
+    releaseFirstFinalEdit.resolve(undefined);
+    await flushing;
+    await publisher.flush();
+
+    const finalDrafts = vi
+      .mocked(transport.update)
+      .mock.calls.filter(([post]) => post.postId === 'final-1')
+      .map(([, draft]) => draft.participantActivity);
+    expect(finalDrafts.map((draft) => draft.state)).toEqual([
+      'timed_out',
+      'completed',
+    ]);
+    expect(finalDrafts.at(-1)?.steps[0]?.title).toBe('Verified the records');
+    await publisher.stop();
+  });
+
+  test('reconciles the final reply even when the carrier edit fails', async () => {
+    const transport = makeTransport();
+    const publisher = makePublisher(transport, { retryDelaysMs: [] });
+    const active = makeLens();
+    publisher.handleEvent({ seq: 1, at: 1_000, phase: 'plan', lens: active });
+    await publisher.flush();
+
+    const initialFinal = publisher.buildFinalProjection(active, 'completed')!;
+    publisher.registerFinalReply({
+      lens: active,
+      sentAt: 2_000,
+      story: [{ inline: ['Here is the answer.'] }],
+      blob: JSON.stringify(initialFinal),
+      participantActivity: initialFinal,
+      outcome: 'completed',
+    });
+    await publisher.flush();
+    vi.mocked(transport.update).mockClear();
+    vi.mocked(transport.update).mockImplementation(async (post) => {
+      if (post.postId === 'carrier-1') {
+        throw new Error('carrier was removed');
+      }
+    });
+
+    const timedOut = lensWithStep(active, {
+      status: 'timed_out',
+      stepStatus: 'running',
+      updatedAt: 3_000,
+    });
+    publisher.handleEvent({
+      seq: 2,
+      at: 3_000,
+      phase: 'final',
+      lens: timedOut,
+    });
+    await publisher.flush();
+
+    expect(transport.update).toHaveBeenCalledWith(
+      { postId: 'final-1', sentAt: 2_000 },
+      expect.objectContaining({
+        participantActivity: expect.objectContaining({ state: 'timed_out' }),
+      })
+    );
+    await publisher.stop();
+  });
+
+  test('does not create a carrier after the normal final reply exists', async () => {
+    const transport = makeTransport();
+    const publisher = makePublisher(transport);
+    const active = makeLens();
+
+    const initialFinal = publisher.buildFinalProjection(active, 'completed')!;
+    publisher.registerFinalReply({
+      lens: active,
+      sentAt: 2_000,
+      story: [{ inline: ['Here is the answer.'] }],
+      blob: JSON.stringify(initialFinal),
+      participantActivity: initialFinal,
+      outcome: 'completed',
+    });
+    await publisher.flush();
+
+    expect(transport.create).not.toHaveBeenCalled();
+    expect(transport.resolve).not.toHaveBeenCalled();
+    expect(transport.update).not.toHaveBeenCalled();
+    await publisher.stop();
+  });
+
+  test('retries a failed shutdown terminal edit before clearing state', async () => {
+    const transport = makeTransport();
+    const publisher = makePublisher(transport);
+    publisher.handleEvent({
+      seq: 1,
+      at: 1_000,
+      phase: 'plan',
+      lens: makeLens(),
+    });
+    await publisher.flush();
+    vi.mocked(transport.update)
+      .mockRejectedValueOnce(new Error('host echo delayed'))
+      .mockResolvedValue(undefined);
+
+    await publisher.stop();
+
+    expect(transport.update).toHaveBeenCalledTimes(2);
+    expect(transport.update).toHaveBeenLastCalledWith(
+      { postId: 'carrier-1', sentAt: 1_100 },
+      expect.objectContaining({
+        participantActivity: expect.objectContaining({ state: 'cancelled' }),
+      })
+    );
+  });
+
+  test('terminalizes a create that was already in flight when shutdown began', async () => {
+    const transport = makeTransport();
+    const pendingCreate = deferred<{ postId: string; sentAt: number }>();
+    vi.mocked(transport.create).mockImplementation(() => pendingCreate.promise);
+    const publisher = makePublisher(transport);
+    publisher.handleEvent({
+      seq: 1,
+      at: 1_000,
+      phase: 'plan',
+      lens: makeLens(),
+    });
+    await vi.waitFor(() => expect(transport.create).toHaveBeenCalledTimes(1));
+
+    const stopping = publisher.stop();
+    pendingCreate.resolve({ postId: 'carrier-1', sentAt: 1_100 });
+    await stopping;
+
+    expect(transport.create).toHaveBeenCalledTimes(1);
+    expect(transport.update).toHaveBeenLastCalledWith(
+      { postId: 'carrier-1', sentAt: 1_100 },
+      expect.objectContaining({
+        story: [{ inline: ['The agent run was cancelled.'] }],
+        participantActivity: expect.objectContaining({ state: 'cancelled' }),
+      })
+    );
+  });
+
+  test('coalesces new activity while a failed create is backing off', async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(1_000);
+    const transport = makeTransport();
+    vi.mocked(transport.create)
+      .mockRejectedValueOnce(new Error('host unavailable'))
+      .mockResolvedValue({ postId: 'carrier-1', sentAt: 1_100 });
+    const publisher = makePublisher(transport, { retryDelaysMs: [100] });
+    const active = makeLens();
+    publisher.handleEvent({ seq: 1, at: 1_000, phase: 'plan', lens: active });
+    await publisher.flush();
+    expect(transport.create).toHaveBeenCalledTimes(1);
+
+    publisher.handleEvent({
+      seq: 2,
+      at: 2_000,
+      phase: 'plan',
+      lens: lensWithStep(active, {
+        status: 'tool_running',
+        stepStatus: 'running',
+        title: 'Check the latest records',
+        updatedAt: 2_000,
+      }),
+    });
+    await vi.advanceTimersByTimeAsync(99);
+    expect(transport.create).toHaveBeenCalledTimes(1);
+
+    await vi.advanceTimersByTimeAsync(1);
+    await publisher.flush();
+    expect(transport.create).toHaveBeenCalledTimes(2);
+    expect(transport.create).toHaveBeenLastCalledWith(
+      expect.objectContaining({
+        participantActivity: expect.objectContaining({
+          steps: [
+            expect.objectContaining({ title: 'Check the latest records' }),
+          ],
+        }),
+      })
+    );
+    await publisher.stop();
+  });
+
+  test('evicts owner Lens state after initial-create retries are exhausted', async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(1_000);
+    const transport = makeTransport();
+    vi.mocked(transport.create).mockRejectedValue(
+      new Error('host unavailable')
+    );
+    const publisher = makePublisher(transport, {
+      retryDelaysMs: [],
+      retentionMs: 1_000,
+    });
+    const active = makeLens();
+    publisher.handleEvent({ seq: 1, at: 1_000, phase: 'plan', lens: active });
+    await publisher.flush();
+    expect(transport.create).toHaveBeenCalledTimes(1);
+
+    await vi.advanceTimersByTimeAsync(1_000);
+    publisher.handleEvent({
+      seq: 2,
+      at: 2_000,
+      phase: 'activity',
+      lens: {
+        ...active,
+        updatedAt: 2_000,
+        activity: {
+          ...active.activity,
+          plan: null,
+          items: [],
+        },
+      },
+    });
+    await publisher.flush();
+
+    // A retained failed state would accept this planless continuation and try
+    // creation again. Eviction makes it ineligible as a new public run.
+    expect(transport.create).toHaveBeenCalledTimes(1);
+    await publisher.stop();
+  });
+
+  test('does not recreate a carrier for a late terminal event after eviction', async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(1_000);
+    const transport = makeTransport();
+    const publisher = makePublisher(transport, { retentionMs: 1_000 });
+    const active = makeLens();
+    publisher.handleEvent({ seq: 1, at: 1_000, phase: 'plan', lens: active });
+    await publisher.flush();
+
+    const completed = lensWithStep(active, {
+      status: 'completed',
+      stepStatus: 'completed',
+      updatedAt: 2_000,
+    });
+    publisher.handleEvent({
+      seq: 2,
+      at: 2_000,
+      phase: 'final',
+      lens: completed,
+    });
+    await publisher.flush();
+    expect(transport.create).toHaveBeenCalledTimes(1);
+    expect(transport.update).toHaveBeenCalledTimes(1);
+
+    await vi.advanceTimersByTimeAsync(1_000);
+    publisher.handleEvent({
+      seq: 3,
+      at: 3_000,
+      phase: 'final',
+      lens: lensWithStep(active, {
+        status: 'completed',
+        stepStatus: 'completed',
+        title: 'Late duplicate terminal event',
+        updatedAt: 3_000,
+      }),
+    });
+    await publisher.flush();
+
+    expect(transport.create).toHaveBeenCalledTimes(1);
+    expect(transport.update).toHaveBeenCalledTimes(1);
+    await publisher.stop();
+  });
+});

--- a/packages/openclaw/src/group-agent-activity-publisher.ts
+++ b/packages/openclaw/src/group-agent-activity-publisher.ts
@@ -6,7 +6,10 @@ import type { RuntimeEnv } from 'openclaw/plugin-sdk/runtime';
 
 import { isContextLensCardEligible } from './context-lens-card-eligibility.js';
 import type { ContextLensEvent } from './context-lens-events.js';
-import type { ContextLens } from './context-lens.js';
+import {
+  type ContextLens,
+  isTerminalContextLensStatus,
+} from './context-lens.js';
 import type {
   GroupAgentActivityPost,
   GroupAgentActivityPostDraft,
@@ -61,14 +64,6 @@ type RunState = {
   publishing: boolean;
   tombstoneUntil: number;
 };
-
-const TERMINAL_STATUSES = new Set<ContextLens['status']>([
-  'completed',
-  'no_reply',
-  'timed_out',
-  'aborted',
-  'error',
-]);
 
 const TERMINAL_PUBLIC_STATES = new Set<
   ParticipantAgentActivityProjectionV1['state']
@@ -384,7 +379,7 @@ export function createGroupAgentActivityPublisher(options: {
       stopping ||
       !state.latestLens ||
       state.finalPost ||
-      TERMINAL_STATUSES.has(state.latestLens.status)
+      isTerminalContextLensStatus(state.latestLens.status)
     ) {
       return;
     }
@@ -484,7 +479,7 @@ export function createGroupAgentActivityPublisher(options: {
       return;
     }
     const inputVersion = state.inputVersion;
-    const terminalLens = TERMINAL_STATUSES.has(lens.status);
+    const terminalLens = isTerminalContextLensStatus(lens.status);
     const carrierOutcome =
       state.forcedOutcome ?? state.finalPost?.outcome ?? undefined;
 
@@ -646,7 +641,7 @@ export function createGroupAgentActivityPublisher(options: {
       const state = ensureState(lens);
       const retryPending = Boolean(state.retryTimer);
       state.dirty = true;
-      if (TERMINAL_STATUSES.has(lens.status)) {
+      if (isTerminalContextLensStatus(lens.status)) {
         // Terminal state is user-visible and bypasses a pending working-state
         // backoff. It receives a fresh bounded terminal retry cycle.
         state.retryAttempt = 0;

--- a/packages/openclaw/src/group-agent-activity-publisher.ts
+++ b/packages/openclaw/src/group-agent-activity-publisher.ts
@@ -1,0 +1,800 @@
+import {
+  type ParticipantAgentActivityProjectionV1,
+  ParticipantAgentActivityProjectionV1Schema,
+} from '@tloncorp/api/client/participantAgentActivity';
+import type { RuntimeEnv } from 'openclaw/plugin-sdk/runtime';
+
+import { isContextLensCardEligible } from './context-lens-card-eligibility.js';
+import type { ContextLensEvent } from './context-lens-events.js';
+import type { ContextLens } from './context-lens.js';
+import type {
+  GroupAgentActivityPost,
+  GroupAgentActivityPostDraft,
+  GroupAgentActivityTransport,
+} from './group-agent-activity-transport.js';
+import { participantAgentDeliveryParentId } from './participant-agent-activity.js';
+import type { BotProfile } from './urbit/send.js';
+import type { Story } from './urbit/story.js';
+
+type ProjectOutcome = 'completed' | 'failed' | 'cancelled';
+
+type ProjectOptions = {
+  surface: ParticipantAgentActivityProjectionV1['surface'];
+  finalReplyDelivered: boolean;
+  revision: number;
+  outcome?: ProjectOutcome;
+};
+
+type FinalPost = {
+  post: GroupAgentActivityPost | null;
+  sentAt: number;
+  draft: GroupAgentActivityPostDraft;
+  baseBlob: string;
+  initialProjection: ParticipantAgentActivityProjectionV1;
+  outcome: 'completed' | 'failed';
+};
+
+type RunState = {
+  lensId: string;
+  latestLens: ContextLens | null;
+  carrier: GroupAgentActivityPost | null;
+  carrierProjection: ParticipantAgentActivityProjectionV1 | null;
+  carrierSemantic: string | null;
+  finalPost: FinalPost | null;
+  finalProjection: ParticipantAgentActivityProjectionV1 | null;
+  finalSemantic: string | null;
+  preparedFinalProjection: ParticipantAgentActivityProjectionV1 | null;
+  lastPublishedAt: number;
+  lastPublicUpdatedAt: number;
+  scheduled: boolean;
+  dirty: boolean;
+  heartbeatDue: boolean;
+  forcedOutcome: ProjectOutcome | null;
+  timer: ReturnType<typeof setTimeout> | null;
+  heartbeatTimer: ReturnType<typeof setTimeout> | null;
+  retryTimer: ReturnType<typeof setTimeout> | null;
+  evictionTimer: ReturnType<typeof setTimeout> | null;
+  retryAttempt: number;
+  chain: Promise<void>;
+  revision: number;
+  inputVersion: number;
+  publishing: boolean;
+  tombstoneUntil: number;
+};
+
+const TERMINAL_STATUSES = new Set<ContextLens['status']>([
+  'completed',
+  'no_reply',
+  'timed_out',
+  'aborted',
+  'error',
+]);
+
+const TERMINAL_PUBLIC_STATES = new Set<
+  ParticipantAgentActivityProjectionV1['state']
+>(['completed', 'incomplete', 'failed', 'timed_out', 'cancelled']);
+
+const DEFAULT_MIN_UPDATE_INTERVAL_MS = 1_000;
+const DEFAULT_HEARTBEAT_INTERVAL_MS = 60_000;
+const DEFAULT_RETENTION_MS = 5 * 60_000;
+const DEFAULT_TOMBSTONE_MS = 30 * 60_000;
+const DEFAULT_RETRY_DELAYS_MS = [1_000, 5_000, 15_000, 30_000, 60_000];
+
+function isGroupConversationLens(lens: ContextLens) {
+  const conversationId = lens.triggerDetails.conversationId?.trim();
+  return (
+    lens.chatType === 'channel' &&
+    lens.runKind === 'conversation' &&
+    Boolean(conversationId && /^chat\/~[^/]+\/[^/]+$/.test(conversationId))
+  );
+}
+
+function carrierFallback(state: ParticipantAgentActivityProjectionV1['state']) {
+  switch (state) {
+    case 'waiting_owner':
+      return 'Waiting for approval…';
+    case 'waiting_requester':
+      return 'Waiting for a response…';
+    case 'completed':
+      return 'Finished.';
+    case 'incomplete':
+      return 'Finished with incomplete steps.';
+    case 'failed':
+      return 'The agent run failed.';
+    case 'timed_out':
+      return 'The agent run timed out.';
+    case 'cancelled':
+      return 'The agent run was cancelled.';
+    case 'working':
+      return 'Working…';
+  }
+}
+
+function semanticProjection(projection: ParticipantAgentActivityProjectionV1) {
+  // Normalize through the wire schema before stringifying. Callers can build
+  // structurally identical objects with different insertion order; comparing
+  // their raw JSON would treat that as public activity churn and edit the
+  // carrier/final post unnecessarily.
+  const normalized =
+    ParticipantAgentActivityProjectionV1Schema.parse(projection);
+  const semantic: Partial<ParticipantAgentActivityProjectionV1> = {
+    ...normalized,
+  };
+  delete semantic.revision;
+  delete semantic.updatedAt;
+  delete semantic.completedAt;
+  return JSON.stringify(semantic);
+}
+
+function isTerminalProjection(
+  projection: ParticipantAgentActivityProjectionV1
+) {
+  return TERMINAL_PUBLIC_STATES.has(projection.state);
+}
+
+/**
+ * Publishes only an allowlisted projection through ordinary channel posts.
+ * The channel host therefore remains the authorization boundary; raw Context
+ * Lens snapshots continue to flow solely to the owner's %steward store.
+ */
+export function createGroupAgentActivityPublisher(options: {
+  transport: GroupAgentActivityTransport;
+  runtime?: RuntimeEnv;
+  botShip: string;
+  getBotProfile: () => BotProfile | undefined;
+  project: (
+    lens: ContextLens,
+    options: ProjectOptions
+  ) => ParticipantAgentActivityProjectionV1 | null;
+  serializeReferenceBlob: (params: {
+    lensId: string;
+    botShip: string;
+    delivery: 'final' | 'intermediate';
+    outcome?: 'completed' | 'failed';
+    participantActivity: ParticipantAgentActivityProjectionV1;
+  }) => string;
+  replaceParticipantActivity: (
+    blob: string,
+    lensId: string,
+    participantActivity: ParticipantAgentActivityProjectionV1
+  ) => string;
+  storyFromText: (text: string) => Story;
+  minUpdateIntervalMs?: number;
+  heartbeatIntervalMs?: number;
+  retryDelaysMs?: readonly number[];
+  retentionMs?: number;
+}) {
+  const states = new Map<string, RunState>();
+  const tombstones = new Map<string, number>();
+  const minUpdateIntervalMs = Math.max(
+    0,
+    options.minUpdateIntervalMs ?? DEFAULT_MIN_UPDATE_INTERVAL_MS
+  );
+  const heartbeatIntervalMs = Math.max(
+    1_000,
+    options.heartbeatIntervalMs ?? DEFAULT_HEARTBEAT_INTERVAL_MS
+  );
+  const retryDelaysMs = options.retryDelaysMs ?? DEFAULT_RETRY_DELAYS_MS;
+  const retentionMs = Math.max(
+    1_000,
+    options.retentionMs ?? DEFAULT_RETENTION_MS
+  );
+  let stopping = false;
+  let stopped = false;
+  let stopPromise: Promise<void> | null = null;
+  let tombstoneSweepTimer: ReturnType<typeof setTimeout> | null = null;
+
+  const reportError = (lensId: string, action: string, error: unknown) => {
+    options.runtime?.error?.(
+      `[tlon] Participant agent activity ${action} failed for ${lensId}: ${
+        error instanceof Error ? error.stack ?? error.message : String(error)
+      }`
+    );
+  };
+
+  const clearTimer = (
+    state: RunState,
+    key: 'timer' | 'heartbeatTimer' | 'retryTimer' | 'evictionTimer'
+  ) => {
+    const timer = state[key];
+    if (timer) {
+      clearTimeout(timer);
+      state[key] = null;
+    }
+  };
+
+  const getDraft = (
+    lens: ContextLens,
+    projection: ParticipantAgentActivityProjectionV1
+  ): GroupAgentActivityPostDraft | null => {
+    const conversationId = lens.triggerDetails.conversationId?.trim();
+    if (!conversationId) {
+      return null;
+    }
+    const parentId = participantAgentDeliveryParentId(lens);
+    return {
+      conversationId,
+      authorId: options.botShip,
+      ...(parentId ? { parentId } : {}),
+      story: options.storyFromText(carrierFallback(projection.state)),
+      blob: options.serializeReferenceBlob({
+        lensId: lens.lensId,
+        botShip: options.botShip,
+        delivery: 'intermediate',
+        participantActivity: projection,
+      }),
+      participantActivity: projection,
+      botProfile: options.getBotProfile(),
+    };
+  };
+
+  const ensureState = (lens: ContextLens) => {
+    let state = states.get(lens.lensId);
+    if (!state) {
+      state = {
+        lensId: lens.lensId,
+        latestLens: lens,
+        carrier: null,
+        carrierProjection: null,
+        carrierSemantic: null,
+        finalPost: null,
+        finalProjection: null,
+        finalSemantic: null,
+        preparedFinalProjection: null,
+        lastPublishedAt: 0,
+        lastPublicUpdatedAt: 0,
+        scheduled: false,
+        dirty: false,
+        heartbeatDue: false,
+        forcedOutcome: null,
+        timer: null,
+        heartbeatTimer: null,
+        retryTimer: null,
+        evictionTimer: null,
+        retryAttempt: 0,
+        chain: Promise.resolve(),
+        revision: 0,
+        inputVersion: 0,
+        publishing: false,
+        tombstoneUntil: 0,
+      };
+      states.set(lens.lensId, state);
+    }
+    if (!state.latestLens) {
+      // A new event after bounded retry exhaustion starts a fresh delivery
+      // cycle instead of inheriting the exhausted attempt counter.
+      state.retryAttempt = 0;
+    }
+    state.latestLens = lens;
+    state.inputVersion += 1;
+    clearTimer(state, 'evictionTimer');
+    return state;
+  };
+
+  const projectCandidate = (
+    state: RunState,
+    lens: ContextLens,
+    surface: ParticipantAgentActivityProjectionV1['surface'],
+    outcome?: ProjectOutcome
+  ) => {
+    return options.project(lens, {
+      surface,
+      finalReplyDelivered: Boolean(state.finalPost),
+      revision: state.revision + 1,
+      ...(outcome ? { outcome } : {}),
+    });
+  };
+
+  const materializeProjection = (
+    state: RunState,
+    candidate: ParticipantAgentActivityProjectionV1,
+    forceTimestamp = false
+  ) => {
+    state.revision += 1;
+    const updatedAt = Math.max(
+      candidate.createdAt,
+      Date.now(),
+      state.lastPublicUpdatedAt + 1
+    );
+    state.lastPublicUpdatedAt = updatedAt;
+    const materialized: ParticipantAgentActivityProjectionV1 = {
+      ...candidate,
+      revision: state.revision,
+      updatedAt,
+      ...(isTerminalProjection(candidate) ? { completedAt: updatedAt } : {}),
+    };
+    if (!isTerminalProjection(candidate) && materialized.completedAt) {
+      delete materialized.completedAt;
+    }
+    // `forceTimestamp` documents that a liveness-only heartbeat is an
+    // intentional public revision even when its semantic content is stable.
+    void forceTimestamp;
+    return ParticipantAgentActivityProjectionV1Schema.parse(materialized);
+  };
+
+  const scheduleTombstoneSweep = () => {
+    if (tombstoneSweepTimer) {
+      clearTimeout(tombstoneSweepTimer);
+      tombstoneSweepTimer = null;
+    }
+    if (stopping || tombstones.size === 0) {
+      return;
+    }
+    const now = Date.now();
+    let nextExpiry = Number.POSITIVE_INFINITY;
+    for (const expiresAt of tombstones.values()) {
+      nextExpiry = Math.min(nextExpiry, expiresAt);
+    }
+    tombstoneSweepTimer = setTimeout(
+      () => {
+        tombstoneSweepTimer = null;
+        const sweepAt = Date.now();
+        for (const [lensId, expiresAt] of tombstones) {
+          if (expiresAt <= sweepAt) {
+            tombstones.delete(lensId);
+          }
+        }
+        scheduleTombstoneSweep();
+      },
+      Math.max(0, nextExpiry - now)
+    );
+  };
+
+  const scheduleEviction = (state: RunState) => {
+    clearTimer(state, 'evictionTimer');
+    state.evictionTimer = setTimeout(() => {
+      state.evictionTimer = null;
+      if (
+        !state.latestLens &&
+        !state.scheduled &&
+        !state.retryTimer &&
+        states.get(state.lensId) === state
+      ) {
+        if (state.tombstoneUntil > Date.now()) {
+          tombstones.set(state.lensId, state.tombstoneUntil);
+          scheduleTombstoneSweep();
+        }
+        states.delete(state.lensId);
+      }
+    }, retentionMs);
+  };
+
+  const releasePrivateState = (state: RunState) => {
+    if (state.carrier || state.finalPost) {
+      const now = Date.now();
+      const lensExpiry = state.latestLens?.expiresAt;
+      state.tombstoneUntil = Math.max(
+        state.tombstoneUntil,
+        now + DEFAULT_TOMBSTONE_MS,
+        typeof lensExpiry === 'number' && Number.isFinite(lensExpiry)
+          ? lensExpiry
+          : 0
+      );
+    }
+    state.latestLens = null;
+    state.forcedOutcome = null;
+    state.heartbeatDue = false;
+    clearTimer(state, 'heartbeatTimer');
+    scheduleEviction(state);
+  };
+
+  const scheduleHeartbeat = (state: RunState) => {
+    clearTimer(state, 'heartbeatTimer');
+    if (
+      stopping ||
+      !state.latestLens ||
+      state.finalPost ||
+      TERMINAL_STATUSES.has(state.latestLens.status)
+    ) {
+      return;
+    }
+    state.heartbeatTimer = setTimeout(() => {
+      state.heartbeatTimer = null;
+      state.heartbeatDue = true;
+      state.dirty = true;
+      if (!state.publishing) {
+        enqueue(state);
+      }
+    }, heartbeatIntervalMs);
+  };
+
+  const publishCarrier = async (
+    state: RunState,
+    lens: ContextLens,
+    outcome?: ProjectOutcome
+  ) => {
+    // Once the normal final reply exists, an absent carrier must stay absent.
+    // Creating a terminal fallback after the final reply would produce an
+    // out-of-order unread post for clients that do not understand the blob.
+    // Shutdown likewise only terminalizes carriers that were already sent.
+    if (!state.carrier && (state.finalPost || stopping)) {
+      return;
+    }
+    const candidate = projectCandidate(state, lens, 'carrier', outcome);
+    if (!candidate) {
+      return;
+    }
+    const candidateSemantic = semanticProjection(candidate);
+    const forceHeartbeat =
+      state.heartbeatDue && !isTerminalProjection(candidate);
+    if (
+      state.carrier &&
+      candidateSemantic === state.carrierSemantic &&
+      !forceHeartbeat
+    ) {
+      scheduleHeartbeat(state);
+      return;
+    }
+    const projection = materializeProjection(state, candidate, forceHeartbeat);
+    const draft = getDraft(lens, projection);
+    if (!draft) {
+      return;
+    }
+    if (!state.carrier) {
+      state.carrier = await options.transport.create(draft);
+    } else {
+      await options.transport.update(state.carrier, draft);
+    }
+    state.carrierProjection = projection;
+    state.carrierSemantic = candidateSemantic;
+    state.heartbeatDue = false;
+    state.lastPublishedAt = Date.now();
+    scheduleHeartbeat(state);
+  };
+
+  const publishFinal = async (state: RunState, lens: ContextLens) => {
+    const finalPost = state.finalPost;
+    if (!finalPost) {
+      return;
+    }
+    const candidate = projectCandidate(state, lens, 'final', finalPost.outcome);
+    if (!candidate) {
+      return;
+    }
+    const candidateSemantic = semanticProjection(candidate);
+    if (candidateSemantic === state.finalSemantic) {
+      return;
+    }
+    const projection = materializeProjection(state, candidate);
+    if (!finalPost.post) {
+      finalPost.post = await options.transport.resolve(
+        finalPost.sentAt,
+        finalPost.draft
+      );
+    }
+    const blob = options.replaceParticipantActivity(
+      finalPost.baseBlob,
+      state.lensId,
+      projection
+    );
+    await options.transport.update(finalPost.post, {
+      ...finalPost.draft,
+      blob,
+      participantActivity: projection,
+    });
+    state.finalProjection = projection;
+    state.finalSemantic = candidateSemantic;
+    state.lastPublishedAt = Date.now();
+  };
+
+  const runPublish = async (state: RunState) => {
+    const lens = state.latestLens;
+    if (!lens) {
+      state.dirty = false;
+      return;
+    }
+    const inputVersion = state.inputVersion;
+    const terminalLens = TERMINAL_STATUSES.has(lens.status);
+    const carrierOutcome =
+      state.forcedOutcome ?? state.finalPost?.outcome ?? undefined;
+
+    // Carrier and final receipts are independent public surfaces. A deleted or
+    // temporarily uneditable carrier must never block reconciliation of the
+    // normal final reply.
+    let publishError: unknown;
+    try {
+      await publishCarrier(state, lens, carrierOutcome);
+    } catch (error) {
+      publishError = error;
+    }
+    if (state.finalPost) {
+      try {
+        await publishFinal(state, lens);
+      } catch (error) {
+        publishError ??= error;
+      }
+    }
+    if (publishError) {
+      throw publishError;
+    }
+
+    // A Lens event may arrive while host create/edit confirmation is pending.
+    // Never let an older successful publish clear that newer private snapshot.
+    if (state.inputVersion !== inputVersion) {
+      state.dirty = true;
+      state.retryAttempt = 0;
+      clearTimer(state, 'retryTimer');
+      if (!state.timer) {
+        enqueue(state);
+      }
+      return;
+    }
+    state.dirty = false;
+    state.retryAttempt = 0;
+    clearTimer(state, 'retryTimer');
+    if (terminalLens || state.finalPost || state.forcedOutcome) {
+      releasePrivateState(state);
+    }
+  };
+
+  const scheduleRetry = (state: RunState) => {
+    if (stopping || state.retryTimer) {
+      return;
+    }
+    const delayMs = retryDelaysMs[state.retryAttempt];
+    if (delayMs === undefined) {
+      // Bounded retries must also bound retention of the full owner-only Lens
+      // snapshot. A later event can revive the retained public handles during
+      // the short eviction window, or start a fresh state after eviction.
+      state.dirty = false;
+      releasePrivateState(state);
+      return;
+    }
+    state.retryAttempt += 1;
+    state.retryTimer = setTimeout(
+      () => {
+        state.retryTimer = null;
+        enqueue(state);
+      },
+      Math.max(0, delayMs)
+    );
+  };
+
+  const enqueue = (state: RunState) => {
+    if (stopped || state.scheduled) {
+      return;
+    }
+    state.scheduled = true;
+    queueMicrotask(() => {
+      state.scheduled = false;
+      state.chain = state.chain
+        .then(async () => {
+          state.publishing = true;
+          try {
+            await runPublish(state);
+          } finally {
+            state.publishing = false;
+          }
+        })
+        .catch((error) => {
+          reportError(state.lensId, 'publish', error);
+          state.dirty = true;
+          scheduleRetry(state);
+        });
+    });
+  };
+
+  const schedule = (state: RunState, immediate: boolean) => {
+    clearTimer(state, 'timer');
+    const delayMs = immediate
+      ? 0
+      : Math.max(0, state.lastPublishedAt + minUpdateIntervalMs - Date.now());
+    if (delayMs === 0) {
+      enqueue(state);
+      return;
+    }
+    state.timer = setTimeout(() => {
+      state.timer = null;
+      enqueue(state);
+    }, delayMs);
+  };
+
+  const drainQueuedWork = async () => {
+    for (const state of states.values()) {
+      if (state.dirty) {
+        enqueue(state);
+      }
+    }
+
+    // Work can append another chain link when it notices that an input arrived
+    // during an awaited host confirmation. Drain until that chain is stable.
+    let stable = false;
+    while (!stable) {
+      await Promise.resolve();
+      const entries = [...states.values()];
+      const chains = entries.map((state) => state.chain);
+      await Promise.all(chains);
+      await Promise.resolve();
+      stable = entries.every(
+        (state, index) =>
+          state.chain === chains[index] && state.scheduled === false
+      );
+    }
+  };
+
+  const hasLiveTombstone = (lensId: string) => {
+    const expiresAt = tombstones.get(lensId);
+    if (expiresAt === undefined) {
+      return false;
+    }
+    if (expiresAt <= Date.now()) {
+      tombstones.delete(lensId);
+      return false;
+    }
+    return true;
+  };
+
+  return {
+    handleEvent(event: ContextLensEvent) {
+      if (stopping || stopped) {
+        return;
+      }
+      const lens = event.lens;
+      if (!isGroupConversationLens(lens)) {
+        return;
+      }
+      // A state that already published and aged out keeps a lightweight public
+      // tombstone. Late terminal/event-bus replay must not create a duplicate
+      // carrier; genuine continuations receive a new Lens id.
+      if (!states.has(lens.lensId) && hasLiveTombstone(lens.lensId)) {
+        return;
+      }
+      const existing = states.get(lens.lensId);
+      if (!existing && !isContextLensCardEligible(lens)) {
+        return;
+      }
+      const state = ensureState(lens);
+      const retryPending = Boolean(state.retryTimer);
+      state.dirty = true;
+      if (TERMINAL_STATUSES.has(lens.status)) {
+        // Terminal state is user-visible and bypasses a pending working-state
+        // backoff. It receives a fresh bounded terminal retry cycle.
+        state.retryAttempt = 0;
+        clearTimer(state, 'retryTimer');
+        clearTimer(state, 'heartbeatTimer');
+        schedule(state, true);
+        return;
+      }
+      // Coalesce activity churn into the in-flight attempt or its pending
+      // backoff. The input generation check will publish the latest snapshot.
+      if (state.publishing || retryPending) {
+        return;
+      }
+      schedule(state, !state.carrier);
+    },
+
+    buildFinalProjection(lens: ContextLens, outcome: 'completed' | 'failed') {
+      const existing = states.has(lens.lensId);
+      if (
+        stopping ||
+        stopped ||
+        !isGroupConversationLens(lens) ||
+        (!existing && !isContextLensCardEligible(lens))
+      ) {
+        return null;
+      }
+      const state = ensureState(lens);
+      const candidate = options.project(lens, {
+        surface: 'final',
+        finalReplyDelivered: true,
+        revision: state.revision + 1,
+        outcome,
+      });
+      if (!candidate) {
+        return null;
+      }
+      const projection = materializeProjection(state, candidate);
+      state.preparedFinalProjection = projection;
+      return projection;
+    },
+
+    registerFinalReply(params: {
+      lens: ContextLens;
+      sentAt: number;
+      story: Story;
+      blob: string;
+      parentId?: string;
+      participantActivity: ParticipantAgentActivityProjectionV1;
+      outcome: 'completed' | 'failed';
+    }) {
+      if (stopping || stopped || !isGroupConversationLens(params.lens)) {
+        return;
+      }
+      const conversationId = params.lens.triggerDetails.conversationId?.trim();
+      if (!conversationId) {
+        return;
+      }
+      const state = ensureState(params.lens);
+      const initialProjection =
+        ParticipantAgentActivityProjectionV1Schema.parse(
+          params.participantActivity
+        );
+      state.finalPost = {
+        post: null,
+        sentAt: params.sentAt,
+        baseBlob: params.blob,
+        initialProjection,
+        outcome: params.outcome,
+        draft: {
+          conversationId,
+          authorId: options.botShip,
+          ...(params.parentId ? { parentId: params.parentId } : {}),
+          story: params.story,
+          blob: params.blob,
+          participantActivity: initialProjection,
+          botProfile: options.getBotProfile(),
+        },
+      };
+      state.finalProjection = initialProjection;
+      state.finalSemantic = semanticProjection(initialProjection);
+      state.preparedFinalProjection = null;
+      state.revision = Math.max(state.revision, initialProjection.revision);
+      state.lastPublicUpdatedAt = Math.max(
+        state.lastPublicUpdatedAt,
+        initialProjection.updatedAt
+      );
+      state.dirty = true;
+      clearTimer(state, 'heartbeatTimer');
+      schedule(state, true);
+    },
+
+    async flush() {
+      if (stopped) {
+        return;
+      }
+      for (const state of states.values()) {
+        clearTimer(state, 'timer');
+      }
+      await drainQueuedWork();
+    },
+
+    stop() {
+      if (stopPromise) {
+        return stopPromise;
+      }
+      stopPromise = (async () => {
+        stopping = true;
+        for (const state of states.values()) {
+          clearTimer(state, 'timer');
+          clearTimer(state, 'heartbeatTimer');
+          clearTimer(state, 'retryTimer');
+          clearTimer(state, 'evictionTimer');
+          if (state.latestLens && !state.finalPost) {
+            // This also covers a create that is currently in flight. The queued
+            // pass will terminalize it if it lands, but will not create a new
+            // carrier solely because shutdown began.
+            state.forcedOutcome = 'cancelled';
+            state.inputVersion += 1;
+            state.dirty = true;
+          }
+        }
+
+        // Transport update already performs host-confirmation retries. Give a
+        // failed terminal edit two additional publisher attempts, without
+        // allowing an unbounded retry timer to hold shutdown open.
+        for (let attempt = 0; attempt < 3; attempt += 1) {
+          await drainQueuedWork();
+          if (![...states.values()].some((state) => state.dirty)) {
+            break;
+          }
+        }
+
+        stopped = true;
+        if (tombstoneSweepTimer) {
+          clearTimeout(tombstoneSweepTimer);
+          tombstoneSweepTimer = null;
+        }
+        for (const state of states.values()) {
+          state.latestLens = null;
+          clearTimer(state, 'timer');
+          clearTimer(state, 'heartbeatTimer');
+          clearTimer(state, 'retryTimer');
+          clearTimer(state, 'evictionTimer');
+        }
+        states.clear();
+        tombstones.clear();
+      })();
+      return stopPromise;
+    },
+  };
+}

--- a/packages/openclaw/src/group-agent-activity-transport.test.ts
+++ b/packages/openclaw/src/group-agent-activity-transport.test.ts
@@ -1,0 +1,401 @@
+import { editPost, getChannelPosts, getPostWithReplies } from '@tloncorp/api';
+import type { ParticipantAgentActivityProjectionV1 } from '@tloncorp/api/client/participantAgentActivity';
+import { beforeEach, describe, expect, test, vi } from 'vitest';
+
+import { createTlonGroupAgentActivityTransport } from './group-agent-activity-transport.js';
+import { allocateChannelSentAt, sendChannelPost } from './urbit/send.js';
+
+vi.mock('@tloncorp/api', () => ({
+  editPost: vi.fn(),
+  getChannelPosts: vi.fn(),
+  getPostWithReplies: vi.fn(),
+}));
+
+vi.mock('./urbit/send.js', () => ({
+  allocateChannelSentAt: vi.fn(() => 1_000),
+  sendChannelPost: vi.fn(),
+}));
+
+function projection(
+  publicRunId = 'run_public_1',
+  revision = 1
+): ParticipantAgentActivityProjectionV1 {
+  return {
+    schemaVersion: 1,
+    surface: 'carrier',
+    publicRunId,
+    revision,
+    triggerPostId: 'request-1',
+    state: 'working',
+    createdAt: 900,
+    updatedAt: 1_000 + revision,
+    steps: [
+      {
+        id: 'step_public_1',
+        title: 'Check the records',
+        status: 'running',
+      },
+    ],
+  };
+}
+
+function projectionBlob(activity: ParticipantAgentActivityProjectionV1) {
+  return JSON.stringify([
+    {
+      type: 'tlon-context-lens',
+      version: 1,
+      lensId: 'private-lens-id',
+      botShip: '~bot',
+      delivery: 'intermediate',
+      participantActivity: activity,
+    },
+  ]);
+}
+
+function draft(activity = projection()) {
+  return {
+    conversationId: 'chat/~host/general',
+    authorId: '~bot',
+    story: [{ inline: ['Working…'] }],
+    blob: projectionBlob(activity),
+    participantActivity: activity,
+  };
+}
+
+describe('Tlon group agent activity transport', () => {
+  beforeEach(() => {
+    vi.resetAllMocks();
+    vi.mocked(allocateChannelSentAt).mockReturnValue(1_000);
+    vi.mocked(sendChannelPost).mockResolvedValue({
+      channel: 'tlon',
+      messageId: '~bot/123',
+      sentAt: 1_000,
+    });
+  });
+
+  test('resolves a root carrier by timestamp and public correlation id', async () => {
+    const expectedDraft = draft();
+    vi.mocked(getChannelPosts).mockResolvedValue({
+      posts: [
+        {
+          id: 'wrong-run',
+          authorId: '~bot',
+          channelId: expectedDraft.conversationId,
+          sentAt: 1_000,
+          blob: projectionBlob(projection('run_other')),
+        },
+        {
+          id: 'host-seal-id',
+          authorId: '~bot',
+          channelId: expectedDraft.conversationId,
+          sentAt: 1_000,
+          blob: expectedDraft.blob,
+        },
+      ],
+    } as Awaited<ReturnType<typeof getChannelPosts>>);
+    const transport = createTlonGroupAgentActivityTransport({
+      resolveDelaysMs: [0],
+    });
+
+    await expect(transport.create(expectedDraft)).resolves.toEqual({
+      postId: 'host-seal-id',
+      sentAt: 1_000,
+    });
+    expect(sendChannelPost).toHaveBeenCalledWith(
+      expect.objectContaining({
+        nest: expectedDraft.conversationId,
+        fromShip: '~bot',
+        sentAt: 1_000,
+      })
+    );
+  });
+
+  test('continues root pagination until it finds the correlated carrier', async () => {
+    const expectedDraft = draft();
+    vi.mocked(getChannelPosts)
+      .mockResolvedValueOnce({
+        posts: [],
+        older: 'older-page',
+      } as Awaited<ReturnType<typeof getChannelPosts>>)
+      .mockResolvedValueOnce({
+        posts: [
+          {
+            id: 'host-seal-id',
+            authorId: '~bot',
+            channelId: expectedDraft.conversationId,
+            sentAt: 1_000,
+            blob: expectedDraft.blob,
+          },
+        ],
+      } as Awaited<ReturnType<typeof getChannelPosts>>);
+    const transport = createTlonGroupAgentActivityTransport({
+      resolveDelaysMs: [0],
+    });
+
+    await expect(transport.create(expectedDraft)).resolves.toEqual({
+      postId: 'host-seal-id',
+      sentAt: 1_000,
+    });
+    expect(getChannelPosts).toHaveBeenNthCalledWith(
+      2,
+      expect.objectContaining({
+        mode: 'older',
+        cursor: 'older-page',
+      })
+    );
+  });
+
+  test('rejects ambiguous participant projection blobs during correlation', async () => {
+    const expectedDraft = draft();
+    const duplicateEntry = JSON.parse(expectedDraft.blob)[0];
+    vi.mocked(getChannelPosts).mockResolvedValue({
+      posts: [
+        {
+          id: 'ambiguous',
+          authorId: '~bot',
+          channelId: expectedDraft.conversationId,
+          sentAt: 1_000,
+          blob: JSON.stringify([duplicateEntry, duplicateEntry]),
+        },
+      ],
+    } as Awaited<ReturnType<typeof getChannelPosts>>);
+    const transport = createTlonGroupAgentActivityTransport({
+      resolveDelaysMs: [0],
+    });
+
+    await expect(transport.create(expectedDraft)).resolves.toEqual({
+      postId: '',
+      sentAt: 1_000,
+    });
+  });
+
+  test('resolves and host-confirms an edit inside its exact thread', async () => {
+    const initialDraft = { ...draft(), parentId: 'thread-root' };
+    vi.mocked(getPostWithReplies).mockResolvedValue({
+      id: 'thread-root',
+      authorId: '~requester',
+      channelId: initialDraft.conversationId,
+      sentAt: 500,
+      replies: [
+        {
+          id: 'reply-seal-id',
+          authorId: '~bot',
+          channelId: initialDraft.conversationId,
+          parentId: 'thread-root',
+          sentAt: 1_000,
+          blob: initialDraft.blob,
+        },
+      ],
+    } as Awaited<ReturnType<typeof getPostWithReplies>>);
+    const transport = createTlonGroupAgentActivityTransport({
+      resolveDelaysMs: [0],
+    });
+    const post = await transport.create(initialDraft);
+
+    expect(post).toEqual({
+      postId: 'reply-seal-id',
+      sentAt: 1_000,
+      parentId: 'thread-root',
+    });
+
+    const updatedProjection = projection('run_public_1', 2);
+    const updatedDraft = {
+      ...initialDraft,
+      blob: projectionBlob(updatedProjection),
+      participantActivity: updatedProjection,
+    };
+    vi.mocked(getPostWithReplies).mockResolvedValue({
+      id: 'thread-root',
+      authorId: '~requester',
+      channelId: initialDraft.conversationId,
+      sentAt: 500,
+      replies: [
+        {
+          id: 'reply-seal-id',
+          authorId: '~bot',
+          channelId: initialDraft.conversationId,
+          parentId: 'thread-root',
+          sentAt: 1_000,
+          blob: updatedDraft.blob,
+        },
+      ],
+    } as Awaited<ReturnType<typeof getPostWithReplies>>);
+
+    await transport.update(post, updatedDraft);
+    expect(editPost).toHaveBeenCalledWith(
+      expect.objectContaining({
+        channelId: initialDraft.conversationId,
+        postId: 'reply-seal-id',
+        parentId: 'thread-root',
+        sentAt: 1_000,
+        blob: updatedDraft.blob,
+      })
+    );
+    expect(getPostWithReplies).toHaveBeenCalledTimes(2);
+  });
+
+  test('retains an unresolved carrier handle instead of duplicating the post', async () => {
+    const expectedDraft = draft();
+    vi.mocked(getChannelPosts).mockResolvedValue({ posts: [] } as Awaited<
+      ReturnType<typeof getChannelPosts>
+    >);
+    const transport = createTlonGroupAgentActivityTransport({
+      resolveDelaysMs: [0],
+    });
+
+    await expect(transport.create(expectedDraft)).resolves.toEqual({
+      postId: '',
+      sentAt: 1_000,
+    });
+    expect(sendChannelPost).toHaveBeenCalledTimes(1);
+  });
+
+  test('resolves an older carrier revision before applying a newer update', async () => {
+    const initialDraft = draft();
+    const nextProjection = projection('run_public_1', 2);
+    const nextDraft = {
+      ...initialDraft,
+      blob: projectionBlob(nextProjection),
+      participantActivity: nextProjection,
+    };
+    vi.mocked(getChannelPosts)
+      .mockResolvedValueOnce({ posts: [] } as Awaited<
+        ReturnType<typeof getChannelPosts>
+      >)
+      .mockResolvedValueOnce({
+        posts: [
+          {
+            id: 'host-seal-id',
+            authorId: '~bot',
+            channelId: initialDraft.conversationId,
+            sentAt: 1_000,
+            blob: initialDraft.blob,
+          },
+        ],
+      } as Awaited<ReturnType<typeof getChannelPosts>>);
+    vi.mocked(getPostWithReplies).mockResolvedValue({
+      id: 'host-seal-id',
+      authorId: '~bot',
+      channelId: initialDraft.conversationId,
+      sentAt: 1_000,
+      blob: nextDraft.blob,
+    } as Awaited<ReturnType<typeof getPostWithReplies>>);
+    const transport = createTlonGroupAgentActivityTransport({
+      resolveDelaysMs: [0],
+    });
+
+    const carrier = await transport.create(initialDraft);
+    expect(carrier.postId).toBe('');
+
+    await transport.update(carrier, nextDraft);
+
+    expect(carrier.postId).toBe('host-seal-id');
+    expect(editPost).toHaveBeenCalledTimes(1);
+    expect(editPost).toHaveBeenCalledWith(
+      expect.objectContaining({
+        postId: 'host-seal-id',
+        blob: nextDraft.blob,
+      })
+    );
+  });
+
+  test('reuses the reserved timestamp when a create retry is uncertain', async () => {
+    const expectedDraft = draft();
+    vi.mocked(sendChannelPost)
+      .mockRejectedValueOnce(new Error('connection closed after poke'))
+      .mockResolvedValueOnce({
+        channel: 'tlon',
+        messageId: '~bot/123',
+        sentAt: 1_000,
+      });
+    vi.mocked(getChannelPosts)
+      .mockResolvedValueOnce({ posts: [] } as Awaited<
+        ReturnType<typeof getChannelPosts>
+      >)
+      .mockResolvedValueOnce({
+        posts: [
+          {
+            id: 'host-seal-id',
+            authorId: '~bot',
+            channelId: expectedDraft.conversationId,
+            sentAt: 1_000,
+            blob: expectedDraft.blob,
+          },
+        ],
+      } as Awaited<ReturnType<typeof getChannelPosts>>);
+    const transport = createTlonGroupAgentActivityTransport({
+      resolveDelaysMs: [0],
+    });
+
+    await expect(transport.create(expectedDraft)).rejects.toThrow(
+      'connection closed after poke'
+    );
+    await expect(transport.create(expectedDraft)).resolves.toEqual({
+      postId: 'host-seal-id',
+      sentAt: 1_000,
+    });
+    expect(allocateChannelSentAt).toHaveBeenCalledTimes(1);
+    expect(sendChannelPost).toHaveBeenNthCalledWith(
+      1,
+      expect.objectContaining({ sentAt: 1_000 })
+    );
+    expect(sendChannelPost).toHaveBeenNthCalledWith(
+      2,
+      expect.objectContaining({ sentAt: 1_000 })
+    );
+  });
+
+  test('resolves a remotely accepted post after the send response is lost', async () => {
+    const expectedDraft = draft();
+    vi.mocked(sendChannelPost).mockRejectedValueOnce(
+      new Error('connection closed after poke')
+    );
+    vi.mocked(getChannelPosts).mockResolvedValue({
+      posts: [
+        {
+          id: 'host-seal-id',
+          authorId: '~bot',
+          channelId: expectedDraft.conversationId,
+          sentAt: 1_000,
+          blob: expectedDraft.blob,
+        },
+      ],
+    } as Awaited<ReturnType<typeof getChannelPosts>>);
+    const transport = createTlonGroupAgentActivityTransport({
+      resolveDelaysMs: [0],
+    });
+
+    await expect(transport.create(expectedDraft)).resolves.toEqual({
+      postId: 'host-seal-id',
+      sentAt: 1_000,
+    });
+    expect(sendChannelPost).toHaveBeenCalledTimes(1);
+    expect(allocateChannelSentAt).toHaveBeenCalledTimes(1);
+  });
+
+  test('retries a transient scry failure before resolving', async () => {
+    const expectedDraft = draft();
+    vi.mocked(getChannelPosts)
+      .mockRejectedValueOnce(new Error('temporary scry failure'))
+      .mockResolvedValueOnce({
+        posts: [
+          {
+            id: 'host-seal-id',
+            authorId: '~bot',
+            channelId: expectedDraft.conversationId,
+            sentAt: 1_000,
+            blob: expectedDraft.blob,
+          },
+        ],
+      } as Awaited<ReturnType<typeof getChannelPosts>>);
+    const transport = createTlonGroupAgentActivityTransport({
+      resolveDelaysMs: [0, 0],
+    });
+
+    await expect(transport.create(expectedDraft)).resolves.toEqual({
+      postId: 'host-seal-id',
+      sentAt: 1_000,
+    });
+    expect(getChannelPosts).toHaveBeenCalledTimes(2);
+  });
+});

--- a/packages/openclaw/src/group-agent-activity-transport.ts
+++ b/packages/openclaw/src/group-agent-activity-transport.ts
@@ -1,0 +1,439 @@
+import {
+  editPost as apiEditPost,
+  getChannelPosts,
+  getPostWithReplies,
+} from '@tloncorp/api';
+import {
+  type ParticipantAgentActivityProjectionV1,
+  ParticipantAgentActivityProjectionV1Schema,
+} from '@tloncorp/api/client/participantAgentActivity';
+
+import type { BotProfile } from './urbit/send.js';
+import { allocateChannelSentAt, sendChannelPost } from './urbit/send.js';
+import type { Story } from './urbit/story.js';
+
+export type GroupAgentActivityPost = {
+  postId: string;
+  sentAt: number;
+  parentId?: string;
+};
+
+export type GroupAgentActivityPostDraft = {
+  conversationId: string;
+  authorId: string;
+  parentId?: string;
+  story: Story;
+  blob: string;
+  participantActivity: ParticipantAgentActivityProjectionV1;
+  botProfile?: BotProfile;
+};
+
+export type GroupAgentActivityTransport = {
+  create: (
+    draft: GroupAgentActivityPostDraft
+  ) => Promise<GroupAgentActivityPost>;
+  update: (
+    post: GroupAgentActivityPost,
+    draft: GroupAgentActivityPostDraft
+  ) => Promise<void>;
+  resolve: (
+    sentAt: number,
+    draft: Pick<
+      GroupAgentActivityPostDraft,
+      'conversationId' | 'authorId' | 'parentId'
+    > &
+      Pick<GroupAgentActivityPostDraft, 'participantActivity'>
+  ) => Promise<GroupAgentActivityPost>;
+};
+
+const DEFAULT_RESOLVE_DELAYS_MS = [0, 100, 300, 1_000, 2_000] as const;
+const DEFAULT_RESOLVE_PAGE_SIZE = 100;
+const DEFAULT_MAX_RESOLVE_PAGES = 10;
+const RESERVED_SENT_AT_TTL_MS = 60 * 60_000;
+const MAX_RESERVED_SENT_AT_ENTRIES = 1_000;
+
+function normalizedShip(ship: string) {
+  return ship.trim().replace(/^~/, '').toLowerCase();
+}
+
+function delay(ms: number) {
+  if (ms <= 0) {
+    return Promise.resolve();
+  }
+  return new Promise<void>((resolve) => setTimeout(resolve, ms));
+}
+
+function participantActivityFromBlob(
+  blob: string | null | undefined
+): ParticipantAgentActivityProjectionV1 | null {
+  if (!blob) {
+    return null;
+  }
+  try {
+    const entries: unknown = JSON.parse(blob);
+    if (!Array.isArray(entries)) {
+      return null;
+    }
+    const projections: ParticipantAgentActivityProjectionV1[] = [];
+    for (const entry of entries) {
+      if (
+        !entry ||
+        typeof entry !== 'object' ||
+        (entry as { type?: unknown }).type !== 'tlon-context-lens' ||
+        (entry as { version?: unknown }).version !== 1
+      ) {
+        continue;
+      }
+      const parsed = ParticipantAgentActivityProjectionV1Schema.safeParse(
+        (entry as { participantActivity?: unknown }).participantActivity
+      );
+      if (parsed.success) {
+        projections.push(parsed.data);
+      }
+    }
+    // A carrier/final post is protocol-owned by exactly one projection. Fail
+    // closed when a malformed combined blob would make correlation depend on
+    // entry order.
+    return projections.length === 1 ? projections[0] : null;
+  } catch {
+    // Malformed unrelated post blobs are not correlation candidates.
+  }
+  return null;
+}
+
+function hasExpectedParticipantActivity(
+  blob: string | null | undefined,
+  expected: ParticipantAgentActivityProjectionV1
+) {
+  const actual = participantActivityFromBlob(blob);
+  return Boolean(actual && JSON.stringify(actual) === JSON.stringify(expected));
+}
+
+function hasExpectedParticipantActivityIdentity(
+  blob: string | null | undefined,
+  expected: ParticipantAgentActivityProjectionV1
+) {
+  const actual = participantActivityFromBlob(blob);
+  return Boolean(
+    actual &&
+      actual.publicRunId === expected.publicRunId &&
+      actual.surface === expected.surface &&
+      actual.triggerPostId === expected.triggerPostId
+  );
+}
+
+type ResolvablePost = {
+  id: string;
+  authorId: string;
+  sentAt: number;
+  blob?: string | null;
+};
+
+function findCreatedPost(
+  candidates: readonly ResolvablePost[],
+  params: {
+    authorId: string;
+    sentAt: number;
+    participantActivity: ParticipantAgentActivityProjectionV1;
+  }
+) {
+  return candidates.find(
+    (candidate) =>
+      normalizedShip(candidate.authorId) === normalizedShip(params.authorId) &&
+      candidate.sentAt === params.sentAt &&
+      hasExpectedParticipantActivityIdentity(
+        candidate.blob,
+        params.participantActivity
+      )
+  );
+}
+
+async function resolveCreatedPost(params: {
+  conversationId: string;
+  authorId: string;
+  sentAt: number;
+  parentId?: string;
+  participantActivity: ParticipantAgentActivityProjectionV1;
+  delaysMs: readonly number[];
+  pageSize: number;
+  maxPages: number;
+}) {
+  let lastError: unknown;
+  for (const delayMs of params.delaysMs) {
+    await delay(delayMs);
+    try {
+      if (params.parentId) {
+        const candidates =
+          (
+            await getPostWithReplies({
+              channelId: params.conversationId,
+              postId: params.parentId,
+              // Channel reply lookup does not use the parent author, but the API
+              // keeps it required for the DM variants of the same endpoint.
+              authorId: params.authorId,
+            })
+          ).replies ?? [];
+        const match = findCreatedPost(candidates, params);
+        if (match) {
+          return match.id;
+        }
+        continue;
+      }
+
+      let cursor: string | undefined;
+      for (let page = 0; page < params.maxPages; page += 1) {
+        const response = await getChannelPosts({
+          channelId: params.conversationId,
+          mode: cursor ? 'older' : 'newest',
+          ...(cursor ? { cursor } : {}),
+          count: params.pageSize,
+          skipGapFill: true,
+        });
+        const match = findCreatedPost(response.posts, params);
+        if (match) {
+          return match.id;
+        }
+        if (!response.older || response.older === cursor) {
+          break;
+        }
+        cursor = response.older;
+      }
+    } catch (error) {
+      lastError = error;
+    }
+  }
+  throw new Error(
+    `Could not resolve agent activity post sent at ${params.sentAt}`,
+    {
+      ...(lastError ? { cause: lastError } : {}),
+    }
+  );
+}
+
+async function confirmUpdatedPost(params: {
+  post: GroupAgentActivityPost;
+  draft: GroupAgentActivityPostDraft;
+  delaysMs: readonly number[];
+}) {
+  let lastError: unknown;
+  for (const delayMs of params.delaysMs) {
+    await delay(delayMs);
+    try {
+      const candidate = params.post.parentId
+        ? (
+            await getPostWithReplies({
+              channelId: params.draft.conversationId,
+              postId: params.post.parentId,
+              authorId: params.draft.authorId,
+            })
+          ).replies?.find((reply) => reply.id === params.post.postId)
+        : await getPostWithReplies({
+            channelId: params.draft.conversationId,
+            postId: params.post.postId,
+            authorId: params.draft.authorId,
+          });
+      if (
+        candidate &&
+        normalizedShip(candidate.authorId) ===
+          normalizedShip(params.draft.authorId) &&
+        candidate.sentAt === params.post.sentAt &&
+        hasExpectedParticipantActivity(
+          candidate.blob,
+          params.draft.participantActivity
+        )
+      ) {
+        return;
+      }
+    } catch (error) {
+      lastError = error;
+    }
+  }
+  throw new Error(
+    `Could not confirm agent activity post ${params.post.postId}`,
+    {
+      ...(lastError ? { cause: lastError } : {}),
+    }
+  );
+}
+
+/**
+ * Channel posts are the authorization boundary for participant activity: the
+ * host applies the channel's reader roles to both root posts and thread
+ * replies. The create poke returns no host seal id, so resolve that id by the
+ * bot-authored essay's exact `sent` timestamp before editing it.
+ */
+export function createTlonGroupAgentActivityTransport(options?: {
+  resolveDelaysMs?: readonly number[];
+  resolvePageSize?: number;
+  maxResolvePages?: number;
+}): GroupAgentActivityTransport {
+  const resolveDelaysMs = options?.resolveDelaysMs ?? DEFAULT_RESOLVE_DELAYS_MS;
+  const resolvePageSize = Math.max(
+    1,
+    options?.resolvePageSize ?? DEFAULT_RESOLVE_PAGE_SIZE
+  );
+  const maxResolvePages = Math.max(
+    1,
+    options?.maxResolvePages ?? DEFAULT_MAX_RESOLVE_PAGES
+  );
+  // Reuse the same host-deduplication timestamp if a create poke fails after
+  // remote acceptance. Retrying with a fresh timestamp could create a second
+  // carrier for the same public run.
+  const reservedSentAtByRunId = new Map<
+    string,
+    { sentAt: number; reservedAt: number }
+  >();
+
+  const reservedSentAt = (publicRunId: string) => {
+    const now = Date.now();
+    for (const [candidateRunId, reservation] of reservedSentAtByRunId) {
+      if (now - reservation.reservedAt >= RESERVED_SENT_AT_TTL_MS) {
+        reservedSentAtByRunId.delete(candidateRunId);
+      }
+    }
+    const existing = reservedSentAtByRunId.get(publicRunId);
+    if (existing) {
+      return existing.sentAt;
+    }
+    while (reservedSentAtByRunId.size >= MAX_RESERVED_SENT_AT_ENTRIES) {
+      const oldestRunId = reservedSentAtByRunId.keys().next().value;
+      if (typeof oldestRunId !== 'string') break;
+      reservedSentAtByRunId.delete(oldestRunId);
+    }
+    const sentAt = allocateChannelSentAt();
+    reservedSentAtByRunId.set(publicRunId, { sentAt, reservedAt: now });
+    return sentAt;
+  };
+
+  const ensureResolved = async (
+    post: GroupAgentActivityPost,
+    draft: Pick<
+      GroupAgentActivityPostDraft,
+      'conversationId' | 'authorId' | 'parentId' | 'participantActivity'
+    >
+  ) => {
+    if (post.postId) {
+      return post;
+    }
+    const resolved = await resolveCreatedPost({
+      conversationId: draft.conversationId,
+      authorId: draft.authorId,
+      sentAt: post.sentAt,
+      parentId: post.parentId ?? draft.parentId,
+      participantActivity: draft.participantActivity,
+      delaysMs: resolveDelaysMs,
+      pageSize: resolvePageSize,
+      maxPages: maxResolvePages,
+    });
+    // Keep the publisher's retained object usable for every later edit.
+    post.postId = resolved;
+    reservedSentAtByRunId.delete(draft.participantActivity.publicRunId);
+    return post;
+  };
+
+  return {
+    async create(draft) {
+      const publicRunId = draft.participantActivity.publicRunId;
+      const sentAt = reservedSentAt(publicRunId);
+      let acceptedSentAt = sentAt;
+      try {
+        const sent = await sendChannelPost({
+          fromShip: draft.authorId,
+          nest: draft.conversationId,
+          story: draft.story,
+          blob: draft.blob,
+          replyToId: draft.parentId,
+          botProfile: draft.botProfile,
+          sentAt,
+        });
+        acceptedSentAt = sent.sentAt;
+      } catch (sendError) {
+        // The poke can reach the channel host even when its HTTP response is
+        // lost. Resolve before retrying so an uncertain acknowledgement does
+        // not create a second visible carrier.
+        try {
+          const postId = await resolveCreatedPost({
+            conversationId: draft.conversationId,
+            authorId: draft.authorId,
+            sentAt,
+            parentId: draft.parentId,
+            participantActivity: draft.participantActivity,
+            delaysMs: resolveDelaysMs,
+            pageSize: resolvePageSize,
+            maxPages: maxResolvePages,
+          });
+          reservedSentAtByRunId.delete(publicRunId);
+          return {
+            postId,
+            sentAt,
+            ...(draft.parentId ? { parentId: draft.parentId } : {}),
+          };
+        } catch {
+          throw sendError;
+        }
+      }
+      let postId = '';
+      try {
+        postId = await resolveCreatedPost({
+          conversationId: draft.conversationId,
+          authorId: draft.authorId,
+          sentAt: acceptedSentAt,
+          parentId: draft.parentId,
+          participantActivity: draft.participantActivity,
+          delaysMs: resolveDelaysMs,
+          pageSize: resolvePageSize,
+          maxPages: maxResolvePages,
+        });
+      } catch {
+        // The post itself was accepted. Retain an unresolved handle so a
+        // delayed host index cannot make the next progress event send a
+        // duplicate carrier; update/remove will resolve it again.
+      }
+      if (postId) {
+        reservedSentAtByRunId.delete(publicRunId);
+      }
+      return {
+        postId,
+        sentAt: acceptedSentAt,
+        ...(draft.parentId ? { parentId: draft.parentId } : {}),
+      };
+    },
+
+    async update(post, draft) {
+      const resolved = await ensureResolved(post, draft);
+      await apiEditPost({
+        channelId: draft.conversationId,
+        postId: resolved.postId,
+        authorId: draft.authorId,
+        sentAt: post.sentAt,
+        content: draft.story,
+        blob: draft.blob,
+        parentId: post.parentId,
+        botProfile: draft.botProfile,
+      });
+      await confirmUpdatedPost({
+        post: resolved,
+        draft,
+        delaysMs: resolveDelaysMs,
+      });
+    },
+
+    async resolve(sentAt, draft) {
+      const postId = await resolveCreatedPost({
+        conversationId: draft.conversationId,
+        authorId: draft.authorId,
+        sentAt,
+        parentId: draft.parentId,
+        participantActivity: draft.participantActivity,
+        delaysMs: resolveDelaysMs,
+        pageSize: resolvePageSize,
+        maxPages: maxResolvePages,
+      });
+      return {
+        postId,
+        sentAt,
+        ...(draft.parentId ? { parentId: draft.parentId } : {}),
+      };
+    },
+  };
+}

--- a/packages/openclaw/src/monitor/index.ts
+++ b/packages/openclaw/src/monitor/index.ts
@@ -1,4 +1,5 @@
 import type { Story } from '@tloncorp/api';
+import type { ParticipantAgentActivityProjectionV1 } from '@tloncorp/api/client/participantAgentActivity';
 import { randomUUID } from 'node:crypto';
 import { format } from 'node:util';
 import { createTypingCallbacks } from 'openclaw/plugin-sdk/channel-runtime';
@@ -24,6 +25,7 @@ import {
   findRecentContextLensById,
   publishContextLensEvent,
   setContextLensEventCapacity,
+  subscribeToContextLensEvents,
 } from '../context-lens-events.js';
 import {
   isContextLensEffectivelyEnabled,
@@ -52,7 +54,10 @@ import {
   gateGatewayStatusActivation,
   getGatewayStatusCoordinator,
 } from '../gateway-status.js';
+import { createGroupAgentActivityPublisher } from '../group-agent-activity-publisher.js';
+import { createTlonGroupAgentActivityTransport } from '../group-agent-activity-transport.js';
 import { handleOwnerListenCommand } from '../owner-listen-command.js';
+import { buildParticipantAgentActivityProjection } from '../participant-agent-activity.js';
 import {
   type PendingNudge,
   clearPendingNudge,
@@ -106,6 +111,7 @@ import {
   isPermanentAuthenticationFailure,
 } from '../urbit/auth.js';
 import {
+  replaceContextLensParticipantActivityInBlob,
   serializeBlobField,
   serializeContextLensReferenceBlob,
 } from '../urbit/blob.js';
@@ -804,6 +810,8 @@ async function monitorTlonProviderScoped(opts: MonitorTlonOpts): Promise<void> {
     once: true,
   });
 
+  let cleanupParticipantAgentActivity: () => Promise<void> = async () => {};
+
   // Outer try/finally wraps everything from slot publication onward.
   // A synchronous throw between slot publication and the inner try
   // (constructor, queue setup, bridge setup, channel discovery, future
@@ -817,6 +825,8 @@ async function monitorTlonProviderScoped(opts: MonitorTlonOpts): Promise<void> {
       cfg,
       opts.accountId ?? undefined
     );
+    const participantAgentActivityEnabled =
+      contextLensEnabled && contextLensConfig.participantActivityEnabled;
     const contextLenses = createContextLensRegistry({
       ttlMs: contextLensConfig.ttlMs ?? undefined,
       maxEntries: contextLensConfig.maxEntries ?? undefined,
@@ -850,6 +860,64 @@ async function monitorTlonProviderScoped(opts: MonitorTlonOpts): Promise<void> {
       botNickname || botAvatar
         ? { nickname: botNickname || '', avatar: botAvatar || '' }
         : undefined;
+
+    const participantAgentActivityPublisher = createGroupAgentActivityPublisher(
+      {
+        transport: createTlonGroupAgentActivityTransport(),
+        runtime,
+        botShip: botShipName,
+        getBotProfile,
+        project: (lens, projectOptions) =>
+          buildParticipantAgentActivityProjection({
+            lens,
+            surface: projectOptions.surface,
+            revision: projectOptions.revision,
+            ...(projectOptions.outcome
+              ? { outcome: projectOptions.outcome }
+              : {}),
+          }),
+        serializeReferenceBlob: ({
+          lensId,
+          botShip,
+          delivery,
+          outcome,
+          participantActivity,
+        }) =>
+          serializeContextLensReferenceBlob(
+            lensId,
+            botShip,
+            delivery,
+            outcome,
+            participantActivity
+          ),
+        replaceParticipantActivity: (blob, lensId, participantActivity) =>
+          replaceContextLensParticipantActivityInBlob(
+            blob,
+            lensId,
+            participantActivity
+          ),
+        storyFromText: markdownToStory,
+      }
+    );
+    const unsubscribeParticipantAgentActivity = participantAgentActivityEnabled
+      ? subscribeToContextLensEvents((event) => {
+          // The event bus is process-wide; only publish runs owned by this
+          // monitor-local registry/account.
+          if (contextLenses.get(event.lens.lensId)) {
+            participantAgentActivityPublisher.handleEvent(event);
+          }
+        })
+      : null;
+    let participantAgentActivityCleanedUp = false;
+    cleanupParticipantAgentActivity = async () => {
+      if (participantAgentActivityCleanedUp) {
+        return;
+      }
+      participantAgentActivityCleanedUp = true;
+      unsubscribeParticipantAgentActivity?.();
+      await participantAgentActivityPublisher.flush();
+      await participantAgentActivityPublisher.stop();
+    };
 
     // Settings store manager for hot-reloading config
     const settingsManager = createSettingsManager(api, {
@@ -1138,7 +1206,8 @@ async function monitorTlonProviderScoped(opts: MonitorTlonOpts): Promise<void> {
     function buildContextLensReferenceBlobField(
       lensId: string,
       delivery?: 'final' | 'intermediate',
-      outcome?: 'completed' | 'failed'
+      outcome?: 'completed' | 'failed',
+      participantActivity?: ParticipantAgentActivityProjectionV1
     ): string | undefined {
       if (!contextLensEnabled) {
         return undefined;
@@ -1148,7 +1217,8 @@ async function monitorTlonProviderScoped(opts: MonitorTlonOpts): Promise<void> {
           lensId,
           botShipName,
           delivery,
-          outcome
+          outcome,
+          participantActivity
         );
       } catch (err) {
         runtime.error?.(
@@ -3514,6 +3584,7 @@ async function monitorTlonProviderScoped(opts: MonitorTlonOpts): Promise<void> {
 
                           sendAttemptCount += 1;
                           let outputMessageId: string | null = null;
+                          let outputSentAt: number | null = null;
                           const finalOutcome:
                             | 'completed'
                             | 'failed'
@@ -3523,12 +3594,23 @@ async function monitorTlonProviderScoped(opts: MonitorTlonOpts): Promise<void> {
                                 ? 'failed'
                                 : 'completed'
                               : undefined;
+                          const participantActivity =
+                            participantAgentActivityEnabled &&
+                            isGroup &&
+                            finalOutcome
+                              ? participantAgentActivityPublisher.buildFinalProjection(
+                                  contextLenses.get(lens.lensId) ?? lens,
+                                  finalOutcome
+                                )
+                              : null;
+                          const replyStory = markdownToStory(replyText);
                           const replyBlob = combineBlobFields(
                             blob,
                             buildContextLensReferenceBlobField(
                               lens.lensId,
                               info.kind === 'final' ? 'final' : 'intermediate',
-                              finalOutcome
+                              finalOutcome,
+                              participantActivity ?? undefined
                             )
                           );
                           if (isGroup && groupChannel) {
@@ -3539,12 +3621,13 @@ async function monitorTlonProviderScoped(opts: MonitorTlonOpts): Promise<void> {
                                   botProfile: getBotProfile(),
                                   fromShip: botShipName,
                                   nest: groupChannel,
-                                  story: markdownToStory(replyText),
+                                  story: replyStory,
                                   replyToId: deliverParentId ?? undefined,
                                   blob: replyBlob,
                                 })
                             );
                             outputMessageId = result.messageId;
+                            outputSentAt = result.sentAt;
                             // Track thread participation for future replies without mention
                             if (deliverParentId) {
                               participatedThreads.add(String(deliverParentId));
@@ -3618,6 +3701,31 @@ async function monitorTlonProviderScoped(opts: MonitorTlonOpts): Promise<void> {
                               lens.lensId,
                               'final_reply_delivered'
                             );
+                            const latestLens =
+                              contextLenses.get(lens.lensId) ?? lens;
+                            if (
+                              isGroup &&
+                              groupChannel &&
+                              outputSentAt !== null &&
+                              replyBlob &&
+                              participantActivity
+                            ) {
+                              participantAgentActivityPublisher.registerFinalReply(
+                                {
+                                  lens: latestLens,
+                                  sentAt: outputSentAt,
+                                  story: replyStory,
+                                  blob: replyBlob,
+                                  ...(deliverParentId
+                                    ? { parentId: String(deliverParentId) }
+                                    : {}),
+                                  participantActivity,
+                                  outcome: finalReplyError
+                                    ? 'failed'
+                                    : 'completed',
+                                }
+                              );
+                            }
                           }
                           replyCharCount += replyText.length;
                           replyWordCount += replyText.trim()
@@ -5569,6 +5677,7 @@ async function monitorTlonProviderScoped(opts: MonitorTlonOpts): Promise<void> {
       await nudgeRunner?.stop();
       await ownerReplyPersistence.flush();
       await pendingNudgePersistence.flush();
+      await cleanupParticipantAgentActivity();
       clearShadowsForAccount(account.accountId);
       setOutboundRouteReporter(null);
       setSessionTelemetryReporter(null);
@@ -5591,6 +5700,7 @@ async function monitorTlonProviderScoped(opts: MonitorTlonOpts): Promise<void> {
     // after the helper definitions). Anything that throws before the
     // inner finally can run hits this one. Idempotent via the helper.
     cleanupGatewayStatus();
+    await cleanupParticipantAgentActivity();
     // Remove the early abort listener so the host's signal does not
     // retain `cleanupGatewayStatus` (which transitively pins
     // `myApiClientParams.poke` and the SSE client) after the monitor

--- a/packages/openclaw/src/participant-agent-activity.test.ts
+++ b/packages/openclaw/src/participant-agent-activity.test.ts
@@ -1,0 +1,379 @@
+import { describe, expect, it } from 'vitest';
+
+import type { ContextLens } from './context-lens.js';
+import {
+  buildParticipantAgentActivityProjection,
+  participantAgentPublicRunId,
+} from './participant-agent-activity.js';
+import { serializeContextLensReferenceBlob } from './urbit/blob.js';
+
+const SECRET = 'SENTINEL_PRIVATE_7d3f86';
+const RAW_STEP_ID = `raw-step-${SECRET}`;
+
+function rawLens(): ContextLens {
+  return {
+    lensId: 'owner-lens-123',
+    botShip: SECRET,
+    runId: SECRET,
+    messageId: '~requester/170.141.184.507.123',
+    sessionKeyHash: SECRET,
+    chatType: 'channel',
+    runKind: 'conversation',
+    visibility: 'owner',
+    trigger: 'thread',
+    triggerDetails: {
+      type: 'thread',
+      messageId: '~requester/170.141.184.507.123',
+      authorShip: SECRET,
+      conversationId: SECRET,
+      conversationKind: 'channel',
+      receivedAt: 1_000,
+      preview: SECRET,
+    },
+    retryOf: `parent-lens-${SECRET}`,
+    continuation: {
+      kind: 'request_input',
+      parentLensId: `waiting-parent-${SECRET}`,
+      requestInputId: `request-input-${SECRET}`,
+      workflowId: `workflow-${SECRET}`,
+      linkedAt: 1_000,
+    },
+    retrySeed: {
+      messageText: SECRET,
+      blobField: JSON.stringify({ token: SECRET }),
+      messageContent: { privateStory: SECRET },
+      parentId: '~requester/170.141.184.500.100',
+      isThreadReply: true,
+      replyParentId: null,
+      cachesHistory: true,
+    },
+    model: SECRET,
+    provider: SECRET,
+    context: {
+      currentMessage: true,
+      threadMessages: 4,
+      channelMessages: 10,
+      citedPosts: 2,
+      attachments: 1,
+      pendingNudge: false,
+      sources: [
+        {
+          kind: 'memory',
+          label: SECRET,
+          sourceId: SECRET,
+          included: true,
+          reason: SECRET,
+          tokenEstimate: 99,
+          preview: SECRET,
+        },
+      ],
+    },
+    persistence: {
+      postsReply: true,
+      updatesSettings: true,
+      writesMedia: true,
+      emitsTelemetry: true,
+      cachesHistory: true,
+      events: [
+        {
+          kind: 'artifact',
+          action: 'created',
+          location: 'external',
+          status: 'ok',
+          key: SECRET,
+          reason: SECRET,
+          at: 1_100,
+        },
+      ],
+    },
+    tools: {
+      ownerOnlyAvailable: [SECRET],
+      called: [SECRET],
+      callCount: 1,
+      lastStartedAt: 1_100,
+      runs: [
+        {
+          id: SECRET,
+          toolCallId: SECRET,
+          callIndex: 1,
+          name: SECRET,
+          phase: SECRET,
+          startedAt: 1_100,
+          completedAt: 1_200,
+          durationMs: 100,
+          status: 'completed',
+          argumentSummary: SECRET,
+          argumentDetail: SECRET,
+          resultSummary: SECRET,
+          error: SECRET,
+        },
+      ],
+    },
+    outputs: [
+      {
+        messageId: SECRET,
+        conversationId: SECRET,
+        kind: 'channel',
+        sentAt: 1_300,
+        preview: SECRET,
+      },
+    ],
+    activity: {
+      schemaVersion: 1,
+      eventCount: 8,
+      lastEventAt: 1_250,
+      truncated: false,
+      plan: {
+        explanation: SECRET,
+        steps: [
+          {
+            id: RAW_STEP_ID,
+            title: 'Compare the requested records',
+            status: 'running',
+          },
+        ],
+        updatedAt: 1_050,
+      },
+      items: [
+        {
+          id: `commentary-${SECRET}`,
+          kind: 'commentary',
+          title: 'Progress',
+          status: 'running',
+          planStepId: RAW_STEP_ID,
+          startedAt: 1_050,
+          updatedAt: 1_200,
+          completedAt: null,
+          progressText: 'Checking each requested record now.',
+        },
+        {
+          id: SECRET,
+          kind: 'tool',
+          title: SECRET,
+          status: 'completed',
+          planStepId: RAW_STEP_ID,
+          startedAt: 1_100,
+          updatedAt: 1_150,
+          completedAt: 1_150,
+          progressText: SECRET,
+          name: SECRET,
+          toolCallId: SECRET,
+          source: SECRET,
+        },
+        {
+          id: `approval-${SECRET}`,
+          kind: 'approval',
+          title: SECRET,
+          status: 'completed',
+          planStepId: RAW_STEP_ID,
+          startedAt: 1_150,
+          updatedAt: 1_175,
+          completedAt: 1_175,
+          progressText: SECRET,
+        },
+        {
+          id: `error-${SECRET}`,
+          kind: 'error',
+          title: SECRET,
+          status: 'error',
+          planStepId: RAW_STEP_ID,
+          startedAt: 1_180,
+          updatedAt: 1_190,
+          completedAt: 1_190,
+          progressText: SECRET,
+        },
+      ],
+    },
+    lifecycle: {
+      queuedAt: 1_000,
+      queuedMs: 20,
+      dispatchStartedAt: 1_020,
+      firstToolStartedAt: 1_100,
+      completedAt: null,
+      durationMs: null,
+      timeoutMs: 180_000,
+      timedOut: false,
+      deliveredMessageCount: 0,
+      queuedFinal: false,
+      queuedFinalCount: 0,
+      queuedBlockCount: 0,
+    },
+    status: 'tool_running',
+    error: SECRET,
+    createdAt: 1_000,
+    updatedAt: 1_300,
+    expiresAt: 30_000,
+  };
+}
+
+describe('buildParticipantAgentActivityProjection', () => {
+  it('serializes only the public allowlist from a fully seeded private Lens', () => {
+    const lens = rawLens();
+    const projection = buildParticipantAgentActivityProjection({
+      lens,
+      surface: 'carrier',
+      revision: 8,
+    });
+
+    expect(projection).toMatchObject({
+      schemaVersion: 1,
+      surface: 'carrier',
+      revision: 8,
+      triggerPostId: '~requester/170.141.184.507.123',
+      threadRootId: '~requester/170.141.184.500.100',
+      state: 'working',
+      createdAt: 1_000,
+      updatedAt: 1_300,
+      steps: [
+        {
+          title: 'Compare the requested records',
+          status: 'running',
+          update: 'Checking each requested record now.',
+          actions: { total: 3, completed: 2 },
+        },
+      ],
+    });
+    expect(projection?.publicRunId).toBe(
+      participantAgentPublicRunId(lens.lensId)
+    );
+    expect(projection?.publicRunId).not.toBe(lens.lensId);
+    expect(projection?.retryOf).toBe(
+      participantAgentPublicRunId(lens.retryOf!)
+    );
+    expect(projection?.continuation).toEqual({
+      kind: 'request_input',
+      parentPublicRunId: participantAgentPublicRunId(
+        lens.continuation!.parentLensId
+      ),
+    });
+    expect(projection).not.toHaveProperty('botShip');
+    expect(projection).not.toHaveProperty('channelId');
+
+    const publicJson = JSON.stringify(projection);
+    expect(publicJson).not.toContain(SECRET);
+    expect(publicJson).not.toContain(RAW_STEP_ID);
+
+    const blob = serializeContextLensReferenceBlob(
+      lens.lensId,
+      '~safe-bot',
+      'intermediate',
+      undefined,
+      projection!
+    );
+    expect(blob).not.toContain(SECRET);
+    expect(JSON.parse(blob)[0].participantActivity).toEqual(projection);
+  });
+
+  it('settles stale running rows on a final incomplete reply', () => {
+    const lens = rawLens();
+    lens.activity.plan!.steps = [
+      { id: 'done', title: 'Collect data', status: 'completed' },
+      { id: 'open', title: 'Verify the result', status: 'running' },
+    ];
+    lens.activity.items = [];
+    lens.status = 'delivering';
+
+    const projection = buildParticipantAgentActivityProjection({
+      lens,
+      surface: 'final',
+      revision: 9,
+    });
+
+    expect(projection?.state).toBe('incomplete');
+    expect(projection?.completedAt).toBe(1_300);
+    expect(projection?.steps.map((step) => step.status)).toEqual([
+      'completed',
+      'pending',
+    ]);
+  });
+
+  it('keeps requester and owner waits open without copying approval text', () => {
+    const requesterLens = rawLens();
+    requesterLens.activity.plan!.steps[0].status = 'waiting';
+    requesterLens.activity.items = [];
+    requesterLens.status = 'completed';
+    const requesterProjection = buildParticipantAgentActivityProjection({
+      lens: requesterLens,
+      surface: 'final',
+      revision: 10,
+    });
+    expect(requesterProjection?.state).toBe('waiting_requester');
+    expect(requesterProjection?.completedAt).toBeUndefined();
+
+    const ownerLens = rawLens();
+    ownerLens.activity.items = [
+      {
+        id: 'approval-private',
+        kind: 'approval',
+        title: SECRET,
+        status: 'waiting',
+        planStepId: RAW_STEP_ID,
+        startedAt: 1_100,
+        updatedAt: 1_200,
+        completedAt: null,
+        progressText: SECRET,
+      },
+    ];
+    const ownerProjection = buildParticipantAgentActivityProjection({
+      lens: ownerLens,
+      surface: 'carrier',
+      revision: 11,
+    });
+    expect(ownerProjection?.state).toBe('waiting_owner');
+    expect(ownerProjection?.steps[0].status).toBe('waiting');
+    expect(JSON.stringify(ownerProjection)).not.toContain(SECRET);
+  });
+
+  it('projects only an explicit request-input item as an uncounted requester gate', () => {
+    const lens = rawLens();
+    lens.activity.plan = null;
+    lens.activity.items = [
+      {
+        id: 'request-input:tool-call-1',
+        kind: 'request_input',
+        title: 'Which group should I create?',
+        status: 'waiting',
+        startedAt: 1_200,
+        updatedAt: 1_250,
+        completedAt: null,
+        source: 'tlon_request_input',
+        toolCallId: 'tool-call-1',
+      },
+    ];
+    lens.tools.callCount = 0;
+    lens.tools.called = [];
+    lens.tools.runs = [];
+    lens.status = 'completed';
+
+    const projection = buildParticipantAgentActivityProjection({
+      lens,
+      surface: 'final',
+      revision: 12,
+    });
+
+    expect(projection).toMatchObject({
+      state: 'waiting_requester',
+      steps: [
+        {
+          title: 'Which group should I create?',
+          status: 'waiting',
+        },
+      ],
+    });
+    expect(projection?.completedAt).toBeUndefined();
+    expect(projection?.steps[0]).not.toHaveProperty('actions');
+  });
+
+  it('refuses to produce participant projections for direct messages', () => {
+    const lens = rawLens();
+    lens.chatType = 'dm';
+    lens.triggerDetails.conversationKind = 'dm';
+    expect(
+      buildParticipantAgentActivityProjection({
+        lens,
+        surface: 'carrier',
+        revision: 1,
+      })
+    ).toBeNull();
+  });
+});

--- a/packages/openclaw/src/participant-agent-activity.ts
+++ b/packages/openclaw/src/participant-agent-activity.ts
@@ -1,0 +1,496 @@
+import {
+  MAX_PARTICIPANT_AGENT_ACTIVITY_BYTES,
+  MAX_PARTICIPANT_AGENT_ACTIVITY_STEPS,
+  MAX_PARTICIPANT_AGENT_ACTIVITY_TITLE_CHARS,
+  MAX_PARTICIPANT_AGENT_ACTIVITY_UPDATE_CHARS,
+  type ParticipantAgentActivityProjectionV1,
+  ParticipantAgentActivityProjectionV1Schema,
+  type ParticipantAgentActivityState,
+  type ParticipantAgentActivityStep,
+  type ParticipantAgentActivityStepStatus,
+} from '@tloncorp/api/client/participantAgentActivity';
+import type {
+  ContextLensActivityItem,
+  ContextLensActivityStatus,
+} from '@tloncorp/api/urbit/lens';
+import { createHash } from 'node:crypto';
+
+import type { ContextLens } from './context-lens.js';
+
+const PUBLIC_ID_DOMAIN = 'tlon-participant-agent-activity-v1';
+
+export type BuildParticipantAgentActivityProjectionOptions = {
+  lens: ContextLens;
+  surface: ParticipantAgentActivityProjectionV1['surface'];
+  /** Monotonic revision allocated by the eventual carrier/final publisher. */
+  revision: number;
+  /** Explicit delivery result when it is more current than the Lens snapshot. */
+  outcome?: 'completed' | 'failed' | 'cancelled';
+};
+
+function opaqueId(kind: 'run' | 'step', value: string): string {
+  const digest = createHash('sha256')
+    .update(PUBLIC_ID_DOMAIN)
+    .update('\0')
+    .update(kind)
+    .update('\0')
+    .update(value)
+    .digest('base64url')
+    .slice(0, 22);
+  return `${kind}_${digest}`;
+}
+
+/** Stable public identity that cannot be used as an owner Lens lookup key. */
+export function participantAgentPublicRunId(lensId: string): string {
+  return opaqueId('run', lensId);
+}
+
+/** The exact thread parent used by outbound delivery and public correlation. */
+export function participantAgentDeliveryParentId(
+  lens: ContextLens
+): string | undefined {
+  return (
+    lens.retrySeed?.replyParentId?.trim() ||
+    (lens.retrySeed?.isThreadReply
+      ? lens.retrySeed.parentId?.trim() || undefined
+      : undefined)
+  );
+}
+
+function compactPublicText(
+  value: unknown,
+  maxChars: number
+): string | undefined {
+  if (typeof value !== 'string') {
+    return undefined;
+  }
+  const withoutControls = Array.from(value, (character) => {
+    const codePoint = character.codePointAt(0) ?? 0;
+    return codePoint <= 0x1f || codePoint === 0x7f ? ' ' : character;
+  }).join('');
+  const compact = withoutControls.replace(/\s+/g, ' ').trim();
+  if (!compact) {
+    return undefined;
+  }
+  return compact.length <= maxChars
+    ? compact
+    : `${compact.slice(0, Math.max(0, maxChars - 1))}…`;
+}
+
+function safeTimestamp(value: number): number {
+  if (!Number.isFinite(value)) {
+    return 0;
+  }
+  return Math.min(Number.MAX_SAFE_INTEGER, Math.max(0, Math.trunc(value)));
+}
+
+function publicStepStatus(
+  status: ContextLensActivityStatus
+): ParticipantAgentActivityStepStatus {
+  switch (status) {
+    case 'running':
+      return 'running';
+    case 'waiting':
+      return 'waiting';
+    case 'completed':
+      return 'completed';
+    case 'error':
+    case 'blocked':
+      return 'failed';
+    case 'cancelled':
+      return 'cancelled';
+    case 'pending':
+    case 'unknown':
+      return 'pending';
+  }
+}
+
+function isWaitingForOwner(lens: ContextLens): boolean {
+  return lens.activity.items.some(
+    (item) => item.kind === 'approval' && item.status === 'waiting'
+  );
+}
+
+function isWaitingForRequester(lens: ContextLens): boolean {
+  return (
+    lens.activity.items.some(
+      (item) => item.kind === 'request_input' && item.status === 'waiting'
+    ) ||
+    Boolean(lens.activity.plan?.steps.some((step) => step.status === 'waiting'))
+  );
+}
+
+function hasFailedPlanStep(lens: ContextLens): boolean {
+  return Boolean(
+    lens.activity.plan?.steps.some(
+      (step) => step.status === 'error' || step.status === 'blocked'
+    )
+  );
+}
+
+function hasIncompletePlanStep(lens: ContextLens): boolean {
+  return Boolean(
+    lens.activity.plan?.steps.some((step) => step.status !== 'completed')
+  );
+}
+
+function projectionState(
+  lens: ContextLens,
+  surface: ParticipantAgentActivityProjectionV1['surface'],
+  outcome?: 'completed' | 'failed' | 'cancelled'
+): ParticipantAgentActivityState {
+  if (outcome === 'cancelled') {
+    return 'cancelled';
+  }
+  if (outcome === 'failed') {
+    return 'failed';
+  }
+  if (lens.lifecycle.timedOut || lens.status === 'timed_out') {
+    return 'timed_out';
+  }
+  if (lens.status === 'error') {
+    return 'failed';
+  }
+  if (lens.status === 'aborted') {
+    return 'cancelled';
+  }
+
+  const waitingOwner = isWaitingForOwner(lens);
+  const waitingRequester = isWaitingForRequester(lens);
+  if (waitingOwner) {
+    return 'waiting_owner';
+  }
+  if (waitingRequester) {
+    return 'waiting_requester';
+  }
+
+  const deliverySettlesSnapshot =
+    surface === 'final' || outcome === 'completed';
+  if (deliverySettlesSnapshot || lens.status === 'completed') {
+    if (hasFailedPlanStep(lens)) {
+      return 'failed';
+    }
+    return hasIncompletePlanStep(lens) ? 'incomplete' : 'completed';
+  }
+  if (lens.status === 'no_reply') {
+    return 'incomplete';
+  }
+  return 'working';
+}
+
+function actionAggregate(items: ContextLensActivityItem[]) {
+  const actions = items.filter(
+    (item) => item.kind !== 'commentary' && item.kind !== 'request_input'
+  );
+  if (actions.length === 0) {
+    return undefined;
+  }
+  return {
+    total: Math.min(10_000, actions.length),
+    completed: Math.min(
+      10_000,
+      actions.filter((item) => item.status === 'completed').length
+    ),
+  };
+}
+
+function latestCommentaryUpdate(
+  items: ContextLensActivityItem[],
+  title: string
+): string | undefined {
+  // `commentary` is the host's user-facing preamble for this conversation,
+  // not assistant text, raw thinking, command output, approval text, or tool
+  // results. registerContextLensAgentEvents deliberately excludes those
+  // private/high-volume streams; widening that contract requires a separate
+  // public-audience review before this allowlist may copy the new content.
+  const commentary = items
+    .filter((item) => item.kind === 'commentary')
+    .sort((left, right) => right.updatedAt - left.updatedAt)[0];
+  const update = compactPublicText(
+    commentary?.progressText ?? commentary?.title,
+    MAX_PARTICIPANT_AGENT_ACTIVITY_UPDATE_CHARS
+  );
+  return update && update !== title ? update : undefined;
+}
+
+function settleStepStatus(
+  status: ParticipantAgentActivityStepStatus,
+  state: ParticipantAgentActivityState
+): ParticipantAgentActivityStepStatus {
+  if (state === 'waiting_owner' || state === 'waiting_requester') {
+    return status === 'running' ? 'waiting' : status;
+  }
+  if (state === 'failed' || state === 'timed_out') {
+    return status === 'running' || status === 'waiting' ? 'failed' : status;
+  }
+  if (state === 'cancelled') {
+    return status === 'running' || status === 'waiting' ? 'cancelled' : status;
+  }
+  if (state === 'incomplete') {
+    // A terminal incomplete receipt must not leave a row visually spinning.
+    return status === 'running' || status === 'waiting' ? 'pending' : status;
+  }
+  return status;
+}
+
+function planSteps(
+  lens: ContextLens,
+  publicRunId: string,
+  state: ParticipantAgentActivityState
+): ParticipantAgentActivityStep[] {
+  const plan = lens.activity.plan;
+  if (!plan?.steps.length) {
+    return [];
+  }
+  return plan.steps
+    .slice(0, MAX_PARTICIPANT_AGENT_ACTIVITY_STEPS)
+    .flatMap((step, index) => {
+      const title = compactPublicText(
+        step.title,
+        MAX_PARTICIPANT_AGENT_ACTIVITY_TITLE_CHARS
+      );
+      if (!title) {
+        return [];
+      }
+      const stepItems = lens.activity.items.filter(
+        (item) => item.planStepId === step.id
+      );
+      const update = latestCommentaryUpdate(stepItems, title);
+      const actions = actionAggregate(stepItems);
+      return [
+        {
+          id: opaqueId('step', `${publicRunId}\0${step.id || index}`),
+          title,
+          status: settleStepStatus(publicStepStatus(step.status), state),
+          ...(update ? { update } : {}),
+          ...(actions ? { actions } : {}),
+        },
+      ];
+    });
+}
+
+function fallbackSteps(
+  lens: ContextLens,
+  publicRunId: string,
+  state: ParticipantAgentActivityState
+): ParticipantAgentActivityStep[] {
+  const requestInput = [...lens.activity.items]
+    .reverse()
+    .find((item) => item.kind === 'request_input');
+  if (requestInput) {
+    const title = compactPublicText(
+      requestInput.title,
+      MAX_PARTICIPANT_AGENT_ACTIVITY_TITLE_CHARS
+    );
+    if (title) {
+      return [
+        {
+          id: opaqueId(
+            'step',
+            `${publicRunId}\0${requestInput.id || 'request-input'}`
+          ),
+          title,
+          status: settleStepStatus(
+            publicStepStatus(requestInput.status),
+            state
+          ),
+        },
+      ];
+    }
+  }
+
+  const commentary = lens.activity.items
+    .filter((item) => item.kind === 'commentary')
+    .slice(-MAX_PARTICIPANT_AGENT_ACTIVITY_STEPS);
+  if (commentary.length > 0) {
+    return commentary.flatMap((item, index) => {
+      const progress = compactPublicText(
+        item.progressText,
+        MAX_PARTICIPANT_AGENT_ACTIVITY_TITLE_CHARS
+      );
+      const itemTitle = compactPublicText(
+        item.title,
+        MAX_PARTICIPANT_AGENT_ACTIVITY_TITLE_CHARS
+      );
+      const title = progress ?? itemTitle;
+      if (!title) {
+        return [];
+      }
+      const update =
+        progress && itemTitle && itemTitle !== progress ? progress : undefined;
+      return [
+        {
+          id: opaqueId(
+            'step',
+            `${publicRunId}\0${item.id || `commentary-${index}`}`
+          ),
+          title,
+          status: settleStepStatus(publicStepStatus(item.status), state),
+          ...(update ? { update } : {}),
+          ...(index === commentary.length - 1
+            ? { actions: actionAggregate(lens.activity.items) }
+            : {}),
+        },
+      ];
+    });
+  }
+
+  const status: ParticipantAgentActivityStepStatus =
+    state === 'completed'
+      ? 'completed'
+      : state === 'failed' || state === 'timed_out'
+        ? 'failed'
+        : state === 'cancelled'
+          ? 'cancelled'
+          : state === 'waiting_owner' || state === 'waiting_requester'
+            ? 'waiting'
+            : state === 'incomplete'
+              ? 'pending'
+              : 'running';
+  const actions = actionAggregate(lens.activity.items);
+  return [
+    {
+      id: opaqueId('step', `${publicRunId}\0generic`),
+      title: 'Working on your request',
+      status,
+      ...(actions ? { actions } : {}),
+    },
+  ];
+}
+
+function serializedBytes(value: unknown): number {
+  return new TextEncoder().encode(JSON.stringify(value)).byteLength;
+}
+
+function fitProjection(
+  projection: ParticipantAgentActivityProjectionV1
+): ParticipantAgentActivityProjectionV1 {
+  const fitted: ParticipantAgentActivityProjectionV1 = {
+    ...projection,
+    steps: projection.steps.map((step) => ({ ...step })),
+  };
+  while (serializedBytes(fitted) > MAX_PARTICIPANT_AGENT_ACTIVITY_BYTES) {
+    const stepWithUpdate = [...fitted.steps]
+      .reverse()
+      .find((step) => step.update !== undefined);
+    if (stepWithUpdate) {
+      delete stepWithUpdate.update;
+      continue;
+    }
+    if (fitted.steps.length > 1) {
+      fitted.steps.pop();
+      continue;
+    }
+    break;
+  }
+  return fitted;
+}
+
+function genericTerminalReason(
+  lens: ContextLens,
+  state: ParticipantAgentActivityState
+): ParticipantAgentActivityProjectionV1['terminalReason'] {
+  if (state === 'timed_out') {
+    return 'timeout';
+  }
+  if (state === 'cancelled') {
+    return 'interrupted';
+  }
+  if (state === 'failed') {
+    const approvalDenied = lens.activity.items.some(
+      (item) =>
+        item.kind === 'approval' &&
+        (item.status === 'error' ||
+          item.status === 'blocked' ||
+          item.status === 'cancelled')
+    );
+    return approvalDenied ? 'denied' : 'failed';
+  }
+  return undefined;
+}
+
+/**
+ * Build the only Lens-derived payload that may be copied into a group post.
+ * This is intentionally an allowlist: adding a field to ContextLens never
+ * makes it public without an explicit mapping here.
+ */
+export function buildParticipantAgentActivityProjection({
+  lens,
+  surface,
+  revision,
+  outcome,
+}: BuildParticipantAgentActivityProjectionOptions): ParticipantAgentActivityProjectionV1 | null {
+  if (
+    lens.chatType !== 'channel' ||
+    lens.triggerDetails.conversationKind !== 'channel'
+  ) {
+    return null;
+  }
+
+  const triggerPostId = compactPublicText(
+    lens.triggerDetails.messageId || lens.messageId,
+    320
+  );
+  if (!triggerPostId) {
+    return null;
+  }
+
+  const publicRunId = participantAgentPublicRunId(lens.lensId);
+  const state = projectionState(lens, surface, outcome);
+  const createdAt = safeTimestamp(lens.createdAt);
+  const rawCompletedAt = safeTimestamp(
+    lens.lifecycle.completedAt ?? lens.updatedAt
+  );
+  const isTerminal =
+    state === 'completed' ||
+    state === 'incomplete' ||
+    state === 'failed' ||
+    state === 'timed_out' ||
+    state === 'cancelled';
+  const completedAt = isTerminal
+    ? Math.max(createdAt, rawCompletedAt)
+    : undefined;
+  const updatedAt = Math.max(
+    createdAt,
+    safeTimestamp(lens.updatedAt),
+    completedAt ?? 0
+  );
+  const threadRootId = compactPublicText(
+    participantAgentDeliveryParentId(lens),
+    320
+  );
+  const steps = planSteps(lens, publicRunId, state);
+  const terminalReason = genericTerminalReason(lens, state);
+
+  const projection: ParticipantAgentActivityProjectionV1 = {
+    schemaVersion: 1,
+    surface,
+    publicRunId,
+    revision,
+    triggerPostId,
+    ...(threadRootId ? { threadRootId } : {}),
+    ...(lens.retryOf
+      ? { retryOf: participantAgentPublicRunId(lens.retryOf) }
+      : {}),
+    ...(lens.continuation?.kind === 'request_input'
+      ? {
+          continuation: {
+            kind: 'request_input' as const,
+            parentPublicRunId: participantAgentPublicRunId(
+              lens.continuation.parentLensId
+            ),
+          },
+        }
+      : {}),
+    state,
+    createdAt,
+    updatedAt,
+    ...(completedAt !== undefined ? { completedAt } : {}),
+    steps: steps.length ? steps : fallbackSteps(lens, publicRunId, state),
+    ...(terminalReason ? { terminalReason } : {}),
+  };
+
+  return ParticipantAgentActivityProjectionV1Schema.parse(
+    fitProjection(projection)
+  );
+}

--- a/packages/openclaw/src/types.test.ts
+++ b/packages/openclaw/src/types.test.ts
@@ -231,6 +231,7 @@ describe('resolveTlonAccount contextLens', () => {
 
     expect(account.contextLens).toEqual({
       enabled: false,
+      participantActivityEnabled: false,
       ttlMs: null,
       maxEntries: null,
       visibilityDefault: 'owner',
@@ -248,6 +249,7 @@ describe('resolveTlonAccount contextLens', () => {
           tlon: {
             contextLens: {
               enabled: true,
+              participantActivityEnabled: true,
               ttlMs: 600_000,
               authToken: 'a-token-of-sufficient-length',
             },
@@ -270,6 +272,7 @@ describe('resolveTlonAccount contextLens', () => {
 
     expect(account.contextLens).toEqual({
       enabled: true,
+      participantActivityEnabled: true,
       ttlMs: 600_000,
       maxEntries: 500,
       visibilityDefault: 'internal',

--- a/packages/openclaw/src/types.ts
+++ b/packages/openclaw/src/types.ts
@@ -22,6 +22,7 @@ export type TlonContextLensStoreConfig = {
 
 export type TlonContextLensConfig = {
   enabled: boolean;
+  participantActivityEnabled: boolean;
   ttlMs: number | null;
   maxEntries: number | null;
   visibilityDefault: TlonContextLensVisibility;
@@ -85,6 +86,7 @@ type TlonContextLensStoreInput = {
 
 type TlonContextLensInput = {
   enabled?: boolean;
+  participantActivityEnabled?: boolean;
   ttlMs?: number;
   maxEntries?: number;
   visibilityDefault?: TlonContextLensVisibility;
@@ -121,6 +123,10 @@ function resolveContextLensConfig(
 ): TlonContextLensConfig {
   return {
     enabled: account?.enabled ?? base?.enabled ?? false,
+    participantActivityEnabled:
+      account?.participantActivityEnabled ??
+      base?.participantActivityEnabled ??
+      false,
     ttlMs: account?.ttlMs ?? base?.ttlMs ?? null,
     maxEntries: account?.maxEntries ?? base?.maxEntries ?? null,
     visibilityDefault:
@@ -202,6 +208,7 @@ export function resolveTlonAccount(
       },
       contextLens: {
         enabled: false,
+        participantActivityEnabled: false,
         ttlMs: null,
         maxEntries: null,
         visibilityDefault: 'owner',

--- a/packages/openclaw/src/urbit/blob.test.ts
+++ b/packages/openclaw/src/urbit/blob.test.ts
@@ -1,0 +1,127 @@
+import type { ParticipantAgentActivityProjectionV1 } from '@tloncorp/api/client/participantAgentActivity';
+import { describe, expect, it } from 'vitest';
+
+import {
+  replaceContextLensParticipantActivityInBlob,
+  serializeContextLensReferenceBlob,
+} from './blob.js';
+
+function projection(
+  surface: ParticipantAgentActivityProjectionV1['surface'] = 'carrier'
+): ParticipantAgentActivityProjectionV1 {
+  return {
+    schemaVersion: 1,
+    surface,
+    publicRunId: 'run_abcdefghijklmnopqrstuvwxyz',
+    revision: surface === 'carrier' ? 2 : 3,
+    triggerPostId: '~sampel-palnet/170.141.184.507.123',
+    state: surface === 'carrier' ? 'working' : 'completed',
+    createdAt: 1_000,
+    updatedAt: surface === 'carrier' ? 1_500 : 2_000,
+    ...(surface === 'final' ? { completedAt: 2_000 } : {}),
+    steps: [
+      {
+        id: 'step_abcdefghijklmnopqrstuvwxyz',
+        title: 'Verify the result',
+        status: surface === 'carrier' ? 'running' : 'completed',
+      },
+    ],
+  };
+}
+
+describe('Context Lens participant activity blobs', () => {
+  it('serializes the projection as an additive Lens v1 field', () => {
+    expect(
+      JSON.parse(
+        serializeContextLensReferenceBlob(
+          'lens-123',
+          '~zod',
+          'final',
+          'completed',
+          projection('final')
+        )
+      )
+    ).toEqual([
+      {
+        type: 'tlon-context-lens',
+        version: 1,
+        lensId: 'lens-123',
+        botShip: '~zod',
+        delivery: 'final',
+        outcome: 'completed',
+        participantActivity: projection('final'),
+      },
+    ]);
+  });
+
+  it('replaces only the matching projection in a combined blob', () => {
+    const untouchedEntry = {
+      type: 'future-extension',
+      version: 9,
+      nested: { preserve: ['all', 'fields'] },
+    };
+    const otherLens = {
+      type: 'tlon-context-lens',
+      version: 1,
+      lensId: 'lens-other',
+      participantActivity: projection('carrier'),
+    };
+    const matchingLens = {
+      type: 'tlon-context-lens',
+      version: 1,
+      lensId: 'lens-123',
+      delivery: 'final',
+      outcome: 'completed',
+      customExtension: { must: 'survive' },
+      participantActivity: projection('carrier'),
+    };
+    const blob = JSON.stringify([untouchedEntry, matchingLens, otherLens]);
+
+    const replaced = JSON.parse(
+      replaceContextLensParticipantActivityInBlob(
+        blob,
+        'lens-123',
+        projection('final')
+      )
+    );
+
+    expect(replaced[0]).toEqual(untouchedEntry);
+    expect(replaced[1]).toEqual({
+      ...matchingLens,
+      participantActivity: projection('final'),
+    });
+    expect(replaced[2]).toEqual(otherLens);
+  });
+
+  it('rejects missing, ambiguous, and malformed replacements', () => {
+    const reference = {
+      type: 'tlon-context-lens',
+      version: 1,
+      lensId: 'lens-123',
+    };
+    expect(() =>
+      replaceContextLensParticipantActivityInBlob(
+        JSON.stringify([reference]),
+        'missing',
+        projection()
+      )
+    ).toThrow('not found');
+    expect(() =>
+      replaceContextLensParticipantActivityInBlob(
+        JSON.stringify([reference, reference]),
+        'lens-123',
+        projection()
+      )
+    ).toThrow('Ambiguous');
+    expect(() =>
+      replaceContextLensParticipantActivityInBlob(
+        JSON.stringify([reference]),
+        'lens-123',
+        {
+          ...projection(),
+          botShip: '~forged',
+        } as ParticipantAgentActivityProjectionV1
+      )
+    ).toThrow();
+  });
+});

--- a/packages/openclaw/src/urbit/blob.ts
+++ b/packages/openclaw/src/urbit/blob.ts
@@ -1,11 +1,19 @@
 import { A2UI, appendToPostBlob } from '@tloncorp/api';
+import {
+  type ParticipantAgentActivityProjectionV1,
+  ParticipantAgentActivityProjectionV1Schema,
+} from '@tloncorp/api/client/participantAgentActivity';
 
 export function serializeContextLensReferenceBlob(
   lensId: string,
   botShip?: string,
   delivery?: 'final' | 'intermediate',
-  outcome?: 'completed' | 'failed'
+  outcome?: 'completed' | 'failed',
+  participantActivity?: ParticipantAgentActivityProjectionV1
 ): string {
+  const publicProjection = participantActivity
+    ? ParticipantAgentActivityProjectionV1Schema.parse(participantActivity)
+    : undefined;
   return JSON.stringify([
     {
       type: 'tlon-context-lens',
@@ -14,8 +22,59 @@ export function serializeContextLensReferenceBlob(
       ...(botShip ? { botShip } : {}),
       ...(delivery ? { delivery } : {}),
       ...(outcome ? { outcome } : {}),
+      ...(publicProjection ? { participantActivity: publicProjection } : {}),
     },
   ]);
+}
+
+function isJsonRecord(value: unknown): value is Record<string, unknown> {
+  return Boolean(value && typeof value === 'object' && !Array.isArray(value));
+}
+
+/**
+ * Replace only the public projection on one existing Context Lens reference.
+ * Other blob entries and extension fields are preserved verbatim as data.
+ */
+export function replaceContextLensParticipantActivityInBlob(
+  blob: string,
+  lensId: string,
+  participantActivity: ParticipantAgentActivityProjectionV1
+): string {
+  const projection =
+    ParticipantAgentActivityProjectionV1Schema.parse(participantActivity);
+  let entries: unknown;
+  try {
+    entries = JSON.parse(blob);
+  } catch {
+    throw new Error('Invalid post blob JSON');
+  }
+  if (!Array.isArray(entries)) {
+    throw new Error('Post blob must be a JSON array');
+  }
+
+  const matches = entries.flatMap((entry, index) =>
+    isJsonRecord(entry) &&
+    entry.type === 'tlon-context-lens' &&
+    entry.version === 1 &&
+    entry.lensId === lensId
+      ? [index]
+      : []
+  );
+  if (matches.length === 0) {
+    throw new Error(`Context Lens reference not found: ${lensId}`);
+  }
+  if (matches.length > 1) {
+    throw new Error(`Ambiguous Context Lens reference: ${lensId}`);
+  }
+
+  const matchIndex = matches[0];
+  return JSON.stringify(
+    entries.map((entry, index) =>
+      index === matchIndex && isJsonRecord(entry)
+        ? { ...entry, participantActivity: projection }
+        : entry
+    )
+  );
 }
 
 export const TLON_A2UI_CATALOG_ID = 'tlon.a2ui.basic.v1';

--- a/packages/openclaw/src/urbit/send.test.ts
+++ b/packages/openclaw/src/urbit/send.test.ts
@@ -176,3 +176,15 @@ describe('buildMediaStory', () => {
     expect(story).toEqual([{ inline: [''] }]);
   });
 });
+
+describe('allocateChannelSentAt', () => {
+  it('allocates distinct timestamps for concurrent channel sends', async () => {
+    const { allocateChannelSentAt } = await import('./send.js');
+    const observedNow = 42;
+
+    const first = allocateChannelSentAt(observedNow);
+    const second = allocateChannelSentAt(observedNow);
+
+    expect(second).toBe(first + 1);
+  });
+});

--- a/packages/openclaw/src/urbit/send.ts
+++ b/packages/openclaw/src/urbit/send.ts
@@ -7,6 +7,7 @@ import {
 } from '@tloncorp/api';
 import { da, scot } from '@urbit/aura';
 
+import { sharedSlot } from '../shared-state.js';
 import { type Story, createImageBlock, markdownToStory } from './story.js';
 
 // --- Helpers ---
@@ -24,6 +25,22 @@ function formatPostId(postId: string): string {
     }
   }
   return postId;
+}
+
+const lastChannelSentAtSlot = sharedSlot<number>(
+  'urbit.send.lastChannelSentAt'
+);
+
+/**
+ * %channels deduplicates adds by their submitted timestamp. Allocate a
+ * process-wide monotonic millisecond even when concurrent sends observe the
+ * same Date.now(), including across OpenClaw's duplicate module contexts.
+ */
+export function allocateChannelSentAt(now = Date.now()): number {
+  const previous = lastChannelSentAtSlot.get() ?? 0;
+  const sentAt = Math.max(Math.trunc(now), previous + 1);
+  lastChannelSentAtSlot.set(sentAt);
+  return sentAt;
 }
 
 /**
@@ -138,6 +155,8 @@ type SendChannelPostParams = {
   title?: string;
   /** Optional bot profile for custom display name/avatar */
   botProfile?: BotProfile;
+  /** Reserved for transports that allocate before dispatch. */
+  sentAt?: number;
 };
 
 /**
@@ -152,8 +171,9 @@ export async function sendChannelPost({
   replyToId,
   title,
   botProfile,
+  sentAt: reservedSentAt,
 }: SendChannelPostParams) {
-  const sentAt = Date.now();
+  const sentAt = reservedSentAt ?? allocateChannelSentAt();
 
   if (replyToId) {
     const formattedReplyId = formatPostId(replyToId);
@@ -170,6 +190,7 @@ export async function sendChannelPost({
     return {
       channel: 'tlon',
       messageId: `${fromShip}/${formatSentAt(sentAt)}`,
+      sentAt,
     };
   }
 
@@ -185,6 +206,7 @@ export async function sendChannelPost({
   return {
     channel: 'tlon',
     messageId: `${fromShip}/${formatSentAt(sentAt)}`,
+    sentAt,
   };
 }
 


### PR DESCRIPTION
## Summary

- publish an explicitly allowlisted task projection for group-channel participants
- use bot-authored channel/thread carrier posts so existing conversation ACLs remain the authorization boundary
- keep raw Context Lens history and owner controls private to `%steward`
- coalesce revisions, preserve exact thread placement, correlate carriers safely, and settle failures/timeouts without perpetual spinners
- add a default-off `participantActivityEnabled` gateway setting

## Privacy boundary

The participant wire type contains only opaque public IDs, task titles/statuses, user-facing commentary, generic terminal state, and aggregate action counts. It excludes prompts, reply/source previews, raw Lens/run/session IDs, model/provider metadata, tool names/arguments/results, approval text, persistence details, raw errors, retry seeds, and thinking content.

The projection is accepted only for authenticated bot-authored posts in the exact channel/thread. It is bounded by schema, revisions are monotonic, malformed or ambiguous blobs fail closed, and DMs are never projected.

## Why

Owner-only activity is useful in DMs, but group work needs one coherent progress view for everyone who can read the conversation. Reusing full Lens events or `%presence` would broaden access to private debug data and has weaker channel-ACL semantics, so this PR introduces a separate public contract and transport.

## Stack

Review bottom-up; each PR is based on the branch above it.

1. #6290 — reusable Ochre task-row UI
2. #6321 — OpenClaw 7.1 runtime
3. #6322 — private durable activity and lifecycle
4. **#6323 — participant-safe group projection (this PR)**
5. #6324 — Messenger DM, group, and thread integration

## Validation

- API participant schema: 1 file / 6 tests
- OpenClaw projection/publisher/transport/blob/send/config: 8 files / 75 tests
- `pnpm --dir packages/api tsc`
- `pnpm --dir packages/openclaw tsc`
- manifest parse, entrypoint shell check, focused Prettier, and `git diff --check`
