### PR TITLE
simplify new agent group setup

### DIFF
--- a/packages/app/features/top/CreateChatSheet.tsx
+++ b/packages/app/features/top/CreateChatSheet.tsx
@@ -760,15 +760,6 @@ function useCreateChat() {
                     'Agent group setup failed after opening',
                     error
                   );
-                  // Durable intro/provision posts take over once present. If
-                  // furnishing failed earlier, clear its provisional marker.
-                  void db.agentGroupOnboardingLocks.setValue((current) => {
-                    const lock = current[furnishing.group.id];
-                    if (!lock || lock.provision) return current;
-                    const remaining = { ...current };
-                    delete remaining[furnishing.group.id];
-                    return remaining;
-                  });
                   setCreateChatError(
                     error instanceof Error
                       ? error.message

--- a/packages/openclaw/src/monitor/agent-onboarding.test.ts
+++ b/packages/openclaw/src/monitor/agent-onboarding.test.ts
@@ -979,43 +979,6 @@ describe('agent onboarding requests', () => {
     ).not.toBeNull();
   });
 
-  it('ends an additional group setup after services without onboarding tours', async () => {
-    const sendPost = successfulSendPost();
-    const trackStep = vi.fn();
-    const history = [
-      introRequest(0, false),
-      botMarker('purpose-picker', 0.5),
-      provisionAck(),
-      servicesCard(),
-      { author: '~ten', content: 'Done', timestamp: 3 },
-    ];
-
-    await expect(
-      scanAgentOnboardingChannel(generalScanContext({ trackStep }), {
-        fetchHistory: vi.fn(async () => history),
-        sendPost,
-      })
-    ).resolves.toBe(true);
-
-    expect(sendPost).toHaveBeenCalledOnce();
-    expect(JSON.stringify(sendPost.mock.calls[0]?.[0])).toContain(
-      'All set. Ask me here anytime'
-    );
-    expect(JSON.stringify(sendPost.mock.calls[0]?.[0])).not.toContain(
-      'what you can do here'
-    );
-    expect(parsePostBlob(sendPost.mock.calls[0]?.[0].blob)).toContainEqual(
-      expect.objectContaining({
-        type: 'tlon-agent-post-marker',
-        key: 'group-setup-complete',
-      })
-    );
-    expect(trackStep).toHaveBeenCalledWith({
-      step: 'onboarding_completed',
-      completionPath: 'additional_group_completed',
-    });
-  });
-
   it('offers each orientation step as a simple Yes/No choice', () => {
     const surface = agentOnboardingTesting.buildTourChoiceSurface(
       'agent-onboarding-app-tour:~ten/group',
@@ -1279,9 +1242,35 @@ describe('agent onboarding requests', () => {
 
     const additionalGroup = await promptFor();
     expect(additionalGroup).toHaveLength(1);
-    expect(JSON.stringify(parsePostBlob(additionalGroup[0]?.blob))).toContain(
+    expect(JSON.stringify(additionalGroup[0]?.story)).toContain(
       'What can I help you with?'
     );
+    expect(
+      JSON.stringify(parsePostBlob(additionalGroup[0]?.blob))
+    ).not.toContain('a2ui');
+    expect(parsePostBlob(additionalGroup[0]?.blob)).toContainEqual(
+      expect.objectContaining({
+        type: 'tlon-agent-post-marker',
+        key: 'group-setup-complete',
+      })
+    );
+  });
+
+  it('leaves replies to a later group greeting for ordinary agent chat', async () => {
+    const sendPost = successfulSendPost();
+    const history = [
+      introRequest(1, false),
+      botMarker('group-setup-complete', 2),
+      { author: '~ten', content: 'A daily digest', timestamp: 3 },
+    ];
+
+    await expect(
+      handleAgentOnboardingRequest(replyContext('A daily digest'), {
+        fetchHistory: vi.fn(async () => history),
+        sendPost,
+      })
+    ).resolves.toBe(false);
+    expect(sendPost).not.toHaveBeenCalled();
   });
 
   it('recognizes an unmarked legacy intro without suppressing other steps', () => {

--- a/packages/openclaw/src/monitor/agent-onboarding.ts
+++ b/packages/openclaw/src/monitor/agent-onboarding.ts
@@ -194,9 +194,6 @@ const AGENT_ONBOARDING_BOT_TOUR_EXPLANATION =
   'authorize. Try asking me to adjust tomorrow’s update or investigate ' +
   'something now.';
 const AGENT_ONBOARDING_TOUR_DECLINED = 'No problem. You can ask me anytime.';
-const AGENT_GROUP_SETUP_COMPLETE =
-  'All set. Ask me here anytime if you want to change what I do, adjust the ' +
-  'schedule, or work on something else.';
 const AGENT_GROUP_SETUP_COMPLETE_MARKER = 'group-setup-complete';
 const AGENT_ONBOARDING_PURPOSE_OPTIONS = [
   {
@@ -653,8 +650,26 @@ async function postIntro(
   presentation: OnboardingPresentation,
   isFirstGroup: boolean
 ) {
-  const needsIntro =
-    isFirstGroup && !hasPostMarker(history, context.botShip, 'intro');
+  if (!isFirstGroup) {
+    const posted = await postOnce(
+      context,
+      history,
+      AGENT_GROUP_SETUP_COMPLETE_MARKER,
+      async () => ({ text: AGENT_ONBOARDING_PURPOSE_PROMPT }),
+      deps,
+      presentation
+    );
+    if (posted) {
+      context.trackStep?.({ step: 'intro_posted' });
+      context.trackStep?.({
+        step: 'onboarding_completed',
+        completionPath: 'additional_group_completed',
+      });
+    }
+    return;
+  }
+
+  const needsIntro = !hasPostMarker(history, context.botShip, 'intro');
   const hadPicker = hasPostMarker(history, context.botShip, 'purpose-picker');
   const pickerPosted = await postOnce(
     context,
@@ -685,10 +700,7 @@ async function postIntro(
     presentation
   );
   if (!hadPicker && pickerPosted) {
-    if (needsIntro || !isFirstGroup) {
-      // Additional groups share the same ordered funnel vocabulary; their
-      // purpose picker is the first setup surface even though no welcome copy
-      // is needed. First groups carry both markers on the combined opening.
+    if (needsIntro) {
       context.trackStep?.({ step: 'intro_posted' });
     }
     context.trackStep?.({ step: 'purpose_picker_posted' });
@@ -796,34 +808,6 @@ async function advanceOrientationConversation(
     hasPostMarker(history, context.botShip, AGENT_GROUP_SETUP_COMPLETE_MARKER)
   ) {
     return false;
-  }
-
-  if (!isFirstGroupSetup(history, context.ownerShip!, context.groupId!)) {
-    const servicesCard = markerPost(history, context.botShip, 'services-card');
-    if (!servicesCard) return false;
-    const completedServices = history.some(
-      (entry) =>
-        entry.author === context.ownerShip &&
-        entry.timestamp > servicesCard.timestamp &&
-        isServicesCompleteReply(entry.content)
-    );
-    if (!completedServices) return false;
-
-    const posted = await postOnce(
-      context,
-      history,
-      AGENT_GROUP_SETUP_COMPLETE_MARKER,
-      async () => ({ text: AGENT_GROUP_SETUP_COMPLETE }),
-      deps,
-      presentation
-    );
-    if (posted) {
-      context.trackStep?.({
-        step: 'onboarding_completed',
-        completionPath: 'additional_group_completed',
-      });
-    }
-    return true;
   }
 
   const botTourOffer = markerPost(history, context.botShip, 'bot-tour-offer');
@@ -2380,23 +2364,6 @@ function blobEntriesByAuthor(
       ? parsePostBlob(post.blob).map((entry) => ({ post, entry }))
       : []
   );
-}
-
-function isFirstGroupSetup(
-  history: TlonHistoryEntry[],
-  ownerShip: string,
-  groupId: string
-) {
-  const intro = blobEntriesByAuthor(history, ownerShip, true).find(
-    ({ entry }) =>
-      entry.type === 'tlon-agent-intro-request' && entry.groupId === groupId
-  )?.entry;
-  if (intro?.type === 'tlon-agent-intro-request') {
-    return intro.isFirstGroup === true;
-  }
-  // Preserve first-run behavior for setup conversations created before the
-  // explicit flag was introduced.
-  return groupId.endsWith('/home-group');
 }
 
 /** True once any provision has been acknowledged in this channel. */

--- a/packages/shared/src/store/agentGroupOnboarding.ts
+++ b/packages/shared/src/store/agentGroupOnboarding.ts
@@ -31,7 +31,6 @@ const agentGroupFurnishingFlights = new Map<
 export type AgentGroupFurnishing = {
   group: db.Group;
   chatChannelId: string;
-  notebookNest: string;
   agentShipId: string;
   /** Membership is visible and the admin grant request has been accepted. */
   readyToReveal: Promise<void>;
@@ -43,7 +42,7 @@ export type AgentGroupFurnishingStart = {
   group: db.Group;
   chatChannel: db.Channel;
   agentShipId: string;
-  /** Notebook setup and the durable intro request continue after chat opens. */
+  /** First-run setup, or the later group's greeting, continues after chat opens. */
   complete: Promise<AgentGroupFurnishing>;
 };
 
@@ -60,9 +59,8 @@ type FurnishParams = {
 };
 
 /**
- * Establish the owner-authenticated half of agent onboarding. The group,
- * chat, and exactly-one notes channel are blocking; seating/admin repair is
- * returned as a concurrent tail.
+ * Establish an agent group. First-run onboarding also gets exactly one notes
+ * channel; later groups open directly into ordinary chat.
  */
 export async function ensureAgentGroupFurnished(
   params: FurnishParams = {}
@@ -72,8 +70,8 @@ export async function ensureAgentGroupFurnished(
 }
 
 /**
- * Establish enough of an agent group to open its chat, then finish the
- * notebook and intro request without keeping later group creation blocked.
+ * Establish enough of an agent group to open its chat, then finish its
+ * first-run setup or later-group greeting without blocking navigation.
  */
 export async function startAgentGroupFurnishing(
   params: FurnishParams = {}
@@ -137,21 +135,24 @@ async function startAgentGroupFurnishingOnce(
         title: params.title ?? DEFAULT_AGENT_GROUP_TITLE,
       });
   const chatChannel = await ensureChatChannel(group);
-  const initialGroupTitle = group.title ?? null;
-  const currentUserContact = await db.getContact({
-    id: api.getCurrentUserId(),
-  });
-  const canRenameGroup = params.groupId
-    ? group.id.endsWith(`/${BotHomeGroupSlugs.slug}`) &&
-      logic.botHomeGroupHasDefaultTitle(group, currentUserContact?.peerNickname)
-    : params.title == null || params.title === DEFAULT_AGENT_GROUP_TITLE;
+  await db.agentGroupAgents.setValue((current) => ({
+    ...current,
+    [group.id]: resolved.agentShipId!,
+  }));
+  if (params.isFirstGroup) {
+    const initialGroupTitle = group.title ?? null;
+    const currentUserContact = await db.getContact({
+      id: api.getCurrentUserId(),
+    });
+    const canRenameGroup = params.groupId
+      ? group.id.endsWith(`/${BotHomeGroupSlugs.slug}`) &&
+        logic.botHomeGroupHasDefaultTitle(
+          group,
+          currentUserContact?.peerNickname
+        )
+      : params.title == null || params.title === DEFAULT_AGENT_GROUP_TITLE;
 
-  await Promise.all([
-    db.agentGroupAgents.setValue((current) => ({
-      ...current,
-      [group.id]: resolved.agentShipId!,
-    })),
-    db.agentGroupOnboardingLocks.setValue((current) => ({
+    await db.agentGroupOnboardingLocks.setValue((current) => ({
       ...current,
       [group.id]: {
         ...current[group.id],
@@ -159,15 +160,13 @@ async function startAgentGroupFurnishingOnce(
         createdAt: current[group.id]?.createdAt ?? Date.now(),
         navigationLockExpiresAt:
           current[group.id]?.navigationLockExpiresAt ??
-          (params.isFirstGroup
-            ? Date.now() + db.AGENT_GROUP_NAVIGATION_LOCK_FAILSAFE_MS
-            : undefined),
+          Date.now() + db.AGENT_GROUP_NAVIGATION_LOCK_FAILSAFE_MS,
         initialGroupTitle:
           current[group.id]?.initialGroupTitle ?? initialGroupTitle,
         canRenameGroup: current[group.id]?.canRenameGroup ?? canRenameGroup,
       },
-    })),
-  ]);
+    }));
+  }
   const complete = finishAgentGroupFurnishing({
     group,
     chatChannel,
@@ -315,11 +314,15 @@ async function finishAgentGroupFurnishingOnce({
   hostedShipId: string | null;
   isFirstGroup: boolean;
 }): Promise<AgentGroupFurnishing> {
-  const notebook = await ensureSingleNotesChannel(initialGroup.id);
-  const group = (await db.getGroup({ id: initialGroup.id })) ?? {
-    ...initialGroup,
-    channels: [...(initialGroup.channels ?? []), notebook],
-  };
+  const notebook = isFirstGroup
+    ? await ensureSingleNotesChannel(initialGroup.id)
+    : null;
+  const group = notebook
+    ? ((await db.getGroup({ id: initialGroup.id })) ?? {
+        ...initialGroup,
+        channels: [...(initialGroup.channels ?? []), notebook],
+      })
+    : initialGroup;
 
   await ensureIntroRequest(group.id, chatChannel.id, isFirstGroup);
   await db.pendingAgentGroupCreation.setValue((current) =>
@@ -331,7 +334,7 @@ async function finishAgentGroupFurnishingOnce({
   logger.trackEvent('Agent Group Furnish Core Completed', {
     groupId: group.id,
     chatChannelId: chatChannel.id,
-    notebookNest: notebook.id,
+    notebookNest: notebook?.id ?? null,
   });
 
   const standing = reconcileAgentStandingUntilReady({
@@ -350,7 +353,6 @@ async function finishAgentGroupFurnishingOnce({
   return {
     group,
     chatChannelId: chatChannel.id,
-    notebookNest: notebook.id,
     agentShipId,
     readyToReveal: standing.readyToReveal,
     tail,


### PR DESCRIPTION
## Summary

Open newly created agent groups directly into normal chat with a simple “What can I help you with?” greeting. The initial first-run agent group keeps the full onboarding flow.

Fixes TLON-6436

## Changes

- skip onboarding locks and notebook setup for later agent groups
- replace the purpose, topic, provisioning, services, and tour flow with one plain bot greeting
- hand replies to the normal agent conversation path
- remove the obsolete later-group onboarding completion branch and cleanup code

## How did I test?

- OpenClaw focused tests: 104 passed
- shared furnishing tests: 17 passed
- OpenClaw, shared, and app TypeScript checks passed
- targeted formatting passed
- targeted lint passed with existing warnings only
- `git diff --check` passed
