### PR TITLE
notifications: give emoji reactions real copy on web and desktop

### DIFF
--- a/packages/app/hooks/notificationCopy.test.ts
+++ b/packages/app/hooks/notificationCopy.test.ts
@@ -1,0 +1,138 @@
+import { describe, expect, it } from 'vitest';
+
+import { getNotificationCopy, isReactActivityType } from './notificationCopy';
+
+describe('isReactActivityType', () => {
+  it.each(['react', 'dm-react'])('recognizes %s', (activityType) => {
+    expect(isReactActivityType(activityType)).toBe(true);
+  });
+
+  it.each(['post', 'dm-post', 'reply', 'flag-post', 'note-create'])(
+    'does not recognize %s',
+    (activityType) => {
+      expect(isReactActivityType(activityType)).toBe(false);
+    }
+  );
+});
+
+describe('getNotificationCopy', () => {
+  it('falls back to the contact name when a DM title is empty', () => {
+    expect(
+      getNotificationCopy({
+        activityType: 'post',
+        channelTitle: '',
+        contactName: 'Alice',
+        contentText: 'Hello',
+        reactValue: '',
+      })
+    ).toEqual({
+      title: 'Alice',
+      body: 'Hello',
+    });
+  });
+
+  it.each([
+    ['flag-post', 'post'],
+    ['flag-reply', 'reply'],
+  ])('uses flag-specific copy for %s activity', (activityType, kind) => {
+    const copy = getNotificationCopy({
+      activityType,
+      channelTitle: 'General',
+      contactName: 'Alice',
+      contentText: '',
+      groupTitle: 'Tlon',
+      reactValue: '',
+    });
+
+    expect(copy).toEqual({
+      title: `Flagged ${kind} in Tlon`,
+      body: `A ${kind} by Alice was flagged in your group`,
+    });
+    expect(copy.body).not.toContain('Alice flagged');
+    expect(copy.body).not.toBe('New message');
+  });
+
+  it('uses invite copy for dm-invite activity instead of the message fallback', () => {
+    expect(
+      getNotificationCopy({
+        activityType: 'dm-invite',
+        channelTitle: '',
+        contactName: 'Alice',
+        contentText: '',
+        reactValue: '',
+      })
+    ).toEqual({
+      title: 'Alice',
+      body: 'Invited you to chat',
+    });
+  });
+
+  it('names the reactor and the emoji for a channel reaction', () => {
+    expect(
+      getNotificationCopy({
+        activityType: 'react',
+        channelTitle: 'General',
+        contactName: 'Alice',
+        contentText: '',
+        groupTitle: 'Tlon',
+        reactValue: '🎉',
+      })
+    ).toEqual({
+      title: 'General in Tlon',
+      body: 'Alice reacted 🎉 to your post',
+    });
+  });
+
+  it('names the reactor and the emoji for a DM reaction', () => {
+    expect(
+      getNotificationCopy({
+        activityType: 'dm-react',
+        channelTitle: '',
+        contactName: 'Alice',
+        contentText: '',
+        reactValue: '🎉',
+      })
+    ).toEqual({
+      title: 'Alice',
+      body: 'Alice reacted 🎉 to your message',
+    });
+  });
+
+  // A custom react can serialize to an empty display value; the copy should
+  // still say who reacted rather than degrading to the message fallback.
+  it.each(['react', 'dm-react'])(
+    'still attributes a %s with no renderable emoji',
+    (activityType) => {
+      const copy = getNotificationCopy({
+        activityType,
+        channelTitle: 'General',
+        contactName: 'Alice',
+        contentText: '',
+        reactValue: '',
+      });
+
+      expect(copy.body).toBe(
+        `Alice reacted to your ${activityType === 'dm-react' ? 'message' : 'post'}`
+      );
+      expect(copy.body).not.toBe('New message');
+    }
+  );
+
+  // Reactions carry their emoji in `content`, so the group-title rewrite that
+  // turns a body into "<sender>: <text>" must not claim the emoji was a message.
+  it.each(['react', 'dm-react'])(
+    'keeps %s copy when a group title is present',
+    (activityType) => {
+      expect(
+        getNotificationCopy({
+          activityType,
+          channelTitle: 'General',
+          contactName: 'Alice',
+          contentText: '',
+          groupTitle: 'Tlon',
+          reactValue: '🎉',
+        }).body
+      ).toContain('Alice reacted 🎉');
+    }
+  );
+});

