### PR TITLE
hermes + openclaw: group-invite parity follow-ups from #6348

### DIFF
--- a/packages/hermes-tlon-adapter/README.md
+++ b/packages/hermes-tlon-adapter/README.md
@@ -213,12 +213,12 @@ Owner commands (deterministic, never wake the model):
 /pending                  list pending requests
 /allow <id>               approve (accepts the DM/group invite if needed, grants access, replays the message)
 /reject <id>              drop the request; a pending group invite is declined on the ship, a DM invite is left untouched
-/ban <id|~ship>           block natively via %chat (and clear pending requests from that ship)
+/ban <id|~ship>           block natively via %chat and revoke the DM grant (banning a group request by id also declines its invite; /ban ~ship clears pending requests without declining)
 /unban ~ship              unblock
 /banned                   list blocked ships
 ```
 
-Approved DM senders persist in the `dmAllowlist` %settings key and pending requests in `pendingApprovals` (48h TTL) — the same keys the OpenClaw plugin uses, so state carries over in both directions. Bans use Tlon's native ship blocking (no plugin state). Repeat messages from a still-pending ship update the stored preview but re-notify the owner at most every 10 minutes.
+Approved DM senders persist in the `dmAllowlist` %settings key and pending requests in `pendingApprovals` (48h TTL) — the same keys the OpenClaw plugin uses, so state carries over in both directions. Bans use Tlon's native ship blocking (no plugin state). A `/ban` on a group request blocks the inviter, removes it from `dmAllowlist`, then declines the invite — the DM grant is revoked before the decline so a partial ban (block succeeded, decline failed) leaves no live authorization behind, and the failed step keeps the request pending for a retry. Repeat messages from a still-pending ship update the stored preview but re-notify the owner at most every 10 minutes.
 
 ### Per-Channel Open Access
 
@@ -263,12 +263,12 @@ Tlon's hosting service (the backend behind the web dashboard and in-app bot sett
 | `dmAllowlist`            | approved DM senders (see [Access Control & Approvals](#access-control--approvals))                          |
 | `channelRules`           | per-channel open/restricted mode + `allowedShips` (see [Per-Channel Open Access](#per-channel-open-access)) |
 | `groupChannels`          | extra monitored channels, additive to `TLON_CHANNELS`                                                       |
-| `groupInviteAllowlist`   | inviters whose group invites auto-accept                                                                    |
+| `groupInviteAllowlist`   | inviters whose group invites auto-accept; a list (even `[]`) overrides, anything else uses the env seed     |
 | `defaultAuthorizedShips` | global fallback `allowedShips` for restricted channels whose rule doesn't pin its own list                  |
 | `autoAcceptDmInvites`    | whether an allowlisted ship's native DM invite auto-accepts (default off; owner always accepts)             |
 | `autoDiscoverChannels`   | whether an inbound message in an unmonitored `chat/`/`heap/` channel starts monitoring it (default off)     |
 
-All seven load on connect, hot-reload live via the `%settings` subscription (no restart needed), and re-sync after every SSE reconnect. `autoAcceptDmInvites`/`autoDiscoverChannels` are read as strict booleans — a non-boolean or missing value falls back to the default (`autoAcceptDmInvites` to `false`; `autoDiscoverChannels` to the `TLON_AUTO_DISCOVER` seed) rather than being truthy-coerced. `defaultAuthorizedShips` accepts only string ship entries; non-string list items are dropped, not coerced.
+All seven load on connect, hot-reload live via the `%settings` subscription (no restart needed), and re-sync after every SSE reconnect. `autoAcceptDmInvites`/`autoDiscoverChannels` are read as strict booleans — a non-boolean or missing value falls back to the default (`autoAcceptDmInvites` to `false`; `autoDiscoverChannels` to the `TLON_AUTO_DISCOVER` seed) rather than being truthy-coerced. `defaultAuthorizedShips` accepts only string ship entries; non-string list items are dropped, not coerced. `groupInviteAllowlist` resolves exactly like OpenClaw's `settings.groupInviteAllowlist ?? account.groupInviteAllowlist`: only a list value is an owner-authored override (an empty list means "nobody auto-accepts"), and it too takes string entries only; a key that is absent, deleted, or holds a non-list value reverts to the `TLON_GROUP_INVITE_ALLOWLIST` seed instead of keeping whatever was loaded before, so a deletion missed during an outage cannot leave revoked authorization in memory.
 
 The `autoAcceptDmInvites` gate follows OpenClaw exactly: only the **owner's** invite bypasses the toggle; every other allowlisted ship — env `TLON_ALLOWED_USERS`/`TLON_ALLOW_ALL_USERS`/`TLON_DM_ALLOWLIST` or the settings-store `dmAllowlist` — is gated, and a gated-off invite is left pending in Tlon (not queued as a fresh approval; the ship is already approved). Unknown ships queue for owner approval regardless of the flag.
 

--- a/packages/hermes-tlon-adapter/adapter.py
+++ b/packages/hermes-tlon-adapter/adapter.py
@@ -2169,10 +2169,11 @@ class TlonAdapter(BasePlatformAdapter):
             SETTINGS_KEY_DM_ALLOWLIST, sorted(self._settings_dm_allowlist)
         )
 
-    async def _remove_from_dm_allowlist(self, ship: str) -> None:
+    async def _remove_from_dm_allowlist(self, ship: str) -> bool:
+        """Revoke the DM grant; False when the settings write failed."""
         ship = normalize_ship(ship)
         if ship not in self._settings_dm_allowlist:
-            return
+            return True
         self._settings_dm_allowlist.discard(ship)
         persisted = await self._persist_settings_entry(
             SETTINGS_KEY_DM_ALLOWLIST, sorted(self._settings_dm_allowlist)
@@ -2182,6 +2183,8 @@ class TlonAdapter(BasePlatformAdapter):
             # restoring the entry keeps a retried /ban re-attempting the write
             # instead of early-returning on the absent ship.
             self._settings_dm_allowlist.add(ship)
+            return False
+        return True
 
     async def _handle_approval_command(
         self,
@@ -2296,7 +2299,15 @@ class TlonAdapter(BasePlatformAdapter):
             # Ahead of the decline: a block-OK/decline-failed partial ban keeps
             # the record for a retry, and until that retry lands the DM grant
             # would be a live authorization the owner believes is gone.
-            await self._remove_from_dm_allowlist(ship)
+            revoked = await self._remove_from_dm_allowlist(ship)
+            if not revoked and approval_type(approval) == "group":
+                # Completing anyway would drop the only record through which a
+                # retry can re-attempt the failed revocation write; dm/channel
+                # bans stay best-effort like their block leg.
+                return (
+                    f"Blocked {ship}, but could not revoke DM access. "
+                    "Request stays pending."
+                )
             if approval_type(approval) == "group":
                 # A ban must also decline the invite: the inviter may have been
                 # allowlisted since the request queued, and auto-accept does not

--- a/packages/hermes-tlon-adapter/adapter.py
+++ b/packages/hermes-tlon-adapter/adapter.py
@@ -48,6 +48,7 @@ from .approval import (
     build_approval_card,
     build_pending_approvals_response,
     create_pending_approval,
+    error_progress_flags,
     find_approval,
     find_duplicate,
     format_approval_request,
@@ -1040,8 +1041,8 @@ class TlonAdapter(BasePlatformAdapter):
         self._settings_loaded = False
         self._pending_approvals: list[dict[str, Any]] = []
         self._settings_dm_allowlist: set[str] = set()
-        self._settings_group_invite_allowlist: set[str] = set(
-            self.tlon_config.group_invite_allowlist
+        self._settings_group_invite_allowlist: set[str] = (
+            self._env_group_invite_allowlist()
         )
         self._channel_rules: dict[str, dict[str, Any]] = {}
         self._processed_dm_invites: set[str] = set()
@@ -1268,6 +1269,22 @@ class TlonAdapter(BasePlatformAdapter):
             default_all=self.tlon_config.owner_listen_default == "all",
         )
 
+    def _env_group_invite_allowlist(self) -> set[str]:
+        return set(self.tlon_config.group_invite_allowlist)
+
+    def _resolve_group_invite_allowlist(self, value: Any) -> set[str]:
+        """Resolve a %settings groupInviteAllowlist value to the live set.
+
+        A list — including an empty one — is an owner-authored override, parsed
+        strictly so malformed entries cannot broaden authorization. Anything
+        else (key absent, deleted, or malformed) is not an override and reverts
+        to the env default, matching openclaw's
+        ``settings.groupInviteAllowlist ?? account.groupInviteAllowlist``.
+        """
+        if not isinstance(value, list):
+            return self._env_group_invite_allowlist()
+        return parse_ship_list(value)
+
     def _is_owner(self, ship: str) -> bool:
         owner = self.tlon_config.owner_ship
         return bool(owner) and normalize_ship(ship) == owner
@@ -1376,10 +1393,11 @@ class TlonAdapter(BasePlatformAdapter):
             self._settings_dm_allowlist = parse_dm_allowlist(
                 bucket.get(SETTINGS_KEY_DM_ALLOWLIST)
             )
-            if SETTINGS_KEY_GROUP_INVITE_ALLOWLIST in bucket:
-                self._settings_group_invite_allowlist = parse_dm_allowlist(
+            self._settings_group_invite_allowlist = (
+                self._resolve_group_invite_allowlist(
                     bucket.get(SETTINGS_KEY_GROUP_INVITE_ALLOWLIST)
                 )
+            )
             self._channel_rules = parse_channel_rules(bucket.get(SETTINGS_KEY_CHANNEL_RULES))
             self._settings_default_authorized_ships = parse_ship_list(
                 bucket.get(SETTINGS_KEY_DEFAULT_AUTHORIZED_SHIPS)
@@ -1583,7 +1601,9 @@ class TlonAdapter(BasePlatformAdapter):
             self._settings_dm_allowlist = parse_dm_allowlist(event.value)
             return
         if event.key == SETTINGS_KEY_GROUP_INVITE_ALLOWLIST:
-            self._settings_group_invite_allowlist = parse_dm_allowlist(event.value)
+            self._settings_group_invite_allowlist = (
+                self._resolve_group_invite_allowlist(event.value)
+            )
             return
         if event.key == SETTINGS_KEY_CHANNEL_RULES:
             self._channel_rules = parse_channel_rules(event.value)
@@ -1833,6 +1853,43 @@ class TlonAdapter(BasePlatformAdapter):
             await self._load_settings_state()
         now_ms = time.time() * 1000.0
         self._pending_approvals = prune_expired(self._pending_approvals, now_ms)
+        # Groups dedup on the flag alone, so the no-op exits can be taken from a
+        # direct lookup — no candidate needed. DM/channel dedup needs the built
+        # candidate and so stays behind the scry.
+        existing = (
+            find_duplicate(
+                self._pending_approvals,
+                {"type": "group", "groupFlag": group_flag},
+            )
+            if approval_kind == "group"
+            else None
+        )
+        if existing is not None:
+            # Delivered => never re-DM while the record lives; undelivered
+            # (including legacy lastNotifiedAt-only records) re-notifies
+            # under the cooldown until a send lands. Persisted JSON can
+            # carry a junk marker, so only a real stamp suppresses.
+            delivered = existing.get("notificationDeliveredAt")
+            if (
+                isinstance(delivered, (int, float))
+                and not isinstance(delivered, bool)
+                and math.isfinite(delivered)
+            ):
+                return
+            try:
+                last_notified = float(existing.get("lastNotifiedAt"))
+            except (TypeError, ValueError):
+                last_notified = 0.0
+            if not math.isfinite(last_notified):
+                # An inf stamp reads as "attempted in the future" and would
+                # suppress every retry for the record's whole life.
+                last_notified = 0.0
+            if now_ms - last_notified < RENOTIFY_COOLDOWN_MS:
+                return
+        # Every path past here sends the owner a DM or creates a record, so the
+        # blocked-list scry runs only when an action is imminent — a no-op
+        # re-observation of a suppressed group approval must not cost a 30s-
+        # worst-case scry per observation.
         if await self._is_ship_blocked(requesting_ship):
             logger.info(
                 "[tlon] ignoring request from blocked ship %s", requesting_ship
@@ -1849,30 +1906,10 @@ class TlonAdapter(BasePlatformAdapter):
             message_preview=message_preview,
             original_message=original_message,
         )
-        existing = find_duplicate(self._pending_approvals, candidate)
+        if approval_kind != "group":
+            existing = find_duplicate(self._pending_approvals, candidate)
         if existing is not None:
             if approval_kind == "group":
-                # Delivered => never re-DM while the record lives; undelivered
-                # (including legacy lastNotifiedAt-only records) re-notifies
-                # under the cooldown until a send lands. Persisted JSON can
-                # carry a junk marker, so only a real stamp suppresses.
-                delivered = existing.get("notificationDeliveredAt")
-                if (
-                    isinstance(delivered, (int, float))
-                    and not isinstance(delivered, bool)
-                    and math.isfinite(delivered)
-                ):
-                    return
-                try:
-                    last_notified = float(existing.get("lastNotifiedAt"))
-                except (TypeError, ValueError):
-                    last_notified = 0.0
-                if not math.isfinite(last_notified):
-                    # An inf stamp reads as "attempted in the future" and would
-                    # suppress every retry for the record's whole life.
-                    last_notified = 0.0
-                if now_ms - last_notified < RENOTIFY_COOLDOWN_MS:
-                    return
                 updated = dict(existing)
                 updated["lastNotifiedAt"] = int(now_ms)
                 if await self._notify_owner_approval(updated):
@@ -2235,8 +2272,12 @@ class TlonAdapter(BasePlatformAdapter):
                         "Request stays pending."
                     )
         elif action == "ban":
-            # %chat's block poke nacks when the ship is already blocked, so a
-            # /ban retried after a failed decline must not re-poke it.
+            # %chat nacks the block poke for an already-blocked ship, but pokes
+            # are fire-and-forget: the nack lands later on the stream and is
+            # only logged, so _block_ship still reports success. This pre-check
+            # only saves the redundant re-poke — a /ban retried after a failed
+            # decline reaches the decline with or without it, including while
+            # the (fail-open) blocked-list scry is down.
             blocked = normalize_ship(ship) in await self._blocked_ships_list()
             if not blocked:
                 blocked = await self._block_ship(ship)
@@ -2247,6 +2288,10 @@ class TlonAdapter(BasePlatformAdapter):
                     f"Could not block {ship}: block failed. "
                     "Request stays pending."
                 )
+            # Ahead of the decline: a block-OK/decline-failed partial ban keeps
+            # the record for a retry, and until that retry lands the DM grant
+            # would be a live authorization the owner believes is gone.
+            await self._remove_from_dm_allowlist(ship)
             if approval_type(approval) == "group":
                 # A ban must also decline the invite: the inviter may have been
                 # allowlisted since the request queued, and auto-accept does not
@@ -2258,7 +2303,6 @@ class TlonAdapter(BasePlatformAdapter):
                         f"Blocked {ship}, but could not decline the invite. "
                         "Request stays pending."
                     )
-            await self._remove_from_dm_allowlist(ship)
         elif action == "reject" and approval_type(approval) == "group":
             # Reject must decline on the ship, or the next observation of the
             # still-pending invite would re-queue it.
@@ -3936,6 +3980,12 @@ class TlonAdapter(BasePlatformAdapter):
 
     async def _handle_foreigns(self, payload: Any) -> None:
         """Process the %groups foreigns map (live sub or catch-up scry)."""
+        for flag in error_progress_flags(payload):
+            # The accept-invite CLI call acked but the backend join failed, so
+            # the flag is actionable again; discarding before the marker check
+            # is what lets a flag marked by the accept (or by the
+            # confirmed-blocked branch) reach a fresh decision.
+            self._processed_group_invites.discard(flag)
         for invite in parse_foreigns(payload):
             flag = invite["groupFlag"]
             if flag in self._processed_group_invites:

--- a/packages/hermes-tlon-adapter/adapter.py
+++ b/packages/hermes-tlon-adapter/adapter.py
@@ -2174,9 +2174,14 @@ class TlonAdapter(BasePlatformAdapter):
         if ship not in self._settings_dm_allowlist:
             return
         self._settings_dm_allowlist.discard(ship)
-        await self._persist_settings_entry(
+        persisted = await self._persist_settings_entry(
             SETTINGS_KEY_DM_ALLOWLIST, sorted(self._settings_dm_allowlist)
         )
+        if not persisted:
+            # Memory must not claim a revocation the store still grants:
+            # restoring the entry keeps a retried /ban re-attempting the write
+            # instead of early-returning on the absent ship.
+            self._settings_dm_allowlist.add(ship)
 
     async def _handle_approval_command(
         self,
@@ -3980,12 +3985,6 @@ class TlonAdapter(BasePlatformAdapter):
 
     async def _handle_foreigns(self, payload: Any) -> None:
         """Process the %groups foreigns map (live sub or catch-up scry)."""
-        for flag in error_progress_flags(payload):
-            # The accept-invite CLI call acked but the backend join failed, so
-            # the flag is actionable again; discarding before the marker check
-            # is what lets a flag marked by the accept (or by the
-            # confirmed-blocked branch) reach a fresh decision.
-            self._processed_group_invites.discard(flag)
         for invite in parse_foreigns(payload):
             flag = invite["groupFlag"]
             if flag in self._processed_group_invites:
@@ -4260,6 +4259,13 @@ class TlonAdapter(BasePlatformAdapter):
         if not isinstance(foreigns, dict):
             logger.debug("[tlon] group-invite catch-up returned no foreigns map")
             return False
+        for flag in error_progress_flags(foreigns):
+            # A join that acked but errored on the backend becomes actionable
+            # again — but only on the catch-up sweep, never on live facts: a
+            # persistently-failing join emits a fresh error fact per attempt,
+            # so a live-path discard would retry at %groups' error-emission
+            # rate. Sweep-only clearing bounds retries to one per (re)connect.
+            self._processed_group_invites.discard(flag)
         await self._handle_foreigns(foreigns)
         return True
 

--- a/packages/hermes-tlon-adapter/approval.py
+++ b/packages/hermes-tlon-adapter/approval.py
@@ -271,6 +271,22 @@ def parse_foreigns(payload: Any) -> list[dict[str, str]]:
     return invites
 
 
+def error_progress_flags(payload: Any) -> list[str]:
+    """Group flags in a %groups foreigns map whose join ended in an error.
+
+    Kept separate from ``parse_foreigns`` because a foreign whose invite list
+    is empty or invalid yields nothing there, and the errored flag still has to
+    become actionable again.
+    """
+    if not isinstance(payload, Mapping):
+        return []
+    return [
+        str(flag)
+        for flag, foreign in payload.items()
+        if isinstance(foreign, Mapping) and foreign.get("progress") == "error"
+    ]
+
+
 def parse_dm_allowlist(value: Any) -> set[str]:
     if not isinstance(value, list):
         return set()

--- a/packages/hermes-tlon-adapter/test_adapter_approvals.py
+++ b/packages/hermes-tlon-adapter/test_adapter_approvals.py
@@ -1202,6 +1202,72 @@ class AdapterApprovalTests(unittest.TestCase):
         self.assertEqual(len(adapter._pending_approvals), 1)
         self.assertEqual(len(adapter._cli.notifications()), 1)
 
+    def test_delivered_group_reobservation_costs_no_blocked_scry(self):
+        adapter = self.make_adapter()
+        clock = FakeClock()
+        with patch.object(adapter_mod.time, "time", clock.time):
+            asyncio.run(adapter._handle_foreigns(self.foreigns("~host/projects", "~ten")))
+        self.assertEqual(adapter._sse.scries.count("/chat/blocked"), 1)
+
+        # A backlog re-observed at boot/reconnect must not pay a 30s-worst-case
+        # scry per already-notified group.
+        clock.advance_ms(adapter_mod.RENOTIFY_COOLDOWN_MS * 3)
+        with patch.object(adapter_mod.time, "time", clock.time):
+            asyncio.run(adapter._handle_foreigns(self.foreigns("~host/projects", "~ten")))
+
+        self.assertEqual(adapter._sse.scries.count("/chat/blocked"), 1)
+        self.assertEqual(len(adapter._cli.notifications()), 1)
+
+    def test_group_reobservation_within_cooldown_costs_no_blocked_scry(self):
+        adapter = self.make_adapter()
+        adapter._cli = FailingCLI(("posts", "send"))
+        clock = FakeClock()
+        with patch.object(adapter_mod.time, "time", clock.time):
+            asyncio.run(adapter._handle_foreigns(self.foreigns("~host/projects", "~ten")))
+        self.assertNotIn("notificationDeliveredAt", adapter._pending_approvals[0])
+        self.assertEqual(adapter._sse.scries.count("/chat/blocked"), 1)
+
+        clock.advance_ms(adapter_mod.RENOTIFY_COOLDOWN_MS - 1_000)
+        with patch.object(adapter_mod.time, "time", clock.time):
+            asyncio.run(adapter._handle_foreigns(self.foreigns("~host/projects", "~ten")))
+
+        self.assertEqual(adapter._sse.scries.count("/chat/blocked"), 1)
+        self.assertEqual(len(adapter._cli.notifications()), 1)
+
+    def test_blocked_group_inviter_without_a_record_is_still_ignored(self):
+        adapter = self.make_adapter()
+        adapter._sse.payloads["/chat/blocked"] = ["~ten"]
+
+        asyncio.run(adapter._handle_foreigns(self.foreigns("~host/projects", "~ten")))
+
+        self.assertEqual(adapter._pending_approvals, [])
+        self.assertEqual(adapter._cli.notifications(), [])
+        self.assertEqual(adapter._sse.scries.count("/chat/blocked"), 1)
+
+    def test_past_cooldown_group_renotify_still_consults_the_block_list(self):
+        adapter = self.make_adapter()
+        clock = FakeClock()
+        adapter._pending_approvals = [
+            {
+                "id": "g1234",
+                "type": "group",
+                "requestingShip": "~ten",
+                "groupFlag": "~host/projects",
+                "timestamp": clock.now_ms(),
+                "lastNotifiedAt": clock.now_ms(),
+            }
+        ]
+        # Blocked after the record was queued: the past-cooldown retry is about
+        # to DM, so the block list still gates it.
+        adapter._sse.payloads["/chat/blocked"] = ["~ten"]
+
+        clock.advance_ms(adapter_mod.RENOTIFY_COOLDOWN_MS)
+        with patch.object(adapter_mod.time, "time", clock.time):
+            asyncio.run(adapter._handle_foreigns(self.foreigns("~host/projects", "~ten")))
+
+        self.assertEqual(adapter._cli.notifications(), [])
+        self.assertEqual(adapter._sse.scries.count("/chat/blocked"), 1)
+
     def test_connect_scry_catches_missed_group_invites(self):
         adapter = self.make_adapter()
         adapter._sse.payloads["/groups-ui/v7/init"] = {
@@ -1211,6 +1277,33 @@ class AdapterApprovalTests(unittest.TestCase):
 
         self.assertTrue(asyncio.run(adapter._process_pending_group_invites()))
 
+        self.assertEqual(len(adapter._pending_approvals), 1)
+        self.assertEqual(adapter._pending_approvals[0]["groupFlag"], "~host/projects")
+
+    def test_allowlist_deleted_during_an_outage_stops_catchup_auto_accept(self):
+        adapter = self.make_adapter()
+        # Authorized before the outage; the owner deleted the key while the bot
+        # was disconnected, so no settings event ever arrived.
+        adapter._settings_group_invite_allowlist = {"~ten"}
+        adapter._sse.payloads["/settings/all"] = {"all": {"moltbot": {"tlon": {}}}}
+        # Readable and empty: with the stale allowlist still in force this
+        # invite would auto-accept, so the pin is not vacuous.
+        adapter._sse.payloads["/chat/blocked"] = []
+        adapter._sse.payloads["/groups-ui/v7/init"] = {
+            "foreigns": self.foreigns("~host/projects", "~ten"),
+            "groups": {},
+        }
+
+        async def reconnect():
+            self.assertTrue(await adapter._load_settings_state())
+            self.assertTrue(await adapter._process_pending_group_invites())
+
+        asyncio.run(reconnect())
+
+        self.assertEqual(adapter._settings_group_invite_allowlist, set())
+        self.assertNotIn(
+            ("groups", "accept-invite", "~host/projects"), adapter._cli.commands
+        )
         self.assertEqual(len(adapter._pending_approvals), 1)
         self.assertEqual(adapter._pending_approvals[0]["groupFlag"], "~host/projects")
 
@@ -1367,6 +1460,7 @@ class AdapterApprovalTests(unittest.TestCase):
         adapter = self.make_adapter()
         asyncio.run(adapter._handle_foreigns(self.foreigns("~host/projects", "~ten")))
         request_id = adapter._pending_approvals[0]["id"]
+        adapter._settings_dm_allowlist = {"~ten"}
         cli = FailingCLI(("groups", "reject-invite"))
         adapter._cli = cli
 
@@ -1376,6 +1470,10 @@ class AdapterApprovalTests(unittest.TestCase):
 
         self.assertEqual(len(adapter._pending_approvals), 1)
         self.assertIn("stays pending", cli.messages[-1][1])
+        # A partial ban still revokes the DM grant: until the retry lands it
+        # would be a live authorization the owner believes is gone.
+        self.assertEqual(adapter._settings_dm_allowlist, set())
+        self.assertEqual(adapter._sse.settings_writes("dmAllowlist")[-1], [])
 
         # The first /ban DID block the ship, and %chat's block poke nacks on
         # an already-blocked one — the retry must skip the re-block and still
@@ -1402,6 +1500,37 @@ class AdapterApprovalTests(unittest.TestCase):
         self.assertIn(
             ("groups", "reject-invite", "~host/projects"), cli.commands
         )
+
+    def test_ban_retry_during_blocked_list_outage_still_declines(self):
+        adapter = self.make_adapter()
+        asyncio.run(adapter._handle_foreigns(self.foreigns("~host/projects", "~ten")))
+        request_id = adapter._pending_approvals[0]["id"]
+        cli = FailingCLI(("groups", "reject-invite"))
+        adapter._cli = cli
+
+        self.dispatches(
+            adapter, dm_event(f"/ban {request_id}", author="~mug", whom="~mug"), dm=True
+        )
+
+        self.assertEqual(len(adapter._pending_approvals), 1)
+        self.assertEqual(len(adapter._sse.pokes_for("chat-block-ship")), 1)
+
+        # /chat/blocked stays unmapped, so the scry raises and the fail-open
+        # pre-check reads "not blocked": the retry re-pokes the block. %chat
+        # nacks that poke for an already-blocked ship, but the poke call itself
+        # still resolves — the nack arrives later on the stream and is only
+        # logged (test_tlon_api.test_nack_also_pops_entry) — so the retry
+        # reaches the decline rather than wedging until the scry recovers.
+        cli.failures = 0
+        self.dispatches(
+            adapter,
+            dm_event(f"/ban {request_id}", author="~mug", whom="~mug", msg_id="cmd-2"),
+            dm=True,
+        )
+
+        self.assertEqual(len(adapter._sse.pokes_for("chat-block-ship")), 2)
+        self.assertIn(("groups", "reject-invite", "~host/projects"), cli.commands)
+        self.assertEqual(adapter._pending_approvals, [])
 
     def test_group_invite_no_owner_is_ignored(self):
         adapter = self.make_adapter({"owner_ship": ""})
@@ -1432,6 +1561,64 @@ class AdapterApprovalTests(unittest.TestCase):
         self.assertIn(
             ("groups", "accept-invite", "~host/projects"), adapter._cli.commands
         )
+
+    @staticmethod
+    def errored_foreigns(flag, from_ship):
+        payload = AdapterApprovalTests.foreigns(flag, from_ship)
+        payload[flag]["progress"] = "error"
+        return payload
+
+    def test_join_error_after_an_accept_ack_resurfaces_the_invite(self):
+        adapter = self.make_adapter({"group_invite_allowlist": "~ten"})
+        adapter._sse.payloads["/chat/blocked"] = []
+        adapter._sse.payloads["/groups-ui/v7/init"] = self.init_with_channels(
+            "~host/projects", []
+        )
+        asyncio.run(adapter._handle_foreigns(self.foreigns("~host/projects", "~ten")))
+        self.assertIn("~host/projects", adapter._processed_group_invites)
+
+        # The accept-invite CLI call acked, but the backend join ended in
+        # error — the invite is a live decision again.
+        asyncio.run(adapter._handle_foreigns(self.errored_foreigns("~host/projects", "~ten")))
+
+        accepts = [
+            cmd
+            for cmd in adapter._cli.commands
+            if cmd == ("groups", "accept-invite", "~host/projects")
+        ]
+        self.assertEqual(len(accepts), 2)
+
+    def test_join_error_clears_the_marker_without_a_valid_invite(self):
+        adapter = self.make_adapter()
+        adapter._processed_group_invites.add("~host/projects")
+
+        asyncio.run(
+            adapter._handle_foreigns(
+                {"~host/projects": {"progress": "error", "invites": []}}
+            )
+        )
+
+        # parse_foreigns yields nothing for this shape, so no decision runs
+        # now; the flag still has to be actionable when an invite reappears.
+        self.assertNotIn("~host/projects", adapter._processed_group_invites)
+        self.assertEqual(adapter._pending_approvals, [])
+        self.assertEqual(adapter._cli.notifications(), [])
+
+    def test_join_error_on_a_blocked_marked_flag_rechecks_and_remarks(self):
+        adapter = self.make_adapter({"group_invite_allowlist": "~ten"})
+        adapter._sse.payloads["/chat/blocked"] = ["~ten"]
+        asyncio.run(adapter._handle_foreigns(self.foreigns("~host/projects", "~ten")))
+        self.assertIn("~host/projects", adapter._processed_group_invites)
+        self.assertEqual(adapter._sse.scries.count("/chat/blocked"), 1)
+
+        asyncio.run(adapter._handle_foreigns(self.errored_foreigns("~host/projects", "~ten")))
+
+        # The re-decision costs one more block-list read and re-marks; the
+        # owner is never carded for a confirmed-blocked inviter.
+        self.assertIn("~host/projects", adapter._processed_group_invites)
+        self.assertEqual(adapter._sse.scries.count("/chat/blocked"), 2)
+        self.assertEqual(adapter._pending_approvals, [])
+        self.assertEqual(adapter._cli.notifications(), [])
 
     def test_failed_notify_persists_undelivered_and_retries_past_cooldown(self):
         adapter = self.make_adapter()

--- a/packages/hermes-tlon-adapter/test_adapter_approvals.py
+++ b/packages/hermes-tlon-adapter/test_adapter_approvals.py
@@ -1456,6 +1456,46 @@ class AdapterApprovalTests(unittest.TestCase):
             ("groups", "reject-invite", "~host/projects"), adapter._cli.commands
         )
 
+    def test_group_ban_with_failed_revocation_keeps_request_pending(self):
+        adapter = self.make_adapter()
+        asyncio.run(adapter._handle_foreigns(self.foreigns("~host/projects", "~ten")))
+        request_id = adapter._pending_approvals[0]["id"]
+        adapter._settings_dm_allowlist = {"~ten"}
+        working_poke = adapter._sse.poke
+
+        async def failing_allowlist_write(app, mark, json_payload):
+            entry = (json_payload or {}).get("put-entry", {})
+            if entry.get("entry-key") == "dmAllowlist":
+                raise ConnectionError("settings poke failed")
+            return await working_poke(app, mark, json_payload)
+
+        adapter._sse.poke = failing_allowlist_write
+
+        self.dispatches(
+            adapter, dm_event(f"/ban {request_id}", author="~mug", whom="~mug"), dm=True
+        )
+
+        # The revocation write failed: the entry is restored, the decline was
+        # never attempted, and the record stays for a retry.
+        self.assertEqual(len(adapter._pending_approvals), 1)
+        self.assertIn("could not revoke DM access", adapter._cli.messages[-1][1])
+        self.assertIn("~ten", adapter._settings_dm_allowlist)
+        self.assertNotIn(
+            ("groups", "reject-invite", "~host/projects"), adapter._cli.commands
+        )
+
+        # The retry re-attempts the write, then declines and clears the record.
+        adapter._sse.poke = working_poke
+        self.dispatches(
+            adapter,
+            dm_event(f"/ban {request_id}", author="~mug", whom="~mug", msg_id="cmd-2"),
+            dm=True,
+        )
+
+        self.assertEqual(adapter._pending_approvals, [])
+        self.assertEqual(adapter._settings_dm_allowlist, set())
+        self.assertEqual(adapter._sse.settings_writes("dmAllowlist")[-1], [])
+
     def test_group_ban_with_failed_decline_keeps_request_pending(self):
         adapter = self.make_adapter()
         asyncio.run(adapter._handle_foreigns(self.foreigns("~host/projects", "~ten")))

--- a/packages/hermes-tlon-adapter/test_adapter_approvals.py
+++ b/packages/hermes-tlon-adapter/test_adapter_approvals.py
@@ -1568,7 +1568,7 @@ class AdapterApprovalTests(unittest.TestCase):
         payload[flag]["progress"] = "error"
         return payload
 
-    def test_join_error_after_an_accept_ack_resurfaces_the_invite(self):
+    def test_join_error_after_an_accept_ack_resurfaces_on_catchup(self):
         adapter = self.make_adapter({"group_invite_allowlist": "~ten"})
         adapter._sse.payloads["/chat/blocked"] = []
         adapter._sse.payloads["/groups-ui/v7/init"] = self.init_with_channels(
@@ -1578,8 +1578,12 @@ class AdapterApprovalTests(unittest.TestCase):
         self.assertIn("~host/projects", adapter._processed_group_invites)
 
         # The accept-invite CLI call acked, but the backend join ended in
-        # error — the invite is a live decision again.
-        asyncio.run(adapter._handle_foreigns(self.errored_foreigns("~host/projects", "~ten")))
+        # error — the reconciliation sweep makes it a live decision again.
+        adapter._sse.payloads["/groups-ui/v7/init"] = {
+            "foreigns": self.errored_foreigns("~host/projects", "~ten"),
+            "groups": {},
+        }
+        self.assertTrue(asyncio.run(adapter._process_pending_group_invites()))
 
         accepts = [
             cmd
@@ -1588,15 +1592,37 @@ class AdapterApprovalTests(unittest.TestCase):
         ]
         self.assertEqual(len(accepts), 2)
 
+    def test_join_error_on_the_live_path_stays_suppressed(self):
+        adapter = self.make_adapter({"group_invite_allowlist": "~ten"})
+        adapter._sse.payloads["/chat/blocked"] = []
+        adapter._sse.payloads["/groups-ui/v7/init"] = self.init_with_channels(
+            "~host/projects", []
+        )
+        asyncio.run(adapter._handle_foreigns(self.foreigns("~host/projects", "~ten")))
+        self.assertIn("~host/projects", adapter._processed_group_invites)
+
+        # A persistently-failing join emits a fresh error fact per attempt;
+        # retrying on each would re-poke %groups at its own failure rate, so
+        # live facts leave the marker and only the sweep clears it.
+        asyncio.run(adapter._handle_foreigns(self.errored_foreigns("~host/projects", "~ten")))
+
+        accepts = [
+            cmd
+            for cmd in adapter._cli.commands
+            if cmd == ("groups", "accept-invite", "~host/projects")
+        ]
+        self.assertEqual(len(accepts), 1)
+        self.assertIn("~host/projects", adapter._processed_group_invites)
+
     def test_join_error_clears_the_marker_without_a_valid_invite(self):
         adapter = self.make_adapter()
         adapter._processed_group_invites.add("~host/projects")
+        adapter._sse.payloads["/groups-ui/v7/init"] = {
+            "foreigns": {"~host/projects": {"progress": "error", "invites": []}},
+            "groups": {},
+        }
 
-        asyncio.run(
-            adapter._handle_foreigns(
-                {"~host/projects": {"progress": "error", "invites": []}}
-            )
-        )
+        self.assertTrue(asyncio.run(adapter._process_pending_group_invites()))
 
         # parse_foreigns yields nothing for this shape, so no decision runs
         # now; the flag still has to be actionable when an invite reappears.
@@ -1611,14 +1637,35 @@ class AdapterApprovalTests(unittest.TestCase):
         self.assertIn("~host/projects", adapter._processed_group_invites)
         self.assertEqual(adapter._sse.scries.count("/chat/blocked"), 1)
 
-        asyncio.run(adapter._handle_foreigns(self.errored_foreigns("~host/projects", "~ten")))
+        adapter._sse.payloads["/groups-ui/v7/init"] = {
+            "foreigns": self.errored_foreigns("~host/projects", "~ten"),
+            "groups": {},
+        }
+        self.assertTrue(asyncio.run(adapter._process_pending_group_invites()))
 
-        # The re-decision costs one more block-list read and re-marks; the
-        # owner is never carded for a confirmed-blocked inviter.
+        # The sweep re-decision costs one more block-list read and re-marks;
+        # the owner is never carded for a confirmed-blocked inviter.
         self.assertIn("~host/projects", adapter._processed_group_invites)
         self.assertEqual(adapter._sse.scries.count("/chat/blocked"), 2)
         self.assertEqual(adapter._pending_approvals, [])
         self.assertEqual(adapter._cli.notifications(), [])
+
+    def test_failed_dm_allowlist_persist_restores_the_entry(self):
+        adapter = self.make_adapter()
+        adapter._settings_dm_allowlist.add("~ten")
+        results = iter([False, True])
+
+        async def fake_persist(key, value):
+            return next(results)
+
+        with patch.object(adapter, "_persist_settings_entry", fake_persist):
+            # Memory must not claim a revocation the store still grants, or
+            # the retry's early return would strand the persisted entry.
+            asyncio.run(adapter._remove_from_dm_allowlist("~ten"))
+            self.assertIn("~ten", adapter._settings_dm_allowlist)
+
+            asyncio.run(adapter._remove_from_dm_allowlist("~ten"))
+            self.assertNotIn("~ten", adapter._settings_dm_allowlist)
 
     def test_failed_notify_persists_undelivered_and_retries_past_cooldown(self):
         adapter = self.make_adapter()

--- a/packages/hermes-tlon-adapter/test_adapter_owner_listen.py
+++ b/packages/hermes-tlon-adapter/test_adapter_owner_listen.py
@@ -885,6 +885,65 @@ class AdapterOwnerListenTests(unittest.TestCase):
         self.assertFalse(adapter._auto_accept_dm_invites)
         self.assertEqual(adapter._settings_default_authorized_ships, set())
 
+    def test_group_invite_allowlist_reverts_to_env_default_when_key_is_absent(self):
+        adapter = self.make_adapter({"group_invite_allowlist": "~zod"})
+        adapter._settings_group_invite_allowlist = {"~ten"}  # simulate a prior load
+        adapter._sse = FakeSSE(
+            payloads={"/settings/all": {"all": {"moltbot": {"tlon": {}}}}}
+        )
+
+        asyncio.run(adapter._load_settings_state())
+
+        # A deletion missed while disconnected must not leave the revoked
+        # inviter authorized in memory.
+        self.assertEqual(adapter._settings_group_invite_allowlist, {"~zod"})
+
+    def test_group_invite_allowlist_reverts_to_env_default_on_a_non_list_value(self):
+        adapter = self.make_adapter({"group_invite_allowlist": "~zod"})
+        adapter._settings_group_invite_allowlist = {"~ten"}
+        adapter._sse = FakeSSE(
+            payloads={
+                "/settings/all": {
+                    "all": {"moltbot": {"tlon": {"groupInviteAllowlist": "~ten"}}}
+                }
+            }
+        )
+
+        asyncio.run(adapter._load_settings_state())
+
+        self.assertEqual(adapter._settings_group_invite_allowlist, {"~zod"})
+
+    def test_group_invite_allowlist_list_overrides_env_and_drops_non_strings(self):
+        adapter = self.make_adapter({"group_invite_allowlist": "~zod"})
+        adapter._sse = FakeSSE(
+            payloads={
+                "/settings/all": {
+                    "all": {
+                        "moltbot": {"tlon": {"groupInviteAllowlist": [7, "~ten"]}}
+                    }
+                }
+            }
+        )
+
+        asyncio.run(adapter._load_settings_state())
+
+        # Non-string entries are dropped, not coerced into an authorization.
+        self.assertEqual(adapter._settings_group_invite_allowlist, {"~ten"})
+
+    def test_group_invite_allowlist_empty_list_overrides_the_env_default(self):
+        adapter = self.make_adapter({"group_invite_allowlist": "~zod"})
+        adapter._sse = FakeSSE(
+            payloads={
+                "/settings/all": {
+                    "all": {"moltbot": {"tlon": {"groupInviteAllowlist": []}}}
+                }
+            }
+        )
+
+        asyncio.run(adapter._load_settings_state())
+
+        self.assertEqual(adapter._settings_group_invite_allowlist, set())
+
     def test_settings_event_del_entry_reverts_new_keys(self):
         adapter = self.make_adapter({"auto_discover": "true"})
 
@@ -1392,6 +1451,30 @@ class AdapterOwnerListenTests(unittest.TestCase):
             },
         )
         self.assertFalse(adapter._owner_listen.enabled)
+
+    def test_settings_del_entry_reverts_group_invite_allowlist_to_env_default(self):
+        adapter = self.make_adapter({"group_invite_allowlist": "~zod"})
+
+        self.apply_settings_event(
+            adapter, self.put_entry_event("groupInviteAllowlist", ["~ten"])
+        )
+        self.assertEqual(adapter._settings_group_invite_allowlist, {"~ten"})
+
+        self.apply_settings_event(
+            adapter,
+            {
+                "settings-event": {
+                    "del-entry": {
+                        "desk": "moltbot",
+                        "bucket-key": "tlon",
+                        "entry-key": "groupInviteAllowlist",
+                    }
+                }
+            },
+        )
+
+        # del-alone and del-then-reconnect must land on the same set.
+        self.assertEqual(adapter._settings_group_invite_allowlist, {"~zod"})
 
     def test_settings_event_updates_monitored_group_channels(self):
         adapter = self.make_adapter({})

--- a/packages/hermes-tlon-adapter/test_approval.py
+++ b/packages/hermes-tlon-adapter/test_approval.py
@@ -231,6 +231,40 @@ class ForeignsTests(unittest.TestCase):
         self.assertEqual(approval.parse_foreigns(None), [])
         self.assertEqual(approval.parse_foreigns([]), [])
 
+    def test_error_progress_flags_lists_only_errored_foreigns(self):
+        errored = foreign("~bus")
+        errored["progress"] = "error"
+        joining = foreign("~ten")
+        joining["progress"] = "join"
+        payload = {
+            "~host/errored": errored,
+            "~host/joining": joining,
+            "~host/plain": foreign("~wet"),
+        }
+
+        self.assertEqual(
+            approval.error_progress_flags(payload), ["~host/errored"]
+        )
+
+    def test_error_progress_flags_covers_foreigns_parse_drops(self):
+        # parse_foreigns yields nothing for these, but the flags still have to
+        # become actionable again.
+        payload = {
+            "~host/noinvites": {"progress": "error", "invites": []},
+            "~host/invalid": {"progress": "error", "invites": [{"valid": False}]},
+        }
+
+        self.assertEqual(approval.parse_foreigns(payload), [])
+        self.assertEqual(
+            sorted(approval.error_progress_flags(payload)),
+            ["~host/invalid", "~host/noinvites"],
+        )
+
+    def test_error_progress_flags_tolerates_malformed_payloads(self):
+        self.assertEqual(approval.error_progress_flags(None), [])
+        self.assertEqual(approval.error_progress_flags([]), [])
+        self.assertEqual(approval.error_progress_flags({"~host/g": "junk"}), [])
+
 
 class CommandParseTests(unittest.TestCase):
     def test_commands_parse(self):

--- a/packages/openclaw/README.md
+++ b/packages/openclaw/README.md
@@ -119,7 +119,7 @@ Reply "approve", "deny", or "block" (ID: dm-1234567890-abc)
 
 -   **approve**: Allow the interaction and add to allowlist. Original message is processed.
 -   **deny**: Reject silently. Ship can try again later. For a group invite this also declines the invite on the ship.
--   **block**: Permanently block using Tlon's native blocking, and remove the ship from `dmAllowlist`. For a group invite this also declines the invite on the ship; a block or a decline the client could not submit keeps the request pending so you can retry.
+-   **block**: Permanently block using Tlon's native blocking, and remove the ship from `dmAllowlist`. For a group invite this also declines the invite on the ship; a block, `dmAllowlist` write, or decline the client could not submit keeps the request pending so you can retry.
 
 ### Admin Commands
 

--- a/packages/openclaw/README.md
+++ b/packages/openclaw/README.md
@@ -104,7 +104,7 @@ The approval system lets you control who can interact with your bot. When `owner
 
 -   **DM requests** from ships not on your `dmAllowlist`
 -   **Channel mentions** from ships not authorized for that channel
