### PR TITLE
iOS: fix reaction viewer colliding with message actions

### DIFF
--- a/apps/tlon-mobile/ios/LandscapeTests/TlonMessageMenuLayoutTests.swift
+++ b/apps/tlon-mobile/ios/LandscapeTests/TlonMessageMenuLayoutTests.swift
@@ -1,7 +1,51 @@
 @testable import TlonMessageContextMenu
+import UIKit
 import XCTest
 
 final class TlonMessageMenuLayoutTests: XCTestCase {
+    func testReactionPressDoesNotOpenMessageMenu() {
+        let hostView = UIView()
+        let reactionView = UIView()
+        reactionView.accessibilityIdentifier = "ReactionDisplay"
+        hostView.addSubview(reactionView)
+
+        XCTAssertFalse(
+            TlonMessageContextMenuView.shouldReceiveMessageMenuTouch(
+                reactionView,
+                within: hostView
+            )
+        )
+    }
+
+    func testReactionDescendantPressDoesNotOpenMessageMenu() {
+        let hostView = UIView()
+        let reactionView = UIView()
+        reactionView.accessibilityIdentifier = "ReactionDisplay"
+        let reactionLabel = UILabel()
+        reactionView.addSubview(reactionLabel)
+        hostView.addSubview(reactionView)
+
+        XCTAssertFalse(
+            TlonMessageContextMenuView.shouldReceiveMessageMenuTouch(
+                reactionLabel,
+                within: hostView
+            )
+        )
+    }
+
+    func testOtherPressDoesOpenMessageMenu() {
+        let hostView = UIView()
+        let messageContent = UIView()
+        hostView.addSubview(messageContent)
+
+        XCTAssertTrue(
+            TlonMessageContextMenuView.shouldReceiveMessageMenuTouch(
+                messageContent,
+                within: hostView
+            )
+        )
+    }
+
     func testLeadingLayoutPreservesSourcePositionUntilAccessoriesNeedSpace() {
         let layout = TlonMessageMenuPresentationView.resolveLayout(
             bounds: CGRect(x: 0, y: 0, width: 390, height: 844),

--- a/apps/tlon-mobile/ios/Podfile.lock
+++ b/apps/tlon-mobile/ios/Podfile.lock
@@ -3466,7 +3466,7 @@ SPEC CHECKSUMS:
   FirebaseSharedSwift: 3d1e448b7202e36821a492941c84592d1308ea14
   GoogleDataTransport: aae35b7ea0c09004c3797d53c8c41f66f219d6a7
   GoogleUtilities: 4f2618a4a1e762a1ee134a1e2323bba9843e06da
-  hermes-engine: faa465b5298774b02176ef07ebad7be1d329570e
+  hermes-engine: 102fde143d2ee5658c5af1ecd876df920eae86ea
   libavif: 5f8e715bea24debec477006f21ef9e95432e254d
   libdav1d: 23581a4d8ec811ff171ed5e2e05cd27bad64c39f
   libwebp: 02b23773aedb6ff1fd38cec7a77b81414c6842a8

--- a/apps/tlon-mobile/modules/tlon-message-context-menu/ios/TlonMessageContextMenuView.swift
+++ b/apps/tlon-mobile/modules/tlon-message-context-menu/ios/TlonMessageContextMenuView.swift
@@ -192,8 +192,15 @@ final class TlonMessageContextMenuView: ExpoView, UIGestureRecognizerDelegate {
         _: UIGestureRecognizer,
         shouldReceive touch: UITouch
     ) -> Bool {
-        var touchedView = touch.view
-        while let view = touchedView, view !== self {
+        Self.shouldReceiveMessageMenuTouch(touch.view, within: self)
+    }
+
+    static func shouldReceiveMessageMenuTouch(
+        _ touchedView: UIView?,
+        within hostView: UIView
+    ) -> Bool {
+        var touchedView = touchedView
+        while let view = touchedView, view !== hostView {
             // Reaction pills own their long press so users can inspect who
             // reacted instead of opening the message-level action menu.
             if view.accessibilityIdentifier?.hasPrefix("ReactionDisplay") == true {

--- a/packages/app/ui/components/ChatMessage/ReactionsDisplay.tsx
+++ b/packages/app/ui/components/ChatMessage/ReactionsDisplay.tsx
@@ -175,12 +175,13 @@ export function ReactionsDisplay({
         <XStack borderRadius="$m" gap="$xs" flexWrap="wrap">
           {reactionDetails.list.map((reaction) => (
             <Tooltip key={reaction.value} placement="top" delay={0} restMs={25}>
-              <Tooltip.Trigger
-                borderRadius="$s"
-                cursor="pointer"
-                testID="ReactionDisplay"
-              >
+              <Tooltip.Trigger borderRadius="$s" cursor="pointer">
                 <Pressable
+                  // The iOS message context menu checks the touched native
+                  // view hierarchy for this identifier before recognizing its
+                  // own long press. Keep it on the actual press target rather
+                  // than the tooltip wrapper.
+                  testID="ReactionDisplay"
                   flexDirection="row"
                   justifyContent="center"
                   alignItems="center"


### PR DESCRIPTION
## Summary

This was just a long press handling issue. The reaction menu's ID was attached at the wrong layer allowing the collision. Moving it onto the actual button fixes the issue.

## Changes

- Moved `ReactionDisplay` identifier onto the actual reaction button.
- Added iOS regression coverage for reaction and regular message presses
- Refactored the existing Swift gesture check to make it testable

## How did I test?

iOS simulator

## Risks and impact

- Safe to rollback without consulting PR author? Yes
- Affects important code area:
  - [x] Channel display