### PR TITLE
chat input: send the corrected word when iOS autocorrect is pending

### DIFF
--- a/packages/app/ui/components/BareChatInput/index.tsx
+++ b/packages/app/ui/components/BareChatInput/index.tsx
@@ -351,9 +351,7 @@ function BareChatInput(
   } = useSlashCommands({ manifest: slashCommandManifest });
   const maxInputHeight = useMaxInputHeight(maxInputHeightBasic);
   const inputRef = useRef<TextInput>(null);
-  const runSendMessageRef = useRef<
-    ((isEdit: boolean, textOverride?: string) => void) | null
-  >(null);
+  const runSendMessageRef = useRef<((isEdit: boolean) => void) | null>(null);
   // Set while waiting for iOS to deliver a pending autocorrection on send.
   const pendingAutocorrectSendRef = useRef<{ isEdit: boolean } | null>(null);
 
@@ -426,14 +424,11 @@ function BareChatInput(
   const handleTextChange = useCallback(
     (newText: string) => {
       // A send is waiting on a pending autocorrection, so this change is the
-      // corrected text. Send that instead of what was on screen when the send
-      // button was tapped.
+      // corrected text. It still goes through the normal path below, so mention
+      // offsets and references stay in sync, and the send runs once that has
+      // been folded into state.
       const pendingSend = pendingAutocorrectSendRef.current;
-      if (pendingSend) {
-        pendingAutocorrectSendRef.current = null;
-        runSendMessageRef.current?.(pendingSend.isEdit, newText);
-        return;
-      }
+      pendingAutocorrectSendRef.current = null;
 
       const oldText = controlledText;
 
@@ -479,6 +474,12 @@ function BareChatInput(
         const jsonContent = textAndMentionsToContent(newText, mentions);
         bareChatInputLogger.log('setting draft', jsonContent);
         storeDraft(jsonContent);
+      }
+
+      if (pendingSend) {
+        // Yield a tick so the post is built from the state this change just
+        // set, rather than the text the send button closed over.
+        setTimeout(() => runSendMessageRef.current?.(pendingSend.isEdit), 0);
       }
     },
     [
@@ -581,11 +582,8 @@ function BareChatInput(
   );
 
   const sendMessage = useCallback(
-    async (isEdit?: boolean, textOverride?: string) => {
-      const jsonContent = textAndMentionsToContent(
-        textOverride ?? controlledText,
-        mentions
-      );
+    async (isEdit?: boolean) => {
+      const jsonContent = textAndMentionsToContent(controlledText, mentions);
       const inlines = JSONToInlines(jsonContent);
 
       const draft: domain.PostDataDraft = (() => {
@@ -661,9 +659,9 @@ function BareChatInput(
   );
 
   const runSendMessage = useCallback(
-    async (isEdit: boolean, textOverride?: string) => {
+    async (isEdit: boolean) => {
       try {
-        await sendMessage(isEdit, textOverride);
+        await sendMessage(isEdit);
       } catch (e) {
         bareChatInputLogger.trackError('failed to send', e);
         setSendError(true);

--- a/packages/app/ui/components/BareChatInput/index.tsx
+++ b/packages/app/ui/components/BareChatInput/index.tsx
@@ -354,6 +354,10 @@ function BareChatInput(
   const runSendMessageRef = useRef<((isEdit: boolean) => void) | null>(null);
   // Set while waiting for iOS to deliver a pending autocorrection on send.
   const pendingAutocorrectSendRef = useRef<{ isEdit: boolean } | null>(null);
+  // Set once that correction arrives, to send it after the commit that carries it.
+  const [queuedSend, setQueuedSend] = useState<{ isEdit: boolean } | null>(
+    null
+  );
 
   usePasteHandler(addAttachment);
 
@@ -477,9 +481,7 @@ function BareChatInput(
       }
 
       if (pendingSend) {
-        // Yield a tick so the post is built from the state this change just
-        // set, rather than the text the send button closed over.
-        setTimeout(() => runSendMessageRef.current?.(pendingSend.isEdit), 0);
+        setQueuedSend(pendingSend);
       }
     },
     [
@@ -702,6 +704,17 @@ function BareChatInput(
     },
     [runSendMessage]
   );
+
+  // setQueuedSend batches with the setState calls in handleTextChange, so this
+  // runs after the commit that carries the corrected text and the mention
+  // offsets it shifted — which is what the post has to be built from.
+  useEffect(() => {
+    if (!queuedSend) {
+      return;
+    }
+    setQueuedSend(null);
+    runSendMessage(queuedSend.isEdit);
+  }, [queuedSend, runSendMessage]);
 
   const handleSend = useCallback(async () => {
     submit(false);

--- a/packages/app/ui/components/BareChatInput/index.tsx
+++ b/packages/app/ui/components/BareChatInput/index.tsx
@@ -30,7 +30,7 @@ import {
   useRef,
   useState,
 } from 'react';
-import { Keyboard, TextInput } from 'react-native';
+import { Keyboard, Platform, TextInput } from 'react-native';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
 import {
   View,
@@ -71,6 +71,9 @@ import {
 } from './useSlashCommands';
 
 const bareChatInputLogger = createDevLogger('bareChatInput', false);
+
+// How long a send waits for iOS to deliver a pending autocorrection.
+const AUTOCORRECT_FLUSH_TIMEOUT = 20;
 
 function normalizePreviewUrl(url: string) {
   try {
@@ -348,6 +351,11 @@ function BareChatInput(
   } = useSlashCommands({ manifest: slashCommandManifest });
   const maxInputHeight = useMaxInputHeight(maxInputHeightBasic);
   const inputRef = useRef<TextInput>(null);
+  const runSendMessageRef = useRef<
+    ((isEdit: boolean, textOverride?: string) => void) | null
+  >(null);
+  // Set while waiting for iOS to deliver a pending autocorrection on send.
+  const pendingAutocorrectSendRef = useRef<{ isEdit: boolean } | null>(null);
 
   usePasteHandler(addAttachment);
 
@@ -417,6 +425,16 @@ function BareChatInput(
 
   const handleTextChange = useCallback(
     (newText: string) => {
+      // A send is waiting on a pending autocorrection, so this change is the
+      // corrected text. Send that instead of what was on screen when the send
+      // button was tapped.
+      const pendingSend = pendingAutocorrectSendRef.current;
+      if (pendingSend) {
+        pendingAutocorrectSendRef.current = null;
+        runSendMessageRef.current?.(pendingSend.isEdit, newText);
+        return;
+      }
+
       const oldText = controlledText;
 
       bareChatInputLogger.log('text change', newText);
@@ -563,8 +581,11 @@ function BareChatInput(
   );
 
   const sendMessage = useCallback(
-    async (isEdit?: boolean) => {
-      const jsonContent = textAndMentionsToContent(controlledText, mentions);
+    async (isEdit?: boolean, textOverride?: string) => {
+      const jsonContent = textAndMentionsToContent(
+        textOverride ?? controlledText,
+        mentions
+      );
       const inlines = JSONToInlines(jsonContent);
 
       const draft: domain.PostDataDraft = (() => {
@@ -640,9 +661,9 @@ function BareChatInput(
   );
 
   const runSendMessage = useCallback(
-    async (isEdit: boolean) => {
+    async (isEdit: boolean, textOverride?: string) => {
       try {
-        await sendMessage(isEdit);
+        await sendMessage(isEdit, textOverride);
       } catch (e) {
         bareChatInputLogger.trackError('failed to send', e);
         setSendError(true);
@@ -657,17 +678,44 @@ function BareChatInput(
     [sendMessage]
   );
 
+  runSendMessageRef.current = runSendMessage;
+
+  const submit = useCallback(
+    (isEdit: boolean) => {
+      if (Platform.OS !== 'ios') {
+        runSendMessage(isEdit);
+        return;
+      }
+
+      // iOS applies a pending autocorrection when the send button is tapped,
+      // and delivers the corrected text after this handler runs. Race that
+      // change against a short timeout: handleTextChange sends the corrected
+      // text if it arrives, otherwise send what is already on screen.
+      pendingAutocorrectSendRef.current = { isEdit };
+      setTimeout(() => {
+        if (pendingAutocorrectSendRef.current) {
+          pendingAutocorrectSendRef.current = null;
+          // Through the ref, so a correction that landed in the same native
+          // batch as the press is picked up instead of the text this handler
+          // closed over.
+          runSendMessageRef.current?.(isEdit);
+        }
+      }, AUTOCORRECT_FLUSH_TIMEOUT);
+    },
+    [runSendMessage]
+  );
+
   const handleSend = useCallback(async () => {
-    runSendMessage(false);
-  }, [runSendMessage]);
+    submit(false);
+  }, [submit]);
 
   const handleEdit = useCallback(async () => {
     Keyboard.dismiss();
     if (!editingPost) {
       return;
     }
-    runSendMessage(true);
-  }, [runSendMessage, editingPost]);
+    submit(true);
+  }, [submit, editingPost]);
 
   // Handle autofocus
   useEffect(() => {

--- a/packages/app/ui/components/BareChatInput/index.tsx
+++ b/packages/app/ui/components/BareChatInput/index.tsx
@@ -72,7 +72,6 @@ import {
 
 const bareChatInputLogger = createDevLogger('bareChatInput', false);
 
-// How long a send waits for iOS to deliver a pending autocorrection.
 const AUTOCORRECT_FLUSH_TIMEOUT_MS = 20;
 
 function normalizePreviewUrl(url: string) {
@@ -352,9 +351,7 @@ function BareChatInput(
   const maxInputHeight = useMaxInputHeight(maxInputHeightBasic);
   const inputRef = useRef<TextInput>(null);
   const runSendMessageRef = useRef<((isEdit: boolean) => void) | null>(null);
-  // Set while waiting for iOS to deliver a pending autocorrection on send.
   const pendingAutocorrectSendRef = useRef<{ isEdit: boolean } | null>(null);
-  // Set once that correction arrives, to send it after the commit that carries it.
   const [queuedSend, setQueuedSend] = useState<{ isEdit: boolean } | null>(
     null
   );
@@ -427,10 +424,6 @@ function BareChatInput(
 
   const handleTextChange = useCallback(
     (newText: string) => {
-      // A send is waiting on a pending autocorrection, so this change is the
-      // corrected text. It still goes through the normal path below, so mention
-      // offsets and references stay in sync, and the send runs once that has
-      // been folded into state.
       const pendingSend = pendingAutocorrectSendRef.current;
       pendingAutocorrectSendRef.current = null;
 
@@ -688,16 +681,12 @@ function BareChatInput(
       }
 
       // iOS applies a pending autocorrection when the send button is tapped,
-      // and delivers the corrected text after this handler runs. Race that
-      // change against a short timeout: handleTextChange sends the corrected
-      // text if it arrives, otherwise send what is already on screen.
+      // and delivers the corrected text through onChangeText after this handler
+      // has already run.
       pendingAutocorrectSendRef.current = { isEdit };
       setTimeout(() => {
         if (pendingAutocorrectSendRef.current) {
           pendingAutocorrectSendRef.current = null;
-          // Through the ref, so a correction that landed in the same native
-          // batch as the press is picked up instead of the text this handler
-          // closed over.
           runSendMessageRef.current?.(isEdit);
         }
       }, AUTOCORRECT_FLUSH_TIMEOUT_MS);
@@ -705,9 +694,9 @@ function BareChatInput(
     [runSendMessage]
   );
 
-  // setQueuedSend batches with the setState calls in handleTextChange, so this
-  // runs after the commit that carries the corrected text and the mention
-  // offsets it shifted — which is what the post has to be built from.
+  // React batches setQueuedSend with the state updates in handleTextChange, so
+  // this effect runs after the commit that carries the corrected text and the
+  // mention offsets it shifted.
   useEffect(() => {
     if (!queuedSend) {
       return;

--- a/packages/app/ui/components/BareChatInput/index.tsx
+++ b/packages/app/ui/components/BareChatInput/index.tsx
@@ -73,7 +73,7 @@ import {
 const bareChatInputLogger = createDevLogger('bareChatInput', false);
 
 // How long a send waits for iOS to deliver a pending autocorrection.
-const AUTOCORRECT_FLUSH_TIMEOUT = 20;
+const AUTOCORRECT_FLUSH_TIMEOUT_MS = 20;
 
 function normalizePreviewUrl(url: string) {
   try {
@@ -698,7 +698,7 @@ function BareChatInput(
           // closed over.
           runSendMessageRef.current?.(isEdit);
         }
-      }, AUTOCORRECT_FLUSH_TIMEOUT);
+      }, AUTOCORRECT_FLUSH_TIMEOUT_MS);
     },
     [runSendMessage]
   );


### PR DESCRIPTION
## Summary

On iOS, sending a message while an autocorrect suggestion is pending sends the typo and leaves the corrected word sitting in the composer, where it goes out again on the next send. This makes the send wait briefly for the correction, so the corrected word is what gets sent — the way iMessage behaves — and the composer clears.

## Changes

`BareChatInput` keeps its text in React state and the native input is driven by children, not a `value` prop. Tapping send makes UIKit commit the pending autocorrection, but that text change reaches JS *after* the press handler has already read `controlledText` and called `setControlledText('')`. So the typo is what gets posted, and the late change repopulates the input with the correction.

On iOS the send now sets a pending flag and races two outcomes:

- `handleTextChange` sees the flag and lets the change do its normal work — mention offsets, references, draft — then queues the send in state. An effect runs it after the commit that carries all of that, so React guarantees the ordering rather than a timer guessing at it.
- A 20ms timeout fires first and sends what is already on screen.

The timeout path goes through `runSendMessageRef` rather than the callback the press handler closed over. When the correction lands in the same native batch as the press — which is what I measured, same millisecond — the closure still holds the typo while the ref points at the callback from the corrected render.

Non-iOS is unchanged and sends synchronously. Android has no equivalent pending-correction state.

This is the same approach [Bluesky uses in their DM composer](https://github.com/bluesky-social/social-app/blob/06cb80a4c3f372f0ebd01ac9477f84e4a39e76fa/src/screens/Messages/components/MessageComposer.tsx#L146-L180) and a variant of [Expensify's](https://github.com/Expensify/App/blob/4076115318881e3428b3fcc4a178f29f71c6f1af/src/pages/inbox/report/ReportActionCompose/useComposerSubmit.ts#L219-L227), which defers a tick and reads the text from a ref.

## How did I test?

iPhone 17 simulator, software keyboard, autocorrect on. Type `adn` so the keyboard offers `And`, then tap send without dismissing the suggestion.

| | message sent | composer after |
|---|---|---|
| develop | `Adn` | holds `And` |
| this branch | `And` | empty |

https://github.com/user-attachments/assets/ec4407be-848c-4cf2-a095-f7bc43f0c3ac

https://github.com/user-attachments/assets/05662c3c-32f2-4edf-bf3e-901b3f540cd8

Also checked on device: a plain send with no suggestion pending, a send containing a mention, and editing a message. The edit path is worth calling out — `handleEdit` dismisses the keyboard first, so I logged it separately rather than assuming: with `wierd` pending, the correction arrives in the same millisecond as the press, gets intercepted, and the edit saves `Weird`. Keyboard stays down, same as develop.

Two sends tapped inside the same 20ms window now collapse into one, because the second `submit` overwrites the pending flag. That looks like an improvement over develop, but it is a behavior change.

One note on reproducing this yourself: iOS learns a typo after you reject its correction a few times, and then stops offering it. If the suggestion stops appearing, use a fresh misspelling or reset the simulator's keyboard dictionary.

## Risks and impact

- Safe to rollback without consulting PR author? Yes
- Affects important code area:
  - [ ] Onboarding
  - [ ] State / providers
  - [ ] Message sync
  - [ ] Channel display
  - [ ] Notifications
  - [x] Other: chat composer send path (iOS)

Every iOS send now goes through a ≤20ms deferral, so the worst case is a send that silently never fires. The path is small and self-contained — the flag is set, then cleared by whichever of the two branches wins — but it is the send button, so it is worth exercising in QA beyond the autocorrect case.

The 20ms ceiling is a guess borrowed from Bluesky. If a correction ever lands later than that, the behaviour degrades to what develop does today: typo sent, correction left in the composer. It does not get worse than the current bug.

## Rollback plan

Revert the commit. One file, no state or schema involved.



