### PR TITLE
presence: stop counting subscription nacks as crashes, stop retrying dead channels

### DIFF
--- a/desk/app/channels.hoon
+++ b/desk/app/channels.hoon
@@ -132,6 +132,7 @@
         [/x/v3/said %noun]
         [/x/v3/v-channels %noun]
       ::
+        [/x/v4/$/$/$/perm %channel-perm]
         [/x/v4/channels %channels-4]
         [/x/v4/said %channel-said-2]
         [/x/v4/heads %channel-heads-3]

--- a/desk/app/groups.hoon
+++ b/desk/app/groups.hoon
@@ -103,6 +103,7 @@
       [/x/v3/changes %group-changed-groups-3]
     ::
       [/x/v2/groups/$/$/channels/can-read %noun]
+      [/x/v2/groups/$/$/channels/$/$/$/can-read/$ %loob]
       [/x/v2/groups/$/$/channels/$/$/$/can-write %noun]
       [/x/v2/groups/$/$/channels/$/$/$/readers %ships]
       [/x/v2/groups/$/$/channels/$/$/$/writers %ships]

--- a/desk/app/presence.hoon
+++ b/desk/app/presence.hoon
@@ -78,6 +78,64 @@
     [%group ship=@ term=@ ~]           (slav %p i.t.context)
   ==
 ::
++$  membership
+  ::  what it takes to participate in a context, once resolved
+  ::
+  $%  [%any ~]
+      [%dm peer=ship]
+      [%channel group=flag:gv kind=@tas host=ship name=@tas]
+      [%group =flag:gv]
+  ==
+::
+++  resolve-context
+  ::  the context-level half of the participant check: resolves the
+  ::  channel to its group and confirms we know it. done once per
+  ::  context so per-ship checks don't repeat these scries.
+  ::
+  |=  [=context =bowl:gall]
+  ^-  (each membership term)
+  ?+  context  &+[%any ~]
+      [%dm @ ~]
+    ?~  peer=(slaw %p i.t.context)  |+%presence-bad-path
+    &+[%dm u.peer]
+  ::
+      [%channel @ @ @ ~]
+    ?~  host=(slaw %p i.t.t.context)  |+%presence-bad-path
+    =*  kind  i.t.context
+    =*  name  i.t.t.t.context
+    =/  group=(unit flag:gv)  (group-for-channel kind u.host name bowl)
+    ?~  group  |+%presence-unknown-channel
+    ?.  (has-group u.group bowl)  |+%presence-unknown-channel-group
+    &+[%channel u.group kind u.host name]
+  ::
+      [%group @ @ ~]
+    ?~  host=(slaw %p i.t.context)  |+%presence-bad-path
+    =/  =flag:gv  [u.host i.t.t.context]
+    ?.  (has-group flag bowl)  |+%presence-unknown-group
+    &+[%group flag]
+  ==
+::
+++  member-error
+  ::  the per-ship half: why .who may not participate, if at all
+  ::
+  |=  [who=ship =membership =bowl:gall]
+  ^-  (unit term)
+  ?-  -.membership
+      %any  ~
+      %dm   ?:(=(who peer.membership) ~ `%presence-not-dm-counterparty)
+      %group
+    ?:((has-seat flag.membership who bowl) ~ `%presence-not-group-member)
+  ::
+      %channel
+    ::  the channel host can always read its own channel, whatever its
+    ::  roles say, mirroring +can-read:perms in /lib/channel-utils
+    ::
+    ?:  =(who host.membership)  ~
+    =,  membership
+    ?:  (can-read group kind host name who bowl)  ~
+    `%presence-cannot-read-channel
+  ==
+::
 ++  participant-error
   ::  why .who may not participate in .context, if at all.
   ::  we are the context host here. the term ends up in the nack tang
@@ -85,28 +143,9 @@
   ::
   |=  [who=ship =context =bowl:gall]
   ^-  (unit term)
-  ?+  context  ~
-      [%dm @ ~]
-    ?~  peer=(slaw %p i.t.context)  `%presence-bad-path
-    ?:  =(who u.peer)  ~
-    `%presence-not-dm-counterparty
-  ::
-      [%channel @ @ @ ~]
-    ?~  host=(slaw %p i.t.t.context)  `%presence-bad-path
-    =*  kind  i.t.context
-    =*  name  i.t.t.t.context
-    =/  group=(unit flag:gv)  (group-for-channel kind u.host name bowl)
-    ?~  group  `%presence-unknown-channel
-    ?.  (has-group u.group bowl)  `%presence-unknown-channel-group
-    ?.  (can-read u.group kind u.host name who bowl)
-      `%presence-cannot-read-channel
-    ~
-  ::
-      [%group @ @ ~]
-    ?~  host=(slaw %p i.t.context)  `%presence-bad-path
-    ?:  (has-seat [u.host i.t.t.context] who bowl)  ~
-    `%presence-not-group-member
-  ==
+  =/  res  (resolve-context context bowl)
+  ?:  ?=(%| -.res)  `p.res
+  (member-error who p.res bowl)
 ::
 ++  context-readable
   ::  whether we, as a subscriber, should still expect the host to accept
@@ -123,6 +162,7 @@
   =*  name  i.t.t.t.context
   =/  group=(unit flag:gv)  (group-for-channel kind u.host name bowl)
   ?~  group  |
+  ?.  (has-group u.group bowl)  |
   (can-read u.group kind u.host name our.bowl bowl)
 ::
 ++  has-group
@@ -133,9 +173,9 @@
   .^(? %gu (weld base /groups/(scot %p p.flag)/[q.flag]))
 ::
 ++  has-seat
+  ::  callers check +has-group first
   |=  [=flag:gv who=ship =bowl:gall]
   ^-  ?
-  ?.  (has-group flag bowl)  |
   =;  seat
     ?=(^ seat)
   .^  (unit seat:v7:gv)  %gx
@@ -145,12 +185,11 @@
 ::
 ++  can-read
   ::  whether .who may read channel [kind host name] of .group, according
-  ::  to our %groups. false if we don't have the group, or if the channel
-  ::  is no longer part of it.
+  ::  to our %groups. false if the channel is no longer part of the group.
+  ::  callers check +has-group first.
   ::
   |=  [group=flag:gv kind=@tas host=ship name=@tas who=ship =bowl:gall]
   ^-  ?
-  ?.  (has-group group bowl)  |
   .^  ?  %gx
     %+  weld  /(scot %p our.bowl)/groups/(scot %da now.bowl)
     %+  weld  /v2/groups/(scot %p p.group)/[q.group]
