### PR TITLE
polish onboarding handoff and note titles

### DIFF
--- a/packages/app/features/top/agentOnboardingFirstEntry.test.ts
+++ b/packages/app/features/top/agentOnboardingFirstEntry.test.ts
@@ -3,6 +3,7 @@ import { appendToPostBlob } from '@tloncorp/shared/logic';
 import { describe, expect, it } from 'vitest';
 
 import {
+  getAgentOnboardingFirstEntryPendingAt,
   hasAgentOnboardingFirstEntry,
   hasAgentOnboardingFirstEntryFailed,
   isAgentOnboardingFirstEntryNote,
@@ -13,6 +14,7 @@ function markerPost(key: string, authorId = '~bot'): db.Post {
   return {
     id: key,
     authorId,
+    receivedAt: 100,
     blob: appendToPostBlob(undefined, {
       type: 'tlon-agent-post-marker',
       version: 1,
@@ -62,6 +64,27 @@ describe('hasAgentOnboardingFirstEntry', () => {
         '~bot'
       )
     ).toBe(false);
+  });
+
+  it('uses the bot pending marker as the start of the first-entry wait', () => {
+    expect(
+      getAgentOnboardingFirstEntryPendingAt(
+        [
+          markerPost('first-entry-pending', '~other'),
+          {
+            ...markerPost('first-entry-pending'),
+            receivedAt: 200,
+          },
+        ],
+        '~bot'
+      )
+    ).toBe(200);
+    expect(
+      getAgentOnboardingFirstEntryPendingAt(
+        [markerPost('first-entry-ping')],
+        '~bot'
+      )
+    ).toBeUndefined();
   });
 
   it('matches only the note cited by the first-entry reveal', () => {

--- a/packages/app/features/top/agentOnboardingFirstEntry.ts
+++ b/packages/app/features/top/agentOnboardingFirstEntry.ts
@@ -5,6 +5,8 @@ import {
 } from '@tloncorp/api';
 import * as db from '@tloncorp/shared/db';
 
+const AGENT_ONBOARDING_FIRST_ENTRY_PENDING_MARKER = 'first-entry-pending';
+
 function hasMarker(
   posts: db.Post[] | null | undefined,
   agentShipId: string | null | undefined,
@@ -38,6 +40,28 @@ export function hasAgentOnboardingFirstEntryFailed(
     agentShipId,
     AGENT_ONBOARDING_FIRST_ENTRY_FAILED_MARKER
   );
+}
+
+/** The pending post is transcript proof that the bot started the first run. */
+export function getAgentOnboardingFirstEntryPendingAt(
+  posts: db.Post[] | null | undefined,
+  agentShipId: string | null | undefined
+): number | undefined {
+  if (!agentShipId) return undefined;
+
+  let latest: number | undefined;
+  for (const post of posts ?? []) {
+    if (
+      post.authorId !== agentShipId ||
+      findPostBlobEntry(post.blob, 'tlon-agent-post-marker')?.key !==
+        AGENT_ONBOARDING_FIRST_ENTRY_PENDING_MARKER
+    ) {
+      continue;
+    }
+    latest =
+      latest == null ? post.receivedAt : Math.max(latest, post.receivedAt);
+  }
+  return latest;
 }
 
 /** Match the opened note to the cite carried by the authenticated reveal. */

--- a/packages/app/features/top/useAgentOnboardingFirstEntry.ts
+++ b/packages/app/features/top/useAgentOnboardingFirstEntry.ts
@@ -3,6 +3,7 @@ import * as store from '@tloncorp/shared/store';
 import { useEffect, useMemo, useState } from 'react';
 
 import {
+  getAgentOnboardingFirstEntryPendingAt,
   hasAgentOnboardingFirstEntry,
   hasAgentOnboardingFirstEntryFailed,
 } from './agentOnboardingFirstEntry';
@@ -44,20 +45,25 @@ export function useAgentOnboardingFirstEntry({
     (durableSettlement !== null &&
       durableSettlement.agentShipId === agentShipId &&
       durableSettlement.channelId === channelId);
+  const renderedPendingAt = useMemo(
+    () => getAgentOnboardingFirstEntryPendingAt(posts, agentShipId),
+    [agentShipId, posts]
+  );
+  const firstEntryStartedAt = provisionAcknowledgedAt ?? renderedPendingAt;
+  const firstEntryActive = awaitingFirstEntry || renderedPendingAt != null;
   const [indicatorExpired, setIndicatorExpired] = useState(false);
 
   useEffect(() => {
     setIndicatorExpired(false);
-    if (!awaitingFirstEntry || settled || !provisionAcknowledgedAt) return;
-    const remainingMs =
-      REFRESH_TIMEOUT_MS - (Date.now() - provisionAcknowledgedAt);
+    if (!firstEntryActive || settled || !firstEntryStartedAt) return;
+    const remainingMs = REFRESH_TIMEOUT_MS - (Date.now() - firstEntryStartedAt);
     if (remainingMs <= 0) {
       setIndicatorExpired(true);
       return;
     }
     const timeout = setTimeout(() => setIndicatorExpired(true), remainingMs);
     return () => clearTimeout(timeout);
-  }, [awaitingFirstEntry, provisionAcknowledgedAt, groupId, settled]);
+  }, [firstEntryActive, firstEntryStartedAt, groupId, settled]);
 
   useEffect(() => {
     if (!groupId || !settled) return;
@@ -70,9 +76,9 @@ export function useAgentOnboardingFirstEntry({
   }, [groupId, provisionId, settled]);
 
   useEffect(() => {
-    if (!isFocused || !awaitingFirstEntry || settled) return;
-    const acknowledgedAt = provisionAcknowledgedAt ?? Date.now();
-    const refreshDeadline = acknowledgedAt + REFRESH_TIMEOUT_MS;
+    if (!isFocused || !firstEntryActive || settled) return;
+    const refreshDeadline =
+      (firstEntryStartedAt ?? Date.now()) + REFRESH_TIMEOUT_MS;
 
     let cancelled = false;
     let refreshInFlight = false;
@@ -123,19 +129,19 @@ export function useAgentOnboardingFirstEntry({
     };
   }, [
     agentShipId,
-    awaitingFirstEntry,
     channelId,
+    firstEntryActive,
+    firstEntryStartedAt,
     isFocused,
-    provisionAcknowledgedAt,
     settled,
   ]);
 
   const withinTimeout = Boolean(
-    provisionAcknowledgedAt &&
-    Date.now() - provisionAcknowledgedAt < REFRESH_TIMEOUT_MS &&
+    firstEntryStartedAt &&
+    Date.now() - firstEntryStartedAt < REFRESH_TIMEOUT_MS &&
     !indicatorExpired
   );
-  return awaitingFirstEntry && !settled && withinTimeout
+  return firstEntryActive && !settled && withinTimeout
     ? 'Writing your first entry…'
     : undefined;
 }

--- a/packages/app/fixtures/AgentOnboarding.fixture.tsx
+++ b/packages/app/fixtures/AgentOnboarding.fixture.tsx
@@ -17,6 +17,8 @@ import {
   DraftInputContextProvider,
 } from '../ui/components/draftInputs/shared';
 import { ChannelProvider } from '../ui/contexts/channel';
+import { TLAWN_HOME_GROUP_WELCOME_MESSAGE } from '../ui/components/Channel/postVisibility';
+import { ChannelFixture } from './Channel.fixture';
 import { FixtureWrapper } from './FixtureWrapper';
 import { makePost, verse } from './contentHelpers';
 import {
@@ -29,6 +31,7 @@ import {
 // making product copy part of the generic API package. The coordinator tests
 // are authoritative for the actual emitted surfaces.
 const AGENT_ONBOARDING_GROUP_INTRO =
+  `${TLAWN_HOME_GROUP_WELCOME_MESSAGE}\n\n` +
   'I can keep you informed, help you learn, or follow a ' +
   'question over time.';
 const AGENT_ONBOARDING_PURPOSE_PROMPT = 'What can I help you with?';
@@ -184,7 +187,7 @@ const purposePicker = makeA2UI('onboarding-purpose-fixture', [
   {
     id: 'prompt',
     component: 'Text',
-    text: AGENT_ONBOARDING_PURPOSE_PROMPT,
+    text: `${AGENT_ONBOARDING_GROUP_INTRO}\n\n${AGENT_ONBOARDING_PURPOSE_PROMPT}`,
   },
   {
     id: 'choices',
@@ -363,17 +366,13 @@ function transcriptPost({
 
 const transcript = [
   transcriptPost({
-    id: 'onboarding-01-intro',
+    id: 'onboarding-01-purpose',
     author: tlonbot,
-    text: AGENT_ONBOARDING_GROUP_INTRO,
-    minute: 1,
-  }),
-  transcriptPost({
-    id: 'onboarding-02-purpose',
-    author: tlonbot,
-    text: `${AGENT_ONBOARDING_PURPOSE_PROMPT} Reply “A daily digest”, “Learn something”, or “Research”.`,
+    text:
+      `${AGENT_ONBOARDING_GROUP_INTRO}\n\n` +
+      `${AGENT_ONBOARDING_PURPOSE_PROMPT} Reply “A daily digest”, “Learn something”, or “Research”.`,
     a2ui: purposePicker,
-    minute: 2,
+    minute: 1,
   }),
   transcriptPost({
     id: 'onboarding-03-purpose-reply',
@@ -452,6 +451,13 @@ const transcript = [
     minute: 14,
   }),
 ];
+
+const provisionedWelcomePost = transcriptPost({
+  id: 'provisioned-tlawn-welcome',
+  author: tlonbot,
+  text: TLAWN_HOME_GROUP_WELCOME_MESSAGE,
+  minute: 0,
+});
 
 function OnboardingDraftProvider({ children }: PropsWithChildren) {
   const [shouldBlur, setShouldBlur] = useState(false);
@@ -567,6 +573,23 @@ function OnboardingTranscript({
   );
 }
 
+function OnboardingConversation({ through = 3 }: { through?: number }) {
+  return (
+    <ChannelFixture
+      theme="light"
+      passedProps={() => ({
+        channel: homeChannel,
+        group: homeGroup,
+        posts: [
+          provisionedWelcomePost,
+          ...transcript.slice(0, through),
+        ].reverse(),
+        suppressAnimatedSendScroll: true,
+      })}
+    />
+  );
+}
+
 function McpServicesPreview() {
   return (
     <FixtureWrapper fillHeight fillWidth safeArea verticalAlign="top">
@@ -597,9 +620,11 @@ function McpServicesPreview() {
 }
 
 export default {
-  'Durable purpose selection': <OnboardingTranscript through={2} />,
-  'Durable topic selection': <OnboardingTranscript through={4} />,
-  'Completed topic selection': <OnboardingTranscript through={5} />,
+  'Durable purpose selection': <OnboardingTranscript through={1} />,
+  'Durable topic selection': <OnboardingTranscript through={3} />,
+  'Conversation combined opening': <OnboardingConversation through={1} />,
+  'Conversation topic selection': <OnboardingConversation />,
+  'Completed topic selection': <OnboardingTranscript through={4} />,
   'Durable completed conversation': <OnboardingTranscript />,
   'MCP services menu': <McpServicesPreview />,
 };

--- a/packages/app/fixtures/AgentOnboarding.fixture.tsx
+++ b/packages/app/fixtures/AgentOnboarding.fixture.tsx
@@ -249,7 +249,7 @@ const acknowledgement =
   'digest in Updates, this group’s notebook. After this first entry, new ones ' +
   'arrive at 8:00 AM.';
 const firstEntryPending =
-  'I’m writing the first entry now. You’re all set—feel free to explore while I work.';
+  'I’ll be back in a few seconds with your tailored post.';
 const firstEntryReady =
   'Your first entry is ready in Updates, this group’s notebook. That notebook ' +
   'is where everything I write for you lands; this chat is for talking to me.';

--- a/packages/app/fixtures/NotesChannel.fixture.tsx
+++ b/packages/app/fixtures/NotesChannel.fixture.tsx
@@ -83,6 +83,12 @@ const notes = [
     'Meeting notes',
     'A second root note so the list has mixed root and nested content.'
   ),
+  makeNote(
+    8,
+    1,
+    'A long note title that should wrap onto the next line instead of getting cut off on narrow screens',
+    'Long note title fixture body.'
+  ),
 ];
 const emptyFolders = [folders[0]];
 const emptyNotes: db.NotesNote[] = [];
@@ -443,6 +449,7 @@ export default {
   'Contents List': <NotebookContentsListFixture />,
   'Folder Contents': <NotesTreeFixture />,
   'Editor Header': <NotesEditorFixture />,
+  'Long Title': <NotesEditorFixture noteId={8} />,
   'Table Preview': <NotesEditorFixture noteId={5} />,
   'Saving Header': <NotesEditorFixture saving />,
 };

--- a/packages/app/ui/components/Channel/PostList/PostList.tsx
+++ b/packages/app/ui/components/Channel/PostList/PostList.tsx
@@ -604,6 +604,10 @@ const ConversationPostListAttempt = React.forwardRef<
           Platform.OS === 'ios' ? 'never' : undefined
         }
         keyboardLiftBehavior="always"
+        // Android already resizes the window for the keyboard. Applying the
+        // list's keyboard lift as well double-counts that height and makes an
+        // end-anchor land below the last message when a post is sent.
+        freeze={Platform.OS === 'android'}
         keyboardOffset={insets.bottom}
         scrollIndicatorInsets={{ top: 0, bottom: insets.bottom }}
         automaticallyAdjustsScrollIndicatorInsets={false}

--- a/packages/app/ui/components/Channel/PostList/PostList.tsx
+++ b/packages/app/ui/components/Channel/PostList/PostList.tsx
@@ -6,6 +6,7 @@ import { Platform } from 'react-native';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
 
 import {
+  useConversationScrollEndAnchor,
   useConversationScrollViewNativeID,
   useScrollDirectionTracker,
 } from '../../../contexts/scroll';
@@ -482,6 +483,32 @@ const ConversationPostListAttempt = React.forwardRef<
     // change. React Native onScroll can retain an intermediate value while the
     // initial anchor settles, briefly showing the scroll-to-bottom control.
     const isNearEnd = useLegendListIsNearEnd(listRef);
+    const conversationScrollEndAnchor = useConversationScrollEndAnchor();
+    const shouldRestoreEndAnchorRef = React.useRef(false);
+    const endAnchorHandler = React.useMemo(
+      () => ({
+        capture: () => {
+          shouldRestoreEndAnchorRef.current =
+            listRef.current?.getState().isNearEnd ?? false;
+        },
+        restore: () => {
+          if (!shouldRestoreEndAnchorRef.current) {
+            return;
+          }
+          shouldRestoreEndAnchorRef.current = false;
+          runImperativeScroll(() =>
+            listRef.current?.scrollToEnd({ animated: false })
+          );
+        },
+      }),
+      []
+    );
+    React.useLayoutEffect(() => {
+      if (!conversationScrollEndAnchor) {
+        return;
+      }
+      return conversationScrollEndAnchor.register(endAnchorHandler);
+    }, [conversationScrollEndAnchor, endAnchorHandler]);
     // The list is hidden while its initial anchor settles, so do not publish
     // transient geometry that could show external scroll chrome first. Until
     // the first user-driven navigation, LegendList's settled state also guards

--- a/packages/app/ui/components/Channel/Scroller.tsx
+++ b/packages/app/ui/components/Channel/Scroller.tsx
@@ -257,8 +257,11 @@ const Scroller = forwardRef(
     const theme = useTheme();
 
     const visiblePosts = useMemo(
-      () => posts?.filter((post) => isVisibleChannelPost(post, currentUserId)),
-      [currentUserId, posts]
+      () =>
+        posts?.filter((post) =>
+          isVisibleChannelPost(post, currentUserId, channel.id)
+        ),
+      [channel.id, currentUserId, posts]
     );
 
     const postsWithNeighbors: PostWithNeighbors[] | undefined = useMemo(

--- a/packages/app/ui/components/Channel/postVisibility.test.ts
+++ b/packages/app/ui/components/Channel/postVisibility.test.ts
@@ -9,6 +9,7 @@ import {
   isAgentOnboardingFirstGroupRequestPost,
   isAgentOnboardingOrientationCompletePost,
   isVisibleChannelPost,
+  TLAWN_HOME_GROUP_WELCOME_MESSAGE,
 } from './postVisibility';
 
 describe('isVisibleChannelPost', () => {
@@ -76,6 +77,49 @@ describe('isVisibleChannelPost', () => {
           }),
         },
         '~ten'
+      )
+    ).toBe(true);
+  });
+
+  it('hides the provisioning welcome only in the bot home group', () => {
+    const welcome = {
+      authorId: '~bot',
+      blob: null,
+      isBot: true,
+      textContent: TLAWN_HOME_GROUP_WELCOME_MESSAGE,
+    };
+
+    expect(
+      isVisibleChannelPost(welcome, '~ten', 'chat/~ten/home-group-chat')
+    ).toBe(false);
+    expect(isVisibleChannelPost(welcome, '~ten', 'chat/~ten/elsewhere')).toBe(
+      true
+    );
+  });
+
+  it('keeps user-authored and combined onboarding welcomes visible', () => {
+    const channelId = 'chat/~ten/home-group-chat';
+    expect(
+      isVisibleChannelPost(
+        {
+          authorId: '~ten',
+          blob: null,
+          textContent: TLAWN_HOME_GROUP_WELCOME_MESSAGE,
+        },
+        '~ten',
+        channelId
+      )
+    ).toBe(true);
+    expect(
+      isVisibleChannelPost(
+        {
+          authorId: '~bot',
+          blob: null,
+          isBot: true,
+          textContent: `${TLAWN_HOME_GROUP_WELCOME_MESSAGE}\n\nWhat can I help you with?`,
+        },
+        '~ten',
+        channelId
       )
     ).toBe(true);
   });

--- a/packages/app/ui/components/Channel/postVisibility.ts
+++ b/packages/app/ui/components/Channel/postVisibility.ts
@@ -1,9 +1,18 @@
 import * as db from '@tloncorp/shared/db';
+import { isMoonOfUser } from '@tloncorp/api/client/apiUtils';
+import { isBotHomeGroupChatChannel } from '@tloncorp/api/client/wayfinding';
 import {
   findPostBlobEntry,
   parsePostBlob,
   postHasBlobEntry,
 } from '@tloncorp/api';
+
+// Provisioned by ylem before the conversational onboarding begins. Keep the
+// exact full copy here so a later bot message that builds on it remains visible.
+export const TLAWN_HOME_GROUP_WELCOME_MESSAGE =
+  'Welcome! This is your private group with me, your Tlonbot. You can @ me ' +
+  'here anytime and I will respond. Invite some friends, and they can @ me ' +
+  'too—we can all chat together.';
 
 /**
  * Typed coordinator requests are durable transport receipts, not chat copy.
@@ -11,11 +20,20 @@ import {
  * from the presented timeline.
  */
 export function isVisibleChannelPost(
-  post: Pick<db.Post, 'blob' | 'authorId'> & {
+  post: Pick<db.Post, 'blob' | 'authorId' | 'isBot' | 'textContent'> & {
     deliveryStatus?: db.Post['deliveryStatus'];
   },
-  currentUserId: string
+  currentUserId: string,
+  channelId?: string
 ): boolean {
+  if (
+    channelId &&
+    isBotHomeGroupChatChannel(currentUserId, channelId) &&
+    (post.isBot === true || isMoonOfUser(post.authorId, currentUserId)) &&
+    post.textContent?.trim() === TLAWN_HOME_GROUP_WELCOME_MESSAGE
+  ) {
+    return false;
+  }
   if (!post.blob) return true;
   if (post.authorId !== currentUserId) return true;
   if (post.deliveryStatus === 'failed') return true;

--- a/packages/app/ui/components/NotesChannel/NotesNoteDetail.tsx
+++ b/packages/app/ui/components/NotesChannel/NotesNoteDetail.tsx
@@ -29,7 +29,6 @@ import {
   NativeSyntheticEvent,
 } from 'react-native';
 import {
-  Input,
   ScrollView,
   TextArea,
   XStack,
@@ -1675,24 +1674,18 @@ export function NotesNoteDetail({
             ) : null}
             <XStack alignItems="center" gap="$s">
               {isPreviewing ? (
-                <Input
+                <Text
                   flex={1}
-                  width="100%"
-                  value={titleDraft}
-                  placeholder="Untitled"
-                  placeholderTextColor="$tertiaryText"
+                  minWidth={0}
                   fontSize={24}
-                  height={34}
                   minHeight={34}
+                  lineHeight={34}
                   fontWeight="400"
-                  borderColor="transparent"
-                  borderWidth={0}
-                  backgroundColor="transparent"
-                  paddingHorizontal={0}
-                  paddingVertical={0}
-                  disabled
+                  color={titleDraft ? '$primaryText' : '$tertiaryText'}
                   testID="NotesTitleDisplay"
-                />
+                >
+                  {titleDraft || 'Untitled'}
+                </Text>
               ) : (
                 <TextInput
                   ref={titleInputRef}

--- a/packages/app/ui/components/PostContent/A2UIBlock.tsx
+++ b/packages/app/ui/components/PostContent/A2UIBlock.tsx
@@ -334,6 +334,26 @@ function SmallChoiceControl({
     setCustomInputVisibility(true);
   }, [oneShot, setCustomInputVisibility]);
 
+  const closeSavedCustomInput = useCallback(() => {
+    customInputOpenRef.current = false;
+    void KeyboardController.dismiss().finally(() => {
+      if (!customInputMountedRef.current || customInputOpenRef.current) {
+        return;
+      }
+
+      // Keep the sheet over the conversation until its keyboard has fully
+      // settled. Closing it first exposes the floating composer's native
+      // bottom-edge effect while it still has keyboard-sized geometry, and a
+      // scroll-to-end during that transition anchors against the wrong inset.
+      conversationScrollEndAnchor?.restore();
+      requestAnimationFrame(() => {
+        if (customInputMountedRef.current && !customInputOpenRef.current) {
+          setCustomInputOpen(false);
+        }
+      });
+    });
+  }, [conversationScrollEndAnchor]);
+
   const saveCustomInput = useCallback(() => {
     if (oneShot.isLocked()) {
       return;
@@ -368,14 +388,14 @@ function SmallChoiceControl({
           : [...previous, topic];
       });
     }
-    setCustomInputVisibility(false);
+    closeSavedCustomInput();
   }, [
+    closeSavedCustomInput,
     component.options,
     customDraft,
     customTopics.length,
     oneShot,
     selectedIds.length,
-    setCustomInputVisibility,
   ]);
 
   const removeCustomTopic = useCallback(

--- a/packages/app/ui/components/PostContent/A2UIBlock.tsx
+++ b/packages/app/ui/components/PostContent/A2UIBlock.tsx
@@ -12,8 +12,10 @@ import React, {
   useRef,
   useState,
 } from 'react';
+import { KeyboardController } from 'react-native-keyboard-controller';
 import { View, XStack, YStack, isWeb } from 'tamagui';
 
+import { useConversationScrollEndAnchor } from '../../contexts/scroll';
 import { ActionSheet } from '../ActionSheet';
 import { TextInput } from '../Form';
 import { A2UIMenuRow } from './A2UIMenuRow';
@@ -184,7 +186,38 @@ function SmallChoiceControl({
   const [customTopics, setCustomTopics] = useState<string[]>([]);
   const [customDraft, setCustomDraft] = useState('');
   const [customInputOpen, setCustomInputOpen] = useState(false);
+  const customInputMountedRef = useRef(true);
+  const customInputOpenRef = useRef(false);
+  const conversationScrollEndAnchor = useConversationScrollEndAnchor();
   const oneShot = useOneShotAction(Boolean(consumedSelection));
+
+  const setCustomInputVisibility = useCallback(
+    (open: boolean) => {
+      customInputOpenRef.current = open;
+      if (open) {
+        conversationScrollEndAnchor?.capture();
+        setCustomInputOpen(true);
+        return;
+      }
+
+      setCustomInputOpen(false);
+      void KeyboardController.dismiss().finally(() => {
+        if (customInputMountedRef.current && !customInputOpenRef.current) {
+          requestAnimationFrame(() => {
+            conversationScrollEndAnchor?.restore();
+          });
+        }
+      });
+    },
+    [conversationScrollEndAnchor]
+  );
+
+  useEffect(
+    () => () => {
+      customInputMountedRef.current = false;
+    },
+    []
+  );
 
   const toggle = useCallback(
     (id: string) => {
@@ -298,8 +331,8 @@ function SmallChoiceControl({
       return;
     }
     setCustomDraft('');
-    setCustomInputOpen(true);
-  }, [oneShot]);
+    setCustomInputVisibility(true);
+  }, [oneShot, setCustomInputVisibility]);
 
   const saveCustomInput = useCallback(() => {
     if (oneShot.isLocked()) {
@@ -335,13 +368,14 @@ function SmallChoiceControl({
           : [...previous, topic];
       });
     }
-    setCustomInputOpen(false);
+    setCustomInputVisibility(false);
   }, [
     component.options,
     customDraft,
     customTopics.length,
     oneShot,
     selectedIds.length,
+    setCustomInputVisibility,
   ]);
 
   const removeCustomTopic = useCallback(
@@ -474,7 +508,7 @@ function SmallChoiceControl({
           moveOnKeyboardChange
           modal
           open={customInputOpen}
-          onOpenChange={setCustomInputOpen}
+          onOpenChange={setCustomInputVisibility}
           unmountOnClose
         >
           <ActionSheet.SimpleHeader title="Add your own" />

--- a/packages/app/ui/components/Wayfinding/AgentOnboarding/AgentOnboardingSequence.tsx
+++ b/packages/app/ui/components/Wayfinding/AgentOnboarding/AgentOnboardingSequence.tsx
@@ -189,14 +189,20 @@ export function AgentOnboardingSequence(props: {
             throw error;
           }
           landedInAgentChat = true;
-          // Do not permanently dismiss the first-run bridge while the agent
-          // still lacks the standing required to accept provisioning. A
-          // failed tail returns to the outer idempotent retry loop.
+          // Keep the cover until the bot is visibly joined and the admin grant
+          // request has been accepted. Its read-back verification can continue
+          // after the already-mounted conversation becomes visible.
           await withTimeout(
-            furnished.tail,
+            furnished.readyToReveal,
             Math.max(1, deadline - Date.now()),
-            'Agent group standing did not become ready before the deadline'
+            'Agent group did not become ready to reveal before the deadline'
           );
+          void furnished.tail.catch((error) => {
+            logger.trackError(
+              'Agent group admin verification failed after handoff',
+              { error, groupId: activeGroupId }
+            );
+          });
           completedRef.current = true;
           logger.trackEvent('Agent Onboarding V2 In-Channel Handoff', {
             groupId: activeGroupId,

--- a/packages/app/ui/components/Wayfinding/AgentOnboarding/AgentOnboardingSequence.tsx
+++ b/packages/app/ui/components/Wayfinding/AgentOnboarding/AgentOnboardingSequence.tsx
@@ -118,7 +118,8 @@ export function AgentOnboardingSequence(props: {
 
       // Hosting provisions the deterministic home group. The local override
       // has no Hosting automation, so let furnishing create a real group.
-      const hostedHomeGroupId = `${api.getCurrentUserId()}/${BotHomeGroupSlugs.slug}`;
+      const ownerId = api.getCurrentUserId();
+      const hostedHomeGroupId = `${ownerId}/${BotHomeGroupSlugs.slug}`;
       let activeGroupId = AGENT_SHIP_OVERRIDE ? undefined : hostedHomeGroupId;
       let activeChannelId: string | undefined;
       let landedInAgentChat = false;
@@ -231,7 +232,7 @@ export function AgentOnboardingSequence(props: {
             void retryLaterAgentGroupFurnishing({
               agentShipId: AGENT_SHIP_OVERRIDE || undefined,
               groupId: furnished.group.id,
-              ownerId: api.getCurrentUserId(),
+              ownerId,
             });
           });
           completedRef.current = true;

--- a/packages/app/ui/components/Wayfinding/AgentOnboarding/AgentOnboardingSequence.tsx
+++ b/packages/app/ui/components/Wayfinding/AgentOnboarding/AgentOnboardingSequence.tsx
@@ -61,6 +61,32 @@ async function clearNavigationLock(groupId: string) {
   });
 }
 
+async function retryLaterAgentGroupFurnishing({
+  agentShipId,
+  groupId,
+  ownerId,
+}: {
+  agentShipId?: string;
+  groupId: string;
+  ownerId: string;
+}) {
+  for (const delayMs of [30_000, 60_000]) {
+    await wait(delayMs);
+    try {
+      if (api.getCurrentUserId() !== ownerId) return;
+      const repaired = await store.ensureAgentGroupFurnished({
+        agentShipId,
+        groupId,
+        isFirstGroup: true,
+      });
+      await repaired.tail;
+      return;
+    } catch (error) {
+      logger.trackError('Agent group furnishing retry failed', error);
+    }
+  }
+}
+
 /**
  * Bridges the post-readiness splash into the real, provisioned home group.
  * The splash is outside the authenticated navigator, so the destination is
@@ -199,9 +225,14 @@ export function AgentOnboardingSequence(props: {
           );
           void furnished.tail.catch((error) => {
             logger.trackError(
-              'Agent group admin verification failed after handoff',
+              'Agent group admin verification failed; scheduling retry',
               { error, groupId: activeGroupId }
             );
+            void retryLaterAgentGroupFurnishing({
+              agentShipId: AGENT_SHIP_OVERRIDE || undefined,
+              groupId: furnished.group.id,
+              ownerId: api.getCurrentUserId(),
+            });
           });
           completedRef.current = true;
           logger.trackEvent('Agent Onboarding V2 In-Channel Handoff', {

--- a/packages/app/ui/contexts/scroll.tsx
+++ b/packages/app/ui/contexts/scroll.tsx
@@ -5,6 +5,7 @@ import React, {
   useEffect,
   useId,
   useMemo,
+  useRef,
   useState,
 } from 'react';
 import { Dimensions, Platform } from 'react-native';
@@ -36,6 +37,15 @@ const defaultConversationScrollViewNativeID =
 const ConversationScrollViewNativeIDContext = createContext(
   defaultConversationScrollViewNativeID
 );
+export type ConversationScrollEndAnchorHandler = {
+  capture: () => void;
+  restore: () => void;
+};
+const ConversationScrollEndAnchorContext = createContext<{
+  capture: () => void;
+  register: (handler: ConversationScrollEndAnchorHandler) => () => void;
+  restore: () => void;
+} | null>(null);
 // Scroller owns the scroll-position state, while the composer renders the
 // control so all iOS actions can share one native GlassContainer. This small
 // cross-tree channel keeps that presentation detail out of both components.
@@ -49,6 +59,8 @@ const ConversationScrollToBottomContext = createContext<{
 export const useScrollContext = () => useContext(ScrollContext);
 export const useConversationScrollViewNativeID = () =>
   useContext(ConversationScrollViewNativeIDContext);
+export const useConversationScrollEndAnchor = () =>
+  useContext(ConversationScrollEndAnchorContext);
 export const useConversationScrollToBottomControl = () =>
   useContext(ConversationScrollToBottomContext).control;
 export const useSetConversationScrollToBottomControl = () =>
@@ -141,6 +153,8 @@ export const ScrollContextProvider: React.FC<React.PropsWithChildren> = ({
   children,
 }) => {
   const scrollValue = useSharedValue(0);
+  const conversationScrollEndAnchor =
+    useRef<ConversationScrollEndAnchorHandler | null>(null);
   const scrollViewNativeID = `${defaultConversationScrollViewNativeID}-${useId()}`;
   const [scrollToBottomControl, setScrollToBottomControl] =
     useState<ConversationScrollToBottomControl | null>(null);
@@ -163,18 +177,37 @@ export const ScrollContextProvider: React.FC<React.PropsWithChildren> = ({
     }),
     [scrollToBottomControl]
   );
+  const scrollEndAnchorContextValue = useMemo(
+    () => ({
+      capture: () => conversationScrollEndAnchor.current?.capture(),
+      register: (handler: ConversationScrollEndAnchorHandler) => {
+        conversationScrollEndAnchor.current = handler;
+        return () => {
+          if (conversationScrollEndAnchor.current === handler) {
+            conversationScrollEndAnchor.current = null;
+          }
+        };
+      },
+      restore: () => conversationScrollEndAnchor.current?.restore(),
+    }),
+    []
+  );
 
   return (
-    <ConversationScrollToBottomContext.Provider
-      value={scrollToBottomContextValue}
+    <ConversationScrollEndAnchorContext.Provider
+      value={scrollEndAnchorContextValue}
     >
-      <ConversationScrollViewNativeIDContext.Provider
-        value={scrollViewNativeID}
+      <ConversationScrollToBottomContext.Provider
+        value={scrollToBottomContextValue}
       >
-        <ScrollContext.Provider value={contextValue}>
-          {children}
-        </ScrollContext.Provider>
-      </ConversationScrollViewNativeIDContext.Provider>
-    </ConversationScrollToBottomContext.Provider>
+        <ConversationScrollViewNativeIDContext.Provider
+          value={scrollViewNativeID}
+        >
+          <ScrollContext.Provider value={contextValue}>
+            {children}
+          </ScrollContext.Provider>
+        </ConversationScrollViewNativeIDContext.Provider>
+      </ConversationScrollToBottomContext.Provider>
+    </ConversationScrollEndAnchorContext.Provider>
   );
 };

--- a/packages/openclaw/src/monitor/agent-onboarding.test.ts
+++ b/packages/openclaw/src/monitor/agent-onboarding.test.ts
@@ -1180,7 +1180,7 @@ describe('agent onboarding requests', () => {
         }
       )
     ).resolves.toBe(true);
-    expect(sendPost).toHaveBeenCalledTimes(2);
+    expect(sendPost).toHaveBeenCalledOnce();
   });
 
   it('describes only the provisioned home group as the first group', async () => {
@@ -1225,12 +1225,27 @@ describe('agent onboarding requests', () => {
     };
 
     const firstGroup = await promptFor(true);
-    expect(firstGroup).toHaveLength(2);
+    expect(firstGroup).toHaveLength(1);
+    expect(JSON.stringify(firstGroup[0]?.story)).toContain(
+      'Welcome! This is your private group with me, your Tlonbot.'
+    );
     expect(JSON.stringify(firstGroup[0]?.story)).toContain(
       'I can keep you informed, help you learn, or follow a question over time.'
     );
-    expect(JSON.stringify(parsePostBlob(firstGroup[1]?.blob))).toContain(
+    expect(JSON.stringify(firstGroup[0]?.story)).toContain(
       'What can I help you with?'
+    );
+    expect(parsePostBlob(firstGroup[0]?.blob)).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          type: 'tlon-agent-post-marker',
+          key: 'intro',
+        }),
+        expect.objectContaining({
+          type: 'tlon-agent-post-marker',
+          key: 'purpose-picker',
+        }),
+      ])
     );
 
     const additionalGroup = await promptFor();
@@ -1299,27 +1314,21 @@ describe('agent onboarding requests', () => {
       { ...base, blob: history[0].blob },
       { fetchHistory: vi.fn(async () => history), sendPost }
     );
-    expect(sent).toHaveLength(2);
-    expect(JSON.stringify(parsePostBlob(sent[1].blob))).not.toContain(
+    expect(sent).toHaveLength(1);
+    expect(JSON.stringify(parsePostBlob(sent[0].blob))).not.toContain(
       'the cards are only starts'
     );
     history.push(
       {
         author: '~bot',
-        content: 'intro',
+        content: 'intro and purpose',
         timestamp: 2,
         blob: sent[0].blob,
       },
       {
-        author: '~bot',
-        content: 'purpose',
-        timestamp: 3,
-        blob: sent[1].blob,
-      },
-      {
         author: '~ten',
         content: 'A daily digest',
-        timestamp: 4,
+        timestamp: 3,
       }
     );
 
@@ -1327,8 +1336,8 @@ describe('agent onboarding requests', () => {
       { ...base, rawText: 'A daily digest', blob: undefined },
       { fetchHistory: vi.fn(async () => history), sendPost }
     );
-    expect(sent).toHaveLength(3);
-    const topicsA2UI = parsePostBlob(sent[2].blob).find(
+    expect(sent).toHaveLength(2);
+    const topicsA2UI = parsePostBlob(sent[1].blob).find(
       (entry) => entry.type === 'a2ui'
     );
     expect(topicsA2UI).toMatchObject({ storyMode: 'fallback' });
@@ -1343,13 +1352,13 @@ describe('agent onboarding requests', () => {
       {
         author: '~bot',
         content: 'topics',
-        timestamp: 5,
-        blob: sent[2].blob,
+        timestamp: 4,
+        blob: sent[1].blob,
       },
       {
         author: '~ten',
         content: 'Open hardware, Space weather',
-        timestamp: 6,
+        timestamp: 5,
       }
     );
 
@@ -1364,13 +1373,13 @@ describe('agent onboarding requests', () => {
     // Topic confirmation is a client-owned provision action because only the
     // client knows the device timezone. A raw-text recovery must never revive
     // the retired timezone prompt or button.
-    expect(sent).toHaveLength(3);
+    expect(sent).toHaveLength(2);
     expect(JSON.stringify(sent)).not.toContain('timezone-picker');
     expect(JSON.stringify(sent)).not.toContain('Use my current timezone');
     expect(JSON.stringify(sent)).not.toContain('One last detail');
   });
 
-  it('shows thinking and paces consecutive onboarding messages', async () => {
+  it('shows thinking and paces the combined onboarding opening', async () => {
     let now = 0;
     const events: string[] = [];
     const abortController = new AbortController();
@@ -1381,12 +1390,10 @@ describe('agent onboarding requests', () => {
       isFirstGroup: true,
     });
     const sendPost = vi.fn(async ({ blob }: { blob?: string }) => {
-      const marker = parsePostBlob(blob).find(
-        (entry) => entry.type === 'tlon-agent-post-marker'
-      );
-      events.push(
-        `post:${marker?.type === 'tlon-agent-post-marker' ? marker.key : 'unknown'}`
-      );
+      const markers = parsePostBlob(blob)
+        .filter((entry) => entry.type === 'tlon-agent-post-marker')
+        .map((entry) => entry.key);
+      events.push(`post:${markers.join('+') || 'unknown'}`);
       return { channel: 'tlon' as const, messageId: 'post', sentAt: now };
     });
 
@@ -1432,8 +1439,7 @@ describe('agent onboarding requests', () => {
     expect(events[0]).toBe('thinking:start');
     expect(events.at(-1)).toBe('thinking:stop');
     expect(events.filter((e) => e.startsWith('post:'))).toEqual([
-      'post:intro',
-      'post:purpose-picker',
+      'post:intro+purpose-picker',
     ]);
 
     // Every post is preceded by a pause, and the pause is composed rather than
@@ -1441,14 +1447,12 @@ describe('agent onboarding requests', () => {
     const sleeps = events
       .filter((e) => e.startsWith('sleep:'))
       .map((e) => Number(e.slice('sleep:'.length)));
-    expect(sleeps).toHaveLength(2);
+    expect(sleeps).toHaveLength(1);
     expect(sleeps[0]).toBeGreaterThanOrEqual(2_000);
-    expect(sleeps[1]).toBeGreaterThanOrEqual(1_750);
     for (const ms of sleeps) {
       expect(ms).toBeGreaterThanOrEqual(800);
       expect(ms).toBeLessThanOrEqual(3500);
     }
-    expect(new Set(sleeps).size).toBeGreaterThan(1);
   });
 
   it('jitters pacing so the rhythm is not metronomic', async () => {
@@ -1460,7 +1464,6 @@ describe('agent onboarding requests', () => {
         type: 'tlon-agent-intro-request',
         version: 1,
         groupId: '~ten/group',
-        isFirstGroup: true,
       });
       await handleAgentOnboardingRequest(
         {
@@ -1644,24 +1647,11 @@ describe('agent onboarding requests', () => {
             blob: sent[0].blob,
           },
         },
-        purpose: {
-          seal: { id: 'purpose' },
-          essay: {
-            author: {
-              ship: '~bot',
-              nickname: "Napdet's Tlonbot",
-              avatar: '',
-            },
-            sent: 3,
-            content: [{ inline: ['What would be useful for this group?'] }],
-            blob: sent[1].blob,
-          },
-        },
         reply: {
           seal: { id: 'reply' },
           essay: {
             author: '~ten',
-            sent: 4,
+            sent: 3,
             content: [{ inline: ['A daily digest'] }],
           },
         },
@@ -1678,8 +1668,8 @@ describe('agent onboarding requests', () => {
         { sendPost }
       )
     ).resolves.toBe(true);
-    expect(sent).toHaveLength(3);
-    expect(JSON.stringify(parsePostBlob(sent[2].blob))).toContain(
+    expect(sent).toHaveLength(2);
+    expect(JSON.stringify(parsePostBlob(sent[1].blob))).toContain(
       'tlon.provisionAgent'
     );
   });

--- a/packages/openclaw/src/monitor/agent-onboarding.test.ts
+++ b/packages/openclaw/src/monitor/agent-onboarding.test.ts
@@ -2585,6 +2585,7 @@ describe('provision coordinator ordering', () => {
 
   it('keeps an early first-run result behind the ordered setup messages', async () => {
     const events: string[] = [];
+    const stories: unknown[] = [];
     const history: Array<{
       author: string;
       content: string;
@@ -2634,7 +2635,8 @@ describe('provision coordinator ordering', () => {
       {
         fetchHistory: vi.fn(async () => history),
         getCron: () => cron,
-        sendPost: vi.fn(async ({ blob }) => {
+        sendPost: vi.fn(async ({ blob, story }) => {
+          stories.push(story);
           const entries = parsePostBlob(blob);
           const marker =
             entries.find(
@@ -2667,6 +2669,9 @@ describe('provision coordinator ordering', () => {
       'post:ack:provision-1',
       'post:first-entry-pending',
     ]);
+    expect(JSON.stringify(stories[1])).toContain(
+      'I’ll be back in a few seconds with your tailored post.'
+    );
     expect(events.indexOf('post:first-entry-ping')).toBeGreaterThan(3);
     expect(
       parsePostBlob(history[0]?.blob).filter(

--- a/packages/openclaw/src/monitor/agent-onboarding.ts
+++ b/packages/openclaw/src/monitor/agent-onboarding.ts
@@ -170,7 +170,12 @@ const READ_MS_PER_CHARACTER = 10;
 const READ_DELAY_CAP_MS = 1_500;
 const JITTER_RATIO = 0.2;
 const LEGACY_GROUP_INTRO_PREFIX = "I'm your Tlonbot.";
+const TLAWN_HOME_GROUP_WELCOME_MESSAGE =
+  'Welcome! This is your private group with me, your Tlonbot. You can @ me ' +
+  'here anytime and I will respond. Invite some friends, and they can @ me ' +
+  'too—we can all chat together.';
 const AGENT_ONBOARDING_GROUP_INTRO =
+  `${TLAWN_HOME_GROUP_WELCOME_MESSAGE}\n\n` +
   'I can keep you informed, help you learn, or follow a ' +
   'question over time.';
 const AGENT_ONBOARDING_PURPOSE_PROMPT = 'What can I help you with?';
@@ -632,45 +637,42 @@ async function postIntro(
   presentation: OnboardingPresentation,
   isFirstGroup: boolean
 ) {
-  if (isFirstGroup) {
-    const hadIntro = hasPostMarker(history, context.botShip, 'intro');
-    const posted = await postOnce(
-      context,
-      history,
-      'intro',
-      async () => ({ text: AGENT_ONBOARDING_GROUP_INTRO }),
-      deps,
-      presentation
-    );
-    // Only on the post that actually lands, so a re-entered opening doesn't
-    // inflate the top of the funnel.
-    if (!hadIntro && posted) {
-      context.trackStep?.({ step: 'intro_posted' });
-    }
-  }
+  const needsIntro =
+    isFirstGroup && !hasPostMarker(history, context.botShip, 'intro');
   const hadPicker = hasPostMarker(history, context.botShip, 'purpose-picker');
   const pickerPosted = await postOnce(
     context,
     history,
     'purpose-picker',
-    async () => ({
-      text: purposePickerFallbackText(AGENT_ONBOARDING_PURPOSE_PROMPT),
-      blob: appendToPostBlob(
-        undefined,
-        buildPurposePickerSurface(
-          context.groupId!,
-          AGENT_ONBOARDING_PURPOSE_PROMPT
-        )
-      ),
-    }),
+    async () => {
+      const prompt = needsIntro
+        ? `${AGENT_ONBOARDING_GROUP_INTRO}\n\n${AGENT_ONBOARDING_PURPOSE_PROMPT}`
+        : AGENT_ONBOARDING_PURPOSE_PROMPT;
+      return {
+        text: purposePickerFallbackText(prompt),
+        blob: appendToPostBlob(
+          undefined,
+          buildPurposePickerSurface(context.groupId!, prompt)
+        ),
+        entries: needsIntro
+          ? [
+              {
+                type: 'tlon-agent-post-marker' as const,
+                version: 1 as const,
+                key: 'intro',
+              },
+            ]
+          : undefined,
+      };
+    },
     deps,
     presentation
   );
   if (!hadPicker && pickerPosted) {
-    if (!isFirstGroup) {
+    if (needsIntro || !isFirstGroup) {
       // Additional groups share the same ordered funnel vocabulary; their
-      // purpose picker is the first setup surface even though no intro post is
-      // needed.
+      // purpose picker is the first setup surface even though no welcome copy
+      // is needed. First groups carry both markers on the combined opening.
       context.trackStep?.({ step: 'intro_posted' });
     }
     context.trackStep?.({ step: 'purpose_picker_posted' });

--- a/packages/openclaw/src/monitor/agent-onboarding.ts
+++ b/packages/openclaw/src/monitor/agent-onboarding.ts
@@ -1111,9 +1111,7 @@ async function provision(
       history,
       'first-entry-pending',
       async () => ({
-        text:
-          'I’m writing the first entry now. You’re all set—feel free to ' +
-          'explore while I work.',
+        text: 'I’ll be back in a few seconds with your tailored post.',
         shouldSend: async () => {
           const latest = await lookupAgentOnboardingRun(
             onboardingAccountId(context),

--- a/packages/shared/src/store/agentGroupOnboarding.test.ts
+++ b/packages/shared/src/store/agentGroupOnboarding.test.ts
@@ -282,4 +282,91 @@ describe('agent group furnishing retry', () => {
     ).rejects.toBe(finalError);
     expect(operation).toHaveBeenCalledTimes(3);
   });
+
+  it('reveals after membership and an accepted admin grant without waiting for read-back', async () => {
+    let finishVerification!: (group: unknown) => void;
+    const verification = new Promise((resolve) => {
+      finishVerification = resolve;
+    });
+    const joinedGroup = {
+      id: '~zod/group',
+      members: [{ contactId: '~bot', status: 'joined', roles: [] }],
+    } as never;
+    const adminGroup = {
+      id: '~zod/group',
+      members: [{ contactId: '~bot', status: 'joined', roles: ['admin'] }],
+    } as never;
+    const getGroup = vi
+      .fn()
+      .mockResolvedValueOnce(joinedGroup)
+      .mockReturnValueOnce(verification);
+    const addMembersToRole = vi.fn().mockResolvedValue(undefined);
+    const onReadyToReveal = vi.fn();
+
+    const reconciliation = agentGroupOnboardingTesting.reconcileAgentStanding({
+      groupId: '~zod/group',
+      agentShipId: '~bot',
+      hostedShipId: 'zod',
+      onReadyToReveal,
+      deps: { getGroup, addMembersToRole },
+    });
+
+    await vi.waitFor(() => expect(onReadyToReveal).toHaveBeenCalledOnce());
+    expect(addMembersToRole).toHaveBeenCalledWith({
+      groupId: '~zod/group',
+      roleId: 'admin',
+      ships: ['~bot'],
+    });
+
+    let verificationFinished = false;
+    void reconciliation.then(() => {
+      verificationFinished = true;
+    });
+    await Promise.resolve();
+    expect(verificationFinished).toBe(false);
+
+    finishVerification(adminGroup);
+    await expect(reconciliation).resolves.toBeUndefined();
+  });
+
+  it('does not reveal before the bot joins and the admin grant is accepted', async () => {
+    const absentGroup = {
+      id: '~zod/group',
+      members: [],
+    } as never;
+    const joinedGroup = {
+      id: '~zod/group',
+      members: [{ contactId: '~bot', status: 'joined', roles: [] }],
+    } as never;
+    const adminGroup = {
+      id: '~zod/group',
+      members: [{ contactId: '~bot', status: 'joined', roles: ['admin'] }],
+    } as never;
+    const getGroup = vi
+      .fn()
+      .mockResolvedValueOnce(absentGroup)
+      .mockResolvedValueOnce(joinedGroup)
+      .mockResolvedValueOnce(adminGroup);
+    const addCordonThenJoin = vi.fn().mockResolvedValue(undefined);
+    const addMembersToRole = vi.fn().mockResolvedValue(undefined);
+    const onReadyToReveal = vi.fn();
+
+    await expect(
+      agentGroupOnboardingTesting.reconcileAgentStanding({
+        groupId: '~zod/group',
+        agentShipId: '~bot',
+        hostedShipId: 'zod',
+        onReadyToReveal,
+        deps: { getGroup, addCordonThenJoin, addMembersToRole },
+      })
+    ).resolves.toBeUndefined();
+
+    expect(addCordonThenJoin.mock.invocationCallOrder[0]).toBeLessThan(
+      addMembersToRole.mock.invocationCallOrder[0]!
+    );
+    expect(addMembersToRole.mock.invocationCallOrder[0]).toBeLessThan(
+      onReadyToReveal.mock.invocationCallOrder[0]!
+    );
+    expect(onReadyToReveal).toHaveBeenCalledOnce();
+  });
 });

--- a/packages/shared/src/store/agentGroupOnboarding.ts
+++ b/packages/shared/src/store/agentGroupOnboarding.ts
@@ -17,7 +17,12 @@ const MAX_GENERATED_GROUP_TITLE_LENGTH = 48;
 const PENDING_GROUP_ADOPTION_ATTEMPTS = 8;
 const PENDING_GROUP_ADOPTION_DELAY_MS = 500;
 const notesChannelFlights = new Map<string, Promise<db.Channel>>();
-const agentStandingFlights = new Map<string, Promise<void>>();
+type AgentStandingFlight = {
+  readyToReveal: Promise<void>;
+  complete: Promise<void>;
+};
+
+const agentStandingFlights = new Map<string, AgentStandingFlight>();
 const agentGroupFurnishingFlights = new Map<
   string,
   Promise<AgentGroupFurnishingStart>
@@ -28,6 +33,8 @@ export type AgentGroupFurnishing = {
   chatChannelId: string;
   notebookNest: string;
   agentShipId: string;
+  /** Membership is visible and the admin grant request has been accepted. */
+  readyToReveal: Promise<void>;
   /** Seating and admin verification deliberately overlap the intro wait. */
   tail: Promise<void>;
 };
@@ -327,11 +334,12 @@ async function finishAgentGroupFurnishingOnce({
     notebookNest: notebook.id,
   });
 
-  const tail = reconcileAgentStandingUntilReady({
+  const standing = reconcileAgentStandingUntilReady({
     groupId: group.id,
     agentShipId,
     hostedShipId,
-  }).catch((error) => {
+  });
+  const tail = standing.complete.catch((error) => {
     logger.trackError('Agent Group Furnish Tail Failed', {
       error,
       groupId: group.id,
@@ -344,6 +352,7 @@ async function finishAgentGroupFurnishingOnce({
     chatChannelId: chatChannel.id,
     notebookNest: notebook.id,
     agentShipId,
+    readyToReveal: standing.readyToReveal,
     tail,
   };
 }
@@ -707,33 +716,49 @@ async function reconcileAgentStanding({
   groupId,
   agentShipId,
   hostedShipId,
+  onReadyToReveal,
+  deps = {},
 }: {
   groupId: string;
   agentShipId: string;
   hostedShipId: string | null;
+  onReadyToReveal: () => void;
+  deps?: {
+    getGroup?: typeof api.getGroup;
+    addMembersToRole?: typeof api.addMembersToRole;
+    addCordonThenJoin?: typeof addCordonThenJoin;
+  };
 }) {
+  const getGroup = deps.getGroup ?? api.getGroup;
+  const addMembersToRole = deps.addMembersToRole ?? api.addMembersToRole;
+  const cordonThenJoin = deps.addCordonThenJoin ?? addCordonThenJoin;
   let lastError: unknown;
   for (const delay of [0, 1_000, 2_000, 5_000, 10_000]) {
     if (delay) await wait(delay);
     try {
-      let group = await api.getGroup(groupId);
+      let group = await getGroup(groupId);
       if (agentHasAdmin(group, agentShipId)) {
+        onReadyToReveal();
         logger.trackEvent('Agent Group Furnish Tail Verified', { groupId });
         return;
       }
       if (hostedShipId && !agentHasJoined(group, agentShipId)) {
         const moon = desig(agentShipId);
-        await addCordonThenJoin(hostedShipId, groupId, moon);
-        group = await api.getGroup(groupId);
+        await cordonThenJoin(hostedShipId, groupId, moon);
+        group = await getGroup(groupId);
       }
       if (agentHasJoined(group, agentShipId)) {
-        await api.addMembersToRole({
+        await addMembersToRole({
           groupId,
           roleId: 'admin',
           ships: [agentShipId],
         });
+        // The bot can consume the intro request as soon as it is joined. Keep
+        // verifying the admin grant in the background, but do not hide the
+        // already-mounted conversation while that read-back propagates.
+        onReadyToReveal();
       }
-      group = await api.getGroup(groupId);
+      group = await getGroup(groupId);
       if (agentHasAdmin(group, agentShipId)) {
         logger.trackEvent('Agent Group Furnish Tail Verified', { groupId });
         return;
@@ -754,10 +779,40 @@ function reconcileAgentStandingUntilReady(params: {
 }) {
   const existing = agentStandingFlights.get(params.groupId);
   if (existing) return existing;
-  const flight = retryAgentStanding(
-    () => reconcileAgentStanding(params),
+  let resolveReadyToReveal!: () => void;
+  let rejectReadyToReveal!: (error: unknown) => void;
+  let revealSettled = false;
+  const readyToReveal = new Promise<void>((resolve, reject) => {
+    resolveReadyToReveal = () => {
+      if (revealSettled) return;
+      revealSettled = true;
+      resolve();
+    };
+    rejectReadyToReveal = (error) => {
+      if (revealSettled) return;
+      revealSettled = true;
+      reject(error);
+    };
+  });
+  // Some furnishing callers only need the completion tail. Keep a rejected
+  // reveal milestone from becoming an unhandled promise in those paths.
+  void readyToReveal.catch(() => undefined);
+
+  const complete = retryAgentStanding(
+    () =>
+      reconcileAgentStanding({
+        ...params,
+        onReadyToReveal: resolveReadyToReveal,
+      }),
     params.groupId
-  ).finally(() => agentStandingFlights.delete(params.groupId));
+  )
+    .then(() => resolveReadyToReveal())
+    .catch((error) => {
+      rejectReadyToReveal(error);
+      throw error;
+    })
+    .finally(() => agentStandingFlights.delete(params.groupId));
+  const flight = { readyToReveal, complete };
   agentStandingFlights.set(params.groupId, flight);
   return flight;
 }
@@ -843,6 +898,7 @@ export const agentGroupOnboardingTesting = {
   isAgentGroupTitleRenameEligible,
   chooseCreatedNotebookResolution,
   retryAgentStanding,
+  reconcileAgentStanding,
   startAgentGroupFurnishingFlight,
   waitForPendingGroupWithChat,
 };


### PR DESCRIPTION
## Summary

Polishes first-run Tlonbot onboarding and fixes long note titles on Android.

## Changes

- wraps long note titles in preview mode while preserving the existing title colors
- keeps the onboarding topic picker anchored at the bottom after adding a custom topic
- hides the exact preloaded home-group welcome and combines that copy with the first plugin onboarding prompt
- reveals the bot group after the bot joins and the admin grant is accepted, while read-back verification continues in the background

## How did I test?

- `packages/app`: focused post visibility tests passed — 13 tests
- `packages/shared`: focused agent group furnishing tests passed — 17 tests
- `packages/openclaw`: focused onboarding tests passed — 104 tests
- app, shared, and OpenClaw TypeScript checks passed
- targeted lint completed with warnings only
- `git diff --check` passed
- verified the custom-topic scroll behavior and onboarding handoff on a physical Galaxy S24