### PR TITLE
fix missed agent group greetings

### DIFF
--- a/packages/openclaw/src/monitor/agent-onboarding.test.ts
+++ b/packages/openclaw/src/monitor/agent-onboarding.test.ts
@@ -21,6 +21,7 @@ import {
   agentOnboardingCronProviderIds,
   agentOnboardingTesting,
   clearAgentOnboardingRuntime,
+  createAgentOnboardingCatchUpScheduler,
   drainAgentOnboardingRuntime,
   handleAgentOnboardingCronChanged,
   handleAgentOnboardingMessageSent,
@@ -654,6 +655,59 @@ describe('first-run correlation', () => {
   });
 });
 
+describe('agent onboarding catch-up', () => {
+  it('recovers a request that appears after the first empty scan', async () => {
+    vi.useFakeTimers();
+    const scan = vi
+      .fn()
+      .mockResolvedValueOnce(false)
+      .mockResolvedValueOnce(true);
+    const scheduler = createAgentOnboardingCatchUpScheduler({
+      scan,
+      retryDelaysMs: [10, 20, 30],
+    });
+
+    await expect(scheduler.reconcile('chat/~ten/general')).resolves.toBe(false);
+    expect(scheduler.schedule('chat/~ten/general')).toBe(false);
+    await vi.advanceTimersByTimeAsync(10);
+    expect(scan).toHaveBeenCalledTimes(2);
+    await vi.advanceTimersByTimeAsync(20);
+    await scheduler.drain();
+    expect(scan).toHaveBeenCalledTimes(2);
+
+    await vi.advanceTimersByTimeAsync(100);
+    expect(scan).toHaveBeenCalledTimes(2);
+  });
+
+  it('stops after the bounded empty-scan window', async () => {
+    vi.useFakeTimers();
+    const scan = vi.fn(async () => false);
+    const scheduler = createAgentOnboardingCatchUpScheduler({
+      scan,
+      retryDelaysMs: [10, 20],
+    });
+
+    await scheduler.reconcile('chat/~ten/general');
+    await vi.advanceTimersByTimeAsync(100);
+    await scheduler.drain();
+    expect(scan).toHaveBeenCalledTimes(3);
+  });
+
+  it('cancels a pending catch-up when live handling completes', async () => {
+    vi.useFakeTimers();
+    const scan = vi.fn(async () => false);
+    const scheduler = createAgentOnboardingCatchUpScheduler({
+      scan,
+      retryDelaysMs: [10],
+    });
+
+    scheduler.schedule('chat/~ten/general');
+    scheduler.complete('chat/~ten/general');
+    await vi.advanceTimersByTimeAsync(100);
+    expect(scan).not.toHaveBeenCalled();
+  });
+});
+
 describe('agent onboarding requests', () => {
   it('forwards cancellation to the group membership scry', async () => {
     const abortController = new AbortController();
@@ -1172,6 +1226,52 @@ describe('agent onboarding requests', () => {
         }
       )
     ).resolves.toBe(true);
+    expect(sendPost).toHaveBeenCalledOnce();
+  });
+
+  it('shows thinking while a later-group greeting is reconciled', async () => {
+    const events: string[] = [];
+    const introBlob = appendToPostBlob(undefined, {
+      type: 'tlon-agent-intro-request',
+      version: 1,
+      groupId: '~ten/group',
+    });
+    const sendPost = vi.fn(async (post: { story: unknown }) => {
+      events.push('post');
+      expect(JSON.stringify(post.story)).toContain('What can I help you with?');
+      return { channel: 'tlon' as const, messageId: 'post', sentAt: 0 };
+    });
+
+    await expect(
+      scanAgentOnboardingChannel(
+        {
+          api: { scry: vi.fn() },
+          botShip: '~bot',
+          channelNest: 'chat/~ten/general',
+          groupId: '~ten/group',
+          ownerShip: '~ten',
+          presentation: {
+            startThinking: () => events.push('thinking:start'),
+            stopThinking: () => events.push('thinking:stop'),
+            minResponseDelayMs: 0,
+          },
+        },
+        {
+          fetchHistory: vi.fn(async () => [
+            {
+              author: '~ten',
+              content: "Let's get set up.",
+              timestamp: 1,
+              blob: introBlob,
+            },
+          ]),
+          sleep: vi.fn(async () => {}),
+          sendPost,
+        }
+      )
+    ).resolves.toBe(true);
+
+    expect(events).toEqual(['thinking:start', 'post', 'thinking:stop']);
     expect(sendPost).toHaveBeenCalledOnce();
   });
 

--- a/packages/openclaw/src/monitor/agent-onboarding.test.ts
+++ b/packages/openclaw/src/monitor/agent-onboarding.test.ts
@@ -22,6 +22,7 @@ import {
   agentOnboardingTesting,
   clearAgentOnboardingRuntime,
   createAgentOnboardingCatchUpScheduler,
+  createAgentOnboardingReconciliationPresence,
   drainAgentOnboardingRuntime,
   handleAgentOnboardingCronChanged,
   handleAgentOnboardingMessageSent,
@@ -30,6 +31,7 @@ import {
   parseAgentOnboardingRequest,
   scanAgentOnboardingChannel,
 } from './agent-onboarding.js';
+import { createComputingPresenceTracker } from './computing-presence.js';
 
 const provision = {
   type: 'tlon-agent-provision' as const,
@@ -693,18 +695,50 @@ describe('agent onboarding catch-up', () => {
     expect(scan).toHaveBeenCalledTimes(3);
   });
 
-  it('cancels a pending catch-up when live handling completes', async () => {
-    vi.useFakeTimers();
-    const scan = vi.fn(async () => false);
-    const scheduler = createAgentOnboardingCatchUpScheduler({
-      scan,
-      retryDelaysMs: [10],
+  it('uses a fresh thinking run after a completed reconciliation', async () => {
+    const reporter = { publish: vi.fn(async () => {}) };
+    const tracker = createComputingPresenceTracker({
+      reporter,
+      minUpdateIntervalMs: 0,
+    });
+    const createRunId = vi
+      .fn()
+      .mockReturnValueOnce('reconcile-1')
+      .mockReturnValueOnce('reconcile-2');
+    const presentation = createAgentOnboardingReconciliationPresence({
+      conversationId: 'chat/~ten/general',
+      createRunId,
+      refreshRun: tracker.refreshRun,
+      stopRun: tracker.stopRun,
     });
 
-    scheduler.schedule('chat/~ten/general');
-    scheduler.complete('chat/~ten/general');
-    await vi.advanceTimersByTimeAsync(100);
-    expect(scan).not.toHaveBeenCalled();
+    presentation.startThinking();
+    await Promise.resolve();
+    await Promise.resolve();
+    presentation.stopThinking();
+    await Promise.resolve();
+    await Promise.resolve();
+    presentation.startThinking();
+    await Promise.resolve();
+    await Promise.resolve();
+
+    expect(createRunId).toHaveBeenCalledTimes(2);
+    expect(reporter.publish).toHaveBeenCalledTimes(3);
+    expect(reporter.publish).toHaveBeenNthCalledWith(1, {
+      conversationId: 'chat/~ten/general',
+      thinking: true,
+      toolNames: [],
+    });
+    expect(reporter.publish).toHaveBeenNthCalledWith(2, {
+      conversationId: 'chat/~ten/general',
+      thinking: false,
+      toolNames: [],
+    });
+    expect(reporter.publish).toHaveBeenNthCalledWith(3, {
+      conversationId: 'chat/~ten/general',
+      thinking: true,
+      toolNames: [],
+    });
   });
 });
 

--- a/packages/openclaw/src/monitor/agent-onboarding.ts
+++ b/packages/openclaw/src/monitor/agent-onboarding.ts
@@ -345,7 +345,35 @@ export function createAgentOnboardingCatchUpScheduler({
     }
   };
 
-  return { reconcile, schedule, complete, stop, drain };
+  return { reconcile, schedule, stop, drain };
+}
+
+export function createAgentOnboardingReconciliationPresence({
+  conversationId,
+  createRunId,
+  refreshRun,
+  stopRun,
+}: {
+  conversationId: string;
+  createRunId: () => string;
+  refreshRun: (params: { conversationId: string; runId: string }) => void;
+  stopRun: (params: { conversationId: string; runId: string }) => void;
+}) {
+  let activeRunId: string | null = null;
+
+  return {
+    startThinking: () => {
+      if (activeRunId) return;
+      activeRunId = createRunId();
+      refreshRun({ conversationId, runId: activeRunId });
+    },
+    stopThinking: () => {
+      if (!activeRunId) return;
+      const runId = activeRunId;
+      activeRunId = null;
+      stopRun({ conversationId, runId });
+    },
+  };
 }
 
 type FirstRunCorrelation = {

--- a/packages/openclaw/src/monitor/agent-onboarding.ts
+++ b/packages/openclaw/src/monitor/agent-onboarding.ts
@@ -162,6 +162,7 @@ const DEFAULT_MIN_INTER_MESSAGE_DELAY_MS = 1_750;
 const FIRST_ENTRY_TO_SERVICES_DELAY_MS = 5_500;
 const RUN_OUTCOME_WRITE_RETRY_DELAYS_MS = [100, 250, 500, 1_000] as const;
 const ADMIN_MEMBERSHIP_RETRY_DELAYS_MS = [250, 500, 1_000, 2_000] as const;
+const EMPTY_SCAN_RETRY_DELAYS_MS = [500, 1_500, 3_000] as const;
 const COMPOSE_MS_PER_CHARACTER = 14;
 const MIN_COMPOSE_DELAY_MS = 800;
 const MAX_COMPOSE_DELAY_MS = 3_500;
@@ -261,6 +262,91 @@ const AGENT_ONBOARDING_PURPOSE_OPTIONS = [
   topicsPrompt: string;
   topics: readonly string[];
 }[];
+
+/**
+ * Give a newly discovered chat a short, bounded window for its durable intro
+ * request to become visible. Group membership and channel posts arrive over
+ * separate subscriptions, so the first history read can legitimately be
+ * empty. Ordinary groups exhaust this window without leaving a polling loop.
+ */
+export function createAgentOnboardingCatchUpScheduler({
+  scan,
+  abortSignal,
+  retryDelaysMs = EMPTY_SCAN_RETRY_DELAYS_MS,
+}: {
+  scan: (channelNest: string) => Promise<boolean | undefined>;
+  abortSignal?: AbortSignal;
+  retryDelaysMs?: readonly number[];
+}) {
+  const timers = new Map<string, ReturnType<typeof setTimeout>>();
+  const attempts = new Map<string, number>();
+  const flights = new Set<Promise<void>>();
+  let stopped = false;
+
+  const complete = (channelNest: string) => {
+    const timer = timers.get(channelNest);
+    if (timer) clearTimeout(timer);
+    timers.delete(channelNest);
+    attempts.delete(channelNest);
+  };
+
+  const schedule = (channelNest: string): boolean => {
+    if (stopped || abortSignal?.aborted || timers.has(channelNest))
+      return false;
+    const attempt = attempts.get(channelNest) ?? 0;
+    const delayMs = retryDelaysMs[attempt];
+    if (delayMs === undefined) {
+      attempts.delete(channelNest);
+      return false;
+    }
+    attempts.set(channelNest, attempt + 1);
+    const timer = setTimeout(() => {
+      timers.delete(channelNest);
+      if (stopped || abortSignal?.aborted) return;
+      const flight = (async () => {
+        const result = await scan(channelNest);
+        if (result === false) schedule(channelNest);
+        else complete(channelNest);
+      })();
+      flights.add(flight);
+      void flight.then(
+        () => flights.delete(flight),
+        () => {
+          flights.delete(flight);
+          complete(channelNest);
+        }
+      );
+    }, delayMs);
+    timer.unref?.();
+    timers.set(channelNest, timer);
+    return true;
+  };
+
+  const stop = () => {
+    stopped = true;
+    for (const timer of timers.values()) clearTimeout(timer);
+    timers.clear();
+    attempts.clear();
+  };
+
+  const reconcile = async (
+    channelNest: string
+  ): Promise<boolean | undefined> => {
+    if (stopped || abortSignal?.aborted) return undefined;
+    const result = await scan(channelNest);
+    if (result === false) schedule(channelNest);
+    else complete(channelNest);
+    return result;
+  };
+
+  const drain = async () => {
+    while (flights.size > 0) {
+      await Promise.allSettled([...flights]);
+    }
+  };
+
+  return { reconcile, schedule, complete, stop, drain };
+}
 
 type FirstRunCorrelation = {
   runId: string;

--- a/packages/openclaw/src/monitor/index.ts
+++ b/packages/openclaw/src/monitor/index.ts
@@ -124,6 +124,7 @@ import {
 import {
   type OnboardingStepReport,
   createAgentOnboardingCatchUpScheduler,
+  createAgentOnboardingReconciliationPresence,
   drainAgentOnboardingRuntime,
   handleAgentOnboardingRequest,
   scanAgentOnboardingChannel,
@@ -3934,6 +3935,12 @@ async function monitorTlonProviderScoped(opts: MonitorTlonOpts): Promise<void> {
         return;
       }
       try {
+        const presentation = createAgentOnboardingReconciliationPresence({
+          conversationId: nest,
+          createRunId: () => `onboarding-reconcile:${randomUUID()}`,
+          refreshRun: (params) => computingPresence.refreshRun(params),
+          stopRun: (params) => computingPresence.stopRun(params),
+        });
         const reconciled = await scanAgentOnboardingChannel({
           accountId: account.accountId,
           api,
@@ -3945,20 +3952,7 @@ async function monitorTlonProviderScoped(opts: MonitorTlonOpts): Promise<void> {
           ownerShip: effectiveOwnerShip,
           log: (message) => runtime.log?.(message),
           trackStep: trackOnboardingStep(nest, groupId),
-          presentation: {
-            startThinking: () => {
-              computingPresence.refreshRun({
-                conversationId: nest,
-                runId: `onboarding-reconcile:${nest}`,
-              });
-            },
-            stopThinking: () => {
-              computingPresence.stopRun({
-                conversationId: nest,
-                runId: `onboarding-reconcile:${nest}`,
-              });
-            },
-          },
+          presentation,
         });
         if (opts.abortSignal?.aborted) return;
         clearAgentOnboardingRetry(nest);
@@ -4230,7 +4224,6 @@ async function monitorTlonProviderScoped(opts: MonitorTlonOpts): Promise<void> {
           throw error;
         }
         if (handledOnboardingRequest) {
-          onboardingCatchUp.complete(nest);
           // Onboarding requests and deterministic picker replies are
           // control-plane messages. Their visible text remains transcript
           // history but never wakes the model.

--- a/packages/openclaw/src/monitor/index.ts
+++ b/packages/openclaw/src/monitor/index.ts
@@ -123,6 +123,7 @@ import {
 } from '../version.js';
 import {
   type OnboardingStepReport,
+  createAgentOnboardingCatchUpScheduler,
   drainAgentOnboardingRuntime,
   handleAgentOnboardingRequest,
   scanAgentOnboardingChannel,
@@ -3865,12 +3866,16 @@ async function monitorTlonProviderScoped(opts: MonitorTlonOpts): Promise<void> {
     const onboardingRetryFlights = new Set<Promise<void>>();
     let drainingAgentOnboarding = false;
     const onboardingRetryAttempts = new Map<string, number>();
+    let onboardingCatchUp: ReturnType<
+      typeof createAgentOnboardingCatchUpScheduler
+    > | null = null;
     clearAgentOnboardingRetries = () => {
       for (const timer of onboardingRetryTimers.values()) {
         clearTimeout(timer);
       }
       onboardingRetryTimers.clear();
       onboardingRetryAttempts.clear();
+      onboardingCatchUp?.stop();
     };
     const scheduleAgentOnboardingRetry = (nest: string) => {
       if (
@@ -3885,7 +3890,9 @@ async function monitorTlonProviderScoped(opts: MonitorTlonOpts): Promise<void> {
       const timer = setTimeout(() => {
         onboardingRetryTimers.delete(nest);
         if (!opts.abortSignal?.aborted) {
-          const flight = scanAgentOnboardingNest(nest);
+          const flight = scanAgentOnboardingNest(nest).then((reconciled) => {
+            if (reconciled === false) onboardingCatchUp?.schedule(nest);
+          });
           onboardingRetryFlights.add(flight);
           void flight.then(
             () => onboardingRetryFlights.delete(flight),
@@ -3903,7 +3910,9 @@ async function monitorTlonProviderScoped(opts: MonitorTlonOpts): Promise<void> {
       onboardingRetryAttempts.delete(nest);
     };
 
-    const scanAgentOnboardingNest = async (nest: string) => {
+    const scanAgentOnboardingNest = async (
+      nest: string
+    ): Promise<boolean | undefined> => {
       if (opts.abortSignal?.aborted) return;
       if (!nest.startsWith('chat/')) return;
       let groupId = channelToGroup.get(nest);
@@ -3925,7 +3934,7 @@ async function monitorTlonProviderScoped(opts: MonitorTlonOpts): Promise<void> {
         return;
       }
       try {
-        await scanAgentOnboardingChannel({
+        const reconciled = await scanAgentOnboardingChannel({
           accountId: account.accountId,
           api,
           abortSignal: opts.abortSignal,
@@ -3936,9 +3945,24 @@ async function monitorTlonProviderScoped(opts: MonitorTlonOpts): Promise<void> {
           ownerShip: effectiveOwnerShip,
           log: (message) => runtime.log?.(message),
           trackStep: trackOnboardingStep(nest, groupId),
+          presentation: {
+            startThinking: () => {
+              computingPresence.refreshRun({
+                conversationId: nest,
+                runId: `onboarding-reconcile:${nest}`,
+              });
+            },
+            stopThinking: () => {
+              computingPresence.stopRun({
+                conversationId: nest,
+                runId: `onboarding-reconcile:${nest}`,
+              });
+            },
+          },
         });
         if (opts.abortSignal?.aborted) return;
         clearAgentOnboardingRetry(nest);
+        return reconciled;
       } catch (error) {
         if (opts.abortSignal?.aborted) return;
         runtime.error?.(
@@ -3950,14 +3974,20 @@ async function monitorTlonProviderScoped(opts: MonitorTlonOpts): Promise<void> {
         // stops. The per-nest timer deduplicates overlapping firehose/boot
         // attempts.
         scheduleAgentOnboardingRetry(nest);
+        return undefined;
       }
     };
 
-    const onboardingDiscoveryFlights = new Set<Promise<void>>();
+    onboardingCatchUp = createAgentOnboardingCatchUpScheduler({
+      scan: scanAgentOnboardingNest,
+      abortSignal: opts.abortSignal,
+    });
+
+    const onboardingDiscoveryFlights = new Set<Promise<boolean | undefined>>();
     let drainingOnboardingDiscovery = false;
     const scanDiscoveredAgentOnboardingNest = async (nest: string) => {
       if (drainingOnboardingDiscovery || opts.abortSignal?.aborted) return;
-      const flight = scanAgentOnboardingNest(nest);
+      const flight = onboardingCatchUp.reconcile(nest);
       onboardingDiscoveryFlights.add(flight);
       try {
         await flight;
@@ -3991,7 +4021,7 @@ async function monitorTlonProviderScoped(opts: MonitorTlonOpts): Promise<void> {
         ) {
           watchedChannels.add(nest);
           runtime.log?.(`[tlon] Auto-watching channel from firehose: ${nest}`);
-          await scanAgentOnboardingNest(nest);
+          await onboardingCatchUp.reconcile(nest);
         }
 
         // Only process channels we're watching
@@ -4200,6 +4230,7 @@ async function monitorTlonProviderScoped(opts: MonitorTlonOpts): Promise<void> {
           throw error;
         }
         if (handledOnboardingRequest) {
+          onboardingCatchUp.complete(nest);
           // Onboarding requests and deterministic picker replies are
           // control-plane messages. Their visible text remains transcript
           // history but never wakes the model.
@@ -5809,6 +5840,7 @@ async function monitorTlonProviderScoped(opts: MonitorTlonOpts): Promise<void> {
       clearAgentOnboardingRetries = null;
       removeBridge(accountKey, commandBridge);
       await Promise.allSettled([...onboardingRetryFlights]);
+      await onboardingCatchUp?.drain();
       drainingOnboardingDiscovery = true;
       await Promise.allSettled([...onboardingDiscoveryFlights]);
       drainingChannelFirehose = true;


### PR DESCRIPTION
## Summary

Fixes the race where a new agent group can be discovered before its intro request is visible, leaving the group without its greeting. Recovered greetings now show the thinking indicator too.

Fixes TLON-6440

## Changes

- retry empty onboarding history scans for a short, bounded window
- stop catch-up work after live onboarding succeeds
- show thinking presence while reconciled onboarding messages are posted
- cover delayed intro arrival, retry bounds, cancellation, and thinking presence

## How did I test?

- focused onboarding tests: 109 passed
- OpenClaw unit suite: 1,691 passed
- OpenClaw TypeScript check passed
- targeted formatting and lint passed with existing warnings only
- git diff check passed
- no native build was needed
