### PR TITLE
ios: fix onboarding category picker after custom submission

### DIFF
--- a/apps/tlon-mobile/modules/tlon-scroll-edge-effect/ios/ScrollEdgeElementContainer.swift
+++ b/apps/tlon-mobile/modules/tlon-scroll-edge-effect/ios/ScrollEdgeElementContainer.swift
@@ -45,11 +45,19 @@ public final class ScrollEdgeElementContainer: ExpoView {
             interaction.edge = edge
             edgeInteraction = interaction
             addInteraction(interaction)
+
+            NotificationCenter.default.addObserver(
+                self,
+                selector: #selector(keyboardDidHide),
+                name: UIResponder.keyboardDidHideNotification,
+                object: nil
+            )
         }
     }
 
     deinit {
         cancelPendingAttachmentWork()
+        NotificationCenter.default.removeObserver(self)
 
         if #available(iOS 26.0, *), let interaction = scrollEdgeInteraction {
             removeInteraction(interaction)
@@ -133,6 +141,29 @@ public final class ScrollEdgeElementContainer: ExpoView {
             : scrollView.bottomEdgeEffect
         edgeEffect.isHidden = false
         edgeEffect.style = .soft
+    }
+
+    @objc private func keyboardDidHide() {
+        guard edge == .bottom, window != nil else {
+            return
+        }
+
+        if #available(iOS 26.0, *), let interaction = scrollEdgeInteraction,
+           interaction.scrollView != nil
+        {
+            // KeyboardStickyView moves the composer with a transform. UIKit's
+            // edge interaction can retain the keyboard-open container geometry
+            // after that transform settles, leaving a tall soft fade over the
+            // conversation. Reattach on the next main-loop turn so UIKit reads
+            // the composer's final, keyboard-closed position.
+            interaction.scrollView = nil
+            cancelPendingAttachmentWork()
+            resetAttachmentSearch()
+
+            DispatchQueue.main.async { [weak self] in
+                self?.attachToScrollViewIfPossible()
+            }
+        }
     }
 
     private func attachToScrollViewIfPossible() {


### PR DESCRIPTION
## Summary

The visual effect in the video is strange, seemingly half the component looked "disabled". The issue was likely a UIKit race: the bottom-edge fade interaction recalculated while the keyboard was dismissing, then remained attached using the keyboard-adjusted geometry. That left an oversized translucent region over the category picker, making it look disabled even though it was still interactive.

The fix listens for keyboardDidHide and reattaches the scroll-edge interaction after UIKit finishes updating the layout.


## Changes

- Added an observer for `UIResponder.keyboardDidHideNotification` in `ScrollEdgeElementContainer`
- When the keyboard finishes hiding, the code removes and reattaches `UIScrollEdgeElementContainerInteraction`, forcing UIKit to recalculate the bottom fade with the correct layout

## How did I test?

Couldn’t reproduce the original artifact in the simulator, but the fixed flow behaved correctly in fixtures.

## Risks and impact

- Safe to rollback without consulting PR author? Yes

Fixes TLON-6464