### PR TITLE
add native reliability tests and fix issues they exposed

### DIFF
--- a/.maestro/reliability/README.md
+++ b/.maestro/reliability/README.md
@@ -31,3 +31,14 @@ settings restores the original theme on success.
 
 Multi-ship delivery, DMs, notifications, media, extended onboarding/recovery, and
 advanced collaborative notebook cases remain outside this suite.
+
+The EAS workflow `apps/tlon-mobile/.eas/workflows/e2e-nightly-ios.yml` runs this
+suite on `develop` nightly at 07:00 UTC and supports manual runs. It has no push
+or pull-request trigger. It reuses the nightly iOS build and builds an Android
+APK; Android tests follow iOS even if iOS fails. The existing smoke alert reports
+smoke results; reliability failures appear in EAS and Maestro Cloud.
+
+The production EAS environment supplies the test credentials for `~batbet-litnec`.
+Keep one Cloud device per platform for this shared account and avoid overlapping
+manual runs: Cloud can parallelize flows within a suite. The suite list comes
+from `config.yaml`, so later default journeys run nightly too.

--- a/.maestro/reliability/README.md
+++ b/.maestro/reliability/README.md
@@ -1,0 +1,33 @@
+# Native reliability tests
+
+Twelve single-ship journeys for chat, message actions, search, history, links,
+groups, channels, notebook, gallery, profile, settings, and relaunch persistence.
+These cover a subset of the QA checklist, not the entire workbook.
+
+Use Maestro 2.6.1 and an installed build containing this branch's app changes.
+Load credentials from your secret store into the environment; do not put them in
+tracked files or command arguments:
+
+- `MAESTRO_APP_ID`: the installed app's bundle/application ID.
+- `MAESTRO_TEST_SHIP`: the expected isolated test ship, including `~`.
+- `MAESTRO_RUN_TAG`: a unique tag containing only letters, numbers, and hyphens.
+- `MAESTRO_EMAIL` and `MAESTRO_PASSWORD`: the hosted test account credentials.
+  Alternatively, use `MAESTRO_LOGIN_URL` and `MAESTRO_LOGIN_CODE` for self-hosting.
+
+From the repository root, with an explicit device ID:
+
+```sh
+maestro --udid DEVICE_ID test .maestro/reliability
+maestro --udid DEVICE_ID test .maestro/reliability/chat.yaml
+```
+
+By default every journey clears local app state and logs in. Set
+`MAESTRO_SESSION=warm` to retain an existing login; the app still restarts and the
+flow verifies the ship identity before modifying data. Do not run concurrent
+profile/settings journeys against the same account. These tests create private
+groups and posts that remain on the ship; only the lifecycle tests delete their
+own fixtures. Profile restores the original nickname in its completion hook;
+settings restores the original theme on success.
+
+Multi-ship delivery, DMs, notifications, media, extended onboarding/recovery, and
+advanced collaborative notebook cases remain outside this suite.

--- a/.maestro/reliability/channels.yaml
+++ b/.maestro/reliability/channels.yaml
@@ -1,0 +1,130 @@
+appId: ${MAESTRO_APP_ID}
+name: Native channel lifecycle
+tags: [regression]
+env:
+  JOURNEY: m
+---
+- runScript: data.js
+- runFlow: subflows/begin.yaml
+- runFlow: subflows/create-group.yaml
+- tapOn: '^Edit channels$'
+- assertVisible: '^Channels$'
+- tapOn: '^New$'
+- tapOn: '^New channel$'
+- assertVisible: '^Create a new channel$'
+- tapOn:
+    id: ChannelTitleInput
+- inputText: ${MAESTRO_RUN_TAG + ' channel'}
+- assertVisible:
+    id: ChannelTitleInput
+    text: ${MAESTRO_RUN_TAG + ' channel'}
+- runFlow:
+    when:
+      platform: Android
+    commands:
+      - hideKeyboard
+- runFlow:
+    when:
+      platform: iOS
+    commands:
+      - pressKey: Enter
+      - scroll
+- tapOn: '^Create channel$'
+- extendedWaitUntil:
+    notVisible: '^Create a new channel$'
+    timeout: 5000
+- extendedWaitUntil:
+    visible: ${MAESTRO_RUN_TAG + ' channel'}
+    timeout: 5000
+- tapOn: '^Back$'
+- assertVisible: ${output.reliability.groupPattern}
+- tapOn: ${MAESTRO_RUN_TAG + ' channel'}
+- runFlow:
+    file: subflows/send.yaml
+    env:
+      MESSAGE: ${output.reliability.text}
+      MESSAGE_PATTERN: ${output.reliability.textPattern}
+      EMPTY_INPUT: '^Message$'
+- hideKeyboard
+- tapOn: '^Back$'
+- assertVisible: ${output.reliability.groupPattern}
+- tapOn: ${MAESTRO_RUN_TAG + ' channel'}
+- assertVisible: ${output.reliability.textPattern}
+- tapOn: ${MAESTRO_RUN_TAG + ' channel'}
+- tapOn: '^(Rename|Edit)$'
+- tapOn:
+    id: ChannelTitleInput
+    point: '95%,50%'
+- eraseText: 30
+- inputText: ${MAESTRO_RUN_TAG + ' renamed'}
+- assertVisible:
+    id: ChannelTitleInput
+    text: ${MAESTRO_RUN_TAG + ' renamed'}
+- tapOn:
+    id: ChannelDescriptionInput
+- inputText: ${MAESTRO_RUN_TAG + ' description'}
+- tapOn: '^Save$'
+- assertVisible: ${MAESTRO_RUN_TAG + ' renamed'}
+- tapOn: '^(Rename|Edit)$'
+- assertVisible:
+    id: ChannelTitleInput
+    text: ${MAESTRO_RUN_TAG + ' renamed'}
+- assertVisible:
+    id: ChannelDescriptionInput
+    text: ${MAESTRO_RUN_TAG + ' description'}
+- tapOn: '^Back$'
+- tapOn: '^Back$'
+- assertVisible: ${output.reliability.textPattern}
+- tapOn: ${MAESTRO_RUN_TAG + ' renamed'}
+- scrollUntilVisible:
+    element:
+      id: ChannelLeaveAction-Delete channel
+    direction: DOWN
+    timeout: 5000
+- tapOn:
+    id: ChannelLeaveAction-Delete channel
+- assertVisible: "^Delete ${MAESTRO_RUN_TAG} renamed[?]$"
+- tapOn: '(?i)^Cancel$'
+- assertVisible: ${MAESTRO_RUN_TAG + ' renamed'}
+- tapOn:
+    id: ChannelLeaveAction-Delete channel
+- assertVisible: "^Delete ${MAESTRO_RUN_TAG} renamed[?]$"
+- runFlow:
+    when:
+      platform: iOS
+    commands:
+      - tapOn:
+          text: '^Delete channel$'
+          above: '^Cancel$'
+- runFlow:
+    when:
+      platform: Android
+    commands:
+      - tapOn: '(?i)^Delete channel$'
+- extendedWaitUntil:
+    notVisible: ${MAESTRO_RUN_TAG + ' renamed'}
+    timeout: 5000
+- tapOn: '^Back$'
+- runFlow:
+    when:
+      visible:
+        id: ScreenHeaderTitle
+        text: '^Home$'
+    commands:
+      - scrollUntilVisible:
+          element:
+            text: ${output.reliability.groupPattern}
+          direction: DOWN
+          timeout: 5000
+      - tapOn: ${output.reliability.groupPattern}
+- assertVisible: ${output.reliability.groupPattern}
+- assertNotVisible: ${MAESTRO_RUN_TAG + ' renamed'}
+- assertVisible: '^Chat$'
+- assertVisible: '^Gallery$'
+- assertVisible: '^Notebook$'
+- runFlow:
+    when:
+      notVisible: '^Home$'
+    commands:
+      - tapOn: '^Back$'
+- assertVisible: '^Home$'

--- a/.maestro/reliability/chat.yaml
+++ b/.maestro/reliability/chat.yaml
@@ -1,0 +1,74 @@
+appId: ${MAESTRO_APP_ID}
+name: Native chat smoke
+tags: [smoke, regression]
+env:
+  JOURNEY: c
+---
+- runScript: data.js
+- runFlow: subflows/begin.yaml
+- runFlow: subflows/create-group.yaml
+- tapOn: '^Chat$'
+- runFlow:
+    file: subflows/send.yaml
+    env:
+      MESSAGE: ${output.reliability.text}
+      MESSAGE_PATTERN: ${output.reliability.textPattern}
+      EMPTY_INPUT: '^Message$'
+# Exercise draft growth and exact text without an expensive history seed.
+- tapOn:
+    id: MessageInput
+- runFlow:
+    file: subflows/input.yaml
+    env:
+      INPUT_TEXT: "One\nTwo\nThree"
+- assertVisible:
+    id: MessageInput
+    text: '^One\nTwo\nThree$'
+- assertVisible:
+    id: MessageInputSendButton
+- hideKeyboard
+- assertVisible:
+    id: MessageInput
+    text: '^One\nTwo\nThree$'
+- tapOn:
+    id: MessageInput
+    point: '95%,90%'
+- eraseText: 100
+- assertVisible:
+    id: MessageInput
+    text: '^Message$'
+- hideKeyboard
+- longPressOn: ${output.reliability.textPattern}
+- tapOn: '^Reply$'
+- assertVisible:
+    id: MessageInput
+    text: '^Reply$'
+- assertVisible: ${output.reliability.textPattern}
+- runFlow:
+    file: subflows/send.yaml
+    env:
+      MESSAGE: ${output.reliability.reply}
+      MESSAGE_PATTERN: ${output.reliability.replyPattern}
+      EMPTY_INPUT: '^Reply$'
+- hideKeyboard
+- tapOn: '^Back$'
+- assertVisible:
+    id: MessageInput
+    text: '^Message$'
+- assertVisible: '^1 reply$'
+- assertNotVisible: ${output.reliability.replyPattern}
+- tapOn: '^1 reply$'
+- assertVisible: ${output.reliability.textPattern}
+- assertVisible: ${output.reliability.replyPattern}
+- assertVisible:
+    id: MessageInput
+    text: '^Reply$'
+- tapOn: '^Back$'
+- assertVisible:
+    id: MessageInput
+    text: '^Message$'
+- tapOn: '^Back$'
+- assertVisible: ${output.reliability.groupPattern}
+- tapOn: '^Back$'
+- assertVisible: '^Home$'
+- assertVisible: ${output.reliability.groupPattern}

