### PR TITLE
desk: bootstrap %tlon on existing piers

### DIFF
--- a/.github/helpers/deploy.sh
+++ b/.github/helpers/deploy.sh
@@ -84,10 +84,26 @@ cat > "$cmdfile" <<EOF
 staging=\$(mktemp -d)
 tar xzf /tmp/janeway-desk.tgz -C \$staging
 cd /urbit || exit 1
-curl -s --data '{"source":{"dojo":"+hood/unmount %$desk"},"sink":{"app":"hood"}}' http://localhost:12321
-curl -s --data '{"source":{"dojo":"+hood/mount %$desk"},"sink":{"app":"hood"}}' http://localhost:12321
+set -euo pipefail
+has_desk() {
+  curl -fsS http://localhost:12321/~/scry/hood/kiln/pikes.json \
+    | grep -Eq '"$desk"[[:space:]]*:'
+}
+if ! has_desk; then
+  echo "Creating %$desk from %base"
+  curl -fsS --data '{"source":{"dojo":"+hood/merge %$desk our %base"},"sink":{"app":"hood"}}' http://localhost:12321
+  for attempt in \$(seq 1 30); do
+    if has_desk; then
+      break
+    fi
+    sleep 1
+  done
+  has_desk || { echo "Timed out waiting for %$desk" >&2; exit 1; }
+fi
+curl -fsS --data '{"source":{"dojo":"+hood/unmount %$desk"},"sink":{"app":"hood"}}' http://localhost:12321
+curl -fsS --data '{"source":{"dojo":"+hood/mount %$desk"},"sink":{"app":"hood"}}' http://localhost:12321
 rsync -avL --delete \$staging/assembled/ $folder
-curl -s --data '{"source":{"dojo":"+hood/commit %$desk"},"sink":{"app":"hood"}}' http://localhost:12321
+curl -fsS --data '{"source":{"dojo":"+hood/commit %$desk"},"sink":{"app":"hood"}}' http://localhost:12321
 rm -rf \$staging /tmp/janeway-desk.tgz
 EOF
 echo "Remote commands:"

--- a/apps/tlon-web/rube/index.ts
+++ b/apps/tlon-web/rube/index.ts
@@ -1057,32 +1057,6 @@ const installTlonDesk = async () => {
   console.log('Tlon desk installed on all ships');
 };
 
-const ensureTlonDesk = async () => {
-  console.log('Ensuring %tlon desk exists on archived ships');
-
-  for (const ship of Object.values(ships) as Ship[]) {
-    if (
-      (targetShip && targetShip !== ship.ship) ||
-      ship.skipCommit === true
-    ) {
-      continue;
-    }
-
-    try {
-      await waitForTlonDeskInKiln(ship, { maxAttempts: 1 });
-      continue;
-    } catch {
-      console.log(`Creating missing %tlon desk on ${ship.ship}`);
-      await hoodCommand(
-        ship.ship as ShipName,
-        'merge %tlon our %base',
-        ship.loopbackPort
-      );
-      await waitForTlonDeskInKiln(ship, { maxAttempts: 30 });
-    }
-  }
-};
-
 const nukeStateOnShips = async () => {
   for (const ship of Object.values(ships) as Ship[]) {
     if (targetShip && targetShip !== ship.ship) {
@@ -1681,11 +1655,10 @@ const shipNeedsExtraction = (ship: Ship): boolean => {
   // Check if the ship directory looks valid (has expected structure).
   // archive-piers.sh excludes .run and .bin/* from the tarballs, so no
   // published archive can ever contain them.
-  const hasArchiveDesk = ['tlon', 'groups'].some((desk) =>
-    fs.existsSync(path.join(shipPath, desk))
+  const expectedFiles = ['.urb', 'tlon'];
+  const hasValidStructure = expectedFiles.every((file) =>
+    fs.existsSync(path.join(shipPath, file))
   );
-  const hasValidStructure =
-    fs.existsSync(path.join(shipPath, '.urb')) && hasArchiveDesk;
 
   if (!hasValidStructure) {
     return true;
@@ -2166,9 +2139,6 @@ const main = async () => {
       await setStorageConfiguration();
       await logStorageState('post-config');
     } else {
-      // Existing archives predate %tlon. Create the desk before reading its
-      // start hash; mounting later will materialize its filesystem directory.
-      await ensureTlonDesk();
       await getStartHashes();
 
       // Nuke state and set reel service ship before mount/commit operations,

--- a/apps/tlon-web/rube/index.ts
+++ b/apps/tlon-web/rube/index.ts
@@ -1057,6 +1057,32 @@ const installTlonDesk = async () => {
   console.log('Tlon desk installed on all ships');
 };
 
+const ensureTlonDesk = async () => {
+  console.log('Ensuring %tlon desk exists on archived ships');
+
+  for (const ship of Object.values(ships) as Ship[]) {
+    if (
+      (targetShip && targetShip !== ship.ship) ||
+      ship.skipCommit === true
+    ) {
+      continue;
+    }
+
+    try {
+      await waitForTlonDeskInKiln(ship, { maxAttempts: 1 });
+      continue;
+    } catch {
+      console.log(`Creating missing %tlon desk on ${ship.ship}`);
+      await hoodCommand(
+        ship.ship as ShipName,
+        'merge %tlon our %base',
+        ship.loopbackPort
+      );
+      await waitForTlonDeskInKiln(ship, { maxAttempts: 30 });
+    }
+  }
+};
+
 const nukeStateOnShips = async () => {
   for (const ship of Object.values(ships) as Ship[]) {
     if (targetShip && targetShip !== ship.ship) {
@@ -1655,10 +1681,11 @@ const shipNeedsExtraction = (ship: Ship): boolean => {
   // Check if the ship directory looks valid (has expected structure).
   // archive-piers.sh excludes .run and .bin/* from the tarballs, so no
   // published archive can ever contain them.
-  const expectedFiles = ['.urb', 'tlon'];
-  const hasValidStructure = expectedFiles.every((file) =>
-    fs.existsSync(path.join(shipPath, file))
+  const hasArchiveDesk = ['tlon', 'groups'].some((desk) =>
+    fs.existsSync(path.join(shipPath, desk))
   );
+  const hasValidStructure =
+    fs.existsSync(path.join(shipPath, '.urb')) && hasArchiveDesk;
 
   if (!hasValidStructure) {
     return true;
@@ -2139,6 +2166,9 @@ const main = async () => {
       await setStorageConfiguration();
       await logStorageState('post-config');
     } else {
+      // Existing archives predate %tlon. Create the desk before reading its
+      // start hash; mounting later will materialize its filesystem directory.
+      await ensureTlonDesk();
       await getStartHashes();
 
       // Nuke state and set reel service ship before mount/commit operations,


### PR DESCRIPTION
## Summary
- create `%tlon` on archived Rube piers before reading its start hash
- accept pre-migration `%groups` archive layouts during the transition
- make deployment preflight create and verify a missing desk before mounting and committing it

## Verification
- `bash -n .github/helpers/deploy.sh`
- `pnpm --dir apps/tlon-web rube:compile` *(blocked: this worktree has no `node_modules`, so `tsc-files` is unavailable)*