### PR TITLE
auto-release Android preview builds

### DIFF
--- a/apps/tlon-mobile/eas.json
+++ b/apps/tlon-mobile/eas.json
@@ -117,9 +117,8 @@
     "preview": {
       "android": {
         "applicationId": "io.tlon.groups.preview",
-        "releaseStatus": "draft",
-        "track": "internal",
-        "changesNotSentForReview": true
+        "releaseStatus": "completed",
+        "track": "internal"
       },
       "ios": {
         "ascAppId": "6477973000",


### PR DESCRIPTION
## Summary

Make Android preview builds available to internal testers without a manual Play Console release step.

## Changes

- complete preview Android submissions on the internal track
- keep production Android submissions as drafts

## How did I test?

- validated the EAS submit profiles with `jq`
- confirmed the preview Gradle flavor uses `io.tlon.groups.preview`
- confirmed preview builds still submit to the `internal` track
- confirmed the production submit profile is unchanged
- `git diff --check`