### PR TITLE
fix: keep the latest message above a growing composer on android

### DIFF
--- a/packages/app/ui/components/Channel/PostList/PostList.tsx
+++ b/packages/app/ui/components/Channel/PostList/PostList.tsx
@@ -1,3 +1,4 @@
+import type * as db from '@tloncorp/shared/db';
 import { KeyboardAwareLegendList } from '@legendapp/list/keyboard';
 import { type LegendListRef } from '@legendapp/list/react-native';
 import { layoutForType } from '@tloncorp/shared';
@@ -29,6 +30,28 @@ import {
 
 const ANCHOR_RESOLUTION_TIMEOUT_MS = 2_000;
 const ESTIMATED_ITEM_SIZE = 120;
+
+// LegendList sizes rows it has not measured yet from a running average per
+// item type. A single average for every chat post lets one long code block or
+// wall of text inflate the estimate for everything, and each estimated row
+// then shrinks when it measures, so the list creeps for seconds after a page
+// of history loads. Bucketing by rough content size keeps the averages close
+// to the rows they stand in for.
+function getPostSizeClass(post: db.Post): string {
+  if (post.hasImage) {
+    return `${post.type}:image`;
+  }
+  const textLength = post.textContent?.length ?? 0;
+  const sizeClass =
+    textLength > 600
+      ? 'xl'
+      : textLength > 200
+        ? 'l'
+        : textLength > 60
+          ? 'm'
+          : 's';
+  return `${post.type}:${sizeClass}`;
+}
 
 function useConversationKeyboardListProps(
   composerContentInset: SharedValue<number>
@@ -657,7 +680,7 @@ const ConversationPostListAttempt = React.forwardRef<
         data={postsWithNeighbors}
         keyExtractor={getPostId}
         renderItem={renderItem}
-        getItemType={({ post }) => post.type}
+        getItemType={({ post }) => getPostSizeClass(post)}
         estimatedItemSize={ESTIMATED_ITEM_SIZE}
         // Chat rows are stateful and highly variable-height; recycling them can
         // briefly reuse stale row state and measurements for another post.

--- a/packages/app/ui/components/Channel/PostList/PostList.tsx
+++ b/packages/app/ui/components/Channel/PostList/PostList.tsx
@@ -541,6 +541,26 @@ const ConversationPostListAttempt = React.forwardRef<
         atBottomThreshold: onScrolledToBottomThreshold,
         bottomAtEnd: true,
       });
+    // LegendList re-anchors the end whenever the list's layout, rows, or
+    // footer change size, and it does so even mid-gesture. On Android a drag
+    // dismisses the keyboard, which resizes the list and the composer while
+    // the finger is still down, so the list would snap back to the end under
+    // the user's scroll. Suspend end maintenance until the gesture, including
+    // its fling, has finished.
+    const [isUserScrolling, setIsUserScrolling] = React.useState(false);
+    const handleScrollBeginDrag = React.useCallback(() => {
+      markUserScrolled();
+      setIsUserScrolling(true);
+    }, [markUserScrolled]);
+    const handleScrollEndDrag = React.useCallback(() => {
+      setIsUserScrolling(false);
+    }, []);
+    const handleMomentumScrollBegin = React.useCallback(() => {
+      setIsUserScrolling(true);
+    }, []);
+    const handleMomentumScrollEnd = React.useCallback(() => {
+      setIsUserScrolling(false);
+    }, []);
     // LegendList recalculates this when scrolling, content, or row measurements
     // change. React Native onScroll can retain an intermediate value while the
     // initial anchor settles, briefly showing the scroll-to-bottom control.
@@ -649,7 +669,7 @@ const ConversationPostListAttempt = React.forwardRef<
           initialScrollIndex === undefined
         }
         initialScrollIndex={initialScrollIndex}
-        maintainScrollAtEnd={anchorToEnd && !hasNewerPosts}
+        maintainScrollAtEnd={anchorToEnd && !hasNewerPosts && !isUserScrolling}
         // A2UI rows can change by more than a small fraction of the viewport.
         // Keep the normal chat end anchor across those remeasurements whenever
         // the list was within one viewport of the latest message. Far-away
@@ -687,7 +707,10 @@ const ConversationPostListAttempt = React.forwardRef<
         onLayout={settleEmptyConversationAtEnd}
         onContentSizeChange={settleEmptyConversationAtEnd}
         onScroll={handleScroll}
-        onScrollBeginDrag={markUserScrolled}
+        onScrollBeginDrag={handleScrollBeginDrag}
+        onScrollEndDrag={handleScrollEndDrag}
+        onMomentumScrollBegin={handleMomentumScrollBegin}
+        onMomentumScrollEnd={handleMomentumScrollEnd}
         onStartReached={onStartReached}
         onStartReachedThreshold={onStartReachedThreshold}
         onEndReached={onEndReached}

