### PR TITLE
openclaw: group activity digest + canRead audience predicate

### DIFF
--- a/packages/openclaw/src/memory/bootstrap-loader.ts
+++ b/packages/openclaw/src/memory/bootstrap-loader.ts
@@ -16,6 +16,7 @@
 import fs from 'node:fs/promises';
 import path from 'node:path';
 
+import { renderGroupDigestForChannel } from './digest.js';
 import { resolveSpeakerForSession } from './speaker-bridge.js';
 import { parseTlonSurface } from './surface.js';
 
@@ -130,9 +131,6 @@ export function createMemoryBootstrapHandler(opts?: {
       return;
     }
     const relPaths = selectMemoryFilePaths(sessionKey);
-    if (relPaths.length === 0) {
-      return;
-    }
     const alreadyLoaded = new Set(
       bootstrapFiles.map((file) => file.path ?? file.name)
     );
@@ -144,6 +142,29 @@ export function createMemoryBootstrapHandler(opts?: {
       bootstrapFiles.push(entry);
       alreadyLoaded.add(entry.path);
       opts?.log?.(`[tlon] memory: loaded ${relPath} for ${sessionKey}`);
+    }
+
+    // Group digest: rendered live (never persisted), rows already filtered
+    // for this channel's audience inside renderGroupDigestForChannel.
+    const surface = parseTlonSurface(sessionKey);
+    if (surface?.kind === 'channel') {
+      const digest = renderGroupDigestForChannel(surface.nest);
+      if (digest) {
+        const flatFlag = digest.groupFlag.replace(/\//g, '.');
+        const name = path.join('memory', 'digest', `${flatFlag}.md`);
+        const virtualPath = path.resolve(workspaceDir, name);
+        if (!alreadyLoaded.has(virtualPath)) {
+          bootstrapFiles.push({
+            name,
+            path: virtualPath,
+            content: digest.content.slice(0, MAX_FILE_CHARS),
+            missing: false,
+          });
+          opts?.log?.(
+            `[tlon] memory: rendered digest for ${digest.groupFlag} into ${sessionKey}`
+          );
+        }
+      }
     }
   };
 }

--- a/packages/openclaw/src/memory/can-read.test.ts
+++ b/packages/openclaw/src/memory/can-read.test.ts
@@ -1,0 +1,62 @@
+import { describe, expect, it } from 'vitest';
+
+import { type GroupSnapshot, audienceContains, canRead } from './can-read.js';
+
+const NEST_OPEN = 'chat/~zod/general';
+const NEST_ADMIN = 'chat/~zod/hiring';
+
+function snapshot(overrides?: Partial<GroupSnapshot>): GroupSnapshot {
+  return {
+    hostShip: '~zod',
+    seats: new Map([
+      ['~nec', ['member']],
+      ['~bus', ['member', 'admin']],
+      ['~wex', []],
+    ]),
+    bannedShips: new Set(['~wex']),
+    channelReaders: new Map([
+      [NEST_OPEN, []],
+      [NEST_ADMIN, ['admin']],
+    ]),
+    ...overrides,
+  };
+}
+
+describe('canRead', () => {
+  it('lets any member read an open channel', () => {
+    expect(canRead('~nec', NEST_OPEN, snapshot())).toBe(true);
+  });
+
+  it('requires an intersecting role for a restricted channel', () => {
+    expect(canRead('~bus', NEST_ADMIN, snapshot())).toBe(true);
+    expect(canRead('~nec', NEST_ADMIN, snapshot())).toBe(false);
+  });
+
+  it('host bypasses everything', () => {
+    expect(canRead('~zod', NEST_ADMIN, snapshot())).toBe(true);
+  });
+
+  it('non-members and banned ships read nothing', () => {
+    expect(canRead('~sampel', NEST_OPEN, snapshot())).toBe(false);
+    expect(canRead('~wex', NEST_OPEN, snapshot())).toBe(false);
+  });
+
+  it('fails closed on unknown channels and unknown kinds', () => {
+    expect(canRead('~nec', 'chat/~zod/mystery', snapshot())).toBe(false);
+    expect(canRead('~nec', 'notes/~zod/book', snapshot())).toBe(false);
+  });
+});
+
+describe('audienceContains', () => {
+  it('open → restricted is allowed (restricted readers ⊂ open readers)', () => {
+    // Memory FROM the open channel INTO the restricted one: everyone who
+    // can read #hiring can also read #general.
+    expect(audienceContains(NEST_ADMIN, NEST_OPEN, snapshot())).toBe(true);
+  });
+
+  it('restricted → open is refused', () => {
+    // Memory FROM #hiring INTO #general: ~nec reads #general but not
+    // #hiring, so the containment fails.
+    expect(audienceContains(NEST_OPEN, NEST_ADMIN, snapshot())).toBe(false);
+  });
+});

--- a/packages/openclaw/src/memory/can-read.ts
+++ b/packages/openclaw/src/memory/can-read.ts
@@ -1,0 +1,76 @@
+/**
+ * Channel read-permission predicate, mirroring the backend model in
+ * desk/app/groups.hoon:
+ *
+ *   1. the group host always reads everything
+ *   2. non-members read nothing
+ *   3. banned ships read nothing
+ *   4. an empty reader set means every member may read
+ *   5. otherwise the ship needs a seat role intersecting the reader set
+ *
+ * This runs against a snapshot of group state supplied by the caller.
+ * chat/heap/diary channels only — %notes group-mode notebooks defer to the
+ * group's can-read upstream, but resolve audience per channel kind and fail
+ * closed on anything unrecognized.
+ */
+
+export interface GroupSnapshot {
+  /** Group host ship (the `~host` in `~host/group-name`). */
+  hostShip: string;
+  /** Seats: member ship → role ids held. */
+  seats: ReadonlyMap<string, readonly string[]>;
+  /** Banned ships (rank bans should be pre-expanded by the caller). */
+  bannedShips?: ReadonlySet<string>;
+  /** Channel reader role ids by nest; empty array = all members. */
+  channelReaders: ReadonlyMap<string, readonly string[]>;
+}
+
+const KNOWN_KINDS = new Set(['chat', 'heap', 'diary']);
+
+export function canRead(
+  ship: string,
+  nest: string,
+  group: GroupSnapshot
+): boolean {
+  const kind = nest.split('/', 1)[0];
+  if (!KNOWN_KINDS.has(kind)) {
+    return false;
+  }
+  if (ship === group.hostShip) {
+    return true;
+  }
+  const roles = group.seats.get(ship);
+  if (!roles) {
+    return false;
+  }
+  if (group.bannedShips?.has(ship)) {
+    return false;
+  }
+  const readers = group.channelReaders.get(nest);
+  if (readers === undefined) {
+    // Unknown channel: fail closed.
+    return false;
+  }
+  if (readers.length === 0) {
+    return true;
+  }
+  return roles.some((role) => readers.includes(role));
+}
+
+/**
+ * Whether everyone who can read `fromNest` can also read `intoNest` — the
+ * containment check behind "a memory may enter a surface only if everyone
+ * who can see that surface is entitled to it".
+ */
+export function audienceContains(
+  intoNest: string,
+  fromNest: string,
+  group: GroupSnapshot
+): boolean {
+  for (const ship of group.seats.keys()) {
+    if (canRead(ship, intoNest, group) && !canRead(ship, fromNest, group)) {
+      return false;
+    }
+  }
+  return true;
+}

--- a/packages/openclaw/src/memory/digest.test.ts
+++ b/packages/openclaw/src/memory/digest.test.ts
@@ -1,0 +1,119 @@
+import { beforeEach, describe, expect, it } from 'vitest';
+
+import {
+  clearDigestStateForTest,
+  recordDigestMessage,
+  renderGroupDigestForChannel,
+} from './digest.js';
+import { clearGroupIndexForTest, updateGroupIndex } from './group-index.js';
+
+const GROUP = '~zod/tlon-core';
+const GENERAL = 'chat/~zod/general';
+const DEV = 'chat/~zod/dev';
+const HIRING = 'chat/~zod/hiring';
+
+function indexGroup(overrides?: { hiringReaders?: string[] }) {
+  updateGroupIndex({
+    channelToGroup: new Map([
+      [GENERAL, GROUP],
+      [DEV, GROUP],
+      [HIRING, GROUP],
+    ]),
+    channelReaders: new Map([
+      [GENERAL, []],
+      [DEV, []],
+      [HIRING, overrides?.hiringReaders ?? ['admin']],
+    ]),
+    channelNames: new Map([
+      [GENERAL, 'general'],
+      [DEV, 'dev'],
+      [HIRING, 'hiring'],
+    ]),
+    groupNames: new Map([[GROUP, 'Tlon Core']]),
+  });
+}
+
+beforeEach(() => {
+  clearGroupIndexForTest();
+  clearDigestStateForTest();
+});
+
+describe('renderGroupDigestForChannel', () => {
+  it('renders sibling activity with counts and the latest snippet', () => {
+    indexGroup();
+    recordDigestMessage({ nest: DEV, sender: '~nec', text: 'CI is red' });
+    recordDigestMessage({ nest: DEV, sender: '~bus', text: 'looking now' });
+    const digest = renderGroupDigestForChannel(GENERAL);
+    expect(digest).not.toBeNull();
+    expect(digest!.groupFlag).toBe(GROUP);
+    expect(digest!.content).toContain('Tlon Core');
+    expect(digest!.content).toContain('#dev — 2 msgs from 2 ships');
+    expect(digest!.content).toContain('looking now');
+  });
+
+  it('omits restricted siblings entirely — no topic, no name', () => {
+    indexGroup();
+    recordDigestMessage({
+      nest: HIRING,
+      sender: '~zod',
+      text: 'discussing offers',
+    });
+    const digest = renderGroupDigestForChannel(GENERAL);
+    expect(digest).not.toBeNull();
+    expect(digest!.content).not.toContain('hiring');
+    expect(digest!.content).not.toContain('discussing offers');
+  });
+
+  it('always includes the current channel, even when restricted', () => {
+    indexGroup();
+    recordDigestMessage({
+      nest: HIRING,
+      sender: '~zod',
+      text: 'discussing offers',
+    });
+    const digest = renderGroupDigestForChannel(HIRING);
+    expect(digest).not.toBeNull();
+    expect(digest!.content).toContain('#hiring — 1 msg');
+  });
+
+  it('fails closed when readers are unknown', () => {
+    updateGroupIndex({
+      channelToGroup: new Map([
+        [GENERAL, GROUP],
+        [DEV, GROUP],
+      ]),
+      channelReaders: new Map([
+        [GENERAL, []],
+        [DEV, ['__unknown__']],
+      ]),
+    });
+    recordDigestMessage({ nest: DEV, sender: '~nec', text: 'secretish' });
+    const digest = renderGroupDigestForChannel(GENERAL);
+    expect(digest?.content ?? '').not.toContain('secretish');
+  });
+
+  it('returns null for channels with no group mapping', () => {
+    expect(renderGroupDigestForChannel('chat/~unknown/where')).toBeNull();
+  });
+
+  it('lists open quiet channels', () => {
+    indexGroup();
+    recordDigestMessage({ nest: GENERAL, sender: '~nec', text: 'hi' });
+    const digest = renderGroupDigestForChannel(GENERAL);
+    expect(digest!.content).toContain('Quiet:');
+    expect(digest!.content).toContain('#dev');
+  });
+
+  it('drops events outside the 24h window', () => {
+    indexGroup();
+    recordDigestMessage({
+      nest: DEV,
+      sender: '~nec',
+      text: 'old news',
+      timestamp: Date.now() - 25 * 60 * 60 * 1000,
+    });
+    const digest = renderGroupDigestForChannel(GENERAL);
+    expect(digest!.content).not.toContain('old news');
+    expect(digest!.content).toContain('Quiet:');
+  });
+});

--- a/packages/openclaw/src/memory/digest.ts
+++ b/packages/openclaw/src/memory/digest.ts
@@ -1,0 +1,184 @@
+/**
+ * Per-group activity digest: a shallow, standing summary of what the bot
+ * has seen lately in each channel of a group, rendered into channel
+ * sessions at bootstrap.
+ *
+ * This is a cue index, not memory — it exists so the bot knows something
+ * happened in a sibling channel and can go read that conversation itself.
+ * Design goals are therefore inverted from the memory files: complete
+ * rather than selective, shallow rather than deep, staleness-tolerant.
+ *
+ * Audience rule (v1, provably safe): when rendering inside channel X, a
+ * sibling row is included only if the sibling's reader set is empty (open
+ * to every group member). Restricted siblings are omitted entirely —
+ * naming them would leak their existence into rooms that can't see them.
+ * The current channel is always included: its readers were admitted by
+ * the backend.
+ */
+import { sharedMap } from '../shared-state.js';
+import { getChannelIndexEntry, getGroupIndexEntry } from './group-index.js';
+
+interface DigestEvent {
+  timestamp: number;
+  sender: string;
+}
+
+interface ChannelDigestState {
+  events: DigestEvent[];
+  latestSnippet?: string;
+  latestTimestamp?: number;
+}
+
+const WINDOW_MS = 24 * 60 * 60 * 1000;
+const MAX_EVENTS_PER_CHANNEL = 200;
+const SNIPPET_MAX_CHARS = 80;
+const MAX_RENDERED_ROWS = 24;
+
+const digestState = sharedMap<string, ChannelDigestState>(
+  'memory-digest-state'
+);
+
+function pruneWindow(state: ChannelDigestState, now: number): void {
+  const cutoff = now - WINDOW_MS;
+  while (state.events.length > 0 && state.events[0].timestamp < cutoff) {
+    state.events.shift();
+  }
+  if (state.events.length > MAX_EVENTS_PER_CHANNEL) {
+    state.events.splice(0, state.events.length - MAX_EVENTS_PER_CHANNEL);
+  }
+}
+
+function toSnippet(text: string): string {
+  const singleLine = text.replace(/\s+/g, ' ').trim();
+  if (singleLine.length <= SNIPPET_MAX_CHARS) {
+    return singleLine;
+  }
+  return `${singleLine.slice(0, SNIPPET_MAX_CHARS - 1)}…`;
+}
+
+/** Record an observed group message. Called from the channel firehose. */
+export function recordDigestMessage(params: {
+  nest: string;
+  sender: string;
+  text?: string;
+  timestamp?: number;
+}): void {
+  const nest = params.nest?.trim();
+  const sender = params.sender?.trim();
+  if (!nest || !sender) {
+    return;
+  }
+  const now = Date.now();
+  const timestamp =
+    typeof params.timestamp === 'number' &&
+    Number.isFinite(params.timestamp) &&
+    params.timestamp > 0
+      ? Math.min(params.timestamp, now)
+      : now;
+  const state = digestState.get(nest) ?? { events: [] };
+  state.events.push({ timestamp, sender });
+  const snippet = params.text ? toSnippet(params.text) : '';
+  if (snippet) {
+    state.latestSnippet = snippet;
+  }
+  state.latestTimestamp = timestamp;
+  pruneWindow(state, now);
+  digestState.set(nest, state);
+}
+
+function channelLabel(nest: string): string {
+  const entry = getChannelIndexEntry(nest);
+  if (entry?.title) {
+    return `#${entry.title}`;
+  }
+  const name = nest.split('/').pop();
+  return name ? `#${name}` : nest;
+}
+
+function describeQuiet(latestTimestamp: number | undefined): string {
+  if (!latestTimestamp) {
+    return 'no activity seen';
+  }
+  const days = Math.floor(
+    (Date.now() - latestTimestamp) / (24 * 60 * 60 * 1000)
+  );
+  if (days <= 0) {
+    return 'quiet today';
+  }
+  return `quiet ${days}d`;
+}
+
+/**
+ * Render the digest for the group containing `currentNest`, filtered for
+ * that channel's audience. Returns null when the channel's group is
+ * unknown (fail closed: no group, no digest) or nothing is renderable.
+ */
+export function renderGroupDigestForChannel(currentNest: string): {
+  groupFlag: string;
+  content: string;
+} | null {
+  const channelEntry = getChannelIndexEntry(currentNest);
+  if (!channelEntry) {
+    return null;
+  }
+  const group = getGroupIndexEntry(channelEntry.groupFlag);
+  if (!group) {
+    return null;
+  }
+
+  const rows: string[] = [];
+  const quiet: string[] = [];
+  for (const nest of group.channels.slice(0, 64)) {
+    const isCurrent = nest === currentNest;
+    const entry = getChannelIndexEntry(nest);
+    // Audience rule: siblings must be open to all members; unknown fails
+    // closed. The current channel is always safe to describe to itself.
+    if (!isCurrent && (!entry || entry.readers.length > 0)) {
+      continue;
+    }
+    const state = digestState.get(nest);
+    if (state) {
+      pruneWindow(state, Date.now());
+    }
+    const count = state?.events.length ?? 0;
+    if (count > 0) {
+      const senders = new Set(state!.events.map((event) => event.sender));
+      const snippet = state!.latestSnippet
+        ? ` · “${state!.latestSnippet}”`
+        : '';
+      rows.push(
+        `- ${channelLabel(nest)} — ${count} msg${count === 1 ? '' : 's'} from ${senders.size} ship${senders.size === 1 ? '' : 's'} (24h)${snippet}`
+      );
+    } else {
+      quiet.push(
+        `${channelLabel(nest)} (${describeQuiet(state?.latestTimestamp)})`
+      );
+    }
+    if (rows.length >= MAX_RENDERED_ROWS) {
+      break;
+    }
+  }
+
+  if (rows.length === 0 && quiet.length === 0) {
+    return null;
+  }
+
+  const title = group.title ?? channelEntry.groupFlag;
+  const lines = [
+    `# Recent activity — ${title}`,
+    '',
+    'What you have seen in this group lately. To recall detail from another',
+    'channel, read that channel with the tlon tool rather than guessing.',
+    '',
+    ...rows,
+  ];
+  if (quiet.length > 0) {
+    lines.push('', `Quiet: ${quiet.join(', ')}`);
+  }
+  return { groupFlag: channelEntry.groupFlag, content: lines.join('\n') };
+}
+
+/** Test helper: reset shared state between tests. */
+export function clearDigestStateForTest(): void {
+  digestState.clear();
+}

--- a/packages/openclaw/src/memory/group-index.ts
+++ b/packages/openclaw/src/memory/group-index.ts
@@ -1,0 +1,76 @@
+/**
+ * Shared index of group structure for memory features: which group each
+ * channel belongs to, each channel's reader roles, and display titles.
+ *
+ * Populated by the monitor from groups-ui init data (the same fetch that
+ * drives channel auto-discovery). The channel→group relation is immutable
+ * on the backend — channels never move between groups — so entries are
+ * only ever added or refreshed, never re-parented. Reader sets DO change
+ * at runtime, so consumers must treat them as a snapshot, not a fact.
+ */
+import { sharedMap } from '../shared-state.js';
+
+export interface ChannelIndexEntry {
+  groupFlag: string;
+  /** Reader role ids; empty array means readable by every group member. */
+  readers: string[];
+  title?: string;
+}
+
+export interface GroupIndexEntry {
+  title?: string;
+  /** Nests in this group, in discovery order. */
+  channels: string[];
+}
+
+const channelIndex = sharedMap<string, ChannelIndexEntry>(
+  'memory-channel-index'
+);
+const groupIndex = sharedMap<string, GroupIndexEntry>('memory-group-index');
+
+export function updateGroupIndex(params: {
+  channelToGroup: ReadonlyMap<string, string>;
+  channelReaders?: ReadonlyMap<string, string[]>;
+  channelNames?: ReadonlyMap<string, string>;
+  groupNames?: ReadonlyMap<string, string>;
+}): void {
+  const grouped = new Map<string, string[]>();
+  for (const [nest, groupFlag] of params.channelToGroup) {
+    channelIndex.set(nest, {
+      groupFlag,
+      readers: params.channelReaders?.get(nest) ?? [],
+      ...(params.channelNames?.get(nest)
+        ? { title: params.channelNames.get(nest) }
+        : {}),
+    });
+    const list = grouped.get(groupFlag) ?? [];
+    list.push(nest);
+    grouped.set(groupFlag, list);
+  }
+  for (const [groupFlag, channels] of grouped) {
+    groupIndex.set(groupFlag, {
+      channels,
+      ...(params.groupNames?.get(groupFlag)
+        ? { title: params.groupNames.get(groupFlag) }
+        : {}),
+    });
+  }
+}
+
+export function getChannelIndexEntry(
+  nest: string
+): ChannelIndexEntry | undefined {
+  return channelIndex.get(nest);
+}
+
+export function getGroupIndexEntry(
+  groupFlag: string
+): GroupIndexEntry | undefined {
+  return groupIndex.get(groupFlag);
+}
+
+/** Test helper: reset shared state between tests. */
+export function clearGroupIndexForTest(): void {
+  channelIndex.clear();
+  groupIndex.clear();
+}

--- a/packages/openclaw/src/monitor/discovery.ts
+++ b/packages/openclaw/src/monitor/discovery.ts
@@ -23,11 +23,33 @@ export async function fetchGroupChanges(
 export interface InitData {
   channels: string[];
   channelToGroup: Map<string, string>;
+  /** Map from channel nest to reader role ids (empty = all members) */
+  channelReaders: Map<string, string[]>;
   /** Map from channel nest to human-readable channel title */
   channelNames: Map<string, string>;
   /** Map from group flag to human-readable group title */
   groupNames: Map<string, string>;
   foreigns: Foreigns | null;
+}
+
+/**
+ * Extract reader role ids from a groups-ui channel record. Unparseable
+ * shapes yield a non-empty sentinel so downstream audience checks fail
+ * closed (a channel we can't read permissions for is treated as
+ * restricted, never as open).
+ */
+function extractReaderRoles(value: unknown): string[] {
+  if (!value || typeof value !== 'object') {
+    return ['__unknown__'];
+  }
+  const readers = (value as { readers?: unknown }).readers;
+  if (readers === undefined || readers === null) {
+    return ['__unknown__'];
+  }
+  if (!Array.isArray(readers)) {
+    return ['__unknown__'];
+  }
+  return readers.filter((role): role is string => typeof role === 'string');
 }
 
 function extractTitle(value: unknown): string | undefined {
@@ -55,6 +77,7 @@ export async function fetchInitData(
 
     const channels: string[] = [];
     const channelToGroup = new Map<string, string>();
+    const channelReaders = new Map<string, string[]>();
     const channelNames = new Map<string, string>();
     const groupNames = new Map<string, string>();
     if (initData?.groups) {
@@ -78,6 +101,10 @@ export async function fetchInitData(
               ) {
                 channels.push(channelNest);
                 channelToGroup.set(channelNest, groupFlag);
+                channelReaders.set(
+                  channelNest,
+                  extractReaderRoles(channelData)
+                );
                 const channelTitle = extractTitle(channelData);
                 if (channelTitle) {
                   channelNames.set(channelNest, channelTitle);
@@ -91,7 +118,14 @@ export async function fetchInitData(
 
     const foreigns = (initData?.foreigns as Foreigns) || null;
 
-    return { channels, channelToGroup, channelNames, groupNames, foreigns };
+    return {
+      channels,
+      channelToGroup,
+      channelReaders,
+      channelNames,
+      groupNames,
+      foreigns,
+    };
   } catch (error: any) {
     runtime.error?.(
       `[tlon] Init data fetch failed: ${error?.message ?? String(error)}`
@@ -99,6 +133,7 @@ export async function fetchInitData(
     return {
       channels: [],
       channelToGroup: new Map(),
+      channelReaders: new Map(),
       channelNames: new Map(),
       groupNames: new Map(),
       foreigns: null,

--- a/packages/openclaw/src/monitor/index.ts
+++ b/packages/openclaw/src/monitor/index.ts
@@ -40,6 +40,8 @@ import {
   gateGatewayStatusActivation,
   getGatewayStatusCoordinator,
 } from '../gateway-status.js';
+import { recordDigestMessage } from '../memory/digest.js';
+import { updateGroupIndex } from '../memory/group-index.js';
 import { recordSpeakerForSession } from '../memory/speaker-bridge.js';
 import { handleOwnerListenCommand } from '../owner-listen-command.js';
 import {
@@ -1456,6 +1458,13 @@ export async function monitorTlonProvider(
         for (const [flag, title] of initData.groupNames) {
           groupNameCache.set(flag, title);
         }
+        // Feed the memory group index (digest rendering + audience checks)
+        updateGroupIndex({
+          channelToGroup: initData.channelToGroup,
+          channelReaders: initData.channelReaders,
+          channelNames: initData.channelNames,
+          groupNames: initData.groupNames,
+        });
         initForeigns = initData.foreigns;
       } catch (error: any) {
         runtime.error?.(
@@ -3954,6 +3963,14 @@ export async function monitorTlonProvider(
         }
 
         const parsed = parseChannelNest(nest);
+        // Digest: record every observed group message (post-authorization),
+        // whether or not the bot replies — this is what it "saw" lately.
+        recordDigestMessage({
+          nest,
+          sender: senderShip,
+          text: rawText,
+          timestamp: content.sent || Date.now(),
+        });
         const citedContent = await resolveCitedContent(content.content);
         await processMessage({
           messageId: messageId ?? '',


### PR DESCRIPTION
## Summary

Second slice of TLON-6375, stacked on #6331. The digest is a cue index, not memory: a shallow per-group summary of what the bot has observed lately (recorded from the channel firehose post-authorization, whether or not it replies), rendered live into channel sessions at bootstrap so the bot knows something happened in a sibling channel and can go read it. Also lands `canRead`, mirroring the backend permission model in `app/groups.hoon`.

Part of TLON-6375.

## Changes

- `src/memory/group-index.ts` — shared nest→group index with reader roles + titles, fed from the existing groups-ui init fetch
- `src/memory/digest.ts` — record/render; 24h window, capped buffers
- `src/memory/can-read.ts` — host bypass, seats, bans, empty-readers=all, role intersection; `audienceContains` for the containment rule (consumed by the recall slice)
- `src/monitor/discovery.ts` — extract reader roles (unparseable → non-empty sentinel, so audience checks fail closed)
- `src/monitor/index.ts` — feed the index; record digest events at the channel firehose

## Audience rules

- sibling rows render only for channels open to all members (empty readers); restricted siblings are **omitted entirely** — naming them would leak their existence
- unknown/unparseable reader sets fail closed
- the current channel always renders to itself

## How did I test?

14 new unit tests (rendering, withholding, fail-closed on unknown readers, 24h window, canRead matrix incl. host bypass and containment direction). Full memory suite 38 passing at this commit; monitor suite 386 passing.

## Risks and impact

Digest renders only in channel sessions and only from data the bot itself observed. Worst case on bad reader data is a *missing* row, never an extra one.

## Rollback plan

Revert; in-memory state only (sharedMap), nothing persisted.

## Screenshots

n/a

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NFZjuCbwYSRnzw3wc9DZeP