### PR TITLE
logs: send ship as an OTel resource attribute

### DIFF
--- a/desk/ted/send-otel.hoon
+++ b/desk/ted/send-otel.hoon
@@ -87,6 +87,14 @@
       :~  'key'^s+'service.namespace'
           'value'^(frond 'stringValue' s+'urbit')
       ==
+    ::  ship as a resource attribute, so collectors can promote it to a
+    ::  label without relying on k8s pod-label lookup. it stays a log
+    ::  attribute below for backwards compatibility.
+    ::
+      %-  pairs
+      :~  'key'^s+'ship'
+          'value'^(frond 'stringValue' ship-id)
+      ==
       ::TODO per-agent criticality setting
       :: %-  pairs
       :: :~  'key'^'service.criticality'


### PR DESCRIPTION
## Why

Backend `%logs` events reach Loki through alloy, which promotes `resources.ship` to the Loki `ship` label. Today that resource attribute only exists because alloy's k8sattributes processor copies the pod's `ship` label onto the record. On us-east5 that lookup does not happen, so those streams have no `ship` label and per-ship queries and counts break there. The thread itself only sends `ship` as a log attribute.

## What

`desk/ted/send-otel.hoon` adds `ship` to the OTLP resource attributes, using the same value already sent as a log attribute (no sigil, `fake` prefix on fake ships). The log attribute stays for compatibility.

## Notes

- Committed and built on the ~simtyc dev moon (%groups revision 322): the thread compiles and %logs reloads cleanly with the change.
- Companion PRs: mass-modules (forward urbit OTLP logs to primary Loki), ylem (re-poke `%set-otel` after OTA).

Part of TLON-6512

🤖 Generated with [Claude Code](https://claude.com/claude-code)