### PR TITLE
chat: emit a %chat-dm-status fact on /v4 when a DM's net changes

### DIFF
--- a/desk/app/chat.hoon
+++ b/desk/app/chat.hoon
@@ -84,7 +84,7 @@
           [/v3/clubs %chat-club-action-1 ~]
           [/v3/dm/$ %writ-response-3 ~]
         ::
-          [/v4 %chat-club-action-2 %writ-response-4 %ships ~]
+          [/v4 %chat-club-action-2 %writ-response-4 %ships %chat-dm-status ~]
           [/v4/club/$ %writ-response-4 ~]
           [/v4/clubs %chat-club-action-2 ~]
           [/v4/dm/$ %writ-response-4 ~]
@@ -2473,6 +2473,15 @@
   =/  invites  ~(key by pending-dms)
   =.  cor  (emit (tell-log %dbug ~['current invites:' >invites<] ~))
   (give %fact ~[/ /dm/invited /v1 /v2 /v3] ships+invites)
+::  +give-dm-status: announce a dm entering, changing, or leaving .dms
+::
+::    the writ facts alone don't tell a subscriber that a dm now exists
+::    (a dm we start ourselves never passes through /dm/invited), so
+::    clients otherwise only learn of new dms from a full init scry.
+::
+++  give-dm-status
+  |=  =status:dm:c
+  (give %fact ~[/v4] chat-dm-status+status)
 ::
 ++  verses-to-inlines  ::  for backcompat
   |=  l=(list verse:d)
@@ -2500,10 +2509,14 @@
 ::  +di-core: direct messaging core
 ::
 ++  di-core
-  |_  [=ship =dm:c gone=_|]
+  ::  .was: net state when the core was entered, ~ if the dm didn't exist
+  ::
+  |_  [=ship =dm:c gone=_| was=(unit net:dm:c)]
   +*  di-pact  ~(. pac pact.dm)
   ++  di-core  .
   ++  di-abet
+    =/  now-net=(unit net:dm:c)  ?:(gone ~ `net.dm)
+    =?  cor  !=(was now-net)  (give-dm-status ship now-net)
     =?  last-updated  |(gone !(~(has by dms) ship))
       (~(put ol last-updated) [%ship ship] now.bowl)
     ?.  gone
@@ -2518,13 +2531,14 @@
     |=  s=@p
     ~>  %spin.['di-abed']
     ~|  ship=s
-    di-core(ship s, dm (~(got by dms) s))
+    =/  d=dm:c  (~(got by dms) s)
+    di-core(ship s, dm d, was `net.d)
   ::
   ++  di-abed-soft
     |=  s=@p
     ~>  %spin.['di-abed-soft']
     =/  dm  (~(get by dms) s)
