### PR TITLE
reconcile all matching recurring schedules

### DIFF
--- a/packages/openclaw/skills/tlon-product-guide/SKILL.md
+++ b/packages/openclaw/skills/tlon-product-guide/SKILL.md
@@ -213,6 +213,8 @@ Tlonbots excel at recurring tasks, called crons. Set one once, then forget about
 - "Remind me every Friday at 4 to submit my timesheet."  
 - "Send me the weather each day before I leave for work."
 
+When changing or cancelling recurring work, the bot should reconcile every cron job that implements the same request, including related or duplicate declarations. It should inspect all matching jobs, update or remove every obsolete one, then list them again before claiming the old cadence or behavior is gone. If it is unclear whether two jobs belong to the same request, the bot should ask rather than silently changing an unrelated schedule.
+
 ### Connected services (MCP)
 
 Extend your bot by connecting outside services under `Bot Settings` → `Connected Services`. (Hosted accounts — self-hosters wire MCP servers up in their own OpenClaw configuration.) With services connected, crons and requests get more powerful:

--- a/packages/openclaw/src/channel.ts
+++ b/packages/openclaw/src/channel.ts
@@ -151,6 +151,11 @@ export const tlonPlugin = createChatChannelPlugin({
 
         hints.push(
           '',
+          'When the owner changes or cancels recurring work, reconcile the complete set of cron jobs for that same user intent.',
+          '- List all jobs, including disabled jobs, and inspect every job whose name, description, or payload matches the requested subject. Do not stop after the first broad match.',
+          '- Update or remove every obsolete declaration so no duplicate or related job keeps the superseded cadence or behavior. If the intended scope is genuinely ambiguous, ask before changing jobs.',
+          '- List the jobs again after writing and only claim completion after verifying that no matching job retains the old cadence or behavior.',
+          '',
           'Tlon gallery channels (heap/~host/name) are for collecting images, links, and media.',
           '- When you were triggered from a gallery post, your normal reply is posted as a comment on that post. Use action=send only when you intend to create a separate NEW top-level gallery item.',
           '- To post to a gallery: use action=send, to=heap/~host/name, message=<text or URL>',

--- a/packages/openclaw/src/cron-reconciliation-prompt.test.ts
+++ b/packages/openclaw/src/cron-reconciliation-prompt.test.ts
@@ -1,0 +1,23 @@
+import { describe, expect, it } from 'vitest';
+
+import { tlonPlugin } from './channel.js';
+
+describe('cron reconciliation prompt guidance', () => {
+  it('requires complete before-and-after reconciliation for schedule changes', () => {
+    const hints = tlonPlugin.agentPrompt?.messageToolHints?.({
+      cfg: {} as never,
+    });
+    const prompt = hints?.join('\n');
+
+    expect(prompt).toContain(
+      'reconcile the complete set of cron jobs for that same user intent'
+    );
+    expect(prompt).toContain('Do not stop after the first broad match.');
+    expect(prompt).toContain(
+      'no duplicate or related job keeps the superseded cadence or behavior'
+    );
+    expect(prompt).toContain(
+      'only claim completion after verifying that no matching job retains the old cadence or behavior'
+    );
+  });
+});


### PR DESCRIPTION
## Summary

Make recurring-schedule changes cover every job that implements the same request, so a broad Monday-only correction cannot leave related daily digests behind.

Fixes TLON-6383

## Changes

- tell the Tlon agent to inspect all matching cron declarations, including disabled jobs
- update or remove every obsolete related declaration instead of stopping at the first broad match
- require a final cron listing before claiming the old cadence is gone
- ask before changing jobs when the intended scope is genuinely ambiguous
- document and contract-test the reconciliation rule

## How did I test?

- `pnpm --dir packages/openclaw test` — 75 files, 1,492 tests passed
- `pnpm --dir packages/openclaw build` passed
- focused formatting and `git diff --check` passed
- exact baseline on OpenClaw 2026.7.1 / adapter 0.20.0 / OpenRouter `openai/gpt-5.6-luna` failed: only 1 of 3 related jobs became Monday-only; two daily jobs survived the 30-second durable-state verification
- candidate `a4f0d1bc86` on the same runtime/model passed 3/3 runs
- every passing run listed all jobs, inspected all three matches, updated all three, listed again, and independently verified all three persisted schedules were Monday-only
- the E2E fixture is marked reconstructed context because the historical cron declarations and prior conversation are unavailable
