### PR TITLE
desk: pioneer threads to publish a desk and install it from the sponsor

### DIFF
--- a/desk/ted/pioneer/install-from-sponsor.hoon
+++ b/desk/ted/pioneer/install-from-sponsor.hoon
@@ -1,0 +1,49 @@
+::  pioneer/install-from-sponsor: track a desk from our sponsor
+::
+::    equivalent to |install ~sponsor %desk. meant to run on a tlawn moon
+::    so its %groups follows the planet's copy (which must be public, see
+::    pioneer/publish-desk) rather than the distribution ship.
+::
+::    arg (json):
+::      { "desk":   "groups",
+::        "source": "~sampel-palnet"    // optional; defaults to our sponsor
+::      }
+::
+::    kiln drops the desk's existing sync and starts one from the new
+::    source when they differ, and is a no-op when they match, so this is
+::    safe to run on every boot.
+::
+::    return:
+::      json: { "desk": "groups", "source": "~sampel-palnet" }
+::
+/-  spider
+/+  *strandio
+=,  strand=strand:spider
+=,  dejs:format
+^-  thread:spider
+|=  arg=vase
+=/  m  (strand ,vase)
+^-  form:m
+;<  =bowl:spider  bind:m  get-bowl
+=+  !<(arg=(unit json) arg)
+?>  ?=(^ arg)
+=*  json  u.arg
+=/  args=[=desk source=(unit ship)]
+  %.  json
+  %-  ou
+  :~  desk+(un (se %tas))
+      source+(uf ~ (mu (se %p)))
+  ==
+=/  source=ship
+  (fall source.args (sein:title our.bowl now.bowl our.bowl))
+?:  =(our.bowl source)
+  %+  strand-fail:strand  %source-is-self
+  [leaf+"{(scow %p our.bowl)} can't install {(trip desk.args)} from itself"]~
+;<  ~  bind:m
+  (poke-our %hood kiln-install+!>([desk.args source desk.args]))
+=/  out=^json
+  %-  pairs:enjs:format
+  :~  desk+s+desk.args
+      source+s+(scot %p source)
+  ==
+(pure:m !>(out))

--- a/desk/ted/pioneer/publish-desk.hoon
+++ b/desk/ted/pioneer/publish-desk.hoon
@@ -1,0 +1,41 @@
+::  pioneer/publish-desk: make a desk publicly readable
+::
+::    equivalent to |public %desk. once a planet's %groups is public its
+::    tlawn moon can |install %groups from the planet instead of the
+::    distribution ship, so the pair can't drift apart on OTA.
+::
+::    arg (json):
+::      { "desk": "groups" }
+::
+::    return:
+::      json: { "desk": "groups", "public": true|false }
+::
+::    "public" is read back from clay after the poke, so a false here
+::    means the permission did not take.
+::
+/-  spider
+/+  *strandio
+=,  strand=strand:spider
+=,  dejs:format
+^-  thread:spider
+|=  arg=vase
+=/  m  (strand ,vase)
+^-  form:m
+=+  !<(arg=(unit json) arg)
+?>  ?=(^ arg)
+=*  json  u.arg
+=/  =desk  ((ot desk+(se %tas) ~) json)
+;<  ~  bind:m  (poke-our %hood kiln-permission+!>([desk / &]))
+;<  perms=[read=dict:clay write=dict:clay]  bind:m
+  (scry ,[dict:clay dict:clay] /cp/[desk])
+=/  public=?
+  ?&  =(%black mod.rul.read.perms)
+      =(~ p.who.rul.read.perms)
+      =(~ q.who.rul.read.perms)
+  ==
+=/  out=^json
+  %-  pairs:enjs:format
+  :~  desk+s+desk
+      public+b+public
+  ==
+(pure:m !>(out))


### PR DESCRIPTION
## Why

Hosted planets and their tlawn bot moons each track `%groups` from the distribution ship on their own. When either sync stalls the pair ends up on different hashes (~33 pairs as of 2026-09-02). Having the moon `|install` `%groups` from its planet instead makes the pair converge by construction.

## What

Two spider threads under `desk/ted/pioneer/`, called by pioneer's `/v1/desk/publish` and `/v1/desk/install-from-sponsor` (tloncorp/ylem PR) and by tlawn.py on moon boot (tloncorp/tlonbot PR):

- **`pioneer/publish-desk`** `{"desk"}`: pokes `%hood` with `%kiln-permission [desk / &]` (what `|public` does), then scries `/cp/<desk>` and returns `{"desk", "public": bool}` read back from clay.
- **`pioneer/install-from-sponsor`** `{"desk", "source"?}`: pokes `%hood` with `%kiln-install [desk source desk]` (what `|install` does); `source` defaults to `sein`. kiln drops the old sync when the source differs and no-ops when it matches, so it is safe to run on every boot. Fails with `%source-is-self` if asked to install from ourselves.

## Testing

- Both compile on a dev moon (`mcp/test-build`).
- `publish-desk` run live on that moon: `{"desk":"groups","public":true}`.
- `install-from-sponsor` compiled only; running it on the dev moon would have replaced its `%groups` with the sponsor's copy.

Part of TLON-6456

🤖 Generated with [Claude Code](https://claude.com/claude-code)
