### PR TITLE
preserve context across rapid messages

### DIFF
--- a/packages/openclaw/src/channel-prompt.test.ts
+++ b/packages/openclaw/src/channel-prompt.test.ts
@@ -9,7 +9,10 @@ describe('Tlon channel prompt guidance', () => {
     });
 
     expect(hints?.join('\n')).toContain(
-      'Treat adjacent user messages received since your last visible reply as one conversational update.'
+      'In a direct chat, treat adjacent messages from that user since your last visible reply as one conversational update.'
+    );
+    expect(hints?.join('\n')).toContain(
+      "In a group channel, combine adjacent messages only when they are from the same sender and directed at you. Keep other participants' messages separate."
     );
     expect(hints?.join('\n')).toContain(
       'Never answer only the newest line while silently dropping useful context from an earlier line.'

--- a/packages/openclaw/src/channel-prompt.test.ts
+++ b/packages/openclaw/src/channel-prompt.test.ts
@@ -1,0 +1,18 @@
+import { describe, expect, it } from 'vitest';
+
+import { tlonPlugin } from './channel.js';
+
+describe('Tlon channel prompt guidance', () => {
+  it('requires replies to preserve context split across rapid messages', () => {
+    const hints = tlonPlugin.agentPrompt?.messageToolHints?.({
+      cfg: {} as never,
+    });
+
+    expect(hints?.join('\n')).toContain(
+      'Treat adjacent user messages received since your last visible reply as one conversational update.'
+    );
+    expect(hints?.join('\n')).toContain(
+      'Never answer only the newest line while silently dropping useful context from an earlier line.'
+    );
+  });
+});

--- a/packages/openclaw/src/channel.ts
+++ b/packages/openclaw/src/channel.ts
@@ -151,6 +151,11 @@ export const tlonPlugin = createChatChannelPlugin({
 
         hints.push(
           '',
+          'Tlon users often split one thought across several consecutive messages.',
+          '- Treat adjacent user messages received since your last visible reply as one conversational update.',
+          '- Your reply must account for every new fact, constraint, correction, and question across those messages, even when only the newest message directly asks a question.',
+          '- Never answer only the newest line while silently dropping useful context from an earlier line.',
+          '',
           'Tlon gallery channels (heap/~host/name) are for collecting images, links, and media.',
           '- When you were triggered from a gallery post, your normal reply is posted as a comment on that post. Use action=send only when you intend to create a separate NEW top-level gallery item.',
           '- To post to a gallery: use action=send, to=heap/~host/name, message=<text or URL>',

--- a/packages/openclaw/src/channel.ts
+++ b/packages/openclaw/src/channel.ts
@@ -153,7 +153,7 @@ export const tlonPlugin = createChatChannelPlugin({
           '',
           'Tlon users often split one thought across several consecutive messages.',
           '- In a direct chat, treat adjacent messages from that user since your last visible reply as one conversational update.',
-          '- In a group channel, combine adjacent messages only when they are from the same sender and directed at you. Keep other participants\' messages separate.',
+          "- In a group channel, combine adjacent messages only when they are from the same sender and directed at you. Keep other participants' messages separate.",
           '- Your reply must account for every new fact, constraint, correction, and question across those messages, even when only the newest message directly asks a question.',
           '- Never answer only the newest line while silently dropping useful context from an earlier line.',
           '',

--- a/packages/openclaw/src/channel.ts
+++ b/packages/openclaw/src/channel.ts
@@ -152,7 +152,8 @@ export const tlonPlugin = createChatChannelPlugin({
         hints.push(
           '',
           'Tlon users often split one thought across several consecutive messages.',
-          '- Treat adjacent user messages received since your last visible reply as one conversational update.',
+          '- In a direct chat, treat adjacent messages from that user since your last visible reply as one conversational update.',
+          '- In a group channel, combine adjacent messages only when they are from the same sender and directed at you. Keep other participants\' messages separate.',
           '- Your reply must account for every new fact, constraint, correction, and question across those messages, even when only the newest message directly asks a question.',
           '- Never answer only the newest line while silently dropping useful context from an earlier line.',
           '',


### PR DESCRIPTION
## Summary

- Preserve useful context when a Tlon user splits one thought across rapid consecutive messages.
- Require the reply to account for each new fact, constraint, correction, and question since the last visible response.
- Fixes TLON-6384

## Changes

- Add Tlon channel guidance that treats adjacent user messages as one conversational update.
- Prevent replies from silently answering only the newest line while dropping earlier context.
- Add a focused prompt contract test.

## How did I test?

- Replayed the exact two audited DMs ten seconds apart through OpenClaw 2026.7.1 and direct OpenAI `gpt-5.6-sol`.
- Baseline plugin `cfb8634` failed 1/3 trials: it answered the pH message but omitted the existing RO hardware and accumulator tank (`20260827-052732-audit-rapid-followups-v0-95b181ee`).
- Candidate `1908cbdfd2` passed 3/3 trials on the same runtime, route, prompts, and timing. Every trial visibly acknowledged the existing hardware and answered the pH/alkalinity point (`b16a669e`, `ceb6d019`, `c98f50b9`).
- `corepack pnpm --dir packages/openclaw test` — 75 files, 1,492 tests passed.
- `corepack pnpm --dir packages/openclaw tsc`
- `corepack pnpm --dir packages/openclaw build`
- Focused `oxfmt --check` and `git diff --check` passed.