--   **Group invites** from ships not on your `groupInviteAllowlist` (owner invites and allowlisted, non-blocked ships are auto-accepted). Pending invites are reconciled at connect and on a 2-minute poll, failed owner notifications are retried, delivered ones are never re-sent, and rejecting declines the invite on the ship — see SECURITY.md for the invariants.
+-   **Group invites** from ships not on your `groupInviteAllowlist` (owner invites and allowlisted, non-blocked ships are auto-accepted). Pending invites are reconciled at connect and on a 2-minute poll, failed owner notifications are retried, delivered ones are never re-sent, and rejecting or blocking declines the invite on the ship — see SECURITY.md for the invariants.
 
 ### Usage
 
@@ -119,7 +119,7 @@ Reply "approve", "deny", or "block" (ID: dm-1234567890-abc)
 
 -   **approve**: Allow the interaction and add to allowlist. Original message is processed.
 -   **deny**: Reject silently. Ship can try again later. For a group invite this also declines the invite on the ship.
--   **block**: Permanently block using Tlon's native blocking.
+-   **block**: Permanently block using Tlon's native blocking, and remove the ship from `dmAllowlist`. For a group invite this also declines the invite on the ship; a block or a decline the client could not submit keeps the request pending so you can retry.
 
 ### Admin Commands
 

