### PR TITLE
api: recover from guest-owned eyre channels and dedupe concurrent reauths

### DIFF
--- a/packages/api/src/__tests__/pokeChannelCleanup.test.ts
+++ b/packages/api/src/__tests__/pokeChannelCleanup.test.ts
@@ -1,0 +1,84 @@
+import { afterEach, expect, test, vi } from 'vitest';
+
+import {
+  internalConfigureClient,
+  internalRemoveClient,
+  poke,
+} from '../client/urbit';
+import { ReapError } from '../http-api';
+import { Urbit } from '../http-api/Urbit';
+import type { FetchEventSourceInit } from '../http-api/fetch-event-source';
+
+const streams = vi.hoisted(() => {
+  vi.resetModules();
+  return [] as { url: string; options: FetchEventSourceInit }[];
+});
+
+vi.mock('../http-api/fetch-event-source', () => ({
+  fetchEventSource: vi.fn((url: string, options: FetchEventSourceInit) => {
+    streams.push({ url, options });
+    void options.onopen?.(new Response(null, { status: 200 }), false);
+    return new Promise<void>(() => {});
+  }),
+}));
+
+function deferred<T>() {
+  let resolve!: (value: T) => void;
+  const promise = new Promise<T>((r) => {
+    resolve = r;
+  });
+  return { resolve, promise };
+}
+
+afterEach(() => {
+  internalRemoveClient();
+  vi.useRealTimers();
+  streams.length = 0;
+});
+
+test('a late old-channel PUT preserves the replacement poke acknowledgement handler', async () => {
+  vi.useFakeTimers();
+  const oldFirst = deferred<Response>();
+  const oldSecond = deferred<Response>();
+  const retry = deferred<Response>();
+  let puts = 0;
+  const fetch = vi.fn((_url: unknown, options?: RequestInit) =>
+    options?.method === 'PUT'
+      ? [oldFirst.promise, oldSecond.promise, retry.promise][puts++]
+      : Promise.resolve(new Response('~sampel-palnet', { status: 200 }))
+  );
+  const client = new Urbit('http://example.test', undefined, undefined, fetch);
+  internalConfigureClient({
+    shipName: '~sampel-palnet',
+    shipUrl: client.url,
+    client,
+    getCode: async () => 'code',
+  });
+  (client as any).sseClientInitialized = true;
+  const originalChannel = client.channelId;
+  const first = poke({ app: 'a', mark: 'm', json: 1 }).catch((e) => e);
+  const second = poke({ app: 'a', mark: 'm', json: 2 }).catch((e) => e);
+
+  // The second poke's 403 rotates the channel. The first is swept with a
+  // ReapError, while the second retries using id 1 on the replacement channel.
+  oldSecond.resolve(new Response(null, { status: 403 }));
+  await vi.advanceTimersByTimeAsync(0);
+  expect(await first).toBeInstanceOf(ReapError);
+  expect(client.channelId).not.toBe(originalChannel);
+  expect(puts).toBe(3);
+  retry.resolve(new Response(null, { status: 204 }));
+  await vi.advanceTimersByTimeAsync(0);
+  expect(streams).toHaveLength(1);
+
+  // The first poke's late failure must not remove the retry's handler just
+  // because both requests used id 1. Deliver a real acknowledgement event.
+  oldFirst.resolve(new Response(null, { status: 403 }));
+  await vi.advanceTimersByTimeAsync(0);
+  streams[0].options.onmessage?.({
+    id: '1',
+    event: '',
+    data: JSON.stringify({ id: 1, response: 'poke', ok: 'ok' }),
+  });
+  await vi.advanceTimersByTimeAsync(30000);
+  expect(await second).toBe(1);
+});

--- a/packages/api/src/__tests__/reauthChannel.test.ts
+++ b/packages/api/src/__tests__/reauthChannel.test.ts
@@ -7,6 +7,8 @@ import {
   poke,
   subscribe,
 } from '../client/urbit';
+import { Atom } from '@urbit/nockjs';
+
 import { AuthError, ChannelPutError } from '../http-api';
 import { Urbit } from '../http-api/Urbit';
 
@@ -130,6 +132,31 @@ describe('reauth', () => {
     expect(client.cookie).toBe('urbauth=refreshed');
   });
 
