### PR TITLE
temporarily restore group chat ordering

### DIFF
--- a/packages/app/hooks/useResolvedChats.test.ts
+++ b/packages/app/hooks/useResolvedChats.test.ts
@@ -1,0 +1,30 @@
+import type * as db from '@tloncorp/shared/db';
+import { expect, test } from 'vitest';
+
+import { getChatTimestampsSignature } from './useResolvedChats';
+
+function makeGroupChat(timestamp: number): db.Chat {
+  return {
+    id: '~zod/test-group',
+    type: 'group',
+    pin: null,
+    volumeSettings: null,
+    timestamp,
+    isPending: false,
+    unreadCount: 0,
+    group: {
+      id: '~zod/test-group',
+      title: 'Test group',
+      lastPostAt: 100,
+    } as db.Group,
+  };
+}
+
+test('chat signature changes when recency advances without reordering', () => {
+  const before = [makeGroupChat(100)];
+  const after = [makeGroupChat(200)];
+
+  expect(getChatTimestampsSignature(after)).not.toBe(
+    getChatTimestampsSignature(before)
+  );
+});

--- a/packages/app/hooks/useResolvedChats.ts
+++ b/packages/app/hooks/useResolvedChats.ts
@@ -4,6 +4,10 @@ import { useEffect, useMemo, useState } from 'react';
 
 type UseCurrentChatsResult = ReturnType<typeof store.useCurrentChats>['data'];
 
