### PR TITLE
fix android composer text alignment

### DIFF
--- a/packages/app/ui/components/BareChatInput/index.tsx
+++ b/packages/app/ui/components/BareChatInput/index.tsx
@@ -30,7 +30,7 @@ import {
   useRef,
   useState,
 } from 'react';
-import { Keyboard, TextInput } from 'react-native';
+import { Keyboard, Platform, TextInput } from 'react-native';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
 import {
   View,
@@ -71,6 +71,7 @@ import {
 } from './useSlashCommands';
 
 const bareChatInputLogger = createDevLogger('bareChatInput', false);
+const MESSAGE_INPUT_CONTAINER_HEIGHT = 48;
 
 function normalizePreviewUrl(url: string) {
   try {
@@ -347,6 +348,13 @@ function BareChatInput(
     resetSlashCommandMode,
   } = useSlashCommands({ manifest: slashCommandManifest });
   const maxInputHeight = useMaxInputHeight(maxInputHeightBasic);
+  // Android's material input pill is 48dp tall and bottom-anchors its content
+  // so multiline composers grow upward. Fill that pill at the single-line
+  // height; otherwise the 44dp text input sits 4dp low inside it.
+  const minimumInputHeight =
+    Platform.OS === 'android'
+      ? Math.max(initialHeight, MESSAGE_INPUT_CONTAINER_HEIGHT)
+      : initialHeight;
   const inputRef = useRef<TextInput>(null);
 
   usePasteHandler(addAttachment);
@@ -1085,7 +1093,7 @@ function BareChatInput(
     <MessageInputContainer
       onPressSend={handleSend}
       setShouldBlur={setShouldBlur}
-      containerHeight={48}
+      containerHeight={MESSAGE_INPUT_CONTAINER_HEIGHT}
       disableSend={disableSend}
       sendError={sendError}
       showWayfindingTooltip={showWayfindingTooltip}
@@ -1133,7 +1141,7 @@ function BareChatInput(
             {...(!isWeb ? placeholderTextColor : {})}
             style={{
               backgroundColor: 'transparent',
-              minHeight: initialHeight,
+              minHeight: minimumInputHeight,
               // Let the native input auto-size while it has content; force the
               // initial height when empty. The uncontrolled native input keeps a
               // stale (expanded) measurement after the text is cleared on send,
@@ -1141,7 +1149,7 @@ function BareChatInput(
               height: isWeb
                 ? inputHeight
                 : controlledText === ''
-                  ? initialHeight
+                  ? minimumInputHeight
                   : undefined,
               maxHeight: maxInputHeight - getTokenValue('$s', 'space'),
               paddingHorizontal: getTokenValue('$l', 'space'),


### PR DESCRIPTION
## Summary

Centers the initial message text and placeholder in the Android input pill.

The text input now fills the existing 48dp pill when empty or on one line. Multiline input keeps the same bounds and continues to grow upward.

Fixes TLON-6457

## Changes

- match the Android text input's minimum height to the existing 48dp pill
- reuse the same height value for the pill and text input
- leave iOS and web sizing unchanged

## How did I test?

- Galaxy S24 running Android 16, using the attached physical device with a cached `productionDebug` build
- verified the empty input changed from 44dp (`[204,2040][894,2172]`) to the full 48dp pill (`[204,2028][894,2172]`)
- verified multiline bounds were unchanged before and after (`[204,1039][894,1290]`)
- `corepack pnpm --filter @tloncorp/app exec tsc --noEmit --pretty false`
- `corepack pnpm exec oxfmt --check packages/app/ui/components/BareChatInput/index.tsx`
- `corepack pnpm exec oxlint packages/app/ui/components/BareChatInput/index.tsx` (warnings only, no errors)
- `git diff --check`
- `stim logs --errors` (no runtime errors)

## Risks and impact

This changes only the Android text input's empty and single-line height from 44dp to 48dp. The overall empty composer was already 48dp, so its list inset and scrolling geometry do not change. Attachment previews remain a sibling above the input and continue to use the composer's measured height; attachment layout was not physically verified.

## Rollback plan

Revert the commit. There are no native project, migration, or data changes.

## Screenshots

| Before | After |
| --- | --- |
| <img src="https://github.com/user-attachments/assets/5a9ae07b-c5af-4dcb-a735-5b975963e45b" alt="Android message input before" width="320" /> | <img src="https://github.com/user-attachments/assets/78fc5eef-4d57-4c7d-917c-cf6c238b4433" alt="Android message input after" width="320" /> |
