### PR TITLE
telemetry: pass Error objects to trackError instead of serialized stacks

### DIFF
--- a/apps/tlon-mobile/src/hooks/useSyncAppBadge.ts
+++ b/apps/tlon-mobile/src/hooks/useSyncAppBadge.ts
@@ -27,8 +27,7 @@ export function useSyncAppBadge() {
       UrbitModule.updateBadgeCount(count, baseUnread.notifTimestamp);
     } catch (e) {
       logger.trackError('Failed to sync OS badge count', {
-        error: e.toString(),
-        errorStack: e.stack,
+        error: e,
         count,
         updatedAt: baseUnread.updatedAt,
       });

--- a/apps/tlon-mobile/src/lib/signupContext.tsx
+++ b/apps/tlon-mobile/src/lib/signupContext.tsx
@@ -245,8 +245,7 @@ async function runProfileAndNotificationActions(params: {
       });
     } catch (e) {
       logger.trackError('onboarding: failed to set notification level', {
-        errorMessage: e instanceof Error ? e.message : String(e),
-        errorStack: e instanceof Error ? e.stack : undefined,
+        error: e,
       });
     }
   }

--- a/packages/api/src/client/postsApi.ts
+++ b/packages/api/src/client/postsApi.ts
@@ -636,8 +636,7 @@ export const getLatestPosts = async ({
     });
   } catch (e) {
     logger.trackError('failed to sync heads', {
-      errorMessage: e.message,
-      errorStack: e.stack,
+      error: e,
     });
     return [];
   }

--- a/packages/app/hooks/useBootSequence.ts
+++ b/packages/app/hooks/useBootSequence.ts
@@ -202,24 +202,21 @@ export function useBootSequence() {
       if (lureMeta?.invitedGroupId !== GETTING_STARTED_GROUP_ID) {
         api.joinGroup(GETTING_STARTED_GROUP_ID).catch((e) => {
           logger.trackError('failed to join getting started group', {
-            errorMessage: e.message,
-            errorStack: e.stack,
+            error: e,
           });
         });
       }
 
       store.leaveGroup(TLON_STUDIO).catch((e) => {
         logger.trackError('failed to leave tlon studio group', {
-          errorMessage: e.message,
-          errorStack: e.stack,
+          error: e,
         });
       });
 
       if (lureMeta?.invitedGroupId !== TLONBOT_GENERAL_GROUP_ID) {
         store.leaveGroup(TLONBOT_GENERAL_GROUP_ID).catch((e) => {
           logger.trackError('failed to leave Tlonbot general group', {
-            errorMessage: e.message,
-            errorStack: e.stack,
+            error: e,
           });
         });
       }

--- a/packages/app/lib/notifications.ts
+++ b/packages/app/lib/notifications.ts
@@ -187,8 +187,7 @@ export const connectNotifications = async () => {
     if (err instanceof Error) {
       logger.trackError('Notifications Debug', {
         contxt: 'Error requesting push notifications token',
-        errorMessage: err.message,
-        stack: err.stack,
+        error: err,
       });
     }
   }
@@ -205,10 +204,8 @@ export const connectNotifications = async () => {
     if (err instanceof Error) {
       logger.trackError('Notifications Debug', {
         contxt: 'Error connecting push notifications provider',
-        errorMessage: err.message,
-        stack: err.stack,
+        error: err,
       });
-      logger;
     }
     return false;
   }

--- a/packages/shared/src/db/query.ts
+++ b/packages/shared/src/db/query.ts
@@ -292,8 +292,7 @@ export async function withTransactionCtx<T>(
         isNested: true,
         rootTransactionLabel: ctx.rootTransaction,
         label: ctx.meta.label,
-        errorMessage: e.message,
-        errorStack: e.stack,
+        error: e,
       });
       throw e;
     }
