### PR TITLE
Fix channel pagination without sequence cursors

### DIFF
--- a/packages/app/features/top/ChannelScreen.tsx
+++ b/packages/app/features/top/ChannelScreen.tsx
@@ -33,6 +33,7 @@ import {
   useIsWindowNarrow,
 } from '../../ui';
 import { isAgentGroupSetupActive } from '../../ui/components/Channel/postVisibility';
+import { shouldAutoLoadOlderPosts } from './channelPagination';
 import { useAgentOnboardingChannel } from './useAgentOnboardingChannel';
 import { useAgentOnboardingFirstEntry } from './useAgentOnboardingFirstEntry';
 
@@ -357,12 +358,15 @@ export default function ChannelScreen(props: Props) {
     // since adding no visible rows will not retrigger the boundary callback.
     const ENOUGH_POSTS_TO_FILL_SCREEN = 20;
     if (
-      !postsQuery.isFetching &&
-      postsQuery.hasNextPage &&
-      unreadDidInitialize &&
-      (!posts ||
-        posts.length < ENOUGH_POSTS_TO_FILL_SCREEN ||
-        oldestPageHasOnlyDeletedPosts)
+      shouldAutoLoadOlderPosts({
+        isFetching: postsQuery.isFetching,
+        isError: postsQuery.isError,
+        hasNextPage: postsQuery.hasNextPage,
+        unreadDidInitialize,
+        postCount: posts?.length,
+        minimumPostCount: ENOUGH_POSTS_TO_FILL_SCREEN,
+        oldestPageHasOnlyDeletedPosts,
+      })
     ) {
       loadOlder();
     }

--- a/packages/app/features/top/channelPagination.test.ts
+++ b/packages/app/features/top/channelPagination.test.ts
@@ -1,0 +1,25 @@
+import { describe, expect, it } from 'vitest';
+
+import { shouldAutoLoadOlderPosts } from './channelPagination';
+
+const readyToFill = {
+  isFetching: false,
+  isError: false,
+  hasNextPage: true,
+  unreadDidInitialize: true,
+  postCount: 10,
+  minimumPostCount: 20,
+  oldestPageHasOnlyDeletedPosts: false,
+};
+
+describe('shouldAutoLoadOlderPosts', () => {
+  it('loads another page when initialized history does not fill the screen', () => {
+    expect(shouldAutoLoadOlderPosts(readyToFill)).toBe(true);
+  });
+
+  it('does not restart automatic pagination after a query error', () => {
+    expect(shouldAutoLoadOlderPosts({ ...readyToFill, isError: true })).toBe(
+      false
+    );
+  });
+});

--- a/packages/app/features/top/channelPagination.ts
+++ b/packages/app/features/top/channelPagination.ts
@@ -1,0 +1,27 @@
+export function shouldAutoLoadOlderPosts({
+  isFetching,
+  isError,
+  hasNextPage,
+  unreadDidInitialize,
+  postCount,
+  minimumPostCount,
+  oldestPageHasOnlyDeletedPosts,
+}: {
+  isFetching: boolean;
+  isError: boolean;
+  hasNextPage: boolean;
+  unreadDidInitialize: boolean;
+  postCount?: number;
+  minimumPostCount: number;
+  oldestPageHasOnlyDeletedPosts: boolean;
+}) {
+  return (
+    !isFetching &&
+    !isError &&
+    hasNextPage &&
+    unreadDidInitialize &&
+    (postCount == null ||
+      postCount < minimumPostCount ||
+      oldestPageHasOnlyDeletedPosts)
+  );
+}

--- a/packages/shared/src/db/queries.test.ts
+++ b/packages/shared/src/db/queries.test.ts
@@ -585,6 +585,77 @@ test('sequenced posts: gets newest posts', async () => {
   expect(newestPosts[4].sequenceNum).toEqual(15);
 });
 
+test('sequenced posts: ignores posts without a positive server sequence', async () => {
+  const channelId = 'unsequenced';
+  await queries.insertChannels([{ id: channelId, type: 'chat' }]);
+  await queries.insertChannelPosts({
+    posts: [
+      {
+        id: 'optimistic',
+        type: 'chat',
+        channelId,
+        receivedAt: refDate,
+        sentAt: refDate,
+        sequenceNum: 0,
+        authorId: 'test',
+        syncedAt: 0,
+      },
+      {
+        id: 'unsequenced',
+        type: 'chat',
+        channelId,
+        receivedAt: refDate + 1,
+        sentAt: refDate + 1,
+        sequenceNum: null,
+        authorId: 'test',
+        syncedAt: 0,
+      },
+    ],
+  });
+
+  await expect(
+    queries.getSequencedChannelPosts({
+      mode: 'newest',
+      channelId,
+      count: 5,
+    })
+  ).resolves.toEqual([]);
+});
+
+test('sequenced posts: older mode stops at sequence one', async () => {
+  const channelId = 'older-with-optimistic';
+  await queries.insertChannels([{ id: channelId, type: 'chat' }]);
+  await queries.insertChannelPosts({
+    posts: getRangedPosts(channelId, 0, 2),
+  });
+
+  const posts = await queries.getSequencedChannelPosts({
+    mode: 'older',
+    channelId,
+    cursorSequenceNum: 2,
+    count: 5,
+  });
+
+  expect(posts.map((post) => post.sequenceNum)).toEqual([1]);
+});
+
+test('sequenced posts: around mode excludes sequence zero', async () => {
+  const channelId = 'around-with-optimistic';
+  await queries.insertChannels([{ id: channelId, type: 'chat' }]);
+  await queries.insertChannelPosts({
+    posts: getRangedPosts(channelId, 0, 2),
+  });
+
+  const posts = await queries.getSequencedChannelPosts({
+    mode: 'around',
+    channelId,
+    cursorSequenceNum: 1,
+    count: 5,
+  });
+
+  expect(posts.map((post) => post.sequenceNum)).toEqual([1]);
+});
+
 test('sequenced posts: gets newer posts', async () => {
   const channelId = 'test';
   await queries.insertChannels([{ id: channelId, type: 'chat' }]);

--- a/packages/shared/src/db/queries.ts
+++ b/packages/shared/src/db/queries.ts
@@ -3592,6 +3592,7 @@ export const getSequencedChannelPosts = createReadQuery(
         where: and(
           eq($posts.channelId, options.channelId),
           not(eq($posts.type, 'reply')),
+          gt($posts.sequenceNum, 0),
           isNull($posts.deliveryStatus)
         ),
         with: {
@@ -3636,6 +3637,7 @@ export const getSequencedChannelPosts = createReadQuery(
         where: and(
           eq($posts.channelId, options.channelId),
           not(eq($posts.type, 'reply')),
+          gt($posts.sequenceNum, 0),
           lt($posts.sequenceNum, options.cursorSequenceNum),
           isNull($posts.deliveryStatus)
         ),
@@ -3754,6 +3756,7 @@ export const getSequencedChannelPosts = createReadQuery(
         where: and(
           eq($posts.channelId, options.channelId),
           not(eq($posts.type, 'reply')),
+          gt($posts.sequenceNum, 0),
           gte($posts.sequenceNum, lowerBound),
           lte($posts.sequenceNum, upperBound),
           isNull($posts.deliveryStatus)

--- a/packages/shared/src/store/useChannelPosts/queries.test.ts
+++ b/packages/shared/src/store/useChannelPosts/queries.test.ts
@@ -1,7 +1,12 @@
+import { InfiniteQueryObserver } from '@tanstack/react-query';
 import { afterEach, describe, expect, it } from 'vitest';
 
 import * as db from '../../db';
-import { getLatestChannelPostsInitialPage, queryKeyPrefix } from './queries';
+import {
+  getLatestChannelPostsInitialPage,
+  getOlderPageParam,
+  queryKeyPrefix,
+} from './queries';
 
 type TestPageParam = { mode: string; cursorPostId?: string; count?: number };
 
@@ -14,6 +19,53 @@ const data = (...entries: [string, TestPageParam, number?][]) => ({
 });
 
 const newest = { mode: 'newest' };
+
+describe('getOlderPageParam', () => {
+  it.each([undefined, null, 0])(
+    'does not paginate from an unsequenced post (%s)',
+    (sequenceNum) => {
+      expect(
+        getOlderPageParam([{ sequenceNum }], {
+          channelId: 'channel',
+          count: 30,
+        })
+      ).toBeUndefined();
+    }
+  );
+
+  it('uses a positive server sequence as the older-page cursor', () => {
+    expect(
+      getOlderPageParam([{ sequenceNum: 10 }, { sequenceNum: 9 }], {
+        channelId: 'channel',
+        count: 30,
+      })
+    ).toEqual({
+      channelId: 'channel',
+      count: 30,
+      mode: 'older',
+      cursorSequenceNum: 9,
+    });
+  });
+
+  it('makes an unsequenced loaded page terminal to the infinite query', async () => {
+    const observer = new InfiniteQueryObserver(db.queryClient, {
+      queryKey: ['channelPosts', 'unsequenced-regression'],
+      initialPageParam: { channelId: 'channel', mode: 'newest' as const },
+      queryFn: async () => ({
+        posts: [{ sequenceNum: 0 }],
+      }),
+      getNextPageParam: (lastPage) =>
+        getOlderPageParam(lastPage.posts, {
+          channelId: 'channel',
+          count: 30,
+        }),
+    });
+
+    await observer.refetch();
+
+    expect(observer.getCurrentResult().hasNextPage).toBe(false);
+  });
+});
 
 describe('getLatestChannelPostsInitialPage', () => {
   afterEach(() => {

--- a/packages/shared/src/store/useChannelPosts/queries.ts
+++ b/packages/shared/src/store/useChannelPosts/queries.ts
@@ -4,6 +4,31 @@ import * as db from '../../db';
 
 export const queryKeyPrefix = ['channelPosts'];
 
+type PaginationPost = {
+  sequenceNum?: number | null;
+};
+
+export function getOlderPageParam(
+  posts: PaginationPost[],
+  options: { channelId: string; count?: number }
+): db.GetSequencedPostsOptions | undefined {
+  const oldestPost = posts.at(-1);
+  const cursorSequenceNum = oldestPost?.sequenceNum;
+
+  // Local/optimistic posts do not have a server sequence and cannot anchor a
+  // history request. Sequence 1 is the beginning of the channel.
+  if (cursorSequenceNum == null || cursorSequenceNum <= 1) {
+    return undefined;
+  }
+
+  return {
+    channelId: options.channelId,
+    count: options.count ?? 50,
+    mode: 'older',
+    cursorSequenceNum,
+  };
+}
+
 export function getLatestChannelPostsInitialPage<
   TPage extends { fetchedAt: number },
   TPageParam extends {

--- a/packages/shared/src/store/useChannelPosts/useChannelPosts.ts
+++ b/packages/shared/src/store/useChannelPosts/useChannelPosts.ts
@@ -16,7 +16,11 @@ import * as sync from '../sync';
 import { SyncPriority } from '../syncQueue';
 import { useDetectSequenceRegression } from '../useDetectSequenceRegression';
 import { mergePendingPosts } from '../useMergePendingPosts';
-import { getLatestChannelPostsInitialPage, queryKeyPrefix } from './queries';
+import {
+  getLatestChannelPostsInitialPage,
+  getOlderPageParam,
+  queryKeyPrefix,
+} from './queries';
 import { refreshStaleChannelPosts } from './refresh';
 import { useDeletedPosts, useNewPostListener } from './subscriptions';
 
@@ -142,25 +146,7 @@ export const useChannelPosts = (options: UseChannelPostsParams) => {
       _allPages,
       _lastPageParam
     ): UseChannelPostsPageParams | undefined => {
-      const oldestPost = lastPage.posts.at(-1);
-      const lastPageIsEmpty = !oldestPost?.id;
-
-      // corner case: if somehow we don't have any posts, we can't load more
-      if (lastPageIsEmpty) {
-        return undefined;
-      }
-
-      // main check: if we're at the beginning of the sequence, we're done
-      if (oldestPost && oldestPost.sequenceNum === 1) {
-        return undefined;
-      }
-
-      return {
-        channelId: options.channelId,
-        count: options.count ?? 50,
-        mode: 'older',
-        cursorSequenceNum: oldestPost.sequenceNum!,
-      };
+      return getOlderPageParam(lastPage.posts, options);
     },
     getPreviousPageParam: (
       firstPage,


### PR DESCRIPTION
## Summary

Prevent channel history pagination from using optimistic or otherwise unsequenced posts as server cursors. Invalid local history now triggers a safe terminal page instead of repeated database errors, while pending posts continue to render through the existing pending-post merge path.

Fixes TLON-6477

## Changes

- Require positive server sequence numbers in newest, older, and around history queries.
- Stop constructing older-page parameters when the last post lacks a usable server sequence.
- Stop automatic screen-filling pagination after the query enters an error state.
- Cover unsequenced database rows, infinite-query termination, and the channel auto-load guard.

## How did I test?

- `pnpm exec oxfmt --check` on all changed TypeScript files.
- Shared package TypeScript check and 99 focused pagination/database tests.
- App package TypeScript check and 2 channel-pagination tests.
- `git diff --check` and a staged-file hygiene scan for environment variables, secrets, `.env` files, and planning documents.

## Risks and impact

- Safe to rollback without consulting PR author? Yes
- Affects important code area:
  - [ ] Onboarding
  - [ ] State / providers
  - [ ] Message sync
  - [x] Channel display
  - [ ] Notifications
  - [ ] Other:

## Rollback plan

Revert commit `55c6543d6c`.

## Screenshots / videos

Not applicable; this changes pagination behavior without a visual redesign.