-    ?^  dm  di-core(ship s, dm u.dm)
+    ?^  dm  di-core(ship s, dm u.dm, was `net.u.dm)
     =|  =remark:c
     =/  new=dm:c
       :*  *pact:c
@@ -2533,7 +2547,7 @@
           ?:(=(src our):bowl %inviting %invited)
           |
       ==
-    =.  di-core  di-core(ship s, dm new)
+    =.  di-core  di-core(ship s, dm new, was ~)
     ?:  &(!=(s our.bowl) =(src our):bowl)  di-core
     (di-activity [%invite ~] *story:d &)
   ::

--- a/desk/lib/chat-json.hoon
+++ b/desk/lib/chat-json.hoon
@@ -16,6 +16,13 @@
     |=  =@da
     s+`@t`(rsh 4 (scot %ui da))
   ::
+  ++  dm-status
+    |=  s=status:dm:c
+    %-  pairs
+    :~  ship+(ship ship.s)
+        net+?~(net.s ~ s+u.net.s)
+    ==
+  ::
   ++  meta
     |=  m=data:^meta
     %-  pairs

--- a/desk/lib/rail.hoon
+++ b/desk/lib/rail.hoon
@@ -133,6 +133,7 @@
 /%  chat-dm-diff-1              %chat-dm-diff-1
 /%  chat-dm-diff-2              %chat-dm-diff-2
 /%  chat-dm-rsvp                %chat-dm-rsvp
+/%  chat-dm-status              %chat-dm-status
 /%  chat-heads                  %chat-heads
 /%  chat-heads-1                %chat-heads-1
 /%  chat-heads-2                %chat-heads-2
@@ -491,6 +492,7 @@
       $:  %chat-dm-diff-1              $+  chat-dm-diff-1              p=_*vale:chat-dm-diff-1              ==
       $:  %chat-dm-diff-2              $+  chat-dm-diff-2              p=_*vale:chat-dm-diff-2              ==
       $:  %chat-dm-rsvp                $+  chat-dm-rsvp                p=_*vale:chat-dm-rsvp                ==
+      $:  %chat-dm-status              $+  chat-dm-status              p=_*vale:chat-dm-status              ==
       $:  %chat-heads                  $+  chat-heads                  p=_*vale:chat-heads                  ==
       $:  %chat-heads-1                $+  chat-heads-1                p=_*vale:chat-heads-1                ==
       $:  %chat-heads-2                $+  chat-heads-2                p=_*vale:chat-heads-2                ==
@@ -851,6 +853,7 @@
     %chat-dm-diff-1              [-.rail !>(+.rail)]
     %chat-dm-diff-2              [-.rail !>(+.rail)]
     %chat-dm-rsvp                [-.rail !>(+.rail)]
+    %chat-dm-status              [-.rail !>(+.rail)]
     %chat-heads                  [-.rail !>(+.rail)]
     %chat-heads-1                [-.rail !>(+.rail)]
     %chat-heads-2                [-.rail !>(+.rail)]
@@ -1209,6 +1212,7 @@
     %chat-dm-diff-1              [p !<(_*vale:chat-dm-diff-1 q)]
     %chat-dm-diff-2              [p !<(_*vale:chat-dm-diff-2 q)]
     %chat-dm-rsvp                [p !<(_*vale:chat-dm-rsvp q)]
+    %chat-dm-status              [p !<(_*vale:chat-dm-status q)]
     %chat-heads                  [p !<(_*vale:chat-heads q)]
     %chat-heads-1                [p !<(_*vale:chat-heads-1 q)]
     %chat-heads-2                [p !<(_*vale:chat-heads-2 q)]
@@ -1567,6 +1571,7 @@
       :-  %chat-dm-diff-1              -:!>(*vale:chat-dm-diff-1)
       :-  %chat-dm-diff-2              -:!>(*vale:chat-dm-diff-2)
       :-  %chat-dm-rsvp                -:!>(*vale:chat-dm-rsvp)
+      :-  %chat-dm-status              -:!>(*vale:chat-dm-status)
       :-  %chat-heads                  -:!>(*vale:chat-heads)
       :-  %chat-heads-1                -:!>(*vale:chat-heads-1)
       :-  %chat-heads-2                -:!>(*vale:chat-heads-2)

--- a/desk/mar/chat/dm-status.hoon
+++ b/desk/mar/chat/dm-status.hoon
@@ -1,0 +1,14 @@
+/-  c=chat
+/+  j=chat-json
+|_  =status:dm:c
+++  grad  %noun
+++  grow
+  |%
+  ++  noun  status
+  ++  json  (dm-status:enjs:j status)
+  --
+++  grab
+  |%
+  ++  noun  status:dm:c
+  --
+--

--- a/desk/sur/chat.hoon
+++ b/desk/sur/chat.hoon
@@ -240,6 +240,7 @@
 ::    .id: a message identifier
 ::    .action: an update to the dm
 ::    .rsvp: a response to a dm invitation
+::    .status: the dm's net state, or ~ once it is gone
 ::
 ++  dm
   |^  dm
@@ -255,6 +256,7 @@
   +$  diff      diff:writs
   +$  action    (pair ship diff)
   +$  rsvp      [=ship ok=?]
+  +$  status    [=ship net=(unit net)]
   --
 ::
 ::  $whom: a polymorphic identifier for chats

--- a/desk/tests/app/chat.hoon
+++ b/desk/tests/app/chat.hoon
@@ -69,6 +69,76 @@
   %+  ex-cards  caz
   :~  (ex-fact ~[/unreads] %chat-unread-update !>([whom unread]))
   ==
+::  a dm we start ourselves (as %grouper does for the reciprocal dm when
+::  a personal invite is redeemed) never touches /dm/invited, so the only
+::  way a /v4 subscriber learns the dm exists is the %chat-dm-status fact.
+::
+++  test-dm-status-facts-for-dm-we-start
+  %-  eval-mare
+  =/  m  (mare ,~)
+  ;<  *  bind:m  (do-init dap agent)
+  ;<  *  bind:m  (set-scry-gate scries)
+  ;<  *  bind:m  (jab-bowl |=(b=bowl b(our ~dev, src ~dev)))
+  ;<  bw=bowl  bind:m  get-bowl
+  =/  =verse:ch  [%inline ~['hi']]
+  ::  we start the dm: it's %inviting until ~zod accepts
+  =/  =action:dm:c  [~zod (dm-message-from ~dev now.bw verse)]
+  ;<  caz=(list card)  bind:m  (do-poke %chat-dm-action-2 !>(action))
+  ;<  *  bind:m  (ex-dm-status caz [~zod `%inviting] ~)
+  ::  ~zod accepts
+  ;<  *  bind:m  (set-src ~zod)
+  ;<  caz=(list card)  bind:m  (do-poke %chat-dm-rsvp !>([~zod &]))
+  ;<  *  bind:m  (ex-dm-status caz [~zod `%done] ~)
+  ::  a message in an existing dm doesn't re-announce it
+  ;<  *  bind:m  (wait ~s1)
+  ;<  bw=bowl  bind:m  get-bowl
+  =/  =diff:dm:c  (dm-message ~zod now.bw verse)
+  ;<  caz=(list card)  bind:m  (do-poke %chat-dm-diff-2 !>(diff))
+  ;<  *  bind:m  (ex-dm-status caz ~)
+  ::  we archive it
+  ;<  *  bind:m  (set-src ~dev)
+  ;<  caz=(list card)  bind:m  (do-poke %chat-dm-archive !>(~zod))
+  (ex-dm-status caz [~zod `%archive] ~)
+::
+++  test-dm-status-facts-for-dm-we-receive
+  %-  eval-mare
+  =/  m  (mare ,~)
+  ;<  *  bind:m  (do-init dap agent)
+  ;<  *  bind:m  (set-scry-gate scries)
+  ;<  *  bind:m  (jab-bowl |=(b=bowl b(our ~dev, src ~zod)))
+  ;<  bw=bowl  bind:m  get-bowl
+  =/  =verse:ch  [%inline ~['hi']]
+  ::  ~zod starts a dm with us: it's a pending invite
+  =/  =diff:dm:c  (dm-message ~zod now.bw verse)
+  ;<  caz=(list card)  bind:m  (do-poke %chat-dm-diff-2 !>(diff))
+  ;<  *  bind:m  (ex-dm-status caz [~zod `%invited] ~)
+  ::  we decline: the dm is gone
+  ;<  *  bind:m  (set-src ~dev)
+  ;<  caz=(list card)  bind:m  (do-poke %chat-dm-rsvp !>([~zod |]))
+  ;<  *  bind:m  (ex-dm-status caz [~zod ~] ~)
+  ::  ~zod tries again and this time we accept
+  ;<  *  bind:m  (set-src ~zod)
+  ;<  *  bind:m  (wait ~s1)
+  ;<  bw=bowl  bind:m  get-bowl
+  =/  =diff:dm:c  (dm-message ~zod now.bw verse)
+  ;<  caz=(list card)  bind:m  (do-poke %chat-dm-diff-2 !>(diff))
+  ;<  *  bind:m  (ex-dm-status caz [~zod `%invited] ~)
+  ;<  *  bind:m  (set-src ~dev)
+  ;<  caz=(list card)  bind:m  (do-poke %chat-dm-rsvp !>([~zod &]))
+  (ex-dm-status caz [~zod `%done] ~)
+::  +ex-dm-status: the %chat-dm-status facts in .caz are exactly .exes
+::
+++  ex-dm-status
+  |=  [caz=(list card) exes=(list status:dm:c)]
+  =/  m  (mare ,~)
+  ^-  form:m
+  %+  ex-cards
+    %+  skim  caz
+    |=(=card ?=([%give %fact * %chat-dm-status *] card))
+  %+  turn  exes
+  |=  =status:dm:c
+  (ex-fact ~[/v4] %chat-dm-status !>(status))
+::
 ++  scries
   |=  =path
   ^-  (unit vase)
@@ -86,4 +156,12 @@
   =/  =essay:c
     [[~[verse] ~zod time] chat+/ ~ ~]
   [[author time] %add essay `time]
+::  +dm-message-from: like +dm-message, but .author also writes the essay
+::
+++  dm-message-from
+  |=  [author=ship =time =verse:ch]
+  ^-  diff:dm:c
+  =/  =essay:c
+    [[~[verse] author time] chat+/ ~ ~]
+  [[author time] %add essay ~]
 --

--- a/packages/api/src/client/chatApi.ts
+++ b/packages/api/src/client/chatApi.ts
@@ -94,7 +94,6 @@ export const updateDMMeta = async ({
 export type ChatEvent =
   | { type: 'showPost'; postId: string }
   | { type: 'hidePost'; postId: string }
-  | { type: 'syncDmInvites'; channels: db.Channel[] }
   | { type: 'dmStatus'; channelId: string; net: ub.DmNet | null }
   | { type: 'groupDmsUpdate' }
   | { type: 'addPost'; post: db.Post; replyMeta?: db.ReplyMeta | null }
@@ -111,12 +110,12 @@ export function subscribeToChatUpdates(
       app: 'chat',
       path: '/v4',
     },
-    (event: ub.WritResponse | ub.ClubAction | ub.DmStatus | string[]) => {
+    (event: ub.WritResponse | ub.ClubAction | ub.DmStatus) => {
       logger.log('raw chat sub event', event);
 
-      // a dm entered, changed, or left the backend's dm set. This is the
-      // only signal for a dm we didn't start from this client (e.g. the
-      // reciprocal dm created when someone redeems our personal invite).
+      // a dm entered, changed, or left the backend's dm set: a new invite
+      // to us, a dm we started (e.g. the reciprocal dm created when someone
+      // redeems our personal invite), an accept, a decline, or leaving.
       if ('ship' in event && 'net' in event) {
         logger.log('dm status', event);
         return eventHandler({
@@ -138,15 +137,6 @@ export function subscribeToChatUpdates(
         logger.log('hide post', event.hide);
         const postId = getCanonicalPostId(event.hide as string);
         return eventHandler({ type: 'hidePost', postId });
-      }
-
-      // check for DM invites sync
-      if (Array.isArray(event)) {
-        // dm invites - this is the complete list of pending invites
-        return eventHandler({
-          type: 'syncDmInvites',
-          channels: toClientDms(event, true),
-        });
       }
 
       // and club events

--- a/packages/api/src/client/chatApi.ts
+++ b/packages/api/src/client/chatApi.ts
@@ -95,6 +95,7 @@ export type ChatEvent =
   | { type: 'showPost'; postId: string }
   | { type: 'hidePost'; postId: string }
   | { type: 'syncDmInvites'; channels: db.Channel[] }
+  | { type: 'dmStatus'; channelId: string; net: ub.DmNet | null }
   | { type: 'groupDmsUpdate' }
   | { type: 'addPost'; post: db.Post; replyMeta?: db.ReplyMeta | null }
   | { type: 'deletePost'; postId: string }
@@ -110,8 +111,20 @@ export function subscribeToChatUpdates(
       app: 'chat',
       path: '/v4',
     },
-    (event: ub.WritResponse | ub.ClubAction | string[]) => {
+    (event: ub.WritResponse | ub.ClubAction | ub.DmStatus | string[]) => {
       logger.log('raw chat sub event', event);
+
+      // a dm entered, changed, or left the backend's dm set. This is the
+      // only signal for a dm we didn't start from this client (e.g. the
+      // reciprocal dm created when someone redeems our personal invite).
+      if ('ship' in event && 'net' in event) {
+        logger.log('dm status', event);
+        return eventHandler({
+          type: 'dmStatus',
+          channelId: event.ship,
+          net: event.net,
+        });
+      }
 
       if ('show' in event) {
         // show/unhide post event

--- a/packages/api/src/index.ts
+++ b/packages/api/src/index.ts
@@ -52,6 +52,8 @@ export {
   type PostResponse,
   type ReplyResponse,
   type WritResponse,
+  type DmNet,
+  type DmStatus,
   type WritResponseDelta,
   type WritDelta,
   type WritDiff,

--- a/packages/api/src/urbit/dms.ts
+++ b/packages/api/src/urbit/dms.ts
@@ -342,6 +342,21 @@ export interface ClubAction {
   diff: ClubDiff;
 }
 
+/**
+ * Backend state of a DM: %inviting until the other side accepts a DM we
+ * started, %invited while their DM to us is pending, %done once accepted.
+ */
+export type DmNet = 'inviting' | 'invited' | 'archive' | 'done';
+
+/**
+ * Emitted on /v4 whenever a DM enters, changes, or leaves the backend's DM
+ * set. `net` is null once the DM is gone (declined or left).
+ */
+export interface DmStatus {
+  ship: string;
+  net: DmNet | null;
+}
+
 export interface DMInit {
   clubs: Clubs;
   dms: string[];

--- a/packages/openclaw/src/monitor/index.ts
+++ b/packages/openclaw/src/monitor/index.ts
@@ -60,7 +60,6 @@ import { emitTlonPluginErrorTelemetry } from '../plugin-error-observability.js';
 import { getTlonRuntime } from '../runtime.js';
 import { setSessionRole } from '../session-roles.js';
 import {
-  DM_INVITE_PREVIEW,
   type TlonSettingsStore,
   createSettingsManager,
 } from '../settings.js';
@@ -4558,6 +4557,9 @@ async function monitorTlonProviderScoped(opts: MonitorTlonOpts): Promise<void> {
     // Track which DM invites we've already processed to avoid duplicate accepts
     const processedDmInvites = new Set<string>();
 
+    // Accept-only: the writ that created the invite has already queued the
+    // owner approval for anyone not auto-accepted here, with the real message
+    // as preview, so this must not queue a second one.
     const handleDmInvite = async (rawShip: string) => {
       const ship = normalizeShip(rawShip || '');
       if (!ship || processedDmInvites.has(ship)) {
@@ -4601,20 +4603,6 @@ async function monitorTlonProviderScoped(opts: MonitorTlonOpts): Promise<void> {
           );
         }
         return;
-      }
-
-      // If owner is configured and ship is not on allowlist, queue approval
-      if (effectiveOwnerShip && !isDmAllowed(ship, effectiveDmAllowlist)) {
-        const approval = createPendingApproval(
-          {
-            type: 'dm',
-            requestingShip: ship,
-            messagePreview: DM_INVITE_PREVIEW,
-          },
-          pendingApprovals.map((a) => a.id)
-        );
-        await queueApprovalRequest(approval);
-        processedDmInvites.add(ship); // Mark as processed to avoid duplicate notifications
       }
     };
 

--- a/packages/openclaw/src/monitor/index.ts
+++ b/packages/openclaw/src/monitor/index.ts
@@ -1,4 +1,4 @@
-import type { DmStatus, Story } from '@tloncorp/api';
+import type { Story } from '@tloncorp/api';
 import { randomUUID } from 'node:crypto';
 import { format } from 'node:util';
 import { createTypingCallbacks } from 'openclaw/plugin-sdk/channel-runtime';
@@ -59,7 +59,11 @@ import {
 import { emitTlonPluginErrorTelemetry } from '../plugin-error-observability.js';
 import { getTlonRuntime } from '../runtime.js';
 import { setSessionRole } from '../session-roles.js';
-import { type TlonSettingsStore, createSettingsManager } from '../settings.js';
+import {
+  DM_INVITE_PREVIEW,
+  type TlonSettingsStore,
+  createSettingsManager,
+} from '../settings.js';
 import { sharedSlot } from '../shared-state.js';
 import {
   createSilentFailureNoticeCooldown,
@@ -108,7 +112,7 @@ import {
 } from '../urbit/blob.js';
 import { ssrfPolicyFromAllowPrivateNetwork } from '../urbit/context.js';
 import { describeError } from '../urbit/errors.js';
-import type { Foreigns } from '../urbit/foreigns.js';
+import type { DmInvite, Foreigns } from '../urbit/foreigns.js';
 import { type BotProfile, sendChannelPost, sendDm } from '../urbit/send.js';
 import { UrbitSSEClient } from '../urbit/sse-client.js';
 import { markdownToStory } from '../urbit/story.js';
@@ -326,10 +330,9 @@ interface ChannelFirehoseEvent {
 }
 
 /**
- * Chat/DM firehose: a WritResponse, or a %chat-dm-status fact for a dm
- * entering, changing, or leaving the dm set
+ * Chat/DM firehose can be an array of DM invites or a WritResponse
  */
-type ChatFirehoseEvent = WritResponse | DmStatus;
+type ChatFirehoseEvent = DmInvite[] | WritResponse;
 
 /** Refresh stale settings subscription state periodically as a fallback for silently-dead SSE subscriptions. */
 const SETTINGS_REFRESH_INTERVAL_MS = 5 * 60 * 1000;
@@ -390,11 +393,6 @@ export async function monitorTlonProvider(
 }
 
 async function monitorTlonProviderScoped(opts: MonitorTlonOpts): Promise<void> {
-  // assigned once the chat firehose handlers exist below; the SSE client's
-  // recovery hook (declared earlier) calls it after a resubscribe
-  let reconcilePendingDmInvites: (
-    cause: string
-  ) => Promise<void> = async () => {};
   const core = getTlonRuntime();
   // Prefer the channel-start config snapshot (Fix B) over an independent
   // load: see the MonitorTlonOpts.cfg doc comment.
@@ -666,15 +664,6 @@ async function monitorTlonProviderScoped(opts: MonitorTlonOpts): Promise<void> {
       // surface recovery progress to PostHog. Sampled: first failure, then
       // every 5th, plus a marker event once the subscription recovers.
       onSubscriptionRecovery: (event) => {
-        if (
-          event.app === 'chat' &&
-          event.path === '/v4' &&
-          event.phase !== 'retrying'
-        ) {
-          // invites that arrived while the subscription was down were never
-          // delivered; the pending list is the only way to see them
-          void reconcilePendingDmInvites(event.phase);
-        }
         const source = subscriptionErrorSource(event.app, event.path);
         if (event.phase === 'retrying') {
           if (event.attempt === 1 || event.attempt % 5 === 0) {
@@ -4568,83 +4557,73 @@ async function monitorTlonProviderScoped(opts: MonitorTlonOpts): Promise<void> {
     // Track which DM invites we've already processed to avoid duplicate accepts
     const processedDmInvites = new Set<string>();
 
-    // Accept-only: the writ that created the invite has already queued the
-    // owner approval for anyone not auto-accepted here, with the real message
-    // as preview, so this must not queue a second one.
-    const handleDmInvite = async (rawShip: string) => {
-      const ship = normalizeShip(rawShip || '');
-      if (!ship || processedDmInvites.has(ship)) {
-        return;
-      }
-
-      // Owner is always allowed
-      if (isOwner(ship)) {
-        try {
-          await api.poke({
-            app: 'chat',
-            mark: 'chat-dm-rsvp',
-            json: { ship, ok: true },
-          });
-          processedDmInvites.add(ship);
-          runtime.log?.(`[tlon] Auto-accepted DM invite from owner ${ship}`);
-        } catch (err) {
-          runtime.error?.(
-            `[tlon] Failed to auto-accept DM from owner: ${String(err)}`
-          );
-        }
-        return;
-      }
-
-      // Auto-accept if on allowlist and auto-accept is enabled
-      if (
-        effectiveAutoAcceptDmInvites &&
-        isDmAllowed(ship, effectiveDmAllowlist)
-      ) {
-        try {
-          await api.poke({
-            app: 'chat',
-            mark: 'chat-dm-rsvp',
-            json: { ship, ok: true },
-          });
-          processedDmInvites.add(ship);
-          runtime.log?.(`[tlon] Auto-accepted DM invite from ${ship}`);
-        } catch (err) {
-          runtime.error?.(
-            `[tlon] Failed to auto-accept DM from ${ship}: ${String(err)}`
-          );
-        }
-        return;
-      }
-    };
-
-    // The status fact is one-shot: an invite that lands while this process is
-    // down, or after its channel has expired, is never replayed. The pending
-    // list on the ship is the truth, so read it at startup and whenever the
-    // chat subscription comes back. handleDmInvite is idempotent via
-    // processedDmInvites, so re-reading is cheap.
-    reconcilePendingDmInvites = async (cause: string) => {
-      try {
-        const invited = (await api.scry('/chat/dm/invited.json')) as string[];
-        for (const ship of invited) {
-          await handleDmInvite(ship);
-        }
-      } catch (err) {
-        runtime.error?.(
-          `[tlon] Failed to reconcile pending DM invites (${cause}): ${String(err)}`
-        );
-      }
-    };
-
     const handleChatFirehose = async (event: ChatFirehoseEvent) => {
       try {
-        // %chat-dm-status: a dm entered, changed, or left %chat's dm set.
-        // This is the live signal for a new invite. A removed dm can be
-        // invited again, so forget it.
-        if ('ship' in event && 'net' in event) {
-          if (event.net === 'invited') {
-            await handleDmInvite(event.ship);
-          } else if (event.net === null) {
-            processedDmInvites.delete(normalizeShip(event.ship));
+        // Handle DM invite lists (arrays)
+        if (Array.isArray(event)) {
+          for (const invite of event) {
+            const ship = normalizeShip(invite.ship || '');
+            if (!ship || processedDmInvites.has(ship)) {
+              continue;
+            }
+
+            // Owner is always allowed
+            if (isOwner(ship)) {
+              try {
+                await api.poke({
+                  app: 'chat',
+                  mark: 'chat-dm-rsvp',
+                  json: { ship, ok: true },
+                });
+                processedDmInvites.add(ship);
+                runtime.log?.(
+                  `[tlon] Auto-accepted DM invite from owner ${ship}`
+                );
+              } catch (err) {
+                runtime.error?.(
+                  `[tlon] Failed to auto-accept DM from owner: ${String(err)}`
+                );
+              }
+              continue;
+            }
+
+            // Auto-accept if on allowlist and auto-accept is enabled
+            if (
+              effectiveAutoAcceptDmInvites &&
+              isDmAllowed(ship, effectiveDmAllowlist)
+            ) {
+              try {
+                await api.poke({
+                  app: 'chat',
+                  mark: 'chat-dm-rsvp',
+                  json: { ship, ok: true },
+                });
+                processedDmInvites.add(ship);
+                runtime.log?.(`[tlon] Auto-accepted DM invite from ${ship}`);
+              } catch (err) {
+                runtime.error?.(
+                  `[tlon] Failed to auto-accept DM from ${ship}: ${String(err)}`
+                );
+              }
+              continue;
+            }
+
+            // If owner is configured and ship is not on allowlist, queue approval
+            if (
+              effectiveOwnerShip &&
+              !isDmAllowed(ship, effectiveDmAllowlist)
+            ) {
+              const approval = createPendingApproval(
+                {
+                  type: 'dm',
+                  requestingShip: ship,
+                  messagePreview: DM_INVITE_PREVIEW,
+                },
+                pendingApprovals.map((a) => a.id)
+              );
+              await queueApprovalRequest(approval);
+              processedDmInvites.add(ship); // Mark as processed to avoid duplicate notifications
+            }
           }
           return;
         }
@@ -4957,7 +4936,6 @@ async function monitorTlonProviderScoped(opts: MonitorTlonOpts): Promise<void> {
         },
       });
       runtime.log?.('[tlon] Subscribed to chat firehose (/v4)');
-      await reconcilePendingDmInvites('startup');
 
       // Subscribe to contacts updates to track nickname changes
       await api.subscribe({

--- a/packages/openclaw/src/monitor/index.ts
+++ b/packages/openclaw/src/monitor/index.ts
@@ -329,10 +329,16 @@ interface ChannelFirehoseEvent {
   response: ChannelResponse;
 }
 
+interface DmStatusEvent {
+  ship: string;
+  net: 'inviting' | 'invited' | 'archive' | 'done' | null;
+}
+
 /**
- * Chat/DM firehose can be an array of DM invites or a WritResponse
+ * Chat/DM firehose: an array of DM invites, a WritResponse, or a
+ * %chat-dm-status fact for a dm entering, changing, or leaving the dm set
  */
-type ChatFirehoseEvent = DmInvite[] | WritResponse;
+type ChatFirehoseEvent = DmInvite[] | WritResponse | DmStatusEvent;
 
 /** Refresh stale settings subscription state periodically as a fallback for silently-dead SSE subscriptions. */
 const SETTINGS_REFRESH_INTERVAL_MS = 5 * 60 * 1000;
@@ -4557,73 +4563,84 @@ async function monitorTlonProviderScoped(opts: MonitorTlonOpts): Promise<void> {
     // Track which DM invites we've already processed to avoid duplicate accepts
     const processedDmInvites = new Set<string>();
 
+    const handleDmInvite = async (rawShip: string) => {
+      const ship = normalizeShip(rawShip || '');
+      if (!ship || processedDmInvites.has(ship)) {
+        return;
+      }
+
+      // Owner is always allowed
+      if (isOwner(ship)) {
+        try {
+          await api.poke({
+            app: 'chat',
+            mark: 'chat-dm-rsvp',
+            json: { ship, ok: true },
+          });
+          processedDmInvites.add(ship);
+          runtime.log?.(`[tlon] Auto-accepted DM invite from owner ${ship}`);
+        } catch (err) {
+          runtime.error?.(
+            `[tlon] Failed to auto-accept DM from owner: ${String(err)}`
+          );
+        }
+        return;
+      }
+
+      // Auto-accept if on allowlist and auto-accept is enabled
+      if (
+        effectiveAutoAcceptDmInvites &&
+        isDmAllowed(ship, effectiveDmAllowlist)
+      ) {
+        try {
+          await api.poke({
+            app: 'chat',
+            mark: 'chat-dm-rsvp',
+            json: { ship, ok: true },
+          });
+          processedDmInvites.add(ship);
+          runtime.log?.(`[tlon] Auto-accepted DM invite from ${ship}`);
+        } catch (err) {
+          runtime.error?.(
+            `[tlon] Failed to auto-accept DM from ${ship}: ${String(err)}`
+          );
+        }
+        return;
+      }
+
+      // If owner is configured and ship is not on allowlist, queue approval
+      if (effectiveOwnerShip && !isDmAllowed(ship, effectiveDmAllowlist)) {
+        const approval = createPendingApproval(
+          {
+            type: 'dm',
+            requestingShip: ship,
+            messagePreview: DM_INVITE_PREVIEW,
+          },
+          pendingApprovals.map((a) => a.id)
+        );
+        await queueApprovalRequest(approval);
+        processedDmInvites.add(ship); // Mark as processed to avoid duplicate notifications
+      }
+    };
+
     const handleChatFirehose = async (event: ChatFirehoseEvent) => {
       try {
         // Handle DM invite lists (arrays)
         if (Array.isArray(event)) {
           for (const invite of event) {
-            const ship = normalizeShip(invite.ship || '');
-            if (!ship || processedDmInvites.has(ship)) {
-              continue;
-            }
-
-            // Owner is always allowed
-            if (isOwner(ship)) {
-              try {
-                await api.poke({
-                  app: 'chat',
-                  mark: 'chat-dm-rsvp',
-                  json: { ship, ok: true },
-                });
-                processedDmInvites.add(ship);
-                runtime.log?.(
-                  `[tlon] Auto-accepted DM invite from owner ${ship}`
-                );
-              } catch (err) {
-                runtime.error?.(
-                  `[tlon] Failed to auto-accept DM from owner: ${String(err)}`
-                );
-              }
-              continue;
-            }
-
-            // Auto-accept if on allowlist and auto-accept is enabled
-            if (
-              effectiveAutoAcceptDmInvites &&
-              isDmAllowed(ship, effectiveDmAllowlist)
-            ) {
-              try {
-                await api.poke({
-                  app: 'chat',
-                  mark: 'chat-dm-rsvp',
-                  json: { ship, ok: true },
-                });
-                processedDmInvites.add(ship);
-                runtime.log?.(`[tlon] Auto-accepted DM invite from ${ship}`);
-              } catch (err) {
-                runtime.error?.(
-                  `[tlon] Failed to auto-accept DM from ${ship}: ${String(err)}`
-                );
-              }
-              continue;
-            }
-
-            // If owner is configured and ship is not on allowlist, queue approval
-            if (
-              effectiveOwnerShip &&
-              !isDmAllowed(ship, effectiveDmAllowlist)
-            ) {
-              const approval = createPendingApproval(
-                {
-                  type: 'dm',
-                  requestingShip: ship,
-                  messagePreview: DM_INVITE_PREVIEW,
-                },
-                pendingApprovals.map((a) => a.id)
-              );
-              await queueApprovalRequest(approval);
-              processedDmInvites.add(ship); // Mark as processed to avoid duplicate notifications
-            }
+            await handleDmInvite(invite.ship);
+          }
+          return;
+        }
+        // %chat-dm-status: a dm entered, changed, or left %chat's dm set.
+        // The invite list above is not emitted on /v4, so this is the live
+        // signal for a new invite. A removed dm can be invited again, so
+        // forget it.
+        if ('ship' in event && 'net' in event) {
+          if (event.net === 'invited') {
+            await handleDmInvite(event.ship);
+          } else if (event.net === null) {
+            processedDmInvites.delete(normalizeShip(event.ship));
           }
           return;
         }

--- a/packages/openclaw/src/monitor/index.ts
+++ b/packages/openclaw/src/monitor/index.ts
@@ -1,4 +1,4 @@
-import type { Story } from '@tloncorp/api';
+import type { DmStatus, Story } from '@tloncorp/api';
 import { randomUUID } from 'node:crypto';
 import { format } from 'node:util';
 import { createTypingCallbacks } from 'openclaw/plugin-sdk/channel-runtime';
@@ -329,16 +329,11 @@ interface ChannelFirehoseEvent {
   response: ChannelResponse;
 }
 
-interface DmStatusEvent {
-  ship: string;
-  net: 'inviting' | 'invited' | 'archive' | 'done' | null;
-}
-
 /**
  * Chat/DM firehose: a WritResponse, or a %chat-dm-status fact for a dm
  * entering, changing, or leaving the dm set
  */
-type ChatFirehoseEvent = WritResponse | DmStatusEvent;
+type ChatFirehoseEvent = WritResponse | DmStatus;
 
 /** Refresh stale settings subscription state periodically as a fallback for silently-dead SSE subscriptions. */
 const SETTINGS_REFRESH_INTERVAL_MS = 5 * 60 * 1000;

--- a/packages/openclaw/src/monitor/index.ts
+++ b/packages/openclaw/src/monitor/index.ts
@@ -59,10 +59,7 @@ import {
 import { emitTlonPluginErrorTelemetry } from '../plugin-error-observability.js';
 import { getTlonRuntime } from '../runtime.js';
 import { setSessionRole } from '../session-roles.js';
-import {
-  type TlonSettingsStore,
-  createSettingsManager,
-} from '../settings.js';
+import { type TlonSettingsStore, createSettingsManager } from '../settings.js';
 import { sharedSlot } from '../shared-state.js';
 import {
   createSilentFailureNoticeCooldown,

--- a/packages/openclaw/src/monitor/index.ts
+++ b/packages/openclaw/src/monitor/index.ts
@@ -390,6 +390,11 @@ export async function monitorTlonProvider(
 }
 
 async function monitorTlonProviderScoped(opts: MonitorTlonOpts): Promise<void> {
+  // assigned once the chat firehose handlers exist below; the SSE client's
+  // recovery hook (declared earlier) calls it after a resubscribe
+  let reconcilePendingDmInvites: (
+    cause: string
+  ) => Promise<void> = async () => {};
   const core = getTlonRuntime();
   // Prefer the channel-start config snapshot (Fix B) over an independent
   // load: see the MonitorTlonOpts.cfg doc comment.
@@ -661,6 +666,15 @@ async function monitorTlonProviderScoped(opts: MonitorTlonOpts): Promise<void> {
       // surface recovery progress to PostHog. Sampled: first failure, then
       // every 5th, plus a marker event once the subscription recovers.
       onSubscriptionRecovery: (event) => {
+        if (
+          event.app === 'chat' &&
+          event.path === '/v4' &&
+          event.phase !== 'retrying'
+        ) {
+          // invites that arrived while the subscription was down were never
+          // delivered; the pending list is the only way to see them
+          void reconcilePendingDmInvites(event.phase);
+        }
         const source = subscriptionErrorSource(event.app, event.path);
         if (event.phase === 'retrying') {
           if (event.attempt === 1 || event.attempt % 5 === 0) {
@@ -4603,6 +4617,24 @@ async function monitorTlonProviderScoped(opts: MonitorTlonOpts): Promise<void> {
       }
     };
 
+    // The status fact is one-shot: an invite that lands while this process is
+    // down, or after its channel has expired, is never replayed. The pending
+    // list on the ship is the truth, so read it at startup and whenever the
+    // chat subscription comes back. handleDmInvite is idempotent via
+    // processedDmInvites, so re-reading is cheap.
+    reconcilePendingDmInvites = async (cause: string) => {
+      try {
+        const invited = (await api.scry('/chat/dm/invited.json')) as string[];
+        for (const ship of invited) {
+          await handleDmInvite(ship);
+        }
+      } catch (err) {
+        runtime.error?.(
+          `[tlon] Failed to reconcile pending DM invites (${cause}): ${String(err)}`
+        );
+      }
+    };
+
     const handleChatFirehose = async (event: ChatFirehoseEvent) => {
       try {
         // %chat-dm-status: a dm entered, changed, or left %chat's dm set.
@@ -4925,6 +4957,7 @@ async function monitorTlonProviderScoped(opts: MonitorTlonOpts): Promise<void> {
         },
       });
       runtime.log?.('[tlon] Subscribed to chat firehose (/v4)');
+      await reconcilePendingDmInvites('startup');
 
       // Subscribe to contacts updates to track nickname changes
       await api.subscribe({

--- a/packages/openclaw/src/monitor/index.ts
+++ b/packages/openclaw/src/monitor/index.ts
@@ -112,7 +112,7 @@ import {
 } from '../urbit/blob.js';
 import { ssrfPolicyFromAllowPrivateNetwork } from '../urbit/context.js';
 import { describeError } from '../urbit/errors.js';
-import type { DmInvite, Foreigns } from '../urbit/foreigns.js';
+import type { Foreigns } from '../urbit/foreigns.js';
 import { type BotProfile, sendChannelPost, sendDm } from '../urbit/send.js';
 import { UrbitSSEClient } from '../urbit/sse-client.js';
 import { markdownToStory } from '../urbit/story.js';
@@ -335,10 +335,10 @@ interface DmStatusEvent {
 }
 
 /**
- * Chat/DM firehose: an array of DM invites, a WritResponse, or a
- * %chat-dm-status fact for a dm entering, changing, or leaving the dm set
+ * Chat/DM firehose: a WritResponse, or a %chat-dm-status fact for a dm
+ * entering, changing, or leaving the dm set
  */
-type ChatFirehoseEvent = DmInvite[] | WritResponse | DmStatusEvent;
+type ChatFirehoseEvent = WritResponse | DmStatusEvent;
 
 /** Refresh stale settings subscription state periodically as a fallback for silently-dead SSE subscriptions. */
 const SETTINGS_REFRESH_INTERVAL_MS = 5 * 60 * 1000;
@@ -4625,17 +4625,9 @@ async function monitorTlonProviderScoped(opts: MonitorTlonOpts): Promise<void> {
 
     const handleChatFirehose = async (event: ChatFirehoseEvent) => {
       try {
-        // Handle DM invite lists (arrays)
-        if (Array.isArray(event)) {
-          for (const invite of event) {
-            await handleDmInvite(invite.ship);
-          }
-          return;
-        }
         // %chat-dm-status: a dm entered, changed, or left %chat's dm set.
-        // The invite list above is not emitted on /v4, so this is the live
-        // signal for a new invite. A removed dm can be invited again, so
-        // forget it.
+        // This is the live signal for a new invite. A removed dm can be
+        // invited again, so forget it.
         if ('ship' in event && 'net' in event) {
           if (event.net === 'invited') {
             await handleDmInvite(event.ship);

--- a/packages/shared/src/db/queries.ts
+++ b/packages/shared/src/db/queries.ts
@@ -2881,36 +2881,69 @@ export const getChannel = createReadQuery(
   ['channels']
 );
 
+export const getDmChannelIds = createReadQuery(
+  'getDmChannelIds',
+  async (ctx: QueryCtx): Promise<string[]> => {
+    const rows = await ctx.db.query.channels.findMany({
+      where: inArray($channels.type, ['dm', 'groupDm']),
+      columns: { id: true },
+    });
+    return rows.map((row) => row.id);
+  },
+  ['channels']
+);
+
 /**
  * The backend's dm list is authoritative: a dm or group dm we have locally
  * but the backend no longer lists was left, declined, or archived while we
- * weren't subscribed. Rows that still hold unsent posts are kept, since a dm
- * we just started locally isn't on the backend until its first message lands.
+ * weren't subscribed.
+ *
+ * Only rows in `candidateIds` can go. Callers capture that set before they
+ * fetch the snapshot, so a row a live fact inserted while the fetch was in
+ * flight is never mistaken for one the snapshot omitted. Rows the server
+ * hasn't confirmed yet are exempt as well: a pending dm the user just opened,
+ * and a dm whose first message hasn't been sent.
  */
 export const deleteAbsentDmChannels = createWriteQuery(
   'deleteAbsentDmChannels',
   async (
-    { keepIds }: { keepIds: string[] },
+    { keepIds, candidateIds }: { keepIds: string[]; candidateIds: string[] },
     ctx: QueryCtx
   ): Promise<string[]> => {
     const keep = new Set(keepIds);
+    const absent = candidateIds.filter((id) => !keep.has(id));
+    if (!absent.length) {
+      return [];
+    }
     const local = await ctx.db.query.channels.findMany({
-      where: inArray($channels.type, ['dm', 'groupDm']),
+      where: and(
+        inArray($channels.id, absent),
+        inArray($channels.type, ['dm', 'groupDm']),
+        // null is the common case: the flag is only ever set on local rows
+        or(
+          isNull($channels.isPendingChannel),
+          eq($channels.isPendingChannel, false)
+        )
+      ),
       columns: { id: true },
     });
-    const absent = local.map((c) => c.id).filter((id) => !keep.has(id));
-    if (!absent.length) {
+    if (!local.length) {
       return [];
     }
     const unsent = await ctx.db.query.posts.findMany({
       where: and(
-        inArray($posts.channelId, absent),
+        inArray(
+          $posts.channelId,
+          local.map((c) => c.id)
+        ),
         inArray($posts.deliveryStatus, ['enqueued', 'pending', 'failed'])
       ),
       columns: { channelId: true },
     });
     const unsentChannelIds = new Set(unsent.map((p) => p.channelId));
-    const toDelete = absent.filter((id) => !unsentChannelIds.has(id));
+    const toDelete = local
+      .map((c) => c.id)
+      .filter((id) => !unsentChannelIds.has(id));
     if (toDelete.length) {
       logger.log('deleteAbsentDmChannels', toDelete);
       await deleteChannels(toDelete, ctx);

--- a/packages/shared/src/db/queries.ts
+++ b/packages/shared/src/db/queries.ts
@@ -2881,6 +2881,45 @@ export const getChannel = createReadQuery(
   ['channels']
 );
 
+/**
+ * The backend's dm list is authoritative: a dm or group dm we have locally
+ * but the backend no longer lists was left, declined, or archived while we
+ * weren't subscribed. Rows that still hold unsent posts are kept, since a dm
+ * we just started locally isn't on the backend until its first message lands.
+ */
+export const deleteAbsentDmChannels = createWriteQuery(
+  'deleteAbsentDmChannels',
+  async (
+    { keepIds }: { keepIds: string[] },
+    ctx: QueryCtx
+  ): Promise<string[]> => {
+    const keep = new Set(keepIds);
+    const local = await ctx.db.query.channels.findMany({
+      where: inArray($channels.type, ['dm', 'groupDm']),
+      columns: { id: true },
+    });
+    const absent = local.map((c) => c.id).filter((id) => !keep.has(id));
+    if (!absent.length) {
+      return [];
+    }
+    const unsent = await ctx.db.query.posts.findMany({
+      where: and(
+        inArray($posts.channelId, absent),
+        inArray($posts.deliveryStatus, ['enqueued', 'pending', 'failed'])
+      ),
+      columns: { channelId: true },
+    });
+    const unsentChannelIds = new Set(unsent.map((p) => p.channelId));
+    const toDelete = absent.filter((id) => !unsentChannelIds.has(id));
+    if (toDelete.length) {
+      logger.log('deleteAbsentDmChannels', toDelete);
+      await deleteChannels(toDelete, ctx);
+    }
+    return toDelete;
+  },
+  ['channels', 'posts', 'chatMembers']
+);
+
 export const getAllMultiDms = createReadQuery(
   'getAllMultiDms',
   async (ctx: QueryCtx) => {

--- a/packages/shared/src/db/queries.ts
+++ b/packages/shared/src/db/queries.ts
@@ -2881,11 +2881,23 @@ export const getChannel = createReadQuery(
   ['channels']
 );
 
+/**
+ * The dm rows the server is expected to know about: pending rows (a dm the
+ * user opened but hasn't messaged) are excluded, since the server has never
+ * seen them.
+ */
 export const getDmChannelIds = createReadQuery(
   'getDmChannelIds',
   async (ctx: QueryCtx): Promise<string[]> => {
     const rows = await ctx.db.query.channels.findMany({
-      where: inArray($channels.type, ['dm', 'groupDm']),
+      where: and(
+        inArray($channels.type, ['dm', 'groupDm']),
+        // null is the common case: the flag is only ever set on local rows
+        or(
+          isNull($channels.isPendingChannel),
+          eq($channels.isPendingChannel, false)
+        )
+      ),
       columns: { id: true },
     });
     return rows.map((row) => row.id);
@@ -2898,11 +2910,12 @@ export const getDmChannelIds = createReadQuery(
  * but the backend no longer lists was left, declined, or archived while we
  * weren't subscribed.
  *
- * Only rows in `candidateIds` can go. Callers capture that set before they
- * fetch the snapshot, so a row a live fact inserted while the fetch was in
- * flight is never mistaken for one the snapshot omitted. Rows the server
- * hasn't confirmed yet are exempt as well: a pending dm the user just opened,
- * and a dm whose first message hasn't been sent.
+ * Only rows in `candidateIds` can go. Callers capture that set (via
+ * getDmChannelIds, which already leaves out pending rows) before they fetch
+ * the snapshot, so a row a live fact inserted while the fetch was in flight,
+ * or a pending dm that got its first message during it, is never mistaken for
+ * one the snapshot omitted. A dm whose first message is still unsent is
+ * exempt as well.
  */
 export const deleteAbsentDmChannels = createWriteQuery(
   'deleteAbsentDmChannels',
@@ -2918,12 +2931,7 @@ export const deleteAbsentDmChannels = createWriteQuery(
     const local = await ctx.db.query.channels.findMany({
       where: and(
         inArray($channels.id, absent),
-        inArray($channels.type, ['dm', 'groupDm']),
-        // null is the common case: the flag is only ever set on local rows
-        or(
-          isNull($channels.isPendingChannel),
-          eq($channels.isPendingChannel, false)
-        )
+        inArray($channels.type, ['dm', 'groupDm'])
       ),
       columns: { id: true },
     });

--- a/packages/shared/src/store/sync/sync.test.ts
+++ b/packages/shared/src/store/sync/sync.test.ts
@@ -611,8 +611,28 @@ test('deleteAbsentDmChannels leaves unconfirmed and newly arrived dms alone', as
     dmChannel('~stale-dm', false),
     { ...dmChannel('~pending-dm', false), isPendingChannel: true },
   ]);
+  // the pending row is never a candidate: the server has never seen it
   const candidateIds = await db.getDmChannelIds();
-  expect(candidateIds.sort()).toEqual(['~pending-dm', '~stale-dm']);
+  expect(candidateIds).toEqual(['~stale-dm']);
+  // ...and while the snapshot is in flight its first message goes out, so by
+  // the time we reconcile it looks like any other confirmed dm
+  await db.updateChannel({ id: '~pending-dm', isPendingChannel: false });
+  await db.insertChannelPosts({
+    posts: [
+      {
+        id: 'first-sent',
+        type: 'chat',
+        channelId: '~pending-dm',
+        authorId: '~zod',
+        sentAt: Date.now(),
+        receivedAt: Date.now(),
+        sequenceNum: 1,
+        content: JSON.stringify([{ inline: ['hello'] }]),
+        deliveryStatus: 'sent',
+        syncedAt: Date.now(),
+      } as unknown as db.Post,
+    ],
+  });
   // arrives (via a status fact) after the snapshot was requested
   await db.insertChannels([dmChannel('~arrived-dm', false)]);
 

--- a/packages/shared/src/store/sync/sync.test.ts
+++ b/packages/shared/src/store/sync/sync.test.ts
@@ -43,6 +43,7 @@ import rawGroupsInit2 from '../../test/init.json';
 import { syncQueue } from '../syncQueue';
 import {
   ensureDmInviteChannel,
+  handleDmStatus,
   syncChannelWithBackoff,
   syncDms,
   syncGroups,
@@ -493,6 +494,74 @@ test('ensureDmInviteChannel returns missing without deleting a non-invite local 
   expect(result).toEqual({ found: false, state: 'missing' });
   const channel = await db.getChannel({ id: '~sampel-palnet' });
   expect(channel?.isDmInvite).toBe(false);
+});
+
+// the %chat-dm-status fact is the only live signal for a dm this client
+// didn't start (e.g. the reciprocal dm %grouper creates when someone redeems
+// our personal invite): posts alone never create the channel row
+test('handleDmStatus keeps the channel row in step with the backend dm set', async () => {
+  // on the wire the writ fact precedes the status fact, so the post is
+  // already in the db when the row gets created
+  await db.insertChannelPosts({
+    posts: [
+      {
+        id: 'first-post',
+        type: 'chat',
+        channelId: '~sampel-palnet',
+        authorId: '~sampel-palnet',
+        sentAt: 1700000000000,
+        receivedAt: 1700000000000,
+        sequenceNum: 1,
+        content: JSON.stringify([{ inline: ['hi'] }]),
+        syncedAt: 1700000000000,
+      } as unknown as db.Post,
+    ],
+  });
+  expect(await db.getChannel({ id: '~sampel-palnet' })).toBeNull();
+
+  // a dm we started, not yet accepted, is a regular dm on our side
+  await handleDmStatus('~sampel-palnet', 'inviting');
+  let channel = await db.getChannel({ id: '~sampel-palnet' });
+  expect(channel?.type).toBe('dm');
+  expect(channel?.isDmInvite).toBe(false);
+  expect(channel?.contactId).toBe('~sampel-palnet');
+  // and the chat list has something to sort and preview
+  expect(channel?.lastPostId).toBe('first-post');
+  expect(channel?.lastPostAt).toBe(1700000000000);
+
+  // a pending invite to us shows as an invite until we accept
+  await handleDmStatus('~wicdev-wisryt', 'invited');
+  channel = await db.getChannel({ id: '~wicdev-wisryt' });
+  expect(channel?.isDmInvite).toBe(true);
+  await handleDmStatus('~wicdev-wisryt', 'done');
+  channel = await db.getChannel({ id: '~wicdev-wisryt' });
+  expect(channel?.isDmInvite).toBe(false);
+
+  // accepting elsewhere must not wipe what we already know about the dm
+  await db.insertChannelPosts({
+    posts: [
+      {
+        id: 'kept-post',
+        type: 'chat',
+        channelId: '~wicdev-wisryt',
+        authorId: '~wicdev-wisryt',
+        sentAt: 1700000000000,
+        receivedAt: 1700000000000,
+        sequenceNum: 1,
+        content: JSON.stringify([{ inline: ['hi'] }]),
+        syncedAt: 1700000000000,
+      } as unknown as db.Post,
+    ],
+  });
+  await handleDmStatus('~wicdev-wisryt', 'done');
+  channel = await db.getChannel({ id: '~wicdev-wisryt' });
+  expect(channel?.lastPostId).toBe('kept-post');
+
+  // gone (declined or left) and archived both drop out of the dm list
+  await handleDmStatus('~sampel-palnet', null);
+  expect(await db.getChannel({ id: '~sampel-palnet' })).toBeNull();
+  await handleDmStatus('~wicdev-wisryt', 'archive');
+  expect(await db.getChannel({ id: '~wicdev-wisryt' })).toBeNull();
 });
 
 const groupId = '~solfer-magfed/test-group';

--- a/packages/shared/src/store/sync/sync.test.ts
+++ b/packages/shared/src/store/sync/sync.test.ts
@@ -564,6 +564,58 @@ test('handleDmStatus keeps the channel row in step with the backend dm set', asy
   expect(await db.getChannel({ id: '~wicdev-wisryt' })).toBeNull();
 });
 
+// the backend's dm list is authoritative: a dm left, declined, or archived
+// from another client while this one had no live channel is only ever
+// noticed by the next full snapshot
+test('syncInitData drops dms the backend no longer lists', async () => {
+  await db.insertChannels([
+    dmChannel('~stale-dm', false),
+    dmChannel('~draft-dm', false),
+  ]);
+  // a dm we just started locally isn't on the backend until its first
+  // message lands, so an unsent post keeps the row
+  await db.insertChannelPosts({
+    posts: [
+      {
+        id: 'draft',
+        type: 'chat',
+        channelId: '~draft-dm',
+        authorId: '~zod',
+        sentAt: Date.now(),
+        receivedAt: Date.now(),
+        sequenceNum: 0,
+        content: JSON.stringify([{ inline: ['first message'] }]),
+        deliveryStatus: 'pending',
+        syncedAt: Date.now(),
+      } as unknown as db.Post,
+    ],
+  });
+
+  setScryOutput(rawGroupsInitData);
+  await syncInitData();
+
+  expect(await db.getChannel({ id: '~stale-dm' })).toBeNull();
+  expect((await db.getChannel({ id: '~draft-dm' }))?.type).toBe('dm');
+  const kept = await getClient()
+    ?.select({ count: $.count() })
+    .from(db.schema.channels)
+    .where($.eq(db.schema.channels.type, 'dm'));
+  expect(kept?.[0].count).toEqual(groupsInitData.chat.dms.length + 1);
+});
+
+test('syncDms drops dms the backend no longer lists', async () => {
+  await db.insertChannels([
+    dmChannel('~sampel-palnet', false),
+    dmChannel('~stale-dm', true),
+  ]);
+  setScryOutputs([['~sampel-palnet'], {}, []]);
+
+  await syncDms();
+
+  expect(await db.getChannel({ id: '~stale-dm' })).toBeNull();
+  expect((await db.getChannel({ id: '~sampel-palnet' }))?.type).toBe('dm');
+});
+
 const groupId = '~solfer-magfed/test-group';
 const channelId = 'chat/~solfer-magfed/test-channel';
 

--- a/packages/shared/src/store/sync/sync.test.ts
+++ b/packages/shared/src/store/sync/sync.test.ts
@@ -42,6 +42,7 @@ import {
 import rawGroupsInit2 from '../../test/init.json';
 import { syncQueue } from '../syncQueue';
 import {
+  ensureDmInviteChannel,
   handleDmStatus,
   syncChannelWithBackoff,
   syncDms,
@@ -101,6 +102,16 @@ const outputData = [
     itemId: inputData[2],
   },
 ];
+
+const dmChannel = (id: string, isDmInvite: boolean): db.Channel => ({
+  id,
+  type: 'dm',
+  title: '',
+  description: '',
+  isDmInvite,
+  contactId: id,
+  members: [{ chatId: id, contactId: id, membershipType: 'channel' }],
+});
 
 test('syncs pins', async () => {
   setScryOutput(inputData);
@@ -418,6 +429,70 @@ test('syncDms lets regular DMs win when backend invite state overlaps', async ()
 
   const channel = await db.getChannel({ id: '~sampel-palnet' });
   expect(channel?.type).toBe('dm');
+  expect(channel?.isDmInvite).toBe(false);
+});
+
+test('ensureDmInviteChannel inserts a pending single-DM invite from backend invites', async () => {
+  setScryOutputs([[], ['~sampel-palnet']]);
+
+  const result = await ensureDmInviteChannel({
+    channelId: '~sampel-palnet',
+  });
+
+  expect(result).toEqual({ found: true, state: 'pending-invite' });
+  const channel = await db.getChannel({ id: '~sampel-palnet' });
+  expect(channel?.type).toBe('dm');
+  expect(channel?.isDmInvite).toBe(true);
+  expect(channel?.contactId).toBe('~sampel-palnet');
+});
+
+test('ensureDmInviteChannel refreshes the target as a regular DM from backend DMs', async () => {
+  await db.insertChannels([dmChannel('~sampel-palnet', true)]);
+  setScryOutputs([['~sampel-palnet'], []]);
+
+  const result = await ensureDmInviteChannel({
+    channelId: '~sampel-palnet',
+  });
+
+  expect(result).toEqual({ found: true, state: 'regular-dm' });
+  const channel = await db.getChannel({ id: '~sampel-palnet' });
+  expect(channel?.type).toBe('dm');
+  expect(channel?.isDmInvite).toBe(false);
+  expect(channel?.contactId).toBe('~sampel-palnet');
+});
+
+test('ensureDmInviteChannel deletes the target when a local invite is stale', async () => {
+  await db.insertChannels([
+    dmChannel('~sampel-palnet', true),
+    {
+      ...dmChannel('~wicdev-wisryt', true),
+      title: 'Unrelated request',
+    },
+  ]);
+  setScryOutputs([[], []]);
+
+  const result = await ensureDmInviteChannel({
+    channelId: '~sampel-palnet',
+  });
+
+  expect(result).toEqual({ found: false, state: 'missing' });
+  expect(await db.getChannel({ id: '~sampel-palnet' })).toBeNull();
+
+  const unrelated = await db.getChannel({ id: '~wicdev-wisryt' });
+  expect(unrelated?.isDmInvite).toBe(true);
+  expect(unrelated?.title).toBe('Unrelated request');
+});
+
+test('ensureDmInviteChannel returns missing without deleting a non-invite local channel', async () => {
+  await db.insertChannels([dmChannel('~sampel-palnet', false)]);
+  setScryOutputs([[], []]);
+
+  const result = await ensureDmInviteChannel({
+    channelId: '~sampel-palnet',
+  });
+
+  expect(result).toEqual({ found: false, state: 'missing' });
+  const channel = await db.getChannel({ id: '~sampel-palnet' });
   expect(channel?.isDmInvite).toBe(false);
 });
 

--- a/packages/shared/src/store/sync/sync.test.ts
+++ b/packages/shared/src/store/sync/sync.test.ts
@@ -627,7 +627,10 @@ test('deleteAbsentDmChannels leaves unconfirmed and newly arrived dms alone', as
   expect((await db.getChannel({ id: '~arrived-dm' }))?.type).toBe('dm');
 });
 
-test('syncDms drops dms the backend no longer lists', async () => {
+// syncDms composes three scries that aren't a consistent snapshot, so it must
+// never delete: a dm accepted between `/dm` and `/dm/invited` returning would
+// be in neither list
+test('syncDms is insert-only', async () => {
   await db.insertChannels([
     dmChannel('~sampel-palnet', false),
     dmChannel('~stale-dm', true),
@@ -636,7 +639,7 @@ test('syncDms drops dms the backend no longer lists', async () => {
 
   await syncDms();
 
-  expect(await db.getChannel({ id: '~stale-dm' })).toBeNull();
+  expect((await db.getChannel({ id: '~stale-dm' }))?.type).toBe('dm');
   expect((await db.getChannel({ id: '~sampel-palnet' }))?.type).toBe('dm');
 });
 

--- a/packages/shared/src/store/sync/sync.test.ts
+++ b/packages/shared/src/store/sync/sync.test.ts
@@ -603,6 +603,30 @@ test('syncInitData drops dms the backend no longer lists', async () => {
   expect(kept?.[0].count).toEqual(groupsInitData.chat.dms.length + 1);
 });
 
+// the two ways a row can look absent from a snapshot without being gone on
+// the backend: it was created locally and not sent yet, or a live fact
+// inserted it while the snapshot fetch was in flight
+test('deleteAbsentDmChannels leaves unconfirmed and newly arrived dms alone', async () => {
+  await db.insertChannels([
+    dmChannel('~stale-dm', false),
+    { ...dmChannel('~pending-dm', false), isPendingChannel: true },
+  ]);
+  const candidateIds = await db.getDmChannelIds();
+  expect(candidateIds.sort()).toEqual(['~pending-dm', '~stale-dm']);
+  // arrives (via a status fact) after the snapshot was requested
+  await db.insertChannels([dmChannel('~arrived-dm', false)]);
+
+  const deleted = await db.deleteAbsentDmChannels({
+    keepIds: [],
+    candidateIds,
+  });
+
+  expect(deleted).toEqual(['~stale-dm']);
+  expect(await db.getChannel({ id: '~stale-dm' })).toBeNull();
+  expect((await db.getChannel({ id: '~pending-dm' }))?.type).toBe('dm');
+  expect((await db.getChannel({ id: '~arrived-dm' }))?.type).toBe('dm');
+});
+
 test('syncDms drops dms the backend no longer lists', async () => {
   await db.insertChannels([
     dmChannel('~sampel-palnet', false),

--- a/packages/shared/src/store/sync/sync.test.ts
+++ b/packages/shared/src/store/sync/sync.test.ts
@@ -42,7 +42,6 @@ import {
 import rawGroupsInit2 from '../../test/init.json';
 import { syncQueue } from '../syncQueue';
 import {
-  ensureDmInviteChannel,
   handleDmStatus,
   syncChannelWithBackoff,
   syncDms,
@@ -102,16 +101,6 @@ const outputData = [
     itemId: inputData[2],
   },
 ];
-
-const dmChannel = (id: string, isDmInvite: boolean): db.Channel => ({
-  id,
-  type: 'dm',
-  title: '',
-  description: '',
-  isDmInvite,
-  contactId: id,
-  members: [{ chatId: id, contactId: id, membershipType: 'channel' }],
-});
 
 test('syncs pins', async () => {
   setScryOutput(inputData);
@@ -429,70 +418,6 @@ test('syncDms lets regular DMs win when backend invite state overlaps', async ()
 
   const channel = await db.getChannel({ id: '~sampel-palnet' });
   expect(channel?.type).toBe('dm');
-  expect(channel?.isDmInvite).toBe(false);
-});
-
-test('ensureDmInviteChannel inserts a pending single-DM invite from backend invites', async () => {
-  setScryOutputs([[], ['~sampel-palnet']]);
-
-  const result = await ensureDmInviteChannel({
-    channelId: '~sampel-palnet',
-  });
-
-  expect(result).toEqual({ found: true, state: 'pending-invite' });
-  const channel = await db.getChannel({ id: '~sampel-palnet' });
-  expect(channel?.type).toBe('dm');
-  expect(channel?.isDmInvite).toBe(true);
-  expect(channel?.contactId).toBe('~sampel-palnet');
-});
-
-test('ensureDmInviteChannel refreshes the target as a regular DM from backend DMs', async () => {
-  await db.insertChannels([dmChannel('~sampel-palnet', true)]);
-  setScryOutputs([['~sampel-palnet'], []]);
-
-  const result = await ensureDmInviteChannel({
-    channelId: '~sampel-palnet',
-  });
-
-  expect(result).toEqual({ found: true, state: 'regular-dm' });
-  const channel = await db.getChannel({ id: '~sampel-palnet' });
-  expect(channel?.type).toBe('dm');
-  expect(channel?.isDmInvite).toBe(false);
-  expect(channel?.contactId).toBe('~sampel-palnet');
-});
-
-test('ensureDmInviteChannel deletes the target when a local invite is stale', async () => {
-  await db.insertChannels([
-    dmChannel('~sampel-palnet', true),
-    {
-      ...dmChannel('~wicdev-wisryt', true),
-      title: 'Unrelated request',
-    },
-  ]);
-  setScryOutputs([[], []]);
-
-  const result = await ensureDmInviteChannel({
-    channelId: '~sampel-palnet',
-  });
-
-  expect(result).toEqual({ found: false, state: 'missing' });
-  expect(await db.getChannel({ id: '~sampel-palnet' })).toBeNull();
-
-  const unrelated = await db.getChannel({ id: '~wicdev-wisryt' });
-  expect(unrelated?.isDmInvite).toBe(true);
-  expect(unrelated?.title).toBe('Unrelated request');
-});
-
-test('ensureDmInviteChannel returns missing without deleting a non-invite local channel', async () => {
-  await db.insertChannels([dmChannel('~sampel-palnet', false)]);
-  setScryOutputs([[], []]);
-
-  const result = await ensureDmInviteChannel({
-    channelId: '~sampel-palnet',
-  });
-
-  expect(result).toEqual({ found: false, state: 'missing' });
-  const channel = await db.getChannel({ id: '~sampel-palnet' });
   expect(channel?.isDmInvite).toBe(false);
 });
 

--- a/packages/shared/src/store/sync/sync.ts
+++ b/packages/shared/src/store/sync/sync.ts
@@ -775,6 +775,58 @@ export const syncDms = async (ctx?: SyncCtx) => {
   await db.insertChannels([...dms, ...groupDms, ...pendingInvites]);
 };
 
+export type EnsureDmInviteChannelResult =
+  | { found: true; state: 'regular-dm' }
+  | { found: true; state: 'pending-invite' }
+  | { found: false; state: 'missing' };
+
+export const ensureDmInviteChannel = async ({
+  channelId,
+  syncCtx,
+  queryCtx,
+}: {
+  channelId: string;
+  syncCtx?: SyncCtx;
+  queryCtx?: QueryCtx;
+}): Promise<EnsureDmInviteChannelResult> => {
+  const { dms, invites } = await syncQueue.add(
+    'ensureDmInviteChannel',
+    syncCtx,
+    async () => {
+      const [dms, invites] = await Promise.all([
+        api.getDms(),
+        api.getDmInvites(),
+      ]);
+      return { dms, invites };
+    }
+  );
+
+  const write = async (ctx: QueryCtx): Promise<EnsureDmInviteChannelResult> => {
+    const regularDm = dms.find((dm) => dm.id === channelId);
+    if (regularDm) {
+      await db.insertChannels([regularDm], ctx);
+      return { found: true, state: 'regular-dm' };
+    }
+
+    const invite = invites.find((dmInvite) => dmInvite.id === channelId);
+    if (invite) {
+      await db.insertChannels([invite], ctx);
+      return { found: true, state: 'pending-invite' };
+    }
+
+    const localChannel = await db.getChannel({ id: channelId }, ctx);
+    if (localChannel?.isDmInvite) {
+      await db.deleteChannels([channelId], ctx);
+    }
+
+    return { found: false, state: 'missing' };
+  };
+
+  return queryCtx
+    ? write(queryCtx)
+    : batchEffects('ensureDmInviteChannel', write);
+};
+
 export const syncUnreads = async (ctx?: SyncCtx, queryCtx?: QueryCtx) => {
   const unreads = await syncQueue.add('unreads', ctx, () =>
     api.getGroupAndChannelUnreads()

--- a/packages/shared/src/store/sync/sync.ts
+++ b/packages/shared/src/store/sync/sync.ts
@@ -1847,11 +1847,42 @@ export const handleChatUpdate = async (
       // We need to sync our local state with this list
       await handleSyncDmInvites(update.channels, ctx);
       break;
+    case 'dmStatus':
+      await handleDmStatus(update.channelId, update.net, ctx);
+      break;
     case 'groupDmsUpdate':
       syncDms();
       break;
   }
 };
+
+/**
+ * Keep the local channel row in step with the backend's dm set. Without this
+ * a dm we didn't start from this client only ever arrives as posts, and the
+ * chat list (built from the channels table) can't show it until the next
+ * init sync.
+ */
+export async function handleDmStatus(
+  channelId: string,
+  net: api.DmNet | null,
+  ctx?: QueryCtx
+) {
+  switch (net) {
+    case 'inviting':
+    case 'done':
+      await db.insertChannels([api.toClientDm(channelId, false)], ctx);
+      break;
+    case 'invited':
+      await db.insertChannels([api.toClientDm(channelId, true)], ctx);
+      break;
+    case 'archive':
+    case null:
+      // the dm list we sync from (`/dm`) excludes archived dms, so locally
+      // an archived dm and a removed one look the same
+      await db.deleteChannels([channelId], ctx);
+      break;
+  }
+}
 
 async function handleSyncDmInvites(invites: db.Channel[], ctx?: QueryCtx) {
   const allChannels = await db.getAllChannels(ctx);

--- a/packages/shared/src/store/sync/sync.ts
+++ b/packages/shared/src/store/sync/sync.ts
@@ -775,58 +775,6 @@ export const syncDms = async (ctx?: SyncCtx) => {
   await db.insertChannels([...dms, ...groupDms, ...pendingInvites]);
 };
 
-export type EnsureDmInviteChannelResult =
-  | { found: true; state: 'regular-dm' }
-  | { found: true; state: 'pending-invite' }
-  | { found: false; state: 'missing' };
-
-export const ensureDmInviteChannel = async ({
-  channelId,
-  syncCtx,
-  queryCtx,
-}: {
-  channelId: string;
-  syncCtx?: SyncCtx;
-  queryCtx?: QueryCtx;
-}): Promise<EnsureDmInviteChannelResult> => {
-  const { dms, invites } = await syncQueue.add(
-    'ensureDmInviteChannel',
-    syncCtx,
-    async () => {
-      const [dms, invites] = await Promise.all([
-        api.getDms(),
-        api.getDmInvites(),
-      ]);
-      return { dms, invites };
-    }
-  );
-
-  const write = async (ctx: QueryCtx): Promise<EnsureDmInviteChannelResult> => {
-    const regularDm = dms.find((dm) => dm.id === channelId);
-    if (regularDm) {
-      await db.insertChannels([regularDm], ctx);
-      return { found: true, state: 'regular-dm' };
-    }
-
-    const invite = invites.find((dmInvite) => dmInvite.id === channelId);
-    if (invite) {
-      await db.insertChannels([invite], ctx);
-      return { found: true, state: 'pending-invite' };
-    }
-
-    const localChannel = await db.getChannel({ id: channelId }, ctx);
-    if (localChannel?.isDmInvite) {
-      await db.deleteChannels([channelId], ctx);
-    }
-
-    return { found: false, state: 'missing' };
-  };
-
-  return queryCtx
-    ? write(queryCtx)
-    : batchEffects('ensureDmInviteChannel', write);
-};
-
 export const syncUnreads = async (ctx?: SyncCtx, queryCtx?: QueryCtx) => {
   const unreads = await syncQueue.add('unreads', ctx, () =>
     api.getGroupAndChannelUnreads()
@@ -1842,11 +1790,6 @@ export const handleChatUpdate = async (
         ctx
       );
       break;
-    case 'syncDmInvites':
-      // This event contains the complete list of pending DM invites
-      // We need to sync our local state with this list
-      await handleSyncDmInvites(update.channels, ctx);
-      break;
     case 'dmStatus':
       await handleDmStatus(update.channelId, update.net, ctx);
       break;
@@ -1881,54 +1824,6 @@ export async function handleDmStatus(
       // an archived dm and a removed one look the same
       await db.deleteChannels([channelId], ctx);
       break;
-  }
-}
-
-async function handleSyncDmInvites(invites: db.Channel[], ctx?: QueryCtx) {
-  const allChannels = await db.getAllChannels(ctx);
-
-  const currentDmInvites = allChannels.filter(
-    (ch) => ch.type === 'dm' && ch.isDmInvite === true
-  );
-  const currentRegularDms = allChannels.filter(
-    (ch) => ch.type === 'dm' && ch.isDmInvite === false
-  );
-
-  const newInviteIds = new Set(invites.map((ch) => ch.id));
-  const currentInviteIds = new Set(currentDmInvites.map((ch) => ch.id));
-
-  const missingInvites = currentDmInvites.filter(
-    (ch) => !newInviteIds.has(ch.id)
-  );
-
-  const backendDms = await api.getDms();
-  const backendDmIds = new Set(backendDms.map((dm) => dm.id));
-
-  for (const invite of missingInvites) {
-    if (backendDmIds.has(invite.id)) {
-      logger.log('dm invite was accepted, updating to regular dm', invite.id);
-      await db.updateChannel({ id: invite.id, isDmInvite: false }, ctx);
-    } else {
-      logger.log('dm invite was declined, deleting', invite.id);
-      await db.deleteChannels([invite.id], ctx);
-    }
-  }
-
-  for (const regularDm of currentRegularDms) {
-    if (!backendDmIds.has(regularDm.id)) {
-      logger.log('regular dm was removed on backend, deleting', regularDm.id);
-      await db.deleteChannels([regularDm.id], ctx);
-    }
-  }
-
-  const toAdd = invites.filter((ch) => !currentInviteIds.has(ch.id));
-
-  if (toAdd.length > 0) {
-    logger.log(
-      'adding new dm invites',
-      toAdd.map((ch) => ch.id)
-    );
-    await db.insertChannels(toAdd, ctx);
   }
 }
 

--- a/packages/shared/src/store/sync/sync.ts
+++ b/packages/shared/src/store/sync/sync.ts
@@ -777,8 +777,10 @@ export const syncGroups = async (ctx?: SyncCtx) => {
   await db.insertGroups({ groups: groups });
 };
 
+// insert-only: these three scries aren't a consistent snapshot (a dm can
+// move between lists while they're in flight), so only init, which reads the
+// dm set in one scry, gets to delete what it doesn't list
 export const syncDms = async (ctx?: SyncCtx) => {
-  const candidateIds = await db.getDmChannelIds();
   const [dms, groupDms, dmInvites] = await syncQueue.add('dms', ctx, () =>
     Promise.all([api.getDms(), api.getGroupDms(), api.getDmInvites()])
   );
@@ -786,12 +788,7 @@ export const syncDms = async (ctx?: SyncCtx) => {
   const pendingInvites = dmInvites.filter(
     (invite) => !regularDmIds.has(invite.id)
   );
-  const channels = [...dms, ...groupDms, ...pendingInvites];
-  await db.insertChannels(channels);
-  await db.deleteAbsentDmChannels({
-    keepIds: channels.map((c) => c.id),
-    candidateIds,
-  });
+  await db.insertChannels([...dms, ...groupDms, ...pendingInvites]);
 };
 
 export type EnsureDmInviteChannelResult =

--- a/packages/shared/src/store/sync/sync.ts
+++ b/packages/shared/src/store/sync/sync.ts
@@ -66,6 +66,9 @@ export const syncInitData = async (
   // the init endpoint version is capability-picked and this can run before
   // syncAppInfo on a fresh boot — apply the persisted capabilities first
   await syncReactionSupport();
+  // captured before the fetch: only dms that existed when the snapshot was
+  // requested can be reconciled away by it
+  const dmCandidateIds = await db.getDmChannelIds(queryCtx);
   const initData = await syncQueue.add('init', syncCtx, () =>
     api.getInitData()
   );
@@ -90,7 +93,10 @@ export const syncInitData = async (
     // init carries the complete dm set, so anything missing from it is gone
     await db
       .deleteAbsentDmChannels(
-        { keepIds: initData.channels.map((c) => c.id) },
+        {
+          keepIds: initData.channels.map((c) => c.id),
+          candidateIds: dmCandidateIds,
+        },
         queryCtx
       )
       .then(() => logger.crumb('reconciled dm channels'));
@@ -772,6 +778,7 @@ export const syncGroups = async (ctx?: SyncCtx) => {
 };
 
 export const syncDms = async (ctx?: SyncCtx) => {
+  const candidateIds = await db.getDmChannelIds();
   const [dms, groupDms, dmInvites] = await syncQueue.add('dms', ctx, () =>
     Promise.all([api.getDms(), api.getGroupDms(), api.getDmInvites()])
   );
@@ -781,7 +788,10 @@ export const syncDms = async (ctx?: SyncCtx) => {
   );
   const channels = [...dms, ...groupDms, ...pendingInvites];
   await db.insertChannels(channels);
-  await db.deleteAbsentDmChannels({ keepIds: channels.map((c) => c.id) });
+  await db.deleteAbsentDmChannels({
+    keepIds: channels.map((c) => c.id),
+    candidateIds,
+  });
 };
 
 export type EnsureDmInviteChannelResult =

--- a/packages/shared/src/store/sync/sync.ts
+++ b/packages/shared/src/store/sync/sync.ts
@@ -87,6 +87,13 @@ export const syncInitData = async (
     await db
       .insertChannels(initData.channels, queryCtx)
       .then(() => logger.crumb('inserted channels'));
+    // init carries the complete dm set, so anything missing from it is gone
+    await db
+      .deleteAbsentDmChannels(
+        { keepIds: initData.channels.map((c) => c.id) },
+        queryCtx
+      )
+      .then(() => logger.crumb('reconciled dm channels'));
     await persistUnreads({
       unreads: initData.unreads,
       ctx: queryCtx,
@@ -772,7 +779,9 @@ export const syncDms = async (ctx?: SyncCtx) => {
   const pendingInvites = dmInvites.filter(
     (invite) => !regularDmIds.has(invite.id)
   );
-  await db.insertChannels([...dms, ...groupDms, ...pendingInvites]);
+  const channels = [...dms, ...groupDms, ...pendingInvites];
+  await db.insertChannels(channels);
+  await db.deleteAbsentDmChannels({ keepIds: channels.map((c) => c.id) });
 };
 
 export type EnsureDmInviteChannelResult =


### PR DESCRIPTION
## Summary

`%chat` only announced DM-list changes for pending incoming invites (`%ships` on `/dm/invited`, and not even on `/v4`). A DM the ship starts itself (`net=%inviting`, most visibly the reciprocal DM `%grouper` pokes in when someone redeems your personal invite) or one that becomes `%done` only ever produced `writ-response` facts, so the client received posts for a channel it had no row for and the conversation stayed invisible until the next init sync. This makes `%chat` announce the DM itself and has the client keep its channel row in step with that.

Backend alternative to the client-side repair in #6371 (TLON-6403). Fixes TLON-6497. Related: TLON-5638 has the same signature for re-invites.

## Changes

- **`%chat`**: `+di-core` remembers the `net` it was entered with (`was`), and `+di-abet` gives a `%chat-dm-status` fact on `/v4` whenever that changed, including removal. The fact is `[=ship net=(unit net)]`, `~` once the DM is gone. `%invited` transitions are announced too, so a `/v4` subscriber no longer depends on the `/dm/invited` `%ships` fact that never went to `/v4`.
- **New mark `%chat-dm-status`** with JSON `{"ship": "~zod", "net": "inviting" | "invited" | "archive" | "done" | null}`. Added to the `discipline` facts list for `/v4` and to the generated `lib/rail.hoon` (five entries, verified against `+groups!rail` on a ship).
- **Client**: `subscribeToChatUpdates` maps the fact to a `dmStatus` event; `handleDmStatus` upserts the channel row for `inviting`/`done`/`invited` and deletes it for `archive`/`null`. Archived DMs are treated like removed ones because the `/dm` scry the client syncs from excludes them.
- **OpenClaw is untouched.** The monitor's DM auto-accept has never fired on `/v4` (it waited for an invite array `%chat` does not send there); fixing that with the new fact is a bot change with its own recovery semantics and is parked on `hunter/openclaw-dm-status-invites` for a separate PR. As it stands the monitor ignores the new fact, since an object without `whom`/`response` falls through.
- **Removed the parallel invite sync path.** The `syncDmInvites` event and `handleSyncDmInvites` (the `%ships` invite list, which `%chat` never emitted on `/v4`, reconciled against a `/dm` scry) are gone, DM membership now reaches the client live in exactly one way, `%chat-dm-status`, plus the init scry at startup. `respondToDMInvite` is unchanged: it is the action that pokes `chat-dm-rsvp`, and the resulting `done` or `null` status confirms its optimistic update. `syncDms` stays as the full-list resync used by the notification listener, boot sequence, and club updates, and `ensureDmInviteChannel` stays for the push-notification tap path, which needs the invite row on demand on a cold app before any fact has been replayed.
- **Init now deletes DMs the backend no longer lists.** A DM left, declined, or archived from another client while this one had no live channel never gets a status fact here, and init only ever inserted. `deleteAbsentDmChannels` removes local DM and group-DM rows missing from the init snapshot. `syncDms` stays insert-only: its three scries are not a consistent snapshot, so it must not delete. Only rows that existed before the snapshot was requested are candidates, so a row a live fact inserted during the fetch is never deleted, and rows the server has not confirmed yet are exempt: pending DMs the user opened but has not messaged, and DMs whose first message is still unsent.
- This stays on `/v4` rather than bumping the path: the convention is that a new fact mark is additive and only a shape change to a known fact warrants a new version, and subscribers must ignore unknown marks. The three subscribers in this repo already do: the app falls through to its `unknown` branch, the OpenClaw monitor returns early without `whom`/`response`, and the tlon-skill client only logs.

## How did I test?

- `-test /=groups=/tests/app/chat ~` on a moon: two new test-agent suites cover a DM we start (`%inviting` → `%done` on the peer's rsvp → no re-announce on a later message → `%archive`) and a DM we receive (`%invited` → `~` on decline → `%invited` again → `%done` on accept). The existing notification test still passes.
- Landed the full `%groups` desk on a moon that runs the production release, with the real bill: every agent reloaded and bumped. Subscribed an eyre channel to `chat` `/v4` and poked `%chat-dm-action-2` from the dojo the way `%grouper` does; the stream carried `writ-response-4` followed by `{"json":{"net":"inviting","ship":"~sampel-palnet"},"mark":"chat-dm-status"}`, and `/dm.json` listed the ship.
- Tested live between real ships on Sep 9 with the app connected to the ship carrying this branch: the DM appears in the chat list when the other side starts it, without a relaunch.
- `packages/shared`: `sync.test.ts` passes (25 tests) including a new one that covers the on-the-wire order, post before channel row, and asserts `lastPostId`/`lastPostAt` are backfilled so the chat list can sort and preview the DM. `tsc --noEmit` clean in `packages/api` and `packages/shared`, `oxfmt --check` clean.

## Risks and impact

- Safe to rollback without consulting PR author? Yes
- Affects important code area:
  - [ ] Onboarding
  - [ ] State / providers
  - [x] Message sync
  - [x] Channel display
  - [ ] Notifications
  - [x] Other: `%chat` agent, new mark

The fact is emitted only when a DM's `net` actually changes or the DM is removed, so ordinary messaging produces no extra cards. The client change is one new `switch` case; the fact arrives after the writ facts, which the existing `insertChannels` → `setLastPosts` backfill already handles.

## Rollback plan

Revert the commit. There is no state migration; the mark and the `rail` entry are additive, and a client without the handler ignores the fact.

## Screenshots / videos

n/a

🤖 Generated with [Claude Code](https://claude.com/claude-code)










