### PR TITLE
Make BareChatInput's reference check stateless

### DIFF
--- a/packages/api/src/__tests__/refRegex.test.ts
+++ b/packages/api/src/__tests__/refRegex.test.ts
@@ -1,0 +1,24 @@
+import { describe, expect, test } from 'vitest';
+
+import { CONTAINS_REF_REGEX, REF_REGEX } from '../client/utils';
+
+const REF_TEXT = 'check this out /1/chan/chat/~zod/test/msg/170.141.184.506';
+
+describe('ref regexes', () => {
+  test('CONTAINS_REF_REGEX is stateless across repeated tests', () => {
+    expect(CONTAINS_REF_REGEX.global).toBe(false);
+    expect(CONTAINS_REF_REGEX.test(REF_TEXT)).toBe(true);
+    expect(CONTAINS_REF_REGEX.test(REF_TEXT)).toBe(true);
+    expect(CONTAINS_REF_REGEX.test(REF_TEXT)).toBe(true);
+  });
+
+  // match-all (processReferences) and replace-all (filterRegexFromJson) callers
+  // depend on the g flag.
+  test('REF_REGEX keeps its global flag', () => {
+    expect(REF_REGEX.global).toBe(true);
+  });
+
+  test('both regexes share one pattern', () => {
+    expect(CONTAINS_REF_REGEX.source).toBe(REF_REGEX.source);
+  });
+});

--- a/packages/api/src/client/utils.ts
+++ b/packages/api/src/client/utils.ts
@@ -19,6 +19,12 @@ import * as ub from '../urbit';
 
 export const PATP_REGEX = /(~[a-z0-9-]+)/i;
 export const REF_REGEX = /\/1\/(chan|group|desk)\/[^\s]+/g;
