### PR TITLE
Show notebook activity in group-list previews

### DIFF
--- a/packages/app/hooks/useResolvedChats.test.ts
+++ b/packages/app/hooks/useResolvedChats.test.ts
@@ -1,7 +1,10 @@
 import type * as db from '@tloncorp/shared/db';
 import { expect, test } from 'vitest';
 
-import { getChatTimestampsSignature } from './useResolvedChats';
+import {
+  getChatNotesActivitySignature,
+  getChatTimestampsSignature,
+} from './useResolvedChats';
 
 function makeGroupChat(timestamp: number): db.Chat {
   return {
@@ -26,5 +29,34 @@ test('chat signature changes when recency advances without reordering', () => {
 
   expect(getChatTimestampsSignature(after)).not.toBe(
     getChatTimestampsSignature(before)
+  );
+});
+
+test('notes activity signature changes when a title arrives at the same recency', () => {
+  const before = makeGroupChat(200);
+  const after = makeGroupChat(200);
+  if (before.type !== 'group' || after.type !== 'group') {
+    throw new Error('expected group chats');
+  }
+  before.notesActivity = {
+    channelId: 'notes/~zod/journal',
+    notebookTitle: 'Journal',
+    noteId: null,
+    noteTitle: null,
+    authorId: null,
+    isNew: true,
+    timestamp: 200,
+  };
+  after.notesActivity = {
+    ...before.notesActivity,
+    noteId: '42',
+    noteTitle: 'Weekly plan',
+  };
+
+  expect(getChatNotesActivitySignature([after])).not.toBe(
+    getChatNotesActivitySignature([before])
+  );
+  expect(getChatTimestampsSignature([after])).toBe(
+    getChatTimestampsSignature([before])
   );
 });

--- a/packages/app/hooks/useResolvedChats.ts
+++ b/packages/app/hooks/useResolvedChats.ts
@@ -8,6 +8,25 @@ export function getChatTimestampsSignature(chats: db.Chat[]): string {
   return chats.map((chat) => chat.timestamp).join('|');
 }
 
+// A title can arrive from a warmed notebook snapshot without changing the
+// activity timestamp or row order, so it needs its own memo identity.
+export function getChatNotesActivitySignature(chats: db.Chat[]): string {
+  return chats
+    .map((chat) => {
+      const activity = chat.type === 'group' ? chat.notesActivity : null;
+      return activity
+        ? [
+            activity.channelId,
+            activity.notebookTitle ?? '',
+            activity.noteId ?? '',
+            activity.noteTitle ?? '',
+            activity.isNew ? 'new' : 'edited',
+          ].join(':')
+        : '';
+    })
+    .join('|');
+}
+
 /**
  * Memoizes the chat list structure based on relevant changes
  * (list lengths, unread counts) to prevent unnecessary recalculations
@@ -41,6 +60,9 @@ export function useResolvedChats(chats: UseCurrentChatsResult): {
       pinnedTimestamps: getChatTimestampsSignature(chats.pinned),
       unpinnedTimestamps: getChatTimestampsSignature(chats.unpinned),
       pendingTimestamps: getChatTimestampsSignature(chats.pending),
+      pinnedNotesActivity: getChatNotesActivitySignature(chats.pinned),
+      unpinnedNotesActivity: getChatNotesActivitySignature(chats.unpinned),
+      pendingNotesActivity: getChatNotesActivitySignature(chats.pending),
       pinnedUnreadCount: chats.pinned.reduce(
         (acc, chat) => acc + (chat.unreadCount ?? 0),
         0

--- a/packages/app/lib/electronDb.test.ts
+++ b/packages/app/lib/electronDb.test.ts
@@ -1,0 +1,29 @@
+import { describe, expect, test } from 'vitest';
+
+import { formatElectronMigrations } from './electronMigrations';
+
+describe('formatElectronMigrations', () => {
+  test('splits generated files so upgrades can continue past existing tables', () => {
+    const formatted = formatElectronMigrations({
+      journal: {
+        entries: [{ tag: '0000_test' }],
+      },
+      migrations: {
+        m0000: [
+          'CREATE TABLE existing_table (id text);',
+          '--> statement-breakpoint',
+          'CREATE TABLE new_table (id text);',
+        ].join('\n'),
+      },
+    });
+
+    expect(formatted).toEqual([
+      {
+        sql: [
+          'CREATE TABLE existing_table (id text);',
+          'CREATE TABLE new_table (id text);',
+        ],
+      },
+    ]);
+  });
+});

--- a/packages/app/lib/electronDb.ts
+++ b/packages/app/lib/electronDb.ts
@@ -10,6 +10,7 @@ import {
   resetDbSyncState,
   useMigrations as useMigrationsBase,
 } from './baseDb';
+import { formatElectronMigrations } from './electronMigrations';
 
 declare global {
   interface Window {
@@ -151,20 +152,7 @@ export class ElectronDb extends BaseDb {
       return;
     }
 
-    const formattedMigrations = [];
-
-    if (migrations.journal && migrations.journal.entries) {
-      for (const entry of migrations.journal.entries) {
-        const migrationHash = `m${entry.tag.split('_')[0]}`;
-        const sqlStatements = migrations.migrations[migrationHash];
-
-        if (sqlStatements) {
-          formattedMigrations.push({
-            sql: [sqlStatements], // Wrap in array if it's a single string
-          });
-        }
-      }
-    }
+    const formattedMigrations = formatElectronMigrations(migrations);
 
     try {
       logger.log('Running migrations in Electron SQLite');

--- a/packages/app/lib/electronMigrations.ts
+++ b/packages/app/lib/electronMigrations.ts
@@ -1,0 +1,31 @@
+const MIGRATION_STATEMENT_BREAKPOINT = '--> statement-breakpoint';
+
+type MigrationConfig = {
+  journal?: { entries?: { tag: string }[] };
+  migrations: Record<string, string>;
+};
+
+export function formatElectronMigrations(migrationConfig: MigrationConfig) {
+  const formattedMigrations: { sql: string[] }[] = [];
+
+  if (migrationConfig.journal?.entries) {
+    for (const entry of migrationConfig.journal.entries) {
+      const migrationHash = `m${entry.tag.split('_')[0]}`;
+      const migrationSql = migrationConfig.migrations[migrationHash];
+
+      if (migrationSql) {
+        formattedMigrations.push({
+          // The main process catches already-exists errors per array item.
+          // Splitting here lets an upgraded database skip old statements and
+          // continue to newly generated tables and indexes in the same file.
+          sql: migrationSql
+            .split(MIGRATION_STATEMENT_BREAKPOINT)
+            .map((statement) => statement.trim())
+            .filter(Boolean),
+        });
+      }
+    }
+  }
+
+  return formattedMigrations;
+}

--- a/packages/app/ui/components/NotesChannel/NotesSearchResults.tsx
+++ b/packages/app/ui/components/NotesChannel/NotesSearchResults.tsx
@@ -4,6 +4,7 @@ import {
   buildNoteSnippet,
   buildNoteTitleSegments,
   noteSearchListState,
+  noteTimestampMs,
 } from '@tloncorp/shared/logic';
 import { LoadingSpinner, Pressable, useIsWindowNarrow } from '@tloncorp/ui';
 import React, { useCallback, useEffect, useMemo, useRef } from 'react';
@@ -12,7 +13,6 @@ import { SizableText, View, XStack, YStack } from 'tamagui';
 
 import { ListItem } from '../ListItem';
 import { HighlightedText } from '../PostContent/InlineRenderer';
-import { noteTimestampMs } from './notesTree';
 
 /**
  * A search hit as the endpoint returns it, not a synced SQLite row: detail

--- a/packages/app/ui/components/NotesChannel/NotesTreeRows.tsx
+++ b/packages/app/ui/components/NotesChannel/NotesTreeRows.tsx
@@ -2,6 +2,7 @@ import * as db from '@tloncorp/shared/db';
 import {
   getNoteBodyPreview,
   getNoteReferencePath,
+  noteTimestampMs,
 } from '@tloncorp/shared/logic';
 import { Icon, Pressable, useIsWindowNarrow } from '@tloncorp/ui';
 import type { IconType } from '@tloncorp/ui';
@@ -17,7 +18,6 @@ import { ListItem } from '../ListItem';
 import { OverflowTriggerButton } from '../OverflowMenuButton';
 import { UnreadDot } from '../UnreadDot';
 import { NotesActionMenu } from './NotesActions';
-import { noteTimestampMs } from './notesTree';
 
 export function FolderTreeRow({
   canEdit,

--- a/packages/app/ui/components/NotesChannel/notesTree.ts
+++ b/packages/app/ui/components/NotesChannel/notesTree.ts
@@ -1,5 +1,6 @@
 import { makePrettyShortDate } from '@tloncorp/api/lib/utils';
 import * as db from '@tloncorp/shared/db';
+import { noteTimestampMs } from '@tloncorp/shared/logic';
 
 export type FolderRow = { folder: db.NotesFolder; path: string };
 export type FolderDestinationRow = {
@@ -447,12 +448,6 @@ export function makeNotesFolderPathLabeler({
 
 export function normalizeSearchText(value: string | null | undefined) {
   return (value ?? '').trim().toLowerCase();
-}
-
-// Note timestamps may arrive in seconds or milliseconds depending on source.
-export function noteTimestampMs(timestamp: number | null | undefined) {
-  if (!timestamp) return null;
-  return timestamp < 10_000_000_000 ? timestamp * 1000 : timestamp;
 }
 
 export function formatNoteDate(timestamp: number | null | undefined) {

--- a/packages/app/ui/components/listItems/GroupListItem.tsx
+++ b/packages/app/ui/components/listItems/GroupListItem.tsx
@@ -1,6 +1,10 @@
 // sort-imports-ignore
 import * as db from '@tloncorp/shared/db';
 import * as logic from '@tloncorp/shared/logic';
+import {
+  notesNotebookFlagFromChannelId,
+  useWarmNotesNotebookSnapshot,
+} from '@tloncorp/shared/store';
 import { Pressable } from '@tloncorp/ui';
 import { TamaguiWebElement, View, isWeb } from 'tamagui';
 
@@ -15,6 +19,22 @@ import { OverflowTriggerButton } from '../OverflowMenuButton';
 import { ListItem, ListItemProps } from '../ListItem';
 import { getGroupStatus, getPostTypeIcon } from './listItemUtils';
 import type { GroupRecencyOverride } from './chatListRecency';
+
+function NotesActivitySubtitle({
+  override,
+}: {
+  override: GroupRecencyOverride;
+}) {
+  useWarmNotesNotebookSnapshot({
+    notebookFlag: notesNotebookFlagFromChannelId(override.channelId),
+  });
+
+  return (
+    <ListItem.SubtitleWithIcon icon="ChannelNotebooks">
+      {override.label}
+    </ListItem.SubtitleWithIcon>
+  );
+}
 
 export const GroupListItem = ({
   model,
@@ -146,9 +166,7 @@ export const GroupListItem = ({
           <ListItem.MainContent>
             <ListItem.Title>{title}</ListItem.Title>
             {recencyOverride ? (
-              <ListItem.SubtitleWithIcon icon="ChannelNotebooks">
-                {recencyOverride.label}
-              </ListItem.SubtitleWithIcon>
+              <NotesActivitySubtitle override={recencyOverride} />
             ) : customSubtitle ? (
               <ListItem.Subtitle>{customSubtitle}</ListItem.Subtitle>
             ) : isSingleChannel ? (

--- a/packages/app/ui/components/listItems/chatListRecency.test.ts
+++ b/packages/app/ui/components/listItems/chatListRecency.test.ts
@@ -8,11 +8,15 @@ function makeGroupChat({
   notesActivityAt = 200,
   timestamp = Math.max(lastPostAt, notesActivityAt),
   isPending = false,
+  isNew = true,
+  noteTitle = 'Weekly plan',
 }: {
   lastPostAt?: number;
   notesActivityAt?: number;
   timestamp?: number;
   isPending?: boolean;
+  isNew?: boolean;
+  noteTitle?: string | null;
 } = {}): Extract<db.Chat, { type: 'group' }> {
   return {
     id: '~zod/test-group',
@@ -22,30 +26,38 @@ function makeGroupChat({
     timestamp,
     isPending,
     unreadCount: 0,
+    notesActivity: {
+      channelId: 'notes/~zod/test-notebook',
+      notebookTitle: 'Journal',
+      noteId: '42',
+      noteTitle,
+      authorId: '~zod',
+      isNew,
+      timestamp: notesActivityAt,
+    },
     group: {
       id: '~zod/test-group',
       lastPostAt,
-      channels: [
-        {
-          id: 'notes/~zod/test-notebook',
-          type: 'notes',
-          currentUserIsMember: true,
-          unread: {
-            channelId: 'notes/~zod/test-notebook',
-            updatedAt: notesActivityAt,
-          },
-        },
-      ],
     } as db.Group,
   };
 }
 
 describe('getGroupRecencyOverride', () => {
-  test('describes Notes activity when it supplies the group sort timestamp', () => {
+  test('describes the note and notebook when Notes supplies recency', () => {
     expect(getGroupRecencyOverride(makeGroupChat())).toEqual({
-      label: 'Notes activity',
+      label: 'New note “Weekly plan” in Journal',
       timestamp: 200,
+      channelId: 'notes/~zod/test-notebook',
     });
+  });
+
+  test('distinguishes edited notes and title-less fallbacks', () => {
+    expect(
+      getGroupRecencyOverride(makeGroupChat({ isNew: false }))?.label
+    ).toBe('Note “Weekly plan” edited in Journal');
+    expect(
+      getGroupRecencyOverride(makeGroupChat({ noteTitle: null }))?.label
+    ).toBe('New note in Journal');
   });
 
   test('keeps the post presentation when the latest post is newer', () => {
@@ -56,26 +68,18 @@ describe('getGroupRecencyOverride', () => {
     ).toBeNull();
   });
 
-  test('does not relabel pending groups or unrelated timestamps', () => {
+  test('does not relabel pending groups', () => {
     expect(
       getGroupRecencyOverride(makeGroupChat({ isPending: true }))
     ).toBeNull();
-    expect(
-      getGroupRecencyOverride(makeGroupChat({ timestamp: 300 }))
-    ).toBeNull();
   });
 
-  test('keeps the post presentation for pinned groups', () => {
+  test('updates the presentation for pinned groups without changing ordering', () => {
     const chat = makeGroupChat();
     chat.pin = { itemId: chat.id } as db.Pin;
 
-    expect(getGroupRecencyOverride(chat)).toBeNull();
-  });
-
-  test('ignores stale activity from a left Notes channel', () => {
-    const chat = makeGroupChat();
-    chat.group.channels![0].currentUserIsMember = false;
-
-    expect(getGroupRecencyOverride(chat)).toBeNull();
+    expect(getGroupRecencyOverride(chat)?.label).toBe(
+      'New note “Weekly plan” in Journal'
+    );
   });
 });

--- a/packages/app/ui/components/listItems/chatListRecency.ts
+++ b/packages/app/ui/components/listItems/chatListRecency.ts
@@ -1,41 +1,32 @@
 import type * as db from '@tloncorp/shared/db';
+import { formatNotesActivityLabel } from '@tloncorp/shared/logic';
 
 export type GroupRecencyOverride = {
   label: string;
   timestamp: number;
+  channelId: string;
 };
 
 /**
- * Temporary UI companion to the TLON-6417 ordering workaround. When Notes
- * activity moves a group ahead of its latest post, describe that activity
- * instead of showing an unrelated post preview and timestamp.
+ * When a group's newest activity is a note rather than a post, describe that
+ * note instead of showing the older post preview and timestamp. Pending groups
+ * retain their invite presentation; pinned groups still get a fresh preview.
  */
 export function getGroupRecencyOverride(
   chat: db.Chat
 ): GroupRecencyOverride | null {
-  if (chat.type !== 'group' || chat.isPending || chat.pin) {
+  if (chat.type !== 'group' || chat.isPending) {
     return null;
   }
 
-  const latestNotesActivityAt = Math.max(
-    0,
-    ...(chat.group.channels ?? [])
-      .filter(
-        (channel) =>
-          channel.type === 'notes' && channel.currentUserIsMember === true
-      )
-      .map((channel) => channel.unread?.updatedAt ?? 0)
-  );
-
-  if (
-    latestNotesActivityAt <= (chat.group.lastPostAt ?? 0) ||
-    latestNotesActivityAt !== chat.timestamp
-  ) {
+  const activity = chat.notesActivity;
+  if (!activity || activity.timestamp <= (chat.group.lastPostAt ?? 0)) {
     return null;
   }
 
   return {
-    label: 'Notes activity',
-    timestamp: latestNotesActivityAt,
+    label: formatNotesActivityLabel(activity),
+    timestamp: activity.timestamp,
+    channelId: activity.channelId,
   };
 }

--- a/packages/shared/src/db/migrations/0000_motionless_amphibian.sql
+++ b/packages/shared/src/db/migrations/0000_motionless_amphibian.sql
@@ -30,6 +30,7 @@ CREATE TABLE `activity_events` (
 	PRIMARY KEY(`id`, `bucket_id`)
 );
 --> statement-breakpoint
+CREATE INDEX `activity_events_channel_id_timestamp_index` ON `activity_events` (`channel_id`,`timestamp`);--> statement-breakpoint
 CREATE TABLE `attestations` (
 	`id` text PRIMARY KEY NOT NULL,
 	`provider` text NOT NULL,

--- a/packages/shared/src/db/migrations/0000_real_omega_sentinel.sql
+++ b/packages/shared/src/db/migrations/0000_real_omega_sentinel.sql
@@ -330,6 +330,12 @@ CREATE TABLE `groups` (
 	`member_count` integer
 );
 --> statement-breakpoint
+CREATE TABLE `notes_activity_event_tombstones` (
+	`channel_id` text NOT NULL,
+	`note_id` text NOT NULL,
+	PRIMARY KEY(`channel_id`, `note_id`)
+);
+--> statement-breakpoint
 CREATE TABLE `notes_folders` (
 	`id` text PRIMARY KEY NOT NULL,
 	`notebook_flag` text NOT NULL,

--- a/packages/shared/src/db/migrations/meta/0000_snapshot.json
+++ b/packages/shared/src/db/migrations/meta/0000_snapshot.json
@@ -1,7 +1,7 @@
 {
   "version": "6",
   "dialect": "sqlite",
-  "id": "f300b19d-827d-47c4-8a88-b695a2ffbcbc",
+  "id": "dae29614-c0f3-47c9-8a88-df5283865f7c",
   "prevId": "00000000-0000-0000-0000-000000000000",
   "tables": {
     "activity_event_contact_group_pins": {
@@ -2217,6 +2217,38 @@
       "indexes": {},
       "foreignKeys": {},
       "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "notes_activity_event_tombstones": {
+      "name": "notes_activity_event_tombstones",
+      "columns": {
+        "channel_id": {
+          "name": "channel_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "note_id": {
+          "name": "note_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "notes_activity_event_tombstones_channel_id_note_id_pk": {
+          "columns": [
+            "channel_id",
+            "note_id"
+          ],
+          "name": "notes_activity_event_tombstones_channel_id_note_id_pk"
+        }
+      },
       "uniqueConstraints": {},
       "checkConstraints": {}
     },

--- a/packages/shared/src/db/migrations/meta/0000_snapshot.json
+++ b/packages/shared/src/db/migrations/meta/0000_snapshot.json
@@ -1,7 +1,7 @@
 {
   "version": "6",
   "dialect": "sqlite",
-  "id": "b06b522e-7780-49ea-a3b7-f9bf8c206fee",
+  "id": "f300b19d-827d-47c4-8a88-b695a2ffbcbc",
   "prevId": "00000000-0000-0000-0000-000000000000",
   "tables": {
     "activity_event_contact_group_pins": {
@@ -208,7 +208,16 @@
           "autoincrement": false
         }
       },
-      "indexes": {},
+      "indexes": {
+        "activity_events_channel_id_timestamp_index": {
+          "name": "activity_events_channel_id_timestamp_index",
+          "columns": [
+            "channel_id",
+            "timestamp"
+          ],
+          "isUnique": false
+        }
+      },
       "foreignKeys": {},
       "compositePrimaryKeys": {
         "activity_events_id_bucket_id_pk": {

--- a/packages/shared/src/db/migrations/meta/_journal.json
+++ b/packages/shared/src/db/migrations/meta/_journal.json
@@ -5,8 +5,8 @@
     {
       "idx": 0,
       "version": "6",
-      "when": 1787786810474,
-      "tag": "0000_aspiring_klaw",
+      "when": 1788535660913,
+      "tag": "0000_motionless_amphibian",
       "breakpoints": true
     }
   ]

--- a/packages/shared/src/db/migrations/meta/_journal.json
+++ b/packages/shared/src/db/migrations/meta/_journal.json
@@ -5,8 +5,8 @@
     {
       "idx": 0,
       "version": "6",
-      "when": 1788535660913,
-      "tag": "0000_motionless_amphibian",
+      "when": 1788538295602,
+      "tag": "0000_real_omega_sentinel",
       "breakpoints": true
     }
   ]

--- a/packages/shared/src/db/migrations/migrations.js
+++ b/packages/shared/src/db/migrations/migrations.js
@@ -1,7 +1,7 @@
 // This file is required for Expo/React Native SQLite migrations - https://orm.drizzle.team/quick-sqlite/expo
 
 import journal from './meta/_journal.json';
-import m0000 from './0000_aspiring_klaw.sql';
+import m0000 from './0000_motionless_amphibian.sql';
 
   export default {
     journal,

--- a/packages/shared/src/db/migrations/migrations.js
+++ b/packages/shared/src/db/migrations/migrations.js
@@ -1,7 +1,7 @@
 // This file is required for Expo/React Native SQLite migrations - https://orm.drizzle.team/quick-sqlite/expo
 
 import journal from './meta/_journal.json';
-import m0000 from './0000_motionless_amphibian.sql';
+import m0000 from './0000_real_omega_sentinel.sql';
 
   export default {
     journal,

--- a/packages/shared/src/db/queries.test.ts
+++ b/packages/shared/src/db/queries.test.ts
@@ -439,10 +439,10 @@ describe('getChats group recency workaround', () => {
     }
   });
 
-  test('prefers the synced title when the event names the same note', async () => {
-    const groupId = '~zod/renamed-note';
-    const channelId = 'notes/~zod/renamed-note';
-    const notebookFlag = '~zod/renamed-note';
+  test('uses a fresh edit event over a stale row for the same note', async () => {
+    const groupId = '~zod/fresh-edit-event';
+    const channelId = 'notes/~zod/fresh-edit-event';
+    const notebookFlag = '~zod/fresh-edit-event';
 
     await queries.insertGroups({ groups: [testGroup(groupId, 100_000)] });
     await queries.insertChannels([
@@ -457,38 +457,39 @@ describe('getChats group recency workaround', () => {
     await queries.insertChannelUnreads([
       makeChannelUnread({ channelId, updatedAt: 400_000 }),
     ]);
-    // The event's content predates the rename; the synced row carries the
-    // current title. A rename re-emits no event, so the row is the fresher
-    // copy even when the event's stamp is higher.
-    await insertNoteActivityEvent(
-      noteActivityEvent({
-        id: 'renamed-note-event',
-        channelId,
-        groupId,
-        postId: '42',
-        title: 'Title before the rename',
-        timestamp: 399_000,
-        type: 'note-edit',
-      })
-    );
+    // An edit to a note already in notesNotes leaves the snapshot alone (see
+    // markNotesNotebookStaleForNoteEvent), so the row keeps the pre-edit
+    // title and its equal createdAt/updatedAt would read as a creation. The
+    // event is the current copy and has to win.
     await queries.saveNotesNotebookSnapshot({
       notebook: makeNotesNotebook({
         id: notebookFlag,
-        flagName: 'renamed-note',
+        flagName: 'fresh-edit-event',
         title: 'Journal',
       }),
       folders: [],
       notes: [
-        makeNotesNote(42, 1, 'Title after the rename', {
+        makeNotesNote(42, 1, 'Title before the edit', {
           id: `${notebookFlag}/note/42`,
           notebookFlag,
           createdAt: 300,
-          updatedAt: 398,
+          updatedAt: 300,
           updatedBy: '~zod',
         }),
       ],
       members: [],
     });
+    await insertNoteActivityEvent(
+      noteActivityEvent({
+        id: 'fresh-edit-event',
+        channelId,
+        groupId,
+        postId: '42',
+        title: 'Title after the edit',
+        timestamp: 399_000,
+        type: 'note-edit',
+      })
+    );
 
     const chat = (await queries.getChats()).unpinned.find(
       (candidate) => candidate.id === groupId
@@ -497,7 +498,9 @@ describe('getChats group recency workaround', () => {
     if (chat?.type === 'group') {
       expect(chat.notesActivity).toMatchObject({
         noteId: '42',
-        noteTitle: 'Title after the rename',
+        noteTitle: 'Title after the edit',
+        isNew: false,
+        timestamp: 400_000,
       });
     }
   });

--- a/packages/shared/src/db/queries.test.ts
+++ b/packages/shared/src/db/queries.test.ts
@@ -19,10 +19,17 @@ import {
   setupDatabaseTestSuite,
 } from '../test/helpers';
 import initResponse from '../test/init.json';
+import { makeNotesNote, makeNotesNotebook } from '../test/notesFixtures';
 import suggestedContactsResponse from '../test/suggestedContacts.json';
 import * as queries from './queries';
 import { queryClient } from './reactQuery';
-import { ChannelUnread, GroupUnread, Post, ThreadUnreadState } from './types';
+import {
+  ActivityEvent,
+  ChannelUnread,
+  GroupUnread,
+  Post,
+  ThreadUnreadState,
+} from './types';
 
 const groupsData = toClientGroups(
   groupsResponse as unknown as Record<string, ub.GroupV11>,
@@ -211,6 +218,47 @@ describe('getChats group recency workaround', () => {
     } as unknown as TestGroup;
   }
 
+  function noteActivityEvent({
+    id,
+    channelId,
+    groupId,
+    title,
+    timestamp,
+    type = 'note-create',
+  }: {
+    id: string;
+    channelId: string;
+    groupId: string;
+    title: string;
+    timestamp: number;
+    type?: 'note-create' | 'note-edit';
+  }): ActivityEvent {
+    return {
+      id,
+      bucketId: 'all',
+      sourceId: `channel/${channelId}`,
+      type,
+      timestamp,
+      postId: '42',
+      authorId: '~bus',
+      channelId,
+      groupId,
+      content: [{ inline: [title] }],
+    } as ActivityEvent;
+  }
+
+  async function insertNoteActivityEvent(event: ActivityEvent) {
+    const client = getClient();
+    if (!client) throw new Error('test db not initialized');
+
+    // The legacy activity-event contact-group FK names only `id` even though
+    // the parent key is `(id, bucketId)`. FK enforcement therefore rejects
+    // any direct activity event insert while FK enforcement is enabled. This
+    // focused selector seed does not exercise that unrelated legacy relation.
+    client.run($.sql`PRAGMA foreign_keys = OFF`);
+    await client.insert(schema.activityEvents).values(event);
+  }
+
   test('ignores broad group activity and legacy notebook activity', async () => {
     const recentGroupId = '~zod/recent-post';
     const noisyGroupId = '~zod/noisy-activity';
@@ -256,11 +304,211 @@ describe('getChats group recency workaround', () => {
       makeChannelUnread({ channelId: notesChannelId, updatedAt: 300 }),
     ]);
 
-    const groupIds = (await queries.getChats()).unpinned
+    const chats = (await queries.getChats()).unpinned;
+    const groupIds = chats
       .filter((chat) => chat.type === 'group')
       .map((chat) => chat.id);
 
     expect(groupIds).toEqual([notesGroupId, recentGroupId]);
+    const notesChat = chats.find((chat) => chat.id === notesGroupId);
+    expect(notesChat?.type).toBe('group');
+    if (notesChat?.type === 'group') {
+      expect(notesChat.notesActivity).toMatchObject({
+        channelId: notesChannelId,
+        noteTitle: null,
+        isNew: true,
+        timestamp: 300,
+      });
+    }
+  });
+
+  test('uses the newest local note for own activity and converts seconds to milliseconds', async () => {
+    const groupId = '~zod/local-note';
+    const channelId = 'notes/~zod/local-note';
+    const notebookFlag = '~zod/local-note';
+
+    await queries.insertGroups({ groups: [testGroup(groupId, 100_000)] });
+    await queries.insertChannels([
+      {
+        id: channelId,
+        type: 'notes',
+        groupId,
+        currentUserIsMember: true,
+      },
+    ]);
+    await queries.insertChannelUnreads([
+      makeChannelUnread({ channelId, updatedAt: 299_000 }),
+    ]);
+    await queries.saveNotesNotebookSnapshot({
+      notebook: makeNotesNotebook({
+        id: notebookFlag,
+        flagName: 'local-note',
+        title: 'Journal',
+      }),
+      folders: [],
+      notes: [
+        makeNotesNote(42, 1, 'Weekly plan', {
+          id: `${notebookFlag}/note/42`,
+          notebookFlag,
+          createdAt: 250,
+          updatedAt: 300,
+          updatedBy: '~zod',
+        }),
+      ],
+      members: [],
+    });
+
+    const chat = (await queries.getChats()).unpinned.find(
+      (candidate) => candidate.id === groupId
+    );
+    expect(chat?.type).toBe('group');
+    if (chat?.type === 'group') {
+      expect(chat.timestamp).toBe(300_000);
+      expect(chat.notesActivity).toEqual({
+        channelId,
+        notebookTitle: 'Journal',
+        noteId: '42',
+        noteTitle: 'Weekly plan',
+        authorId: '~zod',
+        isNew: false,
+        timestamp: 300_000,
+      });
+    }
+  });
+
+  test('prefers a newer persisted note event over an older local note', async () => {
+    const groupId = '~zod/remote-note';
+    const channelId = 'notes/~zod/remote-note';
+    const notebookFlag = '~zod/remote-note';
+
+    await queries.insertGroups({ groups: [testGroup(groupId, 100_000)] });
+    await queries.insertChannels([
+      {
+        id: channelId,
+        type: 'notes',
+        title: 'Team notebook',
+        groupId,
+        currentUserIsMember: true,
+      },
+    ]);
+    await queries.insertChannelUnreads([
+      makeChannelUnread({ channelId, updatedAt: 300_000 }),
+    ]);
+    await queries.saveNotesNotebookSnapshot({
+      notebook: makeNotesNotebook({
+        id: notebookFlag,
+        flagName: 'remote-note',
+        title: 'Team notebook',
+      }),
+      folders: [],
+      notes: [
+        makeNotesNote(1, 1, 'Old local note', {
+          id: `${notebookFlag}/note/1`,
+          notebookFlag,
+          createdAt: 200,
+          updatedAt: 200,
+        }),
+      ],
+      members: [],
+    });
+    await insertNoteActivityEvent(
+      noteActivityEvent({
+        id: 'remote-note-event',
+        channelId,
+        groupId,
+        title: 'Launch checklist',
+        timestamp: 299_000,
+        type: 'note-edit',
+      })
+    );
+
+    const chat = (await queries.getChats()).unpinned.find(
+      (candidate) => candidate.id === groupId
+    );
+    expect(chat?.type).toBe('group');
+    if (chat?.type === 'group') {
+      expect(chat.notesActivity).toMatchObject({
+        noteId: '42',
+        noteTitle: 'Launch checklist',
+        authorId: '~bus',
+        isNew: false,
+        timestamp: 300_000,
+      });
+    }
+  });
+
+  test('does not label a new bump with a stale note event', async () => {
+    const groupId = '~zod/stale-detail';
+    const channelId = 'notes/~zod/stale-detail';
+
+    await queries.insertGroups({ groups: [testGroup(groupId, 100_000)] });
+    await queries.insertChannels([
+      {
+        id: channelId,
+        type: 'notes',
+        title: 'Journal',
+        groupId,
+        currentUserIsMember: true,
+      },
+    ]);
+    await queries.insertChannelUnreads([
+      makeChannelUnread({ channelId, updatedAt: 400_000 }),
+    ]);
+    await insertNoteActivityEvent(
+      noteActivityEvent({
+        id: 'stale-note-event',
+        channelId,
+        groupId,
+        title: 'Wrong old title',
+        timestamp: 99_000,
+      })
+    );
+
+    const chat = (await queries.getChats()).unpinned.find(
+      (candidate) => candidate.id === groupId
+    );
+    expect(chat?.type).toBe('group');
+    if (chat?.type === 'group') {
+      expect(chat.notesActivity).toMatchObject({
+        noteId: null,
+        noteTitle: null,
+        timestamp: 400_000,
+      });
+    }
+  });
+
+  test('keeps a newer post as the group recency when notebook activity is older', async () => {
+    const groupId = '~zod/post-wins';
+    const channelId = 'notes/~zod/post-wins';
+
+    await queries.insertGroups({ groups: [testGroup(groupId, 400_000)] });
+    await queries.insertChannels([
+      {
+        id: channelId,
+        type: 'notes',
+        title: 'Journal',
+        groupId,
+        currentUserIsMember: true,
+      },
+    ]);
+    const client = getClient();
+    if (!client) throw new Error('test db not initialized');
+    await client
+      .update(schema.groups)
+      .set({ lastPostAt: 400_000 })
+      .where($.eq(schema.groups.id, groupId));
+    await queries.insertChannelUnreads([
+      makeChannelUnread({ channelId, updatedAt: 300_000 }),
+    ]);
+
+    const chat = (await queries.getChats()).unpinned.find(
+      (candidate) => candidate.id === groupId
+    );
+    expect(chat?.type).toBe('group');
+    if (chat?.type === 'group') {
+      expect(chat.timestamp).toBe(400_000);
+      expect(chat.notesActivity?.timestamp).toBe(300_000);
+    }
   });
 
   test('ignores stale Notes summaries after leaving a notebook', async () => {
@@ -2529,6 +2777,16 @@ describe('pins reordering (TLON-5948)', () => {
     test('getChats declares a dependency on pins', () => {
       // The reorder UI re-reads via getChats, so a pins write must invalidate it.
       expect(queries.getChats.meta.tableDependencies).toContain('pins');
+    });
+
+    test('getChats refreshes when notebook activity details change', () => {
+      expect(queries.getChats.meta.tableDependencies).toEqual(
+        expect.arrayContaining([
+          'activityEvents',
+          'notesNotebooks',
+          'notesNotes',
+        ])
+      );
     });
 
     test('a pins write invalidates an in-flight getChats query', async () => {

--- a/packages/shared/src/db/queries.test.ts
+++ b/packages/shared/src/db/queries.test.ts
@@ -501,8 +501,8 @@ describe('getChats group recency workaround', () => {
     expect(afterConfirmedDelete?.type).toBe('group');
     if (afterConfirmedDelete?.type === 'group') {
       expect(afterConfirmedDelete.notesActivity).toMatchObject({
-        noteId: '41',
-        noteTitle: 'Old title',
+        noteId: null,
+        noteTitle: null,
         isNew: true,
         timestamp: 400_000,
       });
@@ -561,6 +561,71 @@ describe('getChats group recency workaround', () => {
         noteTitle: 'Deleted secret title',
         authorId: '~bus',
         isNew: true,
+        timestamp: 400_000,
+      });
+    }
+  });
+
+  test('suppresses activity after a later snapshot removes a synced note', async () => {
+    const groupId = '~zod/remote-deleted-note';
+    const channelId = 'notes/~zod/remote-deleted-note';
+    const notebookFlag = '~zod/remote-deleted-note';
+    const notebook = makeNotesNotebook({
+      id: notebookFlag,
+      flagName: 'remote-deleted-note',
+      title: 'Journal',
+    });
+
+    await queries.insertGroups({ groups: [testGroup(groupId, 100_000)] });
+    await queries.insertChannels([
+      {
+        id: channelId,
+        type: 'notes',
+        groupId,
+        currentUserIsMember: true,
+      },
+    ]);
+    await queries.insertChannelUnreads([
+      makeChannelUnread({ channelId, updatedAt: 400_000 }),
+    ]);
+    await queries.saveNotesNotebookSnapshot({
+      notebook,
+      folders: [],
+      notes: [
+        makeNotesNote(42, 1, 'Removed remotely', {
+          id: `${notebookFlag}/note/42`,
+          notebookFlag,
+          syncedAt: 100,
+        }),
+      ],
+      members: [],
+    });
+    await insertNoteActivityEvent(
+      noteActivityEvent({
+        id: 'remote-deleted-note-event',
+        channelId,
+        groupId,
+        title: 'Removed remotely',
+        timestamp: 399_000,
+      })
+    );
+
+    await queries.saveNotesNotebookSnapshot({
+      notebook: { ...notebook, syncedAt: 500 },
+      folders: [],
+      notes: [],
+      members: [],
+    });
+
+    const chat = (await queries.getChats()).unpinned.find(
+      (candidate) => candidate.id === groupId
+    );
+    expect(chat?.type).toBe('group');
+    if (chat?.type === 'group') {
+      expect(chat.notesActivity).toMatchObject({
+        noteId: null,
+        noteTitle: null,
+        authorId: null,
         timestamp: 400_000,
       });
     }

--- a/packages/shared/src/db/queries.test.ts
+++ b/packages/shared/src/db/queries.test.ts
@@ -222,6 +222,7 @@ describe('getChats group recency workaround', () => {
     id,
     channelId,
     groupId,
+    postId = '42',
     title,
     timestamp,
     type = 'note-create',
@@ -229,6 +230,7 @@ describe('getChats group recency workaround', () => {
     id: string;
     channelId: string;
     groupId: string;
+    postId?: string;
     title: string;
     timestamp: number;
     type?: 'note-create' | 'note-edit';
@@ -239,7 +241,7 @@ describe('getChats group recency workaround', () => {
       sourceId: `channel/${channelId}`,
       type,
       timestamp,
-      postId: '42',
+      postId,
       authorId: '~bus',
       channelId,
       groupId,
@@ -432,6 +434,169 @@ describe('getChats group recency workaround', () => {
         noteTitle: 'Launch checklist',
         authorId: '~bus',
         isNew: false,
+        timestamp: 300_000,
+      });
+    }
+  });
+
+  test('selects only the newest persisted note event for each notebook', async () => {
+    const groupId = '~zod/latest-note-event';
+    const channelId = 'notes/~zod/latest-note-event';
+
+    await queries.insertGroups({ groups: [testGroup(groupId, 100_000)] });
+    await queries.insertChannels([
+      {
+        id: channelId,
+        type: 'notes',
+        groupId,
+        currentUserIsMember: true,
+      },
+    ]);
+    await queries.insertChannelUnreads([
+      makeChannelUnread({ channelId, updatedAt: 400_000 }),
+    ]);
+    await insertNoteActivityEvent(
+      noteActivityEvent({
+        id: 'older-note-event',
+        channelId,
+        groupId,
+        postId: '41',
+        title: 'Old title',
+        timestamp: 300_000,
+      })
+    );
+    await insertNoteActivityEvent(
+      noteActivityEvent({
+        id: 'newest-note-event',
+        channelId,
+        groupId,
+        postId: '42',
+        title: 'Newest title',
+        timestamp: 399_000,
+        type: 'note-edit',
+      })
+    );
+
+    const chat = (await queries.getChats()).unpinned.find(
+      (candidate) => candidate.id === groupId
+    );
+    expect(chat?.type).toBe('group');
+    if (chat?.type === 'group') {
+      expect(chat.notesActivity).toMatchObject({
+        noteId: '42',
+        noteTitle: 'Newest title',
+        isNew: false,
+        timestamp: 400_000,
+      });
+    }
+  });
+
+  test('drops stale event details after a newer snapshot confirms deletion', async () => {
+    const groupId = '~zod/deleted-note';
+    const channelId = 'notes/~zod/deleted-note';
+    const notebookFlag = '~zod/deleted-note';
+
+    await queries.insertGroups({ groups: [testGroup(groupId, 100_000)] });
+    await queries.insertChannels([
+      {
+        id: channelId,
+        type: 'notes',
+        groupId,
+        currentUserIsMember: true,
+      },
+    ]);
+    await queries.insertChannelUnreads([
+      makeChannelUnread({ channelId, updatedAt: 400_000 }),
+    ]);
+    await insertNoteActivityEvent(
+      noteActivityEvent({
+        id: 'deleted-note-event',
+        channelId,
+        groupId,
+        title: 'Deleted secret title',
+        timestamp: 399_000,
+      })
+    );
+    await queries.saveNotesNotebookSnapshot({
+      notebook: makeNotesNotebook({
+        id: notebookFlag,
+        flagName: 'deleted-note',
+        title: 'Journal',
+        // Notes timestamps can arrive in seconds, while activity events use
+        // milliseconds. This snapshot is newer than the event.
+        syncedAt: 500,
+      }),
+      folders: [],
+      notes: [],
+      members: [],
+    });
+
+    const chat = (await queries.getChats()).unpinned.find(
+      (candidate) => candidate.id === groupId
+    );
+    expect(chat?.type).toBe('group');
+    if (chat?.type === 'group') {
+      expect(chat.notesActivity).toEqual({
+        channelId,
+        notebookTitle: 'Journal',
+        noteId: null,
+        noteTitle: null,
+        authorId: null,
+        isNew: true,
+        timestamp: 400_000,
+      });
+    }
+  });
+
+  test('uses createdAt when a local note has no updatedAt', async () => {
+    const groupId = '~zod/created-note';
+    const channelId = 'notes/~zod/created-note';
+    const notebookFlag = '~zod/created-note';
+
+    await queries.insertGroups({ groups: [testGroup(groupId, 100_000)] });
+    await queries.insertChannels([
+      {
+        id: channelId,
+        type: 'notes',
+        groupId,
+        currentUserIsMember: true,
+      },
+    ]);
+    await queries.insertChannelUnreads([
+      makeChannelUnread({ channelId, updatedAt: 299_000 }),
+    ]);
+    await queries.saveNotesNotebookSnapshot({
+      notebook: makeNotesNotebook({
+        id: notebookFlag,
+        flagName: 'created-note',
+        title: 'Journal',
+      }),
+      folders: [],
+      notes: [
+        makeNotesNote(42, 1, 'Fresh draft', {
+          id: `${notebookFlag}/note/42`,
+          notebookFlag,
+          createdAt: 300,
+          updatedAt: null,
+          updatedBy: '~zod',
+        }),
+      ],
+      members: [],
+    });
+
+    const chat = (await queries.getChats()).unpinned.find(
+      (candidate) => candidate.id === groupId
+    );
+    expect(chat?.type).toBe('group');
+    if (chat?.type === 'group') {
+      expect(chat.timestamp).toBe(300_000);
+      expect(chat.notesActivity).toEqual({
+        channelId,
+        notebookTitle: 'Journal',
+        noteId: '42',
+        noteTitle: 'Fresh draft',
+        authorId: '~zod',
+        isNew: true,
         timestamp: 300_000,
       });
     }

--- a/packages/shared/src/db/queries.test.ts
+++ b/packages/shared/src/db/queries.test.ts
@@ -894,6 +894,66 @@ describe('getChats group recency workaround', () => {
     }
   });
 
+  test('scopes a tombstone to its own notes channel', async () => {
+    const groups = ['tomb-scoped-a', 'tomb-scoped-b'];
+
+    await queries.insertGroups({
+      groups: groups.map((name) => testGroup(`~zod/${name}`, 100_000)),
+    });
+    await queries.insertChannels(
+      groups.map((name) => ({
+        id: `notes/~zod/${name}`,
+        type: 'notes' as const,
+        groupId: `~zod/${name}`,
+        currentUserIsMember: true,
+      }))
+    );
+    await queries.insertChannelUnreads(
+      groups.map((name) =>
+        makeChannelUnread({
+          channelId: `notes/~zod/${name}`,
+          updatedAt: 400_000,
+        })
+      )
+    );
+    // The same note id in both notebooks, so a tombstone lookup that ignored
+    // the channel would suppress each channel's event.
+    for (const name of groups) {
+      await insertNoteActivityEvent(
+        noteActivityEvent({
+          id: `${name}-note-event`,
+          channelId: `notes/~zod/${name}`,
+          groupId: `~zod/${name}`,
+          postId: '42',
+          title: `${name} title`,
+          timestamp: 399_000,
+        })
+      );
+    }
+    await queries.confirmNotesActivityEventsDeleted({
+      notebookFlag: '~zod/tomb-scoped-a',
+      noteIds: [42],
+    });
+
+    const chats = (await queries.getChats()).unpinned;
+    const deleted = chats.find((c) => c.id === '~zod/tomb-scoped-a');
+    const kept = chats.find((c) => c.id === '~zod/tomb-scoped-b');
+    expect(deleted?.type).toBe('group');
+    if (deleted?.type === 'group') {
+      expect(deleted.notesActivity).toMatchObject({
+        noteId: null,
+        noteTitle: null,
+      });
+    }
+    expect(kept?.type).toBe('group');
+    if (kept?.type === 'group') {
+      expect(kept.notesActivity).toMatchObject({
+        noteId: '42',
+        noteTitle: 'tomb-scoped-b title',
+      });
+    }
+  });
+
   test('keeps a local note the deleted event outranks on a lagging host clock', async () => {
     const groupId = '~zod/lagging-host-clock';
     const channelId = 'notes/~zod/lagging-host-clock';

--- a/packages/shared/src/db/queries.test.ts
+++ b/packages/shared/src/db/queries.test.ts
@@ -439,6 +439,69 @@ describe('getChats group recency workaround', () => {
     }
   });
 
+  test('prefers the synced title when the event names the same note', async () => {
+    const groupId = '~zod/renamed-note';
+    const channelId = 'notes/~zod/renamed-note';
+    const notebookFlag = '~zod/renamed-note';
+
+    await queries.insertGroups({ groups: [testGroup(groupId, 100_000)] });
+    await queries.insertChannels([
+      {
+        id: channelId,
+        type: 'notes',
+        title: 'Journal',
+        groupId,
+        currentUserIsMember: true,
+      },
+    ]);
+    await queries.insertChannelUnreads([
+      makeChannelUnread({ channelId, updatedAt: 400_000 }),
+    ]);
+    // The event's content predates the rename; the synced row carries the
+    // current title. A rename re-emits no event, so the row is the fresher
+    // copy even when the event's stamp is higher.
+    await insertNoteActivityEvent(
+      noteActivityEvent({
+        id: 'renamed-note-event',
+        channelId,
+        groupId,
+        postId: '42',
+        title: 'Title before the rename',
+        timestamp: 399_000,
+        type: 'note-edit',
+      })
+    );
+    await queries.saveNotesNotebookSnapshot({
+      notebook: makeNotesNotebook({
+        id: notebookFlag,
+        flagName: 'renamed-note',
+        title: 'Journal',
+      }),
+      folders: [],
+      notes: [
+        makeNotesNote(42, 1, 'Title after the rename', {
+          id: `${notebookFlag}/note/42`,
+          notebookFlag,
+          createdAt: 300,
+          updatedAt: 398,
+          updatedBy: '~zod',
+        }),
+      ],
+      members: [],
+    });
+
+    const chat = (await queries.getChats()).unpinned.find(
+      (candidate) => candidate.id === groupId
+    );
+    expect(chat?.type).toBe('group');
+    if (chat?.type === 'group') {
+      expect(chat.notesActivity).toMatchObject({
+        noteId: '42',
+        noteTitle: 'Title after the rename',
+      });
+    }
+  });
+
   test('selects only the newest persisted note event for each notebook', async () => {
     const groupId = '~zod/latest-note-event';
     const channelId = 'notes/~zod/latest-note-event';

--- a/packages/shared/src/db/queries.test.ts
+++ b/packages/shared/src/db/queries.test.ts
@@ -894,6 +894,74 @@ describe('getChats group recency workaround', () => {
     }
   });
 
+  test('keeps a local note the deleted event outranks on a lagging host clock', async () => {
+    const groupId = '~zod/lagging-host-clock';
+    const channelId = 'notes/~zod/lagging-host-clock';
+    const notebookFlag = '~zod/lagging-host-clock';
+
+    await queries.insertGroups({ groups: [testGroup(groupId, 100_000)] });
+    await queries.insertChannels([
+      {
+        id: channelId,
+        type: 'notes',
+        groupId,
+        currentUserIsMember: true,
+      },
+    ]);
+    // Recency matches the surviving note, so it is the authority on what the
+    // bump describes even though the deleted event carries a higher stamp.
+    await queries.insertChannelUnreads([
+      makeChannelUnread({ channelId, updatedAt: 399_000 }),
+    ]);
+    await insertNoteActivityEvent(
+      noteActivityEvent({
+        id: 'deleted-note-event',
+        channelId,
+        groupId,
+        postId: '42',
+        title: 'Deleted title',
+        timestamp: 400_000,
+      })
+    );
+    await queries.confirmNotesActivityEventsDeleted({
+      notebookFlag,
+      noteIds: [42],
+    });
+    // Written after the deletion, but the notebook host's clock trails the
+    // activity ship's, so its stamp lands below the deleted event's.
+    await queries.saveNotesNotebookSnapshot({
+      notebook: makeNotesNotebook({
+        id: notebookFlag,
+        flagName: 'lagging-host-clock',
+        title: 'Journal',
+      }),
+      folders: [],
+      notes: [
+        makeNotesNote(43, 1, 'Written after the delete', {
+          id: `${notebookFlag}/note/43`,
+          notebookFlag,
+          createdAt: 399,
+          updatedAt: 399,
+          updatedBy: '~zod',
+        }),
+      ],
+      members: [],
+    });
+
+    const chat = (await queries.getChats()).unpinned.find(
+      (candidate) => candidate.id === groupId
+    );
+    expect(chat?.type).toBe('group');
+    if (chat?.type === 'group') {
+      expect(chat.notesActivity).toMatchObject({
+        noteId: '43',
+        noteTitle: 'Written after the delete',
+        isNew: true,
+        timestamp: 399_000,
+      });
+    }
+  });
+
   test('keeps a newer post as the group recency when notebook activity is older', async () => {
     const groupId = '~zod/post-wins';
     const channelId = 'notes/~zod/post-wins';

--- a/packages/shared/src/db/queries.test.ts
+++ b/packages/shared/src/db/queries.test.ts
@@ -442,6 +442,7 @@ describe('getChats group recency workaround', () => {
   test('selects only the newest persisted note event for each notebook', async () => {
     const groupId = '~zod/latest-note-event';
     const channelId = 'notes/~zod/latest-note-event';
+    const notebookFlag = '~zod/latest-note-event';
 
     await queries.insertGroups({ groups: [testGroup(groupId, 100_000)] });
     await queries.insertChannels([
@@ -489,9 +490,26 @@ describe('getChats group recency workaround', () => {
         timestamp: 400_000,
       });
     }
+
+    await queries.confirmNotesActivityEventDeleted({
+      notebookFlag,
+      noteId: 42,
+    });
+    const afterConfirmedDelete = (await queries.getChats()).unpinned.find(
+      (candidate) => candidate.id === groupId
+    );
+    expect(afterConfirmedDelete?.type).toBe('group');
+    if (afterConfirmedDelete?.type === 'group') {
+      expect(afterConfirmedDelete.notesActivity).toMatchObject({
+        noteId: '41',
+        noteTitle: 'Old title',
+        isNew: true,
+        timestamp: 400_000,
+      });
+    }
   });
 
-  test('drops stale event details after a newer snapshot confirms deletion', async () => {
+  test('does not infer deletion from a fetch-stamped snapshot', async () => {
     const groupId = '~zod/deleted-note';
     const channelId = 'notes/~zod/deleted-note';
     const notebookFlag = '~zod/deleted-note';
@@ -522,8 +540,8 @@ describe('getChats group recency workaround', () => {
         id: notebookFlag,
         flagName: 'deleted-note',
         title: 'Journal',
-        // Notes timestamps can arrive in seconds, while activity events use
-        // milliseconds. This snapshot is newer than the event.
+        // Fetch completion is later than the event, but the read replica may
+        // still lag and this timestamp is not causal deletion evidence.
         syncedAt: 500,
       }),
       folders: [],
@@ -539,9 +557,9 @@ describe('getChats group recency workaround', () => {
       expect(chat.notesActivity).toEqual({
         channelId,
         notebookTitle: 'Journal',
-        noteId: null,
-        noteTitle: null,
-        authorId: null,
+        noteId: '42',
+        noteTitle: 'Deleted secret title',
+        authorId: '~bus',
         isNew: true,
         timestamp: 400_000,
       });
@@ -617,7 +635,7 @@ describe('getChats group recency workaround', () => {
       },
     ]);
     await queries.insertChannelUnreads([
-      makeChannelUnread({ channelId, updatedAt: 1_999_000_000_000 }),
+      makeChannelUnread({ channelId, updatedAt: 1_999_999_900_000 }),
     ]);
     await queries.saveNotesNotebookSnapshot({
       notebook: makeNotesNotebook({
@@ -689,6 +707,47 @@ describe('getChats group recency workaround', () => {
     );
     expect(chat?.type).toBe('group');
     if (chat?.type === 'group') {
+      expect(chat.notesActivity).toMatchObject({
+        noteId: null,
+        noteTitle: null,
+        timestamp: 400_000,
+      });
+    }
+  });
+
+  test('does not use a far-future note detail as group recency', async () => {
+    const groupId = '~zod/future-detail';
+    const channelId = 'notes/~zod/future-detail';
+
+    await queries.insertGroups({ groups: [testGroup(groupId, 100_000)] });
+    await queries.insertChannels([
+      {
+        id: channelId,
+        type: 'notes',
+        title: 'Journal',
+        groupId,
+        currentUserIsMember: true,
+      },
+    ]);
+    await queries.insertChannelUnreads([
+      makeChannelUnread({ channelId, updatedAt: 400_000 }),
+    ]);
+    await insertNoteActivityEvent(
+      noteActivityEvent({
+        id: 'future-note-event',
+        channelId,
+        groupId,
+        title: 'Future title',
+        timestamp: 701_000,
+      })
+    );
+
+    const chat = (await queries.getChats()).unpinned.find(
+      (candidate) => candidate.id === groupId
+    );
+    expect(chat?.type).toBe('group');
+    if (chat?.type === 'group') {
+      expect(chat.timestamp).toBe(400_000);
       expect(chat.notesActivity).toMatchObject({
         noteId: null,
         noteTitle: null,

--- a/packages/shared/src/db/queries.test.ts
+++ b/packages/shared/src/db/queries.test.ts
@@ -602,6 +602,61 @@ describe('getChats group recency workaround', () => {
     }
   });
 
+  test('normalizes mixed timestamp units before choosing the newest note', async () => {
+    const groupId = '~zod/mixed-note-times';
+    const channelId = 'notes/~zod/mixed-note-times';
+    const notebookFlag = '~zod/mixed-note-times';
+
+    await queries.insertGroups({ groups: [testGroup(groupId, 100_000)] });
+    await queries.insertChannels([
+      {
+        id: channelId,
+        type: 'notes',
+        groupId,
+        currentUserIsMember: true,
+      },
+    ]);
+    await queries.insertChannelUnreads([
+      makeChannelUnread({ channelId, updatedAt: 1_999_000_000_000 }),
+    ]);
+    await queries.saveNotesNotebookSnapshot({
+      notebook: makeNotesNotebook({
+        id: notebookFlag,
+        flagName: 'mixed-note-times',
+        title: 'Journal',
+      }),
+      folders: [],
+      notes: [
+        makeNotesNote(1, 1, 'Newer seconds note', {
+          id: `${notebookFlag}/note/1`,
+          notebookFlag,
+          createdAt: 2_000_000_000,
+          updatedAt: 2_000_000_000,
+        }),
+        makeNotesNote(2, 1, 'Older milliseconds note', {
+          id: `${notebookFlag}/note/2`,
+          notebookFlag,
+          createdAt: 1_900_000_000_000,
+          updatedAt: 1_900_000_000_000,
+        }),
+      ],
+      members: [],
+    });
+
+    const chat = (await queries.getChats()).unpinned.find(
+      (candidate) => candidate.id === groupId
+    );
+    expect(chat?.type).toBe('group');
+    if (chat?.type === 'group') {
+      expect(chat.timestamp).toBe(2_000_000_000_000);
+      expect(chat.notesActivity).toMatchObject({
+        noteId: '1',
+        noteTitle: 'Newer seconds note',
+        timestamp: 2_000_000_000_000,
+      });
+    }
+  });
+
   test('does not label a new bump with a stale note event', async () => {
     const groupId = '~zod/stale-detail';
     const channelId = 'notes/~zod/stale-detail';

--- a/packages/shared/src/db/queries.test.ts
+++ b/packages/shared/src/db/queries.test.ts
@@ -491,9 +491,9 @@ describe('getChats group recency workaround', () => {
       });
     }
 
-    await queries.confirmNotesActivityEventDeleted({
+    await queries.confirmNotesActivityEventsDeleted({
       notebookFlag,
-      noteId: 42,
+      noteIds: [42],
     });
     const afterConfirmedDelete = (await queries.getChats()).unpinned.find(
       (candidate) => candidate.id === groupId
@@ -505,6 +505,35 @@ describe('getChats group recency workaround', () => {
         noteTitle: null,
         isNew: true,
         timestamp: 400_000,
+      });
+    }
+
+    await queries.saveNotesNotebookSnapshot({
+      notebook: makeNotesNotebook({
+        id: notebookFlag,
+        flagName: 'latest-note-event',
+        title: 'Journal',
+      }),
+      folders: [],
+      notes: [
+        makeNotesNote(43, 1, 'Newer local note', {
+          id: `${notebookFlag}/note/43`,
+          notebookFlag,
+          createdAt: 500,
+          updatedAt: 500,
+        }),
+      ],
+      members: [],
+    });
+    const afterNewerLocalNote = (await queries.getChats()).unpinned.find(
+      (candidate) => candidate.id === groupId
+    );
+    expect(afterNewerLocalNote?.type).toBe('group');
+    if (afterNewerLocalNote?.type === 'group') {
+      expect(afterNewerLocalNote.notesActivity).toMatchObject({
+        noteId: '43',
+        noteTitle: 'Newer local note',
+        timestamp: 500_000,
       });
     }
   });
@@ -714,7 +743,7 @@ describe('getChats group recency workaround', () => {
           id: `${notebookFlag}/note/1`,
           notebookFlag,
           createdAt: 2_000_000_000,
-          updatedAt: 2_000_000_000,
+          updatedAt: 2_000_000_000_000,
         }),
         makeNotesNote(2, 1, 'Older milliseconds note', {
           id: `${notebookFlag}/note/2`,
@@ -735,6 +764,7 @@ describe('getChats group recency workaround', () => {
       expect(chat.notesActivity).toMatchObject({
         noteId: '1',
         noteTitle: 'Newer seconds note',
+        isNew: true,
         timestamp: 2_000_000_000_000,
       });
     }
@@ -818,6 +848,49 @@ describe('getChats group recency workaround', () => {
         noteTitle: null,
         timestamp: 400_000,
       });
+    }
+  });
+
+  test('bounds a local note timestamp when notebook recency is absent', async () => {
+    const groupId = '~zod/no-notes-recency';
+    const channelId = 'notes/~zod/no-notes-recency';
+    const notebookFlag = '~zod/no-notes-recency';
+    const futureTimestamp =
+      Date.now() + queries.NOTES_ACTIVITY_DETAIL_WINDOW_MS + 10_000;
+
+    await queries.insertGroups({ groups: [testGroup(groupId, 100_000)] });
+    await queries.insertChannels([
+      {
+        id: channelId,
+        type: 'notes',
+        groupId,
+        currentUserIsMember: true,
+      },
+    ]);
+    await queries.saveNotesNotebookSnapshot({
+      notebook: makeNotesNotebook({
+        id: notebookFlag,
+        flagName: 'no-notes-recency',
+      }),
+      folders: [],
+      notes: [
+        makeNotesNote(42, 1, 'Future local note', {
+          id: `${notebookFlag}/note/42`,
+          notebookFlag,
+          createdAt: futureTimestamp,
+          updatedAt: futureTimestamp,
+        }),
+      ],
+      members: [],
+    });
+
+    const chat = (await queries.getChats()).unpinned.find(
+      (candidate) => candidate.id === groupId
+    );
+    expect(chat?.type).toBe('group');
+    if (chat?.type === 'group') {
+      expect(chat.timestamp).toBeLessThanOrEqual(Date.now());
+      expect(chat.notesActivity).toBeNull();
     }
   });
 

--- a/packages/shared/src/db/queries.ts
+++ b/packages/shared/src/db/queries.ts
@@ -55,7 +55,11 @@ import { alias } from 'drizzle-orm/sqlite-core';
 import { trackEvent } from '../analytics';
 import { createDevLogger } from '../debug';
 import * as domain from '../domain';
-import { appendContactIdToReplies, getCompositeGroups } from '../logic';
+import {
+  appendContactIdToReplies,
+  getCompositeGroups,
+  noteTimestampMs,
+} from '../logic';
 import { perfTime } from '../perfLog';
 import { processBatchOperation } from './dbUtils';
 import { createDmChannelsForNewContacts } from './modelBuilders';
@@ -871,19 +875,32 @@ export const deleteNotesNote = createWriteQuery(
   ['notesNotes']
 );
 
-export const confirmNotesActivityEventDeleted = createWriteQuery(
-  'confirmNotesActivityEventDeleted',
+export const confirmNotesActivityEventsDeleted = createWriteQuery(
+  'confirmNotesActivityEventsDeleted',
   async (
-    { notebookFlag, noteId }: { notebookFlag: string; noteId: number },
+    { notebookFlag, noteIds }: { notebookFlag: string; noteIds: number[] },
     ctx: QueryCtx
   ) => {
-    return ctx.db
-      .insert($notesActivityEventTombstones)
-      .values({
-        channelId: `notes/${notebookFlag}`,
-        noteId: String(noteId),
-      })
-      .onConflictDoNothing();
+    if (noteIds.length === 0) {
+      return;
+    }
+    return withTransactionCtx(ctx, async (txCtx) => {
+      await batchAction(
+        noteIds,
+        async (batch) => {
+          await txCtx.db
+            .insert($notesActivityEventTombstones)
+            .values(
+              batch.map((noteId) => ({
+                channelId: `notes/${notebookFlag}`,
+                noteId: String(noteId),
+              }))
+            )
+            .onConflictDoNothing();
+        },
+        NOTES_SNAPSHOT_BATCH_SIZE
+      );
+    });
   },
   ['notesActivityEventTombstones']
 );
@@ -1541,19 +1558,29 @@ async function getGroupNotesActivity(
   for (const { groupId, channel, notebookFlag } of notesChannels) {
     const recency = channel.unread?.updatedAt ?? 0;
     const event = eventsByChannel.get(channel.id);
+    const localNote = notebookFlag
+      ? notesByNotebook.get(notebookFlag)
+      : undefined;
     const detail = event?.isConfirmedDeleted
-      ? undefined
-      : newestNotesActivityDetail(
-          event,
-          notebookFlag ? notesByNotebook.get(notebookFlag) : undefined
-        );
+      ? localNote && localNote.timestamp > event.timestamp
+        ? localNote
+        : undefined
+      : newestNotesActivityDetail(event, localNote);
+    const now = Date.now();
     const describes =
       detail &&
-      (recency <= 0 ||
-        Math.abs(detail.timestamp - recency) <= NOTES_ACTIVITY_DETAIL_WINDOW_MS)
+      (recency > 0
+        ? Math.abs(detail.timestamp - recency) <=
+          NOTES_ACTIVITY_DETAIL_WINDOW_MS
+        : detail.timestamp <= now + NOTES_ACTIVITY_DETAIL_WINDOW_MS)
         ? detail
         : null;
-    const timestamp = Math.max(recency, describes?.timestamp ?? 0);
+    const detailTimestamp = describes
+      ? recency > 0
+        ? describes.timestamp
+        : Math.min(describes.timestamp, now)
+      : 0;
+    const timestamp = Math.max(recency, detailTimestamp);
     if (timestamp <= 0) {
       continue;
     }
@@ -1744,7 +1771,8 @@ async function getLatestNotesByNotebook(
       authorId: row.updatedBy ?? null,
       isNew:
         row.updatedAt == null ||
-        (row.createdAt != null && row.createdAt === row.updatedAt),
+        (row.createdAt != null &&
+          noteTimestampMs(row.createdAt) === noteTimestampMs(row.updatedAt)),
       timestamp: row.effectiveAt,
     });
   }

--- a/packages/shared/src/db/queries.ts
+++ b/packages/shared/src/db/queries.ts
@@ -1681,10 +1681,11 @@ async function getLatestNotesByNotebook(
     return latest;
   }
 
-  const $newerNotes = alias($notesNotes, 'newerNotes');
   const effectiveAt = sql<number>`coalesce(${$notesNotes.updatedAt}, ${$notesNotes.createdAt})`;
-  const newerEffectiveAt = sql<number>`coalesce(${$newerNotes.updatedAt}, ${$newerNotes.createdAt})`;
-  const rows = await ctx.db
+  // Normalize before ranking so mixed seconds/milliseconds rows compare by
+  // their actual time, then let SQLite rank each notebook in one pass.
+  const normalizedEffectiveAt = sql<number>`case when ${effectiveAt} < 10000000000 then ${effectiveAt} * 1000 else ${effectiveAt} end`;
+  const $rankedNotes = ctx.db
     .select({
       notebookFlag: $notesNotes.notebookFlag,
       noteId: $notesNotes.noteId,
@@ -1692,33 +1693,24 @@ async function getLatestNotesByNotebook(
       updatedBy: $notesNotes.updatedBy,
       createdAt: $notesNotes.createdAt,
       updatedAt: $notesNotes.updatedAt,
-      effectiveAt,
+      effectiveAt: normalizedEffectiveAt.as('effectiveAt'),
+      rank: sql<number>`row_number() over (
+        partition by ${$notesNotes.notebookFlag}
+        order by ${normalizedEffectiveAt} desc, ${$notesNotes.noteId} desc
+      )`.as('rank'),
     })
     .from($notesNotes)
     .where(
       and(
         inArray($notesNotes.notebookFlag, notebookFlags),
-        isNotNull(effectiveAt),
-        notExists(
-          ctx.db
-            .select({ id: $newerNotes.id })
-            .from($newerNotes)
-            .where(
-              and(
-                eq($newerNotes.notebookFlag, $notesNotes.notebookFlag),
-                isNotNull(newerEffectiveAt),
-                or(
-                  gt(newerEffectiveAt, effectiveAt),
-                  and(
-                    eq(newerEffectiveAt, effectiveAt),
-                    gt($newerNotes.noteId, $notesNotes.noteId)
-                  )
-                )
-              )
-            )
-        )
+        isNotNull(effectiveAt)
       )
-    );
+    )
+    .as('rankedNotes');
+  const rows = await ctx.db
+    .select()
+    .from($rankedNotes)
+    .where(eq($rankedNotes.rank, 1));
 
   for (const row of rows) {
     latest.set(row.notebookFlag, {
@@ -1728,7 +1720,7 @@ async function getLatestNotesByNotebook(
       isNew:
         row.updatedAt == null ||
         (row.createdAt != null && row.createdAt === row.updatedAt),
-      timestamp: noteTimestampMs(row.effectiveAt) ?? 0,
+      timestamp: row.effectiveAt,
     });
   }
 

--- a/packages/shared/src/db/queries.ts
+++ b/packages/shared/src/db/queries.ts
@@ -1,7 +1,10 @@
 import {
   ACTIVITY_SOURCE_PAGESIZE,
   ChannelInit,
+  formatNotesFlag,
   getCurrentUserId,
+  getTextContent,
+  parseNotesChannelId,
 } from '@tloncorp/api';
 import { parseGroupId } from '@tloncorp/api';
 import {
@@ -42,6 +45,7 @@ import {
   min,
   ne,
   not,
+  notExists,
   notInArray,
   or,
   sql,
@@ -51,7 +55,11 @@ import { alias } from 'drizzle-orm/sqlite-core';
 import { trackEvent } from '../analytics';
 import { createDevLogger } from '../debug';
 import * as domain from '../domain';
-import { appendContactIdToReplies, getCompositeGroups } from '../logic';
+import {
+  appendContactIdToReplies,
+  getCompositeGroups,
+  noteTimestampMs,
+} from '../logic';
 import { perfTime } from '../perfLog';
 import { processBatchOperation } from './dbUtils';
 import { createDmChannelsForNewContacts } from './modelBuilders';
@@ -120,6 +128,7 @@ import {
   Group,
   GroupJoinRequest,
   GroupNavSection,
+  GroupNotesActivity,
   GroupRole,
   GroupUnread,
   NotesFolder,
@@ -1396,6 +1405,235 @@ export const getMentionCandidates = createReadQuery(
   ['chatMembers', 'contacts']
 );
 
+// A note detail must be close to the notebook recency before we claim that it
+// describes that bump. Own edits use the host's note timestamp and the local
+// ship's activity timestamp, so exact equality is not expected.
+export const NOTES_ACTIVITY_DETAIL_WINDOW_MS = 5 * 60 * 1000;
+
+type NotesActivityDetail = Pick<
+  GroupNotesActivity,
+  'noteId' | 'noteTitle' | 'authorId' | 'isNew' | 'timestamp'
+>;
+
+type NotesActivityGroup = {
+  id: string;
+  channels: (Pick<Channel, 'id' | 'type' | 'title' | 'currentUserIsMember'> & {
+    unread?: Pick<ChannelUnread, 'updatedAt'> | null;
+  })[];
+};
+
+/**
+ * Find the newest joined notebook activity in each group. Notebook recency is
+ * authoritative for ordering, while the note identity can come from either a
+ * persisted activity event or the locally synced notebook snapshot.
+ */
+async function getGroupNotesActivity(
+  groups: NotesActivityGroup[],
+  ctx: QueryCtx
+): Promise<Map<string, GroupNotesActivity>> {
+  const notesChannels = groups.flatMap((group) =>
+    group.channels
+      .filter(
+        (channel) =>
+          channel.type === 'notes' && channel.currentUserIsMember === true
+      )
+      .map((channel) => {
+        const flag = parseNotesChannelId(channel.id);
+        return {
+          groupId: group.id,
+          channel,
+          notebookFlag: flag ? formatNotesFlag(flag) : null,
+        };
+      })
+  );
+  const activityByGroup = new Map<string, GroupNotesActivity>();
+  if (notesChannels.length === 0) {
+    return activityByGroup;
+  }
+
+  const notebookFlags = notesChannels.flatMap(({ notebookFlag }) =>
+    notebookFlag ? [notebookFlag] : []
+  );
+  const [eventsByChannel, notesByNotebook, notebookTitlesByFlag] =
+    await Promise.all([
+      getLatestNoteEventsByChannel(
+        notesChannels.map(({ channel }) => channel.id),
+        ctx
+      ),
+      getLatestNotesByNotebook(notebookFlags, ctx),
+      getNotesNotebookTitles(notebookFlags, ctx),
+    ]);
+
+  for (const { groupId, channel, notebookFlag } of notesChannels) {
+    const recency = channel.unread?.updatedAt ?? 0;
+    const detail = newestNotesActivityDetail(
+      eventsByChannel.get(channel.id),
+      notebookFlag ? notesByNotebook.get(notebookFlag) : undefined
+    );
+    const timestamp = Math.max(recency, detail?.timestamp ?? 0);
+    if (timestamp <= 0) {
+      continue;
+    }
+
+    const current = activityByGroup.get(groupId);
+    if (current && current.timestamp >= timestamp) {
+      continue;
+    }
+
+    const describes =
+      detail && detail.timestamp >= recency - NOTES_ACTIVITY_DETAIL_WINDOW_MS
+        ? detail
+        : null;
+    activityByGroup.set(groupId, {
+      channelId: channel.id,
+      notebookTitle:
+        channel.title ??
+        (notebookFlag ? notebookTitlesByFlag.get(notebookFlag) : null) ??
+        null,
+      noteId: describes?.noteId ?? null,
+      noteTitle: describes?.noteTitle ?? null,
+      authorId: describes?.authorId ?? null,
+      // Without a record of the note, the only safe generic copy is "New
+      // note"; the title can fill in when the notebook snapshot is warmed.
+      isNew: describes?.isNew ?? true,
+      timestamp,
+    });
+  }
+
+  return activityByGroup;
+}
+
+function newestNotesActivityDetail(
+  ...details: (NotesActivityDetail | undefined)[]
+): NotesActivityDetail | undefined {
+  return details.reduce<NotesActivityDetail | undefined>(
+    (newest, detail) =>
+      detail && (!newest || detail.timestamp > newest.timestamp)
+        ? detail
+        : newest,
+    undefined
+  );
+}
+
+async function getLatestNoteEventsByChannel(
+  channelIds: string[],
+  ctx: QueryCtx
+): Promise<Map<string, NotesActivityDetail>> {
+  const rows = await ctx.db
+    .select({
+      channelId: $activityEvents.channelId,
+      type: $activityEvents.type,
+      postId: $activityEvents.postId,
+      authorId: $activityEvents.authorId,
+      content: $activityEvents.content,
+      timestamp: $activityEvents.timestamp,
+    })
+    .from($activityEvents)
+    .where(
+      and(
+        inArray($activityEvents.type, ['note-create', 'note-edit']),
+        inArray($activityEvents.channelId, channelIds)
+      )
+    )
+    .orderBy(desc($activityEvents.timestamp));
+
+  const latest = new Map<string, NotesActivityDetail>();
+  for (const row of rows) {
+    if (!row.channelId || latest.has(row.channelId)) {
+      continue;
+    }
+    const title = row.content
+      ? getTextContent(
+          row.content as Parameters<typeof getTextContent>[0]
+        )?.trim() || null
+      : null;
+    latest.set(row.channelId, {
+      noteId: row.postId ?? null,
+      noteTitle: title,
+      authorId: row.authorId ?? null,
+      isNew: row.type === 'note-create',
+      timestamp: row.timestamp,
+    });
+  }
+
+  return latest;
+}
+
+async function getNotesNotebookTitles(
+  notebookFlags: string[],
+  ctx: QueryCtx
+): Promise<Map<string, string>> {
+  if (notebookFlags.length === 0) {
+    return new Map();
+  }
+
+  const rows = await ctx.db
+    .select({ id: $notesNotebooks.id, title: $notesNotebooks.title })
+    .from($notesNotebooks)
+    .where(inArray($notesNotebooks.id, notebookFlags));
+  return new Map(rows.map((row) => [row.id, row.title]));
+}
+
+// A notebook can contain thousands of notes, so select only the newest row
+// per notebook in SQLite instead of paging every note through JavaScript.
+async function getLatestNotesByNotebook(
+  notebookFlags: string[],
+  ctx: QueryCtx
+): Promise<Map<string, NotesActivityDetail>> {
+  const latest = new Map<string, NotesActivityDetail>();
+  if (notebookFlags.length === 0) {
+    return latest;
+  }
+
+  const $newerNotes = alias($notesNotes, 'newerNotes');
+  const rows = await ctx.db
+    .select({
+      notebookFlag: $notesNotes.notebookFlag,
+      noteId: $notesNotes.noteId,
+      title: $notesNotes.title,
+      updatedBy: $notesNotes.updatedBy,
+      createdAt: $notesNotes.createdAt,
+      updatedAt: $notesNotes.updatedAt,
+    })
+    .from($notesNotes)
+    .where(
+      and(
+        inArray($notesNotes.notebookFlag, notebookFlags),
+        isNotNull($notesNotes.updatedAt),
+        notExists(
+          ctx.db
+            .select({ id: $newerNotes.id })
+            .from($newerNotes)
+            .where(
+              and(
+                eq($newerNotes.notebookFlag, $notesNotes.notebookFlag),
+                isNotNull($newerNotes.updatedAt),
+                or(
+                  gt($newerNotes.updatedAt, $notesNotes.updatedAt),
+                  and(
+                    eq($newerNotes.updatedAt, $notesNotes.updatedAt),
+                    gt($newerNotes.noteId, $notesNotes.noteId)
+                  )
+                )
+              )
+            )
+        )
+      )
+    );
+
+  for (const row of rows) {
+    latest.set(row.notebookFlag, {
+      noteId: String(row.noteId),
+      noteTitle: row.title.trim() || null,
+      authorId: row.updatedBy ?? null,
+      isNew: row.createdAt != null && row.createdAt === row.updatedAt,
+      timestamp: noteTimestampMs(row.updatedAt) ?? 0,
+    });
+  }
+
+  return latest;
+}
+
 export const getChats = createReadQuery(
   'getChats',
   async (
@@ -1447,21 +1685,15 @@ export const getChats = createReadQuery(
       },
     });
 
+    const notesActivityByGroup = await getGroupNotesActivity(groups, ctx);
+
     const groupChats: Chat[] = groups.map((g) => {
       // Temporary client-side workaround for TLON-6417. Group activity
       // recency includes membership and other events that should not reorder
       // the chat list. Keep the old post-based ordering, plus the narrower
       // Notes source recency, until the backend provides a sidebar-specific
       // recency value.
-      const latestNotesActivityAt = Math.max(
-        0,
-        ...g.channels
-          .filter(
-            (channel) =>
-              channel.type === 'notes' && channel.currentUserIsMember === true
-          )
-          .map((channel) => channel.unread?.updatedAt ?? 0)
-      );
+      const notesActivity = notesActivityByGroup.get(g.id) ?? null;
 
       return {
         id: g.id,
@@ -1469,10 +1701,11 @@ export const getChats = createReadQuery(
         pin: g.pin,
         timestamp: g.haveInvite
           ? (g.unread?.updatedAt ?? 0)
-          : Math.max(g.lastPostAt ?? 0, latestNotesActivityAt),
+          : Math.max(g.lastPostAt ?? 0, notesActivity?.timestamp ?? 0),
         volumeSettings: g.volumeSettings,
         unreadCount: g.unread?.count ?? 0,
         group: g,
+        notesActivity,
         isPending:
           g.haveInvite === true ||
           !!g.joinStatus ||
@@ -1531,6 +1764,9 @@ export const getChats = createReadQuery(
     'threadUnreads',
     'volumeSettings',
     'pins',
+    'activityEvents',
+    'notesNotebooks',
+    'notesNotes',
   ]
 );
 

--- a/packages/shared/src/db/queries.ts
+++ b/packages/shared/src/db/queries.ts
@@ -1613,22 +1613,20 @@ async function getGroupNotesActivity(
   return activityByGroup;
 }
 
-// Both candidates can describe the same note: an event stamped by the
-// activity ship and a row stamped by the notebook host. Prefer the row there
-// rather than ordering the two clocks -- renames don't bump a revision or
-// re-emit an event, so the event's cached title can be stale while the synced
-// row carries the current one. Distinct notes fall back to the newer stamp;
-// the differing clocks make that imprecise, but the recency window in
-// getGroupNotesActivity bounds how stale the chosen detail can be.
+// The event stamp comes from the activity ship and the note stamp from the
+// notebook host, so this comparison spans two clocks. Newest-wins is still
+// the right rule for a note both sources describe: an edit event carries the
+// note's current title, and markNotesNotebookStaleForNoteEvent deliberately
+// leaves the snapshot alone for a note it already stores, so the row can sit
+// on a stale title for minutes while the event is current. A rename bumps
+// updatedAt, which already lifts the row above an older event. The recency
+// window in getGroupNotesActivity bounds how stale either choice can be.
 function newestNotesActivityDetail(
   event: NotesActivityDetail | undefined,
   localNote: NotesActivityDetail | undefined
 ): NotesActivityDetail | undefined {
   if (!event || !localNote) {
     return event ?? localNote;
-  }
-  if (event.noteId != null && event.noteId === localNote.noteId) {
-    return localNote;
   }
   return event.timestamp > localNote.timestamp ? event : localNote;
 }

--- a/packages/shared/src/db/queries.ts
+++ b/packages/shared/src/db/queries.ts
@@ -1561,11 +1561,15 @@ async function getGroupNotesActivity(
     const localNote = notebookFlag
       ? notesByNotebook.get(notebookFlag)
       : undefined;
-    const detail = event?.isConfirmedDeleted
-      ? localNote && localNote.timestamp > event.timestamp
-        ? localNote
-        : undefined
-      : newestNotesActivityDetail(event, localNote);
+    // A confirmed deletion disqualifies only the event describing it. The
+    // local candidate is not ranked against that event's timestamp: the note
+    // stamp comes from the notebook host and the event stamp from the
+    // activity ship, so ordering them directly would drop a valid note
+    // whenever the host's clock lags. Channel recency arbitrates below.
+    const detail = newestNotesActivityDetail(
+      event?.isConfirmedDeleted ? undefined : event,
+      localNote
+    );
     const now = Date.now();
     const describes =
       detail &&

--- a/packages/shared/src/db/queries.ts
+++ b/packages/shared/src/db/queries.ts
@@ -693,6 +693,45 @@ export const saveNotesNotebookSnapshot = createWriteQuery(
       const currentByNoteId = new Map(
         currentNotes.map((note) => [note.noteId, note])
       );
+      const incomingNoteIds = new Set(notes.map((note) => note.noteId));
+      const channelId = `notes/${notebook.id}`;
+      // A previously synced row disappearing from a later serialized snapshot
+      // is the remote-deletion signal. Rows created locally have no syncedAt
+      // until the replica observes them, so a lagging post-create snapshot
+      // cannot incorrectly tombstone their activity.
+      const remotelyDeletedNotes = currentNotes.filter(
+        (note) => note.syncedAt != null && !incomingNoteIds.has(note.noteId)
+      );
+      await batchAction(
+        notes,
+        async (batch) => {
+          await txCtx.db.delete($notesActivityEventTombstones).where(
+            and(
+              eq($notesActivityEventTombstones.channelId, channelId),
+              inArray(
+                $notesActivityEventTombstones.noteId,
+                batch.map((note) => String(note.noteId))
+              )
+            )
+          );
+        },
+        NOTES_SNAPSHOT_BATCH_SIZE
+      );
+      await batchAction(
+        remotelyDeletedNotes,
+        async (batch) => {
+          await txCtx.db
+            .insert($notesActivityEventTombstones)
+            .values(
+              batch.map((note) => ({
+                channelId,
+                noteId: String(note.noteId),
+              }))
+            )
+            .onConflictDoNothing();
+        },
+        NOTES_SNAPSHOT_BATCH_SIZE
+      );
       // Renames and moves don't bump the revision, so equal revisions are
       // ordered by updatedAt (both stamped by the host clock).
       const mergedNotes = notes.map((incoming) => {
@@ -730,7 +769,13 @@ export const saveNotesNotebookSnapshot = createWriteQuery(
       );
     });
   },
-  ['notesNotebooks', 'notesFolders', 'notesNotes', 'notesMembers']
+  [
+    'notesNotebooks',
+    'notesFolders',
+    'notesNotes',
+    'notesMembers',
+    'notesActivityEventTombstones',
+  ]
 );
 
 /** Persist one authoritative note without replacing concurrent notebook data. */
@@ -1440,6 +1485,10 @@ type NotesActivityDetail = Pick<
   'noteId' | 'noteTitle' | 'authorId' | 'isNew' | 'timestamp'
 >;
 
+type NotesActivityEventDetail = NotesActivityDetail & {
+  isConfirmedDeleted: boolean;
+};
+
 type NotesActivityGroup = {
   id: string;
   channels: (Pick<Channel, 'id' | 'type' | 'title' | 'currentUserIsMember'> & {
@@ -1491,10 +1540,13 @@ async function getGroupNotesActivity(
 
   for (const { groupId, channel, notebookFlag } of notesChannels) {
     const recency = channel.unread?.updatedAt ?? 0;
-    const detail = newestNotesActivityDetail(
-      eventsByChannel.get(channel.id),
-      notebookFlag ? notesByNotebook.get(notebookFlag) : undefined
-    );
+    const event = eventsByChannel.get(channel.id);
+    const detail = event?.isConfirmedDeleted
+      ? undefined
+      : newestNotesActivityDetail(
+          event,
+          notebookFlag ? notesByNotebook.get(notebookFlag) : undefined
+        );
     const describes =
       detail &&
       (recency <= 0 ||
@@ -1545,82 +1597,60 @@ function newestNotesActivityDetail(
 async function getLatestNoteEventsByChannel(
   channelIds: string[],
   ctx: QueryCtx
-): Promise<Map<string, NotesActivityDetail>> {
+): Promise<Map<string, NotesActivityEventDetail>> {
   const $newerEvents = alias($activityEvents, 'newerNoteActivityEvents');
-  const rows = await ctx.db
-    .select({
-      channelId: $activityEvents.channelId,
-      type: $activityEvents.type,
-      postId: $activityEvents.postId,
-      authorId: $activityEvents.authorId,
-      content: $activityEvents.content,
-      timestamp: $activityEvents.timestamp,
-    })
-    .from($activityEvents)
-    .where(
-      and(
-        inArray($activityEvents.type, ['note-create', 'note-edit']),
-        inArray($activityEvents.channelId, channelIds),
-        notExists(
-          ctx.db
-            .select({ channelId: $notesActivityEventTombstones.channelId })
-            .from($notesActivityEventTombstones)
-            .where(
-              and(
-                eq(
-                  $notesActivityEventTombstones.channelId,
-                  $activityEvents.channelId
-                ),
-                eq($notesActivityEventTombstones.noteId, $activityEvents.postId)
-              )
-            )
-        ),
-        notExists(
-          ctx.db
-            .select({ id: $newerEvents.id })
-            .from($newerEvents)
-            .where(
-              and(
-                eq($newerEvents.channelId, $activityEvents.channelId),
-                inArray($newerEvents.type, ['note-create', 'note-edit']),
-                notExists(
-                  ctx.db
-                    .select({
-                      channelId: $notesActivityEventTombstones.channelId,
-                    })
-                    .from($notesActivityEventTombstones)
-                    .where(
-                      and(
-                        eq(
-                          $notesActivityEventTombstones.channelId,
-                          $newerEvents.channelId
-                        ),
-                        eq(
-                          $notesActivityEventTombstones.noteId,
-                          $newerEvents.postId
-                        )
-                      )
+  const [rows, tombstones] = await Promise.all([
+    ctx.db
+      .select({
+        channelId: $activityEvents.channelId,
+        type: $activityEvents.type,
+        postId: $activityEvents.postId,
+        authorId: $activityEvents.authorId,
+        content: $activityEvents.content,
+        timestamp: $activityEvents.timestamp,
+      })
+      .from($activityEvents)
+      .where(
+        and(
+          inArray($activityEvents.type, ['note-create', 'note-edit']),
+          inArray($activityEvents.channelId, channelIds),
+          notExists(
+            ctx.db
+              .select({ id: $newerEvents.id })
+              .from($newerEvents)
+              .where(
+                and(
+                  eq($newerEvents.channelId, $activityEvents.channelId),
+                  inArray($newerEvents.type, ['note-create', 'note-edit']),
+                  or(
+                    gt($newerEvents.timestamp, $activityEvents.timestamp),
+                    and(
+                      eq($newerEvents.timestamp, $activityEvents.timestamp),
+                      gt($newerEvents.id, $activityEvents.id)
+                    ),
+                    and(
+                      eq($newerEvents.timestamp, $activityEvents.timestamp),
+                      eq($newerEvents.id, $activityEvents.id),
+                      gt($newerEvents.bucketId, $activityEvents.bucketId)
                     )
-                ),
-                or(
-                  gt($newerEvents.timestamp, $activityEvents.timestamp),
-                  and(
-                    eq($newerEvents.timestamp, $activityEvents.timestamp),
-                    gt($newerEvents.id, $activityEvents.id)
-                  ),
-                  and(
-                    eq($newerEvents.timestamp, $activityEvents.timestamp),
-                    eq($newerEvents.id, $activityEvents.id),
-                    gt($newerEvents.bucketId, $activityEvents.bucketId)
                   )
                 )
               )
-            )
+          )
         )
-      )
-    );
+      ),
+    ctx.db
+      .select()
+      .from($notesActivityEventTombstones)
+      .where(inArray($notesActivityEventTombstones.channelId, channelIds)),
+  ]);
+  const tombstoneKeys = new Set(
+    tombstones.map(({ channelId, noteId }) =>
+      notesActivityEventKey(channelId, noteId)
+    )
+  );
 
-  const latest = new Map<string, NotesActivityDetail>();
+  const latest = new Map<string, NotesActivityEventDetail>();
   for (const row of rows) {
     if (!row.channelId || latest.has(row.channelId)) {
       continue;
@@ -1636,10 +1666,18 @@ async function getLatestNoteEventsByChannel(
       authorId: row.authorId ?? null,
       isNew: row.type === 'note-create',
       timestamp: row.timestamp,
+      isConfirmedDeleted: Boolean(
+        row.postId &&
+        tombstoneKeys.has(notesActivityEventKey(row.channelId, row.postId))
+      ),
     });
   }
 
   return latest;
+}
+
+function notesActivityEventKey(channelId: string, noteId: string) {
+  return `${channelId}\0${noteId}`;
 }
 
 async function getNotesNotebookTitles(

--- a/packages/shared/src/db/queries.ts
+++ b/packages/shared/src/db/queries.ts
@@ -55,11 +55,7 @@ import { alias } from 'drizzle-orm/sqlite-core';
 import { trackEvent } from '../analytics';
 import { createDevLogger } from '../debug';
 import * as domain from '../domain';
-import {
-  appendContactIdToReplies,
-  getCompositeGroups,
-  noteTimestampMs,
-} from '../logic';
+import { appendContactIdToReplies, getCompositeGroups } from '../logic';
 import { perfTime } from '../perfLog';
 import { processBatchOperation } from './dbUtils';
 import { createDmChannelsForNewContacts } from './modelBuilders';
@@ -95,6 +91,7 @@ import {
   groupRoles as $groupRoles,
   groupUnreads as $groupUnreads,
   groups as $groups,
+  notesActivityEventTombstones as $notesActivityEventTombstones,
   notesFolders as $notesFolders,
   notesMembers as $notesMembers,
   notesNotebooks as $notesNotebooks,
@@ -829,6 +826,23 @@ export const deleteNotesNote = createWriteQuery(
   ['notesNotes']
 );
 
+export const confirmNotesActivityEventDeleted = createWriteQuery(
+  'confirmNotesActivityEventDeleted',
+  async (
+    { notebookFlag, noteId }: { notebookFlag: string; noteId: number },
+    ctx: QueryCtx
+  ) => {
+    return ctx.db
+      .insert($notesActivityEventTombstones)
+      .values({
+        channelId: `notes/${notebookFlag}`,
+        noteId: String(noteId),
+      })
+      .onConflictDoNothing();
+  },
+  ['notesActivityEventTombstones']
+);
+
 export const deleteNotesFolders = createWriteQuery(
   'deleteNotesFolders',
   async (
@@ -889,11 +903,22 @@ export const deleteNotesNotebook = createWriteQuery(
         .delete($notesMembers)
         .where(eq($notesMembers.notebookFlag, notebookFlag));
       await txCtx.db
+        .delete($notesActivityEventTombstones)
+        .where(
+          eq($notesActivityEventTombstones.channelId, `notes/${notebookFlag}`)
+        );
+      await txCtx.db
         .delete($notesNotebooks)
         .where(eq($notesNotebooks.id, notebookFlag));
     });
   },
-  ['notesNotebooks', 'notesFolders', 'notesNotes', 'notesMembers']
+  [
+    'notesNotebooks',
+    'notesFolders',
+    'notesNotes',
+    'notesMembers',
+    'notesActivityEventTombstones',
+  ]
 );
 
 const NOTES_SNAPSHOT_BATCH_SIZE = 50;
@@ -1422,11 +1447,6 @@ type NotesActivityGroup = {
   })[];
 };
 
-type NotesNotebookInfo = {
-  title: string;
-  syncedAt: number | null;
-};
-
 /**
  * Find the newest joined notebook activity in each group. Notebook recency is
  * authoritative for ordering, while the note identity can come from either a
@@ -1459,44 +1479,29 @@ async function getGroupNotesActivity(
   const notebookFlags = notesChannels.flatMap(({ notebookFlag }) =>
     notebookFlag ? [notebookFlag] : []
   );
-  const [eventsByChannel, notesByNotebook, notebooksByFlag] = await Promise.all(
-    [
+  const [eventsByChannel, notesByNotebook, notebookTitlesByFlag] =
+    await Promise.all([
       getLatestNoteEventsByChannel(
         notesChannels.map(({ channel }) => channel.id),
         ctx
       ),
       getLatestNotesByNotebook(notebookFlags, ctx),
-      getNotesNotebookInfo(notebookFlags, ctx),
-    ]
-  );
-  const storedEventNoteKeys = await getStoredEventNoteKeys(
-    notesChannels,
-    eventsByChannel,
-    ctx
-  );
+      getNotesNotebookTitles(notebookFlags, ctx),
+    ]);
 
   for (const { groupId, channel, notebookFlag } of notesChannels) {
     const recency = channel.unread?.updatedAt ?? 0;
-    const event = eventsByChannel.get(channel.id);
-    const localNote = notebookFlag
-      ? notesByNotebook.get(notebookFlag)
-      : undefined;
-    const notebook = notebookFlag
-      ? notebooksByFlag.get(notebookFlag)
-      : undefined;
-    const eventConfirmedDeleted = Boolean(
-      event?.noteId &&
-      notebookFlag &&
-      notebook?.syncedAt != null &&
-      (noteTimestampMs(notebook.syncedAt) ?? 0) >= event.timestamp &&
-      !storedEventNoteKeys.has(noteKey(notebookFlag, event.noteId))
+    const detail = newestNotesActivityDetail(
+      eventsByChannel.get(channel.id),
+      notebookFlag ? notesByNotebook.get(notebookFlag) : undefined
     );
-    const detail = eventConfirmedDeleted
-      ? localNote && event && localNote.timestamp > event.timestamp
-        ? localNote
-        : undefined
-      : newestNotesActivityDetail(event, localNote);
-    const timestamp = Math.max(recency, detail?.timestamp ?? 0);
+    const describes =
+      detail &&
+      (recency <= 0 ||
+        Math.abs(detail.timestamp - recency) <= NOTES_ACTIVITY_DETAIL_WINDOW_MS)
+        ? detail
+        : null;
+    const timestamp = Math.max(recency, describes?.timestamp ?? 0);
     if (timestamp <= 0) {
       continue;
     }
@@ -1506,13 +1511,12 @@ async function getGroupNotesActivity(
       continue;
     }
 
-    const describes =
-      detail && detail.timestamp >= recency - NOTES_ACTIVITY_DETAIL_WINDOW_MS
-        ? detail
-        : null;
     activityByGroup.set(groupId, {
       channelId: channel.id,
-      notebookTitle: channel.title ?? notebook?.title ?? null,
+      notebookTitle:
+        channel.title ??
+        (notebookFlag ? notebookTitlesByFlag.get(notebookFlag) : null) ??
+        null,
       noteId: describes?.noteId ?? null,
       noteTitle: describes?.noteTitle ?? null,
       authorId: describes?.authorId ?? null,
@@ -1559,12 +1563,45 @@ async function getLatestNoteEventsByChannel(
         inArray($activityEvents.channelId, channelIds),
         notExists(
           ctx.db
+            .select({ channelId: $notesActivityEventTombstones.channelId })
+            .from($notesActivityEventTombstones)
+            .where(
+              and(
+                eq(
+                  $notesActivityEventTombstones.channelId,
+                  $activityEvents.channelId
+                ),
+                eq($notesActivityEventTombstones.noteId, $activityEvents.postId)
+              )
+            )
+        ),
+        notExists(
+          ctx.db
             .select({ id: $newerEvents.id })
             .from($newerEvents)
             .where(
               and(
                 eq($newerEvents.channelId, $activityEvents.channelId),
                 inArray($newerEvents.type, ['note-create', 'note-edit']),
+                notExists(
+                  ctx.db
+                    .select({
+                      channelId: $notesActivityEventTombstones.channelId,
+                    })
+                    .from($notesActivityEventTombstones)
+                    .where(
+                      and(
+                        eq(
+                          $notesActivityEventTombstones.channelId,
+                          $newerEvents.channelId
+                        ),
+                        eq(
+                          $notesActivityEventTombstones.noteId,
+                          $newerEvents.postId
+                        )
+                      )
+                    )
+                ),
                 or(
                   gt($newerEvents.timestamp, $activityEvents.timestamp),
                   and(
@@ -1605,69 +1642,19 @@ async function getLatestNoteEventsByChannel(
   return latest;
 }
 
-async function getNotesNotebookInfo(
+async function getNotesNotebookTitles(
   notebookFlags: string[],
   ctx: QueryCtx
-): Promise<Map<string, NotesNotebookInfo>> {
+): Promise<Map<string, string>> {
   if (notebookFlags.length === 0) {
     return new Map();
   }
 
   const rows = await ctx.db
-    .select({
-      id: $notesNotebooks.id,
-      title: $notesNotebooks.title,
-      syncedAt: $notesNotebooks.syncedAt,
-    })
+    .select({ id: $notesNotebooks.id, title: $notesNotebooks.title })
     .from($notesNotebooks)
     .where(inArray($notesNotebooks.id, notebookFlags));
-  return new Map(
-    rows.map((row) => [
-      row.id,
-      { title: row.title, syncedAt: row.syncedAt ?? null },
-    ])
-  );
-}
-
-async function getStoredEventNoteKeys(
-  notesChannels: Array<{
-    channel: Pick<Channel, 'id'>;
-    notebookFlag: string | null;
-  }>,
-  eventsByChannel: Map<string, NotesActivityDetail>,
-  ctx: QueryCtx
-): Promise<Set<string>> {
-  const candidates = notesChannels.flatMap(({ channel, notebookFlag }) => {
-    const noteId = Number(eventsByChannel.get(channel.id)?.noteId);
-    return notebookFlag && Number.isSafeInteger(noteId)
-      ? [{ notebookFlag, noteId }]
-      : [];
-  });
-  if (candidates.length === 0) {
-    return new Set();
-  }
-
-  const rows = await ctx.db
-    .select({
-      notebookFlag: $notesNotes.notebookFlag,
-      noteId: $notesNotes.noteId,
-    })
-    .from($notesNotes)
-    .where(
-      or(
-        ...candidates.map(({ notebookFlag, noteId }) =>
-          and(
-            eq($notesNotes.notebookFlag, notebookFlag),
-            eq($notesNotes.noteId, noteId)
-          )
-        )
-      )
-    );
-  return new Set(rows.map((row) => noteKey(row.notebookFlag, row.noteId)));
-}
-
-function noteKey(notebookFlag: string, noteId: string | number) {
-  return `${notebookFlag}\0${noteId}`;
+  return new Map(rows.map((row) => [row.id, row.title]));
 }
 
 // A notebook can contain thousands of notes, so select only the newest row
@@ -1858,6 +1845,7 @@ export const getChats = createReadQuery(
     'volumeSettings',
     'pins',
     'activityEvents',
+    'notesActivityEventTombstones',
     'notesNotebooks',
     'notesNotes',
   ]

--- a/packages/shared/src/db/queries.ts
+++ b/packages/shared/src/db/queries.ts
@@ -1630,51 +1630,64 @@ async function getLatestNoteEventsByChannel(
   ctx: QueryCtx
 ): Promise<Map<string, NotesActivityEventDetail>> {
   const $newerEvents = alias($activityEvents, 'newerNoteActivityEvents');
-  const [rows, tombstones] = await Promise.all([
-    ctx.db
-      .select({
-        channelId: $activityEvents.channelId,
-        type: $activityEvents.type,
-        postId: $activityEvents.postId,
-        authorId: $activityEvents.authorId,
-        content: $activityEvents.content,
-        timestamp: $activityEvents.timestamp,
-      })
-      .from($activityEvents)
-      .where(
-        and(
-          inArray($activityEvents.type, ['note-create', 'note-edit']),
-          inArray($activityEvents.channelId, channelIds),
-          notExists(
-            ctx.db
-              .select({ id: $newerEvents.id })
-              .from($newerEvents)
-              .where(
-                and(
-                  eq($newerEvents.channelId, $activityEvents.channelId),
-                  inArray($newerEvents.type, ['note-create', 'note-edit']),
-                  or(
-                    gt($newerEvents.timestamp, $activityEvents.timestamp),
-                    and(
-                      eq($newerEvents.timestamp, $activityEvents.timestamp),
-                      gt($newerEvents.id, $activityEvents.id)
-                    ),
-                    and(
-                      eq($newerEvents.timestamp, $activityEvents.timestamp),
-                      eq($newerEvents.id, $activityEvents.id),
-                      gt($newerEvents.bucketId, $activityEvents.bucketId)
-                    )
+  const rows = await ctx.db
+    .select({
+      channelId: $activityEvents.channelId,
+      type: $activityEvents.type,
+      postId: $activityEvents.postId,
+      authorId: $activityEvents.authorId,
+      content: $activityEvents.content,
+      timestamp: $activityEvents.timestamp,
+    })
+    .from($activityEvents)
+    .where(
+      and(
+        inArray($activityEvents.type, ['note-create', 'note-edit']),
+        inArray($activityEvents.channelId, channelIds),
+        notExists(
+          ctx.db
+            .select({ id: $newerEvents.id })
+            .from($newerEvents)
+            .where(
+              and(
+                eq($newerEvents.channelId, $activityEvents.channelId),
+                inArray($newerEvents.type, ['note-create', 'note-edit']),
+                or(
+                  gt($newerEvents.timestamp, $activityEvents.timestamp),
+                  and(
+                    eq($newerEvents.timestamp, $activityEvents.timestamp),
+                    gt($newerEvents.id, $activityEvents.id)
+                  ),
+                  and(
+                    eq($newerEvents.timestamp, $activityEvents.timestamp),
+                    eq($newerEvents.id, $activityEvents.id),
+                    gt($newerEvents.bucketId, $activityEvents.bucketId)
                   )
                 )
               )
+            )
+        )
+      )
+    );
+
+  // Only the selected events can be suppressed, and the filter above leaves
+  // at most one per channel. Tombstones outlive the notes they suppress, so
+  // scope the lookup to those ids -- a seek on the (channel_id, note_id)
+  // primary key -- instead of loading a notebook's whole deletion history.
+  const selectedNoteIds = rows.flatMap((row) =>
+    row.postId ? [row.postId] : []
+  );
+  const tombstones = selectedNoteIds.length
+    ? await ctx.db
+        .select()
+        .from($notesActivityEventTombstones)
+        .where(
+          and(
+            inArray($notesActivityEventTombstones.channelId, channelIds),
+            inArray($notesActivityEventTombstones.noteId, selectedNoteIds)
           )
         )
-      ),
-    ctx.db
-      .select()
-      .from($notesActivityEventTombstones)
-      .where(inArray($notesActivityEventTombstones.channelId, channelIds)),
-  ]);
+    : [];
   const tombstoneKeys = new Set(
     tombstones.map(({ channelId, noteId }) =>
       notesActivityEventKey(channelId, noteId)

--- a/packages/shared/src/db/queries.ts
+++ b/packages/shared/src/db/queries.ts
@@ -1422,6 +1422,11 @@ type NotesActivityGroup = {
   })[];
 };
 
+type NotesNotebookInfo = {
+  title: string;
+  syncedAt: number | null;
+};
+
 /**
  * Find the newest joined notebook activity in each group. Notebook recency is
  * authoritative for ordering, while the note identity can come from either a
@@ -1454,22 +1459,43 @@ async function getGroupNotesActivity(
   const notebookFlags = notesChannels.flatMap(({ notebookFlag }) =>
     notebookFlag ? [notebookFlag] : []
   );
-  const [eventsByChannel, notesByNotebook, notebookTitlesByFlag] =
-    await Promise.all([
+  const [eventsByChannel, notesByNotebook, notebooksByFlag] = await Promise.all(
+    [
       getLatestNoteEventsByChannel(
         notesChannels.map(({ channel }) => channel.id),
         ctx
       ),
       getLatestNotesByNotebook(notebookFlags, ctx),
-      getNotesNotebookTitles(notebookFlags, ctx),
-    ]);
+      getNotesNotebookInfo(notebookFlags, ctx),
+    ]
+  );
+  const storedEventNoteKeys = await getStoredEventNoteKeys(
+    notesChannels,
+    eventsByChannel,
+    ctx
+  );
 
   for (const { groupId, channel, notebookFlag } of notesChannels) {
     const recency = channel.unread?.updatedAt ?? 0;
-    const detail = newestNotesActivityDetail(
-      eventsByChannel.get(channel.id),
-      notebookFlag ? notesByNotebook.get(notebookFlag) : undefined
+    const event = eventsByChannel.get(channel.id);
+    const localNote = notebookFlag
+      ? notesByNotebook.get(notebookFlag)
+      : undefined;
+    const notebook = notebookFlag
+      ? notebooksByFlag.get(notebookFlag)
+      : undefined;
+    const eventConfirmedDeleted = Boolean(
+      event?.noteId &&
+      notebookFlag &&
+      notebook?.syncedAt != null &&
+      (noteTimestampMs(notebook.syncedAt) ?? 0) >= event.timestamp &&
+      !storedEventNoteKeys.has(noteKey(notebookFlag, event.noteId))
     );
+    const detail = eventConfirmedDeleted
+      ? localNote && event && localNote.timestamp > event.timestamp
+        ? localNote
+        : undefined
+      : newestNotesActivityDetail(event, localNote);
     const timestamp = Math.max(recency, detail?.timestamp ?? 0);
     if (timestamp <= 0) {
       continue;
@@ -1486,10 +1512,7 @@ async function getGroupNotesActivity(
         : null;
     activityByGroup.set(groupId, {
       channelId: channel.id,
-      notebookTitle:
-        channel.title ??
-        (notebookFlag ? notebookTitlesByFlag.get(notebookFlag) : null) ??
-        null,
+      notebookTitle: channel.title ?? notebook?.title ?? null,
       noteId: describes?.noteId ?? null,
       noteTitle: describes?.noteTitle ?? null,
       authorId: describes?.authorId ?? null,
@@ -1519,6 +1542,7 @@ async function getLatestNoteEventsByChannel(
   channelIds: string[],
   ctx: QueryCtx
 ): Promise<Map<string, NotesActivityDetail>> {
+  const $newerEvents = alias($activityEvents, 'newerNoteActivityEvents');
   const rows = await ctx.db
     .select({
       channelId: $activityEvents.channelId,
@@ -1532,10 +1556,32 @@ async function getLatestNoteEventsByChannel(
     .where(
       and(
         inArray($activityEvents.type, ['note-create', 'note-edit']),
-        inArray($activityEvents.channelId, channelIds)
+        inArray($activityEvents.channelId, channelIds),
+        notExists(
+          ctx.db
+            .select({ id: $newerEvents.id })
+            .from($newerEvents)
+            .where(
+              and(
+                eq($newerEvents.channelId, $activityEvents.channelId),
+                inArray($newerEvents.type, ['note-create', 'note-edit']),
+                or(
+                  gt($newerEvents.timestamp, $activityEvents.timestamp),
+                  and(
+                    eq($newerEvents.timestamp, $activityEvents.timestamp),
+                    gt($newerEvents.id, $activityEvents.id)
+                  ),
+                  and(
+                    eq($newerEvents.timestamp, $activityEvents.timestamp),
+                    eq($newerEvents.id, $activityEvents.id),
+                    gt($newerEvents.bucketId, $activityEvents.bucketId)
+                  )
+                )
+              )
+            )
+        )
       )
-    )
-    .orderBy(desc($activityEvents.timestamp));
+    );
 
   const latest = new Map<string, NotesActivityDetail>();
   for (const row of rows) {
@@ -1559,19 +1605,69 @@ async function getLatestNoteEventsByChannel(
   return latest;
 }
 
-async function getNotesNotebookTitles(
+async function getNotesNotebookInfo(
   notebookFlags: string[],
   ctx: QueryCtx
-): Promise<Map<string, string>> {
+): Promise<Map<string, NotesNotebookInfo>> {
   if (notebookFlags.length === 0) {
     return new Map();
   }
 
   const rows = await ctx.db
-    .select({ id: $notesNotebooks.id, title: $notesNotebooks.title })
+    .select({
+      id: $notesNotebooks.id,
+      title: $notesNotebooks.title,
+      syncedAt: $notesNotebooks.syncedAt,
+    })
     .from($notesNotebooks)
     .where(inArray($notesNotebooks.id, notebookFlags));
-  return new Map(rows.map((row) => [row.id, row.title]));
+  return new Map(
+    rows.map((row) => [
+      row.id,
+      { title: row.title, syncedAt: row.syncedAt ?? null },
+    ])
+  );
+}
+
+async function getStoredEventNoteKeys(
+  notesChannels: Array<{
+    channel: Pick<Channel, 'id'>;
+    notebookFlag: string | null;
+  }>,
+  eventsByChannel: Map<string, NotesActivityDetail>,
+  ctx: QueryCtx
+): Promise<Set<string>> {
+  const candidates = notesChannels.flatMap(({ channel, notebookFlag }) => {
+    const noteId = Number(eventsByChannel.get(channel.id)?.noteId);
+    return notebookFlag && Number.isSafeInteger(noteId)
+      ? [{ notebookFlag, noteId }]
+      : [];
+  });
+  if (candidates.length === 0) {
+    return new Set();
+  }
+
+  const rows = await ctx.db
+    .select({
+      notebookFlag: $notesNotes.notebookFlag,
+      noteId: $notesNotes.noteId,
+    })
+    .from($notesNotes)
+    .where(
+      or(
+        ...candidates.map(({ notebookFlag, noteId }) =>
+          and(
+            eq($notesNotes.notebookFlag, notebookFlag),
+            eq($notesNotes.noteId, noteId)
+          )
+        )
+      )
+    );
+  return new Set(rows.map((row) => noteKey(row.notebookFlag, row.noteId)));
+}
+
+function noteKey(notebookFlag: string, noteId: string | number) {
+  return `${notebookFlag}\0${noteId}`;
 }
 
 // A notebook can contain thousands of notes, so select only the newest row
@@ -1586,6 +1682,8 @@ async function getLatestNotesByNotebook(
   }
 
   const $newerNotes = alias($notesNotes, 'newerNotes');
+  const effectiveAt = sql<number>`coalesce(${$notesNotes.updatedAt}, ${$notesNotes.createdAt})`;
+  const newerEffectiveAt = sql<number>`coalesce(${$newerNotes.updatedAt}, ${$newerNotes.createdAt})`;
   const rows = await ctx.db
     .select({
       notebookFlag: $notesNotes.notebookFlag,
@@ -1594,12 +1692,13 @@ async function getLatestNotesByNotebook(
       updatedBy: $notesNotes.updatedBy,
       createdAt: $notesNotes.createdAt,
       updatedAt: $notesNotes.updatedAt,
+      effectiveAt,
     })
     .from($notesNotes)
     .where(
       and(
         inArray($notesNotes.notebookFlag, notebookFlags),
-        isNotNull($notesNotes.updatedAt),
+        isNotNull(effectiveAt),
         notExists(
           ctx.db
             .select({ id: $newerNotes.id })
@@ -1607,11 +1706,11 @@ async function getLatestNotesByNotebook(
             .where(
               and(
                 eq($newerNotes.notebookFlag, $notesNotes.notebookFlag),
-                isNotNull($newerNotes.updatedAt),
+                isNotNull(newerEffectiveAt),
                 or(
-                  gt($newerNotes.updatedAt, $notesNotes.updatedAt),
+                  gt(newerEffectiveAt, effectiveAt),
                   and(
-                    eq($newerNotes.updatedAt, $notesNotes.updatedAt),
+                    eq(newerEffectiveAt, effectiveAt),
                     gt($newerNotes.noteId, $notesNotes.noteId)
                   )
                 )
@@ -1626,8 +1725,10 @@ async function getLatestNotesByNotebook(
       noteId: String(row.noteId),
       noteTitle: row.title.trim() || null,
       authorId: row.updatedBy ?? null,
-      isNew: row.createdAt != null && row.createdAt === row.updatedAt,
-      timestamp: noteTimestampMs(row.updatedAt) ?? 0,
+      isNew:
+        row.updatedAt == null ||
+        (row.createdAt != null && row.createdAt === row.updatedAt),
+      timestamp: noteTimestampMs(row.effectiveAt) ?? 0,
     });
   }
 

--- a/packages/shared/src/db/queries.ts
+++ b/packages/shared/src/db/queries.ts
@@ -1613,16 +1613,24 @@ async function getGroupNotesActivity(
   return activityByGroup;
 }
 
+// Both candidates can describe the same note: an event stamped by the
+// activity ship and a row stamped by the notebook host. Prefer the row there
+// rather than ordering the two clocks -- renames don't bump a revision or
+// re-emit an event, so the event's cached title can be stale while the synced
+// row carries the current one. Distinct notes fall back to the newer stamp;
+// the differing clocks make that imprecise, but the recency window in
+// getGroupNotesActivity bounds how stale the chosen detail can be.
 function newestNotesActivityDetail(
-  ...details: (NotesActivityDetail | undefined)[]
+  event: NotesActivityDetail | undefined,
+  localNote: NotesActivityDetail | undefined
 ): NotesActivityDetail | undefined {
-  return details.reduce<NotesActivityDetail | undefined>(
-    (newest, detail) =>
-      detail && (!newest || detail.timestamp > newest.timestamp)
-        ? detail
-        : newest,
-    undefined
-  );
+  if (!event || !localNote) {
+    return event ?? localNote;
+  }
+  if (event.noteId != null && event.noteId === localNote.noteId) {
+    return localNote;
+  }
+  return event.timestamp > localNote.timestamp ? event : localNote;
 }
 
 async function getLatestNoteEventsByChannel(

--- a/packages/shared/src/db/schema.ts
+++ b/packages/shared/src/db/schema.ts
@@ -411,6 +411,9 @@ export const activityEvents = sqliteTable(
   (table) => {
     return {
       pk: primaryKey({ columns: [table.id, table.bucketId] }),
+      channelTimestampIndex: index(
+        'activity_events_channel_id_timestamp_index'
+      ).on(table.channelId, table.timestamp),
     };
   }
 );

--- a/packages/shared/src/db/schema.ts
+++ b/packages/shared/src/db/schema.ts
@@ -1229,6 +1229,20 @@ export const notesNotesRelations = relations(notesNotes, ({ one }) => ({
   }),
 }));
 
+// A fetch-completion timestamp cannot prove that a lagging notebook replica
+// causally includes an activity event. Record only deletions that the Notes
+// action path explicitly confirmed against the host-facing API.
+export const notesActivityEventTombstones = sqliteTable(
+  'notes_activity_event_tombstones',
+  {
+    channelId: text('channel_id').notNull(),
+    noteId: text('note_id').notNull(),
+  },
+  (table) => ({
+    pk: primaryKey({ columns: [table.channelId, table.noteId] }),
+  })
+);
+
 export const notesMembers = sqliteTable(
   'notes_members',
   {

--- a/packages/shared/src/db/types.ts
+++ b/packages/shared/src/db/types.ts
@@ -114,6 +114,21 @@ export type AttestationType = schema.AttestationType;
 export type ContactAttestation = BaseModel<'contactAttestations'>;
 export type ContextLensRun = BaseModel<'contextLensRuns'>;
 
+/**
+ * The newest notebook activity in a group, as far as the local database can
+ * tell. Timestamps are milliseconds. The note fields are null when notebook
+ * recency is known but no matching local note or activity event is available.
+ */
+export interface GroupNotesActivity {
+  channelId: string;
+  notebookTitle: string | null;
+  noteId: string | null;
+  noteTitle: string | null;
+  authorId: string | null;
+  isNew: boolean;
+  timestamp: number;
+}
+
 export type Chat = {
   id: string;
   pin: Pin | null;
@@ -121,7 +136,10 @@ export type Chat = {
   timestamp: number;
   isPending: boolean;
   unreadCount: number;
-} & ({ type: 'group'; group: Group } | { type: 'channel'; channel: Channel });
+} & (
+  | { type: 'group'; group: Group; notesActivity?: GroupNotesActivity | null }
+  | { type: 'channel'; channel: Channel }
+);
 
 export interface GroupedChats {
   pinned: Chat[];

--- a/packages/shared/src/logic/index.ts
+++ b/packages/shared/src/logic/index.ts
@@ -10,6 +10,7 @@ export * from './notesPermissionsCompat';
 export * from './notesSearch';
 export * from './notesSearchSupport';
 export * from './notesText';
+export * from './notesTime';
 export * from '@tloncorp/api/lib/types';
 export * from '@tloncorp/api/lib/utils';
 export * as featureFlags from '@tloncorp/api/lib/featureFlags';

--- a/packages/shared/src/logic/notesText.test.ts
+++ b/packages/shared/src/logic/notesText.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, test } from 'vitest';
 
 import {
+  formatNotesActivityLabel,
   formatNotesChannelSubtitle,
   getNoteBodyPreview,
   stripNoteMarkdown,
@@ -70,5 +71,44 @@ describe('formatNotesChannelSubtitle', () => {
     expect(formatNotesChannelSubtitle({ noteCount: 0, folderCount: 2 })).toBe(
       'No notes in 2 folders'
     );
+  });
+});
+
+describe('formatNotesActivityLabel', () => {
+  test('identifies a new note and its notebook', () => {
+    expect(
+      formatNotesActivityLabel({
+        noteTitle: 'Weekly plan',
+        notebookTitle: 'Journal',
+        isNew: true,
+      })
+    ).toBe('New note “Weekly plan” in Journal');
+  });
+
+  test('distinguishes an edited note', () => {
+    expect(
+      formatNotesActivityLabel({
+        noteTitle: 'Weekly plan',
+        notebookTitle: 'Journal',
+        isNew: false,
+      })
+    ).toBe('Note “Weekly plan” edited in Journal');
+  });
+
+  test('falls back cleanly when titles are unavailable', () => {
+    expect(
+      formatNotesActivityLabel({
+        noteTitle: null,
+        notebookTitle: 'Journal',
+        isNew: true,
+      })
+    ).toBe('New note in Journal');
+    expect(
+      formatNotesActivityLabel({
+        noteTitle: null,
+        notebookTitle: null,
+        isNew: false,
+      })
+    ).toBe('Note edited');
   });
 });

--- a/packages/shared/src/logic/notesText.ts
+++ b/packages/shared/src/logic/notesText.ts
@@ -47,3 +47,23 @@ export function formatNotesChannelSubtitle({
 function countOf(count: number, noun: string) {
   return `${count} ${noun}${count === 1 ? '' : 's'}`;
 }
+
+/** Format the status line for notebook activity shown on a group row. */
+export function formatNotesActivityLabel({
+  noteTitle,
+  notebookTitle,
+  isNew,
+}: {
+  noteTitle: string | null | undefined;
+  notebookTitle: string | null | undefined;
+  isNew: boolean;
+}): string {
+  const title = noteTitle?.trim();
+  const notebook = notebookTitle?.trim();
+  const quotedTitle = title ? ` “${title}”` : '';
+  const location = notebook ? ` in ${notebook}` : '';
+
+  return isNew
+    ? `New note${quotedTitle}${location}`
+    : `Note${quotedTitle} edited${location}`;
+}

--- a/packages/shared/src/logic/notesTime.ts
+++ b/packages/shared/src/logic/notesTime.ts
@@ -1,0 +1,5 @@
+// Note timestamps may arrive in seconds or milliseconds depending on source.
+export function noteTimestampMs(timestamp: number | null | undefined) {
+  if (!timestamp) return null;
+  return timestamp < 10_000_000_000 ? timestamp * 1000 : timestamp;
+}

--- a/packages/shared/src/store/notesActions.test.ts
+++ b/packages/shared/src/store/notesActions.test.ts
@@ -1300,6 +1300,10 @@ test('adoptNotebookNoteRemote persists the host copy locally', async () => {
 });
 
 test('deleteNotebookNote waits for the deleted note to disappear from sync', async () => {
+  const confirmActivityEventDeleted = vi.spyOn(
+    db,
+    'confirmNotesActivityEventDeleted'
+  );
   const note = makeNote('Delete me');
   await db.saveNotesNotebookSnapshot({
     notebook: makeNotesNotebook({ rootFolderId: rootFolder.folderId }),
@@ -1330,9 +1334,17 @@ test('deleteNotebookNote waits for the deleted note to disappear from sync', asy
   await expect(
     db.getNotesNote({ notebookFlag, noteId: note.noteId })
   ).resolves.toBeNull();
+  expect(confirmActivityEventDeleted).toHaveBeenCalledWith({
+    notebookFlag,
+    noteId: note.noteId,
+  });
 });
 
 test('deleteNotebookNote keeps the local delete when sync stays stale', async () => {
+  const confirmActivityEventDeleted = vi.spyOn(
+    db,
+    'confirmNotesActivityEventDeleted'
+  );
   const capture = vi.fn();
   useDebugStore.getState().initializeErrorLogger({ capture });
   const note = makeNote('Delete me eventually');
@@ -1359,6 +1371,7 @@ test('deleteNotebookNote keeps the local delete when sync stays stale', async ()
   expect(
     capture.mock.calls.some(([event]) => event === AnalyticsEvent.NoteDeleted)
   ).toBe(false);
+  expect(confirmActivityEventDeleted).not.toHaveBeenCalled();
 });
 
 test('publishNotebookNote renders current markdown and marks note published', async () => {

--- a/packages/shared/src/store/notesActions.test.ts
+++ b/packages/shared/src/store/notesActions.test.ts
@@ -18,6 +18,7 @@ import {
   NotesNoteConflictError,
   adoptNotebookNoteRemote,
   createNotebookNote,
+  deleteNotebookFolder,
   deleteNotebookNote,
   markNotesNotebookStale,
   markNotesNotebookStaleForNoteEvent,
@@ -1300,9 +1301,9 @@ test('adoptNotebookNoteRemote persists the host copy locally', async () => {
 });
 
 test('deleteNotebookNote waits for the deleted note to disappear from sync', async () => {
-  const confirmActivityEventDeleted = vi.spyOn(
+  const confirmActivityEventsDeleted = vi.spyOn(
     db,
-    'confirmNotesActivityEventDeleted'
+    'confirmNotesActivityEventsDeleted'
   );
   const note = makeNote('Delete me');
   await db.saveNotesNotebookSnapshot({
@@ -1334,16 +1335,16 @@ test('deleteNotebookNote waits for the deleted note to disappear from sync', asy
   await expect(
     db.getNotesNote({ notebookFlag, noteId: note.noteId })
   ).resolves.toBeNull();
-  expect(confirmActivityEventDeleted).toHaveBeenCalledWith({
+  expect(confirmActivityEventsDeleted).toHaveBeenCalledWith({
     notebookFlag,
-    noteId: note.noteId,
+    noteIds: [note.noteId],
   });
 });
 
 test('deleteNotebookNote keeps the local delete when sync stays stale', async () => {
-  const confirmActivityEventDeleted = vi.spyOn(
+  const confirmActivityEventsDeleted = vi.spyOn(
     db,
-    'confirmNotesActivityEventDeleted'
+    'confirmNotesActivityEventsDeleted'
   );
   const capture = vi.fn();
   useDebugStore.getState().initializeErrorLogger({ capture });
@@ -1371,7 +1372,41 @@ test('deleteNotebookNote keeps the local delete when sync stays stale', async ()
   expect(
     capture.mock.calls.some(([event]) => event === AnalyticsEvent.NoteDeleted)
   ).toBe(false);
-  expect(confirmActivityEventDeleted).not.toHaveBeenCalled();
+  expect(confirmActivityEventsDeleted).not.toHaveBeenCalled();
+});
+
+test('deleteNotebookFolder tombstones descendant notes after confirmation', async () => {
+  const confirmActivityEventsDeleted = vi.spyOn(
+    db,
+    'confirmNotesActivityEventsDeleted'
+  );
+  const childFolder = makeNotesFolder(
+    rootFolder.folderId + 1,
+    'Child',
+    rootFolder.folderId
+  );
+  const note = makeNotesNote(42, childFolder.folderId, 'Descendant', {
+    folderId: childFolder.folderId,
+  });
+  await db.saveNotesNotebookSnapshot({
+    notebook: makeNotesNotebook({ rootFolderId: rootFolder.folderId }),
+    folders: [rootFolder, childFolder],
+    notes: [note],
+    members: [],
+  });
+
+  vi.spyOn(api.notes, 'getNotebook').mockResolvedValue(notebookSummary);
+  vi.spyOn(api.notes, 'listFolders').mockResolvedValue([]);
+  vi.spyOn(api.notes, 'listNotes').mockResolvedValue([]);
+  vi.spyOn(api.notes, 'listMembers').mockResolvedValue([]);
+  vi.spyOn(api.notes, 'deleteFolder').mockResolvedValue(undefined);
+
+  await deleteNotebookFolder({ notebookFlag, folder: rootFolder });
+
+  expect(confirmActivityEventsDeleted).toHaveBeenCalledWith({
+    notebookFlag,
+    noteIds: [note.noteId],
+  });
 });
 
 test('publishNotebookNote renders current markdown and marks note published', async () => {

--- a/packages/shared/src/store/notesActions.test.ts
+++ b/packages/shared/src/store/notesActions.test.ts
@@ -1409,6 +1409,51 @@ test('deleteNotebookFolder tombstones descendant notes after confirmation', asyn
   });
 });
 
+test('deleteNotebookFolder tombstones a descendant note with no local row', async () => {
+  const confirmActivityEventsDeleted = vi.spyOn(
+    db,
+    'confirmNotesActivityEventsDeleted'
+  );
+  const childFolder = makeNotesFolder(
+    rootFolder.folderId + 1,
+    'Child',
+    rootFolder.folderId
+  );
+  // On the host and carrying an activity event, but never synced into
+  // notesNotes -- the state markNotesNotebookStaleForNoteEvent handles.
+  const hostOnlyNote = makeNotesNote(42, childFolder.folderId, 'Host only', {
+    folderId: childFolder.folderId,
+  });
+  await db.saveNotesNotebookSnapshot({
+    notebook: makeNotesNotebook({ rootFolderId: rootFolder.folderId }),
+    folders: [rootFolder, childFolder],
+    notes: [],
+    members: [],
+  });
+
+  let deleted = false;
+  vi.spyOn(api.notes, 'getNotebook').mockResolvedValue(notebookSummary);
+  vi.spyOn(api.notes, 'listFolders').mockImplementation(async () =>
+    deleted
+      ? [makeApiNotesFolder(rootFolder)]
+      : [makeApiNotesFolder(rootFolder), makeApiNotesFolder(childFolder)]
+  );
+  vi.spyOn(api.notes, 'listNotes').mockImplementation(async () =>
+    deleted ? [] : [makeApiNotesNote(hostOnlyNote)]
+  );
+  vi.spyOn(api.notes, 'listMembers').mockResolvedValue([]);
+  vi.spyOn(api.notes, 'deleteFolder').mockImplementation(async () => {
+    deleted = true;
+  });
+
+  await deleteNotebookFolder({ notebookFlag, folder: childFolder });
+
+  expect(confirmActivityEventsDeleted).toHaveBeenCalledWith({
+    notebookFlag,
+    noteIds: [hostOnlyNote.noteId],
+  });
+});
+
 test('publishNotebookNote renders current markdown and marks note published', async () => {
   const publishNotesNote = vi
     .spyOn(api.notes, 'publishNote')

--- a/packages/shared/src/store/notesActions.ts
+++ b/packages/shared/src/store/notesActions.ts
@@ -1127,7 +1127,10 @@ export async function deleteNotebookNote({
     // Snapshot fetch time is not causal proof of deletion because subscribed
     // notebook replicas can lag. This confirmation poll is: only now suppress
     // the persisted activity detail that could otherwise expose a stale title.
-    await db.confirmNotesActivityEventDeleted({ notebookFlag, noteId });
+    await db.confirmNotesActivityEventsDeleted({
+      notebookFlag,
+      noteIds: [noteId],
+    });
     trackEvent(AnalyticsEvent.NoteDeleted);
   }
 }
@@ -1141,27 +1144,52 @@ export async function deleteNotebookFolder({
 }) {
   // Queued like deleteNotebookNote. The descendant lookup joins the unit so
   // the ids can't come from a copy a concurrent refresh is about to replace.
-  const folderIds = await queueNotebookSnapshot(notebookFlag, async () => {
-    const folders = await db.getNotesFolders({ notebookFlag });
-    const ids = Array.from(
-      collectDescendantFolderIds(folders, folder.folderId)
-    );
+  const { folderIds, noteIds } = await queueNotebookSnapshot(
+    notebookFlag,
+    async () => {
+      const [folders, notes] = await Promise.all([
+        db.getNotesFolders({ notebookFlag }),
+        db.getNotesNotes({ notebookFlag }),
+      ]);
+      const ids = Array.from(
+        collectDescendantFolderIds(folders, folder.folderId)
+      );
+      const folderIdSet = new Set(ids);
+      const noteIds = notes
+        .filter((note) => folderIdSet.has(note.folderId))
+        .map((note) => note.noteId);
 
-    await api.notes.deleteFolder({
-      flag: notebookFlag,
-      folderId: folder.folderId,
-      recursive: true,
-    });
-    await db.deleteNotesFolders({ notebookFlag, folderIds: ids });
-    return ids;
-  });
-  const confirmed = await syncNotesNotebookUntil(notebookFlag, (snapshot) =>
-    folderIds.every(
-      (folderId) =>
-        !snapshot.folders.some((nextFolder) => nextFolder.folderId === folderId)
-    )
+      await api.notes.deleteFolder({
+        flag: notebookFlag,
+        folderId: folder.folderId,
+        recursive: true,
+      });
+      await db.deleteNotesFolders({ notebookFlag, folderIds: ids });
+      return { folderIds: ids, noteIds };
+    }
   );
-  if (confirmed) {
+  const confirmedDeletedNoteIds = await syncNotesNotebookUntil(
+    notebookFlag,
+    (snapshot) => {
+      const foldersAreDeleted = folderIds.every(
+        (folderId) =>
+          !snapshot.folders.some(
+            (nextFolder) => nextFolder.folderId === folderId
+          )
+      );
+      if (!foldersAreDeleted) {
+        return null;
+      }
+      return noteIds.filter(
+        (noteId) => !snapshot.notes.some((note) => note.noteId === noteId)
+      );
+    }
+  );
+  if (confirmedDeletedNoteIds) {
+    await db.confirmNotesActivityEventsDeleted({
+      notebookFlag,
+      noteIds: confirmedDeletedNoteIds,
+    });
     trackEvent(AnalyticsEvent.NotesFolderDeleted);
   }
 }

--- a/packages/shared/src/store/notesActions.ts
+++ b/packages/shared/src/store/notesActions.ts
@@ -1124,6 +1124,10 @@ export async function deleteNotebookNote({
     (snapshot) => !findSnapshotNote(snapshot, noteId)
   );
   if (confirmed) {
+    // Snapshot fetch time is not causal proof of deletion because subscribed
+    // notebook replicas can lag. This confirmation poll is: only now suppress
+    // the persisted activity detail that could otherwise expose a stale title.
+    await db.confirmNotesActivityEventDeleted({ notebookFlag, noteId });
     trackEvent(AnalyticsEvent.NoteDeleted);
   }
 }

--- a/packages/shared/src/store/notesActions.ts
+++ b/packages/shared/src/store/notesActions.ts
@@ -1147,17 +1147,30 @@ export async function deleteNotebookFolder({
   const { folderIds, noteIds } = await queueNotebookSnapshot(
     notebookFlag,
     async () => {
-      const [folders, notes] = await Promise.all([
+      // Local rows alone can't name every descendant: an activity event may
+      // arrive for a collaborator's note before the snapshot carries it, and
+      // such a note has no local row while only the host knows it sits in
+      // this subtree. Read the host's copy too, and union the two so a stale
+      // local-only row still gets cleaned up.
+      const [{ snapshot }, folders, notes] = await Promise.all([
+        fetchNotesNotebookSnapshot(notebookFlag),
         db.getNotesFolders({ notebookFlag }),
         db.getNotesNotes({ notebookFlag }),
       ]);
       const ids = Array.from(
-        collectDescendantFolderIds(folders, folder.folderId)
+        collectDescendantFolderIds(
+          [...snapshot.folders, ...folders],
+          folder.folderId
+        )
       );
       const folderIdSet = new Set(ids);
-      const noteIds = notes
-        .filter((note) => folderIdSet.has(note.folderId))
-        .map((note) => note.noteId);
+      const noteIds = Array.from(
+        new Set(
+          [...snapshot.notes, ...notes]
+            .filter((note) => folderIdSet.has(note.folderId))
+            .map((note) => note.noteId)
+        )
+      );
 
       await api.notes.deleteFolder({
         flag: notebookFlag,


### PR DESCRIPTION
## Summary

- select the latest group preview activity across posts and joined notebooks
- show note and notebook titles for notebook activity, with safe fallbacks
- refresh notebook-backed preview details and memoized chat rows when titles arrive
- cover cross-source ordering, stale details, pinned groups, formatting, and invalidation

## Test plan

- `pnpm --filter @tloncorp/shared test --run src/db/queries.test.ts src/logic/notesText.test.ts`
- `pnpm --filter @tloncorp/app test --run ui/components/listItems/chatListRecency.test.ts hooks/useResolvedChats.test.ts`
- `pnpm --filter @tloncorp/shared tsc`
- `pnpm --filter @tloncorp/app tsc`

Linear: https://linear.app/tlon/issue/TLON-6462/show-notebook-activity-in-group-list-previews