### PR TITLE
openclaw: tlon_recall — audience-gated recall over memory files + lcm.db

### DIFF
--- a/packages/openclaw/index.ts
+++ b/packages/openclaw/index.ts
@@ -36,6 +36,7 @@ import {
 import { notifyDiaryMigrationDiscovery } from './src/diary-migration-discovery.js';
 import { registerGatewayStatusHooks } from './src/gateway-status-registration.js';
 import { createMemoryBootstrapHandler } from './src/memory/bootstrap-loader.js';
+import { createTlonRecallTool } from './src/memory/recall-tool.js';
 import {
   createMigrateCommandHandler,
   routeMigrateCommand,
@@ -992,6 +993,19 @@ export default defineBundledChannelEntry({
       },
       execute: executeTlonTool,
     });
+
+    // tlon_recall: audience-gated recall for the active-memory sub-agent
+    // (and the main agent). Factory form so each run's tool closes over
+    // its own session key — that's what scopes the search to one surface.
+    api.registerTool(
+      (toolCtx) =>
+        createTlonRecallTool({
+          sessionKey: toolCtx.sessionKey,
+          workspaceDir: toolCtx.workspaceDir,
+          log: (message) => api.logger.debug?.(message),
+        }),
+      { name: 'tlon_recall' }
+    );
 
     // Subject-keyed memory: load person/place files for the current surface
     // on every bootstrap. No-op until the workspace has memory/ files.

--- a/packages/openclaw/src/memory/lcm-reader.test.ts
+++ b/packages/openclaw/src/memory/lcm-reader.test.ts
@@ -1,0 +1,193 @@
+import fs from 'node:fs/promises';
+import os from 'node:os';
+import path from 'node:path';
+import { DatabaseSync } from 'node:sqlite';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+
+import {
+  resolveLcmDbPath,
+  searchLcmHistory,
+  toFtsQuery,
+} from './lcm-reader.js';
+
+let dir: string;
+let dbPath: string;
+
+const DM_KEY = 'agent:main:tlon:direct:~nec';
+const DM_THREAD_KEY = 'agent:main:tlon:direct:~nec:thread:170.141.184';
+const OTHER_DM_KEY = 'agent:main:tlon:direct:~sampel';
+
+function seedDb() {
+  const db = new DatabaseSync(dbPath);
+  db.exec(`
+    CREATE TABLE conversations (
+      conversation_id INTEGER PRIMARY KEY AUTOINCREMENT,
+      session_id TEXT NOT NULL,
+      session_key TEXT,
+      active INTEGER NOT NULL DEFAULT 1,
+      archived_at TEXT,
+      created_at TEXT NOT NULL DEFAULT (datetime('now'))
+    );
+    CREATE TABLE messages (
+      message_id INTEGER PRIMARY KEY AUTOINCREMENT,
+      conversation_id INTEGER NOT NULL,
+      seq INTEGER NOT NULL,
+      role TEXT NOT NULL,
+      content TEXT NOT NULL,
+      token_count INTEGER NOT NULL DEFAULT 1,
+      created_at TEXT NOT NULL DEFAULT (datetime('now'))
+    );
+    CREATE VIRTUAL TABLE messages_fts USING fts5(
+      content,
+      tokenize='porter unicode61'
+    );
+  `);
+  const insertConversation = db.prepare(
+    `INSERT INTO conversations (session_id, session_key, active) VALUES (?, ?, ?)`
+  );
+  const insertMessage = db.prepare(
+    `INSERT INTO messages (conversation_id, seq, role, content, created_at)
+     VALUES (?, ?, ?, ?, ?)`
+  );
+  const insertFts = db.prepare(
+    `INSERT INTO messages_fts (rowid, content) VALUES (?, ?)`
+  );
+  const addMessage = (
+    conversationId: number,
+    seq: number,
+    role: string,
+    content: string,
+    createdAt: string
+  ) => {
+    insertMessage.run(conversationId, seq, role, content, createdAt);
+    const row = db.prepare('SELECT last_insert_rowid() AS id').get() as {
+      id: number;
+    };
+    insertFts.run(row.id, content);
+  };
+
+  insertConversation.run('s1', DM_KEY, 0); // archived pre-reset segment
+  insertConversation.run('s2', DM_KEY, 1); // active segment
+  insertConversation.run('s3', DM_THREAD_KEY, 1); // thread child
+  insertConversation.run('s4', OTHER_DM_KEY, 1); // different person
+
+  addMessage(1, 1, 'user', 'I moved to Pacific time in June', '2026-06-02');
+  addMessage(2, 1, 'user', 'standup reminder please', '2026-08-20');
+  addMessage(
+    3,
+    1,
+    'assistant',
+    'the Pacific move noted in thread',
+    '2026-08-21'
+  );
+  addMessage(
+    4,
+    1,
+    'user',
+    'secret: interviewing at Pacific Corp',
+    '2026-08-01'
+  );
+  addMessage(
+    2,
+    2,
+    'tool',
+    'Pacific tool output should be excluded',
+    '2026-08-22'
+  );
+  db.close();
+}
+
+beforeEach(async () => {
+  dir = await fs.mkdtemp(path.join(os.tmpdir(), 'lcm-reader-'));
+  dbPath = path.join(dir, 'lcm.db');
+  seedDb();
+});
+
+afterEach(async () => {
+  await fs.rm(dir, { recursive: true, force: true });
+});
+
+describe('toFtsQuery', () => {
+  it('quotes terms and strips FTS operators', () => {
+    expect(toFtsQuery('pacific time')).toBe('"pacific" "time"');
+    expect(toFtsQuery('a OR b NOT "c"')).toBe('"a" "OR" "b" "NOT" "c"');
+    expect(toFtsQuery('  ')).toBeNull();
+  });
+});
+
+describe('searchLcmHistory', () => {
+  it('finds hits across archived segments and thread children', () => {
+    const hits = searchLcmHistory({
+      baseSessionKeys: [DM_KEY],
+      query: 'pacific',
+      dbPath,
+    });
+    const contents = hits.map((hit) => hit.content);
+    expect(contents).toContain('I moved to Pacific time in June');
+    expect(contents).toContain('the Pacific move noted in thread');
+  });
+
+  it('never returns hits from other surfaces', () => {
+    const hits = searchLcmHistory({
+      baseSessionKeys: [DM_KEY],
+      query: 'pacific',
+      dbPath,
+    });
+    expect(hits.map((hit) => hit.content)).not.toContain(
+      'secret: interviewing at Pacific Corp'
+    );
+    expect(hits.every((hit) => hit.sessionKey.startsWith(DM_KEY))).toBe(true);
+  });
+
+  it('excludes tool-role messages', () => {
+    const hits = searchLcmHistory({
+      baseSessionKeys: [DM_KEY],
+      query: 'pacific',
+      dbPath,
+    });
+    expect(hits.map((hit) => hit.content)).not.toContain(
+      'Pacific tool output should be excluded'
+    );
+  });
+
+  it('returns [] for a missing database or empty inputs', () => {
+    expect(
+      searchLcmHistory({
+        baseSessionKeys: [DM_KEY],
+        query: 'pacific',
+        dbPath: path.join(dir, 'nope.db'),
+      })
+    ).toEqual([]);
+    expect(
+      searchLcmHistory({ baseSessionKeys: [], query: 'pacific', dbPath })
+    ).toEqual([]);
+    expect(
+      searchLcmHistory({ baseSessionKeys: [DM_KEY], query: '!!!', dbPath })
+    ).toEqual([]);
+  });
+
+  it('returns [] on schema mismatch instead of throwing', async () => {
+    const brokenPath = path.join(dir, 'broken.db');
+    const db = new DatabaseSync(brokenPath);
+    db.exec('CREATE TABLE conversations (wrong TEXT)');
+    db.close();
+    expect(
+      searchLcmHistory({
+        baseSessionKeys: [DM_KEY],
+        query: 'pacific',
+        dbPath: brokenPath,
+      })
+    ).toEqual([]);
+  });
+});
+
+describe('resolveLcmDbPath', () => {
+  it('prefers LCM_DATABASE_PATH, then OPENCLAW_STATE_DIR', () => {
+    expect(resolveLcmDbPath({ LCM_DATABASE_PATH: '/x/lcm.db' } as never)).toBe(
+      '/x/lcm.db'
+    );
+    expect(resolveLcmDbPath({ OPENCLAW_STATE_DIR: '/state' } as never)).toBe(
+      path.join('/state', 'lcm.db')
+    );
+  });
+});

--- a/packages/openclaw/src/memory/lcm-reader.ts
+++ b/packages/openclaw/src/memory/lcm-reader.ts
@@ -1,0 +1,139 @@
+/**
+ * Read-only access to Lossless Claw's SQLite database (lcm.db) for
+ * audience-scoped transcript recall.
+ *
+ * LCM keys conversations by session key, one row per session-family
+ * segment (archived rows share the key), and keeps every raw message in
+ * an FTS5-indexed table. Reading it directly is what lets tlon_recall
+ * search a surface's own history — including across resets and archived
+ * segments — without lcm_grep's one-conversation-or-everything scoping.
+ *
+ * Coupling note: this reads lossless-claw's schema (verified against
+ * 0.15.x: conversations / messages / messages_fts). tlonbot pins the LCM
+ * version; every query here degrades to an empty result on any schema
+ * mismatch rather than throwing into the reply path.
+ */
+import fs from 'node:fs';
+import { createRequire } from 'node:module';
+import os from 'node:os';
+import path from 'node:path';
+
+const require = createRequire(import.meta.url);
+
+export interface LcmSearchHit {
+  sessionKey: string;
+  role: string;
+  content: string;
+  createdAt: string;
+}
+
+export function resolveLcmDbPath(env: NodeJS.ProcessEnv = process.env): string {
+  const explicit = env.LCM_DATABASE_PATH?.trim();
+  if (explicit) {
+    return explicit;
+  }
+  const stateDir =
+    env.OPENCLAW_STATE_DIR?.trim() || path.join(os.homedir(), '.openclaw');
+  return path.join(stateDir, 'lcm.db');
+}
+
+/**
+ * Turn a free-text query into a safe FTS5 MATCH expression: each term
+ * double-quoted (FTS5 phrase syntax, immune to operator injection),
+ * terms implicitly ANDed. Returns null when nothing searchable remains.
+ */
+export function toFtsQuery(query: string): string | null {
+  const terms = query
+    .split(/[^\p{L}\p{N}~-]+/u)
+    .map((term) => term.trim())
+    .filter(Boolean)
+    .slice(0, 8);
+  if (terms.length === 0) {
+    return null;
+  }
+  return terms.map((term) => `"${term.replaceAll('"', '')}"`).join(' ');
+}
+
+/**
+ * Search raw messages within the conversations belonging to the given
+ * session keys (exact matches) and their thread children (prefix
+ * matches). Missing database, missing tables, or any schema mismatch
+ * returns [].
+ */
+export function searchLcmHistory(params: {
+  baseSessionKeys: string[];
+  query: string;
+  limit?: number;
+  dbPath?: string;
+}): LcmSearchHit[] {
+  const dbPath = params.dbPath ?? resolveLcmDbPath();
+  const ftsQuery = toFtsQuery(params.query);
+  const baseKeys = params.baseSessionKeys.filter(Boolean);
+  if (!ftsQuery || baseKeys.length === 0 || !fs.existsSync(dbPath)) {
+    return [];
+  }
+  const limit = Math.min(Math.max(params.limit ?? 10, 1), 50);
+
+  let db: import('node:sqlite').DatabaseSync | undefined;
+  try {
+    // Lazy require keeps the experimental-module warning out of startup
+    // and off every code path that never touches recall.
+    const { DatabaseSync } =
+      require('node:sqlite') as typeof import('node:sqlite');
+    db = new DatabaseSync(dbPath, { readOnly: true });
+
+    const keyClauses = baseKeys
+      .map(() => '(session_key = ? OR session_key LIKE ?)')
+      .join(' OR ');
+    const keyParams = baseKeys.flatMap((key) => [key, `${key}:thread:%`]);
+    const conversations = db
+      .prepare(
+        `SELECT conversation_id, session_key FROM conversations WHERE ${keyClauses}`
+      )
+      .all(...keyParams) as { conversation_id: number; session_key: string }[];
+    if (conversations.length === 0) {
+      return [];
+    }
+    const sessionKeyByConversation = new Map(
+      conversations.map((row) => [row.conversation_id, row.session_key])
+    );
+    const idList = conversations.map(() => '?').join(', ');
+    const rows = db
+      .prepare(
+        `SELECT m.conversation_id, m.role, m.content, m.created_at
+         FROM messages_fts f
+         JOIN messages m ON m.message_id = f.rowid
+         WHERE messages_fts MATCH ?
+           AND m.conversation_id IN (${idList})
+           AND m.role IN ('user', 'assistant')
+         ORDER BY m.created_at DESC
+         LIMIT ?`
+      )
+      .all(
+        ftsQuery,
+        ...conversations.map((row) => row.conversation_id),
+        limit
+      ) as {
+      conversation_id: number;
+      role: string;
+      content: string;
+      created_at: string;
+    }[];
+    return rows.map((row) => ({
+      sessionKey: sessionKeyByConversation.get(row.conversation_id) ?? '',
+      role: row.role,
+      content: row.content,
+      createdAt: row.created_at,
+    }));
+  } catch {
+    // Schema drift, malformed FTS state, locked db: recall degrades to
+    // "nothing found" rather than failing the reply path.
+    return [];
+  } finally {
+    try {
+      db?.close();
+    } catch {
+      // ignore
+    }
+  }
+}

--- a/packages/openclaw/src/memory/recall-tool.test.ts
+++ b/packages/openclaw/src/memory/recall-tool.test.ts
@@ -1,0 +1,118 @@
+import fs from 'node:fs/promises';
+import os from 'node:os';
+import path from 'node:path';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+
+import type { LcmSearchHit } from './lcm-reader.js';
+import { createTlonRecallTool } from './recall-tool.js';
+import { recordSpeakerForSession } from './speaker-bridge.js';
+
+let workspaceDir: string;
+
+function textOf(result: { content: { type: 'text'; text: string }[] }) {
+  return result.content[0].text;
+}
+
+beforeEach(async () => {
+  workspaceDir = await fs.mkdtemp(path.join(os.tmpdir(), 'tlon-recall-'));
+});
+
+afterEach(async () => {
+  await fs.rm(workspaceDir, { recursive: true, force: true });
+});
+
+describe('tlon_recall', () => {
+  it('searches only the calling surface: base key derived through suffixes', async () => {
+    const seen: string[][] = [];
+    const tool = createTlonRecallTool({
+      sessionKey:
+        'agent:main:tlon:direct:~nec:thread:1.2:active-memory:ab12cd34ef56',
+      workspaceDir,
+      searchHistory: (params) => {
+        seen.push(params.baseSessionKeys);
+        return [];
+      },
+    });
+    await tool.execute('call-1', { query: 'pacific' });
+    expect(seen).toEqual([['agent:main:tlon:direct:~nec']]);
+  });
+
+  it('formats hits with provenance and returns NONE when empty', async () => {
+    const hit: LcmSearchHit = {
+      sessionKey: 'agent:main:tlon:direct:~nec',
+      role: 'user',
+      content: 'I moved to Pacific time in June',
+      createdAt: '2026-06-02',
+    };
+    const tool = createTlonRecallTool({
+      sessionKey: 'agent:main:tlon:direct:~nec',
+      workspaceDir,
+      searchHistory: () => [hit],
+    });
+    const result = await tool.execute('call-1', { query: 'pacific' });
+    expect(textOf(result)).toContain('DM ~nec');
+    expect(textOf(result)).toContain('Pacific time in June');
+
+    const empty = createTlonRecallTool({
+      sessionKey: 'agent:main:tlon:direct:~nec',
+      workspaceDir,
+      searchHistory: () => [],
+    });
+    expect(textOf(await empty.execute('c', { query: 'pacific' }))).toBe('NONE');
+  });
+
+  it('includes matches from allowed memory files only', async () => {
+    const personDir = path.join(workspaceDir, 'memory', 'person');
+    await fs.mkdir(personDir, { recursive: true });
+    await fs.writeFile(
+      path.join(personDir, '~nec.md'),
+      'US/Pacific (moved June 2026)\n'
+    );
+    await fs.writeFile(
+      path.join(personDir, '~nec.private.md'),
+      'pacific secret: interviewing\n'
+    );
+
+    // In ~nec's DM: both tiers are in scope.
+    const dmTool = createTlonRecallTool({
+      sessionKey: 'agent:main:tlon:direct:~nec',
+      workspaceDir,
+      searchHistory: () => [],
+    });
+    const dmText = textOf(await dmTool.execute('c', { query: 'pacific' }));
+    expect(dmText).toContain('US/Pacific');
+    expect(dmText).toContain('interviewing');
+
+    // In a channel where ~nec speaks: public tier only.
+    const channelKey = 'agent:main:tlon:channel:chat/~zod/general';
+    recordSpeakerForSession(channelKey, '~nec');
+    const channelTool = createTlonRecallTool({
+      sessionKey: `${channelKey}:active-memory:ab12cd34ef56`,
+      workspaceDir,
+      searchHistory: () => [],
+    });
+    const channelText = textOf(
+      await channelTool.execute('c', { query: 'pacific' })
+    );
+    expect(channelText).toContain('US/Pacific');
+    expect(channelText).not.toContain('interviewing');
+  });
+
+  it('returns NONE for non-tlon sessions and errors on empty query', async () => {
+    const tool = createTlonRecallTool({
+      sessionKey: 'agent:main:main',
+      workspaceDir,
+      searchHistory: () => {
+        throw new Error('must not be called');
+      },
+    });
+    expect(textOf(await tool.execute('c', { query: 'anything' }))).toBe('NONE');
+
+    const dmTool = createTlonRecallTool({
+      sessionKey: 'agent:main:tlon:direct:~nec',
+      workspaceDir,
+      searchHistory: () => [],
+    });
+    expect(textOf(await dmTool.execute('c', {}))).toContain('Error');
+  });
+});

--- a/packages/openclaw/src/memory/recall-tool.ts
+++ b/packages/openclaw/src/memory/recall-tool.ts
@@ -1,0 +1,192 @@
+/**
+ * tlon_recall: audience-gated recall over memory files and LCM transcript
+ * history, designed to be the ONLY tool active-memory's blocking sub-agent
+ * may call (`toolsAllow: ["tlon_recall"]`).
+ *
+ * The gate is structural, not judgment: the tool resolves the surface it
+ * serves from the calling session key (the active-memory sub-agent's key
+ * is its parent's plus a suffix) and searches only what that surface's
+ * audience may see:
+ *
+ *   DM with ~x  → ~x's person files (both tiers) + that DM's own LCM
+ *                 history (all session-family segments, threads included)
+ *   channel     → the channel's place file, the current speaker's public
+ *                 tier, and the channel's own LCM history
+ *
+ * Cross-surface transcript search is deliberately absent in v1 — it needs
+ * seat-level audience containment (audienceContains) fed by group state
+ * we don't snapshot yet. The digest already provides cross-channel
+ * awareness; this provides depth on the current surface.
+ */
+import fs from 'node:fs/promises';
+import path from 'node:path';
+
+import { selectMemoryFilePaths } from './bootstrap-loader.js';
+import { type LcmSearchHit, searchLcmHistory } from './lcm-reader.js';
+import {
+  parseTlonSurface,
+  stripActiveMemorySuffix,
+  stripThreadSuffix,
+} from './surface.js';
+
+const MAX_OUTPUT_CHARS = 6_000;
+const SNIPPET_CHARS = 240;
+
+export interface RecallDeps {
+  /** Injectable for tests; defaults to the real lcm.db search. */
+  searchHistory?: typeof searchLcmHistory;
+  workspaceDir?: string;
+  sessionKey?: string;
+  log?: (message: string) => void;
+}
+
+function textResult(text: string) {
+  return { content: [{ type: 'text' as const, text }] };
+}
+
+function snippet(content: string): string {
+  const singleLine = content.replace(/\s+/g, ' ').trim();
+  return singleLine.length <= SNIPPET_CHARS
+    ? singleLine
+    : `${singleLine.slice(0, SNIPPET_CHARS - 1)}…`;
+}
+
+function describeSource(sessionKey: string): string {
+  const surface = parseTlonSurface(sessionKey);
+  if (!surface) {
+    return sessionKey;
+  }
+  if (surface.kind === 'dm') {
+    return surface.threadId
+      ? `DM ${surface.ship} (thread)`
+      : `DM ${surface.ship}`;
+  }
+  return surface.threadId ? `${surface.nest} (thread)` : surface.nest;
+}
+
+async function searchMemoryFiles(
+  workspaceDir: string,
+  relPaths: string[],
+  query: string
+): Promise<string[]> {
+  const terms = query
+    .toLowerCase()
+    .split(/[^\p{L}\p{N}~-]+/u)
+    .filter(Boolean);
+  if (terms.length === 0) {
+    return [];
+  }
+  const lines: string[] = [];
+  for (const relPath of relPaths) {
+    let content: string;
+    try {
+      content = await fs.readFile(path.resolve(workspaceDir, relPath), 'utf8');
+    } catch {
+      continue;
+    }
+    for (const line of content.split('\n')) {
+      const lower = line.toLowerCase();
+      if (terms.some((term) => lower.includes(term)) && line.trim()) {
+        lines.push(`- [${relPath}] ${snippet(line)}`);
+        if (lines.length >= 6) {
+          return lines;
+        }
+      }
+    }
+  }
+  return lines;
+}
+
+/** Build the tlon_recall tool for one session context. */
+export function createTlonRecallTool(deps: RecallDeps) {
+  return {
+    name: 'tlon_recall',
+    label: 'Tlon Recall',
+    description:
+      'Search this conversation surface’s memory: durable facts about the ' +
+      'current person and place, plus the full transcript history of THIS ' +
+      'surface (including before session resets). Scope is enforced by the ' +
+      'tool — it never returns content from other DMs or channels. ' +
+      'Returns NONE when nothing relevant is found.',
+    parameters: {
+      type: 'object',
+      properties: {
+        query: {
+          type: 'string',
+          description:
+            '1–4 distinctive keywords for what to recall (names, topics, ' +
+            'identifiers). Not a sentence.',
+        },
+        limit: {
+          type: 'number',
+          description: 'Max transcript matches to return (default 8, max 20).',
+        },
+      },
+      required: ['query'],
+    },
+    execute: async (
+      _callId: string,
+      params: { query?: string; limit?: number }
+    ) => {
+      const query = params.query?.trim();
+      if (!query) {
+        return textResult('Error: query is required.');
+      }
+      const sessionKey = deps.sessionKey?.trim();
+      if (!sessionKey) {
+        return textResult('NONE');
+      }
+      const surface = parseTlonSurface(sessionKey);
+      if (!surface) {
+        // Not a Tlon surface (webchat, cron, …): nothing is in scope.
+        return textResult('NONE');
+      }
+
+      const sections: string[] = [];
+
+      if (deps.workspaceDir) {
+        const fileLines = await searchMemoryFiles(
+          deps.workspaceDir,
+          selectMemoryFilePaths(sessionKey),
+          query
+        );
+        if (fileLines.length > 0) {
+          sections.push('## Memory files', ...fileLines);
+        }
+      }
+
+      // Surface base: recall sub-agent and thread suffixes both resolve to
+      // the parent surface; the LIKE clause in the reader then re-includes
+      // every thread under it (a thread inherits its channel's history).
+      const baseKey = stripThreadSuffix(stripActiveMemorySuffix(sessionKey));
+      const search = deps.searchHistory ?? searchLcmHistory;
+      const limit = Math.min(Math.max(params.limit ?? 8, 1), 20);
+      let hits: LcmSearchHit[] = [];
+      try {
+        hits = search({ baseSessionKeys: [baseKey], query, limit });
+      } catch {
+        hits = [];
+      }
+      if (hits.length > 0) {
+        sections.push(
+          '## This surface’s history',
+          ...hits.map(
+            (hit) =>
+              `- [${describeSource(hit.sessionKey)} · ${hit.createdAt} · ${hit.role}] ${snippet(hit.content)}`
+          )
+        );
+      }
+
+      if (sections.length === 0) {
+        return textResult('NONE');
+      }
+      const text = sections.join('\n');
+      deps.log?.(
+        `[tlon] recall: ${hits.length} history hits for ${describeSource(baseKey)}`
+      );
+      return textResult(
+        text.length > MAX_OUTPUT_CHARS ? text.slice(0, MAX_OUTPUT_CHARS) : text
+      );
+    },
+  };
+}


### PR DESCRIPTION
## Summary

Third slice of TLON-6375, stacked on #6332. A single plugin tool designed to be the ONLY entry in active-memory's `toolsAllow`, so per-turn unprompted recall is scoped in plugin code rather than model judgment. It resolves its surface from the calling session key (the active-memory sub-agent's key is its parent's plus a suffix; threads resolve to their channel) and searches only that surface's own material: allowed memory files (private tier iff that ship's DM) plus the surface's own LCM transcript history — read directly from `lcm.db` (node:sqlite, read-only), which spans archived pre-reset segments and thread children that `lcm_grep`'s one-conversation scoping can't express.

Cross-surface transcript search is deliberately absent in v1 — it needs seat-level audience containment fed by group state we don't snapshot yet. The digest (#6332) provides cross-channel awareness; this provides depth on the current surface.

Part of TLON-6375.

## Changes

- `src/memory/lcm-reader.ts` — read-only lcm.db access; FTS5 query built from quoted terms (operator-injection immune); every failure path (missing db, schema drift, locked db) returns `[]`
- `src/memory/recall-tool.ts` — the tool; returns `NONE` when nothing found (active-memory's empty-result protocol)
- `index.ts` — `registerTool` in factory form so each run's tool closes over its own session key

## Coupling note

Reads lossless-claw's schema (verified against 0.15.x: `conversations` / `messages` / `messages_fts`). tlonbot pins the LCM version; schema mismatch degrades to NONE, never into the reply path. A host-supplied conversation-scope grant upstream would remove this coupling — worth filing with Martian regardless, since it also closes the unscoped `allConversations` hole.

## How did I test?

11 new unit tests: an in-test SQLite fixture matching LCM's real schema (archived segments, thread children, other-surface exclusion, tool-role exclusion, schema-mismatch fallback), plus tool tests pinning scope derivation through both suffixes and the private-tier-in-DM-only rule. Full memory suite 49 passing.

## Risks and impact

Dormant until active-memory names this tool in `toolsAllow` (tlonbot activation PR). The tool never throws into the reply path; `node:sqlite` prints one experimental-feature warning on first use.

## Rollback plan

Revert; the tool is self-contained and read-only.

## Screenshots

n/a

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NFZjuCbwYSRnzw3wc9DZeP