### PR TITLE
mobile: handle each notification response once per process

### DIFF
--- a/apps/tlon-mobile/src/__uitests__/useNotificationListener.test.ts
+++ b/apps/tlon-mobile/src/__uitests__/useNotificationListener.test.ts
@@ -4,6 +4,8 @@ import {
   getMissingNotificationTargetRecovery,
   getNotificationRouteCategory,
   groupInvitePreviewRouteStack,
+  notificationResponseKey,
+  takeNotificationResponse,
 } from '../hooks/useNotificationListener';
 import { parseNotificationPayload } from '../lib/notificationPayload';
 import {
@@ -513,5 +515,51 @@ describe('foreground notification presentation', () => {
         viewedChannelId: '~sampel-palnet',
       })
     ).toBe(false);
+  });
+});
+
+
+describe('replayed notification responses (TLON-6424)', () => {
+  const notificationWith = (data: Record<string, unknown>, identifier = 'uid-1') =>
+    ({
+      date: 1,
+      request: {
+        identifier,
+        content: { data },
+        trigger: null,
+      },
+    }) as never;
+
+  it('gives a replayed response the same key as the original', () => {
+    const payload = { type: 'channelNotification', channelId: 'chat/~zod/product' };
+    expect(notificationResponseKey(notificationWith(payload))).toBe(
+      notificationResponseKey(notificationWith(payload))
+    );
+  });
+
+  it('gives a different notification a different key, even when the identifier repeats', () => {
+    // `google.message_id` falls back to a reused int id when the payload has no
+    // uid, so the identifier alone cannot separate two taps.
+    const first = notificationWith({ uid: 'a', channelId: 'chat/~zod/product' }, '7');
+    const second = notificationWith({ uid: 'b', channelId: 'chat/~zod/product' }, '7');
+    expect(notificationResponseKey(first)).not.toBe(notificationResponseKey(second));
+  });
+
+  it('handles a response once and refuses the replay', () => {
+    const handled = new Set<string>();
+    const key = notificationResponseKey(notificationWith({ uid: 'a' }));
+    expect(takeNotificationResponse(key, handled)).toBe(true);
+    expect(takeNotificationResponse(key, handled)).toBe(false);
+    expect(takeNotificationResponse(key, handled)).toBe(false);
+  });
+
+  it('still handles a genuinely new tap after one was handled', () => {
+    const handled = new Set<string>();
+    expect(
+      takeNotificationResponse(notificationResponseKey(notificationWith({ uid: 'a' })), handled)
+    ).toBe(true);
+    expect(
+      takeNotificationResponse(notificationResponseKey(notificationWith({ uid: 'b' })), handled)
+    ).toBe(true);
   });
 });

--- a/apps/tlon-mobile/src/hooks/useNotificationListener.ts
+++ b/apps/tlon-mobile/src/hooks/useNotificationListener.ts
@@ -52,6 +52,35 @@ import {
 
 const logger = createDevLogger('useNotificationListener', false);
 
+// expo-notifications buffers a tap that arrives before JS is ready and replays
+// it to every listener registering afterwards, without ever emptying that
+// buffer (Android `NotificationManager.pendingNotificationResponsesFromExtras`).
+// A process started from a tap therefore re-delivers the same response whenever
+// a listener re-registers, so the app routes to that channel on every open
+// until the process dies.
+const handledNotificationResponseKeys = new Set<string>();
+
+export function notificationResponseKey(notification: Notification): string {
+  let payloadKey: string;
+  try {
+    payloadKey = JSON.stringify(pickPlatformPayload(notification)) ?? 'null';
+  } catch {
+    payloadKey = 'unserializable';
+  }
+  return `${notification.request.identifier}::${payloadKey}`;
+}
+
+export function takeNotificationResponse(
+  key: string,
+  handled: Set<string> = handledNotificationResponseKeys
+): boolean {
+  if (handled.has(key)) {
+    return false;
+  }
+  handled.add(key);
+  return true;
+}
+
 const notificationSyncCtx = {
   priority: SyncPriority.High + 1,
   retry: true,
@@ -175,6 +204,14 @@ export default function useNotificationListener() {
   useEffect(() => {
     if (notificationResponse != null) {
       try {
+        if (
+          !takeNotificationResponse(
+            notificationResponseKey(notificationResponse.notification)
+          )
+        ) {
+          return;
+        }
+
         const data = payloadFromNotification(notificationResponse.notification);
 
         // If the NSE caught an error, it puts it in a list under


### PR DESCRIPTION
Fixes [TLON-6424](https://linear.app/tlon/issue/TLON-6424).

## Summary

After tapping a notification, the Android app routes to that channel on every subsequent open until the app is force killed. The tap is delivered once, but `expo-notifications` re-emits it to JS repeatedly.

## Changes

`expo-notifications` buffers a tap that arrives before the JS module exists — the cold-start-from-tap case — in `NotificationManager.pendingNotificationResponsesFromExtras` (Android). It replays that buffer to **every** listener registering afterwards and never empties it: the field has a declaration, a read, and an add, and no clear anywhere. So a process started from a tap re-delivers the same response whenever a listener registers, and the routing effect navigates again. The buffer is process-scoped, which is exactly why "killing/re-opening does fix this".

The routing effect now records each response it handles and ignores one whose key it has already seen. The record lives at module scope, so it survives a remount and lasts exactly as long as the buffer it guards.

The key is the request identifier **plus** the payload, not the identifier alone. `buildMessagingTappable` sets `google.message_id` to `extras["uid"] ?: extras["id"] ?: id.toString()`, so the identifier repeats whenever a message carries no uid — the same reuse that `clearLastNotificationResponseAsync()` was added to tolerate. A replay carries a byte-identical payload; a genuinely new tap does not.

This is a workaround for an upstream bug. It cannot be fixed with a patch here: expo modules are consumed as prebuilt artifacts in this project (`gradlew projects` lists `📦 expo-notifications (57.0.6)`), so edits to its Kotlin never compile — I confirmed that by dexing the APK. The upstream fix is to empty the buffer after replaying it.

## How did I test?

- `npx jest src/__uitests__/useNotificationListener.test.ts` — 28 pass, including 4 new cases: a replay keys the same as the original, two taps sharing a reused identifier key differently, a repeat is refused, and a genuinely new tap is still handled
- `tsc --noEmit` for `tlon-mobile` — clean
- `stim android --variant productionDebug` on an emulator — builds, launches, `stim logs --errors` exits 0

**Not verified end to end.** I could not complete login on the emulator, so I never watched a before/after navigation. What is verified is the mechanism in expo's shipped source and the dedup behaviour in tests. I also ruled out the other candidate — a sticky task intent — by experiment: after `am kill`, with "Don't keep activities", and on a plain launcher relaunch, `MainActivity.onCreate` always saw `gmid=null`, and the task's stored base intent carries no extras.

Worth a device check before merge: tap a notification, background the app, reopen it, and confirm it lands on the channel list rather than the channel.

## Risks and impact

- Suppression is scoped to one process and to an identical identifier+payload, so a later notification — even one reusing the integer id — still routes.
- If a user could legitimately tap the same notification twice, the second tap would be ignored; notifications are built with `setAutoCancel(true)`, so the notification is dismissed on the first tap.
- Safe to rollback without consulting PR author? (Yes)
- Affects important code area:
  - [x] Notifications

## Rollback plan

Revert the PR. The change is one guard in one effect plus its tests.

## Screenshots / videos

n/a
