### PR TITLE
[DO NOT MERGE] loop test 1: sign up label

### DIFF
--- a/apps/tlon-mobile/src/screens/Onboarding/WelcomeScreen.tsx
+++ b/apps/tlon-mobile/src/screens/Onboarding/WelcomeScreen.tsx
@@ -103,7 +103,10 @@ export const WelcomeScreen = ({ navigation }: Props) => {
               </Pressable>
             ) : (
               <YStack gap="$l">
-                <OnboardingButton onPress={handlePressSignup} label="Sign up" />
+                <OnboardingButton
+                  onPress={handlePressSignup}
+                  label="Sign up [loop test 1]"
+                />
                 <OnboardingButton
                   secondary
                   onPress={() => {


### PR DESCRIPTION
## Summary

Throwaway change. It exists only to test the mobile agent loop described in `docs/tlon-apps/mobile-agent-loop.md`. **Do not merge.** Close this PR and delete the branch once the loop test is reviewed.

## Changes

`apps/tlon-mobile/src/screens/Onboarding/WelcomeScreen.tsx`: the onboarding "Sign up" button label becomes "Sign up [loop test 1]", so a screenshot can prove which build is on the device.

## How did I test?

I ran the loop end to end in a Stim worktree created from `origin/develop`, and I confirmed the new label on both platforms.

- iOS: `stim ios` on the Stim-owned simulator `stim-looptest1-tlon-mobile`. Artifact cache hit, 51s. `stim logs --errors` exit 0.
- Android: `stim android --variant productionDebug` on the Stim-owned emulator `stim-looptest1-tlon-mobile` (`emulator-5554`). Fingerprint miss, real Gradle compile, 10m54s. `stim logs --errors` exit 0.

Two things went wrong during the run, neither of them caused by this diff:

- A first `stim worktree create` failed part way. It left the branch `worktree-looptest1` behind. The retry attached to that branch and printed `--base does not apply`, so `--base origin/develop` was silently dropped. The base was correct only by luck, because the branch already pointed at the fetched tip.
- `stim worktree create` warned that the carried `ios/Pods` did not match `ios/Podfile.lock` and told me to run `pod install`. `Pods/Manifest.lock` and `Podfile.lock` were byte identical, so the warning was wrong. I ignored it and the iOS build passed.

## Risks and impact

- Safe to rollback without consulting PR author? Yes
- Affects important code area:
  - [x] Onboarding
  - [ ] State / providers
  - [ ] Message sync
  - [ ] Channel display
  - [ ] Notifications
  - [ ] Other:

The change is one string literal on the onboarding welcome screen. It must not reach any user, which is why this PR stays a draft.

## Rollback plan

Close this PR without merging, or revert the single commit.

## Screenshots / videos

iOS simulator:

<img src="https://github.com/user-attachments/assets/347e3c7d-8ed5-4511-aaa2-076f726aea79" width="300" />

Android emulator:

<img src="https://github.com/user-attachments/assets/18913d4d-e7b1-4316-a392-60ec069312d0" width="300" />
