### PR TITLE
Add scheduled Sentry sweep script with PostHog alert relay

### DIFF
--- a/.github/workflows/sentry-sweep.yml
+++ b/.github/workflows/sentry-sweep.yml
@@ -8,8 +8,7 @@ on:
       dry_run: { description: 'Print the digest, post nothing, keep state', type: boolean, default: true }
   pull_request:
     paths: ['scripts/sentry-sweep*', '.github/workflows/sentry-sweep.yml']
-permissions: { contents: read, actions: write }
-concurrency: { group: sentry-sweep, cancel-in-progress: false }
+permissions: { contents: read }
 
 jobs:
   test:
@@ -24,6 +23,8 @@ jobs:
 
   sweep:
     if: github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'
+    permissions: { contents: read, actions: write }
+    concurrency: { group: sentry-sweep, cancel-in-progress: false }
     runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:

--- a/.github/workflows/sentry-sweep.yml
+++ b/.github/workflows/sentry-sweep.yml
@@ -1,0 +1,64 @@
+# Scheduled zero-inference Sentry sweep: posts new/regressed issues into the Tlon alert channel; see docs/sentry-sweep.md.
+name: Sentry sweep
+on:
+  schedule:
+    - cron: '*/10 * * * *'
+  workflow_dispatch:
+    inputs:
+      dry_run: { description: 'Print the digest, post nothing, keep state', type: boolean, default: true }
+  pull_request:
+    paths: ['scripts/sentry-sweep*', '.github/workflows/sentry-sweep.yml']
+permissions: { contents: read, actions: write }
+concurrency: { group: sentry-sweep, cancel-in-progress: false }
+
+jobs:
+  test:
+    if: github.event_name == 'pull_request'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+      - run: node --test scripts/sentry-sweep.test.mjs
+
+  sweep:
+    if: github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          sparse-checkout: scripts
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+      - uses: actions/cache/restore@v4
+        with:
+          path: .sentry-sweep/state.json
+          key: sentry-sweep-state-${{ github.run_id }}
+          restore-keys: sentry-sweep-state-
+      - name: Require the PostHog key for a live run
+        if: ${{ !inputs.dry_run }}
+        env:
+          POSTHOG_API_KEY: ${{ secrets.POST_HOG_API_KEY_PROD }}
+        run: |
+          if [ -z "$POSTHOG_API_KEY" ]; then
+            echo "::error::Repository secret POST_HOG_API_KEY_PROD is unset; a live sweep would deliver nothing. Set it, or run with dry_run."
+            exit 1
+          fi
+      - name: Sweep
+        run: |
+          node scripts/sentry-sweep.mjs ${{ inputs.dry_run && '--dry-run' || '' }}
+          # A dry run writes no state; keep cache/save from failing on a missing path.
+          mkdir -p .sentry-sweep && touch .sentry-sweep/state.json
+        env:
+          SENTRY_TOKEN: ${{ secrets.SENTRY_SWEEP_TOKEN }}
+          SWEEP_STATE: .sentry-sweep/state.json
+          POSTHOG_API_KEY: ${{ secrets.POST_HOG_API_KEY_PROD }}
+          POSTHOG_CAPTURE_URL: https://eu.i.posthog.com/batch/
+      - uses: actions/cache/save@v4
+        if: success()
+        with:
+          path: .sentry-sweep/state.json
+          key: sentry-sweep-state-${{ github.run_id }}

--- a/.github/workflows/sentry-sweep.yml
+++ b/.github/workflows/sentry-sweep.yml
@@ -36,7 +36,7 @@ jobs:
       - uses: actions/cache/restore@v4
         with:
           path: .sentry-sweep/state.json
-          key: sentry-sweep-state-${{ github.run_id }}
+          key: sentry-sweep-state-${{ github.run_id }}-${{ github.run_attempt }}
           restore-keys: sentry-sweep-state-
       - name: Require the PostHog key for a live run
         if: ${{ !inputs.dry_run }}
@@ -61,4 +61,4 @@ jobs:
         if: success()
         with:
           path: .sentry-sweep/state.json
-          key: sentry-sweep-state-${{ github.run_id }}
+          key: sentry-sweep-state-${{ github.run_id }}-${{ github.run_attempt }}

--- a/docs/sentry-sweep.md
+++ b/docs/sentry-sweep.md
@@ -1,0 +1,61 @@
+# Sentry sweep
+
+Every 10 minutes, `scripts/sentry-sweep.mjs` (run by `.github/workflows/sentry-sweep.yml`;
+edit its `cron:` line to change the schedule) queries Sentry for issues that are new
+(`is:unresolved firstSeen:><boundary>`) or regressed (`is:regressed lastSeen:><boundary>`)
+since the last run and builds a deterministic digest — no model involved. Each digest line
+goes to PostHog as one `Sentry Issue Alert` event, and a PostHog webhook destination (set up
+once, below) posts them into the Tlon alert channel with credentials PostHog already holds,
+so GitHub Actions never needs a ship cookie.
+
+Secrets/vars (Settings → Secrets and variables → Actions):
+
+| Name | Kind | Purpose |
+| --- | --- | --- |
+| `SENTRY_SWEEP_TOKEN` | secret | Sentry token; scopes `event:read`, `project:read`, `org:read` |
+| `POST_HOG_API_KEY_PROD` | secret | project token of the PostHog project that hosts the alert destinations (Groups Mobile PRODUCTION); the same secret production mobile builds already use |
+
+Dry run: Actions → Sentry sweep → Run workflow → keep `dry_run` checked; the job
+prints the digest into the run log, sends nothing and keeps state. The digest is a
+header line (UTC timestamp, regressed/new totals, per-project `regressed/new`), then
+up to 15 issue lines — kind, project, shortId as a link, title, `N events / M users`
+— then an "and N more" line linking the Sentry `is:regressed` / `is:new` queries.
+
+State (`.sentry-sweep/state.json`: last-run boundary + reported ids) lives in the
+Actions cache; a cache miss is harmless — the sweep falls back to a 30-minute
+window. Reported issues dedupe for 24h; an issue that stays regressed after that
+is reported once more, then quiets for another 24h. Any failure (Sentry or
+PostHog) exits 1 and leaves the state untouched, so the next run re-reports the
+same window. A live run (schedule, or dispatch with dry_run unchecked) fails
+before sweeping if POST_HOG_API_KEY_PROD is unset, so a missing key cannot
+silently turn the sweep into a no-op. Token and key never appear in output.
+
+## PostHog destination (one-time setup)
+
+For the PostHog owner, in the project that holds the existing "Alert: …"
+destinations: type **HTTP Webhook** (`template-webhook`), filter on event name
+`Sentry Issue Alert`, URL/method/headers identical to those destinations, body:
+
+```json
+{ "channel": { "nest": "chat/~litseb-sarfel/v1nnn22o", "action": { "post": { "add": {
+  "sent": 0, "author": "~botsen-lomlex",
+  "content": [ { "inline": [ "{event.properties.text} ", { "link": { "href": "{event.properties.permalink}", "content": "{event.properties.shortId}" } } ] } ],
+  "kind-data": { "chat": null } } } } } }
+```
+
+`MORE` events (the capped "… and N more" line) render the same way; their link is
+the Sentry `is:regressed` search. PostHog delivers events asynchronously, so a
+run's lines can arrive out of order — the per-line `kind`/`project` prefix in
+`text` keeps them readable.
+
+Local run (drop `--dry-run` to send for real); tests: `node --test scripts/sentry-sweep.test.mjs`.
+
+```sh
+SENTRY_TOKEN=... SWEEP_STATE=/tmp/sweep-state.json POSTHOG_API_KEY=... \
+node scripts/sentry-sweep.mjs --dry-run --print-post  # digest + PostHog batch JSON
+```
+
+The script also keeps a direct mode that pokes `%channels` through Eyre on an
+alert moon (`TLON_POST_URL`, `TLON_POST_SHIP`, `TLON_POST_NEST`,
+`TLON_POST_COOKIE`); it is off unless all four are set, and the workflow does not
+use it. With both configured, PostHog is sent first.

--- a/docs/sentry-sweep.md
+++ b/docs/sentry-sweep.md
@@ -3,7 +3,7 @@
 Every 10 minutes, `scripts/sentry-sweep.mjs` (run by `.github/workflows/sentry-sweep.yml`;
 edit its `cron:` line to change the schedule) queries Sentry for issues that are new
 (`is:unresolved firstSeen:><boundary>`) or regressed (`is:regressed lastSeen:><boundary>`)
-since the last run and builds a deterministic digest — no model involved. Each digest line
+since the last run and builds a deterministic digest — no model involved. Each issue line
 goes to PostHog as one `Sentry Issue Alert` event, and a PostHog webhook destination (set up
 once, below) posts them into the Tlon alert channel with credentials PostHog already holds,
 so GitHub Actions never needs a ship cookie.