@@ -321,16 +320,14 @@ export async function withTransactionCtx<T>(
         txLogger.log('tx:error', e);
         txLogger.trackError('DB Transaction Error', {
           label: ctx.meta.label,
-          errorMessage: e.message,
-          errorStack: e.stack,
+          error: e,
         });
         try {
           await ctx.db.run(sql`ROLLBACK`);
         } catch (rollbackError) {
           txLogger.trackError('DB Transaction Rollback Error', {
             label: ctx.meta.label,
-            errorMessage: rollbackError.message,
-            errorStack: rollbackError.stack,
+            error: rollbackError,
           });
         }
         ctx.rootTransaction = null;

--- a/packages/shared/src/debug.test.ts
+++ b/packages/shared/src/debug.test.ts
@@ -1,0 +1,84 @@
+import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest';
+
+import { createDevLogger, useDebugStore } from './debug';
+
+// `trackError` reports asynchronously: `getDebugInfo()` resolves first, then
+// `report()` calls `capture`. Flushing the microtask queue is enough.
+async function flushReport() {
+  await Promise.resolve();
+  await Promise.resolve();
+  await Promise.resolve();
+}
+
+function makeError() {
+  try {
+    // @ts-expect-error deliberate runtime failure so `stack` is real
+    null.boom();
+  } catch (e) {
+    return e as Error;
+  }
+  throw new Error('unreachable');
+}
+
+describe('createDevLogger trackError analytics payload', () => {
+  const capture = vi.fn();
+  const logger = createDevLogger('test', false);
+
+  beforeEach(() => {
+    capture.mockClear();
+    useDebugStore.getState().initializeErrorLogger({ capture });
+  });
+
+  afterEach(() => {
+    useDebugStore.setState({ errorLogger: null });
+  });
+
+  async function captured(data?: Error | Record<string, unknown>) {
+    logger.trackError('failed to sync latest posts', data);
+    await flushReport();
+    expect(capture).toHaveBeenCalledTimes(1);
+    const [event, payload] = capture.mock.calls[0];
+    expect(event).toBe('app_error');
+    return payload as Record<string, unknown>;
+  }
+
+  // PostHog JSON-serializes properties, and an Error's `message`/`stack` are
+  // non-enumerable — so `error: e` alone reaches PostHog as `{}`. These derived
+  // string props are what keeps the error legible there.
+  test('derives errorMessage and errorStack strings from `{ error }`', async () => {
+    const error = makeError();
+    const payload = await captured({ error });
+
+    expect(payload.errorMessage).toBe(error.message);
+    expect(payload.errorStack).toBe(error.stack);
+    expect(typeof payload.errorMessage).toBe('string');
+    expect(typeof payload.errorStack).toBe('string');
+    expect(payload.message).toBe('[test] failed to sync latest posts');
+  });
+
+  test('derives them from a bare Error second argument too', async () => {
+    const error = makeError();
+    const payload = await captured(error);
+
+    expect(payload.errorMessage).toBe(error.message);
+    expect(payload.errorStack).toBe(error.stack);
+  });
+
+  test('caller-supplied errorMessage/errorStack strings still win', async () => {
+    const payload = await captured({
+      errorMessage: 'hand-rolled message',
+      errorStack: 'hand-rolled stack',
+    });
+
+    expect(payload.errorMessage).toBe('hand-rolled message');
+    expect(payload.errorStack).toBe('hand-rolled stack');
+  });
+
+  test('a non-Error `error` value reports without message or stack', async () => {
+    const payload = await captured({ error: 'just a string' });
+
+    expect(payload.error).toBe('just a string');
+    expect(payload.errorMessage).toBeUndefined();
+    expect(payload.errorStack).toBeUndefined();
+  });
+});

--- a/packages/shared/src/store/sync/sync.ts
+++ b/packages/shared/src/store/sync/sync.ts
@@ -503,8 +503,7 @@ export const syncLatestPosts = async (
     }
   } catch (e) {
     logger.trackError('failed to sync latest posts', {
-      errorMessage: e.message,
-      errorStack: e.stack,
+      error: e,
     });
     return () => Promise.resolve();
   }

--- a/packages/ui/src/components/Image.tsx
+++ b/packages/ui/src/components/Image.tsx
@@ -107,8 +107,7 @@ function isValidImageSource(source: any) {
   } catch (e) {
     logger.trackError('Failed to validate image source', {
       source,
-      errorMessage: e.message,
-      errorStack: e.stack,
+      error: e,
     });
   }
   return false;


### PR DESCRIPTION
## Summary

Thirteen `logger.trackError` call sites hand-serialize the caught error into `errorMessage` / `errorStack` (or `stack`) strings instead of passing the `Error` itself. `createDevLogger` only recognizes an error under `customProps` or `customProps.error`, so these sites never yield an error object — the Sentry bridge rebuilds a synthetic `Error` from the string, which titles all of them `Error: …` no matter the real exception type. This passes `error: e` at each site instead.

This is the last bullet of TLON-6478's follow-up list, filed against Sentry [REACT-NATIVE-5](https://tlon-corporation.sentry.io/issues/79485762/) (`capture` / `app_error`, 125,325 events, 544 users). The bridge itself was fixed in #6461, now merged into `develop` and merged into this branch. That bridge keys exclusively off the extracted error object, so left as-is these sites would stop producing stack traces altogether and fall into the message path with the stack stranded in `extra.errorStack`. `error: e` makes each one a true `captureException`.

Fixes TLON-6484

## Changes

Converted `errorMessage` / `errorStack` / `stack` string pairs to `error: e`:

- `apps/tlon-mobile/src/hooks/useSyncAppBadge.ts` (also drops `error: e.toString()`, which shadowed the key the extractor looks at)
- `apps/tlon-mobile/src/lib/signupContext.tsx`
- `packages/api/src/client/postsApi.ts`
- `packages/app/hooks/useBootSequence.ts` (3 sites)
- `packages/app/lib/notifications.ts` (2 sites)
- `packages/shared/src/db/query.ts` (3 sites)
- `packages/shared/src/store/sync/sync.ts`
- `packages/ui/src/components/Image.tsx`

Also drops a stray no-op `logger;` statement in the notifications block being edited.

