### PR TITLE
build(android): upload Crashlytics NDK symbols for release builds

### DIFF
--- a/apps/tlon-mobile/android/app/build.gradle
+++ b/apps/tlon-mobile/android/app/build.gradle
@@ -157,6 +157,19 @@ android {
             minifyEnabled enableProguardInReleaseBuilds
             proguardFiles getDefaultProguardFile("proguard-android.txt"), "proguard-rules.pro"
             crunchPngs (findProperty('android.enablePngCrunchInReleaseBuilds')?.toBoolean() ?: true)
+            firebaseCrashlytics {
+                // Symbolize native crash frames inside third-party .so files. With
+                // unstrippedNativeLibsDir left unset the plugin reads AGP's
+                // MERGED_NATIVE_LIBS artifact — every .so before stripping, from
+                // autolinked CMake modules (libworklets.so, libreanimated.so) and
+                // prebuilt AARs alike. Setting that property *replaces* the default
+                // rather than adding to it, so don't.
+                //
+                // Nothing wires the upload into assemble/bundle, so a build has to ask
+                // for :app:uploadCrashlyticsSymbolFile<Variant> by name — see the
+                // Android gradleCommand entries in eas.json.
+                nativeSymbolUploadEnabled true
+            }
         }
         releaseDebuggable {
             // Like release but with debuggable=true for testing

--- a/apps/tlon-mobile/android/build.gradle
+++ b/apps/tlon-mobile/android/build.gradle
@@ -19,7 +19,7 @@ buildscript {
         classpath('com.android.tools.build:gradle')
         classpath('com.facebook.react:react-native-gradle-plugin')
         classpath('org.jetbrains.kotlin:kotlin-gradle-plugin')
-        classpath('com.google.firebase:firebase-crashlytics-gradle:2.9.9')
+        classpath('com.google.firebase:firebase-crashlytics-gradle:3.0.8')
     }
 }
 

--- a/apps/tlon-mobile/eas.json
+++ b/apps/tlon-mobile/eas.json
@@ -27,7 +27,7 @@
       },
       "android": {
         "resourceClass": "large",
-        "gradleCommand": ":app:bundlePreviewRelease"
+        "gradleCommand": ":app:bundlePreviewRelease :app:uploadCrashlyticsSymbolFilePreviewRelease"
       },
       "ios": {
         "scheme": "Landscape-preview"
@@ -43,7 +43,7 @@
       },
       "android": {
         "resourceClass": "large",
-        "gradleCommand": ":app:bundleProductionRelease"
+        "gradleCommand": ":app:bundleProductionRelease :app:uploadCrashlyticsSymbolFileProductionRelease"
       },
       "ios": {
         "scheme": "Landscape"
@@ -61,7 +61,7 @@
         "NOTIFY_SERVICE": "tlon-preview-release"
       },
       "android": {
-        "gradleCommand": ":app:bundlePreviewRelease",
+        "gradleCommand": ":app:bundlePreviewRelease :app:uploadCrashlyticsSymbolFilePreviewRelease",
         "buildType": "apk",
         "image": "latest"
       },


### PR DESCRIPTION
## Summary

Android native crash frames in third-party `.so` files reach Crashlytics as `(Missing BuildId …)`, so only symbols that happen to be exported in the on-device library resolve. This enables Crashlytics NDK symbol upload for the release variants, which recovers function names *and* file:line inside libraries we don't build ourselves.

Fixes TLON-6471

## Changes

- **`android/build.gradle`** — `firebase-crashlytics-gradle` 2.9.9 → **3.0.8**. Required, not incidental: 3.0.8 is Firebase's documented minimum for NDK symbol upload, and 2.9.9 predates AGP 8 and builds against the deprecated `BaseVariant` API. AGP 8.12.0, Gradle 8.13 and `google-services` 4.4.2 already clear v3's floors (8.1 / 8.0 / 4.4.1), and nothing in the repo used a property v3 removed (`mappingFile`, `strippedNativeLibsDir`, the `symbolGenerator` closure, the `defaultConfig` extension) — so no migration.
- **`android/app/build.gradle`** — `nativeSymbolUploadEnabled true` on the `release` build type only.
- **`eas.json`** — appended `:app:uploadCrashlyticsSymbolFile{Preview,Production}Release` to the Android `gradleCommand` for `preview`, `production` and `demo`.

Two non-obvious details, both captured in a comment at the call site:

1. **`unstrippedNativeLibsDir` is deliberately left unset.** The plugin then reads AGP's `SingleArtifact.MERGED_NATIVE_LIBS` — every `.so` in the app before stripping, from autolinked CMake modules and prebuilt AARs alike. The extension property is an *override* (`if (override.isEmpty()) merged else override`), so setting it to an intermediates path would have narrowed coverage and silently broken on the next AGP bump.
2. **The upload is not automatic.** Only `UploadMappingFileTask` calls `finalizedBy`; `UploadSymbolFileTask` does not. `nativeSymbolUploadEnabled` alone registers a task that never runs, so `bundleProductionRelease` would keep shipping without symbols. Hence naming the task in `eas.json`.

