### PR TITLE
Genericize A2UI approval prompts for OpenClaw

### DIFF
--- a/packages/openclaw/README.md
+++ b/packages/openclaw/README.md
@@ -121,6 +121,13 @@ Reply "approve", "deny", or "block" (ID: dm-1234567890-abc)
 -   **deny**: Reject silently. Ship can try again later.
 -   **block**: Permanently block using Tlon's native blocking.
 
+### OpenClaw Tool Approvals
+
+For Tlon-originated exec and plugin-tool approvals, the plugin sends the
+configured `ownerShip` an A2UI card whose buttons submit OpenClaw's exact
+`/approve` command. OpenClaw still owns approval policy, expiry, decisions, and
+resuming the waiting turn; the plugin only presents and transports the request.
+
 ### Admin Commands
 
 The owner can send these commands via DM:
@@ -137,7 +144,7 @@ The owner can send these commands via DM:
 
 ```
 Harness: OpenClaw
-Harness Version: 2026.5.28
+Harness Version: 2026.7.1
 Adapter Version: 0.4.3
 Tlon Skill: 0.3.2
 Fingerprint: fp1:8aa23ca2bc8d

--- a/packages/openclaw/SECURITY.md
+++ b/packages/openclaw/SECURITY.md
@@ -363,6 +363,10 @@ try {
 | Non-owner tricks LLM into using tool | ❌ Still blocked (hook-level enforcement) |
 | Internal session (heartbeat, cron) | ✅ Allowed (no role = not a user DM) |
 
+OpenClaw approval requests originating in Tlon are sent only to `ownerShip`.
+The buttons submit OpenClaw's approval ID and decision command; the plugin does
+not keep separate approval state or grant permission itself.
+
 **Implementation:**
 - `before_tool_call` hook intercepts calls to restricted tools
 - Checks SenderRole from session tracker

--- a/packages/openclaw/dev/Dockerfile
+++ b/packages/openclaw/dev/Dockerfile
@@ -5,9 +5,9 @@ RUN apt-get update && apt-get install -y git curl gettext-base unzip && apt-get 
 RUN npm install -g pnpm@11.9.0
 
 # Install OpenClaw globally
-RUN npm install -g openclaw@2026.5.28
+RUN npm install -g openclaw@2026.7.1
 
-# Install the Brave web-search plugin. openclaw@2026.5.28 rejects
+# Install the Brave web-search plugin. OpenClaw rejects
 # tools.web.search.provider "brave" (set by entrypoint.sh when BRAVE_API_KEY
 # is present) unless the plugin is installed. Mirrors the test image and
 # production (tlonbot entrypoint); the install ledger in ~/.openclaw/plugins/

--- a/packages/openclaw/dev/Dockerfile.test
+++ b/packages/openclaw/dev/Dockerfile.test
@@ -7,14 +7,13 @@ RUN npm install -g pnpm@11.9.0
 # while the focused gateway-status lane selects affected cores by build arg.
 # Keep this default in lockstep with DEFAULT_CORE_VERSION in
 # test/cases/08-gateway-status.test.ts (08 asserts installed == requested).
-# Bumping both to 2026.6.11/2026.7.1 promotes 08 from a smoke test to the full
-# prewarm regression guard on the existing shared E2E lane — no matrix lane needed.
-ARG OPENCLAW_CORE_VERSION=2026.5.28
+# The 7.1 default runs the full prewarm regression guard.
+ARG OPENCLAW_CORE_VERSION=2026.7.1
 RUN npm install -g "openclaw@${OPENCLAW_CORE_VERSION}"
 ENV OPENCLAW_CORE_VERSION=${OPENCLAW_CORE_VERSION}
 RUN echo "[tlon-e2e-build] openclaw-core-version=${OPENCLAW_CORE_VERSION}"
 
-# Install the Brave web-search plugin at build time. openclaw@2026.5.28
+# Install the Brave web-search plugin at build time. OpenClaw
 # rejects tools.web.search.provider "brave" (set by entrypoint.test.sh when
 # BRAVE_API_KEY is present) unless the plugin is installed. Production
 # installs the same package before gateway start (tlonbot entrypoint);

--- a/packages/openclaw/dev/docker-compose.test.yml
+++ b/packages/openclaw/dev/docker-compose.test.yml
@@ -139,9 +139,9 @@ services:
       context: .
       dockerfile: Dockerfile.test
       args:
-        OPENCLAW_CORE_VERSION: ${OPENCLAW_CORE_VERSION:-2026.5.28}
+        OPENCLAW_CORE_VERSION: ${OPENCLAW_CORE_VERSION:-2026.7.1}
     environment:
-      - OPENCLAW_CORE_VERSION=${OPENCLAW_CORE_VERSION:-2026.5.28}
+      - OPENCLAW_CORE_VERSION=${OPENCLAW_CORE_VERSION:-2026.7.1}
       - TLON_URL=${TLON_URL:-http://ships:8080}
       - TLON_SHIP=${TLON_SHIP:-~zod}
       - TLON_CODE=${TLON_CODE:-lidlut-tabwed-pillex-ridrup}

--- a/packages/openclaw/dev/entrypoint.sh
+++ b/packages/openclaw/dev/entrypoint.sh
@@ -80,7 +80,7 @@ if [ -f "/workspace/tlonbot/openclaw.json" ]; then
   echo "==> Copying config from tlonbot..."
   cp /workspace/tlonbot/openclaw.json "$CONFIG_PATH"
 
-  # Patch in Brave web search if available. openclaw 2026.5.28 only accepts
+  # Patch in Brave web search if available. OpenClaw only accepts
   # provider "brave" when the plugin is installed, allowed, and enabled, so
   # set provider, allow, and enable together (mirrors the test entrypoint and
   # production tlonbot flow). The matching `plugins install` runs later, just

--- a/packages/openclaw/dev/entrypoint.test.sh
+++ b/packages/openclaw/dev/entrypoint.test.sh
@@ -16,7 +16,7 @@ echo "==> OPENCLAW_STATE_DIR=$OPENCLAW_STATE_DIR"
 echo "==> User: $(whoami)"
 echo "==> Working directory: $(pwd)"
 
-requested_core_version="${OPENCLAW_CORE_VERSION:-2026.5.28}"
+requested_core_version="${OPENCLAW_CORE_VERSION:-2026.7.1}"
 installed_core_version="$(node -e 'const fs=require("node:fs"); console.log(JSON.parse(fs.readFileSync(process.argv[1], "utf8")).version)' "$(npm root -g)/openclaw/package.json")"
 if [ "$installed_core_version" != "$requested_core_version" ]; then
   echo "FATAL: requested OpenClaw core $requested_core_version but installed $installed_core_version"
@@ -295,8 +295,8 @@ if [ ! -d "/workspace/tlonbot/image-search" ] && [ -n "$BRAVE_API_KEY" ] && [ -n
     && mv "$CONFIG_DIR/openclaw.json.tmp" "$CONFIG_DIR/openclaw.json"
 fi
 
-# Patch in Brave API key for web search if available. openclaw 2026.5.28
-# only accepts provider "brave" when the brave plugin (installed at image
+# Patch in Brave API key for web search if available. OpenClaw only accepts
+# provider "brave" when the brave plugin (installed at image
 # build time, see Dockerfile.test) is allowed and enabled; the config was
 # rewritten from scratch above, so re-assert both here (mirrors production).
 if [ -n "$BRAVE_API_KEY" ]; then

--- a/packages/openclaw/fixtures/engagement-tokens.json
+++ b/packages/openclaw/fixtures/engagement-tokens.json
@@ -12,5 +12,6 @@
   "/status",
   "/help",
   "/new",
-  "/model"
+  "/model",
+  "/approve"
 ]

--- a/packages/openclaw/package.json
+++ b/packages/openclaw/package.json
@@ -63,14 +63,14 @@
     "@types/node": "^25.4.0",
     "@urbit/nockjs": "^1.6.0",
     "dotenv": "^17.2.4",
-    "openclaw": "2026.5.28",
+    "openclaw": "2026.7.1",
     "typescript": "^5.7.0",
     "vite": "^8.0.7",
     "vitest": "^4.0.0",
     "zod": "^4.4.1"
   },
   "peerDependencies": {
-    "openclaw": ">=2026.5.7"
+    "openclaw": ">=2026.7.1"
   },
   "publishConfig": {
     "access": "public"
@@ -91,7 +91,7 @@
       "quickstartAllowFrom": true
     },
     "install": {
-      "minHostVersion": ">=2026.5.7",
+      "minHostVersion": ">=2026.7.1",
       "npmSpec": "@tloncorp/openclaw",
       "localPath": "extensions/tlon",
       "defaultChoice": "npm"

--- a/packages/openclaw/src/approval-handler.runtime.test.ts
+++ b/packages/openclaw/src/approval-handler.runtime.test.ts
@@ -1,0 +1,67 @@
+import type { OpenClawConfig } from 'openclaw/plugin-sdk/core';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+vi.mock('./approval-presentation.js', () => ({
+  buildTlonNativeApprovalPayload: vi.fn(() => ({
+    text: 'Approval required.',
+    blob: '[{"type":"a2ui"}]',
+  })),
+}));
+vi.mock('./urbit/api-client.js', () => ({
+  withAuthenticatedTlonApi: vi.fn(async (_params, callback) => callback()),
+}));
+vi.mock('./urbit/send.js', () => ({
+  sendChannelPost: vi.fn(),
+  sendDm: vi.fn(async () => ({
+    channel: 'tlon',
+    messageId: '~bus/approval',
+  })),
+}));
+vi.mock('./urbit/story.js', () => ({ markdownToStory: vi.fn() }));
+
+const cfg = {
+  channels: {
+    tlon: {
+      ship: '~bus',
+      url: 'http://localhost:8080',
+      code: 'lidlut-tabwed-pillex-ridrup',
+    },
+  },
+} as OpenClawConfig;
+
+describe('Tlon approval runtime', () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it('delivers an approval card and replies with its resolution', async () => {
+    const { tlonApprovalNativeRuntime } =
+      await import('./approval-handler.runtime.js');
+    const { sendDm } = await import('./urbit/send.js');
+    const prepared = await tlonApprovalNativeRuntime.transport.prepareTarget({
+      cfg,
+      accountId: 'default',
+      plannedTarget: { target: { to: '~zod' } },
+    } as never);
+    const entry = await tlonApprovalNativeRuntime.transport.deliverPending({
+      cfg,
+      preparedTarget: prepared!.target,
+      pendingPayload: {
+        text: 'Approval required.',
+        blob: '[{"type":"a2ui"}]',
+      },
+    } as never);
+
+    expect(entry).toEqual({
+      accountId: 'default',
+      to: '~zod',
+      messageId: '~bus/approval',
+    });
+    await tlonApprovalNativeRuntime.transport.updateEntry!({
+      cfg,
+      entry,
+      payload: { text: 'Decision: allow-once' },
+    } as never);
+    expect(sendDm).toHaveBeenLastCalledWith(
+      expect.objectContaining({ replyToId: '~bus/approval' })
+    );
+  });
+});

--- a/packages/openclaw/src/approval-handler.runtime.ts
+++ b/packages/openclaw/src/approval-handler.runtime.ts
@@ -1,0 +1,146 @@
+import {
+  createChannelApprovalNativeRuntimeAdapter,
+  resolvePreparedApprovalAccountId,
+} from 'openclaw/plugin-sdk/approval-handler-runtime';
+import type {
+  ExecApprovalRequest,
+  PluginApprovalRequest,
+} from 'openclaw/plugin-sdk/approval-runtime';
+import { createSubsystemLogger } from 'openclaw/plugin-sdk/runtime-env';
+
+import { buildTlonNativeApprovalPayload } from './approval-presentation.js';
+import { normalizeShip, parseTlonTarget } from './targets.js';
+import { resolveTlonAccount } from './types.js';
+import { withAuthenticatedTlonApi } from './urbit/api-client.js';
+import { sendChannelPost, sendDm } from './urbit/send.js';
+import { markdownToStory } from './urbit/story.js';
+
+const log = createSubsystemLogger('tlon/approvals');
+type ApprovalRequest = ExecApprovalRequest | PluginApprovalRequest;
+type ApprovalPayload = { text: string; blob?: string };
+type ApprovalTarget = { to: string; accountId: string };
+type PendingApproval = ApprovalTarget & { messageId: string };
+
+async function deliver(params: {
+  cfg: Parameters<typeof resolveTlonAccount>[0];
+  target: ApprovalTarget;
+  payload: ApprovalPayload;
+  replyToId?: string;
+}) {
+  const account = resolveTlonAccount(params.cfg, params.target.accountId);
+  if (
+    !account.enabled ||
+    !account.configured ||
+    !account.ship ||
+    !account.url ||
+    !account.code
+  ) {
+    throw new Error(
+      `Tlon account ${params.target.accountId} is not configured`
+    );
+  }
+  const target = parseTlonTarget(params.target.to);
+  if (!target) throw new Error(`Invalid Tlon target: ${params.target.to}`);
+
+  return await withAuthenticatedTlonApi(
+    {
+      url: account.url,
+      code: account.code,
+      ship: account.ship,
+      allowPrivateNetwork: account.allowPrivateNetwork ?? undefined,
+    },
+    async () => {
+      const fromShip = normalizeShip(account.ship ?? '');
+      if (!fromShip) throw new Error('Configured Tlon ship is empty');
+      if (target.kind === 'dm') {
+        return await sendDm({
+          fromShip,
+          toShip: target.ship,
+          text: params.payload.text,
+          blob: params.payload.blob,
+          replyToId: params.replyToId,
+        });
+      }
+      return await sendChannelPost({
+        fromShip,
+        nest: target.nest,
+        story: markdownToStory(params.payload.text),
+        blob: params.payload.blob,
+        replyToId: params.replyToId,
+      });
+    }
+  );
+}
+
+export const tlonApprovalNativeRuntime =
+  createChannelApprovalNativeRuntimeAdapter<
+    ApprovalPayload,
+    ApprovalTarget,
+    PendingApproval,
+    never,
+    ApprovalPayload
+  >({
+    eventKinds: ['exec', 'plugin'],
+    availability: {
+      isConfigured: ({ context }) => Boolean(context),
+      shouldHandle: ({ context, request }) =>
+        Boolean(context) &&
+        (request as ApprovalRequest).request.turnSourceChannel
+          ?.trim()
+          .toLowerCase() === 'tlon',
+    },
+    presentation: {
+      buildPendingPayload: ({ view }) => buildTlonNativeApprovalPayload(view),
+      buildResolvedResult: ({ view }) => ({
+        kind: 'update',
+        payload: buildTlonNativeApprovalPayload(view),
+      }),
+      buildExpiredResult: ({ view }) => ({
+        kind: 'update',
+        payload: buildTlonNativeApprovalPayload(view),
+      }),
+    },
+    transport: {
+      prepareTarget: ({ plannedTarget, accountId }) => {
+        const parsed = parseTlonTarget(plannedTarget.target.to);
+        if (!parsed) return null;
+        const target: ApprovalTarget = {
+          to: parsed.kind === 'dm' ? parsed.ship : parsed.nest,
+          accountId:
+            resolvePreparedApprovalAccountId({
+              plannedAccountId: (
+                plannedTarget.target as { accountId?: string | null }
+              ).accountId,
+              contextAccountId: accountId,
+              fallbackAccountId: 'default',
+            }) ?? 'default',
+        };
+        return {
+          dedupeKey: `${target.accountId}:${target.to}`,
+          target,
+        };
+      },
+      deliverPending: async ({ cfg, preparedTarget, pendingPayload }) => {
+        const result = await deliver({
+          cfg,
+          target: preparedTarget,
+          payload: pendingPayload,
+        });
+        return result.messageId
+          ? { ...preparedTarget, messageId: result.messageId }
+          : null;
+      },
+      updateEntry: async ({ cfg, entry, payload }) => {
+        await deliver({
+          cfg,
+          target: entry,
+          payload,
+          replyToId: entry.messageId,
+        });
+      },
+    },
+    observe: {
+      onDeliveryError: ({ error, request }) =>
+        log.error(`failed to deliver approval ${request.id}: ${String(error)}`),
+    },
+  });

--- a/packages/openclaw/src/approval-native.test.ts
+++ b/packages/openclaw/src/approval-native.test.ts
@@ -1,0 +1,47 @@
+import type { OpenClawConfig } from 'openclaw/plugin-sdk/core';
+import { afterEach, describe, expect, it } from 'vitest';
+
+import { tlonApprovalCapability } from './approval-native.js';
+import {
+  _testing as effectiveOwnerTesting,
+  setEffectiveOwnerShip,
+} from './effective-owner.js';
+
+const cfg = {
+  channels: {
+    tlon: {
+      ship: '~bus',
+      url: 'http://localhost:8080',
+      code: 'lidlut-tabwed-pillex-ridrup',
+      ownerShip: '~zod',
+    },
+  },
+} as OpenClawConfig;
+
+afterEach(() => effectiveOwnerTesting.clearAll());
+
+describe('Tlon approval capability', () => {
+  it('authorizes only the effective owner', async () => {
+    setEffectiveOwnerShip('default', '~ten');
+    const authorize = tlonApprovalCapability.authorizeActorAction!;
+
+    expect(
+      authorize({
+        cfg,
+        accountId: 'default',
+        senderId: '~ten',
+        action: 'approve',
+        approvalKind: 'exec',
+      })
+    ).toEqual({ authorized: true });
+    expect(
+      authorize({
+        cfg,
+        accountId: 'default',
+        senderId: '~nec',
+        action: 'approve',
+        approvalKind: 'exec',
+      })
+    ).toMatchObject({ authorized: false });
+  });
+});

--- a/packages/openclaw/src/approval-native.ts
+++ b/packages/openclaw/src/approval-native.ts
@@ -1,0 +1,103 @@
+import { createApproverRestrictedNativeApprovalCapability } from 'openclaw/plugin-sdk/approval-delivery-runtime';
+import { createLazyChannelApprovalNativeRuntimeAdapter } from 'openclaw/plugin-sdk/approval-handler-adapter-runtime';
+import type { ChannelApprovalNativeRuntimeAdapter } from 'openclaw/plugin-sdk/approval-handler-runtime';
+import type {
+  ExecApprovalRequest,
+  PluginApprovalRequest,
+} from 'openclaw/plugin-sdk/approval-runtime';
+import type { ChannelApprovalCapability } from 'openclaw/plugin-sdk/channel-contract';
+import type { OpenClawConfig } from 'openclaw/plugin-sdk/config-contracts';
+
+import { getEffectiveOwnerShip } from './effective-owner.js';
+import { normalizeShip, parseTlonTarget } from './targets.js';
+import { listTlonAccountIds, resolveTlonAccount } from './types.js';
+
+type ApprovalRequest = ExecApprovalRequest | PluginApprovalRequest;
+
+function resolveApprovalOwner(
+  cfg: OpenClawConfig,
+  accountId?: string | null
+): string | null {
+  const id = accountId?.trim() || 'default';
+  const account = resolveTlonAccount(cfg, id);
+  return normalizeShip(getEffectiveOwnerShip(id) ?? account.ownerShip ?? '');
+}
+
+function isConfiguredWithOwner(params: {
+  cfg: OpenClawConfig;
+  accountId?: string | null;
+}): boolean {
+  const account = resolveTlonAccount(params.cfg, params.accountId);
+  return Boolean(
+    account.enabled &&
+    account.configured &&
+    resolveApprovalOwner(params.cfg, params.accountId)
+  );
+}
+
+function isOwner(params: {
+  cfg: OpenClawConfig;
+  accountId?: string | null;
+  senderId?: string | null;
+}): boolean {
+  const owner = resolveApprovalOwner(params.cfg, params.accountId);
+  return Boolean(owner && normalizeShip(params.senderId ?? '') === owner);
+}
+
+function isTlonOrigin(request: ApprovalRequest): boolean {
+  return request.request.turnSourceChannel?.trim().toLowerCase() === 'tlon';
+}
+
+function describeSetup({ accountId }: { accountId?: string | null }): string {
+  const prefix =
+    accountId && accountId !== 'default'
+      ? `channels.tlon.accounts.${accountId}`
+      : 'channels.tlon';
+  return `Tlon approval delivery requires a configured \`${prefix}.ownerShip\` and a running Tlon account monitor.`;
+}
+
+export const tlonApprovalCapability: ChannelApprovalCapability =
+  createApproverRestrictedNativeApprovalCapability({
+    channel: 'tlon',
+    channelLabel: 'Tlon',
+    listAccountIds: listTlonAccountIds,
+    hasApprovers: ({ cfg, accountId }) =>
+      Boolean(resolveApprovalOwner(cfg, accountId)),
+    isExecAuthorizedSender: isOwner,
+    isPluginAuthorizedSender: isOwner,
+    isNativeDeliveryEnabled: isConfiguredWithOwner,
+    resolveNativeDeliveryMode: () => 'dm',
+    requireMatchingTurnSourceChannel: true,
+    resolveSuppressionAccountId: ({ target, request }) =>
+      target.accountId?.trim() ||
+      request.request.turnSourceAccountId?.trim() ||
+      undefined,
+    resolveOriginTarget: ({ request }) => {
+      if (!isTlonOrigin(request)) return null;
+      const parsed = parseTlonTarget(request.request.turnSourceTo ?? '');
+      if (!parsed) return null;
+      return {
+        to: parsed.kind === 'dm' ? parsed.ship : parsed.nest,
+        threadId: request.request.turnSourceThreadId ?? undefined,
+      };
+    },
+    resolveApproverDmTargets: ({ cfg, accountId }) => {
+      const owner = resolveApprovalOwner(cfg, accountId);
+      return owner ? [{ to: owner }] : [];
+    },
+    notifyOriginWhenDmOnly: true,
+    describeExecApprovalSetup: describeSetup,
+    describePluginApprovalSetup: describeSetup,
+    nativeRuntime: createLazyChannelApprovalNativeRuntimeAdapter({
+      eventKinds: ['exec', 'plugin'],
+      isConfigured: ({ cfg, accountId, context }) =>
+        Boolean(context) && isConfiguredWithOwner({ cfg, accountId }),
+      shouldHandle: ({ cfg, accountId, context, request }) =>
+        Boolean(context) &&
+        isConfiguredWithOwner({ cfg, accountId }) &&
+        isTlonOrigin(request),
+      load: async () =>
+        (await import('./approval-handler.runtime.js'))
+          .tlonApprovalNativeRuntime as unknown as ChannelApprovalNativeRuntimeAdapter,
+    }),
+  });