--- a/.maestro/reliability/config.yaml
+++ b/.maestro/reliability/config.yaml
@@ -1,0 +1,13 @@
+flows:
+  - chat.yaml
+  - settings.yaml
+  - relaunch.yaml
+  - notebook.yaml
+  - gallery.yaml
+  - message-actions.yaml
+  - search.yaml
+  - history.yaml
+  - home-groups.yaml
+  - profile.yaml
+  - channels.yaml
+  - links.yaml

--- a/.maestro/reliability/data.js
+++ b/.maestro/reliability/data.js
@@ -1,0 +1,51 @@
+function exact(value) {
+  return '^' + value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&') + '$';
+}
+if (!/^~[a-z]+(?:-[a-z]+)*$/.test(MAESTRO_TEST_SHIP))
+  throw new Error('Expected test ship is required');
+if (!/^[A-Za-z0-9-]+$/.test(MAESTRO_RUN_TAG))
+  throw new Error('A unique run tag is required');
+output.reliability = {
+  hosted: typeof MAESTRO_EMAIL !== 'undefined' && !!MAESTRO_EMAIL,
+  session: typeof MAESTRO_SESSION === 'undefined' ? 'fresh' : MAESTRO_SESSION,
+  group: 'QA-' + MAESTRO_RUN_TAG + '-' + JOURNEY,
+  text: MAESTRO_RUN_TAG + ' message',
+  editedText: MAESTRO_RUN_TAG + ' edited',
+  reply: MAESTRO_RUN_TAG + ' reply',
+  title: MAESTRO_RUN_TAG + ' note',
+  body: MAESTRO_RUN_TAG + ' body',
+  shipPattern: exact(MAESTRO_TEST_SHIP),
+};
+output.reliability.groupPattern = exact(output.reliability.group);
+output.reliability.editedTextPattern = exact(
+  output.reliability.editedText
+).replace(/\$$/, ' ?$');
+output.reliability.textPattern = exact(output.reliability.text + ' ').replace(
+  / \$$/,
+  ' ?$'
+);
+output.reliability.replyPattern = exact(output.reliability.reply + ' ').replace(
+  / \$$/,
+  ' ?$'
+);
+
+if (
+  output.reliability.session !== 'fresh' &&
+  output.reliability.session !== 'warm'
+)
+  throw new Error('Use fresh or warm session');
+if (output.reliability.session === 'fresh') {
+  if (output.reliability.hosted) {
+    if (typeof MAESTRO_PASSWORD === 'undefined' || !MAESTRO_PASSWORD)
+      throw new Error('Fresh hosted setup requires a test account password');
+  } else if (
+    typeof MAESTRO_LOGIN_URL === 'undefined' ||
+    !MAESTRO_LOGIN_URL ||
+    typeof MAESTRO_LOGIN_CODE === 'undefined' ||
+    !MAESTRO_LOGIN_CODE
+  ) {
+    throw new Error(
+      'Fresh setup requires hosted credentials or a ship URL and access code'
+    );
+  }
+}

--- a/.maestro/reliability/gallery.yaml
+++ b/.maestro/reliability/gallery.yaml
@@ -1,0 +1,38 @@
+appId: ${MAESTRO_APP_ID}
+name: Native Gallery text post
+tags: [regression]
+env:
+  JOURNEY: g
+---
+- runScript: data.js
+- runFlow: subflows/begin.yaml
+- runFlow: subflows/create-group.yaml
+- tapOn: '^Gallery$'
+- tapOn: '^New$'
+- tapOn: '^Text$'
+- extendedWaitUntil:
+    visible: '^Write something …\n?$'
+    timeout: 5000
+- tapOn: '^Write something …\n?$'
+- runFlow:
+    file: subflows/input.yaml
+    env:
+      INPUT_TEXT: ${output.reliability.text}
+- tapOn: '^Post$'
+- extendedWaitUntil:
+    visible: ${output.reliability.textPattern}
+    timeout: 5000
+- tapOn: '^0$'
+- assertVisible: ${output.reliability.textPattern}
+- runFlow:
+    file: subflows/send.yaml
+    env:
+      MESSAGE: ${output.reliability.reply}
+      MESSAGE_PATTERN: ${output.reliability.replyPattern}
+      EMPTY_INPUT: '^Reply$'
+- hideKeyboard
+- tapOn: '^Back$'
+- tapOn: '^Back$'
+- assertVisible: ${output.reliability.groupPattern}
+- tapOn: '^Back$'
+- assertVisible: '^Home$'

--- a/.maestro/reliability/history.yaml
+++ b/.maestro/reliability/history.yaml
@@ -1,0 +1,77 @@
+appId: ${MAESTRO_APP_ID}
+name: Native history and return to latest
+tags: [regression]
+env:
+  JOURNEY: h
+---
+- runScript: data.js
+- runFlow: subflows/begin.yaml
+- runFlow: subflows/create-group.yaml
+- tapOn: '^Chat$'
+- evalScript: ${output.reliability.historyIndex = 0}
+# Eight six-line posts put the oldest message more than one screen from latest.
+- repeat:
+    times: 8
+    commands:
+      - evalScript: ${output.reliability.historyIndex += 1}
+      - runFlow:
+          file: subflows/send.yaml
+          env:
+            MESSAGE: ${'x\nx\nx\nx\nx\n' + output.reliability.historyIndex}
+            MESSAGE_PATTERN: '^${output.reliability.historyIndex} ?$'
+            EMPTY_INPUT: '^Message$'
+- runFlow:
+    when:
+      platform: Android
+    commands:
+      - hideKeyboard
+- assertVisible:
+    id: Post
+    containsDescendants:
+      - text: '^8 ?$'
+- scrollUntilVisible:
+    element:
+      id: Post
+      containsDescendants:
+        - text: '^1 ?$'
+    direction: UP
+    timeout: 20000
+- assertNotVisible:
+    id: Post
+    containsDescendants:
+      - text: '^8 ?$'
+- assertVisible:
+    id: ScrollToBottomButton
+# A keyboard transition while reading history must preserve the old message.
+- tapOn:
+    id: MessageInput
+- runFlow:
+    when:
+      platform: iOS
+    commands:
+      - assertVisible:
+          id: Return
+      # Maestro hideKeyboard swipes the list; tap the visible text instead.
+      - tapOn: '^1 ?$'
+      - assertNotVisible:
+          id: Return
+- runFlow:
+    when:
+      platform: Android
+    commands:
+      - hideKeyboard
+- assertVisible:
+    id: Post
+    containsDescendants:
+      - text: '^1 ?$'
+- tapOn:
+    id: ScrollToBottomButton
+- assertVisible:
+    id: Post
+    containsDescendants:
+      - text: '^8 ?$'
+- assertNotVisible:
+    id: ScrollToBottomButton
+- tapOn: '^Back$'
+- tapOn: '^Back$'
+- assertVisible: '^Home$'