--- a/scripts/sentry-sweep.mjs
+++ b/scripts/sentry-sweep.mjs
@@ -1,0 +1,719 @@
+#!/usr/bin/env node
+// sentry-sweep — zero-inference Sentry digest for the sentry-sweep workflow.
+// Read-only against Sentry. Prints a digest to stdout ONLY when there is
+// something to report. Two output modes, both off unless configured: when
+// POSTHOG_API_KEY is set it sends one PostHog event per digest line (a PostHog
+// webhook destination relays them into the Tlon channel with credentials this
+// repo never holds); when the TLON_POST_* env vars are set it posts the digest
+// into a Tlon channel directly (Eyre poke to %channels on an alert moon, the
+// same wire format the web client uses). The state file is updated only after
+// every configured output succeeded. No dependencies: global fetch, node:fs,
+// node:test (tests). Never prints the token, the PostHog key or the cookie.
+import { readFileSync, writeFileSync, renameSync, mkdirSync } from 'node:fs';
+import { dirname, resolve } from 'node:path';
+import { pathToFileURL } from 'node:url';
+
+const DEFAULTS = {
+  base: 'https://de.sentry.io/api/0',
+  org: 'tlon-corporation',
+  projects: 'web=4510506111467600,mobile=4510364799467600',
+  state: './sentry-sweep-state.json',
+  maxLines: 15,
+  posthogCaptureUrl: 'https://eu.i.posthog.com/batch/',
+  posthogDistinctId: 'sentry-sweep',
+};
+
+const MINUTE_MS = 60 * 1000;
+const DAY_MS = 24 * 60 * 60 * 1000;
+const WEEK_MS = 7 * DAY_MS;
+const MAX_PAGES = 5; // pagination cap per query
+const REQUEST_TIMEOUT_MS = 20000;
+const TITLE_MAX = 80;
+
+// ---------------------------------------------------------------------------
+// Pure helpers (exported so the test can cover them without any network).
+// ---------------------------------------------------------------------------
+
+// "web=123,mobile=456" -> [{ label: 'web', id: '123' }, { label: 'mobile', id: '456' }]
+export function parseProjects(str) {
+  const out = [];
+  for (const pair of String(str ?? '').split(',')) {
+    const trimmed = pair.trim();
+    if (!trimmed) continue;
+    const eq = trimmed.indexOf('=');
+    if (eq === -1) continue; // ignore malformed entries
+    const label = trimmed.slice(0, eq).trim();
+    const id = trimmed.slice(eq + 1).trim();
+    if (label && id) out.push({ label, id });
+  }
+  return out;
+}
+
+// Sentry search-syntax boundary: UTC, no milliseconds -> YYYY-MM-DDTHH:MM:SS
+function formatBoundary(input) {
+  const d = input instanceof Date ? input : new Date(input);
+  return d.toISOString().slice(0, 19);
+}
+
+// Build the two Sentry issue-search queries for a boundary. Sentry uses
+// `firstSeen`/`lastSeen` with a `>` comparator; `is:unresolved` vs `is:regressed`
+// distinguishes brand-new issues from ones that came back after being resolved.
+export function buildQueries(boundaryIso) {
+  const b = formatBoundary(boundaryIso);
+  return {
+    new: `is:unresolved firstSeen:>${b}`,
+    regressed: `is:regressed lastSeen:>${b}`,
+  };
+}
+
+function toDate(value) {
+  return value instanceof Date ? value : new Date(value);
+}
+
+// Merge per-label { new, regressed } buckets into one sorted list.
+// `reported` is state.reported ({ id: ISO }); `now` is a Date/ISO.
+export function mergeIssues(data, reported = {}, now = new Date()) {
+  const nowMs = toDate(now).getTime();
+  const byId = new Map();
+
+  const consider = (label, issue, kind) => {
+    if (!issue || issue.id == null) return;
+    const id = String(issue.id);
+    const existing = byId.get(id);
+    // An issue in BOTH lists is REGRESSED (regressed wins); never downgrade it.
+    if (existing && existing.kind === 'REGRESSED') return;
+    byId.set(id, {
+      id,
+      label,
+      kind,
+      shortId: issue.shortId ?? '',
+      title: issue.title ?? '',
+      count: Number(issue.count) || 0, // Sentry returns count as a string
+      userCount: Number(issue.userCount) || 0,
+      permalink: issue.permalink ?? '',
+    });
+  };
+
+  // Regressed first so it wins the dedupe-by-id, then new.
+  for (const [label, bucket] of Object.entries(data ?? {})) {
+    for (const issue of bucket?.regressed ?? [])
+      consider(label, issue, 'REGRESSED');
+  }
+  for (const [label, bucket] of Object.entries(data ?? {})) {
+    for (const issue of bucket?.new ?? []) consider(label, issue, 'NEW');
+  }
+
+  const items = [];
+  for (const item of byId.values()) {
+    // Dedupe across runs: skip anything already announced within the last 24h.
+    // Older-than-24h entries are allowed through (they may regress again later).
+    const ts = reported?.[item.id];
+    if (ts && nowMs - Date.parse(ts) < DAY_MS) continue;
+    items.push(item);
+  }
+
+  const rank = { REGRESSED: 0, NEW: 1 };
+  items.sort((a, b) => {
+    if (a.kind !== b.kind) return rank[a.kind] - rank[b.kind];
+    if (b.userCount !== a.userCount) return b.userCount - a.userCount;
+    if (b.count !== a.count) return b.count - a.count;
+    return 0;
+  });
+  return items;
+}
+
+// Totals + per-project regressed/new counts. `order` keeps the project labels in
+// the configured SENTRY_PROJECTS order rather than first-appearance order.
+function computeCounts(items, order = []) {
+  const per = {};
+  let regressed = 0;
+  let fresh = 0;
+  for (const it of items) {
+    per[it.label] ??= { label: it.label, regressed: 0, new: 0 };
+    if (it.kind === 'REGRESSED') {
+      per[it.label].regressed++;
+      regressed++;
+    } else {
+      per[it.label].new++;
+      fresh++;
+    }
+  }
+  const labels = Object.keys(per).sort((a, b) => {
+    const ia = order.indexOf(a);
+    const ib = order.indexOf(b);
+    if (ia === -1 && ib === -1) return 0;
+    if (ia === -1) return 1;
+    if (ib === -1) return -1;
+    return ia - ib;
+  });
+  return { regressed, new: fresh, perProject: labels.map((l) => per[l]) };
+}
+
+function truncateTitle(s) {
+  const str = String(s ?? '');
+  return str.length <= TITLE_MAX ? str : `${str.slice(0, TITLE_MAX - 1)}…`;
+}
+
+// Shared digest computation: header text, capped detail items, and the
+// "and N more" query links. formatDigest renders it as plain text, buildStory
+// renders it as Tlon verses; the two must never drift apart.
+function digestParts(items, opts) {
+  const {
+    now = new Date(),
+    maxLines = DEFAULTS.maxLines,
+    org = DEFAULTS.org,
+    clamped = false,
+  } = opts;
+  const counts = opts.counts ?? computeCounts(items);
+
+  const when = toDate(now).toISOString().slice(0, 16).replace('T', ' ');
+  const perProject = counts.perProject
+    .map((p) => `${p.label} ${p.regressed}/${p.new}`)
+    .join(', ');
+  let header = `Sentry sweep ${when} UTC: ${counts.regressed} regressed, ${counts.new} new`;
+  if (perProject) header += ` (${perProject})`;
+  if (clamped) header += ' (catching up: window clamped to 24h)';
+
+  const shown = items.slice(0, maxLines);
+  const remaining = items.length - shown.length;
+  const regressedUrl = `https://${org}.sentry.io/issues/?query=${encodeURIComponent('is:regressed')}`;
+  const newUrl = `https://${org}.sentry.io/issues/?query=${encodeURIComponent('is:unresolved is:new')}`;
+  return { header, shown, remaining, regressedUrl, newUrl, org };
+}
+
+function issueHref(it, org) {
+  return it.permalink || `https://${org}.sentry.io/issues/${it.id}/`;
+}
+
+// A digest detail line without the short id and the link — the PostHog
+// destination renders the link itself from `permalink`/`shortId`. Must stay in
+// step with formatDigest's detail lines.
+function issueText(it) {
+  return (
+    `${it.kind} ${it.label} "${truncateTitle(it.title)}" ` +
+    `${it.count} events / ${it.userCount} users`
+  );
+}
+
+// Render the plain-text digest. Returns '' when there is nothing to report.
+export function formatDigest(items, opts = {}) {
+  if (!items || items.length === 0) return '';
+  const { header, shown, remaining, regressedUrl, newUrl, org } = digestParts(
+    items,
+    opts
+  );
+
+  const lines = [header];
+  for (const it of shown) {
+    lines.push(
+      `${it.kind} ${it.label} ${it.shortId} "${truncateTitle(it.title)}" ` +
+        `${it.count} events / ${it.userCount} users ${issueHref(it, org)}`
+    );
+  }
+  if (remaining > 0) {
+    lines.push(`… and ${remaining} more: ${regressedUrl}  ${newUrl}`);
+  }
+  return lines.join('\n');
+}
+
+// Render the digest as a Tlon story: one { inline: [...] } verse per digest
+// line (each verse renders as its own line; no `break` inlines needed). Issue
+// links become `link` inlines (content = shortId) instead of raw URLs.
+// See packages/api/src/urbit/content.ts for the inline union.
+export function buildStory(items, opts = {}) {
+  if (!items || items.length === 0) return [];
+  const { header, shown, remaining, regressedUrl, newUrl, org } = digestParts(
+    items,
+    opts
+  );
+
+  const story = [{ inline: [header] }];
+  for (const it of shown) {
+    story.push({
+      inline: [
+        `${it.kind} ${it.label} `,
+        { link: { href: issueHref(it, org), content: it.shortId } },
+        ` "${truncateTitle(it.title)}" ${it.count} events / ${it.userCount} users`,
+      ],
+    });
+  }
+  if (remaining > 0) {
+    story.push({
+      inline: [
+        `… and ${remaining} more: `,
+        { link: { href: regressedUrl, content: 'regressed' } },
+        '  ',
+        { link: { href: newUrl, content: 'new' } },
+      ],
+    });
+  }
+  return story;
+}
+
+// The Eyre channel-PUT envelope carrying one chat post, mirroring
+// packages/api postsApi.sendPost + Urbit.poke: a one-element array with a
+// `channel-action-2` poke of %channels. `ship` is bare (no sig); the essay
+// `author` carries the sig.
+export function buildPokeBody({ ship, nest, story, sent }) {
+  const bare = String(ship ?? '').replace(/^~/, '');
+  return [
+    {
+      id: 1,
+      action: 'poke',
+      ship: bare,
+      app: 'channels',
+      mark: 'channel-action-2',
+      json: {
+        channel: {
+          nest,
+          action: {
+            post: {
+              add: {
+                content: story,
+                sent,
+                author: `~${bare}`,
+                kind: '/chat',
+                meta: null,
+                blob: null,
+              },
+            },
+          },
+        },
+      },
+    },
+  ];
+}
+
+// One PostHog event per printed digest line (same SWEEP_MAX_LINES cap), plus a
+// `MORE` event when the cap left issues unprinted. Pure and key-free: the
+// caller adds `api_key`, so neither the tests nor --print-post ever see it. A
+// PostHog webhook destination turns each event into one Tlon chat post.
+export function buildPosthogBatch(items, opts = {}) {
+  const {
+    now = new Date(),
+    maxLines = DEFAULTS.maxLines,
+    org = DEFAULTS.org,
+    distinctId = DEFAULTS.posthogDistinctId,
+  } = opts;
+  if (!items || items.length === 0) return { api_key: undefined, batch: [] };
+
+  const { shown, remaining, regressedUrl } = digestParts(items, {
+    now,
+    maxLines,
+    org,
+  });
+  const isoNow = toDate(now).toISOString();
+  const event = (properties) => ({
+    event: 'Sentry Issue Alert',
+    distinct_id: distinctId,
+    timestamp: isoNow,
+    properties: {
+      $lib: 'sentry-sweep',
+      $process_person_profile: false, // no person profile: this is a bot feed
+      ...properties,
+      sweepRunAt: isoNow,
+    },
+  });
+
+  const batch = shown.map((it) =>
+    event({
+      kind: it.kind,
+      project: it.label,
+      shortId: it.shortId,
+      title: truncateTitle(it.title),
+      count: it.count,
+      userCount: it.userCount,
+      permalink: issueHref(it, org),
+      text: issueText(it),
+    })
+  );
+  if (remaining > 0) {
+    batch.push(
+      event({
+        kind: 'MORE',
+        project: '',
+        shortId: 'more',
+        title: '',
+        count: 0,
+        userCount: 0,
+        permalink: regressedUrl, // the digest's is:regressed search
+        text: `… and ${remaining} more regressed/new issues`,
+      })
+    );
+  }
+  return { api_key: undefined, batch };
+}
+
+// Next state: lastRun = now, record every printed id, prune entries older than 7 days.
+export function nextState(state, printedIds, now = new Date()) {
+  const nowDate = toDate(now);
+  const nowIso = nowDate.toISOString();
+  const nowMs = nowDate.getTime();
+  const reported = {};
+  for (const [id, ts] of Object.entries(state?.reported ?? {})) {
+    const t = Date.parse(ts);
+    if (!Number.isNaN(t) && nowMs - t <= WEEK_MS) reported[id] = ts; // keep < 7d
+  }
+  for (const id of printedIds ?? []) reported[String(id)] = nowIso;
+  return { lastRun: nowIso, reported };
+}
+
+// ---------------------------------------------------------------------------
+// Network (all of it lives here).
+// ---------------------------------------------------------------------------
+
+// Pull the rel="next"; results="true" URL out of a Sentry Link header.
+function parseLinkNext(header) {
+  if (!header) return null;
+  for (const part of header.split(/,\s*(?=<)/)) {
+    const url = part.match(/<([^>]+)>/);
+    if (!url) continue;
+    if (/rel="?next"?/i.test(part) && /results="?true"?/i.test(part))
+      return url[1];
+  }
+  return null;
+}
+
+async function fetchPage(url, token) {
+  const res = await fetch(url, {
+    headers: { Authorization: `Bearer ${token}`, Accept: 'application/json' },
+    signal: AbortSignal.timeout(REQUEST_TIMEOUT_MS),
+  });
+  if (!res.ok) {
+    let body = '';
+    try {
+      body = await res.text();
+    } catch {
+      /* ignore body read errors */
+    }
+    // Status + first 120 chars of the body. The token is in a header, never the
+    // URL or body, so it cannot leak here.
+    throw new Error(`HTTP ${res.status} ${body.slice(0, 120)}`.trim());
+  }
+  const data = await res.json();
+  return {
+    issues: Array.isArray(data) ? data : [],
+    next: parseLinkNext(res.headers.get('link')),
+  };
+}
+
+async function fetchQuery({ base, org, token, projectId, query }) {
+  const url = new URL(`${base}/organizations/${org}/issues/`);
+  url.searchParams.set('project', projectId);
+  url.searchParams.set('statsPeriod', '24h');
+  url.searchParams.set('limit', '100');
+  url.searchParams.set('sort', 'date');
+  url.searchParams.set('query', query);
+
+  const all = [];
+  let next = url.toString();
+  for (let page = 0; page < MAX_PAGES && next; page++) {
+    const res = await fetchPage(next, token);
+    all.push(...res.issues);
+    next = res.next;
+  }
+  return all;
+}
+
+// Returns { "<label>": { new: [...issues], regressed: [...issues] } }.
+export async function fetchIssues({ base, org, token, projects, queries }) {
+  const out = {};
+  for (const { label, id } of projects) {
+    const [fresh, regressed] = await Promise.all([
+      fetchQuery({ base, org, token, projectId: id, query: queries.new }),
+      fetchQuery({ base, org, token, projectId: id, query: queries.regressed }),
+    ]);
+    out[label] = { new: fresh, regressed };
+  }
+  return out;
+}
+
+// Send one PostHog batch (`{ api_key, batch: [...] }`) to the capture URL; any
+// 2xx is success. The project token lives only in the request body — thrown
+// messages carry status/reason (or the fetch error), never the key.
+async function postPosthogBatch({ url, apiKey, batch }) {
+  let res;
+  try {
+    res = await fetch(url, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ api_key: apiKey, batch }),
+      signal: AbortSignal.timeout(REQUEST_TIMEOUT_MS),
+    });
+  } catch (err) {
+    throw new Error(`posthog ${err?.message ?? String(err)}`);
+  }
+  if (!res.ok) {
+    throw new Error(`posthog HTTP ${res.status} ${res.statusText}`.trim());
+  }
+}
+
+// Post the story into the target channel through Eyre on the alert moon:
+// PUT the poke to a fresh channel URL, then best-effort PUT a `delete` to
+// close the channel again. Eyre answers the poke PUT with 204; any 2xx is
+// success. The cookie lives only in a request header — thrown messages carry
+// status/reason (or the fetch error), never the cookie.
+async function postStory({ url, ship, cookie, nest, story, sent }) {
+  const channelUrl = `${String(url).replace(/\/+$/, '')}/~/channel/${sent}-sentry-sweep`;
+  const headers = {
+    'Content-Type': 'application/json',
+    Cookie: `urbauth-~${String(ship).replace(/^~/, '')}=${cookie}`,
+  };
+
+  let res;
+  try {
+    res = await fetch(channelUrl, {
+      method: 'PUT',
+      headers,
+      body: JSON.stringify(buildPokeBody({ ship, nest, story, sent })),
+      signal: AbortSignal.timeout(REQUEST_TIMEOUT_MS),
+    });
+  } catch (err) {
+    throw new Error(`post ${err?.message ?? String(err)}`);
+  }
+  if (!res.ok) {
+    throw new Error(`post HTTP ${res.status} ${res.statusText}`.trim());
+  }
+
+  try {
+    await fetch(channelUrl, {
+      method: 'PUT',
+      headers,
+      body: JSON.stringify([{ id: 2, action: 'delete' }]),
+      signal: AbortSignal.timeout(REQUEST_TIMEOUT_MS),
+    });
+  } catch {
+    /* best effort: a leaked Eyre channel is harmless */
+  }
+}
+
+// ---------------------------------------------------------------------------
+// State file (atomic temp-file + rename).
+// ---------------------------------------------------------------------------
+
+function loadState(path) {
+  try {
+    const parsed = JSON.parse(readFileSync(path, 'utf8'));
+    if (parsed && typeof parsed === 'object') {
+      return {
+        lastRun: parsed.lastRun ?? null,
+        reported:
+          parsed.reported && typeof parsed.reported === 'object'
+            ? parsed.reported
+            : {},
+      };
+    }
+  } catch {
+    /* missing or corrupt -> start fresh */
+  }
+  return { lastRun: null, reported: {} };
+}
+
+function saveState(path, state) {
+  const abs = resolve(path);
+  mkdirSync(dirname(abs), { recursive: true });
+  const tmp = `${abs}.${process.pid}.${Date.now()}.tmp`;
+  writeFileSync(tmp, `${JSON.stringify(state, null, 2)}\n`);
+  renameSync(tmp, abs); // atomic on POSIX
+}
+
+// ---------------------------------------------------------------------------
+// CLI
+// ---------------------------------------------------------------------------
+
+function parseArgs(argv) {
+  const flags = { dryRun: false, since: null, fixture: null, printPost: false };
+  for (const arg of argv) {
+    if (arg === '--dry-run') flags.dryRun = true;
+    else if (arg === '--print-post') flags.printPost = true;
+    else if (arg.startsWith('--since='))
+      flags.since = arg.slice('--since='.length);
+    else if (arg.startsWith('--fixture='))
+      flags.fixture = arg.slice('--fixture='.length);
+  }
+  return flags;
+}
+
+export async function main(argv = process.argv.slice(2), env = process.env) {
+  const flags = parseArgs(argv);
+  const base = env.SENTRY_BASE || DEFAULTS.base;
+  const org = env.SENTRY_ORG || DEFAULTS.org;
+  const statePath = env.SWEEP_STATE || DEFAULTS.state;
+  const maxLines = Number(env.SWEEP_MAX_LINES || DEFAULTS.maxLines);
+  const token = env.SENTRY_TOKEN || '';
+  const projects = parseProjects(env.SENTRY_PROJECTS || DEFAULTS.projects);
+  // PostHog mode engages on the project token alone (a public capture key,
+  // still never printed). A PostHog webhook destination relays the events into
+  // the Tlon channel — see docs/sentry-sweep.md.
+  const posthog = {
+    apiKey: env.POSTHOG_API_KEY || '',
+    url: env.POSTHOG_CAPTURE_URL || DEFAULTS.posthogCaptureUrl,
+    distinctId: env.POSTHOG_DISTINCT_ID || DEFAULTS.posthogDistinctId,
+  };
+  const posthogEnabled = Boolean(posthog.apiKey);
+  // Direct-Tlon mode engages only when ALL four are set (the cookie is a secret
+  // and is never printed). Without them the script keeps its stdout-only behavior.
+  const post = {
+    url: (env.TLON_POST_URL || '').replace(/\/+$/, ''),
+    ship: env.TLON_POST_SHIP || '',
+    cookie: env.TLON_POST_COOKIE || '',
+    nest: env.TLON_POST_NEST || '',
+  };
+  const postEnabled = Boolean(
+    post.url && post.ship && post.cookie && post.nest
+  );
+  const now = new Date();
+  const state = loadState(statePath);
+
+  // Boundary = last-run time, optionally overridden by --since.
+  let boundary;
+  if (flags.since) {
+    boundary = new Date(flags.since);
+    if (Number.isNaN(boundary.getTime())) {
+      process.stderr.write('sentry-sweep failed: invalid --since value\n');
+      return 1;
+    }
+  } else if (state.lastRun) {
+    boundary = new Date(state.lastRun);
+    if (Number.isNaN(boundary.getTime()))
+      boundary = new Date(now.getTime() - 30 * MINUTE_MS);
+  } else {
+    boundary = new Date(now.getTime() - 30 * MINUTE_MS); // missing state -> last 30 min
+  }
+
+  // 24h clamp: Sentry statsPeriod is fixed at 24h, and a bot that was down for
+  // days should not try to sweep an unbounded window. Note the clamp in the header.
+  let clamped = false;
+  const floor = new Date(now.getTime() - DAY_MS);
+  if (boundary.getTime() < floor.getTime()) {
+    boundary = floor;
+    clamped = true;
+  }
+
+  let data;
+  try {
+    if (flags.fixture) {
+      data = JSON.parse(readFileSync(flags.fixture, 'utf8')); // no network
+    } else {
+      if (!token) throw new Error('SENTRY_TOKEN is required');
+      data = await fetchIssues({
+        base,
+        org,
+        token,
+        projects,
+        queries: buildQueries(boundary),
+      });
+    }
+  } catch (err) {
+    process.stderr.write(
+      `sentry-sweep failed: ${err?.message ?? String(err)}\n`
+    );
+    return 1; // do NOT update state on failure
+  }
+
+  const items = mergeIssues(data, state.reported, now);
+
+  if (items.length === 0) {
+    if (!flags.dryRun) saveState(statePath, nextState(state, [], now));
+    return 0; // nothing to report -> print nothing
+  }
+
+  const counts = computeCounts(
+    items,
+    projects.map((p) => p.label)
+  );
+  const digestOpts = { now, maxLines, org, counts, clamped };
+  const posthogOpts = { now, maxLines, org, distinctId: posthog.distinctId };
+  process.stdout.write(`${formatDigest(items, digestOpts)}\n`);
+
+  if (flags.dryRun) {
+    // --print-post: eyeball the exact JSON a real run would send, for whichever
+    // output modes are configured. The PostHog batch is printed without its
+    // api_key; the poke body carries ship/nest only — no URL, no cookie.
+    if (flags.printPost) {
+      if (!posthogEnabled && (!post.ship || !post.nest)) {
+        process.stderr.write(
+          'sentry-sweep failed: --print-post requires POSTHOG_API_KEY, or TLON_POST_SHIP and TLON_POST_NEST\n'
+        );
+        return 1;
+      }
+      if (posthogEnabled) {
+        const payload = buildPosthogBatch(items, posthogOpts);
+        process.stdout.write(`${JSON.stringify(payload, null, 2)}\n`);
+      }
+      if (post.ship && post.nest) {
+        const body = buildPokeBody({
+          ship: post.ship,
+          nest: post.nest,
+          story: buildStory(items, digestOpts),
+          sent: Date.now(),
+        });
+        process.stdout.write(`${JSON.stringify(body, null, 2)}\n`);
+      }
+    }
+    return 0; // dry-run never posts and never writes state
+  }
+
+  // PostHog first, then the direct Tlon post; either failure aborts the run
+  // before the state is saved, so the next run re-reports this window.
+  if (posthogEnabled) {
+    try {
+      const { batch } = buildPosthogBatch(items, posthogOpts);
+      await postPosthogBatch({
+        url: posthog.url,
+        apiKey: posthog.apiKey,
+        batch,
+      });
+    } catch (err) {
+      process.stderr.write(
+        `sentry-sweep failed: ${err?.message ?? String(err)}\n`
+      );
+      return 1; // state NOT updated -> the next run re-reports this window
+    }
+  }
+
+  if (postEnabled) {
+    try {
+      await postStory({
+        ...post,
+        story: buildStory(items, digestOpts),
+        sent: Date.now(),
+      });
+    } catch (err) {
+      process.stderr.write(
+        `sentry-sweep failed: ${err?.message ?? String(err)}\n`
+      );
+      return 1; // state NOT updated -> the next run re-reports this window
+    }
+  }
+
+  // Mark every issue in the digest as reported (the header/“and N more” line
+  // announce the capped ones too), so the next run does not repeat them.
+  saveState(
+    statePath,
+    nextState(
+      state,
+      items.map((it) => it.id),
+      now
+    )
+  );
+  return 0;
+}
+
+// Run only when executed directly (not when imported by the test).
+if (
+  process.argv[1] &&
+  import.meta.url === pathToFileURL(process.argv[1]).href
+) {
+  main().then(
+    (code) => {
+      process.exitCode = code;
+    },
+    (err) => {
+      process.stderr.write(
+        `sentry-sweep failed: ${err?.message ?? String(err)}\n`
+      );
+      process.exitCode = 1;
+    }
+  );
+}