--- a/packages/openclaw/src/approval-presentation.test.ts
+++ b/packages/openclaw/src/approval-presentation.test.ts
@@ -1,0 +1,51 @@
+import { describe, expect, it, vi } from 'vitest';
+
+vi.mock('./urbit/blob.js', () => ({
+  makeA2UIBlob: vi.fn(
+    (surfaceId: string, root: string, components: unknown[]) => ({
+      surfaceId,
+      root,
+      components,
+    })
+  ),
+  serializeBlobField: vi.fn((value: unknown) => JSON.stringify(value)),
+}));
+
+import { buildTlonPresentationBlobField } from './approval-presentation.js';
+
+describe('Tlon approval presentation', () => {
+  it('maps exact approval commands to A2UI message buttons', () => {
+    const command = '/approve abc allow-once';
+    const blob = buildTlonPresentationBlobField({
+      fallbackText: 'Approval required.',
+      presentation: {
+        title: 'Exec approval',
+        blocks: [
+          {
+            type: 'buttons',
+            buttons: [
+              {
+                label: 'Allow Once',
+                style: 'success',
+                action: { type: 'command', command },
+              },
+            ],
+          },
+        ],
+      },
+    });
+
+    expect(blob).toBeDefined();
+    expect(JSON.parse(blob!).components).toContainEqual(
+      expect.objectContaining({
+        component: 'Button',
+        action: {
+          event: {
+            name: 'tlon.sendMessage',
+            context: { text: command },
+          },
+        },
+      })
+    );
+  });
+});

