### PR TITLE
[DO NOT MERGE] loop test 2: invite label

### DIFF
--- a/apps/tlon-mobile/src/screens/Onboarding/WelcomeScreen.tsx
+++ b/apps/tlon-mobile/src/screens/Onboarding/WelcomeScreen.tsx
@@ -112,7 +112,7 @@ export const WelcomeScreen = ({ navigation }: Props) => {
                     });
                     navigation.navigate('PasteInviteLink');
                   }}
-                  label="Join with an invite"
+                  label="Join with an invite [loop test 2]"
                 />
               </YStack>
             )}


### PR DESCRIPTION
Throwaway change. Do not merge.

This pull request tests the mobile agent loop documented in
`docs/tlon-apps/mobile-agent-loop.md`. The diff renames one onboarding
button label so a screenshot can prove the running app came from this
worktree's own Metro server. The change has no product value.

## What changed

`apps/tlon-mobile/src/screens/Onboarding/WelcomeScreen.tsx`: the label
"Join with an invite" becomes "Join with an invite [loop test 2]".

## Platforms validated

- iOS simulator `stim-looptest2-tlon-mobile`, installed from the artifact
  cache. The welcome screen shows the new label. `stim logs --errors`
  exits 0.
- Android emulator `stim-looptest2-tlon-mobile` (`emulator-5558`),
  variant `productionDebug`, installed from the build cache. The view
  hierarchy reports `text="Join with an invite [loop test 2]"`.
  `stim logs --errors` exits 0.

## Problems seen during the run

- `stim worktree create looptest2` refused twice. A stale
  `worktree-looptest2` branch from an earlier run pointed at an unrelated
  commit. The refusal message named the fix.
- `stim worktree create` warned that the carried `ios/Pods` did not match
  `ios/Podfile.lock` and told me to run `pod install`. The warning was
  wrong. `Pods/Manifest.lock` and the working-tree `Podfile.lock` were
  byte-identical, and the iOS build succeeded with no pod install.
- `stim ios` reported `OK` and `verify ready`, but the simulator still
  showed a loading spinner. The welcome screen appeared about 60 seconds
  later.
- The Android build waited 3m45s for the parallel `looptest1` workspace to
  finish the same fingerprint, then installed that result from the cache.
