### PR TITLE
android: stop react-native-screens from zeroing screen frames when the keyboard resizes the root

### DIFF
--- a/apps/tlon-mobile/index.tsx
+++ b/apps/tlon-mobile/index.tsx
@@ -20,6 +20,7 @@ import { useEffect, useRef } from 'react';
 import { AppState, Platform, TurboModuleRegistry } from 'react-native';
 import 'react-native-get-random-values';
 import { KeyboardProvider } from 'react-native-keyboard-controller';
+import { featureFlags as screensFeatureFlags } from 'react-native-screens';
 import {
   ReanimatedLogLevel,
   configureReanimatedLogger,
@@ -29,6 +30,14 @@ import App from './src/App';
 import { useDbReady } from './src/hooks/useDbReady';
 import { initializeBackgroundSync } from './src/lib/backgroundSync';
 import { shouldSuppressForegroundNotification } from './src/lib/notificationPresentation';
+
+// Keep react-native-screens from zeroing every native-stack screen's Fabric
+// frame whenever the root resizes. On Android 15+ MainActivity resizes the root
+// for the keyboard, and a background screen (the tab host under a channel)
+// never re-reports its frame after that reset, so it ends up laid out one
+// status-bar inset too short and the tab bar floats above the bottom edge.
+// TLON-6443; upstream: software-mansion/react-native-screens#4551.
+screensFeatureFlags.experiment.androidResetScreenShadowStateOnOrientationChangeEnabled = false;
 
 // Extend BigInt so serialization will never crash in JSON.parse
 (BigInt.prototype as any).toJSON = function () {


### PR DESCRIPTION
## Summary

Fixes the Android bottom tab bar sitting one status-bar inset too high (with a blank band beneath it) after focusing the composer in a channel and navigating back. Turns off the react-native-screens experiment that resets native-stack screen frames on every React root resize. TLON-6443.

## Changes

- In `apps/tlon-mobile/index.tsx`, sets `featureFlags.experiment.androidResetScreenShadowStateOnOrientationChangeEnabled = false` at module scope, before any screen mounts.

On Android 15+ MainActivity resizes the React root for the keyboard. That resize makes the react-native-screens commit hook zero the Fabric frame of every native-stack screen, including the tab host, which is detached under the channel and re-attaches with an unchanged frame, so it never re-reports its frame. The screen then falls back to a dummy header correction that double-counts the status-bar inset, and the native tab bar is laid out that much too high (or, transiently, clipped off the bottom, which was TLON-6415). Upstream tracks the same chain in software-mansion/react-native-screens#4551. The hook exists to re-measure early on rotation and multi-window resizes; the app is portrait-locked, and visible screens still track size changes through `Screen.onLayout`. The flag is read only by the Android component descriptor, so iOS behavior is unchanged.

## How did I test?

- `productionDebug` dev-client build on a Pixel 7 Android 15 emulator (API 35, gesture navigation), driven with adb, reading view bounds from `adb shell dumpsys activity top`.
- Before: Home → group → chat channel → focus composer → header back twice left `TabsHost` at 2264 px (bar clipped off the bottom), and 1981 px after one list scroll (raised bar, blank band below). Baseline is 2117 px.
- After: the same sequence keeps `TabsHost` at 2117 px and `BottomNavigationView` at 1844–2117 at every step, while the keyboard still shrinks the React root (2264 → 2201) so the composer stays above it.
- `pnpm -C apps/tlon-mobile tsc` is clean and the JS formatter has been run.
- Same sequence by hand on a physical OnePlus CPH2583 (Android 16 / API 36, gesture navigation, full-height Gboard): the keyboard shrank the React root from 2256 to 1371 px, and after two pops and a scroll `TabsHost` stayed at 2088 px with `BottomNavigationView` at 1800–2088, identical to baseline.

## Risks and impact

- Safe to rollback without consulting PR author? Yes
- Affects important code area:
  - [x] Other: Android native navigation layout (tab bar and native stack screens)

Known limitation, out of scope: Android 14 and below have a separate keyboard defect (nothing resizes the root there, so the composer can sit under the keyboard). It will be filed separately.

## Rollback plan

Revert.
