### PR TITLE
openclaw: subject-keyed memory loader — speaker bridge + bootstrap hook

### DIFF
--- a/packages/openclaw/index.ts
+++ b/packages/openclaw/index.ts
@@ -35,6 +35,7 @@ import {
 } from './src/diagnostic-subscriptions.js';
 import { notifyDiaryMigrationDiscovery } from './src/diary-migration-discovery.js';
 import { registerGatewayStatusHooks } from './src/gateway-status-registration.js';
+import { createMemoryBootstrapHandler } from './src/memory/bootstrap-loader.js';
 import {
   createMigrateCommandHandler,
   routeMigrateCommand,
@@ -991,6 +992,20 @@ export default defineBundledChannelEntry({
       },
       execute: executeTlonTool,
     });
+
+    // Subject-keyed memory: load person/place files for the current surface
+    // on every bootstrap. No-op until the workspace has memory/ files.
+    api.registerHook(
+      'agent:bootstrap',
+      createMemoryBootstrapHandler({
+        log: (message) => api.logger.debug?.(message),
+      }),
+      {
+        name: 'tlon-memory-loader',
+        description:
+          'Loads subject-keyed memory files (person/place) for the current Tlon surface',
+      }
+    );
 
     // Tool access control: block sensitive tools for non-owners
     const ownerOnlyTools = new Set(['tlon', 'cron', 'read']);

