### PR TITLE
patch expo-modules-core: read persisted activity-result Bundle with a ClassLoader

### DIFF
--- a/patches/README.md
+++ b/patches/README.md
@@ -546,3 +546,110 @@ Drop this patch once we pin a `react-native-worklets` release that includes
 [#10278](https://github.com/software-mansion/react-native-reanimated/pull/10278)
 (0.13.0 or later) together with the Reanimated release that pins it, and confirm
 the Crashlytics issue stays closed.
+
+## expo-modules-core@57.0.6
+
+Local patch:
+`patches/expo-modules-core@57.0.6.patch`
+
+Why:
+Android release builds crash at launch with a `ClassNotFoundException` inside
+`AppContextActivityResultRegistry.register$lambda$4` whenever an
+activity-result launch (image picker, document picker, file picker) was
+interrupted by the OS killing our Activity.
+
+`AppContextActivityResultRegistry.persistInstanceState` marshals its in-flight
+state — including the `androidx.activity.result.ActivityResult` pending
+result — into a base64 `Bundle` in `SharedPreferences` on `onHostDestroy`.
+`DataPersistor.toBundle()` read that `Bundle` back with `readBundle(null)`,
+which leaves the `Bundle`'s class loader at the framework default: the boot
+class loader, which cannot resolve *any* class from the app's dex. The
+`Bundle` unparcels lazily, so the failure does not surface at the read. It
+surfaces at the first strict read of a `Parcelable`, which is the pending-result
+lookup in the `ON_START` observer that `register` installs:
+
+```kotlin
+val activityResult = pendingResults.safeGetParcelable<ActivityResult>(key)
+```
+
+`expo-file-system` registers its picker contract at module initialization, so
+every launch of our app reaches that observer — a persisted pending result
+therefore crashes the next cold start rather than just dropping a picker
+result. R8 is on for release builds
+(`android.enableProguardInReleaseBuilds=true`), so Crashlytics reports the
+obfuscated name (`g.a`) instead of `androidx.activity.result.ActivityResult`.
+
+The record expires after 5 minutes and `DataPersistor.retrieveData()` clears
+the store as it reads, so this is one crash per interrupted launch rather than
+a boot loop — which is why it reads as a random launch crash.
+
+Crashlytics `64ea60afab69dc0c718aeada5d06e6c7`, first seen on 9.5.1 — exception
+and blamed frame (`register$lambda$4` is that `LifecycleEventObserver`, the only
+non-inline lambda in `register`):
+
+```
+java.lang.ClassNotFoundException: g.a
+  expo.modules.kotlin.activityresult.AppContextActivityResultRegistry.register$lambda$4
+```
+
+What it does:
+Carries upstream commit `ba1b90db769f` verbatim (minus its CHANGELOG entry):
+passes the `expo-modules-core` class loader to `readBundle` in
+`DataPersistor.toBundle()`, and drops the `@Suppress("ParcelClassLoader")` that
+hid the lint for it. Nested `Bundle`s inherit the parent's class loader while
+they unparcel, so setting it once at the read covers every `retrieve*` method.
+The persisted bytes, the keys and the write path are untouched.
+
+iOS is unaffected: `DataPersistor` and the whole
+`expo.modules.kotlin.activityresult` package are Android-only.
+
+No `buildFromSource` entry is needed: `expo-modules-core` declares no
+`android.publication` in its `expo-module.config.json`, so Expo autolinking
+always compiles it from `node_modules` sources rather than resolving a
+prebuilt AAR. (This is why `expo-notifications` and `expo-background-task`,
+which do publish prebuilt AARs, need their `buildFromSource` entries and this
+patch does not.)
+
+Upstream:
+- repo: `expo/expo`
+- issue: [#49782](https://github.com/expo/expo/issues/49782); earlier report
+  of the same crash: [#26446](https://github.com/expo/expo/issues/26446)
+  (closed as stale, never fixed)
+- fix: [#49836](https://github.com/expo/expo/pull/49836), merged 2026-09-08 as
+  `ba1b90db769f`
+- as of September 8, 2026 the fix is on `main` only. `origin/sdk-57` still
+  carries `readBundle(null)`, so no published `expo-modules-core@57.0.x`
+  includes it and bumping the pin does not help.
+- Linear: `TLON-6495`
+
+Validation done here:
+- `corepack pnpm install --frozen-lockfile` applies the patch and its lockfile
+  hash is current.
+- `./gradlew :expo-modules-core:compileReleaseKotlin` succeeds, and
+  `javap -c` on the resulting `DataPersistorKt.class` shows
+  `Parcel.readBundle(ClassLoader)` fed by
+  `DataPersistor.class.getClassLoader()`. Dropping the `@Suppress` raises no
+  lint in a consumer build.
+
+Still to validate on a device:
+- Reproducing needs our Activity destroyed while an activity-result launch is
+  in flight: enable "Don't keep activities" in Developer options, attach an
+  image in a chat to open the picker, pick an image, and let the app return.
+  Unpatched release builds crash on the following launch; patched builds
+  should restore the pending result and continue.
+- Watch Crashlytics issue `64ea60afab69dc0c718aeada5d06e6c7` on the release
+  after this lands.
+
+Removal:
+Drop this patch once we pin an `expo-modules-core` release that includes
+[#49836](https://github.com/expo/expo/pull/49836), and confirm the Crashlytics
+issue stays closed.
+
+Known limit (not fixed here):
+`restoreInstanceState` still propagates any value it cannot read, so a record
+that is unreadable for some *other* reason stays fatal. The realistic case is
+an app update landing between `persistInstanceState` and the restore, inside
+the 5-minute window: the persisted class names are R8-obfuscated and the
+mapping is per-build. Making the restore path non-fatal is a separate change
+that upstream deliberately left to a maintainer
+([option 3](https://github.com/expo/expo/pull/49836) in the PR description).

--- a/patches/README.md
+++ b/patches/README.md
@@ -581,7 +581,12 @@ obfuscated name (`g.a`) instead of `androidx.activity.result.ActivityResult`.
 
 The record expires after 5 minutes and `DataPersistor.retrieveData()` clears
 the store as it reads, so this is one crash per interrupted launch rather than
-a boot loop — which is why it reads as a random launch crash.
+a boot loop — which is why it reads as a random launch crash. Measured on a
+Pixel 7a (Android 17, API 37) against the shipped `io.tlon.groups.preview`
+9.4.3: one `FATAL EXCEPTION`, then three clean cold starts. Upstream reports
+the record instead being renewed on every `onHostDestroy` and never healing;
+we did not see that, because the crash kills the process before any
+`onHostDestroy` can re-persist it.
 
 Crashlytics `64ea60afab69dc0c718aeada5d06e6c7`, first seen on 9.5.1 — exception
 and blamed frame (`register$lambda$4` is that `LifecycleEventObserver`, the only
@@ -590,6 +595,25 @@ non-inline lambda in `register`):
 ```
 java.lang.ClassNotFoundException: g.a
   expo.modules.kotlin.activityresult.AppContextActivityResultRegistry.register$lambda$4
+```
+
+Reproduced on-device (see Validation below). The obfuscated stack matches
+upstream's unobfuscated one frame for frame, and shows the lazy-value path that
+defers the failure from the read to the `getParcelable`:
+
+```
+android.os.BadParcelableException: ClassNotFoundException when unmarshalling: g.a
+  at android.os.Parcel$LazyValue.apply(Parcel.java:4894)
+  at android.os.BaseBundle.unwrapLazyValueFromMapLocked(BaseBundle.java:450)
+  at android.os.Bundle.getParcelable(Bundle.java:1121)
+  at Kb.i.o(...)                    <- register$lambda$4
+  at androidx.lifecycle.t.a(...)    <- LifecycleRegistry.addObserver
+  at Kb.i.n(...)                    <- register
+  at Kb.a$b.a(...)                  <- ActivityResultsManager.registerForActivityResult
+  Suppressed: [CoroutineName(expo.modules.MainQueue), ...]
+Caused by: java.lang.ClassNotFoundException: g.a
+  at java.lang.Class.forName(Class.java:591)
+  at android.os.Parcel.readParcelableCreatorInternal(Parcel.java:5407)
 ```
 
 What it does:
@@ -630,13 +654,55 @@ Validation done here:
   `Parcel.readBundle(ClassLoader)` fed by
   `DataPersistor.class.getClassLoader()`. Dropping the `@Suppress` raises no
   lint in a consumer build.
+- **A/B on a device, patched vs unpatched `previewRelease`.** Two APKs built
+  from this tree, differing only in this patch. They are byte-identical apart
+  from one instruction in the obfuscated `toBundle` (`Kb.l.d`), at the same
+  address in the same dex:
 
-Still to validate on a device:
-- Reproducing needs our Activity destroyed while an activity-result launch is
-  in flight: enable "Don't keep activities" in Developer options, attach an
-  image in a chat to open the picker, pick an image, and let the app return.
-  Unpatched release builds crash on the following launch; patched builds
-  should restore the pending result and continue.
+  | APK | `toBundle` argument |
+  | --- | --- |
+  | patched | `const-class LKb/k;` -> `Class.getClassLoader()` -> `readBundle(v3)` |
+  | unpatched | `const/4 v3, #0` -> `readBundle(v3)` |
+
+  Same Pixel 7a, same signed-in account, same steps (below), swapped in place
+  with `adb install -r` so the session carried across:
+
+  | APK | Cold start into a poisoned record |
+  | --- | --- |
+  | patched | starts normally; 0 `FATAL EXCEPTION`, 0 `ClassNotFoundException` |
+  | unpatched | `FATAL EXCEPTION` / `BadParcelableException: ClassNotFoundException when unmarshalling: g.a`; app never reaches the foreground |
+
+On-device repro (Pixel 7a, Android 17 / API 37). Two things make it fiddly:
+
+- `settings put global always_finish_activities 1` is **not** enough — the
+  framework only picks that value up at boot or when the Developer options
+  switch is tapped. Cycle the switch (off, then on) and confirm with
+  `dumpsys activity activities`: a backgrounded Activity must report
+  `state=DESTROYED`, not `state=STOPPED`.
+- Android 13+'s system Photo Picker is translucent and launches **into the
+  caller's own task** (`numActivities=2`, `isTopActivityTransparent=true`), so
+  our Activity stays visible and is never destroyed behind it. Pressing Home
+  while the picker is open is what backgrounds the whole task and destroys us.
+
+Full sequence, which poisons the record and then crashes on the next cold
+start:
+
+1. Cycle "Don't keep activities" on.
+2. Open a chat, `+` -> Media Library.
+3. Press Home while the picker is open. Our Activity is destroyed while the
+   launch is in flight: `persistInstanceState` writes the state, and the
+   observer's `ON_DESTROY` branch calls `unregister(key)`, which drops the main
+   callback.
+4. Reopen the app. The picker's result now dispatches with no main callback and
+   no lifecycle container, so `doDispatch` falls to case 3 and puts an
+   `ActivityResult` into `pendingResults`. Re-registration uses fresh
+   `AppContext_rq#N` keys, so nothing reads it yet.
+5. Press Home again. `onHostDestroy` persists the poisoned `pendingResults`.
+6. `am force-stop`, then launch. The new process restarts `nextLocalRequestCode`
+   at 0, so re-registration reproduces the persisted key, the `ON_START`
+   observer reads it, and the app dies with the stack above.
+
+Still to validate:
 - Watch Crashlytics issue `64ea60afab69dc0c718aeada5d06e6c7` on the release
   after this lands.
 

--- a/patches/expo-modules-core@57.0.6.patch
+++ b/patches/expo-modules-core@57.0.6.patch
@@ -1,0 +1,14 @@
+diff --git a/android/src/main/java/expo/modules/kotlin/activityresult/DataPersistor.kt b/android/src/main/java/expo/modules/kotlin/activityresult/DataPersistor.kt
+index 386055f4a5717e511310c3db7f6feb6e327bed0f..0f8e69b46cb774b819b8427f90bc6f3f986cd7e5 100644
+--- a/android/src/main/java/expo/modules/kotlin/activityresult/DataPersistor.kt
++++ b/android/src/main/java/expo/modules/kotlin/activityresult/DataPersistor.kt
+@@ -115,8 +115,7 @@ private fun String.toBundle(): Bundle? {
+   return Parcel.obtain().run {
+     unmarshall(bytes, 0, bytes.size)
+     setDataPosition(0)
+-    @Suppress("ParcelClassLoader")
+-    val bundle = readBundle(null)
++    val bundle = readBundle(DataPersistor::class.java.classLoader)
+     recycle()
+     bundle
+   }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -39,6 +39,7 @@ patchedDependencies:
   drizzle-orm: 834dc52d077cfbc1aab821e9960422d59032b5e4684b82f56bf452cb0d5db1a7
   expo-background-task: 3daff8d4e5dad45164c728ef157cd94381f3c69e621f0d0af42cde77694fa9d3
   expo-image-manipulator: a0cad1b916a3f3d549acf65332d547d04190f2d46d14756c6ae74c0330f6a7b3
+  expo-modules-core@57.0.6: 473a320c19cbd021f695118ce01a63ef34647af9d1fd5d8130c87c035c2ac641
   expo-notifications@57.0.6: 3cd1d0e73793fbcadc25864e129f68fd28d2d2a976ed231ca19ea4d45c69d6ca
   react-cosmos: 658acdaf59c16d70e54b6b0b9d522593cd973839891ed5446a3dd3045d4e37eb
   react-native-country-codes-picker: 53c90d297e1cc4991af0f2d72d0f33a68e8be46e75bdf3da919a20160791bee5
@@ -21901,7 +21902,7 @@ snapshots:
       - supports-color
       - typescript
 
-  expo-modules-core@57.0.6(react-native-worklets@0.10.3(patch_hash=493073c3d3dffc3a19003c8bb99960497eb1d81f29e6dc25068c4b85a86c312e)(@babel/core@7.29.0)(@react-native/metro-config@0.86.3)(react-native@0.86.3(patch_hash=f54baeefce4ebc375a88be0db5fe1bacbabaccfbdcd19d1ccfb5f06c0e307e16)(@react-native/jest-preset@0.86.3(@babel/core@7.29.0)(react@19.2.3))(@react-native/metro-config@0.86.3)(@types/react@19.2.17)(react@19.2.3))(react@19.2.3))(react-native@0.86.3(patch_hash=f54baeefce4ebc375a88be0db5fe1bacbabaccfbdcd19d1ccfb5f06c0e307e16)(@react-native/jest-preset@0.86.3(@babel/core@7.29.0)(react@19.2.3))(@react-native/metro-config@0.86.3)(@types/react@19.2.17)(react@19.2.3))(react@19.2.3):
+  expo-modules-core@57.0.6(patch_hash=473a320c19cbd021f695118ce01a63ef34647af9d1fd5d8130c87c035c2ac641)(react-native-worklets@0.10.3(patch_hash=493073c3d3dffc3a19003c8bb99960497eb1d81f29e6dc25068c4b85a86c312e)(@babel/core@7.29.0)(@react-native/metro-config@0.86.3)(react-native@0.86.3(patch_hash=f54baeefce4ebc375a88be0db5fe1bacbabaccfbdcd19d1ccfb5f06c0e307e16)(@react-native/jest-preset@0.86.3(@babel/core@7.29.0)(react@19.2.3))(@react-native/metro-config@0.86.3)(@types/react@19.2.17)(react@19.2.3))(react@19.2.3))(react-native@0.86.3(patch_hash=f54baeefce4ebc375a88be0db5fe1bacbabaccfbdcd19d1ccfb5f06c0e307e16)(@react-native/jest-preset@0.86.3(@babel/core@7.29.0)(react@19.2.3))(@react-native/metro-config@0.86.3)(@types/react@19.2.17)(react@19.2.3))(react@19.2.3):
     dependencies:
       '@expo/expo-modules-macros-plugin': 0.6.1
       expo-modules-jsi: 57.0.3(react-native@0.86.3(patch_hash=f54baeefce4ebc375a88be0db5fe1bacbabaccfbdcd19d1ccfb5f06c0e307e16)(@react-native/jest-preset@0.86.3(@babel/core@7.29.0)(react@19.2.3))(@react-native/metro-config@0.86.3)(@types/react@19.2.17)(react@19.2.3))
@@ -22016,7 +22017,7 @@ snapshots:
       expo-font: 57.0.1(expo@57.0.7(1a50d969892ffc893a6ddd04f6f32a12))(react-native@0.86.3(patch_hash=f54baeefce4ebc375a88be0db5fe1bacbabaccfbdcd19d1ccfb5f06c0e307e16)(@react-native/jest-preset@0.86.3(@babel/core@7.29.0)(react@19.2.3))(@react-native/metro-config@0.86.3)(@types/react@19.2.17)(react@19.2.3))(react@19.2.3)
       expo-keep-awake: 57.0.1(expo@57.0.7(1a50d969892ffc893a6ddd04f6f32a12))(react@19.2.3)
       expo-modules-autolinking: 57.0.8(typescript@5.9.3)
-      expo-modules-core: 57.0.6(react-native-worklets@0.10.3(patch_hash=493073c3d3dffc3a19003c8bb99960497eb1d81f29e6dc25068c4b85a86c312e)(@babel/core@7.29.0)(@react-native/metro-config@0.86.3)(react-native@0.86.3(patch_hash=f54baeefce4ebc375a88be0db5fe1bacbabaccfbdcd19d1ccfb5f06c0e307e16)(@react-native/jest-preset@0.86.3(@babel/core@7.29.0)(react@19.2.3))(@react-native/metro-config@0.86.3)(@types/react@19.2.17)(react@19.2.3))(react@19.2.3))(react-native@0.86.3(patch_hash=f54baeefce4ebc375a88be0db5fe1bacbabaccfbdcd19d1ccfb5f06c0e307e16)(@react-native/jest-preset@0.86.3(@babel/core@7.29.0)(react@19.2.3))(@react-native/metro-config@0.86.3)(@types/react@19.2.17)(react@19.2.3))(react@19.2.3)
+      expo-modules-core: 57.0.6(patch_hash=473a320c19cbd021f695118ce01a63ef34647af9d1fd5d8130c87c035c2ac641)(react-native-worklets@0.10.3(patch_hash=493073c3d3dffc3a19003c8bb99960497eb1d81f29e6dc25068c4b85a86c312e)(@babel/core@7.29.0)(@react-native/metro-config@0.86.3)(react-native@0.86.3(patch_hash=f54baeefce4ebc375a88be0db5fe1bacbabaccfbdcd19d1ccfb5f06c0e307e16)(@react-native/jest-preset@0.86.3(@babel/core@7.29.0)(react@19.2.3))(@react-native/metro-config@0.86.3)(@types/react@19.2.17)(react@19.2.3))(react@19.2.3))(react-native@0.86.3(patch_hash=f54baeefce4ebc375a88be0db5fe1bacbabaccfbdcd19d1ccfb5f06c0e307e16)(@react-native/jest-preset@0.86.3(@babel/core@7.29.0)(react@19.2.3))(@react-native/metro-config@0.86.3)(@types/react@19.2.17)(react@19.2.3))(react@19.2.3)
       pretty-format: 29.7.0
       react: 19.2.3
       react-native: 0.86.3(patch_hash=f54baeefce4ebc375a88be0db5fe1bacbabaccfbdcd19d1ccfb5f06c0e307e16)(@react-native/jest-preset@0.86.3(@babel/core@7.29.0)(react@19.2.3))(@react-native/metro-config@0.86.3)(@types/react@19.2.17)(react@19.2.3)

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -47,6 +47,7 @@ patchedDependencies:
   expo-notifications@57.0.6: patches/expo-notifications@57.0.6.patch
   react-native@0.86.3: patches/react-native@0.86.3.patch
   react-native-worklets@0.10.3: patches/react-native-worklets@0.10.3.patch
+  expo-modules-core@57.0.6: patches/expo-modules-core@57.0.6.patch
 
 allowUnusedPatches: false
 


### PR DESCRIPTION
## Summary

Fixes TLON-6495 — the fatal Android launch crash
`java.lang.ClassNotFoundException: g.a` inside
`expo.modules.kotlin.activityresult.AppContextActivityResultRegistry.register$lambda$4`
(Crashlytics `64ea60afab69dc0c718aeada5d06e6c7`, first seen on 9.5.1).

Root cause is an upstream expo-modules-core bug. This carries the upstream
fix ([expo/expo#49836](https://github.com/expo/expo/pull/49836), merged
2026-09-08) as a pnpm patch, since it is not in any published release.

## Changes

`AppContextActivityResultRegistry.persistInstanceState` marshals its in-flight
activity-result state — including the pending
`androidx.activity.result.ActivityResult` — into a base64 `Bundle` in
`SharedPreferences` on `onHostDestroy`. That happens whenever the OS destroys
our Activity while an activity-result launch is in flight (image picker,
document picker, file picker).

`DataPersistor.toBundle()` read it back with `readBundle(null)`. A null
`ClassLoader` leaves the `Bundle` at the framework default — the **boot**
`ClassLoader`, which cannot resolve *any* class from the app's dex. The `Bundle`
unparcels lazily, so it does not fail at the read. It fails at the first strict
`Parcelable` read, which is the pending-result lookup in the `ON_START`
observer that `register` installs:

```kotlin
val activityResult = pendingResults.safeGetParcelable<ActivityResult>(key)
```

That is the reported frame: `register$lambda$4` is that `LifecycleEventObserver`
— the only non-inline lambda in `register`. R8 is on for release builds
(`android.enableProguardInReleaseBuilds=true`), so Crashlytics shows the
obfuscated `g.a` rather than `androidx.activity.result.ActivityResult`.

Two details explain the shape of the crash:

- `expo-file-system` registers its picker contract in `RegisterActivityContracts`,
  which `ModuleRegistry.postOnCreate` runs at app-context creation. So *every*
  launch reaches that observer — a persisted pending result crashes the next
  cold start rather than just dropping a picker result.
- The record expires after 5 minutes and `DataPersistor.retrieveData()` clears
  the store as it reads, so it is one crash per interrupted launch, not a boot
  loop. Hence "random launch crash". Measured: one `FATAL EXCEPTION`, then
  three clean cold starts. (Upstream reports the record renewing forever and
  never healing; that did not reproduce here, because the crash kills the
  process before any `onHostDestroy` can re-persist it.)

The patch carries upstream commit `ba1b90db769f` verbatim (minus its CHANGELOG
entry): pass the expo-modules-core `ClassLoader` to `readBundle`, and drop the
`@Suppress("ParcelClassLoader")` that hid the lint for it. Nested `Bundle`s
inherit the parent's class loader while they unparcel, so setting it once at the
read covers every `retrieve*` method. Persisted bytes, keys and the write path
are untouched.

- `patches/expo-modules-core@57.0.6.patch` — the one-line upstream fix
- `pnpm-workspace.yaml` / `pnpm-lock.yaml` — register the patch
- `patches/README.md` — why, upstream refs, validation, removal condition, and
  the one residual case this does not cover

No `buildFromSource` entry is needed: `expo-modules-core` declares no
`android.publication` in its `expo-module.config.json`, so Expo autolinking
always compiles it from `node_modules` sources. (`expo-notifications` and
`expo-background-task` need theirs because they do ship prebuilt AARs.)

iOS is untouched — the whole `expo.modules.kotlin.activityresult` package is
Android-only.

## How did I test?

**Reproduced the crash on a shipped build**, then ran a controlled A/B. Pixel 7a,
Android 17 / API 37.

**Before (shipped `io.tlon.groups.preview` 9.4.3, EAS-signed, R8-minified):**

```
FATAL EXCEPTION: main
android.os.BadParcelableException: ClassNotFoundException when unmarshalling: g.a
	at android.os.Parcel$LazyValue.apply(Parcel.java:4894)
	at android.os.BaseBundle.unwrapLazyValueFromMapLocked(BaseBundle.java:450)
	at android.os.Bundle.getParcelable(Bundle.java:1121)
	at Kb.i.o(…)                     <- register$lambda$4
	at androidx.lifecycle.t.a(…)     <- LifecycleRegistry.addObserver
	at Kb.i.n(…)                     <- register
	at Kb.a$b.a(…)                   <- ActivityResultsManager.registerForActivityResult
	Suppressed: [CoroutineName(expo.modules.MainQueue), …]
Caused by: java.lang.ClassNotFoundException: g.a
```

Same `g.a`, same blamed frame as Crashlytics `64ea60af…`, and frame-for-frame
identical to upstream's unobfuscated stack. The `LazyValue` frames also confirm
why the failure lands in the observer rather than at the read: `Bundle.putAll`
copies *lazy* values, so nothing resolves until the `getParcelable`.

**A/B, patched vs unpatched `previewRelease`.** Two APKs from this tree,
differing only in this patch — byte-identical apart from one instruction in the
obfuscated `toBundle` (`Kb.l.d`), at the same address in the same dex:

| APK | `toBundle` argument |
| --- | --- |
| patched | `const-class LKb/k;` → `Class.getClassLoader()` → `readBundle(v3)` |
| unpatched | `const/4 v3, #0` → `readBundle(v3)` |

Same phone, same signed-in account, same steps, swapped in place with
`adb install -r` so the session carried across:

| APK | Cold start into a poisoned record |
| --- | --- |
| **patched** | starts normally; 0 `FATAL EXCEPTION`, 0 `ClassNotFoundException`, Home loads and syncs |
| **unpatched** | `FATAL EXCEPTION` / `BadParcelableException: … g.a`; app never reaches the foreground |

Repro steps (two non-obvious prerequisites, both now in `patches/README.md`):
`always_finish_activities` set via `settings put` is inert until the Developer
options switch is cycled — verify with `dumpsys activity activities` that a
backgrounded Activity reports `state=DESTROYED`, not `state=STOPPED`. And
Android 13+'s Photo Picker is translucent and launches into the caller's own
task, so our Activity is never destroyed behind it; pressing Home is what does
it. Then: chat → `+` → Media Library → **Home** → reopen → **Home** →
`am force-stop` → launch.

Also verified locally:
- `corepack pnpm install --frozen-lockfile` applies the patch; lockfile hash current
- `./gradlew :expo-modules-core:compileReleaseKotlin` → `BUILD SUCCESSFUL`; dropping the `@Suppress` raised no lint
- `pnpm format:check` clean

<details><summary><b>Raw evidence from the phone</b> (logcat + dex)</summary>

Pixel 7a, Android 17 / API 37. Both runs are the same six steps on the same
signed-in account, swapped with `adb install -r`.

**Counts over the whole run:**

```
patched previewRelease, cold start into poisoned record:
  FATAL EXCEPTION lines:            0
  ClassNotFoundException: g.a:      0
  BadParcelableException:           0
  E/Parcel:                         0

unpatched previewRelease, identical steps:
  FATAL EXCEPTION lines:            1
  ClassNotFoundException: g.a:      4
  BadParcelableException:           1
```

The patched run reached Home with all channels loaded and synced. The unpatched
run never reached the foreground (`dumpsys activity activities` reported no
resumed activity for the package) and the framework logged
`Force finishing activity io.tlon.groups.preview/io.tlon.landscape.MainActivity`.

**Unpatched build, full crash:**

```
09-08 18:01:20.347 E/AndroidRuntime( 8519): FATAL EXCEPTION: main
09-08 18:01:20.347 E/AndroidRuntime( 8519): Process: io.tlon.groups.preview, PID: 8519
09-08 18:01:20.347 E/AndroidRuntime( 8519): android.os.BadParcelableException: ClassNotFoundException when unmarshalling: g.a
09-08 18:01:20.347 E/AndroidRuntime( 8519): 	at android.os.Parcel.readParcelableCreatorInternal(Parcel.java:5441)
09-08 18:01:20.347 E/AndroidRuntime( 8519): 	at android.os.Parcel.readParcelableInternal(Parcel.java:5290)
09-08 18:01:20.347 E/AndroidRuntime( 8519): 	at android.os.Parcel.readValue(Parcel.java:5049)
09-08 18:01:20.347 E/AndroidRuntime( 8519): 	at android.os.Parcel.readValue(Parcel.java:4779)
09-08 18:01:20.347 E/AndroidRuntime( 8519): 	at android.os.Parcel.-$$Nest$mreadValue(Parcel.java:0)
09-08 18:01:20.347 E/AndroidRuntime( 8519): 	at android.os.Parcel$LazyValue.apply(Parcel.java:4894)
09-08 18:01:20.347 E/AndroidRuntime( 8519): 	at android.os.Parcel$LazyValue.apply(Parcel.java:4847)
09-08 18:01:20.347 E/AndroidRuntime( 8519): 	at android.os.BaseBundle.unwrapLazyValueFromMapLocked(BaseBundle.java:450)
09-08 18:01:20.347 E/AndroidRuntime( 8519): 	at android.os.BaseBundle.getValueAt(BaseBundle.java:430)
09-08 18:01:20.347 E/AndroidRuntime( 8519): 	at android.os.BaseBundle.getValue(BaseBundle.java:401)
09-08 18:01:20.347 E/AndroidRuntime( 8519): 	at android.os.BaseBundle.getValue(BaseBundle.java:384)
09-08 18:01:20.347 E/AndroidRuntime( 8519): 	at android.os.BaseBundle.get(BaseBundle.java:776)
09-08 18:01:20.347 E/AndroidRuntime( 8519): 	at android.os.Bundle.getParcelable(Bundle.java:1121)
09-08 18:01:20.347 E/AndroidRuntime( 8519): 	at Kb.i.o(r8-map-id-2caa31715fae7e0cd936da9a31e520859d696e093092ece33832432c93d82fc6:51)
09-08 18:01:20.347 E/AndroidRuntime( 8519): 	at Kb.i.a(r8-map-id-2caa31715fae7e0cd936da9a31e520859d696e093092ece33832432c93d82fc6:1)
09-08 18:01:20.347 E/AndroidRuntime( 8519): 	at Kb.g.a(r8-map-id-2caa31715fae7e0cd936da9a31e520859d696e093092ece33832432c93d82fc6:5)
09-08 18:01:20.347 E/AndroidRuntime( 8519): 	at androidx.lifecycle.t$b.a(r8-map-id-2caa31715fae7e0cd936da9a31e520859d696e093092ece33832432c93d82fc6:25)
09-08 18:01:20.347 E/AndroidRuntime( 8519): 	at androidx.lifecycle.t.a(r8-map-id-2caa31715fae7e0cd936da9a31e520859d696e093092ece33832432c93d82fc6:106)
09-08 18:01:20.347 E/AndroidRuntime( 8519): 	at Kb.i$b.a(r8-map-id-2caa31715fae7e0cd936da9a31e520859d696e093092ece33832432c93d82fc6:8)
09-08 18:01:20.347 E/AndroidRuntime( 8519): 	at Kb.i.n(r8-map-id-2caa31715fae7e0cd936da9a31e520859d696e093092ece33832432c93d82fc6:88)
09-08 18:01:20.347 E/AndroidRuntime( 8519): 	at Kb.a$b.a(r8-map-id-2caa31715fae7e0cd936da9a31e520859d696e093092ece33832432c93d82fc6:60)
09-08 18:01:20.347 E/AndroidRuntime( 8519): 	at Jb.d.e(r8-map-id-2caa31715fae7e0cd936da9a31e520859d696e093092ece33832432c93d82fc6:1)
09-08 18:01:20.347 E/AndroidRuntime( 8519): 	at Jb.d.d(r8-map-id-2caa31715fae7e0cd936da9a31e520859d696e093092ece33832432c93d82fc6:1)
09-08 18:01:20.347 E/AndroidRuntime( 8519): 	at Jb.b.run(r8-map-id-2caa31715fae7e0cd936da9a31e520859d696e093092ece33832432c93d82fc6:5)
09-08 18:01:20.347 E/AndroidRuntime( 8519): 	at android.app.Activity.runOnUiThread(Activity.java:8396)
09-08 18:01:20.347 E/AndroidRuntime( 8519): 	at Jb.d.c(r8-map-id-2caa31715fae7e0cd936da9a31e520859d696e093092ece33832432c93d82fc6:26)
09-08 18:01:20.347 E/AndroidRuntime( 8519): 	at Kb.a.c(r8-map-id-2caa31715fae7e0cd936da9a31e520859d696e093092ece33832432c93d82fc6:8)
09-08 18:01:20.347 E/AndroidRuntime( 8519): 	at Kb.a.a(r8-map-id-2caa31715fae7e0cd936da9a31e520859d696e093092ece33832432c93d82fc6:23)
09-08 18:01:20.347 E/AndroidRuntime( 8519): 	at Kb.m.a(r8-map-id-2caa31715fae7e0cd936da9a31e520859d696e093092ece33832432c93d82fc6:3)
09-08 18:01:20.347 E/AndroidRuntime( 8519): 	at Db.m$c.invokeSuspend(r8-map-id-2caa31715fae7e0cd936da9a31e520859d696e093092ece33832432c93d82fc6:121)
09-08 18:01:20.347 E/AndroidRuntime( 8519): 	at Db.m$c.a(r8-map-id-2caa31715fae7e0cd936da9a31e520859d696e093092ece33832432c93d82fc6:9)
09-08 18:01:20.347 E/AndroidRuntime( 8519): 	at Db.m$c.invoke(r8-map-id-2caa31715fae7e0cd936da9a31e520859d696e093092ece33832432c93d82fc6:5)
09-08 18:01:20.347 E/AndroidRuntime( 8519): 	at Ib.r$a.invokeSuspend(r8-map-id-2caa31715fae7e0cd936da9a31e520859d696e093092ece33832432c93d82fc6:45)
09-08 18:01:20.347 E/AndroidRuntime( 8519): 	at kotlin.coroutines.jvm.internal.a.resumeWith(r8-map-id-2caa31715fae7e0cd936da9a31e520859d696e093092ece33832432c93d82fc6:12)
09-08 18:01:20.347 E/AndroidRuntime( 8519): 	at mf.c0.run(r8-map-id-2caa31715fae7e0cd936da9a31e520859d696e093092ece33832432c93d82fc6:129)
09-08 18:01:20.347 E/AndroidRuntime( 8519): 	at android.os.Handler.handleCallback(Handler.java:1095)
09-08 18:01:20.347 E/AndroidRuntime( 8519): 	at android.os.Handler.dispatchMessageImpl(Handler.java:135)
09-08 18:01:20.347 E/AndroidRuntime( 8519): 	at android.os.Handler.dispatchMessage(Handler.java:125)
09-08 18:01:20.347 E/AndroidRuntime( 8519): 	at android.os.Looper.loopOnce(Looper.java:296)
09-08 18:01:20.347 E/AndroidRuntime( 8519): 	at android.os.Looper.loop(Looper.java:397)
09-08 18:01:20.347 E/AndroidRuntime( 8519): 	at android.app.ActivityThread.main(ActivityThread.java:9569)
09-08 18:01:20.347 E/AndroidRuntime( 8519): 	at java.lang.reflect.Method.invoke(Native Method)
09-08 18:01:20.347 E/AndroidRuntime( 8519): 	at com.android.internal.os.RuntimeInit$MethodAndArgsCaller.run(RuntimeInit.java:575)
09-08 18:01:20.347 E/AndroidRuntime( 8519): 	at com.android.internal.os.ZygoteInit.main(ZygoteInit.java:975)
09-08 18:01:20.347 E/AndroidRuntime( 8519): 	Suppressed: rf.h: [CoroutineName(expo.modules.MainQueue), U0{Cancelling}@629e73a, Dispatchers.Main]
09-08 18:01:20.347 E/AndroidRuntime( 8519): Caused by: java.lang.ClassNotFoundException: g.a
09-08 18:01:20.347 E/AndroidRuntime( 8519): 	at java.lang.Class.classForName(Native Method)
09-08 18:01:20.347 E/AndroidRuntime( 8519): 	at java.lang.Class.forName(Class.java:591)
09-08 18:01:20.347 E/AndroidRuntime( 8519): 	at android.os.Parcel.readParcelableCreatorInternal(Parcel.java:5407)
09-08 18:01:20.347 E/AndroidRuntime( 8519): 	... 43 more
09-08 18:01:20.347 E/AndroidRuntime( 8519): Caused by: java.lang.ClassNotFoundException: g.a
09-08 18:01:20.347 E/AndroidRuntime( 8519): 	... 46 more
09-08 18:01:20.362 W/ActivityTaskManager( 1308):   Force finishing activity io.tlon.groups.preview/io.tlon.landscape.MainActivity
09-08 18:01:20.363 I/DropBoxManagerService( 1308): add tag=data_app_crash isTagEnabled=true flags=0x2
09-08 18:01:20.365 W/TransitionChain( 1308): Combining AR.finish-force-crash into #88(CLOSE|R|0x10) from finishTopCrash
09-08 18:01:20.367 V/WindowManagerShell( 2064): Transition requested (#88): android.os.BinderProxy@14512e3 TransitionRequestInfo { type = CLOSE, triggerTask = TaskInfo{userId=0 taskId=24 effectiveUid=10209 displayId=0 isRunning=true baseIntent=Intent { act=android.intent.action.MAIN cat=[android.intent.category.LAUNCHER] flg=0x10200000 cmp=io.tlon.groups.preview/io.tlon.landscape.MainActivity } baseActivity=ComponentInfo{io.tlon.groups.preview/io.tlon.landscape.MainActivity} topActivity=ComponentInfo{io.tlon.groups.preview/io.tlon.landscape.MainActivity} origActivity=null realActivity=ComponentInfo{io.tlon.groups.preview/io.tlon.landscape.MainActivity} realActivityIsAppLockEnabled=false numActivities=1 lastActiveTime=298170458 supportsMultiWindow=true supportsMultiWindowWithoutConstraints=true resizeMode=1 isResizeable=true minWidth=-1 minHeight=-1 defaultMinSize=220 token=WCT{android.os.BinderProxy@e598f05} topActivityType=1 pictureInPictureParams=null shouldDockBigOverlays=false launchIntoPipHostTaskId=-1 lastParentTaskIdBeforePip=-1 displayCutoutSafeInsets=Rect(0, 0 - 0, 0) topActivityInfo=ActivityInfo{4bc64e0 io.tlon.landscape.MainActivity} launchCookies=[] positionInParent=Point(0, 0) parentTaskId=-1 isFocused=true isInteractive=true isVisible=true isVisibleRequested=true isTopActivityNoDisplay=false isSleeping=false locusId=null displayAreaFeatureId=1 isTopActivityTransparent=false isActivityStackTransparent=false lastNonFullscreenBounds=Rect(278, 687 - 803, 1767) leafTaskBoundsFromOptions= false capturedLink=null capturedLinkTimestamp=0 requestedVisibleTypes=503 topActivityRequestOpenInBrowserEducationTimestamp=0 appCompatTaskInfo=AppCompatTaskInfo { topActivityInSizeCompat=false isLeafTask= true eligibleForLetterboxEducation= false isLetterboxEducationEnabled= false isLetterboxDoubleTapEnabled= false eligibleForUserAspectRatioButton= false topActivityBoundsLetterboxed= false isFromLetterboxDoubleTap= false topActivityLetterboxVerticalPosition= -1 topActivityLetterboxHorizontalPosition= -1 topActivityLetterboxWidth=-1 topActivityLetterboxHeight=-1 topActivityAppBounds=Rect(0, 0 - 1080, 2400) isUserFullscreenOverrideEnabled=false isSystemFullscreenOverrideEnabled=false hasMinAspectRatioOverride=false topActivityLetterboxBounds=null topNonResizableActivityAspectRatio=-1.0} topActivityMainWindowFrame=null isAppBubble=false}, pipChange = null, remoteTransitionInfo = null, displayChanges = null, requestedLocation = null, userChange = null, windowingLayerChange = null, fullscreenRequestChange = null, flags = 16, debugId = 88 }
09-08 18:01:20.367 W/DisconnectHandler( 2064): No disconnect change found in the transition, not handling request.
```

Note the app frames are the *same obfuscated names* the shipped 9.4.3 EAS build
produced (`Kb.i.o` -> `register$lambda$4`, `Kb.i.n` -> `register`,
`Kb.a$b.a` -> `ActivityResultsManager.registerForActivityResult`), under a
different R8 map id -- R8 was deterministic for these inputs, which is also why
the class name lands as `g.a` in both.

**Dex diff between the two APKs** -- the only meaningful difference, at the same
address in the same dex, in the obfuscated `toBundle` (`Kb.l.d`):

```
patched:
  196818: const-class v3, LKb/k;                       // DataPersistor
  19681c: invoke-virtual {v3}, Class.getClassLoader()
  196824: invoke-virtual {v1, v3}, Parcel.readBundle(Ljava/lang/ClassLoader;)

unpatched:
  196818: const/4 v3, #int 0                           // null
  19681a: invoke-virtual {v1, v3}, Parcel.readBundle(Ljava/lang/ClassLoader;)
```

R8 mapping confirms the same thing from the source side: patched maps
`toBundle` to source line 118 (the `readBundle(...)` line in the patched file),
unpatched to line 119 (`readBundle(null)`, with 118 being the dropped
`@Suppress`).

</details>

## Risks and impact

- Safe to rollback without consulting PR author? **Yes**
- Affects important code area:
  - [ ] Onboarding
  - [ ] State / providers
  - [ ] Message sync
  - [ ] Channel display
  - [ ] Notifications
  - [x] Other: Android native — Expo activity-result restore (media/file pickers)

The change can only *widen* the set of classes that resolve at that read, so
the worst case is unchanged behavior. Android-only, release-and-debug alike.
Verified on-device against the unpatched build of the same variant.

Residual case this does **not** fix: `restoreInstanceState` still propagates any
value it cannot read, so a record unreadable for some other reason stays fatal.
The realistic path is an app update landing between `persistInstanceState` and
the restore, inside the 5-minute window — the persisted class names are
R8-obfuscated and the mapping is per-build. Upstream deliberately left "make the
restore path non-fatal" to a maintainer (option 3 in their PR description); I
kept this patch a clean cherry-pick so it drops mechanically on upgrade. Say the
word if we'd rather add the guard now instead of waiting for upstream.

## Rollback plan

Revert the commit and run `pnpm install`. That removes the patch entry, the
lockfile hash and the `patches/` files; nothing else in the tree depends on it.

## Screenshots / videos

Native crash fix, no UI surface — the observable difference is that the app
starts instead of dying, so the evidence is the logcat A/B and dex diff above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