--- a/packages/app/ui/components/Channel/PostList/PostList.tsx
+++ b/packages/app/ui/components/Channel/PostList/PostList.tsx
@@ -584,6 +584,55 @@ const ConversationPostListAttempt = React.forwardRef<
     const handleMomentumScrollEnd = React.useCallback(() => {
       setIsUserScrolling(false);
     }, []);
+    // Android emits no drag-end event for a cancelled touch, which would leave
+    // end maintenance suspended until the next gesture.
+    const handleTouchCancel = React.useCallback(() => {
+      setIsUserScrolling(false);
+    }, []);
+    // Android chat lists pad the scroll container for the composer. LegendList
+    // re-anchors the end of the list when data, rows, or its footer change
+    // size, but not when the container's padding does, so a composer growing
+    // line by line would cover the latest message. When the inset changes
+    // while the list rests at the end, scroll back to the end once the new
+    // padding has laid out. LegendList retargets its own initial scroll for
+    // padding changes, so this only runs after the initial anchor settles.
+    const composerInset = contentInsets.bottom;
+    const composerInsetRef = React.useRef(composerInset);
+    React.useLayoutEffect(() => {
+      const previousInset = composerInsetRef.current;
+      composerInsetRef.current = composerInset;
+      const insetDelta = composerInset - previousInset;
+      if (
+        Platform.OS !== 'android' ||
+        !anchorToEnd ||
+        insetDelta === 0 ||
+        !didFinishInitialScroll ||
+        isUserScrolling
+      ) {
+        return;
+      }
+      const listState = listRef.current?.getState();
+      if (!listState) {
+        return;
+      }
+      // The list has already absorbed the new padding into its content size,
+      // so the distance it reported before the change is the current
+      // distance less the delta.
+      const distanceFromEndBefore =
+        listState.contentLength -
+        listState.scroll -
+        listState.scrollLength -
+        insetDelta;
+      if (distanceFromEndBefore > 1) {
+        return;
+      }
+      const frame = requestAnimationFrame(() => {
+        runImperativeScroll(() =>
+          listRef.current?.scrollToEnd({ animated: false })
+        );
+      });
+      return () => cancelAnimationFrame(frame);
+    }, [anchorToEnd, composerInset, didFinishInitialScroll, isUserScrolling]);
     // LegendList recalculates this when scrolling, content, or row measurements
     // change. React Native onScroll can retain an intermediate value while the
     // initial anchor settles, briefly showing the scroll-to-bottom control.
@@ -734,6 +783,7 @@ const ConversationPostListAttempt = React.forwardRef<
         onScrollEndDrag={handleScrollEndDrag}
         onMomentumScrollBegin={handleMomentumScrollBegin}
         onMomentumScrollEnd={handleMomentumScrollEnd}
+        onTouchCancel={handleTouchCancel}
         onStartReached={onStartReached}
         onStartReachedThreshold={onStartReachedThreshold}
         onEndReached={onEndReached}

