### PR TITLE
add A2UI connector menu

### DIFF
--- a/docs/tlon-apps/post-blobs.md
+++ b/docs/tlon-apps/post-blobs.md
@@ -98,13 +98,28 @@ The current renderer expects one `createSurface` message and one `updateComponen
 
 The supported v1 client subset is intentionally small:
 
-- components: `Card`, `Column`, `Row`, `Text`, `Divider`, and `Button`
+- components: `Card`, `Column`, `Row`, `Text`, `Divider`, `Button`, `Choice`,
+  `SmallChoice`, and `McpConnect`
 - button actions:
   - `tlon.sendMessage`, which sends explicit action text in the current DM
   - `tlon.navigate`, which can navigate to a message, channel, group, profile, chat details, or chat volume screen
     - message reply targets should include `parentAuthorId` when `parentId` is not already prefixed as `~author/id`
 - rendering policy: A2UI blocks render only in direct messages for now
 - validation limits: component count, tree depth, text length, and expanded render size
+
+`McpConnect` is a client-populated menu rather than bot-authored provider data.
+The blob supplies only bounded presentation labels and three validated actions:
+
+- `action`: navigate to the MCP settings screen, optionally focused on a provider
+- `configureAction`: send the selected connected provider ids to the onboarding coordinator
+- `completionAction`: optional send-message action that advances the conversation
+
+The client obtains the provider catalog and current grants from Hosting. It does
+not trust provider names, URLs, grant state, or availability from the post. A
+provider row either opens the normal authorization flow or toggles an already
+connected provider for the group; configuration is applied only when the owner
+submits it. The completion action is one-shot and remains disabled when a live
+`tlon-a2ui-selection` receipt exists for that surface and component.
 
 ## Read/write behavior
 

--- a/packages/api/src/__tests__/content-helpers.test.ts
+++ b/packages/api/src/__tests__/content-helpers.test.ts
@@ -108,6 +108,13 @@ describe('post blob helpers', () => {
         cronJobId: 'cron-1',
       },
       {
+        type: 'tlon-agent-provider-config',
+        version: 1,
+        provisionId: 'provision-1',
+        groupId: '~zod/test',
+        providerIds: ['gmail', 'google-calendar'],
+      },
+      {
         type: 'tlon-a2ui-selection',
         version: 1,
         sourcePostId: 'topics-post',
@@ -141,6 +148,19 @@ describe('post blob helpers', () => {
             scheduleHour: 25,
             scheduleMinute: 0,
             notebookNest: 'notes/~zod/test-updates',
+          },
+        ])
+      )
+    ).toEqual([{ type: 'unknown' }]);
+    expect(
+      parsePostBlob(
+        JSON.stringify([
+          {
+            type: 'tlon-agent-provider-config',
+            version: 1,
+            provisionId: 'provision-1',
+            groupId: '~zod/test',
+            providerIds: ['gmail', 'gmail'],
           },
         ])
       )

--- a/packages/api/src/client/a2ui.ts
+++ b/packages/api/src/client/a2ui.ts
@@ -157,7 +157,6 @@ const buttonEventSchema = z.discriminatedUnion('name', [
   sendMessageEventSchema,
   navigateEventSchema,
   provisionAgentEventSchema,
-  configureAgentProvidersEventSchema,
 ]);
 const buttonActionSchema = z.object({ event: buttonEventSchema });
 const sendMessageActionSchema = z.object({ event: sendMessageEventSchema });
@@ -353,6 +352,8 @@ export namespace A2UI {
   export type ConfigureAgentProvidersAction = z.infer<
     typeof configureAgentProvidersActionSchema
   >;
+  /** Every action the renderer may dispatch; provider config is McpConnect-only. */
+  export type Action = ButtonAction | ConfigureAgentProvidersAction;
   export type Button = z.infer<typeof buttonSchema>;
   /** Allowlisted assets a Choice option may render. */
   export type ChoiceIcon = z.infer<typeof choiceIconSchema>;

--- a/packages/api/src/client/a2ui.ts
+++ b/packages/api/src/client/a2ui.ts
@@ -2,6 +2,7 @@ import { z } from 'zod';
 
 import {
   AGENT_PROTOCOL_LIMITS,
+  AgentProviderConfigContextSchema,
   AgentProvisionActionContextSchema,
   agentProtocolString,
 } from './agentProtocol';
@@ -9,6 +10,7 @@ import {
 const ACTION_SEND_MESSAGE = 'tlon.sendMessage';
 const ACTION_NAVIGATE = 'tlon.navigate';
 const ACTION_PROVISION_AGENT = 'tlon.provisionAgent';
+const ACTION_CONFIGURE_AGENT_PROVIDERS = 'tlon.configureAgentProviders';
 
 const LIMITS = {
   maxBytes: 32 * 1024,
@@ -59,6 +61,7 @@ const buttonVariantSchema = z.enum([
   'secondary',
   'borderless',
 ]);
+const screenNameSchema = z.enum(['botMcpSettings']);
 
 const nonEmptyString = (max?: number) => {
   const schema = max === undefined ? z.string() : z.string().max(max);
@@ -111,6 +114,11 @@ const chatVolumeNavigationTargetSchema = z.object({
   chatId: targetIdSchema,
   groupId: targetIdSchema.optional(),
 });
+const screenNavigationTargetSchema = z.object({
+  type: z.literal('screen'),
+  screen: screenNameSchema,
+  providerId: targetIdSchema.optional(),
+});
 const navigationTargetSchema = z.discriminatedUnion('type', [
   messageNavigationTargetSchema,
   channelNavigationTargetSchema,
@@ -118,6 +126,7 @@ const navigationTargetSchema = z.discriminatedUnion('type', [
   profileNavigationTargetSchema,
   chatDetailsNavigationTargetSchema,
   chatVolumeNavigationTargetSchema,
+  screenNavigationTargetSchema,
 ]);
 
 const sendMessageEventSchema = z.object({
@@ -140,10 +149,15 @@ const provisionAgentEventSchema = z.object({
   name: z.literal(ACTION_PROVISION_AGENT),
   context: AgentProvisionActionContextSchema,
 });
+const configureAgentProvidersEventSchema = z.object({
+  name: z.literal(ACTION_CONFIGURE_AGENT_PROVIDERS),
+  context: AgentProviderConfigContextSchema,
+});
 const buttonEventSchema = z.discriminatedUnion('name', [
   sendMessageEventSchema,
   navigateEventSchema,
   provisionAgentEventSchema,
+  configureAgentProvidersEventSchema,
 ]);
 const buttonActionSchema = z.object({ event: buttonEventSchema });
 const sendMessageActionSchema = z.object({ event: sendMessageEventSchema });
@@ -160,6 +174,9 @@ const smallChoiceProvisionAgentEventSchema = z.object({
       .array(agentProtocolString(AGENT_PROTOCOL_LIMITS.topicLength))
       .max(AGENT_PROTOCOL_LIMITS.topicCount),
   }),
+});
+const configureAgentProvidersActionSchema = z.object({
+  event: configureAgentProvidersEventSchema,
 });
 const smallChoiceActionSchema = z.union([
   z.object({ event: smallChoiceSendMessageEventSchema }),
@@ -235,16 +252,45 @@ const smallChoiceSchema = z.object({
   freeTextPlaceholder: nonEmptyString(LIMITS.maxPillLabelLength).optional(),
   action: smallChoiceActionSchema,
 });
-const componentSchema = z.discriminatedUnion('component', [
-  textSchema,
-  rowSchema,
-  columnSchema,
-  cardSchema,
-  dividerSchema,
-  buttonSchema,
-  choiceSchema,
-  smallChoiceSchema,
-]);
+const mcpSettingsNavigateActionSchema = z.object({
+  event: z.object({
+    name: z.literal(ACTION_NAVIGATE),
+    context: z.object({
+      target: screenNavigationTargetSchema.extend({
+        screen: z.literal('botMcpSettings'),
+      }),
+    }),
+  }),
+});
+const mcpConnectSchema = z.object({
+  ...componentBaseShape,
+  component: z.literal('McpConnect'),
+  maxVisible: z.number().int().min(1).max(LIMITS.maxSmallChoiceOptions),
+  seeAllLabel: nonEmptyString(LIMITS.maxPillLabelLength),
+  submitLabel: nonEmptyString(LIMITS.maxPillLabelLength),
+  action: mcpSettingsNavigateActionSchema,
+  configureAction: configureAgentProvidersActionSchema,
+  completionLabel: nonEmptyString(LIMITS.maxPillLabelLength).optional(),
+  completionAction: sendMessageActionSchema.optional(),
+});
+const componentSchema = z
+  .discriminatedUnion('component', [
+    textSchema,
+    rowSchema,
+    columnSchema,
+    cardSchema,
+    dividerSchema,
+    buttonSchema,
+    choiceSchema,
+    smallChoiceSchema,
+    mcpConnectSchema,
+  ])
+  .refine(
+    (component) =>
+      component.component !== 'McpConnect' ||
+      (component.completionLabel === undefined) ===
+        (component.completionAction === undefined)
+  );
 const createSurfaceMessageSchema = z.object({
   version: z.literal('v0.9'),
   createSurface: z.object({
@@ -284,14 +330,29 @@ export namespace A2UI {
   export type ChatVolumeNavigationTarget = z.infer<
     typeof chatVolumeNavigationTargetSchema
   >;
+  /**
+   * App screens a blob may navigate to. Unknown names fail validation so a
+   * newer card safely degrades to fallback text on an older client.
+   */
+  export type ScreenName = z.infer<typeof screenNameSchema>;
+  export type ScreenNavigationTarget = z.infer<
+    typeof screenNavigationTargetSchema
+  >;
   export type NavigationTarget = z.infer<typeof navigationTargetSchema>;
   export type NavigateEvent = z.infer<typeof navigateEventSchema>;
   /** Finish the durable, client-bound agent onboarding setup. */
   export type ProvisionAgentEvent = z.infer<typeof provisionAgentEventSchema>;
+  /** Bind already-connected Hosting providers to a recurring agent job. */
+  export type ConfigureAgentProvidersEvent = z.infer<
+    typeof configureAgentProvidersEventSchema
+  >;
   export type EventAction = z.infer<typeof buttonActionSchema>;
   export type ButtonAction = EventAction;
   export type SendMessageAction = z.infer<typeof sendMessageActionSchema>;
   export type NavigateAction = z.infer<typeof navigateActionSchema>;
+  export type ConfigureAgentProvidersAction = z.infer<
+    typeof configureAgentProvidersActionSchema
+  >;
   export type Button = z.infer<typeof buttonSchema>;
   /** Allowlisted assets a Choice option may render. */
   export type ChoiceIcon = z.infer<typeof choiceIconSchema>;
@@ -302,6 +363,8 @@ export namespace A2UI {
   export type SmallChoiceOption = z.infer<typeof smallChoiceOptionSchema>;
   /** A client-owned multi-select whose selection is posted only on submit. */
   export type SmallChoice = z.infer<typeof smallChoiceSchema>;
+  /** A client-owned menu populated from the viewer's live MCP providers. */
+  export type McpConnect = z.infer<typeof mcpConnectSchema>;
   export type Component = z.infer<typeof componentSchema>;
   export type CreateSurfaceMessage = z.infer<typeof createSurfaceMessageSchema>;
   export type UpdateComponentsMessage = z.infer<
@@ -444,6 +507,12 @@ function indexComponents(
       if (component.action.event.name === ACTION_SEND_MESSAGE) {
         totalTextLength += component.action.event.context.text.length;
       }
+    } else if (component.component === 'McpConnect') {
+      totalTextLength +=
+        component.seeAllLabel.length + component.submitLabel.length;
+      totalTextLength += component.completionLabel?.length ?? 0;
+      totalTextLength +=
+        component.completionAction?.event.context.text.length ?? 0;
     }
   }
 
@@ -621,6 +690,7 @@ export const A2UI = {
     sendMessage: ACTION_SEND_MESSAGE,
     navigate: ACTION_NAVIGATE,
     provisionAgent: ACTION_PROVISION_AGENT,
+    configureAgentProviders: ACTION_CONFIGURE_AGENT_PROVIDERS,
   },
   getCreateMessage,
   getUpdateMessage,

--- a/packages/api/src/client/a2uiChoice.test.ts
+++ b/packages/api/src/client/a2uiChoice.test.ts
@@ -103,6 +103,18 @@ const wrapped = (component: unknown) =>
 const valid = (component: unknown) =>
   A2UI.validateBlobEntry(wrapped(component));
 
+const validButton = (action: unknown) =>
+  A2UI.validateBlobEntry(
+    entryWith(
+      [
+        { id: 'root', component: 'Column', children: ['main'] },
+        { id: 'main', component: 'Button', child: 'label', action },
+        { id: 'label', component: 'Text', text: 'Configure' },
+      ],
+      'root'
+    )
+  );
+
 describe('Choice validation', () => {
   test('accepts well-formed groups, with or without the optional fields', () => {
     expect(valid(choice())).toBe(true);
@@ -214,6 +226,14 @@ describe('McpConnect validation', () => {
     expect(valid(mcpConnect({ completionAction: sendAction('Done') }))).toBe(
       false
     );
+  });
+
+  test('rejects provider configuration outside McpConnect', () => {
+    const configureAction = mcpConnect().configureAction;
+    expect(validButton(configureAction)).toBe(false);
+    expect(
+      valid(choice({ options: [option({ action: configureAction })] }))
+    ).toBe(false);
   });
 });
 

--- a/packages/api/src/client/a2uiChoice.test.ts
+++ b/packages/api/src/client/a2uiChoice.test.ts
@@ -57,6 +57,31 @@ const choice = (over: Record<string, unknown> = {}) => ({
   ...over,
 });
 
+const mcpConnect = (over: Record<string, unknown> = {}) => ({
+  id: 'main',
+  component: 'McpConnect',
+  maxVisible: 7,
+  seeAllLabel: 'See all',
+  submitLabel: 'Use for this group',
+  action: {
+    event: {
+      name: A2UI.action.navigate,
+      context: { target: { type: 'screen', screen: 'botMcpSettings' } },
+    },
+  },
+  configureAction: {
+    event: {
+      name: A2UI.action.configureAgentProviders,
+      context: {
+        groupId: '~ten/group',
+        provisionId: 'provision-1',
+        providerIds: [],
+      },
+    },
+  },
+  ...over,
+});
+
 const entryWith = (components: unknown[], root = 'root') => ({
   type: 'a2ui',
   version: 1,
@@ -143,6 +168,52 @@ describe('Choice validation', () => {
     const entry = entryWith([choice()], 'main');
     expect(A2UI.validateBlobEntry(entry)).toBe(true);
     expect(A2UI.getRootComponentId(entry as never)).toBe('main');
+  });
+});
+
+describe('McpConnect validation', () => {
+  test('accepts a bounded provider menu targeting MCP settings', () => {
+    expect(valid(mcpConnect())).toBe(true);
+    expect(valid(mcpConnect({ maxVisible: 0 }))).toBe(false);
+    expect(valid(mcpConnect({ maxVisible: 13 }))).toBe(false);
+    expect(
+      valid(
+        mcpConnect({
+          action: sendAction('not navigation'),
+        })
+      )
+    ).toBe(false);
+    expect(
+      valid(
+        mcpConnect({
+          configureAction: {
+            event: {
+              name: A2UI.action.configureAgentProviders,
+              context: {
+                groupId: '~ten/group',
+                provisionId: 'provision-1',
+                providerIds: ['gmail', 'bad provider'],
+              },
+            },
+          },
+        })
+      )
+    ).toBe(false);
+  });
+
+  test('accepts an optional send-message completion action', () => {
+    expect(
+      valid(
+        mcpConnect({
+          completionLabel: 'Done',
+          completionAction: sendAction('Done'),
+        })
+      )
+    ).toBe(true);
+    expect(valid(mcpConnect({ completionLabel: 'Done' }))).toBe(false);
+    expect(valid(mcpConnect({ completionAction: sendAction('Done') }))).toBe(
+      false
+    );
   });
 });
 
@@ -313,6 +384,48 @@ describe('SmallChoice message building', () => {
     );
     expect(valid(smallChoice({ freeTextPlaceholder: '' }))).toBe(false);
     expect(valid(smallChoice({ freeTextPlaceholder: 'x'.repeat(65) }))).toBe(
+      false
+    );
+  });
+});
+
+describe('screen navigation target', () => {
+  const button = (target: unknown) => [
+    { id: 'root', component: 'Column', children: ['b', 'l'] },
+    {
+      id: 'b',
+      component: 'Button',
+      child: 'l',
+      action: { event: { name: A2UI.action.navigate, context: { target } } },
+    },
+    { id: 'l', component: 'Text', text: 'Connect services' },
+  ];
+
+  test('allowlisted screen names only — never a free route', () => {
+    expect(
+      A2UI.validateBlobEntry(
+        entryWith(button({ type: 'screen', screen: 'botMcpSettings' }))
+      )
+    ).toBe(true);
+    expect(
+      A2UI.validateBlobEntry(
+        entryWith(
+          button({
+            type: 'screen',
+            screen: 'botMcpSettings',
+            providerId: 'notion',
+          })
+        )
+      )
+    ).toBe(true);
+    // Anything not on the allowlist fails validation, so a blob can't point
+    // the renderer at an arbitrary navigator route.
+    expect(
+      A2UI.validateBlobEntry(
+        entryWith(button({ type: 'screen', screen: 'BotApiKeySettings' }))
+      )
+    ).toBe(false);
+    expect(A2UI.validateBlobEntry(entryWith(button({ type: 'screen' })))).toBe(
       false
     );
   });

--- a/packages/api/src/client/agentProtocol.ts
+++ b/packages/api/src/client/agentProtocol.ts
@@ -16,6 +16,8 @@ export const AGENT_PROTOCOL_LIMITS = {
   timezoneLength: 100,
   notebookNestLength: 512,
   notebookTitleLength: 200,
+  providerCount: 12,
+  providerIdLength: 128,
 } as const;
 
 /** Stable identifiers shared by the client and the Tlonbot coordinator. */
@@ -51,4 +53,17 @@ export const AgentProvisionActionContextSchema = z.object({
     .max(AGENT_PROTOCOL_LIMITS.topicCount),
   scheduleHour: z.number().int().min(0).max(23),
   scheduleMinute: z.number().int().min(0).max(59),
+});
+
+export const AgentProviderIdSchema = agentProtocolString(
+  AGENT_PROTOCOL_LIMITS.providerIdLength
+).refine((value) => /^[a-z0-9][a-z0-9._-]*$/i.test(value));
+
+export const AgentProviderConfigContextSchema = z.object({
+  groupId: agentProtocolString(AGENT_PROTOCOL_LIMITS.groupIdLength),
+  provisionId: agentProtocolString(AGENT_PROTOCOL_LIMITS.identifierLength),
+  providerIds: z
+    .array(AgentProviderIdSchema)
+    .max(AGENT_PROTOCOL_LIMITS.providerCount)
+    .refine((ids) => new Set(ids).size === ids.length),
 });

--- a/packages/api/src/client/content-helpers.ts
+++ b/packages/api/src/client/content-helpers.ts
@@ -23,6 +23,7 @@ import {
 import { A2UI } from './a2ui';
 import {
   AGENT_PROTOCOL_LIMITS,
+  AgentProviderConfigContextSchema,
   AgentProvisionActionContextSchema,
   agentProtocolString,
 } from './agentProtocol';
@@ -723,6 +724,17 @@ export type PostBlobDataEntryAgentProvision = z.infer<
   typeof PostBlobDataEntryAgentProvisionSchema
 >;
 
+export const PostBlobDataEntryAgentProviderConfigSchema =
+  definePostBlobDataEntrySchema(
+    'tlon-agent-provider-config',
+    1,
+    AgentProviderConfigContextSchema.shape
+  );
+
+export type PostBlobDataEntryAgentProviderConfig = z.infer<
+  typeof PostBlobDataEntryAgentProviderConfigSchema
+>;
+
 export const PostBlobDataEntryAgentProvisionAckSchema =
   definePostBlobDataEntrySchema('tlon-agent-provision-ack', 1, {
     provisionId: z.string().min(1).max(AGENT_PROTOCOL_LIMITS.identifierLength),
@@ -775,6 +787,7 @@ const postBlobDataEntryDefinitions = [
   PostBlobDataEntryContextLensSchema,
   PostBlobDataEntryAgentIntroRequestSchema,
   PostBlobDataEntryAgentProvisionSchema,
+  PostBlobDataEntryAgentProviderConfigSchema,
   PostBlobDataEntryAgentProvisionAckSchema,
   PostBlobDataEntryAgentPostMarkerSchema,
   PostBlobDataEntryA2UISelectionSchema,

--- a/packages/api/src/index.ts
+++ b/packages/api/src/index.ts
@@ -75,6 +75,7 @@ export {
   type PostBlobDataEntry,
   type PostBlobDataEntryAgentIntroRequest,
   type PostBlobDataEntryAgentProvision,
+  type PostBlobDataEntryAgentProviderConfig,
   type PostBlobDataEntryAgentProvisionAck,
   type PostBlobDataEntryAgentPostMarker,
   type PostBlobDataEntryA2UISelection,

--- a/packages/app/features/settings/BotMcpSettingsScreen.tsx
+++ b/packages/app/features/settings/BotMcpSettingsScreen.tsx
@@ -48,6 +48,7 @@ export function BotMcpSettingsScreen(props: Props) {
     string | null
   >(null);
   const handledCompletionUrls = useRef(new Set<string>());
+  const requestedProviders = useRef(new Set<string>());
   const isMounted = useRef(true);
 
   const refreshStatus = useCallback(async () => {
@@ -225,6 +226,37 @@ export function BotMcpSettingsScreen(props: Props) {
     },
     [currentUserId, disconnectingProviderId, showMcpToast, startingProviderId]
   );
+
+  useEffect(() => {
+    const providerId = props.route.params?.providerId;
+    if (!providerId || initialLoading || !status) {
+      return;
+    }
+
+    const provider = providers.find((candidate) => candidate.id === providerId);
+    if (
+      !provider ||
+      !status.available ||
+      provider.status === 'connected' ||
+      requestedProviders.current.has(providerId)
+    ) {
+      props.navigation.setParams({ providerId: undefined });
+      return;
+    }
+
+    requestedProviders.current.add(providerId);
+    props.navigation.setParams({ providerId: undefined });
+    void handleConnectProvider(providerId).finally(() => {
+      requestedProviders.current.delete(providerId);
+    });
+  }, [
+    handleConnectProvider,
+    initialLoading,
+    props.navigation,
+    props.route.params?.providerId,
+    providers,
+    status,
+  ]);
 
   const handleDisconnectProvider = useCallback(
     async (providerId: string) => {

--- a/packages/app/features/settings/BotMcpSettingsScreen.tsx
+++ b/packages/app/features/settings/BotMcpSettingsScreen.tsx
@@ -11,6 +11,7 @@ import { useHandleLogout } from '../../hooks/useHandleLogout';
 import { useResetDb } from '../../hooks/useResetDb';
 import { RootStackParamList } from '../../navigation/types';
 import { BotSettingsScreenView } from '../../ui';
+import { mcpProviderQueryKeys } from '../../lib/mcpProviders';
 import {
   GENERIC_ERROR_MESSAGE,
   MCP_TELEMETRY_EVENTS,
@@ -67,6 +68,17 @@ export function BotMcpSettingsScreen(props: Props) {
         api.getTlawnOAuthProviders(),
         api.getTlawnOAuthStatus(currentUserId),
       ]);
+      // This screen owns mutations to connector grants. Publish its
+      // authoritative refresh into the shared cache so mounted chat controls
+      // reflect changes made here when the user navigates back.
+      db.queryClient.setQueryData(
+        mcpProviderQueryKeys.providers,
+        nextProviders
+      );
+      db.queryClient.setQueryData(
+        mcpProviderQueryKeys.status(currentUserId),
+        nextStatus
+      );
       if (isMounted.current) {
         setProviderConfigs(nextProviders);
         setStatus(nextStatus);

--- a/packages/app/features/settings/bot/useBotSettingsData.ts
+++ b/packages/app/features/settings/bot/useBotSettingsData.ts
@@ -11,6 +11,7 @@ import * as db from '@tloncorp/shared/db';
 import { useCallback, useMemo } from 'react';
 
 import { useCurrentUserId } from '../../../hooks/useCurrentUser';
+import { mcpProviderQueryKeys } from '../../../lib/mcpProviders';
 import {
   BASIC_PROVIDER_ID,
   BASIC_PROVIDER_MODEL,
@@ -140,7 +141,7 @@ export function useBotSettingsQueries() {
   });
 
   const oauthStatusQuery = useQuery({
-    queryKey: ['tlonbot', 'oauth-status', ship],
+    queryKey: mcpProviderQueryKeys.status(ship),
     queryFn: () => api.getTlawnOAuthStatus(ship),
     enabled: Boolean(ship) && isFocused,
     retry: false,
@@ -159,7 +160,7 @@ export function useBotSettingsQueries() {
   });
 
   const oauthProvidersQuery = useQuery({
-    queryKey: ['tlonbot', 'oauth-providers'],
+    queryKey: mcpProviderQueryKeys.providers,
     queryFn: () => api.getTlawnOAuthProviders(),
     retry: false,
     staleTime: 5 * 60 * 1000,

--- a/packages/app/features/settings/botMcpSettingsHelpers.test.ts
+++ b/packages/app/features/settings/botMcpSettingsHelpers.test.ts
@@ -2,6 +2,10 @@ import type { TlawnOAuthProvider } from '@tloncorp/api';
 import { describe, expect, it } from 'vitest';
 import { vi } from 'vitest';
 
+import {
+  prioritizeMcpMenuProviders,
+  selectMcpMenuProviders,
+} from '../../lib/mcpProviders';
 import { buildProviderRows } from './botMcpSettingsHelpers';
 
 vi.mock('@tloncorp/shared', () => ({
@@ -38,5 +42,48 @@ describe('buildProviderRows', () => {
         status: 'not-connected',
       },
     ]);
+  });
+
+  it('puts connected providers first and keeps Gmail in the default menu', () => {
+    expect(
+      prioritizeMcpMenuProviders([
+        { displayName: 'A', id: 'a', status: 'not-connected' },
+        { displayName: 'B', id: 'b', status: 'connected' },
+        { displayName: 'Gmail', id: 'gmail', status: 'not-connected' },
+        { displayName: 'D', id: 'd', status: 'connected' },
+      ]).map((provider) => provider.id)
+    ).toEqual(['b', 'd', 'gmail', 'a']);
+  });
+
+  it('prioritizes the four common preview providers', () => {
+    expect(
+      prioritizeMcpMenuProviders([
+        { displayName: 'Linear', id: 'linear', status: 'not-connected' },
+        { displayName: 'GitHub', id: 'github', status: 'not-connected' },
+        { displayName: 'Notion', id: 'notion', status: 'not-connected' },
+        {
+          displayName: 'Google Calendar',
+          id: 'google-calendar',
+          status: 'not-connected',
+        },
+        { displayName: 'Gmail', id: 'gmail', status: 'not-connected' },
+      ]).map((provider) => provider.id)
+    ).toEqual(['gmail', 'google-calendar', 'notion', 'github', 'linear']);
+  });
+
+  it('keeps every connected provider available in the bounded menu', () => {
+    expect(
+      selectMcpMenuProviders(
+        [
+          { displayName: 'A', id: 'a', status: 'connected' },
+          { displayName: 'B', id: 'b', status: 'connected' },
+          { displayName: 'C', id: 'c', status: 'connected' },
+          { displayName: 'D', id: 'd', status: 'connected' },
+          { displayName: 'E', id: 'e', status: 'connected' },
+          { displayName: 'F', id: 'f', status: 'not-connected' },
+        ],
+        4
+      ).map((provider) => provider.id)
+    ).toEqual(['a', 'b', 'c', 'd', 'e']);
   });
 });

--- a/packages/app/features/settings/botMcpSettingsHelpers.ts
+++ b/packages/app/features/settings/botMcpSettingsHelpers.ts
@@ -1,8 +1,8 @@
-import type { TlawnOAuthGrant, TlawnOAuthProvider } from '@tloncorp/api';
 import { AnalyticsEvent, createDevLogger } from '@tloncorp/shared';
 
 import { APP_SCHEME, MCP_OAUTH_COMPLETION_PATH } from '../../constants';
-import type { BotSettingsProviderRow } from '../../ui';
+
+export { buildProviderRows } from '../../lib/mcpProviders';
 
 export const GENERIC_ERROR_MESSAGE = 'Something went wrong. Please try again.';
 export const TOAST_BOTTOM_OFFSET = 24;
@@ -20,36 +20,6 @@ type OAuthCompletion = {
 };
 
 const logger = createDevLogger('botSettings', false);
-const DISABLED_PROVIDER_IDS = new Set(['supabase']);
-
-export function buildProviderRows(
-  providers: TlawnOAuthProvider[],
-  grants: TlawnOAuthGrant[]
-): BotSettingsProviderRow[] {
-  const grantsByProvider = new Map(
-    grants.map((grant) => [grant.provider.toLowerCase(), grant])
-  );
-
-  return providers
-    .filter((provider) => !DISABLED_PROVIDER_IDS.has(provider.id.toLowerCase()))
-    .map((provider) => {
-      const grant = grantsByProvider.get(provider.id.toLowerCase()) ?? null;
-      const status =
-        grant?.connected && !grant.expired
-          ? 'connected'
-          : grant
-            ? 'expired'
-            : 'not-connected';
-
-      return {
-        displayName: provider.displayName,
-        id: provider.id,
-        logoUrl: provider.logoUrl,
-        status,
-      };
-    });
-}
-
 export function getFinalRedirectUrl() {
   return `${APP_SCHEME}://${MCP_OAUTH_COMPLETION_PATH}`;
 }

