### PR TITLE
ios: stabilize onboarding scroll edge after sheets

### DIFF
--- a/apps/tlon-mobile/modules/tlon-scroll-edge-effect/ios/ScrollEdgeElementContainer.swift
+++ b/apps/tlon-mobile/modules/tlon-scroll-edge-effect/ios/ScrollEdgeElementContainer.swift
@@ -19,6 +19,7 @@ public final class TlonScrollEdgeEffectModule: Module {
 
 public final class ScrollEdgeElementContainer: ExpoView {
     private static let maxAttachmentAttempts = 100
+    private static let keyboardDismissalAttachmentDelay: TimeInterval = 0.25
 
     private var scrollViewNativeID: String?
     // Held as AnyObject because UIScrollEdgeElementContainerInteraction is iOS
@@ -27,6 +28,7 @@ public final class ScrollEdgeElementContainer: ExpoView {
     private var edgeInteraction: AnyObject?
     private var pendingAttachment: DispatchWorkItem?
     private var pendingAttachmentValidation: DispatchWorkItem?
+    private var pendingKeyboardDismissalAttachment: DispatchWorkItem?
     private var attachmentAttempts = 0
     private var didLogAttachmentFailure = false
     private var edge: UIRectEdge = .bottom
@@ -154,20 +156,33 @@ public final class ScrollEdgeElementContainer: ExpoView {
             // KeyboardStickyView moves the composer with a transform. UIKit's
             // edge interaction can retain the keyboard-open container geometry
             // after that transform settles, leaving a tall soft fade over the
-            // conversation. Reattach on the next main-loop turn so UIKit reads
-            // the composer's final, keyboard-closed position.
+            // conversation. Keep every attachment path paused while the sheet
+            // and composer finish their post-keyboard layout, then reattach
+            // once with the final keyboard-closed geometry.
             interaction.scrollView = nil
             cancelPendingAttachmentWork()
             resetAttachmentSearch()
 
-            DispatchQueue.main.async { [weak self] in
-                self?.attachToScrollViewIfPossible()
+            let workItem = DispatchWorkItem { [weak self] in
+                guard let self else {
+                    return
+                }
+                pendingKeyboardDismissalAttachment = nil
+                attachToScrollViewIfPossible()
             }
+            pendingKeyboardDismissalAttachment = workItem
+            DispatchQueue.main.asyncAfter(
+                deadline: .now() + Self.keyboardDismissalAttachmentDelay,
+                execute: workItem
+            )
         }
     }
 
     private func attachToScrollViewIfPossible() {
-        guard window != nil, let scrollViewNativeID else {
+        guard pendingKeyboardDismissalAttachment == nil,
+              window != nil,
+              let scrollViewNativeID
+        else {
             return
         }
 
@@ -276,6 +291,8 @@ public final class ScrollEdgeElementContainer: ExpoView {
         pendingAttachment = nil
         pendingAttachmentValidation?.cancel()
         pendingAttachmentValidation = nil
+        pendingKeyboardDismissalAttachment?.cancel()
+        pendingKeyboardDismissalAttachment = nil
     }
 
     private func resetAttachmentSearch() {

--- a/apps/tlon-mobile/modules/tlon-scroll-edge-effect/ios/ScrollEdgeElementContainer.swift
+++ b/apps/tlon-mobile/modules/tlon-scroll-edge-effect/ios/ScrollEdgeElementContainer.swift
@@ -19,7 +19,9 @@ public final class TlonScrollEdgeEffectModule: Module {
 
 public final class ScrollEdgeElementContainer: ExpoView {
     private static let maxAttachmentAttempts = 100
-    private static let keyboardDismissalAttachmentDelay: TimeInterval = 0.25
+    // The custom-topic sheet starts its 250 ms close animation on the frame
+    // after the keyboard finishes hiding, then keeps a 100 ms teardown grace.
+    private static let keyboardDismissalAttachmentDelay: TimeInterval = 0.4
 
     private var scrollViewNativeID: String?
     // Held as AnyObject because UIScrollEdgeElementContainerInteraction is iOS
@@ -150,15 +152,15 @@ public final class ScrollEdgeElementContainer: ExpoView {
             return
         }
 
-        if #available(iOS 26.0, *), let interaction = scrollEdgeInteraction,
-           interaction.scrollView != nil
-        {
+        if #available(iOS 26.0, *), let interaction = scrollEdgeInteraction {
             // KeyboardStickyView moves the composer with a transform. UIKit's
             // edge interaction can retain the keyboard-open container geometry
             // after that transform settles, leaving a tall soft fade over the
-            // conversation. Keep every attachment path paused while the sheet
-            // and composer finish their post-keyboard layout, then reattach
-            // once with the final keyboard-closed geometry.
+            // conversation. Keep every attachment path paused through the
+            // sheet's close and teardown, then reattach once with the final
+            // keyboard-closed geometry. Establish the pause even when the
+            // interaction is already detached so a pending lookup cannot
+            // attach it during dismissal.
             interaction.scrollView = nil
             cancelPendingAttachmentWork()
             resetAttachmentSearch()


### PR DESCRIPTION
## Summary

The first fix detached and reattached the bottom-edge effect after the keyboard hid, but layout could attach it again before the sheet finished closing. Repeatedly using the custom-topic sheet could therefore leave the same tall white fade over the choices.

This waits through the sheet dismissal before allowing any attachment path to run, so UIKit reads the final keyboard-closed layout.

Fixes TLON-6464

## Changes

- Pause all scroll-edge attachment paths while the keyboard and sheet finish dismissing.
- Reattach the bottom-edge effect after the 250 ms sheet animation.
- Cancel pending keyboard-dismissal work when the view or scroll target changes.

## How did I test?

- Reproduced the remaining bug on iOS 26.4 Simulator with the Conversation topic selection onboarding fixture by reopening the custom-topic sheet and saving a second topic.
- Repeated open, type, and save four consecutive times on this branch; every choice stayed fully visible after each dismissal and three seconds after the final dismissal.