+// `.test()` on a g-flagged regex is stateful (it resumes from lastIndex), so
+// boolean "does this text contain a ref" checks must use this non-global copy.
+export const CONTAINS_REF_REGEX = new RegExp(
+  REF_REGEX.source,
+  REF_REGEX.flags.replace('g', '')
+);
 export const REF_URL_REGEX = /^\/1\/(chan|group|desk)\/[^\s]+/;
 // sig and hep explicitly left out
 export const PUNCTUATION_REGEX = /[.,/#!$%^&*;:{}=_`()]/g;
@@ -365,7 +371,7 @@ export const textPostIsReference = (post: db.Post): boolean => {
   if (inlines.length === 2) {
     const [first] = inlines;
     const isRefString =
-      typeof first === 'string' && REF_REGEX.test(first as string);
+      typeof first === 'string' && CONTAINS_REF_REGEX.test(first as string);
 
     if (isRefString) {
       return true;

--- a/packages/app/ui/components/BareChatInput/helpers.test.ts
+++ b/packages/app/ui/components/BareChatInput/helpers.test.ts
@@ -1,0 +1,45 @@
+import { REF_REGEX } from '@tloncorp/shared/logic';
+import { describe, expect, test } from 'vitest';
+
+import { computeTextChangeAction } from './helpers';
+
+const REF_PATH = '/1/chan/chat/~zod/test/msg/170.141.184.506';
+const REF_TEXT = `check this out ${REF_PATH}`;
+
+describe('computeTextChangeAction', () => {
+  test('unprocessed ref-bearing text asks for reference processing', () => {
+    expect(computeTextChangeAction(REF_TEXT, '')).toBe('processReferences');
+  });
+
+  // The reported bug (TLON-6365): the old two-`.test()` version left the
+  // g-flagged REF_REGEX's lastIndex past the match, so re-evaluating the same
+  // text missed the ref and the event was misrouted.
+  test('evaluation is stateless: identical inputs always yield the same action', () => {
+    expect(computeTextChangeAction(REF_TEXT, '')).toBe('processReferences');
+    expect(computeTextChangeAction(REF_TEXT, '')).toBe('processReferences');
+  });
+
+  test('already-processed ref-bearing text does nothing', () => {
+    expect(computeTextChangeAction(REF_TEXT, REF_TEXT)).toBe('none');
+  });
+
+  test('a poisoned REF_REGEX lastIndex cannot influence the decision', () => {
+    REF_REGEX.lastIndex = REF_TEXT.indexOf(REF_PATH) + 5;
+    expect(computeTextChangeAction(REF_TEXT, '')).toBe('processReferences');
+  });
+
+  test('ref-free text updates normally', () => {
+    expect(computeTextChangeAction('just a message', '')).toBe('update');
+    expect(computeTextChangeAction('', '')).toBe('update');
+  });
+
+  test('refs are detected at the start and in the middle of the text', () => {
+    expect(computeTextChangeAction(REF_PATH, '')).toBe('processReferences');
+    expect(computeTextChangeAction(`${REF_PATH} nice`, '')).toBe(
+      'processReferences'
+    );
+    expect(computeTextChangeAction(`look ${REF_PATH} nice`, '')).toBe(
+      'processReferences'
+    );
+  });
+});

--- a/packages/app/ui/components/BareChatInput/helpers.ts
+++ b/packages/app/ui/components/BareChatInput/helpers.ts
@@ -1,4 +1,31 @@
+// Sourced from the `logic` subpath rather than the `@tloncorp/shared` root
+// (which re-exports it): the root barrel pulls in expo-modules-core, which
+// cannot load in the plain node vitest environment, so importing it here
+// would make this module untestable.
+import { CONTAINS_REF_REGEX } from '@tloncorp/shared/logic';
+
 export {
   textAndMentionsToContent,
   contentToTextAndMentions,
-} from '@tloncorp/shared';
+} from '@tloncorp/shared/logic';
+
+export type TextChangeAction = 'processReferences' | 'update' | 'none';
+
+// Decision for BareChatInput's onChangeText. Evaluates the ref check exactly
+// once with a non-global regex: the previous two-`.test()` version depended on
+// the g-flagged REF_REGEX's hidden lastIndex and could misroute or drop events
+// (TLON-6365). 'none' (refs present but already processed) is the guard that
+// prevents an infinite onChangeText loop on native.
+export function computeTextChangeAction(
+  newText: string,
+  lastProcessedText: string
+): TextChangeAction {
+  const hasRefs = CONTAINS_REF_REGEX.test(newText);
+  if (hasRefs && lastProcessedText !== newText) {
+    return 'processReferences';
+  }
+  if (!hasRefs) {
+    return 'update';
+  }
+  return 'none';
+}

--- a/packages/app/ui/components/BareChatInput/index.tsx
+++ b/packages/app/ui/components/BareChatInput/index.tsx
@@ -57,7 +57,11 @@ import { hydrateEditPost } from '../MessageInput/helpers';
 import { type SlashCommandController } from '../SlashCommandPopup';
 import type { DraftInputHandle } from '../draftInputs/shared';
 import { PasteableTextInput } from './PasteableTextInput';
-import { contentToTextAndMentions, textAndMentionsToContent } from './helpers';
+import {
+  computeTextChangeAction,
+  contentToTextAndMentions,
+  textAndMentionsToContent,
+} from './helpers';
 import { PastedFile, attachPastedImageFiles } from './pastedImage';
 import {
   MentionOption,
@@ -422,11 +426,12 @@ function BareChatInput(
       bareChatInputLogger.log('text change', newText);
 
       // Only process references if the text contains a reference and hasn't been processed before.
-      // This check prevents infinite loops on native platforms where we manually update
-      // the input's text value using setNativeProps after processing references.
+      // This check prevents infinite loops on native platforms where we clear
+      // the input's text value after processing references.
       // Without this guard, each manual text update would trigger another onChangeText,
       // creating an endless cycle.
-      if (REF_REGEX.test(newText) && lastProcessedRef.current !== newText) {
+      const action = computeTextChangeAction(newText, lastProcessedRef.current);
+      if (action === 'processReferences') {
         lastProcessedRef.current = newText;
         const textWithoutRefs = processReferences(newText);
         const cursorPos = getWebSelectionStart();
@@ -451,7 +456,7 @@ function BareChatInput(
             inputRef.current?.clear();
           }, 0);
         }
-      } else if (!REF_REGEX.test(newText)) {
+      } else if (action === 'update') {
         // if there's no reference to process, just update normally
         const cursorPos = getWebSelectionStart();
         setControlledText(newText);


### PR DESCRIPTION
## Summary

Fixes reference detection in `BareChatInput`, which called `.test()` up to twice per text-change event on the module-global, `g`-flagged `REF_REGEX` (once when the event routed to reference processing, twice otherwise). Because `.test()` on a global regex resumes from the regex's hidden `lastIndex`, the two calls could disagree within a single event (a pasted Urbit reference gets committed as literal text instead of becoming an attachment card) or leak state into the next event (a keystroke where neither branch runs, so the input update is dropped). The check is now evaluated exactly once per event using a non-global regex.

## Changes

- Added `CONTAINS_REF_REGEX` in `packages/api/src/client/utils.ts`, derived from `REF_REGEX`'s source and flags minus `g`, for boolean "does this text contain a ref" checks. `REF_REGEX` keeps its `g` flag, which `processReferences` (match-all) and `filterRegexFromJson` (replace-all) rely on.
- Added `computeTextChangeAction(newText, lastProcessedText)` in `packages/app/ui/components/BareChatInput/helpers.ts`, a pure helper returning `'processReferences' | 'update' | 'none'` from a single ref check.
- `BareChatInput`'s `handleTextChange` now branches on that helper's result instead of calling `REF_REGEX.test()` twice. The intentional do-nothing case (refs present but already processed, which guards against an infinite `onChangeText` loop on native) is preserved.
- Switched `textPostIsReference` in `packages/api/src/client/utils.ts` to `CONTAINS_REF_REGEX` so no `.test()` call site shares the stateful regex object.
- `BareChatInput/helpers.ts` now imports from `@tloncorp/shared/logic` instead of the root `@tloncorp/shared` barrel: the root barrel pulls in expo-modules-core, which cannot load under node-env vitest, and the subpath re-exports the identical symbols.
- Fixed a stale comment in `BareChatInput/index.tsx` that described the native text update as using `setNativeProps`; the code clears the input instead.
- Added regression tests: `packages/app/ui/components/BareChatInput/helpers.test.ts` (handler decision logic: repeated evaluation with identical inputs stays stable, the already-processed case still routes to the do-nothing branch, and a deliberately poisoned `REF_REGEX.lastIndex` cannot influence the decision) and `packages/api/src/__tests__/refRegex.test.ts` (regex flag and pattern invariants).

## How did I test?

- `pnpm --filter @tloncorp/api test run`: 36 files / 781 tests passed, including the new `refRegex.test.ts`.
- `pnpm --filter @tloncorp/app test`: 50 files passed (1 skipped) / 476 tests passed (3 skipped), including the new `helpers.test.ts`.
- `pnpm -r tsc` clean across all 14 projects, `pnpm format:check` clean.
- Mutation-checked the new tests: reverting the helper to the old two-`.test()` logic fails 3 of the 6 app tests, and restoring the `g` flag on `CONTAINS_REF_REGEX` fails the api statelessness test.

## Risks and impact

- Safe to rollback without consulting PR author? Yes
- Affects important code area:
  - [x] Other: chat input / reference attachment handling in `BareChatInput`

The behavior change is confined to `handleTextChange`. Ref-free events and first-time ref-bearing events route exactly as before; the only routing change is the refs-present-and-already-processed case, where the old code usually misrouted to the normal-update branch (committing the pasted ref as literal text — the reported bug) and the new code takes the do-nothing branch the `lastProcessedRef` guard always intended.

One pre-existing limitation is unchanged in reach but changes symptom: `lastProcessedRef` is never reset (sending clears text and attachments but not the guard), so pasting byte-identical ref text again later hits the already-processed case. Previously that misrouted to literal text; now it is a no-op. Properly scoping the guard's lifetime to the native input-sync window is tracked as TLON-6373, since it requires reasoning about native `onChangeText` echo ordering.

`textPostIsReference` currently has no callers, so that part of the change has no runtime effect; it is there so a future caller cannot reintroduce the hazard.

## Rollback plan

Revert.