--- a/scripts/sentry-sweep.test.mjs
+++ b/scripts/sentry-sweep.test.mjs
@@ -21,6 +21,25 @@ const SCRIPT = join(
   dirname(fileURLToPath(import.meta.url)),
   'sentry-sweep.mjs'
 );
+
+// CLI tests must never deliver anything for real: strip every delivery and
+// Sentry credential from the inherited environment, then apply per-test values.
+const DELIVERY_ENV_KEYS = [
+  'SENTRY_TOKEN',
+  'POSTHOG_API_KEY',
+  'POSTHOG_CAPTURE_URL',
+  'POSTHOG_DISTINCT_ID',
+  'TLON_POST_URL',
+  'TLON_POST_SHIP',
+  'TLON_POST_COOKIE',
+  'TLON_POST_NEST',
+];
+function childEnv(overrides = {}) {
+  const env = { ...process.env };
+  for (const key of DELIVERY_ENV_KEYS) delete env[key];
+  return { ...env, ...overrides };
+}
+
 const NOW = new Date('2026-09-09T16:30:00Z');
 const iso = (msAgo) => new Date(NOW.getTime() - msAgo).toISOString();
 const H = 60 * 60 * 1000;
@@ -171,7 +190,7 @@ test('CLI --fixture --dry-run prints a digest without writing state', () => {
   const out = execFileSync(
     'node',
     [SCRIPT, `--fixture=${fixture}`, '--dry-run', `--since=${since}`],
-    { env: { ...process.env, SWEEP_STATE: statePath }, encoding: 'utf8' }
+    { env: childEnv({ SWEEP_STATE: statePath }), encoding: 'utf8' }
   );
   assert.match(out, /^Sentry sweep /);
   assert.match(
@@ -203,7 +222,7 @@ test('CLI --fixture writes state, then dedupes to empty stdout on the next run',
       },
     })
   );
