### PR TITLE
Fix duplicate header on bot provider connection and API key screens

### DIFF
--- a/packages/app/features/settings/BotApiKeySettingsScreen.tsx
+++ b/packages/app/features/settings/BotApiKeySettingsScreen.tsx
@@ -194,6 +194,7 @@ export function BotApiKeySettingsScreen(props: Props) {
         borderBottom
         backAction={isWindowNarrow ? handleBack : undefined}
         title={`${provider.label} API key`}
+        placement="navigation"
       />
       <SettingsContentScrollView
         paddingHorizontal="$l"

--- a/packages/app/features/settings/BotOpenAISubscriptionScreen.tsx
+++ b/packages/app/features/settings/BotOpenAISubscriptionScreen.tsx
@@ -120,6 +120,7 @@ export function BotOpenAISubscriptionScreen(props: Props) {
         }}
         backDisabled={!canDismissOpenAIAuth(auth.state.phase)}
         title={subscriptionName}
+        placement="navigation"
       />
       {queries.llmAuthStatusQuery.isLoading ? (
         <YStack flex={1} alignItems="center" justifyContent="center" gap="$m">


### PR DESCRIPTION
## Summary

`BotOpenAISubscription` and `BotApiKeySettings` were opted into the RootStack's native header but still rendered a content-placement `ScreenHeader`, so both screens drew two headers on native. Adding `placement="navigation"` hands the title and back action to the native header and drops the content copy.

Fixes TLON-6429

## Changes

- `BotOpenAISubscriptionScreen`: `ScreenHeader` now uses `placement="navigation"`.
- `BotApiKeySettingsScreen`: same — the sibling route in the same flow had the identical omission.

Both routes carry `nativeHeaderScreenOptions` in `RootStack`, which sets `headerShown: true` on native. A screen on such a route is expected to render `<ScreenHeader placement="navigation">`, which installs the title/actions on the native header and returns `null` in content. These two were the only routes of the 20 opted in that were never switched over, so their native header rendered with no title — hence the raw route name in the screenshot.

The symptom differed by state, because only some branches mount a `ScreenScrollView`:

- **Connect state** (`LLMSubscriptionAuthView`, plain `ScrollView`) — native header stayed opaque, so it stacked above the screen's own header. Two visible headers, extra vertical space, lower chevron still worked.
- **Connected state** (`SettingsContentScrollView`) — `useScreenScrollProps` installs `headerTransparent: true` on iOS 26 with Liquid Glass, so the native header floated *over* the screen's own header and swallowed taps on the back chevron. Since `headerBackVisible: false` is set navigator-wide and no `headerLeft` was installed, there was no back control at all — the user was stranded with no way back to bot settings.

`backDisabled` carries through to the native item as `disabled`, so the auth flow can still hold back mid-connection.

## How did I test?

- Audited all 20 RootStack routes carrying `nativeHeaderScreenOptions`; these two were the only ones missing `placement="navigation"`.
- `tsc --noEmit` clean on `packages/app`.
- `oxfmt --check` clean.
- `vitest`: ScreenHeader + nativeHeaderOptions suites (11 tests) and `features/settings` (86 tests) pass.
- Confirmed `canDismissOpenAIAuth('idle')` is true and that the controller calls `reset()` after `onComplete` resolves, so neither `backDisabled` nor `usePreventRemove` stays latched once a subscription connects.

**Not device-verified.** Reaching these screens needs hosted bot auth and a live subscription, and the bug is native-only (`useNativeHeader` no-ops on web), so it can't be reproduced in a browser. Worth a look on an iOS 26 device before merge.

## Risks and impact

- Safe to rollback without consulting PR author? Yes
- Affects important code area:
  - [ ] Onboarding
  - [ ] State / providers
  - [ ] Message sync
  - [ ] Channel display
  - [ ] Notifications
  - [x] Other: navigation headers on two bot settings screens (native only — web/desktop unaffected, that navigator sets `headerShown: false`)

## Rollback plan

Revert the commit. Two JSX props, no state, schema, or API surface touched.

## Screenshots / videos

<img width="568" height="1084" alt="image" src="https://github.com/user-attachments/assets/604088da-6172-4e32-a464-d5e565248ac5" />


🤖 Generated with [Claude Code](https://claude.com/claude-code)