No new EAS credentials are needed: `UploadSymbolFileTask` takes only an `appIdFile` sourced from the `GoogleServicesTask` output, i.e. the Google App ID in the already-committed `google-services.json`, and `dump_syms/linux/dump_syms.bin` ships inside `firebase-crashlytics-buildtools`.

`firebase.json` needs no change — symbol upload is purely a Gradle-plugin concern, and NDK *capture* already works (that's why TLON-6469 produced a tombstone at all).

## How did I test?

Locally, against a real build — not inferred from docs.

**Plugin configures, and scoping is correct.** `./gradlew :app:tasks --all` → BUILD SUCCESSFUL. `uploadCrashlyticsSymbolFile{Production,Preview}Release` are registered for exactly those two variants; nothing for `debug` or `debugOptimized`, so debug builds are untouched. `uploadCrashlyticsMappingFile*` still registered, so the existing mapping-file upload survived the v3 bump. Worth noting: `releaseDebuggable` also gets no symbol tasks — `initWith release` does not copy the `firebaseCrashlytics` extension — so no explicit opt-out was needed there.

**Symbols actually generate, with the frame we lost.** `./gradlew :app:generateCrashlyticsSymbolFileProductionRelease` → BUILD SUCCESSFUL in 4m56s, producing 102 Breakpad files across all four ABIs. For `libworklets.so`:

```
MODULE Linux arm64 21391E01AF94C6FF7B565318B9887A280 libworklets.so
FUNC a76bc 154 0 worklets::AnimationFrameBatchinator::~AnimationFrameBatchinator()
```

That is the exact frame TLON-6469 could not resolve. The file carries 2281 `FUNC` and 159 `FILE` records including `AnimationFrameQueue/AnimationFrameBatchinator.cpp`, and the line table maps addresses to source lines (`88cbc 14 62 89` → address, size, line 62, file 89).

**Both lib sources are covered**, confirming the unstripped libs are present at upload time: autolinked CMake subprojects (`libworklets.so`, `librnskia.so`, `libop-sqlite.so`) and prebuilt AARs (`libimagepipeline.so`, `libstatic-webp.so`, `libavif_android.so`). The log shows AGP compiling release native code as `buildCMakeRelWithDebInfo` (`-O2 -g`), which is why the debug info exists to extract.

**Multi-task `gradleCommand` verified against EAS's own code.** Expo documents that field in the singular with a single-task example, so I checked the published `@expo/build-tools@23.2.0`: `gradleCommand` is interpolated unquoted into `bash -c "exec ./gradlew ${gradleCommand} --profile"`, so bash word-splits it into separate argv entries. (Heads-up for future readers: [expo/eas-cli#1212](https://github.com/expo/eas-cli/issues/1212) says multiple tasks don't work; that was fixed in Aug 2022 but still dominates search results.)

`pnpm format:check` clean. No lockfile regeneration needed — the plugin lives on the buildscript classpath, which neither `app/gradle.lockfile` nor `settings-gradle.lockfile` locks.

**Not yet tested:** an actual EAS build with a real crash symbolizing in the Crashlytics console. That needs credentials I don't have; everything up to the network upload is verified.

## Risks and impact

- Safe to rollback without consulting PR author? **Yes** — reverting restores today's behavior (no native symbols).
- Affects important code area:
  - [ ] Onboarding
  - [ ] State / providers
  - [ ] Message sync
  - [ ] Channel display
  - [ ] Notifications
  - [x] Other: **Android build & release pipeline (EAS) + crash reporting**

Three things reviewers should weigh:

1. **~151 MB of symbols per release build** (102 files × 4 ABIs), dominated by `libreactnative.so` at 17–22 MB per ABI and `librnskia.so` at 15 MB. Generated and uploaded on every preview/production/demo Android build, adding build time and upload volume. The plugin has no ABI filter, and the smaller `symbolGeneratorType = "csym"` loses the line-level detail that makes this worth doing — so I kept breakpad and ate the size. Happy to drop `demo` if the cost is unwelcome on internal builds.
2. **A failed upload fails the build.** The AAB is produced and then the gradle invocation fails, so a network blip on EAS marks the release build failed. I think that beats silently shipping without symbols, but it is a behavior change to release builds.
3. **The plugin bump touches the whole Android build**, not just Crashlytics. Mitigated by the task-graph check above, but the first EAS build on this branch is the real proof.

## Rollback plan

`git revert` this commit. It only touches `android/build.gradle`, `android/app/build.gradle` and `eas.json`; no migrations, no persisted state, no lockfile changes. Symbol files already uploaded to Crashlytics are keyed by BuildId and simply go unused.

## Screenshots / videos

N/A — build configuration. The meaningful artifact is the generated symbol file quoted under "How did I test?".

🤖 Generated with [Claude Code](https://claude.com/claude-code)