--- a/packages/openclaw/src/memory/bootstrap-loader.test.ts
+++ b/packages/openclaw/src/memory/bootstrap-loader.test.ts
@@ -1,0 +1,184 @@
+import fs from 'node:fs/promises';
+import os from 'node:os';
+import path from 'node:path';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+
+import {
+  createMemoryBootstrapHandler,
+  encodeNestForFilename,
+  selectMemoryFilePaths,
+} from './bootstrap-loader.js';
+import { recordSpeakerForSession } from './speaker-bridge.js';
+
+let workspaceDir: string;
+
+async function writeMemoryFile(relPath: string, content: string) {
+  const absPath = path.join(workspaceDir, relPath);
+  await fs.mkdir(path.dirname(absPath), { recursive: true });
+  await fs.writeFile(absPath, content, 'utf8');
+}
+
+function bootstrapEvent(sessionKey: string, files: unknown[] = []) {
+  return {
+    type: 'agent',
+    action: 'bootstrap',
+    context: {
+      workspaceDir,
+      bootstrapFiles: files as {
+        name: string;
+        path: string;
+        content?: string;
+        missing: boolean;
+      }[],
+      sessionKey,
+    },
+  };
+}
+
+beforeEach(async () => {
+  workspaceDir = await fs.mkdtemp(path.join(os.tmpdir(), 'tlon-memory-'));
+});
+
+afterEach(async () => {
+  await fs.rm(workspaceDir, { recursive: true, force: true });
+});
+
+describe('encodeNestForFilename', () => {
+  it('encodes a nest as a flat filename', () => {
+    expect(encodeNestForFilename('chat/~zod/general')).toBe(
+      'chat.~zod.general'
+    );
+  });
+
+  it('rejects malformed nests', () => {
+    expect(encodeNestForFilename('chat/~zod')).toBeNull();
+    expect(encodeNestForFilename('chat/~zod/../escape')).toBeNull();
+    expect(encodeNestForFilename('notes/~zod/book')).toBeNull();
+  });
+});
+
+describe('selectMemoryFilePaths', () => {
+  it('selects public and private person files for a DM', () => {
+    expect(selectMemoryFilePaths('agent:main:tlon:direct:~nec')).toEqual([
+      path.join('memory', 'person', '~nec.md'),
+      path.join('memory', 'person', '~nec.private.md'),
+    ]);
+  });
+
+  it('selects place plus the speaker public tier for a channel', () => {
+    const sessionKey = 'agent:main:tlon:channel:chat/~zod/general';
+    recordSpeakerForSession(sessionKey, '~nec');
+    expect(selectMemoryFilePaths(sessionKey)).toEqual([
+      path.join('memory', 'place', 'chat.~zod.general.md'),
+      path.join('memory', 'person', '~nec.md'),
+    ]);
+  });
+
+  it('never selects a private tier for a channel', () => {
+    const sessionKey = 'agent:main:tlon:channel:chat/~zod/general';
+    recordSpeakerForSession(sessionKey, '~nec');
+    for (const selected of selectMemoryFilePaths(sessionKey)) {
+      expect(selected).not.toContain('.private.');
+    }
+  });
+
+  it('selects nothing for non-tlon sessions', () => {
+    expect(selectMemoryFilePaths('agent:main:main')).toEqual([]);
+    expect(selectMemoryFilePaths('agent:main:cron:job')).toEqual([]);
+  });
+});
+
+describe('createMemoryBootstrapHandler', () => {
+  it('appends existing files and skips missing ones', async () => {
+    await writeMemoryFile(
+      path.join('memory', 'person', '~nec.md'),
+      '## Public\nGoes by Nec.'
+    );
+    const handler = createMemoryBootstrapHandler();
+    const event = bootstrapEvent('agent:main:tlon:direct:~nec');
+    await handler(event);
+    const files = event.context.bootstrapFiles;
+    expect(files).toHaveLength(1);
+    expect(files[0]).toMatchObject({
+      name: path.join('memory', 'person', '~nec.md'),
+      content: '## Public\nGoes by Nec.',
+      missing: false,
+    });
+  });
+
+  it('loads the private tier only in that ship DM', async () => {
+    await writeMemoryFile(
+      path.join('memory', 'person', '~nec.md'),
+      'public fact'
+    );
+    await writeMemoryFile(
+      path.join('memory', 'person', '~nec.private.md'),
+      'private fact'
+    );
+    await writeMemoryFile(
+      path.join('memory', 'place', 'chat.~zod.general.md'),
+      'room facts'
+    );
+
+    const handler = createMemoryBootstrapHandler();
+
+    const dmEvent = bootstrapEvent('agent:main:tlon:direct:~nec');
+    await handler(dmEvent);
+    const dmContents = dmEvent.context.bootstrapFiles.map((f) => f.content);
+    expect(dmContents).toContain('public fact');
+    expect(dmContents).toContain('private fact');
+
+    const channelKey = 'agent:main:tlon:channel:chat/~zod/general';
+    recordSpeakerForSession(channelKey, '~nec');
+    const channelEvent = bootstrapEvent(channelKey);
+    await handler(channelEvent);
+    const channelContents = channelEvent.context.bootstrapFiles.map(
+      (f) => f.content
+    );
+    expect(channelContents).toContain('room facts');
+    expect(channelContents).toContain('public fact');
+    expect(channelContents).not.toContain('private fact');
+  });
+
+  it('inherits the channel surface for threads', async () => {
+    await writeMemoryFile(
+      path.join('memory', 'place', 'chat.~zod.general.md'),
+      'room facts'
+    );
+    const handler = createMemoryBootstrapHandler();
+    const event = bootstrapEvent(
+      'agent:main:tlon:channel:chat/~zod/general:thread:170.141.184'
+    );
+    await handler(event);
+    expect(event.context.bootstrapFiles.map((f) => f.content)).toContain(
+      'room facts'
+    );
+  });
+
+  it('does not duplicate files already present', async () => {
+    await writeMemoryFile(
+      path.join('memory', 'person', '~nec.md'),
+      'public fact'
+    );
+    const handler = createMemoryBootstrapHandler();
+    const event = bootstrapEvent('agent:main:tlon:direct:~nec');
+    await handler(event);
+    await handler(event);
+    expect(event.context.bootstrapFiles).toHaveLength(1);
+  });
+
+  it('ignores empty files and non-bootstrap events', async () => {
+    await writeMemoryFile(path.join('memory', 'person', '~nec.md'), '   \n');
+    const handler = createMemoryBootstrapHandler();
+    const event = bootstrapEvent('agent:main:tlon:direct:~nec');
+    await handler(event);
+    expect(event.context.bootstrapFiles).toHaveLength(0);
+
+    const other = {
+      type: 'message',
+      action: 'received',
+      context: event.context,
+    };
+    await expect(handler(other)).resolves.toBeUndefined();
+  });
+});

