### PR TITLE
address onboarding feedback

### DIFF
--- a/packages/app/ui/components/PostContent/A2UIBlock.tsx
+++ b/packages/app/ui/components/PostContent/A2UIBlock.tsx
@@ -482,7 +482,7 @@ function SmallChoiceControl({
               >
                 {displayedCustomTopics.length ? (
                   <Text size="$label/s" color="$background" trimmed={false}>
-                    {displayedCustomTopics.length}
+                    {smallChoiceShortcut(component.options.length)}
                   </Text>
                 ) : (
                   <Icon
@@ -516,7 +516,7 @@ function SmallChoiceControl({
           label={component.submitLabel}
           trailing={
             <Icon
-              type="Checkmark"
+              type="ChevronRight"
               color={hasSelection ? '$background' : '$primaryText'}
               customSize={[16, 16]}
             />

--- a/packages/app/ui/components/PostContent/McpConnectControl.tsx
+++ b/packages/app/ui/components/PostContent/McpConnectControl.tsx
@@ -502,6 +502,7 @@ export function McpConnectMenu({
     >
       <YStack
         width="100%"
+        minHeight={loading ? (component.maxVisible + 1) * 56 : undefined}
         borderWidth={1}
         borderColor="$border"
         borderRadius="$m"

--- a/packages/app/ui/components/Wayfinding/AgentOnboarding/AgentOnboardingSequence.tsx
+++ b/packages/app/ui/components/Wayfinding/AgentOnboarding/AgentOnboardingSequence.tsx
@@ -4,12 +4,11 @@ import { createDevLogger } from '@tloncorp/shared';
 import * as db from '@tloncorp/shared/db';
 import { withRetry } from '@tloncorp/shared/logic';
 import * as store from '@tloncorp/shared/store';
-import { LoadingSpinner } from '@tloncorp/ui';
 import React, { useEffect, useRef, useState } from 'react';
-import { View } from 'tamagui';
 
 import { AGENT_SHIP_OVERRIDE } from '../../../../lib/envVars';
 import { getDefaultBotName } from '../botName';
+import { TlonBotSetupPaneView } from '../TlonBotSetupPaneView';
 import { PromiseTimeoutError, withTimeout } from './promiseTimeout';
 
 const logger = createDevLogger('AgentOnboardingSequence', false);
@@ -18,6 +17,10 @@ const wait = (ms: number) =>
 const LANDING_CONSUMPTION_TIMEOUT_MS = 10_000;
 const FURNISH_ATTEMPT_TIMEOUT_MS = 30_000;
 const BOT_NAME_SYNC_TIMEOUT_MS = 8_000;
+const HANDOFF_MESSAGES = [
+  'Your Tlonbot is ready. Finishing the chat setup now.',
+  'Opening your private Tlonbot group.',
+];
 
 async function waitForLandingConsumption(isCancelled: () => boolean) {
   const deadline = Date.now() + LANDING_CONSUMPTION_TIMEOUT_MS;
@@ -287,8 +290,9 @@ export function AgentOnboardingSequence(props: {
   if (useFallback) return <>{props.fallback}</>;
 
   return (
-    <View flex={1} alignItems="center" justifyContent="center">
-      <LoadingSpinner color="$secondaryText" />
-    </View>
+    <TlonBotSetupPaneView
+      title="Opening your Tlonbot chat..."
+      messages={HANDOFF_MESSAGES}
+    />
   );
 }

--- a/packages/app/ui/components/Wayfinding/TlonBotSetupPaneView.tsx
+++ b/packages/app/ui/components/Wayfinding/TlonBotSetupPaneView.tsx
@@ -5,8 +5,6 @@ import { ScreenHeader } from '../ScreenHeader';
 import { FadingTextCarousel } from './FadingTextCarousel';
 import { SegmentedSpinner } from './SegmentedSpinner';
 
-const noop = () => {};
-
 const SETUP_MESSAGES = [
   'This will take a bit. Feel free to background the app.',
   "We'll send you a notification when it's ready.",
@@ -19,6 +17,8 @@ const SETUP_MESSAGES = [
 export function TlonBotSetupPaneView(props: {
   onLogout?: () => void;
   loggingOut?: boolean;
+  messages?: string[];
+  title?: string;
 }) {
   return (
     <View
@@ -29,13 +29,15 @@ export function TlonBotSetupPaneView(props: {
       <ScreenHeader
         backgroundColor="$secondaryBackground"
         leftControls={
-          <ScreenHeader.TextButton
-            onPress={props.onLogout ?? noop}
-            disabled={props.loggingOut}
-            color="$tertiaryText"
-          >
-            Log out
-          </ScreenHeader.TextButton>
+          props.onLogout ? (
+            <ScreenHeader.TextButton
+              onPress={props.onLogout}
+              disabled={props.loggingOut}
+              color="$tertiaryText"
+            >
+              Log out
+            </ScreenHeader.TextButton>
+          ) : undefined
         }
       />
       <YStack flex={1} alignItems="center" justifyContent="center" gap="$2xl">
@@ -47,9 +49,9 @@ export function TlonBotSetupPaneView(props: {
             marginHorizontal="$xl"
             textAlign="center"
           >
-            Setting up your Tlonbot...
+            {props.title ?? 'Setting up your Tlonbot...'}
           </TlonText.Text>
-          <FadingTextCarousel messages={SETUP_MESSAGES} />
+          <FadingTextCarousel messages={props.messages ?? SETUP_MESSAGES} />
         </YStack>
       </YStack>
     </View>

--- a/packages/openclaw/index.ts
+++ b/packages/openclaw/index.ts
@@ -53,6 +53,7 @@ import {
 } from './src/mcp-readonly-policy.js';
 import { setAgentOnboardingRunStore } from './src/monitor/agent-onboarding-run-store.js';
 import {
+  agentOnboardingCronChannelNest,
   agentOnboardingCronProviderIds,
   handleAgentOnboardingCronChanged,
   handleAgentOnboardingMessageSent,
@@ -1022,6 +1023,9 @@ export default defineBundledChannelEntry({
         : undefined;
       const isOnboardingCron =
         isMcpTool && (await isAgentOnboardingCronJob(cronJobId));
+      const onboardingChannelNest = isOnboardingCron
+        ? await agentOnboardingCronChannelNest(cronJobId)
+        : undefined;
       const allowedProviderIds = isOnboardingCron
         ? await agentOnboardingCronProviderIds(cronJobId)
         : [];
@@ -1054,6 +1058,12 @@ export default defineBundledChannelEntry({
         const background = ensureBackgroundContextLensForSession(
           ctx.sessionKey,
           {
+            ...(onboardingChannelNest
+              ? {
+                  chatType: 'channel' as const,
+                  conversationId: onboardingChannelNest,
+                }
+              : {}),
             runKind: isCronSession ? 'cron' : 'internal',
             trigger: isCronSession ? 'cron' : 'tool',
             preview: `${event.toolName} tool activity`,
@@ -1444,7 +1454,7 @@ export default defineBundledChannelEntry({
     // no `:cron:` marker — the agent-level hook context is the only place
     // the gateway exposes the cron trigger, so tag the run's lens here
     // before any tool fires. Idempotent across both hooks.
-    const ensureCronContextLens = (ctx: {
+    const ensureCronContextLens = async (ctx: {
       sessionKey?: string;
       trigger?: string;
       jobId?: string;
@@ -1452,7 +1462,16 @@ export default defineBundledChannelEntry({
       if (!contextLensEnabled || ctx.trigger !== 'cron') {
         return;
       }
+      const onboardingChannelNest = await agentOnboardingCronChannelNest(
+        ctx.jobId
+      );
       const background = ensureBackgroundContextLensForSession(ctx.sessionKey, {
+        ...(onboardingChannelNest
+          ? {
+              chatType: 'channel' as const,
+              conversationId: onboardingChannelNest,
+            }
+          : {}),
         runKind: 'cron',
         trigger: 'cron',
         preview: ctx.jobId ? `cron job ${ctx.jobId}` : 'cron run',
@@ -1465,7 +1484,7 @@ export default defineBundledChannelEntry({
     // model/harness/run failures can bypass the inbound-session telemetry gate
     // and retain their detailed diagnostic fields. The lifecycle hook remains
     // the authoritative source for the final cron outcome.
-    const onCronAgentHook = (ctx: {
+    const onCronAgentHook = async (ctx: {
       sessionId?: string;
       sessionKey?: string;
       trigger?: string;
@@ -1498,16 +1517,16 @@ export default defineBundledChannelEntry({
         // before any interactive MCP tool call is checked against it.
         clearCronJobForSession(ctx.sessionKey);
       }
-      ensureCronContextLens(ctx);
+      await ensureCronContextLens(ctx);
     };
-    api.on('agent_turn_prepare', (_event, ctx) => {
+    api.on('agent_turn_prepare', async (_event, ctx) => {
       // Cron has no active Tlon turn recorder, so its output trace stays nullable.
       if (ctx.trigger !== 'cron') {
         recordTlonAgentRunTrace(ctx.runId, ctx.trace?.traceId);
       }
-      onCronAgentHook(ctx);
+      await onCronAgentHook(ctx);
     });
-    api.on('model_call_started', (_event, ctx) => onCronAgentHook(ctx));
+    api.on('model_call_started', async (_event, ctx) => onCronAgentHook(ctx));
 
     // Background lenses normally finalize on tool-result idle; agent_end
     // re-arms the window so runs that end with model output (no trailing

--- a/packages/openclaw/src/context-lens.test.ts
+++ b/packages/openclaw/src/context-lens.test.ts
@@ -617,6 +617,56 @@ describe('context lens registry', () => {
     expect(recordContextLensToolStartForSession(sessionKey, 'cron')).toBeNull();
   });
 
+  it('attributes onboarding cron runs to their setup channel', () => {
+    const sessionKey = 'session-background-onboarding-cron';
+    const background = ensureBackgroundContextLensForSession(sessionKey, {
+      chatType: 'channel',
+      conversationId: 'chat/~ten/group/general',
+      runKind: 'cron',
+      trigger: 'cron',
+    });
+
+    try {
+      expect(background?.lens).toMatchObject({
+        chatType: 'channel',
+        runKind: 'cron',
+        triggerDetails: {
+          conversationId: 'chat/~ten/group/general',
+          conversationKind: 'channel',
+        },
+      });
+    } finally {
+      finalizeBackgroundContextLensForSession(sessionKey);
+    }
+  });
+
+  it('upgrades a cron lens when channel attribution arrives after creation', () => {
+    const sessionKey = 'session-background-late-onboarding-channel';
+    ensureBackgroundContextLensForSession(sessionKey, {
+      runKind: 'cron',
+      trigger: 'cron',
+    });
+    const attributed = ensureBackgroundContextLensForSession(sessionKey, {
+      chatType: 'channel',
+      conversationId: 'chat/~ten/group/general',
+      runKind: 'cron',
+      trigger: 'cron',
+    });
+
+    try {
+      expect(attributed?.created).toBe(false);
+      expect(attributed?.lens).toMatchObject({
+        chatType: 'channel',
+        triggerDetails: {
+          conversationId: 'chat/~ten/group/general',
+          conversationKind: 'channel',
+        },
+      });
+    } finally {
+      finalizeBackgroundContextLensForSession(sessionKey);
+    }
+  });
+
   it('groups background tool calls until the session is idle', async () => {
     const sessionKey = 'session-background-debounce';
     const finalized: Array<{

--- a/packages/openclaw/src/context-lens.ts
+++ b/packages/openclaw/src/context-lens.ts
@@ -920,6 +920,8 @@ function getBackgroundContextLensRegistry(): ContextLensRegistry {
 export function ensureBackgroundContextLensForSession(
   sessionKey: string | null | undefined,
   input: {
+    chatType?: Extract<ContextLens['chatType'], 'channel' | 'internal'>;
+    conversationId?: string;
     runKind?: ContextLensRunKind;
     trigger?: ContextLensTrigger;
     preview?: string;
@@ -938,21 +940,35 @@ export function ensureBackgroundContextLensForSession(
       delete cleared.finalizeTimer;
       activeLensesBySession.set(resolved.key, cleared);
     }
-    const lens = existing.registry.get(existing.lensId);
+    const current = existing.registry.get(existing.lensId);
+    const lens =
+      current &&
+      input.chatType === 'channel' &&
+      input.conversationId?.trim() &&
+      current.chatType === 'internal'
+        ? existing.registry.update(existing.lensId, {
+            chatType: 'channel',
+            triggerDetails: {
+              conversationId: input.conversationId.trim(),
+              conversationKind: 'channel',
+            },
+          })
+        : current;
     return lens ? { lens, created: false } : null;
   }
 
   const registry = getBackgroundContextLensRegistry();
   const sessionKeyHash = hashSessionKey(key);
   const runKind = input.runKind ?? 'internal';
+  const chatType = input.chatType ?? 'internal';
   const lens = registry.create({
     messageId: `${runKind}:${sessionKeyHash}:${Date.now()}`,
-    chatType: 'internal',
+    chatType,
     runKind,
     visibility: 'owner',
     trigger: input.trigger ?? 'tool',
     sessionKey: key,
-    conversationId: `session:${sessionKeyHash}`,
+    conversationId: input.conversationId?.trim() || `session:${sessionKeyHash}`,
     receivedAt: Date.now(),
     preview: input.preview,
   });

--- a/packages/openclaw/src/monitor/agent-onboarding.test.ts
+++ b/packages/openclaw/src/monitor/agent-onboarding.test.ts
@@ -17,6 +17,7 @@ import {
   setAgentOnboardingRunStore,
 } from './agent-onboarding-run-store.js';
 import {
+  agentOnboardingCronChannelNest,
   agentOnboardingCronProviderIds,
   agentOnboardingTesting,
   clearAgentOnboardingRuntime,
@@ -199,7 +200,7 @@ function provisionRequest(
 function servicesCard(timestamp = 2) {
   return {
     author: '~bot',
-    content: 'Connect anything you’d like, or tap Done to continue.',
+    content: 'Pick anything you’d like, or tap Done to continue.',
     timestamp,
     blob: appendToPostBlob(undefined, {
       type: 'tlon-agent-post-marker' as const,
@@ -599,6 +600,9 @@ describe('durable onboarding cron authorization', () => {
     await expect(
       agentOnboardingCronProviderIds('edited-description-job')
     ).resolves.toEqual(['gmail']);
+    await expect(
+      agentOnboardingCronChannelNest('edited-description-job')
+    ).resolves.toBe('chat/~ten/group/general');
   });
 
   it('does not classify an unrelated MCP-enabled Tlon cron as onboarding', async () => {
@@ -770,6 +774,31 @@ describe('agent onboarding requests', () => {
     });
     expect(servicesComponents.find(({ id }) => id === 'done')).toBeUndefined();
     expect(A2UI.validateBlobEntry(services)).toBe(true);
+  });
+
+  it('labels the topic submit action Done', () => {
+    const topics = agentOnboardingTesting.buildTopicsPickerSurface(
+      '~ten/group',
+      {
+        id: 'agent-daily-digest',
+        label: 'A daily digest',
+        scheduleHour: 8,
+        topicsPrompt: 'What should I keep an eye on?',
+      },
+      ['AI', 'Climate']
+    );
+    const update = topics?.messages.find(
+      (message) => 'updateComponents' in message
+    );
+    const components =
+      update && 'updateComponents' in update
+        ? update.updateComponents.components
+        : [];
+
+    expect(components.find(({ id }) => id === 'topics')).toMatchObject({
+      component: 'SmallChoice',
+      submitLabel: 'Done',
+    });
   });
 
   it('waits for Done on the services card before offering the app tour', async () => {
@@ -3069,6 +3098,9 @@ describe('provision coordinator ordering', () => {
     expect(JSON.stringify(sendPost.mock.calls[1]?.[0])).toContain('McpConnect');
     expect(JSON.stringify(sendPost.mock.calls[1]?.[0])).toContain(
       'tap Done to continue'
+    );
+    expect(JSON.stringify(sendPost.mock.calls[1]?.[0])).not.toContain(
+      'Connect anything'
     );
   });
 

--- a/packages/openclaw/src/monitor/agent-onboarding.ts
+++ b/packages/openclaw/src/monitor/agent-onboarding.ts
@@ -306,6 +306,9 @@ const primaryJobIds = sharedMap<string, true>('agentOnboarding.primaryJobIds');
 const primaryJobProviderIds = sharedMap<string, string[]>(
   'agentOnboarding.primaryJobProviderIds'
 );
+const primaryJobChannelNests = sharedMap<string, string>(
+  'agentOnboarding.primaryJobChannelNests'
+);
 
 function onboardingAccountId(context: AgentOnboardingScanContext) {
   return context.accountId ?? context.botShip;
@@ -335,6 +338,7 @@ export async function isAgentOnboardingCronJob(jobId: string | undefined) {
   if (durable) {
     primaryJobIds.set(jobId, true);
     primaryJobProviderIds.set(jobId, [...(durable.providerIds ?? [])]);
+    primaryJobChannelNests.set(jobId, durable.channelNest);
     return true;
   }
   const cron = getTlonCronService();
@@ -358,6 +362,18 @@ export async function agentOnboardingCronProviderIds(
     (await lookupAgentOnboardingRunByJobId(jobId))?.providerIds ?? [];
   primaryJobProviderIds.set(jobId, [...providerIds]);
   return providerIds;
+}
+
+export async function agentOnboardingCronChannelNest(
+  jobId: string | undefined
+) {
+  if (!jobId) return undefined;
+  const cached = primaryJobChannelNests.get(jobId);
+  if (cached) return cached;
+  const channelNest = (await lookupAgentOnboardingRunByJobId(jobId))
+    ?.channelNest;
+  if (channelNest) primaryJobChannelNests.set(jobId, channelNest);
+  return channelNest;
 }
 
 export function parseAgentOnboardingRequest(
@@ -1717,7 +1733,7 @@ async function postFirstRunServices(
     history,
     'services-card',
     async () => {
-      const message = `${servicesPitch(correlation.purposeId)}\n\nConnect anything you’d like, or tap Done to continue.`;
+      const message = `${servicesPitch(correlation.purposeId)}\n\nPick anything you’d like, or tap Done to continue.`;
       return {
         text: message,
         blob: appendToPostBlob(
@@ -2527,6 +2543,7 @@ async function upsertPrimaryJobOnce(
   }
   primaryJobIds.set(job.id, true);
   primaryJobProviderIds.set(job.id, [...providerIds]);
+  primaryJobChannelNests.set(job.id, failureChatNest);
   return job.id;
 }
 
@@ -2874,7 +2891,7 @@ function buildTopicsPickerSurface(
         id: 'topics',
         component: 'SmallChoice',
         options: topics.map((label) => ({ id: label.toLowerCase(), label })),
-        submitLabel: 'That’s it',
+        submitLabel: 'Done',
         freeTextPlaceholder: 'Add your own…',
         action: {
           event: {
@@ -2963,6 +2980,7 @@ function buildTourChoiceSurface(surfaceId: string, prompt: string) {
 }
 
 export const agentOnboardingTesting = {
+  buildTopicsPickerSurface,
   buildTourChoiceSurface,
   buildRecurringPrompt,
   buildServicesSurface,


### PR DESCRIPTION
## Summary

Applies Bill’s feedback to the onboarding flow on current develop, improving the handoff into chat, choice controls, connector loading, and bot-run visibility.

Fixes TLON-6416

## Changes

- show scheduled onboarding bot runs in their source channel, including after a plugin restart
- replace the nearly empty handoff spinner with a full progress state
- show the expected letter for custom choices, rename the final action to Done, and use a forward arrow
- reserve connector panel space while provider data loads to reduce layout jumps
- avoid repeating Connect in the provider prompt

## How did I test?

- OpenClaw focused tests: 136 passed
- app focused tests: 5 passed
- OpenClaw and app TypeScript checks passed
- targeted formatting and lint passed with existing warnings only
- git diff --check passed
- no native build or simulator run, per request