### PR TITLE
TLON-6466 Fix repeated Notebook reopening on group navigation

### DIFF
--- a/apps/tlon-web/e2e/group-navigation.spec.ts
+++ b/apps/tlon-web/e2e/group-navigation.spec.ts
@@ -1,0 +1,47 @@
+import { expect } from '@playwright/test';
+
+import * as helpers from './helpers';
+import { test } from './test-fixtures';
+
+test('returning to a group preserves the last selected channel instead of reopening a notebook', async ({
+  zodPage,
+}) => {
+  const page = zodPage;
+
+  await helpers.createGroup(page);
+  await helpers.openGroupSettings(page);
+  await page.getByTestId('GroupChannels').getByText('Channels').click();
+
+  await page.getByText('New', { exact: true }).click();
+  await page.getByText('New channel').first().click();
+  await helpers.fillFormField(page, 'ChannelTitleInput', 'Project Notebook');
+  await page.getByText('Notebook', { exact: true }).click();
+  await page.getByText('Create channel').click();
+
+  const notebook = page.getByTestId('ChannelListItem-Project Notebook');
+  await expect(notebook).toBeVisible({ timeout: 15_000 });
+  await notebook.click();
+  await expect(page.getByTestId('NotebookSidebarBackHeader')).toBeVisible({
+    timeout: 10_000,
+  });
+
+  await page
+    .getByTestId('NotebookSidebarBackHeader')
+    .getByTestId('HeaderBackButton')
+    .click();
+  await expect(page.getByTestId('ChannelListItem-General')).toBeVisible();
+
+  await page.getByTestId('ChannelListItem-General').click();
+  await expect(page.getByTestId('MessageInput')).toBeVisible({
+    timeout: 10_000,
+  });
+
+  await page.getByTestId('HomeNavIcon').click();
+  await expect(page.getByTestId('HomeSidebarHeader')).toBeVisible();
+  await page.getByTestId('GroupListItem-Untitled group-unpinned').click();
+
+  await expect(page.getByTestId('MessageInput')).toBeVisible({
+    timeout: 10_000,
+  });
+  await expect(page.getByTestId('NotebookSidebarBackHeader')).not.toBeVisible();
+});

--- a/apps/tlon-web/e2e/helpers.ts
+++ b/apps/tlon-web/e2e/helpers.ts
@@ -109,12 +109,16 @@ export async function createGroupWithTemplate(
   });
   await page.getByText('Create group').click();
 
-  // Wait for group creation to complete and navigate to group
-  const channelHeader = page.getByTestId('ChannelHeaderTitle');
+  // Wait for group creation to complete and navigate to the group. Single-
+  // channel groups open their channel directly, while multi-channel groups
+  // without a remembered channel open the group channel list.
+  const groupDestination = page
+    .getByTestId('ChannelHeaderTitle')
+    .or(page.getByTestId('GroupChannelsHeaderTrigger'));
 
   try {
     // Wait briefly to see if we're automatically navigated to the group
-    await expect(channelHeader).toBeVisible({ timeout: 5000 });
+    await expect(groupDestination).toBeVisible({ timeout: 5000 });
     // Template groups don't show "Welcome to your group!" message
     await page.waitForTimeout(1000);
   } catch {
@@ -126,7 +130,7 @@ export async function createGroupWithTemplate(
     await page
       .getByTestId(`ChatListItem-${expectedGroupTitle}-unpinned`)
       .click();
-    await expect(channelHeader).toBeVisible({ timeout: 5000 });
+    await expect(groupDestination).toBeVisible({ timeout: 5000 });
     await page.waitForTimeout(1000);
   }
 }