--- a/packages/openclaw/src/memory/bootstrap-loader.ts
+++ b/packages/openclaw/src/memory/bootstrap-loader.ts
@@ -1,0 +1,149 @@
+/**
+ * agent:bootstrap hook: load subject-keyed memory files for the current
+ * Tlon surface.
+ *
+ * Selection rules (see the design doc on TLON-6375):
+ * - DM with ~x        → person/~x.md + person/~x.private.md
+ * - channel, ~x spoke → place/<nest>.md + person/~x.md (public tier only —
+ *                       the private tier never enters a surface with an
+ *                       audience larger than its subject)
+ * - thread            → same as its parent surface (inherits downward)
+ *
+ * Missing files are a silent no-op, so the feature rolls out by creating
+ * files rather than by config. Enforcement is structural: what may not be
+ * seen is never loaded.
+ */
+import fs from 'node:fs/promises';
+import path from 'node:path';
+
+import { resolveSpeakerForSession } from './speaker-bridge.js';
+import { parseTlonSurface } from './surface.js';
+
+const PERSON_SUBDIR = path.join('memory', 'person');
+const PLACE_SUBDIR = path.join('memory', 'place');
+
+// Defensive per-file cap; the host applies its own bootstrap budget on top.
+const MAX_FILE_CHARS = 16_000;
+
+const SHIP_FILE_RE = /^~[a-z-]+$/;
+const NEST_RE = /^(chat|heap|diary)\/(~[a-z-]+)\/([a-z0-9.-]+)$/;
+
+type BootstrapFileEntry = {
+  name: string;
+  path: string;
+  content?: string;
+  missing: boolean;
+};
+
+type AgentBootstrapContext = {
+  workspaceDir?: string;
+  bootstrapFiles?: BootstrapFileEntry[];
+  sessionKey?: string;
+};
+
+type InternalHookEventLike = {
+  type?: string;
+  action?: string;
+  context?: AgentBootstrapContext;
+};
+
+/** Encode a channel nest as a flat filename: chat/~zod/general → chat.~zod.general */
+export function encodeNestForFilename(nest: string): string | null {
+  const match = NEST_RE.exec(nest);
+  if (!match) {
+    return null;
+  }
+  return `${match[1]}.${match[2]}.${match[3]}`;
+}
+
+async function readMemoryFile(
+  workspaceDir: string,
+  relPath: string
+): Promise<BootstrapFileEntry | null> {
+  const absPath = path.resolve(workspaceDir, relPath);
+  // Belt-and-suspenders: inputs are regex-validated, but never load outside
+  // the workspace regardless.
+  if (!absPath.startsWith(path.resolve(workspaceDir) + path.sep)) {
+    return null;
+  }
+  let content: string;
+  try {
+    content = await fs.readFile(absPath, 'utf8');
+  } catch {
+    return null;
+  }
+  const trimmed = content.trim();
+  if (!trimmed) {
+    return null;
+  }
+  return {
+    name: relPath,
+    path: absPath,
+    content:
+      trimmed.length > MAX_FILE_CHARS
+        ? trimmed.slice(0, MAX_FILE_CHARS)
+        : trimmed,
+    missing: false,
+  };
+}
+
+/** Compute the workspace-relative memory file paths for a session. */
+export function selectMemoryFilePaths(sessionKey: string): string[] {
+  const surface = parseTlonSurface(sessionKey);
+  if (!surface) {
+    return [];
+  }
+  if (surface.kind === 'dm') {
+    if (!SHIP_FILE_RE.test(surface.ship)) {
+      return [];
+    }
+    return [
+      path.join(PERSON_SUBDIR, `${surface.ship}.md`),
+      path.join(PERSON_SUBDIR, `${surface.ship}.private.md`),
+    ];
+  }
+  const paths: string[] = [];
+  const encodedNest = encodeNestForFilename(surface.nest);
+  if (encodedNest) {
+    paths.push(path.join(PLACE_SUBDIR, `${encodedNest}.md`));
+  }
+  const speaker = resolveSpeakerForSession(sessionKey);
+  if (speaker && SHIP_FILE_RE.test(speaker)) {
+    paths.push(path.join(PERSON_SUBDIR, `${speaker}.md`));
+  }
+  return paths;
+}
+
+/** Create the agent:bootstrap handler that appends memory files in place. */
+export function createMemoryBootstrapHandler(opts?: {
+  log?: (message: string) => void;
+}) {
+  return async (event: InternalHookEventLike): Promise<void> => {
+    if (event?.type !== 'agent' || event?.action !== 'bootstrap') {
+      return;
+    }
+    const context = event.context;
+    const workspaceDir = context?.workspaceDir;
+    const bootstrapFiles = context?.bootstrapFiles;
+    const sessionKey = context?.sessionKey?.trim();
+    if (!workspaceDir || !Array.isArray(bootstrapFiles) || !sessionKey) {
+      return;
+    }
+    const relPaths = selectMemoryFilePaths(sessionKey);
+    if (relPaths.length === 0) {
+      return;
+    }
+    const alreadyLoaded = new Set(
+      bootstrapFiles.map((file) => file.path ?? file.name)
+    );
+    for (const relPath of relPaths) {
+      const entry = await readMemoryFile(workspaceDir, relPath);
+      if (!entry || alreadyLoaded.has(entry.path)) {
+        continue;
+      }
+      bootstrapFiles.push(entry);
+      alreadyLoaded.add(entry.path);
+      opts?.log?.(`[tlon] memory: loaded ${relPath} for ${sessionKey}`);
+    }
+  };
+}

