### PR TITLE
[TEST rn-iso loop] Say "Already have an account?" on the pre-login log-in prompt

### DIFF
--- a/apps/tlon-mobile/src/screens/Onboarding/WelcomeScreen.tsx
+++ b/apps/tlon-mobile/src/screens/Onboarding/WelcomeScreen.tsx
@@ -125,7 +125,7 @@ export const WelcomeScreen = ({ navigation }: Props) => {
               onPress={() => setOpen(true)}
             >
               <SizableText color="$primaryText">
-                Have an account? Log in
+                Already have an account? Log in
               </SizableText>
             </Pressable>
           </XStack>


### PR DESCRIPTION
> **Test PR for the rn-iso agent loop — do not merge.** Exercises
> `docs/mobile-ticket-loop.md` end to end on an invented ticket (TLON-TEST-2).
> Close it rather than merging. Stacked on `rn-iso/loop-base`.

## Summary

The pre-login Welcome screen's log-in prompt read "Have an account? Log in",
which scans as an offer to create one rather than the route back to an account
you already have. "Already have an account? Log in" is the phrasing the rest of
onboarding uses.

Before | After
--- | ---
![before-welcome.png](https://github.com/user-attachments/assets/80425071-a9cd-496e-be0a-f2fccdda03a2) | ![after-welcome.png](https://github.com/user-attachments/assets/fe30379c-8cd3-4323-b7d6-3baa18c268be)

## Changes

One string in `apps/tlon-mobile/src/screens/Onboarding/WelcomeScreen.tsx`. The
`Pressable`, its `onPress`, and the log-in `ActionSheet` are untouched.

## How did I test?

iOS simulator `rn-iso-tlon-test-2-tlon-mobile` (iPhone 17 Pro, iOS 26) running
the dev client, driven with `agent-device` bound to that device. Launched cold
to the pre-login Welcome screen, captured the before shot, made the edit, let
Fast Refresh apply it, and captured the after shot from the same screen with the
same command — that is the pair above. `npx rn-iso logs --errors --json`
returned no records afterwards.

## Risks and impact

- Safe to rollback without consulting PR author? Yes
- Affects important code area:
  - [x] Onboarding
  - [ ] State / providers
  - [ ] Message sync
  - [ ] Channel display
  - [ ] Notifications
  - [ ] Other:

The string is not localized and nothing asserts on it, so nothing else needs to
change and no test goes red.

## Rollback plan

Revert the commit.

## Screenshots / videos

See the before/after pair under Summary.