--- a/packages/app/hooks/notificationCopy.ts
+++ b/packages/app/hooks/notificationCopy.ts
@@ -1,0 +1,74 @@
+// Notification title/body copy, shared by the browser (`useBrowserNotifications`)
+// and Electron (`useDesktopNotifications`) surfaces. Mobile push copy lives in
+// `packages/scripts/src/index.ts` instead, because the native extensions run it
+// as a standalone JS bundle and cannot import from this package.
+
+// Reactions arrive as two distinct event types: `react` in a channel and
+// `dm-react` in a DM. Both carry their emoji in the activity event's `content`
+// column rather than as post content.
+export function isReactActivityType(activityType: string) {
+  return activityType === 'react' || activityType === 'dm-react';
+}
+
+type NotificationCopyInput = {
+  activityType: string;
+  channelTitle?: string | null;
+  contactName: string;
+  contentText: string;
+  groupTitle?: string | null;
+  reactValue: string;
+};
+
+export function getNotificationCopy({
+  activityType,
+  channelTitle,
+  contactName,
+  contentText,
+  groupTitle,
+  reactValue,
+}: NotificationCopyInput) {
+  const flaggedKind =
+    activityType === 'flag-post'
+      ? 'post'
+      : activityType === 'flag-reply'
+        ? 'reply'
+        : null;
+  const isReact = isReactActivityType(activityType);
+  const isDmInvite = activityType === 'dm-invite';
+  // note events carry the note title as their content text
+  const noteVerb =
+    activityType === 'note-create'
+      ? 'added'
+      : activityType === 'note-edit'
+        ? 'edited'
+        : null;
+
+  let title = flaggedKind
+    ? `Flagged ${flaggedKind}`
+    : channelTitle || contactName || 'New message';
+  let body = flaggedKind
+    ? `A ${flaggedKind} by ${contactName} was flagged in your group`
+    : isReact
+      ? // name the emoji when we have one; a custom react can serialize to an
+        // empty string, and "reacted  to your post" reads worse than omitting it
+        `${contactName} reacted${reactValue ? ` ${reactValue}` : ''} to your ${
+          activityType === 'dm-react' ? 'message' : 'post'
+        }`
+      : isDmInvite
+        ? // the title already names the inviter (DM titles are the counterparty)
+          'Invited you to chat'
+        : noteVerb
+          ? `${contactName || 'Someone'} ${noteVerb} a note${contentText ? `: ${contentText}` : ''}`
+          : contentText || 'New message';
+
+  if (groupTitle) {
+    title = `${title} in ${groupTitle}`;
+    if (!isReact && !flaggedKind && !noteVerb) {
+      body = contentText
+        ? `${contactName || 'Someone'}: ${contentText}`
+        : `New message in ${groupTitle}`;
+    }
+  }
+
+  return { title, body };
+}

--- a/packages/app/hooks/useBrowserNotifications.helpers.test.ts
+++ b/packages/app/hooks/useBrowserNotifications.helpers.test.ts
@@ -2,7 +2,6 @@ import { describe, expect, it, vi } from 'vitest';
 
 import {
   getBrowserNotificationContactName,
-  getBrowserNotificationCopy,
   getBrowserNotificationGroupTitle,
   getBrowserNotificationTargetWithRetry,
   isOtherBrowserNotificationTabForegrounded,
@@ -146,59 +145,6 @@ describe('getBrowserNotificationContactName', () => {
         disableNicknames: true,
       })
     ).toBe('~ravmel-ropdyl');