@@ -223,10 +262,14 @@
   ::
   |=  [=context subs=(jug context ship) =bowl:gall]
   ^-  [(list card) _subs]
+  ::  resolve the context once; only the per-ship check runs in the loop
+  ::
+  =/  res  (resolve-context context bowl)
   =/  bad=(list ship)
     %+  skip  ~(tap in (~(get ju subs) context))
     |=  who=ship
-    =(~ (participant-error who context bowl))
+    ?:  ?=(%| -.res)  |
+    =(~ (member-error who p.res bowl))
   ::NOTE  not ?~, which would narrow .bad and make +roll nest-fail
   ?:  =(~ bad)  [~ subs]
   :_  %+  roll  bad
@@ -275,7 +318,9 @@
   %+  murn  ~(tap by chans)
   |=  [=nest:v9:cv =channel:v9:cv]
   ^-  (unit [ship context])
-  ?.  (can-read group.perm.channel kind.nest ship.nest name.nest our.bowl bowl)
+  ?.  ?&  (has-group group.perm.channel bowl)
+          (can-read group.perm.channel kind.nest ship.nest name.nest our.bowl bowl)
+      ==
     ~
   `[ship.nest /channel/[kind.nest]/(scot %p ship.nest)/[name.nest]]
 ::
@@ -755,6 +800,8 @@
       [(tell:log %dbug ~['setup(specific): no longer wanted, skipping' >ship< >context<] ~)]~
     ::  likewise if we can no longer read it: the channel was deleted from
     ::  its group, or we lost read access. the host would keep nacking us.
+    ::  if access comes back, the next activity event in the channel (any
+    ::  post) re-registers it via /activity/all, as does any full setup.
     ::
     ?.  (context-readable context bowl)
       =.  want   (~(del in want) [ship context])

--- a/desk/app/presence.hoon
+++ b/desk/app/presence.hoon
@@ -78,35 +78,84 @@
     [%group ship=@ term=@ ~]           (slav %p i.t.context)
   ==
 ::
-++  is-participant
+++  participant-error
+  ::  why src.bowl may not participate in .context, if at all.
+  ::  we are the context host here. the term ends up in the nack tang
+  ::  the subscriber receives, so it should say what went wrong.
+  ::
   |=  [=context =bowl:gall]
-  ^-  ?
-  ?+  context  &
+  ^-  (unit term)
+  ?+  context  ~
       [%dm @ ~]
-    =(src.bowl (slav %p i.t.context))
+    ?~  who=(slaw %p i.t.context)  `%presence-bad-path
+    ?:  =(src.bowl u.who)  ~
+    `%presence-not-dm-counterparty
   ::
       [%channel @ @ @ ~]
-    =/  group=(unit flag:gv)
-      %^  group-for-channel  i.t.context
-        (slav %p i.t.t.context)
-      [i.t.t.t.context bowl]
-    ?~  group  |
-    (has-seat u.group bowl)
+    ?~  host=(slaw %p i.t.t.context)  `%presence-bad-path
+    =*  kind  i.t.context
+    =*  name  i.t.t.t.context
+    =/  group=(unit flag:gv)  (group-for-channel kind u.host name bowl)
+    ?~  group  `%presence-unknown-channel
+    ?.  (has-group u.group bowl)  `%presence-unknown-channel-group
+    ?.  (can-read u.group kind u.host name src.bowl bowl)
+      `%presence-cannot-read-channel
+    ~
   ::
       [%group @ @ ~]
-    (has-seat [(slav %p i.t.context) i.t.t.context] bowl)
+    ?~  host=(slaw %p i.t.context)  `%presence-bad-path
+    ?:  (has-seat [u.host i.t.t.context] bowl)  ~
+    `%presence-not-group-member
   ==
+::
+++  context-readable
+  ::  whether we, as a subscriber, should still expect the host to accept
+  ::  our subscription to .context. for channels, the channel must still
+  ::  be in its group, and readable by us, per our local %groups. channels
+  ::  that were deleted from their group (or that we lost read access to)
+  ::  may linger in %channels; their hosts nack us forever.
+  ::
+  |=  [=context =bowl:gall]
+  ^-  ?
+  ?.  ?=([%channel @ @ @ ~] context)  &
+  ?~  host=(slaw %p i.t.t.context)  |
+  =*  kind  i.t.context
+  =*  name  i.t.t.t.context
+  =/  group=(unit flag:gv)  (group-for-channel kind u.host name bowl)
+  ?~  group  |
+  (can-read u.group kind u.host name our.bowl bowl)
+::
+++  has-group
+  |=  [=flag:gv =bowl:gall]
+  ^-  ?
+  =/  base=path  /(scot %p our.bowl)/groups/(scot %da now.bowl)
+  ?.  .^(? %gu (weld base /$))  |
+  .^(? %gu (weld base /groups/(scot %p p.flag)/[q.flag]))
 ::
 ++  has-seat
   |=  [=flag:gv =bowl:gall]
   ^-  ?
-  =/  base=path  /(scot %p our.bowl)/groups/(scot %da now.bowl)
-  =/  group=path  (weld base /groups/(scot %p p.flag)/[q.flag])
-  ?.  .^(? %gu (weld base /$))  |
-  ?.  .^(? %gu group)  |
+  ?.  (has-group flag bowl)  |
   =;  seat
     ?=(^ seat)
-  .^((unit seat:v7:gv) %gx (weld group /seats/(scot %p src.bowl)/noun))
+  .^  (unit seat:v7:gv)  %gx
+    %+  weld  /(scot %p our.bowl)/groups/(scot %da now.bowl)
+    /groups/(scot %p p.flag)/[q.flag]/seats/(scot %p src.bowl)/noun
+  ==
+::
+++  can-read
+  ::  whether .who may read channel [kind host name] of .group, according
+  ::  to our %groups. false if we don't have the group, or if the channel
+  ::  is no longer part of it.
+  ::
+  |=  [group=flag:gv kind=@tas host=ship name=@tas who=ship =bowl:gall]
+  ^-  ?
+  ?.  (has-group group bowl)  |
+  .^  ?  %gx
+    %+  weld  /(scot %p our.bowl)/groups/(scot %da now.bowl)
+    %+  weld  /groups/(scot %p p.group)/[q.group]
+    /channels/[kind]/(scot %p host)/[name]/can-read/(scot %p who)/loob
+  ==
 ::
 ++  group-for-channel
   |=  [kind=@tas =ship name=@tas =bowl:gall]
@@ -186,15 +235,22 @@
   ==
 ::
 ++  channel-contexts
+  ::  every channel in our %channels that we can still read, per +can-read.
+  ::  see +context-readable for why we filter.
+  ::
   |=  =bowl:gall
   ^-  (set [ship context])
-  %.  |=  nest:v9:cv
-      [ship /channel/[kind]/(scot %p ship)/[name]]
-  %~  run  in
-  %~  key  by
-  .^  channels:v9:cv  %gx
-    /(scot %p our.bowl)/channels/(scot %da now.bowl)/v4/channels/channels-4
-  ==
+  =/  chans=channels:v9:cv
+    .^  channels:v9:cv  %gx
+      /(scot %p our.bowl)/channels/(scot %da now.bowl)/v4/channels/channels-4
+    ==
+  %-  ~(gas in *(set [ship context]))
+  %+  murn  ~(tap by chans)
+  |=  [=nest:v9:cv =channel:v9:cv]
+  ^-  (unit [ship context])
+  ?.  (can-read group.perm.channel kind.nest ship.nest name.nest our.bowl bowl)
+    ~
+  `[ship.nest /channel/[kind.nest]/(scot %p ship.nest)/[name.nest]]
 ::
 ++  watch-context
   |=  [our=ship who=ship =context]