--- a/.maestro/reliability/home-groups.yaml
+++ b/.maestro/reliability/home-groups.yaml
@@ -1,0 +1,110 @@
+appId: ${MAESTRO_APP_ID}
+name: Native Home filters and group controls
+tags: [regression]
+env:
+  JOURNEY: o
+---
+- runScript: data.js
+- runFlow: subflows/begin.yaml
+- runFlow: subflows/create-group.yaml
+- tapOn: '^Back$'
+- tapOn: '^Groups$'
+- tapOn: '^Search$'
+- inputText: ${MAESTRO_RUN_TAG}
+- assertVisible: ${output.reliability.groupPattern}
+- tapOn: '^Messages$'
+- assertVisible: '^No results found\.$'
+- assertNotVisible: ${output.reliability.groupPattern}
+- tapOn: '^Try in All\?$'
+- assertVisible: ${output.reliability.groupPattern}
+- tapOn: '^Clear$'
+- tapOn: '^Filter by name$'
+- inputText: qzxqzxqzxqzx
+- assertVisible: '^qzxqzxqzxqzx$'
+- assertVisible: '^No results found\.$'
+- tapOn: '^Clear search$'
+- tapOn: '^Filter by name$'
+- inputText: ${MAESTRO_RUN_TAG}
+- assertVisible: ${output.reliability.groupPattern}
+- pressKey: Enter
+- longPressOn: ${output.reliability.groupPattern}
+- tapOn: '^Pin$'
+- tapOn: '^Clear$'
+- tapOn: '^Close$'
+- assertVisible:
+    text: ${output.reliability.groupPattern}
+    below: '^Pinned$'
+- longPressOn: ${output.reliability.groupPattern}
+- tapOn: '^Group info & settings$'
+- assertVisible: '^Group info & settings$'
+- tapOn: '^Unpin$'
+- assertVisible: '^Pin$'
+- tapOn: '^Rename$'
+- tapOn:
+    id: GroupTitleInput
+    point: '95%,50%'
+- eraseText: 30
+- inputText: ${output.reliability.group + ' renamed'}
+- assertVisible:
+    id: GroupTitleInput
+    text: ${output.reliability.group + ' renamed'}
+- tapOn:
+    id: GroupDescriptionInput
+- inputText: ${MAESTRO_RUN_TAG + ' description'}
+- assertVisible:
+    id: GroupDescriptionInput
+    text: ${MAESTRO_RUN_TAG + ' description'}
+- tapOn: '^Save$'
+- assertVisible: ${output.reliability.group + ' renamed'}
+- assertVisible: ${MAESTRO_RUN_TAG + ' description'}
+- tapOn: '^Rename$'
+- assertVisible:
+    id: GroupTitleInput
+    text: ${output.reliability.group + ' renamed'}
+- assertVisible:
+    id: GroupDescriptionInput
+    text: ${MAESTRO_RUN_TAG + ' description'}
+- tapOn: '^Back$'
+- tapOn: '^Back$'
+- assertVisible: '^Home$'
+- tapOn: '^Search$'
+- inputText: ${MAESTRO_RUN_TAG}
+- assertVisible: ${output.reliability.group + ' renamed'}
+- assertNotVisible: ${output.reliability.groupPattern}
+- pressKey: Enter
+# Delete only this run's group, and verify cancellation before confirming.
+- longPressOn: ${output.reliability.group + ' renamed'}
+- tapOn: '^Group info & settings$'
+- scrollUntilVisible:
+    element:
+      id: GroupLeaveAction-Delete group
+    direction: DOWN
+    timeout: 5000
+- tapOn:
+    id: GroupLeaveAction-Delete group
+- assertVisible: '^Delete ${output.reliability.group} renamed[?]$'
+- tapOn: '(?i)^Cancel$'
+- assertNotVisible: '^Delete ${output.reliability.group} renamed[?]$'
+- tapOn:
+    id: GroupLeaveAction-Delete group
+- assertVisible: '^Delete ${output.reliability.group} renamed[?]$'
+- runFlow:
+    when:
+      platform: iOS
+    commands:
+      - tapOn:
+          text: '^Delete group$'
+          rightOf: '^Cancel$'
+- runFlow:
+    when:
+      platform: Android
+    commands:
+      - tapOn: '(?i)^Delete group$'
+- extendedWaitUntil:
+    visible: '^Home$'
+    timeout: 5000
+- assertVisible: '^${MAESTRO_RUN_TAG}$'
+- assertNotVisible: ${output.reliability.group + ' renamed'}
+- tapOn: '^Clear$'
+- tapOn: '^Close$'
+- assertVisible: '^Home$'

--- a/.maestro/reliability/links.yaml
+++ b/.maestro/reliability/links.yaml
@@ -1,0 +1,112 @@
+appId: ${MAESTRO_APP_ID}
+name: Native link preview removal and sending
+tags: [regression]
+env:
+  JOURNEY: l
+---
+- runScript: data.js
+- runFlow: subflows/begin.yaml
+- runFlow: subflows/create-group.yaml
+- tapOn: '^Chat$'
+- tapOn:
+    id: MessageInput
+- inputText: https://example.com
+- assertVisible:
+    id: MessageInput
+    text: '^https://example[.]com$'
+- extendedWaitUntil:
+    visible: '^Example Domain$'
+    timeout: 5000
+- assertVisible:
+    id: MessageInputSendButton
+- tapOn:
+    id: MessageInput
+    point: '95%,50%'
+- eraseText: 100
+- extendedWaitUntil:
+    notVisible: '^Example Domain$'
+    timeout: 5000
+- assertVisible:
+    id: MessageInput
+    text: '^Message$'
+- runFlow:
+    file: subflows/send.yaml
+    env:
+      MESSAGE: ${output.reliability.text}
+      MESSAGE_PATTERN: ${output.reliability.textPattern}
+      EMPTY_INPUT: '^Message$'
+- assertNotVisible: '^Example Domain$'
+- tapOn:
+    id: MessageInput
+- inputText: ${MAESTRO_RUN_TAG + ' https://example.com'}
+- assertVisible:
+    id: MessageInput
+    text: '^${MAESTRO_RUN_TAG} https://example[.]com$'
+- extendedWaitUntil:
+    visible: '^Example Domain$'
+    timeout: 5000
+- tapOn:
+    id: MessageInputSendButton
+- extendedWaitUntil:
+    visible:
+      id: MessageInput
+      text: '^Message$'
+    timeout: 5000
+- extendedWaitUntil:
+    notVisible:
+      id: ChatMessageDeliveryStatus
+    timeout: 5000
+- assertNotVisible: '^Send failed, tap to retry$'
+- assertVisible:
+    id: '^Post$'
+    containsDescendants:
+      - text: '^Example Domain$'
+      - text: '.*${MAESTRO_RUN_TAG}.*'
+# Dismiss a second preview while preserving the exact draft URL.
+- tapOn:
+    id: MessageInput
+- inputText: ${MAESTRO_RUN_TAG + ' plain https://example.com'}
+- extendedWaitUntil:
+    visible: '^Remove attachment$'
+    timeout: 5000
+- tapOn: '^Remove attachment$'
+- runFlow:
+    when:
+      visible: '^Remove attachment$'
+    commands:
+      - tapOn: '^Remove attachment$'
+- assertVisible:
+    id: MessageInput
+    text: '^${MAESTRO_RUN_TAG} plain https://example[.]com$'
+- assertNotVisible: '^Remove attachment$'
+- tapOn:
+    id: MessageInputSendButton
+- extendedWaitUntil:
+    visible:
+      id: MessageInput
+      text: '^Message$'
+    timeout: 5000
+- extendedWaitUntil:
+    notVisible:
+      id: ChatMessageDeliveryStatus
+    timeout: 5000
+- assertVisible:
+    id: '^Post$'
+    containsDescendants:
+      - text: '.*${MAESTRO_RUN_TAG} plain.*'
+      - text: '.*https://example[.]com.*'
+- assertNotVisible:
+    id: '^Post$'
+    containsDescendants:
+      - text: '^Example Domain$'
+    index: 1
+- tapOn: '^Back$'
+- assertVisible: ${output.reliability.groupPattern}
+- tapOn: '^Chat$'
+- assertVisible:
+    id: MessageInput
+- assertVisible: '^Example Domain$'
+- assertVisible: ${output.reliability.textPattern}
+- tapOn: '^Back$'
+- tapOn: '^Back$'
+- assertVisible: '^Home$'