--- a/packages/openclaw/src/memory/speaker-bridge.test.ts
+++ b/packages/openclaw/src/memory/speaker-bridge.test.ts
@@ -1,0 +1,51 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  recordSpeakerForSession,
+  resolveSpeakerForSession,
+} from './speaker-bridge.js';
+
+describe('speaker bridge', () => {
+  it('records and resolves a speaker by exact key', () => {
+    recordSpeakerForSession('agent:main:tlon:channel:chat/~zod/a', '~nec');
+    expect(
+      resolveSpeakerForSession('agent:main:tlon:channel:chat/~zod/a')
+    ).toBe('~nec');
+  });
+
+  it('resolves through the active-memory suffix', () => {
+    recordSpeakerForSession('agent:main:tlon:channel:chat/~zod/b', '~ten');
+    expect(
+      resolveSpeakerForSession(
+        'agent:main:tlon:channel:chat/~zod/b:active-memory:ab12cd34ef56'
+      )
+    ).toBe('~ten');
+  });
+
+  it('falls back through the thread suffix to the parent surface', () => {
+    recordSpeakerForSession('agent:main:tlon:channel:chat/~zod/c', '~bus');
+    expect(
+      resolveSpeakerForSession(
+        'agent:main:tlon:channel:chat/~zod/c:thread:1.2:active-memory:ab12cd34ef56'
+      )
+    ).toBe('~bus');
+  });
+
+  it('prefers the thread key over the parent when both are recorded', () => {
+    recordSpeakerForSession('agent:main:tlon:channel:chat/~zod/d', '~zod');
+    recordSpeakerForSession(
+      'agent:main:tlon:channel:chat/~zod/d:thread:1.2',
+      '~nec'
+    );
+    expect(
+      resolveSpeakerForSession('agent:main:tlon:channel:chat/~zod/d:thread:1.2')
+    ).toBe('~nec');
+  });
+
+  it('ignores blank inputs', () => {
+    recordSpeakerForSession('', '~nec');
+    recordSpeakerForSession('agent:main:tlon:direct:~nec', '');
+    expect(resolveSpeakerForSession('')).toBeUndefined();
+    expect(resolveSpeakerForSession(undefined)).toBeUndefined();
+  });
+});

