### PR TITLE
hide delete markers by default

### DIFF
--- a/apps/tlon-web/e2e/app-settings.spec.ts
+++ b/apps/tlon-web/e2e/app-settings.spec.ts
@@ -21,10 +21,11 @@ test('should test app settings', async ({ zodSetup }) => {
   await expect(
     page.getByTestId('ScreenHeaderTitle').getByText('Privacy Settings')
   ).toBeVisible();
-  await page.getByText('Theme').click();
+  await page.getByText('Appearance').click();
   await expect(
-    page.getByTestId('ScreenHeaderTitle').getByText('Theme')
+    page.getByTestId('ScreenHeaderTitle').getByText('Appearance')
   ).toBeVisible();
+  await expect(page.getByTestId('ShowDeleteMarkersToggle')).toBeVisible();
   await page.getByText('App info').click();
   await page.getByText('Report a bug').click();
   await expect(

--- a/apps/tlon-web/e2e/direct-message.spec.ts
+++ b/apps/tlon-web/e2e/direct-message.spec.ts
@@ -80,5 +80,5 @@ test('should test comprehensive direct message functionality between ~zod and ~t
 
   // Send a message and delete it
   await helpers.sendMessage(zodPage, 'Delete this message');
-  await helpers.deleteMessage(zodPage, 'Delete this message', true);
+  await helpers.deleteMessage(zodPage, 'Delete this message');
 });

--- a/apps/tlon-web/e2e/dm-thread-interactions.spec.ts
+++ b/apps/tlon-web/e2e/dm-thread-interactions.spec.ts
@@ -141,7 +141,7 @@ test('should test DM thread interactions and message operations', async ({
 
   // ZOD: Send another message and delete it
   await helpers.sendThreadReply(zodPage, 'Delete this thread message');
-  await helpers.deleteMessage(zodPage, 'Delete this thread message', true);
+  await helpers.deleteMessage(zodPage, 'Delete this thread message');
 
   // TEN: Navigate to thread and send a message to hide
   await expect(tenPage.getByText(/\d+ repl(y|ies)/).first()).toBeVisible({

--- a/apps/tlon-web/e2e/helpers.ts
+++ b/apps/tlon-web/e2e/helpers.ts
@@ -1971,7 +1971,9 @@ export async function deleteMessage(page: Page, messageText: string) {
   await longPressMessage(page, messageText);
   acceptDeleteConfirmation(page, 'message');
   await page.getByText('Delete message').click();
-  await expect(page.getByText(messageText, { exact: true })).not.toBeVisible();
+  await expect(
+    page.getByTestId('Post').getByText(messageText, { exact: true }).first()
+  ).not.toBeVisible();
 }
 
 /**

--- a/apps/tlon-web/e2e/helpers.ts
+++ b/apps/tlon-web/e2e/helpers.ts
@@ -1964,24 +1964,14 @@ export function dismissDeleteConfirmation(
 /**
  * Deletes a message
  */
-export async function deleteMessage(
-  page: Page,
-  messageText: string,
-  isDM = false
-) {
+export async function deleteMessage(page: Page, messageText: string) {
   // Ensure session is stable before deleting message
   await waitForSessionStability(page);
 
   await longPressMessage(page, messageText);
   acceptDeleteConfirmation(page, 'message');
   await page.getByText('Delete message').click();
-  if (!isDM) {
-    await expect(
-      page.getByText(messageText, { exact: true })
-    ).not.toBeVisible();
-  } else {
-    await expect(page.getByText('Message deleted').first()).toBeVisible();
-  }
+  await expect(page.getByText(messageText, { exact: true })).not.toBeVisible();
 }
 
 /**

--- a/packages/api/src/client/settingsApi.test.ts
+++ b/packages/api/src/client/settingsApi.test.ts
@@ -1,0 +1,17 @@
+import { describe, expect, it } from 'vitest';
+
+import { toClientSettings } from './settingsApi';
+
+describe('toClientSettings showDeleteMarkers', () => {
+  it('defaults delete markers off when the setting has never been saved', () => {
+    expect(toClientSettings({ desk: {} }).showDeleteMarkers).toBe(false);
+  });
+
+  it('preserves an enabled delete marker preference', () => {
+    expect(
+      toClientSettings({
+        desk: { display: { showDeleteMarkers: true } },
+      }).showDeleteMarkers
+    ).toBe(true);
+  });
+});

--- a/packages/api/src/client/settingsApi.ts
+++ b/packages/api/src/client/settingsApi.ts
@@ -58,6 +58,7 @@ function getBucket(key: string): string {
     case 'showUnreadCounts':
       return 'calmEngine';
     case 'theme':
+    case 'showDeleteMarkers':
       return 'display';
     default:
       console.warn(
@@ -175,6 +176,7 @@ export const toClientSettings = (
     // default; getContextLensEnabledRaw exists for callers that need the
     // uncached backend value.
     contextLensEnabled: settings.desk.groups?.contextLensEnabled,
+    showDeleteMarkers: settings.desk.display?.showDeleteMarkers ?? false,
   };
 };
 

--- a/packages/api/src/types/models.ts
+++ b/packages/api/src/types/models.ts
@@ -325,6 +325,7 @@ export interface Settings {
   webAppSplashDismissed?: boolean;
   mobileAppPromoDismissed?: boolean;
   contextLensEnabled?: boolean;
+  showDeleteMarkers?: boolean;
 }
 
 export interface VolumeSettings {

--- a/packages/api/src/urbit/settings.ts
+++ b/packages/api/src/urbit/settings.ts
@@ -60,6 +60,7 @@ export type CalmEngineSettings = {
 
 export type DisplaySettings = {
   theme?: AppTheme;
+  showDeleteMarkers?: boolean;
 };
 
 export type GroupsSettings = {

--- a/packages/app/features/settings/ThemeScreen.tsx
+++ b/packages/app/features/settings/ThemeScreen.tsx
@@ -1,8 +1,7 @@
 import { NativeStackScreenProps } from '@react-navigation/native-stack';
 import { useThemeSettings } from '@tloncorp/shared';
 import * as store from '@tloncorp/shared/store';
-import { Text } from '@tloncorp/ui';
-import { useEffect, useState } from 'react';
+import { Fragment, useEffect, useState } from 'react';
 import { Switch } from 'react-native';
 import { YStack, useTheme } from 'tamagui';
 
@@ -16,6 +15,8 @@ import {
   RadioControl,
   ScreenHeader,
   SettingsContentScrollView,
+  SettingsDivider,
+  SettingsSection,
   View,
   useIsWindowNarrow,
 } from '../../ui';
@@ -83,67 +84,59 @@ export function ThemeScreen(props: Props) {
         }
         placement="navigation"
       />
-      <SettingsContentScrollView>
-        <YStack flex={1} padding="$l">
-          <Text
-            size="$label/m"
-            color="$secondaryText"
-            fontWeight="500"
-            paddingHorizontal="$s"
-          >
-            Messages
-          </Text>
-          <ListItem marginTop="$s">
-            <ListItem.MainContent>
-              <ListItem.Title>Show deleted messages</ListItem.Title>
-              <ListItem.Subtitle>
-                Show a placeholder for deleted messages
-              </ListItem.Subtitle>
-            </ListItem.MainContent>
-            <ListItem.EndContent>
-              <Switch
-                value={showDeleteMarkers}
-                onValueChange={handleShowDeleteMarkersChange}
-                testID="ShowDeleteMarkersToggle"
-              />
-            </ListItem.EndContent>
-          </ListItem>
-          <Text
-            size="$label/m"
-            color="$secondaryText"
-            fontWeight="500"
-            paddingHorizontal="$s"
-            marginTop="$xl"
-            marginBottom="$s"
-          >
-            Theme
-          </Text>
-          {themes.map((theme) => (
-            <Pressable
-              key={theme.value}
-              disabled={loadingTheme !== null}
-              onPress={() => handleThemeChange(theme.value)}
-              borderRadius="$xl"
-            >
-              <ListItem>
-                <ListItem.MainContent>
-                  <ListItem.Title>{theme.title}</ListItem.Title>
-                  {theme.subtitle && (
-                    <ListItem.Subtitle>{theme.subtitle}</ListItem.Subtitle>
-                  )}
-                </ListItem.MainContent>
-                <ListItem.EndContent>
-                  {loadingTheme === theme.value ? (
-                    <View padding="$m">
-                      <LoadingSpinner color="$primaryText" size="small" />
-                    </View>
-                  ) : (
-                    <RadioControl checked={theme.value === selectedTheme} />
-                  )}
-                </ListItem.EndContent>
-              </ListItem>
-            </Pressable>
-          ))}
+      <SettingsContentScrollView
+        paddingHorizontal="$l"
+        paddingTop="$l"
+        paddingBottom="$2xl"
+      >
+        <YStack gap="$2xl">
+          <SettingsSection title="Messages">
+            <ListItem>
+              <ListItem.MainContent>
+                <ListItem.Title>Show deleted messages</ListItem.Title>
+                <ListItem.Subtitle>
+                  Show a placeholder for deleted messages
+                </ListItem.Subtitle>
+              </ListItem.MainContent>
+              <ListItem.EndContent>
+                <Switch
+                  value={showDeleteMarkers}
+                  onValueChange={handleShowDeleteMarkersChange}
+                  testID="ShowDeleteMarkersToggle"
+                />
+              </ListItem.EndContent>
+            </ListItem>
+          </SettingsSection>
+          <SettingsSection title="Theme">
+            {themes.map((theme, index) => (
+              <Fragment key={theme.value}>
+                <Pressable
+                  disabled={loadingTheme !== null}
+                  onPress={() => handleThemeChange(theme.value)}
+                  borderRadius="$xl"
+                >
+                  <ListItem>
+                    <ListItem.MainContent>
+                      <ListItem.Title>{theme.title}</ListItem.Title>
+                      {theme.subtitle && (
+                        <ListItem.Subtitle>{theme.subtitle}</ListItem.Subtitle>
+                      )}
+                    </ListItem.MainContent>
+                    <ListItem.EndContent>
+                      {loadingTheme === theme.value ? (
+                        <View padding="$m">
+                          <LoadingSpinner color="$primaryText" size="small" />
+                        </View>
+                      ) : (
+                        <RadioControl checked={theme.value === selectedTheme} />
+                      )}
+                    </ListItem.EndContent>
+                  </ListItem>
+                </Pressable>
+                {index < themes.length - 1 ? <SettingsDivider /> : null}
+              </Fragment>
+            ))}
+          </SettingsSection>
         </YStack>
       </SettingsContentScrollView>
     </View>

--- a/packages/app/features/settings/ThemeScreen.tsx
+++ b/packages/app/features/settings/ThemeScreen.tsx
@@ -97,7 +97,7 @@ export function ThemeScreen(props: Props) {
             <ListItem.MainContent>
               <ListItem.Title>Show deleted messages</ListItem.Title>
               <ListItem.Subtitle>
-                Display a placeholder when a message is deleted
+                Show a placeholder for deleted messages
               </ListItem.Subtitle>
             </ListItem.MainContent>
             <ListItem.EndContent>

--- a/packages/app/features/settings/ThemeScreen.tsx
+++ b/packages/app/features/settings/ThemeScreen.tsx
@@ -2,6 +2,7 @@ import { NativeStackScreenProps } from '@react-navigation/native-stack';
 import { useThemeSettings } from '@tloncorp/shared';
 import * as store from '@tloncorp/shared/store';
 import { useEffect, useState } from 'react';
+import { Switch } from 'react-native';
 import { YStack, useTheme } from 'tamagui';
 
 import { RootStackParamList } from '../../navigation/types';
@@ -24,6 +25,7 @@ type Props = NativeStackScreenProps<RootStackParamList, 'Theme'>;
 export function ThemeScreen(props: Props) {
   const theme = useTheme();
   const { data: storedTheme, isLoading } = useThemeSettings();
+  const { data: showDeleteMarkers = false } = store.useShowDeleteMarkers();
   const [selectedTheme, setSelectedTheme] = useState<AppTheme>('auto');
   const [loadingTheme, setLoadingTheme] = useState<AppTheme | null>(null);
 
@@ -58,6 +60,10 @@ export function ThemeScreen(props: Props) {
     }
   };
 
+  const handleShowDeleteMarkersChange = async (value: boolean) => {
+    await store.updateShowDeleteMarkers(value);
+  };
+
   useEffect(() => {
     if (!isLoading && storedTheme !== undefined) {
       setSelectedTheme(normalizeTheme(storedTheme));
@@ -69,7 +75,7 @@ export function ThemeScreen(props: Props) {
   return (
     <View backgroundColor={theme?.background?.val} flex={1}>
       <ScreenHeader
-        title="Theme"
+        title="Appearance"
         borderBottom
         backAction={
           isWindowNarrow ? () => props.navigation.goBack() : undefined
@@ -104,6 +110,21 @@ export function ThemeScreen(props: Props) {
               </ListItem>
             </Pressable>
           ))}
+          <ListItem marginTop="$l">
+            <ListItem.MainContent>
+              <ListItem.Title>Show delete markers</ListItem.Title>
+              <ListItem.Subtitle>
+                Show where messages have been deleted
+              </ListItem.Subtitle>
+            </ListItem.MainContent>
+            <ListItem.EndContent>
+              <Switch
+                value={showDeleteMarkers}
+                onValueChange={handleShowDeleteMarkersChange}
+                testID="ShowDeleteMarkersToggle"
+              />
+            </ListItem.EndContent>
+          </ListItem>
         </YStack>
       </SettingsContentScrollView>
     </View>

--- a/packages/app/features/settings/ThemeScreen.tsx
+++ b/packages/app/features/settings/ThemeScreen.tsx
@@ -1,6 +1,7 @@
 import { NativeStackScreenProps } from '@react-navigation/native-stack';
 import { useThemeSettings } from '@tloncorp/shared';
 import * as store from '@tloncorp/shared/store';
+import { Text } from '@tloncorp/ui';
 import { useEffect, useState } from 'react';
 import { Switch } from 'react-native';
 import { YStack, useTheme } from 'tamagui';
@@ -84,6 +85,39 @@ export function ThemeScreen(props: Props) {
       />
       <SettingsContentScrollView>
         <YStack flex={1} padding="$l">
+          <Text
+            size="$label/m"
+            color="$secondaryText"
+            fontWeight="500"
+            paddingHorizontal="$s"
+          >
+            Messages
+          </Text>
+          <ListItem marginTop="$s">
+            <ListItem.MainContent>
+              <ListItem.Title>Show deleted messages</ListItem.Title>
+              <ListItem.Subtitle>
+                Display a placeholder when a message is deleted
+              </ListItem.Subtitle>
+            </ListItem.MainContent>
+            <ListItem.EndContent>
+              <Switch
+                value={showDeleteMarkers}
+                onValueChange={handleShowDeleteMarkersChange}
+                testID="ShowDeleteMarkersToggle"
+              />
+            </ListItem.EndContent>
+          </ListItem>
+          <Text
+            size="$label/m"
+            color="$secondaryText"
+            fontWeight="500"
+            paddingHorizontal="$s"
+            marginTop="$xl"
+            marginBottom="$s"
+          >
+            Theme
+          </Text>
           {themes.map((theme) => (
             <Pressable
               key={theme.value}
@@ -110,21 +144,6 @@ export function ThemeScreen(props: Props) {
               </ListItem>
             </Pressable>
           ))}
-          <ListItem marginTop="$l">
-            <ListItem.MainContent>
-              <ListItem.Title>Show delete markers</ListItem.Title>
-              <ListItem.Subtitle>
-                Show where messages have been deleted
-              </ListItem.Subtitle>
-            </ListItem.MainContent>
-            <ListItem.EndContent>
-              <Switch
-                value={showDeleteMarkers}
-                onValueChange={handleShowDeleteMarkersChange}
-                testID="ShowDeleteMarkersToggle"
-              />
-            </ListItem.EndContent>
-          </ListItem>
         </YStack>
       </SettingsContentScrollView>
     </View>

--- a/packages/app/features/settings/ThemeScreen.tsx
+++ b/packages/app/features/settings/ThemeScreen.tsx
@@ -3,7 +3,7 @@ import { useThemeSettings } from '@tloncorp/shared';
 import * as store from '@tloncorp/shared/store';
 import { Fragment, useEffect, useState } from 'react';
 import { Switch } from 'react-native';
-import { YStack, useTheme } from 'tamagui';
+import { YStack } from 'tamagui';
 
 import { RootStackParamList } from '../../navigation/types';
 import { AppTheme } from '../../types/theme';
@@ -25,7 +25,6 @@ import { normalizeTheme } from '../../ui/utils/themeUtils';
 type Props = NativeStackScreenProps<RootStackParamList, 'Theme'>;
 
 export function ThemeScreen(props: Props) {
-  const theme = useTheme();
   const { data: storedTheme, isLoading } = useThemeSettings();
   const { data: showDeleteMarkers = false } = store.useShowDeleteMarkers();
   const [selectedTheme, setSelectedTheme] = useState<AppTheme>('auto');
@@ -75,7 +74,7 @@ export function ThemeScreen(props: Props) {
   const isWindowNarrow = useIsWindowNarrow();
 
   return (
-    <View backgroundColor={theme?.background?.val} flex={1}>
+    <View backgroundColor="$secondaryBackground" flex={1}>
       <ScreenHeader
         title="Appearance"
         borderBottom

--- a/packages/app/features/settings/bot/BotSettingsUI.tsx
+++ b/packages/app/features/settings/bot/BotSettingsUI.tsx
@@ -14,48 +14,13 @@ import { View, XStack, YStack } from 'tamagui';
 import { ImageAvatar } from '../../../ui/components/Avatar';
 import { Badge } from '../../../ui/components/Badge';
 import { ListItem } from '../../../ui/components/ListItem';
+import {
+  SettingsDivider,
+  SettingsSection,
+} from '../../../ui/components/SettingsSection';
 
-export function BotSettingsSection({
-  title,
-  description,
-  children,
-}: PropsWithChildren<{
-  title?: string;
-  description?: string;
-}>) {
-  return (
-    <YStack gap="$m">
-      {title ? (
-        <Text
-          size="$label/m"
-          color="$secondaryText"
-          fontWeight="500"
-          paddingHorizontal="$s"
-        >
-          {title}
-        </Text>
-      ) : null}
-      <YStack
-        borderWidth={1}
-        borderColor="$border"
-        borderRadius="$xl"
-        backgroundColor="$background"
-        overflow="hidden"
-      >
-        {children}
-      </YStack>
-      {description ? (
-        <Text size="$label/s" color="$secondaryText" paddingHorizontal="$s">
-          {description}
-        </Text>
-      ) : null}
-    </YStack>
-  );
-}
-
-export function BotSettingsDivider() {
-  return <View height={1} backgroundColor="$border" />;
-}
+export const BotSettingsSection = SettingsSection;
+export const BotSettingsDivider = SettingsDivider;
 
 export function BotSettingsRow({
   label,

--- a/packages/app/features/top/ChannelScreen.tsx
+++ b/packages/app/features/top/ChannelScreen.tsx
@@ -217,14 +217,6 @@ export default function ChannelScreen(props: Props) {
     (initialChannelUnread.countWithoutThreads ?? 0) > 0
       ? initialChannelUnread.firstUnreadPostId
       : undefined;
-  const cursor = selectedPostId || unreadCursor;
-
-  useEffect(() => {
-    if (channel?.id) {
-      logger.sensitiveCrumb(`channelId: ${channel?.id}`, `cursor: ${cursor}`);
-    }
-  }, [channel?.id, cursor]);
-
   // Channel navigation establishes a new cursor scope.
   useEffect(() => {
     setClearedCursor(false);
@@ -252,6 +244,28 @@ export default function ChannelScreen(props: Props) {
   const { data: showDeleteMarkers = false } = store.useShowDeleteMarkers();
   const includeDeletedPosts =
     channelConfiguration?.includeDeletedPosts && showDeleteMarkers;
+  const { data: selectedPost } = store.usePostWithRelations(
+    selectedPostId ? { id: selectedPostId } : null
+  );
+  const selectedPostIsHidden = Boolean(
+    selectedPostId && !includeDeletedPosts && selectedPost?.isDeleted
+  );
+  const cursor = selectedPostIsHidden
+    ? undefined
+    : selectedPostId || unreadCursor;
+
+  useEffect(() => {
+    if (selectedPostIsHidden) {
+      setClearedCursor(true);
+      props.navigation.setParams({ selectedPostId: undefined });
+    }
+  }, [props.navigation, selectedPostIsHidden]);
+
+  useEffect(() => {
+    if (channel?.id) {
+      logger.sensitiveCrumb(`channelId: ${channel?.id}`, `cursor: ${cursor}`);
+    }
+  }, [channel?.id, cursor]);
 
   const {
     posts,
@@ -503,7 +517,9 @@ export default function ChannelScreen(props: Props) {
           group={group}
           groupIsLoading={groupIsLoading}
           posts={filteredPosts ?? null}
-          selectedPostId={clearedCursor ? undefined : selectedPostId}
+          selectedPostId={
+            clearedCursor || selectedPostIsHidden ? undefined : selectedPostId
+          }
           goBack={navigationRef.current.goBack}
           goToPost={navigateToPost}
           goToMediaViewer={navigateToImage}

--- a/packages/app/features/top/ChannelScreen.tsx
+++ b/packages/app/features/top/ChannelScreen.tsx
@@ -249,6 +249,9 @@ export default function ChannelScreen(props: Props) {
     () => configurationFromChannel(channel),
     [channel]
   );
+  const { data: showDeleteMarkers = false } = store.useShowDeleteMarkers();
+  const includeDeletedPosts =
+    channelConfiguration?.includeDeletedPosts && showDeleteMarkers;
 
   const {
     posts,
@@ -262,7 +265,7 @@ export default function ChannelScreen(props: Props) {
     enabled: unreadDidInitialize && !!channel && !channel?.isPendingChannel,
     channelId: currentChannelId,
     count: 30,
-    filterDeleted: !channelConfiguration?.includeDeletedPosts,
+    filterDeleted: !includeDeletedPosts,
     ...(cursor && !clearedCursor
       ? {
           mode: 'around',
@@ -315,11 +318,8 @@ export default function ChannelScreen(props: Props) {
   }, [postsQuery, posts, loadOlder, unreadDidInitialize]);
 
   const filteredPosts = useMemo(
-    () =>
-      channelConfiguration?.includeDeletedPosts
-        ? posts
-        : posts?.filter((p) => !p.isDeleted),
-    [posts, channelConfiguration?.includeDeletedPosts]
+    () => (includeDeletedPosts ? posts : posts?.filter((p) => !p.isDeleted)),
+    [posts, includeDeletedPosts]
   );
   usePushNotifTapTelemetry({
     channelId: currentChannelId,

--- a/packages/app/features/top/ChannelScreen.tsx
+++ b/packages/app/features/top/ChannelScreen.tsx
@@ -244,22 +244,23 @@ export default function ChannelScreen(props: Props) {
   const { data: showDeleteMarkers = false } = store.useShowDeleteMarkers();
   const includeDeletedPosts =
     channelConfiguration?.includeDeletedPosts && showDeleteMarkers;
-  const { data: selectedPost } = store.usePostWithRelations(
-    selectedPostId ? { id: selectedPostId } : null
+  const requestedCursor = selectedPostId || unreadCursor;
+  const { data: cursorPost } = store.usePostWithRelations(
+    requestedCursor ? { id: requestedCursor } : null
   );
-  const selectedPostIsHidden = Boolean(
-    selectedPostId && !includeDeletedPosts && selectedPost?.isDeleted
+  const cursorPostIsHidden = Boolean(
+    requestedCursor && !includeDeletedPosts && cursorPost?.isDeleted
   );
-  const cursor = selectedPostIsHidden
-    ? undefined
-    : selectedPostId || unreadCursor;
+  const cursor = cursorPostIsHidden ? undefined : requestedCursor;
 
   useEffect(() => {
-    if (selectedPostIsHidden) {
+    if (cursorPostIsHidden) {
       setClearedCursor(true);
-      props.navigation.setParams({ selectedPostId: undefined });
+      if (selectedPostId) {
+        props.navigation.setParams({ selectedPostId: undefined });
+      }
     }
-  }, [props.navigation, selectedPostIsHidden]);
+  }, [cursorPostIsHidden, props.navigation, selectedPostId]);
 
   useEffect(() => {
     if (channel?.id) {
@@ -292,6 +293,13 @@ export default function ChannelScreen(props: Props) {
         }),
   });
 
+  const oldestPage = postsQuery.data?.pages.at(-1);
+  const oldestPageHasOnlyDeletedPosts = Boolean(
+    !includeDeletedPosts &&
+    oldestPage?.posts.length &&
+    oldestPage.posts.every((post) => post.isDeleted)
+  );
+
   useEffect(() => {
     // This recovers a failed around-cursor query by issuing a newest query.
     // Successful queries that temporarily omit the anchor recover in PostList.
@@ -320,16 +328,26 @@ export default function ChannelScreen(props: Props) {
   useEffect(() => {
     // Make sure the initial page can fill the screen; otherwise the visual
     // start boundary may never move far enough to request another older page.
+    // Likewise, keep going when a page contains only hidden delete markers,
+    // since adding no visible rows will not retrigger the boundary callback.
     const ENOUGH_POSTS_TO_FILL_SCREEN = 20;
     if (
       !postsQuery.isFetching &&
       postsQuery.hasNextPage &&
       unreadDidInitialize &&
-      (!posts || posts.length < ENOUGH_POSTS_TO_FILL_SCREEN)
+      (!posts ||
+        posts.length < ENOUGH_POSTS_TO_FILL_SCREEN ||
+        oldestPageHasOnlyDeletedPosts)
     ) {
       loadOlder();
     }
-  }, [postsQuery, posts, loadOlder, unreadDidInitialize]);
+  }, [
+    loadOlder,
+    oldestPageHasOnlyDeletedPosts,
+    posts,
+    postsQuery,
+    unreadDidInitialize,
+  ]);
 
   const filteredPosts = useMemo(
     () => (includeDeletedPosts ? posts : posts?.filter((p) => !p.isDeleted)),
@@ -508,7 +526,9 @@ export default function ChannelScreen(props: Props) {
           key={currentChannelId}
           channel={channel}
           initialChannelUnread={
-            clearedCursor ? undefined : initialChannelUnread
+            clearedCursor || cursorPostIsHidden
+              ? undefined
+              : initialChannelUnread
           }
           isLoadingPosts={isLoadingPosts}
           loadPostsError={postsQuery.error}
@@ -518,7 +538,7 @@ export default function ChannelScreen(props: Props) {
           groupIsLoading={groupIsLoading}
           posts={filteredPosts ?? null}
           selectedPostId={
-            clearedCursor || selectedPostIsHidden ? undefined : selectedPostId
+            clearedCursor || cursorPostIsHidden ? undefined : selectedPostId
           }
           goBack={navigationRef.current.goBack}
           goToPost={navigateToPost}

--- a/packages/app/features/top/PostScreen.tsx
+++ b/packages/app/features/top/PostScreen.tsx
@@ -1,5 +1,9 @@
 import type { NativeStackScreenProps } from '@react-navigation/native-stack';
-import { AnalyticsEvent, trackEvent } from '@tloncorp/shared';
+import {
+  AnalyticsEvent,
+  configurationFromChannel,
+  trackEvent,
+} from '@tloncorp/shared';
 import * as db from '@tloncorp/shared/db';
 import * as store from '@tloncorp/shared/store';
 import { useCallback, useEffect } from 'react';
@@ -82,11 +86,24 @@ function PostScreenContent({
 
   const currentUserId = useCurrentUserId();
   const channelType = channel?.type;
+  const { data: showDeleteMarkers = false } = store.useShowDeleteMarkers();
+  const shouldHideDeletedPost = Boolean(
+    post.isDeleted &&
+    channel &&
+    configurationFromChannel(channel).includeDeletedPosts &&
+    !showDeleteMarkers
+  );
 
   useEffect(() => {
     if (!channelType) return;
     trackEvent(AnalyticsEvent.PostOpened, { type: channelType });
   }, [channelType, postId]);
+
+  useEffect(() => {
+    if (shouldHideDeletedPost) {
+      navigation.goBack();
+    }
+  }, [navigation, shouldHideDeletedPost]);
 
   const handleDeletePost = useCallback(
     async (post: db.Post) => {
@@ -143,7 +160,7 @@ function PostScreenContent({
     navigateBackFromPost(channel!, postId);
   }, [channel, postId, navigation, navigateBackFromPost]);
 
-  return currentUserId && channel && post ? (
+  return currentUserId && channel && post && !shouldHideDeletedPost ? (
     <PostScreenView
       handleGoToUserProfile={handleGoToUserProfile}
       parentPost={post}

--- a/packages/app/ui/components/PostScreenView.tsx
+++ b/packages/app/ui/components/PostScreenView.tsx
@@ -681,6 +681,11 @@ function SinglePostView({
         : threadPosts?.filter((post) => !post.isDeleted),
     [includeDeletedPosts, threadPosts]
   );
+  const selectedReplyIsHidden = Boolean(
+    !includeDeletedPosts &&
+    selectedPostId &&
+    threadPosts?.some((post) => post.id === selectedPostId && post.isDeleted)
+  );
 
   const posts = useMemo(() => {
     return parentPost ? [...(visibleThreadPosts ?? []), parentPost] : null;
@@ -754,19 +759,19 @@ function SinglePostView({
   // This wires into Scroller's anchor initialization, giving us retry/recovery
   // for unmeasured items instead of a one-shot imperative scroll.
   const threadAnchor: ScrollAnchor | null = useMemo(() => {
-    if (isChatChannel && selectedPostId) {
+    if (isChatChannel && selectedPostId && !selectedReplyIsHidden) {
       return { type: 'selected', postId: selectedPostId };
     }
     return null;
-  }, [isChatChannel, selectedPostId]);
+  }, [isChatChannel, selectedPostId, selectedReplyIsHidden]);
 
   // Trigger the 5s temporary highlight when selectedPostId changes.
   // Scrolling is handled by the anchor via useAnchorScrollLock.
   useEffect(() => {
-    if (isChatChannel && selectedPostId) {
+    if (isChatChannel && selectedPostId && !selectedReplyIsHidden) {
       highlightPost(selectedPostId);
     }
-  }, [isChatChannel, selectedPostId, highlightPost]);
+  }, [isChatChannel, selectedPostId, selectedReplyIsHidden, highlightPost]);
 
   const containingProperties: Partial<
     React.ComponentPropsWithoutRef<typeof View>

--- a/packages/app/ui/components/PostScreenView.tsx
+++ b/packages/app/ui/components/PostScreenView.tsx
@@ -3,6 +3,7 @@ import * as urbit from '@tloncorp/api/urbit';
 import { JSONContent } from '@tloncorp/api/urbit';
 import {
   DraftInputId,
+  configurationFromChannel,
   isChatChannel as getIsChatChannel,
   hasUnreadActivity,
   makePrettyDayAndTime,
@@ -670,9 +671,20 @@ function SinglePostView({
       channelId: channel.id,
     });
 
+  const { data: showDeleteMarkers = false } = store.useShowDeleteMarkers();
+  const includeDeletedPosts =
+    configurationFromChannel(channel).includeDeletedPosts && showDeleteMarkers;
+  const visibleThreadPosts = useMemo(
+    () =>
+      includeDeletedPosts
+        ? threadPosts
+        : threadPosts?.filter((post) => !post.isDeleted),
+    [includeDeletedPosts, threadPosts]
+  );
+
   const posts = useMemo(() => {
-    return parentPost ? [...(threadPosts ?? []), parentPost] : null;
-  }, [parentPost, threadPosts]);
+    return parentPost ? [...(visibleThreadPosts ?? []), parentPost] : null;
+  }, [parentPost, visibleThreadPosts]);
 
   const currentUserId = useCurrentUserId();
   const [activeMessage, setActiveMessage] = useState<db.Post | null>(null);

--- a/packages/app/ui/components/SettingsScreenView.tsx
+++ b/packages/app/ui/components/SettingsScreenView.tsx
@@ -127,7 +127,7 @@ export function SettingsScreenView(props: Props) {
             />
           )}
           <SettingsAction
-            title="Theme"
+            title="Appearance"
             leftIcon="ChannelGalleries"
             rightIcon={'ChevronRight'}
             onPress={props.onThemePressed}

--- a/packages/app/ui/components/SettingsSection.tsx
+++ b/packages/app/ui/components/SettingsSection.tsx
@@ -1,0 +1,45 @@
+import { Text } from '@tloncorp/ui';
+import { PropsWithChildren } from 'react';
+import { View, YStack } from 'tamagui';
+
+export function SettingsSection({
+  title,
+  description,
+  children,
+}: PropsWithChildren<{
+  title?: string;
+  description?: string;
+}>) {
+  return (
+    <YStack gap="$m">
+      {title ? (
+        <Text
+          size="$label/m"
+          color="$secondaryText"
+          fontWeight="500"
+          paddingHorizontal="$s"
+        >
+          {title}
+        </Text>
+      ) : null}
+      <YStack
+        borderWidth={1}
+        borderColor="$border"
+        borderRadius="$xl"
+        backgroundColor="$background"
+        overflow="hidden"
+      >
+        {children}
+      </YStack>
+      {description ? (
+        <Text size="$label/s" color="$secondaryText" paddingHorizontal="$s">
+          {description}
+        </Text>
+      ) : null}
+    </YStack>
+  );
+}
+
+export function SettingsDivider() {
+  return <View height={1} backgroundColor="$border" />;
+}

--- a/packages/app/ui/index.tsx
+++ b/packages/app/ui/index.tsx
@@ -66,6 +66,7 @@ export * from './components/ScreenHeader';
 export * from './components/ScreenScrollView';
 export * from './components/SearchBar';
 export * from './components/SettingsContentScrollView';
+export * from './components/SettingsSection';
 export * from './components/SettingsScreenView';
 export * from './components/ShipPickerSheet';
 export * from './components/StoppedNodePushSheet';

--- a/packages/shared/src/db/migrations/0000_bitter_hammerhead.sql
+++ b/packages/shared/src/db/migrations/0000_bitter_hammerhead.sql
@@ -491,7 +491,8 @@ CREATE TABLE `settings` (
 	`disable_tlon_infra_enhancement` integer,
 	`web_app_splash_dismissed` integer,
 	`mobile_app_promo_dismissed` integer,
-	`context_lens_enabled` integer
+	`context_lens_enabled` integer,
+	`show_delete_markers` integer
 );
 --> statement-breakpoint
 CREATE TABLE `system_contact_sent_invites` (

--- a/packages/shared/src/db/migrations/meta/0000_snapshot.json
+++ b/packages/shared/src/db/migrations/meta/0000_snapshot.json
@@ -1,7 +1,7 @@
 {
   "version": "6",
   "dialect": "sqlite",
-  "id": "489f9b73-cbcb-443e-a99a-aecba4ab1124",
+  "id": "4f27b209-f6e1-4b9e-90a6-5bf685afcdf2",
   "prevId": "00000000-0000-0000-0000-000000000000",
   "tables": {
     "activity_event_contact_group_pins": {
@@ -3334,6 +3334,13 @@
         },
         "context_lens_enabled": {
           "name": "context_lens_enabled",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "show_delete_markers": {
+          "name": "show_delete_markers",
           "type": "integer",
           "primaryKey": false,
           "notNull": false,

--- a/packages/shared/src/db/migrations/meta/_journal.json
+++ b/packages/shared/src/db/migrations/meta/_journal.json
@@ -5,8 +5,8 @@
     {
       "idx": 0,
       "version": "6",
-      "when": 1786472821543,
-      "tag": "0000_pink_forgotten_one",
+      "when": 1787340166820,
+      "tag": "0000_bitter_hammerhead",
       "breakpoints": true
     }
   ]

--- a/packages/shared/src/db/migrations/migrations.js
+++ b/packages/shared/src/db/migrations/migrations.js
@@ -1,11 +1,11 @@
 // This file is required for Expo/React Native SQLite migrations - https://orm.drizzle.team/quick-sqlite/expo
 
-import journal from './meta/_journal.json';
-import m0000 from './0000_pink_forgotten_one.sql';
+import journal from "./meta/_journal.json";
+import m0000 from "./0000_bitter_hammerhead.sql";
 
-  export default {
-    journal,
-    migrations: {
-      m0000
-    }
-  }
+export default {
+  journal,
+  migrations: {
+    m0000,
+  },
+};

--- a/packages/shared/src/db/schema.ts
+++ b/packages/shared/src/db/schema.ts
@@ -79,6 +79,7 @@ export const settings = sqliteTable('settings', {
   webAppSplashDismissed: boolean('web_app_splash_dismissed'),
   mobileAppPromoDismissed: boolean('mobile_app_promo_dismissed'),
   contextLensEnabled: boolean('context_lens_enabled'),
+  showDeleteMarkers: boolean('show_delete_markers'),
 });
 
 export const systemContacts = sqliteTable(

--- a/packages/shared/src/store/dbHooks.ts
+++ b/packages/shared/src/store/dbHooks.ts
@@ -888,6 +888,17 @@ export const useContextLensEnabled = () => {
   });
 };
 
+export const useShowDeleteMarkers = () => {
+  const deps = useKeyFromQueryDeps(db.getSettings);
+  return useQuery({
+    queryKey: ['showDeleteMarkers', deps],
+    queryFn: async () => {
+      const settings = await db.getSettings();
+      return settings?.showDeleteMarkers ?? false;
+    },
+  });
+};
+
 export const useTelemetrySettings = () => {
   const deps = useKeyFromQueryDeps(db.getSettings);
   return useQuery({

--- a/packages/shared/src/store/settingsActions.test.ts
+++ b/packages/shared/src/store/settingsActions.test.ts
@@ -1,0 +1,46 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { updateShowDeleteMarkers } from './settingsActions';
+
+const mocks = vi.hoisted(() => ({
+  getSettings: vi.fn(),
+  insertSettings: vi.fn(),
+  setSetting: vi.fn(),
+}));
+
+vi.mock('@tloncorp/api', () => ({
+  setSetting: mocks.setSetting,
+}));
+
+vi.mock('../db', () => ({
+  getSettings: mocks.getSettings,
+  insertSettings: mocks.insertSettings,
+}));
+
+describe('updateShowDeleteMarkers', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mocks.getSettings.mockResolvedValue({ showDeleteMarkers: false });
+    mocks.insertSettings.mockResolvedValue(undefined);
+    mocks.setSetting.mockResolvedValue(undefined);
+  });
+
+  it('optimistically saves the preference locally and remotely', async () => {
+    await expect(updateShowDeleteMarkers(true)).resolves.toBe(true);
+
+    expect(mocks.insertSettings).toHaveBeenCalledWith({
+      showDeleteMarkers: true,
+    });
+    expect(mocks.setSetting).toHaveBeenCalledWith('showDeleteMarkers', true);
+  });
+
+  it('restores the previous preference when the remote update fails', async () => {
+    mocks.setSetting.mockRejectedValueOnce(new Error('offline'));
+
+    await expect(updateShowDeleteMarkers(true)).resolves.toBe(false);
+
+    expect(mocks.insertSettings).toHaveBeenNthCalledWith(2, {
+      showDeleteMarkers: false,
+    });
+  });
+});

--- a/packages/shared/src/store/settingsActions.ts
+++ b/packages/shared/src/store/settingsActions.ts
@@ -261,6 +261,25 @@ export async function updateContextLensEnabled(value: boolean) {
   }
 }
 
+export async function updateShowDeleteMarkers(value: boolean) {
+  const existing = await db.getSettings();
+  const oldValue = existing?.showDeleteMarkers;
+
+  try {
+    await db.insertSettings({ showDeleteMarkers: value });
+    await api.setSetting('showDeleteMarkers', value);
+    return true;
+  } catch (e) {
+    logger.trackError('Error updating show delete markers setting', {
+      error: e,
+      value,
+      severity: AnalyticsSeverity.Medium,
+    });
+    await db.insertSettings({ showDeleteMarkers: oldValue ?? null });
+    return false;
+  }
+}
+
 // One-time migration for the context lens toggle, which moved from the
 // client-local feature-flag store (`storage.featureFlags.contextLens`) to the
 // synced %settings store (`contextLensEnabled`). Adopt a user's old local


### PR DESCRIPTION
## Summary

Hides delete markers unless the user chooses to show them. The preference is synced across devices and lives in Settings → Appearance.

## Changes

- filters deleted messages from chats, DMs, and group DMs by default
- adds a synced Show delete markers toggle to Appearance
- renames Theme to Appearance to cover the new display preference
- groups Appearance controls into labeled sections
- adds the settings schema migration and preference tests

## Screenshot

<img width="390" alt="Appearance settings with grouped sections on a contrasting background" src="https://github.com/user-attachments/assets/765a5fb2-1510-4f17-a9dd-87a565b5faac" />

## How did I test?

- API TypeScript and 2 focused settings tests
- shared TypeScript and 2 focused settings action tests
- app TypeScript after building the editor
- targeted oxfmt and oxlint on changed source files
- git diff --check
- iOS simulator smoke test of the grouped Appearance screen