### PR TITLE
android: stop dev builds reporting into production Crashlytics

### DIFF
--- a/apps/tlon-mobile/android/app/build.gradle
+++ b/apps/tlon-mobile/android/app/build.gradle
@@ -133,6 +133,15 @@ android {
         compileSdk rootProject.ext.compileSdkVersion
         versionCode 108
         versionName "9.5.0"
+
+        // Read by RNFB as `rnfirebase_crashlytics_auto_collection_enabled`, ahead of
+        // its own `BuildConfig.DEBUG` check. That check can't be trusted here: RNGP
+        // generates a `debugOptimized` build type whose matchingFallbacks send every
+        // dependency lacking it to `release`, so the Crashlytics library believes it
+        // is in a production build while react-android — which does declare
+        // `debugOptimized` — turns Metro dev support on. Default off so a new build
+        // type never starts reporting into the production project by accident.
+        manifestPlaceholders["crashlyticsAutoCollectionEnabled"] = "false"
     }
     compileOptions {
         coreLibraryDesugaringEnabled true
@@ -153,6 +162,7 @@ android {
             // Caution! In production, you need to generate your own keystore file.
             // see https://reactnative.dev/docs/signed-apk-android.
             signingConfig signingConfigs.debug
+            manifestPlaceholders["crashlyticsAutoCollectionEnabled"] = "true"
             shrinkResources (findProperty('android.enableShrinkResourcesInReleaseBuilds')?.toBoolean() ?: false)
             minifyEnabled enableProguardInReleaseBuilds
             proguardFiles getDefaultProguardFile("proguard-android.txt"), "proguard-rules.pro"
@@ -177,6 +187,8 @@ android {
             debuggable true
             signingConfig signingConfigs.debug
             matchingFallbacks = ['release']
+            // initWith copied release's `true`; this variant is never shipped.
+            manifestPlaceholders["crashlyticsAutoCollectionEnabled"] = "false"
         }
     }
     packagingOptions {

--- a/apps/tlon-mobile/android/app/src/main/AndroidManifest.xml
+++ b/apps/tlon-mobile/android/app/src/main/AndroidManifest.xml
@@ -30,6 +30,7 @@
     <meta-data android:name="expo.modules.updates.EXPO_UPDATES_CHECK_ON_LAUNCH" android:value="ALWAYS"/>
     <meta-data android:name="expo.modules.updates.EXPO_UPDATES_LAUNCH_WAIT_MS" android:value="0"/>
     <meta-data android:name="expo.modules.updates.EXPO_UPDATE_URL" android:value="https://u.expo.dev/617bb643-5bf6-4c40-8af6-c6e9dd7e3bd0"/>
+    <meta-data android:name="rnfirebase_crashlytics_auto_collection_enabled" android:value="${crashlyticsAutoCollectionEnabled}"/>
     <meta-data android:name="io.branch.sdk.BranchKey" android:value="key_live_hubypwhuxR6vkwKfdozyRoamErouusXi"/>
     <meta-data android:name="io.branch.sdk.BranchKey.test" android:value="key_test_cBouaumqwI4DdzNbpcxyUhjatqiFwtG5"/>
     <service android:name=".TalkMessagingService" android:exported="false">


### PR DESCRIPTION
## Summary

`TLON-6474` is a Crashlytics "fatal crash" in `com.facebook.react.devsupport.BundleDownloader.processBundleResult` — a local Metro dev server returning HTTP 500. That is a dev-only code path no Play Store build can reach, so the bug is not the crash: it's that a debuggable, Metro-attached build was allowed to report into the production Crashlytics project under the shipped applicationId. This closes that hole.

## Changes

React Native Firebase decides whether to collect crashes in `ReactNativeFirebaseCrashlyticsInitProvider.isCrashlyticsCollectionEnabled()`, and only forces it off when **its own module's** `BuildConfig.DEBUG` is true. Two facts collide:

- The React Native Gradle Plugin auto-generates a `debugOptimized` build type in the app module (`AgpConfiguratorUtils.configureBuildTypesForApp`) with `initWith(debug)` and `matchingFallbacks += ["release"]`. Every dependency that doesn't declare `debugOptimized` therefore resolves its **`release`** variant.
- `ReactAndroid/build.gradle.kts` *does* declare `debugOptimized`, so `react-android` resolves it → `ReactBuildConfig.DEBUG == true` → `ExpoReactHostFactory` turns **Metro dev support on**. `@react-native-firebase/crashlytics` does *not* declare it → resolves `release` → `BuildConfig.DEBUG == false` → the debug gate is skipped and **collection is enabled**.

So `productionDebugOptimized` / `previewDebugOptimized` were debuggable dev builds reporting crashes as `io.tlon.groups` / `9.5.0`. `releaseDebuggable` had the same reporting hole (dev support stays off there, so it can't produce *this* crash, but it is never a shipped artifact either).

The fix drives the decision from our own build types rather than a transitive library's variant resolution, using the meta-data key RNFB consults *before* the `BuildConfig.DEBUG` check:

- `apps/tlon-mobile/android/app/src/main/AndroidManifest.xml` — add `rnfirebase_crashlytics_auto_collection_enabled`, value from a manifest placeholder.
- `apps/tlon-mobile/android/app/build.gradle` — `defaultConfig` defaults it to `"false"` so a future build type can't start reporting by accident; `release` sets `"true"`; `releaseDebuggable` sets `"false"` (it inherits `release`'s value through `initWith`).

Two things deliberately left alone:

- **Not** using Firebase's own `firebase_crashlytics_collection_enabled` key. RNFB calls `setCrashlyticsCollectionEnabled()` on every launch, and that SharedPreferences override beats manifest meta-data, so it would be silently ignored.
- **No** patch to RN's dev-only bundle-download error handling. A Metro 500 arguably should show a red box rather than kill the process, but that is dev-only churn with no production value.

iOS needs no equivalent change: RNFB's gate there is a compile-time `#ifdef DEBUG` in the pod, compiled with the app's own configuration, and there is no `debugOptimized` analogue.

## How did I test?

Ran the real manifest-merge tasks and read the resulting merged manifests (an unresolved placeholder is a hard build failure, so this checks resolution as well as the values):

```
./gradlew :app:processProductionDebugMainManifest \
          :app:processProductionDebugOptimizedMainManifest \
          :app:processPreviewDebugOptimizedMainManifest \
          :app:processProductionReleaseMainManifest \
          :app:processPreviewReleaseMainManifest \
          :app:processProductionReleaseDebuggableMainManifest
```

| variant | `rnfirebase_crashlytics_auto_collection_enabled` |
| --- | --- |
| `productionDebug` | `false` |
| `productionDebugOptimized` | `false` ← the hole, now closed |
| `previewDebugOptimized` | `false` |
| `productionRelease` | **`true`** |
| `previewRelease` | **`true`** |
| `productionReleaseDebuggable` | `false` |

Shipped-build reporting is preserved; every debuggable variant is silenced. `pnpm format:check` clean.

## Risks and impact

- Safe to rollback without consulting PR author? Yes
- Affects important code area:
  - [ ] Onboarding
  - [ ] State / providers
  - [ ] Message sync
  - [ ] Channel display
  - [ ] Notifications
  - [x] Other: Android build config / crash reporting

The one real risk is inverting this and losing production crash reporting, which is why both shipped variants were verified to resolve `true` against the actual merged manifests rather than by inspection. No app code, JS, or native source changes.

## Rollback plan

Revert the commit. Nothing persists — the value is baked into the manifest at build time, so the next build restores the previous behavior.

## Screenshots / videos

n/a — build configuration only.

Fixes TLON-6474

🤖 Generated with [Claude Code](https://claude.com/claude-code)