-  });
-});
-
-describe('getBrowserNotificationCopy', () => {
-  it('falls back to the contact name when a DM title is empty', () => {
-    expect(
-      getBrowserNotificationCopy({
-        activityType: 'post',
-        channelTitle: '',
-        contactName: 'Alice',
-        contentText: 'Hello',
-        reactValue: '',
-      })
-    ).toEqual({
-      title: 'Alice',
-      body: 'Hello',
-    });
-  });
-
-  it.each([
-    ['flag-post', 'post'],
-    ['flag-reply', 'reply'],
-  ])('uses flag-specific copy for %s activity', (activityType, kind) => {
-    const copy = getBrowserNotificationCopy({
-      activityType,
-      channelTitle: 'General',
-      contactName: 'Alice',
-      contentText: '',
-      groupTitle: 'Tlon',
-      reactValue: '',
-    });
-
-    expect(copy).toEqual({
-      title: `Flagged ${kind} in Tlon`,
-      body: `A ${kind} by Alice was flagged in your group`,
-    });
-    expect(copy.body).not.toContain('Alice flagged');
-    expect(copy.body).not.toBe('New message');
-  });
-
-  it('uses invite copy for dm-invite activity instead of the message fallback', () => {
-    expect(
-      getBrowserNotificationCopy({
-        activityType: 'dm-invite',
-        channelTitle: '',
-        contactName: 'Alice',
-        contentText: '',
-        reactValue: '',
-      })
-    ).toEqual({
-      title: 'Alice',
-      body: 'Invited you to chat',
-    });
   });
 });
 

--- a/packages/app/hooks/useBrowserNotifications.helpers.ts
+++ b/packages/app/hooks/useBrowserNotifications.helpers.ts
@@ -104,65 +104,6 @@ export function getBrowserNotificationGroupTitle(
   return groupTitle || fallbackTitle;
 }
 