--- a/.maestro/reliability/message-actions.yaml
+++ b/.maestro/reliability/message-actions.yaml
@@ -1,0 +1,140 @@
+appId: ${MAESTRO_APP_ID}
+name: Native message actions
+tags: [regression]
+env:
+  JOURNEY: a
+---
+- runScript: data.js
+- runFlow: subflows/begin.yaml
+- runFlow: subflows/create-group.yaml
+- tapOn: '^Chat$'
+- runFlow:
+    file: subflows/send.yaml
+    env:
+      MESSAGE: ${output.reliability.text}
+      MESSAGE_PATTERN: ${output.reliability.textPattern}
+      EMPTY_INPUT: '^Message$'
+- hideKeyboard
+- longPressOn:
+    text: ${output.reliability.textPattern}
+    point: '10%,50%'
+- tapOn: '^Edit message$'
+- assertVisible:
+    id: MessageInput
+    text: ${output.reliability.textPattern}
+- tapOn:
+    id: MessageInput
+    point: '95%,50%'
+- eraseText: 100
+- runFlow:
+    file: subflows/input.yaml
+    env:
+      INPUT_TEXT: ${output.reliability.editedText}
+- tapOn:
+    id: MessageInputSendButton
+- assertVisible: ${output.reliability.editedTextPattern}
+- assertNotVisible: ${output.reliability.textPattern}
+- tapOn:
+    id: MessageInput
+- hideKeyboard
+- longPressOn:
+    text: ${output.reliability.editedTextPattern}
+    point: '10%,50%'
+- tapOn: '^Copy message text$'
+- runFlow:
+    when:
+      visible:
+        id: com.android.systemui:id/dismiss_button
+    commands:
+      - tapOn:
+          id: com.android.systemui:id/dismiss_button
+- tapOn:
+    id: MessageInput
+- longPressOn:
+    id: MessageInput
+- tapOn: '(?i)^Paste$'
+- assertVisible:
+    id: MessageInput
+    text: ${output.reliability.editedText}
+- eraseText: 100
+- hideKeyboard
+- waitForAnimationToEnd:
+    timeout: 5000
+- longPressOn:
+    text: ${output.reliability.editedTextPattern}
+    point: '10%,50%'
+- runFlow:
+    when:
+      platform: Android
+    commands:
+      - tapOn:
+          id: EmojiToolbarButton-thumb
+- runFlow:
+    when:
+      platform: iOS
+    commands:
+      - tapOn: '^👍$'
+- assertNotVisible: '^Copy message text$'
+- assertVisible:
+    id: ReactionDisplay
+- longPressOn:
+    text: ${output.reliability.editedTextPattern}
+    point: '10%,50%'
+- runFlow:
+    when:
+      platform: Android
+    commands:
+      - tapOn:
+          id: EmojiToolbarButton-thumb
+- runFlow:
+    when:
+      platform: iOS
+    commands:
+      - tapOn: '^👍$'
+- assertNotVisible: '^Copy message text$'
+- assertNotVisible:
+    id: ReactionDisplay
+- longPressOn:
+    text: ${output.reliability.editedTextPattern}
+    point: '10%,50%'
+- tapOn: '^Quote$'
+- assertVisible: ${output.reliability.editedTextPattern}
+- runFlow:
+    file: subflows/send.yaml
+    env:
+      MESSAGE: ${output.reliability.reply}
+      MESSAGE_PATTERN: ${output.reliability.replyPattern}
+      EMPTY_INPUT: '^Message$'
+- assertVisible:
+    id: '^Post$'
+    containsDescendants:
+      - text: ${output.reliability.replyPattern}
+      - text: ${output.reliability.editedTextPattern}
+- hideKeyboard
+- longPressOn:
+    text: ${output.reliability.replyPattern}
+    point: '10%,50%'
+- scrollUntilVisible:
+    element:
+      text: '^Delete message$'
+    direction: DOWN
+    timeout: 5000
+- tapOn: '^Delete message$'
+- assertVisible: '^Delete message\?$'
+- tapOn: '^Cancel$'
+- assertVisible: ${output.reliability.replyPattern}
+- longPressOn:
+    text: ${output.reliability.replyPattern}
+    point: '10%,50%'
+- scrollUntilVisible:
+    element:
+      text: '^Delete message$'
+    direction: DOWN
+    timeout: 5000
+- tapOn: '^Delete message$'
+- tapOn: '^Delete message$'
+- assertNotVisible: ${output.reliability.replyPattern}
+- assertVisible: ${output.reliability.editedTextPattern}
+- tapOn: '^Back$'
+- tapOn: '^Back$'
+- assertVisible: '^Home$'

--- a/.maestro/reliability/notebook.yaml
+++ b/.maestro/reliability/notebook.yaml
@@ -1,0 +1,80 @@
+appId: ${MAESTRO_APP_ID}
+name: Native Notebook publish, edit and persist
+tags: [regression]
+env:
+  JOURNEY: n
+---
+- runScript: data.js
+- runFlow: subflows/begin.yaml
+- runFlow: subflows/create-group.yaml
+- tapOn: '^Notebook$'
+- tapOn: '^New$'
+- extendedWaitUntil:
+    visible: '^Write something …\n?$'
+    timeout: 5000
+- tapOn: '^Write something …\n?$'
+- tapOn:
+    id: NotebookTitleInput
+    point: '95%,50%'
+- eraseText: 100
+- runFlow:
+    file: subflows/input.yaml
+    env:
+      INPUT_TEXT: ${output.reliability.title}
+- assertVisible:
+    id: NotebookTitleInput
+    text: ${output.reliability.title}
+- tapOn: '^Write something …\n?$'
+- runFlow:
+    file: subflows/input.yaml
+    env:
+      INPUT_TEXT: ${output.reliability.body}
+- tapOn: '^Post$'
+- extendedWaitUntil:
+    visible: ${output.reliability.title}
+    timeout: 5000
+- assertVisible: ${output.reliability.title}
+- assertVisible: ${output.reliability.body}
+- tapOn: ${output.reliability.title}
+- assertVisible: ${output.reliability.title}
+- assertVisible: ${output.reliability.body}
+- tapOn:
+    id: ChannelHeaderEditButton
+- runFlow: subflows/focus-notebook-body.yaml
+- tapOn:
+    id: NotebookTitleInput
+    point: '95%,50%'
+- eraseText: 100
+- runFlow:
+    file: subflows/input.yaml
+    env:
+      INPUT_TEXT: ${MAESTRO_RUN_TAG + ' edited note'}
+- assertVisible:
+    id: NotebookTitleInput
+    text: ${MAESTRO_RUN_TAG + ' edited note'}
+- runFlow: subflows/focus-notebook-body.yaml
+- eraseText: 100
+- runFlow:
+    file: subflows/input.yaml
+    env:
+      INPUT_TEXT: ${MAESTRO_RUN_TAG + ' edited body'}
+- tapOn: '^Save$'
+- assertVisible: ${MAESTRO_RUN_TAG + ' edited note'}
+- assertVisible: ${MAESTRO_RUN_TAG + ' edited body'}
+- tapOn: '^Back$'
+- assertVisible: ${MAESTRO_RUN_TAG + ' edited note'}
+- tapOn: ${MAESTRO_RUN_TAG + ' edited note'}
+- assertVisible: ${MAESTRO_RUN_TAG + ' edited body'}
+- stopApp
+- launchApp
+- assertVisible: '^Home$'
+- tapOn: ${output.reliability.groupPattern}
+- tapOn: '^Notebook$'
+- tapOn: ${MAESTRO_RUN_TAG + ' edited note'}
+- assertVisible: ${MAESTRO_RUN_TAG + ' edited note'}
+- assertVisible: ${MAESTRO_RUN_TAG + ' edited body'}
+- tapOn: '^Back$'
+- tapOn: '^Back$'
+- assertVisible: ${output.reliability.groupPattern}
+- tapOn: '^Back$'
+- assertVisible: '^Home$'

--- a/.maestro/reliability/profile.yaml
+++ b/.maestro/reliability/profile.yaml
@@ -1,0 +1,82 @@
+appId: ${MAESTRO_APP_ID}
+name: Native profile editing and persistence
+tags: [regression]
+env:
+  JOURNEY: p
+onFlowComplete:
+  - runFlow:
+      when:
+        true: ${output.reliability && typeof output.reliability.originalNickname !== 'undefined'}
+      commands:
+        - runFlow:
+            when:
+              notVisible:
+                id: ProfileNicknameInput
+            commands:
+              - runFlow:
+                  when:
+                    notVisible:
+                      id: ContactEditButton
+                  commands:
+                    - runFlow: subflows/contacts-tab.yaml
+                    - tapOn: '^You$'
+              - tapOn:
+                  id: ContactEditButton
+        - tapOn:
+            id: ProfileNicknameInput
+            point: '95%,50%'
+        - eraseText: 100
+        - runFlow:
+            when:
+              true: ${output.reliability.originalNickname !== ''}
+            commands:
+              - inputText: ${output.reliability.originalNickname}
+        - assertVisible:
+            id: ProfileNicknameInput
+            text: ${output.reliability.originalNickname || MAESTRO_TEST_SHIP}
+        - tapOn: '^Save$'
+        - tapOn: '^Back$'
+        - assertNotVisible: ${MAESTRO_RUN_TAG + ' profile'}
+        - runFlow: subflows/home-tab.yaml
+---
+- runScript: data.js
+- runFlow: subflows/begin.yaml
+- runFlow: subflows/contacts-tab.yaml
+- tapOn: '^You$'
+- tapOn:
+    id: ContactEditButton
+- copyTextFrom:
+    id: ProfileNicknameInput
+- evalScript: ${output.reliability.originalNickname = maestro.copiedText || ''}
+- tapOn:
+    id: ProfileNicknameInput
+    point: '95%,50%'
+- eraseText: 100
+- inputText: ${MAESTRO_RUN_TAG + ' profile'}
+- assertVisible:
+    id: ProfileNicknameInput
+    text: ${MAESTRO_RUN_TAG + ' profile'}
+- tapOn: '^Save$'
+- assertVisible: '^Profile$'
+- assertVisible: ${MAESTRO_RUN_TAG + ' profile'}
+- tapOn: '^Back$'
+- assertVisible:
+    text: ${MAESTRO_RUN_TAG + ' profile'}
+    leftOf: '^You$'
+- stopApp
+- launchApp
+- extendedWaitUntil:
+    visible:
+      id: ScreenHeaderTitle
+      text: '^Home$'
+    timeout: 5000
+- runFlow: subflows/contacts-tab.yaml
+- assertVisible:
+    text: ${MAESTRO_RUN_TAG + ' profile'}
+    leftOf: '^You$'
+- tapOn: '^You$'
+- tapOn:
+    id: ContactEditButton
+- assertVisible:
+    id: ProfileNicknameInput
+    text: ${MAESTRO_RUN_TAG + ' profile'}

