### PR TITLE
ops: bump mobile version to 9.5.0

### DIFF
--- a/apps/tlon-mobile/android/app/build.gradle
+++ b/apps/tlon-mobile/android/app/build.gradle
@@ -132,7 +132,7 @@ android {
         targetSdkVersion rootProject.ext.targetSdkVersion
         compileSdk rootProject.ext.compileSdkVersion
         versionCode 108
-        versionName "9.4.4"
+        versionName "9.5.0"
     }
     compileOptions {
         coreLibraryDesugaringEnabled true

--- a/apps/tlon-mobile/android/app/build.gradle
+++ b/apps/tlon-mobile/android/app/build.gradle
@@ -132,7 +132,7 @@ android {
         targetSdkVersion rootProject.ext.targetSdkVersion
         compileSdk rootProject.ext.compileSdkVersion
         versionCode 108
-        versionName "9.4.3"
+        versionName "9.4.4"
     }
     compileOptions {
         coreLibraryDesugaringEnabled true

--- a/apps/tlon-mobile/ios/Landscape.xcodeproj/project.pbxproj
+++ b/apps/tlon-mobile/ios/Landscape.xcodeproj/project.pbxproj
@@ -1818,7 +1818,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 9.4.3;
+				MARKETING_VERSION = 9.4.4;
 				OTHER_LDFLAGS = (
 					"$(inherited)",
 					"-ObjC",
@@ -1856,7 +1856,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 9.4.3;
+				MARKETING_VERSION = 9.4.4;
 				OTHER_LDFLAGS = (
 					"$(inherited)",
 					"-ObjC",
@@ -2088,7 +2088,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 9.4.3;
+				MARKETING_VERSION = 9.4.4;
 				OTHER_LDFLAGS = (
 					"$(inherited)",
 					"-ObjC",
@@ -2131,7 +2131,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 9.4.3;
+				MARKETING_VERSION = 9.4.4;
 				OTHER_LDFLAGS = (
 					"$(inherited)",
 					"-ObjC",

--- a/apps/tlon-mobile/ios/Landscape.xcodeproj/project.pbxproj
+++ b/apps/tlon-mobile/ios/Landscape.xcodeproj/project.pbxproj
@@ -1818,7 +1818,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 9.4.4;
+				MARKETING_VERSION = 9.5.0;
 				OTHER_LDFLAGS = (
 					"$(inherited)",
 					"-ObjC",
@@ -1856,7 +1856,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 9.4.4;
+				MARKETING_VERSION = 9.5.0;
 				OTHER_LDFLAGS = (
 					"$(inherited)",
 					"-ObjC",
@@ -2088,7 +2088,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 9.4.4;
+				MARKETING_VERSION = 9.5.0;
 				OTHER_LDFLAGS = (
 					"$(inherited)",
 					"-ObjC",
@@ -2131,7 +2131,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 9.4.4;
+				MARKETING_VERSION = 9.5.0;
 				OTHER_LDFLAGS = (
 					"$(inherited)",
 					"-ObjC",

--- a/apps/tlon-mobile/package.json
+++ b/apps/tlon-mobile/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tlon-mobile",
-  "version": "9.4.3",
+  "version": "9.4.4",
   "private": true,
   "expo": {
     "autolinking": {

--- a/apps/tlon-mobile/package.json
+++ b/apps/tlon-mobile/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tlon-mobile",
-  "version": "9.4.4",
+  "version": "9.5.0",
   "private": true,
   "expo": {
     "autolinking": {


### PR DESCRIPTION
## Summary

Bump the mobile app version from 9.4.3 to 9.5.0 so the production iOS build can be submitted.

## Changes

- update the mobile package version
- update Android versionName
- update iOS MARKETING_VERSION

## How did I test?

- verified all three mobile version sources are 9.5.0
- verified no 9.4.3 or 9.4.4 references remain in those sources
- `git diff --check` passed
- confirmed the previous production build succeeded and only the iOS submission failed because 9.4.3 had already been submitted