--- a/packages/openclaw/src/approval-presentation.ts
+++ b/packages/openclaw/src/approval-presentation.ts
@@ -1,0 +1,220 @@
+import { A2UI } from '@tloncorp/api';
+import type { ReplyPayload } from 'openclaw/plugin-sdk/core';
+import type {
+  ApprovalViewModel,
+  PendingApprovalView,
+} from 'openclaw/plugin-sdk/approval-handler-runtime';
+
+import { makeA2UIBlob, serializeBlobField } from './urbit/blob.js';
+
+type PortablePresentation = NonNullable<ReplyPayload['presentation']>;
+
+function safeSurfaceId(value: string): string {
+  return value.replace(/[^a-zA-Z0-9_-]/g, '-').slice(0, 80) || 'openclaw';
+}
+
+function buttonVariant(
+  style: 'primary' | 'secondary' | 'success' | 'danger' | undefined
+): 'primary' | 'secondary' | undefined {
+  if (style === 'primary' || style === 'success') return 'primary';
+  if (style === 'secondary' || style === 'danger') return 'secondary';
+  return undefined;
+}
+
+function presentationComponents(
+  presentation: PortablePresentation,
+  fallbackText?: string
+): A2UI.Component[] | null {
+  const children: string[] = [];
+  const components: A2UI.Component[] = [
+    { id: 'root', component: 'Card', child: 'body' },
+    { id: 'body', component: 'Column', children },
+  ];
+
+  if (presentation.title?.trim()) {
+    children.push('title');
+    components.push({
+      id: 'title',
+      component: 'Text',
+      variant: 'h3',
+      text: presentation.title.trim(),
+    });
+  }
+
+  let hasText = false;
+  for (const [index, block] of presentation.blocks.entries()) {
+    const id = `block${index}`;
+    if (block.type === 'text' || block.type === 'context') {
+      if (!block.text.trim()) continue;
+      hasText = true;
+      children.push(id);
+      components.push({
+        id,
+        component: 'Text',
+        ...(block.type === 'context' ? { variant: 'caption' as const } : {}),
+        text: block.text,
+      });
+    } else if (block.type === 'divider') {
+      children.push(id);
+      components.push({ id, component: 'Divider' });
+    } else if (block.type === 'buttons') {
+      const buttonIds: string[] = [];
+      for (const [buttonIndex, button] of block.buttons.entries()) {
+        if (
+          button.disabled ||
+          button.action?.type !== 'command' ||
+          !button.action.command.trim()
+        ) {
+          continue;
+        }
+        const buttonId = `${id}Button${buttonIndex}`;
+        const labelId = `${buttonId}Label`;
+        const variant = buttonVariant(button.style);
+        buttonIds.push(buttonId);
+        components.push(
+          {
+            id: buttonId,
+            component: 'Button',
+            ...(variant ? { variant } : {}),
+            child: labelId,
+            action: {
+              event: {
+                name: A2UI.action.sendMessage,
+                context: { text: button.action.command },
+              },
+            },
+          },
+          { id: labelId, component: 'Text', text: button.label }
+        );
+      }
+      if (buttonIds.length > 0) {
+        children.push(id);
+        components.push({ id, component: 'Row', children: buttonIds });
+      }
+    }
+  }
+
+  if (!hasText && fallbackText?.trim()) {
+    const insertionIndex = presentation.title?.trim() ? 1 : 0;
+    children.splice(insertionIndex, 0, 'fallbackText');
+    components.push({
+      id: 'fallbackText',
+      component: 'Text',
+      text: fallbackText.trim(),
+    });
+  }
+
+  return children.length > 0 ? components : null;
+}
+
+export function buildTlonPresentationBlobField(params: {
+  presentation?: ReplyPayload['presentation'];
+  fallbackText?: string;
+  surfaceId?: string;
+}): string | undefined {
+  if (!params.presentation) return undefined;
+  const components = presentationComponents(
+    params.presentation,
+    params.fallbackText
+  );
+  if (!components) return undefined;
+  return serializeBlobField(
+    makeA2UIBlob(
+      safeSurfaceId(params.surfaceId ?? 'openclaw-presentation'),
+      'root',
+      components
+    )
+  );
+}
+
+function approvalText(view: ApprovalViewModel): string {
+  const lines = [view.title];
+  if (view.description?.trim()) lines.push(view.description.trim());
+  if (view.approvalKind === 'exec') {
+    if (view.warningText?.trim()) lines.push(view.warningText.trim());
+    lines.push(`Command:\n\`\`\`sh\n${view.commandText}\n\`\`\``);
+  }
+  for (const item of view.metadata) lines.push(`${item.label}: ${item.value}`);
+  if (view.phase === 'pending') {
+    lines.push(
+      ...view.actions.map((action) => `- ${action.label}: ${action.command}`),
+      `Expires: ${new Date(view.expiresAtMs).toISOString()}`
+    );
+  } else if (view.phase === 'resolved') {
+    lines.push(`Decision: ${view.decision}`);
+    if (view.resolvedBy) lines.push(`Resolved by: ${view.resolvedBy}`);
+  } else {
+    lines.push('This approval request expired.');
+  }
+  lines.push(`Full id: ${view.approvalId}`);
+  return lines.join('\n\n');
+}
+
+function pendingPresentation(view: PendingApprovalView): PortablePresentation {
+  return {
+    title: view.title,
+    tone:
+      view.approvalKind === 'plugin' && view.severity === 'critical'
+        ? 'danger'
+        : 'warning',
+    blocks: [
+      ...(view.description?.trim()
+        ? [{ type: 'text' as const, text: view.description.trim() }]
+        : []),
+      ...(view.approvalKind === 'exec'
+        ? [
+            {
+              type: 'text' as const,
+              text: `Command:\n\`\`\`sh\n${view.commandText}\n\`\`\``,
+            },
+          ]
+        : []),
+      ...view.metadata.map((item) => ({
+        type: 'context' as const,
+        text: `${item.label}: ${item.value}`,
+      })),
+      {
+        type: 'buttons' as const,
+        buttons: view.actions.map((action) => ({
+          label: action.label,
+          style: action.style,
+          action: { type: 'command' as const, command: action.command },
+        })),
+      },
+    ],
+  };
+}
+
+export function buildTlonNativeApprovalPayload(view: ApprovalViewModel): {
+  text: string;
+  blob?: string;
+} {
+  const text = approvalText(view);
+  return {
+    text,
+    ...(view.phase === 'pending'
+      ? {
+          blob: buildTlonPresentationBlobField({
+            presentation: pendingPresentation(view),
+            fallbackText: text,
+            surfaceId: `openclaw-${view.approvalId}`,
+          }),
+        }
+      : {}),
+  };
+}
+
+export function readTlonReplyBlob(payload: ReplyPayload): string | undefined {
+  const blob = (payload.channelData?.tlon as { blob?: unknown } | undefined)
+    ?.blob;
+  return typeof blob === 'string' ? blob : undefined;
+}
+
+export function approvalSurfaceId(payload: ReplyPayload): string | undefined {
+  const approval = payload.channelData?.execApproval as
+    | { approvalId?: unknown }
+    | undefined;
+  return typeof approval?.approvalId === 'string'
+    ? `openclaw-${approval.approvalId}`
+    : undefined;
+}

--- a/packages/openclaw/src/channel.runtime.test.ts
+++ b/packages/openclaw/src/channel.runtime.test.ts
@@ -17,6 +17,7 @@ const resolveTlonAccount = vi.fn(() => ({
 }));
 
 vi.mock('@tloncorp/api', () => ({
+  A2UI: { action: { sendMessage: 'sendMessage' } },
   notes: { getNotebook, createNote, listNotes },
   scry: vi.fn(),
 }));
