### PR TITLE
android: decode GIFs with Glide instead of APNG4Android

### DIFF
--- a/apps/tlon-mobile/android/.gitignore
+++ b/apps/tlon-mobile/android/.gitignore
@@ -7,6 +7,7 @@
 build/
 .idea
 .gradle
+.kotlin/
 local.properties
 *.iml
 *.hprof

--- a/apps/tlon-mobile/android/app/src/main/java/io/tlon/landscape/MainApplication.kt
+++ b/apps/tlon-mobile/android/app/src/main/java/io/tlon/landscape/MainApplication.kt
@@ -12,6 +12,7 @@ import com.facebook.react.common.ReleaseLevel
 import com.facebook.react.defaults.DefaultNewArchitectureEntryPoint
 import expo.modules.ApplicationLifecycleDispatcher
 import expo.modules.ExpoReactHostFactory
+import io.tlon.landscape.images.GlideGifDecoders
 import io.tlon.landscape.notifications.TalkNotificationManager
 import io.tlon.landscape.storage.SecureStorage
 import io.branch.rnbranch.RNBranchModule
@@ -47,6 +48,10 @@ class MainApplication : Application(), ReactApplication {
     }
 
     TalkNotificationManager.createNotificationChannel(this)
+
+    // Must run before the first image load, so that Glide hasn't cached a load
+    // path that skips these decoders.
+    GlideGifDecoders.install(this)
 
     // Branch logging for debugging
     if (BuildConfig.DEBUG) {

--- a/apps/tlon-mobile/android/app/src/main/java/io/tlon/landscape/images/GlideGifDecoders.kt
+++ b/apps/tlon-mobile/android/app/src/main/java/io/tlon/landscape/images/GlideGifDecoders.kt
@@ -1,0 +1,64 @@
+package io.tlon.landscape.images
+
+import android.content.Context
+import com.bumptech.glide.Glide
+import com.bumptech.glide.load.resource.gif.ByteBufferGifDecoder
+import com.bumptech.glide.load.resource.gif.GifDrawable
+import com.bumptech.glide.load.resource.gif.StreamGifDecoder
+import java.io.InputStream
+import java.nio.ByteBuffer
+
+/**
+ * Puts Glide's own GIF decoder back in front of APNG4Android's.
+ *
+ * expo-image depends on APNG4Android (`com.github.penfeizhou.android.animation`)
+ * for APNG, animated WebP and AVIF, and that library's Glide plugin prepends
+ * decoders which also claim GIF — so on Android every animated GIF was decoded
+ * by APNG4Android rather than by Glide. That path is a bad fit for us:
+ *
+ *  - It decodes at full native resolution, and can't be asked not to.
+ *    `ByteBufferAnimationDecoder.decode` discards the target size Glide passes
+ *    it, and the only other source of a sample size —
+ *    `FrameAnimationDrawable.setBounds` — is handed the drawable's intrinsic
+ *    size by ImageView, so `getDesiredSample` always answers 1. Setting a
+ *    sample size directly doesn't work either: as of 3.0.5 the native GIF
+ *    decoder ignores the `sampleSize` argument to `GifFrame.encode` and fills
+ *    the smaller buffer with unscaled pixels, which comes out as stripes.
+ *  - It holds three java-heap buffers at four bytes per decoded pixel (frame
+ *    buffer, disposal snapshot, LZW output), none pooled or budgeted, so a
+ *    single 1400x1400 GIF costs ~24MB of a 256MB ART heap.
+ *  - `GifFrame.draw` catches Exception, which does not cover the
+ *    OutOfMemoryError that `GifWriter.reset` throws when the heap runs out. It
+ *    escapes onto a bare HandlerThread and kills the process (TLON-6494).
+ *
+ * Glide's decoder honours the target size, takes frame bitmaps from the shared
+ * BitmapPool and scratch arrays from the ArrayPool, reports its real size to the
+ * memory cache, and runs inside GlideExecutor, which catches Throwable — so
+ * running out of heap fails one image instead of the app.
+ *
+ * These are the decoders Glide registers anyway; re-registering them with
+ * `prepend` only moves them ahead of APNG4Android's in the lookup order. They
+ * accept GIF data only, so APNG, animated WebP and AVIF still fall through to
+ * APNG4Android.
+ */
+object GlideGifDecoders {
+    /**
+     * Call before the first image load. Glide caches resolved load paths, so
+     * anything decoded before this runs would keep using APNG4Android for the
+     * rest of the process. expo-image owns the app's only `AppGlideModule`, so a
+     * runtime prepend is the seam available to us.
+     */
+    fun install(context: Context) {
+        val glide = Glide.get(context)
+        val parsers = glide.registry.imageHeaderParsers
+        val byteBufferDecoder =
+            ByteBufferGifDecoder(context, parsers, glide.bitmapPool, glide.arrayPool)
+        glide.registry
+            .prepend(ByteBuffer::class.java, GifDrawable::class.java, byteBufferDecoder)
+            .prepend(
+                InputStream::class.java,
+                GifDrawable::class.java,
+                StreamGifDecoder(parsers, byteBufferDecoder, glide.arrayPool),
+            )
+    }
+}


### PR DESCRIPTION
## Summary

Fixes TLON-6494, a fatal `OutOfMemoryError` in `GifWriter.reset` on Android. Animated GIFs were being decoded at full native resolution no matter how small the view, holding three unpooled java-heap buffers of four bytes per pixel, and the allocation that ran out of heap was unguarded — so it killed the process from a bare decoder thread. Android GIFs now go through Glide's own decoder, which sizes to the view, pools its memory, and fails safely.

## Changes

`expo-image` depends on APNG4Android (`com.github.penfeizhou.android.animation`) for APNG, animated WebP and AVIF, and that library's Glide plugin `Registry.prepend`s decoders that also claim GIF. So every animated GIF on Android was decoded by APNG4Android rather than by Glide. Three things about that path combine badly:

- **It decodes at full native resolution and can't be asked not to.** `ByteBufferAnimationDecoder.decode` discards the width and height Glide passes it, and the only other source of a sample size — `FrameAnimationDrawable.setBounds` — is handed the drawable's *intrinsic* size by `ImageView` (because `NO_ANIMATION_BOUNDS_MEASURE` defaults to false), so `getDesiredSample` computes `min(W/W, H/H) == 1`. Setting a sample size directly doesn't help either: as of 3.0.5 the native GIF decoder ignores the `sampleSize` argument to `GifFrame.encode` and fills the smaller buffer with unscaled pixels. Verified on device — a 1400×1400 four-quadrant GIF at sample 2/4/8 comes out as red/green stripes with two of the four colours missing entirely. That feature is unreachable through the Glide integration, which is presumably why nobody noticed.
- **Three java-heap buffers, four bytes per decoded pixel.** `GifDecoder.read` allocates `frameBuffer` and a disposal snapshot; `GifFrame.draw` allocates the LZW output via `GifWriter.reset`. None are pooled or budgeted, so one 1400×1400 GIF costs ~24 MB.
- **The OOM is unguarded.** `GifFrame.draw` catches `Exception`, which doesn't cover `OutOfMemoryError`, so it escapes onto a `HandlerThread` with no handler.

The crashing device (Nothing A065, Android 16) had 11.8 GB RAM and 4.4 GB free with `low_memory: false`. The binding constraint was ART's own growth limit: **256 MB, with 4.8 MB left** when a 1400×1400 frame asked for 7.8 MB.

The fix is `apps/tlon-mobile/android/app/src/main/java/io/tlon/landscape/images/GlideGifDecoders.kt`, called from `MainApplication.onCreate`. It re-registers `ByteBufferGifDecoder` and `StreamGifDecoder` — the decoders Glide already ships and would use if nothing had displaced them — with `prepend`, which puts them ahead of APNG4Android's in the lookup order. Their `handles` accepts GIF data only, so APNG, animated WebP and AVIF still fall through to APNG4Android untouched. No new dependencies; no lockfile change.

Glide's decoder honours the target size, takes frame bitmaps from the shared `BitmapPool` and scratch arrays from the `ArrayPool`, reports its real decoded size to the memory cache so eviction is driven by what a GIF actually costs, and runs inside `GlideExecutor`, whose thread factory catches `Throwable` (default strategy `LOG`) — so running out of heap now fails one image instead of the app.

Also: `.kotlin/` added to the Android `.gitignore`. Kotlin 2.x leaves session files there on every local Android build and it wasn't ignored.

## How did I test?

Instrumented run on a `Pixel_9_API_36` emulator (throwaway harness — the repo has no instrumented-test setup and CI runs none):

- Our registration wins the race: a GIF loaded through Glide comes back as `com.bumptech.glide.load.resource.gif.GifDrawable`, is `Animatable` (which is what expo-image needs to autoplay), and reports the right frame count.
- A 400×400 GIF at target 400 decodes at 400×400 with exact quadrant colours — no behaviour change for GIFs at or below view size.
- A 1400×1400 GIF at target 350 decodes at **350×350** — 16× fewer pixels — with exact quadrant colours, and reports 2.9 MB rather than 17.7 MB to the memory cache.
- Real-world check on an 828×1792 / 227-frame screen recording: Glide's full-resolution frame 0 is **pixel-identical** to Pillow's decode of the same frame (zero difference on every channel). At half resolution the only deviation is the expected downscale-filter difference (mean per-channel error 0.07 / 0.05 / 2.8).
- Same harness run against APNG4Android's decoder with no Tlon code in the path, to confirm the broken sampling is upstream and not something this change introduced.
- Registry ordering (`ResourceDecoderRegistry.prepend` does `add(0, …)` into the bucket that sorts first) and `GlideExecutor`'s `catch (Throwable)` were both read out of the Glide 5.0.5 bytecode rather than from memory.
- `:app:compileProductionDebugKotlin`, `:app:compileProductionReleaseKotlin`, `:app:testProductionDebugUnitTest`, `pnpm format:check` all pass.

## Risks and impact

- Safe to rollback without consulting PR author? Yes
- Affects important code area:
  - [ ] Onboarding
  - [ ] State / providers
  - [ ] Message sync
  - [x] Channel display
  - [ ] Notifications
  - [x] Other: Android animated-GIF rendering

Worth a look during QA:

- This swaps the GIF rendering engine on Android. Glide's decoder is the mainstream Android GIF path, and the pixel comparison above says it's exact, but it's worth scrolling a channel with a few real GIFs — especially ones with transparency or frame-local disposal.
- `Image.isAnimated` from `useImage()` will now report `false` for GIFs: expo-image's check only knows APNG4Android's three drawable types. Nothing in the app reads it (our only `useImage` calls are tab icons and an avatar), so this is inert today.
- `MainApplication.onCreate` now initializes Glide eagerly, including on headless FCM wakes, which previously never touched it. Placement in the Application rather than the Activity is deliberate: Glide caches resolved load paths, so anything that loaded through Glide before the prepend would permanently bypass these decoders.
- **Not** included: `android:largeHeap="true"`. It would roughly double headroom and would plausibly quiet a whole family of OOMs — Sentry has ~20 distinct signatures over 90 days, every one pinned at the same 256 MB limit on unrelated code paths (`BufferedInputStream.<init>`, `String.fastSubstring`, `Intent.createFromParcel`, `ReactViewManager.createViewInstance`, …) — but it's a blunt app-wide GC trade-off and it papers over crashes instead of fixing them. That systemic heap pressure wants its own investigation; the GIF path was one large, fixable contributor.

## Rollback plan

Revert the commit. It's one new file, one call in `MainApplication.onCreate`, and a `.gitignore` line; reverting restores APNG4Android's decoders as the only GIF path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
