### PR TITLE
center desktop compose bar icons

### DIFF
--- a/packages/app/ui/components/MessageInput/MessageInputBase.tsx
+++ b/packages/app/ui/components/MessageInput/MessageInputBase.tsx
@@ -210,7 +210,7 @@ export const MessageInputContainer = memo(
             ) : null}
 
             {isEditing ? (
-              <MessageInputChromeAction bottomSpacing="2xs">
+              <MessageInputChromeAction>
                 <MessageInputChromeButton
                   preset="secondary"
                   icon="Close"
@@ -405,12 +405,7 @@ function MessageInputChromeRow({
   );
 }
 
-function MessageInputChromeAction({
-  children,
-  bottomSpacing = 'xs',
-}: PropsWithChildren<{
-  bottomSpacing?: 'xs' | '2xs';
-}>) {
+function MessageInputChromeAction({ children }: PropsWithChildren) {
   if (usesIOSGlass) {
     return (
       <GlassSurface isInteractive style={inputChromeStyles.action}>
@@ -435,11 +430,7 @@ function MessageInputChromeAction({
     );
   }
 
-  return (
-    <View marginBottom={bottomSpacing === '2xs' ? '$2xs' : '$xs'}>
-      {children}
-    </View>
-  );
+  return <View top={2}>{children}</View>;
 }
 
 function MessageInputChromeBody({
@@ -535,7 +526,7 @@ function MessageInputChromeButton(props: ComponentProps<typeof Button>) {
 function MessageInputChromeSendAction({ children }: PropsWithChildren) {
   return (
     <View
-      marginBottom={usesFloatingChrome ? undefined : '$xs'}
+      top={usesFloatingChrome ? undefined : 2}
       alignSelf={usesFloatingChrome ? 'center' : undefined}
     >
       {children}


### PR DESCRIPTION
## Summary

Centers the attachment and send icons with the message text in the desktop compose bar.

Fixes TLON-6372

## Changes

- removes the desktop-only bottom offsets that lifted compose actions
- applies a 2 px desktop adjustment that keeps controls aligned with the current text line
- leaves native iOS and Android composer paths unchanged

## How did I test?

Tested in browser - only affects web.

## Screenshots

### Before

<img width="1440" height="813" alt="Desktop compose bar before" src="https://github.com/user-attachments/assets/8bc89c79-d7d3-4ab6-b91e-a8aae3f38df0" />

### After

<img width="1440" height="813" alt="Desktop compose bar after" src="https://github.com/user-attachments/assets/39f1a675-8054-40eb-ab35-da5300cd6ea9" />