### PR TITLE
Defer theme settings query until migrations succeed

### DIFF
--- a/packages/app/provider/BaseProviderStack.tsx
+++ b/packages/app/provider/BaseProviderStack.tsx
@@ -33,7 +33,10 @@ export function BaseProviderStack({
 }: PropsWithChildren<BaseProviderStackProps>) {
   return (
     <GlobalProviderStack>
-      <UIProviderStack tamaguiState={tamaguiState}>
+      <UIProviderStack
+        tamaguiState={tamaguiState}
+        migrationsSucceeded={migrationState.success}
+      >
         <AppProviderStack migrationState={migrationState}>
           {children}
         </AppProviderStack>
@@ -65,12 +68,17 @@ function AppProviderStack({
  */
 function UIProviderStack({
   tamaguiState,
+  migrationsSucceeded,
   children,
 }: PropsWithChildren<{
   tamaguiState?: { defaultTheme?: string };
+  migrationsSucceeded: boolean;
 }>) {
   return (
-    <TamaguiProvider defaultTheme={tamaguiState?.defaultTheme ?? 'light'}>
+    <TamaguiProvider
+      defaultTheme={tamaguiState?.defaultTheme ?? 'light'}
+      migrationsSucceeded={migrationsSucceeded}
+    >
       <SafeAreaProvider initialMetrics={initialWindowMetrics}>
         <GestureHandlerRootView style={{ flex: 1 }}>
           <BottomSheetModalProvider>

--- a/packages/app/provider/index.test.tsx
+++ b/packages/app/provider/index.test.tsx
@@ -1,0 +1,101 @@
+import React from 'react';
+import { ReactTestRenderer, act, create } from 'react-test-renderer';
+import { beforeEach, expect, test, vi } from 'vitest';
+
+vi.hoisted(() => {
+  (globalThis as any).IS_REACT_ACT_ENVIRONMENT = true;
+});
+
+const mocks = vi.hoisted(() => ({
+  THEME_NODE: 'TamaguiProvider',
+  useThemeSettings: vi.fn(),
+  completeSplashTask: vi.fn(),
+}));
+
+vi.mock('react-native', () => ({
+  Appearance: { setColorScheme: vi.fn() },
+  Platform: { OS: 'web' },
+}));
+
+vi.mock('tamagui', async () => {
+  const { createElement } =
+    await vi.importActual<typeof import('react')>('react');
+  return {
+    TamaguiProvider: ({ children, defaultTheme }: any) =>
+      createElement(mocks.THEME_NODE, { defaultTheme }, children),
+  };
+});
+
+vi.mock('../ui/tamagui.config', () => ({ config: {} }));
+
+vi.mock('../hooks/useDarkMode', () => ({
+  useIsDarkMode: () => false,
+  useIsSystemDarkMode: () => false,
+}));
+
+vi.mock('../lib/splashscreen', () => ({
+  SplashScreenTask: { loadTheme: 'loadTheme' },
+  splashScreenProgress: { complete: mocks.completeSplashTask },
+}));
+
+vi.mock('@tloncorp/shared', () => ({
+  useThemeSettings: mocks.useThemeSettings,
+}));
+
+import { Provider } from './index';
+
+// Mirrors react-query: a disabled query stays pending but never loads, so
+// `isLoading` alone would read as "settled" and let the theme resolve early.
+function queryStateFor({ enabled }: { enabled?: boolean } = {}) {
+  return enabled
+    ? { data: 'dark', isPending: false, isLoading: false }
+    : { data: undefined, isPending: true, isLoading: false };
+}
+
+function themeOf(renderer: ReactTestRenderer) {
+  return renderer.root.find(
+    (node) => (node.type as unknown) === mocks.THEME_NODE
+  ).props.defaultTheme;
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mocks.useThemeSettings.mockImplementation(queryStateFor);
+});
+
+test('holds the settings read until migrations have succeeded', () => {
+  let renderer!: ReactTestRenderer;
+  act(() => {
+    renderer = create(
+      <Provider defaultTheme="light" migrationsSucceeded={false}>
+        {null}
+      </Provider>
+    );
+  });
+
+  expect(mocks.useThemeSettings).toHaveBeenCalledWith({ enabled: false });
+  // Theme is unresolved, so the splash task must stay open.
+  expect(mocks.completeSplashTask).not.toHaveBeenCalled();
+  expect(themeOf(renderer)).toBe('light');
+
+  act(() => {
+    renderer.update(
+      <Provider defaultTheme="light" migrationsSucceeded={true}>
+        {null}
+      </Provider>
+    );
+  });
+
+  expect(mocks.useThemeSettings).toHaveBeenLastCalledWith({ enabled: true });
+  expect(themeOf(renderer)).toBe('dark');
+  expect(mocks.completeSplashTask).toHaveBeenCalledTimes(1);
+  expect(mocks.completeSplashTask).toHaveBeenCalledWith('loadTheme');
+});
+
+test('reads settings immediately when no migration state is supplied', () => {
+  act(() => {
+    create(<Provider defaultTheme="light">{null}</Provider>);
+  });
+
+  expect(mocks.useThemeSettings).toHaveBeenCalledWith({ enabled: true });
+});

--- a/packages/app/provider/index.tsx
+++ b/packages/app/provider/index.tsx
@@ -11,21 +11,29 @@ import { getDisplayTheme, normalizeTheme } from '../ui/utils/themeUtils';
 
 export function Provider({
   children,
+  migrationsSucceeded = true,
   ...rest
-}: Omit<TamaguiProviderProps, 'config'>) {
+}: Omit<TamaguiProviderProps, 'config'> & { migrationsSucceeded?: boolean }) {
   return (
-    <ThemeProviderContent tamaguiProps={rest}>{children}</ThemeProviderContent>
+    <ThemeProviderContent
+      tamaguiProps={rest}
+      migrationsSucceeded={migrationsSucceeded}
+    >
+      {children}
+    </ThemeProviderContent>
   );
 }
 
 function ThemeProviderContent({
   children,
   tamaguiProps,
+  migrationsSucceeded,
 }: {
   children: React.ReactNode;
   tamaguiProps: Omit<TamaguiProviderProps, 'config'>;
+  migrationsSucceeded: boolean;
 }) {
-  const { activeTheme, appTheme } = useResolvedAppTheme();
+  const { activeTheme, appTheme } = useResolvedAppTheme(migrationsSucceeded);
 
   return (
     <TamaguiProvider
@@ -55,10 +63,15 @@ function NativeAppearanceSync({ appTheme }: { appTheme: AppTheme | null }) {
   return null;
 }
 
-function useResolvedAppTheme() {
+function useResolvedAppTheme(migrationsSucceeded: boolean) {
   const isSystemDarkMode = useIsSystemDarkMode();
-  const { data: storedThemeRaw, isLoading } = store.useThemeSettings();
-  const appTheme: AppTheme | null = isLoading
+  // The settings table only exists once migrations have run, so keep the read
+  // disabled until then. While disabled, react-query reports `isLoading: false`
+  // but leaves `isPending` true, so `isPending` is what means "no theme yet".
+  const { data: storedThemeRaw, isPending } = store.useThemeSettings({
+    enabled: migrationsSucceeded,
+  });
+  const appTheme: AppTheme | null = isPending
     ? null
     : storedThemeRaw == null
       ? 'auto'

--- a/packages/shared/src/store/dbHooks.ts
+++ b/packages/shared/src/store/dbHooks.ts
@@ -895,9 +895,12 @@ export const useShowNotebookAddTooltip = (channelId: string) => {
   return isCorrectChan && !wayfindingProgress.tappedAddNote;
 };
 
-export const useThemeSettings = () => {
+export const useThemeSettings = ({
+  enabled = true,
+}: { enabled?: boolean } = {}) => {
   const deps = useKeyFromQueryDeps(db.getSettings);
   return useQuery({
+    enabled,
     queryKey: ['themeSettings', deps],
     queryFn: async () => {
       const settings = await db.getSettings();

--- a/packages/shared/src/store/useThemeSettings.test.ts
+++ b/packages/shared/src/store/useThemeSettings.test.ts
@@ -1,0 +1,94 @@
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import React from 'react';
+import { ReactTestRenderer, act, create } from 'react-test-renderer';
+import { beforeEach, expect, test, vi } from 'vitest';
+
+vi.hoisted(() => {
+  (globalThis as any).IS_REACT_ACT_ENVIRONMENT = true;
+});
+
+// The theme read is the first query the app dispatches, before migrations have
+// created the `settings` table. Swap the real query for a spy so we can see
+// whether it reaches the database at all.
+vi.mock('../db', async (importOriginal) => {
+  const actual = (await importOriginal()) as typeof import('../db');
+  return {
+    ...actual,
+    getSettings: Object.assign(
+      vi.fn(async () => ({ theme: 'dark' })),
+      { meta: actual.getSettings.meta }
+    ),
+  };
+});
+
+import * as db from '../db';
+import { useThemeSettings } from './dbHooks';
+
+const RESULT_NODE = 'Result';
+
+function Harness({ enabled }: { enabled?: boolean }) {
+  const query = useThemeSettings(
+    enabled === undefined ? undefined : { enabled }
+  );
+  return React.createElement(RESULT_NODE, { query });
+}
+
+function resultOf(renderer: ReactTestRenderer) {
+  return renderer.root.find((node) => (node.type as unknown) === RESULT_NODE)
+    .props.query as ReturnType<typeof useThemeSettings>;
+}
+
+let client: QueryClient;
+
+function tree(enabled?: boolean) {
+  return React.createElement(
+    QueryClientProvider,
+    { client },
+    React.createElement(Harness, { enabled })
+  );
+}
+
+async function settle(check: () => void) {
+  await act(async () => {
+    await vi.waitFor(check);
+  });
+}
+
+beforeEach(() => {
+  vi.mocked(db.getSettings).mockClear();
+  client = new QueryClient({
+    defaultOptions: { queries: { retry: false, gcTime: 0 } },
+  });
+});
+
+test('does not read settings while disabled, then reads once when enabled', async () => {
+  let renderer!: ReactTestRenderer;
+  await act(async () => {
+    renderer = create(tree(false));
+  });
+
+  expect(db.getSettings).not.toHaveBeenCalled();
+  // `enabled: false` leaves react-query pending without loading, which is what
+  // `useResolvedAppTheme` keys off of to hold the theme back.
+  expect(resultOf(renderer).isPending).toBe(true);
+  expect(resultOf(renderer).isLoading).toBe(false);
+  expect(resultOf(renderer).data).toBeUndefined();
+
+  await act(async () => {
+    renderer.update(tree(true));
+  });
+
+  await settle(() => expect(db.getSettings).toHaveBeenCalledTimes(1));
+  await settle(() => expect(resultOf(renderer).isPending).toBe(false));
+  expect(resultOf(renderer).data).toBe('dark');
+});
+
+test('reads settings when called without options', async () => {
+  let renderer!: ReactTestRenderer;
+  await act(async () => {
+    renderer = create(tree(undefined));
+  });
+
+  await settle(() => expect(resultOf(renderer).data).toBe('dark'));
+  expect(db.getSettings).toHaveBeenCalledTimes(1);
+});


### PR DESCRIPTION
## Summary

Fixes the `SQLITE_ERROR: no such table: settings` that Sentry logs about 0.4 s into every fresh web load ([JAVASCRIPT-REACT-HE](https://tlon-corporation.sentry.io/issues/JAVASCRIPT-REACT-HE): one event per fresh profile, logout/purge, or schema change; 3,422 events from 9 users since February, across 65 releases in the last 90 days). The Tamagui theme `Provider` mounts above the `MigrationCheck` gate in `BaseProviderStack`, so `useThemeSettings` read the `settings` table before migrations had created it; React Query's retry hid the failure but left the app on the system-default theme and held the `loadTheme` splash task open until the retry landed. The theme query is now disabled until migrations succeed, and the theme stays unresolved until that query is enabled and has returned.

## Changes

- `packages/shared/src/store/dbHooks.ts`: `useThemeSettings` accepts `{ enabled }` (default `true`) and forwards it to `useQuery`. The other caller (`ThemeScreen`) passes nothing and is unchanged.
- `packages/app/provider/index.tsx`: `Provider` takes an optional `migrationsSucceeded` prop (default `true`) and threads it through `ThemeProviderContent` into `useResolvedAppTheme`, which passes `enabled: migrationsSucceeded` to the query. Theme resolution now keys off `isPending` instead of `isLoading`: with react-query v5 a disabled query reports `isLoading: false` but stays `isPending`, so `isPending` is what keeps `appTheme` null (system fallback theme, `loadTheme` splash task still open) until the read is enabled and resolved.
- `packages/app/provider/BaseProviderStack.tsx`: passes `migrationState.success` through `UIProviderStack` into the theme `Provider`.
- New tests: `packages/shared/src/store/useThemeSettings.test.ts` runs the real hook against a mocked `db.getSettings`; `packages/app/provider/index.test.tsx` renders the real `Provider` with `@tloncorp/shared` mocked.

## How did I test?

- Unit tests cover the disabled-then-enabled transition: no `getSettings` call while disabled, exactly one after enabling, the system fallback theme and an open splash task while pending, and the `isPending` / `isLoading` semantics the fix depends on.
- `tsc` clean in `shared`, `app`, and `web`; full `shared` (761) and `app` (621) vitest suites pass; formatter clean.
- Post-release check: JAVASCRIPT-REACT-HE should stop receiving new events on fresh loads.

## Risks and impact

- Safe to rollback without consulting PR author? Yes
- Affects important code area:
  - [ ] Onboarding
  - [x] State / providers
  - [ ] Message sync
  - [ ] Channel display
  - [ ] Notifications
  - [x] Other: theme resolution / `loadTheme` splash task (now gated on migrations on every platform)

## Rollback plan

Revert the PR and deploy. No schema, migration, or data changes are involved; reverting only restores the pre-existing first-load race and its Sentry noise.

## Screenshots / videos

N/A, no intended visible change; the fix removes a background query error on first load.
