### PR TITLE
hide successful model fallback notices

### DIFF
--- a/packages/openclaw/index.ts
+++ b/packages/openclaw/index.ts
@@ -36,6 +36,7 @@ import {
   shouldInstallTlonDiagnosticSubscriptions,
 } from './src/diagnostic-subscriptions.js';
 import { notifyDiaryMigrationDiscovery } from './src/diary-migration-discovery.js';
+import { suppressTlonFallbackNotice } from './src/fallback-notice-delivery.js';
 import { registerGatewayStatusHooks } from './src/gateway-status-registration.js';
 import { createMigrateCommandHandler } from './src/migrate-command.js';
 import { isRouteDebugEnabled } from './src/monitor/session-routing.js';
@@ -1253,6 +1254,13 @@ export default defineBundledChannelEntry({
         installTelemetryDiagnosticObservers(api);
       api.on('gateway_stop', unsubscribeDiagnosticEvents);
     }
+
+    // OpenClaw records fallback transitions as lifecycle diagnostics and also
+    // emits a separate user-facing status payload. Keep the diagnostics, but
+    // hide that operational payload on Tlon when the fallback produced a real
+    // answer. Terminal provider failures are not marked as fallback notices
+    // and continue through the normal delivery path.
+    api.on('reply_payload_sending', suppressTlonFallbackNotice);
 
     // ── Route diagnostics ───────────────────────────────────────────────
     // Fires for every outbound send OpenClaw routes — the primary streamed

--- a/packages/openclaw/src/fallback-notice-delivery.test.ts
+++ b/packages/openclaw/src/fallback-notice-delivery.test.ts
@@ -1,0 +1,83 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  TLON_FALLBACK_NOTICE_SUPPRESSION_REASON,
+  suppressTlonFallbackNotice,
+} from './fallback-notice-delivery.js';
+
+const context = { channelId: 'tlon' };
+
+describe('suppressTlonFallbackNotice', () => {
+  it('suppresses an OpenClaw fallback transition on Tlon', () => {
+    expect(
+      suppressTlonFallbackNotice(
+        {
+          payload: { text: 'Model routing status', isFallbackNotice: true },
+          kind: 'final',
+          channel: 'tlon',
+        },
+        context
+      )
+    ).toEqual({
+      cancel: true,
+      reason: TLON_FALLBACK_NOTICE_SUPPRESSION_REASON,
+    });
+  });
+
+  it('uses the resolved hook context when the event omits its channel', () => {
+    expect(
+      suppressTlonFallbackNotice(
+        { payload: { isFallbackNotice: true }, kind: 'final' },
+        context
+      )
+    ).toEqual({
+      cancel: true,
+      reason: TLON_FALLBACK_NOTICE_SUPPRESSION_REASON,
+    });
+  });
+
+  it('preserves a terminal provider error', () => {
+    expect(
+      suppressTlonFallbackNotice(
+        {
+          payload: {
+            text: 'The selected model is unavailable.',
+            isError: true,
+          },
+          kind: 'final',
+          channel: 'tlon',
+        },
+        context
+      )
+    ).toBeUndefined();
+  });
+
+  it('preserves other OpenClaw status notices', () => {
+    expect(
+      suppressTlonFallbackNotice(
+        {
+          payload: {
+            text: 'Compacting conversation context',
+            isStatusNotice: true,
+          },
+          kind: 'final',
+          channel: 'tlon',
+        },
+        context
+      )
+    ).toBeUndefined();
+  });
+
+  it('does not change another channel policy', () => {
+    expect(
+      suppressTlonFallbackNotice(
+        {
+          payload: { isFallbackNotice: true },
+          kind: 'final',
+          channel: 'webchat',
+        },
+        context
+      )
+    ).toBeUndefined();
+  });
+});

--- a/packages/openclaw/src/fallback-notice-delivery.ts
+++ b/packages/openclaw/src/fallback-notice-delivery.ts
@@ -1,0 +1,29 @@
+import type {
+  PluginHookReplyPayloadSendingContext,
+  PluginHookReplyPayloadSendingEvent,
+  PluginHookReplyPayloadSendingResult,
+} from 'openclaw/plugin-sdk/core';
+
+export const TLON_FALLBACK_NOTICE_SUPPRESSION_REASON =
+  'tlon_hides_model_fallback_status';
+
+/**
+ * Tlon users should receive the successful assistant answer, not OpenClaw's
+ * provider-routing status message. The fallback lifecycle event remains
+ * available to logs and telemetry, and terminal provider errors are ordinary
+ * error payloads rather than fallback notices, so they continue to be sent.
+ */
+export function suppressTlonFallbackNotice(
+  event: PluginHookReplyPayloadSendingEvent,
+  ctx: PluginHookReplyPayloadSendingContext
+): PluginHookReplyPayloadSendingResult | undefined {
+  const channel = event.channel ?? ctx.channelId;
+  if (channel !== 'tlon' || event.payload.isFallbackNotice !== true) {
+    return undefined;
+  }
+
+  return {
+    cancel: true,
+    reason: TLON_FALLBACK_NOTICE_SUPPRESSION_REASON,
+  };
+}


### PR DESCRIPTION
## Summary

- Hide OpenClaw's operational fallback-status post when a configured fallback successfully answers on Tlon.
- Preserve fallback attempts in lifecycle diagnostics and continue delivering terminal provider errors.
- Fixes TLON-6392

## Changes

- Cancel only `reply_payload_sending` payloads explicitly marked `isFallbackNotice` and resolved to the Tlon channel.
- Avoid text matching, so ordinary error messages and other OpenClaw status notices keep their existing behavior.
- Add focused coverage for Tlon fallback transitions, context-derived routing, terminal errors, other status notices, and other channels.

## How did I test?

- `corepack pnpm --dir packages/openclaw test` — 75 files, 1,496 tests passed.
- `corepack pnpm --dir packages/openclaw tsc`
- `corepack pnpm --dir packages/openclaw build`
- `oxfmt --check` and `oxlint` on the changed files; only the two existing `index.ts` unused-import warnings remain.
- Controlled live before/after on OpenClaw 2026.7.1 with `openai/gpt-5.5` pointed at a request-time HTTP 429 endpoint and real `openrouter/openai/gpt-5.6-luna` as fallback:
  - Baseline `b4cbe79d02` delivered two Tlon posts, exposing `Model Fallback ... HTTP 429 ... quota limit` before the useful answer (`20260827-044011-audit-fallback-hidden-v0-f71dd694`).
  - Candidate `8b00a01b61` passed 3/3 (`dce676fa`, `6951aa09`, `e178d113`). Every run retained the primary 429 and `candidate_succeeded` fallback decision in logs while the delivered Tlon reply contained only Luna's useful answer.