--- a/packages/openclaw/SECURITY.md
+++ b/packages/openclaw/SECURITY.md
@@ -87,9 +87,12 @@ Suppression invariants: queued invites are never marked in the in-process
 dedup set (it records only auto-accept success and confirmed-blocked); the
 persisted approval record suppresses re-notification once delivered, gates
 retries of failed sends behind a 10-minute cooldown, and its 48h TTL is the
-reminder cadence. A `progress: 'error'` fact clears the dedup marker, so a join
-that acked locally but failed on the backend becomes actionable again. Catch-up
-rescries foreigns at connect and on the 2-minute poll. Rejecting a group request
+reminder cadence. The reconciliation sweeps (connect and the 2-minute poll)
+clear the dedup marker for a join whose `progress` reached `error`, so a join
+that acked locally but failed on the backend becomes actionable again at a
+bounded cadence — live error facts leave the marker, because a persistently
+failing join would otherwise retry at %groups' own error-emission rate.
+Catch-up rescries foreigns at connect and on the 2-minute poll. Rejecting a group request
 declines the invite on the ship (`%groups` `invite-decline`), and banning the
 inviter blocks the ship, revokes its DM grant, and then declines the same way —
 in both cases a decline the client could not submit keeps the request pending

--- a/packages/openclaw/SECURITY.md
+++ b/packages/openclaw/SECURITY.md
@@ -87,9 +87,14 @@ Suppression invariants: queued invites are never marked in the in-process
 dedup set (it records only auto-accept success and confirmed-blocked); the
 persisted approval record suppresses re-notification once delivered, gates
 retries of failed sends behind a 10-minute cooldown, and its 48h TTL is the
