### PR TITLE
OpenClaw: capture tlon tool call context via OTel

### DIFF
--- a/packages/openclaw/dev/entrypoint.sh
+++ b/packages/openclaw/dev/entrypoint.sh
@@ -47,8 +47,8 @@ minimumReleaseAge: 0
 verifyDepsBeforeRun: false
 PNPM_EOF
 pnpm install
-pnpm build
 ./dev/build-local-api-override.sh
+pnpm build
 ./dev/build-local-skill-override.sh
 
 # Expose tlon CLI to PATH

--- a/packages/openclaw/index.ts
+++ b/packages/openclaw/index.ts
@@ -4,6 +4,7 @@ import { fileURLToPath } from 'node:url';
 import { defineBundledChannelEntry } from 'openclaw/plugin-sdk/channel-entry-contract';
 import { type OpenClawPluginApi } from 'openclaw/plugin-sdk/core';
 import {
+  emitDiagnosticEvent,
   onDiagnosticEvent,
   onInternalDiagnosticEvent,
 } from 'openclaw/plugin-sdk/diagnostic-runtime';
@@ -64,6 +65,7 @@ import {
   createTlonToolExecutor,
   summarizeTlonCommand,
 } from './src/tlon-tool-command.js';
+import { buildTlonToolDiagnosticRecord } from './src/tlon-tool-diagnostics.js';
 import {
   formatToolTraceEvent,
   liveToolTraceContentsEnabled,
@@ -1076,6 +1078,10 @@ export default defineBundledChannelEntry({
 
     api.on('after_tool_call', (event, ctx) => {
       const toolCallId = readToolCallId(event);
+      const tlonCommandContext =
+        event.toolName === 'tlon' && typeof event.params.command === 'string'
+          ? summarizeTlonCommand(event.params.command)
+          : undefined;
       recordActiveTlonTurnToolCall();
       if (logToolTraceContents && shouldLogAfterToolTrace(event)) {
         api.logger.info(
@@ -1099,16 +1105,23 @@ export default defineBundledChannelEntry({
         sourceEventName: event.toolName,
         sessionKey: ctx.sessionKey,
         run: () => {
+          if (tlonCommandContext) {
+            emitDiagnosticEvent({
+              type: 'log.record',
+              ...buildTlonToolDiagnosticRecord(tlonCommandContext, {
+                ...event,
+                toolCallId,
+                runId: ctx.runId,
+                sessionId: ctx.sessionId,
+              }),
+            });
+          }
           recordToolCall({
             sessionKey: ctx.sessionKey,
             toolName: event.toolName,
             durationMs: event.durationMs,
             error: event.error,
-            context:
-              event.toolName === 'tlon' &&
-              typeof event.params.command === 'string'
-                ? summarizeTlonCommand(event.params.command)
-                : undefined,
+            context: tlonCommandContext,
           });
         },
       });

--- a/packages/openclaw/package.json
+++ b/packages/openclaw/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tloncorp/openclaw",
-  "version": "0.20.0",
+  "version": "0.25.0",
   "description": "OpenClaw Tlon/Urbit channel plugin",
   "license": "MIT",
   "repository": {

--- a/packages/openclaw/src/tlon-tool-command.test.ts
+++ b/packages/openclaw/src/tlon-tool-command.test.ts
@@ -76,14 +76,22 @@ describe('tlon tool execution', () => {
           state: 'resolved',
           value: {
             content: [{ type: 'text', text: BLOCKED_MIGRATION_MESSAGE }],
-            details: { blocked: true, reason: 'migration_operation' },
+            details: {
+              status: 'blocked',
+              blocked: true,
+              reason: 'migration_operation',
+            },
           },
         },
         {
           state: 'resolved',
           value: {
             content: [{ type: 'text', text: BLOCKED_MIGRATION_MESSAGE }],
-            details: { blocked: true, reason: 'migration_operation' },
+            details: {
+              status: 'blocked',
+              blocked: true,
+              reason: 'migration_operation',
+            },
           },
         },
       ]);
@@ -140,7 +148,11 @@ describe('tlon tool execution', () => {
 
     expect(result).toEqual({
       content: [{ type: 'text', text: BLOCKED_MIGRATION_MESSAGE }],
-      details: { blocked: true, reason: 'migration_operation' },
+      details: {
+        status: 'blocked',
+        blocked: true,
+        reason: 'migration_operation',
+      },
     });
     await vi.waitFor(() =>
       expect(logError).toHaveBeenCalledWith(

--- a/packages/openclaw/src/tlon-tool-command.ts
+++ b/packages/openclaw/src/tlon-tool-command.ts
@@ -358,7 +358,11 @@ export function createTlonToolExecutor(deps: TlonToolExecutorDeps) {
         }
         return {
           content: [{ type: 'text' as const, text: blocked.message }],
-          details: { blocked: true, reason: blocked.reason },
+          details: {
+            status: 'blocked',
+            blocked: true,
+            reason: blocked.reason,
+          },
         };
       }
 

--- a/packages/openclaw/src/tlon-tool-diagnostics.test.ts
+++ b/packages/openclaw/src/tlon-tool-diagnostics.test.ts
@@ -1,0 +1,162 @@
+import { describe, expect, it } from 'vitest';
+
+import { summarizeTlonCommand } from './tlon-tool-command.js';
+import {
+  buildTlonToolDiagnosticRecord,
+  resolveTlonToolOutcome,
+} from './tlon-tool-diagnostics.js';
+
+describe('tlon tool OpenTelemetry diagnostics', () => {
+  it('emits a semantic error record without raw command, result, or error text', () => {
+    const secretCode = 'sampel-ticlyt-migfun-falmel';
+    const targetShip = '~sampel-palnet';
+    const rawOutput = 'private profile payload';
+    const summary = summarizeTlonCommand(
+      `--code ${secretCode} contacts get ${targetShip}`
+    );
+
+    const record = buildTlonToolDiagnosticRecord(summary, {
+      durationMs: 417,
+      toolCallId: 'tool-call-17',
+      runId: 'run-3',
+      sessionId: 'session-5',
+      result: {
+        content: [{ type: 'text', text: rawOutput }],
+        details: { error: true },
+      },
+      error: `CLI failed for ${targetShip}: ${rawOutput}`,
+    });
+
+    expect(record).toEqual({
+      level: 'ERROR',
+      message: 'tlon.tool.execution',
+      loggerName: 'tlon.tool',
+      attributes: {
+        'tlon.tool.event': 'tlon.tool.execution',
+        'tlon.tool.summary_key': 'contacts.get',
+        'tlon.tool.subcommand': 'contacts',
+        'tlon.tool.operation': 'get',
+        'tlon.tool.intent': 'read',
+        'tlon.tool.outcome': 'error',
+        'tlon.tool.known_subcommand': true,
+        'tlon.tool.blocked_send_operation': false,
+        'tlon.tool.duration_ms': 417,
+        'tlon.tool.failure_kind': 'tool_result_error',
+        toolCallId: 'tool-call-17',
+        runId: 'run-3',
+        sessionId: 'session-5',
+      },
+    });
+
+    const serialized = JSON.stringify(record);
+    expect(serialized).not.toContain(secretCode);
+    expect(serialized).not.toContain(targetShip);
+    expect(serialized).not.toContain(rawOutput);
+  });
+
+  it('preserves a safe blocked reason and semantic command fields', () => {
+    const privateNest = 'diary/~bot/private-notebook';
+    const summary = summarizeTlonCommand(
+      `notes migrate-apply ${privateNest} --yes`
+    );
+    const record = buildTlonToolDiagnosticRecord(summary, {
+      durationMs: 3,
+      result: {
+        content: [{ type: 'text', text: `Ask the owner about ${privateNest}` }],
+        details: {
+          status: 'blocked',
+          blocked: true,
+          reason: 'migration_operation',
+        },
+      },
+      error: `Blocked migration of ${privateNest}`,
+    });
+
+    expect(record.level).toBe('WARN');
+    expect(record.attributes).toMatchObject({
+      'tlon.tool.summary_key': 'notes.migrate-apply',
+      'tlon.tool.intent': 'write',
+      'tlon.tool.outcome': 'blocked',
+      'tlon.tool.failure_kind': 'migration_operation',
+    });
+    expect(JSON.stringify(record)).not.toContain(privateNest);
+  });
+
+  it('uses a generic block kind for unrecognized result reasons', () => {
+    const record = buildTlonToolDiagnosticRecord(
+      summarizeTlonCommand('groups delete ~host/group'),
+      {
+        result: {
+          details: {
+            status: 'blocked',
+            reason: 'contains-private-target-name',
+          },
+        },
+      }
+    );
+
+    expect(record.attributes['tlon.tool.failure_kind']).toBe('blocked');
+    expect(JSON.stringify(record)).not.toContain(
+      'contains-private-target-name'
+    );
+  });
+
+  it('marks invalid commands without retaining their text', () => {
+    const privateCommand = 'definitely-private-command';
+    const record = buildTlonToolDiagnosticRecord(
+      summarizeTlonCommand(`${privateCommand} --token hidden-value`),
+      { result: { details: { error: true } } }
+    );
+
+    expect(record.attributes).toMatchObject({
+      'tlon.tool.summary_key': 'unknown.invalid',
+      'tlon.tool.subcommand': 'unknown',
+      'tlon.tool.operation': 'invalid',
+      'tlon.tool.outcome': 'error',
+      'tlon.tool.failure_kind': 'invalid_command',
+    });
+    expect(JSON.stringify(record)).not.toContain(privateCommand);
+    expect(JSON.stringify(record)).not.toContain('hidden-value');
+  });
+
+  it('projects bounded semantic detail for successful calls', () => {
+    const record = buildTlonToolDiagnosticRecord(
+      summarizeTlonCommand(
+        'channels create ~host/group --kind notes --description private-copy'
+      ),
+      { durationMs: 28, result: { details: undefined } }
+    );
+
+    expect(record).toMatchObject({
+      level: 'INFO',
+      attributes: {
+        'tlon.tool.summary_key': 'channels.create',
+        'tlon.tool.outcome': 'ok',
+        'tlon.tool.channel_kind': 'notes',
+        'tlon.tool.has_title': false,
+        'tlon.tool.has_description': true,
+        'tlon.tool.duration_ms': 28,
+      },
+    });
+    expect(JSON.stringify(record)).not.toContain('private-copy');
+    expect(record.attributes).not.toHaveProperty('tlon.tool.failure_kind');
+  });
+
+  it('recognizes the host terminal-result contract', () => {
+    expect(
+      resolveTlonToolOutcome({ result: { details: { status: 'blocked' } } })
+    ).toBe('blocked');
+    expect(
+      resolveTlonToolOutcome({ result: { details: { status: 'timed_out' } } })
+    ).toBe('error');
+    expect(
+      resolveTlonToolOutcome({ result: { details: { success: false } } })
+    ).toBe('error');
+    expect(
+      resolveTlonToolOutcome({ result: { details: { exitCode: 2 } } })
+    ).toBe('error');
+    expect(resolveTlonToolOutcome({ result: { details: { ok: true } } })).toBe(
+      'ok'
+    );
+  });
+});

--- a/packages/openclaw/src/tlon-tool-diagnostics.ts
+++ b/packages/openclaw/src/tlon-tool-diagnostics.ts
@@ -1,0 +1,243 @@
+import type { TlonToolCallContext } from './tlon-tool-command.js';
+
+export type TlonToolOutcome = 'ok' | 'error' | 'blocked';
+
+export type TlonToolDiagnosticRecord = {
+  level: 'INFO' | 'WARN' | 'ERROR';
+  message: 'tlon.tool.execution';
+  loggerName: 'tlon.tool';
+  attributes: Record<string, string | number | boolean>;
+};
+
+type TlonToolTerminalEvent = {
+  result?: unknown;
+  error?: unknown;
+  durationMs?: number;
+  toolCallId?: string;
+  runId?: string;
+  sessionId?: string;
+};
+
+const BLOCKED_STATUSES = new Set([
+  'blocked',
+  'denied',
+  'forbidden',
+  'disabled',
+  'approval-unavailable',
+]);
+
+const FAILURE_STATUSES = new Set([
+  'error',
+  'failed',
+  'failure',
+  'timeout',
+  'timed_out',
+  'unavailable',
+  'aborted',
+  'cancelled',
+  'canceled',
+  'killed',
+  'invalid',
+]);
+
+const SAFE_BLOCK_REASONS = new Set([
+  'diary_operation',
+  'migration_operation',
+  'send_operation',
+]);
+
+function resultDetails(result: unknown): Record<string, unknown> | null {
+  if (!result || typeof result !== 'object' || Array.isArray(result)) {
+    return null;
+  }
+  const details = (result as { details?: unknown }).details;
+  if (!details || typeof details !== 'object' || Array.isArray(details)) {
+    return null;
+  }
+  return details as Record<string, unknown>;
+}
+
+function normalizedStatus(details: Record<string, unknown> | null): string {
+  const status = details?.status;
+  return typeof status === 'string' ? status.trim().toLowerCase() : '';
+}
+
+export function resolveTlonToolOutcome(
+  event: TlonToolTerminalEvent
+): TlonToolOutcome {
+  const details = resultDetails(event.result);
+  const status = normalizedStatus(details);
+
+  if (details?.blocked === true || BLOCKED_STATUSES.has(status)) {
+    return 'blocked';
+  }
+  if (
+    event.error != null ||
+    details?.ok === false ||
+    details?.success === false ||
+    Boolean(details?.error) ||
+    details?.timedOut === true ||
+    FAILURE_STATUSES.has(status) ||
+    (typeof details?.exitCode === 'number' && details.exitCode !== 0)
+  ) {
+    return 'error';
+  }
+  return 'ok';
+}
+
+function safeFailureKind(
+  outcome: TlonToolOutcome,
+  summary: TlonToolCallContext,
+  details: Record<string, unknown> | null
+): string | null {
+  if (outcome === 'blocked') {
+    const reason = details?.reason;
+    return typeof reason === 'string' && SAFE_BLOCK_REASONS.has(reason)
+      ? reason
+      : 'blocked';
+  }
+  if (outcome === 'error') {
+    return !summary.isKnownSubcommand || summary.operation === 'invalid'
+      ? 'invalid_command'
+      : 'tool_result_error';
+  }
+  return null;
+}
+
+function addOptionalAttribute(
+  attributes: Record<string, string | number | boolean>,
+  key: string,
+  value: string | number | boolean | undefined
+): void {
+  if (value !== undefined) {
+    attributes[key] = value;
+  }
+}
+
+function addOptionalIdAttribute(
+  attributes: Record<string, string | number | boolean>,
+  key: string,
+  value: string | undefined
+): void {
+  const normalized = value?.trim();
+  if (normalized) {
+    attributes[key] = normalized;
+  }
+}
+
+export function buildTlonToolDiagnosticRecord(
+  summary: TlonToolCallContext,
+  event: TlonToolTerminalEvent
+): TlonToolDiagnosticRecord {
+  const outcome = resolveTlonToolOutcome(event);
+  const details = resultDetails(event.result);
+  const failureKind = safeFailureKind(outcome, summary, details);
+  const attributes: Record<string, string | number | boolean> = {
+    'tlon.tool.event': 'tlon.tool.execution',
+    'tlon.tool.summary_key': summary.summaryKey,
+    'tlon.tool.subcommand': summary.subcommand,
+    'tlon.tool.operation': summary.operation,
+    'tlon.tool.intent': summary.intent,
+    'tlon.tool.outcome': outcome,
+    'tlon.tool.known_subcommand': summary.isKnownSubcommand,
+    'tlon.tool.blocked_send_operation': summary.blockedSendOperation,
+  };
+
+  if (
+    typeof event.durationMs === 'number' &&
+    Number.isFinite(event.durationMs) &&
+    event.durationMs >= 0
+  ) {
+    attributes['tlon.tool.duration_ms'] = event.durationMs;
+  }
+  if (failureKind) {
+    attributes['tlon.tool.failure_kind'] = failureKind;
+  }
+  addOptionalIdAttribute(attributes, 'toolCallId', event.toolCallId);
+  addOptionalIdAttribute(attributes, 'runId', event.runId);
+  addOptionalIdAttribute(attributes, 'sessionId', event.sessionId);
+
+  addOptionalAttribute(
+    attributes,
+    'tlon.tool.channel_kind',
+    summary.channelKind
+  );
+  addOptionalAttribute(
+    attributes,
+    'tlon.tool.dm_target_kind',
+    summary.dmTargetKind
+  );
+  addOptionalAttribute(
+    attributes,
+    'tlon.tool.upload_source',
+    summary.uploadSource
+  );
+  if (summary.updateFields) {
+    attributes['tlon.tool.update_fields'] = summary.updateFields.join(',');
+  }
+  addOptionalAttribute(
+    attributes,
+    'tlon.tool.invitee_count',
+    summary.inviteeCount
+  );
+  addOptionalAttribute(
+    attributes,
+    'tlon.tool.member_count',
+    summary.memberCount
+  );
+  addOptionalAttribute(
+    attributes,
+    'tlon.tool.contact_count',
+    summary.contactCount
+  );
+  addOptionalAttribute(attributes, 'tlon.tool.role_count', summary.roleCount);
+  addOptionalAttribute(attributes, 'tlon.tool.hook_count', summary.hookCount);
+  addOptionalAttribute(
+    attributes,
+    'tlon.tool.has_description',
+    summary.hasDescription
+  );
+  addOptionalAttribute(attributes, 'tlon.tool.has_title', summary.hasTitle);
+  addOptionalAttribute(attributes, 'tlon.tool.has_content', summary.hasContent);
+  addOptionalAttribute(attributes, 'tlon.tool.has_image', summary.hasImage);
+  addOptionalAttribute(
+    attributes,
+    'tlon.tool.has_name_change',
+    summary.hasNameChange
+  );
+  addOptionalAttribute(
+    attributes,
+    'tlon.tool.has_source_change',
+    summary.hasSourceChange
+  );
+  addOptionalAttribute(attributes, 'tlon.tool.has_nest', summary.hasNest);
+  addOptionalAttribute(
+    attributes,
+    'tlon.tool.privacy_setting',
+    summary.privacySetting
+  );
+  addOptionalAttribute(attributes, 'tlon.tool.limit', summary.limit);
+  addOptionalAttribute(
+    attributes,
+    'tlon.tool.resolve_cites',
+    summary.resolveCites
+  );
+  addOptionalAttribute(
+    attributes,
+    'tlon.tool.scoped_to_channel',
+    summary.scopedToChannel
+  );
+  addOptionalAttribute(
+    attributes,
+    'tlon.tool.content_type_provided',
+    summary.contentTypeProvided
+  );
+
+  return {
+    level:
+      outcome === 'error' ? 'ERROR' : outcome === 'blocked' ? 'WARN' : 'INFO',
+    message: 'tlon.tool.execution',
+    loggerName: 'tlon.tool',
+    attributes,
+  };
+}


### PR DESCRIPTION
## Summary

OTT, uses the tlon tool command parsing we have and forwards it along via OTel for use in Grafana panels/dashboards.

## Changes

- Added sanitized Tlon command details and failure diagnostics to OpenTelemetry spans for easier Grafana debugging, with tests

## How did I test?

Difficult to test locally, confirmed still runs normally from dev server

## Risks and impact

- Safe to rollback without consulting PR author? Yes
