### PR TITLE
test: run backend harness from %tlon

### DIFF
--- a/.github/helpers/deploy.sh
+++ b/.github/helpers/deploy.sh
@@ -84,10 +84,26 @@ cat > "$cmdfile" <<EOF
 staging=\$(mktemp -d)
 tar xzf /tmp/janeway-desk.tgz -C \$staging
 cd /urbit || exit 1
-curl -s --data '{"source":{"dojo":"+hood/unmount %$desk"},"sink":{"app":"hood"}}' http://localhost:12321
-curl -s --data '{"source":{"dojo":"+hood/mount %$desk"},"sink":{"app":"hood"}}' http://localhost:12321
+set -euo pipefail
+has_desk() {
+  curl -fsS http://localhost:12321/~/scry/hood/kiln/pikes.json \
+    | grep -Eq '"$desk"[[:space:]]*:'
+}
+if ! has_desk; then
+  echo "Creating %$desk from %base"
+  curl -fsS --data '{"source":{"dojo":"+hood/merge %$desk our %base"},"sink":{"app":"hood"}}' http://localhost:12321
+  for attempt in \$(seq 1 30); do
+    if has_desk; then
+      break
+    fi
+    sleep 1
+  done
+  has_desk || { echo "Timed out waiting for %$desk" >&2; exit 1; }
+fi
+curl -fsS --data '{"source":{"dojo":"+hood/unmount %$desk"},"sink":{"app":"hood"}}' http://localhost:12321
+curl -fsS --data '{"source":{"dojo":"+hood/mount %$desk"},"sink":{"app":"hood"}}' http://localhost:12321
 rsync -avL --delete \$staging/assembled/ $folder
-curl -s --data '{"source":{"dojo":"+hood/commit %$desk"},"sink":{"app":"hood"}}' http://localhost:12321
+curl -fsS --data '{"source":{"dojo":"+hood/commit %$desk"},"sink":{"app":"hood"}}' http://localhost:12321
 rm -rf \$staging /tmp/janeway-desk.tgz
 EOF
 echo "Remote commands:"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -288,7 +288,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Install peru
-        # run-tests.sh assembles the groups desk via scripts/assemble-desk.sh,
+        # run-tests.sh assembles the tlon desk via scripts/assemble-desk.sh,
         # which runs `peru sync` to vendor desk deps (desk-deps/) — including
         # peru-only deps like sur/mcp-proxy that aren't in the test pill.
         run: |

--- a/.github/workflows/deploy-alt-canary.yml
+++ b/.github/workflows/deploy-alt-canary.yml
@@ -113,7 +113,7 @@ jobs:
       - id: deploy
         name: Deploy
         run:
-          ./.github/helpers/deploy.sh tloncorp/tlon-apps groups
+          ./.github/helpers/deploy.sh tloncorp/tlon-apps tlon
           bosdev-wanpen-marnus us-central1-b mainnet-tlon-other-2d ${{ env.tag
           }} bosdev-wanpen-dozzod-marnus
         env:

--- a/.github/workflows/deploy-alt-livenet.yml
+++ b/.github/workflows/deploy-alt-livenet.yml
@@ -21,7 +21,7 @@ jobs:
       - id: deploy
         name: Deploy
         run:
-          ./.github/helpers/deploy.sh tloncorp/tlon-apps groups
+          ./.github/helpers/deploy.sh tloncorp/tlon-apps tlon
           bosdev-marpen-marnus us-central1-b mainnet-tlon-other-2d ${{
           github.event.inputs.tag }} bosdev-marpen-dozzod-marnus
         env:

--- a/.github/workflows/deploy-canary.yml
+++ b/.github/workflows/deploy-canary.yml
@@ -113,7 +113,7 @@ jobs:
       - id: deploy
         name: Deploy
         run:
-          ./.github/helpers/deploy.sh tloncorp/tlon-apps groups
+          ./.github/helpers/deploy.sh tloncorp/tlon-apps tlon
           binnec-dozzod-marnus us-central1-a mainnet-tlon-other-2d ${{ env.tag
           }}
         env:

--- a/.github/workflows/deploy-ephemeral.yml
+++ b/.github/workflows/deploy-ephemeral.yml
@@ -107,7 +107,7 @@ jobs:
       - id: deploy
         name: Deploy
         run:
-          ./.github/helpers/deploy.sh tloncorp/tlon-apps groups ${{
+          ./.github/helpers/deploy.sh tloncorp/tlon-apps tlon ${{
           needs.build_test_images.outputs.moon_name }} us-central1-a
           mainnet-tlon-other-2d
         env:

--- a/.github/workflows/deploy-external.yml
+++ b/.github/workflows/deploy-external.yml
@@ -26,7 +26,7 @@ jobs:
       - id: deploy
         name: Deploy
         run:
-          ./.github/helpers/deploy.sh tloncorp/tlon-apps groups
+          ./.github/helpers/deploy.sh tloncorp/tlon-apps tlon
           doznec-dozzod-marnus us-central1-a mainnet-tlon-other-2d ${{
           github.event.inputs.tag }}
         env:
@@ -36,7 +36,7 @@ jobs:
         name: Deploy Kernel Moon
         if: ${{ github.event.inputs.kernel == 'true' }}
         run:
-          ./.github/helpers/deploy.sh tloncorp/tlon-apps groups
+          ./.github/helpers/deploy.sh tloncorp/tlon-apps tlon
           bosdev-dozzod-marnus us-central1-b mainnet-tlon-other-2d ${{
           github.event.inputs.tag }}
         env:

--- a/.github/workflows/deploy-internal.yml
+++ b/.github/workflows/deploy-internal.yml
@@ -21,7 +21,7 @@ jobs:
       - id: deploy
         name: Deploy
         run:
-          ./.github/helpers/deploy.sh tloncorp/tlon-apps groups marnec-dozzod-marnus us-central1-a mainnet-tlon-other-2d ${{ github.event.inputs.tag }}
+          ./.github/helpers/deploy.sh tloncorp/tlon-apps tlon marnec-dozzod-marnus us-central1-a mainnet-tlon-other-2d ${{ github.event.inputs.tag }}
         env:
           SSH_SEC_KEY: ${{ secrets.GCP_SSH_SEC_KEY }}
           SSH_PUB_KEY: ${{ secrets.GCP_SSH_PUB_KEY }}

--- a/.github/workflows/deploy-kernel.yml
+++ b/.github/workflows/deploy-kernel.yml
@@ -24,7 +24,7 @@ jobs:
       - id: deploy
         name: Deploy
         run:
-          ./.github/helpers/deploy.sh tloncorp/tlon-apps groups bosdev-dozzod-marnus us-central1-b mainnet-tlon-other-2d ${{ github.event.inputs.tag }}
+          ./.github/helpers/deploy.sh tloncorp/tlon-apps tlon bosdev-dozzod-marnus us-central1-b mainnet-tlon-other-2d ${{ github.event.inputs.tag }}
         env:
           SSH_SEC_KEY: ${{ secrets.GCP_SSH_SEC_KEY }}
           SSH_PUB_KEY: ${{ secrets.GCP_SSH_PUB_KEY }}

--- a/.github/workflows/deploy-livenet.yml
+++ b/.github/workflows/deploy-livenet.yml
@@ -31,7 +31,7 @@ jobs:
       - id: deploy
         name: Deploy
         run:
-          ./.github/helpers/deploy.sh tloncorp/tlon-apps groups sogryp-dister-dozzod-dozzod us-central1-b mainnet-tlon-other-2d ${{ github.event.inputs.tag }}
+          ./.github/helpers/deploy.sh tloncorp/tlon-apps tlon sogryp-dister-dozzod-dozzod us-central1-b mainnet-tlon-other-2d ${{ github.event.inputs.tag }}
         env:
           SSH_SEC_KEY: ${{ secrets.GCP_SSH_SEC_KEY }}
           SSH_PUB_KEY: ${{ secrets.GCP_SSH_PUB_KEY }}

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -111,7 +111,7 @@ jobs:
       - id: deploy
         name: Deploy
         run:
-          ./.github/helpers/deploy.sh tloncorp/tlon-apps groups
+          ./.github/helpers/deploy.sh tloncorp/tlon-apps tlon
           wannec-dozzod-marnus us-central1-a mainnet-tlon-other-2d ${{ env.tag
           }}
         env:

--- a/.github/workflows/glob-and-deploy-kernel.yml
+++ b/.github/workflows/glob-and-deploy-kernel.yml
@@ -79,7 +79,7 @@ jobs:
         uses: "google-github-actions/setup-gcloud@v1"
       - id: deploy
         name: Deploy
-        run: ./.github/helpers/deploy.sh tloncorp/tlon-apps groups bosdev-dozzod-marnus us-central1-b mainnet-tlon-other-2d ${{ github.event.inputs.tag }}
+        run: ./.github/helpers/deploy.sh tloncorp/tlon-apps tlon bosdev-dozzod-marnus us-central1-b mainnet-tlon-other-2d ${{ github.event.inputs.tag }}
         env:
           SSH_SEC_KEY: ${{ secrets.GCP_SSH_SEC_KEY }}
           SSH_PUB_KEY: ${{ secrets.GCP_SSH_PUB_KEY }}

--- a/.github/workflows/hermes-ci.yml
+++ b/.github/workflows/hermes-ci.yml
@@ -18,7 +18,7 @@ jobs:
   shared-e2e:
     name: Shared E2E
     runs-on: blacksmith-8vcpu-ubuntu-2204
-    # Three runtimes boot fresh stacks and re-apply the branch %groups desk
+    # Three runtimes boot fresh stacks and re-apply the branch %tlon desk
     # (baseline and cron scenario partitions, then the package suite; ~8-9
     # minutes per apply on native runners when the desk has drifted). The
     # previous budgets were exceeded at exactly that arithmetic.

--- a/.github/workflows/openclaw-ci.yml
+++ b/.github/workflows/openclaw-ci.yml
@@ -57,7 +57,7 @@ jobs:
   integration-test:
     name: Shared E2E
     runs-on: blacksmith-8vcpu-ubuntu-2204
-    # Three runtimes boot fresh stacks and re-apply the branch %groups desk
+    # Three runtimes boot fresh stacks and re-apply the branch %tlon desk
     # (baseline and cron scenario partitions, then the package suite; ~8-9
     # minutes per apply on native runners when the desk has drifted). The
     # previous budgets were exceeded at exactly that arithmetic.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -59,7 +59,7 @@ broke compilation on new kelvins.
     cloning and after editing `peru.yaml`. Requires peru (`pipx install peru`).
 -   `./scripts/assemble-desk.sh <target>` — build a full desk into `<target>`:
     rsync `desk-deps/` in with `--delete`, then `desk/` on top, then stamp
-    `commit.txt`. This is how a `%groups` desk is assembled for a ship (used by
+    `commit.txt`. This is how a `%tlon` desk is assembled for a ship (used by
     `deploy.sh`, rube, and local dev — see DEVELOPMENT.md).
 -   Upstream revs (urbit tag, landscape commit) are **pinned in `peru.yaml`**.
     To build against a different kernel, change the rev there on your branch.

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -4,7 +4,7 @@ These instructions are for working on the Tlon app as a developer at Tlon.
 
 ## Project Structure
 
--   `/desk`: The folder containing the desk for %groups. This currently contains the agents necessary for the Tlon app.
+-   `/desk`: The folder containing the desk for %tlon. This currently contains the agents necessary for the Tlon app.
 
 -   `/apps/tlon-web`: Tlon is built primarily using [React], [TypeScript], and [Tamagui]. [Vite] ensures that all code and assets are loaded appropriately, bundles the application for distribution and provides a functional dev environment.
 
@@ -18,48 +18,48 @@ Regardless of what you run to develop, Vite will hot-reload code changes as you 
 
 ## Fakezod Development
 
-To get started, make sure your %groups desk is mounted:
+To get started, make sure your %tlon desk is mounted:
 
 ```
-|mount %groups
+|mount %tlon
 ```
 
-Sync the latest %groups files. `assemble-desk.sh` vendors the base-dev/landscape
+Sync the latest %tlon files. `assemble-desk.sh` vendors the base-dev/landscape
 dependencies into `desk-deps/` (gitignored — see `peru.yaml`) and layers them
-with our `desk/` into the ship's mounted groups desk:
+with our `desk/` into the ship's mounted tlon desk:
 
 ```
-./scripts/assemble-desk.sh ~/urbit/zod/groups
+./scripts/assemble-desk.sh ~/urbit/zod/tlon
 ```
 
 And commit:
 
 ```
-|commit %groups
+|commit %tlon
 ```
 
-Since %groups has already been released and is now in the pill. It is very unlikely that you would have to create this desk from scratch, but if you do you can follow these instructions.
+Since %tlon has already been released and is now in the pill. It is very unlikely that you would have to create this desk from scratch, but if you do you can follow these instructions.
 
 1. Clone or pull latest versions of this repo, `tloncorp/landscape` and `urbit/urbit`.
 2. Boot a fake ship. Use local networking with `-F` like so: `urbit -F zod`
 3. Create and mount the appropriate desks on local `~zod`:
     1. `|new-desk %landscape`
     2. `|mount %landscape`
-    3. `|new-desk %groups`
-    4. `|mount %groups`
+    3. `|new-desk %tlon`
+    4. `|mount %tlon`
 4. Assemble the `%landscape` desk (it is built from upstream, not via peru):
     1. From `urbit/urbit`: `rsync -avL --delete pkg/base-dev/* ~/urbit/zod/landscape/`
     2. From `tloncorp/landscape`: `rsync -avL desk/* ~/urbit/zod/landscape/`
-5. Assemble the `%groups` desk from this repo. `assemble-desk.sh` vendors its
+5. Assemble the `%tlon` desk from this repo. `assemble-desk.sh` vendors its
    base-dev and landscape dependencies into `desk-deps/` via peru, then layers
    `desk-deps/` + `desk/` into the mounted desk:
-    1. `./scripts/assemble-desk.sh ~/urbit/zod/groups`
+    1. `./scripts/assemble-desk.sh ~/urbit/zod/tlon`
 6. Commit and install landscape on local `~zod`:
     1. `|commit %landscape`
     2. `|install our %landscape`
 7. Similarly commit and install Tlon:
-    1. `|commit %groups`
-    2. `|install our %groups`
+    1. `|commit %tlon`
+    2. `|install our %tlon`
 
 ## Deploying
 

--- a/apps/tlon-web/rube/Dockerfile
+++ b/apps/tlon-web/rube/Dockerfile
@@ -91,7 +91,7 @@ COPY ../../../packages/ /workspace/packages/
 COPY ../../../apps/tlon-web/ /workspace/apps/tlon-web/
 COPY ../../../desk/ /workspace/desk/
 # peru.yaml + scripts are needed for the runtime `peru sync` (into desk-deps/)
-# and assemble-desk.sh (desk-deps/ + desk/ -> ship groups desk)
+# and assemble-desk.sh (desk-deps/ + desk/ -> ship tlon desk)
 COPY ../../../peru.yaml /workspace/peru.yaml
 COPY ../../../scripts/ /workspace/scripts/
 

--- a/apps/tlon-web/rube/README-ARCHIVING.md
+++ b/apps/tlon-web/rube/README-ARCHIVING.md
@@ -139,7 +139,7 @@ SHIPS_TO_VERIFY="zod ten" ./verify-archives.sh
 ### When to Archive New Piers
 
 Archive new piers when:
-- Significant backend changes have been made to the groups desk
+- Significant backend changes have been made to the tlon desk
 - New apps or features need to be included in test piers
 - Pier state needs to be reset or cleaned up
 - Monthly maintenance (recommended)

--- a/apps/tlon-web/rube/archive-piers.sh
+++ b/apps/tlon-web/rube/archive-piers.sh
@@ -706,8 +706,8 @@ validate_archive_locally() {
 
     # Check for essential files
     local essential_files=(
-        "$ship/groups/sys.kelvin"
-        "$ship/groups/desk.bill"
+        "$ship/tlon/sys.kelvin"
+        "$ship/tlon/desk.bill"
         "$ship/.urb"
     )
 
@@ -811,7 +811,7 @@ EOF
         # Never embed macOS resource forks/xattrs: BSD tar stores them as
         # AppleDouble entries that GNU tar inside the Linux containers
         # materializes as literal ._* files throughout the piers — including
-        # the mounted %groups desk, which then never matches a clean
+        # the mounted %tlon desk, which then never matches a clean
         # assembly (observed breaking the bot-e2e desk apply on v28).
         # COPYFILE_DISABLE covers BSD tar; it is harmless for the GNU paths.
         export COPYFILE_DISABLE=1

--- a/apps/tlon-web/rube/construct-desk.sh
+++ b/apps/tlon-web/rube/construct-desk.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 set -euo pipefail
 
-# Assemble the %groups desk inside an extracted rube pier.
+# Assemble the %tlon desk inside an extracted rube pier.
 #
 # Delegates to scripts/assemble-desk.sh, which layers the peru-vendored deps
 # (desk-deps/, see ../../../../peru.yaml) in with --delete, then our own source
@@ -12,11 +12,11 @@ set -euo pipefail
 # many unused and some that don't compile on the target kelvin) on top of the
 # pier's committed desk. peru picks only the transitively-required subset.
 #
-# It only constructs files on disk. ORDER MATTERS: 'mount %groups' writes clay's
+# It only constructs files on disk. ORDER MATTERS: 'mount %tlon' writes clay's
 # current desk OUT to the dir on first mount (clobbering disk), and the files
 # only enter clay on 'commit'. So the desk is applied by running this BETWEEN
 # mount and commit against a live ship:
-#   boot -> mount %groups -> construct-desk.sh -> commit %groups
+#   boot -> mount %tlon -> construct-desk.sh -> commit %tlon
 # Constructing on a cold pier and skipping commit changes nothing in clay.
 
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
@@ -24,8 +24,8 @@ PROJECT_ROOT="$(cd "$SCRIPT_DIR/../../.." && pwd)"
 RUBE_DIR="$SCRIPT_DIR"
 DIST_DIR="${DIST_DIR:-$RUBE_DIR/dist}"
 
-# Desk to construct (the rube piers only use %groups)
-DESK="${DESK:-groups}"
+# Desk to construct (the rube piers only use %tlon)
+DESK="${DESK:-tlon}"
 
 # Default ships, matching archive-piers.sh's SHIPS_TO_ARCHIVE
 DEFAULT_SHIPS=("zod" "ten" "mug")
@@ -52,7 +52,7 @@ Options:
 
 Optional environment variables:
   DIST_DIR         Where extracted piers live (default: $RUBE_DIR/dist)
-  DESK             Desk name to construct (default: groups)
+  DESK             Desk name to construct (default: tlon)
 
 Pier location: for each ship, looks for the pier dir containing .urb at either
   \$DIST_DIR/<ship>/<ship>   (rube's double-nested extract), or

--- a/apps/tlon-web/rube/index.ts
+++ b/apps/tlon-web/rube/index.ts
@@ -1057,6 +1057,32 @@ const installTlonDesk = async () => {
   console.log('Tlon desk installed on all ships');
 };
 
+const ensureTlonDesk = async () => {
+  console.log('Ensuring %tlon desk exists on archived ships');
+
+  for (const ship of Object.values(ships) as Ship[]) {
+    if (
+      (targetShip && targetShip !== ship.ship) ||
+      ship.skipCommit === true
+    ) {
+      continue;
+    }
+
+    try {
+      await waitForTlonDeskInKiln(ship, { maxAttempts: 1 });
+      continue;
+    } catch {
+      console.log(`Creating missing %tlon desk on ${ship.ship}`);
+      await hoodCommand(
+        ship.ship as ShipName,
+        'merge %tlon our %base',
+        ship.loopbackPort
+      );
+      await waitForTlonDeskInKiln(ship, { maxAttempts: 30 });
+    }
+  }
+};
+
 const nukeStateOnShips = async () => {
   for (const ship of Object.values(ships) as Ship[]) {
     if (targetShip && targetShip !== ship.ship) {
@@ -1655,10 +1681,11 @@ const shipNeedsExtraction = (ship: Ship): boolean => {
   // Check if the ship directory looks valid (has expected structure).
   // archive-piers.sh excludes .run and .bin/* from the tarballs, so no
   // published archive can ever contain them.
-  const expectedFiles = ['.urb', 'tlon'];
-  const hasValidStructure = expectedFiles.every((file) =>
-    fs.existsSync(path.join(shipPath, file))
+  const hasArchiveDesk = ['tlon', 'groups'].some((desk) =>
+    fs.existsSync(path.join(shipPath, desk))
   );
+  const hasValidStructure =
+    fs.existsSync(path.join(shipPath, '.urb')) && hasArchiveDesk;
 
   if (!hasValidStructure) {
     return true;
@@ -2139,6 +2166,9 @@ const main = async () => {
       await setStorageConfiguration();
       await logStorageState('post-config');
     } else {
+      // Existing archives predate %tlon. Create the desk before reading its
+      // start hash; mounting later will materialize its filesystem directory.
+      await ensureTlonDesk();
       await getStartHashes();
 
       // Nuke state and set reel service ship before mount/commit operations,

--- a/apps/tlon-web/rube/index.ts
+++ b/apps/tlon-web/rube/index.ts
@@ -740,12 +740,12 @@ const copyDesks = async (): Promise<string[]> => {
       continue;
     }
 
-    const groupsDir = IN_CONTAINER
-      ? path.join(ship.extractPath, 'groups')
-      : path.join(ship.extractPath, ship.ship, 'groups');
+    const tlonDir = IN_CONTAINER
+      ? path.join(ship.extractPath, 'tlon')
+      : path.join(ship.extractPath, ship.ship, 'tlon');
 
     try {
-      if (desksMatch(DESK_STAGING_DIR, groupsDir)) {
+      if (desksMatch(DESK_STAGING_DIR, tlonDir)) {
         continue;
       }
 
@@ -755,7 +755,7 @@ const copyDesks = async (): Promise<string[]> => {
       // same-mtime edit would be detected by desksMatch and then silently not
       // transferred, and the |commit below would publish stale Hoon.
       childProcess.execSync(
-        `rsync -aL --delete --checksum "${DESK_STAGING_DIR}/" "${groupsDir}/"`,
+        `rsync -aL --delete --checksum "${DESK_STAGING_DIR}/" "${tlonDir}/"`,
         { stdio: 'inherit' }
       );
       shipsNeedingUpdates.push(ship.ship);
@@ -970,10 +970,10 @@ const mountDesks = async () => {
       continue;
     }
 
-    console.log(`Mounting groups on ${ship.ship}`);
+    console.log(`Mounting tlon on ${ship.ship}`);
     await hoodCommand(
       ship.ship as ShipName,
-      `mount %groups`,
+      `mount %tlon`,
       ship.loopbackPort
     );
   }
@@ -1007,7 +1007,7 @@ const commitDesks = async (shipsNeedingUpdates: string[]) => {
         try {
           await hoodCommand(
             ship.ship as ShipName,
-            `commit %groups`,
+            `commit %tlon`,
             ship.loopbackPort
           );
           await assertShipHealthy(
@@ -1032,8 +1032,8 @@ const commitDesks = async (shipsNeedingUpdates: string[]) => {
   }
 };
 
-const installGroupsDesk = async () => {
-  console.log('Installing %groups desk on fresh ships');
+const installTlonDesk = async () => {
+  console.log('Installing %tlon desk on fresh ships');
 
   for (const ship of Object.values(ships) as Ship[]) {
     if (targetShip && targetShip !== ship.ship) {
@@ -1043,10 +1043,10 @@ const installGroupsDesk = async () => {
       continue;
     }
 
-    console.log(`Creating %groups desk on ${ship.ship}`);
+    console.log(`Creating %tlon desk on ${ship.ship}`);
     await hoodCommand(
       ship.ship as ShipName,
-      'merge %groups our %base',
+      'merge %tlon our %base',
       ship.loopbackPort
     );
 
@@ -1054,7 +1054,7 @@ const installGroupsDesk = async () => {
     await new Promise((resolve) => setTimeout(resolve, 3000));
   }
 
-  console.log('Groups desk installed on all ships');
+  console.log('Tlon desk installed on all ships');
 };
 
 const nukeStateOnShips = async () => {
@@ -1067,7 +1067,7 @@ const nukeStateOnShips = async () => {
       console.log(`Nuking state on ${ship.ship}`);
       await hoodCommand(
         ship.ship as ShipName,
-        'nuke %groups, =desk &, =hard &',
+        'nuke %tlon, =desk &, =hard &',
         ship.loopbackPort
       );
     } catch (e) {
@@ -1078,14 +1078,14 @@ const nukeStateOnShips = async () => {
     await new Promise((resolve) => setTimeout(resolve, 3000));
 
     try {
-      console.log(`Reviving groups on ${ship.ship}`);
+      console.log(`Reviving tlon on ${ship.ship}`);
       await hoodCommand(
         ship.ship as ShipName,
-        'revive %groups',
+        'revive %tlon',
         ship.loopbackPort
       );
     } catch (e) {
-      console.error(`Error reviving groups on ${ship.ship}:`, e);
+      console.error(`Error reviving tlon on ${ship.ship}:`, e);
     }
   }
 
@@ -1178,7 +1178,7 @@ const makeRequestWithCookies = async (
   return responseBody;
 };
 
-const waitForGroupsDeskInKiln = async (
+const waitForTlonDeskInKiln = async (
   ship: Ship,
   options: { maxAttempts?: number; delayMs?: number } = {}
 ): Promise<string> => {
@@ -1190,25 +1190,25 @@ const waitForGroupsDeskInKiln = async (
       ship.ship as ShipName,
       `http://localhost:${ship.httpPort}/~/scry/hood/kiln/pikes.json`,
       {
-        context: `wait for %groups desk in kiln (attempt ${attempt}/${maxAttempts})`,
+        context: `wait for %tlon desk in kiln (attempt ${attempt}/${maxAttempts})`,
       }
     );
 
     const json = JSON.parse(response);
-    if (json?.groups?.hash) {
-      return json.groups.hash as string;
+    if (json?.tlon?.hash) {
+      return json.tlon.hash as string;
     }
 
     if (attempt < maxAttempts) {
       console.log(
-        `%groups desk not yet available in kiln for ~${ship.ship} (attempt ${attempt}/${maxAttempts}), retrying...`
+        `%tlon desk not yet available in kiln for ~${ship.ship} (attempt ${attempt}/${maxAttempts}), retrying...`
       );
       await new Promise((resolve) => setTimeout(resolve, delayMs));
     }
   }
 
   throw new Error(
-    `%groups desk did not appear in kiln/pikes.json for ~${ship.ship} after ${maxAttempts} attempts`
+    `%tlon desk did not appear in kiln/pikes.json for ~${ship.ship} after ${maxAttempts} attempts`
   );
 };
 
@@ -1239,17 +1239,20 @@ const assertShipHealthy = async (
 
 const getStartHashes = async () => {
   for (const ship of Object.values(ships) as Ship[]) {
-    if (targetShip && targetShip !== ship.ship) {
+    if (
+      (targetShip && targetShip !== ship.ship) ||
+      ship.skipCommit === true
+    ) {
       continue;
     }
 
-    const groupsHash = await waitForGroupsDeskInKiln(ship, {
+    const tlonHash = await waitForTlonDeskInKiln(ship, {
       maxAttempts: FRESH_BOOT ? 60 : 10,
       delayMs: 1_000,
     });
 
     startHashes[ship.ship] = {
-      groups: groupsHash,
+      tlon: tlonHash,
     };
     console.log(`Start hashes for ~${ship.ship}:`, startHashes[ship.ship]);
   }
@@ -1327,21 +1330,21 @@ const shipsAreReadyForTests = async (shipsNeedingUpdates: string[]) => {
       const json = JSON.parse(response);
 
       if (
-        json.groups.hash !== startHashes[ship.ship].groups &&
+        json.tlon.hash !== startHashes[ship.ship].tlon &&
         ship.skipCommit === false
       ) {
         // Desk has been updated, now verify the app is responding
         const appHealthy = await checkGroupsAppHealth(ship);
         if (appHealthy) {
           console.log(`~${ship.ship} is ready`, {
-            groups: json.groups.hash,
+            tlon: json.tlon.hash,
           });
           return true;
         }
       }
 
       console.log(`~${ship.ship} is not ready`, {
-        groups: json.groups.hash,
+        tlon: json.tlon.hash,
       });
 
       return false;
@@ -1652,7 +1655,7 @@ const shipNeedsExtraction = (ship: Ship): boolean => {
   // Check if the ship directory looks valid (has expected structure).
   // archive-piers.sh excludes .run and .bin/* from the tarballs, so no
   // published archive can ever contain them.
-  const expectedFiles = ['.urb', 'groups'];
+  const expectedFiles = ['.urb', 'tlon'];
   const hasValidStructure = expectedFiles.every((file) =>
     fs.existsSync(path.join(shipPath, file))
   );
@@ -2117,7 +2120,7 @@ const main = async () => {
 
     if (FRESH_BOOT) {
       // Fresh boot: install desk from scratch, skip nuke
-      await installGroupsDesk();
+      await installTlonDesk();
       await getStartHashes();
 
       // Mount desks so Urbit writes its current state to filesystem

--- a/apps/tlon-web/rube/verify-archives.sh
+++ b/apps/tlon-web/rube/verify-archives.sh
@@ -175,19 +175,19 @@ verify_desk_content() {
     
     print_info "Verifying desk content for $ship..."
     
-    # Check for groups desk
-    if [ ! -d "$pier_path/groups" ]; then
-        print_error "Groups desk not found in $ship"
+    # Check for tlon desk
+    if [ ! -d "$pier_path/tlon" ]; then
+        print_error "Tlon desk not found in $ship"
         return 1
     fi
     
     # Check for essential files
     local essential_files=(
-        "groups/sys.kelvin"
-        "groups/desk.bill"
-        "groups/app/groups.hoon"
-        "groups/app/channels.hoon"
-        "groups/app/chat.hoon"
+        "tlon/sys.kelvin"
+        "tlon/desk.bill"
+        "tlon/app/groups.hoon"
+        "tlon/app/channels.hoon"
+        "tlon/app/chat.hoon"
     )
     
     for file in "${essential_files[@]}"; do

--- a/backend/run-tests.sh
+++ b/backend/run-tests.sh
@@ -125,24 +125,24 @@ $run_click $pier <<EOF
 (pure:m !>(%ok))  
 EOF
 
-# Unmount and mount %groups
-echo "Mounting groups..."
+# Create and mount %tlon
+echo "Creating %tlon..."
 $run_click $pier <<EOF
 =/  m  (strand ,vase)  
 ;<  =bowl  bind:m  get-bowl  
-;<  ~  bind:m  (poke [our.bowl %hood] kiln-unmount+!>(%groups))  
+;<  ~  bind:m  (poke [our.bowl %hood] kiln-merge+!>([%tlon our.bowl %base 0 %auto]))
 ;<  ~  bind:m  (sleep ~s0)  
 =/  =path  
-  [(scot %p our.bowl) %groups (scot %da now.bowl) ~]  
-;<  ~  bind:m  (poke [our.bowl %hood] kiln-mount+!>([path %groups]))  
+  [(scot %p our.bowl) %tlon (scot %da now.bowl) ~]
+;<  ~  bind:m  (poke [our.bowl %hood] kiln-mount+!>([path %tlon]))
 (pure:m !>(%ok))  
 EOF
 
 # Insert the jammed pill
 
-if [ ! -f "${pier}/groups/${pill_name}.jam" ]
+if [ ! -f "${pier}/tlon/${pill_name}.jam" ]
 then
-  cp $pill ${pier}/groups/${pill_name}.jam
+  cp $pill ${pier}/tlon/${pill_name}.jam
 fi
 
 echo "Updating base desk..."
@@ -154,10 +154,10 @@ $run_click $pier <<EOF
 EOF
 
 # TODO: We should figure out the source ship for this file and delete it
-rm -f $pier/groups/tests/lib/diary-graph.hoon
+rm -f $pier/tlon/tests/lib/diary-graph.hoon
 
-# Update the groups desk. Assemble the full desk (desk-deps/ vendored deps +
-# desk/ source) and overlay it onto the pill's groups desk. The pill provides a
+# Update the tlon desk. Assemble the full desk (desk-deps/ vendored deps +
+# desk/ source) and overlay it onto the pill's tlon desk. The pill provides a
 # bootable base; the assembled tree brings in peru-vendored deps (e.g.
 # sur/mcp-proxy) that live only in desk-deps/. Overlaid without --delete so the
 # pill's own artifacts (the jammed pill used by the aqua tests) are preserved.
@@ -166,14 +166,14 @@ assembled=$(mktemp -d)
 # assemble-desk stamps the git hash into commit.txt; keep the 'development'
 # placeholder the logs test (/tests/app/logs) asserts on instead.
 cp desk/commit.txt "$assembled/commit.txt"
-rsync -r "$assembled"/ $pier/groups
+rsync -r "$assembled"/ $pier/tlon
 rm -rf "$assembled"
 
-rsync -r --delete desk/tests/ $pier/groups/tests
+rsync -r --delete desk/tests/ $pier/tlon/tests
 
 result=$( $run_click $pier <<EOF
 =/  m  (strand ,vase)  
-;<  hash=@uvI  bind:m  (scry @uvI %cz /groups)  
+;<  hash=@uvI  bind:m  (scry @uvI %cz /tlon)
 (pure:m !>(hash))  
 EOF
 )
@@ -186,11 +186,11 @@ then
   exit 1
 fi
 
-echo "Updating groups desk"
+echo "Updating tlon desk"
 ${run_click} $pier <<EOF
 =/  m  (strand ,vase)  
 ;<  our=ship  bind:m  get-our  
-;<  ~  bind:m  (poke [our %hood] kiln-commit+!>([%groups |]))  
+;<  ~  bind:m  (poke [our %hood] kiln-commit+!>([%tlon |]))
 (pure:m !>(%ok))  
 EOF
 
@@ -200,7 +200,7 @@ await_ship
 
 result=$( $run_click $pier <<EOF
 =/  m  (strand ,vase)  
-;<  hash=@uvI  bind:m  (scry @uvI %cz /groups)  
+;<  hash=@uvI  bind:m  (scry @uvI %cz /tlon)
 (pure:m !>(hash))  
 EOF
 )
@@ -227,7 +227,7 @@ result=$( $run_click $pier <<EOF
 =/  m  (strand ,vase)  
 ;<  =bowl  bind:m  get-bowl  
 =/  tests=path  
-  [(scot %p our.bowl) %groups (scot %da now.bowl) %tests ~]  
+  [(scot %p our.bowl) %tlon (scot %da now.bowl) %tests ~]
 ;<  =thread-result  bind:m  
   (await-thread %test !>(\`tests))  
 ?:  ?=(%| -.thread-result)  
@@ -258,7 +258,7 @@ ${run_click} $pier "/lib/pill/hoon"<<EOF
 =/  =dome:clay  (~(gut by cone) [p.byk.bowl %base] *dome:clay)  
 ;<  ~      bind:m  (sleep ~s0)  
 ;<  ~  bind:m  (poke [our.bowl %hood] kiln-rein+!>([%base (~(put by ren.dome) %aqua &)]))  
-=+  pill-path=/(scot %p p.byk.bowl)/groups/(scot %da now.bowl)/${pill_name}/jam  
+=+  pill-path=/(scot %p p.byk.bowl)/tlon/(scot %da now.bowl)/${pill_name}/jam
 =+  .^(pil=@ %cx pill-path)  
 =/  pill  ;;(pill:pill (cue pil))  
 ;<  ~  bind:m  (poke [our.bowl %aqua] pill+!>(pill))  
@@ -273,7 +273,7 @@ result=$( $run_click $pier <<EOF
 =+  tid=~.ci-ph-fleet  
 =/  args  
   [\`%ci-aqua-tests ~[~zod ~nec ~bud ~wes ~dem ~fen ~loshut-lonreg ~rivfur-livmet] &]  
-=/  poke-vase  !>(\`start-args:spider\`[\`tid.bowl \`tid byk.bowl(q %groups) %ph-fleet !>(\`args)])  
+=/  poke-vase  !>(\`start-args:spider\`[\`tid.bowl \`tid byk.bowl(q %tlon) %ph-fleet !>(\`args)])
 ;<  ~      bind:m  (watch-our /awaiting/[tid] %spider /thread-result/[tid])  
 ;<  ~      bind:m  (poke-our %spider %spider-start poke-vase)  
 ;<  =cage  bind:m  (take-fact /awaiting/[tid])  
@@ -306,11 +306,11 @@ result=$( $run_click $pier <<EOF
 =/  m  (strand ,vase)  
 ;<  =bowl  bind:m  get-bowl  
 =/  ph-tests=path  
-  [(scot %p our.bowl) %groups (scot %da now.bowl) %tests %ph ~]  
+  [(scot %p our.bowl) %tlon (scot %da now.bowl) %tests %ph ~]
 =/  args  
   [\`ph-tests %ci-aqua-tests]  
 =+  tid=~.ci-ph-test  
-=/  poke-vase  !>(\`start-args:spider\`[\`tid.bowl \`tid byk.bowl(q %groups) %ph-test !>(\`args)])  
+=/  poke-vase  !>(\`start-args:spider\`[\`tid.bowl \`tid byk.bowl(q %tlon) %ph-test !>(\`args)])
 ;<  ~      bind:m  (watch-our /awaiting/[tid] %spider /thread-result/[tid])  
 ;<  ~      bind:m  (poke-our %spider %spider-start poke-vase)  
 ;<  =cage  bind:m  (take-fact /awaiting/[tid])  
@@ -341,4 +341,3 @@ fi
 
 kill -TERM $vere_pid
 exit 0
-

--- a/desk/app/channels.hoon
+++ b/desk/app/channels.hoon
@@ -797,7 +797,7 @@
   =.  cor  (emil reconcile-notes-cards)
   inflate-io
 ::  +reconcile-notes-cards: %notes ships as its own gall agent but is kept OUT
-::  of desk.bill, so installing %groups never trips gall's "can't run from two
+::  of desk.bill, so installing %tlon never trips gall's "can't run from two
 ::  desks" against a user's standalone %notes desk. Instead we suspend that
 ::  desk (a no-op if it isn't installed) and rein our %notes agent on. Fired
 ::  once on install (+init) and once on upgrade (state-18-to-19).
@@ -810,7 +810,7 @@
     ^-  (list card:agent:gall)
     :~  [%pass /kiln/suspend-notes %agent [our.bowl %hood] %poke %kiln-suspend !>(`@tas`%notes)]
         :*  %pass  /kiln/rein-notes  %agent  [our.bowl %hood]  %poke
-            %kiln-rein  !>(`[@tas (map @tas ?)]`[%groups (~(put by *(map @tas ?)) %notes &)])
+            %kiln-rein  !>(`[@tas (map @tas ?)]`[%tlon (~(put by *(map @tas ?)) %notes &)])
         ==
     ==
   unsafe:guard

--- a/packages/tlon-bot-e2e/src/runtime/branch-desk.test.ts
+++ b/packages/tlon-bot-e2e/src/runtime/branch-desk.test.ts
@@ -383,11 +383,11 @@ class BranchDeskHarness {
       if (argv[1] === '-e' && script.includes('+hood/')) {
         const ship = argv[3] as ShipLabel;
         const command = argv[4] ?? '';
-        if (command === 'mount %groups') {
+        if (command === 'mount %tlon') {
           this.events.push(`mount:${ship}`);
           return success();
         }
-        if (command === 'commit %groups') {
+        if (command === 'commit %tlon') {
           this.events.push(`commit:${ship}`);
           if (this.commitConnectionFailuresRemaining > 0) {
             this.commitConnectionFailuresRemaining -= 1;
@@ -443,7 +443,7 @@ class BranchDeskHarness {
     }
     if (url.endsWith('/~/scry/hood/kiln/pikes.json')) {
       this.events.push(`hash:${ship}:${this.hashes[ship]}`);
-      return jsonResponse({ groups: { hash: this.hashes[ship] } });
+      return jsonResponse({ tlon: { hash: this.hashes[ship] } });
     }
     if (url.endsWith('/~/scry/groups/groups/light.json')) {
       this.events.push(`health:${ship}`);

--- a/packages/tlon-bot-e2e/src/runtime/branch-desk.ts
+++ b/packages/tlon-bot-e2e/src/runtime/branch-desk.ts
@@ -15,7 +15,7 @@ import { waitFor, waitForShipLogin } from './waiters.js';
 type ShipLabel = keyof RuntimeContext['endpoints']['ships'];
 
 const DEFAULT_DESK_SHIPS = '~zod,~ten';
-const STAGED_DESK = '/tmp/tlon-bot-e2e-groups';
+const STAGED_DESK = '/tmp/tlon-bot-e2e-tlon';
 const COMMIT_ATTEMPTS = 4;
 const ASSEMBLE_DESK_TIMEOUT_MS = 300_000;
 const MOUNT_STABLE_SAMPLES = 3;
@@ -44,7 +44,7 @@ function deskReadyTimeoutMs(): number {
 
 class ShipUnavailableError extends Error {}
 // Distinct from unavailable: the ship holds the connection but has not
-// answered yet. A `%groups` commit makes vere compile the desk, which is
+// answered yet. A `%tlon` commit makes vere compile the desk, which is
 // CPU-bound for minutes and cannot serve eyre meanwhile — treating that as a
 // dead ship and rebooting kills the compile, which is exactly what the first
 // live runs did. Rube imposes no request deadline at all and classifies only
@@ -146,12 +146,12 @@ export async function applyBranchDesk(
   const dependencies = { ...DEFAULT_DEPENDENCIES, ...overrides };
   const ships = parseDeskShips(dependencies.deskShips());
   const tempDir = await mkdtemp(path.join(os.tmpdir(), 'tlon-bot-e2e-desk-'));
-  const deskDir = path.join(tempDir, 'groups');
+  const deskDir = path.join(tempDir, 'tlon');
   const manifestPath = path.join(tempDir, 'manifest.sha256');
 
   try {
     console.log(
-      `==> Applying branch %groups desk to ${ships.map((s) => `~${s}`).join(', ')}...`
+      `==> Applying branch %tlon desk to ${ships.map((s) => `~${s}`).join(', ')}...`
     );
     const assembled = await dependencies.runCommand(
       'bash',
@@ -196,9 +196,9 @@ export async function applyBranchDesk(
     for (const ship of ships) {
       const endpoint = ctx.endpoints.ships[ship];
       let cookie = await login(endpoint, dependencies);
-      await hoodCommand(ctx, ship, 'mount %groups', dependencies);
+      await hoodCommand(ctx, ship, 'mount %tlon', dependencies);
       await waitForMountedDeskStable(ctx, ship, dependencies);
-      const startHash = await waitForGroupsHash(endpoint, cookie, dependencies);
+      const startHash = await waitForTlonHash(endpoint, cookie, dependencies);
       if (await deskMatches(ctx, ship, manifest, dependencies)) {
         console.log(`    ~${ship}: assembled desk unchanged; skipping commit`);
         continue;
@@ -226,9 +226,9 @@ export async function applyBranchDesk(
             await assertDeskMatches(ctx, ship, manifest, dependencies);
           }
           if (
-            (await groupsHash(endpoint, cookie, dependencies)) === startHash
+            (await tlonHash(endpoint, cookie, dependencies)) === startHash
           ) {
-            await hoodCommand(ctx, ship, 'commit %groups', dependencies);
+            await hoodCommand(ctx, ship, 'commit %tlon', dependencies);
           }
           await waitForDeskReady(endpoint, cookie, startHash, dependencies);
         },
@@ -285,12 +285,12 @@ async function readMountedDeskManifest(
       '-c',
       'set -euo pipefail; mount="$1"; test -d "$mount" && test -r "$mount" && test -x "$mount" || exit 20; cd "$mount"; find . -type f ! -path ./commit.txt ! -path ./desk.docket-0 -print0 | sort -z | xargs -0r sha256sum',
       'bash',
-      `/data/${ship}/groups`,
+      `/data/${ship}/tlon`,
     ]
   );
   if (result.exitCode !== 0) {
     throw new MountedDeskUnavailableError(
-      `Mounted %groups desk for ~${ship} is missing or unreadable ` +
+      `Mounted %tlon desk for ~${ship} is missing or unreadable ` +
         `(exit ${result.exitCode}): ${(result.stderr || result.stdout).trim()}`
     );
   }
@@ -314,7 +314,7 @@ async function waitForMountedDeskStable(
     {
       timeoutMs: 30_000,
       intervalMs: 1_000,
-      description: `~${ship} %groups mount to exist and settle`,
+      description: `~${ship} %tlon mount to exist and settle`,
     }
   );
 }
@@ -366,7 +366,7 @@ async function assertDeskMatches(
 ): Promise<void> {
   if (!(await deskMatches(ctx, ship, expectedManifest, dependencies))) {
     throw new Error(
-      `Mounted %groups desk for ~${ship} changed after replacement; refusing to commit.`
+      `Mounted %tlon desk for ~${ship} changed after replacement; refusing to commit.`
     );
   }
 }
@@ -381,8 +381,8 @@ async function replaceMountedDesk(
     '-c',
     'set -euo pipefail; target="$1"; source="$2"; mkdir -p "$target"; find "$target" -mindepth 1 -maxdepth 1 -exec rm -rf -- {} +; cp -a "$source"/. "$target"/',
     'bash',
-    `/data/${ship}/groups`,
-    `${STAGED_DESK}/groups`,
+    `/data/${ship}/tlon`,
+    `${STAGED_DESK}/tlon`,
   ]);
 }
 
@@ -464,7 +464,7 @@ async function hoodCommand(
   requireSuccess(result, `exec in ${ctx.services.ships}`);
 }
 
-async function groupsHash(
+async function tlonHash(
   endpoint: ShipEndpoint,
   cookie: string,
   dependencies: BranchDeskDependencies,
@@ -473,29 +473,29 @@ async function groupsHash(
   const data = await shipJson(
     endpoint,
     cookie,
-    'read %groups desk hash',
+    'read %tlon desk hash',
     '/~/scry/hood/kiln/pikes.json',
     dependencies,
     timeoutMs
   );
-  const hash = (data as { groups?: { hash?: unknown } }).groups?.hash;
+  const hash = (data as { tlon?: { hash?: unknown } }).tlon?.hash;
   if (typeof hash !== 'string') {
-    throw new Error(`No %groups desk hash returned by ${endpoint.ship}.`);
+    throw new Error(`No %tlon desk hash returned by ${endpoint.ship}.`);
   }
   return hash;
 }
 
-async function waitForGroupsHash(
+async function waitForTlonHash(
   endpoint: ShipEndpoint,
   cookie: string,
   dependencies: BranchDeskDependencies
 ) {
   return dependencies.waitFor(
-    () => groupsHash(endpoint, cookie, dependencies),
+    () => tlonHash(endpoint, cookie, dependencies),
     {
       timeoutMs: 30_000,
       intervalMs: 1_000,
-      description: `${endpoint.ship} %groups desk in kiln`,
+      description: `${endpoint.ship} %tlon desk in kiln`,
     }
   );
 }
@@ -510,7 +510,7 @@ async function waitForDeskReady(
     async () => {
       try {
         if (
-          (await groupsHash(
+          (await tlonHash(
             endpoint,
             cookie,
             dependencies,
@@ -541,7 +541,7 @@ async function waitForDeskReady(
     {
       timeoutMs: deskReadyTimeoutMs(),
       intervalMs: 2_000,
-      description: `${endpoint.ship} %groups desk ready after commit`,
+      description: `${endpoint.ship} %tlon desk ready after commit`,
       rethrowError: (error) => error instanceof ShipUnavailableError,
     }
   );

--- a/peru.yaml
+++ b/peru.yaml
@@ -29,7 +29,7 @@ git module base:
     # libraries the desk imports (transitive closure):
     #   default-agent -> skeleton; azimuth -> ethereum; ethereum/dbug standalone
     # azimuth is only reached via the aqua test framework (lib/aqua-azimuth ->
-    # lib/ph/io), so it isn't built by a normal %groups commit, but the aqua
+    # lib/ph/io), so it isn't built by a normal %tlon commit, but the aqua
     # tests need it.
     - pkg/base-dev/lib/azimuth.hoon
     - pkg/base-dev/lib/dbug.hoon

--- a/scripts/assemble-desk.sh
+++ b/scripts/assemble-desk.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 # scripts/assemble-desk.sh <target-dir>
 #
-# Assemble a complete %groups desk into <target-dir> by layering:
+# Assemble a complete %tlon desk into <target-dir> by layering:
 #   1. desk-deps/  (peru-vendored upstream deps)  -- rsync'd in with --delete
 #   2. desk/       (our own source)               -- rsync'd on top
 #
@@ -46,7 +46,7 @@ rsync -aL --exclude=.DS_Store desk/ "$target/"
 # Stamp the build commit, like the deploy pipeline does. Redirecting straight
 # into the file would truncate it before git ran, so a checkout without git
 # metadata (e.g. a Docker build context that .dockerignore strips .git from)
-# left an EMPTY stamp and %groups/%logs then compiled provenance as unknown.
+# left an EMPTY stamp and %tlon/%logs then compiled provenance as unknown.
 # Capture first and only overwrite the copied desk/commit.txt on success.
 commit="$(git rev-parse --short HEAD 2>/dev/null || true)"
 if [ -n "$commit" ]; then


### PR DESCRIPTION
## Summary
- create and mount `%tlon` in the backend test pier
- install assembled desk, unit tests, and Aqua test threads from `%tlon`
- retain `%groups` as the app name inside Aqua test scenarios

## Verification
- `git diff --check`
- `./backend/run-tests.sh` *(running; first run is downloading vendored desk dependencies)*