### PR TITLE
Cosmetic fixes: nickname spacing, note action label, gallery description, filter menu width, onboarding button width

### DIFF
--- a/apps/tlon-mobile/src/screens/Onboarding/AllowNotificationsScreen.tsx
+++ b/apps/tlon-mobile/src/screens/Onboarding/AllowNotificationsScreen.tsx
@@ -147,6 +147,10 @@ export const AllowNotificationsScreen = ({ navigation }: Props) => {
         />
         <YStack
           flex={1}
+          // Yoga drops cross-axis stretch when a horizontal margin is `auto`,
+          // so without an explicit width this hugs its text and the hero
+          // button below shrinks to match.
+          width="100%"
           paddingHorizontal="$2xl"
           maxWidth={600}
           marginHorizontal="auto"

--- a/apps/tlon-mobile/src/screens/Onboarding/SetNicknameScreen.tsx
+++ b/apps/tlon-mobile/src/screens/Onboarding/SetNicknameScreen.tsx
@@ -61,12 +61,16 @@ export const SetNicknameScreen = ({ navigation }: Props) => {
   });
 
   const onSubmit = handleSubmit(({ nickname }) => {
+    // iOS autocapitalize/autocomplete readily leaves a trailing space, which
+    // then shows up in derived names like "Sampel 's Group".
+    const trimmedNickname = nickname?.trim();
+
     signupContext.setOnboardingValues({
-      nickname,
+      nickname: trimmedNickname,
       userWasReadyAt: Date.now(),
     });
 
-    db.splashNickname.setValue(nickname ?? '');
+    db.splashNickname.setValue(trimmedNickname ?? '');
 
     if (!isTlonbotRevival) {
       // Once they've decided on a nickname, keep the existing best-effort
@@ -79,12 +83,12 @@ export const SetNicknameScreen = ({ navigation }: Props) => {
             throw new Error('No user ID found during nickname setup');
           }
 
-          if (!nickname) {
+          if (!trimmedNickname) {
             throw new Error('No nickname provided during nickname setup');
           }
 
           await store.updateCurrentUserProfile(
-            { nickname },
+            { nickname: trimmedNickname },
             { shouldThrow: true }
           );
         },
@@ -188,7 +192,10 @@ export const SetNicknameScreen = ({ navigation }: Props) => {
               message: 'Your nickname is limited to 30 characters',
             },
             validate: (value) => {
-              const result = validateNickname(value ?? '', '');
+              if (!value?.trim()) {
+                return 'Please enter a nickname.';
+              }
+              const result = validateNickname(value.trim(), '');
               if (!result.isValid) {
                 return getNicknameErrorMessage(result.errorType);
               }

--- a/apps/tlon-mobile/src/screens/Onboarding/SetNotificationsScreen.tsx
+++ b/apps/tlon-mobile/src/screens/Onboarding/SetNotificationsScreen.tsx
@@ -77,6 +77,7 @@ export const SetNotificationsScreen = ({ navigation }: Props) => {
       />
       <View
         flex={1}
+        width="100%"
         paddingHorizontal="$2xl"
         maxWidth={600}
         marginHorizontal="auto"

--- a/packages/api/src/client/wayfinding.test.ts
+++ b/packages/api/src/client/wayfinding.test.ts
@@ -1,7 +1,11 @@
 import { describe, expect, it } from 'vitest';
 
 import type * as db from '../types/models';
-import { botHomeGroupHasDefaultTitle } from './wayfinding';
+import {
+  botHomeGroupHasDefaultTitle,
+  generateBotHomeGroupTitle,
+  generatePersonalGroupTitle,
+} from './wayfinding';
 
 const groupWithTitle = (title: string) =>
   ({ title, hostUserId: '~zod' }) as db.Group;
@@ -32,5 +36,27 @@ describe('botHomeGroupHasDefaultTitle', () => {
         false
       );
     }
+  });
+});
+
+describe.each([
+  ['generatePersonalGroupTitle', generatePersonalGroupTitle],
+  ['generateBotHomeGroupTitle', generateBotHomeGroupTitle],
+])('%s', (_name, generateTitle) => {
+  it('builds the title from the nickname', () => {
+    expect(generateTitle({ id: '~zod', nickname: 'Dan' })).toBe("Dan's Group");
+  });
+
+  it('trims surrounding whitespace so the possessive stays flush', () => {
+    expect(generateTitle({ id: '~zod', nickname: 'Dan ' })).toBe("Dan's Group");
+    expect(generateTitle({ id: '~zod', nickname: '  Dan  ' })).toBe(
+      "Dan's Group"
+    );
+  });
+
+  it('falls back to the id when the nickname is missing or blank', () => {
+    expect(generateTitle({ id: '~zod' })).toBe("~zod's Group");
+    expect(generateTitle({ id: '~zod', nickname: '   ' })).toBe("~zod's Group");
+    expect(generateTitle({ id: '~zod', nickname: null })).toBe("~zod's Group");
   });
 });

--- a/packages/api/src/client/wayfinding.ts
+++ b/packages/api/src/client/wayfinding.ts
@@ -147,7 +147,7 @@ export function generatePersonalGroupTitle(contact: {
   id: string;
   nickname?: string | null;
 }) {
-  const displayName = contact.nickname || contact.id;
+  const displayName = contact.nickname?.trim() || contact.id;
   return `${displayName}'s Group`;
 }
 
@@ -155,6 +155,6 @@ export function generateBotHomeGroupTitle(contact: {
   id: string;
   nickname?: string | null;
 }) {
-  const displayName = contact.nickname || contact.id;
+  const displayName = contact.nickname?.trim() || contact.id;
   return `${displayName}'s Group`;
 }

--- a/packages/app/features/top/MessagesFilterMenu.tsx
+++ b/packages/app/features/top/MessagesFilterMenu.tsx
@@ -3,10 +3,18 @@ import { AnalyticsEvent, trackEvent } from '@tloncorp/shared';
 import * as store from '@tloncorp/shared/store';
 import { PropsWithChildren, useCallback, useMemo, useState } from 'react';
 
-import { ActionSheet, createActionGroups } from '../../ui';
+import {
+  ActionSheet,
+  DESKTOP_FLYOUT_MIN_WIDTH,
+  createActionGroups,
+  isWeb,
+  useIsWindowNarrow,
+} from '../../ui';
 
 export function MessagesFilterMenu({ children }: PropsWithChildren) {
   const [isOpen, setIsOpen] = useState(false);
+  const isWindowNarrow = useIsWindowNarrow();
+  const isDesktopFlyout = isWeb && !isWindowNarrow;
   const { data } = store.useMessagesFilter();
   const talkFilter = data ?? 'Direct Messages';
 
@@ -62,7 +70,15 @@ export function MessagesFilterMenu({ children }: PropsWithChildren) {
       mode="popover"
       trigger={children}
     >
-      <ActionSheet.ScrollableContent width={240}>
+      <ActionSheet.ScrollableContent
+        width={
+          isDesktopFlyout
+            ? DESKTOP_FLYOUT_MIN_WIDTH
+            : isWindowNarrow
+              ? '100%'
+              : 240
+        }
+      >
         <ActionSheet.SimpleActionGroupList actionGroups={actionGroups} />
       </ActionSheet.ScrollableContent>
     </ActionSheet>

--- a/packages/app/fixtures/Form.fixture.tsx
+++ b/packages/app/fixtures/Form.fixture.tsx
@@ -52,7 +52,7 @@ const FormFixture = () => {
     },
     {
       title: 'Gallery',
-      subtitle: 'Gather, connect, and arrange rich media',
+      subtitle: 'Gather and arrange rich media',
       value: 'gallery',
       icon: 'ChannelGalleries',
     },

--- a/packages/app/ui/components/ManageChannels/CreateChannelSheet.tsx
+++ b/packages/app/ui/components/ManageChannels/CreateChannelSheet.tsx
@@ -43,7 +43,7 @@ function buildChannelTypes(
   };
   const gallery: Form.ListItemInputOption<ChannelTypeName> = {
     title: 'Gallery',
-    subtitle: 'Gather, connect, and arrange rich media',
+    subtitle: 'Gather and arrange rich media',
     value: 'gallery',
     icon: 'ChannelGalleries',
   };

--- a/packages/app/ui/components/NotesChannel/NotesTreeRows.tsx
+++ b/packages/app/ui/components/NotesChannel/NotesTreeRows.tsx
@@ -192,7 +192,7 @@ export function NoteRow({
   const referenceSection = (
     <ActionSheet.ActionGroup accent="neutral">
       <ActionSheet.CopyAction
-        action={{ title: 'Copy link to note', startIcon: 'Copy' }}
+        action={{ title: 'Copy Tlon reference', startIcon: 'Copy' }}
         copyText={getNoteReferencePath(
           `notes/${note.notebookFlag}`,
           note.noteId


### PR DESCRIPTION
## Summary

Omnibus of five cosmetic fixes from the S4E1 project. Each Linear issue is its own commit, so they can be reviewed — or reverted — independently.

Closes TLON-6427
Closes TLON-6421
Closes TLON-6418
Closes TLON-6397
Closes TLON-6380

## Changes

**TLON-6427 — iOS: extra space before apostrophe in TlonBot group title** (`571076ab3e`)

`autoCapitalize="words"` plus autocomplete readily leaves a trailing space on the onboarding nickname, and that raw value reached the group title templates, producing `"Sampel 's Group"`.

- `SetNicknameScreen` trims on submit, so `splashNickname`, the signup context, and the profile update all receive the clean value. Whitespace-only input now fails validation instead of satisfying `required`.
- `generatePersonalGroupTitle` / `generateBotHomeGroupTitle` trim as well, so accounts that already stored a padded nickname get a correct title the next time it regenerates. `getDefaultBotName` was already trimming; this brings the group-title path in line.

**TLON-6421 — Rename "Copy Link to Note"** (`bf79d1c1d7`)

Now **"Copy Tlon reference"**. The copied value is unchanged. One call site in `NotesTreeRows`, shared by mobile and desktop.

Two judgment calls worth a look: I used sentence case to match every other label in that sheet ("Publish to web", "View published note", "Copy link"), and I took the acceptance criteria's wording over Bill's shorter "Copy Reference" suggestion in the issue thread. Happy to switch to either variant.

**TLON-6418 — Gallery description cut off on creation screen** (`82d57ee6d5`)

Only the *selected* row truncates: it renders a check badge in `ListItem.EndContent` that the other rows don't, so it alone loses that width from its subtitle. Gallery's was the only one long enough to overflow. Shortened to "Gather and arrange rich media" (29 chars, comfortably under Bulletin's 34, which fits alongside the badge). Fixed the Form fixture to match.

**TLON-6397 — Center buttons orientation on desktop** (`f026456dcc`)

`MessagesFilterMenu` hardcoded a 240px content width inside a popover frame that is `DESKTOP_FLYOUT_MIN_WIDTH` (300px), leaving the options visibly short of the overlay's right edge. Now uses the same width expression as `ChatOptionsSheet`, whose group and DM menus already sit flush. That also covers the narrow-window case, where the hardcoded 240px was being applied to a bottom sheet.

**TLON-6380 — Restore onboarding "Next" button to normal width** (`a0381f7dbe`)

Bill's clarification in the thread was the accurate read: the button is *narrower* than the one on the preceding screen, not stretched.

Yoga drops cross-axis stretch when a horizontal margin is `auto`, so `AllowNotificationsScreen`'s container sized to its widest child rather than the screen, and `paddingHorizontal="$2xl"` never pushed anything outward. The hero button then stretched only to that collapsed width. Adding an explicit `width="100%"` alongside the existing `maxWidth={600}` restores full width while keeping the centering. `SetNotificationsScreen` carries the same latent bug — currently masked by its wide `NotificationLevelSelector` — so it gets the same prop.

## How did I test?

- `pnpm vitest run src/client/wayfinding.test.ts` in `packages/api` — 16 passing, including new coverage for the title generators (trailing space, surrounding whitespace, blank-nickname fallback to the ship ID).
- `tsc --noEmit` clean for `packages/api`, `packages/app`, and `apps/tlon-mobile`. (`packages/app` reports the usual `@tloncorp/editor/dist/editorHtml` resolution error until `build:packages` runs; unrelated and pre-existing.)
- `pnpm format:check` clean.
- TLON-6418, TLON-6397 and TLON-6380 were diagnosed by reading the layout code against the issue screenshots rather than by booting a simulator. For TLON-6380 I measured the screenshot to confirm the mechanism: the button spans x=86–465px and the line "On the next screen, make sure you tap" spans x=87–464px — identical, which is the signature of a shrink-to-content container.

**Not yet verified on device.** The three layout changes deserve a quick visual pass before merge: the channel-creation sheet with Gallery selected, the desktop Messages filter menu, and the two onboarding notification screens back to back.

## Risks and impact

- Safe to rollback without consulting PR author? **Yes** — five independent cosmetic commits, no schema, API, or persisted-state changes.
- Affects important code area:
  - [x] Onboarding
  - [ ] State / providers
  - [ ] Message sync
  - [ ] Channel display
  - [ ] Notifications
  - [x] Other: desktop Messages sidebar filter menu; notes action sheet; channel-creation sheet

Notes on blast radius:

- The nickname trim changes what gets persisted for new signups. It does not migrate existing contacts — an account whose stored nickname already has a trailing space keeps it, and its group title only corrects itself the next time the title regenerates. One consequence worth knowing: `botHomeGroupHasDefaultTitle` won't recognize an already-malformed `"James 's Group"` as a default title, so the automatic rename-on-nickname-change skips those. Left alone deliberately, since matching malformed titles seemed worse than the edge case.
- Rejecting whitespace-only nicknames is a small behavior change on that screen: the Next button now stays disabled where it previously enabled.
- The onboarding `width="100%"` addition changes layout on every mobile width, which is why the on-device pass above matters most there.

## Rollback plan

`git revert` any individual commit — they touch disjoint files apart from the two `packages/api/src/client/wayfinding*` files, which belong to a single commit. Reverting the whole branch restores prior behavior with no cleanup or migration.

## Screenshots / videos

Before-state screenshots are attached to the Linear issues (TLON-6418, TLON-6397, TLON-6380). After-state captures pending the on-device pass noted above.