--- a/packages/openclaw/src/memory/speaker-bridge.ts
+++ b/packages/openclaw/src/memory/speaker-bridge.ts
@@ -1,0 +1,83 @@
+/**
+ * Records which ship most recently spoke in each session, so consumers that
+ * only receive a session key (the agent:bootstrap hook, plugin tools called
+ * by the active-memory sub-agent) can resolve the current speaker.
+ *
+ * In a DM the speaker is derivable from the session key itself; in a group
+ * channel it is not — the monitor records it here on every inbound message.
+ * Same sharedMap + TTL pattern as session-roles.ts.
+ */
+import { sharedMap } from '../shared-state.js';
+import { stripActiveMemorySuffix, stripThreadSuffix } from './surface.js';
+
+interface SpeakerEntry {
+  ship: string;
+  timestamp: number;
+}
+
+const sessionSpeakers = sharedMap<string, SpeakerEntry>('session-speakers');
+
+// Speakers are consumed within the same turn they're recorded (bootstrap runs
+// right after inbound routing), so a short TTL is plenty.
+const SPEAKER_TTL_MS = 15 * 60 * 1000;
+
+export function recordSpeakerForSession(
+  sessionKey: string | null | undefined,
+  ship: string | null | undefined
+): void {
+  const key = sessionKey?.trim();
+  const speaker = ship?.trim();
+  if (!key || !speaker) {
+    return;
+  }
+  const now = Date.now();
+  // Opportunistic cleanup, mirroring session-roles.ts.
+  for (const [entryKey, entry] of sessionSpeakers) {
+    if (now - entry.timestamp > SPEAKER_TTL_MS) {
+      sessionSpeakers.delete(entryKey);
+    }
+  }
+  sessionSpeakers.set(key, { ship: speaker, timestamp: now });
+}
+
+function lookup(sessionKey: string): string | undefined {
+  const entry = sessionSpeakers.get(sessionKey);
+  if (!entry) {
+    return undefined;
+  }
+  if (Date.now() - entry.timestamp > SPEAKER_TTL_MS) {
+    sessionSpeakers.delete(sessionKey);
+    return undefined;
+  }
+  return entry.ship;
+}
+
+/**
+ * Resolve the most recent speaker for a session key. Falls back through the
+ * active-memory and thread suffixes so recall sub-agents and thread sessions
+ * resolve to their parent surface's speaker.
+ */
+export function resolveSpeakerForSession(
+  sessionKey: string | null | undefined
+): string | undefined {
+  const key = sessionKey?.trim();
+  if (!key) {
+    return undefined;
+  }
+  const direct = lookup(key);
+  if (direct) {
+    return direct;
+  }
+  const withoutRecall = stripActiveMemorySuffix(key);
+  if (withoutRecall !== key) {
+    const viaParent = lookup(withoutRecall);
+    if (viaParent) {
+      return viaParent;
+    }
+  }
+  const withoutThread = stripThreadSuffix(withoutRecall);
+  if (withoutThread !== withoutRecall) {
+    return lookup(withoutThread);
+  }
+  return undefined;
+}

