### PR TITLE
desk: vendor mar/tang.hoon so thread failures are reportable

### DIFF
--- a/peru.yaml
+++ b/peru.yaml
@@ -53,6 +53,11 @@ git module base:
     - pkg/base-dev/mar/json.hoon
     - pkg/base-dev/mar/htm.hoon
     - pkg/base-dev/mar/html.hoon
+    # %tang is not needed to build the desk, only to report a failure out of
+    # it: spider renders a crashed thread's stack through its outputMark, so
+    # without this mark a thread that nacks on the %groups desk answers
+    # [%no-cast-between %tang %json] and the real error is never seen.
+    - pkg/base-dev/mar/tang.hoon
   export: pkg/base-dev
 
 # %landscape (tloncorp/landscape) docket + settings types. No 408 tag exists


### PR DESCRIPTION
## Summary

Adds `pkg/base-dev/mar/tang.hoon` to `peru.yaml`'s base pick list, so a failing spider thread on the `%groups` desk can report its error.

Spider renders a thread's result through whatever `outputMark` the caller asked for. When a thread crashes, that result is a `tang` — so a caller asking for `json` needs a `%tang → %json` cast. The desk had no `%tang` mark at all (neither `desk/mar/` nor the peru-vendored `desk-deps/mar/`), so clay could not build the tube:

```
clay: read-at-tako fail [desk=%groups care=%c path=/tang/json]
[%error-building-tube %tang %json]
[%error-building-cast %tang %json]
[%no-cast-between %tang %json]
```

The HTTP caller gets a bodyless 404 and the real error is destroyed. Only the ship console retains it, which is invisible in most CI artifacts.

This is not hypothetical. A negotiate crash in the bot-e2e suite — `%poke-to-mismatching-gill` on a ship the harness had left on an older desk — presented for days as an inscrutable cast error instead of as its own tang. Diagnosing it took reading raw container logs line by line.

## Changes

- `peru.yaml`: one line added to the `base` module pick list, plus a comment explaining why a mark that isn't needed to *build* the desk still belongs in a list assembled as "the transitively-required subset" — so it isn't pruned again.

That is the only tracked change. `desk-deps/` is gitignored, so the vendored file does not appear in the diff; `./scripts/sync-deps.sh` fetches it.

## How did I test?

`./backend/run-tests.sh` on this branch: **341 OK**, **Unit tests passed ✅**, **Aqua tests passed ✅**.

That is the check that matters here — a vendored mark that fails to compile at this kelvin would break the entire desk, not just the mark. `pkg/base-dev/mar/tang.hoon` exists at the pinned `408k-rc2` rev with a working `++ json` arm, and `sync-deps.sh` vendors it cleanly.

## Risks and impact

- Safe to rollback without consulting PR author? (Yes)
- Affects important code area:
  - [ ] Onboarding
  - [ ] State / providers
  - [ ] Message sync
  - [ ] Channel display
  - [ ] Notifications
  - [x] Other: desk dependency vendoring / error observability

Adds one file to the desk. No agent, state, wire-format, or client change. The only behavioral difference is that a previously-unrenderable error now renders — callers that received a bodyless 404 on a thread crash will now receive the tang as JSON, which is strictly more information.

Anyone with an existing checkout should re-run `./scripts/sync-deps.sh` after pulling.

## Rollback plan

Revert the PR and re-run `./scripts/sync-deps.sh`.

## Screenshots

n/a — no UI change.
