### PR TITLE
chat input: fix pasting the same message link twice

### DIFF
--- a/packages/api/src/client/utils.ts
+++ b/packages/api/src/client/utils.ts
@@ -356,33 +356,6 @@ export const textPostIsLink = (post: db.Post): boolean => {
   return false;
 };
 
-export const textPostIsReference = (post: db.Post): boolean => {
-  const { inlines, references } = extractContentTypesFromPost(post);
-  if (references.length === 0) {
-    return false;
-  }
-
-  if (inlines.length === 2) {
-    const [first] = inlines;
-    const isRefString =
-      typeof first === 'string' && REF_REGEX.test(first as string);
-
-    if (isRefString) {
-      return true;
-    }
-  }
-
-  if (
-    inlines.length === 1 &&
-    typeof inlines[0] === 'object' &&
-    'break' in inlines[0]
-  ) {
-    return true;
-  }
-
-  return false;
-};
-
 export const getPostTypeFromChannelId = ({
   channelId,
   parentId,

--- a/packages/app/ui/components/BareChatInput/index.tsx
+++ b/packages/app/ui/components/BareChatInput/index.tsx
@@ -1,9 +1,8 @@
-import { getCurrentUserId, toContentReference } from '@tloncorp/api';
-import { JSONContent, Story, pathToCite } from '@tloncorp/api/urbit';
+import { getCurrentUserId } from '@tloncorp/api';
+import { JSONContent, Story } from '@tloncorp/api/urbit';
 import {
   Attachment,
   JSONToInlines,
-  REF_REGEX,
   createDevLogger,
   diaryMixedToJSON,
   useDebouncedValue,
@@ -59,6 +58,7 @@ import type { DraftInputHandle } from '../draftInputs/shared';
 import { PasteableTextInput } from './PasteableTextInput';
 import { contentToTextAndMentions, textAndMentionsToContent } from './helpers';
 import { PastedFile, attachPastedImageFiles } from './pastedImage';
+import { createReferenceExtractor } from './references';
 import {
   MentionOption,
   createMentionRoleOptions,
@@ -362,39 +362,7 @@ function BareChatInput(
   attachmentsRef.current = attachments;
   const prevUrlsRef = useRef<string[]>([]);
 
-  const processReferences = useCallback(
-    (text: string): string => {
-      const references = text.match(REF_REGEX);
-      if (!references) {
-        return text;
-      }
-
-      let newText = text;
-      references.forEach((ref) => {
-        const cite = pathToCite(ref);
-        if (!cite) {
-          return;
-        }
-        const reference = toContentReference(cite);
-        if (!reference) {
-          return;
-        }
-
-        addAttachment({
-          type: 'reference',
-          reference,
-          path: ref,
-        });
-
-        newText = newText.replace(ref, '');
-      });
-
-      return newText;
-    },
-    [addAttachment]
-  );
-
-  const lastProcessedRef = useRef('');
+  const extractReferences = useRef(createReferenceExtractor()).current;
   const mentionRef = useRef<MentionController>(null);
   const slashCommandRef = useRef<SlashCommandController>(null);
 
@@ -421,51 +389,39 @@ function BareChatInput(
 
       bareChatInputLogger.log('text change', newText);
 
-      // Only process references if the text contains a reference and hasn't been processed before.
-      // This check prevents infinite loops on native platforms where we manually update
-      // the input's text value using setNativeProps after processing references.
-      // Without this guard, each manual text update would trigger another onChangeText,
-      // creating an endless cycle.
-      if (REF_REGEX.test(newText) && lastProcessedRef.current !== newText) {
-        lastProcessedRef.current = newText;
-        const textWithoutRefs = processReferences(newText);
-        const cursorPos = getWebSelectionStart();
-        const adjustedCursorPos =
-          cursorPos != null
-            ? Math.max(0, cursorPos - (newText.length - textWithoutRefs.length))
-            : undefined;
-        setControlledText(textWithoutRefs);
-        handleMention(oldText, textWithoutRefs, adjustedCursorPos);
-        handleSlashCommandInput(textWithoutRefs, adjustedCursorPos);
+      const change = extractReferences(newText, addAttachment);
+      if (!change) {
+        return;
+      }
+      const { text, hadReferences } = change;
 
-        const jsonContent = textAndMentionsToContent(textWithoutRefs, mentions);
-        bareChatInputLogger.log('setting draft', jsonContent);
-        storeDraft(jsonContent);
+      const cursorPos = getWebSelectionStart();
+      const adjustedCursorPos =
+        cursorPos != null
+          ? Math.max(0, cursorPos - (newText.length - text.length))
+          : undefined;
+      setControlledText(text);
+      handleMention(oldText, text, adjustedCursorPos);
+      handleSlashCommandInput(text, adjustedCursorPos);
 
-        // Clear the native input's text after processing references.
-        // We defer with setTimeout because .clear() uses mostRecentEventCount
-        // internally, which isn't updated until after onChangeText returns.
-        // Calling it synchronously would use a stale event count that gets rejected.
-        if (!isWeb) {
-          setTimeout(() => {
-            inputRef.current?.clear();
-          }, 0);
-        }
-      } else if (!REF_REGEX.test(newText)) {
-        // if there's no reference to process, just update normally
-        const cursorPos = getWebSelectionStart();
-        setControlledText(newText);
-        handleMention(oldText, newText, cursorPos);
-        handleSlashCommandInput(newText, cursorPos);
+      const jsonContent = textAndMentionsToContent(text, mentions);
+      bareChatInputLogger.log('setting draft', jsonContent);
+      storeDraft(jsonContent);
 
-        const jsonContent = textAndMentionsToContent(newText, mentions);
-        bareChatInputLogger.log('setting draft', jsonContent);
-        storeDraft(jsonContent);
+      // Clear the native input's text after extracting references.
+      // We defer with setTimeout because .clear() uses mostRecentEventCount
+      // internally, which isn't updated until after onChangeText returns.
+      // Calling it synchronously would use a stale event count that gets rejected.
+      if (hadReferences && !isWeb) {
+        setTimeout(() => {
+          inputRef.current?.clear();
+        }, 0);
       }
     },
     [
       controlledText,
-      processReferences,
+      extractReferences,
+      addAttachment,
       getWebSelectionStart,
       handleMention,
       handleSlashCommandInput,

--- a/packages/app/ui/components/BareChatInput/index.tsx
+++ b/packages/app/ui/components/BareChatInput/index.tsx
@@ -58,7 +58,7 @@ import type { DraftInputHandle } from '../draftInputs/shared';
 import { PasteableTextInput } from './PasteableTextInput';
 import { contentToTextAndMentions, textAndMentionsToContent } from './helpers';
 import { PastedFile, attachPastedImageFiles } from './pastedImage';
-import { createReferenceExtractor } from './references';
+import { useReferenceExtractor } from './references';
 import {
   MentionOption,
   createMentionRoleOptions,
@@ -362,7 +362,7 @@ function BareChatInput(
   attachmentsRef.current = attachments;
   const prevUrlsRef = useRef<string[]>([]);
 
-  const extractReferences = useRef(createReferenceExtractor()).current;
+  const extractReferences = useReferenceExtractor();
   const mentionRef = useRef<MentionController>(null);
   const slashCommandRef = useRef<SlashCommandController>(null);
 

--- a/packages/app/ui/components/BareChatInput/references.test.ts
+++ b/packages/app/ui/components/BareChatInput/references.test.ts
@@ -1,0 +1,55 @@
+import { Attachment } from '@tloncorp/shared';
+import { expect, test, vi } from 'vitest';
+
+import { createReferenceExtractor } from './references';
+
+const REF_PATH =
+  '/1/chan/chat/~pilwes-hosren/v2dljqi9/msg/170141184508122822886600330000000000000';
+
+test('converts a pasted reference path into an attachment', () => {
+  const addAttachment = vi.fn();
+
+  const result = createReferenceExtractor()(REF_PATH, addAttachment);
+
+  expect(result).toEqual({ text: '', hadReferences: true });
+  expect(addAttachment).toHaveBeenCalledTimes(1);
+  expect(addAttachment).toHaveBeenCalledWith(
+    expect.objectContaining({ type: 'reference', path: REF_PATH })
+  );
+});
+
+test('converts the same reference path when it is pasted a second time', () => {
+  const attachments: Attachment[] = [];
+  const addAttachment = (attachment: Attachment) => {
+    attachments.push(attachment);
+  };
+  const extractReferences = createReferenceExtractor();
+
+  extractReferences(REF_PATH, addAttachment);
+  const second = extractReferences(REF_PATH, addAttachment);
+
+  expect(second).toEqual({ text: '', hadReferences: true });
+  expect(attachments).toHaveLength(2);
+});
+
+test('leaves text without a reference path unchanged', () => {
+  const addAttachment = vi.fn();
+
+  const result = createReferenceExtractor()('hello there', addAttachment);
+
+  expect(result).toEqual({ text: 'hello there', hadReferences: false });
+  expect(addAttachment).not.toHaveBeenCalled();
+});
+
+test('ignores text echoed back after a reference path could not be parsed', () => {
+  const addAttachment = vi.fn();
+  const unparseablePath = '/1/chan/broken';
+  const extractReferences = createReferenceExtractor();
+
+  const first = extractReferences(unparseablePath, addAttachment);
+  const echo = extractReferences(unparseablePath, addAttachment);
+
+  expect(first).toEqual({ text: unparseablePath, hadReferences: true });
+  expect(echo).toBeNull();
+  expect(addAttachment).not.toHaveBeenCalled();
+});

--- a/packages/app/ui/components/BareChatInput/references.ts
+++ b/packages/app/ui/components/BareChatInput/references.ts
@@ -2,6 +2,7 @@ import { toContentReference } from '@tloncorp/api';
 import { REF_REGEX } from '@tloncorp/api/client/utils';
 import { pathToCite } from '@tloncorp/api/urbit';
 import { Attachment } from '@tloncorp/shared';
+import { useState } from 'react';
 
 export interface ReferenceTextChange {
   /** The text with every parsed reference path removed. */
@@ -61,4 +62,10 @@ export function createReferenceExtractor(): ReferenceExtractor {
     lastExtractedText = text;
     return { text, hadReferences: true };
   };
+}
+
+/** Holds one input's reference handler for the life of the component. */
+export function useReferenceExtractor(): ReferenceExtractor {
+  const [extractReferences] = useState(() => createReferenceExtractor());
+  return extractReferences;
 }

--- a/packages/app/ui/components/BareChatInput/references.ts
+++ b/packages/app/ui/components/BareChatInput/references.ts
@@ -1,0 +1,64 @@
+import { toContentReference } from '@tloncorp/api';
+import { REF_REGEX } from '@tloncorp/api/client/utils';
+import { pathToCite } from '@tloncorp/api/urbit';
+import { Attachment } from '@tloncorp/shared';
+
+export interface ReferenceTextChange {
+  /** The text with every parsed reference path removed. */
+  text: string;
+  /** True when the text contained at least one reference path. */
+  hadReferences: boolean;
+}
+
+export type ReferenceExtractor = (
+  newText: string,
+  addAttachment: (attachment: Attachment) => void
+) => ReferenceTextChange | null;
+
+/**
+ * Builds the reference handler for one text input.
+ *
+ * The handler turns the reference paths in the input's new text into reference
+ * attachments and returns the remaining text. It returns null when the input
+ * echoes back the text the handler itself produced: native inputs re-fire
+ * `onChangeText` for the writes that follow extraction, and handling those
+ * again would loop. Only a path the handler could not parse stays in the text,
+ * so only that case can echo.
+ */
+export function createReferenceExtractor(): ReferenceExtractor {
+  let lastExtractedText: string | null = null;
+
+  return (newText, addAttachment) => {
+    const references = newText.match(REF_REGEX);
+    if (!references) {
+      return { text: newText, hadReferences: false };
+    }
+
+    if (lastExtractedText === newText) {
+      return null;
+    }
+
+    let text = newText;
+    references.forEach((ref) => {
+      const cite = pathToCite(ref);
+      if (!cite) {
+        return;
+      }
+      const reference = toContentReference(cite);
+      if (!reference) {
+        return;
+      }
+
+      addAttachment({
+        type: 'reference',
+        reference,
+        path: ref,
+      });
+
+      text = text.replace(ref, '');
+    });
+
+    lastExtractedText = text;
+    return { text, hadReferences: true };
+  };
+}


### PR DESCRIPTION
## Summary

Pasting the same message link into the chat composer twice in a row dropped the raw path into the message as literal text instead of creating a second "Chat Post" reference attachment. Repro: long-press a message → **Copy link to message** → paste (works) → paste again (broken).

## Changes

`handleTextChange` ran two branches, both keyed on `REF_REGEX.test(newText)`, with the reference branch additionally guarded by `lastProcessedRef.current !== newText`. That guard is there because native inputs re-fire `onChangeText` for the write the composer makes after it extracts references, and reprocessing that echo loops. Remembering the *incoming* text made a deliberate repeat paste indistinguishable from an echo.

- The guard now remembers the text the composer wrote back, not the text it read. A repeat paste never equals that, so it extracts again; a real echo still does and is ignored. Only a path that fails to parse stays in the text, so that is the only case that can echo.
- Extraction and the guard moved into `references.ts`, behind `useReferenceExtractor()`, which decides everything from a single `newText.match(REF_REGEX)`. `REF_REGEX` carries the `g` flag, so `.test()` is stateful through `lastIndex`: the two old `.test()` calls disagreed about the same string, and the raw-path-as-text symptom depended on that disagreement. No `.test()` is left on this path.
- The two branches collapse into one. They differed only by the cursor offset, which is zero when nothing is extracted, and by the native `clear()`, now gated on `hadReferences`.

A second commit deletes `textPostIsReference` from `packages/api/src/client/utils.ts`. It had no callers anywhere in the repo, and it called `.test()` on the same global regex, so it carried the same `lastIndex` bug for anyone who revived it.

## How did I test?

- iOS simulator, in a real chat channel: **Copy link to message**, paste, paste again. Before the fix the second paste dropped the raw path into the composer with one attachment; after it, two "Chat Post" attachments and an empty composer. Clips below.
- `references.test.ts` covers paste-then-paste-again: two attachments, no path left in the text. I confirmed it fails when the guard stores the incoming text again, so it pins the actual bug.

## Risks and impact

- Safe to rollback without consulting PR author? Yes
- Affects important code area:
  - [ ] Onboarding
  - [ ] State / providers
  - [ ] Message sync
  - [ ] Channel display
  - [ ] Notifications
  - [x] Other: chat composer (`BareChatInput`, used on mobile and web)

Blast radius is every keystroke in the composer, since `handleTextChange` now has one path instead of two. The mention and slash-command calls receive the same arguments they did before for text without references.

## Rollback plan

Revert the commit. No migrations, no persisted state, no server side.

## Screenshots / videos

Both clips paste the same copied message link twice into the composer.

Before — the second paste lands as raw text:

https://github.com/user-attachments/assets/2822648e-abf7-4aa5-a49e-fcf0d705d073

After — the second paste becomes a second attachment:

https://github.com/user-attachments/assets/48a3e834-08ad-41a3-9944-67683b6240c1



