### PR TITLE
fix gallery comments under reply composer

### DIFF
--- a/packages/app/ui/components/Channel/DraftInputView.tsx
+++ b/packages/app/ui/components/Channel/DraftInputView.tsx
@@ -52,11 +52,13 @@ const supportsFloatingComposer = Platform.OS !== 'web';
 export function ConversationComposerPlacement({
   children,
   enabled,
+  avoidKeyboard = false,
   onFloatingHeightChange,
   contentProps,
   inlineID,
 }: PropsWithChildren<{
   enabled: boolean;
+  avoidKeyboard?: boolean;
   onFloatingHeightChange?: (height: number) => void;
   contentProps?: ComponentProps<typeof View>;
   inlineID?: string;
@@ -114,15 +116,24 @@ export function ConversationComposerPlacement({
     );
   }
 
-  if (contentProps || inlineID) {
-    return (
+  const inlineContent =
+    contentProps || inlineID ? (
       <View id={inlineID} {...contentProps}>
         {children}
       </View>
+    ) : (
+      children
+    );
+
+  if (avoidKeyboard && Platform.OS === 'ios') {
+    return (
+      <KeyboardStickyView offset={{ closed: 0, opened: insets.bottom }}>
+        {inlineContent}
+      </KeyboardStickyView>
     );
   }
 
-  return <>{children}</>;
+  return <>{inlineContent}</>;
 }
 
 const styles = StyleSheet.create({

--- a/packages/app/ui/components/DetailView.tsx
+++ b/packages/app/ui/components/DetailView.tsx
@@ -130,6 +130,7 @@ export const DetailView = ({
     <View
       paddingHorizontal={isChat ? '$m' : undefined}
       flex={1}
+      overflow={isChat ? undefined : 'hidden'}
       {...containingProperties}
     >
       <Scroller

--- a/packages/app/ui/components/PostScreenView.tsx
+++ b/packages/app/ui/components/PostScreenView.tsx
@@ -924,6 +924,7 @@ function SinglePostView({
         {replyInput && (
           <ConversationComposerPlacement
             enabled={hasFloatingReplyInput}
+            avoidKeyboard={!hasFloatingReplyInput}
             contentProps={containingProperties}
             inlineID="reply-container"
             onFloatingHeightChange={onFloatingHeightChange}

--- a/packages/app/ui/components/PostScreenView.tsx
+++ b/packages/app/ui/components/PostScreenView.tsx
@@ -830,15 +830,16 @@ function SinglePostView({
       isEditingParent &&
       (channel.type === 'notebook' || channel.type === 'gallery')
     );
+  const hasFloatingReplyInput = canRenderReplyInput && isChatChannel;
   const { bottom } = useSafeAreaInsets();
   const { contentInsets, onFloatingHeightChange } = useConversationInsets({
-    hasFloatingComposer: canRenderReplyInput,
+    hasFloatingComposer: hasFloatingReplyInput,
     hasTransparentHeader: isChatChannel,
   });
   // Native floating composers include the home-indicator inset. Web composers
   // stay inline, so the screen still owns its bottom safe-area clearance.
   const screenBottomInset =
-    canRenderReplyInput && Platform.OS !== 'web' ? undefined : bottom;
+    hasFloatingReplyInput && Platform.OS !== 'web' ? undefined : bottom;
 
   const threadComposerContext = useMemo(
     (): DraftInputContext => ({
@@ -922,7 +923,7 @@ function SinglePostView({
 
         {replyInput && (
           <ConversationComposerPlacement
-            enabled
+            enabled={hasFloatingReplyInput}
             contentProps={containingProperties}
             inlineID="reply-container"
             onFloatingHeightChange={onFloatingHeightChange}


### PR DESCRIPTION
## Summary

Stops gallery and notebook reply composers from floating over comments while keeping chat composers floating.

Fixes TLON-6419

## Changes

- float reply composers only in chat channels
- clip non-chat detail scrollers at the docked composer boundary
- keep docked reply composers above the iOS keyboard

## How did I test?

- reproduced the overlap in the production gallery detail screen on a Stim-owned iPhone simulator
- confirmed comments stop above the docked Reply composer after the fix
- reproduced the iOS keyboard covering the docked Reply input, then confirmed it stays above the keyboard with the same safe-area offset used by chat
- compared full-resolution before and after screenshots with Argent
- `corepack pnpm --filter @tloncorp/app tsc`
- targeted `oxfmt` and `oxlint` passed with existing warnings only
- `git diff --check`

## Screenshots

| Before | After |
| --- | --- |
| <img src="https://github.com/user-attachments/assets/1eaa9073-aceb-4ab9-a694-5f0caa0f0b5a" alt="Before: gallery comments paint under the floating Reply composer" width="320" /> | <img src="https://github.com/user-attachments/assets/8f3cea92-5deb-4bdc-b7d8-2ccce27ac436" alt="After: gallery comments stop above the docked Reply composer" width="320" /> |