+export function getChatTimestampsSignature(chats: db.Chat[]): string {
+  return chats.map((chat) => chat.timestamp).join('|');
+}
+
 /**
  * Memoizes the chat list structure based on relevant changes
  * (list lengths, unread counts) to prevent unnecessary recalculations
@@ -32,6 +36,11 @@ export function useResolvedChats(chats: UseCurrentChatsResult): {
       // lastPostAt all unchanged — key on the order itself.
       unpinnedOrder: chats.unpinned.map((c) => c.id).join('|'),
       pendingOrder: chats.pending.map((c) => c.id).join('|'),
+      // Recency can advance without changing order, count, or lastPostAt.
+      // Include it so Notes-driven row presentation sees the new relations.
+      pinnedTimestamps: getChatTimestampsSignature(chats.pinned),
+      unpinnedTimestamps: getChatTimestampsSignature(chats.unpinned),
+      pendingTimestamps: getChatTimestampsSignature(chats.pending),
       pinnedUnreadCount: chats.pinned.reduce(
         (acc, chat) => acc + (chat.unreadCount ?? 0),
         0

--- a/packages/app/ui/components/listItems/ChatListItem.tsx
+++ b/packages/app/ui/components/listItems/ChatListItem.tsx
@@ -5,6 +5,7 @@ import React, { useMemo } from 'react';
 import { ListItemProps } from '../ListItem';
 import { ChannelListItem } from './ChannelListItem';
 import { GroupListItem } from './GroupListItem';
+import { getGroupRecencyOverride } from './chatListRecency';
 
 export const ChatListItem = React.memo(function ChatListItemComponent({
   model,
@@ -35,6 +36,8 @@ export const ChatListItem = React.memo(function ChatListItemComponent({
     }
   }, [model]);
 
+  const groupRecencyOverride = getGroupRecencyOverride(model);
+
   if (model.type === 'group') {
     return (
       <GroupListItem
@@ -42,6 +45,7 @@ export const ChatListItem = React.memo(function ChatListItemComponent({
         onLongPress={handleLongPress}
         model={model.group}
         onLayout={onLayout}
+        recencyOverride={groupRecencyOverride}
         {...props}
       />
     );

--- a/packages/app/ui/components/listItems/GroupListItem.tsx
+++ b/packages/app/ui/components/listItems/GroupListItem.tsx
@@ -14,16 +14,21 @@ import { ContactName } from '../ContactNameV2';
 import { OverflowTriggerButton } from '../OverflowMenuButton';
 import { ListItem, ListItemProps } from '../ListItem';
 import { getGroupStatus, getPostTypeIcon } from './listItemUtils';
+import type { GroupRecencyOverride } from './chatListRecency';
 
 export const GroupListItem = ({
   model,
   onPress,
   onLongPress,
   customSubtitle,
+  recencyOverride,
   disableOptions = false,
   hoverStyle,
   ...props
-}: { customSubtitle?: string } & ListItemProps<db.Group>) => {
+}: {
+  customSubtitle?: string;
+  recencyOverride?: GroupRecencyOverride | null;
+} & ListItemProps<db.Group>) => {
   const [open, setOpen] = useState(false);
   const { setChat } = useChatOptions(disableOptions);
   const [isHovered, setIsHovered] = useState(false);
@@ -140,7 +145,11 @@ export const GroupListItem = ({
           />
           <ListItem.MainContent>
             <ListItem.Title>{title}</ListItem.Title>
-            {customSubtitle ? (
+            {recencyOverride ? (
+              <ListItem.SubtitleWithIcon icon="ChannelNotebooks">
+                {recencyOverride.label}
+              </ListItem.SubtitleWithIcon>
+            ) : customSubtitle ? (
               <ListItem.Subtitle>{customSubtitle}</ListItem.Subtitle>
             ) : isSingleChannel ? (
               <ListItem.SubtitleWithIcon icon="ChannelMultiDM">
@@ -165,7 +174,7 @@ export const GroupListItem = ({
                 </ListItem.Subtitle>
               </>
             ) : null}
-            {model.lastPost ? (
+            {recencyOverride ? null : model.lastPost ? (
               <ListItem.PostPreview post={model.lastPost} />
             ) : !isPending ? (
               model.isPersonalGroup ? (
@@ -185,7 +194,9 @@ export const GroupListItem = ({
                 />
               ) : (
                 <>
-                  <ListItem.Time time={model.lastPostAt} />
+                  <ListItem.Time
+                    time={recencyOverride?.timestamp ?? model.lastPostAt}
+                  />
                   <ListItem.Count
                     opacity={isHovered ? 0 : 1}
                     notified={notified}

--- a/packages/app/ui/components/listItems/chatListRecency.test.ts
+++ b/packages/app/ui/components/listItems/chatListRecency.test.ts
@@ -63,4 +63,11 @@ describe('getGroupRecencyOverride', () => {
       getGroupRecencyOverride(makeGroupChat({ timestamp: 300 }))
     ).toBeNull();
   });
+
+  test('keeps the post presentation for pinned groups', () => {
+    const chat = makeGroupChat();
+    chat.pin = { itemId: chat.id } as db.Pin;
+
+    expect(getGroupRecencyOverride(chat)).toBeNull();
+  });
 });

--- a/packages/app/ui/components/listItems/chatListRecency.test.ts
+++ b/packages/app/ui/components/listItems/chatListRecency.test.ts
@@ -1,0 +1,66 @@
+import type * as db from '@tloncorp/shared/db';
+import { describe, expect, test } from 'vitest';
+
+import { getGroupRecencyOverride } from './chatListRecency';
+
+function makeGroupChat({
+  lastPostAt = 100,
+  notesActivityAt = 200,
+  timestamp = Math.max(lastPostAt, notesActivityAt),
+  isPending = false,
+}: {
+  lastPostAt?: number;
+  notesActivityAt?: number;
+  timestamp?: number;
+  isPending?: boolean;
+} = {}): db.Chat {
+  return {
+    id: '~zod/test-group',
+    type: 'group',
+    pin: null,
+    volumeSettings: null,
+    timestamp,
+    isPending,
+    unreadCount: 0,
+    group: {
+      id: '~zod/test-group',
+      lastPostAt,
+      channels: [
+        {
+          id: 'notes/~zod/test-notebook',
+          type: 'notes',
+          unread: {
+            channelId: 'notes/~zod/test-notebook',
+            updatedAt: notesActivityAt,
+          },
+        },
+      ],
+    } as db.Group,
+  };
+}
+
+describe('getGroupRecencyOverride', () => {
+  test('describes Notes activity when it supplies the group sort timestamp', () => {
+    expect(getGroupRecencyOverride(makeGroupChat())).toEqual({
+      label: 'Notes activity',
+      timestamp: 200,
+    });
+  });
+
+  test('keeps the post presentation when the latest post is newer', () => {
+    expect(
+      getGroupRecencyOverride(
+        makeGroupChat({ lastPostAt: 300, notesActivityAt: 200 })
+      )
+    ).toBeNull();
+  });
+
+  test('does not relabel pending groups or unrelated timestamps', () => {
+    expect(
+      getGroupRecencyOverride(makeGroupChat({ isPending: true }))
+    ).toBeNull();
+    expect(
+      getGroupRecencyOverride(makeGroupChat({ timestamp: 300 }))
+    ).toBeNull();
+  });
+});

--- a/packages/app/ui/components/listItems/chatListRecency.test.ts
+++ b/packages/app/ui/components/listItems/chatListRecency.test.ts
@@ -13,7 +13,7 @@ function makeGroupChat({
   notesActivityAt?: number;
   timestamp?: number;
   isPending?: boolean;
-} = {}): db.Chat {
+} = {}): Extract<db.Chat, { type: 'group' }> {
   return {
     id: '~zod/test-group',
     type: 'group',
@@ -29,6 +29,7 @@ function makeGroupChat({
         {
           id: 'notes/~zod/test-notebook',
           type: 'notes',
+          currentUserIsMember: true,
           unread: {
             channelId: 'notes/~zod/test-notebook',
             updatedAt: notesActivityAt,
@@ -67,6 +68,13 @@ describe('getGroupRecencyOverride', () => {
   test('keeps the post presentation for pinned groups', () => {
     const chat = makeGroupChat();
     chat.pin = { itemId: chat.id } as db.Pin;
+
+    expect(getGroupRecencyOverride(chat)).toBeNull();
+  });
+
+  test('ignores stale activity from a left Notes channel', () => {
+    const chat = makeGroupChat();
+    chat.group.channels![0].currentUserIsMember = false;
 
     expect(getGroupRecencyOverride(chat)).toBeNull();
   });

--- a/packages/app/ui/components/listItems/chatListRecency.ts
+++ b/packages/app/ui/components/listItems/chatListRecency.ts
@@ -1,0 +1,38 @@
+import type * as db from '@tloncorp/shared/db';
+
+export type GroupRecencyOverride = {
+  label: string;
+  timestamp: number;
+};
+
+/**
+ * Temporary UI companion to the TLON-6417 ordering workaround. When Notes
+ * activity moves a group ahead of its latest post, describe that activity
+ * instead of showing an unrelated post preview and timestamp.
+ */
+export function getGroupRecencyOverride(
+  chat: db.Chat
+): GroupRecencyOverride | null {
+  if (chat.type !== 'group' || chat.isPending) {
+    return null;
+  }
+
+  const latestNotesActivityAt = Math.max(
+    0,
+    ...(chat.group.channels ?? [])
+      .filter((channel) => channel.type === 'notes')
+      .map((channel) => channel.unread?.updatedAt ?? 0)
+  );
+
+  if (
+    latestNotesActivityAt <= (chat.group.lastPostAt ?? 0) ||
+    latestNotesActivityAt !== chat.timestamp
+  ) {
+    return null;
+  }
+
+  return {
+    label: 'Notes activity',
+    timestamp: latestNotesActivityAt,
+  };
+}