-reminder cadence. Catch-up rescries foreigns at connect and on the 2-minute
-poll, and rejecting a group request declines the invite on the ship
-(`%groups` `invite-decline`) — a failed decline keeps the request pending.
+reminder cadence. A `progress: 'error'` fact clears the dedup marker, so a join
+that acked locally but failed on the backend becomes actionable again. Catch-up
+rescries foreigns at connect and on the 2-minute poll. Rejecting a group request
+declines the invite on the ship (`%groups` `invite-decline`), and banning the
+inviter blocks the ship, revokes its DM grant, and then declines the same way —
+in both cases a decline the client could not submit keeps the request pending
+(a poke resolves on the channel PUT alone, so a later `%groups` nack is
+log-only and does not retain the record).
 
 **Why This Matters:**
 Malicious actors could invite the bot to groups containing:
@@ -204,7 +209,10 @@ _Note: Not currently enforced — future enhancement._
 | `dmAllowlist`          | Must be array of strings                |
 | `groupInviteAllowlist` | Must be array of strings                |
 | `channelRules`         | Must match schema (mode + allowedShips) |
+| `pendingApprovals`     | Per-record sanitization (see below)     |
 | Boolean settings       | Must be actual booleans                 |
+
+**`pendingApprovals` sanitization:** `id`, `type`, `requestingShip` and `timestamp` must type-check, and a `group`/`channel` record must carry a non-empty-string `groupFlag`/`channelNest` — otherwise the whole record is dropped, because approval execution gates on a truthy locator and then removes the record either way (a locator-less record would report success while doing nothing). A present-but-mistyped `groupTitle`, `messagePreview`, `notificationMessageId` (non-string) or `notifyAttemptAt` (non-number) drops only that field. Unknown fields round-trip untouched — the hermes runtime writes its own delivery stamps onto the same shared record.
 
 **Hot-Reload Safety:**
 