--- a/packages/openclaw/src/memory/surface.test.ts
+++ b/packages/openclaw/src/memory/surface.test.ts
@@ -1,0 +1,79 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  parseTlonSurface,
+  stripActiveMemorySuffix,
+  stripThreadSuffix,
+} from './surface.js';
+
+describe('parseTlonSurface', () => {
+  it('parses a DM session key', () => {
+    expect(parseTlonSurface('agent:main:tlon:direct:~nec')).toEqual({
+      kind: 'dm',
+      ship: '~nec',
+    });
+  });
+
+  it('parses a channel session key', () => {
+    expect(
+      parseTlonSurface('agent:main:tlon:channel:chat/~zod/general')
+    ).toEqual({ kind: 'channel', nest: 'chat/~zod/general' });
+  });
+
+  it('parses a DM thread and keeps the parent surface', () => {
+    expect(
+      parseTlonSurface('agent:main:tlon:direct:~ten:thread:170.141.184')
+    ).toEqual({ kind: 'dm', ship: '~ten', threadId: '170.141.184' });
+  });
+
+  it('parses a channel thread', () => {
+    expect(
+      parseTlonSurface(
+        'agent:main:tlon:channel:chat/~zod/general:thread:170.141.184'
+      )
+    ).toEqual({
+      kind: 'channel',
+      nest: 'chat/~zod/general',
+      threadId: '170.141.184',
+    });
+  });
+
+  it('resolves an active-memory sub-agent key to its parent surface', () => {
+    expect(
+      parseTlonSurface('agent:main:tlon:direct:~nec:active-memory:ab12cd34ef56')
+    ).toEqual({ kind: 'dm', ship: '~nec' });
+    expect(
+      parseTlonSurface(
+        'agent:main:tlon:channel:chat/~zod/general:thread:1.2:active-memory:ab12cd34ef56'
+      )
+    ).toEqual({ kind: 'channel', nest: 'chat/~zod/general', threadId: '1.2' });
+  });
+
+  it('returns null for non-tlon sessions', () => {
+    expect(parseTlonSurface('agent:main:main')).toBeNull();
+    expect(parseTlonSurface('agent:main:telegram:direct')).toBeNull();
+    expect(parseTlonSurface('agent:main:cron:job-1')).toBeNull();
+    expect(parseTlonSurface('agent:main:subagent:reviewer')).toBeNull();
+    expect(parseTlonSurface('')).toBeNull();
+  });
+
+  it('rejects malformed ships and nests', () => {
+    expect(parseTlonSurface('agent:main:tlon:direct:zod')).toBeNull();
+    expect(parseTlonSurface('agent:main:tlon:direct:~ZOD!')).toBeNull();
+    expect(
+      parseTlonSurface('agent:main:tlon:channel:blog/~zod/general')
+    ).toBeNull();
+    expect(
+      parseTlonSurface('agent:main:tlon:channel:chat/~zod/../escape')
+    ).toBeNull();
+  });
+});
+
+describe('suffix strippers', () => {
+  it('strips only trailing recognized suffixes', () => {
+    expect(stripActiveMemorySuffix('a:b:active-memory:x')).toBe('a:b');
+    expect(stripActiveMemorySuffix('a:b')).toBe('a:b');
+    expect(stripThreadSuffix('a:b:thread:1.2')).toBe('a:b');
+    expect(stripThreadSuffix('a:b')).toBe('a:b');
+  });
+});

--- a/packages/openclaw/src/memory/surface.ts
+++ b/packages/openclaw/src/memory/surface.ts
@@ -1,0 +1,67 @@
+/**
+ * Parse Tlon session keys into the surface (DM or group channel) they serve.
+ *
+ * Session keys observed from OpenClaw routing:
+ *   agent:<agent>:tlon:direct:~ship
+ *   agent:<agent>:tlon:channel:chat/~zod/general
+ *
+ * Threads append `:thread:<id>` and the active-memory recall sub-agent
+ * appends `:active-memory:<hash>`. Both suffixes are recognized and stripped;
+ * a thread's surface is its parent channel or DM (memory inherits downward).
+ */
+
+export type TlonSurface =
+  | { kind: 'dm'; ship: string; threadId?: string }
+  | { kind: 'channel'; nest: string; threadId?: string };
+
+const SESSION_KEY_RE = /^agent:[^:]+:tlon:(direct|channel):(.+)$/;
+const SHIP_RE = /^~[a-z-]+$/;
+const NEST_RE = /^(chat|heap|diary)\/~[a-z-]+\/[a-z0-9.-]+$/;
+
+/**
+ * Strip a trailing `:active-memory:<hash>` suffix, if present. The recall
+ * sub-agent's session key is its parent's key plus this suffix, so the
+ * stripped key identifies the surface being served.
+ */
+export function stripActiveMemorySuffix(sessionKey: string): string {
+  const idx = sessionKey.indexOf(':active-memory:');
+  return idx > 0 ? sessionKey.slice(0, idx) : sessionKey;
+}
+
+/** Strip a trailing `:thread:<id>` suffix, if present. */
+export function stripThreadSuffix(sessionKey: string): string {
+  const idx = sessionKey.indexOf(':thread:');
+  return idx > 0 ? sessionKey.slice(0, idx) : sessionKey;
+}
+
+/**
+ * Parse a session key into its Tlon surface, or null when the key does not
+ * belong to the Tlon channel (webchat, cron, subagents, other channels).
+ */
+export function parseTlonSurface(sessionKey: string): TlonSurface | null {
+  const trimmed = sessionKey?.trim();
+  if (!trimmed) {
+    return null;
+  }
+  const base = stripActiveMemorySuffix(trimmed);
+  const threadIdx = base.indexOf(':thread:');
+  const threadId =
+    threadIdx > 0 ? base.slice(threadIdx + ':thread:'.length) : undefined;
+  const surfaceKey = threadIdx > 0 ? base.slice(0, threadIdx) : base;
+
+  const match = SESSION_KEY_RE.exec(surfaceKey);
+  if (!match) {
+    return null;
+  }
+  const [, kind, rest] = match;
+  if (kind === 'direct') {
+    if (!SHIP_RE.test(rest)) {
+      return null;
+    }
+    return { kind: 'dm', ship: rest, ...(threadId ? { threadId } : {}) };
+  }
+  if (!NEST_RE.test(rest)) {
+    return null;
+  }
+  return { kind: 'channel', nest: rest, ...(threadId ? { threadId } : {}) };
+}