--- a/packages/app/ui/components/listItems/chatListRecency.ts
+++ b/packages/app/ui/components/listItems/chatListRecency.ts
@@ -20,7 +20,10 @@ export function getGroupRecencyOverride(
   const latestNotesActivityAt = Math.max(
     0,
     ...(chat.group.channels ?? [])
-      .filter((channel) => channel.type === 'notes')
+      .filter(
+        (channel) =>
+          channel.type === 'notes' && channel.currentUserIsMember === true
+      )
       .map((channel) => channel.unread?.updatedAt ?? 0)
   );
 

--- a/packages/app/ui/components/listItems/chatListRecency.ts
+++ b/packages/app/ui/components/listItems/chatListRecency.ts
@@ -13,7 +13,7 @@ export type GroupRecencyOverride = {
 export function getGroupRecencyOverride(
   chat: db.Chat
 ): GroupRecencyOverride | null {
-  if (chat.type !== 'group' || chat.isPending) {
+  if (chat.type !== 'group' || chat.isPending || chat.pin) {
     return null;
   }
 

--- a/packages/shared/src/db/queries.test.ts
+++ b/packages/shared/src/db/queries.test.ts
@@ -245,7 +245,12 @@ describe('getChats group recency workaround', () => {
       groups: [testGroup(recentGroupId, 200), testGroup(notesGroupId, 100)],
     });
     await queries.insertChannels([
-      { id: notesChannelId, type: 'notes', groupId: notesGroupId },
+      {
+        id: notesChannelId,
+        type: 'notes',
+        groupId: notesGroupId,
+        currentUserIsMember: true,
+      },
     ]);
     await queries.insertChannelUnreads([
       makeChannelUnread({ channelId: notesChannelId, updatedAt: 300 }),
@@ -256,6 +261,33 @@ describe('getChats group recency workaround', () => {
       .map((chat) => chat.id);
 
     expect(groupIds).toEqual([notesGroupId, recentGroupId]);
+  });
+
+  test('ignores stale Notes summaries after leaving a notebook', async () => {
+    const recentGroupId = '~zod/recent-post';
+    const leftNotesGroupId = '~zod/left-notes';
+    const leftNotesChannelId = 'notes/~zod/left-notes';
+
+    await queries.insertGroups({
+      groups: [testGroup(recentGroupId, 200), testGroup(leftNotesGroupId, 100)],
+    });
+    await queries.insertChannels([
+      {
+        id: leftNotesChannelId,
+        type: 'notes',
+        groupId: leftNotesGroupId,
+        currentUserIsMember: false,
+      },
+    ]);
+    await queries.insertChannelUnreads([
+      makeChannelUnread({ channelId: leftNotesChannelId, updatedAt: 300 }),
+    ]);
+
+    const groupIds = (await queries.getChats()).unpinned
+      .filter((chat) => chat.type === 'group')
+      .map((chat) => chat.id);
+
+    expect(groupIds).toEqual([recentGroupId, leftNotesGroupId]);
   });
 });
 

--- a/packages/shared/src/db/queries.test.ts
+++ b/packages/shared/src/db/queries.test.ts
@@ -182,12 +182,12 @@ test('uses init data to get chat list', async () => {
   const ids = result.unpinned.map((r) => r.id).slice(0, 7);
   expect(ids).toEqual([
     'chat/~nibset-napwyn/commons',
-    '~nibset-napwyn/tlon',
     '~nocsyx-lassul',
     'chat/~pondus-watbel/new-channel',
-    '~pondus-watbel/testing-facility',
     'chat/~nibset-napwyn/intros',
     '~ravseg-nosduc',
+    '~solfer-magfed',
+    '~hansel-ribbur',
   ]);
 
   expect(result.pending.map((r) => r.id)).toEqual([
@@ -195,6 +195,68 @@ test('uses init data to get chat list', async () => {
     '~barmyl-sigted/network-being',
     '~salfer-biswed/gamers',
   ]);
+});
+
+describe('getChats group recency workaround', () => {
+  type TestGroup = Parameters<typeof queries.insertGroups>[0]['groups'][number];
+
+  function testGroup(id: string, lastPostAt: number): TestGroup {
+    return {
+      id,
+      currentUserIsMember: true,
+      currentUserIsHost: false,
+      hostUserId: '~zod',
+      lastPostAt,
+      channels: [],
+    } as unknown as TestGroup;
+  }
+
+  test('ignores broad group activity and legacy notebook activity', async () => {
+    const recentGroupId = '~zod/recent-post';
+    const noisyGroupId = '~zod/noisy-activity';
+    const legacyNotebookId = 'diary/~zod/noisy-activity/notebook';
+
+    await queries.insertGroups({
+      groups: [testGroup(recentGroupId, 200), testGroup(noisyGroupId, 100)],
+    });
+    await queries.insertChannels([
+      { id: legacyNotebookId, type: 'notebook', groupId: noisyGroupId },
+    ]);
+    await queries.insertGroupUnreads([
+      makeGroupUnread({ groupId: noisyGroupId, updatedAt: 400 }),
+    ]);
+    await queries.insertChannelUnreads([
+      makeChannelUnread({ channelId: legacyNotebookId, updatedAt: 300 }),
+    ]);
+
+    const groupIds = (await queries.getChats()).unpinned
+      .filter((chat) => chat.type === 'group')
+      .map((chat) => chat.id);
+
+    expect(groupIds).toEqual([recentGroupId, noisyGroupId]);
+  });
+
+  test('reorders groups from a persisted Notes summary without local activity events', async () => {
+    const recentGroupId = '~zod/recent-post';
+    const notesGroupId = '~zod/notes-activity';
+    const notesChannelId = 'notes/~zod/notes-activity';
+
+    await queries.insertGroups({
+      groups: [testGroup(recentGroupId, 200), testGroup(notesGroupId, 100)],
+    });
+    await queries.insertChannels([
+      { id: notesChannelId, type: 'notes', groupId: notesGroupId },
+    ]);
+    await queries.insertChannelUnreads([
+      makeChannelUnread({ channelId: notesChannelId, updatedAt: 300 }),
+    ]);
+
+    const groupIds = (await queries.getChats()).unpinned
+      .filter((chat) => chat.type === 'group')
+      .map((chat) => chat.id);
+
+    expect(groupIds).toEqual([notesGroupId, recentGroupId]);
+  });
 });
 
 test('update channel: new writer roles with existing writer roles', async () => {

--- a/packages/shared/src/db/queries.ts
+++ b/packages/shared/src/db/queries.ts
@@ -1403,7 +1403,10 @@ export const getChats = createReadQuery(
       const latestNotesActivityAt = Math.max(
         0,
         ...g.channels
-          .filter((channel) => channel.type === 'notes')
+          .filter(
+            (channel) =>
+              channel.type === 'notes' && channel.currentUserIsMember === true
+          )
           .map((channel) => channel.unread?.updatedAt ?? 0)
       );
 

--- a/packages/shared/src/db/queries.ts
+++ b/packages/shared/src/db/queries.ts
@@ -1363,6 +1363,7 @@ export const getChats = createReadQuery(
           orderBy: [desc($channels.lastPostAt)],
           with: {
             lastPost: true,
+            unread: true,
           },
         },
         // Just need the first 4 members for avatar display
@@ -1393,25 +1394,36 @@ export const getChats = createReadQuery(
       },
     });
 
-    const groupChats: Chat[] = groups.map((g) => ({
-      id: g.id,
-      type: 'group',
-      pin: g.pin,
-      timestamp: g.haveInvite
-        ? (g.unread?.updatedAt ?? 0)
-        : // whichever is newer: the latest post, or the activity summary's
-          // recency — activity that isn't a post (e.g. a note in a notebook
-          // channel) also reorders the sidebar
-          Math.max(g.lastPostAt ?? 0, g.unread?.updatedAt ?? 0),
-      volumeSettings: g.volumeSettings,
-      unreadCount: g.unread?.count ?? 0,
-      group: g,
-      isPending:
-        g.haveInvite === true ||
-        !!g.joinStatus ||
-        g.haveRequestedInvite ||
-        false,
-    }));
+    const groupChats: Chat[] = groups.map((g) => {
+      // Temporary client-side workaround for TLON-6417. Group activity
+      // recency includes membership and other events that should not reorder
+      // the chat list. Keep the old post-based ordering, plus the narrower
+      // Notes source recency, until the backend provides a sidebar-specific
+      // recency value.
+      const latestNotesActivityAt = Math.max(
+        0,
+        ...g.channels
+          .filter((channel) => channel.type === 'notes')
+          .map((channel) => channel.unread?.updatedAt ?? 0)
+      );
+
+      return {
+        id: g.id,
+        type: 'group',
+        pin: g.pin,
+        timestamp: g.haveInvite
+          ? (g.unread?.updatedAt ?? 0)
+          : Math.max(g.lastPostAt ?? 0, latestNotesActivityAt),
+        volumeSettings: g.volumeSettings,
+        unreadCount: g.unread?.count ?? 0,
+        group: g,
+        isPending:
+          g.haveInvite === true ||
+          !!g.joinStatus ||
+          g.haveRequestedInvite ||
+          false,
+      };
+    });
 
     const channelChats: Chat[] = channels.map((c) => ({
       id: c.id,


### PR DESCRIPTION
## Summary

Temporarily restores post-based ordering for groups while still allowing new Notes activity to move a group.

This is a client-side workaround pending a backend sidebar-recency field. The broad group activity timestamp also includes membership and other events, so it is not safe as the chat-list sort key.

Fixes TLON-6417

## Changes

- sort groups by the latest visible top-level post
- include the newest new Notes notebook summary as a targeted bump
- ignore group-wide activity and legacy notebook reply recency
- show a Notes activity label and effective timestamp when Notes moves a group
- suppress the unrelated old post preview for Notes-driven rows
- document the temporary backend gap in the query and UI helper

## Known UX limitations

- the client cannot identify which Note or author caused a move, or navigate directly to it
- notebook-source initialization and read-floor changes can still affect Notes recency because the summary does not expose its cause
- clients on older builds can order and present the same groups differently

## How did I test?

- `corepack pnpm --filter @tloncorp/shared test --run` (560 passed)
- `corepack pnpm --filter @tloncorp/shared tsc`
- `corepack pnpm --filter @tloncorp/app test --run` (568 passed, 3 skipped)
- `corepack pnpm --filter @tloncorp/app tsc`
- focused Notes-recency presentation tests (3 passed)
- targeted `oxfmt` and `oxlint` (one existing unrelated warning)
- `git diff --check`
- no native build
