### PR TITLE
fix iOS chat input resize flicker

### DIFF
--- a/packages/app/ui/components/Channel/DraftInputView.tsx
+++ b/packages/app/ui/components/Channel/DraftInputView.tsx
@@ -1,5 +1,5 @@
 import { DraftInputId } from '@tloncorp/api';
-import { ComponentProps, PropsWithChildren } from 'react';
+import { ComponentProps, PropsWithChildren, useEffect } from 'react';
 import { Platform, StyleSheet } from 'react-native';
 import { KeyboardStickyView } from 'react-native-keyboard-controller';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
@@ -7,6 +7,7 @@ import { View } from 'tamagui';
 
 import { useComponentsKitContext } from '../../contexts/componentsKits';
 import {
+  useConversationComposerHeight,
   useConversationScrollToBottomControl,
   useConversationScrollViewNativeID,
 } from '../../contexts/scroll';
@@ -63,11 +64,20 @@ export function ConversationComposerPlacement({
   const insets = useSafeAreaInsets();
   const scrollViewNativeID = useConversationScrollViewNativeID();
   const scrollToBottomControl = useConversationScrollToBottomControl();
+  const { report: reportConversationComposerHeight } =
+    useConversationComposerHeight();
   const content = contentProps ? (
     <View {...contentProps}>{children}</View>
   ) : (
     children
   );
+
+  useEffect(() => {
+    if (!enabled || !supportsFloatingComposer) {
+      return;
+    }
+    return () => reportConversationComposerHeight(0);
+  }, [enabled, reportConversationComposerHeight]);
 
   if (enabled && supportsFloatingComposer) {
     return (
@@ -87,12 +97,15 @@ export function ConversationComposerPlacement({
               Platform.OS === 'ios' && scrollToBottomControl?.visible
                 ? floatingScrollControlClearance
                 : 0;
-            onFloatingHeightChange?.(
-              Math.max(
-                0,
-                event.nativeEvent.layout.height - scrollControlClearance
-              )
+            const height = Math.max(
+              0,
+              event.nativeEvent.layout.height - scrollControlClearance
             );
+            // Feed the list's Reanimated content inset before publishing the
+            // React geometry used by surrounding controls. The scroll view can
+            // then adjust its inset and offset in one native commit.
+            reportConversationComposerHeight(height);
+            onFloatingHeightChange?.(height);
           }}
         >
           {content}

--- a/packages/app/ui/components/Channel/PostList/PostList.tsx
+++ b/packages/app/ui/components/Channel/PostList/PostList.tsx
@@ -3,9 +3,11 @@ import { type LegendListRef } from '@legendapp/list/react-native';
 import { layoutForType } from '@tloncorp/shared';
 import * as React from 'react';
 import { Platform } from 'react-native';
+import { useSharedValue } from 'react-native-reanimated';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
 
 import {
+  useConversationComposerHeight,
   useConversationScrollEndAnchor,
   useConversationScrollViewNativeID,
   useScrollDirectionTracker,
@@ -443,6 +445,9 @@ const ConversationPostListAttempt = React.forwardRef<
     forwardedRef
   ) => {
     const listRef = React.useRef<LegendListRef>(null);
+    const composerContentInset = useSharedValue(0);
+    const { register: registerConversationComposerHeight } =
+      useConversationComposerHeight();
     const postsWithNeighborsRef = React.useRef(postsWithNeighbors);
     const scrollViewNativeID = useConversationScrollViewNativeID();
     const insets = useSafeAreaInsets();
@@ -450,6 +455,21 @@ const ConversationPostListAttempt = React.forwardRef<
       () => layoutForType(collectionLayoutType),
       [collectionLayoutType]
     );
+    const reportConversationComposerHeight = React.useCallback(
+      (height: number) => {
+        composerContentInset.set(height);
+        listRef.current?.reportContentInset({ bottom: height });
+      },
+      [composerContentInset]
+    );
+    React.useLayoutEffect(() => {
+      if (Platform.OS !== 'ios') {
+        return;
+      }
+      return registerConversationComposerHeight(
+        reportConversationComposerHeight
+      );
+    }, [registerConversationComposerHeight, reportConversationComposerHeight]);
     const anchorTarget = useConversationAnchorTarget({
       anchor,
       anchorIndex,
@@ -603,7 +623,12 @@ const ConversationPostListAttempt = React.forwardRef<
         contentInsetAdjustmentBehavior={
           Platform.OS === 'ios' ? 'never' : undefined
         }
-        keyboardLiftBehavior="always"
+        contentInsetEndAdjustment={
+          Platform.OS === 'ios' ? composerContentInset : undefined
+        }
+        // Preserve older messages while browsing history, but keep the latest
+        // message anchored as the keyboard or composer grows at the end.
+        keyboardLiftBehavior={Platform.OS === 'ios' ? 'whenAtEnd' : 'always'}
         // Android already resizes the window for the keyboard. Applying the
         // list's keyboard lift as well double-counts that height and makes an
         // end-anchor land below the last message when a post is sent.

--- a/packages/app/ui/components/Channel/PostList/PostList.tsx
+++ b/packages/app/ui/components/Channel/PostList/PostList.tsx
@@ -38,7 +38,6 @@ function useConversationKeyboardListProps(
       // iOS keeps the viewport fixed, so the list owns keyboard and composer
       // insets and commits them with the preserving content offset.
       return {
-        contentInsetAdjustmentBehavior: 'never' as const,
         contentInsetEndAdjustment: composerContentInset,
         freeze: false,
         keyboardDismissMode: 'interactive' as const,
@@ -48,7 +47,6 @@ function useConversationKeyboardListProps(
     // Android adjustResize already shrinks the viewport. Freeze the library's
     // inset path so it does not count the keyboard twice.
     return {
-      contentInsetAdjustmentBehavior: undefined,
       contentInsetEndAdjustment: undefined,
       freeze: true,
       keyboardDismissMode: 'on-drag' as const,

--- a/packages/app/ui/components/Channel/PostList/PostList.tsx
+++ b/packages/app/ui/components/Channel/PostList/PostList.tsx
@@ -3,7 +3,7 @@ import { type LegendListRef } from '@legendapp/list/react-native';
 import { layoutForType } from '@tloncorp/shared';
 import * as React from 'react';
 import { Platform } from 'react-native';
-import { useSharedValue } from 'react-native-reanimated';
+import { type SharedValue, useSharedValue } from 'react-native-reanimated';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
 
 import {
@@ -29,6 +29,32 @@ import {
 
 const ANCHOR_RESOLUTION_TIMEOUT_MS = 2_000;
 const ESTIMATED_ITEM_SIZE = 120;
+
+function useConversationKeyboardListProps(
+  composerContentInset: SharedValue<number>
+) {
+  return React.useMemo(() => {
+    if (Platform.OS === 'ios') {
+      // iOS keeps the viewport fixed, so the list owns keyboard and composer
+      // insets and commits them with the preserving content offset.
+      return {
+        contentInsetAdjustmentBehavior: 'never' as const,
+        contentInsetEndAdjustment: composerContentInset,
+        freeze: false,
+        keyboardDismissMode: 'interactive' as const,
+      };
+    }
+
+    // Android adjustResize already shrinks the viewport. Freeze the library's
+    // inset path so it does not count the keyboard twice.
+    return {
+      contentInsetAdjustmentBehavior: undefined,
+      contentInsetEndAdjustment: undefined,
+      freeze: true,
+      keyboardDismissMode: 'on-drag' as const,
+    };
+  }, [composerContentInset]);
+}
 
 function useLegendListIsNearEnd(
   listRef: React.RefObject<LegendListRef | null>
@@ -446,6 +472,8 @@ const ConversationPostListAttempt = React.forwardRef<
   ) => {
     const listRef = React.useRef<LegendListRef>(null);
     const composerContentInset = useSharedValue(0);
+    const conversationKeyboardListProps =
+      useConversationKeyboardListProps(composerContentInset);
     const { register: registerConversationComposerHeight } =
       useConversationComposerHeight();
     const postsWithNeighborsRef = React.useRef(postsWithNeighbors);
@@ -620,23 +648,13 @@ const ConversationPostListAttempt = React.forwardRef<
         ListHeaderComponent={listHeaderComponent}
         ListFooterComponent={listBottomComponent}
         contentContainerStyle={contentContainerStyle}
-        contentInsetAdjustmentBehavior={
-          Platform.OS === 'ios' ? 'never' : undefined
-        }
-        contentInsetEndAdjustment={
-          Platform.OS === 'ios' ? composerContentInset : undefined
-        }
+        {...conversationKeyboardListProps}
         // Preserve older messages while browsing history, but keep the latest
         // message anchored as the keyboard or composer grows at the end.
-        keyboardLiftBehavior={Platform.OS === 'ios' ? 'whenAtEnd' : 'always'}
-        // Android already resizes the window for the keyboard. Applying the
-        // list's keyboard lift as well double-counts that height and makes an
-        // end-anchor land below the last message when a post is sent.
-        freeze={Platform.OS === 'android'}
+        keyboardLiftBehavior="whenAtEnd"
         keyboardOffset={insets.bottom}
         scrollIndicatorInsets={{ top: 0, bottom: insets.bottom }}
         automaticallyAdjustsScrollIndicatorInsets={false}
-        keyboardDismissMode={Platform.OS === 'ios' ? 'interactive' : 'on-drag'}
         scrollEnabled={scrollEnabled}
         style={[
           { flex: 1 },

--- a/packages/app/ui/components/Channel/Scroller.tsx
+++ b/packages/app/ui/components/Channel/Scroller.tsx
@@ -392,6 +392,11 @@ const Scroller = forwardRef(
     const insets = useSafeAreaInsets();
     const rootVerticalPadding = getTokens().space.l.val;
     const composerBottomInset = contentInsets.bottom;
+    const scrollContentBottomInset =
+      Platform.OS === 'ios' &&
+      collectionLayoutType === 'compact-list-bottom-to-top'
+        ? 0
+        : contentInsets.bottom;
     const standaloneBottomSafeArea =
       composerBottomInset > 0 ? 0 : insets.bottom;
     const scrollButtonBottom =
@@ -411,13 +416,13 @@ const Scroller = forwardRef(
               paddingBottom:
                 standaloneBottomSafeArea +
                 rootVerticalPadding +
-                contentInsets.bottom,
+                scrollContentBottomInset,
             };
           }
           return {
             flexGrow: 1,
             paddingTop: contentInsets.top,
-            paddingBottom: contentInsets.bottom,
+            paddingBottom: scrollContentBottomInset,
           };
         }
 
@@ -426,7 +431,7 @@ const Scroller = forwardRef(
             return {
               paddingHorizontal: '$m',
               paddingTop: contentInsets.top,
-              paddingBottom: contentInsets.bottom,
+              paddingBottom: scrollContentBottomInset,
             };
           }
 
@@ -438,7 +443,7 @@ const Scroller = forwardRef(
               paddingBottom:
                 standaloneBottomSafeArea +
                 rootVerticalPadding +
-                contentInsets.bottom,
+                scrollContentBottomInset,
             };
           }
 
@@ -450,7 +455,7 @@ const Scroller = forwardRef(
               paddingBottom:
                 standaloneBottomSafeArea +
                 rootVerticalPadding +
-                contentInsets.bottom,
+                scrollContentBottomInset,
             };
           }
         }
@@ -458,9 +463,9 @@ const Scroller = forwardRef(
         standaloneBottomSafeArea,
         visiblePosts?.length,
         collectionLayoutType,
-        contentInsets.bottom,
         contentInsets.top,
         rootVerticalPadding,
+        scrollContentBottomInset,
       ])
     ) as StyleProp<ViewStyle>;
 

--- a/packages/app/ui/contexts/scroll.tsx
+++ b/packages/app/ui/contexts/scroll.tsx
@@ -27,6 +27,8 @@ export type ConversationScrollToBottomControl = {
   visible: boolean;
 };
 
+type ConversationComposerHeightHandler = (height: number) => void;
+
 // @ts-expect-error - No other props than value are needed
 const INITIAL_VALUE: ScrollContextTuple = [{ value: 0 }, () => {}];
 
@@ -55,6 +57,10 @@ const ConversationScrollToBottomContext = createContext<{
     React.SetStateAction<ConversationScrollToBottomControl | null>
   >;
 }>({ control: null, setControl: () => {} });
+const ConversationComposerHeightContext = createContext<{
+  register: (handler: ConversationComposerHeightHandler) => () => void;
+  report: (height: number) => void;
+}>({ register: () => () => {}, report: () => {} });
 
 export const useScrollContext = () => useContext(ScrollContext);
 export const useConversationScrollViewNativeID = () =>
@@ -65,6 +71,8 @@ export const useConversationScrollToBottomControl = () =>
   useContext(ConversationScrollToBottomContext).control;
 export const useSetConversationScrollToBottomControl = () =>
   useContext(ConversationScrollToBottomContext).setControl;
+export const useConversationComposerHeight = () =>
+  useContext(ConversationComposerHeightContext);
 
 export const useScrollDirectionTracker = ({
   setIsAtBottom: setIsAtBottomProp,
@@ -155,6 +163,9 @@ export const ScrollContextProvider: React.FC<React.PropsWithChildren> = ({
   const scrollValue = useSharedValue(0);
   const conversationScrollEndAnchor =
     useRef<ConversationScrollEndAnchorHandler | null>(null);
+  const conversationComposerHeightHandler =
+    useRef<ConversationComposerHeightHandler | null>(null);
+  const lastConversationComposerHeight = useRef<number | null>(null);
   const scrollViewNativeID = `${defaultConversationScrollViewNativeID}-${useId()}`;
   const [scrollToBottomControl, setScrollToBottomControl] =
     useState<ConversationScrollToBottomControl | null>(null);
@@ -192,6 +203,26 @@ export const ScrollContextProvider: React.FC<React.PropsWithChildren> = ({
     }),
     []
   );
+  const composerHeightContextValue = useMemo(
+    () => ({
+      register: (handler: ConversationComposerHeightHandler) => {
+        conversationComposerHeightHandler.current = handler;
+        if (lastConversationComposerHeight.current !== null) {
+          handler(lastConversationComposerHeight.current);
+        }
+        return () => {
+          if (conversationComposerHeightHandler.current === handler) {
+            conversationComposerHeightHandler.current = null;
+          }
+        };
+      },
+      report: (height: number) => {
+        lastConversationComposerHeight.current = height;
+        conversationComposerHeightHandler.current?.(height);
+      },
+    }),
+    []
+  );
 
   return (
     <ConversationScrollEndAnchorContext.Provider
@@ -200,13 +231,17 @@ export const ScrollContextProvider: React.FC<React.PropsWithChildren> = ({
       <ConversationScrollToBottomContext.Provider
         value={scrollToBottomContextValue}
       >
-        <ConversationScrollViewNativeIDContext.Provider
-          value={scrollViewNativeID}
+        <ConversationComposerHeightContext.Provider
+          value={composerHeightContextValue}
         >
-          <ScrollContext.Provider value={contextValue}>
-            {children}
-          </ScrollContext.Provider>
-        </ConversationScrollViewNativeIDContext.Provider>
+          <ConversationScrollViewNativeIDContext.Provider
+            value={scrollViewNativeID}
+          >
+            <ScrollContext.Provider value={contextValue}>
+              {children}
+            </ScrollContext.Provider>
+          </ConversationScrollViewNativeIDContext.Provider>
+        </ConversationComposerHeightContext.Provider>
       </ConversationScrollToBottomContext.Provider>
     </ConversationScrollEndAnchorContext.Provider>
   );

--- a/patches/README.md
+++ b/patches/README.md
@@ -148,6 +148,63 @@ Remove this patch once we upgrade off the old `0.5.x` web bundle and confirm
 the replacement no longer vendors the legacy HTML link paste fallback or needs
 the local asset export stripping.
 
+## react-native-keyboard-controller@1.22.0
+
+Local patch:
+`patches/react-native-keyboard-controller@1.22.0.patch`
+
+Why:
+On iOS, `KeyboardChatScrollView` implements composer growth through
+`extraContentPadding`, which updates the scroll view's `contentInset`. When
+`keyboardLiftBehavior="whenAtEnd"` decides not to move a user who is browsing
+older messages, upstream returns without re-emitting the current
+`contentOffset`. `ScrollViewWithBottomPadding` also omits `contentOffset` when
+its numeric target has not changed. UIKit can therefore adjust the offset while
+applying the inset by itself, producing a one-frame flash or jump when a
+multiline chat composer first grows.
+
+What it does:
+- Re-publishes the currently observed offset when an
+  `extraContentPadding` change should not shift the content.
+- Emits that offset whenever bottom padding changes, even if its numeric value
+  is unchanged, so Reanimated sends the new `contentInset` and a
+  `contentOffset` that preserves position in the same animated-props commit.
+
+The app still owns the product behavior: it reports the floating composer
+height to LegendList and uses `whenAtEnd` only on iOS. Android keeps its
+existing `always` lift behavior.
+
+Upstream:
+- repo: `kirillzyusko/react-native-keyboard-controller`
+- related discussion:
+  [#1333](https://github.com/kirillzyusko/react-native-keyboard-controller/discussions/1333)
+  covers layout shifts involving `whenAtEnd` and `extraContentPadding`
+- related open fixes
+  [#1605](https://github.com/kirillzyusko/react-native-keyboard-controller/pull/1605)
+  and
+  [#1609](https://github.com/kirillzyusko/react-native-keyboard-controller/pull/1609)
+  address different animated-padding and Reanimated 4.6 failures
+- as of August 31, 2026, upstream release `1.22.4` still has the same
+  no-shift and unchanged-offset behavior; no exact upstream fix has shipped
+
+Validation:
+- Run `corepack pnpm install --frozen-lockfile` to confirm the patch applies
+  and its lockfile hash is current.
+- Rebuild the iOS app. With the keyboard open, grow and shrink the multiline
+  composer while browsing history; the same visible message should retain its
+  vertical position without flashing.
+- Repeat at the end of the conversation; the latest message should remain
+  anchored above the composer.
+- Exercise emoji keyboard changes, momentum scrolling, and leaving/reopening
+  the conversation to check for stale inset or offset state.
+- Rebuild Android and confirm composer growth and keyboard dismissal retain
+  the existing end-anchor behavior.
+
+Removal:
+Remove this patch after an upstream release commits `contentInset` together
+with a preserving `contentOffset` for no-shift `extraContentPadding` changes,
+then repeat the mid-history and at-end simulator checks without the patch.
+
 ## react-native-reanimated@4.5.0
 
 Why:

--- a/patches/README.md
+++ b/patches/README.md
@@ -164,15 +164,18 @@ applying the inset by itself, producing a one-frame flash or jump when a
 multiline chat composer first grows.
 
 What it does:
-- Re-publishes the currently observed offset when an
-  `extraContentPadding` change should not shift the content.
+- On iOS Fabric, re-publishes the currently observed offset when an
+  `extraContentPadding` change should not shift the content. The guard keeps
+  the workaround out of Android, web, and the legacy iOS architecture.
 - Emits that offset whenever bottom padding changes, even if its numeric value
   is unchanged, so Reanimated sends the new `contentInset` and a
   `contentOffset` that preserves position in the same animated-props commit.
 
 The app still owns the product behavior: it reports the floating composer
-height to LegendList and uses `whenAtEnd` only on iOS. Android keeps its
-existing `always` lift behavior.
+height to LegendList and uses the shared `whenAtEnd` policy on both platforms.
+Android freezes keyboard-controller's inset path because `adjustResize`
+already shrinks its viewport; iOS supplies the composer inset and performs the
+offset-preserving commit.
 
 Upstream:
 - repo: `kirillzyusko/react-native-keyboard-controller`

--- a/patches/react-native-keyboard-controller@1.22.0.patch
+++ b/patches/react-native-keyboard-controller@1.22.0.patch
@@ -1,14 +1,16 @@
 diff --git a/src/components/KeyboardChatScrollView/useExtraContentPadding/index.ts b/src/components/KeyboardChatScrollView/useExtraContentPadding/index.ts
 --- a/src/components/KeyboardChatScrollView/useExtraContentPadding/index.ts
 +++ b/src/components/KeyboardChatScrollView/useExtraContentPadding/index.ts
-@@ -129,6 +129,11 @@ function useExtraContentPadding(options: UseExtraContentPaddingOptions): void {
+@@ -129,6 +129,13 @@ function useExtraContentPadding(options: UseExtraContentPaddingOptions): void {
        }
 
        if (!shouldShiftContent(keyboardLiftBehavior, atEnd)) {
-+        // On iOS, changing contentInset can move contentOffset even when the
-+        // caller requested no lift. Re-emit the current offset so both values
-+        // land in the same animated-props commit.
-+        scrollToTarget(scroll.value);
++        if (contentOffsetY && IS_FABRIC) {
++          // On iOS Fabric, changing contentInset can move contentOffset even
++          // when the caller requested no lift. Re-emit the current offset so
++          // both values land in the same animated-props commit.
++          scrollToTarget(scroll.value);
++        }
 +
          return;
        }
@@ -51,28 +53,32 @@ diff --git a/src/components/ScrollViewWithBottomPadding/index.tsx b/src/componen
 diff --git a/lib/module/components/KeyboardChatScrollView/useExtraContentPadding/index.js b/lib/module/components/KeyboardChatScrollView/useExtraContentPadding/index.js
 --- a/lib/module/components/KeyboardChatScrollView/useExtraContentPadding/index.js
 +++ b/lib/module/components/KeyboardChatScrollView/useExtraContentPadding/index.js
-@@ -76,6 +76,10 @@ function useExtraContentPadding(options) {
+@@ -76,6 +76,12 @@ function useExtraContentPadding(options) {
        return;
      }
      if (!shouldShiftContent(keyboardLiftBehavior, atEnd)) {
-+      // On iOS, changing contentInset can move contentOffset even when the
-+      // caller requested no lift. Re-emit the current offset so both values
-+      // land in the same animated-props commit.
-+      scrollToTarget(scroll.value);
++      if (contentOffsetY && IS_FABRIC) {
++        // On iOS Fabric, changing contentInset can move contentOffset even
++        // when the caller requested no lift. Re-emit the current offset so
++        // both values land in the same animated-props commit.
++        scrollToTarget(scroll.value);
++      }
        return;
      }
      if (inverted) {
 diff --git a/lib/commonjs/components/KeyboardChatScrollView/useExtraContentPadding/index.js b/lib/commonjs/components/KeyboardChatScrollView/useExtraContentPadding/index.js
 --- a/lib/commonjs/components/KeyboardChatScrollView/useExtraContentPadding/index.js
 +++ b/lib/commonjs/components/KeyboardChatScrollView/useExtraContentPadding/index.js
-@@ -82,6 +82,10 @@ function useExtraContentPadding(options) {
+@@ -82,6 +82,12 @@ function useExtraContentPadding(options) {
        return;
      }
      if (!(0, _helpers.shouldShiftContent)(keyboardLiftBehavior, atEnd)) {
-+      // On iOS, changing contentInset can move contentOffset even when the
-+      // caller requested no lift. Re-emit the current offset so both values
-+      // land in the same animated-props commit.
-+      scrollToTarget(scroll.value);
++      if (contentOffsetY && _architecture.IS_FABRIC) {
++        // On iOS Fabric, changing contentInset can move contentOffset even
++        // when the caller requested no lift. Re-emit the current offset so
++        // both values land in the same animated-props commit.
++        scrollToTarget(scroll.value);
++      }
        return;
      }
      if (inverted) {

--- a/patches/react-native-keyboard-controller@1.22.0.patch
+++ b/patches/react-native-keyboard-controller@1.22.0.patch
@@ -1,0 +1,138 @@
+diff --git a/src/components/KeyboardChatScrollView/useExtraContentPadding/index.ts b/src/components/KeyboardChatScrollView/useExtraContentPadding/index.ts
+--- a/src/components/KeyboardChatScrollView/useExtraContentPadding/index.ts
++++ b/src/components/KeyboardChatScrollView/useExtraContentPadding/index.ts
+@@ -129,6 +129,11 @@ function useExtraContentPadding(options: UseExtraContentPaddingOptions): void {
+       }
+
+       if (!shouldShiftContent(keyboardLiftBehavior, atEnd)) {
++        // On iOS, changing contentInset can move contentOffset even when the
++        // caller requested no lift. Re-emit the current offset so both values
++        // land in the same animated-props commit.
++        scrollToTarget(scroll.value);
++
+         return;
+       }
+
+diff --git a/src/components/ScrollViewWithBottomPadding/index.tsx b/src/components/ScrollViewWithBottomPadding/index.tsx
+--- a/src/components/ScrollViewWithBottomPadding/index.tsx
++++ b/src/components/ScrollViewWithBottomPadding/index.tsx
+@@ -75,6 +75,7 @@ const ScrollViewWithBottomPadding = forwardRef<
+     ref,
+   ) => {
+     const prevContentOffsetY = useSharedValue<number | null>(null);
++    const prevBottomPadding = useSharedValue<number | null>(null);
+
+     const insets = useDerivedValue(() => {
+       const dynamicTop = inverted ? bottomPadding.value : 0;
+@@ -122,6 +123,11 @@ const ScrollViewWithBottomPadding = forwardRef<
+
+     const animatedProps = useAnimatedProps(() => {
+       const { dynamic, effective } = insets.value;
++      const currentBottomPadding = bottomPadding.value;
++      const didBottomPaddingChange =
++        prevBottomPadding.value !== null &&
++        currentBottomPadding !== prevBottomPadding.value;
++      prevBottomPadding.value = currentBottomPadding;
+
+       const indicatorPadding = scrollIndicatorPadding ?? bottomPadding;
+       const indicatorTop =
+@@ -155,7 +161,10 @@ const ScrollViewWithBottomPadding = forwardRef<
+           // offset), making the list mount scrolled to the top natively.
+           // eslint-disable-next-line react-compiler/react-compiler
+           prevContentOffsetY.value = curr;
+-        } else if (curr !== prevContentOffsetY.value) {
++        } else if (
++          curr !== prevContentOffsetY.value ||
++          didBottomPaddingChange
++        ) {
+           prevContentOffsetY.value = curr;
+           result.contentOffset = { x: 0, y: curr };
+         }
+diff --git a/lib/module/components/KeyboardChatScrollView/useExtraContentPadding/index.js b/lib/module/components/KeyboardChatScrollView/useExtraContentPadding/index.js
+--- a/lib/module/components/KeyboardChatScrollView/useExtraContentPadding/index.js
++++ b/lib/module/components/KeyboardChatScrollView/useExtraContentPadding/index.js
+@@ -76,6 +76,10 @@ function useExtraContentPadding(options) {
+       return;
+     }
+     if (!shouldShiftContent(keyboardLiftBehavior, atEnd)) {
++      // On iOS, changing contentInset can move contentOffset even when the
++      // caller requested no lift. Re-emit the current offset so both values
++      // land in the same animated-props commit.
++      scrollToTarget(scroll.value);
+       return;
+     }
+     if (inverted) {
+diff --git a/lib/commonjs/components/KeyboardChatScrollView/useExtraContentPadding/index.js b/lib/commonjs/components/KeyboardChatScrollView/useExtraContentPadding/index.js
+--- a/lib/commonjs/components/KeyboardChatScrollView/useExtraContentPadding/index.js
++++ b/lib/commonjs/components/KeyboardChatScrollView/useExtraContentPadding/index.js
+@@ -82,6 +82,10 @@ function useExtraContentPadding(options) {
+       return;
+     }
+     if (!(0, _helpers.shouldShiftContent)(keyboardLiftBehavior, atEnd)) {
++      // On iOS, changing contentInset can move contentOffset even when the
++      // caller requested no lift. Re-emit the current offset so both values
++      // land in the same animated-props commit.
++      scrollToTarget(scroll.value);
+       return;
+     }
+     if (inverted) {
+diff --git a/lib/module/components/ScrollViewWithBottomPadding/index.js b/lib/module/components/ScrollViewWithBottomPadding/index.js
+--- a/lib/module/components/ScrollViewWithBottomPadding/index.js
++++ b/lib/module/components/ScrollViewWithBottomPadding/index.js
+@@ -20,6 +20,7 @@ const ScrollViewWithBottomPadding = /*#__PURE__*/forwardRef(({
+   ...rest
+ }, ref) => {
+   const prevContentOffsetY = useSharedValue(null);
++  const prevBottomPadding = useSharedValue(null);
+   const insets = useDerivedValue(() => {
+     const dynamicTop = inverted ? bottomPadding.value : 0;
+     const dynamicBottom = !inverted ? bottomPadding.value : 0;
+@@ -50,6 +51,9 @@ const ScrollViewWithBottomPadding = /*#__PURE__*/forwardRef(({
+       dynamic,
+       effective
+     } = insets.value;
++    const currentBottomPadding = bottomPadding.value;
++    const didBottomPaddingChange = prevBottomPadding.value !== null && currentBottomPadding !== prevBottomPadding.value;
++    prevBottomPadding.value = currentBottomPadding;
+     const indicatorPadding = scrollIndicatorPadding ?? bottomPadding;
+     const indicatorTop = (inverted ? indicatorPadding.value : 0) + ((scrollIndicatorInsets === null || scrollIndicatorInsets === void 0 ? void 0 : scrollIndicatorInsets.top) || 0);
+     const indicatorBottom = (!inverted ? indicatorPadding.value : 0) + ((scrollIndicatorInsets === null || scrollIndicatorInsets === void 0 ? void 0 : scrollIndicatorInsets.bottom) || 0);
+@@ -75,7 +79,7 @@ const ScrollViewWithBottomPadding = /*#__PURE__*/forwardRef(({
+         // offset), making the list mount scrolled to the top natively.
+         // eslint-disable-next-line react-compiler/react-compiler
+         prevContentOffsetY.value = curr;
+-      } else if (curr !== prevContentOffsetY.value) {
++      } else if (curr !== prevContentOffsetY.value || didBottomPaddingChange) {
+         prevContentOffsetY.value = curr;
+         result.contentOffset = {
+           x: 0,
+diff --git a/lib/commonjs/components/ScrollViewWithBottomPadding/index.js b/lib/commonjs/components/ScrollViewWithBottomPadding/index.js
+--- a/lib/commonjs/components/ScrollViewWithBottomPadding/index.js
++++ b/lib/commonjs/components/ScrollViewWithBottomPadding/index.js
+@@ -28,6 +28,7 @@ const ScrollViewWithBottomPadding = /*#__PURE__*/(0, _react.forwardRef)(({
+   ...rest
+ }, ref) => {
+   const prevContentOffsetY = (0, _reactNativeReanimated.useSharedValue)(null);
++  const prevBottomPadding = (0, _reactNativeReanimated.useSharedValue)(null);
+   const insets = (0, _reactNativeReanimated.useDerivedValue)(() => {
+     const dynamicTop = inverted ? bottomPadding.value : 0;
+     const dynamicBottom = !inverted ? bottomPadding.value : 0;
+@@ -58,6 +59,9 @@ const ScrollViewWithBottomPadding = /*#__PURE__*/(0, _react.forwardRef)(({
+       dynamic,
+       effective
+     } = insets.value;
++    const currentBottomPadding = bottomPadding.value;
++    const didBottomPaddingChange = prevBottomPadding.value !== null && currentBottomPadding !== prevBottomPadding.value;
++    prevBottomPadding.value = currentBottomPadding;
+     const indicatorPadding = scrollIndicatorPadding ?? bottomPadding;
+     const indicatorTop = (inverted ? indicatorPadding.value : 0) + ((scrollIndicatorInsets === null || scrollIndicatorInsets === void 0 ? void 0 : scrollIndicatorInsets.top) || 0);
+     const indicatorBottom = (!inverted ? indicatorPadding.value : 0) + ((scrollIndicatorInsets === null || scrollIndicatorInsets === void 0 ? void 0 : scrollIndicatorInsets.bottom) || 0);
+@@ -83,7 +87,7 @@ const ScrollViewWithBottomPadding = /*#__PURE__*/(0, _react.forwardRef)(({
+         // offset), making the list mount scrolled to the top natively.
+         // eslint-disable-next-line react-compiler/react-compiler
+         prevContentOffsetY.value = curr;
+-      } else if (curr !== prevContentOffsetY.value) {
++      } else if (curr !== prevContentOffsetY.value || didBottomPaddingChange) {
+         prevContentOffsetY.value = curr;
+         result.contentOffset = {
+           x: 0,

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -42,7 +42,7 @@ patchedDependencies:
   react-cosmos: 658acdaf59c16d70e54b6b0b9d522593cd973839891ed5446a3dd3045d4e37eb
   react-native-country-codes-picker: 53c90d297e1cc4991af0f2d72d0f33a68e8be46e75bdf3da919a20160791bee5
   react-native-gesture-handler: e6fc0413229a6f38cc4b2432f69ea6cc8692cc4d611e47452f4c65678df5caf4
-  react-native-keyboard-controller@1.22.0: 3e2c2d7400f0de452e961794f86180dbb374f2467f5250e6f34c84489e9945d0
+  react-native-keyboard-controller@1.22.0: fa419bd2e9aab4d082cd67ab2373cd83c0ee59c03d79a6a5612969c17c27ee0c
   react-native-reanimated: dca1e6927879993905550e8e56f8fa98423ff51ce87750ea4478bd40a4341f7f
   react-native-screens@4.25.2: 0d058cd35b3fc9cef60767373022b08fcd31e41952108b4254a69d716d817f43
 
@@ -389,7 +389,7 @@ importers:
         version: 1.11.0(react-native@0.86.0(@react-native/jest-preset@0.86.0(@babel/core@7.29.0)(react@19.2.3))(@react-native/metro-config@0.86.0)(@types/react@19.2.17)(react@19.2.3))
       react-native-keyboard-controller:
         specifier: 1.22.0
-        version: 1.22.0(patch_hash=3e2c2d7400f0de452e961794f86180dbb374f2467f5250e6f34c84489e9945d0)(react-native-reanimated@4.5.0(patch_hash=dca1e6927879993905550e8e56f8fa98423ff51ce87750ea4478bd40a4341f7f)(react-native-worklets@0.10.3(@babel/core@7.29.0)(@react-native/metro-config@0.86.0)(react-native@0.86.0(@react-native/jest-preset@0.86.0(@babel/core@7.29.0)(react@19.2.3))(@react-native/metro-config@0.86.0)(@types/react@19.2.17)(react@19.2.3))(react@19.2.3))(react-native@0.86.0(@react-native/jest-preset@0.86.0(@babel/core@7.29.0)(react@19.2.3))(@react-native/metro-config@0.86.0)(@types/react@19.2.17)(react@19.2.3))(react@19.2.3))(react-native@0.86.0(@react-native/jest-preset@0.86.0(@babel/core@7.29.0)(react@19.2.3))(@react-native/metro-config@0.86.0)(@types/react@19.2.17)(react@19.2.3))(react@19.2.3)
+        version: 1.22.0(patch_hash=fa419bd2e9aab4d082cd67ab2373cd83c0ee59c03d79a6a5612969c17c27ee0c)(react-native-reanimated@4.5.0(patch_hash=dca1e6927879993905550e8e56f8fa98423ff51ce87750ea4478bd40a4341f7f)(react-native-worklets@0.10.3(@babel/core@7.29.0)(@react-native/metro-config@0.86.0)(react-native@0.86.0(@react-native/jest-preset@0.86.0(@babel/core@7.29.0)(react@19.2.3))(@react-native/metro-config@0.86.0)(@types/react@19.2.17)(react@19.2.3))(react@19.2.3))(react-native@0.86.0(@react-native/jest-preset@0.86.0(@babel/core@7.29.0)(react@19.2.3))(@react-native/metro-config@0.86.0)(@types/react@19.2.17)(react@19.2.3))(react@19.2.3))(react-native@0.86.0(@react-native/jest-preset@0.86.0(@babel/core@7.29.0)(react@19.2.3))(@react-native/metro-config@0.86.0)(@types/react@19.2.17)(react@19.2.3))(react@19.2.3)
       react-native-reanimated:
         specifier: 4.5.0
         version: 4.5.0(patch_hash=dca1e6927879993905550e8e56f8fa98423ff51ce87750ea4478bd40a4341f7f)(react-native-worklets@0.10.3(@babel/core@7.29.0)(@react-native/metro-config@0.86.0)(react-native@0.86.0(@react-native/jest-preset@0.86.0(@babel/core@7.29.0)(react@19.2.3))(@react-native/metro-config@0.86.0)(@types/react@19.2.17)(react@19.2.3))(react@19.2.3))(react-native@0.86.0(@react-native/jest-preset@0.86.0(@babel/core@7.29.0)(react@19.2.3))(@react-native/metro-config@0.86.0)(@types/react@19.2.17)(react@19.2.3))(react@19.2.3)
@@ -25702,7 +25702,7 @@ snapshots:
       react: 19.2.3
       react-native: 0.86.0(@react-native/jest-preset@0.86.0(@babel/core@7.29.0)(react@19.2.3))(@react-native/metro-config@0.86.0)(@types/react@19.2.17)(react@19.2.3)
 
-  react-native-keyboard-controller@1.22.0(patch_hash=3e2c2d7400f0de452e961794f86180dbb374f2467f5250e6f34c84489e9945d0)(react-native-reanimated@4.5.0(patch_hash=dca1e6927879993905550e8e56f8fa98423ff51ce87750ea4478bd40a4341f7f)(react-native-worklets@0.10.3(@babel/core@7.29.0)(@react-native/metro-config@0.86.0)(react-native@0.86.0(@react-native/jest-preset@0.86.0(@babel/core@7.29.0)(react@19.2.3))(@react-native/metro-config@0.86.0)(@types/react@19.2.17)(react@19.2.3))(react@19.2.3))(react-native@0.86.0(@react-native/jest-preset@0.86.0(@babel/core@7.29.0)(react@19.2.3))(@react-native/metro-config@0.86.0)(@types/react@19.2.17)(react@19.2.3))(react@19.2.3))(react-native@0.86.0(@react-native/jest-preset@0.86.0(@babel/core@7.29.0)(react@19.2.3))(@react-native/metro-config@0.86.0)(@types/react@19.2.17)(react@19.2.3))(react@19.2.3):
+  react-native-keyboard-controller@1.22.0(patch_hash=fa419bd2e9aab4d082cd67ab2373cd83c0ee59c03d79a6a5612969c17c27ee0c)(react-native-reanimated@4.5.0(patch_hash=dca1e6927879993905550e8e56f8fa98423ff51ce87750ea4478bd40a4341f7f)(react-native-worklets@0.10.3(@babel/core@7.29.0)(@react-native/metro-config@0.86.0)(react-native@0.86.0(@react-native/jest-preset@0.86.0(@babel/core@7.29.0)(react@19.2.3))(@react-native/metro-config@0.86.0)(@types/react@19.2.17)(react@19.2.3))(react@19.2.3))(react-native@0.86.0(@react-native/jest-preset@0.86.0(@babel/core@7.29.0)(react@19.2.3))(@react-native/metro-config@0.86.0)(@types/react@19.2.17)(react@19.2.3))(react@19.2.3))(react-native@0.86.0(@react-native/jest-preset@0.86.0(@babel/core@7.29.0)(react@19.2.3))(@react-native/metro-config@0.86.0)(@types/react@19.2.17)(react@19.2.3))(react@19.2.3):
     dependencies:
       react: 19.2.3
       react-native: 0.86.0(@react-native/jest-preset@0.86.0(@babel/core@7.29.0)(react@19.2.3))(@react-native/metro-config@0.86.0)(@types/react@19.2.17)(react@19.2.3)

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -42,6 +42,7 @@ patchedDependencies:
   react-cosmos: 658acdaf59c16d70e54b6b0b9d522593cd973839891ed5446a3dd3045d4e37eb
   react-native-country-codes-picker: 53c90d297e1cc4991af0f2d72d0f33a68e8be46e75bdf3da919a20160791bee5
   react-native-gesture-handler: e6fc0413229a6f38cc4b2432f69ea6cc8692cc4d611e47452f4c65678df5caf4
+  react-native-keyboard-controller@1.22.0: 3e2c2d7400f0de452e961794f86180dbb374f2467f5250e6f34c84489e9945d0
   react-native-reanimated: dca1e6927879993905550e8e56f8fa98423ff51ce87750ea4478bd40a4341f7f
   react-native-screens@4.25.2: 0d058cd35b3fc9cef60767373022b08fcd31e41952108b4254a69d716d817f43
 
@@ -388,7 +389,7 @@ importers:
         version: 1.11.0(react-native@0.86.0(@react-native/jest-preset@0.86.0(@babel/core@7.29.0)(react@19.2.3))(@react-native/metro-config@0.86.0)(@types/react@19.2.17)(react@19.2.3))
       react-native-keyboard-controller:
         specifier: 1.22.0
-        version: 1.22.0(react-native-reanimated@4.5.0(patch_hash=dca1e6927879993905550e8e56f8fa98423ff51ce87750ea4478bd40a4341f7f)(react-native-worklets@0.10.3(@babel/core@7.29.0)(@react-native/metro-config@0.86.0)(react-native@0.86.0(@react-native/jest-preset@0.86.0(@babel/core@7.29.0)(react@19.2.3))(@react-native/metro-config@0.86.0)(@types/react@19.2.17)(react@19.2.3))(react@19.2.3))(react-native@0.86.0(@react-native/jest-preset@0.86.0(@babel/core@7.29.0)(react@19.2.3))(@react-native/metro-config@0.86.0)(@types/react@19.2.17)(react@19.2.3))(react@19.2.3))(react-native@0.86.0(@react-native/jest-preset@0.86.0(@babel/core@7.29.0)(react@19.2.3))(@react-native/metro-config@0.86.0)(@types/react@19.2.17)(react@19.2.3))(react@19.2.3)
+        version: 1.22.0(patch_hash=3e2c2d7400f0de452e961794f86180dbb374f2467f5250e6f34c84489e9945d0)(react-native-reanimated@4.5.0(patch_hash=dca1e6927879993905550e8e56f8fa98423ff51ce87750ea4478bd40a4341f7f)(react-native-worklets@0.10.3(@babel/core@7.29.0)(@react-native/metro-config@0.86.0)(react-native@0.86.0(@react-native/jest-preset@0.86.0(@babel/core@7.29.0)(react@19.2.3))(@react-native/metro-config@0.86.0)(@types/react@19.2.17)(react@19.2.3))(react@19.2.3))(react-native@0.86.0(@react-native/jest-preset@0.86.0(@babel/core@7.29.0)(react@19.2.3))(@react-native/metro-config@0.86.0)(@types/react@19.2.17)(react@19.2.3))(react@19.2.3))(react-native@0.86.0(@react-native/jest-preset@0.86.0(@babel/core@7.29.0)(react@19.2.3))(@react-native/metro-config@0.86.0)(@types/react@19.2.17)(react@19.2.3))(react@19.2.3)
       react-native-reanimated:
         specifier: 4.5.0
         version: 4.5.0(patch_hash=dca1e6927879993905550e8e56f8fa98423ff51ce87750ea4478bd40a4341f7f)(react-native-worklets@0.10.3(@babel/core@7.29.0)(@react-native/metro-config@0.86.0)(react-native@0.86.0(@react-native/jest-preset@0.86.0(@babel/core@7.29.0)(react@19.2.3))(@react-native/metro-config@0.86.0)(@types/react@19.2.17)(react@19.2.3))(react@19.2.3))(react-native@0.86.0(@react-native/jest-preset@0.86.0(@babel/core@7.29.0)(react@19.2.3))(@react-native/metro-config@0.86.0)(@types/react@19.2.17)(react@19.2.3))(react@19.2.3)
@@ -25701,7 +25702,7 @@ snapshots:
       react: 19.2.3
       react-native: 0.86.0(@react-native/jest-preset@0.86.0(@babel/core@7.29.0)(react@19.2.3))(@react-native/metro-config@0.86.0)(@types/react@19.2.17)(react@19.2.3)
 
-  react-native-keyboard-controller@1.22.0(react-native-reanimated@4.5.0(patch_hash=dca1e6927879993905550e8e56f8fa98423ff51ce87750ea4478bd40a4341f7f)(react-native-worklets@0.10.3(@babel/core@7.29.0)(@react-native/metro-config@0.86.0)(react-native@0.86.0(@react-native/jest-preset@0.86.0(@babel/core@7.29.0)(react@19.2.3))(@react-native/metro-config@0.86.0)(@types/react@19.2.17)(react@19.2.3))(react@19.2.3))(react-native@0.86.0(@react-native/jest-preset@0.86.0(@babel/core@7.29.0)(react@19.2.3))(@react-native/metro-config@0.86.0)(@types/react@19.2.17)(react@19.2.3))(react@19.2.3))(react-native@0.86.0(@react-native/jest-preset@0.86.0(@babel/core@7.29.0)(react@19.2.3))(@react-native/metro-config@0.86.0)(@types/react@19.2.17)(react@19.2.3))(react@19.2.3):
+  react-native-keyboard-controller@1.22.0(patch_hash=3e2c2d7400f0de452e961794f86180dbb374f2467f5250e6f34c84489e9945d0)(react-native-reanimated@4.5.0(patch_hash=dca1e6927879993905550e8e56f8fa98423ff51ce87750ea4478bd40a4341f7f)(react-native-worklets@0.10.3(@babel/core@7.29.0)(@react-native/metro-config@0.86.0)(react-native@0.86.0(@react-native/jest-preset@0.86.0(@babel/core@7.29.0)(react@19.2.3))(@react-native/metro-config@0.86.0)(@types/react@19.2.17)(react@19.2.3))(react@19.2.3))(react-native@0.86.0(@react-native/jest-preset@0.86.0(@babel/core@7.29.0)(react@19.2.3))(@react-native/metro-config@0.86.0)(@types/react@19.2.17)(react@19.2.3))(react@19.2.3))(react-native@0.86.0(@react-native/jest-preset@0.86.0(@babel/core@7.29.0)(react@19.2.3))(@react-native/metro-config@0.86.0)(@types/react@19.2.17)(react@19.2.3))(react@19.2.3):
     dependencies:
       react: 19.2.3
       react-native: 0.86.0(@react-native/jest-preset@0.86.0(@babel/core@7.29.0)(react@19.2.3))(@react-native/metro-config@0.86.0)(@types/react@19.2.17)(react@19.2.3)

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -43,6 +43,7 @@ patchedDependencies:
   expo-image-manipulator: patches/expo-image-manipulator@57.0.1.patch
   expo-background-task: patches/expo-background-task@57.0.1.patch
   '@mattermost/react-native-paste-input@2.0.1': patches/@mattermost__react-native-paste-input@2.0.1.patch
+  react-native-keyboard-controller@1.22.0: patches/react-native-keyboard-controller@1.22.0.patch
 
 allowUnusedPatches: false
 


### PR DESCRIPTION
## Summary

Prevents the iOS chat scroller from flashing or jumping when the message input changes height, while preserving the existing Android behavior.

Fixes TLON-6420

## Changes

- feed the floating composer height directly into the iOS list content inset
- keep older messages anchored while browsing history and continue following the latest message at the end
- commit iOS inset and offset updates together in the keyboard controller
- avoid double-counting composer padding in compact conversation lists

## How did I test?

- tested one-line and multiline composer growth at the bottom and mid-history on an iPhone 17 Pro simulator running iOS 26.4
- tested emoji keyboard resizing, momentum scrolling, chat remounting, context menus, and standard Dynamic Type sizes through 3XL
- verified the frozen pnpm install and dependency patch application
- `corepack pnpm --filter @tloncorp/app tsc`
- targeted `oxfmt` and `oxlint` passed with existing warnings only
- `git diff --check`