### PR TITLE
fix Android header and composer surfaces

### DIFF
--- a/packages/app/ui/components/Channel/DraftInputView.tsx
+++ b/packages/app/ui/components/Channel/DraftInputView.tsx
@@ -3,7 +3,7 @@ import { ComponentProps, PropsWithChildren, useEffect } from 'react';
 import { Platform, StyleSheet } from 'react-native';
 import { KeyboardStickyView } from 'react-native-keyboard-controller';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
-import { View } from 'tamagui';
+import { View, getVariableValue, useTheme } from 'tamagui';
 
 import { useComponentsKitContext } from '../../contexts/componentsKits';
 import {
@@ -64,6 +64,7 @@ export function ConversationComposerPlacement({
   inlineID?: string;
 }>) {
   const insets = useSafeAreaInsets();
+  const theme = useTheme();
   const scrollViewNativeID = useConversationScrollViewNativeID();
   const scrollToBottomControl = useConversationScrollToBottomControl();
   const { report: reportConversationComposerHeight } =
@@ -93,7 +94,12 @@ export function ConversationComposerPlacement({
         <ScrollEdgeElementContainer
           edge="bottom"
           scrollViewNativeID={scrollViewNativeID}
-          style={{ paddingBottom: insets.bottom }}
+          style={[
+            { paddingBottom: insets.bottom },
+            Platform.OS === 'android'
+              ? { backgroundColor: getVariableValue(theme.background) }
+              : undefined,
+          ]}
           onLayout={(event) => {
             const scrollControlClearance =
               Platform.OS === 'ios' && scrollToBottomControl?.visible

--- a/packages/app/ui/components/MessageInput/AttachmentPreviewList.tsx
+++ b/packages/app/ui/components/MessageInput/AttachmentPreviewList.tsx
@@ -190,6 +190,7 @@ export function AttachmentPreview({
             height={'100%'}
             reference={attachment.reference}
             actionIcon={null}
+            backgroundColor="$background"
           />
         </AttachmentPreviewContainer>
       );

--- a/packages/app/ui/components/MessageInput/MessageInputBase.tsx
+++ b/packages/app/ui/components/MessageInput/MessageInputBase.tsx
@@ -306,12 +306,12 @@ const materialChromeAlignment = usesAndroidMaterialChrome
   ? 'flex-end'
   : 'center';
 
-const materialSurfaceProps = {
-  backgroundColor: usesAndroidMaterialChrome
-    ? '$background'
-    : '$secondaryBackground',
-  boxShadow: '0 2px 6px rgba(0, 0, 0, 0.24)',
-} as const;
+const materialSurfaceProps = usesAndroidMaterialChrome
+  ? ({ backgroundColor: '$secondaryBackground' } as const)
+  : ({
+      backgroundColor: '$secondaryBackground',
+      boxShadow: '0 2px 6px rgba(0, 0, 0, 0.24)',
+    } as const);
 
 function MessageInputChromeRoot({
   children,
@@ -473,11 +473,7 @@ function MessageInputChromeBody({
           alignItems={materialChromeAlignment}
           gap={metrics.rowGap}
           backgroundColor={
-            isEditing
-              ? '$positiveBackground'
-              : usesAndroidMaterialChrome
-                ? '$background'
-                : '$secondaryBackground'
+            isEditing ? '$positiveBackground' : '$secondaryBackground'
           }
           overflow="hidden"
         >

--- a/packages/app/ui/components/ScreenHeader/ScreenHeader.tsx
+++ b/packages/app/ui/components/ScreenHeader/ScreenHeader.tsx
@@ -78,6 +78,7 @@ type ScreenHeaderProps = SharedScreenHeaderProps &
   );
 
 const InlineScreenHeaderContext = createContext(false);
+const androidNativeTitleHeight = 56;
 
 export const InlineScreenHeaderProvider = InlineScreenHeaderContext.Provider;
 
@@ -108,6 +109,14 @@ export const ScreenHeaderComponent = ({
   const [rightControlsWidth, setRightControlsWidth] = useState(0);
 
   const shouldUseAnimatedTitleLayout = typeof title === 'string';
+  const nativeTitleHeight =
+    Platform.OS === 'android' &&
+    placement === 'navigation' &&
+    !forceInline &&
+    loadingSubtitle !== undefined &&
+    shouldUseAnimatedTitleLayout
+      ? androidNativeTitleHeight
+      : undefined;
   const activeLoadingText = loadingSubtitle ?? undefined;
   const isLoadingActive = !!activeLoadingText;
   const lastLoadingTextRef = useRef('');
@@ -210,7 +219,12 @@ export const ScreenHeaderComponent = ({
     );
 
   const titleCluster = (
-    <XStack alignItems="center" justifyContent="center" gap="$s" height="$4xl">
+    <XStack
+      alignItems="center"
+      justifyContent="center"
+      gap="$s"
+      height={nativeTitleHeight ?? '$4xl'}
+    >
       {titleIcon}
       {shouldUseAnimatedTitleLayout ? (
         <HeaderAnimatedTitle
@@ -220,6 +234,7 @@ export const ScreenHeaderComponent = ({
           leftAlignLoadingText={useHorizontalTitleLayout}
           titleMaxWidth={titleMaxWidth}
           loadingTextMaxWidth={loadingTextMaxWidth}
+          titleHeight={nativeTitleHeight}
         />
       ) : (
         <Text
@@ -283,21 +298,10 @@ export const ScreenHeaderComponent = ({
     titleIcon != null ||
     onTitlePress != null ||
     loadingSubtitle !== undefined;
-  const titlePresentationKey = JSON.stringify({
-    title: typeof title === 'string' ? title : null,
-    hasTitleIcon: titleIcon != null,
-    subtitle: resolvedSubtitle,
-    loadingText: displayLoadingText,
-    isLoadingActive,
-    showSubtitle,
-    useHorizontalTitleLayout,
-    isInteractive: onTitlePress != null,
-  });
   const shouldUseNativeHeader = useNativeHeader({
     enabled: placement === 'navigation' && !forceInline,
     title: typeof title === 'string' ? title : '',
     titleElement: interactiveTitleContent,
-    titlePresentationKey,
     usesCustomTitle: usesCustomNativeTitle,
     backgroundColor,
     left: navigationLeftActions,
@@ -455,6 +459,7 @@ function HeaderAnimatedTitle({
   leftAlignLoadingText = false,
   titleMaxWidth,
   loadingTextMaxWidth = 240,
+  titleHeight,
 }: {
   title: string;
   isLoading: boolean;
@@ -462,6 +467,7 @@ function HeaderAnimatedTitle({
   leftAlignLoadingText?: boolean;
   titleMaxWidth?: number | 'unset';
   loadingTextMaxWidth?: number;
+  titleHeight?: number;
 }) {
   const theme = useTheme();
   const loadingOpacity = useSharedValue(0);
@@ -541,7 +547,7 @@ function HeaderAnimatedTitle({
 
   return (
     <View
-      height="$4xl"
+      height={titleHeight ?? '$4xl'}
       alignItems="center"
       justifyContent="center"
       overflow="visible"

--- a/packages/app/ui/components/ScreenHeader/actions.ts
+++ b/packages/app/ui/components/ScreenHeader/actions.ts
@@ -60,7 +60,6 @@ export interface UseNativeHeaderOptions {
   enabled: boolean;
   title: string;
   titleElement: ReactNode;
-  titlePresentationKey: string;
   usesCustomTitle: boolean;
   backgroundColor?: string;
   left: ScreenHeaderAction[];

--- a/packages/app/ui/components/ScreenHeader/nativeTitle.test.tsx
+++ b/packages/app/ui/components/ScreenHeader/nativeTitle.test.tsx
@@ -1,8 +1,19 @@
-import { describe, expect, it, vi } from 'vitest';
+import { useEffect } from 'react';
+import { ReactTestRenderer, act, create } from 'react-test-renderer';
+import { afterAll, beforeAll, describe, expect, it, vi } from 'vitest';
 
-import { createNativeHeaderTitleStore } from './nativeTitle';
+import { NativeHeaderTitle, createNativeHeaderTitleStore } from './nativeTitle';
 
 describe('native header title store', () => {
+  beforeAll(() => {
+    Object.assign(globalThis, { IS_REACT_ACT_ENVIRONMENT: true });
+  });
+
+  afterAll(() => {
+    delete (globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean })
+      .IS_REACT_ACT_ENVIRONMENT;
+  });
+
   it('notifies subscribers when the rendered title changes', () => {
     const store = createNativeHeaderTitleStore('Initial');
     const listener = vi.fn();
@@ -20,5 +31,45 @@ describe('native header title store', () => {
     unsubscribe();
     store.set('Final');
     expect(listener).toHaveBeenCalledOnce();
+  });
+
+  it('updates a stateful title without remounting it', () => {
+    const mounted = vi.fn();
+    const unmounted = vi.fn();
+
+    function StatefulTitle({ text }: { text: string }) {
+      useEffect(() => {
+        mounted();
+        return () => {
+          unmounted();
+        };
+      }, []);
+
+      return <span>{text}</span>;
+    }
+
+    const store = createNativeHeaderTitleStore(
+      <StatefulTitle text="Connecting..." />
+    );
+    let renderer: ReactTestRenderer;
+
+    act(() => {
+      renderer = create(<NativeHeaderTitle store={store} />);
+    });
+
+    act(() => {
+      store.set(<StatefulTitle text="Syncing with node..." />);
+    });
+
+    expect(mounted).toHaveBeenCalledOnce();
+    expect(unmounted).not.toHaveBeenCalled();
+    expect(renderer!.toJSON()).toMatchObject({
+      children: ['Syncing with node...'],
+    });
+
+    act(() => {
+      renderer!.unmount();
+    });
+    expect(unmounted).toHaveBeenCalledOnce();
   });
 });

--- a/packages/app/ui/components/ScreenHeader/nativeTitle.test.tsx
+++ b/packages/app/ui/components/ScreenHeader/nativeTitle.test.tsx
@@ -72,4 +72,63 @@ describe('native header title store', () => {
     });
     expect(unmounted).toHaveBeenCalledOnce();
   });
+
+  it('remounts a stateful title when the owning store changes', () => {
+    const mounted = vi.fn();
+    const unmounted = vi.fn();
+
+    function StatefulTitle({ text }: { text: string }) {
+      useEffect(() => {
+        mounted();
+        return () => {
+          unmounted();
+        };
+      }, []);
+
+      return <span>{text}</span>;
+    }
+
+    function InstalledTitle({
+      ownerKey,
+      store,
+    }: {
+      ownerKey: string;
+      store: ReturnType<typeof createNativeHeaderTitleStore>;
+    }) {
+      return (
+        <div>
+          <NativeHeaderTitle key={ownerKey} store={store} />
+        </div>
+      );
+    }
+
+    const homeStore = createNativeHeaderTitleStore(
+      <StatefulTitle text="Home" />
+    );
+    const activityStore = createNativeHeaderTitleStore(
+      <StatefulTitle text="Activity" />
+    );
+    let renderer: ReactTestRenderer;
+
+    act(() => {
+      renderer = create(<InstalledTitle ownerKey="home" store={homeStore} />);
+    });
+
+    act(() => {
+      renderer!.update(
+        <InstalledTitle ownerKey="activity" store={activityStore} />
+      );
+    });
+
+    expect(mounted).toHaveBeenCalledTimes(2);
+    expect(unmounted).toHaveBeenCalledOnce();
+    expect(renderer!.toJSON()).toMatchObject({
+      children: [{ children: ['Activity'] }],
+    });
+
+    act(() => {
+      renderer!.unmount();
+    });
+    expect(unmounted).toHaveBeenCalledTimes(2);
+  });
 });

--- a/packages/app/ui/components/ScreenHeader/useNativeHeader.tsx
+++ b/packages/app/ui/components/ScreenHeader/useNativeHeader.tsx
@@ -1,6 +1,13 @@
 import { NavigationContext } from '@react-navigation/native';
 import type { NativeStackNavigationOptions } from '@react-navigation/native-stack';
-import { useContext, useLayoutEffect, useMemo, useRef, useState } from 'react';
+import {
+  useContext,
+  useId,
+  useLayoutEffect,
+  useMemo,
+  useRef,
+  useState,
+} from 'react';
 import { Platform } from 'react-native';
 import { useTheme } from 'tamagui';
 
@@ -32,6 +39,7 @@ export function useNativeHeader({
 }: UseNativeHeaderOptions) {
   const navigation = useContext(NavigationContext);
   const theme = useTheme();
+  const titleOwnerKey = useId();
   const [titleStore] = useState(() =>
     createNativeHeaderTitleStore(titleElement)
   );
@@ -46,8 +54,8 @@ export function useNativeHeader({
 
   const shouldUseNativeHeader =
     enabled && Platform.OS !== 'web' && navigation != null;
-  // Keep this renderer mounted while the store reconciles title updates.
-  // Remounting discards stateful title animations during loading transitions.
+  // Keep this renderer mounted while its store reconciles title updates, but
+  // remount when a different screen installs its store into the shared header.
   const resolvedBackgroundColor = resolveNativeHeaderColor(
     backgroundColor,
     theme
@@ -73,7 +81,7 @@ export function useNativeHeader({
         ? { backgroundColor: resolvedBackgroundColor }
         : undefined,
       headerTitle: usesCustomTitle
-        ? () => <NativeHeaderTitle store={titleStore} />
+        ? () => <NativeHeaderTitle key={titleOwnerKey} store={titleStore} />
         : undefined,
       title,
       ...buildNativeHeaderActionOptions({
@@ -91,6 +99,7 @@ export function useNativeHeader({
     actionPresentation,
     resolvedBackgroundColor,
     title,
+    titleOwnerKey,
     titleStore,
     usesCustomTitle,
   ]);

--- a/packages/app/ui/components/ScreenHeader/useNativeHeader.tsx
+++ b/packages/app/ui/components/ScreenHeader/useNativeHeader.tsx
@@ -25,7 +25,6 @@ export function useNativeHeader({
   enabled,
   title,
   titleElement,
-  titlePresentationKey,
   usesCustomTitle,
   backgroundColor,
   left,
@@ -47,11 +46,8 @@ export function useNativeHeader({
 
   const shouldUseNativeHeader =
     enabled && Platform.OS !== 'web' && navigation != null;
-  // iOS keeps the installed renderer stable so title updates cannot dismiss an
-  // open native menu. Android's header is React-rendered and can safely remount
-  // this stateless title when its semantic presentation changes.
-  const installedTitlePresentationKey =
-    Platform.OS === 'ios' ? undefined : titlePresentationKey;
+  // Keep this renderer mounted while the store reconciles title updates.
+  // Remounting discards stateful title animations during loading transitions.
   const resolvedBackgroundColor = resolveNativeHeaderColor(
     backgroundColor,
     theme
@@ -77,12 +73,7 @@ export function useNativeHeader({
         ? { backgroundColor: resolvedBackgroundColor }
         : undefined,
       headerTitle: usesCustomTitle
-        ? () => (
-            <NativeHeaderTitle
-              key={installedTitlePresentationKey}
-              store={titleStore}
-            />
-          )
+        ? () => <NativeHeaderTitle store={titleStore} />
         : undefined,
       title,
       ...buildNativeHeaderActionOptions({
@@ -98,7 +89,6 @@ export function useNativeHeader({
     } as NativeStackNavigationOptions;
   }, [
     actionPresentation,
-    installedTitlePresentationKey,
     resolvedBackgroundColor,
     title,
     titleStore,


### PR DESCRIPTION
## Summary

Fixes the remaining Android header loading behavior so it matches iOS: loading status pushes and scales the title without remounting or clipping it. Also restores clear composer separation with tinted surfaces instead of Android elevation or shadow.

Fixes TLON-6426

## Changes

- keep the native title renderer mounted across loading-state updates
- give animated Android navigation titles enough vertical space for the transition
- keep each native title attached to the screen that owns it
- place an opaque background behind the floating Android composer
- use the secondary background tint for the Android input while keeping embedded references on the primary background
- remove Android composer elevation and shadow while preserving the existing iOS treatment
- add regression coverage for native title updates and ownership

## How did I test?

- built, installed, and launched productionRelease on a physical Samsung Galaxy S24 running Android SDK 36
- cold-started the app and verified the Home title scales upward above Connecting without clipping
- verified the tinted composer in dark mode with the keyboard open and a quoted reference
- focused tests: 10 passed
- packages/app TypeScript check passed
- targeted formatting passed
- targeted lint passed with existing React compiler warnings only
- git diff check passed