--- a/packages/openclaw/SECURITY.md
+++ b/packages/openclaw/SECURITY.md
@@ -95,9 +95,9 @@ failing join would otherwise retry at %groups' own error-emission rate.
 Catch-up rescries foreigns at connect and on the 2-minute poll. Rejecting a group request
 declines the invite on the ship (`%groups` `invite-decline`), and banning the
 inviter blocks the ship, revokes its DM grant, and then declines the same way —
-in both cases a decline the client could not submit keeps the request pending
-(a poke resolves on the channel PUT alone, so a later `%groups` nack is
-log-only and does not retain the record).
+a block, DM-revocation write, or decline the client could not submit keeps the
+request pending (a poke resolves on the channel PUT alone, so a later `%groups`
+nack is log-only and does not retain the record).
 
 **Why This Matters:**
 Malicious actors could invite the bot to groups containing:

--- a/packages/openclaw/src/monitor/approval.test.ts
+++ b/packages/openclaw/src/monitor/approval.test.ts
@@ -4,6 +4,7 @@ import { describe, expect, it, vi } from 'vitest';
 import {
   APPROVAL_TTL_MS,
   type ApprovalQueueContext,
+  type BanActionDeps,
   type DisplayContext,
   type PendingApproval,
   RENOTIFY_COOLDOWN_MS,
@@ -24,6 +25,7 @@ import {
   mergeApprovalDeliveryState,
   normalizeNotificationId,
   removePendingApproval,
+  runBanAction,
 } from './approval.js';
 
 // ---------------------------------------------------------------------------
@@ -1472,5 +1474,83 @@ describe('mergeApprovalDeliveryState', () => {
     );
 
     expect(merged).toEqual([]);
+  });
+});
+
+describe('runBanAction', () => {
+  const approval = (
+    overrides: Partial<PendingApproval> = {}
+  ): PendingApproval => ({
+    id: 'g5f6e',
+    type: 'group',
+    requestingShip: '~inviter',
+    groupFlag: '~host/garden',
+    timestamp: 1_000,
+    ...overrides,
+  });
+
+  const makeDeps = (overrides: Partial<BanActionDeps> = {}) => {
+    const calls: string[] = [];
+    const deps = {
+      blockShip: vi.fn(async () => {
+        calls.push('block');
+        return true;
+      }),
+      removeFromDmAllowlist: vi.fn(async () => {
+        calls.push('removeFromDmAllowlist');
+      }),
+      declineInvite: vi.fn(async () => {
+        calls.push('decline');
+      }),
+      ...overrides,
+    };
+    return { deps, calls };
+  };
+
+  it('blocks, revokes the DM grant, then declines the invite', async () => {
+    const { deps, calls } = makeDeps();
+
+    const result = await runBanAction(approval(), deps);
+
+    expect(result).toEqual({ outcome: 'done' });
+    expect(calls).toEqual(['block', 'removeFromDmAllowlist', 'decline']);
+    expect(deps.declineInvite).toHaveBeenCalledWith('~host/garden');
+  });
+
+  it('keeps the record and skips both follow-ups when the block fails', async () => {
+    const { deps } = makeDeps({ blockShip: vi.fn(async () => false) });
+
+    const result = await runBanAction(approval(), deps);
+
+    // The record is the invite's suppression: dropping it after a failed
+    // block would re-queue and re-DM on the next observation.
+    expect(result).toEqual({ outcome: 'block-failed' });
+    expect(deps.removeFromDmAllowlist).not.toHaveBeenCalled();
+    expect(deps.declineInvite).not.toHaveBeenCalled();
+  });
+
+  it('has already revoked the DM grant when the decline cannot be submitted', async () => {
+    const error = new Error('poke failed');
+    const { deps, calls } = makeDeps({
+      declineInvite: vi.fn(async () => {
+        throw error;
+      }),
+    });
+
+    const result = await runBanAction(approval(), deps);
+
+    expect(result).toEqual({ outcome: 'decline-failed', error });
+    expect(calls).toEqual(['block', 'removeFromDmAllowlist']);
+  });
+
+  it('never declines for a dm or channel ban', async () => {
+    for (const type of ['dm', 'channel'] as const) {
+      const { deps, calls } = makeDeps();
+
+      const result = await runBanAction(approval({ type }), deps);
+
+      expect(result).toEqual({ outcome: 'done' });
+      expect(calls).toEqual(['block', 'removeFromDmAllowlist']);
+    }
   });
 });