--- a/.maestro/reliability/relaunch.yaml
+++ b/.maestro/reliability/relaunch.yaml
@@ -1,0 +1,40 @@
+appId: ${MAESTRO_APP_ID}
+name: Native session and messages survive relaunch
+tags: [regression]
+env:
+  JOURNEY: r
+---
+- runScript: data.js
+- runFlow: subflows/begin.yaml
+- runFlow: subflows/create-group.yaml
+- tapOn: '^Chat$'
+- runFlow:
+    file: subflows/send.yaml
+    env:
+      MESSAGE: ${output.reliability.text}
+      MESSAGE_PATTERN: ${output.reliability.textPattern}
+      EMPTY_INPUT: '^Message$'
+- hideKeyboard
+- tapOn: '^Back$'
+- tapOn: '^Back$'
+- assertVisible: '^Home$'
+- stopApp
+- launchApp
+- extendedWaitUntil:
+    visible: '^Home$'
+    timeout: 5000
+- assertNotVisible: '^Have an account\? Log in$'
+- tapOn: ${output.reliability.groupPattern}
+- tapOn: '^Chat$'
+- assertVisible: ${output.reliability.textPattern}
+- runFlow:
+    file: subflows/send.yaml
+    env:
+      MESSAGE: ${output.reliability.reply}
+      MESSAGE_PATTERN: ${output.reliability.replyPattern}
+      EMPTY_INPUT: '^Message$'
+- assertVisible: ${output.reliability.textPattern}
+- hideKeyboard
+- tapOn: '^Back$'
+- tapOn: '^Back$'
+- assertVisible: '^Home$'

--- a/.maestro/reliability/search.yaml
+++ b/.maestro/reliability/search.yaml
@@ -1,0 +1,32 @@
+appId: ${MAESTRO_APP_ID}
+name: Native search opens exact message
+tags: [regression]
+env:
+  JOURNEY: q
+---
+- runScript: data.js
+- runFlow: subflows/begin.yaml
+- runFlow: subflows/create-group.yaml
+- tapOn: '^Chat$'
+- runFlow:
+    file: subflows/send.yaml
+    env:
+      MESSAGE: ${output.reliability.text}
+      MESSAGE_PATTERN: ${output.reliability.textPattern}
+      EMPTY_INPUT: '^Message$'
+- tapOn: '^Search$'
+- assertVisible: '^Search Chat$'
+- runFlow:
+    file: subflows/input.yaml
+    env:
+      INPUT_TEXT: ${MAESTRO_RUN_TAG}
+- hideKeyboard
+- assertVisible: ${output.reliability.textPattern}
+- tapOn: ${output.reliability.textPattern}
+- assertVisible: '^Chat$'
+- assertVisible: ${output.reliability.textPattern}
+- assertVisible:
+    id: MessageInput
+    text: '^Message$'
+- tapOn: '^Back$'
+- assertVisible: '^Home$'

--- a/.maestro/reliability/settings.yaml
+++ b/.maestro/reliability/settings.yaml
@@ -1,0 +1,103 @@
+appId: ${MAESTRO_APP_ID}
+name: Native settings persistence
+tags: [regression]
+env:
+  JOURNEY: s
+---
+- runScript: data.js
+- runFlow: subflows/begin.yaml
+- runFlow: subflows/contacts-tab.yaml
+- tapOn: '^Settings$'
+- assertVisible: '^Settings$'
+- tapOn: '^App info$'
+- assertVisible: '^Build version$'
+- assertVisible: '^Desk version$'
+- assertNotVisible: '^Cannot load app info settings$'
+- tapOn: '^Back$'
+- tapOn: '^Appearance$'
+- assertVisible: '^Appearance$'
+# iOS exposes radio state as an accessibility value, not a checked flag.
+- runFlow:
+    when:
+      platform: Android
+    commands:
+      - scrollUntilVisible:
+          element:
+            id: 'ThemeOption-.*'
+            checked: true
+          direction: DOWN
+          timeout: 5000
+      - copyTextFrom:
+          id: 'ThemeOption-.*'
+          checked: true
+- runFlow:
+    when:
+      platform: iOS
+    commands:
+      - scrollUntilVisible:
+          element:
+            id: 'ThemeOption-.*'
+            text: '^radio button, checked$'
+          direction: DOWN
+          timeout: 5000
+      - copyTextFrom:
+          text: '.+'
+          index: 0
+          childOf:
+            id: 'ThemeOption-.*'
+            text: '^radio button, checked$'
+- evalScript: ${output.reliability.originalTheme = "ThemeOption-" + maestro.copiedText.toLowerCase().replace("tlon ", "")}
+- scrollUntilVisible:
+    element:
+      id: ThemeOption-light
+    direction: UP
+    timeout: 5000
+- tapOn:
+    id: ThemeOption-light
+- runFlow:
+    file: subflows/assert-theme.yaml
+    env:
+      THEME_ID: ThemeOption-light
+- tapOn:
+    id: ThemeOption-dark
+- runFlow:
+    file: subflows/assert-theme.yaml
+    env:
+      THEME_ID: ThemeOption-dark
+- tapOn: '^Back$'
+- tapOn: '^Appearance$'
+- runFlow:
+    file: subflows/assert-theme.yaml
+    env:
+      THEME_ID: ThemeOption-dark
+- stopApp
+- launchApp
+- assertVisible: '^Home$'
+- runFlow: subflows/contacts-tab.yaml
+- tapOn: '^Settings$'
+- tapOn: '^Appearance$'
+- runFlow:
+    file: subflows/assert-theme.yaml
+    env:
+      THEME_ID: ThemeOption-dark
+- scrollUntilVisible:
+    element:
+      id: ${output.reliability.originalTheme}
+    direction: DOWN
+    timeout: 5000
+- tapOn:
+    id: ${output.reliability.originalTheme}
+- runFlow:
+    file: subflows/assert-theme.yaml
+    env:
+      THEME_ID: ${output.reliability.originalTheme}
+- tapOn: '^Back$'
+- tapOn: '^Blocked users$'
+- assertVisible: '^Blocked users$'
+- tapOn: '^Back$'
+- tapOn: '^Notification settings$'
+- assertVisible: '^Notifications$'
+- tapOn: '^Back$'
+- tapOn: '^Back$'
+- runFlow: subflows/home-tab.yaml
+- assertVisible: '^Home$'

--- a/.maestro/reliability/subflows/assert-theme.yaml
+++ b/.maestro/reliability/subflows/assert-theme.yaml
@@ -1,0 +1,16 @@
+appId: ${MAESTRO_APP_ID}
+---
+- runFlow:
+    when:
+      platform: Android
+    commands:
+      - assertVisible:
+          id: ${THEME_ID}
+          checked: true
+- runFlow:
+    when:
+      platform: iOS
+    commands:
+      - assertVisible:
+          id: ${THEME_ID}
+          text: '^radio button, checked$'

--- a/.maestro/reliability/subflows/begin.yaml
+++ b/.maestro/reliability/subflows/begin.yaml
@@ -1,0 +1,20 @@
+appId: ${MAESTRO_APP_ID}
+---
+- runFlow:
+    when:
+      true: ${output.reliability.session === 'fresh'}
+    file: login.yaml
+- runFlow:
+    when:
+      true: ${output.reliability.session === 'warm'}
+    commands:
+      # Reset navigation and keyboard state while preserving the login.
+      - launchApp
+- extendedWaitUntil:
+    visible: '^(Home|Contacts)$'
+    timeout: 5000
+- runFlow: contacts-tab.yaml
+- tapOn: '^You$'
+- assertVisible: ${output.reliability.shipPattern}
+- tapOn: '^Back$'
+- runFlow: home-tab.yaml

--- a/.maestro/reliability/subflows/contacts-tab.yaml
+++ b/.maestro/reliability/subflows/contacts-tab.yaml
@@ -1,0 +1,18 @@
+appId: ${MAESTRO_APP_ID}
+---
+# The current iOS native tabs expose only their container to accessibility.
+# Anchor within that container, then verify the destination. No screen pixels.
+- runFlow:
+    when:
+      platform: iOS
+    commands:
+      - tapOn:
+          text: '^Tab Bar$'
+          point: '71%,38%'
+- runFlow:
+    when:
+      platform: Android
+    commands:
+      - tapOn: '^Contacts$'
+- assertVisible: '^Contacts$'
+- assertVisible: '^You$'

--- a/.maestro/reliability/subflows/create-group.yaml
+++ b/.maestro/reliability/subflows/create-group.yaml
@@ -1,0 +1,34 @@
+appId: ${MAESTRO_APP_ID}
+---
+- assertNotVisible: ${output.reliability.groupPattern}
+- tapOn: '^Add a chat$'
+- tapOn: '^New group$'
+- tapOn: '^Basic group.*$'
+- tapOn: '^Group name$'
+- waitForAnimationToEnd:
+    timeout: 5000
+- assertVisible:
+    text: '^Name your group$'
+    label: Group editor stays visible with keyboard open
+- runFlow:
+    file: input.yaml
+    env:
+      INPUT_TEXT: ${output.reliability.group}
+- assertVisible:
+    text: ${output.reliability.groupPattern}
+    below: '^Name your group$'
+    above: '^Next$'
+- runFlow:
+    when:
+      platform: Android
+    commands:
+      - hideKeyboard
+- tapOn: '^Next$'
+- assertVisible: '^Select contacts to invite$'
+- tapOn: '^Create group$'
+- extendedWaitUntil:
+    visible: ${output.reliability.groupPattern}
+    timeout: 5000
+- assertVisible: '^Chat$'
+- assertVisible: '^Gallery$'
+- assertVisible: '^Notebook$'

