### PR TITLE
[DO NOT MERGE] loop test 3: login label

### DIFF
--- a/apps/tlon-mobile/src/screens/Onboarding/WelcomeScreen.tsx
+++ b/apps/tlon-mobile/src/screens/Onboarding/WelcomeScreen.tsx
@@ -125,7 +125,7 @@ export const WelcomeScreen = ({ navigation }: Props) => {
               onPress={() => setOpen(true)}
             >
               <SizableText color="$primaryText">
-                Have an account? Log in
+                Have an account? Log in [loop test 3]
               </SizableText>
             </Pressable>
           </XStack>


### PR DESCRIPTION
## Summary

Throwaway change. It exists only to test the mobile agent loop documented in `docs/tlon-apps/mobile-agent-loop.md`. **Do not merge.** Close it when the loop test is complete.

## Changes

One string in `apps/tlon-mobile/src/screens/Onboarding/WelcomeScreen.tsx`: "Have an account? Log in" becomes "Have an account? Log in [loop test 3]".

## How did I test?

Ran the documented loop in an isolated Stim worktree (`looptest3`, Metro port 8086) in parallel with two other worktrees.

- iOS: simulator `stim-looptest3-tlon-mobile`. `stim ios` reported a cache hit, 3m26s. The launch screen shows the changed label.
- Android: emulator `stim-looptest3-tlon-mobile` (`emulator-5556`), `stim android --variant productionDebug`. 7m46s wall, of which 6m51s was a wait on a parallel worktree that was already compiling the same fingerprint. The APK then came from the shared cache. The launch screen shows the changed label.
- `stim logs --errors` exits 0 on both platforms.

Two problems came up during the run:

- `stim worktree create looptest3` refused at first, because a branch named `worktree-looptest3` was left over from an earlier session. The refusal message named the fix. I deleted the stale branch and retried.
- Stim warned that the carried `ios/Pods` did not match `ios/Podfile.lock`. The warning is wrong here. `Pods/Manifest.lock` and `Podfile.lock` are identical in the worktree, so I did not run `pod install`, and the iOS build succeeded.

## Risks and impact

- Safe to rollback without consulting PR author? Yes
- Affects important code area:
  - [x] Onboarding

The change is one label on the onboarding welcome screen. It must not reach `develop`.

## Rollback plan

Close this pull request without merging, and delete the branch.

## Screenshots / videos

Not attached. The label change is described above and was verified on both simulators.
