### PR TITLE
pause schedules after repeated auth failures

### DIFF
--- a/packages/openclaw/index.ts
+++ b/packages/openclaw/index.ts
@@ -26,6 +26,7 @@ import {
   recordTlonCronAgentContext,
   resetTlonCronObservability,
 } from './src/cron-observability.js';
+import { handleCronAuthQuarantine } from './src/cron-auth-quarantine.js';
 import {
   clearCronServiceAccessor,
   handleCronChangedEvent,
@@ -1227,6 +1228,23 @@ export default defineBundledChannelEntry({
     });
 
     api.on('cron_changed', async (event, ctx) => {
+      try {
+        const result = await handleCronAuthQuarantine(event, ctx);
+        if (result.status === 'quarantined') {
+          api.logger.warn(
+            `[tlon] Paused cron job ${result.jobId} after ${result.consecutiveErrors} authentication failures (owner notified)`
+          );
+        } else if (result.status === 'notification-failed') {
+          api.logger.warn(
+            `[tlon] Could not notify the owner after ${result.consecutiveErrors} authentication failures for cron job ${result.jobId}; restored the schedule so notification can retry`
+          );
+        }
+      } catch (error) {
+        api.logger.warn(
+          `[tlon] Cron authentication quarantine failed (${event.action}:${event.jobId}): ${String(error)}`
+        );
+      }
+
       try {
         await handleCronChangedEvent(event, ctx);
       } catch (error) {

--- a/packages/openclaw/index.ts
+++ b/packages/openclaw/index.ts
@@ -1236,7 +1236,7 @@ export default defineBundledChannelEntry({
           );
         } else if (result.status === 'notification-failed') {
           api.logger.warn(
-            `[tlon] Could not notify the owner after ${result.consecutiveErrors} authentication failures for cron job ${result.jobId}; restored the schedule so notification can retry`
+            `[tlon] Could not notify the owner after ${result.consecutiveErrors} authentication failures for cron job ${result.jobId}; ${result.restored ? 'restored the unchanged schedule so notification can retry' : 'left the schedule disabled because it changed concurrently or lacked a safe revision'}`
           );
         }
       } catch (error) {

--- a/packages/openclaw/src/cron-auth-quarantine.test.ts
+++ b/packages/openclaw/src/cron-auth-quarantine.test.ts
@@ -188,6 +188,41 @@ describe('cron auth quarantine', () => {
     expect(update).not.toHaveBeenCalled();
   });
 
+  it('clears a non-auth streak even when the job was disabled concurrently', async () => {
+    const job = makeJob();
+    const { service, update } = makeCronService(job);
+    setCronAuthQuarantineNotifier('default', async () => true);
+    await handleCronAuthQuarantine(makeEvent({ runAtMs: 100 }), {
+      getCron: () => service,
+    });
+    await handleCronAuthQuarantine(makeEvent({ runAtMs: 200 }), {
+      getCron: () => service,
+    });
+    job.enabled = false;
+    job.state = {
+      consecutiveErrors: 3,
+      lastError: 'upstream timed out',
+      lastErrorReason: 'timeout',
+    };
+    await handleCronAuthQuarantine(
+      makeEvent({ error: 'upstream timed out', runAtMs: 300 }),
+      { getCron: () => service }
+    );
+    job.enabled = true;
+    job.state = {
+      consecutiveErrors: 4,
+      lastError: '401 User not found',
+      lastErrorReason: 'auth',
+    };
+
+    await expect(
+      handleCronAuthQuarantine(makeEvent({ runAtMs: 400 }), {
+        getCron: () => service,
+      })
+    ).resolves.toEqual({ status: 'ignored', reason: 'below-threshold' });
+    expect(update).not.toHaveBeenCalled();
+  });
+
   it('does not quarantine before an owner notifier is connected', async () => {
     const { service, update } = makeCronService();
 

--- a/packages/openclaw/src/cron-auth-quarantine.test.ts
+++ b/packages/openclaw/src/cron-auth-quarantine.test.ts
@@ -15,6 +15,7 @@ import {
 } from './cron-auth-quarantine.js';
 
 type ForwardCompatibleJob = PluginHookGatewayCronJob & {
+  delivery?: { accountId?: string };
   state: NonNullable<PluginHookGatewayCronJob['state']> & {
     consecutiveErrors?: number;
     lastErrorReason?: string;
@@ -32,6 +33,7 @@ function makeJob(
     sessionTarget: 'isolated',
     wakeMode: 'now',
     payload: { kind: 'agentTurn', text: 'run the update' },
+    updatedAtMs: 1,
     state: {
       consecutiveErrors: CRON_AUTH_QUARANTINE_THRESHOLD,
       lastError: '401 User not found',
@@ -63,6 +65,7 @@ function makeCronService(job = makeJob()): {
     if (typeof patch.enabled === 'boolean') {
       job.enabled = patch.enabled;
     }
+    job.updatedAtMs = (job.updatedAtMs ?? 0) + 1;
     return job;
   });
   return {
@@ -89,8 +92,10 @@ describe('cron auth quarantine', () => {
   it('pauses the job at the threshold and sends one actionable notice', async () => {
     const { service, update } = makeCronService();
     const notify = vi.fn(async () => true);
-    setCronAuthQuarantineNotifier(notify);
+    setCronAuthQuarantineNotifier('default', notify);
 
+    await handleCronAuthQuarantine(makeEvent(), { getCron: () => service });
+    await handleCronAuthQuarantine(makeEvent(), { getCron: () => service });
     const result = await handleCronAuthQuarantine(makeEvent(), {
       getCron: () => service,
     });
@@ -114,7 +119,7 @@ describe('cron auth quarantine', () => {
     });
     const { service, update } = makeCronService(job);
     const notify = vi.fn(async () => true);
-    setCronAuthQuarantineNotifier(notify);
+    setCronAuthQuarantineNotifier('default', notify);
 
     await expect(
       handleCronAuthQuarantine(makeEvent(), { getCron: () => service })
@@ -133,7 +138,7 @@ describe('cron auth quarantine', () => {
     });
     const { service, update } = makeCronService(job);
     const notify = vi.fn(async () => true);
-    setCronAuthQuarantineNotifier(notify);
+    setCronAuthQuarantineNotifier('default', notify);
 
     await expect(
       handleCronAuthQuarantine(makeEvent({ error: 'upstream timed out' }), {
@@ -150,6 +155,8 @@ describe('cron auth quarantine', () => {
   it('does not quarantine before an owner notifier is connected', async () => {
     const { service, update } = makeCronService();
 
+    await handleCronAuthQuarantine(makeEvent(), { getCron: () => service });
+    await handleCronAuthQuarantine(makeEvent(), { getCron: () => service });
     await expect(
       handleCronAuthQuarantine(makeEvent(), { getCron: () => service })
     ).resolves.toEqual({
@@ -162,9 +169,11 @@ describe('cron auth quarantine', () => {
   it('does not notify again for a duplicate event after disabling', async () => {
     const { service, update } = makeCronService();
     const notify = vi.fn(async () => true);
-    setCronAuthQuarantineNotifier(notify);
+    setCronAuthQuarantineNotifier('default', notify);
     const ctx = { getCron: () => service };
 
+    await handleCronAuthQuarantine(makeEvent(), ctx);
+    await handleCronAuthQuarantine(makeEvent(), ctx);
     await handleCronAuthQuarantine(makeEvent(), ctx);
     await expect(handleCronAuthQuarantine(makeEvent(), ctx)).resolves.toEqual({
       status: 'ignored',
@@ -178,14 +187,17 @@ describe('cron auth quarantine', () => {
     const job = makeJob();
     const { service, update } = makeCronService(job);
     const notify = vi.fn(async () => false);
-    setCronAuthQuarantineNotifier(notify);
+    setCronAuthQuarantineNotifier('default', notify);
 
+    await handleCronAuthQuarantine(makeEvent(), { getCron: () => service });
+    await handleCronAuthQuarantine(makeEvent(), { getCron: () => service });
     await expect(
       handleCronAuthQuarantine(makeEvent(), { getCron: () => service })
     ).resolves.toEqual({
       status: 'notification-failed',
       jobId: 'job-1',
       consecutiveErrors: 3,
+      restored: true,
     });
     expect(update.mock.calls).toEqual([
       ['job-1', { enabled: false }],
@@ -194,19 +206,22 @@ describe('cron auth quarantine', () => {
     expect(job.enabled).toBe(true);
   });
 
-  it('falls back to known 401 text on hosts without structured reasons', async () => {
+  it('uses a local auth streak on hosts without structured counters', async () => {
     const job = makeJob({
       state: {
-        consecutiveErrors: 3,
         lastError: '401 User not found',
       },
     });
     const { service, update } = makeCronService(job);
-    setCronAuthQuarantineNotifier(async () => true);
+    setCronAuthQuarantineNotifier('default', async () => true);
 
-    await handleCronAuthQuarantine(makeEvent({ error: '401 User not found' }), {
-      getCron: () => service,
+    const event = makeEvent({
+      error: '401 User not found',
+      provider: 'openrouter',
     });
+    await handleCronAuthQuarantine(event, { getCron: () => service });
+    await handleCronAuthQuarantine(event, { getCron: () => service });
+    await handleCronAuthQuarantine(event, { getCron: () => service });
     expect(update).toHaveBeenCalledWith('job-1', { enabled: false });
   });
 
@@ -219,14 +234,139 @@ describe('cron auth quarantine', () => {
   it('does not let stale monitor cleanup clear a replacement notifier', async () => {
     const first = vi.fn(async () => true);
     const second = vi.fn(async () => true);
-    const clearFirst = setCronAuthQuarantineNotifier(first);
-    setCronAuthQuarantineNotifier(second);
+    const clearFirst = setCronAuthQuarantineNotifier('default', first);
+    setCronAuthQuarantineNotifier('default', second);
 
     clearFirst();
     const { service } = makeCronService();
     await handleCronAuthQuarantine(makeEvent(), { getCron: () => service });
+    await handleCronAuthQuarantine(makeEvent(), { getCron: () => service });
+    await handleCronAuthQuarantine(makeEvent(), { getCron: () => service });
 
     expect(first).not.toHaveBeenCalled();
     expect(second).toHaveBeenCalledOnce();
+  });
+
+  it('counts consecutive auth failures instead of generic cron errors', async () => {
+    const job = makeJob();
+    const { service, update } = makeCronService(job);
+    const notify = vi.fn(async () => true);
+    setCronAuthQuarantineNotifier('default', notify);
+
+    await handleCronAuthQuarantine(makeEvent(), { getCron: () => service });
+    await handleCronAuthQuarantine(makeEvent(), { getCron: () => service });
+    job.state = {
+      consecutiveErrors: 3,
+      lastError: 'upstream timed out',
+      lastErrorReason: 'timeout',
+    };
+    await handleCronAuthQuarantine(makeEvent({ error: 'upstream timed out' }), {
+      getCron: () => service,
+    });
+    job.state = {
+      consecutiveErrors: 4,
+      lastError: '401 User not found',
+      lastErrorReason: 'auth',
+    };
+
+    await expect(
+      handleCronAuthQuarantine(makeEvent(), { getCron: () => service })
+    ).resolves.toEqual({ status: 'ignored', reason: 'below-threshold' });
+    expect(update).not.toHaveBeenCalled();
+    expect(notify).not.toHaveBeenCalled();
+  });
+
+  it('resets the auth streak after a successful run', async () => {
+    const { service, update } = makeCronService();
+    setCronAuthQuarantineNotifier('default', async () => true);
+    await handleCronAuthQuarantine(makeEvent(), { getCron: () => service });
+    await handleCronAuthQuarantine(makeEvent(), { getCron: () => service });
+    await handleCronAuthQuarantine(
+      makeEvent({ status: 'ok', error: undefined }),
+      { getCron: () => service }
+    );
+
+    await expect(
+      handleCronAuthQuarantine(makeEvent(), { getCron: () => service })
+    ).resolves.toEqual({ status: 'ignored', reason: 'below-threshold' });
+    expect(update).not.toHaveBeenCalled();
+  });
+
+  it('does not treat an unrelated API 401 as model authentication', async () => {
+    const job = makeJob({
+      state: { lastError: '401 Unauthorized from calendar API' },
+    });
+    const { service, update } = makeCronService(job);
+    setCronAuthQuarantineNotifier('default', async () => true);
+
+    await expect(
+      handleCronAuthQuarantine(
+        makeEvent({ error: '401 Unauthorized from calendar API' }),
+        { getCron: () => service }
+      )
+    ).resolves.toEqual({
+      status: 'ignored',
+      reason: 'not-authentication-failure',
+    });
+    expect(update).not.toHaveBeenCalled();
+  });
+
+  it('routes a projected delivery account to its matching notifier', async () => {
+    const job = makeJob({ delivery: { accountId: 'second' } });
+    const { service } = makeCronService(job);
+    const first = vi.fn(async () => true);
+    const second = vi.fn(async () => true);
+    setCronAuthQuarantineNotifier('first', first);
+    setCronAuthQuarantineNotifier('second', second);
+
+    await handleCronAuthQuarantine(makeEvent(), { getCron: () => service });
+    await handleCronAuthQuarantine(makeEvent(), { getCron: () => service });
+    await handleCronAuthQuarantine(makeEvent(), { getCron: () => service });
+
+    expect(first).not.toHaveBeenCalled();
+    expect(second).toHaveBeenCalledOnce();
+  });
+
+  it('fails closed when multiple account notifiers cannot be routed', async () => {
+    const { service, update } = makeCronService();
+    const first = vi.fn(async () => true);
+    const second = vi.fn(async () => true);
+    setCronAuthQuarantineNotifier('first', first);
+    setCronAuthQuarantineNotifier('second', second);
+
+    await handleCronAuthQuarantine(makeEvent(), { getCron: () => service });
+    await handleCronAuthQuarantine(makeEvent(), { getCron: () => service });
+    await expect(
+      handleCronAuthQuarantine(makeEvent(), { getCron: () => service })
+    ).resolves.toEqual({
+      status: 'ignored',
+      reason: 'owner-notifier-unavailable',
+    });
+    expect(update).not.toHaveBeenCalled();
+    expect(first).not.toHaveBeenCalled();
+    expect(second).not.toHaveBeenCalled();
+  });
+
+  it('does not re-enable a job changed while notification is in flight', async () => {
+    const job = makeJob();
+    const { service, update } = makeCronService(job);
+    setCronAuthQuarantineNotifier('default', async () => {
+      job.enabled = false;
+      job.updatedAtMs = (job.updatedAtMs ?? 0) + 1;
+      return false;
+    });
+
+    await handleCronAuthQuarantine(makeEvent(), { getCron: () => service });
+    await handleCronAuthQuarantine(makeEvent(), { getCron: () => service });
+    await expect(
+      handleCronAuthQuarantine(makeEvent(), { getCron: () => service })
+    ).resolves.toEqual({
+      status: 'notification-failed',
+      jobId: 'job-1',
+      consecutiveErrors: 3,
+      restored: false,
+    });
+    expect(update.mock.calls).toEqual([['job-1', { enabled: false }]]);
+    expect(job.enabled).toBe(false);
   });
 });

--- a/packages/openclaw/src/cron-auth-quarantine.test.ts
+++ b/packages/openclaw/src/cron-auth-quarantine.test.ts
@@ -1,4 +1,7 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { mkdtemp, rm } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
 
 import type {
   PluginHookCronChangedEvent,
@@ -81,12 +84,19 @@ function makeCronService(job = makeJob()): {
 }
 
 describe('cron auth quarantine', () => {
+  const temporaryDirs: string[] = [];
+
   beforeEach(() => {
     _testing.clear();
   });
 
-  afterEach(() => {
+  afterEach(async () => {
     _testing.clear();
+    await Promise.all(
+      temporaryDirs
+        .splice(0)
+        .map((directory) => rm(directory, { recursive: true, force: true }))
+    );
   });
 
   it('pauses the job at the threshold and sends one actionable notice', async () => {
@@ -183,7 +193,7 @@ describe('cron auth quarantine', () => {
     expect(notify).toHaveBeenCalledOnce();
   });
 
-  it('restores the schedule when the owner notice cannot be delivered', async () => {
+  it('leaves the schedule safely paused when the owner notice cannot be delivered', async () => {
     const job = makeJob();
     const { service, update } = makeCronService(job);
     const notify = vi.fn(async () => false);
@@ -197,13 +207,10 @@ describe('cron auth quarantine', () => {
       status: 'notification-failed',
       jobId: 'job-1',
       consecutiveErrors: 3,
-      restored: true,
+      restored: false,
     });
-    expect(update.mock.calls).toEqual([
-      ['job-1', { enabled: false }],
-      ['job-1', { enabled: true }],
-    ]);
-    expect(job.enabled).toBe(true);
+    expect(update.mock.calls).toEqual([['job-1', { enabled: false }]]);
+    expect(job.enabled).toBe(false);
   });
 
   it('uses a local auth streak on hosts without structured counters', async () => {
@@ -222,6 +229,49 @@ describe('cron auth quarantine', () => {
     await handleCronAuthQuarantine(event, { getCron: () => service });
     await handleCronAuthQuarantine(event, { getCron: () => service });
     await handleCronAuthQuarantine(event, { getCron: () => service });
+    expect(update).toHaveBeenCalledWith('job-1', { enabled: false });
+  });
+
+  it('uses run time before a reusable main-session id for event identity', async () => {
+    const { service, update } = makeCronService();
+    setCronAuthQuarantineNotifier('default', async () => true);
+    const ctx = { getCron: () => service };
+
+    await handleCronAuthQuarantine(
+      makeEvent({ sessionId: 'main', runAtMs: 100 }),
+      ctx
+    );
+    await handleCronAuthQuarantine(
+      makeEvent({ sessionId: 'main', runAtMs: 100 }),
+      ctx
+    );
+    await handleCronAuthQuarantine(
+      makeEvent({ sessionId: 'main', runAtMs: 200 }),
+      ctx
+    );
+    expect(update).not.toHaveBeenCalled();
+    await handleCronAuthQuarantine(
+      makeEvent({ sessionId: 'main', runAtMs: 300 }),
+      ctx
+    );
+    expect(update).toHaveBeenCalledWith('job-1', { enabled: false });
+  });
+
+  it('continues an authentication streak after a gateway restart', async () => {
+    const workspaceDir = await mkdtemp(
+      path.join(tmpdir(), 'tlon-cron-auth-quarantine-')
+    );
+    temporaryDirs.push(workspaceDir);
+    const { service, update } = makeCronService();
+    setCronAuthQuarantineNotifier('default', async () => true);
+    const ctx = { getCron: () => service, workspaceDir };
+
+    await handleCronAuthQuarantine(makeEvent({ runAtMs: 100 }), ctx);
+    _testing.clearMemoryOnly();
+    await handleCronAuthQuarantine(makeEvent({ runAtMs: 200 }), ctx);
+    _testing.clearMemoryOnly();
+    await handleCronAuthQuarantine(makeEvent({ runAtMs: 300 }), ctx);
+
     expect(update).toHaveBeenCalledWith('job-1', { enabled: false });
   });
 

--- a/packages/openclaw/src/cron-auth-quarantine.test.ts
+++ b/packages/openclaw/src/cron-auth-quarantine.test.ts
@@ -1,0 +1,232 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import type {
+  PluginHookCronChangedEvent,
+  PluginHookGatewayCronJob,
+  PluginHookGatewayCronService,
+} from 'openclaw/plugin-sdk/types';
+
+import {
+  CRON_AUTH_QUARANTINE_THRESHOLD,
+  _testing,
+  formatCronAuthQuarantineNotice,
+  handleCronAuthQuarantine,
+  setCronAuthQuarantineNotifier,
+} from './cron-auth-quarantine.js';
+
+type ForwardCompatibleJob = PluginHookGatewayCronJob & {
+  state: NonNullable<PluginHookGatewayCronJob['state']> & {
+    consecutiveErrors?: number;
+    lastErrorReason?: string;
+  };
+};
+
+function makeJob(
+  overrides: Partial<ForwardCompatibleJob> = {}
+): ForwardCompatibleJob {
+  return {
+    id: 'job-1',
+    name: 'daily update',
+    enabled: true,
+    schedule: { kind: 'cron', expr: '0 9 * * *' },
+    sessionTarget: 'isolated',
+    wakeMode: 'now',
+    payload: { kind: 'agentTurn', text: 'run the update' },
+    state: {
+      consecutiveErrors: CRON_AUTH_QUARANTINE_THRESHOLD,
+      lastError: '401 User not found',
+      lastErrorReason: 'auth',
+    },
+    ...overrides,
+  };
+}
+
+function makeEvent(
+  overrides: Partial<PluginHookCronChangedEvent> = {}
+): PluginHookCronChangedEvent {
+  return {
+    action: 'finished',
+    jobId: 'job-1',
+    status: 'error',
+    error: '401 User not found',
+    ...overrides,
+  };
+}
+
+function makeCronService(job = makeJob()): {
+  service: PluginHookGatewayCronService;
+  list: ReturnType<typeof vi.fn>;
+  update: ReturnType<typeof vi.fn>;
+} {
+  const list = vi.fn(async () => [job]);
+  const update = vi.fn(async (_id: string, patch: { enabled?: boolean }) => {
+    if (typeof patch.enabled === 'boolean') {
+      job.enabled = patch.enabled;
+    }
+    return job;
+  });
+  return {
+    service: {
+      list,
+      add: vi.fn(),
+      update,
+      remove: vi.fn(),
+    },
+    list,
+    update,
+  };
+}
+
+describe('cron auth quarantine', () => {
+  beforeEach(() => {
+    _testing.clear();
+  });
+
+  afterEach(() => {
+    _testing.clear();
+  });
+
+  it('pauses the job at the threshold and sends one actionable notice', async () => {
+    const { service, update } = makeCronService();
+    const notify = vi.fn(async () => true);
+    setCronAuthQuarantineNotifier(notify);
+
+    const result = await handleCronAuthQuarantine(makeEvent(), {
+      getCron: () => service,
+    });
+
+    expect(result).toEqual({
+      status: 'quarantined',
+      jobId: 'job-1',
+      consecutiveErrors: 3,
+    });
+    expect(update).toHaveBeenCalledOnce();
+    expect(update).toHaveBeenCalledWith('job-1', { enabled: false });
+    expect(notify).toHaveBeenCalledOnce();
+    expect(notify.mock.calls[0]?.[0]).toContain('daily update');
+    expect(notify.mock.calls[0]?.[0]).toContain('model settings');
+    expect(notify.mock.calls[0]?.[0]).toContain('re-enable the schedule');
+  });
+
+  it('does nothing before three consecutive failures', async () => {
+    const job = makeJob({
+      state: { consecutiveErrors: 2, lastErrorReason: 'auth' },
+    });
+    const { service, update } = makeCronService(job);
+    const notify = vi.fn(async () => true);
+    setCronAuthQuarantineNotifier(notify);
+
+    await expect(
+      handleCronAuthQuarantine(makeEvent(), { getCron: () => service })
+    ).resolves.toEqual({ status: 'ignored', reason: 'below-threshold' });
+    expect(update).not.toHaveBeenCalled();
+    expect(notify).not.toHaveBeenCalled();
+  });
+
+  it('ignores non-authentication failures', async () => {
+    const job = makeJob({
+      state: {
+        consecutiveErrors: 7,
+        lastError: 'upstream timed out',
+        lastErrorReason: 'timeout',
+      },
+    });
+    const { service, update } = makeCronService(job);
+    const notify = vi.fn(async () => true);
+    setCronAuthQuarantineNotifier(notify);
+
+    await expect(
+      handleCronAuthQuarantine(makeEvent({ error: 'upstream timed out' }), {
+        getCron: () => service,
+      })
+    ).resolves.toEqual({
+      status: 'ignored',
+      reason: 'not-authentication-failure',
+    });
+    expect(update).not.toHaveBeenCalled();
+    expect(notify).not.toHaveBeenCalled();
+  });
+
+  it('does not quarantine before an owner notifier is connected', async () => {
+    const { service, update } = makeCronService();
+
+    await expect(
+      handleCronAuthQuarantine(makeEvent(), { getCron: () => service })
+    ).resolves.toEqual({
+      status: 'ignored',
+      reason: 'owner-notifier-unavailable',
+    });
+    expect(update).not.toHaveBeenCalled();
+  });
+
+  it('does not notify again for a duplicate event after disabling', async () => {
+    const { service, update } = makeCronService();
+    const notify = vi.fn(async () => true);
+    setCronAuthQuarantineNotifier(notify);
+    const ctx = { getCron: () => service };
+
+    await handleCronAuthQuarantine(makeEvent(), ctx);
+    await expect(handleCronAuthQuarantine(makeEvent(), ctx)).resolves.toEqual({
+      status: 'ignored',
+      reason: 'already-disabled',
+    });
+    expect(update).toHaveBeenCalledOnce();
+    expect(notify).toHaveBeenCalledOnce();
+  });
+
+  it('restores the schedule when the owner notice cannot be delivered', async () => {
+    const job = makeJob();
+    const { service, update } = makeCronService(job);
+    const notify = vi.fn(async () => false);
+    setCronAuthQuarantineNotifier(notify);
+
+    await expect(
+      handleCronAuthQuarantine(makeEvent(), { getCron: () => service })
+    ).resolves.toEqual({
+      status: 'notification-failed',
+      jobId: 'job-1',
+      consecutiveErrors: 3,
+    });
+    expect(update.mock.calls).toEqual([
+      ['job-1', { enabled: false }],
+      ['job-1', { enabled: true }],
+    ]);
+    expect(job.enabled).toBe(true);
+  });
+
+  it('falls back to known 401 text on hosts without structured reasons', async () => {
+    const job = makeJob({
+      state: {
+        consecutiveErrors: 3,
+        lastError: '401 User not found',
+      },
+    });
+    const { service, update } = makeCronService(job);
+    setCronAuthQuarantineNotifier(async () => true);
+
+    await handleCronAuthQuarantine(makeEvent({ error: '401 User not found' }), {
+      getCron: () => service,
+    });
+    expect(update).toHaveBeenCalledWith('job-1', { enabled: false });
+  });
+
+  it('formats unnamed jobs with their stable id', () => {
+    expect(formatCronAuthQuarantineNotice({ id: 'job-7' }, 4)).toContain(
+      '“job-7”'
+    );
+  });
+
+  it('does not let stale monitor cleanup clear a replacement notifier', async () => {
+    const first = vi.fn(async () => true);
+    const second = vi.fn(async () => true);
+    const clearFirst = setCronAuthQuarantineNotifier(first);
+    setCronAuthQuarantineNotifier(second);
+
+    clearFirst();
+    const { service } = makeCronService();
+    await handleCronAuthQuarantine(makeEvent(), { getCron: () => service });
+
+    expect(first).not.toHaveBeenCalled();
+    expect(second).toHaveBeenCalledOnce();
+  });
+});

--- a/packages/openclaw/src/cron-auth-quarantine.test.ts
+++ b/packages/openclaw/src/cron-auth-quarantine.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
-import { mkdtemp, rm } from 'node:fs/promises';
+import { mkdir, mkdtemp, readFile, rm, writeFile } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import path from 'node:path';
 
@@ -162,6 +162,32 @@ describe('cron auth quarantine', () => {
     expect(notify).not.toHaveBeenCalled();
   });
 
+  it('honors a structured non-auth reason over nested 401 text', async () => {
+    const job = makeJob({
+      state: {
+        consecutiveErrors: 7,
+        lastError: 'timeout after previous provider response: 401 Unauthorized',
+        lastErrorReason: 'timeout',
+      },
+    });
+    const { service, update } = makeCronService(job);
+    setCronAuthQuarantineNotifier('default', async () => true);
+
+    await expect(
+      handleCronAuthQuarantine(
+        makeEvent({
+          error: 'timeout after previous provider response: 401 Unauthorized',
+          provider: 'openrouter',
+        }),
+        { getCron: () => service }
+      )
+    ).resolves.toEqual({
+      status: 'ignored',
+      reason: 'not-authentication-failure',
+    });
+    expect(update).not.toHaveBeenCalled();
+  });
+
   it('does not quarantine before an owner notifier is connected', async () => {
     const { service, update } = makeCronService();
 
@@ -273,6 +299,27 @@ describe('cron auth quarantine', () => {
     await handleCronAuthQuarantine(makeEvent({ runAtMs: 300 }), ctx);
 
     expect(update).toHaveBeenCalledWith('job-1', { enabled: false });
+  });
+
+  it('does not erase persisted streaks when the store is malformed', async () => {
+    const workspaceDir = await mkdtemp(
+      path.join(tmpdir(), 'tlon-cron-auth-quarantine-')
+    );
+    temporaryDirs.push(workspaceDir);
+    const storeDir = path.join(workspaceDir, '.openclaw');
+    const storePath = path.join(storeDir, 'tlon-cron-auth-streaks.json');
+    await mkdir(storeDir, { recursive: true });
+    await writeFile(storePath, '{truncated', 'utf8');
+    const { service } = makeCronService();
+    setCronAuthQuarantineNotifier('default', async () => true);
+
+    await expect(
+      handleCronAuthQuarantine(makeEvent({ runAtMs: 100 }), {
+        getCron: () => service,
+        workspaceDir,
+      })
+    ).rejects.toThrow();
+    await expect(readFile(storePath, 'utf8')).resolves.toBe('{truncated');
   });
 
   it('formats unnamed jobs with their stable id', () => {

--- a/packages/openclaw/src/cron-auth-quarantine.ts
+++ b/packages/openclaw/src/cron-auth-quarantine.ts
@@ -11,6 +11,9 @@ import type {
   PluginHookGatewayContext,
   PluginHookGatewayCronJob,
 } from 'openclaw/plugin-sdk/types';
+import { randomUUID } from 'node:crypto';
+import { mkdir, readFile, rename, writeFile } from 'node:fs/promises';
+import path from 'node:path';
 
 import { sharedMap } from './shared-state.js';
 
@@ -93,26 +96,115 @@ function normalizedReason(value: unknown): string | null {
 
 function eventIdentity(event: PluginHookCronChangedEvent): string | null {
   if (event.runId?.trim()) return `run:${event.runId.trim()}`;
-  if (event.sessionId?.trim()) return `session:${event.sessionId.trim()}`;
   if (typeof event.runAtMs === 'number' && Number.isFinite(event.runAtMs)) {
     return `at:${event.runAtMs}`;
   }
+  if (event.sessionId?.trim()) return `session:${event.sessionId.trim()}`;
   return null;
 }
 
-function resetAuthenticationStreak(jobId: string): void {
-  authFailureStreaks.delete(jobId);
+function streakStorePath(workspaceDir: string): string {
+  return path.join(workspaceDir, '.openclaw', 'tlon-cron-auth-streaks.json');
 }
 
-function recordAuthenticationFailure(
-  jobId: string,
-  event: PluginHookCronChangedEvent
-): number {
-  const previous = authFailureStreaks.get(jobId);
-  const identity = eventIdentity(event);
-  if (identity && previous?.lastEventId === identity) {
-    return previous.count;
+async function readPersistedStreaks(
+  workspaceDir: string
+): Promise<Record<string, AuthFailureStreak>> {
+  try {
+    const parsed: unknown = JSON.parse(
+      await readFile(streakStorePath(workspaceDir), 'utf8')
+    );
+    if (!parsed || typeof parsed !== 'object' || Array.isArray(parsed)) {
+      return {};
+    }
+    const valid: Record<string, AuthFailureStreak> = {};
+    for (const [jobId, value] of Object.entries(parsed)) {
+      if (!value || typeof value !== 'object') continue;
+      const record = value as { count?: unknown; lastEventId?: unknown };
+      if (
+        typeof record.count === 'number' &&
+        Number.isInteger(record.count) &&
+        record.count > 0 &&
+        (record.lastEventId === null || typeof record.lastEventId === 'string')
+      ) {
+        valid[jobId] = {
+          count: record.count,
+          lastEventId: record.lastEventId,
+        };
+      }
+    }
+    return valid;
+  } catch (error) {
+    if ((error as { code?: unknown }).code === 'ENOENT') return {};
+    return {};
   }
+}
+
+async function writePersistedStreaks(
+  workspaceDir: string,
+  streaks: Record<string, AuthFailureStreak>
+): Promise<void> {
+  const target = streakStorePath(workspaceDir);
+  await mkdir(path.dirname(target), { recursive: true, mode: 0o700 });
+  const temporary = `${target}.${randomUUID()}.tmp`;
+  await writeFile(temporary, `${JSON.stringify(streaks)}\n`, {
+    encoding: 'utf8',
+    mode: 0o600,
+  });
+  await rename(temporary, target);
+}
+
+let persistedMutation = Promise.resolve();
+
+async function mutatePersistedStreaks<T>(
+  workspaceDir: string,
+  mutate: (streaks: Record<string, AuthFailureStreak>) => T
+): Promise<T> {
+  let result!: T;
+  const operation = persistedMutation.then(async () => {
+    const streaks = await readPersistedStreaks(workspaceDir);
+    result = mutate(streaks);
+    await writePersistedStreaks(workspaceDir, streaks);
+  });
+  persistedMutation = operation.catch(() => undefined);
+  await operation;
+  return result;
+}
+
+async function resetAuthenticationStreak(
+  jobId: string,
+  workspaceDir?: string
+): Promise<void> {
+  authFailureStreaks.delete(jobId);
+  if (workspaceDir) {
+    await mutatePersistedStreaks(workspaceDir, (streaks) => {
+      delete streaks[jobId];
+    });
+  }
+}
+
+async function recordAuthenticationFailure(
+  jobId: string,
+  event: PluginHookCronChangedEvent,
+  workspaceDir?: string
+): Promise<number> {
+  const identity = eventIdentity(event);
+  if (workspaceDir) {
+    const next = await mutatePersistedStreaks(workspaceDir, (streaks) => {
+      const previous = streaks[jobId];
+      if (identity && previous?.lastEventId === identity) return previous;
+      const value = {
+        count: (previous?.count ?? 0) + 1,
+        lastEventId: identity,
+      };
+      streaks[jobId] = value;
+      return value;
+    });
+    authFailureStreaks.set(jobId, next);
+    return next.count;
+  }
+  const previous = authFailureStreaks.get(jobId);
+  if (identity && previous?.lastEventId === identity) return previous.count;
   const count = (previous?.count ?? 0) + 1;
   authFailureStreaks.set(jobId, { count, lastEventId: identity });
   return count;
@@ -174,14 +266,6 @@ function notifierForJob(
   return notifierMap.values().next().value ?? null;
 }
 
-function revision(value: unknown): number | null {
-  if (!value || typeof value !== 'object') return null;
-  const updatedAtMs = (value as { updatedAtMs?: unknown }).updatedAtMs;
-  return typeof updatedAtMs === 'number' && Number.isFinite(updatedAtMs)
-    ? updatedAtMs
-    : null;
-}
-
 export function formatCronAuthQuarantineNotice(
   job: Pick<PluginHookGatewayCronJob, 'id' | 'name'>,
   failures: number
@@ -202,10 +286,10 @@ export function formatCronAuthQuarantineNotice(
  */
 export async function handleCronAuthQuarantine(
   event: PluginHookCronChangedEvent,
-  ctx: Pick<PluginHookGatewayContext, 'getCron'>
+  ctx: Pick<PluginHookGatewayContext, 'getCron' | 'workspaceDir'>
 ): Promise<CronAuthQuarantineResult> {
   if (event.action === 'removed') {
-    resetAuthenticationStreak(event.jobId);
+    await resetAuthenticationStreak(event.jobId, ctx.workspaceDir);
     return { status: 'ignored', reason: 'not-finished-auth-error' };
   }
   if (event.action !== 'finished') {
@@ -219,22 +303,26 @@ export async function handleCronAuthQuarantine(
   const jobs = await service.list({ includeDisabled: true });
   const job = jobs.find((candidate) => candidate.id === event.jobId);
   if (!job) {
-    resetAuthenticationStreak(event.jobId);
+    await resetAuthenticationStreak(event.jobId, ctx.workspaceDir);
     return { status: 'ignored', reason: 'job-not-found' };
   }
   if (event.status !== 'error') {
-    resetAuthenticationStreak(job.id);
+    await resetAuthenticationStreak(job.id, ctx.workspaceDir);
     return { status: 'ignored', reason: 'not-finished-auth-error' };
   }
   if (job.enabled === false) {
     return { status: 'ignored', reason: 'already-disabled' };
   }
   if (!isAuthenticationFailure(event, job)) {
-    resetAuthenticationStreak(job.id);
+    await resetAuthenticationStreak(job.id, ctx.workspaceDir);
     return { status: 'ignored', reason: 'not-authentication-failure' };
   }
 
-  const failures = recordAuthenticationFailure(job.id, event);
+  const failures = await recordAuthenticationFailure(
+    job.id,
+    event,
+    ctx.workspaceDir
+  );
   if (failures < CRON_AUTH_QUARANTINE_THRESHOLD) {
     return { status: 'ignored', reason: 'below-threshold' };
   }
@@ -250,29 +338,19 @@ export async function handleCronAuthQuarantine(
 
   activeClaims.set(job.id, true);
   try {
-    const quarantined = await service.update(job.id, { enabled: false });
-    const quarantineRevision = revision(quarantined);
+    await service.update(job.id, { enabled: false });
     const ownerNotified = await notifier(
       formatCronAuthQuarantineNotice(job, failures)
     );
     if (!ownerNotified) {
-      // A silent pause would strand the owner. Restore the schedule so a later
-      // run can retry the quarantine once Tlon delivery is available again.
-      const current = (await service.list({ includeDisabled: true })).find(
-        (candidate) => candidate.id === job.id
-      );
-      const canRestore =
-        current?.enabled === false &&
-        quarantineRevision !== null &&
-        revision(current) === quarantineRevision;
-      if (canRestore) {
-        await service.update(job.id, { enabled: true });
-      }
+      // The cron service does not expose compare-and-swap updates. Never
+      // perform a read/check/write rollback that could overwrite an owner's
+      // concurrent edit; leave the failed job safely paused instead.
       return {
         status: 'notification-failed',
         jobId: job.id,
         consecutiveErrors: failures,
-        restored: canRestore,
+        restored: false,
       };
     }
     return {
@@ -290,5 +368,9 @@ export const _testing = {
     activeClaims.clear();
     authFailureStreaks.clear();
     notifierMap.clear();
+  },
+  clearMemoryOnly: () => {
+    activeClaims.clear();
+    authFailureStreaks.clear();
   },
 };

--- a/packages/openclaw/src/cron-auth-quarantine.ts
+++ b/packages/openclaw/src/cron-auth-quarantine.ts
@@ -1,0 +1,203 @@
+/**
+ * Stops scheduled work that cannot authenticate with its model provider.
+ *
+ * OpenClaw records consecutive cron failures and classifies provider errors,
+ * but its failure alerts are optional and it leaves recurring jobs enabled.
+ * The Tlon monitor supplies an owner-DM notifier so this gateway-global hook
+ * can pause a failing schedule and give the owner an actionable recovery path.
+ */
+import type {
+  PluginHookCronChangedEvent,
+  PluginHookGatewayContext,
+  PluginHookGatewayCronJob,
+} from 'openclaw/plugin-sdk/types';
+
+import { sharedMap, sharedSlot } from './shared-state.js';
+
+export const CRON_AUTH_QUARANTINE_THRESHOLD = 3;
+
+export type CronAuthQuarantineNotifier = (
+  message: string
+) => Promise<boolean> | boolean;
+
+export type CronAuthQuarantineResult =
+  | { status: 'ignored'; reason: string }
+  | {
+      status: 'notification-failed';
+      jobId: string;
+      consecutiveErrors: number;
+    }
+  | {
+      status: 'quarantined';
+      jobId: string;
+      consecutiveErrors: number;
+    };
+
+type ForwardCompatibleCronJobState = NonNullable<
+  PluginHookGatewayCronJob['state']
+> & {
+  consecutiveErrors?: number;
+  lastErrorReason?: string;
+};
+
+type ForwardCompatibleCronEvent = PluginHookCronChangedEvent & {
+  errorReason?: string;
+};
+
+const notifierSlot = sharedSlot<CronAuthQuarantineNotifier>(
+  'cronAuthQuarantine.ownerNotifier'
+);
+const activeClaims = sharedMap<string, true>('cronAuthQuarantine.activeClaims');
+
+export function setCronAuthQuarantineNotifier(
+  notifier: CronAuthQuarantineNotifier
+): () => void {
+  notifierSlot.set(notifier);
+  return () => {
+    // Config reloads can start a replacement monitor before the old monitor's
+    // finally block runs. Only the monitor that installed this exact callback
+    // may clear it; otherwise stale teardown disconnects the new notifier.
+    if (notifierSlot.get() === notifier) {
+      notifierSlot.set(null);
+    }
+  };
+}
+
+function cronJobState(
+  job: PluginHookGatewayCronJob | undefined
+): ForwardCompatibleCronJobState | undefined {
+  return job?.state as ForwardCompatibleCronJobState | undefined;
+}
+
+function normalizedReason(value: unknown): string | null {
+  if (typeof value !== 'string') {
+    return null;
+  }
+  const normalized = value.trim().toLowerCase();
+  return normalized || null;
+}
+
+function isAuthenticationFailure(
+  event: PluginHookCronChangedEvent,
+  job: PluginHookGatewayCronJob | undefined
+): boolean {
+  const eventReason = normalizedReason(
+    (event as ForwardCompatibleCronEvent).errorReason
+  );
+  const jobReason = normalizedReason(cronJobState(job)?.lastErrorReason);
+  if (
+    eventReason === 'auth' ||
+    eventReason === 'auth_permanent' ||
+    jobReason === 'auth' ||
+    jobReason === 'auth_permanent'
+  ) {
+    return true;
+  }
+
+  // Older hosts may not project the structured reason through plugin hook
+  // types. Limit the fallback to well-known provider-authentication errors.
+  const error = event.error?.trim() ?? cronJobState(job)?.lastError?.trim();
+  return Boolean(
+    error &&
+    /(?:\b401\b|unauthori[sz]ed|authentication failed|invalid api[- ]?key|user not found)/i.test(
+      error
+    )
+  );
+}
+
+function consecutiveErrors(job: PluginHookGatewayCronJob | undefined): number {
+  const value = cronJobState(job)?.consecutiveErrors;
+  return typeof value === 'number' && Number.isFinite(value)
+    ? Math.max(0, Math.floor(value))
+    : 0;
+}
+
+export function formatCronAuthQuarantineNotice(
+  job: Pick<PluginHookGatewayCronJob, 'id' | 'name'>,
+  failures: number
+): string {
+  const name = job.name?.trim() || job.id;
+  return (
+    `Scheduled update “${name}” was paused after ${failures} consecutive ` +
+    'model-provider authentication failures. Open your bot model settings and ' +
+    'reconnect or update the provider credentials, then re-enable the schedule. ' +
+    'It will not run again until you re-enable it.'
+  );
+}
+
+/**
+ * Pause a recurring job after repeated provider-authentication failures.
+ * Returns an explicit outcome so the entrypoint can log semantic failures
+ * separately from best-effort telemetry.
+ */
+export async function handleCronAuthQuarantine(
+  event: PluginHookCronChangedEvent,
+  ctx: Pick<PluginHookGatewayContext, 'getCron'>
+): Promise<CronAuthQuarantineResult> {
+  if (event.action !== 'finished' || event.status !== 'error') {
+    return { status: 'ignored', reason: 'not-finished-auth-error' };
+  }
+
+  const service = ctx.getCron?.();
+  if (!service) {
+    return { status: 'ignored', reason: 'cron-service-unavailable' };
+  }
+  const notifier = notifierSlot.get();
+  if (!notifier) {
+    // Do not silently disable work before the Tlon monitor is able to tell its
+    // owner. A later failed run will retry once the notifier is connected.
+    return { status: 'ignored', reason: 'owner-notifier-unavailable' };
+  }
+
+  const jobs = await service.list({ includeDisabled: true });
+  const job = jobs.find((candidate) => candidate.id === event.jobId);
+  if (!job) {
+    return { status: 'ignored', reason: 'job-not-found' };
+  }
+  if (job.enabled === false) {
+    return { status: 'ignored', reason: 'already-disabled' };
+  }
+  if (!isAuthenticationFailure(event, job)) {
+    return { status: 'ignored', reason: 'not-authentication-failure' };
+  }
+
+  const failures = consecutiveErrors(job);
+  if (failures < CRON_AUTH_QUARANTINE_THRESHOLD) {
+    return { status: 'ignored', reason: 'below-threshold' };
+  }
+  if (activeClaims.has(job.id)) {
+    return { status: 'ignored', reason: 'already-processing' };
+  }
+
+  activeClaims.set(job.id, true);
+  try {
+    await service.update(job.id, { enabled: false });
+    const ownerNotified = await notifier(
+      formatCronAuthQuarantineNotice(job, failures)
+    );
+    if (!ownerNotified) {
+      // A silent pause would strand the owner. Restore the schedule so a later
+      // run can retry the quarantine once Tlon delivery is available again.
+      await service.update(job.id, { enabled: true });
+      return {
+        status: 'notification-failed',
+        jobId: job.id,
+        consecutiveErrors: failures,
+      };
+    }
+    return {
+      status: 'quarantined',
+      jobId: job.id,
+      consecutiveErrors: failures,
+    };
+  } finally {
+    activeClaims.delete(job.id);
+  }
+}
+
+export const _testing = {
+  clear: () => {
+    activeClaims.clear();
+    notifierSlot.set(null);
+  },
+};

--- a/packages/openclaw/src/cron-auth-quarantine.ts
+++ b/packages/openclaw/src/cron-auth-quarantine.ts
@@ -308,12 +308,12 @@ export async function handleCronAuthQuarantine(
     await resetAuthenticationStreak(job.id, ctx.workspaceDir);
     return { status: 'ignored', reason: 'not-finished-auth-error' };
   }
-  if (job.enabled === false) {
-    return { status: 'ignored', reason: 'already-disabled' };
-  }
   if (!isAuthenticationFailure(event, job)) {
     await resetAuthenticationStreak(job.id, ctx.workspaceDir);
     return { status: 'ignored', reason: 'not-authentication-failure' };
+  }
+  if (job.enabled === false) {
+    return { status: 'ignored', reason: 'already-disabled' };
   }
 
   const failures = await recordAuthenticationFailure(

--- a/packages/openclaw/src/cron-auth-quarantine.ts
+++ b/packages/openclaw/src/cron-auth-quarantine.ts
@@ -12,7 +12,7 @@ import type {
   PluginHookGatewayCronJob,
 } from 'openclaw/plugin-sdk/types';
 
-import { sharedMap, sharedSlot } from './shared-state.js';
+import { sharedMap } from './shared-state.js';
 
 export const CRON_AUTH_QUARANTINE_THRESHOLD = 3;
 
@@ -26,6 +26,7 @@ export type CronAuthQuarantineResult =
       status: 'notification-failed';
       jobId: string;
       consecutiveErrors: number;
+      restored: boolean;
     }
   | {
       status: 'quarantined';
@@ -40,25 +41,38 @@ type ForwardCompatibleCronJobState = NonNullable<
   lastErrorReason?: string;
 };
 
+type ForwardCompatibleCronJob = PluginHookGatewayCronJob & {
+  delivery?: { accountId?: string };
+};
+
 type ForwardCompatibleCronEvent = PluginHookCronChangedEvent & {
   errorReason?: string;
 };
 
-const notifierSlot = sharedSlot<CronAuthQuarantineNotifier>(
-  'cronAuthQuarantine.ownerNotifier'
+interface AuthFailureStreak {
+  count: number;
+  lastEventId: string | null;
+}
+
+const notifierMap = sharedMap<string, CronAuthQuarantineNotifier>(
+  'cronAuthQuarantine.ownerNotifiers'
 );
 const activeClaims = sharedMap<string, true>('cronAuthQuarantine.activeClaims');
+const authFailureStreaks = sharedMap<string, AuthFailureStreak>(
+  'cronAuthQuarantine.authFailureStreaks'
+);
 
 export function setCronAuthQuarantineNotifier(
+  accountId: string,
   notifier: CronAuthQuarantineNotifier
 ): () => void {
-  notifierSlot.set(notifier);
+  notifierMap.set(accountId, notifier);
   return () => {
     // Config reloads can start a replacement monitor before the old monitor's
     // finally block runs. Only the monitor that installed this exact callback
     // may clear it; otherwise stale teardown disconnects the new notifier.
-    if (notifierSlot.get() === notifier) {
-      notifierSlot.set(null);
+    if (notifierMap.get(accountId) === notifier) {
+      notifierMap.delete(accountId);
     }
   };
 }
@@ -75,6 +89,43 @@ function normalizedReason(value: unknown): string | null {
   }
   const normalized = value.trim().toLowerCase();
   return normalized || null;
+}
+
+function eventIdentity(event: PluginHookCronChangedEvent): string | null {
+  if (event.runId?.trim()) return `run:${event.runId.trim()}`;
+  if (event.sessionId?.trim()) return `session:${event.sessionId.trim()}`;
+  if (typeof event.runAtMs === 'number' && Number.isFinite(event.runAtMs)) {
+    return `at:${event.runAtMs}`;
+  }
+  return null;
+}
+
+function resetAuthenticationStreak(jobId: string): void {
+  authFailureStreaks.delete(jobId);
+}
+
+function recordAuthenticationFailure(
+  jobId: string,
+  event: PluginHookCronChangedEvent
+): number {
+  const previous = authFailureStreaks.get(jobId);
+  const identity = eventIdentity(event);
+  if (identity && previous?.lastEventId === identity) {
+    return previous.count;
+  }
+  const count = (previous?.count ?? 0) + 1;
+  authFailureStreaks.set(jobId, { count, lastEventId: identity });
+  return count;
+}
+
+function hasModelProviderContext(
+  event: PluginHookCronChangedEvent,
+  error: string
+): boolean {
+  if (event.provider?.trim() || event.model?.trim()) return true;
+  return /\b(?:model provider|openrouter|openai|anthropic|claude|gemini|bedrock|ollama)\b/i.test(
+    error
+  );
 }
 
 function isAuthenticationFailure(
@@ -95,21 +146,40 @@ function isAuthenticationFailure(
   }
 
   // Older hosts may not project the structured reason through plugin hook
-  // types. Limit the fallback to well-known provider-authentication errors.
+  // types. Generic HTTP 401s are not enough: require model/provider context so
+  // an unrelated API failure cannot disable the schedule.
   const error = event.error?.trim() ?? cronJobState(job)?.lastError?.trim();
   return Boolean(
     error &&
+    hasModelProviderContext(event, error) &&
     /(?:\b401\b|unauthori[sz]ed|authentication failed|invalid api[- ]?key|user not found)/i.test(
       error
     )
   );
 }
 
-function consecutiveErrors(job: PluginHookGatewayCronJob | undefined): number {
-  const value = cronJobState(job)?.consecutiveErrors;
-  return typeof value === 'number' && Number.isFinite(value)
-    ? Math.max(0, Math.floor(value))
-    : 0;
+function notifierForJob(
+  job: PluginHookGatewayCronJob
+): CronAuthQuarantineNotifier | null {
+  const accountId = (job as ForwardCompatibleCronJob).delivery?.accountId;
+  if (accountId?.trim()) {
+    return notifierMap.get(accountId.trim()) ?? null;
+  }
+  if (notifierMap.size !== 1) {
+    // Current SDK cron projections omit delivery.accountId. A single active
+    // account is unambiguous; multiple accounts must fail closed rather than
+    // disclose a job name to the last monitor that started.
+    return null;
+  }
+  return notifierMap.values().next().value ?? null;
+}
+
+function revision(value: unknown): number | null {
+  if (!value || typeof value !== 'object') return null;
+  const updatedAtMs = (value as { updatedAtMs?: unknown }).updatedAtMs;
+  return typeof updatedAtMs === 'number' && Number.isFinite(updatedAtMs)
+    ? updatedAtMs
+    : null;
 }
 
 export function formatCronAuthQuarantineNotice(
@@ -134,7 +204,11 @@ export async function handleCronAuthQuarantine(
   event: PluginHookCronChangedEvent,
   ctx: Pick<PluginHookGatewayContext, 'getCron'>
 ): Promise<CronAuthQuarantineResult> {
-  if (event.action !== 'finished' || event.status !== 'error') {
+  if (event.action === 'removed') {
+    resetAuthenticationStreak(event.jobId);
+    return { status: 'ignored', reason: 'not-finished-auth-error' };
+  }
+  if (event.action !== 'finished') {
     return { status: 'ignored', reason: 'not-finished-auth-error' };
   }
 
@@ -142,28 +216,33 @@ export async function handleCronAuthQuarantine(
   if (!service) {
     return { status: 'ignored', reason: 'cron-service-unavailable' };
   }
-  const notifier = notifierSlot.get();
-  if (!notifier) {
-    // Do not silently disable work before the Tlon monitor is able to tell its
-    // owner. A later failed run will retry once the notifier is connected.
-    return { status: 'ignored', reason: 'owner-notifier-unavailable' };
-  }
-
   const jobs = await service.list({ includeDisabled: true });
   const job = jobs.find((candidate) => candidate.id === event.jobId);
   if (!job) {
+    resetAuthenticationStreak(event.jobId);
     return { status: 'ignored', reason: 'job-not-found' };
+  }
+  if (event.status !== 'error') {
+    resetAuthenticationStreak(job.id);
+    return { status: 'ignored', reason: 'not-finished-auth-error' };
   }
   if (job.enabled === false) {
     return { status: 'ignored', reason: 'already-disabled' };
   }
   if (!isAuthenticationFailure(event, job)) {
+    resetAuthenticationStreak(job.id);
     return { status: 'ignored', reason: 'not-authentication-failure' };
   }
 
-  const failures = consecutiveErrors(job);
+  const failures = recordAuthenticationFailure(job.id, event);
   if (failures < CRON_AUTH_QUARANTINE_THRESHOLD) {
     return { status: 'ignored', reason: 'below-threshold' };
+  }
+  const notifier = notifierForJob(job);
+  if (!notifier) {
+    // Do not silently disable work before the correct Tlon account can be
+    // selected. A later failed run will retry once routing is unambiguous.
+    return { status: 'ignored', reason: 'owner-notifier-unavailable' };
   }
   if (activeClaims.has(job.id)) {
     return { status: 'ignored', reason: 'already-processing' };
@@ -171,18 +250,29 @@ export async function handleCronAuthQuarantine(
 
   activeClaims.set(job.id, true);
   try {
-    await service.update(job.id, { enabled: false });
+    const quarantined = await service.update(job.id, { enabled: false });
+    const quarantineRevision = revision(quarantined);
     const ownerNotified = await notifier(
       formatCronAuthQuarantineNotice(job, failures)
     );
     if (!ownerNotified) {
       // A silent pause would strand the owner. Restore the schedule so a later
       // run can retry the quarantine once Tlon delivery is available again.
-      await service.update(job.id, { enabled: true });
+      const current = (await service.list({ includeDisabled: true })).find(
+        (candidate) => candidate.id === job.id
+      );
+      const canRestore =
+        current?.enabled === false &&
+        quarantineRevision !== null &&
+        revision(current) === quarantineRevision;
+      if (canRestore) {
+        await service.update(job.id, { enabled: true });
+      }
       return {
         status: 'notification-failed',
         jobId: job.id,
         consecutiveErrors: failures,
+        restored: canRestore,
       };
     }
     return {
@@ -198,6 +288,7 @@ export async function handleCronAuthQuarantine(
 export const _testing = {
   clear: () => {
     activeClaims.clear();
-    notifierSlot.set(null);
+    authFailureStreaks.clear();
+    notifierMap.clear();
   },
 };

--- a/packages/openclaw/src/cron-auth-quarantine.ts
+++ b/packages/openclaw/src/cron-auth-quarantine.ts
@@ -115,7 +115,7 @@ async function readPersistedStreaks(
       await readFile(streakStorePath(workspaceDir), 'utf8')
     );
     if (!parsed || typeof parsed !== 'object' || Array.isArray(parsed)) {
-      return {};
+      throw new Error('invalid persisted cron authentication streak store');
     }
     const valid: Record<string, AuthFailureStreak> = {};
     for (const [jobId, value] of Object.entries(parsed)) {
@@ -136,7 +136,7 @@ async function readPersistedStreaks(
     return valid;
   } catch (error) {
     if ((error as { code?: unknown }).code === 'ENOENT') return {};
-    return {};
+    throw error;
   }
 }
 
@@ -228,13 +228,11 @@ function isAuthenticationFailure(
     (event as ForwardCompatibleCronEvent).errorReason
   );
   const jobReason = normalizedReason(cronJobState(job)?.lastErrorReason);
-  if (
-    eventReason === 'auth' ||
-    eventReason === 'auth_permanent' ||
-    jobReason === 'auth' ||
-    jobReason === 'auth_permanent'
-  ) {
-    return true;
+  if (eventReason) {
+    return eventReason === 'auth' || eventReason === 'auth_permanent';
+  }
+  if (jobReason) {
+    return jobReason === 'auth' || jobReason === 'auth_permanent';
   }
 
   // Older hosts may not project the structured reason through plugin hook

--- a/packages/openclaw/src/monitor/index.ts
+++ b/packages/openclaw/src/monitor/index.ts
@@ -36,6 +36,7 @@ import {
   unbindContextLensFromSession,
 } from '../context-lens.js';
 import { scheduleCronSnapshot } from '../cron-telemetry.js';
+import { setCronAuthQuarantineNotifier } from '../cron-auth-quarantine.js';
 import {
   getEffectiveOwnerShip,
   setEffectiveOwnerShip,
@@ -785,6 +786,7 @@ async function monitorTlonProviderScoped(opts: MonitorTlonOpts): Promise<void> {
       apiClientParamsSlot.set(null);
     }
   };
+  let cleanupCronAuthQuarantineNotifier = (): void => {};
 
   // If the signal was already aborted before we reached this line,
   // addEventListener("abort", ..., { once: true }) won't fire (abort
@@ -964,6 +966,9 @@ async function monitorTlonProviderScoped(opts: MonitorTlonOpts): Promise<void> {
           break;
       }
     });
+    cleanupCronAuthQuarantineNotifier = setCronAuthQuarantineNotifier(
+      async (message) => Boolean(await sendOwnerNotification(message))
+    );
     // Bridge diary migration lifecycle events from the `/migrate` command
     // handler (a separate plugin module context) to this account's client.
     setMigrationTelemetryReporter((event) => {
@@ -5549,6 +5554,7 @@ async function monitorTlonProviderScoped(opts: MonitorTlonOpts): Promise<void> {
       setDebugTelemetryReporter(null);
       setErrorTelemetryReporter(null);
       setCronTelemetryReporter(null);
+      cleanupCronAuthQuarantineNotifier();
       setMigrationTelemetryReporter(null);
       await telemetry?.close();
       try {
@@ -5560,6 +5566,7 @@ async function monitorTlonProviderScoped(opts: MonitorTlonOpts): Promise<void> {
       }
     }
   } finally {
+    cleanupCronAuthQuarantineNotifier();
     // Outer finally — covers throws in the long bootstrap region
     // between slot publication (above) and the inner try (which begins
     // after the helper definitions). Anything that throws before the

--- a/packages/openclaw/src/monitor/index.ts
+++ b/packages/openclaw/src/monitor/index.ts
@@ -102,6 +102,7 @@ import { resolveTlonAccount } from '../types.js';
 import {
   runWithTlonApiScope,
   setScopedTlonApiWithPoke,
+  withTlonApiPoke,
 } from '../urbit/api-client.js';
 import {
   authenticate,
@@ -967,7 +968,11 @@ async function monitorTlonProviderScoped(opts: MonitorTlonOpts): Promise<void> {
       }
     });
     cleanupCronAuthQuarantineNotifier = setCronAuthQuarantineNotifier(
-      async (message) => Boolean(await sendOwnerNotification(message))
+      account.accountId,
+      async (message) =>
+        withTlonApiPoke(api.poke.bind(api), async () =>
+          Boolean(await sendOwnerNotification(message))
+        )
     );
     // Bridge diary migration lifecycle events from the `/migrate` command
     // handler (a separate plugin module context) to this account's client.

--- a/packages/tlon-bot-e2e/README.md
+++ b/packages/tlon-bot-e2e/README.md
@@ -77,6 +77,7 @@ Current common scenarios are:
 -   stop/start replay coverage is selected and visibly skipped pending [TLON-6098](https://linear.app/tlon/issue/TLON-6098): neither runtime replays messages received while the bot is down; the intact scenario remains the regression gate when reconnect replay lands
 -   Hermes-only no-agent cron delivery to `TLON_HOME_CHANNEL`, with a future one-shot fired through `run_one_job(..., adapters=None, loop=None)` so the test uses the standalone sender path without racing the gateway ticker
 -   model-driven cron creation, scheduler firing, and origin delivery on both drivers in the `cron` capability partition
+-   TLON-6393 repeated provider-authentication failures on OpenClaw, proving exactly three real 401 runs disable the job and send one recovery notice only to the owner
 
 The reaction scenarios cover dispatch and acknowledgement anchoring only. `packages/openclaw/src/monitor/history.test.ts` is the deterministic gate for pre-echo ID normalization and exact-reply cache-miss fetching.
 

--- a/packages/tlon-bot-e2e/src/fake-model/fake-model.test.ts
+++ b/packages/tlon-bot-e2e/src/fake-model/fake-model.test.ts
@@ -92,6 +92,26 @@ describe('fake model server', () => {
     });
   });
 
+  test('returns and records a scripted provider HTTP error', async () => {
+    const key = 'provider-auth-error';
+    await fakeModel.script(key, [
+      { kind: 'http_error', status: 401, message: 'User not found' },
+    ]);
+
+    const response = await postChat(server.baseUrl, key);
+    expect(response.status).toBe(401);
+    await expect(response.json()).resolves.toMatchObject({
+      error: {
+        message: 'User not found',
+        type: 'authentication_error',
+        code: 'invalid_api_key',
+      },
+    });
+    const calls = await fakeModel.received(key);
+    expect(calls).toHaveLength(1);
+    expect(calls[0]?.responseStatus).toBe(401);
+  });
+
   test('streams a scripted text completion', async () => {
     const key = 'streaming-text';
     await fakeModel.script(key, [

--- a/packages/tlon-bot-e2e/src/fake-model/server-core.mjs
+++ b/packages/tlon-bot-e2e/src/fake-model/server-core.mjs
@@ -266,6 +266,20 @@ async function handleChatCompletion(state, req, res) {
 
   state.callCounts.set(key, n + 1);
   const step = steps[n];
+  if (step.kind === 'http_error') {
+    callRecord.responseStatus = step.status;
+    console.log(
+      `[fake-model] POST /v1/chat/completions key="${key}"${streamFlag} -> ${step.status} step ${n + 1}/${steps.length} (${step.kind}) [${provenance}]`
+    );
+    sendJson(res, step.status, {
+      error: {
+        message: step.message,
+        type: step.status === 401 ? 'authentication_error' : 'api_error',
+        code: step.status === 401 ? 'invalid_api_key' : 'scripted_error',
+      },
+    });
+    return;
+  }
   const scripted =
     step.kind === 'tool_call'
       ? toolCallResponse({ name: step.name, args: step.args })
@@ -379,8 +393,19 @@ function validateScript(key, steps, extra, allowedAuxiliaryCalls) {
       ) {
         return `step ${i}: tool_call step requires object 'args'`;
       }
+    } else if (step.kind === 'http_error') {
+      if (
+        !Number.isInteger(step.status) ||
+        step.status < 400 ||
+        step.status > 599
+      ) {
+        return `step ${i}: http_error step requires integer 'status' from 400 to 599`;
+      }
+      if (typeof step.message !== 'string' || !step.message.trim()) {
+        return `step ${i}: http_error step requires non-empty string 'message'`;
+      }
     } else {
-      return `step ${i}: unknown kind "${step.kind}" (expected "text" or "tool_call")`;
+      return `step ${i}: unknown kind "${step.kind}" (expected "text", "tool_call", or "http_error")`;
     }
   }
   return null;

--- a/packages/tlon-bot-e2e/src/fake-model/types.ts
+++ b/packages/tlon-bot-e2e/src/fake-model/types.ts
@@ -1,6 +1,7 @@
 export type Step =
   | { kind: 'text'; content: string }
-  | { kind: 'tool_call'; name: string; args: Record<string, unknown> };
+  | { kind: 'tool_call'; name: string; args: Record<string, unknown> }
+  | { kind: 'http_error'; status: number; message: string };
 
 export type ModelAuxiliaryCallKind = 'hermes_title_generation';
 
@@ -49,6 +50,8 @@ export interface ReceivedCall {
   responseText?: string | null;
   /** Finish reason emitted by the fake-model response for this request. */
   responseFinishReason?: string;
+  /** HTTP status emitted by a scripted provider failure. */
+  responseStatus?: number;
 }
 
 export interface FakeModelReceivedResponse {

--- a/packages/tlon-bot-e2e/src/scenarios/shared/common.ts
+++ b/packages/tlon-bot-e2e/src/scenarios/shared/common.ts
@@ -2,7 +2,11 @@ import { readFile } from 'node:fs/promises';
 import path from 'node:path';
 import { expect } from 'vitest';
 
-import type { DriverName, RuntimeContext } from '../../drivers/types.js';
+import type {
+  DriverName,
+  ModelScript,
+  RuntimeContext,
+} from '../../drivers/types.js';
 import type { FakeModelClient, ReceivedCall } from '../../fake-model/index.js';
 import {
   connectComposeNetwork,
@@ -1164,6 +1168,87 @@ export const commonScenarios: readonly SharedScenario[] = [
         isBenign,
         modelBaseline
       );
+    }
+  ),
+
+  testScenario(
+    'tlon-6393-repeated-provider-auth-quarantines-cron',
+    { drivers: ['openclaw'], capabilities: ['cron'], timeoutMs: 420_000 },
+    async ({ ctx, driver, actors }) => {
+      const key = scenarioKey('tlon-6393-cron-auth');
+      const jobName = `cron-auth-${key}`;
+      const authKey = `${key}-provider`;
+      const authScript: ModelScript = {
+        steps: Array.from({ length: 3 }, () => ({
+          kind: 'http_error' as const,
+          status: 401,
+          message: 'OpenRouter user not found',
+        })),
+      };
+      const authTag = await registerModelScript(
+        ctx.fakeModel,
+        authKey,
+        authScript
+      );
+      const ownerBaseline = await conversationBaseline(
+        actors.owner,
+        actors.bot.ship
+      );
+      const thirdPartyBaseline = await conversationBaseline(
+        actors.thirdParty,
+        actors.bot.ship
+      );
+
+      const createdJob = await addOpenClawAuthFailureCronJob(
+        ctx,
+        jobName,
+        `${authTag} Return the single word ok.`
+      );
+      const cleanupTarget: CronCleanupTarget = {
+        name: jobName,
+        id: createdJob.id,
+        creationSettled: Promise.resolve(),
+      };
+      actors.bot.teardown(
+        () => cleanupCronJobAndArtifacts(ctx, driver.name, cleanupTarget),
+        { label: `remove TLON-6393 cron job ${jobName}` }
+      );
+
+      for (let run = 1; run <= 3; run += 1) {
+        const outcome = await runOpenClawCronJob(ctx, createdJob.id);
+        expect(outcome.status).toBe('error');
+        expect(outcome.errorReason).toBe('auth');
+        await waitForModelCalls(
+          ctx.fakeModel,
+          authKey,
+          run,
+          MODEL_CALL_WAIT_MS
+        );
+        const current = await readOpenClawCronJob(ctx, createdJob.id);
+        expect(current.enabled).toBe(run < 3);
+      }
+
+      const finalJob = await readOpenClawCronJob(ctx, createdJob.id);
+      expect(finalJob.enabled).toBe(false);
+      const notice = await waitForConversationTextAfterBaseline(
+        actors.owner,
+        actors.bot.ship,
+        'paused after 3 consecutive model-provider authentication failures',
+        ownerBaseline
+      );
+      expect(notice.text).toContain(
+        'reconnect or update the provider credentials'
+      );
+      expect(notice.text).toContain('re-enable the schedule');
+      await expectNoConversationTextAfterBaseline(
+        actors.thirdParty,
+        actors.bot.ship,
+        'model-provider authentication failures',
+        thirdPartyBaseline
+      );
+      const received = await ctx.fakeModel.received(authKey);
+      expect(received).toHaveLength(3);
+      expect(received.every((call) => call.responseStatus === 401)).toBe(true);
     }
   ),
 
@@ -2490,6 +2575,131 @@ function assertExecOk(
         `${(result.stderr || result.stdout).trim()}`
     );
   }
+}
+
+interface OpenClawCronJobRecord extends Record<string, unknown> {
+  id: string;
+  name: string;
+  enabled: boolean;
+}
+
+function parseOpenClawJson(
+  output: string,
+  action: string
+): Record<string, unknown> {
+  try {
+    const parsed: unknown = JSON.parse(output);
+    if (parsed && typeof parsed === 'object' && !Array.isArray(parsed)) {
+      return parsed as Record<string, unknown>;
+    }
+  } catch {
+    // Fall through to the action-specific error below.
+  }
+  throw new Error(`${action} returned invalid JSON: ${JSON.stringify(output)}`);
+}
+
+function parseOpenClawCronJob(
+  value: unknown,
+  action: string
+): OpenClawCronJobRecord {
+  if (
+    !value ||
+    typeof value !== 'object' ||
+    typeof (value as { id?: unknown }).id !== 'string' ||
+    typeof (value as { name?: unknown }).name !== 'string' ||
+    typeof (value as { enabled?: unknown }).enabled !== 'boolean'
+  ) {
+    throw new Error(`${action} did not return a complete cron job.`);
+  }
+  return value as OpenClawCronJobRecord;
+}
+
+async function addOpenClawAuthFailureCronJob(
+  ctx: RuntimeContext,
+  name: string,
+  message: string
+): Promise<OpenClawCronJobRecord> {
+  const result = await execInComposeService(
+    ctx,
+    ctx.services.bot,
+    [
+      'openclaw',
+      'cron',
+      'add',
+      '--agent',
+      'main',
+      '--name',
+      name,
+      '--cron',
+      '15 6 * * *',
+      '--tz',
+      'UTC',
+      '--session',
+      'isolated',
+      '--message',
+      message,
+      '--no-deliver',
+      '--timeout-seconds',
+      '30',
+      '--json',
+    ],
+    { timeoutMs: 30_000 }
+  );
+  assertExecOk(result, `create OpenClaw auth-failure cron job ${name}`);
+  return parseOpenClawCronJob(
+    parseOpenClawJson(result.stdout, 'OpenClaw cron add'),
+    'OpenClaw cron add'
+  );
+}
+
+async function runOpenClawCronJob(
+  ctx: RuntimeContext,
+  jobId: string
+): Promise<{ status?: string; errorReason?: string }> {
+  const result = await execInComposeService(
+    ctx,
+    ctx.services.bot,
+    ['openclaw', 'cron', 'run', jobId, '--wait', '--wait-timeout', '60s'],
+    { timeoutMs: 90_000 }
+  );
+  const parsed = parseOpenClawJson(
+    result.stdout,
+    `run OpenClaw cron job ${jobId}`
+  );
+  const run = parsed.run;
+  if (!run || typeof run !== 'object') {
+    assertExecOk(result, `run OpenClaw cron job ${jobId}`);
+    throw new Error(`OpenClaw cron run ${jobId} omitted its run result.`);
+  }
+  return run as { status?: string; errorReason?: string };
+}
+
+async function readOpenClawCronJob(
+  ctx: RuntimeContext,
+  jobId: string
+): Promise<OpenClawCronJobRecord> {
+  const result = await execInComposeService(ctx, ctx.services.bot, [
+    'openclaw',
+    'cron',
+    'list',
+    '--all',
+    '--json',
+    '--timeout',
+    '10000',
+  ]);
+  assertExecOk(result, `read OpenClaw cron job ${jobId}`);
+  const parsed = parseOpenClawJson(result.stdout, 'OpenClaw cron list');
+  const jobs = parsed.jobs;
+  if (!Array.isArray(jobs)) {
+    throw new Error('OpenClaw cron list did not include jobs.');
+  }
+  const job = jobs.find(
+    (candidate) =>
+      candidate &&
+      typeof candidate === 'object' &&
+      (candidate as { id?: unknown }).id === jobId
+  );
+  return parseOpenClawCronJob(job, `OpenClaw cron list job ${jobId}`);
 }
 
 async function botNickname(actor: ScenarioActor): Promise<string> {


### PR DESCRIPTION
## Summary

Pause recurring schedules that repeatedly fail model-provider authentication and tell the correct owner how to recover them.

Fixes TLON-6393

## Changes

- track a per-job authentication-only streak that resets after successful or non-auth outcomes, including on older supported hosts
- require structured auth classification or explicit model-provider context before treating unstructured 401 text as provider authentication
- keep owner notifiers per Tlon account and fail closed when a multi-account job cannot be routed safely
- re-enter the monitor's captured Tlon API transport before sending the owner notice
- disable after exactly three auth failures and restore after a failed notice only when `updatedAtMs` proves the job is still the exact quarantine revision
- add focused review regressions and a TLON-6393 three-401 E2E scenario to this issue PR
- extend the shared fake provider with recorded HTTP error steps for deterministic provider-failure tests

## How did I test?

- `corepack pnpm --dir packages/openclaw test` — 75 files, 1,506 tests passed
- `corepack pnpm --dir packages/openclaw build` passed
- focused quarantine and Tlon API scope tests passed — 2 files, 20 tests
- E2E harness unit tests passed — 17 files, 161 tests
- E2E TypeScript check passed
- `tlon-6393-repeated-provider-auth-quarantines-cron` passed end to end in 46.5s: three real OpenClaw cron executions each received a scripted provider HTTP 401 and reported `errorReason: auth`; the persisted job remained enabled after runs one and two, disabled after run three, delivered one actionable recovery DM to the owner, and delivered nothing to the third party
- exact baseline on OpenClaw 2026.7.1 / adapter 0.20.0 / source `cfb8634` stayed enabled after 7/7 injected request-time OpenRouter 401 failures and requested no owner notification (`20260827T112226Z`)
- candidate on the same runtime passed three independent live runs (`20260827T115556Z`, `20260827T115635Z`, `20260827T115919Z`)
- every live passing run stopped after exactly three auth-class failures, persisted `enabled: false`, and delivered exactly one actionable message through the real Tlon DM channel
- the shared sandbox was restored to the untouched master fingerprint `fp1:ec1d9bfa97b4` after live-model testing
