### PR TITLE
fix profile header layout

### DIFF
--- a/packages/app/ui/components/UserProfileScreenView.tsx
+++ b/packages/app/ui/components/UserProfileScreenView.tsx
@@ -115,7 +115,7 @@ export function UserProfileScreenView(props: Props) {
           flexDirection: 'row',
         }}
       >
-        <View paddingHorizontal={'$l'}>
+        <View paddingHorizontal={'$l'} width="100%">
           <UserInfoRow
             userId={props.userId}
             hasNickname={!!userContact?.nickname?.length}


### PR DESCRIPTION
## Summary

Restore profile names and normal spacing after the Bot badge layout caused the header to collapse.

Fixes TLON-6408

## Changes

- give the profile identity wrapper a definite full width
- preserve long-name truncation and the trailing Bot badge

## How did I test?

- `packages/app` TypeScript check passed
- targeted formatting passed
- targeted lint completed with two existing warnings
- `git diff --check` passed
- verified normal and Bot profiles on a physical Galaxy S24
- verified long Bot names truncate while the badge remains visible
- verified profile scrolling down and back up

## Screenshots

| Before | After |
| --- | --- |
| <img src="https://github.com/user-attachments/assets/0aaf93bd-92e6-48c8-8c99-f4f5ed99b21d" alt="Profile before the fix" width="320" /> | <img src="https://github.com/user-attachments/assets/82220ffa-e85e-43f0-a007-7bcaccfef396" alt="Profile after the fix" width="320" /> |