### PR TITLE
ops: repair E2E signup test

### DIFF
--- a/.maestro/03-signup.yaml
+++ b/.maestro/03-signup.yaml
@@ -71,7 +71,6 @@ onFlowComplete:
 
 # set a nickname
 - assertVisible: Sampel Palnet
-- evalScript: ${output.operationStart = Date.now()}
 - tapOn: Sampel Palnet
 - inputText: E2E Tester
 - assertVisible: Next
@@ -87,6 +86,13 @@ onFlowComplete:
     text: Next
     retryTapIfNoChange: true
 
+# Measure only the time spent waiting for Hosting to ready the node. The
+# notification screens above and the bot interaction below are separate work.
+- extendedWaitUntil:
+    visible: We're setting you up
+    timeout: 30000
+- evalScript: ${output.nodeReadyStartedAt = Date.now()}
+
 # Wait for the deterministic onboarding rail. TLONBOARD deliberately selects
 # ships carrying the current plugin, so fallback bootstrap chatter is a test
 # failure rather than an alternate path.
@@ -94,6 +100,7 @@ onFlowComplete:
     visible:
       id: A2UIChoice-agent-daily-digest
     timeout: 600000
+- evalScript: ${output.initialRailVisibleAt = Date.now()}
 
 # Complete the new on-rails Tlonbot setup conversation.
 - tapOn:
@@ -113,6 +120,7 @@ onFlowComplete:
     visible:
       id: A2UIMcpConnectComplete
     timeout: 600000
+- evalScript: ${output.starterReadyAt = Date.now()}
 - tapOn:
     id: A2UIMcpConnectComplete
 
@@ -147,5 +155,4 @@ onFlowComplete:
 - assertVisible: Open hardware Digest
 - assertVisible: Getting Started
 
-- evalScript: ${output.operationEnd = Date.now()}
 - evalScript: ${output.didComplete = true}

--- a/.maestro/03-signup.yaml
+++ b/.maestro/03-signup.yaml
@@ -9,25 +9,28 @@ onFlowComplete:
 - tapOn: 'Join with an invite'
 - assertVisible: 'TLON  or  join.tlon.io/0v4.pca...'
 
-# add invite link
+# Use the onboarding short code so Hosting assigns a ship with the current
+# OpenClaw plugin and the deterministic setup coordinator.
 - tapOn: 'TLON  or  join.tlon.io/0v4.pca...'
-- inputText: 'https://join.tlon.io/0v7.mmmlk.5bold.rac1l.79r0m.93vef' # ~dozped-mogtec Bot Farm 2
+- inputText: TLONBOARD
 
 # select email signup
 - assertVisible: Or if you'd prefer, sign up with an email address
 - tapOn:
     text: .*sign up with an email address.*
-    retryTapIfNoChange: true
+- assertVisible: Email
 
 # get test email and use it
 - runScript: scripts/generateSignupEmail.js
 - inputText: ${output.signupEmail}
-- tapOn: Sign up
+- pressKey: Enter
 
 # get OTP and submit it digit by digit. Attempting to insert
 # all at once causes flakiness. extendedWaitUntil calls are a
 # workaround to delay next digit insertion
-- assertVisible: Check your email for a confirmation code
+- extendedWaitUntil:
+    visible: Check your email for a confirmation code
+    timeout: 60000
 - runScript: scripts/getEmailOtp.js
 
 - inputText: ${output.otpDigit1}
@@ -84,57 +87,51 @@ onFlowComplete:
     text: Next
     retryTapIfNoChange: true
 
-# wait until setup is complete
-- extendedWaitUntil:
-    visible: Let's get started
-    timeout: 600000
-
-- evalScript: ${output.operationEnd = Date.now()}
-
-# click through welcome tour
-- assertVisible: Let's get started
-- tapOn:
-    id: lets-get-started
-
-- assertVisible:
-    id: bot-configure
-- tapOn:
-    id: bot-configure
-
-- assertVisible:
-    id: bot-name-input
-- tapOn:
-    id: bot-name-input
-- inputText: Test Bot
-- assertVisible:
-    id: bot-name-next
-- tapOn:
-    id: bot-name-next
-
-- assertVisible:
-    id: bot-avatar-skip
-- tapOn:
-    id: bot-avatar-skip
-
-- extendedWaitUntil:
-    visible: Default (free, used as fallback)
-    timeout: 60000
-- assertVisible:
-    id: bot-provider-next
-- tapOn:
-    id: bot-provider-next
-
-- assertVisible:
-    id: got-it
-- tapOn:
-    id: got-it
-
+# Wait for the deterministic onboarding rail. TLONBOARD deliberately selects
+# ships carrying the current plugin, so fallback bootstrap chatter is a test
+# failure rather than an alternate path.
 - extendedWaitUntil:
     visible:
-      id: finish-invites
-    timeout: 30000
+      id: A2UIChoice-agent-daily-digest
+    timeout: 600000
+
+# Complete the new on-rails Tlonbot setup conversation.
 - tapOn:
-    id: finish-invites
+    id: A2UIChoice-agent-daily-digest
+- extendedWaitUntil:
+    visible:
+      id: 'A2UISmallChoice-open hardware'
+    timeout: 60000
+- tapOn:
+    id: 'A2UISmallChoice-open hardware'
+- tapOn:
+    id: A2UISmallChoiceSubmit
+
+# Provisioning creates the recurring job, publishes its first entry, and then
+# offers optional service connections. Skip those to continue.
+- extendedWaitUntil:
+    visible:
+      id: A2UIMcpConnectComplete
+    timeout: 600000
+- tapOn:
+    id: A2UIMcpConnectComplete
+
+# Declining the optional app tour completes the setup conversation.
+- extendedWaitUntil:
+    visible:
+      id: A2UIChoice-no
+    timeout: 60000
+- tapOn:
+    id: A2UIChoice-no
+- extendedWaitUntil:
+    visible: No problem. You can ask me anytime.
+    timeout: 60000
+
+# Return from the setup conversation to the home screen.
+- tapOn:
+    text: Back
+- tapOn:
+    text: Back
 
 # assert we made it through signup and onboarding
 - extendedWaitUntil:
@@ -142,15 +139,13 @@ onFlowComplete:
     timeout: 30000
 - extendedWaitUntil:
     visible:
-      id: ChatListItem-Bot Farm 2-unpinned
+      id: GroupListItem-Open hardware Digest-pinned
     timeout: 30000
 
 # assert the expected signup chat titles are present
-- assertVisible: Test Bot
-- assertVisible: E2E Tester's Group
-- assertVisible: shadow brian :\)
-- assertVisible: Tlon Team
+- assertVisible: E2E Tester's Tlonbot 🌱
+- assertVisible: Open hardware Digest
 - assertVisible: Getting Started
-- assertVisible: Bot Farm 2
 
+- evalScript: ${output.operationEnd = Date.now()}
 - evalScript: ${output.didComplete = true}

--- a/.maestro/scripts/handleSignupSuccess.js
+++ b/.maestro/scripts/handleSignupSuccess.js
@@ -1,9 +1,12 @@
 const endpoint = `${MAESTRO_SERVERLESS_INFRA_API}/sendAlertBotMessage`;
 
 if (output.didComplete) {
-  const duration = Number(output.operationEnd) - Number(output.operationStart);
-  const durationSeconds = (duration / 1000).toFixed(0);
-  const accountURL = `${MAESTRO_HOSTING_DASH}/users?users-email=${output.signupEmail}`;
+  const nodeReadyDuration =
+    Number(output.initialRailVisibleAt) - Number(output.nodeReadyStartedAt);
+  const starterSetupDuration =
+    Number(output.starterReadyAt) - Number(output.initialRailVisibleAt);
+  const nodeReadySeconds = (nodeReadyDuration / 1000).toFixed(0);
+  const starterSetupSeconds = (starterSetupDuration / 1000).toFixed(0);
   const workflowsURL = `${MAESTRO_EXPO_PROJECT}/workflows`;
 
   http.post(endpoint, {
@@ -15,14 +18,7 @@ if (output.didComplete) {
       content: [
         {
           inline: [
-            '✅ E2E Signup Success: ',
-            {
-              link: {
-                href: accountURL,
-                content: 'automated user',
-              },
-            },
-            ` completed signup in ${durationSeconds} seconds (`,
+            '✅ E2E Signup Success (',
             {
               link: {
                 href: workflowsURL,
@@ -31,6 +27,12 @@ if (output.didComplete) {
             },
             `)`,
           ],
+        },
+        {
+          inline: [`Node ready wait: ${nodeReadySeconds} seconds`],
+        },
+        {
+          inline: [`Bot dialogue duration: ${starterSetupSeconds} seconds`],
         },
       ],
     }),


### PR DESCRIPTION
Updated to account for new onboarding flow, tested locally. For now, it'll use the test pool short code to make sure it gets a compatible ship.