### PR TITLE
fix: prevent non-group channels from entering changed-post sync

### DIFF
--- a/packages/shared/src/store/sync/sync.test.ts
+++ b/packages/shared/src/store/sync/sync.test.ts
@@ -1,5 +1,6 @@
 import {
   StructuredChannelDescriptionPayload,
+  scry,
   toClientGroup,
 } from '@tloncorp/api';
 import '@tloncorp/api';
@@ -39,6 +40,7 @@ import {
   setupDatabaseTestSuite,
 } from '../../test/helpers';
 import rawGroupsInit2 from '../../test/init.json';
+import { syncQueue } from '../syncQueue';
 import {
   ensureDmInviteChannel,
   syncChannelWithBackoff,
@@ -49,6 +51,7 @@ import {
   syncPinnedItems,
   syncPosts,
   syncThreadPosts,
+  syncUpdatedPosts,
 } from './sync';
 import { syncContacts } from './syncContacts';
 
@@ -643,6 +646,58 @@ test('syncs thread posts', async () => {
   expect(posts.length).toEqual(
     Object.keys(channelPostWithRepliesData.seal.replies).length + 1
   );
+});
+
+test.each([
+  ['DM', '~pinser-botter-podfyl-parseb'],
+  ['group DM', '0v4.00000.qd4mk.d4htu.er4b8.eao21'],
+])('syncUpdatedPosts skips %s before queueing', async (_label, channelId) => {
+  const enqueue = vi.spyOn(syncQueue, 'add');
+  vi.mocked(scry).mockClear();
+  try {
+    await expect(
+      syncUpdatedPosts(
+        {
+          channelId,
+          startCursor: '1',
+          endCursor: '2',
+          afterTime: new Date(0),
+        },
+        { priority: 4 }
+      )
+    ).resolves.toBeUndefined();
+
+    expect(enqueue).not.toHaveBeenCalled();
+    expect(scry).not.toHaveBeenCalled();
+    expect(await db.getPosts()).toEqual([]);
+  } finally {
+    enqueue.mockRestore();
+  }
+});
+
+test('syncUpdatedPosts fetches and persists changed group-channel posts', async () => {
+  await db.insertChannels([{ id: channelId, type: 'chat' }]);
+  vi.mocked(scry).mockClear();
+  setScryOutput(rawChannelPostsData);
+
+  const response = await syncUpdatedPosts({
+    channelId,
+    startCursor: '1',
+    endCursor: '2',
+    afterTime: new Date(0),
+  });
+
+  expect(scry).toHaveBeenCalledOnce();
+  expect(scry).toHaveBeenCalledWith({
+    app: 'channels',
+    path: `/v4/${channelId}/posts/changes/1/2/~1970.1.1`,
+  });
+  expect(response?.posts.length).toBeGreaterThan(0);
+  const savedPosts = await db.getPosts();
+  expect(savedPosts.map((post) => post.id).sort()).toEqual(
+    response?.posts.map((post) => post.id).sort()
+  );
+  expect(savedPosts.every((post) => post.channelId === channelId)).toBe(true);
 });
 
 test('syncs groups, decoding structured description payloads', async () => {

--- a/packages/shared/src/store/sync/sync.ts
+++ b/packages/shared/src/store/sync/sync.ts
@@ -947,6 +947,12 @@ export async function syncUpdatedPosts(
   options: GetChangedPostsOptions,
   ctx?: SyncCtx
 ) {
+  // DMs and group DMs receive updates through syncLatestChanges. Reject
+  // cursor-bounded refreshes before they enter the group-channel sync queue.
+  if (!api.isGroupChannelId(options.channelId)) {
+    return;
+  }
+
   logger.log(
     'syncing updated posts',
     runIfDev(() => JSON.stringify(options))


### PR DESCRIPTION
## Summary

Prevent DM and group-DM IDs from reaching the group-only changed-posts endpoint, which rejects them with sync errors. The UI refresh path already filters these IDs; this adds the same protection at the sync entry point.

Fixes TLON-6476

## Changes

- Skip non-group channels in `syncUpdatedPosts` before adding work to the sync queue. DM and group-DM updates continue through the existing global changes-since feed.
- Add regression coverage for skipped DMs and group DMs, and successful fetching and persistence of changed group-channel posts.

## How did I test?

- Confirmed the new DM and group-DM tests reproduce the endpoint rejection before the fix.
- Ran `pnpm --filter @tloncorp/shared exec vitest run src/store/sync/sync.test.ts src/store/useChannelPosts/refresh.test.ts`: all 31 tests passed.
- Formatting and `git diff --check` passed. Targeted lint reported only existing warnings.

## Risks and impact

The change is limited to skipping unsupported cursor-bounded refresh requests. Group-channel syncing and the global changes feed retain their existing behavior. Sentry and PostHog error volume still need verification after release.

- Safe to rollback without consulting PR author? Yes
- Affects important code area:
  - [ ] Onboarding
  - [ ] State / providers
  - [x] Message sync
  - [ ] Channel display
  - [ ] Notifications
  - [ ] Other:

## Rollback plan

Revert this PR and release the reverted client. This removes the sync-entry guard and may allow unsupported requests to fail again.

## Screenshots / videos

Not applicable; no visual changes.
