### PR TITLE
fix(notes): link published footer to tlon.io

### DIFF
--- a/packages/shared/src/logic/notesPublish.test.ts
+++ b/packages/shared/src/logic/notesPublish.test.ts
@@ -2,6 +2,17 @@ import { expect, test } from 'vitest';
 
 import { renderPublishedNoteHtml } from './notesPublish';
 
+test('renderPublishedNoteHtml links the published footer to Tlon', () => {
+  const html = renderPublishedNoteHtml({
+    title: 'Published note',
+    body: 'Hello',
+  });
+
+  expect(html).toContain(
+    '<div class="tlon-published-footer">Published from <a href="https://tlon.io">Tlon</a></div>'
+  );
+});
+
 test('renderPublishedNoteHtml renders markdown list children as list items', () => {
   const html = renderPublishedNoteHtml({
     title: 'List note',

--- a/packages/shared/src/logic/notesPublish.ts
+++ b/packages/shared/src/logic/notesPublish.ts
@@ -74,7 +74,7 @@ export function renderPublishedNoteHtml({
 <main>
 <h1>${escapeHtml(safeTitle)}</h1>
 ${bodyHtml || '<p></p>'}
-<div class="tlon-published-footer">Published from Tlon</div>
+<div class="tlon-published-footer">Published from <a href="https://tlon.io">Tlon</a></div>
 </main>
 </body>
 </html>`;


### PR DESCRIPTION
## Summary

Links “Tlon” in the footer of every published note to https://tlon.io.

## Changes

- Add the link to generated published-note HTML.
- Add regression coverage for the footer markup.

## How did I test?

- `pnpm --filter @tloncorp/shared test --run src/logic/notesPublish.test.ts`
- `pnpm --filter @tloncorp/shared tsc`
- `pnpm exec oxlint src/logic/notesPublish.ts src/logic/notesPublish.test.ts`

## Risks and impact

- Safe to rollback without consulting PR author? Yes
- Affects important code area:
  - [ ] Onboarding
  - [ ] State / providers
  - [ ] Message sync
  - [ ] Channel display
  - [ ] Notifications
  - [x] Other: Published notes rendering

## Rollback plan

Revert commit `09d9f0d1d`.

## Screenshots / videos

Not included; this only makes the existing “Tlon” footer text clickable.