### PR TITLE
Turn off position maintenance for empty conversations

### DIFF
--- a/packages/app/fixtures/Channel.fixture.tsx
+++ b/packages/app/fixtures/Channel.fixture.tsx
@@ -507,14 +507,19 @@ function ChannelWithControlledPostLoading() {
 
 // Replays the agent group setup lifecycle on a timer: posts load into an
 // empty channel, the first-entry indicator appears, the first entry arrives,
-// then the indicator clears. The header height mimics the transparent native
-// header so the list carries a top content inset like it does on iOS.
+// then the indicator clears. The header height arrives late, as the
+// transparent native header does on iOS, so the top inset changes under
+// an empty list.
 function AgentGroupSetupSequence() {
   const [posts, setPosts] = useState<db.Post[] | null>(null);
   const [label, setLabel] = useState<string | undefined>(undefined);
+  // The transparent native header reports its height after the channel
+  // mounts, so the list's top inset changes while it is still empty.
+  const [headerHeight, setHeaderHeight] = useState(0);
   useEffect(() => {
     const timeouts = [
       setTimeout(() => setPosts([]), 1500),
+      setTimeout(() => setHeaderHeight(103), 2500),
       setTimeout(() => setLabel('Writing your first entry…'), 5000),
       setTimeout(() => setPosts([createFakePost()]), 9000),
       setTimeout(() => setLabel(undefined), 11000),
@@ -522,7 +527,7 @@ function AgentGroupSetupSequence() {
     return () => timeouts.forEach(clearTimeout);
   }, []);
   return (
-    <HeaderHeightContext.Provider value={103}>
+    <HeaderHeightContext.Provider value={headerHeight}>
       <ChannelFixture
         negotiationMatch={true}
         theme={'light'}

--- a/packages/app/ui/components/Channel/PostList/PostList.tsx
+++ b/packages/app/ui/components/Channel/PostList/PostList.tsx
@@ -582,11 +582,17 @@ const ConversationPostListAttempt = React.forwardRef<
     // Data anchoring and end anchoring choose different items to preserve.
     // Let end anchoring own updates while the conversation is being followed;
     // retain data anchoring only after the user has moved away from the end.
+    // With no rows there is nothing to keep in view, and LegendList's default
+    // size anchoring (left on by `undefined`) scrolls iOS by any top padding
+    // change, which carried an empty conversation up by the header inset when
+    // the transparent header reported its height after mount.
     const maintainVisibleContentPosition =
-      collectionLayout.shouldMaintainVisibleContentPosition &&
-      !(anchorToEnd && !hasNewerPosts && isNearEnd)
-        ? true
-        : undefined;
+      postsWithNeighbors.length === 0
+        ? false
+        : collectionLayout.shouldMaintainVisibleContentPosition &&
+            !(anchorToEnd && !hasNewerPosts && isNearEnd)
+          ? true
+          : undefined;
     usePostListBottomCallbacks(isAtBottom, {
       onScrolledToBottom,
       onScrolledAwayFromBottom,


### PR DESCRIPTION
## Summary

Follow-up to #6427 for [TLON-6447](https://linear.app/tlon/issue/TLON-6447) (and [TLON-6440](https://linear.app/tlon/issue/TLON-6440)): on a real device the thinking indicator in a brand-new agent group still floated one header height above the composer. The remaining trigger is the transparent native header reporting its height after the channel mounts, which changes the empty list's top padding; LegendList's size-based position maintenance "compensated" that padding change by scrolling the empty content up by the same amount, and nothing clamps or corrects it because there are no rows.

## Changes

- **`PostList.tsx`**: pass `maintainVisibleContentPosition={false}` while the conversation has no rows. There is nothing to keep in view, and LegendList treats an unset flag as `{ data: false, size: true }`, so our previous `undefined` never turned the size adjustment off. On iOS that adjustment calls `requestAdjust(paddingDiff)` whenever `stylePaddingTop` changes, which is exactly what moved the footer. Populated lists keep their existing behavior.
- **`Channel.fixture.tsx`**: the `agentGroupSetupSequence` cosmos fixture now delivers the header height late (0 → 103 at 2.5s), reproducing the device timing. Without this fix the fixture puts the indicator at 673 (103 above the composer); with it, at 776.

### Why #6427 missed this

The simulator fixture used to provide the header height from mount, so `paddingTop` never changed under an empty list. On the phone the sequence is: mount with top inset 0 → content sized to 776 and settled at offset 0 → header reports 116 → LegendList scrolls by +116 → indicator renders at bottom 660 (device beacons below).

## How did I test?

iPhone 16 Pro (iOS 26.6.1), preview dev build from this branch, real account, Home → + → Agent group, with temporary `measureInWindow` beacons (composer top edge at 776pt):

| Stage | Before (staging) | After |
| --- | --- | --- |
| Header inset arrives (`contentInsets.top` 0 → 116) | offset shifts +116 | offset stays 0 |
| Bot thinking indicator appears | bottom 660 | bottom 776 |
| 1.5s / 4s re-measure | 660 / 660 | 776 / 776 |
| First post arrives, indicator clears | 776 | 776 |

Simulator (iPhone 17, cosmos `agentGroupSetupSequence` with the late header inset): fix removed → indicator bottom 673; fix applied → 776.

Also: `tsc` for `packages/app`, `oxfmt --check`, and the related vitest suites pass.

## Risks and impact

- Safe to rollback without consulting PR author? (Yes)
- Affects important code area:
  - [ ] Onboarding
  - [ ] State / providers
  - [ ] Message sync
  - [x] Channel display
  - [ ] Notifications
  - [ ] Other:

Only the zero-row state of iOS/Android conversation lists changes; once a row exists the flag is computed exactly as before.

## Rollback plan

Revert this commit. No data or schema changes.

## Screenshots / videos

Device geometry is in the table above; the earlier PR's screenshots show the intended placement.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
