### PR TITLE
Create missing DM channel rows during incremental sync

### DIFF
--- a/packages/shared/src/db/queries.ts
+++ b/packages/shared/src/db/queries.ts
@@ -2813,6 +2813,24 @@ export const getChannel = createReadQuery(
   ['channels']
 );
 
+export const getExistingChannelIds = createReadQuery(
+  'getExistingChannelIds',
+  async (
+    { channelIds }: { channelIds: string[] },
+    ctx: QueryCtx
+  ): Promise<string[]> => {
+    if (!channelIds.length) {
+      return [];
+    }
+    const rows = await ctx.db.query.channels.findMany({
+      where: inArray($channels.id, channelIds),
+      columns: { id: true },
+    });
+    return rows.map((row) => row.id);
+  },
+  ['channels']
+);
+
 export const getAllMultiDms = createReadQuery(
   'getAllMultiDms',
   async (ctx: QueryCtx) => {

--- a/packages/shared/src/store/sync/sync.test.ts
+++ b/packages/shared/src/store/sync/sync.test.ts
@@ -46,6 +46,7 @@ import {
   syncChannelWithBackoff,
   syncDms,
   syncGroups,
+  syncCachedChanges,
   syncInitData,
   syncLatestChanges,
   syncLatestPosts,
@@ -566,19 +567,23 @@ test('recoverMissingDmChannels falls back to a full DM sync for group DMs', asyn
   expect(channel?.lastPostId).toBe('group-dm-post');
 });
 
+const changesWithPosts = (posts: db.Post[]) => ({
+  groups: [],
+  posts,
+  contacts: [],
+  unreads: {
+    channelUnreads: [],
+    groupUnreads: [],
+    threadActivity: [],
+    baseUnread: undefined,
+  },
+  deletedChannelIds: [],
+});
+
 test('syncLatestChanges surfaces a DM that arrives as posts with no channel row', async () => {
   const posts = [noticePost('~sampel-palnet', 'invite-notice')];
   vi.mocked(fetchChangesSince).mockResolvedValueOnce({
-    groups: [],
-    posts,
-    contacts: [],
-    unreads: {
-      channelUnreads: [],
-      groupUnreads: [],
-      threadActivity: [],
-      baseUnread: undefined,
-    },
-    deletedChannelIds: [],
+    ...changesWithPosts(posts),
     nodeBusyStatus: 'available',
   });
   setScryOutputs([['~sampel-palnet'], []]);
@@ -588,6 +593,53 @@ test('syncLatestChanges surfaces a DM that arrives as posts with no channel row'
   const channel = await db.getChannel({ id: '~sampel-palnet' });
   expect(channel?.type).toBe('dm');
   expect(channel?.lastPostId).toBe('invite-notice');
+});
+
+// syncCachedChanges advances the watermark past the cached window, so the
+// foreground sync that follows never sees these posts again — recovery has to
+// happen here or the DM stays invisible for the whole session.
+test('syncCachedChanges surfaces a DM that only appears in the cached window', async () => {
+  const posts = [noticePost('~sampel-palnet', 'cached-notice')];
+  const syncedAt = vi
+    .spyOn(db.changesSyncedAt, 'getValue')
+    .mockResolvedValue(1000);
+  setScryOutputs([['~sampel-palnet'], []]);
+
+  try {
+    const applied = await syncCachedChanges({
+      begin: 500,
+      end: 2000,
+      changes: changesWithPosts(posts),
+    });
+    expect(applied).toBe(true);
+  } finally {
+    syncedAt.mockRestore();
+  }
+
+  const channel = await db.getChannel({ id: '~sampel-palnet' });
+  expect(channel?.type).toBe('dm');
+  expect(channel?.lastPostId).toBe('cached-notice');
+});
+
+test('recoverMissingDmChannels retries a channel whose recovery failed', async () => {
+  const posts = [noticePost('~sampel-palnet', 'invite-notice')];
+  await db.insertChannelPosts({ posts });
+
+  // no scry outputs queued: the fetch resolves to undefined and throws
+  setScryOutputs([]);
+  await expect(recoverMissingDmChannels({ posts })).rejects.toThrow();
+  expect(await db.getChannel({ id: '~sampel-palnet' })).toBeNull();
+
+  // the next sync window carries no posts for that DM at all — the queued id
+  // is the only thing keeping it recoverable
+  setScryOutputs([['~sampel-palnet'], []]);
+  const result = await recoverMissingDmChannels({ posts: [] });
+
+  expect(result).toEqual({
+    missingChannelIds: ['~sampel-palnet'],
+    strategy: 'ensureDmInvite',
+  });
+  expect((await db.getChannel({ id: '~sampel-palnet' }))?.type).toBe('dm');
 });
 
 test('recoverMissingDmChannels leaves known channels and group channels alone', async () => {

--- a/packages/shared/src/store/sync/sync.test.ts
+++ b/packages/shared/src/store/sync/sync.test.ts
@@ -19,6 +19,7 @@ import {
   ContactsDirectoryScryResult1,
 } from '@tloncorp/api/urbit/contact';
 import { GroupV11 as UrbitGroup } from '@tloncorp/api/urbit/groups';
+import { fetchChangesSince } from '@tloncorp/api/client/changesApi';
 import * as $ from 'drizzle-orm';
 import { pick } from 'lodash';
 import { expect, test, vi } from 'vitest';
@@ -41,10 +42,12 @@ import {
 import rawGroupsInit2 from '../../test/init.json';
 import {
   ensureDmInviteChannel,
+  recoverMissingDmChannels,
   syncChannelWithBackoff,
   syncDms,
   syncGroups,
   syncInitData,
+  syncLatestChanges,
   syncLatestPosts,
   syncPinnedItems,
   syncPosts,
@@ -72,6 +75,10 @@ const inputData = [
   '~solfer-magfed',
   '~nibset-napwyn/tlon',
 ];
+
+vi.mock('@tloncorp/api/client/changesApi', () => ({
+  fetchChangesSince: vi.fn(),
+}));
 
 vi.mock('../lure', () => ({
   useLureState: {
@@ -490,6 +497,114 @@ test('ensureDmInviteChannel returns missing without deleting a non-invite local 
   expect(result).toEqual({ found: false, state: 'missing' });
   const channel = await db.getChannel({ id: '~sampel-palnet' });
   expect(channel?.isDmInvite).toBe(false);
+});
+
+// TLON-6403: the changes feed carries posts but no channels, and a DM has no
+// group blob to ride in on — so the reciprocal DM created when someone redeems
+// a personal invite arrives as a post for a channel the local DB has never
+// seen, and the chat list (built from the channels table) can't show it until
+// the next init sync at app start.
+const noticePost = (channelId: string, id: string): db.Post =>
+  ({
+    id,
+    type: 'chat',
+    channelId,
+    authorId: '~sampel-palnet',
+    sentAt: 1700000000000,
+    receivedAt: 1700000000000,
+    sequenceNum: 1,
+    content: JSON.stringify([{ inline: ['has joined the network'] }]),
+    syncedAt: 1700000000000,
+  }) as unknown as db.Post;
+
+test('recoverMissingDmChannels creates the channel row for a DM that arrived as posts only', async () => {
+  const posts = [noticePost('~sampel-palnet', 'invite-notice')];
+  await db.insertChannelPosts({ posts });
+  expect(await db.getChannel({ id: '~sampel-palnet' })).toBeNull();
+
+  setScryOutputs([['~sampel-palnet'], []]);
+  const result = await recoverMissingDmChannels({ posts });
+
+  expect(result).toEqual({
+    missingChannelIds: ['~sampel-palnet'],
+    strategy: 'ensureDmInvite',
+  });
+  const channel = await db.getChannel({ id: '~sampel-palnet' });
+  expect(channel?.type).toBe('dm');
+  expect(channel?.isDmInvite).toBe(false);
+  // the recovered row has to carry the post forward or the chat list still
+  // has nothing to sort or preview
+  expect(channel?.lastPostId).toBe('invite-notice');
+  expect(channel?.lastPostAt).toBe(1700000000000);
+});
+
+test('recoverMissingDmChannels falls back to a full DM sync for group DMs', async () => {
+  const groupDmId = '0v4.00000.qcr0l.r1r6c.pj6cp.j6cpj';
+  const posts = [noticePost(groupDmId, 'group-dm-post')];
+  await db.insertChannelPosts({ posts });
+
+  setScryOutputs([
+    [],
+    {
+      [groupDmId]: {
+        net: 'done',
+        hive: [],
+        team: ['~solfer-magfed', '~sampel-palnet'],
+        meta: { image: '', title: 'club', cover: '', description: '' },
+      },
+    },
+    [],
+  ]);
+  const result = await recoverMissingDmChannels({ posts });
+
+  expect(result).toEqual({
+    missingChannelIds: [groupDmId],
+    strategy: 'syncDms',
+  });
+  const channel = await db.getChannel({ id: groupDmId });
+  expect(channel?.type).toBe('groupDm');
+  expect(channel?.lastPostId).toBe('group-dm-post');
+});
+
+test('syncLatestChanges surfaces a DM that arrives as posts with no channel row', async () => {
+  const posts = [noticePost('~sampel-palnet', 'invite-notice')];
+  vi.mocked(fetchChangesSince).mockResolvedValueOnce({
+    groups: [],
+    posts,
+    contacts: [],
+    unreads: {
+      channelUnreads: [],
+      groupUnreads: [],
+      threadActivity: [],
+      baseUnread: undefined,
+    },
+    deletedChannelIds: [],
+    nodeBusyStatus: 'available',
+  });
+  setScryOutputs([['~sampel-palnet'], []]);
+
+  await syncLatestChanges({});
+
+  const channel = await db.getChannel({ id: '~sampel-palnet' });
+  expect(channel?.type).toBe('dm');
+  expect(channel?.lastPostId).toBe('invite-notice');
+});
+
+test('recoverMissingDmChannels leaves known channels and group channels alone', async () => {
+  await db.insertChannels([dmChannel('~sampel-palnet', false)]);
+  // No scry outputs queued: a fetch here would resolve to undefined and throw.
+  setScryOutputs([]);
+
+  const result = await recoverMissingDmChannels({
+    posts: [
+      noticePost('~sampel-palnet', 'known-dm-post'),
+      // group channels ride in on the group blob, so a missing row here is
+      // not ours to repair
+      noticePost('chat/~solfer-magfed/unknown', 'group-channel-post'),
+    ],
+  });
+
+  expect(result).toEqual({ missingChannelIds: [], strategy: 'none' });
 });
 
 const groupId = '~solfer-magfed/test-group';

--- a/packages/shared/src/store/sync/sync.ts
+++ b/packages/shared/src/store/sync/sync.ts
@@ -1,5 +1,6 @@
 import * as api from '@tloncorp/api';
 import { GetChangedPostsOptions } from '@tloncorp/api';
+import { isDmChannelId, isGroupDmChannelId } from '@tloncorp/api/client';
 import { extractClientVolumes } from '@tloncorp/api/client/activity';
 import { fetchChangesSince } from '@tloncorp/api/client/changesApi';
 import { isLanyardMockEnabled } from '@tloncorp/api/dev/lanyardMock';
@@ -390,6 +391,16 @@ export const syncLatestChanges = async ({
   const msToWrite = Date.now() - doneFetching;
   await db.changesSyncedAt.setValue(start);
   updateLastActivityTime();
+  // after the watermark, so a failure here can't cost us the posts we just
+  // wrote — the next sync will find the same missing rows and retry
+  try {
+    await recoverMissingDmChannels({ posts: result.posts, syncCtx, queryCtx });
+  } catch (e) {
+    logger.trackError('failed to recover missing dm channels', {
+      error: e,
+      ...callCtx,
+    });
+  }
   logger.trackEvent('sync changes debug', {
     context: 'updated timestamp',
     ...callCtx,
@@ -824,6 +835,84 @@ export const ensureDmInviteChannel = async ({
   return queryCtx
     ? write(queryCtx)
     : batchEffects('ensureDmInviteChannel', write);
+};
+
+export type RecoverMissingDmChannelsResult = {
+  missingChannelIds: string[];
+  strategy: 'none' | 'ensureDmInvite' | 'syncDms';
+};
+
+/**
+ * The changes feed carries posts but never channels. Group channels still
+ * arrive, because they ride along in the group blob, but a DM has no group —
+ * so a conversation created while we weren't subscribed (the reciprocal DM
+ * from a redeemed personal invite, a re-invite after leaving) shows up as
+ * posts for a channel the local DB has never seen, and the chat list, which
+ * is built from the channels table, can't render it until the next init sync.
+ * Fetch the missing rows instead of waiting for an app relaunch.
+ */
+export const recoverMissingDmChannels = async ({
+  posts,
+  syncCtx,
+  queryCtx,
+}: {
+  posts: db.Post[];
+  syncCtx?: SyncCtx;
+  queryCtx?: QueryCtx;
+}): Promise<RecoverMissingDmChannelsResult> => {
+  const none: RecoverMissingDmChannelsResult = {
+    missingChannelIds: [],
+    strategy: 'none',
+  };
+
+  const channelIds = [
+    ...new Set(
+      posts
+        .map((post) => post.channelId)
+        .filter(
+          (channelId): channelId is string =>
+            !!channelId &&
+            (isDmChannelId(channelId) || isGroupDmChannelId(channelId))
+        )
+    ),
+  ];
+  if (!channelIds.length) {
+    return none;
+  }
+
+  const existing = new Set(
+    await db.getExistingChannelIds({ channelIds }, queryCtx)
+  );
+  const missingChannelIds = channelIds.filter((id) => !existing.has(id));
+  if (!missingChannelIds.length) {
+    return none;
+  }
+
+  // One `ensureDmInviteChannel` costs two scries and resolves a single DM
+  // exactly (regular DM, pending invite, or a stale local invite to clear).
+  // Past one target `syncDms` is both cheaper and broader, and it's the only
+  // thing that can describe a group DM.
+  const strategy =
+    missingChannelIds.length === 1 && isDmChannelId(missingChannelIds[0])
+      ? 'ensureDmInvite'
+      : 'syncDms';
+
+  logger.trackEvent('recovering missing dm channels', {
+    count: missingChannelIds.length,
+    strategy,
+  });
+
+  if (strategy === 'ensureDmInvite') {
+    await ensureDmInviteChannel({
+      channelId: missingChannelIds[0],
+      syncCtx,
+      queryCtx,
+    });
+  } else {
+    await syncDms(syncCtx);
+  }
+
+  return { missingChannelIds, strategy };
 };
 
 export const syncUnreads = async (ctx?: SyncCtx, queryCtx?: QueryCtx) => {

--- a/packages/shared/src/store/sync/sync.ts
+++ b/packages/shared/src/store/sync/sync.ts
@@ -392,15 +392,11 @@ export const syncLatestChanges = async ({
   await db.changesSyncedAt.setValue(start);
   updateLastActivityTime();
   // after the watermark, so a failure here can't cost us the posts we just
-  // wrote — the next sync will find the same missing rows and retry
-  try {
-    await recoverMissingDmChannels({ posts: result.posts, syncCtx, queryCtx });
-  } catch (e) {
-    logger.trackError('failed to recover missing dm channels', {
-      error: e,
-      ...callCtx,
-    });
-  }
+  // wrote
+  await tryRecoverMissingDmChannels(
+    { posts: result.posts, syncCtx, queryCtx },
+    callCtx.cause
+  );
   logger.trackEvent('sync changes debug', {
     context: 'updated timestamp',
     ...callCtx,
@@ -480,6 +476,13 @@ export const syncCachedChanges = async (input: {
     await db.insertChanges(input.changes);
     notifyChannelPostListenersFromLatestChanges(input.changes.posts);
     await db.changesSyncedAt.setValue(input.end);
+    // this path advances the watermark past the cached window, so the
+    // foreground sync that follows will never see these posts again — a DM
+    // created inside the window has to be recovered here or not at all
+    await tryRecoverMissingDmChannels(
+      { posts: input.changes.posts },
+      'cached-changes'
+    );
     return true;
   }
   return false;
@@ -842,6 +845,12 @@ export type RecoverMissingDmChannelsResult = {
   strategy: 'none' | 'ensureDmInvite' | 'syncDms';
 };
 
+// Channels we know are missing locally but whose recovery fetch failed. The
+// changes feed never replays posts we've already consumed, so without this the
+// ids are gone and the conversation stays invisible until another post arrives
+// in it or the app is relaunched.
+const unresolvedDmChannelIds = new Set<string>();
+
 /**
  * The changes feed carries posts but never channels. Group channels still
  * arrive, because they ride along in the group blob, but a DM has no group —
@@ -866,15 +875,16 @@ export const recoverMissingDmChannels = async ({
   };
 
   const channelIds = [
-    ...new Set(
-      posts
+    ...new Set([
+      ...posts
         .map((post) => post.channelId)
         .filter(
           (channelId): channelId is string =>
             !!channelId &&
             (isDmChannelId(channelId) || isGroupDmChannelId(channelId))
-        )
-    ),
+        ),
+      ...unresolvedDmChannelIds,
+    ]),
   ];
   if (!channelIds.length) {
     return none;
@@ -883,6 +893,7 @@ export const recoverMissingDmChannels = async ({
   const existing = new Set(
     await db.getExistingChannelIds({ channelIds }, queryCtx)
   );
+  existing.forEach((id) => unresolvedDmChannelIds.delete(id));
   const missingChannelIds = channelIds.filter((id) => !existing.has(id));
   if (!missingChannelIds.length) {
     return none;
@@ -902,17 +913,44 @@ export const recoverMissingDmChannels = async ({
     strategy,
   });
 
-  if (strategy === 'ensureDmInvite') {
-    await ensureDmInviteChannel({
-      channelId: missingChannelIds[0],
-      syncCtx,
-      queryCtx,
-    });
-  } else {
-    await syncDms(syncCtx);
+  try {
+    if (strategy === 'ensureDmInvite') {
+      await ensureDmInviteChannel({
+        channelId: missingChannelIds[0],
+        syncCtx,
+        queryCtx,
+      });
+    } else {
+      await syncDms(syncCtx);
+    }
+  } catch (e) {
+    // queue for the next sync. A completed attempt clears the id even when the
+    // backend doesn't know the channel either — that answer won't change on a
+    // retry, and re-scrying it forever would be pure waste.
+    missingChannelIds.forEach((id) => unresolvedDmChannelIds.add(id));
+    throw e;
   }
+  missingChannelIds.forEach((id) => unresolvedDmChannelIds.delete(id));
 
   return { missingChannelIds, strategy };
+};
+
+/**
+ * Recovery is a repair, not part of the sync contract: a failure here must not
+ * fail the sync that carried the posts, since those are already written.
+ */
+const tryRecoverMissingDmChannels = async (
+  args: Parameters<typeof recoverMissingDmChannels>[0],
+  cause?: string
+) => {
+  try {
+    await recoverMissingDmChannels(args);
+  } catch (e) {
+    logger.trackError('failed to recover missing dm channels', {
+      error: e,
+      cause,
+    });
+  }
 };
 
 export const syncUnreads = async (ctx?: SyncCtx, queryCtx?: QueryCtx) => {


### PR DESCRIPTION
## Summary

New DM channel rows never reach the local DB through incremental sync, so a DM created while the app wasn't subscribed — most visibly the reciprocal DM you get when someone redeems your personal invite — is invisible on the chat list until the app is relaunched. This wires up a repair on the changes path so the channel row is fetched as soon as its posts arrive.

Fixes [TLON-6403](https://linear.app/tlon/issue/TLON-6403/new-dm-channel-rows-never-reach-the-local-db-via-incremental-sync-so). Reported by `~ravmel-ropdyl`, who couldn't see a reciprocal DM for ~2h05m across multiple successful background syncs.

The gap: the changes feed returns `{groups, posts, contacts, unreads, deletedChannelIds}` — no channels. Group channels still make it into the DB because they ride inside the group blob that `insertGroups` upserts, but a DM has no group, so its posts land against a `channelId` with no row. `getChats` is built from the `channels` table, so the conversation is absent rather than buried, and only `syncInitData` — which runs at app start — creates it. That is the whole "force-quit and reopen" workaround.

## Changes

- **`recoverMissingDmChannels`** (`packages/shared/src/store/sync/sync.ts`): takes the DM and group-DM channel ids off the incoming posts, checks which have no local row, and repairs them. One missing single DM → `ensureDmInviteChannel`, which already resolved regular-DM vs pending-invite vs stale-local-invite and was unit-tested but had no caller on this path. Anything broader (a group DM, or more than one target) → `syncDms`, which is cheaper past one target and is the only thing that can describe a club.
- **Call site in `syncLatestChanges`**: runs after `insertChanges`, so `insertChannels` → `setLastPosts` backfills `lastPostId`/`lastPostAt` from the rows just written (a channel row with no preview or sort key would still look broken), and after `changesSyncedAt` advances, so a scry failure here can't cost the posts already committed — the next sync finds the same missing rows and retries. Wrapped in try/catch with a `trackError`.
- **`getExistingChannelIds`** (`packages/shared/src/db/queries.ts`): one indexed PK lookup, so the common case (nothing missing) costs a single cheap query and no network.
- Four tests covering DM recovery from posts alone, the group-DM fallback, the no-op case, and the `syncLatestChanges` wiring end to end.

### Scope decisions

- **Missing group channel ids are deliberately not repaired here.** They aren't structurally broken, and triggering `debouncedSyncInit` from this path would be costly in the background task.
- **`checkForNewlyJoined` is not wired into the incremental path**, though the issue notes its absence. `joinedGroupsAndChannels` is module state and the background sync runs in a fresh JS context, so the set is always empty there — every background sync carrying any unread would fire a full init sync. The DB-truth check does the same job without that failure mode.
- The larger backend fix (adding channels to the changes feed) is out of scope. TLON-6404 (`syncSince` swallowing its exception, so failed background syncs report success) is untouched, as filed.

## How did I test?

`packages/shared`: 560 tests pass, `tsc --noEmit` clean, `pnpm format:check` clean.

New tests:

- `recoverMissingDmChannels creates the channel row for a DM that arrived as posts only` — the core repro, asserting `lastPostId`/`lastPostAt` land so the chat list has something to sort and preview.
- `recoverMissingDmChannels falls back to a full DM sync for group DMs`.
- `recoverMissingDmChannels leaves known channels and group channels alone` — no scries queued, so an unexpected fetch fails the test.
- `syncLatestChanges surfaces a DM that arrives as posts with no channel row` — end to end through the changes path. I confirmed this one fails when the call site is removed, so it guards the wiring itself, which is what was missing before.

Not done: the two-ship repro (inviter backgrounded, inspecting the inviter's `channels` table before relaunch) that would turn the issue's "no channel row" inference into a direct observation.

## Risks and impact

- Safe to rollback without consulting PR author? Yes
- Affects important code area:
  - [ ] Onboarding
  - [ ] State / providers
  - [x] Message sync
  - [x] Channel display
  - [ ] Notifications
  - [ ] Other:

The added work on the hot path is one indexed `WHERE id IN (...)` query per sync that carries DM posts. Network calls happen only when a row is genuinely missing, and a failure there is caught and logged rather than failing the sync.

## Rollback plan

Revert the commit. The change is additive — a new query, a new function, and one guarded call — with no schema or migration involved, so reverting restores the previous behavior exactly (DMs invisible until relaunch).

## Screenshots / videos

n/a — no UI changes; the fix makes an already-designed chat list row appear when it should.
