### PR TITLE
onboarding: rotate first-entry thinking statuses

### DIFF
--- a/packages/app/features/top/useAgentOnboardingFirstEntry.test.tsx
+++ b/packages/app/features/top/useAgentOnboardingFirstEntry.test.tsx
@@ -1,0 +1,176 @@
+import React from 'react';
+import { ReactTestRenderer, act, create } from 'react-test-renderer';
+import {
+  afterAll,
+  afterEach,
+  beforeAll,
+  beforeEach,
+  describe,
+  expect,
+  it,
+  vi,
+} from 'vitest';
+
+import {
+  AGENT_ONBOARDING_FIRST_ENTRY_STATUSES,
+  useAgentOnboardingFirstEntry,
+} from './useAgentOnboardingFirstEntry';
+
+const mocks = vi.hoisted(() => ({
+  hasFirstEntry: false,
+  hasFirstEntryFailed: false,
+  pendingAt: undefined as number | undefined,
+}));
+
+vi.mock('@tloncorp/shared/db', () => ({
+  agentGroupOnboardingLocks: { setValue: vi.fn(async () => undefined) },
+  getChanPosts: vi.fn(async () => []),
+}));
+vi.mock('@tloncorp/shared/store', () => ({
+  syncSince: vi.fn(async () => undefined),
+}));
+vi.mock('./agentOnboardingFirstEntry', () => ({
+  hasAgentOnboardingFirstEntry: () => mocks.hasFirstEntry,
+  hasAgentOnboardingFirstEntryFailed: () => mocks.hasFirstEntryFailed,
+  getAgentOnboardingFirstEntryPendingAt: () => mocks.pendingAt,
+}));
+
+type HookProps = Parameters<typeof useAgentOnboardingFirstEntry>[0];
+
+const LABEL_NODE = 'Label';
+function Harness(props: HookProps) {
+  const label = useAgentOnboardingFirstEntry(props);
+  return React.createElement(LABEL_NODE, { label });
+}
+
+function labelOf(renderer: ReactTestRenderer): string | undefined {
+  return renderer.root.find((node) => (node.type as unknown) === LABEL_NODE)
+    .props.label;
+}
+
+// Polling is off (`isFocused: false`) so the rotation is the only timer here.
+const waitingProps = (): HookProps => ({
+  agentShipId: '~bot',
+  awaitingFirstEntry: true,
+  channelId: 'chat/~zod/setup',
+  groupId: '~zod/home',
+  isFocused: false,
+  posts: [],
+  provisionId: 'provision-1',
+  provisionAcknowledgedAt: Date.now(),
+});
+
+const STATUS_INTERVAL_MS = 5_000;
+const [firstStatus, secondStatus] = AGENT_ONBOARDING_FIRST_ENTRY_STATUSES;
+
+function render(props: HookProps) {
+  let renderer: ReactTestRenderer;
+  act(() => {
+    renderer = create(<Harness {...props} />);
+  });
+  return renderer!;
+}
+
+function update(renderer: ReactTestRenderer, props: HookProps) {
+  act(() => {
+    renderer.update(<Harness {...props} />);
+  });
+}
+
+function advance(ms: number) {
+  act(() => {
+    vi.advanceTimersByTime(ms);
+  });
+}
+
+describe('useAgentOnboardingFirstEntry', () => {
+  beforeAll(() => {
+    Object.assign(globalThis, { IS_REACT_ACT_ENVIRONMENT: true });
+  });
+
+  afterAll(() => {
+    delete (globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean })
+      .IS_REACT_ACT_ENVIRONMENT;
+  });
+
+  beforeEach(() => {
+    vi.useFakeTimers();
+    mocks.hasFirstEntry = false;
+    mocks.hasFirstEntryFailed = false;
+    mocks.pendingAt = undefined;
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('shows nothing until the bot has taken on the first entry', () => {
+    const renderer = render({
+      ...waitingProps(),
+      awaitingFirstEntry: false,
+      provisionAcknowledgedAt: undefined,
+    });
+    expect(labelOf(renderer)).toBeUndefined();
+    act(() => renderer.unmount());
+  });
+
+  it('opens with the first status', () => {
+    const renderer = render(waitingProps());
+    expect(labelOf(renderer)).toBe(firstStatus);
+    act(() => renderer.unmount());
+  });
+
+  it('rotates through every status on a five-second timer, then loops', () => {
+    const renderer = render(waitingProps());
+
+    advance(STATUS_INTERVAL_MS - 1);
+    expect(labelOf(renderer)).toBe(firstStatus);
+    advance(1);
+    expect(labelOf(renderer)).toBe(secondStatus);
+
+    for (const status of AGENT_ONBOARDING_FIRST_ENTRY_STATUSES.slice(2)) {
+      advance(STATUS_INTERVAL_MS);
+      expect(labelOf(renderer)).toBe(status);
+    }
+
+    advance(STATUS_INTERVAL_MS);
+    expect(labelOf(renderer)).toBe(firstStatus);
+    act(() => renderer.unmount());
+  });
+
+  it('stops rotating once the first entry lands', () => {
+    const props = waitingProps();
+    const renderer = render(props);
+    advance(STATUS_INTERVAL_MS);
+    expect(labelOf(renderer)).toBe(secondStatus);
+
+    mocks.hasFirstEntry = true;
+    update(renderer, { ...props, posts: [] });
+    expect(labelOf(renderer)).toBeUndefined();
+
+    advance(STATUS_INTERVAL_MS * 3);
+    expect(labelOf(renderer)).toBeUndefined();
+    act(() => renderer.unmount());
+  });
+
+  it('restarts from the first status when the wait begins again', () => {
+    const props = waitingProps();
+    const renderer = render(props);
+    advance(STATUS_INTERVAL_MS * 2);
+    expect(labelOf(renderer)).toBe(AGENT_ONBOARDING_FIRST_ENTRY_STATUSES[2]);
+
+    update(renderer, { ...props, awaitingFirstEntry: false });
+    expect(labelOf(renderer)).toBeUndefined();
+
+    update(renderer, props);
+    expect(labelOf(renderer)).toBe(firstStatus);
+    act(() => renderer.unmount());
+  });
+
+  it('gives up with the indicator after five minutes', () => {
+    const renderer = render(waitingProps());
+    advance(5 * 60_000);
+    expect(labelOf(renderer)).toBeUndefined();
+    act(() => renderer.unmount());
+  });
+});

--- a/packages/app/features/top/useAgentOnboardingFirstEntry.ts
+++ b/packages/app/features/top/useAgentOnboardingFirstEntry.ts
@@ -10,6 +10,21 @@ import {
 
 const REFRESH_INTERVAL_MS = 5_000;
 const REFRESH_TIMEOUT_MS = 5 * 60_000;
+const STATUS_ROTATION_INTERVAL_MS = 5_000;
+
+/**
+ * The first entry can take a minute or more with nothing new posted in the
+ * chat, so a single label reads as stuck. Cycle through what the bot is doing
+ * instead; the list loops, so every status has to stay true on a second pass.
+ */
+export const AGENT_ONBOARDING_FIRST_ENTRY_STATUSES = [
+  'Writing your first entry…',
+  'Gathering sources…',
+  'Reading up…',
+  'Drafting the entry…',
+  'Checking the details…',
+  'Still working on it…',
+] as const;
 
 export function useAgentOnboardingFirstEntry({
   agentShipId,
@@ -141,7 +156,26 @@ export function useAgentOnboardingFirstEntry({
     Date.now() - firstEntryStartedAt < REFRESH_TIMEOUT_MS &&
     !indicatorExpired
   );
-  return firstEntryActive && !settled && withinTimeout
-    ? 'Writing your first entry…'
+  const showIndicator = firstEntryActive && !settled && withinTimeout;
+
+  const [statusIndex, setStatusIndex] = useState(0);
+  useEffect(() => {
+    if (!showIndicator) return;
+    const interval = setInterval(
+      () =>
+        setStatusIndex(
+          (index) => (index + 1) % AGENT_ONBOARDING_FIRST_ENTRY_STATUSES.length
+        ),
+      STATUS_ROTATION_INTERVAL_MS
+    );
+    return () => {
+      clearInterval(interval);
+      // Start over from the first status if the indicator is shown again.
+      setStatusIndex(0);
+    };
+  }, [showIndicator]);
+
+  return showIndicator
+    ? AGENT_ONBOARDING_FIRST_ENTRY_STATUSES[statusIndex]
     : undefined;
 }


### PR DESCRIPTION
## Summary

While Tlonbot writes the first notebook entry during onboarding, the chat footer showed one fixed label ("Writing your first entry…") for the whole wait, which reads as stuck. The indicator now rotates through six statuses on a 5-second timer, looping until the entry lands or the existing 5-minute timeout fires.

Fixes TLON-6465

## Changes

- `useAgentOnboardingFirstEntry`: export `AGENT_ONBOARDING_FIRST_ENTRY_STATUSES` and advance through them every 5s while the indicator is visible. The list loops, so every status stays true on a second pass (none claims to be finishing). The sequence restarts from the first status if the indicator is hidden and shown again. Settle and timeout behavior is unchanged; no changes to `ThinkingState` or to the bot.
- New `useAgentOnboardingFirstEntry.test.tsx` covering the rotation with fake timers: opens with the first status, rotates every 5s and wraps, stops when the entry lands, restarts after a hide/show, gives up at 5 minutes.

## How did I test?

- `npx vitest run` in `packages/app` for the new test plus `agentOnboardingFirstEntry.test.ts` and `ThinkingState.test.tsx` (17 passing).
- `tsc --noEmit` in `packages/app`, oxlint (no new warnings), oxfmt.
- Not verified on a device: the flow needs a fresh onboarding with a provisioned bot. The rendering path (`forcedLabel` on `ThinkingState`) is unchanged; only the string changes over time.

## Risks and impact

- Safe to rollback without consulting PR author? Yes
- Affects important code area:
  - [x] Onboarding
  - [ ] State / providers
  - [ ] Message sync
  - [x] Channel display
  - [ ] Notifications
  - [ ] Other:

## Rollback plan

Revert the commit; the hook returns to the single fixed label.

## Screenshots / videos

The reference video on TLON-6465 (0:54–1:25) shows the fixed label this replaces.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
