### PR TITLE
Avoid Android IME duplication in onboarding inputs

### DIFF
--- a/apps/tlon-mobile/src/screens/Onboarding/SetNicknameScreen.tsx
+++ b/apps/tlon-mobile/src/screens/Onboarding/SetNicknameScreen.tsx
@@ -9,6 +9,7 @@ import {
   View,
   XStack,
   YStack,
+  isWeb,
   useTheme,
 } from '@tloncorp/app/ui';
 import { createDevLogger } from '@tloncorp/shared';
@@ -19,7 +20,7 @@ import {
   withRetry,
 } from '@tloncorp/shared/logic';
 import * as store from '@tloncorp/shared/store';
-import { useEffect } from 'react';
+import { useEffect, useState } from 'react';
 import { Controller, useForm } from 'react-hook-form';
 
 import { useSignupContext } from '../../lib/signupContext';
@@ -42,6 +43,10 @@ export const SetNicknameScreen = ({ navigation }: Props) => {
   const facesImage = theme.dark
     ? require('../../../assets/images/faces-dark.png')
     : require('../../../assets/images/faces.png');
+
+  // Bumped when the revival prefill lands so the uncontrolled native input
+  // remounts and picks up the new defaultValue.
+  const [prefillKey, setPrefillKey] = useState(0);
 
   const {
     control,
@@ -137,6 +142,7 @@ export const SetNicknameScreen = ({ navigation }: Props) => {
         currentUser?.peerNickname?.trim() || currentUser?.nickname?.trim();
       if (existingNickname && !cancelled) {
         setValue('nickname', existingNickname, { shouldValidate: true });
+        setPrefillKey((key) => key + 1);
       }
     })().catch((err) => {
       logger.trackError('Failed to prefill revival nickname', {
@@ -192,7 +198,14 @@ export const SetNicknameScreen = ({ navigation }: Props) => {
           render={({ field: { onChange, onBlur, value } }) => (
             <Field label="Nickname" error={errors.nickname?.message}>
               <TextInput
-                value={value}
+                key={prefillKey}
+                // Echoing a controlled value back mid-IME-composition
+                // duplicates the composed text on Android (stale
+                // mostRecentEventCount), so native stays uncontrolled;
+                // defaultValue seeds the form value, and the key remount
+                // re-seeds it when the async revival prefill lands.
+                value={isWeb ? value : undefined}
+                defaultValue={isWeb ? undefined : value}
                 placeholder="Sampel Palnet"
                 onBlur={onBlur}
                 onChangeText={onChange}

--- a/packages/app/ui/components/Form/OTPInput.tsx
+++ b/packages/app/ui/components/Form/OTPInput.tsx
@@ -1,6 +1,6 @@
 import { useCallback, useEffect, useRef } from 'react';
 import { TextInput as RNTextInput } from 'react-native';
-import { Text, View, XStack } from 'tamagui';
+import { Text, View, XStack, isWeb } from 'tamagui';
 
 import { Field } from './Field';
 
@@ -18,10 +18,12 @@ export function OTPInput({
   error?: string;
 }) {
   const inputRef = useRef<RNTextInput>(null);
+  const lastNativeTextRef = useRef('');
   const fullValue = value.join('');
 
   const handleChangeText = useCallback(
     (text: string) => {
+      lastNativeTextRef.current = text;
       const sanitizedText = text.replace(/\D/g, '').slice(0, length);
       const nextCode = sanitizedText.split('');
       while (nextCode.length < length) {
@@ -37,6 +39,17 @@ export function OTPInput({
       inputRef.current?.focus();
     });
   }, []);
+
+  useEffect(() => {
+    // The native input is uncontrolled (see below), so when the parent
+    // resets the code externally (e.g. requesting a new one) we have to
+    // clear the native text imperatively.
+    if (isWeb || fullValue !== '' || lastNativeTextRef.current === '') {
+      return;
+    }
+    lastNativeTextRef.current = '';
+    inputRef.current?.clear();
+  }, [fullValue]);
 
   return (
     <Field
@@ -70,7 +83,11 @@ export function OTPInput({
         })}
         <RNTextInput
           ref={inputRef}
-          value={fullValue}
+          // Echoing a controlled value back mid-IME-composition duplicates
+          // the composed text on Android (stale mostRecentEventCount) —
+          // worse here because the echoed value is sanitized — so native
+          // stays uncontrolled; the digit boxes above render from state.
+          value={isWeb ? fullValue : undefined}
           onChangeText={handleChangeText}
           keyboardType="number-pad"
           autoComplete="off"

--- a/packages/app/ui/components/Form/OTPInput.tsx
+++ b/packages/app/ui/components/Form/OTPInput.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useRef } from 'react';
+import { useCallback, useEffect, useRef, useState } from 'react';
 import { TextInput as RNTextInput } from 'react-native';
 import { Text, View, XStack, isWeb } from 'tamagui';
 
@@ -19,12 +19,21 @@ export function OTPInput({
 }) {
   const inputRef = useRef<RNTextInput>(null);
   const lastNativeTextRef = useRef('');
+  const [reseedKey, setReseedKey] = useState(0);
   const fullValue = value.join('');
 
   const handleChangeText = useCallback(
     (text: string) => {
       lastNativeTextRef.current = text;
       const sanitizedText = text.replace(/\D/g, '').slice(0, length);
+      if (!isWeb && text !== sanitizedText) {
+        // Left alone, stray characters (separators in a pasted code, typing
+        // past a full code) would linger invisibly in the uncontrolled
+        // native buffer and swallow backspaces. Remount the input so
+        // defaultValue re-seeds the buffer with the sanitized code.
+        lastNativeTextRef.current = sanitizedText;
+        setReseedKey((key) => key + 1);
+      }
       const nextCode = sanitizedText.split('');
       while (nextCode.length < length) {
         nextCode.push('');
@@ -35,10 +44,11 @@ export function OTPInput({
   );
 
   useEffect(() => {
+    // Runs on mount and again after a reseed remount replaces the input.
     setTimeout(() => {
       inputRef.current?.focus();
     });
-  }, []);
+  }, [reseedKey]);
 
   useEffect(() => {
     // The native input is uncontrolled (see below), so when the parent
@@ -83,11 +93,15 @@ export function OTPInput({
         })}
         <RNTextInput
           ref={inputRef}
+          // Remounting is the only race-free way to rewrite the uncontrolled
+          // native buffer (see handleChangeText).
+          key={reseedKey}
           // Echoing a controlled value back mid-IME-composition duplicates
           // the composed text on Android (stale mostRecentEventCount) —
           // worse here because the echoed value is sanitized — so native
           // stays uncontrolled; the digit boxes above render from state.
           value={isWeb ? fullValue : undefined}
+          defaultValue={isWeb ? undefined : fullValue}
           onChangeText={handleChangeText}
           keyboardType="number-pad"
           autoComplete="off"

--- a/packages/app/ui/components/PostContent/A2UIBlock.tsx
+++ b/packages/app/ui/components/PostContent/A2UIBlock.tsx
@@ -12,7 +12,7 @@ import React, {
   useRef,
   useState,
 } from 'react';
-import { View, XStack, YStack } from 'tamagui';
+import { View, XStack, YStack, isWeb } from 'tamagui';
 
 import { ActionSheet } from '../ActionSheet';
 import { TextInput } from '../Form';
@@ -545,7 +545,11 @@ function SmallChoiceControl({
               <TextInput
                 testID="A2UISmallChoiceFreeText"
                 autoFocus
-                value={customDraft}
+                // Echoing a controlled value back mid-IME-composition
+                // duplicates the composed text on Android (stale
+                // mostRecentEventCount), so native stays uncontrolled; the
+                // sheet unmounts on close, so each open starts empty.
+                value={isWeb ? customDraft : undefined}
                 onChangeText={setCustomDraft}
                 maxLength={AGENT_PROTOCOL_LIMITS.topicLength}
                 placeholder={component.freeTextPlaceholder}

--- a/packages/app/ui/components/Wayfinding/SplashSequence.tsx
+++ b/packages/app/ui/components/Wayfinding/SplashSequence.tsx
@@ -1263,7 +1263,12 @@ export function BotNamePane(props: {
               <TextInput
                 ref={inputRef}
                 testID="bot-name-input"
-                value={props.name}
+                // Echoing a controlled value back mid-IME-composition
+                // duplicates the composed text on Android (stale
+                // mostRecentEventCount), so native seeds the revival
+                // prefill via defaultValue and stays uncontrolled.
+                value={isWeb ? props.name : undefined}
+                defaultValue={isWeb ? undefined : props.name}
                 onChangeText={handleNameChange}
                 onBlur={refocusInput}
                 autoCapitalize="none"

--- a/packages/app/ui/components/Wayfinding/SplashSequence.tsx
+++ b/packages/app/ui/components/Wayfinding/SplashSequence.tsx
@@ -1229,10 +1229,24 @@ export function BotNamePane(props: {
   const insets = useSafeAreaInsets();
   const [error, setError] = useState<string | null>(null);
   const inputRef = useRef<TextInputRef>(null);
+  const [seedKey, setSeedKey] = useState(0);
+  const lastTypedNameRef = useRef(props.name);
   const handleNameChange = (value: string) => {
+    lastTypedNameRef.current = value;
     setError(null);
     props.onNameChange(value);
   };
+
+  // The persisted revival name hydrates asynchronously, so props.name can
+  // change without the user typing. The native input is uncontrolled (see
+  // below), so remount it to re-seed defaultValue when that happens.
+  useEffect(() => {
+    if (isWeb || props.name === lastTypedNameRef.current) {
+      return;
+    }
+    lastTypedNameRef.current = props.name;
+    setSeedKey((key) => key + 1);
+  }, [props.name]);
 
   const handlePress = () => {
     if (!props.name.trim()) {
@@ -1262,11 +1276,13 @@ export function BotNamePane(props: {
             <Field error={error ?? undefined}>
               <TextInput
                 ref={inputRef}
+                key={seedKey}
                 testID="bot-name-input"
                 // Echoing a controlled value back mid-IME-composition
                 // duplicates the composed text on Android (stale
                 // mostRecentEventCount), so native seeds the revival
-                // prefill via defaultValue and stays uncontrolled.
+                // prefill via defaultValue and stays uncontrolled; the
+                // key remount re-seeds it when the prefill hydrates late.
                 value={isWeb ? props.name : undefined}
                 defaultValue={isWeb ? undefined : props.name}
                 onChangeText={handleNameChange}


### PR DESCRIPTION
## Summary

Controlled TextInputs on the React Native new architecture re-apply their `value` against a stale `mostRecentEventCount` mid-IME-composition, duplicating the composed text on Android ("Bas" → "BasBa"). This makes the four onboarding text inputs uncontrolled on native, following the existing BareChatInput precedent (`value={isWeb ? text : undefined}`). Web stays controlled and unchanged.

## Changes

- **A2UI custom-topic input** (`packages/app/ui/components/PostContent/A2UIBlock.tsx`): uncontrolled on native; the sheet unmounts on close, so each open starts empty.
- **Bot-name input** (`packages/app/ui/components/Wayfinding/SplashSequence.tsx`): uncontrolled on native, seeding the revival prefill via `defaultValue`.
- **Nickname screen** (`apps/tlon-mobile/src/screens/Onboarding/SetNicknameScreen.tsx`): uncontrolled on native with `defaultValue` seeding. Because the revival prefill lands asynchronously (contact read → `setValue`), the input remounts via a `key` bump when the prefill arrives so the seeded value updates.
- **OTP input** (`packages/app/ui/components/Form/OTPInput.tsx`): the hidden input is uncontrolled on native (the visible digit boxes already render from sanitized state — echoing the sanitized value was an extra re-entrancy risk). When the parent resets the code externally ("Request a new code" → `setOtp([])`), an effect clears the native text imperatively via `inputRef.current?.clear()`, guarded so user backspace-to-empty doesn't trigger a redundant clear.

## How did I test?

- Manual testing of the onboarding flow on Android (RN new architecture): composed text no longer duplicates in these inputs; revival prefill still displays in the nickname and bot-name inputs; OTP resend clears the field.
- `pnpm exec tsc --noEmit` clean in `packages/app` and `apps/tlon-mobile` on this branch.
- `oxfmt --check` clean on the four touched files.

## Risks and impact

- Safe to rollback without consulting PR author? (Yes | No): **Yes**
- Affects important code area:
  - [x] Onboarding
  - [ ] State / providers
  - [ ] Message sync
  - [ ] Channel display
  - [ ] Notifications
  - [ ] Other:

## Rollback plan

Revert the two commits; the inputs return to fully controlled behavior on all platforms.

## Screenshots / videos

N/A

🤖 Generated with [Claude Code](https://claude.com/claude-code)