@@ -357,8 +413,8 @@
     ?>  =(src.bowl ship.key)
     ::  for non-dm contexts, verify participant membership
     ::
-    ?>  ?:  ?=([%dm *] context.key)  &
-        (is-participant context.key bowl)
+    ?^  err=?:(?=([%dm *] context.key) ~ (participant-error context.key bowl))
+      ~|(u.err !!)
     ?-  -.cmd
         %set
       ::  ack but no-op on timed out presence
@@ -415,10 +471,13 @@
       [%context @ *]
     ::  context watch paths must be properly personalized
     ::
-    ?>  =(src.bowl (slav %p i.t.path))
-    ::  verify the subscriber is a participant in this context
+    ?.  =(`src.bowl (slaw %p i.t.path))
+      ~|(%presence-bad-path !!)
+    ::  verify the subscriber is a participant in this context.
+    ::  the hint ends up in the subscriber's nack tang.
     ::
-    ?>  (is-participant t.t.path bowl)
+    ?^  err=(participant-error t.t.path bowl)
+      ~|(u.err !!)
     =.  subs  (~(put ju subs) t.t.path src.bowl)
     ::NOTE  no initial fact, since all data is short-lived,        ::REVIEW
     ::      and we don't want to hot-loop on mark incompatibility  ::REVIEW
@@ -527,12 +586,28 @@
         =.  tries  (~(del by tries) [src.bowl context])
         :_  this
         [(tell:log %dbug ~['context sub ack ok' >src.bowl< >context<] ~)]~
-      ::  nacked. nacks are commonly transient (host hasn't synced the
+      ::  nacked. if we can no longer read the context (the channel was
+      ::  deleted from its group, or we lost read access), retrying will
+      ::  never succeed: drop the desire right away.
+      ::
+      ::  otherwise the nack may be transient (host hasn't synced the
       ::  group or channel yet), so retry with linear backoff. after
       ::  +max-tries consecutive nacks, drop the desire so we don't
       ::  retry forever; the next full setup starts a fresh cycle if
       ::  the context is still relevant.
       ::
+      ::  none of this is a crash on our end, so we only ever +tell.
+      ::  keep the message texts stable, dashboards filter on them.
+      ::
+      ?.  (context-readable context bowl)
+        =.  want   (~(del in want) [src.bowl context])
+        =.  tries  (~(del by tries) [src.bowl context])
+        :_  this
+        =-  [(tell:log %info - ~)]~
+        :*  'context sub nacked, no longer readable, dropping'
+            >[src=src.bowl context=context]<
+            u.p.sign
+        ==
       =/  try=@ud  +((~(gut by tries) [src.bowl context] 0))
       ?:  (gth try max-tries)
         =.  want   (~(del in want) [src.bowl context])
@@ -540,16 +615,16 @@
         :_  this
         =-  [(tell:log %warn - ~)]~
         :*  'context sub nacked, giving up'
-            >[src=src.bowl context=context]<
+            >[src=src.bowl context=context tries=max-tries]<
             u.p.sign
         ==
       =.  tries  (~(put by tries) [src.bowl context] try)
       :_  this
       :~  (await-setup (add now.bowl (mul try ~m5)) `[src.bowl context])
-          =-  (fail:log %warn - u.p.sign ~)
+          =-  (tell:log %info - ~)
           :*  'context sub nacked, will retry'
               >[src=src.bowl context=context try=try]<
-              ~
+              u.p.sign
           ==
       ==
     ::
@@ -655,6 +730,13 @@
       =.  tries  (~(del by tries) [ship context])
       :_  this
       [(tell:log %dbug ~['setup(specific): no longer wanted, skipping' >ship< >context<] ~)]~
+    ::  likewise if we lost the ability to read it in the meantime
+    ::
+    ?.  (context-readable context bowl)
+      =.  want   (~(del in want) [ship context])
+      =.  tries  (~(del by tries) [ship context])
+      :_  this
+      [(tell:log %dbug ~['setup(specific): no longer readable, dropping' >ship< >context<] ~)]~
     ?:  ?|  (~(has by wex.bowl) [%context context] ship dap.bowl)
             (~(has by wex.bowl) [%context-2 context] ship dap.bowl)
         ==

--- a/desk/app/presence.hoon
+++ b/desk/app/presence.hoon
@@ -153,7 +153,7 @@
   ?.  (has-group group bowl)  |
   .^  ?  %gx
     %+  weld  /(scot %p our.bowl)/groups/(scot %da now.bowl)
-    %+  weld  /groups/(scot %p p.group)/[q.group]
+    %+  weld  /v2/groups/(scot %p p.group)/[q.group]
     /channels/[kind]/(scot %p host)/[name]/can-read/(scot %p who)/loob
   ==
 ::

--- a/desk/app/presence.hoon
+++ b/desk/app/presence.hoon
@@ -586,12 +586,10 @@
         =.  tries  (~(del by tries) [src.bowl context])
         :_  this
         [(tell:log %dbug ~['context sub ack ok' >src.bowl< >context<] ~)]~
