### PR TITLE
telemetry: forward Critical trackEvent errors to Sentry as typed exceptions

### DIFF
--- a/packages/api/src/client/groupsApi.ts
+++ b/packages/api/src/client/groupsApi.ts
@@ -466,14 +466,15 @@ export const createGroup = async ({
       logger.trackEvent('Create Group Error', {
         severity: AnalyticsSeverity.Critical,
         status: err.status,
-        error: err.toString(),
+        error: err,
+        errorMessage: err.message,
         context: 'group-create-thread request failed',
       });
     } else {
       logger.trackEvent('Create Group Error', {
         severity: AnalyticsSeverity.Critical,
+        error: err,
         errorMessage: err.message,
-        errorStack: err.stack,
         context: 'group-create-thread unexpected error',
       });
     }

--- a/packages/app/lib/nativeDb.ts
+++ b/packages/app/lib/nativeDb.ts
@@ -103,8 +103,8 @@ export class NativeDb extends BaseDb {
       } catch (e) {
         logger.trackEvent(AnalyticsEvent.ErrorNativeDb, {
           context: 'setupDb: error setting up db',
+          error: e,
           errorMessage: e.message,
-          errorStack: e.stack,
           severity: AnalyticsSeverity.Critical,
         });
         throw e;
@@ -169,8 +169,8 @@ export class NativeDb extends BaseDb {
     } catch (e) {
       logger.trackEvent(AnalyticsEvent.ErrorNativeDb, {
         context: 'purgeDb: error purging db',
+        error: e,
         errorMessage: e.message,
-        errorStack: e.stack,
         severity: AnalyticsSeverity.Critical,
       });
       throw e;
@@ -258,8 +258,8 @@ export class NativeDb extends BaseDb {
       );
       logger.trackEvent(AnalyticsEvent.ErrorNativeDb, {
         context: 'runMigrations: schema health check failed',
+        error,
         errorMessage: error.message,
-        errorStack: error.stack,
         missingTables,
         attemptId: opts?.attemptId,
         elapsedMs: opts?.elapsedMs?.(),
@@ -300,8 +300,8 @@ export class NativeDb extends BaseDb {
       );
       logger.trackEvent(AnalyticsEvent.ErrorNativeDb, {
         context: 'runMigrations: setup incomplete before migration',
+        error,
         errorMessage: error.message,
-        errorStack: error.stack,
         severity: AnalyticsSeverity.Critical,
       });
       throw error;
@@ -355,8 +355,8 @@ export class NativeDb extends BaseDb {
       logger.trackEvent(AnalyticsEvent.ErrorNativeDb, {
         context:
           'runMigrations: migration/schema verification failed. Attempting to purge and retry',
+        error: e,
         errorMessage: e.message,
-        errorStack: e.stack,
         attemptId,
         elapsedMs: getElapsedMs(),
         migrationPhase: 'initial',
@@ -384,8 +384,8 @@ export class NativeDb extends BaseDb {
     } catch (e) {
       logger.trackEvent(AnalyticsEvent.ErrorNativeDb, {
         context: 'runMigrations: retry purge failed',
+        error: e,
         errorMessage: e.message,
-        errorStack: e.stack,
         attemptId,
         elapsedMs: getElapsedMs(),
         severity: AnalyticsSeverity.Critical,
@@ -418,8 +418,8 @@ export class NativeDb extends BaseDb {
     } catch (e) {
       logger.trackEvent(AnalyticsEvent.ErrorNativeDb, {
         context: 'runMigrations: retry migrate failed',
+        error: e,
         errorMessage: e.message,
-        errorStack: e.stack,
         attemptId,
         elapsedMs: getElapsedMs(),
         migrationPhase: 'retry',

--- a/packages/shared/src/compositeLogger.test.ts
+++ b/packages/shared/src/compositeLogger.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it, vi } from 'vitest';
 
 import { createCompositeLogger } from './compositeLogger';
+import { AnalyticsSeverity } from './domain';
 
 describe('createCompositeLogger', () => {
   it('forwards app_error to both sinks with the same event name', () => {
@@ -47,6 +48,37 @@ describe('createCompositeLogger', () => {
 
     logger.capture('Attestation Error', { message: 'attestation' });
     logger.capture('Error Sending Post', { message: 'send' });
+
+    expect(posthog).toHaveBeenCalledTimes(2);
+    expect(sentry).not.toHaveBeenCalled();
+  });
+
+  it('forwards a Critical-severity analytics event to sentry', () => {
+    const posthog = vi.fn();
+    const sentry = vi.fn();
+    const logger = createCompositeLogger({ posthog, sentry });
+
+    logger.capture('Native DB Error', {
+      context: 'setupDb failed',
+      severity: AnalyticsSeverity.Critical,
+    });
+
+    expect(posthog).toHaveBeenCalledTimes(1);
+    expect(sentry).toHaveBeenCalledTimes(1);
+    expect(sentry.mock.calls[0][0]).toBe('Native DB Error');
+  });
+
+  it('keeps a non-Critical severity analytics event in posthog only', () => {
+    const posthog = vi.fn();
+    const sentry = vi.fn();
+    const logger = createCompositeLogger({ posthog, sentry });
+
+    logger.capture('Attestation Error', {
+      severity: AnalyticsSeverity.High,
+    });
+    logger.capture('Error Sending Post', {
+      severity: AnalyticsSeverity.Medium,
+    });
 
     expect(posthog).toHaveBeenCalledTimes(2);
     expect(sentry).not.toHaveBeenCalled();

--- a/packages/shared/src/compositeLogger.ts
+++ b/packages/shared/src/compositeLogger.ts
@@ -1,17 +1,37 @@
+import { AnalyticsSeverity } from './domain';
+
 /**
  * Composite logger that fans analytics events out to PostHog and Sentry.
  *
- * PostHog receives every event. Sentry receives only the events listed in
- * `SENTRY_FORWARDED_EVENTS`: `app_error` (from `trackError`) and `App Error`
- * (from the debug-log upload failure path). Analytics events whose names
- * merely contain "error" (e.g. `Attestation Error`, `Error Sending Post`)
- * are PostHog-only; there is no name-based matching.
+ * PostHog receives every event. Sentry receives the events listed in
+ * `SENTRY_FORWARDED_EVENTS` -- `app_error` (from `trackError`) and `App Error`
+ * (from the debug-log upload failure path) -- plus any event tagged
+ * `severity: Critical`. Everything else is PostHog-only; names are never
+ * matched against a pattern, so an analytics event that merely contains
+ * "error" (e.g. `Attestation Error`, `Error Sending Post`) does not qualify.
  */
 
 export const SENTRY_FORWARDED_EVENTS: readonly string[] = [
   'app_error',
   'App Error',
 ];
+
+/**
+ * `trackEvent` analytics stay in PostHog unless they are tagged
+ * `severity: Critical`, which marks a failure the app cannot recover from --
+ * native DB setup and migration, group creation, contact matching. Those are
+ * worth a typed, symbolicated Sentry issue, so they ride the same path as
+ * `trackError` reports.
+ */
+export function isSentryForwarded(
+  event: string,
+  data: Record<string, unknown>
+): boolean {
+  return (
+    SENTRY_FORWARDED_EVENTS.includes(event) ||
+    data.severity === AnalyticsSeverity.Critical
+  );
+}
 
 export type CompositeSink = (
   event: string,
@@ -48,7 +68,7 @@ export function createCompositeLogger(
           console.warn('[compositeLogger] posthog sink failed', e);
         }
       }
-      if (SENTRY_FORWARDED_EVENTS.includes(event)) {
+      if (isSentryForwarded(event, data)) {
         try {
           options.sentry(event, data);
         } catch (e) {

--- a/packages/shared/src/db/query.ts
+++ b/packages/shared/src/db/query.ts
@@ -1,7 +1,7 @@
 import { sql } from 'drizzle-orm';
 
 import { createDevLogger, escapeLog, listDebugLabel } from '../debug';
-import { AnalyticsEvent } from '../domain';
+import { AnalyticsEvent, AnalyticsSeverity } from '../domain';
 import { startTrace } from '../perf';
 import { perfEnabled, perfLog } from '../perfLog';
 import * as changeListener from './changeListener';
@@ -143,7 +143,7 @@ export const createQuery = <TOptions, TReturn>(
           label: meta.label,
           error: e,
           errorMessage: e.message,
-          errorStack: e.stack,
+          severity: AnalyticsSeverity.Critical,
         });
         throw e;
       }

--- a/packages/shared/src/debug.test.ts
+++ b/packages/shared/src/debug.test.ts
@@ -1,5 +1,7 @@
 import { beforeEach, expect, test, vi } from 'vitest';
 
+import { AnalyticsSeverity } from './domain';
+
 import { clearBreadcrumbs, createDevLogger, useDebugStore } from './debug';
 
 let capture: ReturnType<typeof vi.fn>;
@@ -74,6 +76,55 @@ test('trackError breadcrumbs exclude sensitive crumbs', async () => {
   expect(
     payload.breadcrumbs.some((entry: string) => entry.includes('visited x'))
   ).toBe(true);
+  expect(
+    payload.breadcrumbs.some((entry: string) => entry.includes('token abc'))
+  ).toBe(false);
+});
+
+test('trackEvent attaches the error object for Critical events', async () => {
+  const logger = createDevLogger('t', false);
+  const error = new RangeError('db gone');
+  logger.crumb('visited', 'x');
+  logger.trackEvent('Native DB Error', {
+    context: 'setupDb failed',
+    error,
+    severity: AnalyticsSeverity.Critical,
+  });
+  await vi.waitFor(() => expect(capture).toHaveBeenCalled());
+  const [event, payload] = capture.mock.calls[0];
+  expect(event).toBe('Native DB Error');
+  expect(payload.errorObject).toBe(error);
+  expect(payload.errorTitle).toBe('Native DB Error');
+  expect(payload.logger).toBe('t');
+  expect(payload.message).toBe('[t] Native DB Error');
+  expect(
+    payload.breadcrumbs.some((entry: string) => entry.includes('visited x'))
+  ).toBe(true);
+});
+
+test('trackEvent leaves ordinary analytics payloads alone', async () => {
+  const logger = createDevLogger('t', false);
+  logger.crumb('visited', 'x');
+  logger.trackEvent('Attestation Error', {
+    error: new Error('nope'),
+    severity: AnalyticsSeverity.High,
+  });
+  await vi.waitFor(() => expect(capture).toHaveBeenCalled());
+  const payload = capture.mock.calls[0][1];
+  expect(payload.errorObject).toBeUndefined();
+  expect(payload.errorTitle).toBeUndefined();
+  expect(payload.breadcrumbs).toBeUndefined();
+});
+
+test('trackEvent Critical breadcrumbs exclude sensitive crumbs', async () => {
+  const logger = createDevLogger('t', false);
+  logger.crumb('visited', 'x');
+  logger.sensitiveCrumb('token abc');
+  logger.trackEvent('Native DB Error', {
+    severity: AnalyticsSeverity.Critical,
+  });
+  await vi.waitFor(() => expect(capture).toHaveBeenCalled());
+  const payload = capture.mock.calls[0][1];
   expect(
     payload.breadcrumbs.some((entry: string) => entry.includes('token abc'))
   ).toBe(false);

--- a/packages/shared/src/debug.ts
+++ b/packages/shared/src/debug.ts
@@ -4,6 +4,7 @@ import { v4 as uuidv4 } from 'uuid';
 import create from 'zustand';
 import { persist } from 'zustand/middleware';
 
+import { isSentryForwarded } from './compositeLogger';
 import { getStorageMethods } from './db/getStorageMethods';
 import { useLiveRef } from './logic/utilHooks';
 import { useCurrentSession } from './store/session';
@@ -15,6 +16,23 @@ const BREADCRUMB_LIMIT = 100;
 let _buildInfo: string | null = null;
 export function setDebugBuildInfo(info: string) {
   _buildInfo = info;
+}
+
+// Call sites attach the caught error in one of three shapes:
+// - logger.trackError('msg', error)            -> the props are the Error
+// - logger.trackError('msg', { error })        -> under `error`
+// - logger.trackError('msg', { stack: error }) -> under `stack`
+function extractErrorObject(customProps: object): Error | undefined {
+  if (customProps instanceof Error) {
+    return customProps;
+  }
+  if ('error' in customProps && customProps.error instanceof Error) {
+    return customProps.error;
+  }
+  if ('stack' in customProps && customProps.stack instanceof Error) {
+    return customProps.stack;
+  }
+  return undefined;
 }
 
 interface Breadcrumb {
@@ -286,24 +304,7 @@ export function createDevLogger(tag: string, enabled: boolean) {
             .getState()
             .getBreadcrumbs({ includeSensitive: false });
 
-          // Extract error from various patterns:
-          // - logger.trackError('msg', error) -> customProps is Error
-          // - logger.trackError('msg', { error }) -> customProps.error is Error
-          // - logger.trackError('msg', { stack: error }) -> customProps.stack is Error
-          let errorObj: Error | undefined;
-          if (customProps instanceof Error) {
-            errorObj = customProps;
-          } else if (
-            'error' in customProps &&
-            customProps.error instanceof Error
-          ) {
-            errorObj = customProps.error;
-          } else if (
-            'stack' in customProps &&
-            customProps.stack instanceof Error
-          ) {
-            errorObj = customProps.stack;
-          }
+          const errorObj = extractErrorObject(customProps);
 
           const report = (debugInfo: any = undefined) => {
             // Send to error logger (PostHog, Sentry, or both via composite logger)
@@ -333,12 +334,28 @@ export function createDevLogger(tag: string, enabled: boolean) {
           if (args[0] && typeof args[0] === 'string') {
             const customProps =
               args[1] && typeof args[1] === 'object' ? args[1] : {};
+            // Only the events Sentry receives need an error object and a
+            // breadcrumb trail; attaching either to all ~500 analytics events
+            // would bloat every PostHog payload for no reader.
+            const forwarded = isSentryForwarded(
+              args[0],
+              customProps as Record<string, unknown>
+            );
             errorLogger?.capture(args[0], {
               ...customProps,
               message: `[${tag}] ${args[0]}`,
               logger: tag,
               jsContextId,
               buildInfo: _buildInfo,
+              ...(forwarded
+                ? {
+                    breadcrumbs: useDebugStore
+                      .getState()
+                      .getBreadcrumbs({ includeSensitive: false }),
+                    errorObject: extractErrorObject(customProps),
+                    errorTitle: args[0],
+                  }
+                : {}),
             });
           }
           resolvedProp = 'log';


### PR DESCRIPTION
## Summary

Stacked on #6461 — **base branch is `po/sentry-cleanup`, not `develop`.** Merge after that one.

#6461 replaces `develop`'s `/error/i` name match with an exact-match allowlist (`SENTRY_FORWARDED_EVENTS = ['app_error', 'App Error']`). That's right for the ~480 analytics events the name match was sweeping in, but it also drops errors that belong in Sentry, because they're reported through `trackEvent` rather than `trackError`. This gates forwarding on `severity: Critical` instead, and teaches `trackEvent` the same error extraction `trackError` already has.

Fixes TLON-6485

## Changes

**What #6461 would drop.** Sweeping all 503 `trackEvent` call sites (64 carry an error payload), these are in Sentry on `develop` and would not be after it — with 30-day production volume for scale:

| event | sites | events / users (30d) |
| --- | --- | --- |
| `Database Query Error` | 1 (`packages/shared/src/db/query.ts:142`) | 3,213 / 120 |
| `Native DB Error` | 7 (`packages/app/lib/nativeDb.ts`) | 17 / 14 |
| `Create Group Error` | 2 (`packages/api/src/client/groupsApi.ts:466`, `:473`) | 10 / 2 |

For scale: the existing `app_error` stream is 48,593 events / 642 users over the same window, so restoring all three is about +6.7%.

(The five `UnexpectedHostingError` sites in `hostingApi.ts` also carry `errorStack` strings, but their event value is `Unexpected Hosting API Response`, which never matched `/error/i` — not in Sentry today either, left alone.)

**`compositeLogger.ts`** — new `isSentryForwarded(event, data)`: the two `trackError` events, plus anything tagged `severity: AnalyticsSeverity.Critical`. Severity is a marker the codebase already maintains (22 call sites across 10 files), so nothing new has to be kept in sync, and this stays a deliberate allowlist rather than a reintroduced name pattern.

**`debug.ts`** — the error extraction in the `trackError` branch is hoisted to a module-level `extractErrorObject`, and `trackEvent` now uses it too, attaching `errorObject`, `errorTitle` and breadcrumbs. Only for forwarded events: attaching a breadcrumb trail to all ~500 analytics events would bloat every PostHog payload for no reader. Non-forwarded payloads are byte-for-byte unchanged.

**Ten call sites** (7 in `nativeDb.ts`, 2 in `groupsApi.ts`, 1 in `query.ts`) hand-serialized into `errorMessage` / `errorStack`, or stringified with `toString()`, so `toSentryCapture` could never build an exception from them. They now pass the object. `errorMessage` stays alongside it — PostHog renders an `Error` as `{}`, and `toSentryCapture` drops the duplicate from `extra` once the capture is an exception.

`query.ts:142` also gains `severity: Critical`, which it was missing (caught by Codex — the first revision of this PR claimed the event was covered when the predicate didn't match it). Tagging the call site keeps severity as the single rule rather than growing a second allowlist, and `DB Transaction Error` a few lines down already reaches Sentry through `trackError`, so treating a query failure differently would be odd.

After this, 20 of the 22 Critical sites carry an error object. The two that don't (`signupContext.tsx:210`, `useBootSequence.ts:419`) have no caught error to attach — failure branches carrying only a `context` — and become fingerprinted message events.

## How did I test?

- Five new tests: severity forwarding and non-forwarding in `compositeLogger.test.ts`; `trackEvent` error-object/breadcrumb attachment, non-forwarded payloads left untouched, and sensitive-crumb exclusion in `debug.test.ts`.
- `vitest run`: `packages/shared` 712 passed (47 files), `packages/api` 854 passed (39 files), `packages/app` 578 passed / 3 skipped (67 files). Counts verified identical at the base commit, so this adds no regressions.
- `tsc --noEmit` clean on `packages/{shared,api,app}` and `apps/tlon-mobile`.
- `pnpm format:check` clean; `oxlint` on the changed files reports nothing new at the changed lines.
- Volume figures above are from a PostHog query against Groups Mobile PRODUCTION, 30-day window.
- Not exercised against a live Sentry ingest.

## Risks and impact

- Safe to rollback without consulting PR author? **Yes**
- Affects important code area:
  - [ ] Onboarding
  - [ ] State / providers
  - [ ] Message sync
  - [ ] Notifications
  - [x] Other: telemetry routing, local database setup/migration/query reporting

The main judgment call is re-widening what reaches Sentry after #6461 deliberately narrowed it. The widening is bounded and enumerable — 22 `Critical` sites, ~+6.7% on current `app_error` volume — and I'd rather have it reviewed than assumed; see the [note on #6461](https://github.com/tloncorp/tlon-apps/pull/6461#issuecomment-5560180432). If the answer is "Critical should stay PostHog-only", drop the `isSentryForwarded` change and keep the call-site conversions.

Second-order risk: `severity: Critical` now decides Sentry volume, so mis-tagging a hot path would spike ingest. `Database Query Error` is the highest-volume member at 3,213/30d and is the one to watch if query failures ever become routine.

## Rollback plan

`git revert` the two commits. No migration, no persisted state, no wire-format change.

## Screenshots / videos

n/a — telemetry-only change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)