### PR TITLE
fix android tab bar layout after navigation

### DIFF
--- a/apps/tlon-mobile/android/app/src/main/java/io/tlon/landscape/MainActivity.kt
+++ b/apps/tlon-mobile/android/app/src/main/java/io/tlon/landscape/MainActivity.kt
@@ -7,7 +7,6 @@ import android.util.Log
 import android.view.View
 import androidx.core.view.ViewCompat
 import androidx.core.view.WindowInsetsCompat
-import androidx.core.graphics.Insets
 import com.facebook.react.ReactActivity
 import com.posthog.PostHog
 import com.posthog.android.PostHogAndroid
@@ -37,18 +36,26 @@ class MainActivity : ReactActivity() {
     ensurePostHogInitialized()
     captureLifecycleEvent("App Created")
 
-    // Handle window insets for Android API 35+
-    // ref: https://github.com/facebook/react-native/issues/49759#issuecomment-3048056660
+    // React Native does not resize the edge-to-edge root for the IME on API 35+.
+    // Only mutate its padding when the IME inset changes; reapplying zero padding
+    // during unrelated inset dispatches can leave native tabs with stale layout.
     if (Build.VERSION.SDK_INT >= 35) {
       val rootView = findViewById<View>(android.R.id.content)
-      ViewCompat.setOnApplyWindowInsetsListener(rootView) { v, insets ->
-        val innerPadding = insets.getInsets(WindowInsetsCompat.Type.ime())
-        rootView.setPadding(
-          innerPadding.left,
-          innerPadding.top,
-          innerPadding.right,
-          innerPadding.bottom
-        )
+      ViewCompat.setOnApplyWindowInsetsListener(rootView) { view, insets ->
+        val imeInsets = insets.getInsets(WindowInsetsCompat.Type.ime())
+        if (
+          view.paddingLeft != imeInsets.left ||
+          view.paddingTop != imeInsets.top ||
+          view.paddingRight != imeInsets.right ||
+          view.paddingBottom != imeInsets.bottom
+        ) {
+          view.setPadding(
+            imeInsets.left,
+            imeInsets.top,
+            imeInsets.right,
+            imeInsets.bottom
+          )
+        }
         insets
       }
     }


### PR DESCRIPTION
## Summary

Fixes the Android bottom tabs shifting after returning from chat and scrolling.

Fixes TLON-6415

## Changes

- keeps the Android keyboard inset workaround for chat
- avoids reapplying unchanged root padding during navigation and scrolling

## How did I test?

- reproduced on the parent commit using gesture navigation on a physical Samsung Galaxy S24 running Android 16 / API 36
- opened the chat keyboard, dismissed it, returned Home, and confirmed the tabs were mostly off-screen before jumping on scroll
- repeated the same keyboard/back/scroll flow with this change; the chat composer stayed above the keyboard and the tabs stayed fixed
- built and installed `previewDebug` with the worktree verification wrapper
- `git diff --check`