-      ::  nacked. if we can no longer read the context (the channel was
-      ::  deleted from its group, or we lost read access), retrying will
-      ::  never succeed: drop the desire right away.
-      ::
-      ::  otherwise the nack may be transient (host hasn't synced the
-      ::  group or channel yet), so retry with linear backoff. after
+      ::  nacked. the nack may be transient (host hasn't synced the
+      ::  group or channel yet, or our own %groups hasn't caught up), so
+      ::  retry with linear backoff. the retry wake re-checks whether we
+      ::  can still read the context, and drops it if not. after
       ::  +max-tries consecutive nacks, drop the desire so we don't
       ::  retry forever; the next full setup starts a fresh cycle if
       ::  the context is still relevant.
@@ -599,15 +597,6 @@
       ::  none of this is a crash on our end, so we only ever +tell.
       ::  keep the message texts stable, dashboards filter on them.
       ::
-      ?.  (context-readable context bowl)
-        =.  want   (~(del in want) [src.bowl context])
-        =.  tries  (~(del by tries) [src.bowl context])
-        :_  this
-        =-  [(tell:log %info - ~)]~
-        :*  'context sub nacked, no longer readable, dropping'
-            >[src=src.bowl context=context]<
-            u.p.sign
-        ==
       =/  try=@ud  +((~(gut by tries) [src.bowl context] 0))
       ?:  (gth try max-tries)
         =.  want   (~(del in want) [src.bowl context])
@@ -730,13 +719,14 @@
       =.  tries  (~(del by tries) [ship context])
       :_  this
       [(tell:log %dbug ~['setup(specific): no longer wanted, skipping' >ship< >context<] ~)]~
-    ::  likewise if we lost the ability to read it in the meantime
+    ::  likewise if we can no longer read it: the channel was deleted from
+    ::  its group, or we lost read access. the host would keep nacking us.
     ::
     ?.  (context-readable context bowl)
       =.  want   (~(del in want) [ship context])
       =.  tries  (~(del by tries) [ship context])
       :_  this
-      [(tell:log %dbug ~['setup(specific): no longer readable, dropping' >ship< >context<] ~)]~
+      [(tell:log %info ~['context sub no longer readable, dropping' >[src=ship context=context]<] ~)]~
     ?:  ?|  (~(has by wex.bowl) [%context context] ship dap.bowl)
             (~(has by wex.bowl) [%context-2 context] ship dap.bowl)
         ==

--- a/desk/app/presence.hoon
+++ b/desk/app/presence.hoon
@@ -79,16 +79,16 @@
   ==
 ::
 ++  participant-error
-  ::  why src.bowl may not participate in .context, if at all.
+  ::  why .who may not participate in .context, if at all.
   ::  we are the context host here. the term ends up in the nack tang
   ::  the subscriber receives, so it should say what went wrong.
   ::
-  |=  [=context =bowl:gall]
+  |=  [who=ship =context =bowl:gall]
   ^-  (unit term)
   ?+  context  ~
       [%dm @ ~]
-    ?~  who=(slaw %p i.t.context)  `%presence-bad-path
-    ?:  =(src.bowl u.who)  ~
+    ?~  peer=(slaw %p i.t.context)  `%presence-bad-path
+    ?:  =(who u.peer)  ~
     `%presence-not-dm-counterparty
   ::
       [%channel @ @ @ ~]
@@ -98,13 +98,13 @@
     =/  group=(unit flag:gv)  (group-for-channel kind u.host name bowl)
     ?~  group  `%presence-unknown-channel
     ?.  (has-group u.group bowl)  `%presence-unknown-channel-group
-    ?.  (can-read u.group kind u.host name src.bowl bowl)
+    ?.  (can-read u.group kind u.host name who bowl)
       `%presence-cannot-read-channel
     ~
   ::
       [%group @ @ ~]
     ?~  host=(slaw %p i.t.context)  `%presence-bad-path
-    ?:  (has-seat [u.host i.t.t.context] bowl)  ~
+    ?:  (has-seat [u.host i.t.t.context] who bowl)  ~
     `%presence-not-group-member
   ==
 ::
@@ -133,14 +133,14 @@
   .^(? %gu (weld base /groups/(scot %p p.flag)/[q.flag]))
 ::
 ++  has-seat
-  |=  [=flag:gv =bowl:gall]
+  |=  [=flag:gv who=ship =bowl:gall]
   ^-  ?
   ?.  (has-group flag bowl)  |
   =;  seat
     ?=(^ seat)
   .^  (unit seat:v7:gv)  %gx
     %+  weld  /(scot %p our.bowl)/groups/(scot %da now.bowl)
-    /groups/(scot %p p.flag)/[q.flag]/seats/(scot %p src.bowl)/noun
+    /groups/(scot %p p.flag)/[q.flag]/seats/(scot %p who)/noun
   ==
 ::
 ++  can-read
@@ -213,6 +213,33 @@
     %+  turn  ~(tap in s)
     |=(s=ship `path`[%context (scot %p s) context.key])
   [%give %fact paz %presence-update-1 !>(upd)]~
+::
+++  revalidate
+  ::  subscribers are only checked when they subscribe. before fanning out
+  ::  to .context, kick and forget any that may no longer participate in
+  ::  it (reader roles changed, left or removed from the group, channel
+  ::  deleted). a kicked subscriber re-checks on its own end and either
+  ::  drops the context or resubscribes and gets a nack that says why.
+  ::
+  |=  [=context subs=(jug context ship) =bowl:gall]
+  ^-  [(list card) _subs]
+  =/  bad=(list ship)
+    %+  skip  ~(tap in (~(get ju subs) context))
+    |=  who=ship
+    =(~ (participant-error who context bowl))
+  ::NOTE  not ?~, which would narrow .bad and make +roll nest-fail
+  ?:  =(~ bad)  [~ subs]
+  :_  %+  roll  bad
+      |=([who=ship s=_subs] (~(del ju s) context who))
+  :~  %^  tell:~(. logs [bowl /logs])  %info
+        ~['kicking subscribers that lost access' >[context=context ships=bad]<]
+      ~
+    ::
+      :+  %give  %kick
+      :_  ~
+      %+  turn  bad
+      |=(who=ship `path`[%context (scot %p who) context])
+  ==
 ::
 ++  give-response
   |=  res=response-1
@@ -413,8 +440,13 @@
     ?>  =(src.bowl ship.key)
     ::  for non-dm contexts, verify participant membership
     ::
-    ?^  err=?:(?=([%dm *] context.key) ~ (participant-error context.key bowl))
+    ?^  err=?:(?=([%dm *] context.key) ~ (participant-error src.bowl context.key bowl))
       ~|(u.err !!)
+    ::  subscribers are only checked when they subscribe. before fanning
+    ::  out, kick any that have since lost access (reader roles changed,
+    ::  left or got removed from the group, channel deleted).
+    ::
+    =^  kicks=(list card)  subs  (revalidate context.key subs bowl)
     ?-  -.cmd
         %set
       ::  ack but no-op on timed out presence
@@ -426,7 +458,7 @@
         (fall timeout.timing.cmd (default-timeout topic.key.cmd))
       ?:  (gth now.bowl end)
         ::TODO  maybe delete existing one at key?
-        [~ this]
+        [kicks this]
       =/  fus=(list card)
         %+  give-update
           (~(del ju subs) context.key.cmd src.bowl)
@@ -436,9 +468,10 @@
       ::  for contexts it hosts.
       ::
       ?.  |(=(~ disclose.cmd) (~(has in disclose.cmd) our.bowl))
-        [fus this]
+        [(weld kicks fus) this]
       ::TODO  send response too?
       :_  this(places (put-presence places +>.cmd))
+      %+  weld  kicks
       :+  (give-response %here +>.cmd)
         :+  %pass
           ::TODO  +key-wire
@@ -450,6 +483,7 @@
       ::TODO  no-op if we didn't have it anyway
       :_  this(places (del-presence places key.cmd))
       ;:  weld
+        kicks
         (cancel-expire places key.cmd)
         [(give-response %gone key.cmd)]~
         %+  give-update
@@ -476,7 +510,7 @@
     ::  verify the subscriber is a participant in this context.
     ::  the hint ends up in the subscriber's nack tang.
     ::
-    ?^  err=(participant-error t.t.path bowl)
+    ?^  err=(participant-error src.bowl t.t.path bowl)
       ~|(u.err !!)
     =.  subs  (~(put ju subs) t.t.path src.bowl)
     ::NOTE  no initial fact, since all data is short-lived,        ::REVIEW

--- a/desk/tests/app/presence.hoon
+++ b/desk/tests/app/presence.hoon
@@ -157,7 +157,7 @@
       [%gx @ %channels @ %v4 @ @ @ %perm %channel-perm ~]
     `!>(`perm:v9:cv`[~ group-flag])
   ::
-      [%gx @ %groups @ %groups @ @ %channels @ @ @ %can-read @ %loob ~]
+      [%gx @ %groups @ %v2 %groups @ @ %channels @ @ @ %can-read @ %loob ~]
     `!>(readable)
   ==
 ::
@@ -287,10 +287,10 @@
     :-  ~  !>  ^-  channels:v9:cv
     (my ~[[[%chat host %general] chan] [[%chat host %old] chan]])
   ::
-      [%gx @ %groups @ %groups @ @ %channels @ @ %general %can-read @ %loob ~]
+      [%gx @ %groups @ %v2 %groups @ @ %channels @ @ %general %can-read @ %loob ~]
     `!>(&)
   ::
-      [%gx @ %groups @ %groups @ @ %channels @ @ @ %can-read @ %loob ~]
+      [%gx @ %groups @ %v2 %groups @ @ %channels @ @ @ %can-read @ %loob ~]
     `!>(|)
   ==
 ::

--- a/desk/tests/app/presence.hoon
+++ b/desk/tests/app/presence.hoon
@@ -336,4 +336,40 @@
   ;<  ~  bind:m  (set-src host)
   ;<  caz=(list card)  bind:m  (do-watch [%context (scot %p host) host-context])
   (ex-cards caz ~)
+::
+::  as a host, when fanning out we kick and forget subscribers that can no
+::  longer read the channel. ~ten can still read, ~fun cannot.
+::
+++  who-scry
+  |=  =path
+  ^-  (unit vase)
+  ?+  path  ((chan-scry &) path)
+      [%gx @ %groups @ %v2 %groups @ @ %channels @ @ @ %can-read @ %loob ~]
+    `!>(=((snag 13 `(list @ta)`path) (scot %p host)))
+  ==
+::
+++  test-set-kicks-subscribers-that-lost-access
+  %-  eval-mare
+  =/  m  (mare ,~)
+  ^-  form:m
+  ;<  ~  bind:m  setup
+  ;<  ~  bind:m  (set-scry-gate who-scry)
+  ;<  *  bind:m
+    %+  do-load  agent
+    %-  some  !>
+    :*  %2  *places:p
+        want=*(set [ship context:p])
+        subs=(~(put ju (~(put ju *(jug context:p ship)) host-context host)) host-context ~fun)
+        tries=*(map [ship context:p] @ud)
+    ==
+  ;<  ~  bind:m  (set-src host)
+  =/  =key:p  [host-context host %typing]
+  ;<  caz=(list card)  bind:m
+    %+  do-poke  %presence-command-1
+    !>(`command-1:p`[%set ~ key [t0 ~] display])
+  %+  ex-cards  caz
+  :~  (ex-card [%give %kick ~[[%context (scot %p ~fun) host-context]] ~])
+      (ex-fact ~[/v1] %presence-response-1 !>(`response-1:p`[%here key [t0 ~] display]))
+      (ex-arvo [%expire (scot %p host) %typing host-context] [%b %wait (add t0 ~s30)])
+  ==
 --

--- a/desk/tests/app/presence.hoon
+++ b/desk/tests/app/presence.hoon
@@ -372,4 +372,23 @@
       (ex-fact ~[/v1] %presence-response-1 !>(`response-1:p`[%here key [t0 ~] display]))
       (ex-arvo [%expire (scot %p host) %typing host-context] [%b %wait (add t0 ~s30)])
   ==
+::
+::  the channel host can set presence in its own channel even when its
+::  group roles would not let it read it. ~zod hosts; who-scry says only
+::  ~ten can read.
+::
+++  test-host-sets-presence-without-reader-role
+  %-  eval-mare
+  =/  m  (mare ,~)
+  ^-  form:m
+  ;<  ~  bind:m  setup
+  ;<  ~  bind:m  (set-scry-gate who-scry)
+  =/  =key:p  [host-context ~zod %typing]
+  ;<  caz=(list card)  bind:m
+    %+  do-poke  %presence-command-1
+    !>(`command-1:p`[%set ~ key [t0 ~] display])
+  %+  ex-cards  caz
+  :~  (ex-fact ~[/v1] %presence-response-1 !>(`response-1:p`[%here key [t0 ~] display]))
+      (ex-arvo [%expire (scot %p ~zod) %typing host-context] [%b %wait (add t0 ~s30)])
+  ==
 --

--- a/desk/tests/app/presence.hoon
+++ b/desk/tests/app/presence.hoon
@@ -5,10 +5,10 @@
 ::    from a stale timer must not delete presence that fresher %sets have
 ::    kept alive.
 ::
-::    subscription nacks on the subscriber's ship: a nack for a channel
-::    we can no longer read (deleted from its group, or we lost access)
-::    drops the desire outright; otherwise we retry with backoff and give
-::    up after +max-tries. neither is a crash, so we only ever +tell.
+::    subscription nacks on the subscriber's ship: we retry with backoff,
+::    the retry wake drops a channel we can no longer read (deleted from
+::    its group, or we lost access), and we give up after +max-tries.
+::    none of that is a crash, so we only ever +tell.
 ::
 ::    participant checks on the host's ship: a context watch by a ship
 ::    that cannot read the channel is rejected, with a hint saying why.
@@ -234,10 +234,11 @@
   %+  ex-cards  caz
   [(ex-task chan-wire [host dap] %watch-as %presence-update-1 chan-watch)]~
 ::
-::  a nack for a channel we can no longer read drops the desire outright:
-::  no retry timer, and a later wake finds nothing to do
+::  a nack for a channel we can no longer read is still retried once (our
+::  %groups may simply not have caught up yet), but the retry wake drops
+::  the desire instead of resubscribing, and a later wake is a no-op
 ::
-++  test-chan-nack-unreadable-drops
+++  test-chan-nack-unreadable-drops-at-retry
   %-  eval-mare
   =/  m  (mare ,~)
   ^-  form:m
@@ -245,7 +246,14 @@
   ;<  caz=(list card)  bind:m  do-chan-nack
   ;<  ~  bind:m
     %+  ex-cards-with-logs  caz
-    [(ex-log %tell %info 'context sub nacked, no longer readable, dropping')]~
+    :~  (ex-arvo chan-setup %b %wait (add t0 ~m5))
+        (ex-log %tell %info 'context sub nacked, will retry')
+    ==
+  ;<  ~  bind:m  (wait ~m5)
+  ;<  caz=(list card)  bind:m  do-chan-wake
+  ;<  ~  bind:m
+    %+  ex-cards-with-logs  caz
+    [(ex-log %tell %info 'context sub no longer readable, dropping')]~
   ;<  caz=(list card)  bind:m  do-chan-wake
   (ex-cards caz ~)
 ::

--- a/desk/tests/app/presence.hoon
+++ b/desk/tests/app/presence.hoon
@@ -1,11 +1,19 @@
 ::  tests for %presence
 ::
-::    focused on expiry-timer behavior on the subscriber's ship: every
-::    incoming %set fact arms its own expiry timer without cancelling
-::    prior ones, so a wake from a stale timer must not delete presence
-::    that fresher %sets have kept alive.
+::    expiry timers on the subscriber's ship: every incoming %set fact
+::    arms its own expiry timer without cancelling prior ones, so a wake
+::    from a stale timer must not delete presence that fresher %sets have
+::    kept alive.
 ::
-/-  p=presence
+::    subscription nacks on the subscriber's ship: a nack for a channel
+::    we can no longer read (deleted from its group, or we lost access)
+::    drops the desire outright; otherwise we retry with backoff and give
+::    up after +max-tries. neither is a crash, so we only ever +tell.
+::
+::    participant checks on the host's ship: a context watch by a ship
+::    that cannot read the channel is rejected, with a hint saying why.
+::
+/-  p=presence, gv=groups-ver, cv=channels-ver, l=logs
 /+  *test-agent
 /=  agent  /app/presence
 |%
@@ -118,4 +126,206 @@
       (ex-task /context/dm/~zod [~fus dap] %leave ~)
       (ex-task /context-2/dm/~zod [~fus dap] %watch-as %presence-update-1 /context/~zod/dm/~zod)
   ==
+::
+::  channel contexts. the channel /channel/chat/~ten/general belongs to
+::  group ~ten/grp. the agent consults its local %channels (for the
+::  channel's group) and %groups (for readability), which we mock.
+::
+++  group-flag    `flag:gv`[host %grp]
+++  chan-context  `context:p`/channel/chat/(scot %p host)/general
+++  chan-wire     `wire`[%context-2 chan-context]
+++  chan-setup    `wire`[%setup (scot %p host) chan-context]
+++  chan-watch    `path`[%context (scot %p ~zod) chan-context]
+::  the same shape of channel, hosted by us
+::
+++  host-context  `context:p`/channel/chat/(scot %p ~zod)/general
+::
+::  mocked %channels and %groups: every channel is in .group-flag,
+::  and readability is whatever the test says
+::
+++  chan-scry
+  |=  readable=?
+  ^-  scry
+  |=  =path
+  ^-  (unit vase)
+  ?+  path  ~
+    [%gu @ %channels @ %$ ~]           `!>(&)
+    [%gu @ %channels @ %v4 @ @ @ ~]    `!>(&)
+    [%gu @ %groups @ %$ ~]             `!>(&)
+    [%gu @ %groups @ %groups @ @ ~]    `!>(&)
+  ::
+      [%gx @ %channels @ %v4 @ @ @ %perm %channel-perm ~]
+    `!>(`perm:v9:cv`[~ group-flag])
+  ::
+      [%gx @ %groups @ %groups @ @ %channels @ @ @ %can-read @ %loob ~]
+    `!>(readable)
+  ==
+::
+::  we (~zod) want ~ten's channel, our subscription to it is pending,
+::  and we have been nacked .tries times before
+::
+++  setup-chan
+  |=  [readable=? tries=@ud]
+  =/  m  (mare ,~)
+  ^-  form:m
+  ;<  ~  bind:m  setup
+  ;<  ~  bind:m  (set-scry-gate (chan-scry readable))
+  ;<  ~  bind:m
+    %-  jab-bowl
+    |=  b=bowl
+    b(wex (~(put by wex.b) [chan-wire host dap] [| chan-watch]))
+  ;<  *  bind:m
+    %+  do-load  agent
+    %-  some  !>
+    :*  %2  *places:p
+        want=(sy ~[[host chan-context]])
+        subs=*(jug context:p ship)
+        tries=(~(put by *(map [ship context:p] @ud)) [host chan-context] tries)
+    ==
+  (pure:m ~)
+::
+++  do-chan-nack
+  (do-agent chan-wire [host dap] %watch-ack `~[leaf+"nope"])
+::
+++  do-chan-wake
+  (do-arvo chan-setup [%behn %wake ~])
+::
+::  +ex-cards, but keeping the cards going to the %logs agent
+::
+++  ex-cards-with-logs
+  =/  ex  ex-cards
+  ex(drop-logs |)
+::
+::  a log poke of the given kind, volume, and leading message
+::
+++  ex-log
+  |=  [kind=?(%tell %fail) vol=volume:l msg=@t]
+  |=  =card
+  ^-  tang
+  ?.  ?=([%pass [%logs ~] %agent [@ %logs] %poke %log-action-1 *] card)
+    ['expected a log poke' >card< ~]
+  =+  !<(act=a-log:l q.cage.task.q.card)
+  ?.  ?=(%log -.act)  ['expected a %log action' >act< ~]
+  ?.  =(kind -.event.act)  ['log kind mismatch' >-.event.act< ~]
+  ?.  =(vol vol.event.act)  ['log volume mismatch' >vol.event.act< ~]
+  =/  =echo:l  ?-(-.event.act %fail echo.event.act, %tell echo.event.act)
+  ?.  ?&(?=(^ echo) =(msg i.echo))
+    ['log message mismatch' >echo< ~]
+  ~
+::
+::  a nack for a channel we can still read is retried with backoff,
+::  and only logged as a %tell
+::
+++  test-chan-nack-readable-retries
+  %-  eval-mare
+  =/  m  (mare ,~)
+  ^-  form:m
+  ;<  ~  bind:m  (setup-chan & 0)
+  ;<  caz=(list card)  bind:m  do-chan-nack
+  ;<  ~  bind:m
+    %+  ex-cards-with-logs  caz
+    :~  (ex-arvo chan-setup %b %wait (add t0 ~m5))
+        (ex-log %tell %info 'context sub nacked, will retry')
+    ==
+  ::  when the retry timer fires, we resubscribe
+  ::
+  ;<  ~  bind:m  (wait ~m5)
+  ;<  caz=(list card)  bind:m  do-chan-wake
+  %+  ex-cards  caz
+  [(ex-task chan-wire [host dap] %watch-as %presence-update-1 chan-watch)]~
+::
+::  a nack for a channel we can no longer read drops the desire outright:
+::  no retry timer, and a later wake finds nothing to do
+::
+++  test-chan-nack-unreadable-drops
+  %-  eval-mare
+  =/  m  (mare ,~)
+  ^-  form:m
+  ;<  ~  bind:m  (setup-chan | 0)
+  ;<  caz=(list card)  bind:m  do-chan-nack
+  ;<  ~  bind:m
+    %+  ex-cards-with-logs  caz
+    [(ex-log %tell %info 'context sub nacked, no longer readable, dropping')]~
+  ;<  caz=(list card)  bind:m  do-chan-wake
+  (ex-cards caz ~)
+::
+::  after +max-tries consecutive nacks we give up, with a single %warn
+::
+++  test-chan-nack-gives-up-after-max-tries
+  %-  eval-mare
+  =/  m  (mare ,~)
+  ^-  form:m
+  ;<  ~  bind:m  (setup-chan & 5)
+  ;<  caz=(list card)  bind:m  do-chan-nack
+  ;<  ~  bind:m
+    %+  ex-cards-with-logs  caz
+    [(ex-log %tell %warn 'context sub nacked, giving up')]~
+  ;<  caz=(list card)  bind:m  do-chan-wake
+  (ex-cards caz ~)
+::
+::  a full setup only wants the channels we can read. our %channels
+::  has two of ~ten's channels, but only /general is still readable.
+::
+++  setup-scry
+  |=  =path
+  ^-  (unit vase)
+  ?+  path  ((chan-scry &) path)
+      [%gx @ %chat @ %dm %ships ~]
+    `!>(`(set ship)`(sy ~[host]))
+  ::
+      [%gx @ %channels @ %v4 %channels %channels-4 ~]
+    =/  chan=channel:v9:cv  *channel:v9:cv
+    =.  perm.chan  [~ group-flag]
+    :-  ~  !>  ^-  channels:v9:cv
+    (my ~[[[%chat host %general] chan] [[%chat host %old] chan]])
+  ::
+      [%gx @ %groups @ %groups @ @ %channels @ @ %general %can-read @ %loob ~]
+    `!>(&)
+  ::
+      [%gx @ %groups @ %groups @ @ %channels @ @ @ %can-read @ %loob ~]
+    `!>(|)
+  ==
+::
+++  test-setup-skips-unreadable-channels
+  %-  eval-mare
+  =/  m  (mare ,~)
+  ^-  form:m
+  ;<  ~  bind:m  setup
+  ;<  ~  bind:m  (set-scry-gate setup-scry)
+  ;<  caz=(list card)  bind:m  (do-arvo /setup [%behn %wake ~])
+  %+  ex-cards  caz
+  :~  (ex-task chan-wire [host dap] %watch-as %presence-update-1 chan-watch)
+      (ex-task /activity/all [~zod %activity] %watch /v4)
+  ==
+::
+::  as a host, we reject context watches from ships that cannot read
+::  the channel, and from ships watching someone else's path
+::
+++  test-watch-rejects-unreadable
+  %-  eval-mare
+  =/  m  (mare ,~)
+  ^-  form:m
+  ;<  ~  bind:m  setup
+  ;<  ~  bind:m  (set-scry-gate (chan-scry |))
+  ;<  ~  bind:m  (set-src host)
+  (ex-fail (do-watch [%context (scot %p host) host-context]))
+::
+++  test-watch-rejects-impersonation
+  %-  eval-mare
+  =/  m  (mare ,~)
+  ^-  form:m
+  ;<  ~  bind:m  setup
+  ;<  ~  bind:m  (set-scry-gate (chan-scry &))
+  ;<  ~  bind:m  (set-src host)
+  (ex-fail (do-watch [%context (scot %p ~fun) host-context]))
+::
+++  test-watch-accepts-readable
+  %-  eval-mare
+  =/  m  (mare ,~)
+  ^-  form:m
+  ;<  ~  bind:m  setup
+  ;<  ~  bind:m  (set-scry-gate (chan-scry &))
+  ;<  ~  bind:m  (set-src host)
+  ;<  caz=(list card)  bind:m  (do-watch [%context (scot %p host) host-context])
+  (ex-cards caz ~)
 --


### PR DESCRIPTION
## Summary

`%presence` produced ~95% of all backend "crashes" in PostHog (~11.5k `type=fail` events/week from ~300 ships, 33k on the Aug 27 release day), all `context sub nacked, will retry`. These are expected subscription nacks logged through `+fail:log`, retried five times per setup on every ship forever. This PR logs them as `+tell`, makes the host say *why* it nacked, and stops wanting channels that can never succeed.

Fixes TLON-6137

## Changes

**Why hosts nack (investigation).** Last 7 days of nacks by host: `~nibset-napwyn` 5875 events / 177 ships / 20 contexts (51% of volume), `~halbex-palheb` 650 / 112 / 3, `~natnex-ronret` 498 / 58 / 3, then a long tail. The top six contexts are all `~nibset-napwyn` channels (`local-memory-2`, `news---announcements`, `local-ai-15`, `winter-updates`, `assembly--23`, `overheard--and-seen--lisbon`), each nacked by 160–175 ships, i.e. every active subscriber, deterministically. These are channels deleted from their group that linger in subscribers' `%channels` (`ca-take-update` only slogs on a nack and keeps the channel). `+channel-contexts` fed every channel in `%channels` into `.want` on every setup and every upgrade; the host's `+group-for-channel` could not resolve the channel, so `+is-participant` nacked.

**Subscriber side** (`desk/app/presence.hoon`)
- Nack retries are `+tell %info`; giving up after `+max-tries` is a single `+tell %warn` with src, context, and try count. Message texts are unchanged (`context sub nacked, will retry` / `context sub nacked, giving up`), plus a new `context sub no longer readable, dropping`. Nothing on this path uses `+fail:log` any more.
- `+channel-contexts` filters `%channels` through the `%groups` can-read scry (`/v2/groups/<flag>/channels/<nest>/can-read/<ship>/loob`), which returns false when the channel is no longer in the group or we cannot read it. The path is declared in `%groups`' discipline scry list with mark `%loob`, ahead of the broader `/x/v2/groups/$/$` entry that would otherwise fail it on a mark mismatch. Dead channels never enter `.want`, so there is no retry cycle and no cooldown state needed.
- A nack is always retried once with backoff, so a join race (channel lands in `%channels` before our copy of the group catches up) has time to resolve. The retry wake runs the same readability check via `+context-readable` and drops the desire instead of resubscribing if it fails, so a dead channel exits after one wake rather than five.

**Host side**
- `+is-participant` becomes `+participant-error`, returning a term that `+on-watch` and the `%presence-command-1` poke raise via `~|`: `%presence-bad-path`, `%presence-not-dm-counterparty`, `%presence-unknown-channel`, `%presence-unknown-channel-group`, `%presence-cannot-read-channel`, `%presence-not-group-member`. The subscriber's nack tang, and therefore our logs, now say why.
- Channel participation is now "can read the channel" per `%groups`, not merely "holds a seat in the group". Previously a seat-holder outside a channel's reader roles could subscribe to and publish presence for it.
- Subscribers are re-checked when the host fans out a `%set` or `%clear` (`+revalidate`). Anyone who has since lost access is kicked on their personalized path and dropped from `subs`; they re-check on their own end and either drop the context or resubscribe and get a nack that says why. Previously an accepted subscriber kept receiving presence until their gall subscription happened to end. The context is resolved once per fan-out (`+resolve-context`); only the per-ship seat or can-read lookup runs per subscriber (`+member-error`). The channel host is always treated as a reader of its own channel, matching `+can-read:perms` in channel-utils.

No wire format, mark, or state changes. The only `%groups` and `%channels` changes are one-line discipline scry declarations: the groups can-read path above, and the versioned `/x/v4/<nest>/perm` path presence already read on the host side, which printed an `%unknown-scry-path` warning on every incoming watch. `/context` and `/context-2` wires, `%presence-update-1`, `%presence-command-1` are untouched; state stays at `%2`.

**Tests** (`desk/tests/app/presence.hoon`): 9 new tests with mocked `%channels`/`%groups` scries — readable nack retries with backoff and logs `%tell %info`; unreadable nack is retried once and dropped at the retry wake; give-up after max tries logs `%tell %warn`; full setup skips unreadable channels; host rejects unreadable subscribers and impersonated paths, accepts readable ones; host kicks a subscriber that lost access when fanning out; host may set presence in its own channel without a reader role.

## How did I test?

- Built the branch (develop + this change) as an empty-bill throwaway desk `%pnk` on dev moon `~macmur-hantyv-nocsyx-lassul`; `test-build` of `/app/presence/hoon` succeeds; all 13 tests in `/tests/app/presence` pass (4 existing + 9 new).
- Verified the real `%groups` agent answers the scry path the fix relies on: `%gu` on a held group is true, and can-read for a nest not in the group returns `%.n`.
- Live two-moon test on the branch desk (`~macmur` subscribing to channels hosted by `~dopbes`, both running this branch as `%groups`): with both channels readable, presence subscribed to both and the host recorded both. After restricting one channel's readers to a role macmur lacks, macmur's `%channels` kept the now-unreadable channel (the pre-existing stale-channel condition), and the next presence setup wanted only the readable channel and left the other, with `tries` empty and no nack cycle. The host's `subs` dropped macmur for the restricted channel. Restoring the role brought the channel back into `want` through the normal join path with no restart and no nack, and deleting a channel on the host removed it from `want` and from the host's `subs` immediately. A throwaway spider thread on macmur that watches the host's presence path for a channel macmur cannot read fails with `%watch-ack-fail` and the tang reads `%presence-cannot-read-channel` at the `+on-watch` line, so the reason reaches the subscriber intact.
- PostHog aggregates over `Backend Log` events for the numbers above.

**Expected effect on fail-event volume.** All `~11.5k/week` presence fail events come from the one `+fail:log` call this PR removes, so presence's contribution to `type=fail` should drop to ~0 (about 95% of the total) and the release-day spike goes with it. For the dominant cause (deleted channels lingering in `%channels`), the can-read filter also stops the subscriptions being attempted at all, so the replacement `%info` lines should be a small fraction of today's volume rather than a relabelling of it. Contexts whose group copy is *also* stale on the subscriber will still retry five times per setup, at `%info`.

Not in this PR: cleaning the stale channels out of `%channels` itself (a channel-sub nack where the group no longer lists the nest should `ca-leave`). That is the lifecycle work and belongs in a follow-up.

## Risks and impact

- Safe to rollback without consulting PR author? Yes
- Affects important code area:
  - [ ] Onboarding
  - [ ] State / providers
  - [ ] Message sync
  - [ ] Channel display
  - [ ] Notifications
  - [x] Other: presence / typing indicators. Hosts now enforce channel read permission for presence subscriptions and pokes; a seat-holder who is not a reader of a channel loses presence for that channel (they could not read it anyway).

## Rollback plan

Revert the commit. No state or protocol migration is involved; a reverted agent resumes the previous retry behaviour on its next setup.

## Screenshots / videos

n/a

🤖 Generated with [Claude Code](https://claude.com/claude-code)