--- a/packages/app/ui/components/Channel/Scroller.tsx
+++ b/packages/app/ui/components/Channel/Scroller.tsx
@@ -397,30 +397,9 @@ const Scroller = forwardRef(
     const listOwnsComposerInset =
       Platform.OS === 'ios' &&
       collectionLayoutType === 'compact-list-bottom-to-top';
-    // Android chat lists carry the composer clearance as footer content rather
-    // than container padding. LegendList re-anchors the end of the list when
-    // its footer grows but not when the container's padding does, so padding
-    // would let a growing composer cover the latest message.
-    const footerOwnsComposerInset =
-      Platform.OS === 'android' &&
-      collectionLayoutType === 'compact-list-bottom-to-top' &&
-      (visiblePosts?.length ?? 0) > 0;
-    const scrollContentBottomInset =
-      listOwnsComposerInset || footerOwnsComposerInset
-        ? 0
-        : contentInsets.bottom;
-    const listFooterComponent = useMemo(
-      () =>
-        footerOwnsComposerInset ? (
-          <>
-            {listBottomComponent}
-            <View height={contentInsets.bottom} />
-          </>
-        ) : (
-          listBottomComponent
-        ),
-      [footerOwnsComposerInset, listBottomComponent, contentInsets.bottom]
-    );
+    const scrollContentBottomInset = listOwnsComposerInset
+      ? 0
+      : contentInsets.bottom;
     const [listFrameHeight, setListFrameHeight] = useState<number | null>(null);
     const handleListFrameLayout = useCallback((event: LayoutChangeEvent) => {
       const { height } = event.nativeEvent.layout;
@@ -690,7 +669,7 @@ const Scroller = forwardRef(
             scrollEnabled={!editingPost}
             style={style}
             listHeaderComponent={listHeaderComponent}
-            listBottomComponent={listFooterComponent}
+            listBottomComponent={listBottomComponent}
             contentInsets={contentInsets}
           />
         )}

--- a/packages/app/ui/components/Channel/Scroller.tsx
+++ b/packages/app/ui/components/Channel/Scroller.tsx
@@ -397,9 +397,30 @@ const Scroller = forwardRef(
     const listOwnsComposerInset =
       Platform.OS === 'ios' &&
       collectionLayoutType === 'compact-list-bottom-to-top';
-    const scrollContentBottomInset = listOwnsComposerInset
-      ? 0
-      : contentInsets.bottom;
+    // Android chat lists carry the composer clearance as footer content rather
+    // than container padding. LegendList re-anchors the end of the list when
+    // its footer grows but not when the container's padding does, so padding
+    // would let a growing composer cover the latest message.
+    const footerOwnsComposerInset =
+      Platform.OS === 'android' &&
+      collectionLayoutType === 'compact-list-bottom-to-top' &&
+      (visiblePosts?.length ?? 0) > 0;
+    const scrollContentBottomInset =
+      listOwnsComposerInset || footerOwnsComposerInset
+        ? 0
+        : contentInsets.bottom;
+    const listFooterComponent = useMemo(
+      () =>
+        footerOwnsComposerInset ? (
+          <>
+            {listBottomComponent}
+            <View height={contentInsets.bottom} />
+          </>
+        ) : (
+          listBottomComponent
+        ),
+      [footerOwnsComposerInset, listBottomComponent, contentInsets.bottom]
+    );
     const [listFrameHeight, setListFrameHeight] = useState<number | null>(null);
     const handleListFrameLayout = useCallback((event: LayoutChangeEvent) => {
       const { height } = event.nativeEvent.layout;
@@ -669,7 +690,7 @@ const Scroller = forwardRef(
             scrollEnabled={!editingPost}
             style={style}
             listHeaderComponent={listHeaderComponent}
-            listBottomComponent={listBottomComponent}
+            listBottomComponent={listFooterComponent}
             contentInsets={contentInsets}
           />
         )}


### PR DESCRIPTION
## Summary

On Android, a chat composer that grew while you typed did not push the conversation up with it, so the latest message ended up hidden behind the composer until something else re-anchored the list. This carries the composer clearance as list footer content instead of container padding, which is the path LegendList already re-anchors on.

Based on `staging`, following #6430.

## Changes

- `packages/app/ui/components/Channel/Scroller.tsx`: on Android compact chat lists with rows, render the composer inset as a spacer inside the list footer (after the thinking indicator when present) and drop it from `contentContainerStyle.paddingBottom`. Empty conversations keep the padding path since they have nothing to re-anchor.

Why this works: LegendList's `maintainScrollAtEnd` runs when data, a row, or the footer changes size, but not when the scroll container's padding changes. With padding, every extra composer line grew the content while the scroll offset stayed put, so the composer slid over the last message. Footer growth goes through `updateFooterSize` → `doMaintainScrollAtEnd`, which scrolls the end back into view in the same frame the composer grows or shrinks. iOS is untouched; it already routes the composer inset through keyboard-controller's content inset path.

## How did I test?

- Galaxy S24 (Android 16, API 36), physical device, served over Metro. Bot DM with the keyboard open.
- Typed a 151-character draft in chunks, growing the composer from 1 to 7 lines. Read the accessibility tree after each chunk: the last message's feedback buttons stayed above the composer top every time. On `staging` before the change they sat behind the composer (buttons at y = 0.438 of screen height, composer top at 0.347).
- Deleted three lines: the composer shrank and the list followed back down, still anchored at the end.
- Frame analysis of two 30 fps screen recordings of the same typing burst: with the change, six growth steps, each with a matching one-line upward shift of the list content in the same frame and no reverse movement. Without it, zero list movement across the whole burst.
- Console probes on the native TextInput content size, text length, and row layout showed the composer's own height stepping cleanly (no oscillation) in every typing mode tried: end of draft, mid-draft insertion, on-screen keyboard taps, fresh entry into the DM.
- `pnpm tsc` in `packages/app` and `oxfmt --check` on the changed file.

## Risks and impact

- Safe to rollback without consulting PR author? Yes
- Affects important code area:
  - [ ] Onboarding
  - [ ] State / providers
  - [ ] Message sync
  - [x] Channel display
  - [ ] Notifications
  - [ ] Other:

Android chat lists only. The footer spacer is measured by LegendList's footer `LayoutView`, so the list's content size and end alignment include it exactly as the padding did. When the user has scrolled up into history, `maintainScrollAtEnd` is outside its threshold and does nothing, same as before. Not OTA-able in practice for this repo; ships with the next native build.

## Rollback plan

Revert the commit. No native, migration, or data changes.

## Screenshots / videos

Before and after trees are in the testing notes above. The check on any device: type until the composer wraps a few times and confirm the latest message is still fully visible above it.