--- a/packages/app/hooks/useA2UINavigation.ts
+++ b/packages/app/hooks/useA2UINavigation.ts
@@ -114,7 +114,10 @@ export function useA2UINavigation() {
   );
 
   return useCallback(
-    async (target: A2UI.NavigationTarget) => {
+    async (
+      target: A2UI.NavigationTarget,
+      options?: { allowBotMcpSettings?: boolean }
+    ) => {
       switch (target.type) {
         case 'message':
           await navigateToMessage(target);
@@ -160,6 +163,10 @@ export function useA2UINavigation() {
         case 'screen':
           switch (target.screen) {
             case 'botMcpSettings':
+              if (!options?.allowBotMcpSettings) {
+                logger.log('blocked untrusted MCP settings target', target);
+                return;
+              }
               rootNavigation.navigateToBotMcpSettings(target.providerId);
               return;
           }

--- a/packages/app/hooks/useA2UINavigation.ts
+++ b/packages/app/hooks/useA2UINavigation.ts
@@ -157,6 +157,12 @@ export function useA2UINavigation() {
             groupId: target.groupId,
           });
           return;
+        case 'screen':
+          switch (target.screen) {
+            case 'botMcpSettings':
+              rootNavigation.navigateToBotMcpSettings(target.providerId);
+              return;
+          }
       }
     },
     [navigateToMessage, rootNavigation]

--- a/packages/app/lib/mcpProviders.ts
+++ b/packages/app/lib/mcpProviders.ts
@@ -1,0 +1,98 @@
+import type { TlawnOAuthGrant, TlawnOAuthProvider } from '@tloncorp/api';
+
+export type McpProviderStatus = 'connected' | 'expired' | 'not-connected';
+
+export interface McpProviderRow {
+  displayName: string;
+  id: string;
+  logoUrl?: string;
+  status: McpProviderStatus;
+}
+
+const DISABLED_PROVIDER_IDS = new Set(['supabase']);
+
+/** Hosting owns the provider order; the client only adds live grant status. */
+export function buildProviderRows(
+  providers: TlawnOAuthProvider[],
+  grants: TlawnOAuthGrant[]
+): McpProviderRow[] {
+  const grantsByProvider = new Map(
+    grants.map((grant) => [grant.provider.toLowerCase(), grant])
+  );
+
+  return providers
+    .filter((provider) => !DISABLED_PROVIDER_IDS.has(provider.id.toLowerCase()))
+    .map((provider) => {
+      const grant = grantsByProvider.get(provider.id.toLowerCase()) ?? null;
+      const status =
+        grant?.connected && !grant.expired
+          ? 'connected'
+          : grant
+            ? 'expired'
+            : 'not-connected';
+
+      return {
+        displayName: provider.displayName,
+        id: provider.id,
+        logoUrl: provider.logoUrl,
+        status,
+      };
+    });
+}
+
+const FEATURED_PROVIDER_ORDER = new Map(
+  ['gmail', 'google-calendar', 'notion', 'github'].map((id, index) => [
+    id,
+    index,
+  ])
+);
+
+function featuredProviderRank(provider: McpProviderRow): number {
+  const normalizedName = provider.displayName
+    .toLowerCase()
+    .replace(/\s+/g, '-');
+  return (
+    FEATURED_PROVIDER_ORDER.get(provider.id.toLowerCase()) ??
+    FEATURED_PROVIDER_ORDER.get(normalizedName) ??
+    Number.POSITIVE_INFINITY
+  );
+}
+
+/** Keep connected services and the most familiar defaults in the preview. */
+export function prioritizeMcpMenuProviders(
+  providers: McpProviderRow[]
+): McpProviderRow[] {
+  return providers
+    .map((provider, index) => ({ provider, index }))
+    .sort((left, right) => {
+      const connectedDelta =
+        Number(right.provider.status === 'connected') -
+        Number(left.provider.status === 'connected');
+      if (connectedDelta !== 0) return connectedDelta;
+
+      const featuredDelta =
+        featuredProviderRank(left.provider) -
+        featuredProviderRank(right.provider);
+      return featuredDelta || left.index - right.index;
+    })
+    .map(({ provider }) => provider);
+}
+
+/**
+ * Keep the bounded common-provider preview, but never hide a connected
+ * provider whose group-level inclusion can be toggled from this menu.
+ */
+export function selectMcpMenuProviders(
+  providers: McpProviderRow[],
+  maxVisible: number
+): McpProviderRow[] {
+  const preview = providers.slice(0, maxVisible);
+  const previewIds = new Set(preview.map((provider) => provider.id));
+  return [
+    ...preview,
+    ...providers.filter(
+      (provider) =>
+        provider.status === 'connected' && !previewIds.has(provider.id)
+    ),
+  ];
+}

--- a/packages/app/lib/mcpProviders.ts
+++ b/packages/app/lib/mcpProviders.ts
@@ -1,5 +1,10 @@
 import type { TlawnOAuthGrant, TlawnOAuthProvider } from '@tloncorp/api';
 
+export const mcpProviderQueryKeys = {
+  providers: ['tlonbot', 'oauth-providers'] as const,
+  status: (ship: string) => ['tlonbot', 'oauth-status', ship] as const,
+};
+
 export type McpProviderStatus = 'connected' | 'expired' | 'not-connected';
 
 export interface McpProviderRow {

--- a/packages/app/lib/mcpProviders.ts
+++ b/packages/app/lib/mcpProviders.ts
@@ -2,7 +2,8 @@ import type { TlawnOAuthGrant, TlawnOAuthProvider } from '@tloncorp/api';
 
 export const mcpProviderQueryKeys = {
   providers: ['tlonbot', 'oauth-providers'] as const,
-  status: (ship: string) => ['tlonbot', 'oauth-status', ship] as const,
+  status: (ship: string) =>
+    ['tlonbot', 'oauth-status', ship.replace(/^~/, '')] as const,
 };
 
 export type McpProviderStatus = 'connected' | 'expired' | 'not-connected';

--- a/packages/app/navigation/types.ts
+++ b/packages/app/navigation/types.ts
@@ -87,7 +87,7 @@ export type RootStackParamList = {
   FeatureFlags: undefined;
   ManageAccount: undefined;
   BotSettings: undefined;
-  BotMcpSettings: undefined;
+  BotMcpSettings: { providerId?: string } | undefined;
   BotModelSettings: { mode: 'default' | 'fallbacks' };
   BotApiKeySettings: { provider: string };
   BotOpenAISubscription: undefined;

--- a/packages/app/navigation/utils.ts
+++ b/packages/app/navigation/utils.ts
@@ -12,6 +12,9 @@ import * as logic from '@tloncorp/shared/logic';
 import * as store from '@tloncorp/shared/store';
 import { useGlobalSearch, useIsWindowNarrow } from '@tloncorp/ui';
 import { useCallback, useMemo } from 'react';
+import { Platform } from 'react-native';
+
+import { openExternalBotSettings } from '../utils/botSettings';
 
 import type {
   DesktopBasePathStackParamList,
@@ -498,6 +501,33 @@ export function useRootNavigation() {
     });
   }, [isWindowNarrow, navigationRef]);
 
+  const navigateToBotMcpSettings = useCallback(
+    (providerId?: string) => {
+      if (Platform.OS === 'web') {
+        openExternalBotSettings();
+        return;
+      }
+      const params = providerId ? { providerId } : undefined;
+      if (isWindowNarrow) {
+        navigationRef.current.navigate('BotMcpSettings', params);
+        return;
+      }
+
+      const navigateToNestedSettings = navigationRef.current.navigate as (
+        screen: 'Settings',
+        params: {
+          screen: 'BotMcpSettings';
+          params?: RootStackParamList['BotMcpSettings'];
+        }
+      ) => void;
+      navigateToNestedSettings('Settings', {
+        screen: 'BotMcpSettings',
+        params,
+      });
+    },
+    [isWindowNarrow, navigationRef]
+  );
+
   const resetToChannel = useResetToChannel();
   const navigateToChannel = useNavigateToChannel();
   const navigateToChatDetails = useNavigateToChatDetails();
@@ -525,6 +555,7 @@ export function useRootNavigation() {
       resetToPost,
       navigateBack,
       navigateToBotSettings,
+      navigateToBotMcpSettings,
     }),
     [
       navigation,
@@ -533,6 +564,7 @@ export function useRootNavigation() {
       navigateToChatDetails,
       navigateToChatVolume,
       navigateToBotSettings,
+      navigateToBotMcpSettings,
       navigateBackFromPost,
       navigateToGroup,
       navigateToPost,

--- a/packages/app/navigation/utils.ts
+++ b/packages/app/navigation/utils.ts
@@ -508,24 +508,9 @@ export function useRootNavigation() {
         return;
       }
       const params = providerId ? { providerId } : undefined;
-      if (isWindowNarrow) {
-        navigationRef.current.navigate('BotMcpSettings', params);
-        return;
-      }
-
-      const navigateToNestedSettings = navigationRef.current.navigate as (
-        screen: 'Settings',
-        params: {
-          screen: 'BotMcpSettings';
-          params?: RootStackParamList['BotMcpSettings'];
-        }
-      ) => void;
-      navigateToNestedSettings('Settings', {
-        screen: 'BotMcpSettings',
-        params,
-      });
+      navigationRef.current.navigate('BotMcpSettings', params);
     },
-    [isWindowNarrow, navigationRef]
+    [navigationRef]
   );
 
   const resetToChannel = useResetToChannel();

--- a/packages/app/ui/components/BotSettingsScreenView.tsx
+++ b/packages/app/ui/components/BotSettingsScreenView.tsx
@@ -10,23 +10,12 @@ import {
 import { useState } from 'react';
 import { View, XStack, YStack } from 'tamagui';
 
+import type { McpProviderRow } from '../../lib/mcpProviders';
 import { useIsWindowNarrow } from '../utils';
 import { ListItem } from './ListItem';
 import { McpProviderLogo } from './McpProviderLogo';
 import { ScreenHeader } from './ScreenHeader';
 import { SettingsContentScrollView } from './SettingsContentScrollView';
-
-export type BotSettingsProviderStatus =
-  | 'connected'
-  | 'expired'
-  | 'not-connected';
-
-export interface BotSettingsProviderRow {
-  displayName: string;
-  id: string;
-  logoUrl?: string;
-  status: BotSettingsProviderStatus;
-}
 
 interface BotSettingsScreenViewProps {
   available: boolean;
@@ -36,7 +25,7 @@ interface BotSettingsScreenViewProps {
   onConnectProvider: (providerId: string) => void;
   onDisconnectProvider: (providerId: string) => void;
   onRefresh: () => void;
-  providers: BotSettingsProviderRow[];
+  providers: McpProviderRow[];
   refreshing: boolean;
   showUnavailableNotice: boolean;
 }
@@ -149,7 +138,7 @@ function ProviderSection({
   loadingProviderId: string | null;
   onConnect: (providerId: string) => void;
   onDisconnect: (providerId: string) => void;
-  providers: BotSettingsProviderRow[];
+  providers: McpProviderRow[];
   title: string;
 }) {
   return (
@@ -184,7 +173,7 @@ function ProviderListItem({
   loading: boolean;
   onConnect: (providerId: string) => void;
   onDisconnect: (providerId: string) => void;
-  provider: BotSettingsProviderRow;
+  provider: McpProviderRow;
 }) {
   const isConnected = provider.status === 'connected';
   const canConnect = !disabled && !isConnected;

--- a/packages/app/ui/components/BotSettingsScreenView.tsx
+++ b/packages/app/ui/components/BotSettingsScreenView.tsx
@@ -8,6 +8,7 @@ import {
   triggerHaptic,
 } from '@tloncorp/ui';
 import { useState } from 'react';
+import { Platform } from 'react-native';
 import { View, XStack, YStack } from 'tamagui';
 
 import type { McpProviderRow } from '../../lib/mcpProviders';
@@ -54,7 +55,9 @@ export function BotSettingsScreenView({
     <View flex={1} backgroundColor="$background">
       <ScreenHeader
         borderBottom
-        backAction={isWindowNarrow ? onBackPressed : undefined}
+        backAction={
+          Platform.OS !== 'web' || isWindowNarrow ? onBackPressed : undefined
+        }
         loadingSubtitle={refreshing && !initialLoading ? 'Refreshing' : null}
         rightActions={[
           {

--- a/packages/app/ui/components/ChatMessage/StaticChatMessage.tsx
+++ b/packages/app/ui/components/ChatMessage/StaticChatMessage.tsx
@@ -117,7 +117,11 @@ export function StaticChatMessage({
         post.groupId ??
         draftInputContext.group?.id ??
         draftInputContext.channel.groupId;
-      if (!currentGroupId || currentGroupId !== groupId) {
+      if (currentGroupId && currentGroupId !== groupId) {
+        throw new Error('The agent group is not available');
+      }
+      const targetGroup = await db.getGroup({ id: groupId });
+      if (!targetGroup?.currentUserIsHost) {
         throw new Error('The agent group is not available');
       }
       const uniqueProviderIds = [...new Set(providerIds)];
@@ -229,8 +233,7 @@ export function StaticChatMessage({
           canUseAgentProviderControls &&
           draftInputContext &&
           draftInputContext.canStartDraft !== false &&
-          currentGroupId &&
-          action.event.context.groupId === currentGroupId
+          (!currentGroupId || action.event.context.groupId === currentGroupId)
         );
       }
 

--- a/packages/app/ui/components/ChatMessage/StaticChatMessage.tsx
+++ b/packages/app/ui/components/ChatMessage/StaticChatMessage.tsx
@@ -1,5 +1,6 @@
 import {
   appendToPostBlob,
+  getBotUserIdForUser,
   type PostBlobDataEntryA2UISelection,
 } from '@tloncorp/api';
 import { isDmChannelId } from '@tloncorp/api/client';
@@ -172,6 +173,8 @@ export function StaticChatMessage({
     [postContent]
   );
   const currentUserId = useCurrentUserId();
+  const canUseAgentProviderControls =
+    post.authorId === getBotUserIdForUser(currentUserId);
   // One live query per channel (deduped across messages); the posts-table
   // dependency re-runs it when the viewer's reply lands, including the
   // optimistic insert, so an answered control stays locked across remounts.
@@ -288,6 +291,7 @@ export function StaticChatMessage({
             )}
             areA2UISelectionsPending={a2uiSelections.isPending}
             a2uiSourcePostId={post.id}
+            canUseAgentProviderControls={canUseAgentProviderControls}
             getConsumedA2UISelection={
               canRenderA2UI ? getConsumedA2UISelection : undefined
             }

--- a/packages/app/ui/components/ChatMessage/StaticChatMessage.tsx
+++ b/packages/app/ui/components/ChatMessage/StaticChatMessage.tsx
@@ -108,12 +108,60 @@ export function StaticChatMessage({
     }
   }, [onPressRetry, post]);
 
+  const configureAgentProviders = useCallback(
+    async (groupId: string, provisionId: string, providerIds: string[]) => {
+      if (!draftInputContext || draftInputContext.canStartDraft === false) {
+        throw new Error('This channel is not ready to send messages');
+      }
+      const currentGroupId =
+        post.groupId ??
+        draftInputContext.group?.id ??
+        draftInputContext.channel.groupId;
+      if (!currentGroupId || currentGroupId !== groupId) {
+        throw new Error('The agent group is not available');
+      }
+      const uniqueProviderIds = [...new Set(providerIds)];
+      const blob = appendToPostBlob(undefined, {
+        type: 'tlon-agent-provider-config',
+        version: 1,
+        provisionId,
+        groupId,
+        providerIds: uniqueProviderIds,
+      });
+      const content = uniqueProviderIds.length
+        ? `Use ${uniqueProviderIds.join(', ')} for this group’s future entries.`
+        : 'Do not use connected services for this group’s future entries.';
+      await draftInputContext.sendPostFromDraft(
+        {
+          channelId: draftInputContext.channel.id,
+          content: [content],
+          attachments: [],
+          blob,
+          channelType: draftInputContext.channel.type,
+          replyToPostId: null,
+          isEdit: false,
+        },
+        { rejectOnDefinitiveFailure: true }
+      );
+    },
+    [draftInputContext, post.groupId]
+  );
+
   const handleA2UIAction = useCallback(
     async (action: A2UI.Action, selection?: PostBlobDataEntryA2UISelection) => {
       if (action.event.name === A2UI.action.navigate) {
         await navigateToA2UITarget(action.event.context.target, {
           allowBotMcpSettings: canUseAgentProviderControls,
         });
+        return;
+      }
+
+      if (action.event.name === A2UI.action.configureAgentProviders) {
+        await configureAgentProviders(
+          action.event.context.groupId,
+          action.event.context.provisionId,
+          action.event.context.providerIds
+        );
         return;
       }
 
@@ -145,7 +193,12 @@ export function StaticChatMessage({
         }
       );
     },
-    [canUseAgentProviderControls, draftInputContext, navigateToA2UITarget]
+    [
+      canUseAgentProviderControls,
+      configureAgentProviders,
+      draftInputContext,
+      navigateToA2UITarget,
+    ]
   );
 
   const isA2UIActionAvailable = useCallback(
@@ -167,9 +220,23 @@ export function StaticChatMessage({
         );
       }
 
+      if (action.event.name === A2UI.action.configureAgentProviders) {
+        const currentGroupId =
+          post.groupId ??
+          draftInputContext?.group?.id ??
+          draftInputContext?.channel.groupId;
+        return Boolean(
+          canUseAgentProviderControls &&
+          draftInputContext &&
+          draftInputContext.canStartDraft !== false &&
+          currentGroupId &&
+          action.event.context.groupId === currentGroupId
+        );
+      }
+
       return false;
     },
-    [canUseAgentProviderControls, draftInputContext]
+    [canUseAgentProviderControls, draftInputContext, post.groupId]
   );
 
   const canRenderA2UI = isDmChannelId(post.channelId);

--- a/packages/app/ui/components/ChatMessage/StaticChatMessage.tsx
+++ b/packages/app/ui/components/ChatMessage/StaticChatMessage.tsx
@@ -109,10 +109,7 @@ export function StaticChatMessage({
   }, [onPressRetry, post]);
 
   const handleA2UIAction = useCallback(
-    async (
-      action: A2UI.Button['action'],
-      selection?: PostBlobDataEntryA2UISelection
-    ) => {
+    async (action: A2UI.Action, selection?: PostBlobDataEntryA2UISelection) => {
       if (action.event.name === A2UI.action.navigate) {
         await navigateToA2UITarget(action.event.context.target, {
           allowBotMcpSettings: canUseAgentProviderControls,
@@ -152,7 +149,7 @@ export function StaticChatMessage({
   );
 
   const isA2UIActionAvailable = useCallback(
-    (action: A2UI.Button['action']) => {
+    (action: A2UI.Action) => {
       if (action.event.name === A2UI.action.navigate) {
         const target = action.event.context.target;
         return (

--- a/packages/app/ui/components/ChatMessage/StaticChatMessage.tsx
+++ b/packages/app/ui/components/ChatMessage/StaticChatMessage.tsx
@@ -72,6 +72,9 @@ export function StaticChatMessage({
   const isNotice = post.type === 'notice';
   const draftInputContext = useDraftInputContext();
   const navigateToA2UITarget = useA2UINavigation();
+  const currentUserId = useCurrentUserId();
+  const canUseAgentProviderControls =
+    post.authorId === getBotUserIdForUser(currentUserId);
 
   if (isNotice) {
     showAuthor = false;
@@ -111,7 +114,9 @@ export function StaticChatMessage({
       selection?: PostBlobDataEntryA2UISelection
     ) => {
       if (action.event.name === A2UI.action.navigate) {
-        await navigateToA2UITarget(action.event.context.target);
+        await navigateToA2UITarget(action.event.context.target, {
+          allowBotMcpSettings: canUseAgentProviderControls,
+        });
         return;
       }
 
@@ -143,13 +148,18 @@ export function StaticChatMessage({
         }
       );
     },
-    [draftInputContext, navigateToA2UITarget]
+    [canUseAgentProviderControls, draftInputContext, navigateToA2UITarget]
   );
 
   const isA2UIActionAvailable = useCallback(
     (action: A2UI.Button['action']) => {
       if (action.event.name === A2UI.action.navigate) {
-        return true;
+        const target = action.event.context.target;
+        return (
+          target.type !== 'screen' ||
+          target.screen !== 'botMcpSettings' ||
+          canUseAgentProviderControls
+        );
       }
 
       if (action.event.name === A2UI.action.sendMessage) {
@@ -162,7 +172,7 @@ export function StaticChatMessage({
 
       return false;
     },
-    [draftInputContext]
+    [canUseAgentProviderControls, draftInputContext]
   );
 
   const canRenderA2UI = isDmChannelId(post.channelId);
@@ -172,9 +182,6 @@ export function StaticChatMessage({
     () => postContent.some((block) => block.type === 'a2ui'),
     [postContent]
   );
-  const currentUserId = useCurrentUserId();
-  const canUseAgentProviderControls =
-    post.authorId === getBotUserIdForUser(currentUserId);
   // One live query per channel (deduped across messages); the posts-table
   // dependency re-runs it when the viewer's reply lands, including the
   // optimistic insert, so an answered control stays locked across remounts.

--- a/packages/app/ui/components/McpProviderLogo.tsx
+++ b/packages/app/ui/components/McpProviderLogo.tsx
@@ -45,21 +45,26 @@ export function McpProviderLogo({
   displayName,
   logoUrl,
   providerId,
+  compact = false,
 }: {
+  compact?: boolean;
   displayName: string;
   logoUrl?: string;
   providerId: string;
 }) {
+  const logoSize = compact ? 20 : LOGO_SIZE;
+  const hostingLogoSize = compact ? 32 : HOSTING_LOGO_SIZE;
+  const containerSize = compact ? 32 : '$4xl';
   const SvgLogo = svgLogos[providerId];
   const imageLogo = imageLogos[providerId];
   const fallbackLogo = SvgLogo ? (
-    <SvgLogo height={LOGO_SIZE} width={LOGO_SIZE} />
+    <SvgLogo height={logoSize} width={logoSize} />
   ) : imageLogo ? (
     <Image
       fallback={null}
-      height={LOGO_SIZE}
+      height={logoSize}
       source={imageLogo.source}
-      width={LOGO_SIZE}
+      width={logoSize}
       contentFit="contain"
     />
   ) : (
@@ -75,17 +80,17 @@ export function McpProviderLogo({
       borderColor="$border"
       borderRadius="$s"
       borderWidth={1}
-      height="$4xl"
+      height={containerSize}
       justifyContent="center"
       overflow="hidden"
-      width="$4xl"
+      width={containerSize}
     >
       {logoUrl ? (
         <Image
           fallback={fallbackLogo}
-          height={HOSTING_LOGO_SIZE}
+          height={hostingLogoSize}
           source={logoUrl}
-          width={HOSTING_LOGO_SIZE}
+          width={hostingLogoSize}
           contentFit="contain"
         />
       ) : (

--- a/packages/app/ui/components/PostContent/A2UIBlock.tsx
+++ b/packages/app/ui/components/PostContent/A2UIBlock.tsx
@@ -17,6 +17,7 @@ import { View, XStack, YStack, isWeb } from 'tamagui';
 import { ActionSheet } from '../ActionSheet';
 import { TextInput } from '../Form';
 import { A2UIMenuRow } from './A2UIMenuRow';
+import { McpConnectControl } from './McpConnectControl';
 import { useContentContext } from './contentUtils';
 
 type RenderOptions = {
@@ -691,6 +692,8 @@ function getComponentText(
       // Text extraction feeds previews and labels: the option titles are the
       // meaningful summary of a choice group.
       return component.options.map((option) => option.label).join(', ');
+    case 'McpConnect':
+      return component.seeAllLabel;
     case 'Divider':
       return '';
   }
@@ -1230,6 +1233,43 @@ export function A2UIBlock({
             </YStack>
           );
         }
+        case 'McpConnect':
+          return (
+            <YStack
+              key={component.id}
+              width="100%"
+              marginTop={CHOICE_CONTROL_OUTER_MARGIN}
+            >
+              <McpConnectControl
+                component={component}
+                completionConsumed={Boolean(
+                  component.completionAction &&
+                  getConsumedA2UISelection?.(surfaceId, component.id)
+                )}
+                completionSelection={
+                  component.completionAction
+                    ? buildActionSelection(
+                        surfaceId,
+                        component.id,
+                        component.completionAction
+                      )
+                    : undefined
+                }
+                onConfigure={
+                  isA2UIActionAvailable?.(component.configureAction) === false
+                    ? undefined
+                    : onA2UIAction
+                }
+                onComplete={
+                  component.completionAction &&
+                  isA2UIActionAvailable?.(component.completionAction) !== false
+                    ? onA2UIAction
+                    : undefined
+                }
+                onNavigate={onA2UIAction}
+              />
+            </YStack>
+          );
       }
     },
     [

--- a/packages/app/ui/components/PostContent/A2UIBlock.tsx
+++ b/packages/app/ui/components/PostContent/A2UIBlock.tsx
@@ -684,6 +684,7 @@ export function A2UIBlock({
     a2uiSourcePostId,
     areA2UISelectionsPending,
     canSendA2UIResponse,
+    canUseAgentProviderControls,
     getConsumedA2UISelection,
     isA2UIActionAvailable,
     onA2UIAction,
@@ -1211,6 +1212,7 @@ export function A2UIBlock({
           );
         }
         case 'McpConnect':
+          if (!canUseAgentProviderControls) return null;
           return (
             <YStack
               key={component.id}
@@ -1226,6 +1228,7 @@ export function A2UIBlock({
                 completionSelection={
                   component.completionAction
                     ? buildActionSelection(
+                        a2uiSourcePostId,
                         surfaceId,
                         component.id,
                         component.completionAction

--- a/packages/app/ui/components/PostContent/A2UIBlock.tsx
+++ b/packages/app/ui/components/PostContent/A2UIBlock.tsx
@@ -19,6 +19,7 @@ import { TextInput } from '../Form';
 import { A2UIMenuRow } from './A2UIMenuRow';
 import { McpConnectControl } from './McpConnectControl';
 import { useContentContext } from './contentUtils';
+import { useOneShotAction } from './useOneShotAction';
 
 type RenderOptions = {
   cardDepth?: number;
@@ -183,33 +184,11 @@ function SmallChoiceControl({
   const [customTopics, setCustomTopics] = useState<string[]>([]);
   const [customDraft, setCustomDraft] = useState('');
   const [customInputOpen, setCustomInputOpen] = useState(false);
-  // Lock the whole picker synchronously when submit starts. React state alone
-  // leaves a brief window before re-render where a pill can still be toggled.
-  // Keep the lock after success; only release it when the send fails.
-  const [submitted, setSubmitted] = useState(false);
-  const [consumedLocally, setConsumedLocally] = useState(false);
-  const submittingRef = useRef(false);
-  const durableSelectionObservedRef = useRef(false);
-
-  useEffect(() => {
-    if (consumedSelection) {
-      durableSelectionObservedRef.current = true;
-      return;
-    }
-    if (!durableSelectionObservedRef.current) return;
-
-    // A successful reply was later deleted (or a failed optimistic row was
-    // removed). Release the local lock so the durable timeline is once again
-    // the source of truth and the owner can answer this control again.
-    durableSelectionObservedRef.current = false;
-    submittingRef.current = false;
-    setSubmitted(false);
-    setConsumedLocally(false);
-  }, [consumedSelection]);
+  const oneShot = useOneShotAction(Boolean(consumedSelection));
 
   const toggle = useCallback(
     (id: string) => {
-      if (submittingRef.current) {
+      if (oneShot.isLocked()) {
         return;
       }
       setSelectedIds((previous) => {
@@ -225,7 +204,7 @@ function SmallChoiceControl({
         return [...previous, id];
       });
     },
-    [customTopics.length]
+    [customTopics.length, oneShot]
   );
 
   const messageForSelection = useMemo(
@@ -268,47 +247,36 @@ function SmallChoiceControl({
     : Boolean(messageForSelection);
 
   const handleSubmit = useCallback(async () => {
-    if (!hasValidSelection || submittingRef.current) {
+    if (!hasValidSelection || oneShot.isLocked()) {
       return;
     }
-    // Disable first so a double tap can't send twice, but put it back if
-    // the send fails: the picker is the only way to answer the setup, and
-    // a card disabled over a message that never posted leaves the owner
-    // looking at their own selection with nothing to do about it.
-    submittingRef.current = true;
-    setSubmitted(true);
-    try {
-      await onSubmit(actionForSelection, {
+    await oneShot.run(() =>
+      onSubmit(actionForSelection, {
         type: 'tlon-a2ui-selection',
         version: 1,
         sourcePostId,
         surfaceId,
         componentId: component.id,
         values: valuesForSelection,
-      });
-      setConsumedLocally(true);
-    } catch {
-      // The transport reports failures elsewhere; this surface only needs to
-      // become available again so the owner can retry.
-      submittingRef.current = false;
-      setSubmitted(false);
-    }
+      })
+    );
   }, [
     actionForSelection,
     component.id,
     hasValidSelection,
     onSubmit,
+    oneShot,
     sourcePostId,
     surfaceId,
     valuesForSelection,
   ]);
 
-  const completed = consumedLocally || Boolean(consumedSelection);
-  const disabled = submitted || completed || !canSend;
+  const completed = oneShot.consumed;
+  const disabled = oneShot.pending || completed || !canSend;
   const submitDisabled = disabled || !hasValidSelection;
   const customChoiceLabel =
     component.freeTextPlaceholder?.replace(/…+$/, '') || '';
-  const completedTopics = consumedLocally
+  const completedTopics = oneShot.consumedLocally
     ? valuesForSelection
     : (consumedSelection?.values ?? []);
   const completedOptionLabels = new Set(
@@ -326,15 +294,15 @@ function SmallChoiceControl({
   const hasSelection = hasValidSelection;
 
   const openCustomInput = useCallback(() => {
-    if (submittingRef.current) {
+    if (oneShot.isLocked()) {
       return;
     }
     setCustomDraft('');
     setCustomInputOpen(true);
-  }, []);
+  }, [oneShot]);
 
   const saveCustomInput = useCallback(() => {
-    if (submittingRef.current) {
+    if (oneShot.isLocked()) {
       return;
     }
     const topic = customDraft.trim();
@@ -368,16 +336,25 @@ function SmallChoiceControl({
       });
     }
     setCustomInputOpen(false);
-  }, [component.options, customDraft, customTopics.length, selectedIds.length]);
+  }, [
+    component.options,
+    customDraft,
+    customTopics.length,
+    oneShot,
+    selectedIds.length,
+  ]);
 
-  const removeCustomTopic = useCallback((topic: string) => {
-    if (submittingRef.current) {
-      return;
-    }
-    setCustomTopics((previous) =>
-      previous.filter((existing) => existing !== topic)
-    );
-  }, []);
+  const removeCustomTopic = useCallback(
+    (topic: string) => {
+      if (oneShot.isLocked()) {
+        return;
+      }
+      setCustomTopics((previous) =>
+        previous.filter((existing) => existing !== topic)
+      );
+    },
+    [oneShot]
+  );
 
   return (
     <>

--- a/packages/app/ui/components/PostContent/A2UIBlock.tsx
+++ b/packages/app/ui/components/PostContent/A2UIBlock.tsx
@@ -1221,6 +1221,7 @@ export function A2UIBlock({
             >
               <McpConnectControl
                 component={component}
+                selectionsPending={areA2UISelectionsPending}
                 completionConsumed={Boolean(
                   component.completionAction &&
                   getConsumedA2UISelection?.(surfaceId, component.id)

--- a/packages/app/ui/components/PostContent/ContentRenderer.tsx
+++ b/packages/app/ui/components/PostContent/ContentRenderer.tsx
@@ -68,6 +68,7 @@ function ContentRenderer({
   canSendA2UIResponse,
   areA2UISelectionsPending,
   a2uiSourcePostId,
+  canUseAgentProviderControls,
   getConsumedA2UISelection,
   isNotice,
   searchQuery,
@@ -88,6 +89,7 @@ function ContentRenderer({
       canSendA2UIResponse={canSendA2UIResponse}
       areA2UISelectionsPending={areA2UISelectionsPending}
       a2uiSourcePostId={a2uiSourcePostId}
+      canUseAgentProviderControls={canUseAgentProviderControls}
       getConsumedA2UISelection={getConsumedA2UISelection}
       isNotice={isNotice}
       searchQuery={searchQuery}

--- a/packages/app/ui/components/PostContent/McpConnectControl.tsx
+++ b/packages/app/ui/components/PostContent/McpConnectControl.tsx
@@ -4,7 +4,7 @@ import * as api from '@tloncorp/api';
 import { A2UI } from '@tloncorp/shared/logic';
 import { Icon, LoadingSpinner } from '@tloncorp/ui';
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
-import { XStack, YStack, isWeb } from 'tamagui';
+import { XStack, YStack } from 'tamagui';
 
 import { useCurrentUserId } from '../../../hooks/useCurrentUser';
 import {
@@ -19,7 +19,10 @@ import { useOneShotAction } from './useOneShotAction';
 
 const MAX_PROVIDER_SELECTIONS = api.AGENT_PROTOCOL_LIMITS.providerCount;
 const pendingProviderSelections = new Map<string, string[]>();
-const pendingProviderAuthorizations = new Map<string, string>();
+const pendingProviderAuthorizations = new Map<
+  string,
+  { providerId: string; leftSurface: boolean; returned: boolean }
+>();
 const clampProviderIds = (providerIds: string[]) =>
   providerIds.slice(0, MAX_PROVIDER_SELECTIONS);
 
@@ -50,6 +53,9 @@ export function McpConnectControl({
     queryKey: ['tlonbot', 'oauth-providers'],
     queryFn: () => api.getTlawnOAuthProviders(),
     staleTime: 5 * 60 * 1000,
+    // React Query owns the single app/window focus listener. Historical cards
+    // share this cache instead of each installing its own refresh listeners.
+    refetchOnWindowFocus: 'always',
     retry: false,
   });
   const statusQuery = useQuery({
@@ -57,35 +63,16 @@ export function McpConnectControl({
     queryFn: () => api.getTlawnOAuthStatus(currentUserId),
     enabled: Boolean(currentUserId),
     staleTime: 30 * 1000,
+    refetchOnWindowFocus: 'always',
     retry: false,
   });
 
-  const refreshProviders = useCallback(() => {
-    void providersQuery.refetch();
-    if (currentUserId) void statusQuery.refetch();
+  const refreshProviders = useCallback(async () => {
+    await Promise.all([
+      providersQuery.refetch(),
+      currentUserId ? statusQuery.refetch() : Promise.resolve(),
+    ]);
   }, [currentUserId, providersQuery.refetch, statusQuery.refetch]);
-
-  useFocusEffect(
-    useCallback(() => {
-      // OAuth leaves and re-enters the channel. Refresh the shared cache when
-      // it regains focus so every historical connector control sees the grant.
-      refreshProviders();
-    }, [refreshProviders])
-  );
-
-  useEffect(() => {
-    if (!isWeb) return;
-    const handleFocus = () => refreshProviders();
-    const handleVisibility = () => {
-      if (document.visibilityState === 'visible') refreshProviders();
-    };
-    window.addEventListener('focus', handleFocus);
-    document.addEventListener('visibilitychange', handleVisibility);
-    return () => {
-      window.removeEventListener('focus', handleFocus);
-      document.removeEventListener('visibilitychange', handleVisibility);
-    };
-  }, [refreshProviders]);
 
   const providers = useMemo(
     () =>
@@ -117,6 +104,7 @@ export function McpConnectControl({
       onConfigure={onConfigure}
       onComplete={onComplete}
       onNavigate={onNavigate}
+      onRefreshProviders={refreshProviders}
       providers={providers}
     />
   );
@@ -132,6 +120,7 @@ export function McpConnectMenu({
   onConfigure,
   onComplete,
   onNavigate,
+  onRefreshProviders,
   providers,
 }: {
   component: A2UI.McpConnect;
@@ -148,6 +137,7 @@ export function McpConnectMenu({
     selection?: api.PostBlobDataEntryA2UISelection
   ) => void | Promise<void>;
   onNavigate?: (action: A2UI.NavigateAction) => void | Promise<void>;
+  onRefreshProviders?: () => Promise<void>;
   providers: McpProviderRow[];
 }) {
   const selectionKey = `${component.configureAction.event.context.groupId}\u0000${component.configureAction.event.context.provisionId}\u0000${component.id}`;
@@ -155,6 +145,8 @@ export function McpConnectMenu({
     () => pendingProviderSelections.get(selectionKey) ?? []
   );
   const [submitting, setSubmitting] = useState(false);
+  const [authorizationReturnVersion, setAuthorizationReturnVersion] =
+    useState(0);
   const configuringRef = useRef(false);
   const initializedRef = useRef(false);
   const knownConnectedRef = useRef(new Set<string>());
@@ -165,6 +157,28 @@ export function McpConnectMenu({
         .filter((provider) => provider.status === 'connected')
         .map((provider) => provider.id),
     [providers]
+  );
+
+  useFocusEffect(
+    useCallback(() => {
+      const pending = pendingProviderAuthorizations.get(selectionKey);
+      if (pending?.leftSurface) {
+        const refresh = onRefreshProviders?.() ?? Promise.resolve();
+        const finishRoundTrip = () => {
+          const current = pendingProviderAuthorizations.get(selectionKey);
+          if (current === pending) {
+            current.returned = true;
+            setAuthorizationReturnVersion((version) => version + 1);
+          }
+        };
+        void refresh.then(finishRoundTrip, finishRoundTrip);
+      }
+
+      return () => {
+        const current = pendingProviderAuthorizations.get(selectionKey);
+        if (current) current.leftSurface = true;
+      };
+    }, [onRefreshProviders, selectionKey])
   );
 
   useEffect(() => {
@@ -183,9 +197,15 @@ export function McpConnectMenu({
     const pendingAuthorization =
       pendingProviderAuthorizations.get(selectionKey);
     const newlyConnected = connectedProviderIds.filter(
-      (id) => id === pendingAuthorization && !knownConnectedRef.current.has(id)
+      (id) =>
+        pendingAuthorization?.returned === true &&
+        id === pendingAuthorization.providerId &&
+        !knownConnectedRef.current.has(id)
     );
-    if (newlyConnected.length > 0) {
+    if (pendingAuthorization?.returned) {
+      // A returned OAuth round trip owns exactly one refresh. Clear the marker
+      // whether it connected, failed, or was canceled so a later settings
+      // change cannot be mistaken for this control's authorization.
       pendingProviderAuthorizations.delete(selectionKey);
     }
     knownConnectedRef.current = connected;
@@ -201,7 +221,13 @@ export function McpConnectMenu({
         ? current
         : next;
     });
-  }, [connectedProviderIds, loading, providersLoaded, selectionKey]);
+  }, [
+    authorizationReturnVersion,
+    connectedProviderIds,
+    loading,
+    providersLoaded,
+    selectionKey,
+  ]);
 
   useEffect(() => {
     pendingProviderSelections.set(selectionKey, selectedProviderIds);
@@ -293,7 +319,11 @@ export function McpConnectMenu({
       const target = component.action.event.context.target;
       if (target.type !== 'screen') return;
       if (providerId) {
-        pendingProviderAuthorizations.set(selectionKey, providerId);
+        pendingProviderAuthorizations.set(selectionKey, {
+          providerId,
+          leftSurface: false,
+          returned: false,
+        });
       } else {
         pendingProviderAuthorizations.delete(selectionKey);
       }

--- a/packages/app/ui/components/PostContent/McpConnectControl.tsx
+++ b/packages/app/ui/components/PostContent/McpConnectControl.tsx
@@ -23,7 +23,12 @@ const MAX_PROVIDER_SELECTIONS = api.AGENT_PROTOCOL_LIMITS.providerCount;
 const pendingProviderSelections = new Map<string, string[]>();
 const pendingProviderAuthorizations = new Map<
   string,
-  { providerId: string; leftSurface: boolean; returned: boolean }
+  {
+    providerId: string;
+    leftSurface: boolean;
+    refreshing: boolean;
+    returned: boolean;
+  }
 >();
 const clampProviderIds = (providerIds: string[]) =>
   providerIds.slice(0, MAX_PROVIDER_SELECTIONS);
@@ -156,11 +161,13 @@ export function McpConnectMenu({
   const [submitting, setSubmitting] = useState(false);
   const [authorizationReturnVersion, setAuthorizationReturnVersion] =
     useState(0);
+  const authorizationIsReconciling = () => {
+    const pending = pendingProviderAuthorizations.get(selectionKey);
+    return pending?.refreshing === true || pending?.returned === true;
+  };
   const [authorizationRefreshPending, setAuthorizationRefreshPending] =
-    useState(() => pendingProviderAuthorizations.has(selectionKey));
-  const authorizationRefreshPendingRef = useRef(
-    pendingProviderAuthorizations.has(selectionKey)
-  );
+    useState(authorizationIsReconciling);
+  const authorizationRefreshPendingRef = useRef(authorizationIsReconciling());
   const configuringRef = useRef(false);
   const initializedRef = useRef(false);
   const completionAction = useOneShotAction(completionConsumed);
@@ -183,6 +190,7 @@ export function McpConnectMenu({
     // Claim this return before refreshing so a focus + visibility pair cannot
     // start duplicate refreshes for the same browser round trip.
     pending.leftSurface = false;
+    pending.refreshing = true;
     authorizationRefreshPendingRef.current = true;
     setAuthorizationRefreshPending(true);
     const refresh = onRefreshProviders?.() ?? Promise.resolve(true);
@@ -191,6 +199,7 @@ export function McpConnectMenu({
       if (current === pending) {
         if (!succeeded) {
           current.leftSurface = true;
+          current.refreshing = false;
           authorizationRefreshPendingRef.current = false;
           setAuthorizationRefreshPending(false);
           return;
@@ -406,6 +415,7 @@ export function McpConnectMenu({
         pendingProviderAuthorizations.set(selectionKey, {
           providerId,
           leftSurface: false,
+          refreshing: false,
           returned: false,
         });
       } else {

--- a/packages/app/ui/components/PostContent/McpConnectControl.tsx
+++ b/packages/app/ui/components/PostContent/McpConnectControl.tsx
@@ -241,6 +241,10 @@ export function McpConnectMenu({
           },
         },
       });
+    } catch {
+      // The post transport records the failure and the control below is
+      // released for retry. Consume the rejected callback so a failed send
+      // does not also reach the platform's unhandled-rejection handler.
     } finally {
       configuringRef.current = false;
       setSubmitting(false);

--- a/packages/app/ui/components/PostContent/McpConnectControl.tsx
+++ b/packages/app/ui/components/PostContent/McpConnectControl.tsx
@@ -151,7 +151,6 @@ export function McpConnectMenu({
     useState(0);
   const configuringRef = useRef(false);
   const initializedRef = useRef(false);
-  const knownConnectedRef = useRef(new Set<string>());
   const completionAction = useOneShotAction(completionConsumed);
   const connectedProviderIds = useMemo(
     () =>
@@ -214,7 +213,6 @@ export function McpConnectMenu({
     if (!initializedRef.current) {
       if (loading || !providersLoaded) return;
       initializedRef.current = true;
-      knownConnectedRef.current = connected;
       setSelectedProviderIds(clampProviderIds(connectedProviderIds));
       return;
     }
@@ -224,19 +222,19 @@ export function McpConnectMenu({
     // settings or another group must not silently change this group's config.
     const pendingAuthorization =
       pendingProviderAuthorizations.get(selectionKey);
-    const newlyConnected = connectedProviderIds.filter(
-      (id) =>
-        pendingAuthorization?.returned === true &&
-        id === pendingAuthorization.providerId &&
-        !knownConnectedRef.current.has(id)
-    );
+    const authorizedProviderId = pendingAuthorization?.providerId;
+    const newlyConnected =
+      pendingAuthorization?.returned === true &&
+      authorizedProviderId !== undefined &&
+      connected.has(authorizedProviderId)
+        ? [authorizedProviderId]
+        : [];
     if (pendingAuthorization?.returned) {
       // A returned OAuth round trip owns exactly one refresh. Clear the marker
       // whether it connected, failed, or was canceled so a later settings
       // change cannot be mistaken for this control's authorization.
       pendingProviderAuthorizations.delete(selectionKey);
     }
-    knownConnectedRef.current = connected;
     setSelectedProviderIds((current) => {
       const next = clampProviderIds([
         ...new Set([

--- a/packages/app/ui/components/PostContent/McpConnectControl.tsx
+++ b/packages/app/ui/components/PostContent/McpConnectControl.tsx
@@ -101,7 +101,9 @@ export function McpConnectControl({
 
   const hasProviderData = providersQuery.data !== undefined;
   const hasStatusData = statusQuery.data !== undefined;
-  const failed = providersQuery.isError || statusQuery.isError;
+  const failed =
+    (providersQuery.isError && !hasProviderData) ||
+    (statusQuery.isError && !hasStatusData);
 
   return (
     <McpConnectMenu
@@ -208,7 +210,8 @@ export function McpConnectMenu({
     [component.maxVisible, providers]
   );
   const showSeeAll = providers.length > visibleProviders.length;
-  const completionLocked = completionAction.consumed;
+  const completionLocked =
+    completionAction.consumed || completionAction.pending;
 
   const toggleProvider = useCallback(
     (providerId: string) => {

--- a/packages/app/ui/components/PostContent/McpConnectControl.tsx
+++ b/packages/app/ui/components/PostContent/McpConnectControl.tsx
@@ -19,6 +19,7 @@ import { useOneShotAction } from './useOneShotAction';
 
 const MAX_PROVIDER_SELECTIONS = api.AGENT_PROTOCOL_LIMITS.providerCount;
 const pendingProviderSelections = new Map<string, string[]>();
+const pendingProviderAuthorizations = new Map<string, string>();
 const clampProviderIds = (providerIds: string[]) =>
   providerIds.slice(0, MAX_PROVIDER_SELECTIONS);
 
@@ -176,12 +177,17 @@ export function McpConnectMenu({
       return;
     }
 
-    // A provider that became connected while this surface was open was just
-    // authorized from this menu. Include it without making the owner tap the
-    // same row a second time after returning from OAuth.
+    // Shared OAuth queries update every historical control. Auto-select only
+    // the provider whose setup this exact surface initiated; a grant made in
+    // settings or another group must not silently change this group's config.
+    const pendingAuthorization =
+      pendingProviderAuthorizations.get(selectionKey);
     const newlyConnected = connectedProviderIds.filter(
-      (id) => !knownConnectedRef.current.has(id)
+      (id) => id === pendingAuthorization && !knownConnectedRef.current.has(id)
     );
+    if (newlyConnected.length > 0) {
+      pendingProviderAuthorizations.delete(selectionKey);
+    }
     knownConnectedRef.current = connected;
     setSelectedProviderIds((current) => {
       const next = clampProviderIds([
@@ -195,14 +201,17 @@ export function McpConnectMenu({
         ? current
         : next;
     });
-  }, [connectedProviderIds, loading, providersLoaded]);
+  }, [connectedProviderIds, loading, providersLoaded, selectionKey]);
 
   useEffect(() => {
     pendingProviderSelections.set(selectionKey, selectedProviderIds);
   }, [selectedProviderIds, selectionKey]);
 
   useEffect(() => {
-    if (completionConsumed) pendingProviderSelections.delete(selectionKey);
+    if (completionConsumed) {
+      pendingProviderSelections.delete(selectionKey);
+      pendingProviderAuthorizations.delete(selectionKey);
+    }
   }, [completionConsumed, selectionKey]);
 
   const visibleProviders = useMemo(
@@ -283,6 +292,11 @@ export function McpConnectMenu({
       if (!onNavigate) return;
       const target = component.action.event.context.target;
       if (target.type !== 'screen') return;
+      if (providerId) {
+        pendingProviderAuthorizations.set(selectionKey, providerId);
+      } else {
+        pendingProviderAuthorizations.delete(selectionKey);
+      }
       void onNavigate({
         event: {
           ...component.action.event,
@@ -295,7 +309,7 @@ export function McpConnectMenu({
         },
       });
     },
-    [component.action.event, onNavigate]
+    [component.action.event, onNavigate, selectionKey]
   );
 
   return (

--- a/packages/app/ui/components/PostContent/McpConnectControl.tsx
+++ b/packages/app/ui/components/PostContent/McpConnectControl.tsx
@@ -225,6 +225,7 @@ export function McpConnectMenu({
   const showSeeAll = providers.length > visibleProviders.length;
 
   const toggleProvider = useCallback((providerId: string) => {
+    if (configuringRef.current || completingRef.current) return;
     setSelectedProviderIds((current) => {
       if (current.includes(providerId)) {
         return current.filter((id) => id !== providerId);
@@ -342,18 +343,21 @@ export function McpConnectMenu({
               const connected = provider.status === 'connected';
               const selected = selectedProviderIds.includes(provider.id);
               const enabled = connected
-                ? Boolean(onConfigure)
+                ? Boolean(onConfigure) && !submitting
                 : Boolean(onNavigate);
+              const disabled = connected
+                ? !onConfigure || submitting
+                : !onNavigate;
               return (
                 <A2UIMenuRow
                   key={provider.id}
                   testID={`A2UIMcpConnect-${provider.id}`}
                   accessibilityLabel={provider.displayName}
                   accessibilityState={{
-                    disabled: connected ? !onConfigure : !onNavigate,
+                    disabled,
                     selected,
                   }}
-                  disabled={connected ? !onConfigure : !onNavigate}
+                  disabled={disabled}
                   onPress={
                     connected
                       ? () => toggleProvider(provider.id)

--- a/packages/app/ui/components/PostContent/McpConnectControl.tsx
+++ b/packages/app/ui/components/PostContent/McpConnectControl.tsx
@@ -346,7 +346,13 @@ export function McpConnectMenu({
 
   const navigate = useCallback(
     (providerId?: string) => {
-      if (!onNavigate) return;
+      if (
+        !onNavigate ||
+        configuringRef.current ||
+        completionAction.isLocked()
+      ) {
+        return;
+      }
       const target = component.action.event.context.target;
       if (target.type !== 'screen') return;
       if (providerId) {
@@ -370,7 +376,7 @@ export function McpConnectMenu({
         },
       });
     },
-    [component.action.event, onNavigate, selectionKey]
+    [completionAction, component.action.event, onNavigate, selectionKey]
   );
 
   return (
@@ -399,7 +405,7 @@ export function McpConnectMenu({
           </XStack>
         ) : failed || visibleProviders.length === 0 ? (
           <ProviderFallbackRow
-            disabled={!onNavigate || completionLocked}
+            disabled={!onNavigate || submitting || completionLocked}
             onPress={() => navigate()}
           />
         ) : (
@@ -409,10 +415,10 @@ export function McpConnectMenu({
               const selected = selectedProviderIds.includes(provider.id);
               const enabled = connected
                 ? Boolean(onConfigure) && !submitting && !completionLocked
-                : Boolean(onNavigate) && !completionLocked;
+                : Boolean(onNavigate) && !submitting && !completionLocked;
               const disabled = connected
                 ? !onConfigure || submitting || completionLocked
-                : !onNavigate || completionLocked;
+                : !onNavigate || submitting || completionLocked;
               return (
                 <A2UIMenuRow
                   key={provider.id}
@@ -466,9 +472,9 @@ export function McpConnectMenu({
               <A2UIMenuRow
                 testID="A2UIMcpConnectSeeAll"
                 accessibilityLabel={component.seeAllLabel}
-                disabled={!onNavigate || completionLocked}
+                disabled={!onNavigate || submitting || completionLocked}
                 onPress={() => navigate()}
-                dimmed={!onNavigate || completionLocked}
+                dimmed={!onNavigate || submitting || completionLocked}
                 label={component.seeAllLabel}
                 trailing={
                   <Icon

--- a/packages/app/ui/components/PostContent/McpConnectControl.tsx
+++ b/packages/app/ui/components/PostContent/McpConnectControl.tsx
@@ -1,0 +1,507 @@
+import { useFocusEffect } from '@react-navigation/native';
+import * as api from '@tloncorp/api';
+import { A2UI } from '@tloncorp/shared/logic';
+import { Icon, LoadingSpinner } from '@tloncorp/ui';
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import { XStack, YStack } from 'tamagui';
+
+import { useCurrentUserId } from '../../../hooks/useCurrentUser';
+import {
+  type McpProviderRow,
+  buildProviderRows,
+  prioritizeMcpMenuProviders,
+  selectMcpMenuProviders,
+} from '../../../lib/mcpProviders';
+import { McpProviderLogo } from '../McpProviderLogo';
+import { A2UIMenuRow } from './A2UIMenuRow';
+
+type McpProviderSnapshot = {
+  providers: api.TlawnOAuthProvider[];
+  status: api.TlawnOAuthStatus;
+};
+
+// Channel screens are normally popped when the owner leaves them, so local
+// component state cannot preserve this historical row's height. Keep the last
+// successful Hosting snapshot for each account and refresh it in place.
+const providerSnapshots = new Map<string, McpProviderSnapshot>();
+const MAX_PROVIDER_SELECTIONS = api.AGENT_PROTOCOL_LIMITS.providerCount;
+const clampProviderIds = (providerIds: string[]) =>
+  providerIds.slice(0, MAX_PROVIDER_SELECTIONS);
+
+export function McpConnectControl({
+  component,
+  completionConsumed,
+  completionSelection,
+  onConfigure,
+  onComplete,
+  onNavigate,
+}: {
+  component: A2UI.McpConnect;
+  /** True when a durable post already answered the completion action. */
+  completionConsumed?: boolean;
+  /** Durable record to attach to the post the completion action creates. */
+  completionSelection?: api.PostBlobDataEntryA2UISelection;
+  onConfigure?: (
+    action: A2UI.ConfigureAgentProvidersAction
+  ) => void | Promise<void>;
+  onComplete?: (
+    action: A2UI.SendMessageAction,
+    selection?: api.PostBlobDataEntryA2UISelection
+  ) => void | Promise<void>;
+  onNavigate?: (action: A2UI.NavigateAction) => void | Promise<void>;
+}) {
+  const currentUserId = useCurrentUserId();
+  const initialSnapshot = currentUserId
+    ? providerSnapshots.get(currentUserId)
+    : undefined;
+  const [loading, setLoading] = useState(!initialSnapshot);
+  const [failed, setFailed] = useState(false);
+  const [providerConfigs, setProviderConfigs] = useState<
+    api.TlawnOAuthProvider[]
+  >(initialSnapshot?.providers ?? []);
+  const [status, setStatus] = useState<api.TlawnOAuthStatus | null>(
+    initialSnapshot?.status ?? null
+  );
+  const loadedUserIdRef = useRef<string | null>(
+    initialSnapshot ? currentUserId : null
+  );
+
+  useFocusEffect(
+    useCallback(() => {
+      let active = true;
+
+      async function loadProviders() {
+        if (!currentUserId) {
+          if (active) {
+            setFailed(true);
+            setLoading(false);
+          }
+          return;
+        }
+
+        // Keep the existing rows mounted while refreshing after navigation.
+        // Replacing a full menu with a one-row spinner changes the historical
+        // message height and makes the conversation jump on every refocus.
+        const isInitialLoad = loadedUserIdRef.current !== currentUserId;
+        if (isInitialLoad) {
+          setLoading(true);
+        }
+        setFailed(false);
+        try {
+          const [nextProviders, nextStatus] = await Promise.all([
+            api.getTlawnOAuthProviders(),
+            api.getTlawnOAuthStatus(currentUserId),
+          ]);
+          if (active) {
+            providerSnapshots.set(currentUserId, {
+              providers: nextProviders,
+              status: nextStatus,
+            });
+            setProviderConfigs(nextProviders);
+            setStatus(nextStatus);
+            loadedUserIdRef.current = currentUserId;
+          }
+        } catch {
+          if (active && isInitialLoad) {
+            setFailed(true);
+          }
+        } finally {
+          if (active) {
+            setLoading(false);
+          }
+        }
+      }
+
+      void loadProviders();
+      return () => {
+        active = false;
+      };
+    }, [currentUserId])
+  );
+
+  const providers = useMemo(
+    () =>
+      prioritizeMcpMenuProviders(
+        buildProviderRows(providerConfigs, status?.grants ?? [])
+      ),
+    [providerConfigs, status?.grants]
+  );
+
+  return (
+    <McpConnectMenu
+      component={component}
+      failed={failed}
+      loading={loading}
+      providersLoaded={loadedUserIdRef.current === currentUserId}
+      completionConsumed={completionConsumed}
+      completionSelection={completionSelection}
+      onConfigure={onConfigure}
+      onComplete={onComplete}
+      onNavigate={onNavigate}
+      providers={providers}
+    />
+  );
+}
+
+export function McpConnectMenu({
+  component,
+  completionConsumed = false,
+  completionSelection,
+  failed = false,
+  loading = false,
+  providersLoaded = true,
+  onConfigure,
+  onComplete,
+  onNavigate,
+  providers,
+}: {
+  component: A2UI.McpConnect;
+  completionConsumed?: boolean;
+  completionSelection?: api.PostBlobDataEntryA2UISelection;
+  failed?: boolean;
+  loading?: boolean;
+  providersLoaded?: boolean;
+  onConfigure?: (
+    action: A2UI.ConfigureAgentProvidersAction
+  ) => void | Promise<void>;
+  onComplete?: (
+    action: A2UI.SendMessageAction,
+    selection?: api.PostBlobDataEntryA2UISelection
+  ) => void | Promise<void>;
+  onNavigate?: (action: A2UI.NavigateAction) => void | Promise<void>;
+  providers: McpProviderRow[];
+}) {
+  const [selectedProviderIds, setSelectedProviderIds] = useState<string[]>([]);
+  const [submitting, setSubmitting] = useState(false);
+  const [completing, setCompleting] = useState(false);
+  const [completedLocally, setCompletedLocally] = useState(false);
+  const configuringRef = useRef(false);
+  const completingRef = useRef(false);
+  const initializedRef = useRef(false);
+  const knownConnectedRef = useRef(new Set<string>());
+  const connectedProviderIds = useMemo(
+    () =>
+      providers
+        .filter((provider) => provider.status === 'connected')
+        .map((provider) => provider.id),
+    [providers]
+  );
+
+  useEffect(() => {
+    const connected = new Set(connectedProviderIds);
+    if (!initializedRef.current) {
+      if (loading || !providersLoaded) return;
+      initializedRef.current = true;
+      knownConnectedRef.current = connected;
+      setSelectedProviderIds(clampProviderIds(connectedProviderIds));
+      return;
+    }
+
+    // A provider that became connected while this surface was open was just
+    // authorized from this menu. Include it without making the owner tap the
+    // same row a second time after returning from OAuth.
+    const newlyConnected = connectedProviderIds.filter(
+      (id) => !knownConnectedRef.current.has(id)
+    );
+    knownConnectedRef.current = connected;
+    setSelectedProviderIds((current) => {
+      const next = clampProviderIds([
+        ...new Set([
+          ...current.filter((id) => connected.has(id)),
+          ...newlyConnected,
+        ]),
+      ]);
+      return next.length === current.length &&
+        next.every((id, index) => id === current[index])
+        ? current
+        : next;
+    });
+  }, [connectedProviderIds, loading, providersLoaded]);
+
+  const visibleProviders = useMemo(
+    () => selectMcpMenuProviders(providers, component.maxVisible),
+    [component.maxVisible, providers]
+  );
+  const showSeeAll = providers.length > visibleProviders.length;
+
+  const toggleProvider = useCallback((providerId: string) => {
+    setSelectedProviderIds((current) => {
+      if (current.includes(providerId)) {
+        return current.filter((id) => id !== providerId);
+      }
+      return current.length < MAX_PROVIDER_SELECTIONS
+        ? [...current, providerId]
+        : current;
+    });
+  }, []);
+
+  const configure = useCallback(async () => {
+    if (!onConfigure || configuringRef.current || completingRef.current) {
+      return;
+    }
+    configuringRef.current = true;
+    setSubmitting(true);
+    try {
+      await onConfigure({
+        event: {
+          ...component.configureAction.event,
+          context: {
+            ...component.configureAction.event.context,
+            providerIds: clampProviderIds(selectedProviderIds),
+          },
+        },
+      });
+    } finally {
+      configuringRef.current = false;
+      setSubmitting(false);
+    }
+  }, [component.configureAction.event, onConfigure, selectedProviderIds]);
+
+  const complete = useCallback(async () => {
+    if (
+      !component.completionAction ||
+      !onComplete ||
+      configuringRef.current ||
+      completingRef.current ||
+      completionConsumed ||
+      completedLocally
+    ) {
+      return;
+    }
+    completingRef.current = true;
+    setCompleting(true);
+    try {
+      await onComplete(component.completionAction, completionSelection);
+      setCompletedLocally(true);
+    } catch (error) {
+      completingRef.current = false;
+      throw error;
+    } finally {
+      setCompleting(false);
+    }
+  }, [
+    completedLocally,
+    completionConsumed,
+    completionSelection,
+    component.completionAction,
+    onComplete,
+  ]);
+
+  const navigate = useCallback(
+    (providerId?: string) => {
+      if (!onNavigate) return;
+      const target = component.action.event.context.target;
+      if (target.type !== 'screen') return;
+      void onNavigate({
+        event: {
+          ...component.action.event,
+          context: {
+            target: {
+              ...target,
+              providerId,
+            },
+          },
+        },
+      });
+    },
+    [component.action.event, onNavigate]
+  );
+
+  return (
+    <YStack
+      width="100%"
+      padding="$m"
+      borderRadius="$xl"
+      backgroundColor="$secondaryBackground"
+    >
+      <YStack
+        width="100%"
+        borderWidth={1}
+        borderColor="$border"
+        borderRadius="$m"
+        overflow="hidden"
+      >
+        {loading ? (
+          <XStack
+            minHeight={52}
+            paddingHorizontal="$m"
+            alignItems="center"
+            justifyContent="center"
+            backgroundColor="$background"
+          >
+            <LoadingSpinner size="small" />
+          </XStack>
+        ) : failed || visibleProviders.length === 0 ? (
+          <ProviderFallbackRow
+            disabled={!onNavigate}
+            onPress={() => navigate()}
+          />
+        ) : (
+          <>
+            {visibleProviders.map((provider, index) => {
+              const connected = provider.status === 'connected';
+              const selected = selectedProviderIds.includes(provider.id);
+              const enabled = connected
+                ? Boolean(onConfigure)
+                : Boolean(onNavigate);
+              return (
+                <A2UIMenuRow
+                  key={provider.id}
+                  testID={`A2UIMcpConnect-${provider.id}`}
+                  accessibilityLabel={provider.displayName}
+                  accessibilityState={{
+                    disabled: connected ? !onConfigure : !onNavigate,
+                    selected,
+                  }}
+                  disabled={connected ? !onConfigure : !onNavigate}
+                  onPress={
+                    connected
+                      ? () => toggleProvider(provider.id)
+                      : onNavigate
+                        ? () => navigate(provider.id)
+                        : undefined
+                  }
+                  minHeight={56}
+                  paddingVertical="$s"
+                  dividerAfter={
+                    index < visibleProviders.length - 1 || showSeeAll
+                  }
+                  dimmed={!enabled}
+                  label={provider.displayName}
+                  subtitle={connected ? 'Connected' : undefined}
+                  leading={
+                    <McpProviderLogo
+                      compact
+                      displayName={provider.displayName}
+                      logoUrl={provider.logoUrl}
+                      providerId={provider.id}
+                    />
+                  }
+                  trailing={
+                    connected && !selected ? (
+                      <XStack width={16} height={16} />
+                    ) : (
+                      <Icon
+                        type={selected ? 'Checkmark' : 'ChevronRight'}
+                        color={
+                          selected ? '$positiveActionText' : '$secondaryText'
+                        }
+                        customSize={[16, 16]}
+                      />
+                    )
+                  }
+                />
+              );
+            })}
+            {showSeeAll ? (
+              <A2UIMenuRow
+                testID="A2UIMcpConnectSeeAll"
+                accessibilityLabel={component.seeAllLabel}
+                disabled={!onNavigate}
+                onPress={() => navigate()}
+                dimmed={!onNavigate}
+                label={component.seeAllLabel}
+                trailing={
+                  <Icon
+                    type="ChevronRight"
+                    color="$secondaryText"
+                    customSize={[16, 16]}
+                  />
+                }
+              />
+            ) : null}
+          </>
+        )}
+      </YStack>
+      {!loading && !failed && connectedProviderIds.length > 0 ? (
+        <A2UIMenuRow
+          testID="A2UIMcpConnectSubmit"
+          accessibilityLabel={component.submitLabel}
+          accessibilityState={{
+            disabled: !onConfigure || submitting,
+          }}
+          disabled={!onConfigure || submitting}
+          onPress={configure}
+          bordered
+          marginTop="$m"
+          dimmed={!onConfigure || submitting}
+          label={component.submitLabel}
+          trailing={
+            submitting ? (
+              <LoadingSpinner size="small" />
+            ) : (
+              <Icon
+                type="Checkmark"
+                color="$primaryText"
+                customSize={[16, 16]}
+              />
+            )
+          }
+        />
+      ) : null}
+      {component.completionLabel && component.completionAction ? (
+        <A2UIMenuRow
+          testID="A2UIMcpConnectComplete"
+          accessibilityLabel={component.completionLabel}
+          accessibilityState={{
+            disabled:
+              !onComplete ||
+              submitting ||
+              completing ||
+              completionConsumed ||
+              completedLocally,
+          }}
+          disabled={
+            !onComplete ||
+            submitting ||
+            completing ||
+            completionConsumed ||
+            completedLocally
+          }
+          onPress={complete}
+          bordered
+          marginTop="$m"
+          prominent
+          dimmed={completionConsumed || completedLocally}
+          label={component.completionLabel}
+          trailing={
+            completing ? (
+              <LoadingSpinner size="small" />
+            ) : (
+              <Icon
+                type="Checkmark"
+                color="$background"
+                customSize={[16, 16]}
+              />
+            )
+          }
+        />
+      ) : null}
+    </YStack>
+  );
+}
+
+function ProviderFallbackRow({
+  disabled,
+  onPress,
+}: {
+  disabled: boolean;
+  onPress: () => void;
+}) {
+  return (
+    <A2UIMenuRow
+      accessibilityLabel="See all services"
+      disabled={disabled}
+      onPress={onPress}
+      dimmed={disabled}
+      label="See all services"
+      trailing={
+        <Icon
+          type="ChevronRight"
+          color="$secondaryText"
+          customSize={[16, 16]}
+        />
+      }
+    />
+  );
+}

--- a/packages/app/ui/components/PostContent/McpConnectControl.tsx
+++ b/packages/app/ui/components/PostContent/McpConnectControl.tsx
@@ -30,6 +30,7 @@ const clampProviderIds = (providerIds: string[]) =>
 
 export function McpConnectControl({
   component,
+  selectionsPending,
   completionConsumed,
   completionSelection,
   onConfigure,
@@ -37,6 +38,8 @@ export function McpConnectControl({
   onNavigate,
 }: {
   component: A2UI.McpConnect;
+  /** True until durable completion receipts have finished loading. */
+  selectionsPending?: boolean;
   /** True when a durable post already answered the completion action. */
   completionConsumed?: boolean;
   /** Durable record to attach to the post the completion action creates. */
@@ -99,6 +102,7 @@ export function McpConnectControl({
   return (
     <McpConnectMenu
       component={component}
+      selectionsPending={selectionsPending}
       failed={failed}
       loading={!failed && (!hasProviderData || !hasStatusData)}
       providersLoaded={hasProviderData && hasStatusData}
@@ -115,6 +119,7 @@ export function McpConnectControl({
 
 export function McpConnectMenu({
   component,
+  selectionsPending = false,
   completionConsumed = false,
   completionSelection,
   failed = false,
@@ -127,6 +132,7 @@ export function McpConnectMenu({
   providers,
 }: {
   component: A2UI.McpConnect;
+  selectionsPending?: boolean;
   completionConsumed?: boolean;
   completionSelection?: api.PostBlobDataEntryA2UISelection;
   failed?: boolean;
@@ -150,6 +156,11 @@ export function McpConnectMenu({
   const [submitting, setSubmitting] = useState(false);
   const [authorizationReturnVersion, setAuthorizationReturnVersion] =
     useState(0);
+  const [authorizationRefreshPending, setAuthorizationRefreshPending] =
+    useState(() => pendingProviderAuthorizations.has(selectionKey));
+  const authorizationRefreshPendingRef = useRef(
+    pendingProviderAuthorizations.has(selectionKey)
+  );
   const configuringRef = useRef(false);
   const initializedRef = useRef(false);
   const completionAction = useOneShotAction(completionConsumed);
@@ -172,16 +183,23 @@ export function McpConnectMenu({
     // Claim this return before refreshing so a focus + visibility pair cannot
     // start duplicate refreshes for the same browser round trip.
     pending.leftSurface = false;
+    authorizationRefreshPendingRef.current = true;
+    setAuthorizationRefreshPending(true);
     const refresh = onRefreshProviders?.() ?? Promise.resolve(true);
     const finish = (succeeded: boolean) => {
       const current = pendingProviderAuthorizations.get(selectionKey);
       if (current === pending) {
         if (!succeeded) {
           current.leftSurface = true;
+          authorizationRefreshPendingRef.current = false;
+          setAuthorizationRefreshPending(false);
           return;
         }
         current.returned = true;
         setAuthorizationReturnVersion((version) => version + 1);
+      } else {
+        authorizationRefreshPendingRef.current = false;
+        setAuthorizationRefreshPending(false);
       }
     };
     void refresh.then(finish, () => finish(false));
@@ -252,6 +270,13 @@ export function McpConnectMenu({
         ? current
         : next;
     });
+    if (pendingAuthorization?.returned) {
+      // Keep the menu locked until this selection update is committed in the
+      // same render as the unlock. This prevents an OAuth return from briefly
+      // submitting the pre-authorization provider set.
+      authorizationRefreshPendingRef.current = false;
+      setAuthorizationRefreshPending(false);
+    }
   }, [
     authorizationReturnVersion,
     connectedProviderIds,
@@ -277,11 +302,21 @@ export function McpConnectMenu({
   );
   const showSeeAll = providers.length > visibleProviders.length;
   const completionLocked =
-    completionAction.consumed || completionAction.pending;
+    selectionsPending ||
+    authorizationRefreshPending ||
+    completionAction.consumed ||
+    completionAction.pending;
 
   const toggleProvider = useCallback(
     (providerId: string) => {
-      if (configuringRef.current || completionAction.isLocked()) return;
+      if (
+        selectionsPending ||
+        authorizationRefreshPendingRef.current ||
+        configuringRef.current ||
+        completionAction.isLocked()
+      ) {
+        return;
+      }
       setSelectedProviderIds((current) => {
         if (current.includes(providerId)) {
           return current.filter((id) => id !== providerId);
@@ -291,11 +326,17 @@ export function McpConnectMenu({
           : current;
       });
     },
-    [completionAction]
+    [completionAction, selectionsPending]
   );
 
   const configure = useCallback(async () => {
-    if (!onConfigure || configuringRef.current || completionAction.isLocked()) {
+    if (
+      !onConfigure ||
+      selectionsPending ||
+      authorizationRefreshPendingRef.current ||
+      configuringRef.current ||
+      completionAction.isLocked()
+    ) {
       return;
     }
     configuringRef.current = true;
@@ -322,6 +363,7 @@ export function McpConnectMenu({
     completionAction,
     component.configureAction.event,
     onConfigure,
+    selectionsPending,
     selectedProviderIds,
   ]);
 
@@ -329,6 +371,8 @@ export function McpConnectMenu({
     if (
       !component.completionAction ||
       !onComplete ||
+      selectionsPending ||
+      authorizationRefreshPendingRef.current ||
       configuringRef.current ||
       completionAction.isLocked()
     ) {
@@ -342,12 +386,15 @@ export function McpConnectMenu({
     completionSelection,
     component.completionAction,
     onComplete,
+    selectionsPending,
   ]);
 
   const navigate = useCallback(
     (providerId?: string) => {
       if (
         !onNavigate ||
+        selectionsPending ||
+        authorizationRefreshPendingRef.current ||
         configuringRef.current ||
         completionAction.isLocked()
       ) {
@@ -376,7 +423,13 @@ export function McpConnectMenu({
         },
       });
     },
-    [completionAction, component.action.event, onNavigate, selectionKey]
+    [
+      completionAction,
+      component.action.event,
+      onNavigate,
+      selectionKey,
+      selectionsPending,
+    ]
   );
 
   return (

--- a/packages/app/ui/components/PostContent/McpConnectControl.tsx
+++ b/packages/app/ui/components/PostContent/McpConnectControl.tsx
@@ -70,10 +70,11 @@ export function McpConnectControl({
   });
 
   const refreshProviders = useCallback(async () => {
-    await Promise.all([
+    const [, statusResult] = await Promise.all([
       providersQuery.refetch(),
-      currentUserId ? statusQuery.refetch() : Promise.resolve(),
+      currentUserId ? statusQuery.refetch() : Promise.resolve(null),
     ]);
+    return Boolean(currentUserId && statusResult && statusResult.isSuccess);
   }, [currentUserId, providersQuery.refetch, statusQuery.refetch]);
 
   const providers = useMemo(
@@ -139,7 +140,7 @@ export function McpConnectMenu({
     selection?: api.PostBlobDataEntryA2UISelection
   ) => void | Promise<void>;
   onNavigate?: (action: A2UI.NavigateAction) => void | Promise<void>;
-  onRefreshProviders?: () => Promise<void>;
+  onRefreshProviders?: () => Promise<boolean>;
   providers: McpProviderRow[];
 }) {
   const selectionKey = `${component.configureAction.event.context.groupId}\u0000${component.configureAction.event.context.provisionId}\u0000${component.id}`;
@@ -171,15 +172,19 @@ export function McpConnectMenu({
     // Claim this return before refreshing so a focus + visibility pair cannot
     // start duplicate refreshes for the same browser round trip.
     pending.leftSurface = false;
-    const refresh = onRefreshProviders?.() ?? Promise.resolve();
-    const finish = () => {
+    const refresh = onRefreshProviders?.() ?? Promise.resolve(true);
+    const finish = (succeeded: boolean) => {
       const current = pendingProviderAuthorizations.get(selectionKey);
       if (current === pending) {
+        if (!succeeded) {
+          current.leftSurface = true;
+          return;
+        }
         current.returned = true;
         setAuthorizationReturnVersion((version) => version + 1);
       }
     };
-    void refresh.then(finish, finish);
+    void refresh.then(finish, () => finish(false));
   }, [onRefreshProviders, selectionKey]);
 
   useFocusEffect(

--- a/packages/app/ui/components/PostContent/McpConnectControl.tsx
+++ b/packages/app/ui/components/PostContent/McpConnectControl.tsx
@@ -1,4 +1,5 @@
 import { useFocusEffect } from '@react-navigation/native';
+import { useQuery } from '@tanstack/react-query';
 import * as api from '@tloncorp/api';
 import { A2UI } from '@tloncorp/shared/logic';
 import { Icon, LoadingSpinner } from '@tloncorp/ui';
@@ -14,17 +15,10 @@ import {
 } from '../../../lib/mcpProviders';
 import { McpProviderLogo } from '../McpProviderLogo';
 import { A2UIMenuRow } from './A2UIMenuRow';
+import { useOneShotAction } from './useOneShotAction';
 
-type McpProviderSnapshot = {
-  providers: api.TlawnOAuthProvider[];
-  status: api.TlawnOAuthStatus;
-};
-
-// Channel screens are normally popped when the owner leaves them, so local
-// component state cannot preserve this historical row's height. Keep the last
-// successful Hosting snapshot for each account and refresh it in place.
-const providerSnapshots = new Map<string, McpProviderSnapshot>();
 const MAX_PROVIDER_SELECTIONS = api.AGENT_PROTOCOL_LIMITS.providerCount;
+const pendingProviderSelections = new Map<string, string[]>();
 const clampProviderIds = (providerIds: string[]) =>
   providerIds.slice(0, MAX_PROVIDER_SELECTIONS);
 
@@ -51,88 +45,51 @@ export function McpConnectControl({
   onNavigate?: (action: A2UI.NavigateAction) => void | Promise<void>;
 }) {
   const currentUserId = useCurrentUserId();
-  const initialSnapshot = currentUserId
-    ? providerSnapshots.get(currentUserId)
-    : undefined;
-  const [loading, setLoading] = useState(!initialSnapshot);
-  const [failed, setFailed] = useState(false);
-  const [providerConfigs, setProviderConfigs] = useState<
-    api.TlawnOAuthProvider[]
-  >(initialSnapshot?.providers ?? []);
-  const [status, setStatus] = useState<api.TlawnOAuthStatus | null>(
-    initialSnapshot?.status ?? null
-  );
-  const loadedUserIdRef = useRef<string | null>(
-    initialSnapshot ? currentUserId : null
-  );
+  const providersQuery = useQuery({
+    queryKey: ['tlonbot', 'oauth-providers'],
+    queryFn: () => api.getTlawnOAuthProviders(),
+    staleTime: 5 * 60 * 1000,
+    retry: false,
+  });
+  const statusQuery = useQuery({
+    queryKey: ['tlonbot', 'oauth-status', currentUserId],
+    queryFn: () => api.getTlawnOAuthStatus(currentUserId),
+    enabled: Boolean(currentUserId),
+    staleTime: 30 * 1000,
+    retry: false,
+  });
 
   useFocusEffect(
     useCallback(() => {
-      let active = true;
-
-      async function loadProviders() {
-        if (!currentUserId) {
-          if (active) {
-            setFailed(true);
-            setLoading(false);
-          }
-          return;
-        }
-
-        // Keep the existing rows mounted while refreshing after navigation.
-        // Replacing a full menu with a one-row spinner changes the historical
-        // message height and makes the conversation jump on every refocus.
-        const isInitialLoad = loadedUserIdRef.current !== currentUserId;
-        if (isInitialLoad) {
-          setLoading(true);
-        }
-        setFailed(false);
-        try {
-          const [nextProviders, nextStatus] = await Promise.all([
-            api.getTlawnOAuthProviders(),
-            api.getTlawnOAuthStatus(currentUserId),
-          ]);
-          if (active) {
-            providerSnapshots.set(currentUserId, {
-              providers: nextProviders,
-              status: nextStatus,
-            });
-            setProviderConfigs(nextProviders);
-            setStatus(nextStatus);
-            loadedUserIdRef.current = currentUserId;
-          }
-        } catch {
-          if (active && isInitialLoad) {
-            setFailed(true);
-          }
-        } finally {
-          if (active) {
-            setLoading(false);
-          }
-        }
-      }
-
-      void loadProviders();
-      return () => {
-        active = false;
-      };
-    }, [currentUserId])
+      // OAuth leaves and re-enters the channel. Refresh the shared cache when
+      // it regains focus so every historical connector control sees the grant.
+      void providersQuery.refetch();
+      if (currentUserId) void statusQuery.refetch();
+    }, [currentUserId, providersQuery.refetch, statusQuery.refetch])
   );
 
   const providers = useMemo(
     () =>
-      prioritizeMcpMenuProviders(
-        buildProviderRows(providerConfigs, status?.grants ?? [])
-      ),
-    [providerConfigs, status?.grants]
+      statusQuery.data?.available === false
+        ? []
+        : prioritizeMcpMenuProviders(
+            buildProviderRows(
+              providersQuery.data ?? [],
+              statusQuery.data?.grants ?? []
+            )
+          ),
+    [providersQuery.data, statusQuery.data]
   );
+
+  const hasProviderData = providersQuery.data !== undefined;
+  const hasStatusData = statusQuery.data !== undefined;
 
   return (
     <McpConnectMenu
       component={component}
-      failed={failed}
-      loading={loading}
-      providersLoaded={loadedUserIdRef.current === currentUserId}
+      failed={providersQuery.isError || statusQuery.isError}
+      loading={!hasProviderData || !hasStatusData}
+      providersLoaded={hasProviderData && hasStatusData}
       completionConsumed={completionConsumed}
       completionSelection={completionSelection}
       onConfigure={onConfigure}
@@ -171,14 +128,15 @@ export function McpConnectMenu({
   onNavigate?: (action: A2UI.NavigateAction) => void | Promise<void>;
   providers: McpProviderRow[];
 }) {
-  const [selectedProviderIds, setSelectedProviderIds] = useState<string[]>([]);
+  const selectionKey = `${component.configureAction.event.context.groupId}\u0000${component.configureAction.event.context.provisionId}\u0000${component.id}`;
+  const [selectedProviderIds, setSelectedProviderIds] = useState<string[]>(
+    () => pendingProviderSelections.get(selectionKey) ?? []
+  );
   const [submitting, setSubmitting] = useState(false);
-  const [completing, setCompleting] = useState(false);
-  const [completedLocally, setCompletedLocally] = useState(false);
   const configuringRef = useRef(false);
-  const completingRef = useRef(false);
   const initializedRef = useRef(false);
   const knownConnectedRef = useRef(new Set<string>());
+  const completionAction = useOneShotAction(completionConsumed);
   const connectedProviderIds = useMemo(
     () =>
       providers
@@ -218,26 +176,38 @@ export function McpConnectMenu({
     });
   }, [connectedProviderIds, loading, providersLoaded]);
 
+  useEffect(() => {
+    pendingProviderSelections.set(selectionKey, selectedProviderIds);
+  }, [selectedProviderIds, selectionKey]);
+
+  useEffect(() => {
+    if (completionConsumed) pendingProviderSelections.delete(selectionKey);
+  }, [completionConsumed, selectionKey]);
+
   const visibleProviders = useMemo(
     () => selectMcpMenuProviders(providers, component.maxVisible),
     [component.maxVisible, providers]
   );
   const showSeeAll = providers.length > visibleProviders.length;
+  const completionLocked = completionAction.consumed;
 
-  const toggleProvider = useCallback((providerId: string) => {
-    if (configuringRef.current || completingRef.current) return;
-    setSelectedProviderIds((current) => {
-      if (current.includes(providerId)) {
-        return current.filter((id) => id !== providerId);
-      }
-      return current.length < MAX_PROVIDER_SELECTIONS
-        ? [...current, providerId]
-        : current;
-    });
-  }, []);
+  const toggleProvider = useCallback(
+    (providerId: string) => {
+      if (configuringRef.current || completionAction.isLocked()) return;
+      setSelectedProviderIds((current) => {
+        if (current.includes(providerId)) {
+          return current.filter((id) => id !== providerId);
+        }
+        return current.length < MAX_PROVIDER_SELECTIONS
+          ? [...current, providerId]
+          : current;
+      });
+    },
+    [completionAction]
+  );
 
   const configure = useCallback(async () => {
-    if (!onConfigure || configuringRef.current || completingRef.current) {
+    if (!onConfigure || configuringRef.current || completionAction.isLocked()) {
       return;
     }
     configuringRef.current = true;
@@ -256,33 +226,27 @@ export function McpConnectMenu({
       configuringRef.current = false;
       setSubmitting(false);
     }
-  }, [component.configureAction.event, onConfigure, selectedProviderIds]);
+  }, [
+    completionAction,
+    component.configureAction.event,
+    onConfigure,
+    selectedProviderIds,
+  ]);
 
   const complete = useCallback(async () => {
     if (
       !component.completionAction ||
       !onComplete ||
       configuringRef.current ||
-      completingRef.current ||
-      completionConsumed ||
-      completedLocally
+      completionAction.isLocked()
     ) {
       return;
     }
-    completingRef.current = true;
-    setCompleting(true);
-    try {
-      await onComplete(component.completionAction, completionSelection);
-      setCompletedLocally(true);
-    } catch (error) {
-      completingRef.current = false;
-      throw error;
-    } finally {
-      setCompleting(false);
-    }
+    await completionAction.run(() =>
+      onComplete(component.completionAction!, completionSelection)
+    );
   }, [
-    completedLocally,
-    completionConsumed,
+    completionAction,
     completionSelection,
     component.completionAction,
     onComplete,
@@ -334,7 +298,7 @@ export function McpConnectMenu({
           </XStack>
         ) : failed || visibleProviders.length === 0 ? (
           <ProviderFallbackRow
-            disabled={!onNavigate}
+            disabled={!onNavigate || completionLocked}
             onPress={() => navigate()}
           />
         ) : (
@@ -343,11 +307,11 @@ export function McpConnectMenu({
               const connected = provider.status === 'connected';
               const selected = selectedProviderIds.includes(provider.id);
               const enabled = connected
-                ? Boolean(onConfigure) && !submitting
-                : Boolean(onNavigate);
+                ? Boolean(onConfigure) && !submitting && !completionLocked
+                : Boolean(onNavigate) && !completionLocked;
               const disabled = connected
-                ? !onConfigure || submitting
-                : !onNavigate;
+                ? !onConfigure || submitting || completionLocked
+                : !onNavigate || completionLocked;
               return (
                 <A2UIMenuRow
                   key={provider.id}
@@ -401,9 +365,9 @@ export function McpConnectMenu({
               <A2UIMenuRow
                 testID="A2UIMcpConnectSeeAll"
                 accessibilityLabel={component.seeAllLabel}
-                disabled={!onNavigate}
+                disabled={!onNavigate || completionLocked}
                 onPress={() => navigate()}
-                dimmed={!onNavigate}
+                dimmed={!onNavigate || completionLocked}
                 label={component.seeAllLabel}
                 trailing={
                   <Icon
@@ -422,13 +386,13 @@ export function McpConnectMenu({
           testID="A2UIMcpConnectSubmit"
           accessibilityLabel={component.submitLabel}
           accessibilityState={{
-            disabled: !onConfigure || submitting,
+            disabled: !onConfigure || submitting || completionLocked,
           }}
-          disabled={!onConfigure || submitting}
+          disabled={!onConfigure || submitting || completionLocked}
           onPress={configure}
           bordered
           marginTop="$m"
-          dimmed={!onConfigure || submitting}
+          dimmed={!onConfigure || submitting || completionLocked}
           label={component.submitLabel}
           trailing={
             submitting ? (
@@ -451,25 +415,23 @@ export function McpConnectMenu({
             disabled:
               !onComplete ||
               submitting ||
-              completing ||
-              completionConsumed ||
-              completedLocally,
+              completionAction.pending ||
+              completionLocked,
           }}
           disabled={
             !onComplete ||
             submitting ||
-            completing ||
-            completionConsumed ||
-            completedLocally
+            completionAction.pending ||
+            completionLocked
           }
           onPress={complete}
           bordered
           marginTop="$m"
           prominent
-          dimmed={completionConsumed || completedLocally}
+          dimmed={completionLocked}
           label={component.completionLabel}
           trailing={
-            completing ? (
+            completionAction.pending ? (
               <LoadingSpinner size="small" />
             ) : (
               <Icon

--- a/packages/app/ui/components/PostContent/McpConnectControl.tsx
+++ b/packages/app/ui/components/PostContent/McpConnectControl.tsx
@@ -169,6 +169,9 @@ export function McpConnectMenu({
     useState(authorizationIsReconciling);
   const authorizationRefreshPendingRef = useRef(authorizationIsReconciling());
   const configuringRef = useRef(false);
+  const hadStoredSelectionRef = useRef(
+    pendingProviderSelections.has(selectionKey)
+  );
   const initializedRef = useRef(false);
   const completionAction = useOneShotAction(completionConsumed);
   const connectedProviderIds = useMemo(
@@ -245,7 +248,11 @@ export function McpConnectMenu({
     if (!initializedRef.current) {
       if (loading || !providersLoaded) return;
       initializedRef.current = true;
-      setSelectedProviderIds(clampProviderIds(connectedProviderIds));
+      setSelectedProviderIds((current) =>
+        hadStoredSelectionRef.current
+          ? current.filter((id) => connected.has(id))
+          : clampProviderIds(connectedProviderIds)
+      );
       return;
     }
 

--- a/packages/app/ui/components/PostContent/McpConnectControl.tsx
+++ b/packages/app/ui/components/PostContent/McpConnectControl.tsx
@@ -11,6 +11,7 @@ import { useCurrentUserId } from '../../../hooks/useCurrentUser';
 import {
   type McpProviderRow,
   buildProviderRows,
+  mcpProviderQueryKeys,
   prioritizeMcpMenuProviders,
   selectMcpMenuProviders,
 } from '../../../lib/mcpProviders';
@@ -51,7 +52,7 @@ export function McpConnectControl({
 }) {
   const currentUserId = useCurrentUserId();
   const providersQuery = useQuery({
-    queryKey: ['tlonbot', 'oauth-providers'],
+    queryKey: mcpProviderQueryKeys.providers,
     queryFn: () => api.getTlawnOAuthProviders(),
     staleTime: 5 * 60 * 1000,
     // React Query owns the single app/window focus listener. Historical cards
@@ -60,7 +61,7 @@ export function McpConnectControl({
     retry: false,
   });
   const statusQuery = useQuery({
-    queryKey: ['tlonbot', 'oauth-status', currentUserId],
+    queryKey: mcpProviderQueryKeys.status(currentUserId),
     queryFn: () => api.getTlawnOAuthStatus(currentUserId),
     enabled: Boolean(currentUserId),
     staleTime: 30 * 1000,

--- a/packages/app/ui/components/PostContent/McpConnectControl.tsx
+++ b/packages/app/ui/components/PostContent/McpConnectControl.tsx
@@ -4,7 +4,7 @@ import * as api from '@tloncorp/api';
 import { A2UI } from '@tloncorp/shared/logic';
 import { Icon, LoadingSpinner } from '@tloncorp/ui';
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
-import { XStack, YStack } from 'tamagui';
+import { XStack, YStack, isWeb } from 'tamagui';
 
 import { useCurrentUserId } from '../../../hooks/useCurrentUser';
 import {
@@ -59,14 +59,32 @@ export function McpConnectControl({
     retry: false,
   });
 
+  const refreshProviders = useCallback(() => {
+    void providersQuery.refetch();
+    if (currentUserId) void statusQuery.refetch();
+  }, [currentUserId, providersQuery.refetch, statusQuery.refetch]);
+
   useFocusEffect(
     useCallback(() => {
       // OAuth leaves and re-enters the channel. Refresh the shared cache when
       // it regains focus so every historical connector control sees the grant.
-      void providersQuery.refetch();
-      if (currentUserId) void statusQuery.refetch();
-    }, [currentUserId, providersQuery.refetch, statusQuery.refetch])
+      refreshProviders();
+    }, [refreshProviders])
   );
+
+  useEffect(() => {
+    if (!isWeb) return;
+    const handleFocus = () => refreshProviders();
+    const handleVisibility = () => {
+      if (document.visibilityState === 'visible') refreshProviders();
+    };
+    window.addEventListener('focus', handleFocus);
+    document.addEventListener('visibilitychange', handleVisibility);
+    return () => {
+      window.removeEventListener('focus', handleFocus);
+      document.removeEventListener('visibilitychange', handleVisibility);
+    };
+  }, [refreshProviders]);
 
   const providers = useMemo(
     () =>
@@ -83,12 +101,13 @@ export function McpConnectControl({
 
   const hasProviderData = providersQuery.data !== undefined;
   const hasStatusData = statusQuery.data !== undefined;
+  const failed = providersQuery.isError || statusQuery.isError;
 
   return (
     <McpConnectMenu
       component={component}
-      failed={providersQuery.isError || statusQuery.isError}
-      loading={!hasProviderData || !hasStatusData}
+      failed={failed}
+      loading={!failed && (!hasProviderData || !hasStatusData)}
       providersLoaded={hasProviderData && hasStatusData}
       completionConsumed={completionConsumed}
       completionSelection={completionSelection}

--- a/packages/app/ui/components/PostContent/McpConnectControl.tsx
+++ b/packages/app/ui/components/PostContent/McpConnectControl.tsx
@@ -4,6 +4,7 @@ import * as api from '@tloncorp/api';
 import { A2UI } from '@tloncorp/shared/logic';
 import { Icon, LoadingSpinner } from '@tloncorp/ui';
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import { Platform } from 'react-native';
 import { XStack, YStack } from 'tamagui';
 
 import { useCurrentUserId } from '../../../hooks/useCurrentUser';
@@ -159,27 +160,53 @@ export function McpConnectMenu({
     [providers]
   );
 
+  const markAuthorizationLeftSurface = useCallback(() => {
+    const pending = pendingProviderAuthorizations.get(selectionKey);
+    if (pending) pending.leftSurface = true;
+  }, [selectionKey]);
+
+  const finishAuthorizationRoundTrip = useCallback(() => {
+    const pending = pendingProviderAuthorizations.get(selectionKey);
+    if (!pending?.leftSurface || pending.returned) return;
+    // Claim this return before refreshing so a focus + visibility pair cannot
+    // start duplicate refreshes for the same browser round trip.
+    pending.leftSurface = false;
+    const refresh = onRefreshProviders?.() ?? Promise.resolve();
+    const finish = () => {
+      const current = pendingProviderAuthorizations.get(selectionKey);
+      if (current === pending) {
+        current.returned = true;
+        setAuthorizationReturnVersion((version) => version + 1);
+      }
+    };
+    void refresh.then(finish, finish);
+  }, [onRefreshProviders, selectionKey]);
+
   useFocusEffect(
     useCallback(() => {
-      const pending = pendingProviderAuthorizations.get(selectionKey);
-      if (pending?.leftSurface) {
-        const refresh = onRefreshProviders?.() ?? Promise.resolve();
-        const finishRoundTrip = () => {
-          const current = pendingProviderAuthorizations.get(selectionKey);
-          if (current === pending) {
-            current.returned = true;
-            setAuthorizationReturnVersion((version) => version + 1);
-          }
-        };
-        void refresh.then(finishRoundTrip, finishRoundTrip);
-      }
-
-      return () => {
-        const current = pendingProviderAuthorizations.get(selectionKey);
-        if (current) current.leftSurface = true;
-      };
-    }, [onRefreshProviders, selectionKey])
+      finishAuthorizationRoundTrip();
+      return markAuthorizationLeftSurface;
+    }, [finishAuthorizationRoundTrip, markAuthorizationLeftSurface])
   );
+
+  useEffect(() => {
+    if (Platform.OS !== 'web' || typeof window === 'undefined') return;
+    const handleVisibility = () => {
+      if (document.visibilityState === 'hidden') {
+        markAuthorizationLeftSurface();
+      } else {
+        finishAuthorizationRoundTrip();
+      }
+    };
+    window.addEventListener('blur', markAuthorizationLeftSurface);
+    window.addEventListener('focus', finishAuthorizationRoundTrip);
+    document.addEventListener('visibilitychange', handleVisibility);
+    return () => {
+      window.removeEventListener('blur', markAuthorizationLeftSurface);
+      window.removeEventListener('focus', finishAuthorizationRoundTrip);
+      document.removeEventListener('visibilitychange', handleVisibility);
+    };
+  }, [finishAuthorizationRoundTrip, markAuthorizationLeftSurface]);
 
   useEffect(() => {
     const connected = new Set(connectedProviderIds);

--- a/packages/app/ui/components/PostContent/McpConnectControl.tsx
+++ b/packages/app/ui/components/PostContent/McpConnectControl.tsx
@@ -315,6 +315,7 @@ export function McpConnectMenu({
     authorizationRefreshPending ||
     completionAction.consumed ||
     completionAction.pending;
+  const completionDisabled = !onComplete || submitting || completionLocked;
 
   const toggleProvider = useCallback(
     (providerId: string) => {
@@ -476,11 +477,21 @@ export function McpConnectMenu({
             {visibleProviders.map((provider, index) => {
               const connected = provider.status === 'connected';
               const selected = selectedProviderIds.includes(provider.id);
+              const selectionLimitReached =
+                connected &&
+                !selected &&
+                selectedProviderIds.length >= MAX_PROVIDER_SELECTIONS;
               const enabled = connected
-                ? Boolean(onConfigure) && !submitting && !completionLocked
+                ? Boolean(onConfigure) &&
+                  !submitting &&
+                  !completionLocked &&
+                  !selectionLimitReached
                 : Boolean(onNavigate) && !submitting && !completionLocked;
               const disabled = connected
-                ? !onConfigure || submitting || completionLocked
+                ? !onConfigure ||
+                  submitting ||
+                  completionLocked ||
+                  selectionLimitReached
                 : !onNavigate || submitting || completionLocked;
               return (
                 <A2UIMenuRow
@@ -582,23 +593,14 @@ export function McpConnectMenu({
           testID="A2UIMcpConnectComplete"
           accessibilityLabel={component.completionLabel}
           accessibilityState={{
-            disabled:
-              !onComplete ||
-              submitting ||
-              completionAction.pending ||
-              completionLocked,
+            disabled: completionDisabled,
           }}
-          disabled={
-            !onComplete ||
-            submitting ||
-            completionAction.pending ||
-            completionLocked
-          }
+          disabled={completionDisabled}
           onPress={complete}
           bordered
           marginTop="$m"
           prominent
-          dimmed={completionLocked}
+          dimmed={completionDisabled}
           label={component.completionLabel}
           trailing={
             completionAction.pending ? (

--- a/packages/app/ui/components/PostContent/contentUtils.tsx
+++ b/packages/app/ui/components/PostContent/contentUtils.tsx
@@ -42,6 +42,8 @@ export interface ContentContextProps {
   areA2UISelectionsPending?: boolean;
   /** Post containing the rendered A2UI surface. */
   a2uiSourcePostId?: string;
+  /** Whether this post is trusted to display authenticated provider state. */
+  canUseAgentProviderControls?: boolean;
   /**
    * Durable selection the viewer already submitted for a control, recovered
    * from their own posts in this channel. Presence marks the control

--- a/packages/app/ui/components/PostContent/contentUtils.tsx
+++ b/packages/app/ui/components/PostContent/contentUtils.tsx
@@ -33,10 +33,10 @@ export interface ContentContextProps {
   getImageViewerId?: (src: string) => string | undefined;
   onLongPress?: () => void;
   onA2UIAction?: (
-    action: A2UI.Button['action'],
+    action: A2UI.Action,
     selection?: PostBlobDataEntryA2UISelection
   ) => void | Promise<void>;
-  isA2UIActionAvailable?: (action: A2UI.Button['action']) => boolean;
+  isA2UIActionAvailable?: (action: A2UI.Action) => boolean;
   canSendA2UIResponse?: boolean;
   /** Consumable controls stay locked until durable selections finish loading. */
   areA2UISelectionsPending?: boolean;

--- a/packages/app/ui/components/PostContent/useOneShotAction.ts
+++ b/packages/app/ui/components/PostContent/useOneShotAction.ts
@@ -1,0 +1,60 @@
+import { useCallback, useEffect, useRef, useState } from 'react';
+
+/** Run cleanup when a durable receipt that was once present is deleted. */
+export function useDurableRelease(
+  durablyConsumed: boolean,
+  onRelease: () => void
+) {
+  const observedRef = useRef(false);
+
+  useEffect(() => {
+    if (durablyConsumed) {
+      observedRef.current = true;
+      return;
+    }
+    if (!observedRef.current) return;
+    observedRef.current = false;
+    onRelease();
+  }, [durablyConsumed, onRelease]);
+}
+
+/**
+ * Synchronously lock a one-shot control, release it on failure, and keep it
+ * locked until its durable receipt is deleted.
+ */
+export function useOneShotAction(durablyConsumed: boolean) {
+  const lockRef = useRef(false);
+  const [pending, setPending] = useState(false);
+  const [consumedLocally, setConsumedLocally] = useState(false);
+
+  const release = useCallback(() => {
+    lockRef.current = false;
+    setPending(false);
+    setConsumedLocally(false);
+  }, []);
+  useDurableRelease(durablyConsumed, release);
+
+  const run = useCallback(async (action: () => void | Promise<void>) => {
+    if (lockRef.current) return false;
+    lockRef.current = true;
+    setPending(true);
+    try {
+      await action();
+      setConsumedLocally(true);
+      return true;
+    } catch {
+      lockRef.current = false;
+      return false;
+    } finally {
+      setPending(false);
+    }
+  }, []);
+
+  return {
+    consumed: durablyConsumed || consumedLocally,
+    consumedLocally,
+    isLocked: () => lockRef.current,
+    pending,
+    run,
+  };
+}


### PR DESCRIPTION
## Summary

Adds connector selection as a focused follow-up to the reusable A2UI choice controls in #6336.

## Changes

- adds the MCP connector menu and provider status model
- lets connected providers be selected for an agent group
- routes unconnected providers into their setup flow
- adds a bounded screen-navigation target for connector settings
- keeps configuration and completion mutually exclusive and retryable
- shares provider normalization between settings and chat

## How did I test?

- `packages/api`: 38 files and 826 tests passed
- `packages/api`: build passed
- connector settings tests: 4 passed
- `packages/shared`: TypeScript passed
- `packages/app`: TypeScript passed
- formatting and diff checks passed

## Reviewer guide

Start with `packages/app/ui/components/PostContent/McpConnectControl.tsx`, then the `McpConnect` schema in `packages/api/src/client/a2ui.ts`. The remaining files connect provider state to existing settings and navigation.