### PR TITLE
Report web database setup failures to Sentry

### DIFF
--- a/apps/tlon-web/src/app.tsx
+++ b/apps/tlon-web/src/app.tsx
@@ -46,6 +46,7 @@ import {
 import {
   AnalyticsEvent,
   AnalyticsSeverity,
+  createDevLogger,
   getAuthInfo,
 } from '@tloncorp/shared';
 import { sync } from '@tloncorp/shared';
@@ -74,6 +75,8 @@ import { useTheme } from '@/state/settings';
 
 import { DesktopLoginScreen } from './components/DesktopLoginScreen';
 import { isElectron } from './electron-bridge';
+
+const logger = createDevLogger('app', false);
 
 // Conditionally import the appropriate database functions
 const { checkDb, useMigrations } = isElectron()
@@ -464,12 +467,17 @@ function ConnectedDesktopApp({
   return <AppRoutes />;
 }
 
+// The web db is rebuilt on every load, so the splash screen waits for it to
+// report a nonzero size before handing over to the app.
+const DB_LOAD_ATTEMPTS = 10;
+
 function ConnectedWebApp() {
   const currentUserId = useCurrentUserId();
   const [dbIsLoaded, setDbIsLoaded] = useState(false);
   const configureClient = useConfigureUrbitClient();
   const session = store.useCurrentSession();
   const hasSyncedRef = React.useRef(false);
+  const dbLoadFailureReportedRef = React.useRef(false);
   const telemetry = useTelemetry();
 
   const isNewSignup = useMemo(() => {
@@ -503,9 +511,9 @@ function ConnectedWebApp() {
       // this is necessary because we load a fresh db on every load and we
       // can't be sure of when data has been loaded
 
-      for (let i = 0; i < 10; i++) {
+      for (let i = 0; i < DB_LOAD_ATTEMPTS; i++) {
         if (dbIsLoaded) {
-          break;
+          return;
         }
 
         const { databaseSizeBytes } = (await checkDb()) || {
@@ -515,10 +523,22 @@ function ConnectedWebApp() {
         if (databaseSizeBytes && databaseSizeBytes > 0) {
           setDbIsLoaded(true);
           splashScreenProgress.complete(SplashScreenTask.startDatabase);
-          break;
+          return;
         }
 
         await new Promise((resolve) => setTimeout(resolve, 1000));
+      }
+
+      // Every attempt came back empty, so the splash screen is still up with no
+      // database behind it and nothing retries from here. Without this the only
+      // trace is whatever query happens to fail next.
+      if (!dbLoadFailureReportedRef.current) {
+        dbLoadFailureReportedRef.current = true;
+        logger.trackEvent(AnalyticsEvent.ErrorWebDb, {
+          context: 'ConnectedWebApp: database never became readable',
+          attempts: DB_LOAD_ATTEMPTS,
+          severity: AnalyticsSeverity.Critical,
+        });
       }
     };
 

--- a/packages/api/src/types/analytics.ts
+++ b/packages/api/src/types/analytics.ts
@@ -41,6 +41,7 @@ export enum AnalyticsEvent {
   ErrorThread = 'Thread Error',
   ErrorSubscribeOnceTimeout = 'Error Subscribe Once Timeout',
   ErrorNativeDb = 'Native DB Error',
+  ErrorWebDb = 'Web DB Error',
   InitDataFetched = 'Init Data Fetched',
   InitDataWritten = 'Init Data Written',
   LatestPostsFetched = 'Latest Posts Fetched',

--- a/packages/app/lib/electronDb.ts
+++ b/packages/app/lib/electronDb.ts
@@ -1,3 +1,4 @@
+import { AnalyticsEvent, AnalyticsSeverity } from '@tloncorp/shared';
 import { schema, setClient } from '@tloncorp/shared/db';
 import { handleChange } from '@tloncorp/shared/db';
 import { migrations } from '@tloncorp/shared/db/migrations';
@@ -109,7 +110,12 @@ export class ElectronDb extends BaseDb {
 
       logger.log('Electron SQLite database initialized');
     } catch (e) {
-      logger.error('Failed to setup Electron SQLite db', e);
+      logger.trackEvent(AnalyticsEvent.ErrorWebDb, {
+        context: 'electronDb.setupDb: failed to set up SQLite db',
+        errorMessage: e.message,
+        errorStack: e.stack,
+        severity: AnalyticsSeverity.Critical,
+      });
       throw e;
     }
   }
@@ -147,7 +153,12 @@ export class ElectronDb extends BaseDb {
     }
 
     if (!this.client) {
-      logger.warn('runMigrations called before setupDb, ignoring');
+      // See webDb.runMigrations: the app carries on without a database, so this
+      // is the only signal that it happened.
+      logger.trackEvent(AnalyticsEvent.ErrorWebDb, {
+        context: 'electronDb.runMigrations: called without a database',
+        severity: AnalyticsSeverity.Critical,
+      });
       return;
     }
 

--- a/packages/app/lib/webDb.test.ts
+++ b/packages/app/lib/webDb.test.ts
@@ -1,0 +1,243 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { WebDb } from './webDb';
+
+type SqlocalOptions = {
+  databasePath: string;
+  verbose: boolean;
+  onConnect: () => void;
+};
+
+const sqlocalRuntime = vi.hoisted(() => {
+  // Whether the constructed instance ever calls `onConnect`. SQLocal calls it
+  // asynchronously once the WASM driver is up; a driver that never loads is
+  // what the init timeout exists for.
+  let shouldConnect = true;
+  let sqlBehavior: (query: unknown) => Promise<unknown> = async () => [];
+  let deleteBehavior: () => Promise<void> = async () => undefined;
+
+  const makeInstance = (options: SqlocalOptions) => ({
+    options,
+    driver: { __driver: true },
+    sql: vi.fn((query: unknown) => sqlBehavior(query)),
+    createCallbackFunction: vi.fn(async () => undefined),
+    getDatabaseInfo: vi.fn(async () => ({
+      databasePath: ':memory:',
+      databaseSizeBytes: 1024,
+    })),
+    overwriteDatabaseFile: vi.fn(async () => undefined),
+    deleteDatabaseFile: vi.fn(() => deleteBehavior()),
+    getDatabaseFile: vi.fn(async () => null),
+    destroy: vi.fn(async () => undefined),
+  });
+
+  const instances: ReturnType<typeof makeInstance>[] = [];
+
+  const create = (options: SqlocalOptions) => {
+    const instance = makeInstance(options);
+    instances.push(instance);
+    if (shouldConnect) {
+      // Mirror the real driver: onConnect never fires synchronously.
+      queueMicrotask(() => options.onConnect());
+    }
+    return instance;
+  };
+
+  return {
+    create,
+    instances,
+    setShouldConnect: (value: boolean) => {
+      shouldConnect = value;
+    },
+    setSqlBehavior: (behavior: (query: unknown) => Promise<unknown>) => {
+      sqlBehavior = behavior;
+    },
+    setDeleteBehavior: (behavior: () => Promise<void>) => {
+      deleteBehavior = behavior;
+    },
+    reset: () => {
+      instances.length = 0;
+      shouldConnect = true;
+      sqlBehavior = async () => [];
+      deleteBehavior = async () => undefined;
+    },
+  };
+});
+
+const loggerSpies = vi.hoisted(() => ({
+  trackEvent: vi.fn(),
+  log: vi.fn(),
+  warn: vi.fn(),
+  error: vi.fn(),
+}));
+
+const sharedDbSpies = vi.hoisted(() => ({
+  setClient: vi.fn(),
+  getSqliteContent: vi.fn(async () => null as ArrayBuffer | null),
+  resetValue: vi.fn(async () => undefined),
+}));
+
+const webMigratorSpies = vi.hoisted(() => ({
+  migrate: vi.fn(async () => ({ applied: [] as string[] })),
+}));
+
+vi.mock('sqlocal/drizzle', () => ({
+  SQLocalDrizzle: function MockSQLocalDrizzle(options: SqlocalOptions) {
+    return sqlocalRuntime.create(options);
+  },
+}));
+
+vi.mock('drizzle-orm/sqlite-proxy', () => ({
+  drizzle: vi.fn(() => ({ __client: true })),
+}));
+
+vi.mock('@tloncorp/shared', () => ({
+  AnalyticsEvent: { ErrorWebDb: 'ErrorWebDb' },
+  AnalyticsSeverity: { Critical: 'Critical' },
+  createDevLogger: () => loggerSpies,
+}));
+
+vi.mock('@tloncorp/shared/perfLog', () => ({
+  perfMark: () => () => undefined,
+}));
+
+vi.mock('@tloncorp/shared/db', () => ({
+  changesSyncedAt: { resetValue: sharedDbSpies.resetValue },
+  didSyncInitialPosts: { resetValue: sharedDbSpies.resetValue },
+  handleChange: vi.fn(),
+  headsSyncedAt: { resetValue: sharedDbSpies.resetValue },
+  schema: {},
+  setClient: sharedDbSpies.setClient,
+  sqliteContent: {
+    getValue: sharedDbSpies.getSqliteContent,
+    setValue: vi.fn(async () => undefined),
+    resetValue: sharedDbSpies.resetValue,
+  },
+  userHasCompletedFirstSync: { resetValue: sharedDbSpies.resetValue },
+}));
+
+vi.mock('@tloncorp/shared/db/migrations', () => ({
+  migrations: { journal: { entries: [] }, migrations: {} },
+}));
+
+vi.mock('@tloncorp/shared/utils', () => ({
+  readArrayBufferFromBlob: vi.fn(async () => new ArrayBuffer(0)),
+}));
+
+vi.mock('./webMigrator', () => ({
+  default: webMigratorSpies.migrate,
+}));
+
+const errorEvents = () =>
+  loggerSpies.trackEvent.mock.calls.filter(([event]) => event === 'ErrorWebDb');
+
+const onlyErrorEvent = () => {
+  const events = errorEvents();
+  expect(events).toHaveLength(1);
+  return events[0][1] as Record<string, unknown>;
+};
+
+const failingSql = async () => {
+  throw new Error('PRAGMA failed');
+};
+
+describe('WebDb', () => {
+  beforeEach(() => {
+    sqlocalRuntime.reset();
+    loggerSpies.trackEvent.mockClear();
+    loggerSpies.log.mockClear();
+    loggerSpies.warn.mockClear();
+    sharedDbSpies.setClient.mockClear();
+    sharedDbSpies.getSqliteContent.mockResolvedValue(null);
+    webMigratorSpies.migrate.mockClear();
+    webMigratorSpies.migrate.mockResolvedValue({ applied: [] });
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('registers the shared client on a successful setup', async () => {
+    const db = new WebDb({ enableStoragePersistence: false });
+
+    await db.setupDb();
+
+    expect(sharedDbSpies.setClient).toHaveBeenCalledTimes(1);
+    expect(errorEvents()).toHaveLength(0);
+  });
+
+  it('reports a setup failure without throwing, so the splash screen stays up', async () => {
+    sqlocalRuntime.setSqlBehavior(failingSql);
+    const db = new WebDb({ enableStoragePersistence: false });
+
+    await expect(db.setupDb()).resolves.toBeUndefined();
+
+    expect(sharedDbSpies.setClient).not.toHaveBeenCalled();
+    expect(onlyErrorEvent()).toMatchObject({
+      context: 'setupDb: failed to set up SQLite db',
+      phase: 'configure',
+      clientRegistered: false,
+      errorMessage: 'PRAGMA failed',
+      severity: 'Critical',
+    });
+  });
+
+  it('reports the connect phase when the driver never comes up', async () => {
+    vi.useFakeTimers();
+    sqlocalRuntime.setShouldConnect(false);
+    const db = new WebDb({ enableStoragePersistence: false });
+
+    const setup = db.setupDb();
+    await vi.advanceTimersByTimeAsync(15000);
+    await setup;
+
+    expect(sharedDbSpies.setClient).not.toHaveBeenCalled();
+    expect(onlyErrorEvent()).toMatchObject({
+      phase: 'connect',
+      clientRegistered: false,
+      errorMessage: 'SQLocal init timed out',
+    });
+  });
+
+  it('reports the phase when loading a persisted database fails', async () => {
+    sharedDbSpies.getSqliteContent.mockResolvedValue(new ArrayBuffer(8));
+    sqlocalRuntime.setSqlBehavior(failingSql);
+    sqlocalRuntime.setDeleteBehavior(async () => {
+      throw new Error('deleteDatabaseFile failed');
+    });
+    const db = new WebDb({ enableStoragePersistence: true });
+
+    await db.setupDb();
+
+    expect(onlyErrorEvent()).toMatchObject({
+      phase: 'load-persisted',
+      clientRegistered: false,
+      storagePersistenceEnabled: true,
+      errorMessage: 'deleteDatabaseFile failed',
+    });
+  });
+
+  it('reports when migrations run without a database, and skips migrating', async () => {
+    const db = new WebDb({ enableStoragePersistence: false });
+
+    await db.runMigrations();
+
+    expect(webMigratorSpies.migrate).not.toHaveBeenCalled();
+    expect(onlyErrorEvent()).toMatchObject({
+      context: 'runMigrations: called without a database',
+      hasClient: false,
+      hasSqlocal: false,
+      severity: 'Critical',
+    });
+  });
+
+  it('runs migrations once the database is set up', async () => {
+    const db = new WebDb({ enableStoragePersistence: false });
+    await db.setupDb();
+
+    await db.runMigrations();
+
+    expect(webMigratorSpies.migrate).toHaveBeenCalledTimes(1);
+    expect(errorEvents()).toHaveLength(0);
+  });
+});

--- a/packages/app/lib/webDb.ts
+++ b/packages/app/lib/webDb.ts
@@ -1,3 +1,4 @@
+import { AnalyticsEvent, AnalyticsSeverity } from '@tloncorp/shared';
 import type { Schema } from '@tloncorp/shared/db';
 import { schema, setClient, sqliteContent } from '@tloncorp/shared/db';
 import { migrations } from '@tloncorp/shared/db/migrations';
@@ -21,6 +22,15 @@ const ENABLE_DB_FILE_LOAD = IS_SECURE_CONTEXT;
 const ENABLE_DB_FILE_SAVE = IS_SECURE_CONTEXT;
 const MIN_FREE_BYTES_BEFORE_VACUUM = 4 * 1024 * 1024;
 const MIN_FREE_RATIO_BEFORE_VACUUM = 0.25;
+
+/** Stage of `setupDb` in progress, reported when setup fails. */
+type SetupPhase =
+  | 'connect'
+  | 'load-persisted'
+  | 'reset-sync-state'
+  | 'configure'
+  | 'register-client'
+  | 'read-db-info';
 
 type WebDbOptions = {
   enableStoragePersistence?: boolean;
@@ -52,6 +62,13 @@ export class WebDb extends BaseDb {
       logger.warn('setupDb called multiple times, ignoring');
       return;
     }
+    // Setup spans a worker handshake, an OPFS read and a batch of pragmas, and
+    // the resulting error rarely says which one gave out. Tracking the phase is
+    // what makes the reported failure diagnosable.
+    let phase: SetupPhase = 'connect';
+    // Whether the shared client ever got registered decides whether the rest of
+    // the session has a database at all, so report it outright.
+    let clientRegistered = false;
     try {
       // Await the onConnect callback to ensure the WASM driver is fully
       // initialized before sending any queries. In non-worker mode (used for
@@ -75,6 +92,7 @@ export class WebDb extends BaseDb {
 
       const { driver } = sqlocal;
       this.client = drizzle(driver, { schema });
+      phase = 'load-persisted';
 
       // Immediately try to load DB from persisted file.
       // If successful, this will `overwriteDatabaseFile` which will reset the
@@ -115,6 +133,7 @@ export class WebDb extends BaseDb {
       // tracked in localStorage about "what has been synced" is meaningless.
       // Reset the sync markers so the initial sync hydrates the new DB.
       if (!loadedFromFile && this.enableStoragePersistence) {
+        phase = 'reset-sync-state';
         await resetDbSyncState();
       }
 
@@ -154,6 +173,7 @@ export class WebDb extends BaseDb {
 
       // Experimental SQLite settings. May cause crashes. More here:
       // https://ospfranco.notion.site/Configuration-6b8b9564afcc4ac6b6b377fe34475090
+      phase = 'configure';
       await this.sqlocal.sql('PRAGMA mmap_size=268435456');
       // await this.sqlocal.sql('PRAGMA journal_mode=MEMORY');
       await this.sqlocal.sql('PRAGMA synchronous=OFF');
@@ -163,12 +183,27 @@ export class WebDb extends BaseDb {
         this.enqueueProcessChanges();
       });
 
+      phase = 'register-client';
       setClient(this.client);
+      clientRegistered = true;
 
+      phase = 'read-db-info';
       const dbInfo = await this.sqlocal.getDatabaseInfo();
       logger.log('SQLite database opened:', dbInfo);
     } catch (e) {
-      logger.error('Failed to setup SQLite db', e);
+      // `logger.error` only records a breadcrumb, so this failure never reached
+      // Sentry — the only visible trace was thousands of downstream
+      // `Database not set.` reports with no sign of what actually broke.
+      logger.trackEvent(AnalyticsEvent.ErrorWebDb, {
+        context: 'setupDb: failed to set up SQLite db',
+        phase,
+        clientRegistered,
+        storagePersistenceEnabled: this.enableStoragePersistence,
+        secureContext: IS_SECURE_CONTEXT,
+        errorMessage: e.message,
+        errorStack: e.stack,
+        severity: AnalyticsSeverity.Critical,
+      });
     }
   }
 
@@ -314,7 +349,14 @@ export class WebDb extends BaseDb {
 
   async runMigrations() {
     if (!this.client || !this.sqlocal) {
-      logger.warn('runMigrations called before setupDb, ignoring');
+      // Migrating is skipped here, but the app carries on regardless — so this
+      // is the signal that a session is running without a database behind it.
+      logger.trackEvent(AnalyticsEvent.ErrorWebDb, {
+        context: 'runMigrations: called without a database',
+        hasClient: this.client != null,
+        hasSqlocal: this.sqlocal != null,
+        severity: AnalyticsSeverity.Critical,
+      });
       return;
     }
 

--- a/packages/shared/src/db/client.test.ts
+++ b/packages/shared/src/db/client.test.ts
@@ -1,0 +1,47 @@
+import { beforeAll, beforeEach, describe, expect, it } from 'vitest';
+
+import { getClient, setupDb } from '../test/helpers';
+import {
+  DatabaseNotSetError,
+  setClient,
+  shouldReportQueryError,
+} from './client';
+
+describe('shouldReportQueryError', () => {
+  beforeAll(() => {
+    setupDb();
+  });
+
+  // Re-registering the client clears the "already reported" latch, which is
+  // what makes these cases independent of each other.
+  beforeEach(() => {
+    setClient(getClient()!);
+  });
+
+  it('reports ordinary query errors every time', () => {
+    const error = new Error('no such table: posts');
+    expect(shouldReportQueryError(error)).toBe(true);
+    expect(shouldReportQueryError(error)).toBe(true);
+  });
+
+  it('reports a missing database once and suppresses the rest', () => {
+    expect(shouldReportQueryError(new DatabaseNotSetError())).toBe(true);
+    expect(shouldReportQueryError(new DatabaseNotSetError())).toBe(false);
+    expect(shouldReportQueryError(new DatabaseNotSetError())).toBe(false);
+  });
+
+  it('keeps reporting unrelated errors while a missing database is suppressed', () => {
+    expect(shouldReportQueryError(new DatabaseNotSetError())).toBe(true);
+    expect(shouldReportQueryError(new DatabaseNotSetError())).toBe(false);
+    expect(shouldReportQueryError(new Error('disk I/O error'))).toBe(true);
+  });
+
+  it('re-arms once a client is registered', () => {
+    expect(shouldReportQueryError(new DatabaseNotSetError())).toBe(true);
+    expect(shouldReportQueryError(new DatabaseNotSetError())).toBe(false);
+
+    setClient(getClient()!);
+
+    expect(shouldReportQueryError(new DatabaseNotSetError())).toBe(true);
+  });
+});

--- a/packages/shared/src/db/client.ts
+++ b/packages/shared/src/db/client.ts
@@ -17,10 +17,39 @@ export type AnySqliteTransaction = Parameters<
   Parameters<AnySqliteDatabase['transaction']>[0]
 >[0];
 
+/**
+ * Thrown when a query runs before the platform db layer has called
+ * `setClient` — i.e. database setup never completed.
+ */
+export class DatabaseNotSetError extends Error {
+  constructor() {
+    super('Database not set.');
+    this.name = 'DatabaseNotSetError';
+  }
+}
+
 let clientInstance: AnySqliteDatabase | null = null;
+let didReportMissingClient = false;
+
+/**
+ * A missing client is a single startup failure, but every query in the app
+ * trips over it. Reporting each one buries the actual setup error under
+ * thousands of identical events, so only the first is worth sending.
+ */
+export function shouldReportQueryError(error: unknown) {
+  if (!(error instanceof DatabaseNotSetError)) {
+    return true;
+  }
+  if (didReportMissingClient) {
+    return false;
+  }
+  didReportMissingClient = true;
+  return true;
+}
 
 export function setClient<T extends AnySqliteDatabase>(client: T) {
   clientInstance = client;
+  didReportMissingClient = false;
 
   if (__DEV__) {
     const exec = (strings: TemplateStringsArray, ...values: any[]) =>
@@ -44,7 +73,7 @@ export const client = new Proxy(
   {
     get: function (target, prop, receiver) {
       if (!clientInstance) {
-        throw new Error('Database not set.');
+        throw new DatabaseNotSetError();
       }
       return Reflect.get(clientInstance, prop, receiver);
     },

--- a/packages/shared/src/db/query.ts
+++ b/packages/shared/src/db/query.ts
@@ -5,7 +5,12 @@ import { AnalyticsEvent } from '../domain';
 import { startTrace } from '../perf';
 import { perfEnabled, perfLog } from '../perfLog';
 import * as changeListener from './changeListener';
-import { AnySqliteDatabase, AnySqliteTransaction, client } from './client';
+import {
+  AnySqliteDatabase,
+  AnySqliteTransaction,
+  client,
+  shouldReportQueryError,
+} from './client';
 import { queryClient } from './reactQuery';
 import { TableName } from './types';
 
@@ -139,12 +144,14 @@ export const createQuery = <TOptions, TReturn>(
         }
         return result;
       } catch (e) {
-        logger.trackEvent(AnalyticsEvent.ErrorDatabaseQuery, {
-          label: meta.label,
-          error: e,
-          errorMessage: e.message,
-          errorStack: e.stack,
-        });
+        if (shouldReportQueryError(e)) {
+          logger.trackEvent(AnalyticsEvent.ErrorDatabaseQuery, {
+            label: meta.label,
+            error: e,
+            errorMessage: e.message,
+            errorStack: e.stack,
+          });
+        }
         throw e;
       }
     });
@@ -288,13 +295,15 @@ export async function withTransactionCtx<T>(
       return result;
     } catch (e) {
       txLogger.log(ctx.meta.label, 'tx:error', e);
-      txLogger.trackError('transaction error', {
-        isNested: true,
-        rootTransactionLabel: ctx.rootTransaction,
-        label: ctx.meta.label,
-        errorMessage: e.message,
-        errorStack: e.stack,
-      });
+      if (shouldReportQueryError(e)) {
+        txLogger.trackError('transaction error', {
+          isNested: true,
+          rootTransactionLabel: ctx.rootTransaction,
+          label: ctx.meta.label,
+          errorMessage: e.message,
+          errorStack: e.stack,
+        });
+      }
       throw e;
     }
   }
@@ -319,19 +328,23 @@ export async function withTransactionCtx<T>(
         return result;
       } catch (e) {
         txLogger.log('tx:error', e);
-        txLogger.trackError('DB Transaction Error', {
-          label: ctx.meta.label,
-          errorMessage: e.message,
-          errorStack: e.stack,
-        });
+        if (shouldReportQueryError(e)) {
+          txLogger.trackError('DB Transaction Error', {
+            label: ctx.meta.label,
+            errorMessage: e.message,
+            errorStack: e.stack,
+          });
+        }
         try {
           await ctx.db.run(sql`ROLLBACK`);
         } catch (rollbackError) {
-          txLogger.trackError('DB Transaction Rollback Error', {
-            label: ctx.meta.label,
-            errorMessage: rollbackError.message,
-            errorStack: rollbackError.stack,
-          });
+          if (shouldReportQueryError(rollbackError)) {
+            txLogger.trackError('DB Transaction Rollback Error', {
+              label: ctx.meta.label,
+              errorMessage: rollbackError.message,
+              errorStack: rollbackError.stack,
+            });
+          }
         }
         ctx.rootTransaction = null;
         reject(e);


### PR DESCRIPTION
## Summary

`WebDb.setupDb()` reported failures through `logger.error`, which in this codebase only records a breadcrumb and never reaches Sentry. So when web database setup failed, `setClient` was never called, `runMigrations` skipped with a warning, the app rendered anyway, and every query threw `Database not set.` for the rest of the session — **~6.5k events over 30 days across ~24 Sentry groupings**, with no trace of what actually broke.

This PR is **tracking only — no behavior changes**. The splash spinner stays, since the database often does come up.

Fixes TLON-6482. Sentry: [JAVASCRIPT-REACT-1RK](https://tlon-corporation.sentry.io/issues/JAVASCRIPT-REACT-1RK), plus siblings [-10E](https://tlon-corporation.sentry.io/issues/JAVASCRIPT-REACT-10E) (4k events) and [-1NC](https://tlon-corporation.sentry.io/issues/JAVASCRIPT-REACT-1NC).

## Changes

- **`AnalyticsEvent.ErrorWebDb`** (new). `webDb.setupDb()` and `electronDb.setupDb()` now report through it at `Critical` severity instead of the breadcrumb-only `logger.error`. Web still swallows, electron still rethrows — unchanged.
- **Phase tagging on setup failures.** Setup spans a worker handshake, an OPFS read and a batch of pragmas, and the error alone rarely says which gave out. The event carries `phase` (`connect` / `load-persisted` / `reset-sync-state` / `configure` / `register-client` / `read-db-info`), `clientRegistered` (whether `setClient` ever ran, which decides if the session has a database at all), `storagePersistenceEnabled`, and `secureContext`.
- **`runMigrations` without a database** now reports, with `hasClient` / `hasSqlocal` to distinguish "setup never ran" from "setup died partway". It still returns rather than throwing, so the migration gate behaves exactly as before.
- **Splash-screen polling giving up** now reports. `ConnectedWebApp` polls `checkDb()` 10 times and then silently leaves the spinner up forever; this is the only signal that a spinner is genuinely stuck rather than slow.
- **Deduplicated `Database not set.`** The client proxy throws a `DatabaseNotSetError` subclass, and `shouldReportQueryError` reports it once per outage instead of once per query, re-arming when `setClient` runs. Unrelated query errors still report every time. The thrown message is unchanged, so existing Sentry grouping still matches.

## How did I test?

- New `packages/app/lib/webDb.test.ts` (6 tests) and `packages/shared/src/db/client.test.ts` (4 tests).
- Verified the new webDb tests actually catch the gap: run against `HEAD~1`'s `webDb.ts`, 4 of 6 fail.
- Full suites pass — `packages/app` 596 passed / 3 skipped, `packages/shared` 590 passed.
- `tsc --noEmit` clean on `shared`, `api`, and `tlon-web` apart from a pre-existing `@tloncorp/editor/dist/editorHtml` error (unbuilt artifact, unrelated).
- `pnpm format:check` clean.

Not verified in a browser: the whole point is that the failure only shows up on user machines where SQLocal doesn't come up, and it isn't reproducible locally. That's also why the first change here is making it reportable at all.

## Risks and impact

- Safe to rollback without consulting PR author? **Yes**
- Affects important code area:
  - [ ] Onboarding
  - [x] State / providers
  - [ ] Message sync
  - [ ] Channel display
  - [ ] Notifications
  - [x] Other: local database setup, Sentry/PostHog error reporting

Low risk — no control flow changed. The one thing worth a reviewer's eye is the dedup in `query.ts`: it suppresses repeat `Database not set.` reports only, and only until a client is registered, so it should not hide any other class of query failure.

## Rollback plan

Revert the commit. Nothing is persisted, migrated, or version-gated, and no analytics consumer depends on the new event yet.

## Screenshots / videos

N/A — no UI changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)