### PR TITLE
[TEST rn-iso loop] Use a warm orange accent for the primary onboarding button

### DIFF
--- a/packages/app/ui/components/Onboarding/OnboardingButton.tsx
+++ b/packages/app/ui/components/Onboarding/OnboardingButton.tsx
@@ -15,7 +15,7 @@ export function OnboardingButton({
   label,
   ...props
 }: OnboardingButtonProps) {
-  const color = secondary ? '$secondaryText' : '$primaryText';
+  const color = secondary ? '$secondaryText' : '$orange';
   return (
     <Button
       {...props}


### PR DESCRIPTION
> [!WARNING]
> **This is an automated agent-loop validation PR. Please CLOSE it — do not merge.**
> The ticket ("TLON-TEST-1") is invented. The change is real and correct, but it exists
> only to exercise the `docs/mobile-ticket-loop.md` workflow end to end (rn-iso worktree
> → build → on-device before/after evidence → repo gates → PR). Base branch is
> `rn-iso/loop-base`, not `develop`.

## Summary

The primary onboarding call to action renders on `$primaryText` — the same near-black as
body copy — so the pre-login Welcome screen has no accent colour at all and the primary and
secondary buttons read as two shades of grey. This points the primary variant at the design
system's existing `$orange` token (`#FF9040`).

**Caveat a designer should settle before this ships:** the `hero` preset draws its label in
`$background`, which is white in the light theme. White on `#FF9040` is ~2.3:1, below WCAG AA
for text; it was ~16:1 on the old near-black. Dark theme is fine (near-black label on orange).
A darker orange or a dark label would fix it — I left it alone rather than invent a token.

## Changes

One line in `packages/app/ui/components/Onboarding/OnboardingButton.tsx`: the non-`secondary`
branch of the `color` constant, which feeds `backgroundColor`, `borderColor` and `pressStyle`.
`$orange` is an existing token in `packages/ui/tamagui.config.ts`, already used by `Badge` and
`ConnectionStatus`; no new token is introduced. The `secondary` variant is untouched.

**Open question:** this is the shared onboarding button, so the accent lands on the primary CTA
across the whole onboarding stack, not only Welcome. That seemed more coherent than special-casing
one screen — but if the intent is Welcome-only, say so and I'll scope it down.

## How did I test?

iOS simulator `rn-iso-tlon-test-1-tlon-mobile` (iPhone 17, iOS 26.5), debug dev-client build of
`io.tlon.groups` on a dedicated Metro (port 8085).

Launched to the pre-login Welcome screen — reachable with no ship and no credentials — captured
the "before" shot, made the edit, let Fast Refresh apply it (JS-only, no rebuild), then captured
"after" on the same screen in the same session by the same route. That pair is below. The
accessibility tree is identical across the two (`Sign up` / `Join with an invite` /
`Have an account? Log in`), so only the fill changed.

## Risks and impact

- Safe to rollback without consulting PR author? **Yes**
- Affects important code area:
  - [x] Onboarding
  - [ ] State / providers
  - [ ] Message sync
  - [ ] Channel display
  - [ ] Notifications
  - [ ] Other:

Cosmetic and contained to one component. The contrast caveat in the Summary is the only thing
here that should block a merge.

## Rollback plan

Revert the commit. No migration, no persisted state, no native side.

## Screenshots / videos

| Before | After |
|---|---|
| <img src="https://github.com/user-attachments/assets/2b1cfa93-fe60-46a6-acb1-e0361ee7447f" width="300" /> | <img src="https://github.com/user-attachments/assets/9e6e5147-db9c-42bb-a92a-6001efeb650d" width="300" /> |
