### PR TITLE
fix profile identity layout

### DIFF
--- a/packages/app/ui/components/UserProfileScreenView.tsx
+++ b/packages/app/ui/components/UserProfileScreenView.tsx
@@ -427,7 +427,7 @@ function UserInfoRow(props: { userId: string; hasNickname: boolean }) {
         <ContactAvatar contactId={props.userId} size="$5xl" />
       </Pressable>
       <Pressable flex={1} minWidth={0} onPress={handleCopy}>
-        <YStack flex={1} justifyContent="center">
+        <YStack justifyContent="center">
           <XStack alignItems="center" gap="$s">
             <ContactName
               contactId={props.userId}


### PR DESCRIPTION
## Summary

Keeps the profile identity column from collapsing so every profile shows either its nickname and ID or its ID alone.

Fixes TLON-6437

## Changes

- let the profile identity content provide its intrinsic height inside the flexible press target

## How did I test?

- verified nickname + ID and ID-only profile fixtures on the Stim-owned iOS 26.4 simulator
- confirmed visible, nonzero accessibility frames for `Dan b`, `~solfer-magfed`, and `latter - bolden`
- `corepack pnpm --filter @tloncorp/app tsc`
- full app Vitest suite: 571 passed, 3 skipped
- targeted `oxfmt` check
- targeted `oxlint` (two existing warnings in `UserProfileScreenView.tsx`)
- `git diff --check`