### PR TITLE
Keep the thinking indicator above the composer in empty conversations

### DIFF
--- a/packages/app/fixtures/Channel.fixture.tsx
+++ b/packages/app/fixtures/Channel.fixture.tsx
@@ -3,6 +3,7 @@ import { appendToPostBlob } from '@tloncorp/shared/logic';
 import { range } from 'lodash';
 import type { ComponentProps, PropsWithChildren, SetStateAction } from 'react';
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import { HeaderHeightContext } from '@react-navigation/elements';
 import {
   Button,
   FlatList,
@@ -504,6 +505,38 @@ function ChannelWithControlledPostLoading() {
   );
 }
 
+// Replays the agent group setup lifecycle on a timer: posts load into an
+// empty channel, the first-entry indicator appears, the first entry arrives,
+// then the indicator clears. The header height mimics the transparent native
+// header so the list carries a top content inset like it does on iOS.
+function AgentGroupSetupSequence() {
+  const [posts, setPosts] = useState<db.Post[] | null>(null);
+  const [label, setLabel] = useState<string | undefined>(undefined);
+  useEffect(() => {
+    const timeouts = [
+      setTimeout(() => setPosts([]), 1500),
+      setTimeout(() => setLabel('Writing your first entry…'), 5000),
+      setTimeout(() => setPosts([createFakePost()]), 9000),
+      setTimeout(() => setLabel(undefined), 11000),
+    ];
+    return () => timeouts.forEach(clearTimeout);
+  }, []);
+  return (
+    <HeaderHeightContext.Provider value={103}>
+      <ChannelFixture
+        negotiationMatch={true}
+        theme={'light'}
+        passedProps={() => ({
+          posts,
+          isLoadingPosts: posts == null,
+          suppressEmptyState: true,
+          pendingThinkingLabel: label,
+        })}
+      />
+    </HeaderHeightContext.Provider>
+  );
+}
+
 function createTestChannelUnread({
   channel,
   post,
@@ -539,6 +572,14 @@ export default {
       passedProps={() => ({
         posts: [],
       })}
+    />
+  ),
+  agentGroupSetupSequence: <AgentGroupSetupSequence />,
+  chatWithThinking: (
+    <ChannelFixture
+      negotiationMatch={true}
+      theme={'light'}
+      passedProps={() => ({ pendingThinkingLabel: 'Thinking...' })}
     />
   ),
   chatWithSimulatedLoad: <ChannelWithControlledPostLoading />,

--- a/packages/app/ui/components/Channel/PostList/PostList.tsx
+++ b/packages/app/ui/components/Channel/PostList/PostList.tsx
@@ -2,7 +2,7 @@ import { KeyboardAwareLegendList } from '@legendapp/list/keyboard';
 import { type LegendListRef } from '@legendapp/list/react-native';
 import { layoutForType } from '@tloncorp/shared';
 import * as React from 'react';
-import { Platform } from 'react-native';
+import { Platform, type ScrollView } from 'react-native';
 import { type SharedValue, useSharedValue } from 'react-native-reanimated';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
 
@@ -520,6 +520,22 @@ const ConversationPostListAttempt = React.forwardRef<
     React.useLayoutEffect(() => {
       postsWithNeighborsRef.current = postsWithNeighbors;
     }, [postsWithNeighbors]);
+    // Nothing else re-anchors an empty conversation: LegendList skips its end
+    // alignment and maintainScrollAtEnd without rows, and the composer inset
+    // reaction can run before the scroll view has reported its size. Rest the
+    // empty content at its end (offset 0, or the keyboard height while one is
+    // open) whenever its frame or content size settles.
+    const settleEmptyConversationAtEnd = React.useCallback(() => {
+      if (postsWithNeighborsRef.current.length > 0) {
+        return;
+      }
+      // LegendList types the native ref as the bare ScrollView component class;
+      // at runtime it is the ScrollView instance with its scroll methods.
+      const scrollView = listRef.current?.getNativeScrollRef() as
+        | ScrollView
+        | undefined;
+      scrollView?.scrollToEnd({ animated: false });
+    }, []);
     const { onScroll: handleScroll, isAtBottom: isWithinBottomThreshold } =
       useScrollDirectionTracker({
         atBottomThreshold: onScrolledToBottomThreshold,
@@ -668,6 +684,8 @@ const ConversationPostListAttempt = React.forwardRef<
         // the attachment at low frequency in case Screens replaces the view.
         testID={scrollViewNativeID}
         onLoad={scheduleInitialScroll}
+        onLayout={settleEmptyConversationAtEnd}
+        onContentSizeChange={settleEmptyConversationAtEnd}
         onScroll={handleScroll}
         onScrollBeginDrag={markUserScrolled}
         onStartReached={onStartReached}

--- a/packages/app/ui/components/Channel/Scroller.tsx
+++ b/packages/app/ui/components/Channel/Scroller.tsx
@@ -392,11 +392,19 @@ const Scroller = forwardRef(
     const insets = useSafeAreaInsets();
     const rootVerticalPadding = getTokens().space.l.val;
     const composerBottomInset = contentInsets.bottom;
-    const scrollContentBottomInset =
+    // iOS conversation lists keep the composer inset native so the list can
+    // own keyboard and composer clearance; every other layout pads for it.
+    const listOwnsComposerInset =
       Platform.OS === 'ios' &&
-      collectionLayoutType === 'compact-list-bottom-to-top'
-        ? 0
-        : contentInsets.bottom;
+      collectionLayoutType === 'compact-list-bottom-to-top';
+    const scrollContentBottomInset = listOwnsComposerInset
+      ? 0
+      : contentInsets.bottom;
+    const [listFrameHeight, setListFrameHeight] = useState<number | null>(null);
+    const handleListFrameLayout = useCallback((event: LayoutChangeEvent) => {
+      const { height } = event.nativeEvent.layout;
+      setListFrameHeight((current) => (current === height ? current : height));
+    }, []);
     const standaloneBottomSafeArea =
       composerBottomInset > 0 ? 0 : insets.bottom;
     const scrollButtonBottom =
@@ -417,6 +425,18 @@ const Scroller = forwardRef(
                 standaloneBottomSafeArea +
                 rootVerticalPadding +
                 scrollContentBottomInset,
+            };
+          }
+          // LegendList end-aligns rows within the area above the native composer
+          // inset, but only once it has rows. With none it falls back to a
+          // viewport-sized container whose footer (the thinking indicator)
+          // lands wherever the scroll offset happens to be. Give the empty
+          // conversation that same above-the-composer height so the footer
+          // rests in place at offset 0 with no scroll range to drift into.
+          if (listOwnsComposerInset && listFrameHeight != null) {
+            return {
+              minHeight: Math.max(0, listFrameHeight - contentInsets.bottom),
+              paddingTop: contentInsets.top,
             };
           }
           return {
@@ -463,7 +483,10 @@ const Scroller = forwardRef(
         standaloneBottomSafeArea,
         visiblePosts?.length,
         collectionLayoutType,
+        contentInsets.bottom,
         contentInsets.top,
+        listFrameHeight,
+        listOwnsComposerInset,
         rootVerticalPadding,
         scrollContentBottomInset,
       ])
@@ -610,7 +633,10 @@ const Scroller = forwardRef(
     );
 
     return (
-      <View flex={1}>
+      <View
+        flex={1}
+        onLayout={listOwnsComposerInset ? handleListFrameLayout : undefined}
+      >
         {postsWithNeighbors != null && (
           <PostList
             anchor={anchor}


### PR DESCRIPTION
## Summary

Cherry-pick of f37ccce onto `staging` (the same change as #6426, which targeted `develop` and is closed in favor of this PR).

Fixes [TLON-6447](https://linear.app/tlon/issue/TLON-6447) and [TLON-6440](https://linear.app/tlon/issue/TLON-6440): in a brand-new agent group the thinking indicator either floated well above the message input or was pushed below it, instead of sitting directly on top of it. Both are the same defect: the empty conversation list left its scroll offset unreconciled, so the footer landed wherever that offset put it — one header height plus the composer inset too high (TLON-6447), or hidden behind the composer at offset 0 (TLON-6440).

## Changes

- **`Scroller.tsx`**: for an empty iOS conversation, size the list content to the list frame minus the composer inset instead of a viewport-filling `flexGrow`. This is the same geometry LegendList produces via `alignItemsAtEnd` once it has rows, so the footer rests directly above the composer at offset 0 with no scroll range to drift into. Other layouts and platforms keep their existing empty-state padding.
- **`PostList.tsx`**: while the conversation has no rows, scroll the native scroll view to its end whenever its frame or content size settles. LegendList skips end alignment and `maintainScrollAtEnd` without rows, and its `initialScrollAtEnd` for empty data resolves to an offset equal to the top content inset; the keyboard-controller inset reaction can also run before the scroll view has reported its size. The callback exits immediately once rows exist, so populated lists take exactly the same path as before.
- **`Channel.fixture.tsx`**: two cosmos fixtures used to reproduce and verify: `agentGroupSetupSequence` (timed replay: loading → empty channel → indicator → first entry → indicator clears, with a transparent-header top inset) and `chatWithThinking` (populated chat with the indicator).

### Root cause detail

LegendList only computes `alignItemsAtEndPadding` when `data.length > 0`. With zero rows it falls back to `flexGrow: 1; justifyContent: flex-end`, so the footer's on-screen position is dictated purely by scroll offset. `calculateOffsetWithOffsetPosition` returns `stylePaddingTop` for an empty end target (our top content inset, ~116pt for the transparent iOS 26 header), and `useExtraContentPadding` in react-native-keyboard-controller then adds the 98pt composer inset when it fires before layout is known. 116 + 98 matches the gap in the issue screenshot. Once the first post arrives LegendList's normal end-alignment math takes over, which is why the first message rendered in the right place.

## How did I test?

iOS Simulator (iPhone 17 Pro, iOS 26.5) running the existing debug build against Metro in cosmos mode, measuring the indicator's window position with a temporary `measureInWindow` beacon (composer top edge is at 776pt on this device):

| Scenario | Before | After |
| --- | --- | --- |
| Empty channel, indicator appears after load | 874 (hidden behind composer) | 776 |
| Same, composer inset arriving after list mount (production ordering) | drifted by top inset + composer inset | 776 |
| First post arrives, then indicator clears | — | post and indicator both end at 776 |
| Populated chat (100 posts) with indicator | 776 | 776 (unchanged) |
| Plain empty channel welcome notice | offset-dependent | rests above composer |

Also: `tsc` for `packages/app`, `oxfmt --check`, and vitest for `ThinkingState`, `postListInitialization`, `conversationInsets`, and `postVisibility` (32 tests) pass.

Not verified: keyboard open on an empty channel (simulator tap injection doesn't work on this machine), and the real agent-provisioning flow (needs the private tlonbot sandbox). Both are reasoned through in code comments; the settle callback uses the native `scrollToEnd`, which includes the live keyboard inset.

## Risks and impact

- Safe to rollback without consulting PR author? (Yes)
- Affects important code area:
  - [ ] Onboarding
  - [ ] State / providers
  - [ ] Message sync
  - [x] Channel display
  - [ ] Notifications
  - [ ] Other:

Scope is limited to conversations with zero rows on iOS (content sizing) plus a no-op-once-populated settle callback. LegendList never consumes `onContentSizeChange` and chains `onLayout`, so the new props do not shadow its handlers. Thread views always contain the parent post and never hit the empty branch.

## Rollback plan

Revert this commit. No data or schema changes.

## Screenshots / videos

| Before (issue, build 460) | After (simulator, empty channel, indicator visible) |
| --- | --- |
| <img width="300" alt="before: indicator floating above the composer" src="https://github.com/user-attachments/assets/383f13b9-6e91-445f-8e3d-0d542aace4ff" /> | <img width="300" alt="after: indicator directly above the composer" src="https://github.com/user-attachments/assets/02476569-d355-44df-b58a-b5d17d585bd2" /> |

| After: first post arrived, indicator cleared | After: populated chat with indicator (unchanged path) |
| --- | --- |
| <img width="300" alt="after: first post directly above the composer" src="https://github.com/user-attachments/assets/3ee573f5-1798-435a-b4fd-c69abb1ada9f" /> | <img width="300" alt="after: populated chat with indicator at the end" src="https://github.com/user-attachments/assets/4b68fcd0-20c4-4fe4-841d-c72c9f684085" /> |

🤖 Generated with [Claude Code](https://claude.com/claude-code)