-  const env = { ...process.env, SWEEP_STATE: statePath };
+  const env = childEnv({ SWEEP_STATE: statePath });
   const since = new Date(Date.now() - H).toISOString();
   const run = () =>
     execFileSync('node', [SCRIPT, `--fixture=${fixture}`, `--since=${since}`], {
@@ -390,7 +409,7 @@ test('CLI --dry-run --print-post prints the poke body without writing state', ()
       `--since=${since}`,
     ],
     {
-      env: { ...process.env, SWEEP_STATE: statePath, ...POST_ENV },
+      env: childEnv({ SWEEP_STATE: statePath, ...POST_ENV }),
       encoding: 'utf8',
     }
   );
@@ -447,13 +466,12 @@ test('CLI post failure exits 1 and leaves the state file unchanged', () => {
   let err = null;
   try {
     execFileSync('node', [SCRIPT, `--fixture=${fixture}`, `--since=${since}`], {
-      env: {
-        ...process.env,
+      env: childEnv({
         SWEEP_STATE: statePath,
         ...POST_ENV,
         TLON_POST_URL: 'http://127.0.0.1:9',
         TLON_POST_COOKIE: 'sentinel-cookie-value',
-      },
+      }),
       encoding: 'utf8',
     });
   } catch (e) {
@@ -615,7 +633,7 @@ test('CLI --dry-run --print-post prints the PostHog batch without the key', () =
       `--since=${since}`,
     ],
     {
-      env: { ...process.env, SWEEP_STATE: statePath, ...POSTHOG_ENV },
+      env: childEnv({ SWEEP_STATE: statePath, ...POSTHOG_ENV }),
       encoding: 'utf8',
     }
   );
@@ -671,12 +689,11 @@ test('CLI PostHog failure exits 1 and leaves the state file unchanged', () => {
   let err = null;
   try {
     execFileSync('node', [SCRIPT, `--fixture=${fixture}`, `--since=${since}`], {
-      env: {
-        ...process.env,
+      env: childEnv({
         SWEEP_STATE: statePath,
         POSTHOG_API_KEY: 'sentinel-posthog-key',
         POSTHOG_CAPTURE_URL: 'http://127.0.0.1:9/batch/',
-      },
+      }),
       encoding: 'utf8',
     });
   } catch (e) {

--- a/scripts/sentry-sweep.test.mjs
+++ b/scripts/sentry-sweep.test.mjs
@@ -1,0 +1,691 @@
+// Fixture-driven tests, no network. Run: node --test sentry-sweep.test.mjs
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { execFileSync } from 'node:child_process';
+import { writeFileSync, mkdtempSync, readFileSync, existsSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join, dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import {
+  parseProjects,
+  buildQueries,
+  mergeIssues,
+  formatDigest,
+  nextState,
+  buildStory,
+  buildPokeBody,
+  buildPosthogBatch,
+} from './sentry-sweep.mjs';
+
+const SCRIPT = join(
+  dirname(fileURLToPath(import.meta.url)),
+  'sentry-sweep.mjs'
+);
+const NOW = new Date('2026-09-09T16:30:00Z');
+const iso = (msAgo) => new Date(NOW.getTime() - msAgo).toISOString();
+const H = 60 * 60 * 1000;
+const D = 24 * H;
+
+// (7) buildQueries: exact search strings, boundary without milliseconds.
+test('buildQueries formats both queries without milliseconds', () => {
+  const q = buildQueries('2026-09-09T15:00:00.000Z');
+  assert.equal(q.new, 'is:unresolved firstSeen:>2026-09-09T15:00:00');
+  assert.equal(q.regressed, 'is:regressed lastSeen:>2026-09-09T15:00:00');
+});
+
+test('parseProjects parses label=id pairs', () => {
+  assert.deepEqual(parseProjects('web=123,mobile=456'), [
+    { label: 'web', id: '123' },
+    { label: 'mobile', id: '456' },
+  ]);
+});
+
+// (1) an issue in both lists is reported once, as REGRESSED.
+test('mergeIssues reports an issue in both lists once as REGRESSED', () => {
+  const issue = {
+    id: '1',
+    shortId: 'X-1',
+    title: 'Boom',
+    count: '5',
+    userCount: 2,
+  };
+  const items = mergeIssues(
+    { web: { new: [issue], regressed: [{ ...issue }] } },
+    {},
+    NOW
+  );
+  assert.equal(items.length, 1);
+  assert.equal(items[0].kind, 'REGRESSED');
+  assert.equal(items[0].count, 5); // string count coerced to number
+});
+
+// (2) reported within 24h is skipped; older than 24h is not.
+test('mergeIssues dedupes against reported within 24h only', () => {
+  const data = {
+    web: {
+      new: [
+        { id: 'recent', title: 'r', count: 1, userCount: 1 },
+        { id: 'old', title: 'o', count: 1, userCount: 1 },
+      ],
+      regressed: [],
+    },
+  };
+  const reported = { recent: iso(1 * H), old: iso(25 * H) };
+  const items = mergeIssues(data, reported, NOW);
+  assert.deepEqual(
+    items.map((i) => i.id),
+    ['old']
+  );
+});
+
+// (3) sorting: regressed before new, then userCount desc, then count desc.
+test('mergeIssues sorts regressed-first then users desc then count desc', () => {
+  const data = {
+    web: {
+      new: [
+        { id: 'n1', title: 'n1', count: 10, userCount: 5 },
+        { id: 'n2', title: 'n2', count: 99, userCount: 1 },
+      ],
+      regressed: [
+        { id: 'r1', title: 'r1', count: 3, userCount: 2 },
+        { id: 'r2', title: 'r2', count: 50, userCount: 7 },
+      ],
+    },
+  };
+  const items = mergeIssues(data, {}, NOW);
+  assert.deepEqual(
+    items.map((i) => i.id),
+    ['r2', 'r1', 'n1', 'n2']
+  );
+});
+
+// (4) cap at maxLines emits the "and N more" line with the correct N.
+test('formatDigest caps detail lines and reports the remaining count', () => {
+  const items = Array.from({ length: 5 }, (_, i) => ({
+    id: String(i),
+    label: 'web',
+    kind: i < 2 ? 'REGRESSED' : 'NEW',
+    shortId: `S-${i}`,
+    title: `t${i}`,
+    count: i,
+    userCount: i,
+    permalink: `https://tlon-corporation.sentry.io/issues/${i}/`,
+  }));
+  const lines = formatDigest(items, {
+    now: NOW,
+    maxLines: 2,
+    org: 'tlon-corporation',
+  }).split('\n');
+  assert.equal(lines.length, 4); // header + 2 detail + "and more"
+  assert.match(
+    lines[0],
+    /^Sentry sweep 2026-09-09 16:30 UTC: 2 regressed, 3 new \(web 2\/3\)$/
+  );
+  assert.match(lines[3], /^… and 3 more: /);
+  assert.match(lines[3], /is%3Aregressed/);
+  assert.match(lines[3], /is%3Aunresolved%20is%3Anew/);
+});
+
+// (5) empty input -> empty string.
+test('formatDigest returns empty string for no items', () => {
+  assert.equal(formatDigest([], { now: NOW, org: 'tlon-corporation' }), '');
+});
+
+// (6) nextState prunes >7d entries and records printed ids.
+test('nextState prunes entries older than 7 days and records printed ids', () => {
+  const state = {
+    lastRun: iso(1 * H),
+    reported: { keep: iso(3 * D), drop: iso(8 * D) },
+  };
+  const next = nextState(state, ['p1', 'p2'], NOW);
+  assert.equal(next.lastRun, NOW.toISOString());
+  assert.equal(next.reported.p1, NOW.toISOString());
+  assert.equal(next.reported.p2, NOW.toISOString());
+  assert.equal(next.reported.keep, iso(3 * D));
+  assert.equal(next.reported.drop, undefined);
+});
+
+// Integration: --fixture + --dry-run prints a digest and writes no state.
+test('CLI --fixture --dry-run prints a digest without writing state', () => {
+  const dir = mkdtempSync(join(tmpdir(), 'sweep-'));
+  const fixture = join(dir, 'fx.json');
+  const statePath = join(dir, 'state.json');
+  writeFileSync(
+    fixture,
+    JSON.stringify({
+      web: {
+        new: [
+          {
+            id: '999',
+            shortId: 'JS-1',
+            title: 'Boom',
+            count: '3',
+            userCount: 2,
+          },
+        ],
+        regressed: [],
+      },
+    })
+  );
+  const since = new Date(Date.now() - H).toISOString();
+  const out = execFileSync(
+    'node',
+    [SCRIPT, `--fixture=${fixture}`, '--dry-run', `--since=${since}`],
+    { env: { ...process.env, SWEEP_STATE: statePath }, encoding: 'utf8' }
+  );
+  assert.match(out, /^Sentry sweep /);
+  assert.match(
+    out,
+    /NEW web JS-1 "Boom" 3 events \/ 2 users https:\/\/tlon-corporation\.sentry\.io\/issues\/999\//
+  );
+  assert.equal(existsSync(statePath), false); // dry-run must not write
+});
+
+// Integration: a real run records state and the next run dedupes to empty stdout.
+test('CLI --fixture writes state, then dedupes to empty stdout on the next run', () => {
+  const dir = mkdtempSync(join(tmpdir(), 'sweep-'));
+  const fixture = join(dir, 'fx.json');
+  const statePath = join(dir, 'state.json');
+  writeFileSync(
+    fixture,
+    JSON.stringify({
+      web: {
+        new: [
+          {
+            id: '777',
+            shortId: 'JS-2',
+            title: 'Once',
+            count: '1',
+            userCount: 1,
+          },
+        ],
+        regressed: [],
+      },
+    })
+  );
+  const env = { ...process.env, SWEEP_STATE: statePath };
+  const since = new Date(Date.now() - H).toISOString();
+  const run = () =>
+    execFileSync('node', [SCRIPT, `--fixture=${fixture}`, `--since=${since}`], {
+      env,
+      encoding: 'utf8',
+    });
+
+  assert.match(run(), /NEW web JS-2/);
+  const st = JSON.parse(readFileSync(statePath, 'utf8'));
+  assert.ok(st.reported['777']);
+  assert.equal(run(), ''); // already announced within 24h -> nothing to report
+});
+
+// ---------------------------------------------------------------------------
+// Post mode: buildStory/buildPokeBody pin the poke JSON without any network.
+// ---------------------------------------------------------------------------
+
+const POST_ITEMS = [
+  {
+    id: '100',
+    label: 'web',
+    kind: 'REGRESSED',
+    shortId: 'JS-100',
+    title: 'Cannot read property',
+    count: 5,
+    userCount: 2,
+    permalink: 'https://tlon-corporation.sentry.io/issues/100/',
+  },
+  {
+    id: '200',
+    label: 'mobile',
+    kind: 'NEW',
+    shortId: 'APP-200',
+    title: 'Crash on launch',
+    count: 9,
+    userCount: 4,
+    permalink: 'https://tlon-corporation.sentry.io/issues/200/',
+  },
+];
+
+// (a) one verse per digest line, header first, link inline = shortId/permalink.
+test('buildStory yields a header verse then one linked verse per item', () => {
+  const story = buildStory(POST_ITEMS, { now: NOW, org: 'tlon-corporation' });
+  assert.equal(story.length, 3); // header + 2 issue verses
+  assert.deepEqual(story[0], {
+    inline: [
+      'Sentry sweep 2026-09-09 16:30 UTC: 1 regressed, 1 new (web 1/0, mobile 0/1)',
+    ],
+  });
+  assert.deepEqual(story[1].inline, [
+    'REGRESSED web ',
+    {
+      link: {
+        href: 'https://tlon-corporation.sentry.io/issues/100/',
+        content: 'JS-100',
+      },
+    },
+    ' "Cannot read property" 5 events / 2 users',
+  ]);
+  assert.deepEqual(story[2].inline, [
+    'NEW mobile ',
+    {
+      link: {
+        href: 'https://tlon-corporation.sentry.io/issues/200/',
+        content: 'APP-200',
+      },
+    },
+    ' "Crash on launch" 9 events / 4 users',
+  ]);
+});
+
+// (b) the poke envelope matches the Eyre/%channels wire format exactly.
+test('buildPokeBody produces the exact channel-action-2 envelope', () => {
+  const story = [{ inline: ['hi'] }];
+  const body = buildPokeBody({
+    ship: 'sampel-palnet',
+    nest: 'chat/~litseb-sarfel/v1nnn22o',
+    story,
+    sent: 1757435400000,
+  });
+  assert.deepEqual(body, [
+    {
+      id: 1,
+      action: 'poke',
+      ship: 'sampel-palnet',
+      app: 'channels',
+      mark: 'channel-action-2',
+      json: {
+        channel: {
+          nest: 'chat/~litseb-sarfel/v1nnn22o',
+          action: {
+            post: {
+              add: {
+                content: story,
+                sent: 1757435400000,
+                author: '~sampel-palnet',
+                kind: '/chat',
+                meta: null,
+                blob: null,
+              },
+            },
+          },
+        },
+      },
+    },
+  ]);
+  // A sigged ship is normalized: bare in `ship`, sigged in `author`.
+  const sigged = buildPokeBody({
+    ship: '~sampel-palnet',
+    nest: 'n',
+    story,
+    sent: 1,
+  });
+  assert.equal(sigged[0].ship, 'sampel-palnet');
+  assert.equal(sigged[0].json.channel.action.post.add.author, '~sampel-palnet');
+});
+
+// (c) the "and N more" verse carries the regressed + new query links.
+test('buildStory "and N more" verse carries two links', () => {
+  const items = Array.from({ length: 4 }, (_, i) => ({
+    id: String(i),
+    label: 'web',
+    kind: 'NEW',
+    shortId: `S-${i}`,
+    title: `t${i}`,
+    count: 1,
+    userCount: 1,
+    permalink: `https://tlon-corporation.sentry.io/issues/${i}/`,
+  }));
+  const story = buildStory(items, {
+    now: NOW,
+    maxLines: 2,
+    org: 'tlon-corporation',
+  });
+  assert.equal(story.length, 4); // header + 2 shown + "and more"
+  const last = story[3].inline;
+  assert.equal(last[0], '… and 2 more: ');
+  const links = last.filter((i) => typeof i === 'object' && i.link);
+  assert.equal(links.length, 2);
+  assert.equal(links[0].link.content, 'regressed');
+  assert.match(links[0].link.href, /is%3Aregressed/);
+  assert.equal(links[1].link.content, 'new');
+  assert.match(links[1].link.href, /is%3Aunresolved%20is%3Anew/);
+});
+
+const POST_ENV = {
+  TLON_POST_URL: 'https://example.invalid',
+  TLON_POST_SHIP: 'sampel-palnet',
+  TLON_POST_COOKIE: 'dummy-cookie-sentinel',
+  TLON_POST_NEST: 'chat/~sampel-palnet/test',
+};
+
+// (d) --dry-run --print-post prints the poke JSON and writes no state.
+test('CLI --dry-run --print-post prints the poke body without writing state', () => {
+  const dir = mkdtempSync(join(tmpdir(), 'sweep-'));
+  const fixture = join(dir, 'fx.json');
+  const statePath = join(dir, 'state.json');
+  writeFileSync(
+    fixture,
+    JSON.stringify({
+      web: {
+        new: [
+          {
+            id: '999',
+            shortId: 'JS-1',
+            title: 'Boom',
+            count: '3',
+            userCount: 2,
+            permalink: 'https://tlon-corporation.sentry.io/issues/999/',
+          },
+        ],
+        regressed: [],
+      },
+    })
+  );
+  const since = new Date(Date.now() - H).toISOString();
+  const out = execFileSync(
+    'node',
+    [
+      SCRIPT,
+      `--fixture=${fixture}`,
+      '--dry-run',
+      '--print-post',
+      `--since=${since}`,
+    ],
+    {
+      env: { ...process.env, SWEEP_STATE: statePath, ...POST_ENV },
+      encoding: 'utf8',
+    }
+  );
+  assert.match(out, /^Sentry sweep /m); // digest still prints, first
+  const body = JSON.parse(out.slice(out.indexOf('\n[') + 1));
+  assert.equal(body.length, 1);
+  assert.equal(body[0].id, 1);
+  assert.equal(body[0].action, 'poke');
+  assert.equal(body[0].ship, 'sampel-palnet');
+  assert.equal(body[0].app, 'channels');
+  assert.equal(body[0].mark, 'channel-action-2');
+  assert.equal(body[0].json.channel.nest, 'chat/~sampel-palnet/test');
+  const add = body[0].json.channel.action.post.add;
+  assert.equal(add.author, '~sampel-palnet');
+  assert.equal(add.kind, '/chat');
+  assert.deepEqual(add.meta, null);
+  assert.deepEqual(add.blob, null);
+  assert.equal(typeof add.sent, 'number');
+  assert.equal(add.content[1].inline[1].link.content, 'JS-1');
+  assert.equal(
+    add.content[1].inline[1].link.href,
+    'https://tlon-corporation.sentry.io/issues/999/'
+  );
+  assert.equal(existsSync(statePath), false); // dry-run must not write
+  assert.equal(out.includes('dummy-cookie-sentinel'), false);
+});
+
+// (e) a failed post exits 1, leaves the state file untouched (so the next run
+// re-reports), and never leaks the cookie. 127.0.0.1:9 refuses the connection.
+test('CLI post failure exits 1 and leaves the state file unchanged', () => {
+  const dir = mkdtempSync(join(tmpdir(), 'sweep-'));
+  const fixture = join(dir, 'fx.json');
+  const statePath = join(dir, 'state.json');
+  writeFileSync(
+    fixture,
+    JSON.stringify({
+      web: {
+        new: [
+          {
+            id: '555',
+            shortId: 'JS-5',
+            title: 'Post fail',
+            count: '1',
+            userCount: 1,
+          },
+        ],
+        regressed: [],
+      },
+    })
+  );
+  const before = `${JSON.stringify({ lastRun: iso(1 * H), reported: {} }, null, 2)}\n`;
+  writeFileSync(statePath, before);
+  const since = new Date(Date.now() - H).toISOString();
+  let err = null;
+  try {
+    execFileSync('node', [SCRIPT, `--fixture=${fixture}`, `--since=${since}`], {
+      env: {
+        ...process.env,
+        SWEEP_STATE: statePath,
+        ...POST_ENV,
+        TLON_POST_URL: 'http://127.0.0.1:9',
+        TLON_POST_COOKIE: 'sentinel-cookie-value',
+      },
+      encoding: 'utf8',
+    });
+  } catch (e) {
+    err = e;
+  }
+  assert.ok(err, 'expected a non-zero exit');
+  assert.equal(err.status, 1);
+  assert.match(err.stderr, /^sentry-sweep failed: post /m);
+  assert.equal(err.stderr.includes('sentinel-cookie-value'), false);
+  assert.equal(err.stdout.includes('sentinel-cookie-value'), false);
+  assert.equal(readFileSync(statePath, 'utf8'), before); // untouched
+});
+
+// ---------------------------------------------------------------------------
+// PostHog mode: buildPosthogBatch pins the event JSON without any network.
+// ---------------------------------------------------------------------------
+
+// The exact property set a destination may rely on, in emission order.
+const POSTHOG_PROPS = [
+  '$lib',
+  '$process_person_profile',
+  'kind',
+  'project',
+  'shortId',
+  'title',
+  'count',
+  'userCount',
+  'permalink',
+  'text',
+  'sweepRunAt',
+];
+const BATCH_OPTS = { now: NOW, maxLines: 15, org: 'tlon-corporation' };
+
+// (a) one event per printed line, exact properties, `text` without the short id.
+test('buildPosthogBatch yields one event per item with the exact properties', () => {
+  const built = buildPosthogBatch(POST_ITEMS, {
+    ...BATCH_OPTS,
+    distinctId: 'sentry-sweep',
+  });
+  assert.equal(built.api_key, undefined); // the caller adds the key
+  assert.equal('api_key' in JSON.parse(JSON.stringify(built)), false);
+  assert.equal(built.batch.length, 2); // under the cap -> no MORE event
+  assert.deepEqual(built.batch[0], {
+    event: 'Sentry Issue Alert',
+    distinct_id: 'sentry-sweep',
+    timestamp: NOW.toISOString(),
+    properties: {
+      $lib: 'sentry-sweep',
+      $process_person_profile: false,
+      kind: 'REGRESSED',
+      project: 'web',
+      shortId: 'JS-100',
+      title: 'Cannot read property',
+      count: 5,
+      userCount: 2,
+      permalink: 'https://tlon-corporation.sentry.io/issues/100/',
+      text: 'REGRESSED web "Cannot read property" 5 events / 2 users',
+      sweepRunAt: NOW.toISOString(),
+    },
+  });
+  assert.deepEqual(Object.keys(built.batch[1].properties), POSTHOG_PROPS);
+  assert.equal(built.batch[1].properties.kind, 'NEW');
+  assert.equal(built.batch[1].properties.project, 'mobile');
+  assert.equal(built.batch[1].properties.text.includes('APP-200'), false);
+});
+
+// (a2) titles truncate exactly as they do in the digest.
+test('buildPosthogBatch truncates long titles like the digest', () => {
+  const long = 'x'.repeat(100);
+  const props = buildPosthogBatch([{ ...POST_ITEMS[0], title: long }], {
+    ...BATCH_OPTS,
+    distinctId: 'sentry-sweep',
+  }).batch[0].properties;
+  assert.equal(props.title, `${'x'.repeat(79)}…`);
+  assert.equal(
+    props.text,
+    `REGRESSED web "${'x'.repeat(79)}…" 5 events / 2 users`
+  );
+});
+
+// (a3) the MORE event appears only when the cap left issues unprinted.
+test('buildPosthogBatch appends a MORE event only when items exceed maxLines', () => {
+  const items = Array.from({ length: 4 }, (_, i) => ({
+    id: String(i),
+    label: 'web',
+    kind: i < 2 ? 'REGRESSED' : 'NEW',
+    shortId: `S-${i}`,
+    title: `t${i}`,
+    count: i,
+    userCount: i,
+    permalink: `https://tlon-corporation.sentry.io/issues/${i}/`,
+  }));
+  const capped = buildPosthogBatch(items, {
+    now: NOW,
+    maxLines: 2,
+    org: 'tlon-corporation',
+    distinctId: 'sentry-sweep',
+  });
+  assert.equal(capped.batch.length, 3); // 2 printed lines + MORE
+  const more = capped.batch[2].properties;
+  assert.deepEqual(Object.keys(more), POSTHOG_PROPS);
+  assert.equal(more.kind, 'MORE');
+  assert.equal(more.shortId, 'more');
+  assert.equal(more.text, '… and 2 more regressed/new issues');
+  assert.equal(
+    more.permalink,
+    'https://tlon-corporation.sentry.io/issues/?query=is%3Aregressed'
+  );
+  assert.equal(more.count, 0);
+  assert.equal(more.userCount, 0);
+  assert.equal(capped.batch[2].timestamp, NOW.toISOString());
+  // Exactly at the cap -> no MORE event.
+  const exact = buildPosthogBatch(items, {
+    now: NOW,
+    maxLines: 4,
+    org: 'tlon-corporation',
+    distinctId: 'sentry-sweep',
+  });
+  assert.equal(exact.batch.length, 4);
+  assert.equal(
+    exact.batch.some((e) => e.properties.kind === 'MORE'),
+    false
+  );
+});
+
+const POSTHOG_ENV = { POSTHOG_API_KEY: 'dummy-posthog-key-sentinel' };
+
+// (b) --dry-run --print-post prints the batch JSON, key omitted, no state.
+test('CLI --dry-run --print-post prints the PostHog batch without the key', () => {
+  const dir = mkdtempSync(join(tmpdir(), 'sweep-'));
+  const fixture = join(dir, 'fx.json');
+  const statePath = join(dir, 'state.json');
+  writeFileSync(
+    fixture,
+    JSON.stringify({
+      web: {
+        new: [
+          {
+            id: '999',
+            shortId: 'JS-1',
+            title: 'Boom',
+            count: '3',
+            userCount: 2,
+            permalink: 'https://tlon-corporation.sentry.io/issues/999/',
+          },
+        ],
+        regressed: [],
+      },
+    })
+  );
+  const since = new Date(Date.now() - H).toISOString();
+  const out = execFileSync(
+    'node',
+    [
+      SCRIPT,
+      `--fixture=${fixture}`,
+      '--dry-run',
+      '--print-post',
+      `--since=${since}`,
+    ],
+    {
+      env: { ...process.env, SWEEP_STATE: statePath, ...POSTHOG_ENV },
+      encoding: 'utf8',
+    }
+  );
+  assert.match(out, /^Sentry sweep /m); // digest still prints, first
+  const payload = JSON.parse(out.slice(out.indexOf('\n{') + 1));
+  assert.equal('api_key' in payload, false);
+  assert.equal(out.includes('api_key'), false);
+  assert.equal(out.includes('dummy-posthog-key-sentinel'), false);
+  assert.equal(payload.batch.length, 1);
+  const event = payload.batch[0];
+  assert.equal(event.event, 'Sentry Issue Alert');
+  assert.equal(event.distinct_id, 'sentry-sweep');
+  assert.equal(typeof event.timestamp, 'string');
+  assert.deepEqual(Object.keys(event.properties), POSTHOG_PROPS);
+  assert.equal(event.properties.$process_person_profile, false);
+  assert.equal(event.properties.kind, 'NEW');
+  assert.equal(event.properties.shortId, 'JS-1');
+  assert.equal(event.properties.text, 'NEW web "Boom" 3 events / 2 users');
+  assert.equal(
+    event.properties.permalink,
+    'https://tlon-corporation.sentry.io/issues/999/'
+  );
+  assert.equal(existsSync(statePath), false); // dry-run must not write
+});
+
+// (c) a failed PostHog post exits 1, leaves the state file untouched (so the
+// next run re-reports), and never leaks the key. 127.0.0.1:9 refuses the
+// connection.
+test('CLI PostHog failure exits 1 and leaves the state file unchanged', () => {
+  const dir = mkdtempSync(join(tmpdir(), 'sweep-'));
+  const fixture = join(dir, 'fx.json');
+  const statePath = join(dir, 'state.json');
+  writeFileSync(
+    fixture,
+    JSON.stringify({
+      web: {
+        new: [
+          {
+            id: '555',
+            shortId: 'JS-5',
+            title: 'Post fail',
+            count: '1',
+            userCount: 1,
+          },
+        ],
+        regressed: [],
+      },
+    })
+  );
+  const before = `${JSON.stringify({ lastRun: iso(1 * H), reported: {} }, null, 2)}\n`;
+  writeFileSync(statePath, before);
+  const since = new Date(Date.now() - H).toISOString();
+  let err = null;
+  try {
+    execFileSync('node', [SCRIPT, `--fixture=${fixture}`, `--since=${since}`], {
+      env: {
+        ...process.env,
+        SWEEP_STATE: statePath,
+        POSTHOG_API_KEY: 'sentinel-posthog-key',
+        POSTHOG_CAPTURE_URL: 'http://127.0.0.1:9/batch/',
+      },
+      encoding: 'utf8',
+    });
+  } catch (e) {
+    err = e;
+  }
+  assert.ok(err, 'expected a non-zero exit');
+  assert.equal(err.status, 1);
+  assert.match(err.stderr, /^sentry-sweep failed: posthog /m);
+  assert.equal(err.stderr.includes('sentinel-posthog-key'), false);
+  assert.equal(err.stdout.includes('sentinel-posthog-key'), false);
+  assert.equal(readFileSync(statePath, 'utf8'), before); // untouched
+});


### PR DESCRIPTION
## Summary

Adds a scheduled script that polls Sentry for new and regressed issues across the web and mobile projects and relays them into the Tlon alert channel through a PostHog webhook destination, since Sentry alert actions can't post to Tlon and giving GitHub Actions a ship cookie was ruled out. Part of TLON-6478.

## Changes

- `scripts/sentry-sweep.mjs`: dependency-free Node 22 script (built-in `fetch`/`fs`, no npm packages). Each run queries the Sentry org issues API for issues new (`is:unresolved firstSeen:>boundary`) or regressed (`is:regressed lastSeen:>boundary`) since the previous run, across the `javascript-react` (web) and `react-native` (mobile) projects, and prints a deterministic digest (header with counts, up to 15 issue lines, an "and N more" line). No model or inference involved.
- Delivery: when `POSTHOG_API_KEY` is set, sends one `Sentry Issue Alert` PostHog event per digest line to the PostHog batch endpoint. A PostHog HTTP-webhook destination ("Alert: Sentry sweep", already created in the Groups Mobile PRODUCTION project) relays each event as a chat post from `~botsen-lomlex` into the Tlon alert channel, using credentials PostHog already holds. A direct Eyre-posting mode also exists in the script (activates only if all four `TLON_POST_*` vars are set) but the workflow doesn't use it.
- State (`.sentry-sweep/state.json`: last boundary + reported issue ids) is kept in the GitHub Actions cache. Reported ids dedupe for 24h and are pruned after 7 days; a cache miss falls back to a 30-minute window, clamped to 24h. Any Sentry or PostHog failure exits 1 without saving state, so the next run re-reports the same window. Tokens, keys, and cookies never appear in output. Flags: `--dry-run`, `--since=`, `--fixture=` (offline JSON input), `--print-post` (prints the exact PostHog batch, key omitted).
- `.github/workflows/sentry-sweep.yml`: runs on a 10-minute cron, plus `workflow_dispatch` with a `dry_run` boolean (default true) and a `pull_request` trigger (on the sweep's own paths) that runs only the test job. The sweep job (Node 22, sparse checkout of `scripts/`, 5-minute timeout, non-overlapping concurrency group) restores the state cache, fails a non-dry run if the PostHog secret is empty, runs the script with `SENTRY_SWEEP_TOKEN` (read-only Sentry scopes) and `POST_HOG_API_KEY_PROD` (existing production mobile PostHog token), then saves the state cache.
- `scripts/sentry-sweep.test.mjs`: `node --test` suite covering the query/window, digest, state and PostHog batch logic, plus CLI behaviour via fixtures.
- `docs/sentry-sweep.md`: operational note covering schedule, secrets, dry-run procedure, state/dedupe semantics, the PostHog destination config, and a local-run recipe.

## How did I test?

- `node --test scripts/sentry-sweep.test.mjs`: 20 pass. Spot-checked with a few mutations (person-profile flag, short id leaking into `text`, swallowed PostHog failure); each broke a test.
- Live dry run against Sentry with a read-only token and `--print-post`: printed the current new issues and a correctly shaped, key-free PostHog batch.
- `pnpm format:check` passes; workflow YAML parses with the expected step order.
- Not yet exercised: a real GitHub Actions run. Planned after merge: one `workflow_dispatch` with `dry_run` checked (digest in the run log, nothing sent), then one with it unchecked for a real delivery.

## Risks and impact

- Safe to rollback without consulting PR author? Yes
- Affects important code area:
  - [ ] Onboarding
  - [ ] State / providers
  - [ ] Message sync
  - [ ] Channel display
  - [ ] Notifications
  - [x] Other: new CI/CD workflow + standalone script; no app code touched

Additional notes: a wrong or revoked Sentry token fails every run visibly in Actions (no alerts sent); a wrong PostHog key is silently dropped by PostHog, so the workflow's empty-key guard only catches the "unset" case, and the post-merge live dispatch is the real check. Alert volume is bounded (15 lines per run plus an "and N more" line, each issue repeats at most once per 24h). The PostHog destination posts into `chat/~litseb-sarfel/v1nnn22o`; disabling that destination stops delivery without touching this repo.

## Rollback plan

Disable the workflow (Actions → Sentry sweep → Disable workflow) or revert this PR; alternatively disable the PostHog destination to stop delivery. No data or schema changes.

## Screenshots / videos

N/A
