### PR TITLE
preserve conditional alert thresholds

### DIFF
--- a/packages/openclaw/index.ts
+++ b/packages/openclaw/index.ts
@@ -27,6 +27,7 @@ import {
   resetTlonCronObservability,
 } from './src/cron-observability.js';
 import {
+  hasTrustedCronOwnerPrompt,
   preserveConditionalCronUpdate,
   recordCronGetResult,
   rememberCronOwnerPrompt,
@@ -990,7 +991,8 @@ export default defineBundledChannelEntry({
       const isOwnerOnlyTool = ownerOnlyTools.has(event.toolName);
       const isBlocked = isOwnerOnlyTool && role === 'user';
       const adjustedCronParams =
-        event.toolName === 'cron' && role === 'owner'
+        event.toolName === 'cron' &&
+        (role === 'owner' || hasTrustedCronOwnerPrompt(ctx.sessionKey))
           ? preserveConditionalCronUpdate(ctx.sessionKey, event.params)
           : undefined;
       const blockReason = isBlocked
@@ -1099,7 +1101,12 @@ export default defineBundledChannelEntry({
 
     api.on('after_tool_call', (event, ctx) => {
       if (event.toolName === 'cron') {
-        recordCronGetResult(ctx.sessionKey, event.params, event.result);
+        recordCronGetResult(
+          ctx.sessionKey,
+          event.params,
+          event.result,
+          event.error
+        );
       }
       const toolCallId = readToolCallId(event);
       const tlonCommandContext =

--- a/packages/openclaw/index.ts
+++ b/packages/openclaw/index.ts
@@ -27,6 +27,11 @@ import {
   resetTlonCronObservability,
 } from './src/cron-observability.js';
 import {
+  preserveConditionalCronUpdate,
+  recordCronGetResult,
+  rememberCronOwnerPrompt,
+} from './src/conditional-cron-update.js';
+import {
   clearCronServiceAccessor,
   handleCronChangedEvent,
   setCronServiceAccessor,
@@ -846,6 +851,14 @@ export default defineBundledChannelEntry({
     exportName: 'setTlonRuntime',
   },
   registerFull(api) {
+    api.on('before_agent_run', (event, ctx) => {
+      rememberCronOwnerPrompt(
+        ctx.sessionKey,
+        event.prompt,
+        event.senderIsOwner
+      );
+    });
+
     // ── Gateway-status liveness integration ───────────────────
     //
     // registerFull is NOT a once-per-process call: OpenClaw invokes it once
@@ -976,6 +989,10 @@ export default defineBundledChannelEntry({
       const role = getSessionRole(ctx.sessionKey ?? '');
       const isOwnerOnlyTool = ownerOnlyTools.has(event.toolName);
       const isBlocked = isOwnerOnlyTool && role === 'user';
+      const adjustedCronParams =
+        event.toolName === 'cron' && role === 'owner'
+          ? preserveConditionalCronUpdate(ctx.sessionKey, event.params)
+          : undefined;
       const blockReason = isBlocked
         ? `The ${event.toolName} tool is not available.`
         : undefined;
@@ -1033,7 +1050,7 @@ export default defineBundledChannelEntry({
       }
 
       if (!isOwnerOnlyTool) {
-        return undefined;
+        return adjustedCronParams ? { params: adjustedCronParams } : undefined;
       }
 
       // Allow owner sessions and internal sessions (heartbeat, cron, etc.).
@@ -1077,10 +1094,13 @@ export default defineBundledChannelEntry({
       api.logger.info(
         `[tlon] Allowed ${event.toolName} tool for ${role ?? 'internal'} session. Session: ${ctx.sessionKey}`
       );
-      return undefined;
+      return adjustedCronParams ? { params: adjustedCronParams } : undefined;
     });
 
     api.on('after_tool_call', (event, ctx) => {
+      if (event.toolName === 'cron') {
+        recordCronGetResult(ctx.sessionKey, event.params, event.result);
+      }
       const toolCallId = readToolCallId(event);
       const tlonCommandContext =
         event.toolName === 'tlon' && typeof event.params.command === 'string'

--- a/packages/openclaw/skills/tlon-product-guide/SKILL.md
+++ b/packages/openclaw/skills/tlon-product-guide/SKILL.md
@@ -213,6 +213,8 @@ Tlonbots excel at recurring tasks, called crons. Set one once, then forget about
 - "Remind me every Friday at 4 to submit my timesheet."  
 - "Send me the weather each day before I leave for work."
 
+For conditional alerts, a correction such as “that is known information” or “only tell me when my funds are at risk” must become durable job criteria. Make the change as a lossless edit: copy the existing payload message verbatim, then append an `Owner correction (higher priority):` block that restates the owner's exact negative criteria and overrides conflicting delivery instructions. Do not summarize or replace the old declaration. Preserve the monitor's existing subject, sources, and input scope; never broaden a narrow monitor or fixed scenario into a search for anything that sounds urgent. An announce-mode job should return exactly `NO_REPLY` when the criteria are not met and alert text only when they are met—never a heartbeat or “nothing urgent” update. After editing, read the job back and verify the original scope, corrected threshold, and silent negative path.
+
 ### Connected services (MCP)
 
 Extend your bot by connecting outside services under `Bot Settings` → `Connected Services`. (Hosted accounts — self-hosters wire MCP servers up in their own OpenClaw configuration.) With services connected, crons and requests get more powerful:

--- a/packages/openclaw/src/channel.ts
+++ b/packages/openclaw/src/channel.ts
@@ -151,6 +151,13 @@ export const tlonPlugin = createChatChannelPlugin({
 
         hints.push(
           '',
+          "When the owner corrects the relevance or urgency threshold of a recurring alert, preserve the job's existing subject, sources, and input scope unless the owner explicitly broadens them.",
+          '- Treat this as a lossless edit: copy the existing payload message verbatim, then append an `Owner correction (higher priority):` block. Do not summarize, paraphrase, or replace the old declaration.',
+          "- In that block, restate the owner's exact negative criteria and examples, and say they override any conflicting earlier delivery instruction. Do not replace a narrow monitor or fixed scenario with a vague search for anything urgent.",
+          '- If the job supplies a fixed scenario or input, evaluate only that input; do not search for or introduce unrelated events to justify an alert.',
+          '- For delivery.mode=announce, never call the message tool. Return exactly NO_REPLY when the threshold is not met, with no heartbeat, status, or "nothing urgent" text; return only the alert text when it is met.',
+          '- After updating the job, read it back and verify that the original scope, the corrected threshold, and the silent negative path are all present.',
+          '',
           'Tlon gallery channels (heap/~host/name) are for collecting images, links, and media.',
           '- When you were triggered from a gallery post, your normal reply is posted as a comment on that post. Use action=send only when you intend to create a separate NEW top-level gallery item.',
           '- To post to a gallery: use action=send, to=heap/~host/name, message=<text or URL>',

--- a/packages/openclaw/src/conditional-alert-prompt.test.ts
+++ b/packages/openclaw/src/conditional-alert-prompt.test.ts
@@ -1,0 +1,31 @@
+import { describe, expect, it } from 'vitest';
+
+import { tlonPlugin } from './channel.js';
+
+describe('conditional alert prompt guidance', () => {
+  it('preserves monitor scope and makes the negative path silent', () => {
+    const hints = tlonPlugin.agentPrompt?.messageToolHints?.({
+      cfg: {} as never,
+    });
+    const prompt = hints?.join('\n');
+
+    expect(prompt).toContain(
+      "preserve the job's existing subject, sources, and input scope"
+    );
+    expect(prompt).toContain(
+      'copy the existing payload message verbatim, then append an `Owner correction (higher priority):` block'
+    );
+    expect(prompt).toContain(
+      'Do not summarize, paraphrase, or replace the old declaration'
+    );
+    expect(prompt).toContain(
+      'do not search for or introduce unrelated events to justify an alert'
+    );
+    expect(prompt).toContain(
+      'Return exactly NO_REPLY when the threshold is not met'
+    );
+    expect(prompt).toContain(
+      'verify that the original scope, the corrected threshold, and the silent negative path are all present'
+    );
+  });
+});

--- a/packages/openclaw/src/conditional-cron-update.test.ts
+++ b/packages/openclaw/src/conditional-cron-update.test.ts
@@ -198,6 +198,47 @@ describe('conditional cron update preservation', () => {
     expect(adjusted?.patch).toMatchObject({ enabled: true });
   });
 
+  it('preserves schedule and delivery when the owner says not to change them', () => {
+    rememberCronOwnerPrompt(
+      sessionKey,
+      'Do not change the schedule or delivery mode; only notify me when there is real risk.',
+      true
+    );
+    rememberJob();
+
+    const adjusted = preserveConditionalCronUpdate(sessionKey, {
+      action: 'update',
+      jobId,
+      patch: {
+        delivery: { mode: 'none' },
+        schedule: { kind: 'cron', expr: '*/5 * * * *' },
+        payload: { message: 'Alert on actual risk.' },
+      },
+    });
+
+    expect(adjusted?.patch).toMatchObject({
+      delivery: { mode: 'announce' },
+      schedule: { kind: 'cron', expr: '0 * * * *' },
+    });
+  });
+
+  it('does not embed a destructive notification side effect', () => {
+    rememberCronOwnerPrompt(
+      sessionKey,
+      'Delete the old notifications, and only alert me for actual risk.',
+      true
+    );
+    rememberJob();
+
+    expect(
+      preserveConditionalCronUpdate(sessionKey, {
+        action: 'update',
+        jobId,
+        patch: { payload: { message: 'Delete old notifications each run.' } },
+      })
+    ).toBeUndefined();
+  });
+
   it('requires a fresh read for a repeated owner correction', () => {
     const prompt = 'Only notify me when my keys are actually at risk.';
     rememberCronOwnerPrompt(sessionKey, prompt, true);

--- a/packages/openclaw/src/conditional-cron-update.test.ts
+++ b/packages/openclaw/src/conditional-cron-update.test.ts
@@ -20,6 +20,7 @@ function rememberJob(): void {
       details: {
         id: jobId,
         payload: { kind: 'agentTurn', message: original },
+        delivery: { mode: 'announce' },
       },
     }
   );
@@ -57,6 +58,7 @@ describe('conditional cron update preservation', () => {
     expect(message).toContain(original);
     expect(message).toContain(prompt);
     expect(message).toContain('return exactly NO_REPLY');
+    expect(message).toContain('never call or use the message tool');
     expect(message).not.toContain('Search for any genuinely urgent');
   });
 
@@ -73,6 +75,102 @@ describe('conditional cron update preservation', () => {
         action: 'update',
         jobId,
         patch: { payload: { message: 'Monitor Ethereum.' } },
+      })
+    ).toBeUndefined();
+  });
+
+  it('does not rewrite a direct source change', () => {
+    rememberCronOwnerPrompt(
+      sessionKey,
+      'Only monitor CoinDesk now, not Reuters.',
+      true
+    );
+    rememberJob();
+
+    expect(
+      preserveConditionalCronUpdate(sessionKey, {
+        action: 'update',
+        jobId,
+        patch: { payload: { message: 'Monitor CoinDesk only.' } },
+      })
+    ).toBeUndefined();
+  });
+
+  it('declines to persist a prompt that also contains an unrelated task', () => {
+    rememberCronOwnerPrompt(
+      sessionKey,
+      'Delete note X, and only alert me when this monitor is urgent.',
+      true
+    );
+    rememberJob();
+
+    expect(
+      preserveConditionalCronUpdate(sessionKey, {
+        action: 'update',
+        jobId,
+        patch: { payload: { message: 'Alert only when urgent.' } },
+      })
+    ).toBeUndefined();
+  });
+
+  it('repairs a proposal that retains old text but omits the correction', () => {
+    const prompt = 'Only notify me when my keys are actually at risk.';
+    rememberCronOwnerPrompt(sessionKey, prompt, true);
+    rememberJob();
+
+    const adjusted = preserveConditionalCronUpdate(sessionKey, {
+      action: 'update',
+      jobId,
+      patch: {
+        payload: {
+          message: `${original}\nAlert on anything urgent.`,
+        },
+      },
+    });
+
+    expect(adjusted).toBeDefined();
+    const message = (
+      (adjusted?.patch as Record<string, unknown>).payload as Record<
+        string,
+        unknown
+      >
+    ).message;
+    expect(message).toContain(prompt);
+    expect(message).not.toContain('Alert on anything urgent');
+    expect(message).toContain('return exactly NO_REPLY');
+    expect(message).toContain('never call or use the message tool');
+  });
+
+  it('accepts a complete correction without rewriting it', () => {
+    const prompt = 'Only notify me when my keys are actually at risk.';
+    rememberCronOwnerPrompt(sessionKey, prompt, true);
+    rememberJob();
+    const complete = `${original}\n${prompt}\nNever use the message tool. When the threshold is not met, return exactly NO_REPLY.`;
+
+    expect(
+      preserveConditionalCronUpdate(sessionKey, {
+        action: 'update',
+        jobId,
+        patch: { payload: { message: complete } },
+      })
+    ).toBeUndefined();
+  });
+
+  it('invalidates the old snapshot after an update result', () => {
+    const prompt = 'Only notify me when my keys are actually at risk.';
+    rememberCronOwnerPrompt(sessionKey, prompt, true);
+    rememberJob();
+    recordCronGetResult(
+      sessionKey,
+      { action: 'update', jobId, patch: { payload: { message: 'updated' } } },
+      { ok: true }
+    );
+
+    expect(
+      preserveConditionalCronUpdate(sessionKey, {
+        action: 'update',
+        jobId,
+        patch: { payload: { message: 'second update' } },
       })
     ).toBeUndefined();
   });

--- a/packages/openclaw/src/conditional-cron-update.test.ts
+++ b/packages/openclaw/src/conditional-cron-update.test.ts
@@ -70,6 +70,20 @@ describe('conditional cron update preservation', () => {
     expect(message).not.toContain('Search for any genuinely urgent');
   });
 
+  it('recognizes plural alert and notification corrections', () => {
+    const prompt = 'These routine notifications are not relevant.';
+    rememberCronOwnerPrompt(sessionKey, prompt, true);
+    rememberJob();
+
+    expect(
+      preserveConditionalCronUpdate(sessionKey, {
+        action: 'update',
+        jobId,
+        patch: { payload: { message: 'Only send important alerts.' } },
+      })
+    ).toBeDefined();
+  });
+
   it('preserves delivery, schedule, and enabled while correcting the message', () => {
     rememberCronOwnerPrompt(
       sessionKey,

--- a/packages/openclaw/src/conditional-cron-update.test.ts
+++ b/packages/openclaw/src/conditional-cron-update.test.ts
@@ -2,6 +2,7 @@ import { beforeEach, describe, expect, it } from 'vitest';
 
 import {
   _testing,
+  hasTrustedCronOwnerPrompt,
   preserveConditionalCronUpdate,
   recordCronGetResult,
   rememberCronOwnerPrompt,
@@ -12,14 +13,14 @@ const jobId = 'job-1';
 const original =
   "Evaluate this fixed scenario: Bitcoin's price moved one percent. This is known, routine market information; the owner's keys and coins are safe. Send a status update every run.";
 
-function rememberJob(): void {
+function rememberJob(id = jobId, message = original): void {
   recordCronGetResult(
     sessionKey,
-    { action: 'get', jobId },
+    { action: 'get', jobId: id },
     {
       details: {
-        id: jobId,
-        payload: { kind: 'agentTurn', message: original },
+        id,
+        payload: { kind: 'agentTurn', message },
         delivery: { mode: 'announce' },
       },
     }
@@ -79,6 +80,23 @@ describe('conditional cron update preservation', () => {
     ).toBeUndefined();
   });
 
+  it('does not rewrite an explicit alert-subject replacement', () => {
+    rememberCronOwnerPrompt(
+      sessionKey,
+      'Only alert me about Ethereum now, not Bitcoin.',
+      true
+    );
+    rememberJob();
+
+    expect(
+      preserveConditionalCronUpdate(sessionKey, {
+        action: 'update',
+        jobId,
+        patch: { payload: { message: 'Monitor Ethereum.' } },
+      })
+    ).toBeUndefined();
+  });
+
   it('does not rewrite a direct source change', () => {
     rememberCronOwnerPrompt(
       sessionKey,
@@ -113,6 +131,55 @@ describe('conditional cron update preservation', () => {
     ).toBeUndefined();
   });
 
+  it('declines a bare-and unrelated side effect', () => {
+    rememberCronOwnerPrompt(
+      sessionKey,
+      'Delete note X and only alert me when this monitor is urgent.',
+      true
+    );
+    rememberJob();
+
+    expect(
+      preserveConditionalCronUpdate(sessionKey, {
+        action: 'update',
+        jobId,
+        patch: { payload: { message: 'Alert only when urgent.' } },
+      })
+    ).toBeUndefined();
+  });
+
+  it('preserves a correction that merely describes the existing source', () => {
+    const prompt =
+      'This source reports known routine information, so only alert me when funds are at risk.';
+    rememberCronOwnerPrompt(sessionKey, prompt, true);
+    rememberJob();
+
+    expect(
+      preserveConditionalCronUpdate(sessionKey, {
+        action: 'update',
+        jobId,
+        patch: { payload: { message: 'Alert on urgent events.' } },
+      })
+    ).toBeDefined();
+  });
+
+  it('recognizes smart-apostrophe threshold language', () => {
+    rememberCronOwnerPrompt(
+      sessionKey,
+      'Don’t bother me with these routine updates; only alert me about risk.',
+      true
+    );
+    rememberJob();
+
+    expect(
+      preserveConditionalCronUpdate(sessionKey, {
+        action: 'update',
+        jobId,
+        patch: { payload: { message: 'Alert on anything urgent.' } },
+      })
+    ).toBeDefined();
+  });
+
   it('repairs a proposal that retains old text but omits the correction', () => {
     const prompt = 'Only notify me when my keys are actually at risk.';
     rememberCronOwnerPrompt(sessionKey, prompt, true);
@@ -145,7 +212,17 @@ describe('conditional cron update preservation', () => {
     const prompt = 'Only notify me when my keys are actually at risk.';
     rememberCronOwnerPrompt(sessionKey, prompt, true);
     rememberJob();
-    const complete = `${original}\n${prompt}\nNever use the message tool. When the threshold is not met, return exactly NO_REPLY.`;
+    const first = preserveConditionalCronUpdate(sessionKey, {
+      action: 'update',
+      jobId,
+      patch: { payload: { message: 'incomplete' } },
+    });
+    const complete = (
+      (first?.patch as Record<string, unknown>).payload as Record<
+        string,
+        unknown
+      >
+    ).message as string;
 
     expect(
       preserveConditionalCronUpdate(sessionKey, {
@@ -154,6 +231,38 @@ describe('conditional cron update preservation', () => {
         patch: { payload: { message: complete } },
       })
     ).toBeUndefined();
+  });
+
+  it('removes conflicting criteria appended to an otherwise complete proposal', () => {
+    const prompt = 'Only notify me when my keys are actually at risk.';
+    rememberCronOwnerPrompt(sessionKey, prompt, true);
+    rememberJob();
+    const first = preserveConditionalCronUpdate(sessionKey, {
+      action: 'update',
+      jobId,
+      patch: { payload: { message: 'incomplete' } },
+    });
+    const canonical = (
+      (first?.patch as Record<string, unknown>).payload as Record<
+        string,
+        unknown
+      >
+    ).message as string;
+    const adjusted = preserveConditionalCronUpdate(sessionKey, {
+      action: 'update',
+      jobId,
+      patch: {
+        payload: { message: `${canonical}\nAlso alert on anything urgent.` },
+      },
+    });
+    const message = (
+      (adjusted?.patch as Record<string, unknown>).payload as Record<
+        string,
+        unknown
+      >
+    ).message;
+    expect(message).toBe(canonical);
+    expect(message).not.toContain('Also alert on anything urgent');
   });
 
   it('invalidates the old snapshot after an update result', () => {
@@ -175,6 +284,68 @@ describe('conditional cron update preservation', () => {
     ).toBeUndefined();
   });
 
+  it('preserves the snapshot after a failed update result', () => {
+    const prompt = 'Only notify me when my keys are actually at risk.';
+    rememberCronOwnerPrompt(sessionKey, prompt, true);
+    rememberJob();
+    recordCronGetResult(
+      sessionKey,
+      { action: 'update', jobId, patch: { payload: { message: 'updated' } } },
+      undefined,
+      'transient update failure'
+    );
+
+    expect(
+      preserveConditionalCronUpdate(sessionKey, {
+        action: 'update',
+        jobId,
+        patch: { payload: { message: 'retry' } },
+      })
+    ).toBeDefined();
+  });
+
+  it('requires a new exact-job read after each owner correction', () => {
+    rememberCronOwnerPrompt(
+      sessionKey,
+      'Only notify me when my keys are actually at risk.',
+      true
+    );
+    rememberJob();
+    rememberCronOwnerPrompt(
+      sessionKey,
+      'Routine moves are safe; only alert me about a real loss risk.',
+      true
+    );
+
+    expect(
+      preserveConditionalCronUpdate(sessionKey, {
+        action: 'update',
+        jobId,
+        patch: { payload: { message: 'stale rewrite' } },
+      })
+    ).toBeUndefined();
+  });
+
+  it('does not apply one correction when multiple jobs were read', () => {
+    rememberCronOwnerPrompt(
+      sessionKey,
+      'Only notify me when my keys are actually at risk.',
+      true
+    );
+    rememberJob('job-a', 'Monitor Bitcoin.');
+    rememberJob('job-b', 'Monitor weather.');
+
+    for (const id of ['job-a', 'job-b']) {
+      expect(
+        preserveConditionalCronUpdate(sessionKey, {
+          action: 'update',
+          jobId: id,
+          patch: { payload: { message: 'changed' } },
+        })
+      ).toBeUndefined();
+    }
+  });
+
   it('requires an owner prompt and a preceding exact-job read', () => {
     rememberCronOwnerPrompt(
       sessionKey,
@@ -191,16 +362,67 @@ describe('conditional cron update preservation', () => {
     ).toBeUndefined();
   });
 
-  it('accepts older hosts that omit senderIsOwner and relies on the tool-role gate', () => {
+  it('does not trust ownerless background prompts', () => {
     rememberCronOwnerPrompt(
       sessionKey,
-      'This is routine, so only alert me if my keys are at risk.',
+      'Only notify me when my keys are actually at risk.',
+      true
+    );
+    rememberCronOwnerPrompt(
+      sessionKey,
+      'This is an internal run; only alert on routine updates.',
       undefined
     );
     rememberJob();
 
+    expect(hasTrustedCronOwnerPrompt(sessionKey)).toBe(false);
     expect(
       preserveConditionalCronUpdate(sessionKey, {
+        action: 'update',
+        jobId,
+        patch: { payload: { message: 'Search for any urgent event.' } },
+      })
+    ).toBeUndefined();
+  });
+
+  it('keeps a trusted Tlon prompt when the generic hook sees the same text', () => {
+    const prompt = 'Only notify me when my keys are actually at risk.';
+    rememberCronOwnerPrompt(sessionKey, prompt, true);
+    rememberCronOwnerPrompt(sessionKey, prompt, undefined);
+    rememberJob();
+
+    expect(hasTrustedCronOwnerPrompt(sessionKey)).toBe(true);
+    expect(
+      preserveConditionalCronUpdate(sessionKey, {
+        action: 'update',
+        jobId,
+        patch: { payload: { message: 'Search for any urgent event.' } },
+      })
+    ).toBeDefined();
+  });
+
+  it('resolves prompts and snapshots through a parent thread session', () => {
+    const threadKey = `${sessionKey}:thread:170.141`;
+    rememberCronOwnerPrompt(
+      sessionKey,
+      'Only notify me when my keys are actually at risk.',
+      true
+    );
+    recordCronGetResult(
+      threadKey,
+      { action: 'get', jobId },
+      {
+        details: {
+          id: jobId,
+          payload: { kind: 'agentTurn', message: original },
+          delivery: { mode: 'announce' },
+        },
+      }
+    );
+
+    expect(hasTrustedCronOwnerPrompt(threadKey)).toBe(true);
+    expect(
+      preserveConditionalCronUpdate(threadKey, {
         action: 'update',
         jobId,
         patch: { payload: { message: 'Search for any urgent event.' } },

--- a/packages/openclaw/src/conditional-cron-update.test.ts
+++ b/packages/openclaw/src/conditional-cron-update.test.ts
@@ -1,0 +1,112 @@
+import { beforeEach, describe, expect, it } from 'vitest';
+
+import {
+  _testing,
+  preserveConditionalCronUpdate,
+  recordCronGetResult,
+  rememberCronOwnerPrompt,
+} from './conditional-cron-update.js';
+
+const sessionKey = 'agent:main:tlon:direct:~ten';
+const jobId = 'job-1';
+const original =
+  "Evaluate this fixed scenario: Bitcoin's price moved one percent. This is known, routine market information; the owner's keys and coins are safe. Send a status update every run.";
+
+function rememberJob(): void {
+  recordCronGetResult(
+    sessionKey,
+    { action: 'get', jobId },
+    {
+      details: {
+        id: jobId,
+        payload: { kind: 'agentTurn', message: original },
+      },
+    }
+  );
+}
+
+describe('conditional cron update preservation', () => {
+  beforeEach(() => _testing.clear());
+
+  it('turns a lossy threshold rewrite into a lossless owner correction', () => {
+    const prompt =
+      "This is known information. My keys and coins aren't at risk, so it does not count as urgent. Don't bother me with routine updates.";
+    rememberCronOwnerPrompt(sessionKey, prompt, true);
+    rememberJob();
+
+    const adjusted = preserveConditionalCronUpdate(sessionKey, {
+      action: 'update',
+      jobId,
+      patch: {
+        payload: {
+          kind: 'agentTurn',
+          message: 'Search for any genuinely urgent security event.',
+        },
+      },
+    });
+
+    if (!adjusted) {
+      throw new Error('expected the cron update to be adjusted');
+    }
+    const message = (
+      (adjusted.patch as Record<string, unknown>).payload as Record<
+        string,
+        unknown
+      >
+    ).message;
+    expect(message).toContain(original);
+    expect(message).toContain(prompt);
+    expect(message).toContain('return exactly NO_REPLY');
+    expect(message).not.toContain('Search for any genuinely urgent');
+  });
+
+  it('does not rewrite an explicit scope change', () => {
+    rememberCronOwnerPrompt(
+      sessionKey,
+      'Stop monitoring Bitcoin and switch the subject to Ethereum alerts.',
+      true
+    );
+    rememberJob();
+
+    expect(
+      preserveConditionalCronUpdate(sessionKey, {
+        action: 'update',
+        jobId,
+        patch: { payload: { message: 'Monitor Ethereum.' } },
+      })
+    ).toBeUndefined();
+  });
+
+  it('requires an owner prompt and a preceding exact-job read', () => {
+    rememberCronOwnerPrompt(
+      sessionKey,
+      'Only notify me when the threshold is met.',
+      false
+    );
+
+    expect(
+      preserveConditionalCronUpdate(sessionKey, {
+        action: 'update',
+        jobId,
+        patch: { payload: { message: 'Notify only on threshold.' } },
+      })
+    ).toBeUndefined();
+  });
+
+  it('accepts older hosts that omit senderIsOwner and relies on the tool-role gate', () => {
+    rememberCronOwnerPrompt(
+      sessionKey,
+      'This is routine, so only alert me if my keys are at risk.',
+      undefined
+    );
+    rememberJob();
+
+    expect(
+      preserveConditionalCronUpdate(sessionKey, {
+        action: 'update',
+        jobId,
+        patch: { payload: { message: 'Search for any urgent event.' } },
+      })
+    ).toBeDefined();
+  });
+});

--- a/packages/openclaw/src/conditional-cron-update.test.ts
+++ b/packages/openclaw/src/conditional-cron-update.test.ts
@@ -131,7 +131,7 @@ describe('conditional cron update preservation', () => {
   it('keeps an explicitly requested delivery change consistent', () => {
     rememberCronOwnerPrompt(
       sessionKey,
-      'Only notify me when my keys are actually at risk, and stop announcing updates.',
+      'Only notify me when my keys are actually at risk, and change the delivery mode to none.',
       true
     );
     rememberJob();
@@ -154,6 +154,48 @@ describe('conditional cron update preservation', () => {
         >
       )?.message
     ).not.toContain('delivery.mode=announce');
+  });
+
+  it('does not mistake a negative alert filter for a delivery change', () => {
+    rememberCronOwnerPrompt(
+      sessionKey,
+      "Don't send routine updates; only notify me when my keys are actually at risk.",
+      true
+    );
+    rememberJob();
+
+    const adjusted = preserveConditionalCronUpdate(sessionKey, {
+      action: 'update',
+      jobId,
+      patch: {
+        delivery: { mode: 'none' },
+        payload: { message: 'Alert on actual risk.' },
+      },
+    });
+
+    expect(adjusted?.patch).toMatchObject({
+      delivery: { mode: 'announce' },
+    });
+  });
+
+  it('does not treat a negated stop phrase as a disable request', () => {
+    rememberCronOwnerPrompt(
+      sessionKey,
+      'Do not stop the monitor; only notify me when there is real risk.',
+      true
+    );
+    rememberJob();
+
+    const adjusted = preserveConditionalCronUpdate(sessionKey, {
+      action: 'update',
+      jobId,
+      patch: {
+        enabled: false,
+        payload: { message: 'Alert on actual risk.' },
+      },
+    });
+
+    expect(adjusted?.patch).toMatchObject({ enabled: true });
   });
 
   it('requires a fresh read for a repeated owner correction', () => {

--- a/packages/openclaw/src/conditional-cron-update.test.ts
+++ b/packages/openclaw/src/conditional-cron-update.test.ts
@@ -104,6 +104,73 @@ describe('conditional cron update preservation', () => {
     expect(message).toContain('delivery.mode=announce');
   });
 
+  it('keeps control changes the owner explicitly requested', () => {
+    rememberCronOwnerPrompt(
+      sessionKey,
+      'Only notify me when my keys are actually at risk, run every five minutes, and pause the schedule.',
+      true
+    );
+    rememberJob();
+
+    const adjusted = preserveConditionalCronUpdate(sessionKey, {
+      action: 'update',
+      jobId,
+      patch: {
+        enabled: false,
+        schedule: { kind: 'cron', expr: '*/5 * * * *' },
+        payload: { message: 'Alert on actual risk.' },
+      },
+    });
+
+    expect(adjusted?.patch).toMatchObject({
+      enabled: false,
+      schedule: { kind: 'cron', expr: '*/5 * * * *' },
+    });
+  });
+
+  it('keeps an explicitly requested delivery change consistent', () => {
+    rememberCronOwnerPrompt(
+      sessionKey,
+      'Only notify me when my keys are actually at risk, and stop announcing updates.',
+      true
+    );
+    rememberJob();
+
+    const adjusted = preserveConditionalCronUpdate(sessionKey, {
+      action: 'update',
+      jobId,
+      patch: {
+        delivery: { mode: 'none' },
+        payload: { message: 'Alert on actual risk.' },
+      },
+    });
+
+    expect(adjusted?.patch).toMatchObject({ delivery: { mode: 'none' } });
+    expect(
+      (
+        (adjusted?.patch as Record<string, unknown>)?.payload as Record<
+          string,
+          unknown
+        >
+      )?.message
+    ).not.toContain('delivery.mode=announce');
+  });
+
+  it('requires a fresh read for a repeated owner correction', () => {
+    const prompt = 'Only notify me when my keys are actually at risk.';
+    rememberCronOwnerPrompt(sessionKey, prompt, true);
+    rememberJob();
+    rememberCronOwnerPrompt(sessionKey, prompt, true);
+
+    expect(
+      preserveConditionalCronUpdate(sessionKey, {
+        action: 'update',
+        jobId,
+        patch: { payload: { message: 'Alert on actual risk.' } },
+      })
+    ).toBeUndefined();
+  });
+
   it('drops control-field mutations when the original job omitted them', () => {
     rememberCronOwnerPrompt(
       sessionKey,

--- a/packages/openclaw/src/conditional-cron-update.test.ts
+++ b/packages/openclaw/src/conditional-cron-update.test.ts
@@ -13,7 +13,11 @@ const jobId = 'job-1';
 const original =
   "Evaluate this fixed scenario: Bitcoin's price moved one percent. This is known, routine market information; the owner's keys and coins are safe. Send a status update every run.";
 
-function rememberJob(id = jobId, message = original): void {
+function rememberJob(
+  id = jobId,
+  message = original,
+  overrides: Record<string, unknown> = {}
+): void {
   recordCronGetResult(
     sessionKey,
     { action: 'get', jobId: id },
@@ -22,6 +26,9 @@ function rememberJob(id = jobId, message = original): void {
         id,
         payload: { kind: 'agentTurn', message },
         delivery: { mode: 'announce' },
+        enabled: true,
+        schedule: { kind: 'cron', expr: '0 * * * *' },
+        ...overrides,
       },
     }
   );
@@ -61,6 +68,68 @@ describe('conditional cron update preservation', () => {
     expect(message).toContain('return exactly NO_REPLY');
     expect(message).toContain('never call or use the message tool');
     expect(message).not.toContain('Search for any genuinely urgent');
+  });
+
+  it('preserves delivery, schedule, and enabled while correcting the message', () => {
+    rememberCronOwnerPrompt(
+      sessionKey,
+      'Only notify me when my keys are actually at risk.',
+      true
+    );
+    rememberJob();
+
+    const adjusted = preserveConditionalCronUpdate(sessionKey, {
+      action: 'update',
+      jobId,
+      patch: {
+        delivery: { mode: 'none' },
+        enabled: false,
+        schedule: { kind: 'cron', expr: '* * * * *' },
+        payload: { message: 'Alert on anything urgent.' },
+      },
+    });
+
+    if (!adjusted) throw new Error('expected the cron update to be adjusted');
+    expect(adjusted.patch).toMatchObject({
+      delivery: { mode: 'announce' },
+      enabled: true,
+      schedule: { kind: 'cron', expr: '0 * * * *' },
+    });
+    const message = (
+      (adjusted.patch as Record<string, unknown>).payload as Record<
+        string,
+        unknown
+      >
+    ).message;
+    expect(message).toContain('delivery.mode=announce');
+  });
+
+  it('drops control-field mutations when the original job omitted them', () => {
+    rememberCronOwnerPrompt(
+      sessionKey,
+      'Only notify me when my keys are actually at risk.',
+      true
+    );
+    recordCronGetResult(
+      sessionKey,
+      { action: 'get', jobId },
+      { details: { id: jobId, payload: { message: original } } }
+    );
+
+    const adjusted = preserveConditionalCronUpdate(sessionKey, {
+      action: 'update',
+      jobId,
+      patch: {
+        delivery: { mode: 'none' },
+        enabled: false,
+        schedule: { kind: 'cron', expr: '* * * * *' },
+        payload: { message: 'Alert on anything urgent.' },
+      },
+    });
+
+    expect(adjusted?.patch).not.toHaveProperty('delivery');
+    expect(adjusted?.patch).not.toHaveProperty('enabled');
+    expect(adjusted?.patch).not.toHaveProperty('schedule');
   });
 
   it('does not rewrite an explicit scope change', () => {

--- a/packages/openclaw/src/conditional-cron-update.ts
+++ b/packages/openclaw/src/conditional-cron-update.ts
@@ -5,14 +5,22 @@ interface TimedValue<T> {
   value: T;
 }
 
+interface OwnerPromptState {
+  generation: number;
+  prompt: string;
+  timestamp: number;
+  trusted: boolean;
+}
+
 interface CronSnapshot {
   id: string;
   message: string;
   deliveryMode: string | null;
+  promptGeneration: number;
 }
 
 const STATE_TTL_MS = 60 * 60 * 1000;
-const ownerPrompts = sharedMap<string, TimedValue<string>>(
+const ownerPrompts = sharedMap<string, OwnerPromptState>(
   'conditionalCronUpdate.ownerPrompts'
 );
 const cronSnapshots = sharedMap<string, TimedValue<CronSnapshot>>(
@@ -36,8 +44,13 @@ function cleanup(now = Date.now()): void {
   }
 }
 
+function parentSessionKey(sessionKey: string): string {
+  const threadIndex = sessionKey.indexOf(':thread:');
+  return threadIndex > 0 ? sessionKey.slice(0, threadIndex) : sessionKey;
+}
+
 function snapshotKey(sessionKey: string, jobId: string): string {
-  return `${sessionKey}\u0000${jobId}`;
+  return `${parentSessionKey(sessionKey)}\u0000${jobId}`;
 }
 
 function parseJsonObject(value: unknown): Record<string, unknown> | null {
@@ -93,23 +106,27 @@ function cronDeliveryMode(job: Record<string, unknown>): string | null {
 }
 
 function explicitlyChangesMonitorScope(prompt: string): boolean {
+  const normalized = prompt.replace(/[’‘]/g, "'");
   return (
     /\b(?:replace|switch|broaden|all sources|any source|stop monitoring|change (?:the )?(?:subject|source|scope|topic))\b/i.test(
-      prompt
+      normalized
     ) ||
-    /\b(?:source|sources|feed|feeds|site|sites|website|websites)\b/i.test(
-      prompt
-    ) ||
-    /\b(?:only|now)\s+(?:monitor|check|watch|use|search)\b/i.test(prompt) ||
+    /\b(?:only|now)\s+(?:monitor|check|watch|use|search)\b/i.test(normalized) ||
     /\b(?:monitor|check|watch|use|search)\b[^.!?\n]*(?:\binstead\b|\bnow\b)/i.test(
-      prompt
+      normalized
+    ) ||
+    /\bonly\s+(?:alert|notify|message|tell)(?:\s+me)?\s+about\b[^.!?\n]*(?:\bnow\b|\binstead\b|\bnot\b)/i.test(
+      normalized
+    ) ||
+    /\b(?:switch|replace|change)\b[^.!?\n]*\b(?:source|sources|feed|feeds|site|sites|website|websites)\b/i.test(
+      normalized
     )
   );
 }
 
 function hasUnrelatedSideEffect(prompt: string): boolean {
   const clauses = prompt
-    .split(/(?<=[.!?])\s+|\n+|;\s*|,\s+and\s+/i)
+    .split(/(?<=[.!?])\s+|\n+|;\s*|,?\s+and\s+/i)
     .map((clause) => clause.trim())
     .filter(Boolean);
   return clauses.some((clause) => {
@@ -127,19 +144,20 @@ function hasUnrelatedSideEffect(prompt: string): boolean {
 }
 
 function isThresholdCorrection(prompt: string): boolean {
+  const normalized = prompt.replace(/[’‘]/g, "'");
   const hasThresholdLanguage =
     /\b(?:not|don't|do not|only|unless|ignore|suppress|routine|known|safe|risk|urgent|important|relevant)\b/i.test(
-      prompt
+      normalized
     );
   const concernsDelivery =
     /\b(?:alert|notify|notification|monitor|update|bother|message|tell|send|urgent|risk)\b/i.test(
-      prompt
+      normalized
     );
   return (
     hasThresholdLanguage &&
     concernsDelivery &&
-    !explicitlyChangesMonitorScope(prompt) &&
-    !hasUnrelatedSideEffect(prompt)
+    !explicitlyChangesMonitorScope(normalized) &&
+    !hasUnrelatedSideEffect(normalized)
   );
 }
 
@@ -148,17 +166,58 @@ export function rememberCronOwnerPrompt(
   prompt: string,
   senderIsOwner: boolean | undefined
 ): void {
-  if (!sessionKey || senderIsOwner === false || !prompt.trim()) {
+  const value = prompt.trim();
+  if (!sessionKey || !value) {
     return;
   }
   cleanup();
-  ownerPrompts.set(sessionKey, { timestamp: Date.now(), value: prompt.trim() });
+  const key = parentSessionKey(sessionKey);
+  const existing = ownerPrompts.get(key);
+  if (senderIsOwner === true) {
+    ownerPrompts.set(key, {
+      generation:
+        existing?.trusted && existing.prompt === value
+          ? existing.generation
+          : (existing?.generation ?? 0) + 1,
+      prompt: value,
+      timestamp: Date.now(),
+      trusted: true,
+    });
+    return;
+  }
+
+  // A Tlon inbound message records trusted ownership before this generic hook.
+  // Preserve that record when both hooks saw the same text. A different
+  // ownerless/internal prompt deactivates it without treating the background
+  // text as an owner correction.
+  if (
+    senderIsOwner === undefined &&
+    existing?.trusted &&
+    existing.prompt === value
+  ) {
+    return;
+  }
+  ownerPrompts.set(key, {
+    generation: (existing?.generation ?? 0) + 1,
+    prompt: existing?.prompt ?? '',
+    timestamp: Date.now(),
+    trusted: false,
+  });
+}
+
+export function hasTrustedCronOwnerPrompt(
+  sessionKey: string | undefined
+): boolean {
+  if (!sessionKey) return false;
+  cleanup();
+  return ownerPrompts.get(parentSessionKey(sessionKey))?.trusted === true;
 }
 
 export function recordCronGetResult(
   sessionKey: string | undefined,
   params: Record<string, unknown>,
-  result: unknown
+  result: unknown,
+  error?: unknown
 ): void {
   if (!sessionKey) {
     return;
@@ -170,7 +229,10 @@ export function recordCronGetResult(
         ? params.id
         : null;
   if (params.action === 'update') {
-    if (requestedJobId) {
+    const failed =
+      (typeof error === 'string' && error.trim().length > 0) ||
+      (error !== null && error !== undefined && typeof error !== 'string');
+    if (requestedJobId && !failed) {
       // The after-tool hook cannot reliably recover the effective params after
       // a before-tool rewrite. Force a fresh exact-job read before another
       // correction rather than rebuilding from stale pre-update content.
@@ -179,6 +241,8 @@ export function recordCronGetResult(
     return;
   }
   if (params.action !== 'get') return;
+  const promptState = ownerPrompts.get(parentSessionKey(sessionKey));
+  if (!promptState?.trusted) return;
   const job = cronResultObject(result);
   if (!job) {
     return;
@@ -191,7 +255,12 @@ export function recordCronGetResult(
   cleanup();
   cronSnapshots.set(snapshotKey(sessionKey, id), {
     timestamp: Date.now(),
-    value: { id, message, deliveryMode: cronDeliveryMode(job) },
+    value: {
+      id,
+      message,
+      deliveryMode: cronDeliveryMode(job),
+      promptGeneration: promptState.generation,
+    },
   });
 }
 
@@ -203,8 +272,10 @@ export function preserveConditionalCronUpdate(
     return undefined;
   }
   cleanup();
-  const prompt = ownerPrompts.get(sessionKey)?.value;
-  if (!prompt || !isThresholdCorrection(prompt)) {
+  const canonicalSessionKey = parentSessionKey(sessionKey);
+  const promptState = ownerPrompts.get(canonicalSessionKey);
+  const prompt = promptState?.prompt;
+  if (!promptState?.trusted || !prompt || !isThresholdCorrection(prompt)) {
     return undefined;
   }
 
@@ -217,8 +288,16 @@ export function preserveConditionalCronUpdate(
   if (!jobId) {
     return undefined;
   }
+  const currentSnapshots = Array.from(cronSnapshots.entries()).filter(
+    ([key, entry]) =>
+      key.startsWith(`${canonicalSessionKey}\u0000`) &&
+      entry.value.promptGeneration === promptState.generation
+  );
+  if (currentSnapshots.length !== 1) {
+    return undefined;
+  }
   const previous = cronSnapshots.get(snapshotKey(sessionKey, jobId))?.value;
-  if (!previous) {
+  if (!previous || previous.promptGeneration !== promptState.generation) {
     return undefined;
   }
 
@@ -229,29 +308,18 @@ export function preserveConditionalCronUpdate(
     return undefined;
   }
   const correction = prompt.trim();
-  const alreadyPreservesOriginal = proposedMessage.includes(previous.message);
-  const alreadyHasExactCorrection = proposedMessage.includes(correction);
-  const alreadyHasSilentNegativePath =
-    /return exactly [`'\"]?NO_REPLY[`'\"]?/i.test(proposedMessage);
-  const alreadyProhibitsMessageTool =
-    previous.deliveryMode !== 'announce' ||
-    /(?:do not|don't|never)\s+(?:call|use)\s+(?:the\s+)?message\s+tool/i.test(
-      proposedMessage
-    );
-  if (
-    alreadyPreservesOriginal &&
-    alreadyHasExactCorrection &&
-    alreadyHasSilentNegativePath &&
-    alreadyProhibitsMessageTool
-  ) {
-    return undefined;
-  }
-
   const announceRule =
     previous.deliveryMode === 'announce'
       ? '\nThis job uses delivery.mode=announce: never call or use the message tool for delivery. Return alert text only through announce delivery.'
       : '';
   const correctedMessage = `${previous.message}\n\nOwner correction (higher priority):\n${correction}\nThis correction overrides any conflicting earlier delivery instruction. Preserve the original subject, sources, and input scope; do not introduce unrelated events.${announceRule}\nWhen the corrected alert criteria are not met, return exactly NO_REPLY with no heartbeat, status update, or explanation.`;
+
+  // Presence checks are insufficient: a proposal can contain every required
+  // sentence and append a conflicting broad alert criterion. Only the exact
+  // canonical form is accepted unchanged.
+  if (proposedMessage === correctedMessage) {
+    return undefined;
+  }
 
   return {
     ...params,

--- a/packages/openclaw/src/conditional-cron-update.ts
+++ b/packages/openclaw/src/conditional-cron-update.ts
@@ -171,6 +171,24 @@ function isThresholdCorrection(prompt: string): boolean {
   );
 }
 
+function explicitlyChangesSchedule(prompt: string): boolean {
+  return /\bevery\b[^.!?\n]{0,40}\b(?:minute|hour|day|week|month)s?\b|\b(?:hourly|daily|weekly|monthly|schedule|cadence|frequency|run\s+(?:at|on)|cron)\b/i.test(
+    prompt
+  );
+}
+
+function explicitlyChangesEnabled(prompt: string): boolean {
+  return /\b(?:enable|disable|pause|resume|start|stop)\b[^.!?\n]{0,80}\b(?:job|schedule|task|monitor|running|run)\b|\bturn\b[^.!?\n]{0,80}\b(?:on|off)\b/i.test(
+    prompt
+  );
+}
+
+function explicitlyChangesDelivery(prompt: string): boolean {
+  return /\b(?:announc(?:e|ing)|delivery\s+mode|send|deliver|post)\b[^.!?\n]{0,80}\b(?:instead|direct|channel|dm|message|nowhere|none)\b|\b(?:don't|do not|stop)\s+(?:announc(?:e|ing)|send|deliver|post)\b/i.test(
+    prompt
+  );
+}
+
 export function rememberCronOwnerPrompt(
   sessionKey: string | undefined,
   prompt: string,
@@ -185,10 +203,7 @@ export function rememberCronOwnerPrompt(
   const existing = ownerPrompts.get(key);
   if (senderIsOwner === true) {
     ownerPrompts.set(key, {
-      generation:
-        existing?.trusted && existing.prompt === value
-          ? existing.generation
-          : (existing?.generation ?? 0) + 1,
+      generation: (existing?.generation ?? 0) + 1,
       prompt: value,
       timestamp: Date.now(),
       trusted: true,
@@ -326,8 +341,13 @@ export function preserveConditionalCronUpdate(
     return undefined;
   }
   const correction = prompt.trim();
+  const keepProposedDelivery =
+    explicitlyChangesDelivery(correction) && hasOwn(patch, 'delivery');
+  const effectiveDeliveryMode = keepProposedDelivery
+    ? cronDeliveryMode({ delivery: patch.delivery })
+    : previous.deliveryMode;
   const announceRule =
-    previous.deliveryMode === 'announce'
+    effectiveDeliveryMode === 'announce'
       ? '\nThis job uses delivery.mode=announce: never call or use the message tool for delivery. Return alert text only through announce delivery.'
       : '';
   const correctedMessage = `${previous.message}\n\nOwner correction (higher priority):\n${correction}\nThis correction overrides any conflicting earlier delivery instruction. Preserve the original subject, sources, and input scope; do not introduce unrelated events.${announceRule}\nWhen the corrected alert criteria are not met, return exactly NO_REPLY with no heartbeat, status update, or explanation.`;
@@ -347,12 +367,18 @@ export function preserveConditionalCronUpdate(
   // from the exact-job read so the rewritten message and its announce rule
   // describe the effective update that will actually be applied.
   const safePatch = { ...patch };
-  delete safePatch.delivery;
-  delete safePatch.enabled;
-  delete safePatch.schedule;
-  if (previous.hasDelivery) safePatch.delivery = previous.delivery;
-  if (previous.hasEnabled) safePatch.enabled = previous.enabled;
-  if (previous.hasSchedule) safePatch.schedule = previous.schedule;
+  if (!keepProposedDelivery) {
+    delete safePatch.delivery;
+    if (previous.hasDelivery) safePatch.delivery = previous.delivery;
+  }
+  if (!explicitlyChangesEnabled(correction)) {
+    delete safePatch.enabled;
+    if (previous.hasEnabled) safePatch.enabled = previous.enabled;
+  }
+  if (!explicitlyChangesSchedule(correction)) {
+    delete safePatch.schedule;
+    if (previous.hasSchedule) safePatch.schedule = previous.schedule;
+  }
 
   return {
     ...params,

--- a/packages/openclaw/src/conditional-cron-update.ts
+++ b/packages/openclaw/src/conditional-cron-update.ts
@@ -1,0 +1,194 @@
+import { sharedMap } from './shared-state.js';
+
+interface TimedValue<T> {
+  timestamp: number;
+  value: T;
+}
+
+interface CronSnapshot {
+  id: string;
+  message: string;
+}
+
+const STATE_TTL_MS = 60 * 60 * 1000;
+const ownerPrompts = sharedMap<string, TimedValue<string>>(
+  'conditionalCronUpdate.ownerPrompts'
+);
+const cronSnapshots = sharedMap<string, TimedValue<CronSnapshot>>(
+  'conditionalCronUpdate.snapshots'
+);
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+function cleanup(now = Date.now()): void {
+  for (const [key, entry] of ownerPrompts) {
+    if (now - entry.timestamp > STATE_TTL_MS) {
+      ownerPrompts.delete(key);
+    }
+  }
+  for (const [key, entry] of cronSnapshots) {
+    if (now - entry.timestamp > STATE_TTL_MS) {
+      cronSnapshots.delete(key);
+    }
+  }
+}
+
+function snapshotKey(sessionKey: string, jobId: string): string {
+  return `${sessionKey}\u0000${jobId}`;
+}
+
+function parseJsonObject(value: unknown): Record<string, unknown> | null {
+  if (isRecord(value)) {
+    return value;
+  }
+  if (typeof value !== 'string') {
+    return null;
+  }
+  try {
+    const parsed: unknown = JSON.parse(value);
+    return isRecord(parsed) ? parsed : null;
+  } catch {
+    return null;
+  }
+}
+
+function cronResultObject(result: unknown): Record<string, unknown> | null {
+  const direct = parseJsonObject(result);
+  if (!direct) {
+    return null;
+  }
+  const details = parseJsonObject(direct.details);
+  if (details) {
+    return details;
+  }
+  if (Array.isArray(direct.content)) {
+    for (const item of direct.content) {
+      if (!isRecord(item) || item.type !== 'text') {
+        continue;
+      }
+      const parsed = parseJsonObject(item.text);
+      if (parsed) {
+        return parsed;
+      }
+    }
+  }
+  return direct;
+}
+
+function cronMessage(job: Record<string, unknown>): string | null {
+  const payload = isRecord(job.payload) ? job.payload : null;
+  const message = payload?.message;
+  return typeof message === 'string' && message.trim() ? message : null;
+}
+
+function isThresholdCorrection(prompt: string): boolean {
+  const hasThresholdLanguage =
+    /\b(?:not|don't|do not|only|unless|ignore|suppress|routine|known|safe|risk|urgent|important|relevant)\b/i.test(
+      prompt
+    );
+  const concernsDelivery =
+    /\b(?:alert|notify|notification|monitor|update|bother|message|tell|send|urgent|risk)\b/i.test(
+      prompt
+    );
+  const explicitlyChangesScope =
+    /\b(?:replace|switch|broaden|all sources|any source|stop monitoring|change (?:the )?(?:subject|source|scope|topic))\b/i.test(
+      prompt
+    );
+  return hasThresholdLanguage && concernsDelivery && !explicitlyChangesScope;
+}
+
+export function rememberCronOwnerPrompt(
+  sessionKey: string | undefined,
+  prompt: string,
+  senderIsOwner: boolean | undefined
+): void {
+  if (!sessionKey || senderIsOwner === false || !prompt.trim()) {
+    return;
+  }
+  cleanup();
+  ownerPrompts.set(sessionKey, { timestamp: Date.now(), value: prompt.trim() });
+}
+
+export function recordCronGetResult(
+  sessionKey: string | undefined,
+  params: Record<string, unknown>,
+  result: unknown
+): void {
+  if (!sessionKey || params.action !== 'get') {
+    return;
+  }
+  const job = cronResultObject(result);
+  if (!job) {
+    return;
+  }
+  const id = typeof job.id === 'string' ? job.id : null;
+  const message = cronMessage(job);
+  if (!id || !message) {
+    return;
+  }
+  cleanup();
+  cronSnapshots.set(snapshotKey(sessionKey, id), {
+    timestamp: Date.now(),
+    value: { id, message },
+  });
+}
+
+export function preserveConditionalCronUpdate(
+  sessionKey: string | undefined,
+  params: Record<string, unknown>
+): Record<string, unknown> | undefined {
+  if (!sessionKey || params.action !== 'update') {
+    return undefined;
+  }
+  cleanup();
+  const prompt = ownerPrompts.get(sessionKey)?.value;
+  if (!prompt || !isThresholdCorrection(prompt)) {
+    return undefined;
+  }
+
+  const jobId =
+    typeof params.jobId === 'string'
+      ? params.jobId
+      : typeof params.id === 'string'
+        ? params.id
+        : null;
+  if (!jobId) {
+    return undefined;
+  }
+  const previous = cronSnapshots.get(snapshotKey(sessionKey, jobId))?.value;
+  if (!previous) {
+    return undefined;
+  }
+
+  const patch = isRecord(params.patch) ? params.patch : null;
+  const payload = patch && isRecord(patch.payload) ? patch.payload : null;
+  const proposedMessage = payload?.message;
+  if (typeof proposedMessage !== 'string' || !proposedMessage.trim()) {
+    return undefined;
+  }
+  if (proposedMessage.includes(previous.message)) {
+    return undefined;
+  }
+
+  const correctedMessage = `${previous.message}\n\nOwner correction (higher priority):\n${prompt}\nThis correction overrides any conflicting earlier delivery instruction. Preserve the original subject, sources, and input scope; do not introduce unrelated events. When the corrected alert criteria are not met, return exactly NO_REPLY with no heartbeat, status update, or explanation.`;
+
+  return {
+    ...params,
+    patch: {
+      ...patch,
+      payload: {
+        ...payload,
+        message: correctedMessage,
+      },
+    },
+  };
+}
+
+export const _testing = {
+  clear: () => {
+    ownerPrompts.clear();
+    cronSnapshots.clear();
+  },
+};

--- a/packages/openclaw/src/conditional-cron-update.ts
+++ b/packages/openclaw/src/conditional-cron-update.ts
@@ -178,13 +178,17 @@ function explicitlyChangesSchedule(prompt: string): boolean {
 }
 
 function explicitlyChangesEnabled(prompt: string): boolean {
+  const affirmative = prompt.replace(
+    /\b(?:do not|don't|never)\s+(?:enable|disable|pause|resume|start|stop|turn)\b[^.!?\n]*/gi,
+    ''
+  );
   return /\b(?:enable|disable|pause|resume|start|stop)\b[^.!?\n]{0,80}\b(?:job|schedule|task|monitor|running|run)\b|\bturn\b[^.!?\n]{0,80}\b(?:on|off)\b/i.test(
-    prompt
+    affirmative
   );
 }
 
 function explicitlyChangesDelivery(prompt: string): boolean {
-  return /\b(?:announc(?:e|ing)|delivery\s+mode|send|deliver|post)\b[^.!?\n]{0,80}\b(?:instead|direct|channel|dm|message|nowhere|none)\b|\b(?:don't|do not|stop)\s+(?:announc(?:e|ing)|send|deliver|post)\b/i.test(
+  return /\bdelivery\s+mode\b|\b(?:send|deliver|post)\b[^.!?\n]{0,80}\b(?:via|instead|to\s+(?:my\s+)?(?:dm|direct messages?)|in\s+(?:the\s+)?channel)\b|\b(?:disable|stop|turn\s+off)\s+(?:the\s+)?announce\s+delivery\b/i.test(
     prompt
   );
 }

--- a/packages/openclaw/src/conditional-cron-update.ts
+++ b/packages/openclaw/src/conditional-cron-update.ts
@@ -8,6 +8,7 @@ interface TimedValue<T> {
 interface CronSnapshot {
   id: string;
   message: string;
+  deliveryMode: string | null;
 }
 
 const STATE_TTL_MS = 60 * 60 * 1000;
@@ -83,6 +84,48 @@ function cronMessage(job: Record<string, unknown>): string | null {
   return typeof message === 'string' && message.trim() ? message : null;
 }
 
+function cronDeliveryMode(job: Record<string, unknown>): string | null {
+  const delivery = isRecord(job.delivery) ? job.delivery : null;
+  const mode = delivery?.mode;
+  return typeof mode === 'string' && mode.trim()
+    ? mode.trim().toLowerCase()
+    : null;
+}
+
+function explicitlyChangesMonitorScope(prompt: string): boolean {
+  return (
+    /\b(?:replace|switch|broaden|all sources|any source|stop monitoring|change (?:the )?(?:subject|source|scope|topic))\b/i.test(
+      prompt
+    ) ||
+    /\b(?:source|sources|feed|feeds|site|sites|website|websites)\b/i.test(
+      prompt
+    ) ||
+    /\b(?:only|now)\s+(?:monitor|check|watch|use|search)\b/i.test(prompt) ||
+    /\b(?:monitor|check|watch|use|search)\b[^.!?\n]*(?:\binstead\b|\bnow\b)/i.test(
+      prompt
+    )
+  );
+}
+
+function hasUnrelatedSideEffect(prompt: string): boolean {
+  const clauses = prompt
+    .split(/(?<=[.!?])\s+|\n+|;\s*|,\s+and\s+/i)
+    .map((clause) => clause.trim())
+    .filter(Boolean);
+  return clauses.some((clause) => {
+    if (
+      !/\b(?:delete|remove|create|rename|move|edit|write|save|post|upload|download|invite|leave|join|archive|install|buy|pay|book|call|email)\b/i.test(
+        clause
+      )
+    ) {
+      return false;
+    }
+    return !/\b(?:alert|notify|notification|monitor|update|bother|message|tell|send|urgent|risk|routine|threshold|relevant)\b/i.test(
+      clause
+    );
+  });
+}
+
 function isThresholdCorrection(prompt: string): boolean {
   const hasThresholdLanguage =
     /\b(?:not|don't|do not|only|unless|ignore|suppress|routine|known|safe|risk|urgent|important|relevant)\b/i.test(
@@ -92,11 +135,12 @@ function isThresholdCorrection(prompt: string): boolean {
     /\b(?:alert|notify|notification|monitor|update|bother|message|tell|send|urgent|risk)\b/i.test(
       prompt
     );
-  const explicitlyChangesScope =
-    /\b(?:replace|switch|broaden|all sources|any source|stop monitoring|change (?:the )?(?:subject|source|scope|topic))\b/i.test(
-      prompt
-    );
-  return hasThresholdLanguage && concernsDelivery && !explicitlyChangesScope;
+  return (
+    hasThresholdLanguage &&
+    concernsDelivery &&
+    !explicitlyChangesMonitorScope(prompt) &&
+    !hasUnrelatedSideEffect(prompt)
+  );
 }
 
 export function rememberCronOwnerPrompt(
@@ -116,9 +160,25 @@ export function recordCronGetResult(
   params: Record<string, unknown>,
   result: unknown
 ): void {
-  if (!sessionKey || params.action !== 'get') {
+  if (!sessionKey) {
     return;
   }
+  const requestedJobId =
+    typeof params.jobId === 'string'
+      ? params.jobId
+      : typeof params.id === 'string'
+        ? params.id
+        : null;
+  if (params.action === 'update') {
+    if (requestedJobId) {
+      // The after-tool hook cannot reliably recover the effective params after
+      // a before-tool rewrite. Force a fresh exact-job read before another
+      // correction rather than rebuilding from stale pre-update content.
+      cronSnapshots.delete(snapshotKey(sessionKey, requestedJobId));
+    }
+    return;
+  }
+  if (params.action !== 'get') return;
   const job = cronResultObject(result);
   if (!job) {
     return;
@@ -131,7 +191,7 @@ export function recordCronGetResult(
   cleanup();
   cronSnapshots.set(snapshotKey(sessionKey, id), {
     timestamp: Date.now(),
-    value: { id, message },
+    value: { id, message, deliveryMode: cronDeliveryMode(job) },
   });
 }
 
@@ -168,11 +228,30 @@ export function preserveConditionalCronUpdate(
   if (typeof proposedMessage !== 'string' || !proposedMessage.trim()) {
     return undefined;
   }
-  if (proposedMessage.includes(previous.message)) {
+  const correction = prompt.trim();
+  const alreadyPreservesOriginal = proposedMessage.includes(previous.message);
+  const alreadyHasExactCorrection = proposedMessage.includes(correction);
+  const alreadyHasSilentNegativePath =
+    /return exactly [`'\"]?NO_REPLY[`'\"]?/i.test(proposedMessage);
+  const alreadyProhibitsMessageTool =
+    previous.deliveryMode !== 'announce' ||
+    /(?:do not|don't|never)\s+(?:call|use)\s+(?:the\s+)?message\s+tool/i.test(
+      proposedMessage
+    );
+  if (
+    alreadyPreservesOriginal &&
+    alreadyHasExactCorrection &&
+    alreadyHasSilentNegativePath &&
+    alreadyProhibitsMessageTool
+  ) {
     return undefined;
   }
 
-  const correctedMessage = `${previous.message}\n\nOwner correction (higher priority):\n${prompt}\nThis correction overrides any conflicting earlier delivery instruction. Preserve the original subject, sources, and input scope; do not introduce unrelated events. When the corrected alert criteria are not met, return exactly NO_REPLY with no heartbeat, status update, or explanation.`;
+  const announceRule =
+    previous.deliveryMode === 'announce'
+      ? '\nThis job uses delivery.mode=announce: never call or use the message tool for delivery. Return alert text only through announce delivery.'
+      : '';
+  const correctedMessage = `${previous.message}\n\nOwner correction (higher priority):\n${correction}\nThis correction overrides any conflicting earlier delivery instruction. Preserve the original subject, sources, and input scope; do not introduce unrelated events.${announceRule}\nWhen the corrected alert criteria are not met, return exactly NO_REPLY with no heartbeat, status update, or explanation.`;
 
   return {
     ...params,

--- a/packages/openclaw/src/conditional-cron-update.ts
+++ b/packages/openclaw/src/conditional-cron-update.ts
@@ -147,9 +147,17 @@ function hasUnrelatedSideEffect(prompt: string): boolean {
     ) {
       return false;
     }
-    return !/\b(?:alert|notify|notification|monitor|update|bother|message|tell|send|urgent|risk|routine|threshold|relevant)\b/i.test(
-      clause
-    );
+    const changesAlertCriteria =
+      /\b(?:edit|change|update|save)\b[^.!?\n]{0,80}\b(?:alert|notification|monitor)(?:ing)?\s+(?:rule|criteria|threshold|settings?)\b/i.test(
+        clause
+      ) ||
+      /\b(?:delete|remove)\b[^.!?\n]{0,40}\b(?:routine|non-urgent|irrelevant)\s+(?:alerts?|notifications?|updates?)\b/i.test(
+        clause
+      ) ||
+      /\bpost\b[^.!?\n]{0,40}\b(?:alerts?|notifications?|updates?)\b/i.test(
+        clause
+      );
+    return !changesAlertCriteria;
   });
 }
 
@@ -172,8 +180,12 @@ function isThresholdCorrection(prompt: string): boolean {
 }
 
 function explicitlyChangesSchedule(prompt: string): boolean {
+  const affirmative = prompt.replace(
+    /\b(?:do not|don't|never)\s+(?:change|edit|update|modify)\b[^.!?\n]{0,80}\b(?:schedule|cadence|frequency|cron)\b/gi,
+    ''
+  );
   return /\bevery\b[^.!?\n]{0,40}\b(?:minute|hour|day|week|month)s?\b|\b(?:hourly|daily|weekly|monthly|schedule|cadence|frequency|run\s+(?:at|on)|cron)\b/i.test(
-    prompt
+    affirmative
   );
 }
 
@@ -188,8 +200,12 @@ function explicitlyChangesEnabled(prompt: string): boolean {
 }
 
 function explicitlyChangesDelivery(prompt: string): boolean {
+  const affirmative = prompt.replace(
+    /\b(?:do not|don't|never)\s+(?:change|edit|update|modify)\b[^.!?\n]{0,80}\b(?:delivery\s+mode|delivery|destination)\b/gi,
+    ''
+  );
   return /\bdelivery\s+mode\b|\b(?:send|deliver|post)\b[^.!?\n]{0,80}\b(?:via|instead|to\s+(?:my\s+)?(?:dm|direct messages?)|in\s+(?:the\s+)?channel)\b|\b(?:disable|stop|turn\s+off)\s+(?:the\s+)?announce\s+delivery\b/i.test(
-    prompt
+    affirmative
   );
 }
 

--- a/packages/openclaw/src/conditional-cron-update.ts
+++ b/packages/openclaw/src/conditional-cron-update.ts
@@ -15,8 +15,14 @@ interface OwnerPromptState {
 interface CronSnapshot {
   id: string;
   message: string;
+  delivery: unknown;
   deliveryMode: string | null;
+  enabled: unknown;
+  hasDelivery: boolean;
+  hasEnabled: boolean;
+  hasSchedule: boolean;
   promptGeneration: number;
+  schedule: unknown;
 }
 
 const STATE_TTL_MS = 60 * 60 * 1000;
@@ -103,6 +109,10 @@ function cronDeliveryMode(job: Record<string, unknown>): string | null {
   return typeof mode === 'string' && mode.trim()
     ? mode.trim().toLowerCase()
     : null;
+}
+
+function hasOwn(record: Record<string, unknown>, key: string): boolean {
+  return Object.prototype.hasOwnProperty.call(record, key);
 }
 
 function explicitlyChangesMonitorScope(prompt: string): boolean {
@@ -258,8 +268,14 @@ export function recordCronGetResult(
     value: {
       id,
       message,
+      delivery: job.delivery,
       deliveryMode: cronDeliveryMode(job),
+      enabled: job.enabled,
+      hasDelivery: hasOwn(job, 'delivery'),
+      hasEnabled: hasOwn(job, 'enabled'),
+      hasSchedule: hasOwn(job, 'schedule'),
       promptGeneration: promptState.generation,
+      schedule: job.schedule,
     },
   });
 }
@@ -302,7 +318,9 @@ export function preserveConditionalCronUpdate(
   }
 
   const patch = isRecord(params.patch) ? params.patch : null;
-  const payload = patch && isRecord(patch.payload) ? patch.payload : null;
+  if (!patch) return undefined;
+  const payload = isRecord(patch.payload) ? patch.payload : null;
+  if (!payload) return undefined;
   const proposedMessage = payload?.message;
   if (typeof proposedMessage !== 'string' || !proposedMessage.trim()) {
     return undefined;
@@ -318,13 +336,28 @@ export function preserveConditionalCronUpdate(
   // sentence and append a conflicting broad alert criterion. Only the exact
   // canonical form is accepted unchanged.
   if (proposedMessage === correctedMessage) {
-    return undefined;
+    const changesControlFields = ['delivery', 'enabled', 'schedule'].some(
+      (key) => hasOwn(patch, key)
+    );
+    if (!changesControlFields) return undefined;
   }
+
+  // A threshold-only correction must not silently change when a job runs,
+  // whether it remains enabled, or how it is delivered. Restore those fields
+  // from the exact-job read so the rewritten message and its announce rule
+  // describe the effective update that will actually be applied.
+  const safePatch = { ...patch };
+  delete safePatch.delivery;
+  delete safePatch.enabled;
+  delete safePatch.schedule;
+  if (previous.hasDelivery) safePatch.delivery = previous.delivery;
+  if (previous.hasEnabled) safePatch.enabled = previous.enabled;
+  if (previous.hasSchedule) safePatch.schedule = previous.schedule;
 
   return {
     ...params,
     patch: {
-      ...patch,
+      ...safePatch,
       payload: {
         ...payload,
         message: correctedMessage,

--- a/packages/openclaw/src/conditional-cron-update.ts
+++ b/packages/openclaw/src/conditional-cron-update.ts
@@ -168,7 +168,7 @@ function isThresholdCorrection(prompt: string): boolean {
       normalized
     );
   const concernsDelivery =
-    /\b(?:alert|notify|notification|monitor|update|bother|message|tell|send|urgent|risk)\b/i.test(
+    /\b(?:alerts?|notify|notifications?|monitor|updates?|bother|messages?|tell|send|urgent|risk)\b/i.test(
       normalized
     );
   return (

--- a/packages/openclaw/src/monitor/index.ts
+++ b/packages/openclaw/src/monitor/index.ts
@@ -18,6 +18,7 @@ import {
   syncBotInfo,
 } from '../bot-info.js';
 import { engagementTokens } from '../commands-registry.js';
+import { rememberCronOwnerPrompt } from '../conditional-cron-update.js';
 import {
   findRecentContextLensById,
   publishContextLensEvent,
@@ -3012,6 +3013,15 @@ async function monitorTlonProviderScoped(opts: MonitorTlonOpts): Promise<void> {
       // Store role for before_tool_call hook (tool access control)
       for (const sessionKey of lensSessionKeys) {
         setSessionRole(sessionKey, senderRole);
+        // Keep the exact trusted inbound text next to every session-key form
+        // the tool hooks may receive. The generic before_agent_run hook is a
+        // useful fallback for non-Tlon entry points, but it can be unavailable
+        // when conversation-access hooks are restricted by the host.
+        rememberCronOwnerPrompt(
+          sessionKey,
+          currentMessageText,
+          senderRole === 'owner'
+        );
       }
       runtime.log?.(
         `[tlon] Stored session role: sessionKeys=${lensSessionKeys.join(', ')}, role=${senderRole}`

--- a/packages/tlon-bot-e2e/README.md
+++ b/packages/tlon-bot-e2e/README.md
@@ -77,6 +77,7 @@ Current common scenarios are:
 -   stop/start replay coverage is selected and visibly skipped pending [TLON-6098](https://linear.app/tlon/issue/TLON-6098): neither runtime replays messages received while the bot is down; the intact scenario remains the regression gate when reconnect replay lands
 -   Hermes-only no-agent cron delivery to `TLON_HOME_CHANNEL`, with a future one-shot fired through `run_one_job(..., adapters=None, loop=None)` so the test uses the standalone sender path without racing the gateway ticker
 -   model-driven cron creation, scheduler firing, and origin delivery on both drivers in the `cron` capability partition
+-   TLON-6387 urgent-only cron correction on OpenClaw, proving the persisted job retains its exact scope, owner threshold, silent negative path, and announce-mode delivery contract
 
 The reaction scenarios cover dispatch and acknowledgement anchoring only. `packages/openclaw/src/monitor/history.test.ts` is the deterministic gate for pre-echo ID normalization and exact-reply cache-miss fetching.
 

--- a/packages/tlon-bot-e2e/src/scenarios/shared/common.ts
+++ b/packages/tlon-bot-e2e/src/scenarios/shared/common.ts
@@ -1296,6 +1296,44 @@ export const commonScenarios: readonly SharedScenario[] = [
       expect(persistedMessage).toContain('return exactly NO_REPLY');
       expect(persistedMessage).toContain('never call or use the message tool');
       expect(persistedMessage).not.toContain('Alert on anything urgent.');
+
+      // Remove the fixture through the same already-authorized owner route.
+      // A standalone OpenClaw CLI process may require a new WRITE-scope
+      // pairing approval, so it is only a fallback in scenario teardown.
+      const removeKey = `${key}-remove`;
+      const removeReply = `Removed urgent-only fixture ${key}`;
+      const removeScript: ModelScript = {
+        steps: [
+          {
+            kind: 'tool_call',
+            name: 'cron',
+            args: { action: 'remove', jobId: createdJob.id },
+          },
+          { kind: 'text', content: removeReply },
+        ],
+        expectations: {
+          advertisedTools: { exact: ['message', 'tlon', 'cron'] },
+          expectedCallCount: 2,
+          toolEffectOnly: true,
+        },
+      };
+      const removeTag = await registerModelScript(
+        ctx.fakeModel,
+        removeKey,
+        removeScript
+      );
+      const removeResult = await actors.owner.prompt(
+        `${removeTag} Remove the scripted cron fixture, then reply with the scripted result.`,
+        { timeoutMs: CRON_CREATE_PROMPT_WAIT_MS }
+      );
+      expectPromptSuccess(removeResult, removeReply);
+      await expectModelExpectations(ctx.fakeModel, removeKey, removeScript);
+      await waitForCronJobRemoved(
+        ctx,
+        driver.name,
+        createdJob.id,
+        CRON_JOB_REMOVAL_WAIT_MS
+      );
     }
   ),
 

--- a/packages/tlon-bot-e2e/src/scenarios/shared/common.ts
+++ b/packages/tlon-bot-e2e/src/scenarios/shared/common.ts
@@ -2,7 +2,11 @@ import { readFile } from 'node:fs/promises';
 import path from 'node:path';
 import { expect } from 'vitest';
 
-import type { DriverName, RuntimeContext } from '../../drivers/types.js';
+import type {
+  DriverName,
+  ModelScript,
+  RuntimeContext,
+} from '../../drivers/types.js';
 import type { FakeModelClient, ReceivedCall } from '../../fake-model/index.js';
 import {
   connectComposeNetwork,
@@ -1164,6 +1168,134 @@ export const commonScenarios: readonly SharedScenario[] = [
         isBenign,
         modelBaseline
       );
+    }
+  ),
+
+  testScenario(
+    'tlon-6387-urgent-only-cron-update-preserves-threshold',
+    { drivers: ['openclaw'], capabilities: ['cron'], timeoutMs: 300_000 },
+    async ({ ctx, driver, actors }) => {
+      const key = scenarioKey('tlon-6387-urgent-only');
+      const jobName = `urgent-only-${key}`;
+      const original =
+        'Monitor the fixed Bitcoin scenario from Reuters. Send a status update every run.';
+      const correction =
+        "This is known routine information. My keys and coins aren't at risk, so only alert me when there is a genuinely urgent security risk.";
+      const cleanupTarget: CronCleanupTarget = {
+        name: jobName,
+        creationSettled: Promise.resolve(),
+      };
+      actors.bot.teardown(
+        () => cleanupCronJobAndArtifacts(ctx, driver.name, cleanupTarget),
+        { label: `remove TLON-6387 cron job ${jobName}` }
+      );
+
+      const createKey = `${key}-create`;
+      const createReply = `Created urgent-only fixture ${key}`;
+      const createScript: ModelScript = {
+        steps: [
+          {
+            kind: 'tool_call',
+            name: 'cron',
+            args: {
+              action: 'add',
+              job: {
+                name: jobName,
+                schedule: {
+                  kind: 'at',
+                  at: new Date(Date.now() + 60 * 60 * 1000).toISOString(),
+                },
+                payload: { kind: 'agentTurn', message: original },
+                delivery: { mode: 'announce' },
+                sessionTarget: 'isolated',
+              },
+            },
+          },
+          { kind: 'text', content: createReply },
+        ],
+        expectations: {
+          advertisedTools: { exact: ['message', 'tlon', 'cron'] },
+          expectedCallCount: 2,
+          toolEffectOnly: true,
+        },
+      };
+      const createTag = await registerModelScript(
+        ctx.fakeModel,
+        createKey,
+        createScript
+      );
+      const createResultPromise = actors.owner.prompt(
+        `${createTag} Create the scripted future cron fixture.`,
+        { timeoutMs: CRON_CREATE_PROMPT_WAIT_MS }
+      );
+      const createdJobPromise = waitForCronJobCreated(
+        ctx,
+        driver.name,
+        jobName,
+        CRON_CREATE_PROMPT_WAIT_MS
+      ).then((job) => {
+        cleanupTarget.id = job.id;
+        return job;
+      });
+      const [createResult, createdJob] = await settleCronJobCreation(
+        cleanupTarget,
+        createResultPromise,
+        createdJobPromise
+      );
+      expectPromptSuccess(createResult, createReply);
+      await expectModelExpectations(ctx.fakeModel, createKey, createScript);
+
+      const updateKey = `${key}-update`;
+      const updateReply = `Updated urgent-only fixture ${key}`;
+      const incompleteProposal = `${original}\nAlert on anything urgent.`;
+      const updateScript: ModelScript = {
+        steps: [
+          {
+            kind: 'tool_call',
+            name: 'cron',
+            args: { action: 'get', jobId: createdJob.id },
+          },
+          {
+            kind: 'tool_call',
+            name: 'cron',
+            args: {
+              action: 'update',
+              jobId: createdJob.id,
+              patch: {
+                payload: { kind: 'agentTurn', message: incompleteProposal },
+              },
+            },
+          },
+          { kind: 'text', content: updateReply },
+        ],
+        expectations: {
+          advertisedTools: { exact: ['message', 'tlon', 'cron'] },
+          expectedCallCount: 3,
+          toolEffectOnly: true,
+        },
+      };
+      const updateTag = await registerModelScript(
+        ctx.fakeModel,
+        updateKey,
+        updateScript
+      );
+      const updateResult = await actors.owner.prompt(
+        `${updateTag} ${correction} Read the exact job, apply the scripted update, then reply with the scripted result.`,
+        { timeoutMs: CRON_CREATE_PROMPT_WAIT_MS }
+      );
+      expectPromptSuccess(updateResult, updateReply);
+      await expectModelExpectations(ctx.fakeModel, updateKey, updateScript);
+
+      const persisted = await readOpenClawCronJob(ctx, createdJob.id);
+      const persistedMessage = (
+        persisted.payload as Record<string, unknown> | undefined
+      )?.message;
+      expect(persistedMessage).toEqual(expect.any(String));
+      expect(persistedMessage).toContain(original);
+      expect(persistedMessage).toContain(correction);
+      expect(persistedMessage).toContain('return exactly NO_REPLY');
+      expect(persistedMessage).toContain('never call or use the message tool');
+      expect(persistedMessage).not.toContain('Alert on anything urgent.');
     }
   ),
 
@@ -2490,6 +2622,40 @@ function assertExecOk(
         `${(result.stderr || result.stdout).trim()}`
     );
   }
+}
+
+async function readOpenClawCronJob(
+  ctx: RuntimeContext,
+  jobId: string
+): Promise<Record<string, unknown>> {
+  const result = await execInComposeService(ctx, ctx.services.bot, [
+    'openclaw',
+    'cron',
+    'list',
+    '--all',
+    '--json',
+    '--timeout',
+    '10000',
+  ]);
+  assertExecOk(result, `read OpenClaw cron job ${jobId}`);
+  const parsed: unknown = JSON.parse(result.stdout);
+  if (!parsed || typeof parsed !== 'object') {
+    throw new Error('OpenClaw cron list did not return an object.');
+  }
+  const jobs = (parsed as { jobs?: unknown }).jobs;
+  if (!Array.isArray(jobs)) {
+    throw new Error('OpenClaw cron list did not include jobs.');
+  }
+  const job = jobs.find(
+    (candidate) =>
+      candidate &&
+      typeof candidate === 'object' &&
+      (candidate as { id?: unknown }).id === jobId
+  );
+  if (!job || typeof job !== 'object') {
+    throw new Error(`OpenClaw cron job ${jobId} was not found.`);
+  }
+  return job as Record<string, unknown>;
 }
 
 async function botNickname(actor: ScenarioActor): Promise<string> {


### PR DESCRIPTION
## Summary

Keep an owner's urgent-only correction attached to the existing recurring monitor instead of letting a model rewrite it into a broader alert.

Fixes TLON-6387

## Changes

- treat conditional-alert corrections as lossless edits in the Tlon prompt and product guide
- remember the exact cron declaration and announce delivery mode returned by `cron get`
- verify that an update contains the original declaration, exact correction, silent `NO_REPLY` path, and announce-mode message-tool prohibition
- reject automatic rewriting when the owner directly changes sources or combines the correction with an unrelated task
- invalidate the cached declaration after an update so a later edit cannot restore stale content
- add focused review regression tests and a TLON-6387 persisted-cron E2E scenario to this issue PR

## How did I test?

- focused conditional-alert tests passed — 2 files, 10 tests
- E2E harness unit tests passed — 17 files, 151 tests
- E2E TypeScript check and OpenClaw build passed
- full OpenClaw suite reached 1,499 passing tests; two unrelated wall-clock-sensitive command-timeout tests failed under host saturation, then passed in isolation — 6/6
- `tlon-6387-urgent-only-cron-update-preserves-threshold` creates a real future OpenClaw cron job, drives model-issued `get` and incomplete `update` tool calls, then reads the persisted job and verifies exact scope, correction, `NO_REPLY`, and announce delivery
- two targeted local E2E attempts did not reach the scenario: the first timed out before fake-ship login; the retry reached ships and branch desk but npm registry I/O errors prevented OpenClaw gateway readiness; both had zero model calls
- exact baseline on OpenClaw 2026.7.1 / adapter 0.20.0 / OpenRouter `openai/gpt-5.6-luna` repeatedly lost the fixed Bitcoin scenario and later sent routine owner DMs such as “No urgent security event detected; no notification sent.”
- candidate passed 3/3 fresh-session, freshly-seeded runs on the same runtime and model (`18a76d1f`, `62e9d6cf`, `45ff13c5`)
- every passing run independently verified the stored declaration retained the fixed Bitcoin scenario, known/routine and safe keys/coins criteria, and literal `NO_REPLY`; a forced later run produced no owner DM
- the historical scheduled declaration and exact August 24 alert content are unavailable, so reconstructed context is labeled separately from the same-route behavioral proof
