### PR TITLE
normalize immutable cron update fields

### DIFF
--- a/packages/openclaw/index.ts
+++ b/packages/openclaw/index.ts
@@ -31,6 +31,7 @@ import {
   handleCronChangedEvent,
   setCronServiceAccessor,
 } from './src/cron-telemetry.js';
+import { stripImmutableCronUpdateAgentId } from './src/cron-tool-params.js';
 import {
   installTlonDiagnosticSubscriptions,
   shouldInstallTlonDiagnosticSubscriptions,
@@ -1044,11 +1045,20 @@ export default defineBundledChannelEntry({
               allowedProviderIds
             )));
       const isBlocked = blocksNonOwner || blocksOnboardingMcp;
+      const strippedImmutableCronAgentId =
+        event.toolName === 'cron' &&
+        !isBlocked &&
+        stripImmutableCronUpdateAgentId(event.params);
       const blockReason = blocksOnboardingMcp
         ? 'This scheduled onboarding update may inspect and call only selected-provider MCP tools explicitly described as read-only.'
         : blocksNonOwner
           ? `The ${event.toolName} tool is not available.`
           : undefined;
+      if (strippedImmutableCronAgentId) {
+        api.logger.info(
+          `[tlon] Removed immutable agentId from cron update patch. Session: ${ctx.sessionKey}`
+        );
+      }
       if (contextLensEnabled) {
         // Capture tool activity even when no conversation run owns this
         // session (cron wakes — including jobs that reuse the main session

--- a/packages/openclaw/src/cron-tool-params.test.ts
+++ b/packages/openclaw/src/cron-tool-params.test.ts
@@ -1,0 +1,60 @@
+import { describe, expect, it } from 'vitest';
+
+import { stripImmutableCronUpdateAgentId } from './cron-tool-params.js';
+
+describe('cron tool params', () => {
+  it('removes a populated immutable agent id from update patches', () => {
+    const params = {
+      action: 'update',
+      jobId: 'job-1',
+      patch: {
+        agentId: 'dev',
+        payload: { toolsAllow: ['web_search'] },
+      },
+    };
+
+    expect(stripImmutableCronUpdateAgentId(params)).toBe(true);
+    expect(params).toEqual({
+      action: 'update',
+      jobId: 'job-1',
+      patch: { payload: { toolsAllow: ['web_search'] } },
+    });
+  });
+
+  it('removes a schema-padded null agent id from update patches', () => {
+    const params = {
+      action: 'update',
+      patch: { agentId: null, description: 'updated description' },
+    };
+
+    expect(stripImmutableCronUpdateAgentId(params)).toBe(true);
+    expect(params.patch).toEqual({ description: 'updated description' });
+  });
+
+  it('does not alter add calls or update patches without agent id', () => {
+    const add = {
+      action: 'add',
+      job: { agentId: 'dev' },
+    };
+    const update = {
+      action: 'update',
+      patch: { description: 'updated description' },
+    };
+
+    expect(stripImmutableCronUpdateAgentId(add)).toBe(false);
+    expect(stripImmutableCronUpdateAgentId(update)).toBe(false);
+    expect(add).toEqual({ action: 'add', job: { agentId: 'dev' } });
+    expect(update).toEqual({
+      action: 'update',
+      patch: { description: 'updated description' },
+    });
+  });
+
+  it('ignores malformed tool params', () => {
+    expect(stripImmutableCronUpdateAgentId(null)).toBe(false);
+    expect(stripImmutableCronUpdateAgentId([])).toBe(false);
+    expect(
+      stripImmutableCronUpdateAgentId({ action: 'update', patch: null })
+    ).toBe(false);
+  });
+});

--- a/packages/openclaw/src/cron-tool-params.ts
+++ b/packages/openclaw/src/cron-tool-params.ts
@@ -1,0 +1,23 @@
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return value !== null && typeof value === 'object' && !Array.isArray(value);
+}
+
+/**
+ * OpenClaw exposes one broad cron schema for every action. Some providers fill
+ * unused schema fields, so an update can arrive with `patch.agentId` even when
+ * the model is only changing mutable payload fields. Core correctly rejects
+ * agent ownership changes; omit that immutable field so the remaining patch
+ * is validated and applied without changing ownership.
+ */
+export function stripImmutableCronUpdateAgentId(params: unknown): boolean {
+  if (!isRecord(params) || params.action !== 'update') {
+    return false;
+  }
+
+  const patch = params.patch;
+  if (!isRecord(patch) || !Object.hasOwn(patch, 'agentId')) {
+    return false;
+  }
+
+  return Reflect.deleteProperty(patch, 'agentId');
+}


### PR DESCRIPTION
## Summary

Allow a Tlon owner to repair an existing recurring job when the model provider pads its cron update patch with the immutable `agentId` field.

Fixes TLON-6433

## Changes

- remove only `patch.agentId` from authorized owner-issued cron updates before OpenClaw validates the remaining patch
- preserve cron ownership, add calls, non-owner blocking, and every mutable update field
- add focused regressions for populated, null-padded, absent, add-action, and malformed inputs
- avoid inspecting or matching message content; normalization uses structured cron parameters only

## How did I test?

- `corepack pnpm --filter @tloncorp/openclaw exec oxfmt --check index.ts src/cron-tool-params.ts src/cron-tool-params.test.ts`
- `corepack pnpm --filter @tloncorp/openclaw lint` — passed with pre-existing warnings only
- `corepack pnpm --filter @tloncorp/openclaw test` — 81 files, 1,691 tests passed
- `corepack pnpm --filter @tloncorp/openclaw tsc`
- exact baseline on OpenClaw 2026.7.1 / plugin `cfb8634` / OpenRouter `openai/gpt-5.6-luna` reproduced the repair loop: eight consecutive cron updates were rejected because schema padding supplied immutable `patch.agentId`; the job stayed unchanged and no manual run occurred
- candidate `815f55ffc2` on the same runtime, provider, fake ships, persisted job, and natural-language repair request removed the immutable field, updated the existing job, and queued a manual run
- the candidate run made successful Brave searches, enforced per-item publication-date verification, returned an empty digest when no item could be verified within 24 hours, finished `ok`, and was recorded as delivered to the fake owner
- the user-visible repair reply correctly withheld success until execution and delivery evidence existed