Adds `packages/shared/src/debug.test.ts` covering the `trackError` → analytics payload contract that these call sites now rely on.

Deliberately left alone:

- The four `stack: err` sites in `packages/api/src/client/urbit.ts` already passed the `Error` object; #6461 rewrote all four, and none remain.
- The three `stack: new Error().stack` sites in `postsApi.ts` and `postActions.ts` are deliberate call-site traces, not caught errors.
- `trackEvent` sites carrying `errorStack` strings (six in `packages/app/lib/nativeDb.ts`, plus one in `query.ts`) needed `createDevLogger`'s `trackEvent` branch to extract an error object too. #6461 did that for `severity: Critical` events and converted those sites, so nothing is left over here.

A full sweep of all 275 `trackError` call sites confirms no string-valued `errorStack` or `stack` remains.

## How did I test?

- `pnpm format:check` — clean.
- `tsc --noEmit` on `packages/{shared,api,ui,app}` and `apps/tlon-mobile` — clean.
- `oxlint` on all eight changed files — no new warnings; nothing reported at the changed lines.
- `vitest run`: `packages/shared` 594 passed (46 files), `packages/api` 855 passed (39 files), `packages/app` 590 passed / 3 skipped (67 files), `packages/ui` 5 passed.
- Not exercised against a live Sentry ingest; the behavioral claim rests on reading `createDevLogger`'s extraction path on `develop` and `toSentryCapture` on `po/sentry-cleanup`.

### PostHog compatibility

`trackError` feeds PostHog and Sentry through the same composite logger, so the call-site change had to be checked against PostHog too:

- **The properties PostHog reads are derived, not passed.** `createDevLogger` sets `errorMessage: errorObj?.message` / `errorStack: errorObj?.stack` from the extracted error before spreading `...customProps`. `error: e` is what makes `errorObj` resolve, so those two keys carry the same strings the call sites were hand-rolling.
- **Verified the wire format against the real SDKs** — posthog-js 1.234.4 (under jsdom) and `@posthog/core` 1.19.0 (the class posthog-react-native 4.29.0 extends), each with a stub transport. The raw `Error` under `error` JSON-serializes to `{}` (its `message`/`stack` are non-enumerable); `errorMessage` and `errorStack` arrive intact.
- **Confirmed against production PostHog.** This shape is already the majority of `app_error`: `[sync] sync since failed` (2820 events / 7d, already `error: e`) records `error = {}` alongside populated `errorMessage` and `errorStack`. The sites this PR touches land on that same shape.
- **One real property change:** `notifications.ts` used `stack:` rather than `errorStack:`, and both `Notifications Debug` sites are in this PR, so that message's `stack` property is replaced by `errorStack`. No non-deleted insight in the project filters or breaks down on `stack`, `error`, or `Notifications Debug`; the insights reading `errorMessage` are unaffected.
- **Regression test** in `packages/shared/src/debug.test.ts` locks in the payload contract: both extraction shapes, caller-supplied string precedence, and a non-Error `error` value.

### After merging `develop` (with #6461)

#6461 landed and was merged in. It reshapes the reporting path but not the conclusion above:

- `createDevLogger` still derives `errorMessage` / `errorStack` from the extracted error, still ahead of the `...customProps` spread, so `error: e` still produces them.
- `createCompositeLogger` strips the new `errorObject` key from the PostHog payload and passes it only to Sentry — so PostHog now depends *entirely* on those two derived strings. That makes this PR's change load-bearing for PostHog rather than merely equivalent.
- One conflict in `packages/shared/src/db/query.ts`: `develop` had wrapped the same three `trackError` calls in `shouldReportQueryError(…)` guards. Resolved by keeping both — the guards from `develop`, the `error: e` payloads from here.
- One add/add conflict on `packages/shared/src/debug.test.ts`, which #6461 also created. Resolved by taking its file and appending the three cases it does not cover: the derived strings from `{ error }`, caller-supplied string precedence, and a non-Error `error` value.

Re-ran after the merge: `packages/shared` 742 passed (49 files), `packages/api` 882 passed (42 files), `packages/app` 604 passed / 3 skipped; `tsc --noEmit` clean on `packages/{shared,api,app,ui}` and `apps/tlon-mobile`; `oxfmt --check` and `oxlint` clean.

## Risks and impact

- Safe to rollback without consulting PR author? **Yes**
- Affects important code area:
  - [x] Onboarding
  - [ ] State / providers
  - [x] Message sync
  - [ ] Channel display
  - [x] Notifications
  - [x] Other: local database transactions, image source validation

Every change is inside a `catch` block that only reports telemetry. No control flow, no rethrow behavior, and no user-visible surface changes. The one wrinkle is that `error` is now also present in the Sentry `extra` payload as the raw `Error`; that matches the 46 call sites already using this shape, and #6461's `scrubExtra` renders it as `"Name: message"`.

## Rollback plan

`git revert` the single commit. Nothing depends on it and it carries no migration or state change.

## Screenshots / videos

n/a — telemetry-only change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