--- a/.maestro/reliability/subflows/focus-notebook-body.yaml
+++ b/.maestro/reliability/subflows/focus-notebook-body.yaml
@@ -1,0 +1,21 @@
+appId: ${MAESTRO_APP_ID}
+---
+# The saved post remains behind the editor. Target the editable body on each OS.
+- runFlow:
+    when:
+      platform: Android
+    commands:
+      - tapOn:
+          text: ${output.reliability.body + '\n?'}
+          childOf:
+            text: RichTextEditor
+          point: '95%,50%'
+- runFlow:
+    when:
+      platform: iOS
+    commands:
+      - tapOn:
+          text: ${output.reliability.body + '\n?'}
+          below:
+            id: NotebookTitleInput
+          point: '95%,50%'

--- a/.maestro/reliability/subflows/home-tab.yaml
+++ b/.maestro/reliability/subflows/home-tab.yaml
@@ -1,0 +1,20 @@
+appId: ${MAESTRO_APP_ID}
+---
+- runFlow:
+    when:
+      platform: iOS
+    commands:
+      - tapOn:
+          text: '^Tab Bar$'
+          point: '29%,38%'
+- runFlow:
+    when:
+      platform: Android
+    commands:
+      - tapOn:
+          text: '^Home$'
+          leftOf: '^Activity.*$'
+      - assertVisible:
+          id: ScreenHeaderTitle
+          text: '^Home$'
+- assertVisible: '^Home$'

--- a/.maestro/reliability/subflows/input-next.js
+++ b/.maestro/reliability/subflows/input-next.js
@@ -1,0 +1,6 @@
+// WebView accessibility may append one paragraph newline.
+var next = Math.min(output.fixtureInput.index + 1, INPUT_TEXT.length);
+output.fixtureInput = {
+  index: next,
+  pattern: '^' + INPUT_TEXT.slice(0, next) + '\\n?$',
+};

--- a/.maestro/reliability/subflows/input.js
+++ b/.maestro/reliability/subflows/input.js
@@ -1,0 +1,1 @@
+output.fixtureInput = { index: 0, pattern: '^' + INPUT_TEXT + '\\n?$' };

--- a/.maestro/reliability/subflows/input.yaml
+++ b/.maestro/reliability/subflows/input.yaml
@@ -1,0 +1,45 @@
+appId: ${MAESTRO_APP_ID}
+---
+- assertTrue: ${/^[A-Za-z0-9 _\n-]+$/.test(INPUT_TEXT)}
+- runScript: input.js
+# Try complete lines first; verify exact text before accepting bulk input.
+- repeat:
+    times: ${INPUT_TEXT.split('\n').length}
+    commands:
+      - runFlow:
+          when:
+            true: ${output.fixtureInput.index > 0}
+          commands:
+            - pressKey: Enter
+      - inputText: ${INPUT_TEXT.split('\n')[output.fixtureInput.index]}
+      - evalScript: ${output.fixtureInput.index += 1}
+# A positive check returns immediately for correct input; notVisible
+# would wait for that text to disappear before skipping the fallback.
+- runFlow:
+    when:
+      visible: ${output.fixtureInput.pattern}
+    commands:
+      - evalScript: ${output.fixtureInput.complete = true}
+# Fall back once to acknowledged prefixes if bulk entry dropped text.
+- runFlow:
+    when:
+      true: ${!output.fixtureInput.complete}
+    commands:
+      - eraseText: 100
+      - evalScript: ${output.fixtureInput.index = 0}
+      - repeat:
+          times: ${INPUT_TEXT.length}
+          commands:
+            - runFlow:
+                when:
+                  true: ${maestro.platform === 'android' && INPUT_TEXT.slice(output.fixtureInput.index, output.fixtureInput.index + 1) === '\n'}
+                commands:
+                  - pressKey: Enter
+            - runFlow:
+                when:
+                  true: ${maestro.platform !== 'android' || INPUT_TEXT.slice(output.fixtureInput.index, output.fixtureInput.index + 1) !== '\n'}
+                commands:
+                  - inputText: ${INPUT_TEXT.slice(output.fixtureInput.index, output.fixtureInput.index + 1)}
+            - runScript: input-next.js
+            - assertVisible: ${output.fixtureInput.pattern}
+- assertVisible: ${output.fixtureInput.pattern}

--- a/.maestro/reliability/subflows/login.yaml
+++ b/.maestro/reliability/subflows/login.yaml
@@ -1,0 +1,70 @@
+appId: ${MAESTRO_APP_ID}
+---
+- launchApp:
+    clearState: true
+    clearKeychain: true
+- assertVisible: '^Tlon Messenger$'
+- tapOn: '^Have an account\? Log in$'
+- runFlow:
+    when:
+      true: ${output.reliability.hosted}
+    commands:
+      - runFlow:
+          when:
+            visible:
+              id: log-in-with-email
+          commands:
+            - tapOn:
+                id: log-in-with-email
+      - tapOn:
+          id: or-use-password
+      - tapOn:
+          id: email-input-legacy
+      - inputText:
+          text: ${MAESTRO_EMAIL}
+          label: Enter configured test account email
+      - tapOn:
+          id: password-input-legacy
+      - inputText:
+          text: ${MAESTRO_PASSWORD}
+          label: Enter configured test account password
+      - tapOn: '^Submit$'
+- runFlow:
+    when:
+      true: ${!output.reliability.hosted}
+    commands:
+      - tapOn: '^Or configure self hosted$'
+      - assertVisible: '^Connect Ship$'
+      - tapOn:
+          id: '^textInput shipUrl$'
+      - eraseText: 100
+      - inputText:
+          text: ${MAESTRO_LOGIN_URL}
+          label: Enter configured test ship URL
+      - tapOn:
+          id: '^textInput accessCode$'
+      - eraseText: 100
+      - inputText:
+          text: ${MAESTRO_LOGIN_CODE}
+          label: Enter test ship access code
+      - tapOn: '^Connect$'
+# Declared login/network phase; outside the 5-second warm interaction budget.
+- extendedWaitUntil:
+    visible: '^(Home|Usage Statistics|Save Password\?)$'
+    timeout: 60000
+- runFlow:
+    when:
+      visible: '^Save Password\?$'
+    commands:
+      - tapOn: '^Not Now$'
+- extendedWaitUntil:
+    visible: '^(Home|Usage Statistics)$'
+    timeout: 60000
+- runFlow:
+    when:
+      visible: '^Usage Statistics$'
+    commands:
+      - tapOn: '^Next$'
+- extendedWaitUntil:
+    visible: '^Home$'
+    timeout: 60000

--- a/.maestro/reliability/subflows/send.yaml
+++ b/.maestro/reliability/subflows/send.yaml
@@ -1,0 +1,37 @@
+appId: ${MAESTRO_APP_ID}
+---
+- tapOn:
+    id: MessageInput
+- waitForAnimationToEnd:
+    timeout: 5000
+- assertVisible:
+    id: MessageInput
+    label: Composer stays visible with keyboard open
+- runFlow:
+    file: input.yaml
+    env:
+      INPUT_TEXT: ${MESSAGE}
+- assertVisible:
+    id: MessageInput
+    text: ${MESSAGE}
+- tapOn:
+    id: MessageInputSendButton
+- extendedWaitUntil:
+    visible:
+      id: MessageInput
+      text: ${EMPTY_INPUT}
+    timeout: 5000
+- extendedWaitUntil:
+    notVisible:
+      id: ChatMessageDeliveryStatus
+    timeout: 5000
+- assertNotVisible: '^Send failed, tap to retry$'
+- assertVisible:
+    id: '^Post$'
+    containsDescendants:
+      - text: ${MESSAGE_PATTERN}
+- assertNotVisible:
+    id: '^Post$'
+    containsDescendants:
+      - text: ${MESSAGE_PATTERN}
+    index: 1

--- a/apps/tlon-mobile/.eas/workflows/e2e-nightly-ios.yml
+++ b/apps/tlon-mobile/.eas/workflows/e2e-nightly-ios.yml
@@ -1,8 +1,9 @@
-name: e2e-nightly-ios
+name: e2e-nightly-mobile
 
 on:
   schedule:
     - cron: "0 7 * * *"
+  workflow_dispatch: {}
 
 jobs:
   build_ios_for_e2e:
@@ -11,6 +12,13 @@ jobs:
     params:
       platform: ios
       profile: e2e
+
+  build_android_for_reliability:
+    type: build
+    environment: production
+    params:
+      platform: android
+      profile: local-testing
 
   tests_started:
     needs: [build_ios_for_e2e]
@@ -32,6 +40,48 @@ jobs:
       maestro_project_id: proj_01jjmcqhxneg69zpqdty84xqvt
       flows: "../../.maestro"
       name: nightly-develop-ios