--- a/packages/openclaw/src/monitor/approval.test.ts
+++ b/packages/openclaw/src/monitor/approval.test.ts
@@ -1498,6 +1498,7 @@ describe('runBanAction', () => {
       }),
       removeFromDmAllowlist: vi.fn(async () => {
         calls.push('removeFromDmAllowlist');
+        return true;
       }),
       declineInvite: vi.fn(async () => {
         calls.push('decline');
@@ -1527,6 +1528,29 @@ describe('runBanAction', () => {
     expect(result).toEqual({ outcome: 'block-failed' });
     expect(deps.removeFromDmAllowlist).not.toHaveBeenCalled();
     expect(deps.declineInvite).not.toHaveBeenCalled();
+  });
+
+  it('keeps a group ban pending when the revocation write fails', async () => {
+    const { deps } = makeDeps({
+      removeFromDmAllowlist: vi.fn(async () => false),
+    });
+
+    const result = await runBanAction(approval(), deps);
+
+    // Completing would drop the only record through which a retry can
+    // re-attempt the failed settings write (the helper restored the entry).
+    expect(result).toEqual({ outcome: 'revoke-failed' });
+    expect(deps.declineInvite).not.toHaveBeenCalled();
+  });
+
+  it('tolerates a failed revocation for a dm ban (best-effort, like its block leg)', async () => {
+    const { deps } = makeDeps({
+      removeFromDmAllowlist: vi.fn(async () => false),
+    });
+
+    const result = await runBanAction(approval({ type: 'dm' }), deps);
+
+    expect(result).toEqual({ outcome: 'done' });
   });
 
   it('has already revoked the DM grant when the decline cannot be submitted', async () => {

--- a/packages/openclaw/src/monitor/approval.ts
+++ b/packages/openclaw/src/monitor/approval.ts
@@ -467,6 +467,57 @@ export function mergeApprovalDeliveryState(
 }
 
 // ============================================================================
+// Ban Action (runBanAction)
+// ============================================================================
+
+export type BanActionDeps = {
+  /** False on submission failure (see blockShip). */
+  blockShip: (ship: string) => Promise<boolean>;
+  /** Persists the revocation. */
+  removeFromDmAllowlist: (ship: string) => Promise<void>;
+  /**
+   * Rejects on *submission* failure only: the poke resolves from the channel
+   * PUT's status and a later %groups nack is log-only, so this carries no
+   * stronger delivery guarantee than the deny branch's decline.
+   */
+  declineInvite: (groupFlag: string) => Promise<void>;
+};
+
+export type BanActionResult =
+  | { outcome: 'done' }
+  | { outcome: 'block-failed' }
+  | { outcome: 'decline-failed'; error: unknown };
+
+/**
+ * The /ban side effects in their required order: block the ship, revoke its DM
+ * grant, then decline the group invite.
+ *
+ * The DM revocation runs before the decline so that a block-OK/decline-failed
+ * partial ban has still taken the ship's DM access away — that outcome keeps
+ * the approval record for a retry, and leaving the grant in place until the
+ * retry succeeded would be a live authorization the owner believes is gone.
+ * `done` is the only outcome that may remove the record.
+ */
+export async function runBanAction(
+  approval: PendingApproval,
+  deps: BanActionDeps
+): Promise<BanActionResult> {
+  const blocked = await deps.blockShip(approval.requestingShip);
+  if (!blocked && approval.type === 'group') {
+    return { outcome: 'block-failed' };
+  }
+  await deps.removeFromDmAllowlist(approval.requestingShip);
+  if (approval.type === 'group' && approval.groupFlag) {
+    try {
+      await deps.declineInvite(approval.groupFlag);
+    } catch (error) {
+      return { outcome: 'decline-failed', error };
+    }
+  }
+  return { outcome: 'done' };
+}
+
+// ============================================================================
 // Approval Request A2UI
 // ============================================================================
 

--- a/packages/openclaw/src/monitor/approval.ts
+++ b/packages/openclaw/src/monitor/approval.ts
@@ -473,8 +473,11 @@ export function mergeApprovalDeliveryState(
 export type BanActionDeps = {
   /** False on submission failure (see blockShip). */
   blockShip: (ship: string) => Promise<boolean>;
-  /** Persists the revocation. */
-  removeFromDmAllowlist: (ship: string) => Promise<void>;
+  /**
+   * Persists the revocation; false when the write failed (the caller's
+   * in-memory entry is restored so a retry can re-attempt it).
+   */
+  removeFromDmAllowlist: (ship: string) => Promise<boolean>;
   /**
    * Rejects on *submission* failure only: the poke resolves from the channel
    * PUT's status and a later %groups nack is log-only, so this carries no
@@ -486,6 +489,7 @@ export type BanActionDeps = {
 export type BanActionResult =
   | { outcome: 'done' }
   | { outcome: 'block-failed' }
+  | { outcome: 'revoke-failed' }
   | { outcome: 'decline-failed'; error: unknown };
 
 /**
@@ -506,7 +510,13 @@ export async function runBanAction(
   if (!blocked && approval.type === 'group') {
     return { outcome: 'block-failed' };
   }
-  await deps.removeFromDmAllowlist(approval.requestingShip);
+  const revoked = await deps.removeFromDmAllowlist(approval.requestingShip);
+  if (!revoked && approval.type === 'group') {
+    // Completing anyway would drop the only record through which a retry can
+    // re-attempt the failed revocation write; dm/channel bans stay best-effort
+    // like their block leg.
+    return { outcome: 'revoke-failed' };
+  }
   if (approval.type === 'group' && approval.groupFlag) {
     try {
       await deps.declineInvite(approval.groupFlag);

--- a/packages/openclaw/src/monitor/group-invites.test.ts
+++ b/packages/openclaw/src/monitor/group-invites.test.ts
@@ -176,6 +176,75 @@ describe('processPendingForeigns', () => {
     expect(deps.queueApproval).toHaveBeenCalledTimes(1);
   });
 
+  it('clears the processed marker when an auto-accepted join later errors', async () => {
+    const deps = makeDeps({
+      processedGroupInvites: new Set(['~host/garden']),
+    });
+
+    await processPendingForeigns(
+      makeForeign('~host/garden', '~owner', { progress: 'error' }),
+      deps
+    );
+
+    // The accept poke acked but the backend join failed; the flag has to be
+    // a live decision again rather than stay suppressed until restart.
+    expect(deps.acceptInvite).toHaveBeenCalledWith('~host/garden');
+    expect(deps.processedGroupInvites.has('~host/garden')).toBe(true);
+  });
+
+  it('clears the processed marker on an error even with no valid invite', async () => {
+    const deps = makeDeps({
+      processedGroupInvites: new Set(['~host/garden']),
+    });
+
+    await processPendingForeigns(
+      makeForeign('~host/garden', '~owner', {
+        progress: 'error',
+        valid: false,
+      }),
+      deps
+    );
+
+    // The loop exits at the invites check, but the flag must be actionable
+    // again for the observation that carries a valid invite.
+    expect(deps.processedGroupInvites.has('~host/garden')).toBe(false);
+    expect(deps.acceptInvite).not.toHaveBeenCalled();
+  });
+
+  it('re-decides and re-marks a confirmed-blocked flag when the join errors', async () => {
+    const deps = makeDeps({
+      processedGroupInvites: new Set(['~host/garden']),
+      allowlist: () => ['~inviter'],
+      fetchBlockedShips: vi.fn().mockResolvedValue(['~inviter']),
+    });
+
+    await processPendingForeigns(
+      makeForeign('~host/garden', '~inviter', { progress: 'error' }),
+      deps
+    );
+
+    // Bounded cost: one batch-memoized block-list read, no owner card.
+    expect(deps.fetchBlockedShips).toHaveBeenCalledTimes(1);
+    expect(deps.processedGroupInvites.has('~host/garden')).toBe(true);
+    expect(deps.queueApproval).not.toHaveBeenCalled();
+  });
+
+  it('queues with no title when the invite preview title is not a string', async () => {
+    const deps = makeDeps();
+    const foreigns = makeForeign('~host/group', '~stranger');
+    // Remote-inviter-controlled and only type-asserted on the way in.
+    (
+      foreigns['~host/group'].invites[0].preview!.meta as { title: unknown }
+    ).title = 7;
+
+    await processPendingForeigns(foreigns, deps);
+
+    expect(deps.queueApproval).toHaveBeenCalledWith({
+      requestingShip: '~stranger',
+      groupFlag: '~host/group',
+    });
+  });
+
   it('stays silent for foreigners without invites (previews/joins-in-progress)', async () => {
     const foreigns: Foreigns = {
       '~host/group': {

--- a/packages/openclaw/src/monitor/group-invites.test.ts
+++ b/packages/openclaw/src/monitor/group-invites.test.ts
@@ -3,6 +3,7 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 import type { Foreigns } from '../urbit/foreigns.js';
 import {
   type GroupInviteDeps,
+  clearErroredMarkers,
   createCatchUpRunner,
   parseForeignsSnapshot,
   processPendingForeigns,
@@ -176,7 +177,25 @@ describe('processPendingForeigns', () => {
     expect(deps.queueApproval).toHaveBeenCalledTimes(1);
   });
 
-  it('clears the processed marker when an auto-accepted join later errors', async () => {
+  it('reconsiders an auto-accepted join that later errored, on the sweep', async () => {
+    const deps = makeDeps({
+      processedGroupInvites: new Set(['~host/garden']),
+    });
+    const foreigns = makeForeign('~host/garden', '~owner', {
+      progress: 'error',
+    });
+
+    // The catch-up sequence: sweep the errored markers, then process.
+    clearErroredMarkers(foreigns, deps.processedGroupInvites);
+    await processPendingForeigns(foreigns, deps);
+
+    // The accept poke acked but the backend join failed; the sweep makes the
+    // flag a live decision again rather than suppressed until restart.
+    expect(deps.acceptInvite).toHaveBeenCalledWith('~host/garden');
+    expect(deps.processedGroupInvites.has('~host/garden')).toBe(true);
+  });
+
+  it('leaves an errored marked flag suppressed on the live path (no sweep)', async () => {
     const deps = makeDeps({
       processedGroupInvites: new Set(['~host/garden']),
     });
@@ -186,29 +205,42 @@ describe('processPendingForeigns', () => {
       deps
     );
 
-    // The accept poke acked but the backend join failed; the flag has to be
-    // a live decision again rather than stay suppressed until restart.
-    expect(deps.acceptInvite).toHaveBeenCalledWith('~host/garden');
+    // A persistently-failing join emits a fresh error fact per attempt;
+    // retrying on each would poke %groups at its own failure rate. Live facts
+    // leave the marker; only the reconciliation sweep clears it.
+    expect(deps.acceptInvite).not.toHaveBeenCalled();
     expect(deps.processedGroupInvites.has('~host/garden')).toBe(true);
   });
 
-  it('clears the processed marker on an error even with no valid invite', async () => {
-    const deps = makeDeps({
-      processedGroupInvites: new Set(['~host/garden']),
-    });
+  it('clears the marker on an error even with no valid invite', () => {
+    const processed = new Set(['~host/garden']);
 
-    await processPendingForeigns(
+    clearErroredMarkers(
       makeForeign('~host/garden', '~owner', {
         progress: 'error',
         valid: false,
       }),
-      deps
+      processed
     );
 
-    // The loop exits at the invites check, but the flag must be actionable
-    // again for the observation that carries a valid invite.
-    expect(deps.processedGroupInvites.has('~host/garden')).toBe(false);
-    expect(deps.acceptInvite).not.toHaveBeenCalled();
+    // The processor would exit at the invites check, but the flag must be
+    // actionable again for the observation that carries a valid invite.
+    expect(processed.has('~host/garden')).toBe(false);
+  });
+
+  it('clears only errored flags in the sweep', () => {
+    const processed = new Set(['~host/garden', '~host/kitchen']);
+
+    clearErroredMarkers(
+      {
+        ...makeForeign('~host/garden', '~owner', { progress: 'error' }),
+        ...makeForeign('~host/kitchen', '~owner', { progress: 'join' }),
+      },
+      processed
+    );
+
+    expect(processed.has('~host/garden')).toBe(false);
+    expect(processed.has('~host/kitchen')).toBe(true);
   });
 
   it('re-decides and re-marks a confirmed-blocked flag when the join errors', async () => {
@@ -217,11 +249,12 @@ describe('processPendingForeigns', () => {
       allowlist: () => ['~inviter'],
       fetchBlockedShips: vi.fn().mockResolvedValue(['~inviter']),
     });
+    const foreigns = makeForeign('~host/garden', '~inviter', {
+      progress: 'error',
+    });
 
-    await processPendingForeigns(
-      makeForeign('~host/garden', '~inviter', { progress: 'error' }),
-      deps
-    );
+    clearErroredMarkers(foreigns, deps.processedGroupInvites);
+    await processPendingForeigns(foreigns, deps);
 
     // Bounded cost: one batch-memoized block-list read, no owner card.
     expect(deps.fetchBlockedShips).toHaveBeenCalledTimes(1);

--- a/packages/openclaw/src/monitor/group-invites.ts
+++ b/packages/openclaw/src/monitor/group-invites.ts
@@ -55,6 +55,13 @@ export async function processPendingForeigns(
     (blockedShipsOnce ??= deps.fetchBlockedShips());
 
   for (const [groupFlag, foreign] of Object.entries(foreigns)) {
+    // The local join acked but the backend join failed, so the flag is
+    // actionable again; clearing before the marker check is what lets a flag
+    // marked by the accept (or by the confirmed-blocked branch) fall through
+    // to the error handling below.
+    if (foreign.progress === 'error') {
+      deps.processedGroupInvites.delete(groupFlag);
+    }
     if (deps.processedGroupInvites.has(groupFlag)) {
       continue;
     }
@@ -121,11 +128,17 @@ export async function processPendingForeigns(
     }
 
     if (decision.action === 'queue') {
+      // The preview title is remote-inviter-controlled and never crosses the
+      // settings parser, so its type is asserted, not checked: a non-string
+      // would reach the record and throw at first-notify time.
+      const previewTitle = validInvite.preview?.meta?.title;
       // Do NOT mark processed — suppression/retry live in the approval record.
       await deps.queueApproval({
         requestingShip: inviterShip,
         groupFlag,
-        groupTitle: validInvite.preview?.meta?.title,
+        ...(typeof previewTitle === 'string'
+          ? { groupTitle: previewTitle }
+          : {}),
       });
       continue;
     }

--- a/packages/openclaw/src/monitor/group-invites.ts
+++ b/packages/openclaw/src/monitor/group-invites.ts
@@ -37,6 +37,30 @@ export function parseForeignsSnapshot(raw: unknown): Foreigns {
   throw new Error('Malformed foreigns snapshot: expected a flag→foreign map');
 }
 
+/**
+ * Un-suppress joins that errored after their accept acked, so the next
+ * processor run reconsiders them.
+ *
+ * Called only from the reconciliation sweeps (post-connect and the 2-minute
+ * catch-up), never on live facts: a persistently-failing backend join emits a
+ * fresh error fact per attempt, so a live-path clear would retry at whatever
+ * rate %groups can fail — an unbounded join-poke loop. Sweep-only clearing
+ * bounds the retry cadence to one attempt per sweep.
+ */
+export function clearErroredMarkers(
+  foreigns: Foreigns,
+  processedGroupInvites: Set<string>
+): void {
+  if (!foreigns || typeof foreigns !== 'object') {
+    return;
+  }
+  for (const [groupFlag, foreign] of Object.entries(foreigns)) {
+    if (foreign.progress === 'error') {
+      processedGroupInvites.delete(groupFlag);
+    }
+  }
+}
+
 export async function processPendingForeigns(
   foreigns: Foreigns,
   deps: GroupInviteDeps
@@ -55,13 +79,6 @@ export async function processPendingForeigns(
     (blockedShipsOnce ??= deps.fetchBlockedShips());
 
   for (const [groupFlag, foreign] of Object.entries(foreigns)) {
-    // The local join acked but the backend join failed, so the flag is
-    // actionable again; clearing before the marker check is what lets a flag
-    // marked by the accept (or by the confirmed-blocked branch) fall through
-    // to the error handling below.
-    if (foreign.progress === 'error') {
-      deps.processedGroupInvites.delete(groupFlag);
-    }
     if (deps.processedGroupInvites.has(groupFlag)) {
       continue;
     }

--- a/packages/openclaw/src/monitor/index.ts
+++ b/packages/openclaw/src/monitor/index.ts
@@ -1648,15 +1648,17 @@ async function monitorTlonProviderScoped(opts: MonitorTlonOpts): Promise<void> {
       }
     }
 
-    // Helper to remove ship from dmAllowlist in both memory and settings store
-    async function removeFromDmAllowlist(ship: string): Promise<void> {
+    // Helper to remove ship from dmAllowlist in both memory and settings store.
+    // Returns false when the settings write failed (the in-memory entry is
+    // restored so a retry re-attempts the write).
+    async function removeFromDmAllowlist(ship: string): Promise<boolean> {
       const normalizedShip = normalizeShip(ship);
       const before = effectiveDmAllowlist.length;
       effectiveDmAllowlist = effectiveDmAllowlist.filter(
         (s) => s !== normalizedShip
       );
       if (effectiveDmAllowlist.length === before) {
-        return; // Ship wasn't on the list
+        return true; // Ship wasn't on the list — nothing to revoke
       }
       try {
         await api!.poke({
@@ -1678,7 +1680,9 @@ async function monitorTlonProviderScoped(opts: MonitorTlonOpts): Promise<void> {
         // early-returning on the absent ship.
         effectiveDmAllowlist = [...effectiveDmAllowlist, normalizedShip];
         runtime.error?.(`[tlon] Failed to update dmAllowlist: ${String(err)}`);
+        return false;
       }
+      return true;
     }
 
     // Helper to update channelRules in settings store
@@ -2122,6 +2126,11 @@ async function monitorTlonProviderScoped(opts: MonitorTlonOpts): Promise<void> {
           // The record is the invite's suppression, so dropping it after a
           // failed block re-queues and re-DMs on the next observation.
           return `Could not block ${approval.requestingShip}: block failed. Request stays pending, try again.`;
+        }
+        if (result.outcome === 'revoke-failed') {
+          // The in-memory entry was restored by the helper; the retained
+          // record is what lets a retry re-attempt the settings write.
+          return `Blocked ${approval.requestingShip}, but could not revoke its DM access. Request stays pending, try again.`;
         }
         if (result.outcome === 'decline-failed') {
           capturePluginError('group_invite_decline', result.error, {

--- a/packages/openclaw/src/monitor/index.ts
+++ b/packages/openclaw/src/monitor/index.ts
@@ -144,6 +144,7 @@ import {
   normalizeNotificationId,
   pruneExpired,
   removePendingApproval,
+  runBanAction,
 } from './approval.js';
 import {
   handleChannelReaction,
@@ -2098,13 +2099,36 @@ async function monitorTlonProviderScoped(opts: MonitorTlonOpts): Promise<void> {
             break;
         }
       } else if (action === 'block') {
-        const blocked = await blockShip(approval.requestingShip);
-        if (!blocked && approval.type === 'group') {
+        const result = await runBanAction(approval, {
+          blockShip,
+          removeFromDmAllowlist,
+          declineInvite: async (groupFlag) => {
+            await api!.poke({
+              app: 'groups',
+              mark: 'invite-decline',
+              json: groupFlag,
+            });
+            runtime.log?.(
+              `[tlon] Declined group invite ${groupFlag} after ban`
+            );
+          },
+        });
+        if (result.outcome === 'block-failed') {
           // The record is the invite's suppression, so dropping it after a
           // failed block re-queues and re-DMs on the next observation.
           return `Could not block ${approval.requestingShip}: block failed. Request stays pending, try again.`;
         }
-        await removeFromDmAllowlist(approval.requestingShip);
+        if (result.outcome === 'decline-failed') {
+          capturePluginError('group_invite_decline', result.error, {
+            errorKind: 'ban_decline_failed',
+          });
+          runtime.error?.(
+            `[tlon] Failed to decline group invite ${approval.groupFlag} after ban: ${String(result.error)}`
+          );
+          // The ban landed but the invite is still on the ship; keep the
+          // record so the owner can retry the decline.
+          return `Blocked ${approval.requestingShip}, but could not submit the decline for ${approval.groupFlag}. Request stays pending, try again.`;
+        }
       } else if (
         action === 'deny' &&
         approval.type === 'group' &&

--- a/packages/openclaw/src/monitor/index.ts
+++ b/packages/openclaw/src/monitor/index.ts
@@ -169,6 +169,7 @@ import { dmReactionReplyParentId } from './dm-reactions.js';
 import {
   type GroupInviteDeps,
   createCatchUpRunner,
+  clearErroredMarkers,
   parseForeignsSnapshot,
   processPendingForeigns,
 } from './group-invites.js';
@@ -1672,6 +1673,10 @@ async function monitorTlonProviderScoped(opts: MonitorTlonOpts): Promise<void> {
         });
         runtime.log?.(`[tlon] Removed ${normalizedShip} from dmAllowlist`);
       } catch (err) {
+        // Memory must not claim a revocation the store still grants: restoring
+        // the entry keeps a retried /ban re-attempting the write instead of
+        // early-returning on the absent ship.
+        effectiveDmAllowlist = [...effectiveDmAllowlist, normalizedShip];
         runtime.error?.(`[tlon] Failed to update dmAllowlist: ${String(err)}`);
       }
     }
@@ -5518,6 +5523,9 @@ async function monitorTlonProviderScoped(opts: MonitorTlonOpts): Promise<void> {
             const foreigns = parseForeignsSnapshot(
               await api.scry('/groups/v1/foreigns.json')
             );
+            // Sweep-only: clearing errored markers on live facts would retry
+            // a persistently-failing join at %groups' error-emission rate.
+            clearErroredMarkers(foreigns, processedGroupInvites);
             await processPendingForeigns(foreigns, groupInviteDeps);
           } catch (err) {
             runtime.error?.(

--- a/packages/openclaw/src/settings.test.ts
+++ b/packages/openclaw/src/settings.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it, vi } from 'vitest';
 
+import { buildPendingApprovalsResponse } from './monitor/approval.js';
 import {
   APPROVAL_TTL_MS,
   DM_INVITE_PREVIEW,
@@ -170,12 +171,14 @@ describe('Settings: parseSettingsResponse', () => {
               id: 'expired',
               type: 'channel',
               requestingShip: '~old',
+              channelNest: 'chat/~host/general',
               timestamp: now - APPROVAL_TTL_MS - 1,
             },
             {
               id: 'fresh',
               type: 'channel',
               requestingShip: '~new',
+              channelNest: 'chat/~host/general',
               timestamp: now,
               originalMessage: {
                 messageId: '170.000',
@@ -202,6 +205,7 @@ describe('Settings: parseSettingsResponse', () => {
               id: 'stale-channel',
               type: 'channel',
               requestingShip: '~old',
+              channelNest: 'chat/~host/general',
               timestamp: now,
             },
             {
@@ -215,6 +219,7 @@ describe('Settings: parseSettingsResponse', () => {
               id: 'fresh-channel',
               type: 'channel',
               requestingShip: '~new',
+              channelNest: 'chat/~host/general',
               timestamp: now,
               originalMessage: {
                 messageId: '170.000',
@@ -254,6 +259,114 @@ describe('Settings: parseSettingsResponse', () => {
         notificationMessageId: '170141184507',
         notifyAttemptAt: 2_000,
       });
+    });
+
+    it("round-trips the other runtime's delivery fields", () => {
+      const result = parseSettingsResponse({
+        tlon: {
+          pendingApprovals: JSON.stringify([
+            {
+              id: 'g1234',
+              type: 'group',
+              requestingShip: '~inviter',
+              groupFlag: '~host/group',
+              timestamp: Date.now(),
+              // hermes-private stamps: this runtime never reads them but must
+              // not strip them, or a shared record loses its retry state.
+              notificationDeliveredAt: 1_700_000_000_000,
+              lastNotifiedAt: 1_700_000_000_000,
+            },
+          ]),
+        },
+      });
+
+      expect(result.pendingApprovals?.[0]).toMatchObject({
+        notificationDeliveredAt: 1_700_000_000_000,
+        lastNotifiedAt: 1_700_000_000_000,
+      });
+    });
+
+    it.each([
+      { type: 'group' as const, locator: 'groupFlag' },
+      { type: 'channel' as const, locator: 'channelNest' },
+    ])(
+      'drops a $type record whose $locator is missing or mistyped',
+      ({ type, locator }) => {
+        const base = {
+          id: 'x1234',
+          type,
+          requestingShip: '~inviter',
+          timestamp: Date.now(),
+          originalMessage: {
+            messageId: '170.000',
+            messageText: 'hi',
+            timestamp: Date.now(),
+          },
+        };
+
+        for (const bad of [undefined, 7, '', null, ['~host/group']]) {
+          const result = parseSettingsResponse({
+            tlon: {
+              pendingApprovals: JSON.stringify([{ ...base, [locator]: bad }]),
+            },
+          });
+          // Execution gates on a truthy locator and removes the record either
+          // way, so a locator-less record would report success while the
+          // approval never happened.
+          expect(result.pendingApprovals).toEqual([]);
+        }
+      }
+    );
+
+    it.each([
+      { field: 'groupTitle', bad: 7 },
+      { field: 'messagePreview', bad: { text: 'hi' } },
+      { field: 'notificationMessageId', bad: 170141184507 },
+      { field: 'notifyAttemptAt', bad: '2000' },
+    ])('drops only a mistyped $field, keeping the record', ({ field, bad }) => {
+      const result = parseSettingsResponse({
+        tlon: {
+          pendingApprovals: JSON.stringify([
+            {
+              id: 'g1234',
+              type: 'group',
+              requestingShip: '~inviter',
+              groupFlag: '~host/group',
+              timestamp: Date.now(),
+              [field]: bad,
+            },
+          ]),
+        },
+      });
+
+      expect(result.pendingApprovals).toHaveLength(1);
+      expect(result.pendingApprovals?.[0]).not.toHaveProperty(field);
+      expect(result.pendingApprovals?.[0]?.id).toBe('g1234');
+    });
+
+    it('renders a sanitized record in /pending without throwing', () => {
+      const result = parseSettingsResponse({
+        tlon: {
+          pendingApprovals: JSON.stringify([
+            {
+              id: 'g1234',
+              type: 'group',
+              requestingShip: '~inviter',
+              groupFlag: '~host/group',
+              groupTitle: 7,
+              timestamp: Date.now(),
+            },
+          ]),
+        },
+      });
+
+      // truncate() would throw a TypeError on a numeric title.
+      const response = buildPendingApprovalsResponse(
+        result.pendingApprovals ?? [],
+        undefined,
+        () => undefined
+      );
+      expect(response.text).toContain('~host/group');
     });
   });
 });

--- a/packages/openclaw/src/settings.ts
+++ b/packages/openclaw/src/settings.ts
@@ -432,6 +432,59 @@ function isChannelRulesObject(
   return true;
 }
 
+function isNonEmptyString(value: unknown): value is string {
+  return typeof value === 'string' && value.length > 0;
+}
+
+/**
+ * Validate and sanitize one raw pendingApprovals entry; undefined drops it.
+ *
+ * Two tiers. The operational locators are load-bearing, not decoration:
+ * approval execution gates on a truthy `groupFlag`/`channelNest` and then
+ * removes the record either way, so a record that lost its locator would
+ * report success to the owner while doing nothing — drop the whole record.
+ * Cosmetic and delivery fields are shed individually instead (dropping the bad
+ * part beats throwing away good state — see parseBlockedShips). Unknown fields
+ * are carried through: hermes stamps its own delivery fields onto the shared
+ * record and they must round-trip.
+ */
+function sanitizePendingApproval(
+  obj: Record<string, unknown>
+): PendingApproval | undefined {
+  if (
+    typeof obj.id !== 'string' ||
+    (obj.type !== 'dm' && obj.type !== 'channel' && obj.type !== 'group') ||
+    typeof obj.requestingShip !== 'string' ||
+    typeof obj.timestamp !== 'number'
+  ) {
+    return undefined;
+  }
+  if (obj.type === 'group' && !isNonEmptyString(obj.groupFlag)) {
+    return undefined;
+  }
+  if (obj.type === 'channel' && !isNonEmptyString(obj.channelNest)) {
+    return undefined;
+  }
+
+  const sanitized: Record<string, unknown> = { ...obj };
+  for (const field of [
+    'groupTitle',
+    'messagePreview',
+    'notificationMessageId',
+  ]) {
+    if (field in sanitized && typeof sanitized[field] !== 'string') {
+      delete sanitized[field];
+    }
+  }
+  if (
+    'notifyAttemptAt' in sanitized &&
+    typeof sanitized.notifyAttemptAt !== 'number'
+  ) {
+    delete sanitized.notifyAttemptAt;
+  }
+  return sanitized as unknown as PendingApproval;
+}
+
 /**
  * Parse pendingApprovals - handles both JSON string and array formats.
  * Settings-store stores complex objects as JSON strings.
@@ -457,23 +510,19 @@ function parsePendingApprovals(value: unknown): PendingApproval[] | undefined {
   }
 
   // Filter to valid, unexpired PendingApproval objects.
-  return parsed.filter((item): item is PendingApproval => {
+  return parsed.flatMap((item) => {
     if (!item || typeof item !== 'object') {
-      return false;
+      return [];
     }
-    const obj = item as Record<string, unknown>;
-    const valid =
-      typeof obj.id === 'string' &&
-      (obj.type === 'dm' || obj.type === 'channel' || obj.type === 'group') &&
-      typeof obj.requestingShip === 'string' &&
-      typeof obj.timestamp === 'number';
-
-    const approval = obj as PendingApproval;
-    return (
-      valid &&
-      hasUsableOriginalMessage(approval) &&
-      !isPendingApprovalExpired(approval)
-    );
+    const approval = sanitizePendingApproval(item as Record<string, unknown>);
+    if (
+      !approval ||
+      !hasUsableOriginalMessage(approval) ||
+      isPendingApprovalExpired(approval)
+    ) {
+      return [];
+    }
+    return [approval];
   });
 }
 

--- a/packages/openclaw/src/telemetry.ts
+++ b/packages/openclaw/src/telemetry.ts
@@ -628,7 +628,8 @@ export type TlonPluginErrorSource =
   | 'steward_subscription'
   | 'settings_refresh'
   | 'sse_stream'
-  | 'approval_notification';
+  | 'approval_notification'
+  | 'group_invite_decline';
 
 export type TlonPluginErrorEvent = {
   harness: TlonHarnessName;


### PR DESCRIPTION
## Summary

Follow-ups to #6348 across the two bot runtimes. **Stacked on #6348's branch** — review against its head, not `develop`; retargets to `develop` if #6348 merges first.

## Changes

openclaw:

- `/ban` on a group invite now revokes the ship's `dmAllowlist` grant and declines the invite on the ship, instead of only blocking. Any leg that fails to submit keeps the request pending for a retry (extracted `runBanAction`, unit-tested; decline failures emit telemetry).
- Persisted `pendingApprovals` records are sanitized on load: a record missing its `groupFlag`/`channelNest` locator is dropped, mistyped cosmetic fields are shed, unknown (hermes) fields still round-trip. Previously one malformed record broke `/pending` and notification retries. The remote-controlled foreigns preview title is type-guarded the same way.
- A group join that errors after auto-accept becomes actionable again on the reconciliation sweeps (connect + the 2-minute poll). Live error facts don't retry, so a persistently-failing join can't enter a poke loop.

hermes:

- Group approvals take the delivered/cooldown no-op exits before the `/chat/blocked` scry, mirroring openclaw — a backlog of already-notified invites no longer costs a 30s-worst-case scry each at boot/reconnect.
- `groupInviteAllowlist` resolves like openclaw's `settings ?? account`: a list value (even `[]`) is an override; absent, deleted, or non-list reverts to the env seed. Previously a deletion missed while disconnected left the stale allowlist auto-accepting after reconnect.
- Same ban and errored-join changes as openclaw (block → revoke → decline ordering, revocation-failure restore, sweep-only marker clearing).
- The filed "ban retry wedges during a blocked-list outage" is a no-fix: pokes are fire-and-forget and nacks are log-only, so the wedge cannot occur. Corrected the misleading comment and pinned the behavior with a regression test.

Not included: a hermes periodic reconciliation timer (hermes isn't deployed; stays open on TLON-6394).

## How did I test?

hermes: 1228 unittest OK, also under python3.10 (matches CI). openclaw: 1677 vitest, `tsc`/oxlint/oxfmt clean. Each fix's new tests fail with it reverted. Not automated: the `monitor/index.ts` closure wiring and owner-facing reply strings (the extracted helpers are tested).

## Risks and impact

- Safe to rollback without consulting PR author? Yes
- Affects important code area:
  - [x] Other: bot group-invite/approval flow (openclaw plugin, hermes adapter). No app, desk, or shared-package changes.

Corrupt persisted records are now dropped on load and the sanitized list is persisted back, so a revert doesn't restore them (no writer produces such records). An errored join can now surface an approval DM that previously stayed suppressed.

## Rollback plan

Revert
