### PR TITLE
runtime: remove explicit groups desk references

### DIFF
--- a/desk/app/channels-server.hoon
+++ b/desk/app/channels-server.hoon
@@ -1012,7 +1012,7 @@
       =/  groups
         .^  groups:v9:gv
           %gx
-          /(scot %p our.bowl)/groups/(scot %da now.bowl)/v2/groups/noun
+          /(scot %p our.bowl)/tlon/(scot %da now.bowl)/v2/groups/noun
         ==
       =+  group=(~(get by groups) group.new)
       ?~  group  |

--- a/desk/app/notes.hoon
+++ b/desk/app/notes.hoon
@@ -1034,7 +1034,7 @@
   |=  [grp=flag:n =flag:n who=ship]
   ^-  ?
   =/  gpath=path
-    /(scot %p our.bowl)/groups/(scot %da now.bowl)/v2/groups/(scot %p ship.grp)/[name.grp]/channels/can-read/noun
+    /(scot %p our.bowl)/tlon/(scot %da now.bowl)/v2/groups/(scot %p ship.grp)/[name.grp]/channels/can-read/noun
   =/  test=$-([ship nest:n] ?)  .^($-([ship nest:n] ?) %gx gpath)
   (test who [%notes ship.flag name.flag])
 ::  +group-synced: is group `grp` present in our local %groups replica? Used
@@ -1044,7 +1044,7 @@
   |=  grp=flag:n
   ^-  ?
   =/  gpath=path
-    /(scot %p our.bowl)/groups/(scot %da now.bowl)/groups/(scot %p ship.grp)/[name.grp]
+    /(scot %p our.bowl)/tlon/(scot %da now.bowl)/groups/(scot %p ship.grp)/[name.grp]
   .^(? %gu gpath)
 ::  +can-view-flag: check if ship can view a notebook by flag. Group-mode
 ::  notebooks defer to the group's can-read; others use the members map.

--- a/desk/lib/channel-utils.hoon
+++ b/desk/lib/channel-utils.hoon
@@ -1224,7 +1224,7 @@
   ++  groups-scry
     ^-  path
     :-  (scot %p our)
-    /groups/(scot %da now)/v2/groups/(scot %p p.group)/[q.group]
+    /tlon/(scot %da now)/v2/groups/(scot %p p.group)/[q.group]
   ::
   ++  is-admin
     |=  her=ship

--- a/packages/api/src/client/channelsApi.ts
+++ b/packages/api/src/client/channelsApi.ts
@@ -137,7 +137,7 @@ export const setupChannelFromTemplate = async (
   targetChannelId: string
 ) => {
   return thread({
-    desk: 'groups',
+    desk: 'tlon',
     inputMark: 'hook-setup-template-args',
     outputMark: 'json',
     threadName: 'channel-setup-from-template',

--- a/packages/api/src/client/groupsApi.ts
+++ b/packages/api/src/client/groupsApi.ts
@@ -433,7 +433,7 @@ export const createGroup = async ({
 
   try {
     const result = await thread<ub.GroupCreateThreadInput, ub.GroupV11>({
-      desk: 'groups',
+      desk: 'tlon',
       inputMark: 'group-create-thread',
       threadName: 'group-create-1',
       outputMark: 'group-ui-2',

--- a/packages/api/src/client/settingsApi.ts
+++ b/packages/api/src/client/settingsApi.ts
@@ -77,7 +77,7 @@ export async function getBotReplyFeedback(
 ): Promise<BotReplyFeedbackEntry | null> {
   const settings = await scry<ub.GroupsDeskSettings>({
     app: 'settings',
-    path: '/desk/groups',
+    path: '/desk/tlon',
   });
   return parseBotReplyFeedbackValue(
     settings.desk.botReplyFeedback?.[messageId]
@@ -93,7 +93,7 @@ export async function setBotReplyFeedback(
     mark: 'settings-event',
     json: {
       'put-entry': {
-        desk: 'groups',
+        desk: 'tlon',
         'bucket-key': BOT_REPLY_FEEDBACK_BUCKET,
         'entry-key': messageId,
         // The settings wire type supports scalar values, so encode the
@@ -166,7 +166,7 @@ export const setSetting = async (key: string, val: any) => {
     mark: 'settings-event',
     json: {
       'put-entry': {
-        desk: 'groups',
+        desk: 'tlon',
         'bucket-key': getBucket(key),
         'entry-key': key,
         value: val,
@@ -183,7 +183,7 @@ export const getSettings = async (): Promise<{
 }> => {
   const results = await scry<ub.GroupsDeskSettings>({
     app: 'settings',
-    path: '/desk/groups',
+    path: '/desk/tlon',
   });
 
   const settings = toClientSettings(results);
@@ -209,7 +209,7 @@ export const getContextLensEnabledRaw = async (): Promise<
 > => {
   const results = await scry<ub.GroupsDeskSettings>({
     app: 'settings',
-    path: '/desk/groups',
+    path: '/desk/tlon',
   });
   return results.desk.groups?.contextLensEnabled;
 };
@@ -424,7 +424,7 @@ export function subscribeToSettings(handler: (update: SettingsUpdate) => void) {
   subscribe<ub.SettingsEvent>(
     {
       app: 'settings',
-      path: '/desk/groups',
+      path: '/desk/tlon',
     },
     (update) => {
       if (!('settings-event' in update)) {


### PR DESCRIPTION
## Summary

First slice of the `%tlon`-only runtime cleanup.

- source client thread requests from `%tlon`
- use `%tlon` for settings desk data
- retarget direct Notes and channel Clay desk paths

Follow-up work on remaining rube and legacy-desk compatibility paths stays in this PR.

## Verification

- `git diff --check`