### PR TITLE
[TEST rn-iso loop] Group AppDelegate lifecycle entry under a MARK header

### DIFF
--- a/apps/tlon-mobile/ios/Landscape/AppDelegate.swift
+++ b/apps/tlon-mobile/ios/Landscape/AppDelegate.swift
@@ -13,6 +13,7 @@ class AppDelegate: ExpoAppDelegate {
   var reactNativeDelegate: ReactNativeDelegate?
   var reactNativeFactory: RCTReactNativeFactory?
 
+  // MARK: - App Lifecycle
   override func application(
     _ application: UIApplication,
     didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]? = nil


### PR DESCRIPTION
> **Test PR for the rn-iso agent loop — do not merge.** This is the native-change
> leg of validating `docs/mobile-ticket-loop.md` (invented ticket TLON-TEST-3),
> chosen to exercise the fingerprint miss + Xcode compilation-cache path. Close
> it rather than merging. Stacked on `rn-iso/loop-base`.

## Summary

`AppDelegate.swift` groups each responder-chain section under a `// MARK: -`
banner — Linking API, Universal Links, Remote Notifications, the delegate — with
one exception: `application(_:didFinishLaunchingWithOptions:)`, which sat under
the stored properties with no divider. This adds a matching `// MARK: - App
Lifecycle` so the Xcode jump bar lists it alongside the others.

## Changes

One comment line in `apps/tlon-mobile/ios/Landscape/AppDelegate.swift`. No code
runs differently.

## How did I test?

Comment-only, but it lands in a compiled Swift source, so it changes the native
fingerprint and forces a rebuild — which is the point of using it to exercise the
loop. Built and launched on iOS simulator `rn-iso-tlon-test-3-tlon-mobile`
(iPhone 17 Pro, iOS 26), dev client on Metro port 8085. The app boots through to
the pre-login Welcome screen; `npx rn-iso logs --errors --json` returned no
records.

![boot-welcome.png](https://github.com/user-attachments/assets/c963c9e3-44f7-482b-b9e1-bd59dee05fcc)

## Risks and impact

- Safe to rollback without consulting PR author? Yes
- Affects important code area:
  - [ ] Onboarding
  - [ ] State / providers
  - [ ] Message sync
  - [ ] Channel display
  - [ ] Notifications
  - [x] Other: iOS AppDelegate (comment only)

None. A source comment; no behavior, no API, no dependency changes.

## Rollback plan

Revert the commit.

## Screenshots / videos

The post-build boot to the Welcome screen is above.