@@ -27,6 +28,7 @@ vi.mock('./urbit/upload.js', () => ({
 
 vi.mock('./urbit/send.js', () => ({
   buildMediaStory: vi.fn(() => [{ inline: ['mock'] }]),
+  buildMediaText: vi.fn((text: string) => text),
   sendChannelPost: vi.fn(async () => ({
     channel: 'tlon',
     messageId: '~zod/123',
@@ -99,6 +101,12 @@ vi.mock('./setup-surface.js', () => ({
 }));
 
 vi.mock('./urbit/blob.js', () => ({
+  combineBlobFields: vi.fn(
+    (...fields: Array<string | undefined>) =>
+      fields.filter(Boolean).join('|') || undefined
+  ),
+  makeA2UIBlob: vi.fn(() => ({ type: 'a2ui' })),
+  serializeBlobField: vi.fn(() => '[{"type":"a2ui"}]'),
   serializeContextLensReferenceBlob: vi.fn(),
 }));
 
@@ -220,6 +228,45 @@ describe('sendMedia', () => {
       deliveryFailureCount: 0,
       deliverySuccessCount: 1,
     });
+  });
+});
+
+describe('sendPayload presentation', () => {
+  it('sends portable approval controls as an A2UI blob', async () => {
+    const { tlonRuntimeOutbound } = await import('./channel.runtime.js');
+    const { sendDm } = await import('./urbit/send.js');
+
+    await tlonRuntimeOutbound.sendPayload!({
+      cfg: {} as never,
+      to: '~nec',
+      text: 'Approval required.',
+      accountId: null,
+      replyToId: null,
+      threadId: null,
+      payload: {
+        text: 'Approval required.',
+        presentation: {
+          blocks: [
+            {
+              type: 'buttons',
+              buttons: [
+                {
+                  label: 'Allow Once',
+                  action: {
+                    type: 'command',
+                    command: '/approve abc allow-once',
+                  },
+                },
+              ],
+            },
+          ],
+        },
+      },
+    });
+
+    expect(sendDm).toHaveBeenCalledWith(
+      expect.objectContaining({ blob: '[{"type":"a2ui"}]' })
+    );
   });
 });
 

--- a/packages/openclaw/src/channel.runtime.ts
+++ b/packages/openclaw/src/channel.runtime.ts
@@ -13,6 +13,11 @@ import {
 } from 'openclaw/plugin-sdk/reply-payload';
 
 import {
+  approvalSurfaceId,
+  buildTlonPresentationBlobField,
+  readTlonReplyBlob,
+} from './approval-presentation.js';
+import {
   type ContextLensRegistry,
   getActiveBackgroundContextLens,
   getActiveForegroundContextLensForConversation,
@@ -26,7 +31,10 @@ import { observeActiveTlonTurnDelivery } from './turn-recorder.js';
 import { resolveTlonAccount } from './types.js';
 import { withAuthenticatedTlonApi } from './urbit/api-client.js';
 import { authenticate } from './urbit/auth.js';
-import { serializeContextLensReferenceBlob } from './urbit/blob.js';
+import {
+  combineBlobFields,
+  serializeContextLensReferenceBlob,
+} from './urbit/blob.js';
 import { ssrfPolicyFromAllowPrivateNetwork } from './urbit/context.js';
 import { urbitFetch } from './urbit/fetch.js';
 import {
@@ -303,164 +311,134 @@ async function sendNotesEntryWithLens({
   return result;
 }
 
+type TlonOutboundMessageParams = {
+  cfg: OpenClawConfig;
+  to: string;
+  text: string;
+  mediaUrl?: string;
+  accountId?: string | null;
+  replyToId?: string | null;
+  threadId?: string | number | null;
+  blob?: string;
+};
+
+async function sendTlonOutboundMessage(params: TlonOutboundMessageParams) {
+  const { account, parsed } = resolveOutboundContext(params);
+  return await withAuthenticatedTlonApi(
+    {
+      url: account.url,
+      code: account.code,
+      ship: account.ship,
+      allowPrivateNetwork: account.allowPrivateNetwork ?? undefined,
+    },
+    async () => {
+      const media = params.mediaUrl
+        ? await prepareOutboundMedia(params.mediaUrl)
+        : undefined;
+      const fromShip = normalizeShip(account.ship);
+      const story = media
+        ? buildMediaStory(params.text, media)
+        : markdownToStory(params.text);
+      const replyId = resolveReplyId(params.replyToId, params.threadId);
+      const botProfile = await getBotProfile(fromShip);
+
+      if (parsed.kind === 'dm') {
+        const conversationId = normalizeShip(parsed.ship);
+        const target = resolveOutboundLensTarget(
+          account,
+          fromShip,
+          conversationId
+        );
+        const blob = combineBlobFields(params.blob, target?.blob);
+        const result = media
+          ? await sendDmWithStory({
+              fromShip,
+              toShip: parsed.ship,
+              story,
+              blob,
+              replyToId: replyId,
+              botProfile,
+            })
+          : await sendDm({
+              fromShip,
+              toShip: parsed.ship,
+              text: params.text,
+              blob,
+              replyToId: replyId,
+              botProfile,
+            });
+        recordOutboundLensDelivery(target, {
+          messageId: result.messageId,
+          conversationId,
+          kind: 'dm',
+          sentAt: result.sentAt,
+          text: params.text,
+        });
+        return result;
+      }
+
+      if (parsed.kind === 'notebook') {
+        return await sendNotesEntryWithLens({
+          account,
+          fromShip,
+          nest: parsed.nest,
+          text: media ? buildMediaText(params.text, media.url) : params.text,
+        });
+      }
+
+      const target = resolveOutboundLensTarget(account, fromShip, parsed.nest);
+      const result = await sendChannelPost({
+        fromShip,
+        nest: parsed.nest,
+        story,
+        blob: combineBlobFields(params.blob, target?.blob),
+        replyToId: replyId,
+        botProfile,
+      });
+      recordOutboundLensDelivery(target, {
+        messageId: result.messageId,
+        conversationId: parsed.nest,
+        kind: 'channel',
+        text: params.text,
+      });
+      return result;
+    }
+  );
+}
+
 const unobservedTlonRuntimeOutbound: Pick<
   ChannelOutboundAdapter,
-  'sendText' | 'sendMedia'
+  'renderPresentation' | 'sendText' | 'sendMedia'
 > = {
-  sendText: async ({ cfg, to, text, accountId, replyToId, threadId }) => {
-    const { account, parsed } = resolveOutboundContext({ cfg, accountId, to });
-    return await withAuthenticatedTlonApi(
-      {
-        url: account.url,
-        code: account.code,
-        ship: account.ship,
-        allowPrivateNetwork: account.allowPrivateNetwork ?? undefined,
+  renderPresentation: ({ payload, presentation }) => {
+    const blob = buildTlonPresentationBlobField({
+      presentation,
+      fallbackText: payload.text,
+      surfaceId: approvalSurfaceId(payload),
+    });
+    if (!blob) return payload;
+    return {
+      ...payload,
+      channelData: {
+        ...payload.channelData,
+        tlon: {
+          ...(payload.channelData?.tlon as Record<string, unknown> | undefined),
+          blob: combineBlobFields(readTlonReplyBlob(payload), blob),
+          presentationRendered: true,
+        },
       },
-      async () => {
-        const fromShip = normalizeShip(account.ship);
-        const replyId = resolveReplyId(replyToId, threadId);
-        const botProfile = await getBotProfile(fromShip);
-        if (parsed.kind === 'dm') {
-          const conversationId = normalizeShip(parsed.ship);
-          const target = resolveOutboundLensTarget(
-            account,
-            fromShip,
-            conversationId
-          );
-          const result = await sendDm({
-            fromShip,
-            toShip: parsed.ship,
-            text,
-            blob: target?.blob,
-            replyToId: replyId,
-            botProfile,
-          });
-          recordOutboundLensDelivery(target, {
-            messageId: result.messageId,
-            conversationId,
-            kind: 'dm',
-            sentAt: result.sentAt,
-            text,
-          });
-          return result;
-        }
-        if (parsed.kind === 'notebook') {
-          return await sendNotesEntryWithLens({
-            account,
-            fromShip,
-            nest: parsed.nest,
-            text,
-          });
-        }
-        const target = resolveOutboundLensTarget(
-          account,
-          fromShip,
-          parsed.nest
-        );
-        const result = await sendChannelPost({
-          fromShip,
-          nest: parsed.nest,
-          story: markdownToStory(text),
-          blob: target?.blob,
-          replyToId: replyId,
-          botProfile,
-        });
-        recordOutboundLensDelivery(target, {
-          messageId: result.messageId,
-          conversationId: parsed.nest,
-          kind: 'channel',
-          text,
-        });
-        return result;
-      }
-    );
+    };
   },
-  sendMedia: async ({
-    cfg,
-    to,
-    text,
-    mediaUrl,
-    accountId,
-    replyToId,
-    threadId,
-  }) => {
-    const { account, parsed } = resolveOutboundContext({ cfg, accountId, to });
-    return await withAuthenticatedTlonApi(
-      {
-        url: account.url,
-        code: account.code,
-        ship: account.ship,
-        allowPrivateNetwork: account.allowPrivateNetwork ?? undefined,
-      },
-      async () => {
-        const media = mediaUrl
-          ? await prepareOutboundMedia(mediaUrl)
-          : undefined;
-        const fromShip = normalizeShip(account.ship);
-        const story = buildMediaStory(text, media);
-        const replyId = resolveReplyId(replyToId, threadId);
-        const botProfile = await getBotProfile(fromShip);
-        if (parsed.kind === 'dm') {
-          const conversationId = normalizeShip(parsed.ship);
-          const target = resolveOutboundLensTarget(
-            account,
-            fromShip,
-            conversationId
-          );
-          const result = await sendDmWithStory({
-            fromShip,
-            toShip: parsed.ship,
-            story,
-            blob: target?.blob,
-            replyToId: replyId,
-            botProfile,
-          });
-          recordOutboundLensDelivery(target, {
-            messageId: result.messageId,
-            conversationId,
-            kind: 'dm',
-            sentAt: result.sentAt,
-            text,
-          });
-          return result;
-        }
-        if (parsed.kind === 'notebook') {
-          return await sendNotesEntryWithLens({
-            account,
-            fromShip,
-            nest: parsed.nest,
-            text: buildMediaText(text, media?.url),
-          });
-        }
-        const target = resolveOutboundLensTarget(
-          account,
-          fromShip,
-          parsed.nest
-        );
-        const result = await sendChannelPost({
-          fromShip,
-          nest: parsed.nest,
-          story,
-          blob: target?.blob,
-          replyToId: replyId,
-          botProfile,
-        });
-        recordOutboundLensDelivery(target, {
-          messageId: result.messageId,
-          conversationId: parsed.nest,
-          kind: 'channel',
-          text,
-        });
-        return result;
-      }
-    );
-  },
+  sendText: async (params) => await sendTlonOutboundMessage(params),
+  sendMedia: async (params) => await sendTlonOutboundMessage(params),
 };
 
 export const tlonRuntimeOutbound: Pick<
   ChannelOutboundAdapter,
-  'sendPayload' | 'sendText' | 'sendMedia'
+  'renderPresentation' | 'sendPayload' | 'sendText' | 'sendMedia'
 > = {
+  renderPresentation: (params) =>
+    unobservedTlonRuntimeOutbound.renderPresentation!(params),
   sendText: (params) =>
     observeActiveTlonTurnDelivery(() =>
       unobservedTlonRuntimeOutbound.sendText!(params)
@@ -470,6 +448,22 @@ export const tlonRuntimeOutbound: Pick<
       unobservedTlonRuntimeOutbound.sendMedia!(params)
     ),
   sendPayload: async (ctx) => {
+    const alreadyRendered =
+      (
+        ctx.payload.channelData?.tlon as
+          | { presentationRendered?: unknown }
+          | undefined
+      )?.presentationRendered === true;
+    const rendered =
+      ctx.payload.presentation && !alreadyRendered
+        ? await unobservedTlonRuntimeOutbound.renderPresentation!({
+            payload: ctx.payload,
+            presentation: ctx.payload.presentation,
+            ctx,
+          })
+        : ctx.payload;
+    if (!rendered) return { channel: 'tlon', messageId: '' };
+    const payloadCtx = { ...ctx, payload: rendered };
     const parsed = parseTlonTarget(ctx.to);
     if (parsed?.kind === 'notebook') {
       const { account } = resolveOutboundContext({
@@ -486,23 +480,36 @@ export const tlonRuntimeOutbound: Pick<
         },
         async () =>
           Promise.all(
-            resolvePayloadMediaUrls(ctx.payload).map(
+            resolvePayloadMediaUrls(rendered).map(
               async (mediaUrl) => (await prepareOutboundMedia(mediaUrl)).url
             )
           )
       );
-      const text = formatTextWithAttachmentLinks(ctx.payload.text, mediaUrls);
+      const text = formatTextWithAttachmentLinks(rendered.text, mediaUrls);
       return await observeActiveTlonTurnDelivery(() =>
         unobservedTlonRuntimeOutbound.sendText!({ ...ctx, text })
       );
     }
+
+    let blob = readTlonReplyBlob(rendered);
+    const takeBlob = () => {
+      const value = blob;
+      blob = undefined;
+      return value;
+    };
     return await sendTextMediaPayload({
       channel: 'tlon',
-      ctx,
+      ctx: payloadCtx,
       adapter: {
         chunker: chunkText,
-        sendMedia: tlonRuntimeOutbound.sendMedia,
-        sendText: tlonRuntimeOutbound.sendText,
+        sendMedia: (params) =>
+          observeActiveTlonTurnDelivery(() =>
+            sendTlonOutboundMessage({ ...params, blob: takeBlob() })
+          ),
+        sendText: (params) =>
+          observeActiveTlonTurnDelivery(() =>
+            sendTlonOutboundMessage({ ...params, blob: takeBlob() })
+          ),
         textChunkLimit: 10_000,
       },
     });

--- a/packages/openclaw/src/channel.ts
+++ b/packages/openclaw/src/channel.ts
@@ -14,6 +14,7 @@ import {
 } from 'openclaw/plugin-sdk/status-helpers';
 
 import { tlonMessageActions } from './actions.js';
+import { tlonApprovalCapability } from './approval-native.js';
 import { tlonChannelConfigSchema } from './config-schema.js';
 import { resolveTlonOutboundSessionRoute } from './session-route.js';
 import {
@@ -144,6 +145,7 @@ export const tlonPlugin = createChatChannelPlugin({
         resolveTlonOutboundSessionRoute(params),
     },
     actions: tlonMessageActions,
+    approvalCapability: tlonApprovalCapability,
     agentPrompt: {
       messageToolHints: ({ cfg, accountId }) => {
         const account = resolveTlonAccount(cfg, accountId ?? undefined);
@@ -261,6 +263,42 @@ export const tlonPlugin = createChatChannelPlugin({
   outbound: {
     deliveryMode: 'direct',
     textChunkLimit: 10000,
+    presentationCapabilities: {
+      supported: true,
+      buttons: true,
+      context: true,
+      divider: true,
+      limits: {
+        actions: {
+          maxActions: 3,
+          maxActionsPerRow: 3,
+          maxRows: 1,
+          maxLabelLength: 40,
+          maxValueBytes: 512,
+          supportsStyles: true,
+          supportsDisabled: false,
+        },
+        text: {
+          maxLength: 10000,
+          encoding: 'characters',
+          markdownDialect: 'markdown',
+          supportsEdit: false,
+        },
+      },
+    },
+    deliveryCapabilities: {
+      durableFinal: {
+        text: true,
+        media: true,
+        payload: true,
+        replyTo: true,
+        thread: true,
+      },
+    },
+    shouldSuppressLocalPayloadPrompt: ({ hint }) =>
+      hint?.kind === 'approval-pending' &&
+      hint.approvalKind === 'exec' &&
+      hint.nativeRouteActive === true,
     resolveTarget: ({ to }) => {
       const parsed = parseTlonTarget(to ?? '');
       if (!parsed) {
@@ -276,6 +314,9 @@ export const tlonPlugin = createChatChannelPlugin({
     },
     ...createRuntimeOutboundDelegates({
       getRuntime: loadTlonChannelRuntime,
+      renderPresentation: {
+        resolve: (runtime) => runtime.tlonRuntimeOutbound.renderPresentation,
+      },
       sendPayload: {
         resolve: (runtime) => runtime.tlonRuntimeOutbound.sendPayload,
       },

--- a/packages/openclaw/src/commands-registry.test.ts
+++ b/packages/openclaw/src/commands-registry.test.ts
@@ -5,6 +5,7 @@ import type { PluginCommandContext } from 'openclaw/plugin-sdk/core';
 import { describe, expect, it, vi } from 'vitest';
 
 import {
+  APPROVAL_COMMAND_TOKENS,
   CORE_COMMAND_TOKENS,
   TLON_COMMAND_REGISTRY,
   type TlonCommandDeps,
@@ -149,6 +150,11 @@ describe('core command tokens', () => {
       expect(commandTokens()).not.toContain(token);
     }
   });
+
+  it('engages approval card commands without advertising them', () => {
+    expect(APPROVAL_COMMAND_TOKENS).toEqual(['/approve']);
+    expect(commandTokens()).not.toContain('/approve');
+  });
 });
 
 describe('buildEngagementTokensJson', () => {
@@ -160,10 +166,11 @@ describe('buildEngagementTokensJson', () => {
     expect(buildEngagementTokensJson()).toBe(buildEngagementTokensJson());
   });
 
-  it('is the registry tokens followed by the core trio', () => {
+  it('includes registry, core, and approval commands', () => {
     expect(engagementTokens()).toEqual([
       ...commandTokens(),
       ...CORE_COMMAND_TOKENS,
+      ...APPROVAL_COMMAND_TOKENS,
     ]);
   });
 });

--- a/packages/openclaw/src/commands-registry.ts
+++ b/packages/openclaw/src/commands-registry.ts
@@ -228,17 +228,24 @@ export function buildCommandTokensJson(): string {
 
 // OpenClaw CORE commands the client's popup offers alongside the registry
 // tokens. Audit-pinned constant mirroring the client's OPENCLAW_CORE_COMMANDS
-// (same audit pin, core 2026.5.28): the keys "help", "status", "new", and
+// (same audit pin, core 2026.7.1): the keys "help", "status", "new", and
 // "model" (textAlias "/model", tier "essential", ungated) in core's builtin
 // command registry, which core dispatches itself once a message reaches it. The plugin neither registers nor dispatches them, but
 // bare owner engagement (isRegisteredCommandText) must let them through, so
 // the popup's bare insertion works in any watched chat channel.
 export const CORE_COMMAND_TOKENS = ['/status', '/help', '/new', '/model'];
 
+// Approval cards send this complete command when their buttons are clicked.
+export const APPROVAL_COMMAND_TOKENS = ['/approve'];
+
 // Every token that engages bare from the owner in a watched chat channel:
 // the registered plugin commands plus the core trio above.
 export function engagementTokens(): string[] {
-  return [...commandTokens(), ...CORE_COMMAND_TOKENS];
+  return [
+    ...commandTokens(),
+    ...CORE_COMMAND_TOKENS,
+    ...APPROVAL_COMMAND_TOKENS,
+  ];
 }
 
 // The committed fixture's exact bytes (fixtures/engagement-tokens.json). The

--- a/packages/openclaw/src/cron-telemetry.test.ts
+++ b/packages/openclaw/src/cron-telemetry.test.ts
@@ -42,7 +42,7 @@ function makeJob(overrides: Partial<HookCronJob> = {}): HookCronJob {
 function makeOnExitJob(overrides: Partial<HookCronJob> = {}): HookCronJob {
   return {
     ...makeJob(overrides),
-    // The pinned 2026.5.28 SDK does not include this newer runtime shape.
+    // Keep the cast localized to this compatibility fixture.
     schedule: {
       kind: 'on-exit',
       command: 'secret watcher command --token sensitive',

--- a/packages/openclaw/src/cron-telemetry.ts
+++ b/packages/openclaw/src/cron-telemetry.ts
@@ -55,10 +55,8 @@ type CronObservabilityOptions = {
   observer?: TlonCronOtelObserver;
 };
 
-// OpenClaw 2026.5.28 predates event-driven `on-exit` schedules, while this
-// plugin's peer range also permits newer hosts that expose them. Keep the
-// pinned SDK for development and add only the newer runtime projection here.
-// The command and cwd are intentionally never included in telemetry.
+// Keep the runtime projection local so older persisted job shapes remain safe
+// to normalize. The command and cwd are intentionally never included in telemetry.
 type ForwardCompatibleCronSchedule =
   | NonNullable<PluginHookGatewayCronJob['schedule']>
   | { kind: 'on-exit'; command?: string; cwd?: string };

--- a/packages/openclaw/src/monitor/index.ts
+++ b/packages/openclaw/src/monitor/index.ts
@@ -13,6 +13,11 @@ import {
   recordAuthRetryFailure,
 } from '../auth-retry-state.js';
 import {
+  approvalSurfaceId,
+  buildTlonPresentationBlobField,
+  readTlonReplyBlob,
+} from '../approval-presentation.js';
+import {
   type SelfContactRead,
   buildBotInfoJson,
   syncBotInfo,
@@ -107,6 +112,7 @@ import {
   isPermanentAuthenticationFailure,
 } from '../urbit/auth.js';
 import {
+  combineBlobFields,
   serializeBlobField,
   serializeContextLensReferenceBlob,
 } from '../urbit/blob.js';
@@ -419,7 +425,7 @@ async function monitorTlonProviderScoped(opts: MonitorTlonOpts): Promise<void> {
     throw new Error('Tlon account ship is empty after normalization');
   }
   const tlonSkillVersion = await resolveTlonSkillVersion();
-  const effectiveOwnerShip: string | null = account.ownerShip
+  let effectiveOwnerShip: string | null = account.ownerShip
     ? normalizeShip(account.ownerShip)
     : null;
   setEffectiveOwnerShip(account.accountId, effectiveOwnerShip);
@@ -1239,6 +1245,11 @@ async function monitorTlonProviderScoped(opts: MonitorTlonOpts): Promise<void> {
           fileValue: account.showModelSignature,
           settingsValue: currentSettings.showModelSig,
         },
+        {
+          key: 'ownerShip',
+          fileValue: account.ownerShip,
+          settingsValue: currentSettings.ownerShip,
+        },
       ];
 
       for (const { key, fileValue, settingsValue } of migrations) {
@@ -1322,6 +1333,10 @@ async function monitorTlonProviderScoped(opts: MonitorTlonOpts): Promise<void> {
       }
       if (currentSettings.showModelSig !== undefined) {
         effectiveShowModelSig = currentSettings.showModelSig;
+      }
+      if (currentSettings.ownerShip !== undefined) {
+        effectiveOwnerShip = normalizeShip(currentSettings.ownerShip);
+        setEffectiveOwnerShip(account.accountId, effectiveOwnerShip);
       }
       if (currentSettings.autoAcceptDmInvites !== undefined) {
         effectiveAutoAcceptDmInvites = currentSettings.autoAcceptDmInvites;
@@ -1838,34 +1853,6 @@ async function monitorTlonProviderScoped(opts: MonitorTlonOpts): Promise<void> {
         );
         return undefined;
       }
-    }
-
-    function getReplyBlob(payload: ReplyPayload): string | undefined {
-      const blob = (payload.channelData?.tlon as { blob?: unknown } | undefined)
-        ?.blob;
-      return typeof blob === 'string' ? blob : undefined;
-    }
-
-    // Merge serialized post-blob fields (each a JSON array of entries) into one,
-    // so a reply can carry both an a2ui card and a context-lens reference.
-    function combineBlobFields(
-      ...fields: Array<string | undefined>
-    ): string | undefined {
-      const entries: unknown[] = [];
-      for (const field of fields) {
-        if (!field) {
-          continue;
-        }
-        try {
-          const parsed = JSON.parse(field);
-          if (Array.isArray(parsed)) {
-            entries.push(...parsed);
-          }
-        } catch {
-          // Skip a malformed blob field rather than dropping the whole message.
-        }
-      }
-      return entries.length > 0 ? JSON.stringify(entries) : undefined;
     }
 
     // Regex to match block directives in agent responses
@@ -3414,7 +3401,14 @@ async function monitorTlonProviderScoped(opts: MonitorTlonOpts): Promise<void> {
                         },
                         deliver: async (payload: ReplyPayload, info) => {
                           contextLenses.setStatus(lens.lensId, 'delivering');
-                          const blob = getReplyBlob(payload);
+                          const blob = combineBlobFields(
+                            readTlonReplyBlob(payload),
+                            buildTlonPresentationBlobField({
+                              presentation: payload.presentation,
+                              fallbackText: payload.text,
+                              surfaceId: approvalSurfaceId(payload),
+                            })
+                          );
                           let replyText = payload.text ?? '';
                           replyText = rewriteGenericTerminalErrorReply({
                             text: replyText,
@@ -5016,6 +5010,17 @@ async function monitorTlonProviderScoped(opts: MonitorTlonOpts): Promise<void> {
         snapshotOpts: { fresh?: boolean } = {}
       ) => {
         const prevSettings = currentSettings;
+
+        const nextOwnerShip = normalizeShip(
+          newSettings.ownerShip ?? account.ownerShip ?? ''
+        );
+        if (nextOwnerShip !== effectiveOwnerShip) {
+          effectiveOwnerShip = nextOwnerShip;
+          setEffectiveOwnerShip(account.accountId, effectiveOwnerShip);
+          runtime.log?.(
+            `[tlon] Settings: ownerShip updated to ${effectiveOwnerShip ?? '(unset)'}`
+          );
+        }
 
         // If pendingNudge has been rehydrated (startup succeeded or monitor has locally
         // set/cleared it), the in-memory state is authoritative — refreshes cannot clobber

--- a/packages/openclaw/src/monitor/owner-listen.test.ts
+++ b/packages/openclaw/src/monitor/owner-listen.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest';
 
-import { CORE_COMMAND_TOKENS, commandTokens } from '../commands-registry.js';
+import { engagementTokens } from '../commands-registry.js';
 import {
   isOwnerListenSlashCommand,
   isRegisteredCommandText,
@@ -15,7 +15,7 @@ const OWNED_BY_OWNER = 'chat/~zod/general';
 const OWNED_BY_BOT = 'chat/~bus/garage';
 const STRANGER_HOSTED = 'chat/~nec/lounge';
 
-const ALL_ENGAGEMENT_TOKENS = [...commandTokens(), ...CORE_COMMAND_TOKENS];
+const ALL_ENGAGEMENT_TOKENS = engagementTokens();
 
 function baseOpts(
   overrides: Partial<Parameters<typeof shouldEngageInGroup>[0]> = {}

--- a/packages/openclaw/src/urbit/blob.ts
+++ b/packages/openclaw/src/urbit/blob.ts
@@ -44,3 +44,19 @@ export function makeA2UIBlob(
 export function serializeBlobField(entry: TlonA2UIBlob): string {
   return appendToPostBlob(undefined, entry);
 }
+
+export function combineBlobFields(
+  ...fields: Array<string | undefined>
+): string | undefined {
+  const entries: unknown[] = [];
+  for (const field of fields) {
+    if (!field) continue;
+    try {
+      const parsed = JSON.parse(field);
+      if (Array.isArray(parsed)) entries.push(...parsed);
+    } catch {
+      // Keep valid entries when an optional blob field is malformed.
+    }
+  }
+  return entries.length > 0 ? JSON.stringify(entries) : undefined;
+}

--- a/packages/openclaw/test/cases/08-gateway-status.test.ts
+++ b/packages/openclaw/test/cases/08-gateway-status.test.ts
@@ -32,10 +32,8 @@ import {
 
 const ARCHIVE = 'pinned rube-zod-group-blob';
 // Must match dev/Dockerfile.test's ARG OPENCLAW_CORE_VERSION default: the test
-// asserts the container's installed core equals this requested version. Bumping
-// both together to 2026.6.11/2026.7.1 (already in the known-prewarm map below)
-// promotes this case from a 5.28 smoke test to the full prewarm regression guard.
-const DEFAULT_CORE_VERSION = '2026.5.28';
+// asserts the container's installed core equals this requested version.
+const DEFAULT_CORE_VERSION = '2026.7.1';
 const HARD_TEST_TIMEOUT_MS = 180_000;
 const INTERNAL_TEST_TIMEOUT_MS = 165_000;
 const DIAGNOSTIC_RESERVE_MS = 12_000;

--- a/packages/openclaw/test/run.sh
+++ b/packages/openclaw/test/run.sh
@@ -43,9 +43,9 @@ COMPOSE_PROJECT_NAME="$(printf '%s' "$requested_project_name" | tr '[:upper:]' '
 TEST_COMPOSE_PROJECT_NAME="$COMPOSE_PROJECT_NAME"
 export COMPOSE_PROJECT_NAME TEST_COMPOSE_PROJECT_NAME
 
-# The image defaults to 5.28. Affected/future versions must carry an explicit
-# prewarm expectation so a missing core marker never silently becomes smoke.
-OPENCLAW_CORE_VERSION="${OPENCLAW_CORE_VERSION:-2026.5.28}"
+# Future versions must carry an explicit prewarm expectation so a missing core
+# marker never silently becomes smoke.
+OPENCLAW_CORE_VERSION="${OPENCLAW_CORE_VERSION:-2026.7.1}"
 case "$OPENCLAW_CORE_VERSION" in
   2026.5.28) derived_expect_prewarm=0 ;;
   2026.6.11|2026.7.1) derived_expect_prewarm=1 ;;

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1105,8 +1105,8 @@ importers:
         specifier: ^17.2.4
         version: 17.4.2
       openclaw:
-        specifier: 2026.5.28
-        version: 2026.5.28(encoding@0.1.13)
+        specifier: 2026.7.1
+        version: 2026.7.1(@opentelemetry/api@1.9.1)(encoding@0.1.13)
       typescript:
         specifier: ~5.9.2
         version: 5.9.3
@@ -1325,13 +1325,13 @@ packages:
   '@adobe/css-tools@4.0.1':
     resolution: {integrity: sha512-+u76oB43nOHrF4DDWRLWDCtci7f3QJoEBigemIdIeTi1ODqjx6Tad9NCVnPRwewWlKkVab5PlK8DCtPTyX7S8g==}
 
-  '@agentclientprotocol/sdk@0.22.1':
-    resolution: {integrity: sha512-DfqXtl/8gO9NImq094MTaCXEU2vkhh6v7q/kT+9UjZxUqj8hYaya2OjLVIqn16MzNHcXEpShTR2RIauLSYeDQQ==}
+  '@agentclientprotocol/sdk@1.1.0':
+    resolution: {integrity: sha512-NT2KqphUJ3w6EksUL51ZhJgIYgq/ZLGcBPkyMKgRSO5PMVwe9DnKKX+Htnvk6KHh6dUuh34UHK4gKp+4te1Mdg==}
     peerDependencies:
       zod: ^3.25.0 || ^4.0.0
 
-  '@anthropic-ai/sdk@0.98.0':
-    resolution: {integrity: sha512-N7aXtCvC5g6T1Y4V29lJjceu/zTkVkIZF0jdBvagr0TRFHuKeImffalGWEfqZKrvjH+IQbzJWw6TmSmUzrlMgg==}
+  '@anthropic-ai/sdk@0.109.1':
+    resolution: {integrity: sha512-q9OnEKLr5H9nxSuXdgDgJhxfYMiE+AaUEBze2Gk91UcaaLnsN+Lx5fbCYywiqurU/APLdwv23x03Wm6WN3EBsg==}
     hasBin: true
     peerDependencies:
       zod: ^3.25.0 || ^4.0.0
@@ -2385,12 +2385,12 @@ packages:
   '@borewit/text-codec@0.2.2':
     resolution: {integrity: sha512-DDaRehssg1aNrH4+2hnj1B7vnUGEjU6OIlyRdkMd0aUdIUvKXrJfXsy8LVtXAy7DRvYVluWbMspsRhz2lcW0mQ==}
 
-  '@clack/core@1.3.1':
-    resolution: {integrity: sha512-fT1qHVGAag4IEkrupZ6lRRbNCs1vS9P01KB/sG8zKgvUztbYtFBtQpjSITNwooDZ83tpsPzP0mRNs1/KVszCRA==}
+  '@clack/core@1.4.2':
+    resolution: {integrity: sha512-0Ty/1Gfm+Kb07sXcuESjyKfwEhSy4Ns1AgeEisHb/bDY5fWme0tTeTkU14T1Gmcs17YIjB/teiDe4uaCghbYqQ==}
     engines: {node: '>= 20.12.0'}
 
-  '@clack/prompts@1.4.0':
-    resolution: {integrity: sha512-S0My7XPGIgpRWMDG8uRqalbgT+a6FmCUdOW+HaIOVVpUPHOb7RrpvjTjiODadKp06fsrVDJZlIzc6yCTp4AnxA==}
+  '@clack/prompts@1.6.0':
+    resolution: {integrity: sha512-EYlRokl8szrP9Z25qT5aepMdBjzBvHF9ZEhzIiUBc9guz/T31EqRgvD0QSgZcpE93xiwrr+OkB4nz0BZyF6fSA==}
     engines: {node: '>= 20.12.0'}
 
   '@dev-plugins/async-storage@0.4.0':
@@ -2443,8 +2443,8 @@ packages:
   '@drizzle-team/brocli@0.10.2':
     resolution: {integrity: sha512-z33Il7l5dKjUgGULTqBsQBQwckHh5AbIuxhdsIxDDiZAzBOrZO6q9ogcWC65kU382AfynTfgNumVcNIjuIua6w==}
 
-  '@earendil-works/pi-tui@0.76.0':
-    resolution: {integrity: sha512-TWQEWqc38gVRYr/VTrlfePQPpJk938gNNLL1xuv0M+9cTkVr880/Q3baZQrxKoLrmN/MmVx7TyR8knYZGxTqqg==}
+  '@earendil-works/pi-tui@0.80.3':
+    resolution: {integrity: sha512-2BJI6qwRQfnM0Q7seL1+SbacU/jRRjBnN7Hu3n9BjAn7/s5FaBNnvdD1qBQYRsFTHfjqMaDsjYqanPyqwXj99w==}
     engines: {node: '>=22.19.0'}
 
   '@egjs/hammerjs@2.0.17':
@@ -3108,8 +3108,8 @@ packages:
       react: 19.2.3
       react-native: 0.86.0
 
-  '@google/genai@2.6.0':
-    resolution: {integrity: sha512-HjoW3mPuEn7pnuKABJl9VbDoWDSF4nbwYKYvYYor7YjPeDxrrBxHzu2d1Prcd+BAuC4w+85UP6y7ZdcrQAoO7g==}
+  '@google/genai@2.10.0':
+    resolution: {integrity: sha512-e4cFxj3tiuMtsgOT4G9c1hXyGJhg7/Buj7VVeBacRY3fRtkRZZ59Q3nuVp2xbq8BGQXLXCDB253qMhklMOeUDg==}
     engines: {node: '>=20.0.0'}
     peerDependencies:
       '@modelcontextprotocol/sdk': ^1.25.2
@@ -3150,8 +3150,8 @@ packages:
     peerDependencies:
       grammy: ^1.0.0
 
-  '@grammyjs/types@3.27.3':
-    resolution: {integrity: sha512-yUKMLliGsGbnxu96YUJ7km7B0zy4PzeH/Jvti5705R/LeKDMqkDV4DckMSt+OrliWQpTwQljHE0QLol5zgxBkg==}
+  '@grammyjs/types@3.28.0':
+    resolution: {integrity: sha512-4JvXCdxRZHCje0M4gHzLwtB4bLno3WD28xd8CNfk4POWIu73BFnSvGeW6OQ5gPem4eYTEwkD9yDaXssixl6tMQ==}
 
   '@grpc/grpc-js@1.9.15':
     resolution: {integrity: sha512-nqE7Hc0AzI+euzUwDAy0aY5hCp10r734gMGRdU+qOPX0XSceI2ULrcXB5U2xSc5VkWwalCj4M7GzCAygZl2KoQ==}
@@ -3349,8 +3349,13 @@ packages:
   '@microsoft/fetch-event-source@2.0.1':
     resolution: {integrity: sha512-W6CLUJ2eBMw3Rec70qrsEW0jOm/3twwJv21mrmj2yORiaVmVYGS4sSS5yUwvQc1ZlDLYGPnClVWmUUMagKNsfA==}
 
-  '@mistralai/mistralai@2.2.5':
-    resolution: {integrity: sha512-ATbWzKkNzNAZ+gtw9MI/c/ULTMG80tKUiRNIbQFfg4OP0uEZZpTfXZeBCNfs5Dq0uqMQ/tQWc4o6RRJQtMrpDA==}
+  '@mistralai/mistralai@2.4.0':
+    resolution: {integrity: sha512-t6hCx242MTGolB76CI+17jDtPIe/bzLsMdUTMMoMn9Qo1h02N2G5jQYHmKDGU3X//OgR2wvngTD7tO6tPp5poQ==}
+    peerDependencies:
+      '@opentelemetry/api': ^1.9.0
+    peerDependenciesMeta:
+      '@opentelemetry/api':
+        optional: true
 
   '@modelcontextprotocol/sdk@1.29.0':
     resolution: {integrity: sha512-zo37mZA9hJWpULgkRpowewez1y6ML5GsXJPY8FI0tBBCd77HEvza4jDqRKOXgHNn867PVGCyTdzqpz0izu5ZjQ==}
@@ -3541,9 +3546,13 @@ packages:
   '@open-draft/until@1.0.3':
     resolution: {integrity: sha512-Aq58f5HiWdyDlFffbbSjAlv596h/cOnt2DO1w3DOC7OJ5EHs0hd/nycJfiu9RJbT6Yk6F1knnRRXNSpxoIVZ9Q==}
 
-  '@openclaw/fs-safe@0.3.0':
-    resolution: {integrity: sha512-uIBE441CIt1kIURoP9qRGKZ8LkGyfD9ZzeESjwAd29ZPWtghws/5GR3Pjb67jKdcJHP1I6roNXcvnhzAU7lHlA==}
-    engines: {node: '>=20.11'}
+  '@openclaw/ai@2026.7.1':
+    resolution: {integrity: sha512-FsKy5DXSHf4qyN8Huoz/10HZRgoEwLF4uk8UWaCafaIler+q5Fsl51HcrIqIrEe0S38OT7LOaxnR++MOshAlmw==}
+    engines: {node: '>=22.19.0'}
+
+  '@openclaw/fs-safe@0.4.1':
+    resolution: {integrity: sha512-hQi+BxO10KdRFlYUot1syC+hTaUnGeQNdqX5kwkKJig8CFq1tKsYJLPm+zkiiGsSKOprPAquQl/txejEhpKPgg==}
+    engines: {node: '>=22'}
 
   '@openclaw/proxyline@0.3.3':
     resolution: {integrity: sha512-sftHnW69NHQqLjCxBTvQ8f/eQl+peZ5pHCBQtuTWBbeuYRHZ0/GXVTmw/O/YKsShMbqPWhJB0UYtPPdvCUSS8w==}
@@ -3554,6 +3563,10 @@ packages:
   '@opentelemetry/api@1.9.1':
     resolution: {integrity: sha512-gLyJlPHPZYdAk1JENA9LeHejZe1Ti77/pTeFm/nMXmQH/HFZlcS/O2XJB+L8fkbrNSqhdtlvjBVjxwUYanNH5Q==}
     engines: {node: '>=8.0.0'}
+
+  '@opentelemetry/semantic-conventions@1.43.0':
+    resolution: {integrity: sha512-eSYWTm620tTk45EKSedaUL8MFYI8hW164hIXsgIHyxu3VobUB3fFCu5t0hQby6OoWRPsG1KkKUG2M5UadiLiVg==}
+    engines: {node: '>=14'}
 
   '@oxc-project/types@0.130.0':
     resolution: {integrity: sha512-ibD2usx9JRu7f5pu2tMKMI4cpA4NgXJQoYRP4pQ7Pxmn1l6k/53qWtQWZayhYy3X4QZkt90Ot+mJEaeXouio6Q==}
@@ -7030,9 +7043,10 @@ packages:
   classnames@2.5.1:
     resolution: {integrity: sha512-saHYOzhIQs6wy2sVxTM6bUDsQO4F50V9RQ22qBpEdCW+I+/Wmke2HOl6lS6dTpdxVhb88/I6+Hs+438c3lfUow==}
 
-  clawpdf@0.2.0:
-    resolution: {integrity: sha512-Za4HD3CMRHNqOXOOyVJiQLnEuezRZR/oXiBzraTwL5XEQZuBwFxnyC1UzN4AjQWV2JrLN3ItbzfPRGE0gGOVwg==}
+  clawpdf@0.3.0:
+    resolution: {integrity: sha512-41+3AnKk9yek2sm+/9XvUlDTN8Wi+ag7fmxZuqw+ySn4lqaf/fCgLeamqPLiXY4gVbizKEHGoTG/JrIIFNE2rw==}
     engines: {node: '>=20'}
+    hasBin: true
 
   clean-stack@2.2.0:
     resolution: {integrity: sha512-4diC9HaTE+KRAMWhDhrGOECgWZxoevMc5TlkObMqNSsVU62PYzXZ/SMTjzyGAFF1YusgxGcSWTEXBhp0CPwQ1A==}
@@ -7135,9 +7149,9 @@ packages:
     resolution: {integrity: sha512-Vw8qHK3bZM9y/P10u3Vib8o/DdkvA2OtPtZvD871QKjy74Wj1WSKFILMPRPSdUSx5RFK1arlJzEtA4PkFgnbuA==}
     engines: {node: '>=18'}
 
-  commander@14.0.3:
-    resolution: {integrity: sha512-H+y0Jo/T1RZ9qPP4Eh1pkcQcLRglraJaSLoyOtHxu6AapkjWVCy2Sit1QQ4x3Dng8qDlSsZEet7g5Pq06MvTgw==}
-    engines: {node: '>=20'}
+  commander@15.0.0:
+    resolution: {integrity: sha512-z67u4ZhzCL/Tydu1lJARtEZYWbWaN7oYLHbsuzocr6y4N6WZAagG3RQ4FW61V1/0+jImpj293XfrcYnd1qxtPg==}
+    engines: {node: '>=22.12.0'}
 
   commander@2.20.3:
     resolution: {integrity: sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==}
@@ -8661,8 +8675,8 @@ packages:
   graceful-fs@4.2.11:
     resolution: {integrity: sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==}
 
-  grammy@1.43.0:
-    resolution: {integrity: sha512-7dYm06A945mXuIk/5HUlSjeyIYChW8vCEiU2dkOKKqJJzwAWxTkCc91Eqbz7TgODh2rtFFKWI/fekowWHOkmjQ==}
+  grammy@1.44.0:
+    resolution: {integrity: sha512-gGVykS5+c5f1tPV97LuU6IDRMawE2NzpwM9pNz58HQ35IZXDnYL3VOLvNzYognPSeBIOSzQXRu5w96V0aY8y8A==}
     engines: {node: ^12.20.0 || >=14.13.1}
 
   graphql@16.6.0:
@@ -8750,6 +8764,10 @@ packages:
     resolution: {integrity: sha512-2NFaIyNVgJmBs/ecmtGzlmluTFs5cHEWGTdu0t1HBwYzoGXOL5nUQBRMXsXWla5i4KkG//QMzVP88m1+I3fdAQ==}
     engines: {node: '>=16.9.0'}
 
+  hosted-git-info@10.1.1:
+    resolution: {integrity: sha512-DeOnSPAvOndYKfw075gt8yZzQ7S2hNztw34zBTfhIzLhmBTswIBg5/y+pqu/VD5cYWm5goAFTusDmUEmKZ0PEQ==}
+    engines: {node: ^22.22.2 || ^24.15.0 || >=26.0.0}
+
   hosted-git-info@4.1.0:
     resolution: {integrity: sha512-kyCuEOWjJqZuDbRHzL8V93NzQhwIB71oFWSyzVo+KPZI+pnQPPxucdkrOZvkLRnrf5URsQM+IJ09Dw29cRALIA==}
     engines: {node: '>=10'}
@@ -8757,10 +8775,6 @@ packages:
   hosted-git-info@7.0.2:
     resolution: {integrity: sha512-puUZAUKT5m8Zzvs72XWy3HtvVbTWljRE66cP60bxJzAqf2DgICo7lYTY2IHUmLnNpjYvw5bvmoHvPc0QO2a62w==}
     engines: {node: ^16.14.0 || >=18.0.0}
-
-  hosted-git-info@9.0.3:
-    resolution: {integrity: sha512-Hc+ghLoSt6QaYZUv0WBiIvmMDZuZZ7oaDvdH8MbfOO4lOsxdXLEvuC6ePoGs9H1X9oCLyq6+NVN0MKqD+ydxyg==}
-    engines: {node: ^20.17.0 || >=22.9.0}
 
   html-encoding-sniffer@3.0.0:
     resolution: {integrity: sha512-oWv4T4yJ52iKrufjnyZPkrN0CH3QnrUqdB6In1g5Fe1mia8GmF36gnfNySxoZtxD5+NmYw1EElVXiBk93UeskA==}
@@ -8931,10 +8945,6 @@ packages:
   ipaddr.js@1.9.1:
     resolution: {integrity: sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g==}
     engines: {node: '>= 0.10'}
-
-  ipaddr.js@2.4.0:
-    resolution: {integrity: sha512-9VGk3HGanVE6JoZXHiCpnGy5X0jYDnN4EA4lntFPj+1vIWlFhIylq2CrrCOJH9EAhc5CYhq18F2Av2tgoAPsYQ==}
-    engines: {node: '>= 10'}
 
   is-alphabetical@2.0.1:
     resolution: {integrity: sha512-FWyyY60MeTNyeSRpkM2Iry0G9hpr7/9kD40mD/cGQEuilcZYS4okz8SN2Q6rLCJ8gbCt6fN+rC+6tMGS99LaxQ==}
@@ -9634,9 +9644,6 @@ packages:
   linkify-it@5.0.0:
     resolution: {integrity: sha512-5aHCbzQRADcdP+ATqnDuhhJ/MRIqDkZX5pyjFHRRysS8vZ5AbqGEoFIb6pYHPZ+L/OC2Lc+xT8uHVVR5CAK/wQ==}
 
-  linkify-it@5.0.2:
-    resolution: {integrity: sha512-ONTm2jCMAVZjgQa/Fy1kScXsuOoF5NPTsoFBdE1KVIZ2vAh/r9+Bqo+0jINCBYnavTPQZz38QzFTme79ENoN3Q==}
-
   linkifyjs@4.1.1:
     resolution: {integrity: sha512-zFN/CTVmbcVef+WaDXT63dNzzkfRBKT1j464NJQkV7iSgJU0sLBus9W0HBwnXK13/hf168pbrx/V/bjEHOXNHA==}
 
@@ -9786,16 +9793,12 @@ packages:
     resolution: {integrity: sha512-BuU2qnTti9YKgK5N+IeMubp14ZUKUUw7yeJbkjtosvHiP0AZ5c8IAgEMk79D0eC8F23r4Ac/q8cAIFdm2FtyoA==}
     hasBin: true
 
-  markdown-it@14.2.0:
-    resolution: {integrity: sha512-1TGiQiJVRQ3NPmZH6sx5Cfnmg6GQm9jvC1ch4TK511NjSJvjzKLzn5pPfZRNZkRPZP0HqCioSndqH8v2nRaWVQ==}
-    hasBin: true
-
   markdown-table@3.0.4:
     resolution: {integrity: sha512-wiYz4+JrLyb/DqW2hkFJxP7Vd7JuTDm77fvbM8VfEQdmSMqcImWeeRbHwZjBjIFki/VaMK2BhFi7oUUZeM5bqw==}
 
-  marked@15.0.12:
-    resolution: {integrity: sha512-8dD6FusOQSrpv9Z1rdNMdlSgQOIP880DHqnohobOmYLElGEqAL/JvxvuxZO16r4HtjTlfPRDC1hbvxC9dPN2nA==}
-    engines: {node: '>= 18'}
+  marked@18.0.5:
+    resolution: {integrity: sha512-S6GcvALHg6K4ohtu4E7x0a1AqhAjp6cV8KhLSyN9qVapnzJkusVBxZRcIU9AeYsbe6P1hKDusSbEOzGyyuce6w==}
+    engines: {node: '>= 20'}
     hasBin: true
 
   marky@1.2.5:
@@ -10413,21 +10416,29 @@ packages:
     resolution: {integrity: sha512-7x81NCL719oNbsq/3mh+hVrAWmFuEYUqrq/Iw3kUzH8ReypT9QQ0BLoJS7/G9k6N81XjW4qHWtjWwe/9eLy1EQ==}
     engines: {node: '>=12'}
 
-  openai@6.39.0:
-    resolution: {integrity: sha512-O61LIsimY3acVabwvomwFhwrnN36yvHY2quIfy9keEcFytGgWeV35yLHQ6NVMLSBxRpHmcg2yuhCnlu2HT4pLQ==}
-    hasBin: true
+  openai@6.45.0:
+    resolution: {integrity: sha512-5DQVNErssk0afNpTTHUm/qZPU4iKR9OYdNid8Ib4puq4gHNNvGWZht2zY4h9a8JMF949Ik6m8gQutllVPbjdnw==}
     peerDependencies:
+      '@aws-sdk/credential-provider-node': '>=3.972.0 <4'
+      '@smithy/hash-node': '>=4.3.0 <5'
+      '@smithy/signature-v4': '>=5.4.0 <6'
       ws: ^8.18.0
       zod: ^3.25 || ^4.0
     peerDependenciesMeta:
+      '@aws-sdk/credential-provider-node':
+        optional: true
+      '@smithy/hash-node':
+        optional: true
+      '@smithy/signature-v4':
+        optional: true
       ws:
         optional: true
       zod:
         optional: true
 
-  openclaw@2026.5.28:
-    resolution: {integrity: sha512-p7jGN9wzCrqEvHNI6Y7+eh6DWoYDzJ1iQGKTm8xqQ2uQ9/2mY1CCf87WoZeb0+m3eHKSGchlI3tN33fE1lMtEA==}
-    engines: {node: '>=22.19.0'}
+  openclaw@2026.7.1:
+    resolution: {integrity: sha512-ge/Xss99CHAjPL/ikmH/UFoiOrjcxDB4sW3y9mhyCD+dYW3wzV7TKbAVdkrXFgAG2d2BjpJofP97zUZ+umxo8g==}
+    engines: {node: '>=22.22.3 <23 || >=24.15.0 <25 || >=25.9.0'}
     hasBin: true
 
   ora@3.4.0:
@@ -10674,8 +10685,8 @@ packages:
     engines: {node: '>=18'}
     hasBin: true
 
-  playwright-core@1.60.0:
-    resolution: {integrity: sha512-9bW6zvX/m0lEbgTKJ6YppOKx8H3VOPBMOCFh2irXFOT4BbHgrx5hPjwJYLT40Lu+4qtD36qKc/Hn56StUW57IA==}
+  playwright-core@1.61.1:
+    resolution: {integrity: sha512-h7Qlt6m4REp25qvIdvbDtVmD4LqVXfpRxhORv9L0jzETM05p4fuPJ3dKyuSXQxDSbXnmS79HAgi9589lGSpLkg==}
     engines: {node: '>=18'}
     hasBin: true
 
@@ -11001,8 +11012,8 @@ packages:
     resolution: {integrity: sha512-WuyALRjWPDGtt/wzJiadO5AXY+8hZ80hVpe6MyivgraREW751X3SbhRvG3eLKOYN+8VEvqLcf3wdnt44Z4S4SA==}
     engines: {node: '>=10'}
 
-  quickjs-wasi@3.0.0:
-    resolution: {integrity: sha512-X7ouKC4ZVf9bXQ8rsE7+L6TeBbesejAJH61x16xRaGAQGfBHHRcniWgzJZZVtHc8rS9yVsY+Tvk8/usAosg4bg==}
+  quickjs-wasi@3.0.2:
+    resolution: {integrity: sha512-SyfPzlrfz67/kv0SogmQgW4c2I1klkLcbvj9Y2gc1h7+VylmvuGevFljLXibGKajKJKiJV29d4S6FQLA6Sc80A==}
 
   r-json@1.3.1:
     resolution: {integrity: sha512-5nhRFfjVMQdrwKUfUlRpDUCocdKtjSnYZ1R/86mpZDV3MfsZ3dYYNjSGuMX+mPBvFvQBhdzxSqxkuLPLv4uFGg==}
@@ -11014,9 +11025,9 @@ packages:
     resolution: {integrity: sha512-Hrgsx+orqoygnmhFbKaHE6c296J+HTAQXoxEF6gNupROmmGJRoyzfG3ccAveqCBrwr/2yxQ5BVd/GTl5agOwSg==}
     engines: {node: '>= 0.6'}
 
-  rastermill@0.3.0:
-    resolution: {integrity: sha512-4g2i0I7M5sba//lFBh19Wi0hDGw8o+isnt/BtEyqQXIZaYclhcNBwL/Fw/6gDCp7aaLwQHADuUvyHCB0Oat5Vw==}
-    engines: {node: '>=20'}
+  rastermill@0.3.1:
+    resolution: {integrity: sha512-CX4nij6+ZLHYIaojJNfLTr7W+AiH/IPJi6E9Aw1br2///1KZL2KBOHd68rkcLedc47MPvb4hhH+fzYeGFa4A/Q==}
+    engines: {node: '>=22'}
 
   raw-body@2.5.3:
     resolution: {integrity: sha512-s4VSOf6yN0rvbRZGxs8Om5CWj6seneMwK3oDb4lWDH0UPhWcxwOWw5+qk24bxq87szX1ydrwylIOp2uG1ojUpA==}
@@ -12195,12 +12206,8 @@ packages:
     engines: {node: '>=10'}
     deprecated: Old versions of tar are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me
 
-  tar@7.5.13:
-    resolution: {integrity: sha512-tOG/7GyXpFevhXVh8jOPJrmtRpOTsYqUIkVdVooZYJS/z8WhfQUX8RJILmeuJNinGAMSu1veBr4asSHFt5/hng==}
-    engines: {node: '>=18'}
-
-  tar@7.5.15:
-    resolution: {integrity: sha512-dzGK0boVlC4W5QFuQN1EFSl3bIDYsk7Tj40U6eIBnK2k/8ml7TZ5agbI5j5+qnoVcAA+rNtBml8SEiLxZpNqRQ==}
+  tar@7.5.19:
+    resolution: {integrity: sha512-4LeEWl96twnS2Q7Bz4MGqgazLqO+hJN63GZxXoIqh1T3VweYD997gbU1ItNsQafqqXTXd5WFyFdReLtwvRBNiw==}
     engines: {node: '>=18'}
 
   temp-dir@2.0.0:
@@ -12437,8 +12444,8 @@ packages:
     resolution: {integrity: sha512-faYHw0anBbc/kWF3zFTEnxSFOAGUX9GFbOBthvDdLsIlEoWOFOtS0zgCiQYwIskL9iGXZL3kAXD8OoZ4GmMATA==}
     engines: {node: '>= 18'}
 
-  typebox@1.1.38:
-    resolution: {integrity: sha512-pZ0aQPmMmXoUvSbeuWf/Hzsc+avNw/Zd6VeE8CFgkVGWyuHPJvqeJJDeJqLve+K70LvjYIoleGcoJHPT17cWoA==}
+  typebox@1.3.3:
+    resolution: {integrity: sha512-URXGUE31PJDQC+PtRMJeLdF4kmmOdFoVPikPCtV2oOIhUpNpppEdIz7W8bH8cFYPYHdDpaRvqwdegMTmHliudg==}
 
   typed-array-buffer@1.0.3:
     resolution: {integrity: sha512-nAYYwfY3qnzX30IkA6AQZjVbtK6duGontcQm1WSG1MD94YLqK0515GNApXkoxKOWMusVssAHWLh9SeaoefYFGw==}
@@ -12490,8 +12497,8 @@ packages:
   undici-types@7.24.6:
     resolution: {integrity: sha512-WRNW+sJgj5OBN4/0JpHFqtqzhpbnV0GuB+OozA9gCL7a993SmU+1JBZCzLNxYsbMfIeDL+lTsphD5jN5N+n0zg==}
 
-  undici@8.3.0:
-    resolution: {integrity: sha512-TkUDgb6tl7KOGZ+7e8E3d2FYgUQgF6z5YypqjWmixVQSQERFcVrVg0ySADm2LVLRh5ljAaHTCR5Fmz3Q34rB7Q==}
+  undici@8.5.0:
+    resolution: {integrity: sha512-xamtWoB1EshgjpmlXd7GGm2VfdDtw1+rD8uhry8pSNW3If6S8E0m2T2+orSKeZXEn/aPJMviCpDBA65WJt8zhg==}
     engines: {node: '>=22.19.0'}
 
   unicode-canonical-property-names-ecmascript@2.0.0:
@@ -12920,8 +12927,8 @@ packages:
     resolution: {integrity: sha512-d2JWLCivmZYTSIoge9MsgFCZrt571BikcWGYkjC1khllbTeDlGqZ2D8vD8E/lJa8WGWbb7Plm8/XJYV7IJHZZw==}
     engines: {node: '>= 8'}
 
-  web-tree-sitter@0.26.9:
-    resolution: {integrity: sha512-YJwSHANl6XFgeEjB8nitgj0qZYt5gkIesJ4w2srS2wcLB4GUa4xcOkM0YaMsU6WNR53YVIkDSY7Ej4pf3IXtCA==}
+  web-tree-sitter@0.26.10:
+    resolution: {integrity: sha512-vengBGYS7FpAerkR3o04oBL4L8MkVmjawK50AFBu7v0HZBkmF9ZavPGKoXLSSmRhp7T/YgsJ7joAS3yAxHPEqQ==}
 
   web-vitals@4.2.4:
     resolution: {integrity: sha512-r4DIlprAGwJ7YM11VZp4R884m0Vmgr6EAKe3P+kO0PPj3Unqyvv59rczf6UiGcb9Z8QxZVcqKNwv/g0WNdWwsw==}
@@ -13310,11 +13317,11 @@ snapshots:
 
   '@adobe/css-tools@4.0.1': {}
 
-  '@agentclientprotocol/sdk@0.22.1(zod@4.4.3)':
+  '@agentclientprotocol/sdk@1.1.0(zod@4.4.3)':
     dependencies:
       zod: 4.4.3
 
-  '@anthropic-ai/sdk@0.98.0(zod@4.4.3)':
+  '@anthropic-ai/sdk@0.109.1(zod@4.4.3)':
     dependencies:
       json-schema-to-ts: 3.1.1
       standardwebhooks: 1.0.0
@@ -14880,14 +14887,14 @@ snapshots:
 
   '@borewit/text-codec@0.2.2': {}
 
-  '@clack/core@1.3.1':
+  '@clack/core@1.4.2':
     dependencies:
       fast-wrap-ansi: 0.2.2
       sisteransi: 1.0.5
 
-  '@clack/prompts@1.4.0':
+  '@clack/prompts@1.6.0':
     dependencies:
-      '@clack/core': 1.3.1
+      '@clack/core': 1.4.2
       fast-string-width: 3.0.2
       fast-wrap-ansi: 0.2.2
       sisteransi: 1.0.5
@@ -14945,10 +14952,10 @@ snapshots:
 
   '@drizzle-team/brocli@0.10.2': {}
 
-  '@earendil-works/pi-tui@0.76.0':
+  '@earendil-works/pi-tui@0.80.3':
     dependencies:
       get-east-asian-width: 1.6.0
-      marked: 15.0.12
+      marked: 18.0.5
 
   '@egjs/hammerjs@2.0.17':
     dependencies:
@@ -15960,7 +15967,7 @@ snapshots:
       react: 19.2.3
       react-native: 0.86.0(@react-native/jest-preset@0.86.0(@babel/core@7.29.0)(react@19.2.3))(@react-native/metro-config@0.86.0)(@types/react@19.2.17)(react@19.2.3)
 
-  '@google/genai@2.6.0(@modelcontextprotocol/sdk@1.29.0(zod@4.4.3))':
+  '@google/genai@2.10.0(@modelcontextprotocol/sdk@1.29.0(zod@4.4.3))':
     dependencies:
       google-auth-library: 10.7.0
       p-retry: 4.6.2
@@ -15991,17 +15998,17 @@ snapshots:
       react: 19.2.3
       react-native: 0.86.0(@react-native/jest-preset@0.86.0(@babel/core@7.29.0)(react@19.2.3))(@react-native/metro-config@0.86.0)(@types/react@19.2.17)(react@19.2.3)
 
-  '@grammyjs/runner@2.0.3(grammy@1.43.0(encoding@0.1.13))':
+  '@grammyjs/runner@2.0.3(grammy@1.44.0(encoding@0.1.13))':
     dependencies:
       abort-controller: 3.0.0
-      grammy: 1.43.0(encoding@0.1.13)
+      grammy: 1.44.0(encoding@0.1.13)
 
-  '@grammyjs/transformer-throttler@1.2.1(grammy@1.43.0(encoding@0.1.13))':
+  '@grammyjs/transformer-throttler@1.2.1(grammy@1.44.0(encoding@0.1.13))':
     dependencies:
       bottleneck: 2.19.5
-      grammy: 1.43.0(encoding@0.1.13)
+      grammy: 1.44.0(encoding@0.1.13)
 
-  '@grammyjs/types@3.27.3': {}
+  '@grammyjs/types@3.28.0': {}
 
   '@grpc/grpc-js@1.9.15':
     dependencies:
@@ -16304,11 +16311,14 @@ snapshots:
 
   '@microsoft/fetch-event-source@2.0.1': {}
 
-  '@mistralai/mistralai@2.2.5':
+  '@mistralai/mistralai@2.4.0(@opentelemetry/api@1.9.1)':
     dependencies:
+      '@opentelemetry/semantic-conventions': 1.43.0
       ws: 8.21.0
       zod: 4.4.3
       zod-to-json-schema: 3.25.2(zod@4.4.3)
+    optionalDependencies:
+      '@opentelemetry/api': 1.9.1
     transitivePeerDependencies:
       - bufferutil
       - utf-8-validate
@@ -16498,16 +16508,38 @@ snapshots:
 
   '@open-draft/until@1.0.3': {}
 
-  '@openclaw/fs-safe@0.3.0':
+  '@openclaw/ai@2026.7.1(@modelcontextprotocol/sdk@1.29.0(zod@4.4.3))(@opentelemetry/api@1.9.1)(ws@8.21.0)(zod@4.4.3)':
+    dependencies:
+      '@anthropic-ai/sdk': 0.109.1(zod@4.4.3)
+      '@google/genai': 2.10.0(@modelcontextprotocol/sdk@1.29.0(zod@4.4.3))
+      '@mistralai/mistralai': 2.4.0(@opentelemetry/api@1.9.1)
+      openai: 6.45.0(ws@8.21.0)(zod@4.4.3)
+      partial-json: 0.1.7
+      typebox: 1.3.3
+    transitivePeerDependencies:
+      - '@aws-sdk/credential-provider-node'
+      - '@modelcontextprotocol/sdk'
+      - '@opentelemetry/api'
+      - '@smithy/hash-node'
+      - '@smithy/signature-v4'
+      - bufferutil
+      - supports-color
+      - utf-8-validate
+      - ws
+      - zod
+
+  '@openclaw/fs-safe@0.4.1':
     optionalDependencies:
       jszip: 3.10.1
-      tar: 7.5.13
+      tar: 7.5.19
 
-  '@openclaw/proxyline@0.3.3(undici@8.3.0)':
+  '@openclaw/proxyline@0.3.3(undici@8.5.0)':
     dependencies:
-      undici: 8.3.0
+      undici: 8.5.0
 
   '@opentelemetry/api@1.9.1': {}
+
+  '@opentelemetry/semantic-conventions@1.43.0': {}
 
   '@oxc-project/types@0.130.0': {}
 
@@ -20672,7 +20704,7 @@ snapshots:
 
   classnames@2.5.1: {}
 
-  clawpdf@0.2.0: {}
+  clawpdf@0.3.0: {}
 
   clean-stack@2.2.0: {}
 
@@ -20775,7 +20807,7 @@ snapshots:
 
   commander@12.1.0: {}
 
-  commander@14.0.3: {}
+  commander@15.0.0: {}
 
   commander@2.20.3: {}
 
@@ -22549,9 +22581,9 @@ snapshots:
 
   graceful-fs@4.2.11: {}
 
-  grammy@1.43.0(encoding@0.1.13):
+  grammy@1.44.0(encoding@0.1.13):
     dependencies:
-      '@grammyjs/types': 3.27.3
+      '@grammyjs/types': 3.28.0
       abort-controller: 3.0.0
       debug: 4.4.3
       node-fetch: 2.7.0(encoding@0.1.13)
@@ -22635,6 +22667,10 @@ snapshots:
 
   hono@4.12.25: {}
 
+  hosted-git-info@10.1.1:
+    dependencies:
+      lru-cache: 11.2.5
+
   hosted-git-info@4.1.0:
     dependencies:
       lru-cache: 6.0.0
@@ -22642,10 +22678,6 @@ snapshots:
   hosted-git-info@7.0.2:
     dependencies:
       lru-cache: 10.4.3
-
-  hosted-git-info@9.0.3:
-    dependencies:
-      lru-cache: 11.2.5
 
   html-encoding-sniffer@3.0.0:
     dependencies:
@@ -22841,8 +22873,6 @@ snapshots:
   ip-address@10.2.0: {}
 
   ipaddr.js@1.9.1: {}
-
-  ipaddr.js@2.4.0: {}
 
   is-alphabetical@2.0.1: {}
 
@@ -23737,10 +23767,6 @@ snapshots:
     dependencies:
       uc.micro: 2.1.0
 
-  linkify-it@5.0.2:
-    dependencies:
-      uc.micro: 2.1.0
-
   linkifyjs@4.1.1: {}
 
   lint-staged@15.2.0:
@@ -23912,18 +23938,9 @@ snapshots:
       punycode.js: 2.3.1
       uc.micro: 2.1.0
 
-  markdown-it@14.2.0:
-    dependencies:
-      argparse: 2.0.1
-      entities: 4.5.0
-      linkify-it: 5.0.2
-      mdurl: 2.0.0
-      punycode.js: 2.3.1
-      uc.micro: 2.1.0
-
   markdown-table@3.0.4: {}
 
-  marked@15.0.12: {}
+  marked@18.0.5: {}
 
   marky@1.2.5: {}
 
@@ -24784,75 +24801,77 @@ snapshots:
       is-docker: 2.2.1
       is-wsl: 2.2.0
 
-  openai@6.39.0(ws@8.21.0)(zod@4.4.3):
+  openai@6.45.0(ws@8.21.0)(zod@4.4.3):
     optionalDependencies:
       ws: 8.21.0
       zod: 4.4.3
 
-  openclaw@2026.5.28(encoding@0.1.13):
+  openclaw@2026.7.1(@opentelemetry/api@1.9.1)(encoding@0.1.13):
     dependencies:
-      '@agentclientprotocol/sdk': 0.22.1(zod@4.4.3)
-      '@anthropic-ai/sdk': 0.98.0(zod@4.4.3)
-      '@clack/core': 1.3.1
-      '@clack/prompts': 1.4.0
-      '@earendil-works/pi-tui': 0.76.0
-      '@google/genai': 2.6.0(@modelcontextprotocol/sdk@1.29.0(zod@4.4.3))
-      '@grammyjs/runner': 2.0.3(grammy@1.43.0(encoding@0.1.13))
-      '@grammyjs/transformer-throttler': 1.2.1(grammy@1.43.0(encoding@0.1.13))
+      '@agentclientprotocol/sdk': 1.1.0(zod@4.4.3)
+      '@anthropic-ai/sdk': 0.109.1(zod@4.4.3)
+      '@clack/core': 1.4.2
+      '@clack/prompts': 1.6.0
+      '@earendil-works/pi-tui': 0.80.3
+      '@google/genai': 2.10.0(@modelcontextprotocol/sdk@1.29.0(zod@4.4.3))
+      '@grammyjs/runner': 2.0.3(grammy@1.44.0(encoding@0.1.13))
+      '@grammyjs/transformer-throttler': 1.2.1(grammy@1.44.0(encoding@0.1.13))
       '@homebridge/ciao': 1.3.9
       '@lydell/node-pty': 1.2.0-beta.12
-      '@mistralai/mistralai': 2.2.5
+      '@mistralai/mistralai': 2.4.0(@opentelemetry/api@1.9.1)
       '@modelcontextprotocol/sdk': 1.29.0(zod@4.4.3)
       '@mozilla/readability': 0.6.0
-      '@openclaw/fs-safe': 0.3.0
-      '@openclaw/proxyline': 0.3.3(undici@8.3.0)
+      '@openclaw/ai': 2026.7.1(@modelcontextprotocol/sdk@1.29.0(zod@4.4.3))(@opentelemetry/api@1.9.1)(ws@8.21.0)(zod@4.4.3)
+      '@openclaw/fs-safe': 0.4.1
+      '@openclaw/proxyline': 0.3.3(undici@8.5.0)
       '@silvia-odwyer/photon-node': 0.3.4
       chalk: 5.6.2
       chokidar: 5.0.0
-      clawpdf: 0.2.0
-      commander: 14.0.3
+      clawpdf: 0.3.0
+      commander: 15.0.0
       croner: 10.0.1
-      cross-spawn: 7.0.6
       diff: 9.0.0
       dotenv: 17.4.2
       express: 5.2.1
       file-type: 22.0.1
       glob: 13.0.6
-      grammy: 1.43.0(encoding@0.1.13)
+      grammy: 1.44.0(encoding@0.1.13)
       highlight.js: 11.11.1
-      hosted-git-info: 9.0.3
+      hosted-git-info: 10.1.1
       ignore: 7.0.5
-      ipaddr.js: 2.4.0
       jiti: 2.7.0
       json5: 2.2.3
       jszip: 3.10.1
       kysely: 0.29.2
       linkedom: 0.18.12
-      markdown-it: 14.2.0
       minimatch: 10.2.5
       node-edge-tts: 1.2.10
-      openai: 6.39.0(ws@8.21.0)(zod@4.4.3)
+      openai: 6.45.0(ws@8.21.0)(zod@4.4.3)
       partial-json: 0.1.7
-      playwright-core: 1.60.0
+      playwright-core: 1.61.1
       proper-lockfile: 4.1.2
       qrcode: 1.5.4
-      quickjs-wasi: 3.0.0
-      rastermill: 0.3.0
-      tar: 7.5.15
+      quickjs-wasi: 3.0.2
+      rastermill: 0.3.1
+      tar: 7.5.19
       tree-sitter-bash: 0.25.1
       tslog: 4.10.2
-      typebox: 1.1.38
+      typebox: 1.3.3
       typescript: 5.9.3
-      undici: 8.3.0
+      undici: 8.5.0
       web-push: 3.6.7
-      web-tree-sitter: 0.26.9
+      web-tree-sitter: 0.26.10
       ws: 8.21.0
       yaml: 2.9.0
       zod: 4.4.3
     optionalDependencies:
       sqlite-vec: 0.1.9
     transitivePeerDependencies:
+      - '@aws-sdk/credential-provider-node'
       - '@cfworker/json-schema'
+      - '@opentelemetry/api'
+      - '@smithy/hash-node'
+      - '@smithy/signature-v4'
       - bufferutil
       - canvas
       - encoding
@@ -25127,7 +25146,7 @@ snapshots:
 
   playwright-core@1.52.0: {}
 
-  playwright-core@1.60.0: {}
+  playwright-core@1.61.1: {}
 
   playwright@1.52.0:
     dependencies:
@@ -25478,7 +25497,7 @@ snapshots:
 
   quick-lru@5.1.1: {}
 
-  quickjs-wasi@3.0.0: {}
+  quickjs-wasi@3.0.2: {}
 
   r-json@1.3.1:
     dependencies:
@@ -25490,7 +25509,7 @@ snapshots:
 
   range-parser@1.2.1: {}
 
-  rastermill@0.3.0:
+  rastermill@0.3.1:
     dependencies:
       '@silvia-odwyer/photon-node': 0.3.4
 
@@ -26975,16 +26994,7 @@ snapshots:
       mkdirp: 1.0.4
       yallist: 4.0.0
 
-  tar@7.5.13:
-    dependencies:
-      '@isaacs/fs-minipass': 4.0.1
-      chownr: 3.0.0
-      minipass: 7.1.3
-      minizlib: 3.1.0
-      yallist: 5.0.0
-    optional: true
-
-  tar@7.5.15:
+  tar@7.5.19:
     dependencies:
       '@isaacs/fs-minipass': 4.0.1
       chownr: 3.0.0
@@ -27203,7 +27213,7 @@ snapshots:
       media-typer: 1.1.0
       mime-types: 3.0.2
 
-  typebox@1.1.38: {}
+  typebox@1.3.3: {}
 
   typed-array-buffer@1.0.3:
     dependencies:
@@ -27263,7 +27273,7 @@ snapshots:
 
   undici-types@7.24.6: {}
 
-  undici@8.3.0: {}
+  undici@8.5.0: {}
 
   unicode-canonical-property-names-ecmascript@2.0.0: {}
 
@@ -27692,7 +27702,7 @@ snapshots:
 
   web-streams-polyfill@3.3.3: {}
 
-  web-tree-sitter@0.26.9: {}
+  web-tree-sitter@0.26.10: {}
 
   web-vitals@4.2.4: {}
 


### PR DESCRIPTION
this is so OpenClaw tool approvals are visible and actionable inside tlon instead of requiring you to do approvals inside the core OC ui's. this adds owner-only A2UI approval cards with `/approve` buttons, approval-result replies, presentation/blob transport, and 2026.7.1 integration (this breaks the tests)