--- a/packages/app/navigation/routeHelpers.test.ts
+++ b/packages/app/navigation/routeHelpers.test.ts
@@ -51,9 +51,7 @@ describe('getDesktopGroupEntryRoute', () => {
   });
 
   test('keeps the single-channel desktop shortcut', () => {
-    expect(
-      getDesktopGroupEntryRoute(groupId, [chatId], null)
-    ).toMatchObject({
+    expect(getDesktopGroupEntryRoute(groupId, [chatId], null)).toMatchObject({
       name: 'Home',
       params: {
         screen: 'Channel',

--- a/packages/app/navigation/routeHelpers.test.ts
+++ b/packages/app/navigation/routeHelpers.test.ts
@@ -4,11 +4,64 @@ import {
   NavigationChainNode,
   getActiveNestedGroupId,
   getActiveTopLevelDrawerRouteName,
+  getDesktopGroupEntryRoute,
   getDesktopGroupInvitePreviewProps,
   getDesktopGroupInviteRoute,
   getDesktopPostRoute,
   isActivityBackTarget,
 } from './routeHelpers';
+
+describe('getDesktopGroupEntryRoute', () => {
+  const groupId = '~zod/project';
+  const notebookId = 'notes/~zod/project/notebook';
+  const chatId = 'chat/~zod/project/general';
+
+  test('returns to the most recently visited current channel', () => {
+    expect(
+      getDesktopGroupEntryRoute(groupId, [notebookId, chatId], chatId)
+    ).toMatchObject({
+      name: 'Home',
+      params: {
+        screen: 'Channel',
+        params: { channelId: chatId, groupId },
+      },
+    });
+  });
+
+  test('opens the group channel list when no channel has been visited', () => {
+    expect(
+      getDesktopGroupEntryRoute(groupId, [notebookId, chatId], null)
+    ).toEqual({
+      name: 'Home',
+      params: {
+        screen: 'GroupChannels',
+        pop: true,
+        params: { groupId },
+      },
+    });
+  });
+
+  test('does not reopen a stale remembered channel', () => {
+    expect(
+      getDesktopGroupEntryRoute(groupId, [notebookId, chatId], 'notes/deleted')
+    ).toMatchObject({
+      name: 'Home',
+      params: { screen: 'GroupChannels', params: { groupId } },
+    });
+  });
+
+  test('keeps the single-channel desktop shortcut', () => {
+    expect(
+      getDesktopGroupEntryRoute(groupId, [chatId], null)
+    ).toMatchObject({
+      name: 'Home',
+      params: {
+        screen: 'Channel',
+        params: { channelId: chatId, groupId },
+      },
+    });
+  });
+});
 
 describe('getActiveNestedGroupId', () => {
   test('finds the group on the active nested desktop channel route', () => {

--- a/packages/app/navigation/routeHelpers.ts
+++ b/packages/app/navigation/routeHelpers.ts
@@ -19,6 +19,74 @@ export function screenNameFromChannelId(channelId: string) {
       : 'Channel';
 }
 
+export function getDesktopChannelRoute(
+  tab: 'Home' | 'Messages',
+  channelId: string,
+  groupId?: string,
+  selectedPostId?: string
+) {
+  const screenName = screenNameFromChannelId(channelId);
+  // Notes channels always open under Home: the notebook sidebar wiring
+  // (NotebookSidebarProvider + the GroupChannelsScreenView takeover) exists
+  // only in that drawer, so under Messages the desktop split view would
+  // render a note detail with no tree or create actions.
+  const resolvedTab = parseNotesChannelId(channelId) ? 'Home' : tab;
+  return {
+    name: resolvedTab,
+    params: {
+      screen: screenName,
+      pop: true,
+      params: {
+        channelId,
+        selectedPostId,
+        ...(groupId ? { groupId } : {}),
+        screen: 'ChannelRoot',
+        pop: true,
+        params: {
+          channelId,
+          selectedPostId,
+          ...(groupId ? { groupId } : {}),
+        },
+      },
+    },
+  } as const;
+}
+
+export function getDesktopGroupRoute(groupId: string) {
+  return {
+    name: 'Home',
+    params: {
+      screen: 'GroupChannels',
+      pop: true,
+      params: { groupId },
+    },
+  } as const;
+}
+
+/**
+ * Build the desktop route used when entering a group from a group row.
+ *
+ * A remembered channel is only useful while it still belongs to the group.
+ * With no valid memory, multi-channel groups open their channel list instead
+ * of whichever channel happens to be first in the backend map's hash order.
+ */
+export function getDesktopGroupEntryRoute(
+  groupId: string,
+  channelIds: string[],
+  lastVisitedChannelId: string | null
+) {
+  const validLastVisitedChannelId = lastVisitedChannelId
+    ? channelIds.find((channelId) => channelId === lastVisitedChannelId)
+    : undefined;
+  const channelId =
+    validLastVisitedChannelId ??
+    (channelIds.length === 1 ? channelIds[0] : undefined);
+
+  return channelId
+    ? getDesktopChannelRoute('Home', channelId, groupId)
+    : getDesktopGroupRoute(groupId);
+}
+
 // The real desktop top-level drawer route names (see
 // `navigation/desktop/TopLevelDrawer.tsx`). Shared with `getTab` in `utils.ts`
 // so the two top-level-drawer detectors can't drift. Note the correct name is

--- a/packages/app/navigation/utils.ts
+++ b/packages/app/navigation/utils.ts
@@ -594,11 +594,7 @@ export async function getMainGroupRoute(
     );
   }
 
-  if (
-    group &&
-    group.channels &&
-    group.channels.length === 1
-  ) {
+  if (group && group.channels && group.channels.length === 1) {
     return {
       name: 'Channel',
       params: { channelId: group.channels[0].id, groupId },

--- a/packages/app/navigation/utils.ts
+++ b/packages/app/navigation/utils.ts
@@ -5,7 +5,6 @@ import {
   useNavigation as useReactNavigation,
 } from '@react-navigation/native';
 import type { NativeStackNavigationOptions } from '@react-navigation/native-stack';
-import { parseNotesChannelId } from '@tloncorp/api/client';
 import { createDevLogger } from '@tloncorp/shared';
 import * as db from '@tloncorp/shared/db';
 import * as logic from '@tloncorp/shared/logic';
@@ -23,6 +22,8 @@ import type {
 import {
   TOP_LEVEL_DRAWER_ROUTES,
   getActiveTopLevelDrawerRouteName,
+  getDesktopChannelRoute,
+  getDesktopGroupEntryRoute,
   getDesktopGroupInviteRoute,
   getDesktopPostRoute,
   isActivityBackTarget,
@@ -573,40 +574,6 @@ export function useRootNavigation() {
   );
 }
 
-export function getDesktopChannelRoute(
-  tab: 'Home' | 'Messages',
-  channelId: string,
-  groupId?: string,
-  selectedPostId?: string
-) {
-  const screenName = screenNameFromChannelId(channelId);
-  logger.log('getDesktopChannelRoute', screenName);
-  // Notes channels always open under Home: the notebook sidebar wiring
-  // (NotebookSidebarProvider + the GroupChannelsScreenView takeover) exists
-  // only in that drawer, so under Messages the desktop split view would
-  // render a note detail with no tree or create actions.
-  const resolvedTab = parseNotesChannelId(channelId) ? 'Home' : tab;
-  return {
-    name: resolvedTab,
-    params: {
-      screen: screenName,
-      pop: true,
-      params: {
-        channelId,
-        selectedPostId,
-        ...(groupId ? { groupId } : {}),
-        screen: 'ChannelRoot',
-        pop: true,
-        params: {
-          channelId,
-          selectedPostId,
-          ...(groupId ? { groupId } : {}),
-        },
-      },
-    },
-  } as const;
-}
-
 export async function getMainGroupRoute(
   groupId: string,
   isWindowNarrow: boolean
@@ -618,25 +585,20 @@ export async function getMainGroupRoute(
     store.fetchGroup(groupId),
     isWindowNarrow ? null : db.lastVisitedChannelId(groupId).getValue(),
   ]);
+
+  if (!isWindowNarrow) {
+    return getDesktopGroupEntryRoute(
+      groupId,
+      group?.channels?.map((channel) => channel.id) ?? [],
+      lastVisitedChannelId
+    );
+  }
+
   if (
     group &&
     group.channels &&
-    (group.channels.length === 1 || !isWindowNarrow)
+    group.channels.length === 1
   ) {
-    if (!isWindowNarrow && lastVisitedChannelId) {
-      return getDesktopChannelRoute('Home', lastVisitedChannelId, groupId);
-    }
-
-    if (!isWindowNarrow) {
-      if (group.channels.length > 0) {
-        return getDesktopChannelRoute('Home', group.channels[0].id, groupId);
-      }
-      return {
-        name: 'GroupChannels',
-        params: { groupId },
-      } as const;
-    }
-
     return {
       name: 'Channel',
       params: { channelId: group.channels[0].id, groupId },


### PR DESCRIPTION
## Summary

Prevent desktop group navigation from repeatedly reopening an arbitrary nested Notebook view. Group entry now restores only a valid remembered channel, otherwise opens the normal group channel view while preserving the existing single-channel shortcut.

Linear: https://linear.app/tlon/issue/TLON-6466/group-navigation-repeatedly-reopens-nested-notebook-view

## Changes

- Extract desktop group-entry route selection into a focused helper.
- Validate that the remembered channel still belongs to the group.
- Route multi-channel groups without a valid remembered channel to `Home -> GroupChannels` instead of `group.channels[0]`.
- Preserve direct opening for single-channel groups and leave mobile behavior unchanged.
- Add unit coverage and a web regression test for leaving and re-entering a group after dismissing the Notebook view.

## How did I test?

- `routeHelpers.test.ts`: 25/25 passing
- `@tloncorp/app` TypeScript check: passing
- Headed web E2E: 3/3 passing, including the focused regression
- `git diff --check origin/develop...HEAD`: passing

## Risks and impact

- Safe to rollback without consulting PR author? Yes
- Affects important code area:
  - [ ] Onboarding
  - [ ] State / providers
  - [ ] Message sync
  - [x] Channel display
  - [ ] Notifications
  - [ ] Other:

## Rollback plan

Revert commit `27684c3ffc`.

## Screenshots / videos

Not applicable; this is a navigation behavior fix covered by automated regression tests.