+  test('exhausted 401 retries hand off to the auth failure handler', async () => {
+    vi.useFakeTimers();
+    const handleAuthFailure = vi.fn();
+    const client = fakeClient({
+      poke: vi.fn().mockRejectedValue(new AuthError('invalid session')),
+    });
+    const loginFetch = vi.fn().mockResolvedValue(loginResponse(401));
+    vi.stubGlobal('fetch', loginFetch);
+    internalConfigureClient({
+      shipName: '~zod',
+      shipUrl: 'http://example.test',
+      getCode: vi.fn(async () => 'code'),
+      handleAuthFailure,
+      client: client as any,
+    });
+
+    const pending = poke({ app: 'a', mark: 'm', json: {} }).catch((e) => e);
+    await vi.advanceTimersByTimeAsync(30_000);
+    await expect(pending).resolves.toMatchObject({
+      message: expect.stringContaining('Authentication failed with status 401'),
+    });
+    expect(loginFetch).toHaveBeenCalledTimes(4);
+    expect(handleAuthFailure).toHaveBeenCalledWith({ mustLogout: false });
+  });
+
   test('a rejected access code logs out instead of retrying', async () => {
     const handleAuthFailure = vi.fn();
     const client = fakeClient({
@@ -249,12 +276,45 @@ describe('channel identity mismatch', () => {
 });
 
 describe('seamlessReset', () => {
+  test('a stale subscribe PUT failing after a reset leaves the new subscription alone', async () => {
+    let rejectStale!: (err: unknown) => void;
+    const fetch = vi
+      .fn()
+      // the first subscribe PUT stays pending until we say so
+      .mockImplementationOnce(
+        () => new Promise((_, reject) => (rejectStale = reject))
+      )
+      .mockResolvedValue(new Response(null, { status: 204 }));
+    const urbit = new Urbit('http://example.test', undefined, undefined, fetch);
+    urbit.nodeId = '~zod';
+    (urbit as any).sseClientInitialized = true;
+
+    const stale = urbit
+      .subscribe({ app: 'a', path: '/old', event: () => {} })
+      .catch((e) => e);
+    // rotation restarts the id sequence and replays the subscription, so the
+    // replacement lands on id 1 as well
+    urbit.seamlessReset();
+    // the replayed PUT would otherwise try to open an event source
+    (urbit as any).sseClientInitialized = true;
+    const subs = (urbit as any).outstandingSubscriptions as Map<number, any>;
+    expect(subs.get(1)?.path).toBe('/old');
+    const replayed = subs.get(1);
+
+    rejectStale(new ChannelPutError(403));
+    await expect(stale).resolves.toMatchObject({ status: 403 });
+    // the stale failure must not evict the replayed subscription in its slot
+    expect(subs.get(1)).toBe(replayed);
+  });
+
   test('aborts the old channel connection so its retry loop stops', async () => {
+    vi.useFakeTimers();
     const fetch = vi.fn(async () => new Response(null, { status: 204 }));
     const urbit = new Urbit('http://example.test', undefined, undefined, fetch);
     urbit.nodeId = '~zod';
     (urbit as any).sseClientInitialized = true;
-    await urbit.poke({ app: 'a', mark: 'm', json: {} }).catch(() => {});
+    // the PUT goes out synchronously; the poke itself only settles on an ack
+    void urbit.poke({ app: 'a', mark: 'm', json: {} }).catch(() => {});
     const oldSignal: AbortSignal = (fetch.mock.calls[0] as any)[1].signal;
     const oldChannel = urbit.channelId;
 
@@ -262,9 +322,18 @@ describe('seamlessReset', () => {
 
     expect(oldSignal.aborted).toBe(true);
     expect(urbit.channelId).not.toBe(oldChannel);
-    await urbit.poke({ app: 'a', mark: 'm', json: {} }).catch(() => {});
+    void urbit.poke({ app: 'a', mark: 'm', json: {} }).catch(() => {});
     const newSignal: AbortSignal = (fetch.mock.calls[1] as any)[1].signal;
     expect(newSignal.aborted).toBe(false);
+  });
+
+  test('a noun PUT failure carries the status', async () => {
+    const fetch = vi.fn(async () => new Response('forbidden', { status: 403 }));
+    const urbit = new Urbit('http://example.test', undefined, undefined, fetch);
+    urbit.nodeId = '~zod';
+    await expect(
+      (urbit as any).sendNounsToChannel(new Atom(0n))
+    ).rejects.toMatchObject({ name: 'ChannelPutError', status: 403 });
   });
 });
 

--- a/packages/api/src/__tests__/reauthChannel.test.ts
+++ b/packages/api/src/__tests__/reauthChannel.test.ts
@@ -413,13 +413,13 @@ describe('storms', () => {
     expect(client.poke).toHaveBeenCalledTimes(6);
   });
 
-  test('a poke the rotation rejected goes again on the new channel', async () => {
+  test('a poke swept by a rotation is not resent, since the ship may have taken it', async () => {
+    const reaped = new ReapError('Channel was reaped');
     const client = rotatingClient({
       poke: vi
         .fn()
         .mockRejectedValueOnce(new ChannelPutError(403))
-        // the peer: outstanding when seamlessReset ran, so it was reaped
-        .mockRejectedValueOnce(new ReapError('Channel was reaped'))
+        .mockRejectedValueOnce(reaped)
         .mockResolvedValue(5),
     });
     internalConfigureClient({
@@ -429,28 +429,36 @@ describe('storms', () => {
       client: client as any,
     });
 
-    await expect(
-      Promise.all([
-        poke({ app: 'a', mark: 'm', json: 1 }),
-        poke({ app: 'b', mark: 'm', json: 2 }),
-      ])
-    ).resolves.toEqual([5, 5]);
-    expect(client.seamlessReset).toHaveBeenCalledTimes(1);
-    expect(client.poke).toHaveBeenCalledTimes(4);
+    const results = await Promise.allSettled([
+      poke({ app: 'a', mark: 'm', json: 1 }),
+      poke({ app: 'b', mark: 'm', json: 2 }),
+    ]);
+    expect(results[0]).toEqual({ status: 'fulfilled', value: 5 });
+    expect(results[1]).toEqual({ status: 'rejected', reason: reaped });
+    // the rejected PUT retried; the reaped one did not
+    expect(client.poke).toHaveBeenCalledTimes(3);
   });
 
-  test('a reap with no rotation behind it is still a failure', async () => {
-    const failure = new ReapError('Channel was reaped');
-    const client = rotatingClient({ poke: vi.fn().mockRejectedValue(failure) });
-    internalConfigureClient({
-      shipName: '~zod',
-      shipUrl: 'http://example.test',
-      getCode: vi.fn(async () => 'code'),
-      client: client as any,
-    });
+  test('a stale subscribe PUT that succeeds after a reset still yields the replayed id', async () => {
+    let resolveStale!: (value: Response) => void;
+    const fetch = vi
+      .fn()
+      .mockImplementationOnce(
+        () => new Promise<Response>((resolve) => (resolveStale = resolve))
+      )
+      .mockResolvedValue(new Response(null, { status: 204 }));
+    const urbit = new Urbit('http://example.test', undefined, undefined, fetch);
+    urbit.nodeId = '~zod';
+    (urbit as any).sseClientInitialized = true;
+    // burn an id so the replayed subscription cannot land on the same slot
+    void urbit.poke({ app: 'a', mark: 'm', json: {} }).catch(() => {});
 
-    await expect(poke({ app: 'a', mark: 'm', json: {} })).rejects.toBe(failure);
-    expect(client.poke).toHaveBeenCalledTimes(1);
+    const stale = urbit.subscribe({ app: 'a', path: '/old', event: () => {} });
+    urbit.seamlessReset();
+    (urbit as any).sseClientInitialized = true;
+    resolveStale(new Response(null, { status: 204 }));
+    // the replay took id 1 on the new channel; the stale PUT was id 2
+    await expect(stale).resolves.toBe(1);
   });
 
   test('an auth failure that lands after a reauth retries without a second login', async () => {

--- a/packages/api/src/__tests__/reauthChannel.test.ts
+++ b/packages/api/src/__tests__/reauthChannel.test.ts
@@ -353,6 +353,20 @@ describe('seamlessReset', () => {
     expect((urbit as any).sseAbort.signal.aborted).toBe(false);
   });
 
+  test('a rotation before the event source opens settles the pending setup', async () => {
+    // the stream request never opens; a rotation must not leave the awaiting
+    // channel setup pending forever
+    const fetch = vi.fn(() => new Promise<Response>(() => {}));
+    const urbit = new Urbit('http://example.test', undefined, undefined, fetch);
+    urbit.nodeId = '~zod';
+    (urbit as any).lastEventId = 1;
+    const opening = (urbit as any).eventSource() as Promise<void>;
+
+    urbit.seamlessReset();
+
+    await expect(opening).rejects.toBeInstanceOf(ReapError);
+  });
+
   test('a noun PUT failure carries the status', async () => {
     const fetch = vi.fn(async () => new Response('forbidden', { status: 403 }));
     const urbit = new Urbit('http://example.test', undefined, undefined, fetch);

--- a/packages/api/src/__tests__/reauthChannel.test.ts
+++ b/packages/api/src/__tests__/reauthChannel.test.ts
@@ -248,6 +248,26 @@ describe('channel identity mismatch', () => {
   });
 });
 
+describe('seamlessReset', () => {
+  test('aborts the old channel connection so its retry loop stops', async () => {
+    const fetch = vi.fn(async () => new Response(null, { status: 204 }));
+    const urbit = new Urbit('http://example.test', undefined, undefined, fetch);
+    urbit.nodeId = '~zod';
+    (urbit as any).sseClientInitialized = true;
+    await urbit.poke({ app: 'a', mark: 'm', json: {} }).catch(() => {});
+    const oldSignal: AbortSignal = (fetch.mock.calls[0] as any)[1].signal;
+    const oldChannel = urbit.channelId;
+
+    urbit.seamlessReset();
+
+    expect(oldSignal.aborted).toBe(true);
+    expect(urbit.channelId).not.toBe(oldChannel);
+    await urbit.poke({ app: 'a', mark: 'm', json: {} }).catch(() => {});
+    const newSignal: AbortSignal = (fetch.mock.calls[1] as any)[1].signal;
+    expect(newSignal.aborted).toBe(false);
+  });
+});
+
 describe('AuthFailureError', () => {
   test('describes what each eyre status means', () => {
     expect(new AuthFailureError(400).message).toMatch(
@@ -255,5 +275,82 @@ describe('AuthFailureError', () => {
     );
     expect(new AuthFailureError(401).message).toMatch(/stale session cookie/);
     expect(new AuthFailureError(500).message).toMatch(/Unexpected response/);
+  });
+});
+
+describe('storms', () => {
+  // several requests fail together when a channel dies; only the first one
+  // back should rotate, the rest retry on the new channel
+  function rotatingClient(overrides: Record<string, unknown> = {}) {
+    const client: Record<string, any> = fakeClient({
+      channelId: 'chan-1',
+      ...overrides,
+    });
+    client.seamlessReset = vi.fn(() => {
+      client.channelId = `chan-${client.seamlessReset.mock.calls.length + 1}`;
+    });
+    return client;
+  }
+
+  test('concurrent channel 403s rotate the channel once', async () => {
+    const client = rotatingClient({
+      poke: vi
+        .fn()
+        .mockRejectedValueOnce(new ChannelPutError(403))
+        .mockRejectedValueOnce(new ChannelPutError(403))
+        .mockRejectedValueOnce(new ChannelPutError(403))
+        .mockResolvedValue(1),
+    });
+    internalConfigureClient({
+      shipName: '~zod',
+      shipUrl: 'http://example.test',
+      getCode: vi.fn(async () => 'code'),
+      client: client as any,
+    });
+
+    const pokes = [
+      poke({ app: 'a', mark: 'm', json: 1 }),
+      poke({ app: 'b', mark: 'm', json: 2 }),
+      poke({ app: 'c', mark: 'm', json: 3 }),
+    ];
+    await expect(Promise.all(pokes)).resolves.toEqual([1, 1, 1]);
+    expect(client.seamlessReset).toHaveBeenCalledTimes(1);
+    expect(client.poke).toHaveBeenCalledTimes(6);
+  });
+
+  test('an auth failure that lands after a reauth retries without a second login', async () => {
+    let calls = 0;
+    const client = rotatingClient({
+      poke: vi.fn(() => {
+        calls += 1;
+        if (calls === 1) {
+          return Promise.reject(new AuthError('invalid session'));
+        }
+        if (calls === 2) {
+          // in flight while the first failure's reauth runs; comes back late
+          return new Promise((_, reject) =>
+            setTimeout(() => reject(new AuthError('invalid session')), 30)
+          );
+        }
+        return Promise.resolve(calls);
+      }),
+    });
+    const loginFetch = vi.fn().mockResolvedValue(loginResponse());
+    vi.stubGlobal('fetch', loginFetch);
+    internalConfigureClient({
+      shipName: '~zod',
+      shipUrl: 'http://example.test',
+      getCode: vi.fn(async () => 'code'),
+      client: client as any,
+    });
+
+    const pokes = [
+      poke({ app: 'a', mark: 'm', json: 1 }),
+      poke({ app: 'b', mark: 'm', json: 2 }),
+    ];
+    await expect(Promise.all(pokes)).resolves.toEqual([3, 4]);
+    // the late failure saw the epoch move and just retried
+    expect(loginFetch).toHaveBeenCalledTimes(1);
+    expect(client.seamlessReset).toHaveBeenCalledTimes(1);
   });
 });

--- a/packages/api/src/__tests__/reauthChannel.test.ts
+++ b/packages/api/src/__tests__/reauthChannel.test.ts
@@ -9,7 +9,7 @@ import {
 } from '../client/urbit';
 import { Atom } from '@urbit/nockjs';
 
-import { AuthError, ChannelPutError } from '../http-api';
+import { AuthError, ChannelPutError, ReapError } from '../http-api';
 import { Urbit } from '../http-api/Urbit';
 
 // A stand-in for the singleton Urbit client with just enough surface for the
@@ -302,29 +302,55 @@ describe('seamlessReset', () => {
     const replayed = subs.get(1);
 
     rejectStale(new ChannelPutError(403));
-    await expect(stale).resolves.toMatchObject({ status: 403 });
-    // the stale failure must not evict the replayed subscription in its slot
+    // the caller gets the replayed subscription instead of a failure, and the
+    // stale failure must not evict it from its slot
+    await expect(stale).resolves.toBe(1);
     expect(subs.get(1)).toBe(replayed);
   });
 
-  test('aborts the old channel connection so its retry loop stops', async () => {
+  test('a subscribe without resubOnQuit still fails when its PUT fails after a reset', async () => {
+    let rejectStale!: (err: unknown) => void;
+    const fetch = vi
+      .fn()
+      .mockImplementationOnce(
+        () => new Promise((_, reject) => (rejectStale = reject))
+      )
+      .mockResolvedValue(new Response(null, { status: 204 }));
+    const urbit = new Urbit('http://example.test', undefined, undefined, fetch);
+    urbit.nodeId = '~zod';
+    (urbit as any).sseClientInitialized = true;
+
+    const stale = urbit
+      .subscribe({
+        app: 'a',
+        path: '/old',
+        event: () => {},
+        resubOnQuit: false,
+      })
+      .catch((e) => e);
+    urbit.seamlessReset();
+    rejectStale(new ChannelPutError(403));
+    await expect(stale).resolves.toMatchObject({ status: 403 });
+  });
+
+  test('aborts the old event source but leaves in-flight PUTs alone', async () => {
     vi.useFakeTimers();
     const fetch = vi.fn(async () => new Response(null, { status: 204 }));
     const urbit = new Urbit('http://example.test', undefined, undefined, fetch);
     urbit.nodeId = '~zod';
     (urbit as any).sseClientInitialized = true;
+    const sseSignal: AbortSignal = (urbit as any).sseAbort.signal;
     // the PUT goes out synchronously; the poke itself only settles on an ack
     void urbit.poke({ app: 'a', mark: 'm', json: {} }).catch(() => {});
-    const oldSignal: AbortSignal = (fetch.mock.calls[0] as any)[1].signal;
+    const putSignal: AbortSignal = (fetch.mock.calls[0] as any)[1].signal;
     const oldChannel = urbit.channelId;
 
     urbit.seamlessReset();
 
-    expect(oldSignal.aborted).toBe(true);
+    expect(sseSignal.aborted).toBe(true);
+    expect(putSignal.aborted).toBe(false);
     expect(urbit.channelId).not.toBe(oldChannel);
-    void urbit.poke({ app: 'a', mark: 'm', json: {} }).catch(() => {});
-    const newSignal: AbortSignal = (fetch.mock.calls[1] as any)[1].signal;
-    expect(newSignal.aborted).toBe(false);
+    expect((urbit as any).sseAbort.signal.aborted).toBe(false);
   });
 
   test('a noun PUT failure carries the status', async () => {
@@ -385,6 +411,46 @@ describe('storms', () => {
     await expect(Promise.all(pokes)).resolves.toEqual([1, 1, 1]);
     expect(client.seamlessReset).toHaveBeenCalledTimes(1);
     expect(client.poke).toHaveBeenCalledTimes(6);
+  });
+
+  test('a poke the rotation rejected goes again on the new channel', async () => {
+    const client = rotatingClient({
+      poke: vi
+        .fn()
+        .mockRejectedValueOnce(new ChannelPutError(403))
+        // the peer: outstanding when seamlessReset ran, so it was reaped
+        .mockRejectedValueOnce(new ReapError('Channel was reaped'))
+        .mockResolvedValue(5),
+    });
+    internalConfigureClient({
+      shipName: '~zod',
+      shipUrl: 'http://example.test',
+      getCode: vi.fn(async () => 'code'),
+      client: client as any,
+    });
+
+    await expect(
+      Promise.all([
+        poke({ app: 'a', mark: 'm', json: 1 }),
+        poke({ app: 'b', mark: 'm', json: 2 }),
+      ])
+    ).resolves.toEqual([5, 5]);
+    expect(client.seamlessReset).toHaveBeenCalledTimes(1);
+    expect(client.poke).toHaveBeenCalledTimes(4);
+  });
+
+  test('a reap with no rotation behind it is still a failure', async () => {
+    const failure = new ReapError('Channel was reaped');
+    const client = rotatingClient({ poke: vi.fn().mockRejectedValue(failure) });
+    internalConfigureClient({
+      shipName: '~zod',
+      shipUrl: 'http://example.test',
+      getCode: vi.fn(async () => 'code'),
+      client: client as any,
+    });
+
+    await expect(poke({ app: 'a', mark: 'm', json: {} })).rejects.toBe(failure);
+    expect(client.poke).toHaveBeenCalledTimes(1);
   });
 
   test('an auth failure that lands after a reauth retries without a second login', async () => {

--- a/packages/api/src/__tests__/reauthChannel.test.ts
+++ b/packages/api/src/__tests__/reauthChannel.test.ts
@@ -1,0 +1,259 @@
+import { afterEach, describe, expect, test, vi } from 'vitest';
+
+import { AuthFailureError } from '../client/landscapeApi';
+import {
+  internalConfigureClient,
+  internalRemoveClient,
+  poke,
+  subscribe,
+} from '../client/urbit';
+import { AuthError, ChannelPutError } from '../http-api';
+import { Urbit } from '../http-api/Urbit';
+
+// A stand-in for the singleton Urbit client with just enough surface for the
+// client wrapper's retry paths. `channelOpened` mirrors a client that has
+// already sent something over its channel, which is the case that matters.
+function fakeClient(overrides: Record<string, unknown> = {}) {
+  return {
+    poke: vi.fn(),
+    subscribe: vi.fn(),
+    seamlessReset: vi.fn(),
+    channelOpened: true,
+    cookie: 'urbauth=old',
+    delete: vi.fn(),
+    on: vi.fn(),
+    ...overrides,
+  };
+}
+
+function loginResponse(status = 200) {
+  return new Response(null, {
+    status,
+    headers:
+      status === 200
+        ? { 'set-cookie': 'urbauth=refreshed; Path=/; Max-Age=2592000' }
+        : {},
+  });
+}
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+  vi.useRealTimers();
+  internalRemoveClient();
+});
+
+describe('reauth', () => {
+  test('concurrent auth failures share one login and one channel rotation', async () => {
+    const client = fakeClient({
+      poke: vi
+        .fn()
+        .mockRejectedValueOnce(new AuthError('invalid session'))
+        .mockRejectedValueOnce(new AuthError('invalid session'))
+        .mockRejectedValueOnce(new AuthError('invalid session'))
+        .mockResolvedValue(1),
+    });
+    const loginFetch = vi.fn().mockResolvedValue(loginResponse());
+    vi.stubGlobal('fetch', loginFetch);
+    // resolve the code on a later tick so every caller reaches reauth() before
+    // the first one has a cookie; this is the window the old code raced in
+    const getCode = vi.fn(
+      () => new Promise<string>((resolve) => setTimeout(() => resolve('code')))
+    );
+
+    internalConfigureClient({
+      shipName: '~zod',
+      shipUrl: 'http://example.test',
+      getCode,
+      client: client as any,
+    });
+
+    const pokes = [
+      poke({ app: 'activity', mark: 'activity-action-2', json: {} }),
+      poke({ app: 'settings', mark: 'settings-event', json: {} }),
+      poke({ app: 'contacts', mark: 'contact-action-1', json: {} }),
+    ];
+    await expect(Promise.all(pokes)).resolves.toEqual([1, 1, 1]);
+
+    expect(getCode).toHaveBeenCalledTimes(1);
+    expect(loginFetch).toHaveBeenCalledTimes(1);
+    expect(client.cookie).toBe('urbauth=refreshed');
+    // the channel we had belonged to the old session; one rotation, shared
+    expect(client.seamlessReset).toHaveBeenCalledTimes(1);
+    // three failures, three retries
+    expect(client.poke).toHaveBeenCalledTimes(6);
+  });
+
+  test('does not rotate the channel when nothing was sent on it yet', async () => {
+    const client = fakeClient({
+      channelOpened: false,
+      poke: vi
+        .fn()
+        .mockRejectedValueOnce(new AuthError('invalid session'))
+        .mockResolvedValue(1),
+    });
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue(loginResponse()));
+    internalConfigureClient({
+      shipName: '~zod',
+      shipUrl: 'http://example.test',
+      getCode: vi.fn(async () => 'code'),
+      client: client as any,
+    });
+
+    await expect(poke({ app: 'a', mark: 'm', json: {} })).resolves.toBe(1);
+    expect(client.seamlessReset).not.toHaveBeenCalled();
+  });
+
+  test('retries a login that eyre rejected for a stale cookie', async () => {
+    vi.useFakeTimers();
+    const client = fakeClient({
+      poke: vi
+        .fn()
+        .mockRejectedValueOnce(new AuthError('invalid session'))
+        .mockResolvedValue(1),
+    });
+    const loginFetch = vi
+      .fn()
+      .mockResolvedValueOnce(loginResponse(401))
+      .mockResolvedValueOnce(loginResponse(200));
+    vi.stubGlobal('fetch', loginFetch);
+    internalConfigureClient({
+      shipName: '~zod',
+      shipUrl: 'http://example.test',
+      getCode: vi.fn(async () => 'code'),
+      client: client as any,
+    });
+
+    const pending = poke({ app: 'a', mark: 'm', json: {} });
+    await vi.advanceTimersByTimeAsync(10_000);
+    await expect(pending).resolves.toBe(1);
+    expect(loginFetch).toHaveBeenCalledTimes(2);
+    expect(client.cookie).toBe('urbauth=refreshed');
+  });
+
+  test('a rejected access code logs out instead of retrying', async () => {
+    const handleAuthFailure = vi.fn();
+    const client = fakeClient({
+      poke: vi.fn().mockRejectedValue(new AuthError('invalid session')),
+    });
+    const loginFetch = vi.fn().mockResolvedValue(loginResponse(400));
+    vi.stubGlobal('fetch', loginFetch);
+    internalConfigureClient({
+      shipName: '~zod',
+      shipUrl: 'http://example.test',
+      getCode: vi.fn(async () => 'code'),
+      handleAuthFailure,
+      client: client as any,
+    });
+
+    await expect(
+      poke({ app: 'a', mark: 'm', json: {} })
+    ).rejects.toBeInstanceOf(AuthError);
+    expect(loginFetch).toHaveBeenCalledTimes(1);
+    expect(handleAuthFailure).toHaveBeenCalledWith({ mustLogout: true });
+    expect(client.seamlessReset).not.toHaveBeenCalled();
+  });
+});
+
+describe('channel identity mismatch', () => {
+  test('a 403 on the channel PUT rotates the channel and retries the poke', async () => {
+    const client = fakeClient({
+      poke: vi
+        .fn()
+        .mockRejectedValueOnce(new ChannelPutError(403))
+        .mockResolvedValue(9),
+    });
+    const loginFetch = vi.fn();
+    vi.stubGlobal('fetch', loginFetch);
+    internalConfigureClient({
+      shipName: '~zod',
+      shipUrl: 'http://example.test',
+      getCode: vi.fn(async () => 'code'),
+      client: client as any,
+    });
+
+    await expect(
+      poke({ app: 'activity', mark: 'activity-action-2', json: {} })
+    ).resolves.toBe(9);
+    expect(client.seamlessReset).toHaveBeenCalledTimes(1);
+    // our session is fine; the channel was the problem, so no login
+    expect(loginFetch).not.toHaveBeenCalled();
+    expect(client.poke).toHaveBeenCalledTimes(2);
+  });
+
+  test('a 403 on a subscribe PUT rotates the channel and resubscribes', async () => {
+    const client = fakeClient({
+      subscribe: vi
+        .fn()
+        .mockRejectedValueOnce(new ChannelPutError(403))
+        .mockResolvedValue(4),
+    });
+    internalConfigureClient({
+      shipName: '~zod',
+      shipUrl: 'http://example.test',
+      getCode: vi.fn(async () => 'code'),
+      client: client as any,
+    });
+
+    await expect(
+      subscribe({ app: 'activity', path: '/v6' }, () => {})
+    ).resolves.toBe(4);
+    expect(client.seamlessReset).toHaveBeenCalledTimes(1);
+    expect(client.subscribe).toHaveBeenCalledTimes(2);
+  });
+
+  test('other channel PUT failures surface without a rotation', async () => {
+    const failure = new ChannelPutError(500);
+    const client = fakeClient({ poke: vi.fn().mockRejectedValue(failure) });
+    internalConfigureClient({
+      shipName: '~zod',
+      shipUrl: 'http://example.test',
+      getCode: vi.fn(async () => 'code'),
+      client: client as any,
+    });
+
+    await expect(poke({ app: 'a', mark: 'm', json: {} })).rejects.toBe(failure);
+    expect(client.seamlessReset).not.toHaveBeenCalled();
+    expect(client.poke).toHaveBeenCalledTimes(1);
+  });
+
+  test('the http-api client reports the channel PUT status', async () => {
+    const fetch = vi.fn(async () => new Response('forbidden', { status: 403 }));
+    const urbit = new Urbit('http://example.test', undefined, undefined, fetch);
+    urbit.nodeId = '~zod';
+
+    await expect(
+      urbit.poke({ app: 'a', mark: 'm', json: {} })
+    ).rejects.toMatchObject({ name: 'ChannelPutError', status: 403 });
+    expect(urbit.channelOpened).toBe(true);
+  });
+
+  test('a failed subscribe PUT is not replayed by a later channel reset', async () => {
+    const fetch = vi
+      .fn()
+      .mockResolvedValueOnce(new Response('forbidden', { status: 403 }))
+      .mockResolvedValue(new Response(null, { status: 204 }));
+    const urbit = new Urbit('http://example.test', undefined, undefined, fetch);
+    urbit.nodeId = '~zod';
+    // pretend the SSE side is already up so a successful PUT stays a PUT
+    (urbit as any).sseClientInitialized = true;
+
+    await expect(
+      urbit.subscribe({ app: 'a', path: '/p', event: () => {} })
+    ).rejects.toMatchObject({ status: 403 });
+    expect((urbit as any).outstandingSubscriptions.size).toBe(0);
+
+    urbit.seamlessReset();
+    // the reset had nothing to resubscribe; only the original PUT went out
+    expect(fetch).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe('AuthFailureError', () => {
+  test('describes what each eyre status means', () => {
+    expect(new AuthFailureError(400).message).toMatch(
+      /access code was rejected/
+    );
+    expect(new AuthFailureError(401).message).toMatch(/stale session cookie/);
+    expect(new AuthFailureError(500).message).toMatch(/Unexpected response/);
+  });
+});

--- a/packages/api/src/__tests__/subscribeOnceLifecycle.test.ts
+++ b/packages/api/src/__tests__/subscribeOnceLifecycle.test.ts
@@ -1,0 +1,112 @@
+import { afterEach, expect, test, vi } from 'vitest';
+
+import { Urbit } from '../http-api/Urbit';
+
+function deferred<T>() {
+  let resolve!: (value: T) => void;
+  let reject!: (reason: unknown) => void;
+  const promise = new Promise<T>((res, rej) => {
+    resolve = res;
+    reject = rej;
+  });
+  return { resolve, reject, promise };
+}
+
+function setup() {
+  vi.useFakeTimers();
+  const initialPut = deferred<Response>();
+  const fetch = vi
+    .fn()
+    .mockReturnValueOnce(initialPut.promise)
+    .mockImplementation(async () => new Response(null, { status: 204 }));
+  const client = new Urbit('http://example.test', undefined, undefined, fetch);
+  (client as any).sseClientInitialized = true;
+  const unsubscribe = vi.spyOn(client, 'unsubscribe');
+  return { client, initialPut, unsubscribe };
+}
+
+afterEach(() => {
+  vi.useRealTimers();
+});
+
+test.each(['before', 'after'] as const)(
+  'cancellation %s the PUT finishes cannot unsubscribe a replacement channel subscription',
+  async (timing) => {
+    const { client, initialPut, unsubscribe } = setup();
+    const once = client.subscribeOnce('a', '/once', undefined, 1000).catch((e) => e);
+    if (timing === 'after') {
+      initialPut.resolve(new Response(null, { status: 204 }));
+      await vi.advanceTimersByTimeAsync(0);
+    }
+
+    client.seamlessReset();
+    await expect(once).resolves.toBe('quit');
+    (client as any).sseClientInitialized = true;
+    const replacementId = await client.subscribe({
+      app: 'a',
+      path: '/live',
+      event: () => {},
+    });
+    expect(replacementId).toBe(1);
+    if (timing === 'before') {
+      initialPut.resolve(new Response(null, { status: 204 }));
+      await vi.advanceTimersByTimeAsync(0);
+    }
+
+    await vi.advanceTimersByTimeAsync(1000);
+    expect(unsubscribe).not.toHaveBeenCalled();
+    expect((client as any).outstandingSubscriptions.get(replacementId)?.path).toBe(
+      '/live'
+    );
+  }
+);
+
+test('the first fact settles once and prevents a late PUT from scheduling a timeout', async () => {
+  const { client, initialPut, unsubscribe } = setup();
+  const once = client.subscribeOnce<string>('a', '/once', undefined, 1000);
+  const entry = (client as any).outstandingSubscriptions.get(1);
+  entry.event('first', 'm', 1);
+  entry.event('second', 'm', 1);
+  await expect(once).resolves.toBe('first');
+  initialPut.resolve(new Response(null, { status: 204 }));
+  await vi.advanceTimersByTimeAsync(1000);
+  expect(unsubscribe).toHaveBeenCalledTimes(1);
+  expect(unsubscribe).toHaveBeenCalledWith(1);
+});
+
+test('a failed PUT rejects the one-shot instead of leaving it pending', async () => {
+  const { client, initialPut, unsubscribe } = setup();
+  const failure = new Error('PUT failed');
+  let outcome: unknown;
+  void client.subscribeOnce('a', '/once', undefined, 1000).catch((e) => {
+    outcome = e;
+  });
+  initialPut.reject(failure);
+  await vi.advanceTimersByTimeAsync(1000);
+  expect(outcome).toBe(failure);
+  expect(unsubscribe).not.toHaveBeenCalled();
+});
+
+test('a subscription error cancels its already scheduled timeout', async () => {
+  const { client, initialPut, unsubscribe } = setup();
+  const once = client.subscribeOnce('a', '/once', undefined, 1000).catch((e) => e);
+  const entry = (client as any).outstandingSubscriptions.get(1);
+  initialPut.resolve(new Response(null, { status: 204 }));
+  await vi.advanceTimersByTimeAsync(0);
+  entry.err('watch failed');
+  await expect(once).resolves.toBe('watch failed');
+  await vi.advanceTimersByTimeAsync(1000);
+  expect(unsubscribe).not.toHaveBeenCalled();
+});
+
+test('an unanswered one-shot still times out and unsubscribes once', async () => {
+  const { client, initialPut, unsubscribe } = setup();
+  const once = client.subscribeOnce('a', '/once', undefined, 1000).catch((e) => e);
+  const entry = (client as any).outstandingSubscriptions.get(1);
+  initialPut.resolve(new Response(null, { status: 204 }));
+  await vi.advanceTimersByTimeAsync(1000);
+  await expect(once).resolves.toBe('timeout');
+  entry.event('late', 'm', 1);
+  expect(unsubscribe).toHaveBeenCalledTimes(1);
+  expect(unsubscribe).toHaveBeenCalledWith(1);
+});

--- a/packages/api/src/__tests__/subscribeOnceLifecycle.test.ts
+++ b/packages/api/src/__tests__/subscribeOnceLifecycle.test.ts
@@ -33,7 +33,9 @@ test.each(['before', 'after'] as const)(
   'cancellation %s the PUT finishes cannot unsubscribe a replacement channel subscription',
   async (timing) => {
     const { client, initialPut, unsubscribe } = setup();
-    const once = client.subscribeOnce('a', '/once', undefined, 1000).catch((e) => e);
+    const once = client
+      .subscribeOnce('a', '/once', undefined, 1000)
+      .catch((e) => e);
     if (timing === 'after') {
       initialPut.resolve(new Response(null, { status: 204 }));
       await vi.advanceTimersByTimeAsync(0);
@@ -55,9 +57,9 @@ test.each(['before', 'after'] as const)(
 
     await vi.advanceTimersByTimeAsync(1000);
     expect(unsubscribe).not.toHaveBeenCalled();
-    expect((client as any).outstandingSubscriptions.get(replacementId)?.path).toBe(
-      '/live'
-    );
+    expect(
+      (client as any).outstandingSubscriptions.get(replacementId)?.path
+    ).toBe('/live');
   }
 );
 
@@ -89,7 +91,9 @@ test('a failed PUT rejects the one-shot instead of leaving it pending', async ()
 
 test('a subscription error cancels its already scheduled timeout', async () => {
   const { client, initialPut, unsubscribe } = setup();
-  const once = client.subscribeOnce('a', '/once', undefined, 1000).catch((e) => e);
+  const once = client
+    .subscribeOnce('a', '/once', undefined, 1000)
+    .catch((e) => e);
   const entry = (client as any).outstandingSubscriptions.get(1);
   initialPut.resolve(new Response(null, { status: 204 }));
   await vi.advanceTimersByTimeAsync(0);
@@ -101,7 +105,9 @@ test('a subscription error cancels its already scheduled timeout', async () => {
 
 test('an unanswered one-shot still times out and unsubscribes once', async () => {
   const { client, initialPut, unsubscribe } = setup();
-  const once = client.subscribeOnce('a', '/once', undefined, 1000).catch((e) => e);
+  const once = client
+    .subscribeOnce('a', '/once', undefined, 1000)
+    .catch((e) => e);
   const entry = (client as any).outstandingSubscriptions.get(1);
   initialPut.resolve(new Response(null, { status: 204 }));
   await vi.advanceTimersByTimeAsync(1000);

--- a/packages/api/src/client/landscapeApi.ts
+++ b/packages/api/src/client/landscapeApi.ts
@@ -21,9 +21,16 @@ export const getLandscapeAuthCookie = async (
 export class AuthFailureError extends Error {
   public responseStatus: number;
   constructor(responseStatus: number) {
-    super(
-      `Authentication failed with status ${responseStatus}. Is your access code correct?`
-    );
+    // eyre answers 400 when the code itself is wrong, and 401 when the request
+    // carried a session cookie it no longer recognizes (it expires that
+    // cookie in the response); only the former says anything about the code
+    const hint =
+      responseStatus === 400
+        ? 'The access code was rejected.'
+        : responseStatus === 401
+          ? 'The ship rejected a stale session cookie.'
+          : 'Unexpected response from the ship.';
+    super(`Authentication failed with status ${responseStatus}. ${hint}`);
     this.name = 'AuthFailureError';
     this.responseStatus = responseStatus;
   }

--- a/packages/api/src/client/urbit.ts
+++ b/packages/api/src/client/urbit.ts
@@ -3,6 +3,7 @@ import _ from 'lodash';
 
 import {
   AuthError,
+  ChannelPutError,
   ChannelStatus,
   NounPokeInterface,
   Thread,
@@ -330,6 +331,36 @@ function printEndpoint(endpoint: UrbitEndpoint) {
   return `${endpoint.app}${endpoint.path}`;
 }
 
+// Error instances serialize to `{}` once they reach analytics, so pull the
+// useful bits out. `error` is what the debug logger knows how to unpack into
+// errorMessage/errorStack; the rest covers eyre's string nacks and Responses.
+function describeError(err: unknown) {
+  const shaped = err as { name?: unknown; status?: unknown } | null | undefined;
+  return {
+    error: err instanceof Error ? err : undefined,
+    rawError: err instanceof Error ? undefined : String(err),
+    errorName: typeof shaped?.name === 'string' ? shaped.name : undefined,
+    errorStatus: typeof shaped?.status === 'number' ? shaped.status : undefined,
+  };
+}
+
+// Eyre binds each channel to the identity that created it and 403s any PUT
+// from another identity. We hit this when a channel was opened before login
+// (as a guest) and reused after, or after a session change. The channel id is
+// unrecoverable; mint a new one so the caller's retry lands on a fresh channel.
+function isChannelIdentityMismatch(err: unknown): err is ChannelPutError {
+  return err instanceof ChannelPutError && err.status === 403;
+}
+
+function rotateChannel(client: Urbit, context: string) {
+  logger.log('rotating channel', context);
+  logger.trackEvent(AnalyticsEvent.NodeConnectionDebug, {
+    context: 'channel rotated',
+    reason: context,
+  });
+  client.seamlessReset();
+}
+
 export async function subscribe<T>(
   endpoint: UrbitEndpoint,
   handler: (update: T, id?: number) => void
@@ -379,9 +410,10 @@ export async function subscribe<T>(
         config.onQuitOrReset?.('subscriptionQuit', printEndpoint(endpoint));
       },
       err: (error, id) => {
-        logger.trackError(`subscribe error on ${printEndpoint(endpoint)}`, {
-          stack: error,
-        });
+        logger.trackError(
+          `subscribe error on ${printEndpoint(endpoint)}`,
+          describeError(error)
+        );
 
         if (err) {
           logger.log(
@@ -396,11 +428,15 @@ export async function subscribe<T>(
 
   const retry = async (err: any) => {
     logger.error('bad subscribe', printEndpoint(endpoint), err);
+    if (config.client && isChannelIdentityMismatch(err)) {
+      rotateChannel(config.client, `subscribe ${printEndpoint(endpoint)}`);
+      return doSub(retry);
+    }
     if (!(err instanceof AuthError)) {
       throw err;
     }
 
-    config.pendingAuth = reauth();
+    await reauth();
     // keep the err handler wired so the re-established subscription can
     // recover from a later auth death the same way the initial one does
     return doSub(retry);
@@ -436,7 +472,7 @@ export async function subscribeOnce<T>(
   } catch (err) {
     if (err !== 'timeout' && err !== 'quit') {
       logger.trackError(`bad subscribeOnce ${printEndpoint(endpoint)}`, {
-        stack: err,
+        ...describeError(err),
       });
     } else if (err === 'timeout') {
       logger.error('subscribeOnce timed out', printEndpoint(endpoint));
@@ -498,21 +534,35 @@ export async function pokeNoun<T>({ app, mark, noun }: NounPokeParams) {
       noun,
     });
   };
+  const fail = (err: any) => {
+    logger.trackError(
+      `NOUN POKE: bad poke to ${app} with mark ${mark}`,
+      describeError(err)
+    );
+    throw err;
+  };
   const retry = async (err: any) => {
-    logger.trackError(`NOUN POKE: bad poke to ${app} with mark ${mark}`, {
-      stack: err,
-      noun: noun,
-    });
-    if (!(err instanceof AuthError)) {
-      throw err;
+    if (!config.client) {
+      return fail(err);
     }
-
-    await reauth();
-    return doPoke();
+    if (isChannelIdentityMismatch(err)) {
+      rotateChannel(config.client, `noun poke ${app}/${mark}`);
+    } else if (err instanceof AuthError) {
+      await reauth();
+    } else {
+      return fail(err);
+    }
+    try {
+      return await doPoke();
+    } catch (retryErr) {
+      return fail(retryErr);
+    }
   };
 
   try {
-    return await doPoke({ onError: retry });
+    // the http-api client rejects the promise on failure, so a separate
+    // onError handler would run the retry a second time
+    return await doPoke();
   } catch (err) {
     return retry(err);
   }
@@ -534,18 +584,31 @@ export async function poke({ app, mark, json }: PokeParams) {
     }
     return activeClient.poke({ app, mark, json });
   };
-  const retry = async (err: any) => {
+  const fail = (err: any) => {
     logger.trackError(`bad poke to ${app} with mark ${mark}`, {
-      stack: err,
+      ...describeError(err),
       body: json,
     });
-    if (!(err instanceof AuthError) || activeClient !== config.client) {
-      trackDuration('error');
-      throw err;
+    trackDuration('error');
+    throw err;
+  };
+  const retry = async (err: any) => {
+    // scoped (non-singleton) clients own their own auth; don't touch them
+    if (!activeClient || activeClient !== config.client) {
+      return fail(err);
     }
-
-    await reauth();
-    return doPoke();
+    if (isChannelIdentityMismatch(err)) {
+      rotateChannel(activeClient, `poke ${app}/${mark}`);
+    } else if (err instanceof AuthError) {
+      await reauth();
+    } else {
+      return fail(err);
+    }
+    try {
+      return await doPoke();
+    } catch (retryErr) {
+      return fail(retryErr);
+    }
   };
 
   try {
@@ -922,69 +985,80 @@ async function reauth() {
     throw new Error('Unable to authenticate with urbit');
   }
 
-  if (config.pendingAuth) {
-    return config.pendingAuth;
-  }
-
-  try {
-    let tries = 0;
-    logger.log('getting urbit code');
-    const code = await config.getCode();
-    config.pendingAuth = new Promise<string>((resolve, reject) => {
-      const tryAuth = async () => {
-        try {
-          logger.log('trying to auth with code', code);
-          const authCookie = await getLandscapeAuthCookie(config.shipUrl, code);
-
-          if (!authCookie && tries < 3) {
-            logger.log('auth failed, trying again', tries);
-            tries++;
-            setTimeout(tryAuth, 1000 + 2 ** tries * 1000);
-            return;
-          }
-
-          if (!authCookie) {
-            config.pendingAuth = null;
-            if (config.handleAuthFailure) {
-              logger.log('auth failed, calling auth failure handler');
-              config.handleAuthFailure({ mustLogout: false });
-            }
-
-            reject(new Error("Couldn't authenticate with urbit"));
-            return;
-          }
-
-          if (config.client) {
-            config.client.cookie = authCookie;
-          }
-
-          config.pendingAuth = null;
-          resolve(authCookie);
-          return;
-        } catch (e) {
-          if (e instanceof AuthFailureError && e.responseStatus === 400) {
-            // the info we tried to reauth with is invalid, it's not going to work and they need to logout
-            config.pendingAuth = null;
-            config.loggingOut = true;
-            config.handleAuthFailure?.({ mustLogout: true });
-            return;
-          }
-          reject(new Error(`Error during reauth: ${e}`));
-        }
-      };
-
-      tryAuth();
+  // Dedupe synchronously, before anything is awaited: every caller that shows
+  // up while a reauth is in flight shares it. Concurrent logins are actively
+  // harmful, since eyre closes the session a login request arrives with, so
+  // parallel logins invalidate each other and all but one come back 401.
+  if (!config.pendingAuth) {
+    config.pendingAuth = performReauth().finally(() => {
+      config.pendingAuth = null;
     });
+  }
+  return config.pendingAuth;
+}
 
-    return await config.pendingAuth;
+const MAX_LOGIN_ATTEMPTS = 4;
+
+async function performReauth(): Promise<string | void> {
+  let code: string;
+  try {
+    logger.log('getting urbit code');
+    code = await config.getCode!();
   } catch (e) {
     logger.error('error getting urbit code', e);
-    config.pendingAuth = null;
     if (config.handleAuthFailure) {
       return config.handleAuthFailure({ mustLogout: false });
     }
-
     throw e;
+  }
+
+  for (let attempt = 0; ; attempt++) {
+    const lastAttempt = attempt >= MAX_LOGIN_ATTEMPTS - 1;
+    let authCookie: string | undefined;
+    try {
+      logger.log('trying to auth with code', code);
+      authCookie = await getLandscapeAuthCookie(config.shipUrl, code);
+    } catch (e) {
+      if (e instanceof AuthFailureError && e.responseStatus === 400) {
+        // the code itself was rejected; no retry will fix that, so log out
+        config.loggingOut = true;
+        config.handleAuthFailure?.({ mustLogout: true });
+        return;
+      }
+      // a 401 means the request carried a session cookie the ship no longer
+      // recognizes; the response expires it, so a retry can go through clean
+      const staleCookie =
+        e instanceof AuthFailureError && e.responseStatus === 401;
+      if (!staleCookie || lastAttempt) {
+        throw new Error(`Error during reauth: ${e}`);
+      }
+    }
+
+    if (authCookie) {
+      if (config.client) {
+        config.client.cookie = authCookie;
+        // logging in moved us to a new session. any channel we opened under
+        // the old one is either gone (eyre closed the old session's channels)
+        // or bound to an identity that is no longer ours, so start fresh
+        // before waiters retry against it
+        if (config.client.channelOpened) {
+          rotateChannel(config.client, 'reauth');
+        }
+      }
+      return authCookie;
+    }
+
+    if (lastAttempt) {
+      if (config.handleAuthFailure) {
+        logger.log('auth failed, calling auth failure handler');
+        config.handleAuthFailure({ mustLogout: false });
+      }
+      throw new Error("Couldn't authenticate with urbit");
+    }
+    logger.log('auth failed, trying again', attempt);
+    await new Promise((resolve) =>
+      setTimeout(resolve, 1000 + 2 ** (attempt + 1) * 1000)
+    );
   }
 }
 

--- a/packages/api/src/client/urbit.ts
+++ b/packages/api/src/client/urbit.ts
@@ -5,6 +5,7 @@ import {
   AuthError,
   ChannelPutError,
   ChannelStatus,
+  ReapError,
   NounPokeInterface,
   Thread,
   Urbit,
@@ -380,6 +381,20 @@ function captureSendContext(client: Urbit | null): SendContext {
   return { authEpoch: config.authEpoch, channelId: client?.channelId };
 }
 
+// A poke that was outstanding when the channel rotated is rejected with a
+// ReapError; the channel it targeted is gone but nothing is wrong with the
+// request, so it should simply go again on the new channel.
+function rotatedUnderneath(
+  err: unknown,
+  client: Urbit,
+  sent: SendContext
+): boolean {
+  if (sent.channelId === undefined || client.channelId === sent.channelId) {
+    return false;
+  }
+  return err instanceof ReapError || (err as any)?.name === 'AbortError';
+}
+
 function rotateChannelOnce(client: Urbit, sent: SendContext, context: string) {
   if (sent.channelId !== undefined && client.channelId !== sent.channelId) {
     logger.log('channel already rotated, retrying', context);
@@ -592,6 +607,8 @@ export async function pokeNoun<T>({ app, mark, noun }: NounPokeParams) {
       rotateChannelOnce(config.client, sent, `noun poke ${app}/${mark}`);
     } else if (err instanceof AuthError) {
       await reauthOnce(sent);
+    } else if (rotatedUnderneath(err, config.client, sent)) {
+      logger.log('channel rotated during noun poke, retrying', app, mark);
     } else {
       return fail(err);
     }
@@ -646,6 +663,8 @@ export async function poke({ app, mark, json }: PokeParams) {
       rotateChannelOnce(activeClient, sent, `poke ${app}/${mark}`);
     } else if (err instanceof AuthError) {
       await reauthOnce(sent);
+    } else if (rotatedUnderneath(err, activeClient, sent)) {
+      logger.log('channel rotated during poke, retrying', app, mark);
     } else {
       return fail(err);
     }

--- a/packages/api/src/client/urbit.ts
+++ b/packages/api/src/client/urbit.ts
@@ -1077,6 +1077,12 @@ async function performReauth(): Promise<string | void> {
       const staleCookie =
         e instanceof AuthFailureError && e.responseStatus === 401;
       if (!staleCookie || lastAttempt) {
+        if (staleCookie && config.handleAuthFailure) {
+          // we are out of retries with a cookie the ship keeps rejecting; let
+          // the app decide what an unrecoverable session means for it
+          logger.log('auth failed, calling auth failure handler');
+          config.handleAuthFailure({ mustLogout: false });
+        }
         throw new Error(`Error during reauth: ${e}`);
       }
     }

--- a/packages/api/src/client/urbit.ts
+++ b/packages/api/src/client/urbit.ts
@@ -28,6 +28,9 @@ interface Config extends Pick<
   client: Urbit | null;
   subWatchers: Watchers;
   pendingAuth: Promise<string | void> | null;
+  // bumped on every successful reauth so a request that failed while a
+  // reauth was already in flight can retry without starting another one
+  authEpoch: number;
   loggingOut: boolean;
   lastStatus: string;
   activitySupportsReactions: boolean;
@@ -111,6 +114,7 @@ const config: Config = {
   shipUrl: '',
   subWatchers: {},
   pendingAuth: null,
+  authEpoch: 0,
   loggingOut: false,
   onQuitOrReset: undefined,
   getCode: undefined,
@@ -252,6 +256,9 @@ export function internalConfigureClient({
   config.client.verbose = verbose;
   config.client.nodeId = preSig(shipName);
   config.shipUrl = shipUrl;
+  // a fresh configuration is a fresh session; a forced logout on the previous
+  // one must not leave reauth disabled for this one
+  config.loggingOut = false;
   config.onQuitOrReset = onQuitOrReset;
   config.getCode = getCode;
   config.handleAuthFailure = handleAuthFailure;
@@ -361,10 +368,39 @@ function rotateChannel(client: Urbit, context: string) {
   client.seamlessReset();
 }
 
+// What a request saw when it went out. Several requests fail together when a
+// channel or session dies, and only the first one to come back should fix it;
+// the rest just retry against whatever the fix produced.
+interface SendContext {
+  authEpoch: number;
+  channelId: string | undefined;
+}
+
+function captureSendContext(client: Urbit | null): SendContext {
+  return { authEpoch: config.authEpoch, channelId: client?.channelId };
+}
+
+function rotateChannelOnce(client: Urbit, sent: SendContext, context: string) {
+  if (sent.channelId !== undefined && client.channelId !== sent.channelId) {
+    logger.log('channel already rotated, retrying', context);
+    return;
+  }
+  rotateChannel(client, context);
+}
+
+async function reauthOnce(sent: SendContext) {
+  if (config.authEpoch !== sent.authEpoch) {
+    logger.log('session already refreshed, retrying');
+    return;
+  }
+  await reauth();
+}
+
 export async function subscribe<T>(
   endpoint: UrbitEndpoint,
   handler: (update: T, id?: number) => void
 ): Promise<number> {
+  let sent = captureSendContext(config.client);
   const doSub = async (err?: (error: any, id: string) => void) => {
     if (!config.client) {
       throw new Error('Client not initialized');
@@ -373,6 +409,7 @@ export async function subscribe<T>(
       await config.pendingAuth;
     }
     logger.log('subscribing to', printEndpoint(endpoint));
+    sent = captureSendContext(config.client);
     return config.client.subscribe({
       app: endpoint.app,
       path: endpoint.path,
@@ -429,14 +466,18 @@ export async function subscribe<T>(
   const retry = async (err: any) => {
     logger.error('bad subscribe', printEndpoint(endpoint), err);
     if (config.client && isChannelIdentityMismatch(err)) {
-      rotateChannel(config.client, `subscribe ${printEndpoint(endpoint)}`);
+      rotateChannelOnce(
+        config.client,
+        sent,
+        `subscribe ${printEndpoint(endpoint)}`
+      );
       return doSub(retry);
     }
     if (!(err instanceof AuthError)) {
       throw err;
     }
 
-    await reauth();
+    await reauthOnce(sent);
     // keep the err handler wired so the re-established subscription can
     // recover from a later auth death the same way the initial one does
     return doSub(retry);
@@ -519,6 +560,7 @@ export async function unsubscribe(id: number) {
 }
 
 export async function pokeNoun<T>({ app, mark, noun }: NounPokeParams) {
+  let sent = captureSendContext(config.client);
   const doPoke = async (params?: Partial<NounPokeInterface>) => {
     if (!config.client) {
       throw new Error('Client not initialized');
@@ -527,6 +569,7 @@ export async function pokeNoun<T>({ app, mark, noun }: NounPokeParams) {
       await config.pendingAuth;
     }
     logger.log('noun poke', { app, mark });
+    sent = captureSendContext(config.client);
     return config.client.pokeNoun({
       ...params,
       app,
@@ -546,9 +589,9 @@ export async function pokeNoun<T>({ app, mark, noun }: NounPokeParams) {
       return fail(err);
     }
     if (isChannelIdentityMismatch(err)) {
-      rotateChannel(config.client, `noun poke ${app}/${mark}`);
+      rotateChannelOnce(config.client, sent, `noun poke ${app}/${mark}`);
     } else if (err instanceof AuthError) {
-      await reauth();
+      await reauthOnce(sent);
     } else {
       return fail(err);
     }
@@ -575,6 +618,7 @@ export async function poke({ app, mark, json }: PokeParams) {
     mark,
   });
   const activeClient = resolveClient();
+  let sent = captureSendContext(activeClient);
   const doPoke = async () => {
     if (!activeClient) {
       throw new Error('Client not initialized');
@@ -582,6 +626,7 @@ export async function poke({ app, mark, json }: PokeParams) {
     if (activeClient === config.client && config.pendingAuth) {
       await config.pendingAuth;
     }
+    sent = captureSendContext(activeClient);
     return activeClient.poke({ app, mark, json });
   };
   const fail = (err: any) => {
@@ -598,9 +643,9 @@ export async function poke({ app, mark, json }: PokeParams) {
       return fail(err);
     }
     if (isChannelIdentityMismatch(err)) {
-      rotateChannel(activeClient, `poke ${app}/${mark}`);
+      rotateChannelOnce(activeClient, sent, `poke ${app}/${mark}`);
     } else if (err instanceof AuthError) {
-      await reauth();
+      await reauthOnce(sent);
     } else {
       return fail(err);
     }
@@ -777,6 +822,7 @@ export async function scry<T>({
     path: redactPath(path),
     shouldTimeoutAfter: timeout ?? DEFAULT_SCRY_TIMEOUT,
   });
+  const sent = captureSendContext(activeClient);
   try {
     const { result, responseSizeInBytes, responseStatus } =
       await activeClient.scryWithInfo<T>({
@@ -790,7 +836,7 @@ export async function scry<T>({
     logger.log('bad scry', app, path, res.status);
     if (res.status === 403 && activeClient === config.client) {
       logger.log('scry failed with 403, authing to try again');
-      await reauth();
+      await reauthOnce(sent);
       const { result, responseSizeInBytes, responseStatus } =
         await activeClient.scryWithInfo<T>({ app, path });
       trackDuration('success', { responseSizeInBytes, responseStatus });
@@ -825,6 +871,7 @@ export async function requestJson<T = any>(
     await config.pendingAuth;
   }
   const reauthStatuses = options.reauthStatuses ?? [403];
+  const sent = captureSendContext(activeClient);
   const send = () =>
     options.signal
       ? activeClient.requestJson<T>(path, method, body, {
@@ -842,7 +889,7 @@ export async function requestJson<T = any>(
       activeClient === config.client &&
       reauthStatuses.includes(res?.status)
     ) {
-      await reauth();
+      await reauthOnce(sent);
       return await send();
     }
     const errorBody = await responseErrorBody(res);
@@ -1035,6 +1082,7 @@ async function performReauth(): Promise<string | void> {
     }
 
     if (authCookie) {
+      config.authEpoch += 1;
       if (config.client) {
         config.client.cookie = authCookie;
         // logging in moved us to a new session. any channel we opened under

--- a/packages/api/src/client/urbit.ts
+++ b/packages/api/src/client/urbit.ts
@@ -5,7 +5,6 @@ import {
   AuthError,
   ChannelPutError,
   ChannelStatus,
-  ReapError,
   NounPokeInterface,
   Thread,
   Urbit,
@@ -381,20 +380,6 @@ function captureSendContext(client: Urbit | null): SendContext {
   return { authEpoch: config.authEpoch, channelId: client?.channelId };
 }
 
-// A poke that was outstanding when the channel rotated is rejected with a
-// ReapError; the channel it targeted is gone but nothing is wrong with the
-// request, so it should simply go again on the new channel.
-function rotatedUnderneath(
-  err: unknown,
-  client: Urbit,
-  sent: SendContext
-): boolean {
-  if (sent.channelId === undefined || client.channelId === sent.channelId) {
-    return false;
-  }
-  return err instanceof ReapError || (err as any)?.name === 'AbortError';
-}
-
 function rotateChannelOnce(client: Urbit, sent: SendContext, context: string) {
   if (sent.channelId !== undefined && client.channelId !== sent.channelId) {
     logger.log('channel already rotated, retrying', context);
@@ -607,9 +592,8 @@ export async function pokeNoun<T>({ app, mark, noun }: NounPokeParams) {
       rotateChannelOnce(config.client, sent, `noun poke ${app}/${mark}`);
     } else if (err instanceof AuthError) {
       await reauthOnce(sent);
-    } else if (rotatedUnderneath(err, config.client, sent)) {
-      logger.log('channel rotated during noun poke, retrying', app, mark);
     } else {
+      // a ReapError here may mean the ship already took the poke; don't resend
       return fail(err);
     }
     try {
@@ -663,9 +647,10 @@ export async function poke({ app, mark, json }: PokeParams) {
       rotateChannelOnce(activeClient, sent, `poke ${app}/${mark}`);
     } else if (err instanceof AuthError) {
       await reauthOnce(sent);
-    } else if (rotatedUnderneath(err, activeClient, sent)) {
-      logger.log('channel rotated during poke, retrying', app, mark);
     } else {
+      // this includes a ReapError from a rotation that swept the poke while
+      // its PUT was in flight: the ship may have taken it, so it must not be
+      // sent again here. the caller decides whether to retry.
       return fail(err);
     }
     try {

--- a/packages/api/src/http-api/Urbit.ts
+++ b/packages/api/src/http-api/Urbit.ts
@@ -745,13 +745,25 @@ export class Urbit {
   ) {
     return new Promise<T>((resolve, reject) => {
       let done = false;
-      const quit = () => {
-        if (!done) {
-          reject('quit');
+      let timer: ReturnType<typeof setTimeout> | undefined;
+      const finish = () => {
+        if (done) {
+          return false;
+        }
+        // A reset can reuse this subscription's id. Once settled, neither a
+        // late PUT nor an existing timeout may unsubscribe that replacement.
+        done = true;
+        clearTimeout(timer);
+        return true;
+      };
+      const fail = (error: unknown) => {
+        if (finish()) {
+          reject(error);
         }
       };
+      const quit = () => fail('quit');
       const event = (e: T, mark: string, id: number) => {
-        if (!done) {
+        if (finish()) {
           resolve(e);
           this.unsubscribe(id);
         }
@@ -762,21 +774,23 @@ export class Urbit {
         ship,
         resubOnQuit: false,
         event,
-        err: reject,
+        err: fail,
         quit,
       };
 
-      this.subscribe(request).then((subId) => {
-        if (timeout) {
-          setTimeout(() => {
-            if (!done) {
-              done = true;
-              reject('timeout');
-              this.unsubscribe(subId);
-            }
-          }, timeout);
-        }
-      });
+      this.subscribe(request).then(
+        (subId) => {
+          if (timeout && !done) {
+            timer = setTimeout(() => {
+              if (finish()) {
+                reject('timeout');
+                this.unsubscribe(subId);
+              }
+            }, timeout);
+          }
+        },
+        fail
+      );
     });
   }
 

--- a/packages/api/src/http-api/Urbit.ts
+++ b/packages/api/src/http-api/Urbit.ts
@@ -404,6 +404,7 @@ export class Urbit {
       return;
     }
     this.sseClientInitialized = true;
+    const signal = this.sseAbort.signal;
     return new Promise((resolve, reject) => {
       const sseOptions: SSEOptions = {
         headers: {},
@@ -411,9 +412,18 @@ export class Urbit {
       if (isBrowser) {
         sseOptions.withCredentials = true;
       }
+      // a rotation that aborts this stream before it opens would otherwise
+      // leave anyone awaiting the channel setup hanging; fetchEventSource
+      // resolves on abort without calling any of the handlers below
+      signal.addEventListener(
+        'abort',
+        () =>
+          reject(new ReapError('Channel rotated before event source opened')),
+        { once: true }
+      );
       fetchEventSource(this.channelUrl, {
         ...this.fetchOptions,
-        signal: this.sseAbort.signal,
+        signal,
         reactNative: { textStreaming: true },
         openWhenHidden: true,
         responseTimeout: 25000,

--- a/packages/api/src/http-api/Urbit.ts
+++ b/packages/api/src/http-api/Urbit.ts
@@ -118,6 +118,22 @@ export class Urbit {
   private channelAbort = new AbortController();
 
   /**
+   * Abort controller for the event source alone, so a channel rotation can
+   * drop the old stream's reconnect loop without cancelling PUTs in flight
+   */
+  private sseAbort = new AbortController();
+
+  /**
+   * Subscriptions replayed onto a new channel by +seamlessReset, keyed by the
+   * entry they replaced. A subscribe whose PUT was still in flight during the
+   * rotation resolves to its replacement instead of failing.
+   */
+  private replayedSubscriptions = new WeakMap<
+    SubscriptionRequestInterface,
+    Promise<number>
+  >();
+
+  /**
    * Identity of the ship we're connected to
    */
   nodeId?: string | null;
@@ -397,7 +413,7 @@ export class Urbit {
       }
       fetchEventSource(this.channelUrl, {
         ...this.fetchOptions,
-        signal: this.channelAbort.signal,
+        signal: this.sseAbort.signal,
         reactNative: { textStreaming: true },
         openWhenHidden: true,
         responseTimeout: 25000,
@@ -565,9 +581,11 @@ export class Urbit {
     // called if a channel was reaped by %eyre before we reconnected, or if
     // our session can no longer use it, so we have to make a new channel.
     // drop the old channel's event source first: its reconnect loop keeps
-    // the old channel url and would otherwise retry it forever
-    this.channelAbort.abort();
-    this.channelAbort = new AbortController();
+    // the old channel url and would otherwise retry it forever. PUTs still in
+    // flight are left alone; they fail or succeed on their own and their
+    // callers handle the rotation
+    this.sseAbort.abort();
+    this.sseAbort = new AbortController();
     this.uid = `${Math.floor(Date.now() / 1000)}-${hexString(6)}`;
     this.emit('seamless-reset', { uid: this.uid });
     this.emit('status-update', { status: 'initial' });
@@ -588,7 +606,9 @@ export class Urbit {
       });
 
       if (sub.resubOnQuit) {
-        this.subscribe(sub);
+        const replay = this.subscribe(sub);
+        replay.catch(() => {});
+        this.replayedSubscriptions.set(sub, replay);
       }
     });
 
@@ -885,10 +905,17 @@ export class Urbit {
     try {
       await this.sendJSONtoChannel(message);
     } catch (err) {
-      // the ship never saw this subscription, so don't let a later channel
-      // reset resubscribe it on the caller's behalf; the caller retries.
-      // a reset while this PUT was pending restarts the id sequence, so the
-      // slot may already belong to a live subscription on the new channel
+      // a reset while this PUT was pending has already replayed us onto the
+      // new channel; hand the caller that subscription rather than failing
+      const replay = this.replayedSubscriptions.get(entry);
+      if (replay) {
+        this.replayedSubscriptions.delete(entry);
+        return replay;
+      }
+      // otherwise the ship never saw this subscription, so don't let a later
+      // channel reset resubscribe it on the caller's behalf; the caller
+      // retries. a reset restarts the id sequence, so the slot may already
+      // belong to a live subscription on the new channel
       if (this.outstandingSubscriptions.get(message.id) === entry) {
         this.outstandingSubscriptions.delete(message.id);
         this.emit('subscription', { id: message.id, status: 'close' });
@@ -924,6 +951,8 @@ export class Urbit {
   async delete() {
     this.channelAbort.abort();
     this.channelAbort = new AbortController();
+    this.sseAbort.abort();
+    this.sseAbort = new AbortController();
     const body = JSON.stringify([
       {
         id: this.getEventId(),

--- a/packages/api/src/http-api/Urbit.ts
+++ b/packages/api/src/http-api/Urbit.ts
@@ -10,6 +10,7 @@ import { EventSourceMessage, fetchEventSource } from './fetch-event-source';
 import {
   Ack,
   AuthError,
+  ChannelPutError,
   AuthenticationInterface,
   FatalError,
   Message,
@@ -140,6 +141,14 @@ export class Urbit {
    * Custom fetch implementation to use.
    */
   fetchFn: typeof fetch = (...args) => fetch(...args);
+
+  /**
+   * Whether anything has been sent over the current channel id yet. Once true,
+   * the ship has a channel bound to whatever identity we had at the time.
+   */
+  get channelOpened(): boolean {
+    return this.lastEventId > 0;
+  }
 
   /** This is basic interpolation to get the channel URL of an instantiated Urbit connection. */
   private get channelUrl(): string {
@@ -645,7 +654,7 @@ export class Urbit {
     });
 
     if (!response.ok) {
-      throw new Error('Failed to PUT channel');
+      throw new ChannelPutError(response.status);
     }
     if (!this.sseClientInitialized) {
       if (this.verbose) {
@@ -860,7 +869,15 @@ export class Urbit {
       status: 'open',
     });
 
-    await this.sendJSONtoChannel(message);
+    try {
+      await this.sendJSONtoChannel(message);
+    } catch (err) {
+      // the ship never saw this subscription, so don't let a later channel
+      // reset resubscribe it on the caller's behalf; the caller retries
+      this.outstandingSubscriptions.delete(message.id);
+      this.emit('subscription', { id: message.id, status: 'close' });
+      throw err;
+    }
 
     return message.id;
   }

--- a/packages/api/src/http-api/Urbit.ts
+++ b/packages/api/src/http-api/Urbit.ts
@@ -638,7 +638,7 @@ export class Urbit {
     });
     if (!response.ok) {
       console.log(response.status, response.statusText, await response.text());
-      throw new Error('Failed to PUT channel command(s)');
+      throw new ChannelPutError(response.status);
     }
     if (!this.sseClientInitialized) {
       if (this.verbose) {
@@ -865,14 +865,15 @@ export class Urbit {
       path,
     };
 
-    this.outstandingSubscriptions.set(message.id, {
+    const entry: SubscriptionRequestInterface = {
       app,
       path,
       resubOnQuit,
       err,
       event,
       quit,
-    });
+    };
+    this.outstandingSubscriptions.set(message.id, entry);
 
     this.emit('subscription', {
       id: message.id,
@@ -885,9 +886,13 @@ export class Urbit {
       await this.sendJSONtoChannel(message);
     } catch (err) {
       // the ship never saw this subscription, so don't let a later channel
-      // reset resubscribe it on the caller's behalf; the caller retries
-      this.outstandingSubscriptions.delete(message.id);
-      this.emit('subscription', { id: message.id, status: 'close' });
+      // reset resubscribe it on the caller's behalf; the caller retries.
+      // a reset while this PUT was pending restarts the id sequence, so the
+      // slot may already belong to a live subscription on the new channel
+      if (this.outstandingSubscriptions.get(message.id) === entry) {
+        this.outstandingSubscriptions.delete(message.id);
+        this.emit('subscription', { id: message.id, status: 'close' });
+      }
       throw err;
     }
 

--- a/packages/api/src/http-api/Urbit.ts
+++ b/packages/api/src/http-api/Urbit.ts
@@ -836,9 +836,13 @@ export class Urbit {
     return new Promise((resolve, reject) => {
       const cleanup = () => {
         clearTimeout(ackTimer);
-        this.outstandingPokes.delete(message.id);
+        // A reset reuses numeric ids while old PUTs can still finish. Only
+        // remove this poke, not a replacement that now occupies its slot.
+        if (this.outstandingPokes.get(message.id) === entry) {
+          this.outstandingPokes.delete(message.id);
+        }
       };
-      this.outstandingPokes.set(message.id, {
+      const entry: PokeHandlers = {
         onSuccess: () => {
           cleanup();
           onSuccess();
@@ -849,7 +853,8 @@ export class Urbit {
           onError(err);
           reject(err);
         },
-      });
+      };
+      this.outstandingPokes.set(message.id, entry);
 
       const ackTimer = setTimeout(() => {
         cleanup();

--- a/packages/api/src/http-api/Urbit.ts
+++ b/packages/api/src/http-api/Urbit.ts
@@ -150,6 +150,14 @@ export class Urbit {
     return this.lastEventId > 0;
   }
 
+  /**
+   * The current channel id. Changes on every reset, so a caller can tell
+   * whether the channel it sent on is still the live one.
+   */
+  get channelId(): string {
+    return this.uid;
+  }
+
   /** This is basic interpolation to get the channel URL of an instantiated Urbit connection. */
   private get channelUrl(): string {
     return `${this.url}/~/channel/${this.uid}`;
@@ -554,8 +562,12 @@ export class Urbit {
   }
 
   seamlessReset() {
-    // called if a channel was reaped by %eyre before we reconnected
-    // so we have to make a new channel.
+    // called if a channel was reaped by %eyre before we reconnected, or if
+    // our session can no longer use it, so we have to make a new channel.
+    // drop the old channel's event source first: its reconnect loop keeps
+    // the old channel url and would otherwise retry it forever
+    this.channelAbort.abort();
+    this.channelAbort = new AbortController();
     this.uid = `${Math.floor(Date.now() / 1000)}-${hexString(6)}`;
     this.emit('seamless-reset', { uid: this.uid });
     this.emit('status-update', { status: 'initial' });

--- a/packages/api/src/http-api/Urbit.ts
+++ b/packages/api/src/http-api/Urbit.ts
@@ -902,25 +902,32 @@ export class Urbit {
       status: 'open',
     });
 
+    let putError: unknown = null;
     try {
       await this.sendJSONtoChannel(message);
     } catch (err) {
-      // a reset while this PUT was pending has already replayed us onto the
-      // new channel; hand the caller that subscription rather than failing
-      const replay = this.replayedSubscriptions.get(entry);
-      if (replay) {
-        this.replayedSubscriptions.delete(entry);
-        return replay;
-      }
-      // otherwise the ship never saw this subscription, so don't let a later
-      // channel reset resubscribe it on the caller's behalf; the caller
-      // retries. a reset restarts the id sequence, so the slot may already
-      // belong to a live subscription on the new channel
+      putError = err;
+    }
+
+    // a reset while this PUT was pending has already replayed us onto the new
+    // channel with a new id. whether the stale PUT then failed or landed on
+    // the abandoned channel, the replay is the subscription the caller owns
+    const replay = this.replayedSubscriptions.get(entry);
+    if (replay) {
+      this.replayedSubscriptions.delete(entry);
+      return replay;
+    }
+
+    if (putError !== null) {
+      // the ship never saw this subscription, so don't let a later channel
+      // reset resubscribe it on the caller's behalf; the caller retries. a
+      // reset restarts the id sequence, so the slot may already belong to a
+      // live subscription on the new channel
       if (this.outstandingSubscriptions.get(message.id) === entry) {
         this.outstandingSubscriptions.delete(message.id);
         this.emit('subscription', { id: message.id, status: 'close' });
       }
-      throw err;
+      throw putError;
     }
 
     return message.id;

--- a/packages/api/src/http-api/Urbit.ts
+++ b/packages/api/src/http-api/Urbit.ts
@@ -778,19 +778,16 @@ export class Urbit {
         quit,
       };
 
-      this.subscribe(request).then(
-        (subId) => {
-          if (timeout && !done) {
-            timer = setTimeout(() => {
-              if (finish()) {
-                reject('timeout');
-                this.unsubscribe(subId);
-              }
-            }, timeout);
-          }
-        },
-        fail
-      );
+      this.subscribe(request).then((subId) => {
+        if (timeout && !done) {
+          timer = setTimeout(() => {
+            if (finish()) {
+              reject('timeout');
+              this.unsubscribe(subId);
+            }
+          }, timeout);
+        }
+      }, fail);
     });
   }
 

--- a/packages/api/src/http-api/types.ts
+++ b/packages/api/src/http-api/types.ts
@@ -248,6 +248,21 @@ export class ReapError extends Error {}
 
 export class AuthError extends Error {}
 
+/**
+ * A PUT to the channel endpoint came back non-2xx. Eyre answers 403 when the
+ * channel id already exists under a different identity (for example a channel
+ * created before login, as a guest, then reused after authenticating); the
+ * client must mint a new channel id to recover.
+ */
+export class ChannelPutError extends Error {
+  public status: number;
+  constructor(status: number) {
+    super('Failed to PUT channel');
+    this.name = 'ChannelPutError';
+    this.status = status;
+  }
+}
+
 export class SSETimeoutError extends Error {}
 
 export class SSEBadResponseError extends Error {


### PR DESCRIPTION
## Summary

A hosted user who reopens the native app after 30+ days idle has no eyre cookie left in the iOS jar. The client opened its eyre channel concurrently with the first scries, so eyre created the channel under a guest identity; once the 403-triggered reauth succeeded, every PUT to that channel id hit eyre's identity check and all pokes failed in ~45 ms until the app was killed (scries kept working). Separately, `reauth()` only assigned `pendingAuth` after awaiting `getCode()`, so every caller in that window ran its own `/~/login`; eyre closes the session a login arrives with, so parallel logins invalidated each other and all but one came back 401, which we reported as "Is your access code correct?".

Diagnosed on ~rillyx-tabtes on 2026-09-04 from PostHog `app_error`/`Poke` events plus the cluster's ingress-nginx access logs. The node was healthy throughout.

Fixes TLON-6470

## Changes

- `sendJSONtoChannel` throws `ChannelPutError` carrying the HTTP status instead of a bare `Error('Failed to PUT channel')`.
- `poke`, `pokeNoun`, and `subscribe` rotate the channel (`seamlessReset()`) and retry once on a 403 channel PUT. Other statuses surface as before; scoped (non-singleton) clients are left alone.
- `reauth()` dedupes synchronously before anything is awaited; a 401 login (stale cookie, which eyre expires in its response) is retried with the existing backoff; after a successful login the channel is rotated if anything had been sent on it, so waiters retry against a fresh channel under the new session.
- A failed subscribe PUT is removed from `outstandingSubscriptions` so a later reset does not replay it behind the caller's own retry.
- `pokeNoun` no longer passes `retry` as `onError` as well, which ran the retry twice.
- `AuthFailureError` explains 400 (code rejected) vs 401 (stale session cookie) instead of blaming the code.
- `trackError` payloads pass the `Error` under `error` (plus `rawError`, `errorName`, `errorStatus`) instead of `stack: err`, which serialized to `{}` in PostHog.
- Requests capture the auth epoch and channel id when they go out; a retry only rotates the channel or reauths if nothing changed since, so a burst of failures produces one login and one rotation instead of one each.
- `seamlessReset` now aborts the old channel's event source before minting a new channel id. Its reconnect loop kept the old URL and, after rotating away from a guest-owned channel, hit a 403 every 5s forever (same orphan existed after a channel reap).
- `config.loggingOut` is reset when a client is configured; it was never cleared after a forced logout, which disabled reauth for the rest of the JS session.
- A subscribe PUT that fails after a reset only removes the entry it inserted (the reset restarts the id sequence and replays subscriptions into the same slots). If the reset already replayed it, the caller gets the replayed subscription instead of a failure.
- The event source has its own abort controller, so a rotation drops only the old stream and leaves in-flight PUTs alone. A poke swept by a rotation still fails to its caller with `ReapError` (its PUT may have reached the ship, so it is never resent here); only a PUT the ship rejected with 403 is retried. A stale subscribe PUT that lands after a reset resolves to the replayed subscription either way.
- A rotation that aborts the event source before it opens rejects the pending `eventSource()` promise with `ReapError` instead of leaving the awaiting subscribe or noun poke hanging (fetchEventSource resolves on abort without calling any handler).
- `sendNounsToChannel` throws `ChannelPutError` too, so noun pokes reach the 403 recovery.
- Exhausting the 401 login retries calls `handleAuthFailure({ mustLogout: false })` before throwing.

## How did I test?

- `pnpm tsc` and `pnpm vitest run` in `packages/api`: 864 tests pass, 10 new in `src/__tests__/reauthChannel.test.ts` covering concurrent-reauth dedupe, no rotation when no channel was opened, the 401 retry, the 400 logout path, 403 rotation for poke and subscribe, non-403 passthrough, the real `Urbit` class surfacing the status, and the subscribe cleanup.
- Reproduced and verified end to end on the iOS simulator against a hosted ship (~tinren-pocben, Xcode 26.6 dev build). The returning-user state was induced by deleting the app's cookie jar (`Library/Cookies/*.binarycookies`) and relaunching, which is exactly what iOS does after eyre's 30-day `Max-Age` elapses.
  - develop: 7 logins in one burst, 5 rejected 401, every channel PUT 403, pokes still failing 20s+ later, connection never left `opening`. Also reproduced on a plain fresh hosted login with no cookie wipe.
  - this branch (final, `ea9ba27d`): 0 401s, connection `active` in 13–17s, pokes succeed, no orphaned 403 reconnect loop in the following 60s. Across three runs: 1–2 logins and 2–3 channel rotations. One rotation is unavoidable pre-login (concurrent cookie-less PUTs each get a distinct guest identity) and one follows the login. The occasional second login comes from a straggling unauthenticated response landing after login and re-setting a guest cookie in the iOS jar; the epoch guard keeps it to one extra login and it converges within a second.

Residual, out of scope here: the guest channel and the straggler race would both disappear if the app verified its session before the first channel PUT on launch (one extra round trip on cold start). The hosting-API `GET /v1/ships/<ship>` also fails on every dev-build launch, same as in the incident, and wasn't investigated.

## Risks and impact

- Safe to rollback without consulting PR author? (Yes)
- Affects important code area:
  - [ ] Onboarding
  - [x] State / providers
  - [x] Message sync
  - [ ] Channel display
  - [ ] Notifications
  - [ ] Other:

The post-reauth rotation fires `seamless-reset`, which already runs today on channel reaps and drives a resync via `handleDiscontinuity`. Reauth is rare (4 users in the last 3 days fleet-wide), so the added resyncs are few.

## Rollback plan

Revert the commit. No schema or protocol changes.

## Screenshots / videos

N/A

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XnPZe6jJfd7q2XwH6hB9Dr





