### PR TITLE
mobile: only register expo-dev-menu items in development builds

### DIFF
--- a/packages/app/lib/devMenuItems.test.ts
+++ b/packages/app/lib/devMenuItems.test.ts
@@ -1,0 +1,70 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+const registerDevMenuItems = vi.hoisted(() =>
+  vi.fn(async (_items: { name: string }[]) => undefined)
+);
+const isEmulator = vi.hoisted(() => vi.fn(async () => false));
+
+vi.mock('expo-dev-menu', () => ({ registerDevMenuItems }));
+vi.mock('react-native-device-info', () => ({ isEmulator }));
+vi.mock('expo-constants', () => ({
+  default: { expoConfig: { hostUri: 'localhost:8081' } },
+}));
+vi.mock('react-native', () => ({
+  Alert: { alert: vi.fn() },
+  DevSettings: { reload: vi.fn() },
+}));
+vi.mock('@tloncorp/shared', () => ({
+  syncSince: vi.fn(),
+  queryClient: { resetQueries: vi.fn() },
+}));
+vi.mock('./nativeDb', () => ({ getDbPath: vi.fn(), purgeDb: vi.fn() }));
+vi.mock('./notifications', () => ({ discoverContactsAndNotify: vi.fn() }));
+
+async function importWithDev(dev: boolean) {
+  vi.stubGlobal('__DEV__', dev);
+  vi.resetModules();
+  await vi.importActual('./devMenuItems');
+  // Let the isEmulator().then(...) chain settle.
+  await new Promise((resolve) => setTimeout(resolve, 0));
+}
+
+function registeredNames() {
+  return registerDevMenuItems.mock.calls[0][0].map((item) => item.name);
+}
+
+describe('devMenuItems', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it('never touches expo-dev-menu in release builds', async () => {
+    await importWithDev(false);
+
+    expect(isEmulator).not.toHaveBeenCalled();
+    expect(registerDevMenuItems).not.toHaveBeenCalled();
+  });
+
+  it('registers device items in development builds', async () => {
+    isEmulator.mockResolvedValueOnce(false);
+
+    await importWithDev(true);
+
+    expect(registerDevMenuItems).toHaveBeenCalledTimes(1);
+    expect(registeredNames()).toContain('Delete local database');
+    expect(registeredNames()).not.toContain('Drizzle studio');
+  });
+
+  it('adds simulator-only items when running in an emulator', async () => {
+    isEmulator.mockResolvedValueOnce(true);
+
+    await importWithDev(true);
+
+    expect(registerDevMenuItems).toHaveBeenCalledTimes(1);
+    expect(registeredNames()).toContain('Drizzle studio');
+  });
+});

--- a/packages/app/lib/devMenuItems.ts
+++ b/packages/app/lib/devMenuItems.ts
@@ -85,8 +85,8 @@ const simulatorOnlyMenuItems: ExpoDevMenuItem[] = [
   },
 ];
 
-const devMenuItems: Promise<ExpoDevMenuItem[]> = DeviceInfo.isEmulator().then(
-  (isEmulator) => [
+function getDevMenuItems(isEmulator: boolean): ExpoDevMenuItem[] {
+  return [
     {
       name: 'Delete local database',
       callback: () => purgeDb(),
@@ -104,8 +104,8 @@ const devMenuItems: Promise<ExpoDevMenuItem[]> = DeviceInfo.isEmulator().then(
       },
     },
     ...(isEmulator ? simulatorOnlyMenuItems : []),
-  ]
-);
+  ];
+}
 
 async function sendBundlerRequest(
   path: string,
@@ -128,4 +128,12 @@ async function sendBundlerRequest(
   }
 }
 
-devMenuItems.then((items) => registerDevMenuItems(items));
+// expo-dev-menu's native module is only linked into development builds. In
+// release builds registerDevMenuItems rejects with "Cannot read property
+// 'addDevMenuCallbacks' of null" on every launch (Sentry REACT-NATIVE-3), so
+// never touch it outside __DEV__.
+if (__DEV__) {
+  DeviceInfo.isEmulator().then((isEmulator) =>
+    registerDevMenuItems(getDevMenuItems(isEmulator))
+  );
+}


### PR DESCRIPTION
## Summary

Production builds were calling `registerDevMenuItems` from `expo-dev-menu` on every launch. The `ExpoDevMenu` native module is only linked into development builds, so in release builds the call rejected with `TypeError: Cannot read property 'addDevMenuCallbacks' of null`. This is Sentry's highest-volume React Native issue (~330k events, ~1.8k users since 2025-11) and still fires on July/August 2026 develop builds, so it is live noise, not stale installs.

## Changes

- `packages/app/lib/devMenuItems.ts`: the `DeviceInfo.isEmulator()` → `registerDevMenuItems()` chain now runs only under `if (__DEV__)`. The item list moved into `getDevMenuItems(isEmulator)` so nothing executes at import time in release builds.
- `packages/app/lib/devMenuItems.test.ts`: new regression test. Release builds never touch `expo-dev-menu` or `react-native-device-info`; dev builds register the device items; emulators additionally get the simulator-only items.

## How did I test?

- Confirmed the root cause in `expo-dev-menu@57.0.7` (what develop ships): `ExpoDevMenu` is `requireOptionalNativeModule('ExpoDevMenu')`, which is `null` in release builds, and `registerDevMenuItems` dereferences it with no guard.
- Ran the new test against the previous source: the release-build case fails there and all three cases pass with the fix.
- `vitest`, `oxfmt --check`, `oxlint`, and `tsc --noEmit` in `packages/app` all pass.

## Risks and impact

- Safe to rollback without consulting PR author? Yes
- Affects important code area:
  - [ ] Onboarding
  - [ ] State / providers
  - [ ] Message sync
  - [ ] Channel display
  - [ ] Notifications
  - [x] Other: dev menu (development builds only). The only production change is that the failing call no longer runs.

## Rollback plan

Revert the commit. No data, schema, or native changes.

## Screenshots / videos

N/A, no UI change. Sentry issue: https://tlon-corporation.sentry.io/issues/REACT-NATIVE-3

Fixes TLON-6483
Fixes REACT-NATIVE-3

🤖 Generated with [Claude Code](https://claude.com/claude-code)
