### PR TITLE
fixtures: drop vestigial tlon-group-agent-config description block

### DIFF
--- a/packages/app/fixtures/AgentOnboarding.fixture.tsx
+++ b/packages/app/fixtures/AgentOnboarding.fixture.tsx
@@ -129,23 +129,7 @@ const homeGroup: db.Group = {
   currentUserIsHost: true,
   title: 'Open hardware + Space weather Digest',
   channels: [homeChannel, updatesNotebook],
-  description: JSON.stringify([
-    {
-      type: 'tlon-group-agent-config',
-      version: 1,
-      templateId: 'agent-daily-digest',
-      purpose: 'A daily digest',
-      instructions: '',
-      agents: [tlonbot.id],
-      jobs: [{}],
-      onboarding: {
-        state: 'complete',
-        topics: 'Open hardware, Space weather',
-        timezone: 'America/New_York',
-      },
-      updatedAt: 1,
-    },
-  ]),
+  description: 'A daily digest of open hardware and space weather.',
 };
 
 function action(text: string): A2UI.ButtonAction {


### PR DESCRIPTION
## Summary

Removes a leftover fixture block implying group descriptions carry `tlon-group-agent-config` JSON. That format existed only on the closed #6221; the merged onboarding keeps its durable state in post blobs and coordinator state. The block is inert set-dressing, but it reads as documentation of a wire format that was never shipped — it cost us a confused afternoon of code archaeology this week.

## How did I test?

Fixture-only string change; `tsc` clean in packages/app, oxfmt clean.

## Risks and impact

None — cosmos fixture data only.

## Rollback plan

Revert.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01K32JNc3ZZZQyeKHnCtB4Re