+
+  reliability_ios:
+    after: [build_ios_for_e2e, maestro_nightly]
+    if: ${{ after.build_ios_for_e2e.status == 'success' }}
+    type: maestro-cloud
+    environment: production
+    env:
+      MAESTRO_APP_ID: io.tlon.groups
+      MAESTRO_EMAIL: ${{ env.MAESTRO_RELIABILITY_EMAIL }}
+      MAESTRO_PASSWORD: ${{ env.MAESTRO_RELIABILITY_PASSWORD }}
+      MAESTRO_TEST_SHIP: '~batbet-litnec'
+      MAESTRO_RUN_TAG: nightly-${{ workflow.id }}-ios
+    params:
+      build_id: ${{ after.build_ios_for_e2e.outputs.build_id }}
+      maestro_project_id: proj_01jjmcqhxneg69zpqdty84xqvt
+      maestro_version: 2.6.1
+      flows: '../../.maestro/reliability'
+      device_model: iPhone-17
+      device_os: iOS-26-2
+      name: nightly-reliability-ios
+
+  # Both platforms share the test ship. Run Android even if iOS tests failed,
+  # but wait for iOS to finish so profile/settings changes cannot race.
+  reliability_android:
+    after: [build_android_for_reliability, reliability_ios]
+    if: ${{ after.build_android_for_reliability.status == 'success' }}
+    type: maestro-cloud
+    environment: production
+    env:
+      MAESTRO_APP_ID: io.tlon.groups
+      MAESTRO_EMAIL: ${{ env.MAESTRO_RELIABILITY_EMAIL }}
+      MAESTRO_PASSWORD: ${{ env.MAESTRO_RELIABILITY_PASSWORD }}
+      MAESTRO_TEST_SHIP: '~batbet-litnec'
+      MAESTRO_RUN_TAG: nightly-${{ workflow.id }}-android
+    params:
+      build_id: ${{ after.build_android_for_reliability.outputs.build_id }}
+      maestro_project_id: proj_01jjmcqhxneg69zpqdty84xqvt
+      maestro_version: 2.6.1
+      flows: '../../.maestro/reliability'
+      device_model: pixel_6
+      device_os: android-33
+      name: nightly-reliability-android
 
   notify_webhook:
     name: Alert
