### PR TITLE
explain ChatGPT subscription model access

### DIFF
--- a/packages/openclaw/skills/tlon-product-guide/SKILL.md
+++ b/packages/openclaw/skills/tlon-product-guide/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: tlon-product-guide
-description: Answer questions about Tlon, Urbit, Tlon Messenger, Tlonbot, and OpenClaw — what they are, how they work, and how to use them. Covers signup and onboarding, contacts and invites, groups, channels (Chat/Notebook/Bulletin/Gallery), roles and permissions, DMs, bot setup, crons, connected services (MCP), slash commands, models and API keys, privacy and encryption, hosting, exporting, self-hosting, and support. Use whenever someone asks what Tlon is, how a product feature works, what they can do with their node or bot, or asks to be walked through a task in the app.
+description: Answer questions about Tlon, Urbit, Tlon Messenger, Tlonbot, and OpenClaw — what they are, how they work, and how to use them. Covers signup and onboarding, contacts and invites, groups, channels (Chat/Notebook/Bulletin/Gallery), roles and permissions, DMs, bot setup, crons, connected services (MCP), slash commands, models and API keys, privacy and encryption, hosting, exporting, self-hosting, and support. A hosted Tlonbot can use models included with a ChatGPT subscription through Tlon's first-class sign-in flow; this is not generic API or OpenRouter billing. Use whenever someone asks what Tlon is, how a product feature works, what they can do with their node or bot, or asks to be walked through a task in the app.
 ---
 
 # Tlon Messenger: Product Guide
@@ -267,7 +267,11 @@ Bot behavior:
 
 ### Models and API keys
 
-Hosted accounts include an AI model for free — basic usage costs nothing. Want Claude, ChatGPT, or something else? Add your own Anthropic, OpenAI, or OpenRouter key under `Bot Settings` to switch models anytime, or use `/model` to check and change what's running. Self-hosting means no included model and no `Bot Settings` screen: you configure the provider in your own OpenClaw setup and pay whoever you point it at. Either way there's no lock-in — everything you build with your bot stays with you.
+Hosted accounts include an AI model for free — basic usage costs nothing. They also have a first-class **ChatGPT subscription** option: under `Bot Settings` → `ChatGPT subscription`, the owner signs in to authorize their ChatGPT account, then chooses one of the models included with that subscription for Tlonbot. When someone asks what it means to "use a ChatGPT subscription for this," answer this Tlon-specific flow directly; don't substitute generic OpenClaw or OpenRouter billing advice.
+
+ChatGPT subscription access and an OpenAI API key are alternatives, not the same credential. Connecting the subscription removes a saved OpenAI API key, and saving an OpenAI API key disconnects the subscription. Other model providers still use their own API keys under `Bot Settings`. Use `/model` to check or change what's running after the provider is connected.
+
+Self-hosting means no included model, ChatGPT-subscription screen, or `Bot Settings` screen: configure the provider in your own OpenClaw setup and pay whoever you point it at. Either way there's no lock-in — everything you build with your bot stays with you.
 
 ### Guardrails
 

--- a/packages/openclaw/src/product-guide-contract.test.ts
+++ b/packages/openclaw/src/product-guide-contract.test.ts
@@ -1,0 +1,30 @@
+import { readFileSync } from 'node:fs';
+
+import { describe, expect, it } from 'vitest';
+
+const guide = readFileSync(
+  new URL('../skills/tlon-product-guide/SKILL.md', import.meta.url),
+  'utf8'
+);
+
+describe('Tlon product guide contracts', () => {
+  it('distinguishes the hosted ChatGPT subscription flow from API-key billing', () => {
+    const frontmatter = guide.match(/^---\n([\s\S]*?)\n---/)?.[1];
+    expect(frontmatter).toContain(
+      "A hosted Tlonbot can use models included with a ChatGPT subscription through Tlon's first-class sign-in flow"
+    );
+    expect(frontmatter).toContain(
+      'this is not generic API or OpenRouter billing'
+    );
+    expect(guide).toContain('`Bot Settings` → `ChatGPT subscription`');
+    expect(guide).toContain(
+      'chooses one of the models included with that subscription for Tlonbot'
+    );
+    expect(guide).toContain(
+      'ChatGPT subscription access and an OpenAI API key are alternatives'
+    );
+    expect(guide).toContain(
+      "don't substitute generic OpenClaw or OpenRouter billing advice"
+    );
+  });
+});


### PR DESCRIPTION
## Summary

Teach Tlonbot that hosted accounts have a first-class ChatGPT subscription sign-in flow, so an ambiguous product question is not answered as generic OpenClaw or OpenRouter billing guidance.

Fixes TLON-6390

## Changes

- add the hosted ChatGPT subscription distinction to the product-guide trigger description
- document the sign-in, model-selection, and API-key replacement behavior in the guide body
- add a contract test that keeps the always-visible trigger and detailed guidance aligned

## How did I test?

- Baseline: the exact audited prompt failed the local E2E fixture on OpenRouter Luna; it answered generically and never identified Tlon.
- Candidate installed from commit `dc4ca30941` into the production-shaped OpenClaw container. A fresh Luna session answered the same prompt with the Tlon Messenger sign-in flow, distinguished it from API/OpenRouter billing, read the packaged guide, used no fallback, and completed without tool errors.
- `corepack pnpm --filter @tloncorp/openclaw test`: 75 files, 1,492 tests passed.
- `corepack pnpm --filter @tloncorp/openclaw tsc` passed.
- `corepack pnpm --filter @tloncorp/openclaw lint` exited 0 with existing warnings.
- `oxfmt --check` and `git diff --check` passed.

The final ship-layer replay was blocked by the local `~ten` fake ship hanging during fixture setup; the baseline used that full route, while the green proof used a fresh agent session in the same candidate container because this change affects model knowledge, not Tlon message transport.