### PR TITLE
fix android floating composer chrome

### DIFF
--- a/packages/app/ui/components/MessageInput/MessageInputBase.tsx
+++ b/packages/app/ui/components/MessageInput/MessageInputBase.tsx
@@ -301,9 +301,15 @@ MessageInputContainer.displayName = 'MessageInputContainer';
 
 const usesFloatingChrome = Platform.OS !== 'web';
 const usesIOSGlass = supportsLiquidGlass();
+const usesAndroidMaterialChrome = Platform.OS === 'android';
+const materialChromeAlignment = usesAndroidMaterialChrome
+  ? 'flex-end'
+  : 'center';
 
 const materialSurfaceProps = {
-  backgroundColor: '$secondaryBackground',
+  backgroundColor: usesAndroidMaterialChrome
+    ? '$background'
+    : '$secondaryBackground',
   boxShadow: '0 2px 6px rgba(0, 0, 0, 0.24)',
 } as const;
 
@@ -377,7 +383,7 @@ function MessageInputChromeRow({
     return (
       <XStack
         width="100%"
-        alignItems="center"
+        alignItems={materialChromeAlignment}
         gap={metrics.rowGap}
         paddingHorizontal={metrics.rowPaddingHorizontal}
         paddingVertical={metrics.rowPaddingVertical}
@@ -464,10 +470,14 @@ function MessageInputChromeBody({
           flex={1}
           minHeight={metrics.controlSize}
           borderRadius={metrics.controlRadius}
-          alignItems="center"
+          alignItems={materialChromeAlignment}
           gap={metrics.rowGap}
           backgroundColor={
-            isEditing ? '$positiveBackground' : '$secondaryBackground'
+            isEditing
+              ? '$positiveBackground'
+              : usesAndroidMaterialChrome
+                ? '$background'
+                : '$secondaryBackground'
           }
           overflow="hidden"
         >
@@ -527,7 +537,7 @@ function MessageInputChromeSendAction({ children }: PropsWithChildren) {
   return (
     <View
       top={usesFloatingChrome ? undefined : 2}
-      alignSelf={usesFloatingChrome ? 'center' : undefined}
+      alignSelf={usesFloatingChrome ? materialChromeAlignment : undefined}
     >
       {children}
     </View>


### PR DESCRIPTION
## Summary

Makes the Android floating message composer use white surfaces and keeps the attachment and send controls pinned to the bottom as the composer grows.

Fixes TLON-6425

## Changes

- use the normal background color for Android floating composer surfaces, including the attachment button
- bottom-align the attachment control with the growing composer
- bottom-align the send control inside the composer
- preserve the existing iOS and web styling

## How did I test?

- verified a PDF attachment in the production `MessageInput` fixture on a physical Samsung SM-S921U (Android 16 / SDK 36)
- confirmed the composer and plus button are white while the file preview remains gray
- confirmed the plus and send buttons stay aligned to the bottom of the expanded composer
- `corepack pnpm exec oxfmt --check ui/components/MessageInput/MessageInputBase.tsx`
- `corepack pnpm exec oxlint ui/components/MessageInput/MessageInputBase.tsx`
- `corepack pnpm tsc`
- `stim logs --errors`
- `git diff --check`

## Screenshots

| Before | After |
| --- | --- |
| <img src="https://github.com/user-attachments/assets/21244fe0-0e4f-4938-8e73-0897c157301a" alt="Before: centered controls and gray plus surface" width="320" /> | <img src="https://github.com/user-attachments/assets/3d34ab38-b19b-49fc-9917-ece09406fb02" alt="After: white controls aligned to the composer bottom" width="320" /> |