### PR TITLE
restore the iOS channel header fade

### DIFF
--- a/packages/app/ui/components/Channel/ContextLens/ContextLensPanel.tsx
+++ b/packages/app/ui/components/Channel/ContextLens/ContextLensPanel.tsx
@@ -2,7 +2,14 @@ import { lensRunMatchesChannel } from '@tloncorp/shared/logic';
 import * as store from '@tloncorp/shared/store';
 import { Icon, Pressable } from '@tloncorp/ui';
 import { useEffect, useMemo, useState } from 'react';
-import { ScrollView, SizableText, View, XStack, YStack } from 'tamagui';
+import {
+  ScrollView,
+  SizableText,
+  View,
+  XStack,
+  YStack,
+  getTokens,
+} from 'tamagui';
 
 import { CopyRawPayloadButton } from './CopyRawPayloadButton';
 import { RecentRunList } from './RecentRunList';
@@ -158,12 +165,14 @@ export function ContextLensPanel({
   selectedMessage,
   onClearSelectedMessage,
   channelId,
+  topInset = 0,
 }: {
   events: ContextLensEvent[];
   streamStatus: LensStreamState['status'];
   selectedMessage?: ContextLensSelectedMessage | null;
   onClearSelectedMessage?: () => void;
   channelId?: string;
+  topInset?: number;
 }) {
   const gatewayConfig = useContextLensGatewayConfig();
   const [selectedRun, setSelectedRun] = useState<ContextLensEvent | null>(null);
@@ -375,6 +384,7 @@ export function ContextLensPanel({
       borderColor="$border"
       backgroundColor="$background"
       padding="$l"
+      paddingTop={getTokens().space.l.val + topInset}
       gap="$l"
     >
       <XStack alignItems="center" justifyContent="space-between">

--- a/packages/app/ui/components/Channel/index.tsx
+++ b/packages/app/ui/components/Channel/index.tsx
@@ -27,6 +27,7 @@ import {
   View,
   XStack,
   YStack,
+  getTokens,
   getVariableValue,
   useTheme,
 } from 'tamagui';
@@ -48,10 +49,11 @@ import { FileDrop } from '../FileDrop';
 import { supportsLiquidGlass } from '../GlassSurface';
 import { GroupPreviewAction, GroupPreviewSheet } from '../GroupPreviewSheet';
 import { PostCollectionView } from '../PostCollectionView';
-import SystemNotices from '../SystemNotices';
+import SystemNotices, { hasRelevantJoinRequests } from '../SystemNotices';
 import { AgentOnboardingBackTooltip } from '../Wayfinding/Notices';
 import {
   floatingPinnedPostBannerClearance,
+  getPostCollectionTopInset,
   useConversationInsets,
 } from '../conversationScrollChrome';
 import { DraftInputContext } from '../draftInputs';
@@ -880,14 +882,20 @@ export function Channel({
     (shouldReservePinnedPostBannerSpace
       ? floatingPinnedPostBannerClearance
       : 0);
+  const shouldRenderJoinRequestNotice =
+    !!includeJoinRequestNotice && hasRelevantJoinRequests(group);
   const postCollectionInsets = useMemo(
     () => ({
       ...contentInsets,
-      // The channel container clears floating top chrome so notices and side
-      // panels share the list's visible content boundary.
-      top: Math.max(0, contentInsets.top - sharedTopInset),
+      // Keep the scroll view beneath transparent chrome so iOS can render its
+      // top edge effect. A visible fixed notice owns that clearance instead.
+      top: getPostCollectionTopInset({
+        contentTopInset: contentInsets.top,
+        fixedLeadingContentOwnsInset: shouldRenderJoinRequestNotice,
+        sharedTopInset,
+      }),
     }),
-    [contentInsets, sharedTopInset]
+    [contentInsets, sharedTopInset, shouldRenderJoinRequestNotice]
   );
 
   return (
@@ -992,15 +1000,21 @@ export function Channel({
                           <XStack
                             alignItems="stretch"
                             flex={1}
-                            paddingTop={sharedTopInset || undefined}
+                            paddingTop={
+                              draftInputPresentationMode === 'fullscreen'
+                                ? sharedTopInset || undefined
+                                : undefined
+                            }
                             position="relative"
                           >
                             <YStack alignItems="stretch" flex={1} minWidth={0}>
-                              {includeJoinRequestNotice && (
+                              {shouldRenderJoinRequestNotice && (
                                 <SystemNotices.ConnectedJoinRequestNotice
                                   group={group}
                                   onViewRequests={goToGroupSettings}
-                                  marginTop="$l"
+                                  marginTop={
+                                    sharedTopInset + getTokens().space.l.val
+                                  }
                                 />
                               )}
                               <AnimatePresence>
@@ -1099,6 +1113,7 @@ export function Channel({
                                     clearSelectedContextLensMessage
                                   }
                                   channelId={channel.id}
+                                  topInset={sharedTopInset}
                                 />
                               )}
                           </XStack>

--- a/packages/app/ui/components/SystemNotices.tsx
+++ b/packages/app/ui/components/SystemNotices.tsx
@@ -534,16 +534,10 @@ export function ConnectedJoinRequestNotice({
   presentation?: SystemNoticePresentation;
 }) {
   // see if we have any pending join requests that haven't been dismissed
-  const hasRelevantJoinRequests = useMemo(() => {
-    if (group && group.joinRequests && group.joinRequests.length > 0) {
-      const dismissedAt = group.pendingMembersDismissedAt ?? 0;
-      return group.joinRequests.some((jr) => {
-        const requestedAt = jr.requestedAt ?? Date.now() - 24 * 60 * 60 * 1000;
-        return requestedAt > dismissedAt;
-      });
-    }
-    return false;
-  }, [group]);
+  const hasJoinRequests = useMemo(
+    () => hasRelevantJoinRequests(group),
+    [group]
+  );
 
   // handler to dismiss join requests
   const handleDismissJoinRequests = useCallback(() => {
@@ -557,12 +551,12 @@ export function ConnectedJoinRequestNotice({
 
   // clear any unread counts for the join requests whenever displayed
   useEffect(() => {
-    if (group && hasRelevantJoinRequests) {
+    if (group && hasJoinRequests) {
       store.markGroupRead(group.id, false);
     }
-  }, [group, hasRelevantJoinRequests]);
+  }, [group, hasJoinRequests]);
 
-  if (!hasRelevantJoinRequests) {
+  if (!hasJoinRequests) {
     return null;
   }
 
@@ -575,6 +569,18 @@ export function ConnectedJoinRequestNotice({
       presentation={presentation}
     />
   );
+}
+
+export function hasRelevantJoinRequests(group?: db.Group | null) {
+  if (!group?.joinRequests?.length) {
+    return false;
+  }
+
+  const dismissedAt = group.pendingMembersDismissedAt ?? 0;
+  return group.joinRequests.some((request) => {
+    const requestedAt = request.requestedAt ?? Date.now() - 24 * 60 * 60 * 1000;
+    return requestedAt > dismissedAt;
+  });
 }
 
 export function NonHostAdminChannelNotice({

--- a/packages/app/ui/components/conversationInsets.test.ts
+++ b/packages/app/ui/components/conversationInsets.test.ts
@@ -4,6 +4,7 @@ import {
   floatingComposerEstimatedHeight,
   floatingPinnedPostBannerClearance,
   getConversationContentInsets,
+  getPostCollectionTopInset,
   unobscuredConversationBottomGap,
 } from './conversationInsets';
 
@@ -88,5 +89,27 @@ describe('getConversationContentInsets', () => {
         hasFloatingPinnedPostBanner: false,
       }).bottom
     ).toBe(34 + unobscuredConversationBottomGap);
+  });
+});
+
+describe('getPostCollectionTopInset', () => {
+  it('keeps the full inset in the scroll content when no fixed notice is visible', () => {
+    expect(
+      getPostCollectionTopInset({
+        contentTopInset: 155,
+        fixedLeadingContentOwnsInset: false,
+        sharedTopInset: 155,
+      })
+    ).toBe(155);
+  });
+
+  it('does not duplicate clearance owned by a fixed leading notice', () => {
+    expect(
+      getPostCollectionTopInset({
+        contentTopInset: 155,
+        fixedLeadingContentOwnsInset: true,
+        sharedTopInset: 155,
+      })
+    ).toBe(0);
   });
 });

--- a/packages/app/ui/components/conversationInsets.ts
+++ b/packages/app/ui/components/conversationInsets.ts
@@ -25,6 +25,21 @@ export const floatingPinnedPostBannerClearance =
   floatingPinnedPostBannerHeight + floatingPinnedPostBannerGap;
 export const unobscuredConversationBottomGap = 8;
 
+export function getPostCollectionTopInset({
+  contentTopInset,
+  fixedLeadingContentOwnsInset,
+  sharedTopInset,
+}: {
+  contentTopInset: number;
+  fixedLeadingContentOwnsInset: boolean;
+  sharedTopInset: number;
+}) {
+  return Math.max(
+    0,
+    contentTopInset - (fixedLeadingContentOwnsInset ? sharedTopInset : 0)
+  );
+}
+
 export function getConversationContentInsets({
   platform,
   headerHeight,

--- a/packages/app/ui/components/conversationScrollChrome.tsx
+++ b/packages/app/ui/components/conversationScrollChrome.tsx
@@ -32,6 +32,7 @@ export {
   floatingPinnedPostBannerGap,
   floatingPinnedPostBannerHeight,
   floatingScrollControlClearance,
+  getPostCollectionTopInset,
 } from './conversationInsets';
 
 /** Owns all measured geometry reserved around a conversation list. */


### PR DESCRIPTION
## Summary

Restores the fade behind channel headers on iOS 26 while preserving the existing spacing for notices and side panels.

## Changes

- keep the channel scroll view underneath the transparent header so iOS can draw its top edge effect
- let visible join-request notices, fullscreen drafts, and the context panel own their header spacing without duplicating it
- add focused coverage for the list inset behavior

## How did I test?

- used Stim for the isolated mobile worktree and its worktree-owned Metro server
- built, installed, and launched the exact PR head on an iPhone 17 Pro simulator running iOS 26.4 with the repo build wrapper
- signed in to the preview app and visually verified that channel messages fade beneath the transparent top header while scrolling, with the existing bottom fade still visible
- `corepack pnpm --filter @tloncorp/app exec vitest run ui/components/conversationInsets.test.ts` (7 tests passed)
- `corepack pnpm --filter @tloncorp/app tsc`
- targeted `oxfmt --check` passed
- targeted `oxlint` passed with existing warnings only
- `git diff --check`