### PR TITLE
mobile: telemetry for bot settings changes

### DIFF
--- a/packages/api/src/types/analytics.ts
+++ b/packages/api/src/types/analytics.ts
@@ -64,6 +64,7 @@ export enum AnalyticsEvent {
   TlonbotMcpConnected = 'Tlonbot MCP: Connected',
   TlonbotMcpDisconnected = 'Tlonbot MCP: Disconnected',
   TlonbotMcpError = 'Tlonbot MCP: Error',
+  TlonbotSettingUpdated = 'Tlonbot Setting Updated',
   TlonbotReplyFeedbackChanged = 'Tlonbot Reply Feedback Changed',
   TlonbotReplyFeedbackDetailsSubmitted = 'Tlonbot Reply Feedback Details Submitted',
   AttachmentUploadSuccess = 'Attachment Upload Success',

--- a/packages/app/features/settings/BotMcpSettingsScreen.tsx
+++ b/packages/app/features/settings/BotMcpSettingsScreen.tsx
@@ -22,6 +22,7 @@ import {
   trackMcpError,
   trackMcpEvent,
 } from './botMcpSettingsHelpers';
+import { trackTlonbotSettingUpdated } from './bot/botSettingsTelemetry';
 
 type Props = NativeStackScreenProps<RootStackParamList, 'BotMcpSettings'>;
 
@@ -161,6 +162,11 @@ export function BotMcpSettingsScreen(props: Props) {
         trackMcpEvent(MCP_TELEMETRY_EVENTS.connected, {
           providerId: completion.providerId,
         });
+        trackTlonbotSettingUpdated({
+          setting: 'connected_service',
+          action: 'connected',
+          provider: completion.providerId ?? undefined,
+        });
         triggerHaptic('success');
       }
       showMcpToast({
@@ -280,6 +286,11 @@ export function BotMcpSettingsScreen(props: Props) {
       try {
         await api.deleteTlawnOAuthGrant(currentUserId, providerId);
         trackMcpEvent(MCP_TELEMETRY_EVENTS.disconnected, { providerId });
+        trackTlonbotSettingUpdated({
+          setting: 'connected_service',
+          action: 'disconnected',
+          provider: providerId,
+        });
         triggerHaptic('success');
         showMcpToast({ message: 'Connection disconnected.' });
         await refreshStatus();

--- a/packages/app/features/settings/bot/botSettingsTelemetry.test.ts
+++ b/packages/app/features/settings/bot/botSettingsTelemetry.test.ts
@@ -1,0 +1,64 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const mocks = vi.hoisted(() => ({
+  trackEvent: vi.fn(),
+}));
+
+vi.mock('@tloncorp/shared', () => ({
+  AnalyticsEvent: {
+    TlonbotSettingUpdated: 'Tlonbot Setting Updated',
+  },
+  trackEvent: mocks.trackEvent,
+}));
+
+import { trackTlonbotSettingUpdated } from './botSettingsTelemetry';
+
+describe('trackTlonbotSettingUpdated', () => {
+  beforeEach(() => {
+    mocks.trackEvent.mockClear();
+  });
+
+  it('captures the common event with privacy-safe setting properties', () => {
+    trackTlonbotSettingUpdated({
+      setting: 'zero_data_retention',
+      action: 'updated',
+      enabled: true,
+      provider: 'openrouter',
+    });
+
+    expect(mocks.trackEvent).toHaveBeenCalledWith('Tlonbot Setting Updated', {
+      surface: 'bot_settings',
+      setting: 'zero_data_retention',
+      action: 'updated',
+      enabled: true,
+      provider: 'openrouter',
+    });
+  });
+
+  it('omits undefined optional properties', () => {
+    trackTlonbotSettingUpdated({
+      setting: 'connected_service',
+      action: 'connected',
+      provider: undefined,
+    });
+
+    expect(mocks.trackEvent).toHaveBeenCalledWith('Tlonbot Setting Updated', {
+      surface: 'bot_settings',
+      setting: 'connected_service',
+      action: 'connected',
+    });
+  });
+
+  it('does not fail a successful settings write when analytics throws', () => {
+    mocks.trackEvent.mockImplementationOnce(() => {
+      throw new Error('analytics unavailable');
+    });
+
+    expect(() =>
+      trackTlonbotSettingUpdated({
+        setting: 'nickname',
+        action: 'updated',
+      })
+    ).not.toThrow();
+  });
+});

--- a/packages/app/features/settings/bot/botSettingsTelemetry.ts
+++ b/packages/app/features/settings/bot/botSettingsTelemetry.ts
@@ -1,0 +1,43 @@
+import { AnalyticsEvent, trackEvent } from '@tloncorp/shared';
+
+export type TlonbotSettingUpdatedProperties = {
+  setting:
+    | 'api_key'
+    | 'auto_accept_dm_invites'
+    | 'auto_discover_channels'
+    | 'channel_rules'
+    | 'connected_service'
+    | 'default_authorized_ships'
+    | 'dm_allowlist'
+    | 'fallback_models'
+    | 'group_invite_allowlist'
+    | 'nickname'
+    | 'primary_model'
+    | 'subscription'
+    | 'zero_data_retention';
+  action?: 'connected' | 'disconnected' | 'removed' | 'saved' | 'updated';
+  count?: number;
+  enabled?: boolean;
+  model?: string;
+  provider?: string;
+};
+
+/**
+ * Capture a successfully persisted bot setting without sending user-authored
+ * values such as nicknames, ship lists, or channel identifiers.
+ */
+export function trackTlonbotSettingUpdated(
+  properties: TlonbotSettingUpdatedProperties
+) {
+  try {
+    trackEvent(AnalyticsEvent.TlonbotSettingUpdated, {
+      surface: 'bot_settings',
+      ...Object.fromEntries(
+        Object.entries(properties).filter(([, value]) => value !== undefined)
+      ),
+    });
+  } catch {
+    // Analytics is best-effort and must never turn a successful settings write
+    // into a visible apply failure or leave the local draft uncommitted.
+  }
+}

--- a/packages/app/features/settings/bot/useBotSettingsData.ts
+++ b/packages/app/features/settings/bot/useBotSettingsData.ts
@@ -35,6 +35,7 @@ import {
   getLLMAuthSubscriptionModels,
   mergeProviderModels,
 } from './openAiSubscription';
+import { trackTlonbotSettingUpdated } from './botSettingsTelemetry';
 
 /**
  * Identifiers for the tlonbot hosting endpoints. User-level endpoints
@@ -335,6 +336,11 @@ export function useBotSettingsMutations() {
     onSuccess: (data, { provider }) => {
       setProviderConfig(data);
       invalidateProviderModels(provider);
+      trackTlonbotSettingUpdated({
+        setting: 'api_key',
+        action: 'saved',
+        provider,
+      });
     },
   });
 
@@ -344,24 +350,39 @@ export function useBotSettingsMutations() {
     onSuccess: (data, { provider }) => {
       setProviderConfig(data);
       invalidateProviderModels(provider);
+      trackTlonbotSettingUpdated({
+        setting: 'api_key',
+        action: 'removed',
+        provider,
+      });
     },
   });
 
   const disconnectLLMSubscription = useMutation({
     mutationFn: (provider: api.TlawnLLMAuthProvider) =>
       api.disconnectTlawnLLMAuth(ship, provider),
-    onSuccess: (_data, provider) =>
-      Promise.all(
+    onSuccess: (_data, provider) => {
+      trackTlonbotSettingUpdated({
+        setting: 'subscription',
+        action: 'disconnected',
+        provider,
+      });
+      return Promise.all(
         getLLMAuthDisconnectQueryKeys(ship, hostingUserId, provider).map(
           (queryKey) => queryClient.invalidateQueries({ queryKey })
         )
-      ),
+      );
+    },
   });
 
   const updateNickname = useMutation({
     mutationFn: (nickname: string) => api.setTlawnNickname(ship, nickname),
     onSuccess: (data) => {
       queryClient.setQueryData(['tlonbot', 'nickname', ship], data);
+      trackTlonbotSettingUpdated({
+        setting: 'nickname',
+        action: 'updated',
+      });
     },
   });
 

--- a/packages/app/features/settings/bot/useBotSettingsDraft.ts
+++ b/packages/app/features/settings/bot/useBotSettingsDraft.ts
@@ -17,12 +17,14 @@ import {
   getModelFormValues,
   haveChannelModelEntriesChanged,
   mergeChannelRules,
+  normalizeShipList,
   normalizeChannelRuleKey,
   normalizeProviderConfig,
   normalizeTlonbotConfig,
   runApplySteps,
   toChatFormValues,
 } from './helpers';
+import { trackTlonbotSettingUpdated } from './botSettingsTelemetry';
 import {
   BotSettingsQueries,
   useBotSettingsMutations,
@@ -381,6 +383,30 @@ export function useApplyBotSettings(queries: BotSettingsQueries) {
                 : serverModel.fallbacks,
             });
             const savedProviderConfig = normalizeProviderConfig(saved);
+            const savedModel = getModelFormValues(savedProviderConfig);
+            if (draft.pending.modelProvider || draft.pending.model) {
+              trackTlonbotSettingUpdated({
+                setting: 'primary_model',
+                action: 'updated',
+                provider: savedModel.provider,
+                model: savedModel.model,
+              });
+            }
+            if (draft.pending.zdr) {
+              trackTlonbotSettingUpdated({
+                setting: 'zero_data_retention',
+                action: 'updated',
+                enabled: savedModel.zdr,
+                provider: savedModel.provider,
+              });
+            }
+            if (draft.pending.fallbacks) {
+              trackTlonbotSettingUpdated({
+                setting: 'fallback_models',
+                action: 'updated',
+                count: savedModel.fallbacks.length,
+              });
+            }
             // The save returns the full post-save provider config; adopt it as
             // the cached fresh config so the later channelModels merge (in the
             // chat step of this same apply) works from the newest snapshot —
@@ -390,7 +416,7 @@ export function useApplyBotSettings(queries: BotSettingsQueries) {
             // Basic pinned to its default) rather than the draft snapshot, so a
             // later failing step doesn't leave a stale model shown.
             return {
-              model: getModelFormValues(savedProviderConfig),
+              model: savedModel,
             };
           },
           commit: { model: nextValues.model },
@@ -554,6 +580,49 @@ export function useApplyBotSettings(queries: BotSettingsQueries) {
         const savedProviderConfig = normalizeProviderConfig(
           result.providerConfig
         );
+        const savedChat = toChatFormValues(savedConfig, savedProviderConfig);
+        if (draft.pending.dmAllowlist) {
+          trackTlonbotSettingUpdated({
+            setting: 'dm_allowlist',
+            action: 'updated',
+            count: normalizeShipList(savedChat.dmAllowlist).length,
+          });
+        }
+        if (draft.pending.defaultAuthorizedShips) {
+          trackTlonbotSettingUpdated({
+            setting: 'default_authorized_ships',
+            action: 'updated',
+            count: normalizeShipList(savedChat.defaultAuthorizedShips).length,
+          });
+        }
+        if (draft.pending.groupInviteAllowlist) {
+          trackTlonbotSettingUpdated({
+            setting: 'group_invite_allowlist',
+            action: 'updated',
+            count: normalizeShipList(savedChat.groupInviteAllowlist).length,
+          });
+        }
+        if (draft.pending.autoAcceptDmInvites) {
+          trackTlonbotSettingUpdated({
+            setting: 'auto_accept_dm_invites',
+            action: 'updated',
+            enabled: savedChat.autoAcceptDmInvites,
+          });
+        }
+        if (draft.pending.autoDiscoverChannels) {
+          trackTlonbotSettingUpdated({
+            setting: 'auto_discover_channels',
+            action: 'updated',
+            enabled: savedChat.autoDiscoverChannels,
+          });
+        }
+        if (draft.pending.channelRules) {
+          trackTlonbotSettingUpdated({
+            setting: 'channel_rules',
+            action: 'updated',
+            count: Object.keys(savedChat.channelRuleDrafts).length,
+          });
+        }
         mutations.queryClient.setQueryData(
           ['tlonbot', 'settings', queries.ship],
           savedConfig
@@ -563,7 +632,7 @@ export function useApplyBotSettings(queries: BotSettingsQueries) {
         // another client added and the merge preserved) rather than the draft
         // snapshot, so those aren't hidden until the next remount/refetch.
         return {
-          chat: toChatFormValues(savedConfig, savedProviderConfig),
+          chat: savedChat,
         };
       };
       if (chatConfigDirty) {

--- a/packages/app/features/settings/bot/useOpenAISubscriptionAuth.test.tsx
+++ b/packages/app/features/settings/bot/useOpenAISubscriptionAuth.test.tsx
@@ -17,6 +17,8 @@ const mocks = vi.hoisted(() => ({
   setQueryData: vi.fn(),
   startAuth: vi.fn(),
   completeAuth: vi.fn(),
+  getAuthStatus: vi.fn(),
+  trackSettingUpdated: vi.fn(),
   queryClient: null as null | { setQueryData: ReturnType<typeof vi.fn> },
 }));
 
@@ -30,7 +32,11 @@ vi.mock('@tloncorp/api', () => ({
   startTlawnLLMAuth: mocks.startAuth,
   completeTlawnLLMAuth: mocks.completeAuth,
   getTlawnLLMAuthFlow: vi.fn(),
-  getTlawnLLMAuthStatus: vi.fn(),
+  getTlawnLLMAuthStatus: mocks.getAuthStatus,
+}));
+
+vi.mock('./botSettingsTelemetry', () => ({
+  trackTlonbotSettingUpdated: mocks.trackSettingUpdated,
 }));
 
 vi.mock('react-native', () => ({
@@ -190,6 +196,58 @@ describe('useOpenAISubscriptionAuth', () => {
       phase: 'active',
       flow: { provider: 'anthropic', status: 'authenticating' },
     });
+
+    act(() => renderer!.unmount());
+  });
+
+  it('tracks the provider after a subscription is successfully connected', async () => {
+    let auth: ReturnType<typeof useOpenAISubscriptionAuth> | null = null;
+    let renderer: ReactTestRenderer;
+    const onComplete = vi.fn();
+    const awaitingToken = {
+      id: 'flow-anthropic',
+      provider: 'anthropic',
+      status: 'awaiting_token',
+      expiresAt: Date.now() + 60_000,
+    };
+    mocks.startAuth.mockResolvedValue({ flow: awaitingToken });
+    mocks.completeAuth.mockResolvedValue({
+      flow: { ...awaitingToken, status: 'complete' },
+    });
+    mocks.getAuthStatus.mockResolvedValue({
+      ts: Date.now(),
+      providers: [{ provider: 'anthropic', status: 'connected' }],
+      subscriptionModels: {
+        anthropic: [{ id: 'claude-test' }],
+      },
+    });
+
+    function Harness() {
+      const currentAuth = useOpenAISubscriptionAuth({
+        ship: 'zod',
+        provider: 'anthropic',
+        onComplete,
+      });
+      React.useEffect(() => {
+        auth = currentAuth;
+      }, [currentAuth]);
+      return null;
+    }
+
+    await act(async () => {
+      renderer = create(<Harness />);
+    });
+    await act(async () => {
+      await auth!.start();
+      await auth!.completeToken('setup-token');
+    });
+
+    expect(mocks.trackSettingUpdated).toHaveBeenCalledWith({
+      setting: 'subscription',
+      action: 'connected',
+      provider: 'anthropic',
+    });
+    expect(onComplete).toHaveBeenCalledWith([{ id: 'claude-test' }]);
 
     act(() => renderer!.unmount());
   });

--- a/packages/app/features/settings/bot/useOpenAISubscriptionAuth.ts
+++ b/packages/app/features/settings/bot/useOpenAISubscriptionAuth.ts
@@ -8,6 +8,7 @@ import {
   getLLMAuthVerificationUrl,
 } from './openAiSubscription';
 import { OpenAIAuthController } from './openAiSubscriptionController';
+import { trackTlonbotSettingUpdated } from './botSettingsTelemetry';
 
 function flowFromState(state: OpenAIAuthState) {
   return 'flow' in state ? state.flow : undefined;
@@ -46,6 +47,11 @@ export function useOpenAISubscriptionAuth({
       loadStatus: () => api.getTlawnLLMAuthStatus(ship),
       onComplete: async (models, status) => {
         queryClient.setQueryData(['tlonbot', 'llm-auth-status', ship], status);
+        trackTlonbotSettingUpdated({
+          setting: 'subscription',
+          action: 'connected',
+          provider,
+        });
         await onCompleteRef.current(models);
       },
     });


### PR DESCRIPTION
Adds telemetry for capturing bot settings changes. Notably so we can tell how much usage zero data retention is getting