@@ -90,14 +140,14 @@ jobs:
 
           let summary;
           if (buildStatus !== 'success') {
-            summary = `❌ Nightly iOS E2E build failed before tests ran${duration ? ` after ${duration}` : ''}`;
+            summary = `❌ Nightly iOS smoke build failed before tests ran${duration ? ` after ${duration}` : ''}`;
           } else if (maestroStatus !== 'success' && Number(totalCount) === 0) {
-            summary = `❌ Nightly iOS E2E run failed before Maestro results were available${duration ? ` after ${duration}` : ''}`;
+            summary = `❌ Nightly iOS smoke run failed before Maestro results were available${duration ? ` after ${duration}` : ''}`;
           } else if (Number(failedCount) > 0) {
             const failedNames = failedFlows.length ? ` (${failedFlows.join(', ')})` : '';
-            summary = `❌ Nightly iOS E2E finished with failures: ${successfulCount}/${totalCount} passed, ${failedCount} failed${duration ? ` in ${duration}` : ''}${failedNames}`;
+            summary = `❌ Nightly iOS smoke finished with failures: ${successfulCount}/${totalCount} passed, ${failedCount} failed${duration ? ` in ${duration}` : ''}${failedNames}`;
           } else {
-            summary = `✅ Nightly iOS E2E passed: ${successfulCount}/${totalCount} flows completed${duration ? ` in ${duration}` : ''}`;
+            summary = `✅ Nightly iOS smoke passed: ${successfulCount}/${totalCount} flows completed${duration ? ` in ${duration}` : ''}`;
           }
 
           process.stdout.write(

--- a/apps/tlon-mobile/.eas/workflows/e2e-nightly-ios.yml
+++ b/apps/tlon-mobile/.eas/workflows/e2e-nightly-ios.yml
@@ -6,6 +6,19 @@ on:
   workflow_dispatch: {}
 
 jobs:
+  prepare_reliability:
+    outputs:
+      run_tag: ${{ steps.run_tag.outputs.run_tag }}
+    steps:
+      - id: run_tag
+        name: Create a short reliability run tag
+        env:
+          RUN_ID: ${{ workflow.id }}
+        run: |
+          # Hash the whole workflow ID; UUID prefixes can share a timestamp.
+          # 14 characters with a platform suffix leaves room for renamed groups.
+          set-output run_tag "$(node -e 'process.stdout.write("r" + require("node:crypto").createHash("sha256").update(process.env.RUN_ID).digest("hex").slice(0, 12))')"
+
   build_ios_for_e2e:
     type: build
     environment: production
@@ -42,8 +55,8 @@ jobs:
       name: nightly-develop-ios
 
   reliability_ios:
-    after: [build_ios_for_e2e, maestro_nightly]
-    if: ${{ after.build_ios_for_e2e.status == 'success' }}
+    after: [build_ios_for_e2e, maestro_nightly, prepare_reliability]
+    if: ${{ after.build_ios_for_e2e.status == 'success' && after.prepare_reliability.status == 'success' }}
     type: maestro-cloud
     environment: production
     env:
@@ -51,7 +64,7 @@ jobs:
       MAESTRO_EMAIL: ${{ env.MAESTRO_RELIABILITY_EMAIL }}
       MAESTRO_PASSWORD: ${{ env.MAESTRO_RELIABILITY_PASSWORD }}
       MAESTRO_TEST_SHIP: '~batbet-litnec'
-      MAESTRO_RUN_TAG: nightly-${{ workflow.id }}-ios
+      MAESTRO_RUN_TAG: ${{ after.prepare_reliability.outputs.run_tag }}i
     params:
       build_id: ${{ after.build_ios_for_e2e.outputs.build_id }}
       maestro_project_id: proj_01jjmcqhxneg69zpqdty84xqvt
@@ -64,8 +77,8 @@ jobs:
   # Both platforms share the test ship. Run Android even if iOS tests failed,
   # but wait for iOS to finish so profile/settings changes cannot race.
   reliability_android:
-    after: [build_android_for_reliability, reliability_ios]
-    if: ${{ after.build_android_for_reliability.status == 'success' }}
+    after: [build_android_for_reliability, reliability_ios, prepare_reliability]
+    if: ${{ after.build_android_for_reliability.status == 'success' && after.prepare_reliability.status == 'success' }}
     type: maestro-cloud
     environment: production
     env:
@@ -73,7 +86,7 @@ jobs:
       MAESTRO_EMAIL: ${{ env.MAESTRO_RELIABILITY_EMAIL }}
       MAESTRO_PASSWORD: ${{ env.MAESTRO_RELIABILITY_PASSWORD }}
       MAESTRO_TEST_SHIP: '~batbet-litnec'
-      MAESTRO_RUN_TAG: nightly-${{ workflow.id }}-android
+      MAESTRO_RUN_TAG: ${{ after.prepare_reliability.outputs.run_tag }}a
     params:
       build_id: ${{ after.build_android_for_reliability.outputs.build_id }}
       maestro_project_id: proj_01jjmcqhxneg69zpqdty84xqvt

--- a/packages/app/features/settings/ThemeScreen.tsx
+++ b/packages/app/features/settings/ThemeScreen.tsx
@@ -110,6 +110,12 @@ export function ThemeScreen(props: Props) {
             {themes.map((theme, index) => (
               <Fragment key={theme.value}>
                 <Pressable
+                  accessibilityRole="radio"
+                  accessibilityLabel={theme.title}
+                  accessibilityState={{
+                    checked: theme.value === selectedTheme,
+                  }}
+                  testID={`ThemeOption-${theme.value}`}
                   disabled={loadingTheme !== null}
                   onPress={() => handleThemeChange(theme.value)}
                   borderRadius="$xl"

--- a/packages/app/ui/components/BigInput.tsx
+++ b/packages/app/ui/components/BigInput.tsx
@@ -586,6 +586,7 @@ export function BigInput({
                 width="100%"
                 borderColor="transparent"
                 placeholder="New Title"
+                testID="NotebookTitleInput"
                 placeholderTextColor={'$tertiaryText'}
                 onChangeText={setTitle}
                 value={title}

--- a/packages/app/ui/components/ChatMessage/ChatMessageActions/Component.android.tsx
+++ b/packages/app/ui/components/ChatMessage/ChatMessageActions/Component.android.tsx
@@ -1,8 +1,7 @@
 import { MotiView } from 'moti';
-import { useEffect, useState } from 'react';
-import { Dimensions, LayoutChangeEvent } from 'react-native';
+import { useEffect } from 'react';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
-import { View, YStack } from 'tamagui';
+import { ScrollView, View, YStack } from 'tamagui';
 
 import { triggerHaptic } from '../../../utils';
 import { EmojiToolbar } from './EmojiToolbar';
@@ -20,26 +19,8 @@ export function ChatMessageActions({
   onViewBotRun,
   onShowEmojiPicker,
 }: ChatMessageActionsProps) {
-  const [topOffset, setTopOffset] = useState(0);
   const insets = useSafeAreaInsets();
   const PADDING_THRESHOLD = 40;
-
-  function handleLayout(event: LayoutChangeEvent) {
-    const { height } = event.nativeEvent.layout;
-    const verticalPosition = calcVerticalPosition(height);
-    setTopOffset(verticalPosition);
-  }
-
-  function calcVerticalPosition(height: number): number {
-    const screenHeight = Dimensions.get('window').height;
-    const safeTop = insets.top + PADDING_THRESHOLD;
-    const safeBottom = screenHeight - insets.bottom - PADDING_THRESHOLD;
-    const availableHeight = safeBottom - safeTop;
-
-    const centeredPosition = (availableHeight - height) / 2 + safeTop;
-
-    return Math.min(Math.max(centeredPosition, safeTop), safeBottom - height);
-  }
 
   useEffect(() => {
     // on mount, give initial haptic feeedback
@@ -48,33 +29,39 @@ export function ChatMessageActions({
 
   return (
     <MotiView
+      style={{ flex: 1 }}
+      pointerEvents="box-none"
       from={{ opacity: 0 }}
       animate={{ opacity: 1 }}
       transition={{ duration: 200 }}
     >
       <View
-        position="absolute"
-        top={topOffset}
-        onLayout={handleLayout}
+        flex={1}
+        justifyContent="center"
+        paddingTop={insets.top + PADDING_THRESHOLD}
+        paddingBottom={insets.bottom + PADDING_THRESHOLD}
         paddingHorizontal="$xl"
+        pointerEvents="box-none"
       >
-        <YStack gap="$xs">
-          <EmojiToolbar
-            post={post}
-            onDismiss={onDismiss}
-            openExternalSheet={onShowEmojiPicker}
-          />
-          <MessageContainer post={post} />
-          <MessageActions
-            post={post}
-            postActionIds={postActionIds}
-            dismiss={onDismiss}
-            onReply={onReply}
-            onEdit={onEdit}
-            onViewReactions={onViewReactions}
-            onViewBotRun={onViewBotRun}
-          />
-        </YStack>
+        <ScrollView flexGrow={0} flexShrink={1}>
+          <YStack gap="$xs">
+            <EmojiToolbar
+              post={post}
+              onDismiss={onDismiss}
+              openExternalSheet={onShowEmojiPicker}
+            />
+            <MessageContainer post={post} />
+            <MessageActions
+              post={post}
+              postActionIds={postActionIds}
+              dismiss={onDismiss}
+              onReply={onReply}
+              onEdit={onEdit}
+              onViewReactions={onViewReactions}
+              onViewBotRun={onViewBotRun}
+            />
+          </YStack>
+        </ScrollView>
       </View>
     </MotiView>
   );

--- a/packages/app/ui/components/ManageChannels/CreateChannelSheet.tsx
+++ b/packages/app/ui/components/ManageChannels/CreateChannelSheet.tsx
@@ -141,7 +141,7 @@ export function CreateChannelSheet({
     <FormProvider {...form}>
       <ActionSheet open onOpenChange={onOpenChange} {...sheetProps}>
         <ActionSheet.SimpleHeader title="Create a new channel" />
-        <ActionSheet.ScrollableContent>
+        <ActionSheet.ScrollableContent keyboardShouldPersistTaps="handled">
           <ActionSheet.FormBlock>
             <Form.ControlledTextField
               control={control}

--- a/packages/app/ui/components/ManageChannels/CreateChannelSheet.tsx
+++ b/packages/app/ui/components/ManageChannels/CreateChannelSheet.tsx
@@ -141,7 +141,7 @@ export function CreateChannelSheet({
     <FormProvider {...form}>
       <ActionSheet open onOpenChange={onOpenChange} {...sheetProps}>
         <ActionSheet.SimpleHeader title="Create a new channel" />
-        <ActionSheet.Content>
+        <ActionSheet.ScrollableContent>
           <ActionSheet.FormBlock>
             <Form.ControlledTextField
               control={control}
@@ -190,7 +190,7 @@ export function CreateChannelSheet({
               centered
             />
           </ActionSheet.FormBlock>
-        </ActionSheet.Content>
+        </ActionSheet.ScrollableContent>
       </ActionSheet>
     </FormProvider>
   );

--- a/packages/app/ui/components/MessageInput/AttachmentPreviewList.tsx
+++ b/packages/app/ui/components/MessageInput/AttachmentPreviewList.tsx
@@ -340,6 +340,9 @@ const RemoveAttachmentButton = ({
   }, [removeAttachment, attachment]);
   return (
     <Pressable
+      accessible
+      accessibilityLabel="Remove attachment"
+      accessibilityRole="button"
       width="$xl"
       height="$xl"
       borderColor="$border"
@@ -405,9 +408,7 @@ const LinkPreview = ({ attachment }: { attachment: domain.LinkAttachment }) => {
           </YStack>
         </YStack>
 
-        <View style={{ position: 'absolute', top: 8, right: 8, zIndex: 1000 }}>
-          <RemoveAttachmentButton attachment={attachment} />
-        </View>
+        <RemoveAttachmentButton attachment={attachment} />
       </ZStack>
     </View>
   );

--- a/packages/app/ui/components/MessageInput/index.tsx
+++ b/packages/app/ui/components/MessageInput/index.tsx
@@ -596,6 +596,9 @@ export const MessageInput = forwardRef<MessageInputHandle, MessageInputProps>(
             `
               function updateContentHeight() {
                 const editorElement = document.querySelector('#root div .ProseMirror');
+                // The ready message can arrive before React mounts the editor.
+                // The observer below will measure it once it exists.
+                if (!editorElement) return;
                 editorElement.style.height = 'auto';
                 editorElement.style.overflow = 'auto';
                 const newHeight = editorElement.scrollHeight;

--- a/packages/app/ui/components/ScreenHeader/primitives.tsx
+++ b/packages/app/ui/components/ScreenHeader/primitives.tsx
@@ -66,6 +66,8 @@ export const HeaderBackButton = ({
 }) => {
   return (
     <HeaderIconButton
+      accessible
+      accessibilityLabel="Back"
       accessibilityRole="button"
       accessibilityState={{ disabled }}
       color={disabled ? '$tertiaryText' : '$primaryText'}

--- a/packages/app/ui/components/conversationScrollChrome.tsx
+++ b/packages/app/ui/components/conversationScrollChrome.tsx
@@ -167,7 +167,12 @@ function AnimatedScrollToBottomButton({
       pointerEvents={visible ? 'auto' : 'none'}
       style={animatedStyle}
     >
-      <FloatingActionButton icon={content} onPress={onPress} />
+      <FloatingActionButton
+        icon={content}
+        onPress={onPress}
+        accessibilityLabel="Scroll to bottom"
+        testID="ScrollToBottomButton"
+      />
     </Animated.View>
   );
 }

--- a/packages/ui/src/components/FloatingActionButton.tsx
+++ b/packages/ui/src/components/FloatingActionButton.tsx
@@ -13,12 +13,19 @@ import {
 export function FloatingActionButton({
   onPress,
   icon,
+  accessibilityLabel,
+  testID,
 }: {
   onPress: () => void;
   icon?: React.ReactNode;
+  accessibilityLabel?: string;
+  testID?: string;
 }) {
   return (
     <Button
+      accessibilityRole="button"
+      accessibilityLabel={accessibilityLabel}
+      testID={testID}
       paddingHorizontal="$m"
       paddingVertical="$m"
       alignItems="center"

--- a/packages/ui/src/components/Modal.tsx
+++ b/packages/ui/src/components/Modal.tsx
@@ -16,7 +16,7 @@ export function Modal(props: ComponentProps<typeof RNModal>) {
     <RNModal transparent={true} {...props}>
       <ZStack flex={1}>
         <Overlay onPress={onDismiss} />
-        <View flex={1} position="absolute" pointerEvents="box-none">
+        <View flex={1} position="absolute" inset={0} pointerEvents="box-none">
           {props.children}
         </View>
       </ZStack>


### PR DESCRIPTION
## Summary

Adds 12 native reliability journeys for iOS and Android, with fixes for the issues they exposed. Rebased on current `develop`; the keyboard and button navigation fixes have landed, so the duplicate button implementation and tests are removed.

## Changes

- Cover chat, message actions, search, history, links, groups, channels, notebook, gallery, profile, settings, and relaunch persistence.
- Fix overflowing Android sheets, link-preview removal, and notebook editor readiness; add the accessibility labels needed by the tests.
- Run the default suite nightly at 07:00 UTC on iOS and Android through the existing EAS workflow, with manual runs and no push/PR trigger. Reuse its iOS build; Android tests continue even after an iOS failure.
- Keep native build/cache plumbing and later test additions out of this PR.

## How did I test?

All 12 journeys previously passed across iOS Simulator and Android Cloud runs. Five journeys also [passed together on Android API 33 with the keyboard changes](https://app.maestro.dev/project/proj_01jjmcqhxneg69zpqdty84xqvt/maestro-test/app/app_01jjwmhkgefynv88q0fkbq024j/upload/mupload_01m25rpcepfwnas6nver2tg4w1).

After rebasing, checked the diff against the tested version and validated all flow files and references. Flow behavior is unchanged; the full native suite has not been rerun on this rebased head.

Nightly wiring: EAS workflow validation passes. Checked nightly/manual-only triggers, both suite paths, exact build-ID references, and Android continuation after iOS failure. Dedicated test-account secrets are configured in EAS production. The scheduled build/test chain has not been run end to end; scheduling starts after this lands on `develop`. The current Maestro project has one device per platform; avoid concurrent manual runs against this shared ship.
