### PR TITLE
Upload Android native debug symbols to Sentry

### DIFF
--- a/apps/tlon-mobile/android/app/build.gradle
+++ b/apps/tlon-mobile/android/app/build.gradle
@@ -120,8 +120,49 @@ def hasSentryAuthToken = System.getenv("SENTRY_AUTH_TOKEN")
 def hasSentryProperties = file("$rootDir/sentry.properties").exists() || file("$projectDir/sentry.properties").exists()
 if (hasSentryAuthToken || hasSentryProperties) {
     apply from: new File(["node", "--print", "require.resolve('@sentry/react-native/package.json')"].execute().text.trim(), "../sentry.gradle")
+
+    // `sentry.gradle` above only uploads the JS source map. Native (NDK) frames stay
+    // unsymbolicated without the Sentry Android Gradle Plugin, which is what uploads
+    // the unstripped .so debug info — so a Fabric SIGSEGV shows one exported symbol
+    // and `?` for every other frame.
+    //
+    // Applied inside the same gate as the source map upload: SAGP has no per-variant
+    // switch (the `sentry {}` extension is project-wide), so gating the `apply` is the
+    // gate. Scoping to release is left to the plugin, which only registers upload
+    // tasks for non-debuggable variants.
+    apply plugin: "io.sentry.android.gradle"
+
+    sentry {
+        // `shouldSentryAutoUpload()` comes from sentry.gradle and honours
+        // SENTRY_DISABLE_AUTO_UPLOAD / SENTRY_DISABLE_NATIVE_DEBUG_UPLOAD, so native
+        // symbols obey the same escape hatches as the source map upload. Org, project
+        // and token are deliberately not set here: sentry-cli then reads the same
+        // SENTRY_* environment / sentry.properties the source map upload uses.
+        uploadNativeSymbols = shouldSentryAutoUpload()
+        autoUploadNativeSymbols = shouldSentryAutoUpload()
+        includeNativeSources = true
+
+        // @sentry/react-native already brings io.sentry:sentry-android (pinned in
+        // app/gradle.lockfile). Auto-installation would add the plugin's own version
+        // on top and break the lock.
+        autoInstallation {
+            enabled = false
+        }
+        // Bytecode instrumentation is a tracing feature we don't use; leaving it on
+        // would rewrite classes at build time for no benefit.
+        tracingInstrumentation {
+            enabled = false
+        }
+        // On by default, which would report build metrics to Sentry from every
+        // credentialed CI build; nobody asked for that.
+        telemetry = false
+        // R8 mapping handling stays exactly as it is today — sentry.gradle uploads no
+        // mapping, and turning that on is a separate change from native symbols.
+        includeProguardMapping = false
+        autoUploadProguardMapping = false
+    }
 } else {
-    logger.lifecycle("Skipping Sentry source map upload (no SENTRY_AUTH_TOKEN or sentry.properties found)")
+    logger.lifecycle("Skipping Sentry source map and native symbol upload (no SENTRY_AUTH_TOKEN or sentry.properties found)")
 }
 android {
     ndkVersion rootProject.ext.ndkVersion

--- a/apps/tlon-mobile/android/build.gradle
+++ b/apps/tlon-mobile/android/build.gradle
@@ -20,6 +20,7 @@ buildscript {
         classpath('com.facebook.react:react-native-gradle-plugin')
         classpath('org.jetbrains.kotlin:kotlin-gradle-plugin')
         classpath('com.google.firebase:firebase-crashlytics-gradle:3.0.8')
+        classpath('io.sentry:sentry-android-gradle-plugin:6.21.0')
     }
 }
 


### PR DESCRIPTION
## Summary

Applies the Sentry Android Gradle Plugin so native (NDK) debug symbols are uploaded to Sentry alongside the existing JS source map upload. Without this, native crashes show one exported symbol and `?` for every other native frame (Sentry issue REACT-NATIVE-15G, a Fabric `SIGSEGV` on a Pixel 9 Pro).

Part of TLON-6478.

## Changes

- `apps/tlon-mobile/android/build.gradle`: adds buildscript classpath `io.sentry:sentry-android-gradle-plugin:6.21.0`.
- `apps/tlon-mobile/android/app/build.gradle`: inside the existing `hasSentryAuthToken || hasSentryProperties` gate, applies the `io.sentry.android.gradle` plugin and configures a `sentry {}` block:
  - `uploadNativeSymbols` / `autoUploadNativeSymbols` driven by `shouldSentryAutoUpload()` (from `sentry.gradle`), so native uploads respect the same `SENTRY_DISABLE_AUTO_UPLOAD` / `SENTRY_DISABLE_NATIVE_DEBUG_UPLOAD` escape hatches as the source map upload.
  - `includeNativeSources = true`.
  - `autoInstallation.enabled = false`, since `app/gradle.lockfile` already pins the `io.sentry:sentry-android` version brought in by `@sentry/react-native`.
  - `tracingInstrumentation.enabled = false` and `telemetry = false` (unused bytecode instrumentation and plugin build telemetry).
  - `includeProguardMapping = false` / `autoUploadProguardMapping = false` (R8 mapping upload stays out of scope).
  - Updates the "skipping" log message in the else-branch to also mention native symbols.
- No org/project/token configured in the block; sentry-cli reads the same `SENTRY_*` env or `sentry.properties` already used for the source map upload.
- With no token and no `sentry.properties`, nothing changes: no Sentry Gradle tasks are registered, same as before.

## How did I test?

- `./gradlew help` succeeds with and without `SENTRY_AUTH_TOKEN` set.
- With a dummy token, `./gradlew :app:tasks --all` lists `uploadSentryNativeSymbolsForPreviewRelease` and `uploadSentryNativeSymbolsForProductionRelease`, and `./gradlew bundleProductionRelease --dry-run` includes the native symbol upload task. Without a token, zero Sentry tasks are registered.
- `app/gradle.lockfile` is unchanged; `pnpm format:check` passes.
- Did not verify an actual upload (no real Sentry credentials locally). That gets confirmed after the next EAS release build: the react-native project's Debug Files page in Sentry should list the app's native libraries, and the next native crash should symbolicate.

## Risks and impact

- Safe to rollback without consulting PR author? Yes
- Affects important code area:
  - [ ] Onboarding
  - [ ] State / providers
  - [ ] Message sync
  - [ ] Channel display
  - [ ] Notifications
  - [x] Other: Android release build pipeline (native crash symbolication)

Additional risk notes:
- The EAS `SENTRY_AUTH_TOKEN` needs debug-file upload permission (an organization auth token, or a user token with `project:write`). If it lacks that, the plugin's upload task throws and the first credentialed release build fails. `SENTRY_DISABLE_NATIVE_DEBUG_UPLOAD=true` in the build environment disables just the native upload while keeping the source map upload.
- Credentialed release builds take longer, since unstripped native libraries are uploaded per ABI.
- React Native's own prebuilt native libraries ship stripped, so frames inside RN core may still not symbolicate; libraries built from source in this project will.

## Rollback plan

Revert the two Gradle files. No data or schema changes involved.

## Screenshots / videos

N/A
