### PR TITLE
add recurring task management screens

### DIFF
--- a/apps/tlon-mobile/cosmos.imports.ts
+++ b/apps/tlon-mobile/cosmos.imports.ts
@@ -59,6 +59,7 @@ import * as fixture54 from './../../packages/app/fixtures/Pressable.fixture';
 import * as fixture55 from './../../packages/app/fixtures/ProfileBlock.fixture';
 import * as fixture56 from './../../packages/app/fixtures/ProfileSheet.fixture';
 import * as fixture57 from './../../packages/app/fixtures/ProfileStatusSheet.fixture';
+import * as fixture64 from './../../packages/app/fixtures/RecurringTasks.fixture';
 import * as fixture58 from './../../packages/app/fixtures/ReferenceSkeleton.fixture';
 import * as fixture59 from './../../packages/app/fixtures/ScreenHeader.fixture';
 import * as fixture60 from './../../packages/app/fixtures/SearchBar.fixture';
@@ -216,6 +217,9 @@ const fixtures = {
   '../../packages/app/fixtures/ProfileSheet.fixture.tsx': { module: fixture56 },
   '../../packages/app/fixtures/ProfileStatusSheet.fixture.tsx': {
     module: fixture57,
+  },
+  '../../packages/app/fixtures/RecurringTasks.fixture.tsx': {
+    module: fixture64,
   },
   '../../packages/app/fixtures/ReferenceSkeleton.fixture.tsx': {
     module: fixture58,

--- a/apps/tlon-mobile/src/App.cosmos.tsx
+++ b/apps/tlon-mobile/src/App.cosmos.tsx
@@ -2,6 +2,7 @@ import {
   SplashScreenTask,
   splashScreenProgress,
 } from '@tloncorp/app/lib/splashscreen';
+import * as SplashScreen from 'expo-splash-screen';
 import { Component } from 'react';
 import { NativeFixtureLoader } from 'react-cosmos-native';
 
@@ -11,6 +12,10 @@ import { moduleWrappers, rendererConfig } from '../cosmos.imports';
 splashScreenProgress.complete(SplashScreenTask.loadTheme);
 
 export default class CosmosApp extends Component {
+  componentDidMount() {
+    void SplashScreen.hideAsync();
+  }
+
   render() {
     return (
       <NativeFixtureLoader

--- a/packages/api/src/client/index.ts
+++ b/packages/api/src/client/index.ts
@@ -121,4 +121,5 @@ export * from './changesApi';
 export * from './computingStatus';
 export * from './presenceApi';
 export * from './stewardGatewayApi';
+export * from './stewardAutomationApi';
 export * from './lensApi';

--- a/packages/api/src/client/stewardAutomationApi.ts
+++ b/packages/api/src/client/stewardAutomationApi.ts
@@ -1,0 +1,14 @@
+import type { StewardAutomationTasks } from '../urbit/stewardAutomation';
+import { scry } from './urbit';
+
+/**
+ * Read Steward's best-effort mirror of OpenClaw cron definitions.
+ * OpenClaw remains authoritative; this endpoint intentionally has no mutation
+ * or runtime-status surface.
+ */
+export function getStewardAutomationTasks() {
+  return scry<StewardAutomationTasks>({
+    app: 'steward',
+    path: '/v1/automation/tasks',
+  });
+}

--- a/packages/api/src/urbit/index.ts
+++ b/packages/api/src/urbit/index.ts
@@ -34,4 +34,5 @@ export * from './metagrab';
 export * from './meta';
 export * from './presence';
 export * from './stewardGateway';
+export * from './stewardAutomation';
 export * from './lens';

--- a/packages/api/src/urbit/stewardAutomation.ts
+++ b/packages/api/src/urbit/stewardAutomation.ts
@@ -1,0 +1,37 @@
+export type StewardAutomationSchedule =
+  | {
+      kind: 'cron';
+      expr?: string;
+      tz?: string;
+      staggerMs?: number;
+    }
+  | {
+      kind: 'at';
+      at?: number;
+    }
+  | {
+      kind: 'every';
+      everyMs?: number;
+      anchorMs?: number;
+    };
+
+export interface StewardAutomationTask {
+  agentId?: string;
+  name?: string;
+  description?: string;
+  enabled?: boolean;
+  schedule?: StewardAutomationSchedule;
+  sessionTarget?: string;
+  wakeMode?: string;
+  payload?: {
+    kind?: string;
+    message?: string;
+  };
+  createdAtMs?: number;
+  updatedAtMs?: number;
+}
+
+export type StewardAutomationTasks = Record<
+  string,
+  Record<string, StewardAutomationTask>
+>;

--- a/packages/app/features/automations/ScheduledTaskEditorScreen.tsx
+++ b/packages/app/features/automations/ScheduledTaskEditorScreen.tsx
@@ -1,0 +1,54 @@
+import type { NativeStackScreenProps } from '@react-navigation/native-stack';
+import { useMemo, useState } from 'react';
+
+import type { RootStackParamList } from '../../navigation/types';
+import {
+  type RecurringTaskDraft,
+  RecurringTaskEditorView,
+} from '../../ui/components/RecurringTasks';
+import {
+  tasksForShip,
+  useStewardAutomationTasks,
+} from './useStewardAutomationTasks';
+
+type Props = NativeStackScreenProps<RootStackParamList, 'ScheduledTaskEditor'>;
+
+const emptyDraft: RecurringTaskDraft = {
+  name: '',
+  prompt: '',
+  repeat: 'Weekly',
+  selectedDays: [1, 2, 3, 4, 5],
+  timeLabel: '7:00 AM',
+  destinationLabel: 'Not available',
+};
+
+export function ScheduledTaskEditorScreen({ navigation, route }: Props) {
+  const query = useStewardAutomationTasks();
+  const task = route.params.taskId
+    ? tasksForShip(query.data, route.params.botShip)[route.params.taskId]
+    : undefined;
+  const initialDraft = useMemo<RecurringTaskDraft>(
+    () =>
+      task
+        ? {
+            ...emptyDraft,
+            name: task.name || task.description || 'Untitled task',
+            prompt: task.payload?.message || task.description || '',
+          }
+        : emptyDraft,
+    [task]
+  );
+  const [draftOverride, setDraftOverride] = useState<RecurringTaskDraft | null>(
+    null
+  );
+  const draft = draftOverride ?? initialDraft;
+
+  return (
+    <RecurringTaskEditorView
+      draft={draft}
+      readOnly
+      onChange={setDraftOverride}
+      onBack={navigation.goBack}
+    />
+  );
+}

--- a/packages/app/features/automations/ScheduledTasksScreen.tsx
+++ b/packages/app/features/automations/ScheduledTasksScreen.tsx
@@ -1,0 +1,41 @@
+import type { NativeStackScreenProps } from '@react-navigation/native-stack';
+import { useMemo } from 'react';
+
+import type { RootStackParamList } from '../../navigation/types';
+import {
+  type IdentifiedAutomationTask,
+  ScheduledTasksScreenView,
+} from '../../ui/components/RecurringTasks';
+import {
+  tasksForShip,
+  useStewardAutomationTasks,
+} from './useStewardAutomationTasks';
+
+type Props = NativeStackScreenProps<RootStackParamList, 'ScheduledTasks'>;
+
+export function ScheduledTasksScreen({ navigation, route }: Props) {
+  const query = useStewardAutomationTasks();
+  const tasks = useMemo<IdentifiedAutomationTask[]>(
+    () =>
+      Object.entries(tasksForShip(query.data, route.params.botShip)).map(
+        ([id, task]) => ({ id, task })
+      ),
+    [query.data, route.params.botShip]
+  );
+
+  return (
+    <ScheduledTasksScreenView
+      available={query.data?.available ?? false}
+      loading={query.isLoading}
+      tasks={tasks}
+      canMutate={false}
+      onBack={navigation.goBack}
+      onPressTask={({ id }) =>
+        navigation.push('ScheduledTaskEditor', {
+          botShip: route.params.botShip,
+          taskId: id,
+        })
+      }
+    />
+  );
+}

--- a/packages/app/features/automations/useStewardAutomationTasks.ts
+++ b/packages/app/features/automations/useStewardAutomationTasks.ts
@@ -1,0 +1,42 @@
+import { useQuery } from '@tanstack/react-query';
+import * as api from '@tloncorp/api';
+import type { StewardAutomationTasks } from '@tloncorp/api/urbit';
+
+export interface StewardAutomationSnapshot {
+  available: boolean;
+  tasks: StewardAutomationTasks;
+}
+
+export const stewardAutomationQueryKey = ['stewardAutomationTasks'] as const;
+
+export function useStewardAutomationTasks(enabled = true) {
+  return useQuery<StewardAutomationSnapshot>({
+    queryKey: stewardAutomationQueryKey,
+    queryFn: async () => {
+      try {
+        return {
+          available: true,
+          tasks: await api.getStewardAutomationTasks(),
+        };
+      } catch (error) {
+        if (error instanceof api.BadResponseError && error.status === 404) {
+          return { available: false, tasks: {} };
+        }
+        throw error;
+      }
+    },
+    enabled,
+    staleTime: 15_000,
+    refetchOnMount: 'always',
+    retry: (attempts, error) =>
+      !(error instanceof api.BadResponseError && error.status === 404) &&
+      attempts < 2,
+  });
+}
+
+export function tasksForShip(
+  snapshot: StewardAutomationSnapshot | undefined,
+  ship: string
+) {
+  return snapshot?.tasks[ship] ?? {};
+}

--- a/packages/app/features/top/UserProfileScreen.tsx
+++ b/packages/app/features/top/UserProfileScreen.tsx
@@ -9,6 +9,7 @@ import { View, isWeb, useTheme } from 'tamagui';
 
 import { useCurrentUserId } from '../../hooks/useCurrentUser';
 import { useGroupActions } from '../../hooks/useGroupActions';
+import { useFeatureFlag } from '../../lib/featureFlags';
 import { RootStackParamList } from '../../navigation/types';
 import { useRootNavigation } from '../../navigation/utils';
 import {
@@ -26,6 +27,10 @@ import {
   useHasExpectedBotDm,
 } from '../../utils/botSettings';
 import { useShipConnectionStatus } from './useShipConnectionStatus';
+import {
+  tasksForShip,
+  useStewardAutomationTasks,
+} from '../automations/useStewardAutomationTasks';
 
 type Props = NativeStackScreenProps<RootStackParamList, 'UserProfile'>;
 
@@ -106,6 +111,15 @@ export function UserProfileScreen({ route, navigation }: Props) {
   const isOwnBotProfile = useMemo(() => {
     return api.isBotUserIdForUser(userId, currentUserId);
   }, [currentUserId, userId]);
+  const [scheduledTasksEnabled] = useFeatureFlag('scheduledTasks');
+  const automationQuery = useStewardAutomationTasks(
+    scheduledTasksEnabled && isOwnBotProfile
+  );
+  const scheduledTasks = tasksForShip(automationQuery.data, userId);
+
+  const handlePressScheduledTasks = useCallback(() => {
+    navigation.push('ScheduledTasks', { botShip: userId });
+  }, [navigation, userId]);
 
   const isHostedUser = isWeb ? getCurrentUserIsHostedSafely() : false;
   const hasExpectedBotDm = useHasExpectedBotDm(
@@ -156,22 +170,20 @@ export function UserProfileScreen({ route, navigation }: Props) {
               title="Profile"
               backgroundColor={theme.secondaryBackground.val}
               useHorizontalTitleLayout={!isWindowNarrow && shouldShowBackButton}
-              leftControls={
-                shouldShowBackButton ? (
-                  <ScreenHeader.BackButton
-                    onPress={() => navigation.goBack()}
-                  />
-                ) : null
+              backAction={
+                shouldShowBackButton ? () => navigation.goBack() : undefined
               }
-              rightControls={
-                canEdit ? (
-                  <ScreenHeader.IconButton
-                    onPress={handlePressEdit}
-                    testID="ContactEditButton"
-                    type="Draw"
-                  />
-                ) : null
-              }
+              rightActions={[
+                {
+                  id: 'edit-profile',
+                  icon: 'EditList',
+                  label: 'Edit profile',
+                  testID: 'ContactEditButton',
+                  onPress: handlePressEdit,
+                  visible: Boolean(canEdit),
+                },
+              ]}
+              placement="navigation"
             />
             <UserProfileScreenView
               userId={userId}
@@ -181,6 +193,14 @@ export function UserProfileScreen({ route, navigation }: Props) {
                   ? handlePressBotSettings
                   : undefined
               }
+              onPressScheduledTasks={
+                scheduledTasksEnabled &&
+                isOwnBotProfile &&
+                automationQuery.data?.available
+                  ? handlePressScheduledTasks
+                  : undefined
+              }
+              scheduledTaskCount={Object.keys(scheduledTasks).length}
               onPressGroup={handlePressGroup}
             />
           </View>

--- a/packages/app/fixtures/RecurringTasks.fixture.tsx
+++ b/packages/app/fixtures/RecurringTasks.fixture.tsx
@@ -1,0 +1,468 @@
+import { createNativeStackNavigator } from '@react-navigation/native-stack';
+import type { JSONContent } from '@tloncorp/api/urbit';
+import type { JSONValue } from '@tloncorp/shared';
+import type * as db from '@tloncorp/shared/db';
+import type { A2UI } from '@tloncorp/shared/logic';
+import { appendToPostBlob } from '@tloncorp/shared/logic';
+import { type PropsWithChildren, useMemo, useState } from 'react';
+import { Image } from 'react-native';
+import { View, useTheme } from 'tamagui';
+
+import { ShipProvider } from '../contexts/ship';
+import { nativeHeaderPresentationOptions } from '../navigation/nativeHeaderOptions';
+import {
+  AppDataContextProvider,
+  ChatMessage,
+  type IdentifiedAutomationTask,
+  type RecurringTaskDraft,
+  RecurringTaskEditorView,
+  ScheduledTasksScreenView,
+  ScreenHeader,
+  ScrollView,
+  UserProfileScreenView,
+} from '../ui';
+import {
+  type DraftInputContext,
+  DraftInputContextProvider,
+} from '../ui/components/draftInputs/shared';
+import { ChannelProvider } from '../ui/contexts/channel';
+import { FixtureWrapper } from './FixtureWrapper';
+import { makePost, verse } from './contentHelpers';
+import {
+  danContact,
+  group,
+  hostedBotContact,
+  initialContacts,
+  tlonLocalBulletinBoard,
+  tlonLocalIntros,
+  tlonLocalWaterCooler,
+} from './fakeData';
+
+const noop = () => {};
+const FixtureStack = createNativeStackNavigator<{ Surface: undefined }>();
+const botContact = {
+  ...hostedBotContact,
+  id: '~pinser-botter-solfer-magfed',
+  nickname: '🌱 News reader',
+  avatarImage: Image.resolveAssetSource(require('../ui/assets/raster/bot.png'))
+    .uri,
+  isContact: false,
+  isContactSuggestion: true,
+  isBlocked: false,
+};
+const botDmChannel = {
+  ...tlonLocalIntros,
+  id: botContact.id,
+  type: 'dm' as const,
+  groupId: null,
+  contactId: botContact.id,
+  title: botContact.nickname,
+};
+
+const taskDefinitions: IdentifiedAutomationTask[] = [
+  {
+    id: 'morning-news',
+    task: {
+      name: 'Morning news summary',
+      enabled: true,
+      schedule: {
+        kind: 'cron',
+        expr: '0 7 * * 1-5',
+        tz: 'America/New_York',
+      },
+      sessionTarget: 'isolated',
+      payload: {
+        kind: 'agentTurn',
+        message:
+          "Summarize today's five most important news stories, with a short explanation of why each matters. Link to the original reporting, prioritize technology and science, and skip sports unless there is major breaking news.",
+      },
+    },
+  },
+  {
+    id: 'ship-backup',
+    task: {
+      name: 'Ship backup check',
+      enabled: true,
+      schedule: { kind: 'cron', expr: '0 2 * * *', tz: 'UTC' },
+      payload: {
+        kind: 'agentTurn',
+        message:
+          "Check that last night's ship backup completed, confirm the archive can be opened, and report the backup size. If anything failed, identify the most recent healthy backup and suggest the safest next step.",
+      },
+    },
+  },
+  {
+    id: 'weekly-digest',
+    task: {
+      name: 'Weekly group digest',
+      enabled: true,
+      schedule: {
+        kind: 'cron',
+        expr: '0 9 * * 1',
+        tz: 'America/New_York',
+      },
+      payload: {
+        kind: 'agentTurn',
+        message:
+          "Review this week's conversations and produce a concise digest of decisions, unresolved questions, promised follow-ups, and messages that still need a reply. Group related items together and mention the responsible person when one is clear.",
+      },
+    },
+  },
+  {
+    id: 'unread-triage',
+    task: {
+      name: 'Unread triage',
+      enabled: true,
+      schedule: { kind: 'every', everyMs: 4 * 60 * 60 * 1000 },
+      payload: {
+        kind: 'agentTurn',
+        message:
+          'Review unread messages across my direct messages and groups. Flag only messages that mention me, ask me a direct question, assign me work, or are blocking a decision. For each item, include the sender, conversation, a one-sentence summary, and the specific response or action needed. Group duplicate requests together, put urgent or time-sensitive items first, and ignore announcements, reactions, automated notices, and threads where someone else has already provided a complete answer. End with a short count of urgent items, replies needed today, and items that can wait.',
+      },
+    },
+  },
+  {
+    id: 'monthly-bill',
+    task: {
+      name: 'Monthly bill reminder',
+      description: 'Remind the group to settle the server bill.',
+      enabled: false,
+      schedule: { kind: 'cron', expr: '0 10 1 * *', tz: 'UTC' },
+    },
+  },
+];
+
+function FullScreen({ children }: { children: React.ReactNode }) {
+  return (
+    <FixtureWrapper fillHeight fillWidth verticalAlign="top">
+      <FixtureStack.Navigator
+        screenOptions={{
+          ...nativeHeaderPresentationOptions,
+          headerShown: true,
+          headerBackVisible: false,
+        }}
+      >
+        <FixtureStack.Screen name="Surface">
+          {() => (
+            <View flex={1} backgroundColor="$background">
+              {children}
+            </View>
+          )}
+        </FixtureStack.Screen>
+      </FixtureStack.Navigator>
+    </FixtureWrapper>
+  );
+}
+
+function BotProfileFixture() {
+  const theme = useTheme();
+
+  return (
+    <FullScreen>
+      <AppDataContextProvider
+        currentUserId={danContact.id}
+        contacts={[...initialContacts, botContact]}
+      >
+        <View flex={1} backgroundColor={theme.secondaryBackground.val}>
+          <ScreenHeader
+            title="Profile"
+            backgroundColor={theme.secondaryBackground.val}
+            backAction={noop}
+            placement="navigation"
+          />
+          <UserProfileScreenView
+            userId={botContact.id}
+            connectionStatus={{ complete: true, status: 'yes' }}
+            onPressBotSettings={noop}
+            onPressScheduledTasks={noop}
+            scheduledTaskCount={taskDefinitions.length}
+            onPressGroup={noop}
+          />
+        </View>
+      </AppDataContextProvider>
+    </FullScreen>
+  );
+}
+
+function TaskListFixture({ empty = false }: { empty?: boolean }) {
+  return (
+    <FullScreen>
+      <ScheduledTasksScreenView
+        available
+        tasks={empty ? [] : taskDefinitions}
+        canMutate={false}
+        onBack={noop}
+      />
+    </FullScreen>
+  );
+}
+
+const initialDraft: RecurringTaskDraft = {
+  name: 'Morning news summary',
+  prompt:
+    "Summarize today's news in five bullets. Link every source. Skip sports.",
+  repeat: 'Weekly',
+  selectedDays: [1, 2, 3, 4, 5],
+  timeLabel: '7:00 AM',
+  destinationLabel: 'General',
+};
+
+const recurringTaskGroup: db.Group = {
+  ...group,
+  id: '~nibset-napwyn/tlon',
+  title: 'Tlon',
+};
+
+const destinationChannelChats: Array<db.Chat & { type: 'channel' }> = [
+  { channel: tlonLocalWaterCooler, title: 'General' },
+  { channel: tlonLocalIntros, title: 'News' },
+  { channel: tlonLocalBulletinBoard, title: 'Announcements' },
+].map(({ channel, title }, index) => ({
+  id: channel.id,
+  type: 'channel',
+  channel: {
+    ...channel,
+    title,
+    groupId: recurringTaskGroup.id,
+    group: recurringTaskGroup,
+  },
+  pin: null,
+  volumeSettings: null,
+  timestamp: Date.now() - index * 60_000,
+  isPending: false,
+  unreadCount: channel.unreadCount ?? 0,
+}));
+
+function TaskEditorFixture() {
+  const [draft, setDraft] = useState(initialDraft);
+  return (
+    <AppDataContextProvider
+      currentUserId={danContact.id}
+      contacts={initialContacts}
+    >
+      <FullScreen>
+        <RecurringTaskEditorView
+          draft={draft}
+          readOnly={false}
+          onChange={setDraft}
+          onBack={noop}
+          onAutosave={noop}
+          destinationChannelChats={destinationChannelChats}
+        />
+      </FullScreen>
+    </AppDataContextProvider>
+  );
+}
+
+const taskCardA2UI: A2UI.BlobEntry = {
+  type: 'a2ui',
+  version: 1,
+  messages: [
+    {
+      version: 'v0.9',
+      createSurface: {
+        surfaceId: 'recurring-task-card',
+        catalogId: 'tlon.a2ui.basic.v1',
+      },
+    },
+    {
+      version: 'v0.9',
+      updateComponents: {
+        surfaceId: 'recurring-task-card',
+        root: 'root',
+        components: [
+          { id: 'root', component: 'Card', child: 'body' },
+          {
+            id: 'body',
+            component: 'Column',
+            children: ['eyebrow', 'title', 'schedule', 'divider', 'actions'],
+          },
+          {
+            id: 'eyebrow',
+            component: 'Text',
+            variant: 'caption',
+            text: 'RECURRING TASK · ACTIVE',
+          },
+          {
+            id: 'title',
+            component: 'Text',
+            variant: 'h3',
+            text: 'Morning news summary',
+          },
+          {
+            id: 'schedule',
+            component: 'Text',
+            variant: 'caption',
+            text: 'Every weekday at 7:00 · posts here',
+          },
+          { id: 'divider', component: 'Divider' },
+          {
+            id: 'actions',
+            component: 'Row',
+            children: ['view', 'notify'],
+          },
+          {
+            id: 'view',
+            component: 'Button',
+            variant: 'secondary',
+            child: 'view-label',
+            action: {
+              event: {
+                name: 'tlon.sendMessage',
+                context: { text: 'Show me this scheduled task' },
+              },
+            },
+          },
+          { id: 'view-label', component: 'Text', text: 'View task' },
+          {
+            id: 'notify',
+            component: 'Button',
+            variant: 'borderless',
+            child: 'notify-label',
+            action: {
+              event: {
+                name: 'tlon.sendMessage',
+                context: { text: 'Notify me if this scheduled task fails' },
+              },
+            },
+          },
+          { id: 'notify-label', component: 'Text', text: 'Notify on failure' },
+        ],
+      },
+    },
+  ],
+};
+
+const now = Date.now();
+const requestPost = makePost(
+  danContact,
+  [verse.inline('Can you set up the morning news digest we discussed?')],
+  {
+    channelId: botDmChannel.id,
+    sentAt: now,
+    receivedAt: now,
+    replyCount: 0,
+  }
+);
+const taskCardPost = makePost(
+  botContact,
+  [verse.inline('Done — the schedule is active.')],
+  {
+    sentAt: now + 1_000,
+    receivedAt: now + 1_000,
+    replyCount: 0,
+    channelId: botDmChannel.id,
+    blob: appendToPostBlob(undefined, taskCardA2UI),
+  }
+);
+const resultRequestPost = makePost(
+  danContact,
+  [verse.inline('Did the morning news task run?')],
+  {
+    channelId: botDmChannel.id,
+    sentAt: now,
+    receivedAt: now,
+    replyCount: 0,
+  }
+);
+const resultPost = makePost(
+  botContact,
+  [
+    verse.inline(
+      'Five things this morning:\n\n— Port strike enters day four.\n— Appeals court narrows the chip export rule.\n— City council moved the budget vote.\n— Two grocery recalls were announced.\n— Rain arrives Thursday.'
+    ),
+  ],
+  {
+    channelId: botDmChannel.id,
+    sentAt: now + 1_000,
+    receivedAt: now + 1_000,
+    replyCount: 0,
+  }
+);
+
+function FixtureDraftProvider({ children }: PropsWithChildren) {
+  const [shouldBlur, setShouldBlur] = useState(false);
+  const value = useMemo<DraftInputContext>(
+    () => ({
+      canStartDraft: true,
+      channel: botDmChannel,
+      clearDraft: async () => {},
+      configuration: {} as Record<string, JSONValue>,
+      getDraft: async () => null,
+      group,
+      sendPostFromDraft: async () => {},
+      setShouldBlur,
+      shouldBlur,
+      startDraft: noop,
+      storeDraft: async (_content: JSONContent) => {},
+    }),
+    [shouldBlur]
+  );
+
+  return (
+    <DraftInputContextProvider value={value}>
+      {children}
+    </DraftInputContextProvider>
+  );
+}
+
+function ChannelStateFixture({ posts }: { posts: (typeof requestPost)[] }) {
+  return (
+    <ShipProvider
+      initialShipInfo={{
+        authType: 'hosted',
+        ship: 'zod',
+        shipUrl: 'https://zod.test',
+        authCookie: 'fixture',
+        needsSplashSequence: false,
+      }}
+    >
+      <FullScreen>
+        <ScreenHeader
+          title={botContact.nickname}
+          backAction={noop}
+          rightActions={[
+            { id: 'search', icon: 'Search', label: 'Search', onPress: noop },
+          ]}
+          placement="navigation"
+        />
+        <ChannelProvider value={{ channel: botDmChannel }}>
+          <FixtureDraftProvider>
+            <ScrollView
+              flex={1}
+              contentContainerStyle={{
+                flexGrow: 1,
+                justifyContent: 'flex-end',
+                paddingHorizontal: '$l',
+                paddingVertical: '$2xl',
+              }}
+            >
+              {posts.map((post) => (
+                <View key={post.id} marginTop="$l">
+                  <ChatMessage
+                    post={post}
+                    showAuthor={true}
+                    showReplies={true}
+                  />
+                </View>
+              ))}
+            </ScrollView>
+          </FixtureDraftProvider>
+        </ChannelProvider>
+      </FullScreen>
+    </ShipProvider>
+  );
+}
+
+export default {
+  '1 · Bot profile': <BotProfileFixture />,
+  '2 · Scheduled tasks': <TaskListFixture />,
+  '2b · Empty state': <TaskListFixture empty />,
+  '3 · Definition editor': <TaskEditorFixture />,
+  '4 · Shared task card (A2UI)': (
+    <ChannelStateFixture posts={[requestPost, taskCardPost]} />
+  ),
+  '5 · Run result (channel post)': (
+    <ChannelStateFixture posts={[resultRequestPost, resultPost]} />
+  ),
+};

--- a/packages/app/hooks/useFilteredChannelChats.ts
+++ b/packages/app/hooks/useFilteredChannelChats.ts
@@ -39,24 +39,33 @@ export function useFilteredChannelChats({
   mode = 'live',
   searchQuery,
   channelFilter,
+  channelChats: channelChatsOverride,
 }: {
   mode?: 'live' | 'snapshot';
   searchQuery: string;
   channelFilter?: (channel: db.Channel) => boolean;
+  channelChats?: Array<db.Chat & { type: 'channel' }>;
 }) {
   const { disableNicknames } = useCalm();
   const { data: chats } = store.useCurrentChats();
   const resolvedChats = useResolvedChats(chats);
 
   const channelChats = useMemo(() => {
-    const all = [...resolvedChats.pinned, ...resolvedChats.unpinned].filter(
-      isChannelChat
-    );
+    const all =
+      channelChatsOverride ??
+      [...resolvedChats.pinned, ...resolvedChats.unpinned].filter(
+        isChannelChat
+      );
 
     return channelFilter
       ? all.filter((chat) => channelFilter(chat.channel))
       : all;
-  }, [channelFilter, resolvedChats.pinned, resolvedChats.unpinned]);
+  }, [
+    channelChatsOverride,
+    channelFilter,
+    resolvedChats.pinned,
+    resolvedChats.unpinned,
+  ]);
   const liveChannelChatsRef = useRef(channelChats);
   liveChannelChatsRef.current = channelChats;
   const [frozenChannelChats, setFrozenChannelChats] =

--- a/packages/app/lib/featureFlags.ts
+++ b/packages/app/lib/featureFlags.ts
@@ -21,6 +21,11 @@ export const featureMeta = {
     label: 'Enable Markdown mode for notebook posts',
     onlyTlon: true,
   },
+  scheduledTasks: {
+    default: false,
+    label: 'Enable scheduled task management',
+    onlyTlon: true,
+  },
 } satisfies Record<
   string,
   { default: boolean; label: string; onlyTlon: boolean }

--- a/packages/app/navigation/RootStack.tsx
+++ b/packages/app/navigation/RootStack.tsx
@@ -11,6 +11,8 @@ import { InviteSystemContactsScreen } from '../features/contacts/InviteSystemCon
 import { ContextLensRunScreen } from '../features/lens/ContextLensRunScreen';
 import { ContextLensRunsScreen } from '../features/lens/ContextLensRunsScreen';
 import { AttestationScreen } from '../features/profile/AttestationScreen';
+import { ScheduledTaskEditorScreen } from '../features/automations/ScheduledTaskEditorScreen';
+import { ScheduledTasksScreen } from '../features/automations/ScheduledTasksScreen';
 import { AppInfoScreen } from '../features/settings/AppInfoScreen';
 import { BlockedUsersScreen } from '../features/settings/BlockedUsersScreen';
 import { BotApiKeySettingsScreen } from '../features/settings/BotApiKeySettingsScreen';
@@ -228,7 +230,21 @@ export function RootStack() {
         component={PushNotificationSettingsScreen}
         options={nativeHeaderScreenOptions}
       />
-      <Root.Screen name="UserProfile" component={UserProfileScreen} />
+      <Root.Screen
+        name="UserProfile"
+        component={UserProfileScreen}
+        options={nativeHeaderScreenOptions}
+      />
+      <Root.Screen
+        name="ScheduledTasks"
+        component={ScheduledTasksScreen}
+        options={nativeHeaderScreenOptions}
+      />
+      <Root.Screen
+        name="ScheduledTaskEditor"
+        component={ScheduledTaskEditorScreen}
+        options={nativeHeaderScreenOptions}
+      />
       <Root.Screen name="Attestation" component={AttestationScreen} />
       <Root.Screen name="EditProfile" component={EditProfileScreen} />
       <Root.Screen

--- a/packages/app/navigation/desktop/HomeNavigator.tsx
+++ b/packages/app/navigation/desktop/HomeNavigator.tsx
@@ -24,6 +24,8 @@ import { NotesFolderScreen } from '../../features/top/NotesFolderScreen';
 import { NotesSearchScreen } from '../../features/top/NotesSearchScreen';
 import PostScreen from '../../features/top/PostScreen';
 import { UserProfileScreen } from '../../features/top/UserProfileScreen';
+import { ScheduledTaskEditorScreen } from '../../features/automations/ScheduledTaskEditorScreen';
+import { ScheduledTasksScreen } from '../../features/automations/ScheduledTasksScreen';
 import { GroupSettingsStack } from '../../navigation/GroupSettingsStack';
 import { DESKTOP_SIDEBAR_WIDTH, useGlobalSearch } from '../../ui';
 import { NotebookSidebarProvider } from '../../ui/contexts/notebookSidebar';
@@ -231,6 +233,14 @@ function ChannelStack(
         <ChannelStackNavigator.Screen
           name="UserProfile"
           component={UserProfileScreen}
+        />
+        <ChannelStackNavigator.Screen
+          name="ScheduledTasks"
+          component={ScheduledTasksScreen}
+        />
+        <ChannelStackNavigator.Screen
+          name="ScheduledTaskEditor"
+          component={ScheduledTaskEditorScreen}
         />
         <ChannelStackNavigator.Screen
           name="EditProfile"

--- a/packages/app/navigation/desktop/MessagesNavigator.tsx
+++ b/packages/app/navigation/desktop/MessagesNavigator.tsx
@@ -23,6 +23,8 @@ import { NotesFolderScreen } from '../../features/top/NotesFolderScreen';
 import { NotesSearchScreen } from '../../features/top/NotesSearchScreen';
 import PostScreen from '../../features/top/PostScreen';
 import { UserProfileScreen } from '../../features/top/UserProfileScreen';
+import { ScheduledTaskEditorScreen } from '../../features/automations/ScheduledTaskEditorScreen';
+import { ScheduledTasksScreen } from '../../features/automations/ScheduledTasksScreen';
 import { DESKTOP_SIDEBAR_WIDTH, useGlobalSearch } from '../../ui';
 import { GroupSettingsStack } from '../GroupSettingsStack';
 import { HomeDrawerParamList } from '../types';
@@ -167,6 +169,14 @@ function ChannelStack(
         <ChannelStackNavigator.Screen
           name="UserProfile"
           component={UserProfileScreen}
+        />
+        <ChannelStackNavigator.Screen
+          name="ScheduledTasks"
+          component={ScheduledTasksScreen}
+        />
+        <ChannelStackNavigator.Screen
+          name="ScheduledTaskEditor"
+          component={ScheduledTaskEditorScreen}
         />
         <ChannelStackNavigator.Screen
           name="EditProfile"

--- a/packages/app/navigation/desktop/ProfileNavigator.tsx
+++ b/packages/app/navigation/desktop/ProfileNavigator.tsx
@@ -14,6 +14,8 @@ import { AddContactsScreen } from '../../features/contacts/AddContactsScreen';
 import { AttestationScreen } from '../../features/profile/AttestationScreen';
 import { EditProfileScreen } from '../../features/settings/EditProfileScreen';
 import { UserProfileScreen } from '../../features/top/UserProfileScreen';
+import { ScheduledTaskEditorScreen } from '../../features/automations/ScheduledTaskEditorScreen';
+import { ScheduledTasksScreen } from '../../features/automations/ScheduledTasksScreen';
 import { useMarkMatchesSeen } from '../../hooks/useMarkMatchesSeen';
 import {
   ContactsScreenView,
@@ -88,7 +90,15 @@ function DrawerContent(props: DrawerContentComponentProps) {
       <ContactsScreenView
         contacts={userContacts ?? []}
         suggestions={suggestions ?? []}
-        focusedContactId={focusedRoute.params?.userId}
+        focusedContactId={
+          focusedRoute.name === 'UserProfile'
+            ? (
+                focusedRoute.params as
+                  | ProfileDrawerParamList['UserProfile']
+                  | undefined
+              )?.userId
+            : undefined
+        }
         onContactPress={onContactPress}
         onAddContact={onAddContact}
         onContactLongPress={onContactLongPress}
@@ -118,6 +128,14 @@ export const ProfileNavigator = () => {
     >
       <ProfileDrawer.Screen name="AddContacts" component={AddContactsScreen} />
       <ProfileDrawer.Screen name="UserProfile" component={UserProfileScreen} />
+      <ProfileDrawer.Screen
+        name="ScheduledTasks"
+        component={ScheduledTasksScreen}
+      />
+      <ProfileDrawer.Screen
+        name="ScheduledTaskEditor"
+        component={ScheduledTaskEditorScreen}
+      />
       <ProfileDrawer.Screen name="EditProfile" component={EditProfileScreen} />
       <ProfileDrawer.Screen name="Attestation" component={AttestationScreen} />
     </ProfileDrawer.Navigator>

--- a/packages/app/navigation/types.ts
+++ b/packages/app/navigation/types.ts
@@ -107,6 +107,13 @@ export type RootStackParamList = {
     channelLabel: string;
     groupJoined: boolean;
   };
+  ScheduledTasks: {
+    botShip: string;
+  };
+  ScheduledTaskEditor: {
+    botShip: string;
+    taskId?: string;
+  };
   BlockedUsers: undefined;
   PrivacySettings: undefined;
   AppInfo: undefined;
@@ -192,7 +199,10 @@ export type HomeDrawerParamList = Pick<TopLevelTabParamList, 'ChatList'> &
   };
 
 export type ProfileDrawerParamList = Pick<TopLevelTabParamList, 'Contacts'> &
-  Pick<RootStackParamList, 'AddContacts' | 'UserProfile'>;
+  Pick<
+    RootStackParamList,
+    'AddContacts' | 'UserProfile' | 'ScheduledTasks' | 'ScheduledTaskEditor'
+  >;
 
 export type SettingsDrawerParamList = Pick<
   RootStackParamList,
@@ -225,6 +235,8 @@ export type ChannelStackParamList = {
   NotesSearch: RootStackParamList['NotesSearch'];
   MediaViewer: RootStackParamList['MediaViewer'];
   UserProfile: RootStackParamList['UserProfile'];
+  ScheduledTasks: RootStackParamList['ScheduledTasks'];
+  ScheduledTaskEditor: RootStackParamList['ScheduledTaskEditor'];
   EditProfile: RootStackParamList['EditProfile'];
   ChannelMembers: RootStackParamList['ChannelMembers'];
   ChannelMeta: RootStackParamList['ChannelMeta'];
@@ -240,6 +252,8 @@ export type DesktopChannelStackParamList = Pick<
   | 'NotesSearch'
   | 'MediaViewer'
   | 'UserProfile'
+  | 'ScheduledTasks'
+  | 'ScheduledTaskEditor'
   | 'EditProfile'
   | 'ChannelMembers'
   | 'ChannelMeta'

--- a/packages/app/package.json
+++ b/packages/app/package.json
@@ -27,6 +27,7 @@
     "@types/react-native": "0.73.0"
   },
   "peerDependencies": {
+    "@react-native-picker/picker": "*",
     "expo-audio": "*",
     "expo-document-picker": "*",
     "expo-file-system": "*",

--- a/packages/app/ui/components/ForwardChannelSelector.tsx
+++ b/packages/app/ui/components/ForwardChannelSelector.tsx
@@ -9,13 +9,16 @@ import { useFilteredChannelChats } from '../../hooks/useFilteredChannelChats';
 import { ForwardChannelListItem } from './ForwardChannelListItem';
 import { SearchBar } from './SearchBar';
 
+export type ForwardChannelChat = db.Chat & { type: 'channel' };
+
 type ForwardChannelSelectorProps = {
   isOpen: boolean;
   onChannelSelected: (channel: db.Channel) => void;
   channelFilter?: (channel: db.Channel) => boolean;
+  channelChats?: ForwardChannelChat[];
 };
 
-type ChannelChat = db.Chat & { type: 'channel' };
+type ChannelChat = ForwardChannelChat;
 
 const ITEM_H = 76;
 const LIST_HEIGHT_RATIO = 0.68;
@@ -34,6 +37,7 @@ export function ForwardChannelSelector({
   isOpen,
   onChannelSelected,
   channelFilter,
+  channelChats: channelChatsOverride,
 }: ForwardChannelSelectorProps) {
   const { width: screenWidth, height: screenHeight } = useWindowDimensions();
   const [query, setQuery] = useState('');
@@ -45,6 +49,7 @@ export function ForwardChannelSelector({
     mode: isOpen ? 'snapshot' : 'live',
     searchQuery: query,
     channelFilter,
+    channelChats: channelChatsOverride,
   });
 
   const handleQueryChanged = useCallback((newQuery: string) => {

--- a/packages/app/ui/components/ForwardToChannelSheet.tsx
+++ b/packages/app/ui/components/ForwardToChannelSheet.tsx
@@ -2,7 +2,10 @@ import * as db from '@tloncorp/shared/db';
 import { ComponentProps } from 'react';
 
 import { ActionSheet } from './ActionSheet';
-import { ForwardChannelSelector } from './ForwardChannelSelector';
+import {
+  ForwardChannelChat,
+  ForwardChannelSelector,
+} from './ForwardChannelSelector';
 import {
   FORWARD_SHEET_SNAP_POINTS,
   useDelayedClose,
@@ -17,6 +20,7 @@ type ForwardToChannelSheetProps = {
   // Temporary escape hatch for share-target filtering. Should probably push it
   // down into the underlying query.
   channelFilter?: (channel: db.Channel) => boolean;
+  channelChats?: ForwardChannelChat[];
   footerComponent?: ComponentProps<typeof ActionSheet>['footerComponent'];
 };
 
@@ -27,6 +31,7 @@ export function ForwardToChannelSheet({
   subtitle,
   onChannelSelected,
   channelFilter,
+  channelChats,
   footerComponent,
 }: ForwardToChannelSheetProps) {
   const showSelector = useDelayedClose(open);
@@ -56,6 +61,7 @@ export function ForwardToChannelSheet({
             isOpen={showSelector}
             onChannelSelected={onChannelSelected}
             channelFilter={channelFilter}
+            channelChats={channelChats}
           />
         ) : null}
       </ActionSheet.Content>

--- a/packages/app/ui/components/RecurringTasks.tsx
+++ b/packages/app/ui/components/RecurringTasks.tsx
@@ -1,0 +1,545 @@
+import type { StewardAutomationTask } from '@tloncorp/api/urbit';
+import { useDebouncedValue } from '@tloncorp/shared';
+import type * as db from '@tloncorp/shared/db';
+import { Button, Icon, Pressable, Text } from '@tloncorp/ui';
+import { Picker } from '@react-native-picker/picker';
+import { useCallback, useEffect, useRef, useState } from 'react';
+import { View, XStack, YStack } from 'tamagui';
+
+import { ActionSheet } from './ActionSheet';
+import { TextInput } from './Form/inputs';
+import type { ForwardChannelChat } from './ForwardChannelSelector';
+import { ForwardToChannelSheet } from './ForwardToChannelSheet';
+import { ScreenHeader } from './ScreenHeader';
+import { SettingsContentScrollView } from './SettingsContentScrollView';
+import { formatAutomationSchedule } from './formatAutomationSchedule';
+import { useForwardToChannelSheet } from './useForwardToChannelSheet';
+
+export interface IdentifiedAutomationTask {
+  id: string;
+  task: StewardAutomationTask;
+}
+
+export interface RecurringTaskDraft {
+  name: string;
+  prompt: string;
+  repeat: 'Daily' | 'Weekly' | 'Monthly' | 'Yearly';
+  selectedDays: number[];
+  timeLabel: string;
+  destinationLabel: string;
+}
+
+export function ScheduledTasksScreenView({
+  available,
+  loading,
+  tasks,
+  canMutate,
+  onAddTask,
+  onBack,
+  onPressTask,
+}: {
+  available: boolean;
+  loading?: boolean;
+  tasks: IdentifiedAutomationTask[];
+  canMutate: boolean;
+  onAddTask?: () => void;
+  onBack: () => void;
+  onPressTask?: (task: IdentifiedAutomationTask) => void;
+}) {
+  return (
+    <View flex={1} backgroundColor="$secondaryBackground">
+      <ScreenHeader
+        backgroundColor="$secondaryBackground"
+        backAction={onBack}
+        rightActions={[
+          {
+            id: 'new-scheduled-task',
+            icon: 'Add',
+            label: 'New task',
+            onPress: onAddTask,
+            visible: canMutate && Boolean(onAddTask),
+          },
+        ]}
+        title="Scheduled"
+        placement="navigation"
+      />
+      {loading ? (
+        <ScheduledTasksNotice
+          title="Loading scheduled tasks"
+          body="Reading the latest definitions mirrored to Steward."
+        />
+      ) : !available ? (
+        <ScheduledTasksNotice
+          title="Scheduled tasks unavailable"
+          body="This ship does not expose Steward's automation mirror yet."
+        />
+      ) : tasks.length === 0 ? (
+        <ScheduledTasksNotice
+          title="No scheduled tasks"
+          body="OpenClaw has not mirrored any task definitions for this bot."
+          action={
+            canMutate && onAddTask
+              ? { label: 'New task', onPress: onAddTask }
+              : undefined
+          }
+        />
+      ) : (
+        <SettingsContentScrollView
+          paddingHorizontal="$xl"
+          paddingTop="$xl"
+          safeAreaBottomOffset={24}
+        >
+          <YStack gap="$xl">
+            {tasks.map((identified) => (
+              <YStack
+                key={identified.id}
+                backgroundColor="$background"
+                borderRadius="$2xl"
+                overflow="hidden"
+              >
+                <ScheduledTaskListItem
+                  identified={identified}
+                  onPress={
+                    onPressTask ? () => onPressTask(identified) : undefined
+                  }
+                />
+              </YStack>
+            ))}
+          </YStack>
+        </SettingsContentScrollView>
+      )}
+    </View>
+  );
+}
+
+function ScheduledTasksNotice({
+  title,
+  body,
+  action,
+}: {
+  title: string;
+  body: string;
+  action?: { label: string; onPress: () => void };
+}) {
+  return (
+    <YStack
+      flex={1}
+      alignItems="center"
+      justifyContent="center"
+      gap="$2xl"
+      paddingHorizontal="$4xl"
+      paddingBottom={96}
+    >
+      <Icon type="Clock" customSize={[32, 32]} color="$secondaryText" />
+      <YStack alignItems="center" gap="$2xl" maxWidth={350}>
+        <Text size="$label/2xl" fontWeight="600" textAlign="center">
+          {title}
+        </Text>
+        <Text size="$label/l" color="$secondaryText" textAlign="center">
+          {body}
+        </Text>
+      </YStack>
+      {action ? (
+        <Button
+          preset="primary"
+          label={action.label}
+          onPress={action.onPress}
+        />
+      ) : null}
+    </YStack>
+  );
+}
+
+function ScheduledTaskListItem({
+  identified,
+  onPress,
+}: {
+  identified: IdentifiedAutomationTask;
+  onPress?: () => void;
+}) {
+  const { task } = identified;
+  const title = task.name || task.description || 'Untitled task';
+  const prompt = task.payload?.message || task.description;
+  const content = (
+    <YStack padding="$2xl" gap="$2xl">
+      <Text size="$label/2xl" fontWeight="600" numberOfLines={1}>
+        {title}
+      </Text>
+      {prompt ? (
+        <Text size="$label/xl" color="$secondaryText" numberOfLines={3}>
+          {prompt}
+        </Text>
+      ) : null}
+      <Text size="$label/xl" color="$tertiaryText">
+        {formatAutomationSchedule(task)}
+      </Text>
+    </YStack>
+  );
+
+  if (!onPress) return content;
+  return (
+    <Pressable onPress={onPress} pressStyle={{ opacity: 0.72 }}>
+      {content}
+    </Pressable>
+  );
+}
+
+const DAY_LABELS = ['S', 'M', 'T', 'W', 'T', 'F', 'S'];
+const HOURS = Array.from({ length: 12 }, (_, index) => index + 1);
+const MINUTES = Array.from({ length: 60 }, (_, index) => index);
+
+type TimeSelection = {
+  hour: number;
+  minute: number;
+  period: 'AM' | 'PM';
+};
+
+function parseTimeLabel(value: string): TimeSelection {
+  const match = value.trim().match(/^(\d{1,2}):(\d{2})\s*(AM|PM)$/i);
+  const hour = Number(match?.[1]);
+  const minute = Number(match?.[2]);
+
+  if (
+    !match ||
+    !Number.isInteger(hour) ||
+    hour < 1 ||
+    hour > 12 ||
+    !Number.isInteger(minute) ||
+    minute < 0 ||
+    minute > 59
+  ) {
+    return { hour: 8, minute: 0, period: 'AM' };
+  }
+
+  return {
+    hour,
+    minute,
+    period: match[3].toUpperCase() as TimeSelection['period'],
+  };
+}
+
+function formatTimeSelection({ hour, minute, period }: TimeSelection) {
+  return `${hour}:${minute.toString().padStart(2, '0')} ${period}`;
+}
+
+export function RecurringTaskEditorView({
+  draft,
+  readOnly,
+  onChange,
+  onBack,
+  onAutosave,
+  destinationChannelChats,
+}: {
+  draft: RecurringTaskDraft;
+  readOnly: boolean;
+  onChange: (draft: RecurringTaskDraft) => void;
+  onBack: () => void;
+  onAutosave?: (draft: RecurringTaskDraft) => void | Promise<void>;
+  destinationChannelChats?: ForwardChannelChat[];
+}) {
+  const debouncedDraft = useDebouncedValue(draft, 500);
+  const lastAutosavedDraft = useRef(draft);
+  const [promptHeight, setPromptHeight] = useState(128);
+  const [timeSheetOpen, setTimeSheetOpen] = useState(false);
+  const [destinationSheetOpen, setDestinationSheetOpen] = useState(false);
+  useEffect(() => {
+    if (
+      readOnly ||
+      !onAutosave ||
+      debouncedDraft === lastAutosavedDraft.current
+    ) {
+      return;
+    }
+    lastAutosavedDraft.current = debouncedDraft;
+    void onAutosave(debouncedDraft);
+  }, [debouncedDraft, onAutosave, readOnly]);
+
+  const update = <K extends keyof RecurringTaskDraft>(
+    key: K,
+    value: RecurringTaskDraft[K]
+  ) => onChange({ ...draft, [key]: value });
+  const toggleDay = (day: number) => {
+    if (readOnly) return;
+    update(
+      'selectedDays',
+      draft.selectedDays.includes(day)
+        ? draft.selectedDays.filter((current) => current !== day)
+        : [...draft.selectedDays, day].sort()
+    );
+  };
+  const updateDestination = useCallback(
+    async (channel: db.Channel) => {
+      const destination = channel.title?.trim() || 'Direct message';
+      onChange({ ...draft, destinationLabel: destination });
+    },
+    [draft, onChange]
+  );
+  const { handleChannelSelected, renderFooter: renderDestinationFooter } =
+    useForwardToChannelSheet({
+      isOpen: destinationSheetOpen,
+      onClose: () => setDestinationSheetOpen(false),
+      onForwardToChannel: updateDestination,
+      successMessage: () => null,
+      failureMessage: 'Could not select channel',
+      submitLabel: (channelTitle) => `Post to ${channelTitle}`,
+      submittingLabel: 'Selecting...',
+    });
+  const timeDisabled = readOnly;
+  const destinationDisabled = readOnly;
+
+  return (
+    <View flex={1} backgroundColor="$secondaryBackground">
+      <ScreenHeader
+        backgroundColor="$secondaryBackground"
+        backAction={onBack}
+        title="Recurring task"
+        placement="navigation"
+      />
+      <SettingsContentScrollView
+        paddingHorizontal="$2xl"
+        paddingTop="$2xl"
+        safeAreaBottomOffset={24}
+      >
+        <YStack gap="$xl">
+          <TextInput
+            accessibilityLabel="Task name"
+            editable={!readOnly}
+            value={draft.name}
+            onChangeText={(value) => update('name', value)}
+            placeholder="Task name"
+            frameStyle={{
+              borderWidth: 0,
+              borderRadius: '$2xl',
+              backgroundColor: '$background',
+            }}
+          />
+          <TextInput
+            accessibilityLabel="Task prompt"
+            editable={!readOnly}
+            value={draft.prompt}
+            onChangeText={(value) => update('prompt', value)}
+            placeholder="What should the bot do?"
+            multiline
+            numberOfLines={4}
+            scrollEnabled={false}
+            onContentSizeChange={(event) => {
+              setPromptHeight(
+                Math.max(
+                  128,
+                  Math.ceil(event.nativeEvent.contentSize.height) + 24
+                )
+              );
+            }}
+            frameStyle={{
+              height: promptHeight,
+              alignItems: 'flex-start',
+              borderWidth: 0,
+              borderRadius: '$2xl',
+              backgroundColor: '$background',
+            }}
+          />
+          <YStack
+            backgroundColor="$background"
+            borderRadius="$2xl"
+            padding="$2xl"
+            gap="$2xl"
+            overflow="hidden"
+          >
+            <XStack justifyContent="space-between" alignItems="center">
+              <Text size="$label/l">Repeat</Text>
+              <Text size="$label/l" color="$secondaryText">
+                {draft.repeat}
+              </Text>
+            </XStack>
+            <XStack gap="$s">
+              {DAY_LABELS.map((label, day) => {
+                const selected = draft.selectedDays.includes(day);
+                return (
+                  <Pressable
+                    key={`${label}-${day}`}
+                    flex={1}
+                    aspectRatio={1}
+                    borderRadius="$4xl"
+                    alignItems="center"
+                    justifyContent="center"
+                    backgroundColor={
+                      selected ? '$primaryText' : '$secondaryBackground'
+                    }
+                    disabled={readOnly}
+                    onPress={() => toggleDay(day)}
+                  >
+                    <Text
+                      size="$label/m"
+                      color={selected ? '$background' : '$tertiaryText'}
+                    >
+                      {label}
+                    </Text>
+                  </Pressable>
+                );
+              })}
+            </XStack>
+          </YStack>
+          <Pressable
+            accessibilityLabel="Time"
+            accessibilityRole="button"
+            accessibilityState={{ disabled: timeDisabled }}
+            disabled={timeDisabled}
+            onPress={() => setTimeSheetOpen(true)}
+            pressStyle={{ opacity: 0.72 }}
+          >
+            <XStack
+              minHeight={64}
+              backgroundColor="$background"
+              borderRadius="$2xl"
+              paddingHorizontal="$2xl"
+              alignItems="center"
+              justifyContent="space-between"
+            >
+              <Text size="$label/l">Time</Text>
+              <YStack
+                backgroundColor="$secondaryBackground"
+                borderRadius="$4xl"
+                paddingHorizontal="$xl"
+                paddingVertical="$m"
+              >
+                <Text size="$label/l">{draft.timeLabel}</Text>
+              </YStack>
+            </XStack>
+          </Pressable>
+          <Pressable
+            accessibilityLabel="Posts to"
+            accessibilityRole="button"
+            accessibilityState={{ disabled: destinationDisabled }}
+            disabled={destinationDisabled}
+            onPress={() => setDestinationSheetOpen(true)}
+            pressStyle={{ opacity: 0.72 }}
+          >
+            <XStack
+              minHeight={64}
+              backgroundColor="$background"
+              borderRadius="$2xl"
+              paddingHorizontal="$2xl"
+              alignItems="center"
+              justifyContent="space-between"
+            >
+              <Text size="$label/l">Posts to</Text>
+              <Text size="$label/l" color="$secondaryText">
+                {draft.destinationLabel}
+              </Text>
+            </XStack>
+          </Pressable>
+          {readOnly ? (
+            <Text size="$label/s" color="$secondaryText" padding="$s">
+              Steward mirrors definitions but cannot edit OpenClaw schedules
+              yet.
+            </Text>
+          ) : null}
+        </YStack>
+      </SettingsContentScrollView>
+      <TimePickerSheet
+        open={timeSheetOpen}
+        onOpenChange={setTimeSheetOpen}
+        value={draft.timeLabel}
+        onChange={(time) => update('timeLabel', time)}
+      />
+      <ForwardToChannelSheet
+        open={destinationSheetOpen}
+        onOpenChange={setDestinationSheetOpen}
+        title="Posts to"
+        onChannelSelected={handleChannelSelected}
+        channelChats={destinationChannelChats}
+        footerComponent={renderDestinationFooter}
+      />
+    </View>
+  );
+}
+
+function TimePickerSheet({
+  open,
+  onOpenChange,
+  value,
+  onChange,
+}: {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  value: string;
+  onChange: (value: string) => void;
+}) {
+  const [selection, setSelection] = useState(() => parseTimeLabel(value));
+
+  useEffect(() => {
+    if (open) {
+      setSelection(parseTimeLabel(value));
+    }
+  }, [open, value]);
+
+  return (
+    <ActionSheet
+      open={open}
+      onOpenChange={onOpenChange}
+      snapPointsMode="percent"
+      snapPoints={[46]}
+      modal
+    >
+      <ActionSheet.SimpleHeader title="Time" />
+      <ActionSheet.Content paddingHorizontal="$xl" paddingBottom="$2xl">
+        <XStack height={190} alignItems="center">
+          <Picker
+            accessibilityLabel="Hour"
+            selectedValue={selection.hour}
+            onValueChange={(hour) =>
+              setSelection((current) => ({ ...current, hour: Number(hour) }))
+            }
+            style={{ flex: 1 }}
+          >
+            {HOURS.map((hour) => (
+              <Picker.Item key={hour} label={`${hour}`} value={hour} />
+            ))}
+          </Picker>
+          <Picker
+            accessibilityLabel="Minute"
+            selectedValue={selection.minute}
+            onValueChange={(minute) =>
+              setSelection((current) => ({
+                ...current,
+                minute: Number(minute),
+              }))
+            }
+            style={{ flex: 1 }}
+          >
+            {MINUTES.map((minute) => (
+              <Picker.Item
+                key={minute}
+                label={minute.toString().padStart(2, '0')}
+                value={minute}
+              />
+            ))}
+          </Picker>
+          <Picker
+            accessibilityLabel="AM or PM"
+            selectedValue={selection.period}
+            onValueChange={(period) =>
+              setSelection((current) => ({
+                ...current,
+                period: period as TimeSelection['period'],
+              }))
+            }
+            style={{ flex: 1 }}
+          >
+            <Picker.Item label="AM" value="AM" />
+            <Picker.Item label="PM" value="PM" />
+          </Picker>
+        </XStack>
+        <Button
+          preset="primary"
+          label="Done"
+          centered
+          onPress={() => {
+            onChange(formatTimeSelection(selection));
+            onOpenChange(false);
+          }}
+        />
+      </ActionSheet.Content>
+    </ActionSheet>
+  );
+}

--- a/packages/app/ui/components/UserProfileScreenView.tsx
+++ b/packages/app/ui/components/UserProfileScreenView.tsx
@@ -41,6 +41,8 @@ interface Props {
   userId: string;
   connectionStatus: api.ConnectionStatus | null;
   onPressBotSettings?: () => void;
+  onPressScheduledTasks?: () => void;
+  scheduledTaskCount?: number;
   onPressGroup: (group: db.Group) => void;
 }
 
@@ -115,7 +117,7 @@ export function UserProfileScreenView(props: Props) {
           flexDirection: 'row',
         }}
       >
-        <View paddingHorizontal={'$l'}>
+        <View paddingHorizontal={'$l'} width="100%">
           <UserInfoRow
             userId={props.userId}
             hasNickname={!!userContact?.nickname?.length}
@@ -127,8 +129,12 @@ export function UserProfileScreenView(props: Props) {
           <ProfileButtons userId={props.userId} contact={userContact} />
         ) : null}
 
-        {props.onPressBotSettings ? (
-          <BotSettingsListItem onPress={props.onPressBotSettings} />
+        {props.onPressBotSettings || props.onPressScheduledTasks ? (
+          <BotManagementList
+            onPressBotSettings={props.onPressBotSettings}
+            onPressScheduledTasks={props.onPressScheduledTasks}
+            scheduledTaskCount={props.scheduledTaskCount}
+          />
         ) : null}
 
         {userContact?.status && (
@@ -166,38 +172,87 @@ export function UserProfileScreenView(props: Props) {
   );
 }
 
-function BotSettingsListItem({ onPress }: { onPress: () => void }) {
-  const handlePress = useCallback(() => {
-    onPress();
-    triggerHaptic('baseButtonClick');
-  }, [onPress]);
+function BotManagementList({
+  onPressBotSettings,
+  onPressScheduledTasks,
+  scheduledTaskCount,
+}: {
+  onPressBotSettings?: () => void;
+  onPressScheduledTasks?: () => void;
+  scheduledTaskCount?: number;
+}) {
+  const makePressHandler = useCallback((onPress: () => void) => {
+    return () => {
+      onPress();
+      triggerHaptic('baseButtonClick');
+    };
+  }, []);
 
   return (
-    <View paddingHorizontal="$xl" width="100%">
-      <Pressable
+    <View paddingHorizontal="$xl" width="100%" gap="$l">
+      {onPressScheduledTasks ? (
+        <BotManagementListItem
+          icon="Clock"
+          label="Scheduled tasks"
+          value={
+            scheduledTaskCount == null ? undefined : String(scheduledTaskCount)
+          }
+          onPress={makePressHandler(onPressScheduledTasks)}
+        />
+      ) : null}
+      {onPressBotSettings ? (
+        <BotManagementListItem
+          icon="Face"
+          label="Bot settings"
+          onPress={makePressHandler(onPressBotSettings)}
+        />
+      ) : null}
+    </View>
+  );
+}
+
+function BotManagementListItem({
+  icon,
+  label,
+  value,
+  onPress,
+}: {
+  icon: 'Clock' | 'Face';
+  label: string;
+  value?: string;
+  onPress: () => void;
+}) {
+  return (
+    <Pressable
+      borderRadius="$2xl"
+      onPress={onPress}
+      pressStyle={{ backgroundColor: '$secondaryBackground' }}
+    >
+      <ListItem
+        alignItems="center"
+        backgroundColor="$background"
         borderRadius="$2xl"
-        onPress={handlePress}
-        pressStyle={{ backgroundColor: '$secondaryBackground' }}
+        padding="$l"
       >
-        <ListItem
-          alignItems="center"
-          backgroundColor="$background"
-          borderRadius="$2xl"
-          padding="$l"
-        >
-          <ListItem.SystemIcon icon="Face" rounded />
-          <ListItem.MainContent>
-            <ListItem.Title>Bot settings</ListItem.Title>
-          </ListItem.MainContent>
-          <ListItem.EndContent>
+        <ListItem.SystemIcon icon={icon} rounded />
+        <ListItem.MainContent>
+          <ListItem.Title>{label}</ListItem.Title>
+        </ListItem.MainContent>
+        <ListItem.EndContent>
+          <XStack alignItems="center" gap="$m">
+            {value ? (
+              <Text size="$label/m" color="$secondaryText">
+                {value}
+              </Text>
+            ) : null}
             <ListItem.SystemIcon
               icon="ChevronRight"
               backgroundColor="$transparent"
             />
-          </ListItem.EndContent>
-        </ListItem>
-      </Pressable>
-    </View>
+          </XStack>
+        </ListItem.EndContent>
+      </ListItem>
+    </Pressable>
   );
 }
 

--- a/packages/app/ui/components/formatAutomationSchedule.test.ts
+++ b/packages/app/ui/components/formatAutomationSchedule.test.ts
@@ -1,0 +1,35 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  formatAutomationSchedule,
+  formatCronSchedule,
+} from './formatAutomationSchedule';
+
+describe('formatCronSchedule', () => {
+  it.each([
+    ['0 7 * * 1-5', 'Weekdays at 7:00 AM'],
+    ['0 2 * * *', 'Daily at 2:00 AM'],
+    ['0 9 * * 1', 'Mondays at 9:00 AM'],
+    ['0 10 1 * *', 'Monthly on the 1st at 10:00 AM'],
+    ['30 8 15 3 *', 'Yearly on March 15th at 8:30 AM'],
+    ['*/15 * * * *', 'Every 15 minutes'],
+    ['30 * * * *', 'Every hour at :30'],
+  ])('describes %s', (expression, expected) => {
+    expect(formatCronSchedule(expression)).toBe(expected);
+  });
+
+  it('does not expose expressions it cannot accurately describe', () => {
+    expect(formatCronSchedule('0 9 L * *')).toBe('Custom schedule');
+    expect(formatCronSchedule('not a cron expression')).toBe('Custom schedule');
+  });
+});
+
+describe('formatAutomationSchedule', () => {
+  it('preserves readable interval schedules', () => {
+    expect(
+      formatAutomationSchedule({
+        schedule: { kind: 'every', everyMs: 4 * 60 * 60 * 1000 },
+      })
+    ).toBe('Every 4 hours');
+  });
+});

--- a/packages/app/ui/components/formatAutomationSchedule.ts
+++ b/packages/app/ui/components/formatAutomationSchedule.ts
@@ -1,0 +1,189 @@
+import type {
+  StewardAutomationSchedule,
+  StewardAutomationTask,
+} from '@tloncorp/api/urbit';
+
+const DAY_NAMES = [
+  'Sunday',
+  'Monday',
+  'Tuesday',
+  'Wednesday',
+  'Thursday',
+  'Friday',
+  'Saturday',
+];
+
+const MONTH_NAMES = [
+  'January',
+  'February',
+  'March',
+  'April',
+  'May',
+  'June',
+  'July',
+  'August',
+  'September',
+  'October',
+  'November',
+  'December',
+];
+
+function numberInRange(value: string, minimum: number, maximum: number) {
+  if (!/^\d+$/.test(value)) return undefined;
+  const number = Number(value);
+  return number >= minimum && number <= maximum ? number : undefined;
+}
+
+function formatTime(hour: number, minute: number) {
+  const period = hour < 12 ? 'AM' : 'PM';
+  const displayHour = hour % 12 || 12;
+  return `${displayHour}:${String(minute).padStart(2, '0')} ${period}`;
+}
+
+function ordinal(value: number) {
+  const lastTwoDigits = value % 100;
+  if (lastTwoDigits >= 11 && lastTwoDigits <= 13) return `${value}th`;
+  if (value % 10 === 1) return `${value}st`;
+  if (value % 10 === 2) return `${value}nd`;
+  if (value % 10 === 3) return `${value}rd`;
+  return `${value}th`;
+}
+
+function normalizeDay(value: number) {
+  return value === 7 ? 0 : value;
+}
+
+function parseDaysOfWeek(field: string) {
+  if (field === '1-5') return 'Weekdays';
+
+  const days = field
+    .split(',')
+    .map((part) => numberInRange(part, 0, 7))
+    .filter((day): day is number => day !== undefined)
+    .map(normalizeDay);
+
+  if (days.length !== field.split(',').length) return undefined;
+  const uniqueDays = [...new Set(days)].sort();
+  if (uniqueDays.length === 2 && uniqueDays[0] === 0 && uniqueDays[1] === 6) {
+    return 'Weekends';
+  }
+  if (uniqueDays.length === 1) return `${DAY_NAMES[uniqueDays[0]]}s`;
+  if (uniqueDays.length === 0) return undefined;
+
+  const names = uniqueDays.map((day) => DAY_NAMES[day]);
+  return `${names.slice(0, -1).join(', ')} and ${names.at(-1)}s`;
+}
+
+export function formatCronSchedule(expression?: string) {
+  if (!expression) return 'Custom schedule';
+
+  const fields = expression.trim().split(/\s+/);
+  if (fields.length !== 5) return 'Custom schedule';
+
+  const [minuteField, hourField, dayOfMonthField, monthField, dayOfWeekField] =
+    fields;
+  const minute = numberInRange(minuteField, 0, 59);
+  const hour = numberInRange(hourField, 0, 23);
+
+  if (
+    minute !== undefined &&
+    hour !== undefined &&
+    dayOfMonthField === '*' &&
+    monthField === '*'
+  ) {
+    const time = formatTime(hour, minute);
+    if (dayOfWeekField === '*') {
+      return `Daily at ${time}`;
+    }
+    const days = parseDaysOfWeek(dayOfWeekField);
+    if (days) return `${days} at ${time}`;
+  }
+
+  if (minute !== undefined && hour !== undefined && dayOfWeekField === '*') {
+    const dayOfMonth = numberInRange(dayOfMonthField, 1, 31);
+    if (dayOfMonth !== undefined && monthField === '*') {
+      return `Monthly on the ${ordinal(dayOfMonth)} at ${formatTime(hour, minute)}`;
+    }
+
+    const month = numberInRange(monthField, 1, 12);
+    if (dayOfMonth !== undefined && month !== undefined) {
+      return `Yearly on ${MONTH_NAMES[month - 1]} ${ordinal(dayOfMonth)} at ${formatTime(hour, minute)}`;
+    }
+  }
+
+  if (
+    minuteField === '*' &&
+    hourField === '*' &&
+    dayOfMonthField === '*' &&
+    monthField === '*' &&
+    dayOfWeekField === '*'
+  ) {
+    return 'Every minute';
+  }
+
+  const minuteInterval = /^\*\/(\d+)$/.exec(minuteField)?.[1];
+  if (
+    minuteInterval &&
+    hourField === '*' &&
+    dayOfMonthField === '*' &&
+    monthField === '*' &&
+    dayOfWeekField === '*'
+  ) {
+    const interval = numberInRange(minuteInterval, 1, 59);
+    if (interval) {
+      return `Every ${interval} ${interval === 1 ? 'minute' : 'minutes'}`;
+    }
+  }
+
+  if (
+    minute !== undefined &&
+    hourField === '*' &&
+    dayOfMonthField === '*' &&
+    monthField === '*' &&
+    dayOfWeekField === '*'
+  ) {
+    return `Every hour at :${String(minute).padStart(2, '0')}`;
+  }
+
+  const hourInterval = /^\*\/(\d+)$/.exec(hourField)?.[1];
+  if (
+    minute !== undefined &&
+    hourInterval &&
+    dayOfMonthField === '*' &&
+    monthField === '*' &&
+    dayOfWeekField === '*'
+  ) {
+    const interval = numberInRange(hourInterval, 1, 23);
+    if (interval) {
+      return `Every ${interval} ${interval === 1 ? 'hour' : 'hours'} at :${String(minute).padStart(2, '0')}`;
+    }
+  }
+
+  return 'Custom schedule';
+}
+
+function formatEverySchedule(schedule: StewardAutomationSchedule) {
+  if (schedule.kind !== 'every' || !schedule.everyMs) {
+    return 'Repeating schedule';
+  }
+  const hours = schedule.everyMs / (60 * 60 * 1000);
+  if (Number.isInteger(hours) && hours >= 1) {
+    return `Every ${hours} ${hours === 1 ? 'hour' : 'hours'}`;
+  }
+  const minutes = Math.round(schedule.everyMs / (60 * 1000));
+  return `Every ${minutes} ${minutes === 1 ? 'minute' : 'minutes'}`;
+}
+
+export function formatAutomationSchedule(task: StewardAutomationTask) {
+  const schedule = task.schedule;
+  if (!schedule) return 'Schedule unavailable';
+  if (schedule.kind === 'cron') {
+    return formatCronSchedule(schedule.expr);
+  }
+  if (schedule.kind === 'at') {
+    return schedule.at
+      ? `Once · ${new Date(schedule.at).toLocaleString()}`
+      : 'One-time schedule';
+  }
+  return formatEverySchedule(schedule);
+}

--- a/packages/app/ui/components/useForwardToChannelSheet.tsx
+++ b/packages/app/ui/components/useForwardToChannelSheet.tsx
@@ -14,6 +14,8 @@ type UseForwardToChannelSheetParams = {
   successMessage: (channelTitle: string) => string | null;
   failureMessage: string;
   closeBeforeForward?: boolean;
+  submitLabel?: (channelTitle: string) => string;
+  submittingLabel?: string;
 };
 
 export const FORWARD_SHEET_SNAP_POINTS: number[] = [85];
@@ -46,6 +48,8 @@ export function useForwardToChannelSheet({
   successMessage,
   failureMessage,
   closeBeforeForward = false,
+  submitLabel = (channelTitle) => `Forward to ${channelTitle}`,
+  submittingLabel = 'Forwarding...',
 }: UseForwardToChannelSheetParams) {
   const isDelayedCloseOpen = useDelayedClose(isOpen);
   const [selectedChannel, setSelectedChannel] = useState<db.Channel | null>(
@@ -134,10 +138,10 @@ export function useForwardToChannelSheet({
           disabled={isSending || !!errorMessage}
           label={
             isSending
-              ? 'Forwarding...'
+              ? submittingLabel
               : errorMessage
                 ? errorMessage
-                : `Forward to ${selectedChannelTitle}`
+                : submitLabel(selectedChannelTitle)
           }
           centered
         />
@@ -150,6 +154,8 @@ export function useForwardToChannelSheet({
     isSending,
     selectedChannel,
     selectedChannelTitle,
+    submitLabel,
+    submittingLabel,
   ]);
 
   return {

--- a/packages/app/ui/index.tsx
+++ b/packages/app/ui/index.tsx
@@ -63,6 +63,7 @@ export * from './components/PostScreenView';
 export * from './components/ProfileSheet';
 export * from './components/GroupMemberProfileSheet';
 export * from './components/ScreenHeader';
+export * from './components/RecurringTasks';
 export * from './components/ScreenScrollView';
 export * from './components/SearchBar';
 export * from './components/SettingsContentScrollView';


### PR DESCRIPTION
## Summary

Add a feature-flagged scheduled-task management flow for owned bot profiles using task definitions mirrored by Steward.

## Changes

- Add a Scheduled tasks entry to owned bot profiles when task data is available or needs a retry.
- Add populated, empty, unavailable, loading, error, and missing-task states.
- Refresh task data when the profile, list, or detail screen regains focus.
- Preserve cached tasks when a background refresh fails.
- Show each task's schedule, timezone, and active or paused status without rounding sub-minute intervals.
- Keep Steward-backed task details read-only until mutations are available.
- Add integrated fixtures for profile, list, task detail, shared task, and run-result states.

## How did I test?

- Focused Steward API tests passed: 16 tests.
- Focused schedule and image-sizing tests passed: 30 tests.
- `packages/app` and `packages/api` TypeScript checks passed.
- Verified the profile, list, and editor refetch on focus while retaining cached data during a failed refresh.

