### PR TITLE
auto-release Android production builds

### DIFF
--- a/apps/tlon-mobile/eas.json
+++ b/apps/tlon-mobile/eas.json
@@ -128,9 +128,8 @@
     "production": {
       "android": {
         "applicationId": "io.tlon.groups",
-        "releaseStatus": "draft",
-        "track": "internal",
-        "changesNotSentForReview": true
+        "releaseStatus": "completed",
+        "track": "internal"
       },
       "ios": {
         "ascAppId": "6451392109",


### PR DESCRIPTION
## Summary

Make Android production builds available to internal testers without a manual Play Console release step.

## Changes

- complete production Android submissions on the internal track
- leave preview Android submissions unchanged

## How did I test?

- validated the EAS submit profiles with `jq`
- confirmed the production Gradle flavor uses `io.tlon.groups`
- confirmed production builds still submit to the `internal` track
- confirmed the preview submit profile is unchanged
- `git diff --check`
