### PR TITLE
e2e: fix create-group quick-group failure from strict-mode .or()

### DIFF
--- a/apps/tlon-web/e2e/helpers.ts
+++ b/apps/tlon-web/e2e/helpers.ts
@@ -112,9 +112,14 @@ export async function createGroupWithTemplate(
   // Wait for group creation to complete and navigate to the group. Single-
   // channel groups open their channel directly, while multi-channel groups
   // without a remembered channel open the group channel list.
+  //
+  // `.first()` is required: on desktop the group channel-list pane and the
+  // channel pane render side by side, so both testIDs are present and a bare
+  // `.or()` trips strict mode instead of resolving.
   const groupDestination = page
     .getByTestId('ChannelHeaderTitle')
-    .or(page.getByTestId('GroupChannelsHeaderTrigger'));
+    .or(page.getByTestId('GroupChannelsHeaderTrigger'))
+    .first();
 
   try {
     // Wait briefly to see if we're automatically navigated to the group

--- a/packages/app/features/chat-list/ChatList.tsx
+++ b/packages/app/features/chat-list/ChatList.tsx
@@ -100,6 +100,12 @@ export const ChatList = React.memo(function ChatListComponent({
 
   // A single interactive chat row, shared by the virtualized rest-list and the
   // non-sort-mode pinned block in the header.
+  //
+  // The testIDs below fall back with `||`, not `??`: a quick group is created
+  // with an empty-string title (see `createDefaultGroup`), which `??` would
+  // keep, collapsing the testID to `ChatListItem--unpinned` while the row still
+  // renders as 'Untitled group'. Keep the group fallback in step with the
+  // rendered title and with `GroupListItem`.
   const renderChat = useCallback(
     (item: db.Chat) => {
       if (item.type === 'channel' && !item.isPending) {
@@ -109,7 +115,7 @@ export const ChatList = React.memo(function ChatListComponent({
             onPress={onPressItem}
             onLongPress={handleLongPress}
             hoverStyle={listItemHoverStyle}
-            testID={`ChatListItem-${item.channel.title ?? item.channel.id}-${item.pin ? 'pinned' : 'unpinned'}`}
+            testID={`ChatListItem-${item.channel.title || item.channel.id}-${item.pin ? 'pinned' : 'unpinned'}`}
           />
         );
       } else if (item.type === 'group' && !item.isPending) {
@@ -119,7 +125,7 @@ export const ChatList = React.memo(function ChatListComponent({
             onPress={onPressItem}
             onLongPress={handleLongPress}
             hoverStyle={listItemHoverStyle}
-            testID={`ChatListItem-${item.group.title ?? item.group.id}-${item.pin ? 'pinned' : 'unpinned'}`}
+            testID={`ChatListItem-${item.group.title || 'Untitled group'}-${item.pin ? 'pinned' : 'unpinned'}`}
           />
         );
       } else {


### PR DESCRIPTION
Fixes TLON-6518

## Summary

`create-group.spec.ts › should create a quick group with default single channel` has been failing on most PR E2E runs since #6450 merged at 17:19 UTC, including on branches that don't touch the web app (PR runs test the branch merged with develop, so every branch picked it up at once). Two separate faults compound; this fixes both.

## Changes

**1. `apps/tlon-web/e2e/helpers.ts` — the actual trigger.**

The `groupDestination` wait added in #6450 is:

```ts
page.getByTestId('ChannelHeaderTitle').or(page.getByTestId('GroupChannelsHeaderTrigger'))
```

On desktop the group channel-list pane and the channel pane render **side by side**, so both testIDs are present and the locator resolves to two elements. That's a strict-mode violation, not a timeout — from the failing run's trace:

```
Error: strict mode violation: getByTestId('ChannelHeaderTitle').or(getByTestId('GroupChannelsHeaderTrigger')) resolved to 2 elements:
    1) <div data-testid="GroupChannelsHeaderTrigger" …>
    2) <div data-testid="ChannelHeaderTitle" …>
```

Whether the second pane has rendered when the locator first resolves is a race, which is why the failure is intermittent rather than deterministic. **Navigation itself works correctly — there is no product regression here.** Fixed with `.first()`.

**2. `packages/app/features/chat-list/ChatList.tsx` — why the fallback couldn't rescue it.**

The strict-mode throw lands in the `catch`, whose fallback looks for `ChatListItem-Untitled group-unpinned`. `ChatList` built that testID with `item.group.title ?? item.group.id`. `??` does not fall back on an *empty string*, and `createDefaultGroup` gives a quick group `title: params.title ?? ''`. So the row rendered as "Untitled group" (via the separate `'Untitled group'` fallback in `getGroupTitle`) while carrying the testID `ChatListItem--unpinned` — confirmed verbatim in the trace.

The fallback path could therefore *never* succeed for a quick group, turning a recoverable race into a hard failure. Switched to `||` with the same `'Untitled group'` fallback the row renders, matching `GroupListItem.tsx:155`, which already gets this right. The channel branch had the same latent empty-string collapse and now uses `||` too.

Fixing the testID rather than loosening the assertion means the fallback path becomes a genuine safety net instead of dead code.

## How did I test?

- Confirmed the mechanism from CI artifacts rather than by guessing: extracted `trace.zip` from run 34386667010 and read the action log. The try-block `expect` fails with a strict-mode violation (not the assumed timeout), and the rendered testID in the DOM snapshot is literally `ChatListItem--unpinned`.
- Confirmed from the failure screenshot that the group is created and rendered in the chat list as "Untitled group" — only the locator fails to match.
- Verified the timeline: no `create-group` failures in runs sampled before 17:19; the failure appears across five unrelated branches afterwards, with intermittent passes (e.g. 18:10, 18:36) consistent with a render-timing race.
- `oxfmt` clean on both files.
- Not run locally: `tsc` and the E2E suite — this worktree has no `node_modules`. The TS change is a `??`→`||` swap inside a template literal on a `string | null` column, so it carries no type risk; the E2E behaviour is what CI will exercise on this PR.

## Risks and impact

- Safe to rollback without consulting PR author? **Yes**
- Affects important code area:
  - [x] Other: E2E test helper, plus a testID string in the chat list. No product behaviour changes — testIDs are not rendered to users, and the visible row title was already "Untitled group".

## Rollback plan

Revert this commit. The test returns to failing intermittently on most PR runs; nothing user-facing is affected.

## Screenshots / videos

The failure screenshot shows the group present and labelled "Untitled group", so only the locator was wrong. It's in the `e2e-test-results` artifact of run 34386667010, at `shard-2/create-group-should-create-371d4-with-default-single-channel-chromium/test-failed-1.png`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)