-type BrowserNotificationCopyInput = {
-  activityType: string;
-  channelTitle?: string | null;
-  contactName: string;
-  contentText: string;
-  groupTitle?: string | null;
-  reactValue: string;
-};
-
-export function getBrowserNotificationCopy({
-  activityType,
-  channelTitle,
-  contactName,
-  contentText,
-  groupTitle,
-  reactValue,
-}: BrowserNotificationCopyInput) {
-  const flaggedKind =
-    activityType === 'flag-post'
-      ? 'post'
-      : activityType === 'flag-reply'
-        ? 'reply'
-        : null;
-  const isReact = activityType === 'react';
-  const isDmInvite = activityType === 'dm-invite';
-  // note events carry the note title as their content text
-  const noteVerb =
-    activityType === 'note-create'
-      ? 'added'
-      : activityType === 'note-edit'
-        ? 'edited'
-        : null;
-
-  let title = flaggedKind
-    ? `Flagged ${flaggedKind}`
-    : channelTitle || contactName || 'New message';
-  let body = flaggedKind
-    ? `A ${flaggedKind} by ${contactName} was flagged in your group`
-    : isReact
-      ? `${contactName} reacted${reactValue ? ` ${reactValue}` : ''} to your post`
-      : isDmInvite
-        ? // the title already names the inviter (DM titles are the counterparty)
-          'Invited you to chat'
-        : noteVerb
-          ? `${contactName || 'Someone'} ${noteVerb} a note${contentText ? `: ${contentText}` : ''}`
-          : contentText || 'New message';
-
-  if (groupTitle) {
-    title = `${title} in ${groupTitle}`;
-    if (!isReact && !flaggedKind && !noteVerb) {
-      body = contentText
-        ? `${contactName || 'Someone'}: ${contentText}`
-        : `New message in ${groupTitle}`;
-    }
-  }
-
-  return { title, body };
-}
-
 type BrowserNotificationTargetInput = {
   parentAuthorId?: string | null;
   parentId?: string | null;

--- a/packages/app/hooks/useBrowserNotifications.ts
+++ b/packages/app/hooks/useBrowserNotifications.ts
@@ -7,10 +7,10 @@ import { useCallback, useEffect, useRef, useSyncExternalStore } from 'react';
 import { useRootNavigation } from '../navigation/utils';
 import { useAgentGroupOnboardingNavGate } from './useAgentGroupOnboardingLock';
 import { reactDisplayValue } from '../ui/components/Activity/ActivitySummaryMessage';
+import { getNotificationCopy, isReactActivityType } from './notificationCopy';
 import { useCalm, useCurrentUserId } from '../ui/contexts/appDataContext';
 import {
   getBrowserNotificationContactName,
-  getBrowserNotificationCopy,
   getBrowserNotificationGroupTitle,
   getBrowserNotificationTargetWithRetry,
   isOtherBrowserNotificationTabForegrounded,
@@ -392,7 +392,7 @@ export default function useBrowserNotifications() {
           activityEvent.authorId,
           disableNicknames
         );
-        const isReact = activityEvent.type === 'react';
+        const isReact = isReactActivityType(activityEvent.type);
         const reactValue = isReact
           ? reactDisplayValue(activityEvent.content)
           : '';
@@ -403,7 +403,7 @@ export default function useBrowserNotifications() {
         const group = activityEvent.groupId
           ? await db.getGroup({ id: activityEvent.groupId })
           : null;
-        const { title, body } = getBrowserNotificationCopy({
+        const { title, body } = getNotificationCopy({
           activityType: activityEvent.type,
           channelTitle: channel.title,
           contactName,

--- a/packages/app/hooks/useDesktopNotifications.ts
+++ b/packages/app/hooks/useDesktopNotifications.ts
@@ -10,6 +10,8 @@ import { getTextContent } from '@tloncorp/shared/logic';
 import * as store from '@tloncorp/shared/store';
 import { useCallback, useEffect, useRef, useSyncExternalStore } from 'react';
 
+import { reactDisplayValue } from '../ui/components/Activity/ActivitySummaryMessage';
+import { getNotificationCopy, isReactActivityType } from './notificationCopy';
 import { useIsElectron } from './useIsElectron';
 
 const logger = createDevLogger('useDesktopNotifications', false);
@@ -48,8 +50,6 @@ export default function useDesktopNotifications(isClientReady: boolean) {
         );
       }
 
-      let body = '';
-
       if (!activityEvent.channelId) {
         logger.error('No channel ID in activity event:', activityEvent);
         return;
@@ -59,13 +59,6 @@ export default function useDesktopNotifications(isClientReady: boolean) {
         const channel = await db.getChannelWithRelations({
           id: activityEvent.channelId,
         });
-        if (activityEvent.content) {
-          body =
-            getTextContent(activityEvent.content as api.PostContent) ||
-            'New message';
-        } else {
-          body = 'New message';
-        }
 
         const contactId = activityEvent.authorId;
         const contact = contactId
@@ -78,19 +71,24 @@ export default function useDesktopNotifications(isClientReady: boolean) {
         // This matches the logic in ContactNameV2
         const contactName = contact?.nickname ?? contactId ?? 'Unknown';
 
-        let title = channel.title ? channel.title : contactName;
+        const group = activityEvent.groupId
+          ? await db.getGroup({ id: activityEvent.groupId })
+          : null;
 
-        if (activityEvent.groupId) {
-          const group = await db.getGroup({ id: activityEvent.groupId });
-          if (group) {
-            if (activityEvent.content) {
-              body = `${contactName}: ${getTextContent(activityEvent.content as api.PostContent)}`;
-              title = title + ` in ${group.title}`;
-            } else {
-              body = `New message in ${group.title}`;
-            }
-          }
-        }
+        // Reactions carry their emoji in `content` instead of post content, so
+        // running it through getTextContent would yield a bare emoji body.
+        const isReact = isReactActivityType(activityEvent.type);
+        const { title, body } = getNotificationCopy({
+          activityType: activityEvent.type,
+          channelTitle: channel.title,
+          contactName,
+          contentText:
+            !isReact && activityEvent.content
+              ? (getTextContent(activityEvent.content as api.PostContent) ?? '')
+              : '',
+          groupTitle: group?.title,
+          reactValue: isReact ? reactDisplayValue(activityEvent.content) : '',
+        });
 
         logger.log('Showing desktop notification:', title);
 


### PR DESCRIPTION
## Summary

Emoji reactions produced detail-free notification copy on web and desktop — a DM reaction on web fell through to "New message", and Electron had no reaction handling at all, so the body degraded to a bare emoji with no author and no verb. This extracts the web copy function into a platform-neutral module, teaches it about `dm-react`, and points the desktop hook at it instead of its own parallel implementation.

Fixes TLON-6509

## Changes

Reactions were rendered inconsistently across **three independent** notification-copy implementations:

| Surface | Before | After |
| --- | --- | --- |
| iOS + Android (`packages/scripts/src/index.ts`) | `~ship reacted with 😀` | unchanged — mobile already carried the detail |
| Web (`useBrowserNotifications`) | only `react` was handled; `dm-react` is a separate `ExtendedEventType`, so DM reactions fell through to `contentText \|\| 'New message'` | both react types |
| Desktop (`useDesktopNotifications`) | **no react handling** — the react value went through `getTextContent()`, yielding a bare emoji or `'New message'` | both react types |

- New `packages/app/hooks/notificationCopy.ts` holds `getNotificationCopy` (moved from `useBrowserNotifications.helpers.ts`, no re-export left behind) plus an `isReactActivityType` predicate, so `react`/`dm-react` can't drift apart again.
- `useDesktopNotifications` now calls that helper instead of computing title/body inline. It picks up correct `flag-post`, `flag-reply`, note, and `dm-invite` copy for free, and loses the `"Alice: undefined"` body it could emit when `getTextContent` returned nothing for a group post.
- Copy tests moved alongside the helper and extended to cover both react types, the group-title rewrite path, and a custom react whose display value is empty.

Resulting copy (non-react cases verified unchanged):

```
channel react           | General in Tlon | ~ravmel-ropdyl reacted 🎉 to your post
channel react, no group | General         | Alice reacted ❤️ to your post
dm react                | Alice           | Alice reacted 👀 to your message
dm react, empty emoji   | Alice           | Alice reacted to your message
group post (unchanged)  | General in Tlon | Alice: hello there
dm post (unchanged)     | Alice           | hey
```

No Hoon change is needed: `desk/lib/activity-json.hoon` already serializes the react value for both `%react` and `%dm-react`, so the emoji was on the wire all along.

## How did I test?

- `pnpm vitest run` in `packages/app` — **636 passed**, 3 skipped, 0 failed. 17 of those are new in `hooks/notificationCopy.test.ts`.
- `tsc --noEmit` on `packages/app` — only pre-existing `@tloncorp/editor/dist/editorHtml` unbuilt-artifact error, nothing in the changed files.
- `oxlint` — diffed against the same files at `HEAD`: identical 11 warnings, same rules, all pre-existing (refs-during-render, exhaustive-deps). No new warnings.
- `pnpm format` run from the repo root.
- Rendered the full copy matrix above through the helper to confirm reaction copy reads correctly and non-reaction copy is byte-identical.

Not exercised on a device: this touches only the web and Electron surfaces. The mobile bundle path is untouched.

## Risks and impact

- Safe to rollback without consulting PR author? **Yes**
- Affects important code area:
  - [ ] Onboarding
  - [ ] State / providers
  - [ ] Message sync
  - [ ] Channel display
  - [x] Notifications
  - [ ] Other:

Copy-only, behind no flag. Reaction and desktop copy change; every other event type's title/body is unchanged on both surfaces (covered by the moved tests). The one non-reaction behavior change is desktop no longer rendering `"Alice: undefined"`.

## Rollback plan

`git revert` the single commit. Nothing persisted, no migration, no backend change.

## Screenshots / videos

Copy matrix in the Changes section above; these are OS-level notifications, so there is no in-app surface to capture.

---

### Noted while investigating, filed separately

Android push falls back to the generic `"You have a new message"` more than expected: over 7 days, internal accounts excluded, **65 of 137 Android accounts are majority-fallback** (median per-account fallback rate 25.8%), dominated by `Activity event fetch failed`. Root cause is a stale notification auth cookie after reauth; filed and fixed separately as TLON-6516.

This PR's own trigger was an iOS report of reaction pushes arriving without detail, which turned out to be a backend problem on that user's node rather than a copy bug — mobile reaction copy was already correct. The web and desktop gaps fixed here are real and unrelated; see TLON-6509 for that history.

One reaction-specific contributor there: clients pick the `activity-event` mark from a native capability flag that is cleared on login, and `notify.hoon:439-441` 404s every reaction on the v8 mark because `v8:event:v9` drops `%react`/`%dm-react`. Worth noting for whoever picks that up — a naive "try the newest mark first" fallback is *not* safe, since a pre-11.4.0 `notify.hoon` route doesn't match `%activity-event-1`/`-2` at all and the request stalls to the client's 8s timeout rather than 404ing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
