### PR TITLE
shared: delete dead scaffoldPersonalGroup, the last %diary construction site

### DIFF
--- a/packages/shared/src/store/groupActions.ts
+++ b/packages/shared/src/store/groupActions.ts
@@ -13,7 +13,6 @@ import { createDevLogger } from '../debug';
 import { AnalyticsEvent } from '../domain';
 import * as logic from '../logic';
 import { getRandomId } from '../logic';
-import { pinGroup } from './channelActions';
 
 const logger = createDevLogger('groupActions', false);
 
@@ -23,70 +22,6 @@ interface CreateGroupParams {
   title?: string;
   image?: string;
   memberIds?: string[];
-}
-
-export async function scaffoldPersonalGroup() {
-  const currentUserId = api.getCurrentUserId();
-  const PersonalGroupKeys = logic.getPersonalGroupKeys(currentUserId);
-  const groupIconUrl = logic.getRandomDefaultPersonalGroupIcon();
-
-  logger.trackEvent('Personal Group Scaffold', {
-    context: 'starting personal group scaffold',
-    method: 'thread creation',
-  });
-
-  try {
-    const personalGroup: db.Group = {
-      id: PersonalGroupKeys.groupId,
-      title: PersonalGroupKeys.groupName,
-      iconImage: groupIconUrl,
-      currentUserIsMember: true,
-      isPersonalGroup: true,
-      hostUserId: currentUserId,
-      currentUserIsHost: true,
-      privacy: 'secret',
-    };
-
-    const chatChannel: db.Channel = {
-      id: PersonalGroupKeys.chatChannelId,
-      groupId: PersonalGroupKeys.groupId,
-      type: 'chat',
-      title: PersonalGroupKeys.chatChannelName,
-      lastPostSequenceNum: 0,
-    };
-
-    const collectionChannel: db.Channel = {
-      id: PersonalGroupKeys.collectionChannelId,
-      groupId: PersonalGroupKeys.groupId,
-      type: 'gallery',
-      title: PersonalGroupKeys.collectionChannelName,
-      lastPostSequenceNum: 0,
-    };
-
-    const notebookChannel: db.Channel = {
-      id: PersonalGroupKeys.notebookChannelId,
-      groupId: PersonalGroupKeys.groupId,
-      type: 'notebook',
-      title: PersonalGroupKeys.notebookChannelName,
-      lastPostSequenceNum: 0,
-    };
-
-    personalGroup.channels = [chatChannel, collectionChannel, notebookChannel];
-
-    const createdGroup = await createGroup({ group: personalGroup });
-
-    // attempt to pin it
-    pinGroup(createdGroup);
-
-    logger.trackEvent('Completed Personal Group Scaffold', {
-      ...logic.getModelAnalytics({ group: { id: PersonalGroupKeys.groupId } }),
-    });
-  } catch (e) {
-    logger.trackEvent('Error Personal Group Scaffold', {
-      error: e,
-    });
-    throw new Error('Something went wrong');
-  }
 }
 
 export async function createDefaultGroup(


### PR DESCRIPTION
## Summary

`scaffoldPersonalGroup` in `packages/shared/src/store/groupActions.ts` was exported but had no callers anywhere in the monorepo. It still built a `type: 'notebook'` channel, which made it the last place in app code that constructs a legacy %diary channel. This deletes it.

Fixes TLON-6517

## Changes

Deletions only, 65 lines in one file:

- Removed `scaffoldPersonalGroup`, including the notebook/%diary channel it constructed alongside the chat and gallery channels.
- Removed `import { pinGroup } from './channelActions';`. That import existed solely for the `pinGroup(createdGroup)` call inside the deleted function, so it would otherwise have become unused.

Deliberately left alone:

- **`logic.getPersonalGroupKeys`** — still called at three sites in `packages/api/src/client/wayfinding.ts`, `notebookChannelId` included, for existing personal groups. It was reached here through the `import * as logic` namespace, so no import cleanup was needed.
- **`logic.getRandomDefaultPersonalGroupIcon`** — still used by `createGroupFromTemplate` further down the same file.

The three `'… Personal Group Scaffold'` analytics events were only ever emitted from inside this function, so nothing is orphaned by their removal.

## How did I test?

- Verified the function is genuinely dead: `grep -rn "scaffoldPersonalGroup"` across the repo (both TS/TSX-scoped and unscoped, excluding `node_modules`) matches only the definition. No barrel re-export, no string reference.
- `pnpm -r tsc` from the repo root — exit 0, all 14 workspace projects with a `tsc` script clean.
- `pnpm format:check` from the repo root — clean, 1791 files.

No runtime testing, because there is no runtime path to test: nothing called this function.

## Risks and impact

- Safe to rollback without consulting PR author? **Yes**
- Affects important code area:
  - [ ] Onboarding
  - [ ] State / providers
  - [ ] Message sync
  - [ ] Channel display
  - [ ] Notifications
  - [x] Other: none in practice — dead code with no callers

**Reviewer note — this conflicts with #6484 (TLON-6480), which is still open.** Both PRs edit the same import line in `groupActions.ts`:

- This PR deletes `import { pinGroup } from './channelActions';` outright.
- #6484 rewrites it to `import { createChannel, pinGroup } from './channelActions';`.

Whichever merges second will hit a conflict on that line. The correct resolution once both have landed is:

```ts
import { createChannel } from './channelActions';
```

`pinGroup` is only imported for the call inside `scaffoldPersonalGroup`, and #6484 adds no new `pinGroup` call — it only extends the import — so with this function gone, `pinGroup` is unused and must come off the line or `noUnusedLocals` will fail the build.

## Rollback plan

`git revert` the single commit. The function had no callers, so restoring it cannot change behavior.

## Screenshots / videos

N/A — no user-visible change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