--- a/packages/openclaw/src/monitor/index.ts
+++ b/packages/openclaw/src/monitor/index.ts
@@ -40,6 +40,7 @@ import {
   gateGatewayStatusActivation,
   getGatewayStatusCoordinator,
 } from '../gateway-status.js';
+import { recordSpeakerForSession } from '../memory/speaker-bridge.js';
 import { handleOwnerListenCommand } from '../owner-listen-command.js';
 import {
   type PendingNudge,
@@ -3257,6 +3258,13 @@ export async function monitorTlonProvider(
               );
             }
           }, dispatchTimeoutMs);
+          // Record the speaker for this session so the agent:bootstrap
+          // memory loader (which only receives a session key) can resolve
+          // who is talking — in a group channel the key alone can't say.
+          recordSpeakerForSession(
+            ctxPayload.SessionKey ?? route.sessionKey,
+            senderShip
+          );
           dispatchResult = await recordTlonRouteAndDispatch({
             session: core.channel.session,
             cfg,


### PR DESCRIPTION
## Summary

First slice of subject-keyed bot memory (TLON-6375, design doc on the issue). Loads person/place memory files into the model context per surface on every `agent:bootstrap`: a DM loads that ship's public + private person files; a channel loads its place file plus the current speaker's **public tier only**; threads inherit their parent surface. The monitor records the current speaker per session (sharedMap, same pattern as session-roles) so the hook — which only receives a session key — can pick the right person file in group channels.

Part of TLON-6375.

## Changes

- `src/memory/surface.ts` — session key → surface parser (strict ship/nest regexes; `:thread:` and `:active-memory:` suffixes resolve to the parent surface)
- `src/memory/speaker-bridge.ts` — per-session speaker record/resolve with TTL + suffix fallback
- `src/memory/bootstrap-loader.ts` — the hook; `selectMemoryFilePaths` structurally cannot emit a `.private.` path for a channel
- `index.ts` — `registerHook('agent:bootstrap', …)`
- `src/monitor/index.ts` — one `recordSpeakerForSession` call before dispatch

## How did I test?

- 24 new unit tests (surface parsing, bridge TTL/fallbacks, loader tier rules incl. a test pinning "no private tier in channels")
- full plugin suite: 1383 passed
- `tsc --noEmit` clean relative to baseline (one pre-existing error on develop in `gateway-status.ts` from a stale `@tloncorp/api` build)

## Risks and impact

Inert by design: with no `memory/` files in the workspace the hook is a no-op, so this merges and deploys dark. Rollout is by creating files (tlonbot activation PR), not config.

## Rollback plan

Revert the commit; no state or config migration involved.

## Screenshots

n/a

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NFZjuCbwYSRnzw3wc9DZeP