### PR TITLE
openclaw: stop offering a calendar connection in onboarding

### DIFF
--- a/packages/app/fixtures/AgentOnboarding.fixture.tsx
+++ b/packages/app/fixtures/AgentOnboarding.fixture.tsx
@@ -254,8 +254,8 @@ const firstEntryReady =
   'Your first entry is ready in Updates, this group’s notebook. That notebook ' +
   'is where everything I write for you lands; this chat is for talking to me.';
 const servicesPitch =
-  'Connect your calendar and docs and your morning digest can cover your own ' +
-  'day — meetings, deadlines, notes — not just the news.';
+  'Connect your docs and notes and your morning digest can cover your own ' +
+  'projects, not just the news.';
 const servicesMessage = `${servicesPitch}\n\nConnect anything you’d like, or tap Done to continue.`;
 const servicesComponent: A2UI.McpConnect = {
   id: 'providers',
@@ -295,11 +295,7 @@ const servicesSurface = makeA2UI('onboarding-services-fixture', [
 
 const servicesPreviewProviders: McpProviderRow[] = [
   { displayName: 'Notion', id: 'notion', status: 'connected' },
-  {
-    displayName: 'Google Calendar',
-    id: 'google-calendar',
-    status: 'connected',
-  },
+  { displayName: 'AgentMail', id: 'agentmail', status: 'connected' },
   { displayName: 'Gmail', id: 'gmail', status: 'not-connected' },
   { displayName: 'GitHub', id: 'github', status: 'not-connected' },
   { displayName: 'Linear', id: 'linear', status: 'not-connected' },

--- a/packages/openclaw/src/monitor/agent-onboarding.test.ts
+++ b/packages/openclaw/src/monitor/agent-onboarding.test.ts
@@ -1769,6 +1769,9 @@ describe('agent onboarding requests', () => {
       const pitch = agentOnboardingTesting.servicesPitch(purposeId);
       expect(pitch).toMatch(/^Connect your/);
       expect(pitch).not.toContain('to give me more to work with');
+      // No calendar connector exists, so nothing can source meetings or
+      // deadlines. The pitch must not offer what can't be connected.
+      expect(pitch).not.toMatch(/calendar|meetings|deadlines/i);
     }
   );
 

--- a/packages/openclaw/src/monitor/agent-onboarding.ts
+++ b/packages/openclaw/src/monitor/agent-onboarding.ts
@@ -2851,14 +2851,15 @@ function scheduleConfirmation(request: PostBlobDataEntryAgentProvision) {
  * The services pitch, in terms of what the owner just built. The old copy
  * ("Connect calendars, docs, or notes to give me more to work with") named
  * the mechanism and no benefit, and read identically whichever purpose was
- * chosen.
+ * chosen. Name only what the connector catalog actually offers: there is no
+ * calendar connector, so the pitch can't promise one.
  */
 function servicesPitch(purposeId: AgentOnboardingPurposeId) {
   switch (purposeId) {
     case 'agent-learning':
       return (
-        'Connect your calendar or notes and I can fit each update around ' +
-        'your day and build on what you’re already reading.'
+        'Connect your notes or docs and I can build each update on what ' +
+        'you’re already reading.'
       );
     case 'agent-research':
       return (
@@ -2867,8 +2868,8 @@ function servicesPitch(purposeId: AgentOnboardingPurposeId) {
       );
     case 'agent-daily-digest':
       return (
-        'Connect your calendar and docs and your morning digest can cover ' +
-        'your own day — meetings, deadlines, notes — not just the news.'
+        'Connect your docs and notes and your morning digest can cover your ' +
+        'own projects, not just the news.'
       );
   }
 }

--- a/packages/openclaw/src/tlon-command-runner.test.ts
+++ b/packages/openclaw/src/tlon-command-runner.test.ts
@@ -76,14 +76,20 @@ describe('runTlonCommand timeout output capture', () => {
   });
 
   it('rejects near the timeout when a spawnSync grandchild keeps the pipes open', async () => {
-    const timeoutMs = 500;
+    // The budget has to cover two cold Node boots — the wrapper, then the
+    // spawnSync grandchild — before the grandchild's writes can reach us.
+    // A loaded CI runner spends longer on those than the writes themselves,
+    // and a timeout that fires first carries empty output. Keep the
+    // grandchild's hold-open delay well past the timeout so the pipes are
+    // still open when it fires.
+    const timeoutMs = 1_500;
     const grandchildScript = [
       "process.stdout.write('stdout-before-timeout\\n');",
       "process.stderr.write('stderr-before-timeout\\n');",
       'setTimeout(() => {',
       "  process.stdout.write('grandchild-finished\\n');",
       '  process.exit(0);',
-      '}, 2500);',
+      '}, 6000);',
     ].join('\n');
     const wrapperScript = [
       "const { spawnSync } = require('node:child_process');",
@@ -110,7 +116,8 @@ describe('runTlonCommand timeout output capture', () => {
     const elapsedMs = performance.now() - startedAt;
 
     expect(elapsedMs).toBeGreaterThanOrEqual(timeoutMs - 50);
-    expect(elapsedMs).toBeLessThan(1_500);
+    // Rejected on the timeout, not by waiting out the grandchild's exit.
+    expect(elapsedMs).toBeLessThan(3_000);
     expect(failure).toMatchObject({
       message: `tlon command timed out after ${timeoutMs}ms`,
       stdout: 'stdout-before-timeout\n',


### PR DESCRIPTION
## Summary

Fixes TLON-6441

Tlonbot's first-run services pitch asked owners to connect a calendar, but hosting's connector catalog has no calendar provider — the picker rendered directly below the copy offered Notion, GitHub, AgentMail, and Airtable. The daily-digest variant also promised content with no source ("meetings, deadlines"). This rewrites the pitch around docs and notes, which the catalog does serve.

## Changes

- `packages/openclaw/src/monitor/agent-onboarding.ts` — `servicesPitch` no longer names calendars:
  - `agent-learning`: "Connect your notes or docs and I can build each update on what you're already reading."
  - `agent-daily-digest`: "Connect your docs and notes and your morning digest can cover your own projects, not just the news."
  - `agent-research` was already calendar-free and is unchanged.
- `packages/openclaw/src/monitor/agent-onboarding.test.ts` — the existing pitch test now asserts no variant matches `/calendar|meetings|deadlines/i`, so the promise can't come back by accident.
- `packages/app/fixtures/AgentOnboarding.fixture.tsx` — the Cosmos fixture mirrors the shipped copy, so it gets the same text; its provider preview swaps the `Google Calendar` row for `AgentMail` (a real connector) and keeps two connected rows so the connected-sorts-first ordering stays exercised.

### Unrelated CI flake, fixed in the second commit

`Unit Tests` failed on the first push in `src/tlon-command-runner.test.ts` — "rejects near the timeout when a spawnSync grandchild keeps the pipes open" — with the timeout error carrying empty `stdout`/`stderr`. The runner attaches whatever the `data` handlers have drained by the deadline ([tlon-command-runner.ts:144](packages/openclaw/src/tlon-command-runner.ts:144)), so empty streams mean nothing had arrived yet: the test's 500ms budget had to cover a wrapper Node boot, a `spawnSync` grandchild Node boot, and the grandchild's first writes, and on a 4-vCPU runner sharing the box with 78 other test files the boots outran it.

The budget is now 1500ms, the grandchild holds the pipes open to 6s so they're still open when the timeout fires, and the elapsed ceiling is 3s — which still proves the rejection came from the timeout, not from waiting out the grandchild. Nothing about this touches the copy change; it was failing for its own reasons.

## How did I test?

- `npx vitest run src/monitor/agent-onboarding.test.ts` in `packages/openclaw` — 105 passed, including the 3 pitch cases with the new assertion.
- `tsc --noEmit` clean in `packages/openclaw` and `packages/app`.
- `pnpm format:check` clean at the repo root.

Copy-only change; no runtime behavior, wire format, or state involved.

## Risks and impact

- Safe to rollback without consulting PR author? (Yes)
- Affects important code area:
  - [x] Onboarding
  - [ ] State / providers
  - [ ] Message sync
  - [ ] Channel display
  - [ ] Notifications
  - [ ] Other:

Note for a follow-up, deliberately left alone here: `FEATURED_PROVIDER_ORDER` in [packages/app/lib/mcpProviders.ts](packages/app/lib/mcpProviders.ts:50) still ranks `gmail` and `google-calendar` first. It's inert — the ranking only applies to providers hosting actually serves — and it would be the right ordering if either connector ships, so this PR doesn't touch it.

## Rollback plan

Revert the commit. Nothing persists and no migration is involved.

## Screenshots / videos

Reported copy (the pitch names a calendar; the picker below it has no calendar connector): https://storage.googleapis.com/tlon-prod-memex-assets/malmur-halmex/malmur-halmex/2026.9.2..13.19.16..0147.ae14.7ae1.47ae-22DF858B-46A0-493A-A42D-313F8C3A7FFF.png

🤖 Generated with [Claude Code](https://claude.com/claude-code)
