### PR TITLE
Drop togten hosting class, scrub as self-hosted

### DIFF
--- a/packages/shared/src/errorReporting.test.ts
+++ b/packages/shared/src/errorReporting.test.ts
@@ -20,9 +20,9 @@ const HOSTING_CASES: Array<[string, Hosting]> = [
   ['TLON.NETWORK.', 'tlon'],
   ['notlon.network', 'self'],
   ['tlon.network.evil.com', 'self'],
-  ['togten.com', 'togten'],
-  ['poster-findul.togten.com', 'togten'],
-  ['sub.togten.com.', 'togten'],
+  ['togten.com', 'self'],
+  ['sampel-palnet.togten.com', 'self'],
+  ['sub.togten.com.', 'self'],
   ['localhost', 'local'],
   ['foo.localhost', 'local'],
   ['127.0.0.1', 'local'],
@@ -114,7 +114,7 @@ describe('reduceUrls', () => {
       reduceUrls(
         'a https://x.tlon.network/apps/groups/dm/~one b https://y.togten.com/apps/groups/group/~two c'
       )
-    ).toBe('a https://tlon/dm b https://togten/group c');
+    ).toBe('a https://tlon/dm b https://self/group c');
   });
 
   it('leaves text without urls unchanged', () => {
@@ -135,6 +135,12 @@ describe('reduceUrls bare hostnames', () => {
     expect(reduceUrls('Unable to resolve host "groups.example.org"')).toBe(
       'Unable to resolve host "self"'
     );
+  });
+
+  it('reduces a quoted togten host as self-hosted', () => {
+    expect(
+      reduceUrls('Unable to resolve host "sampel-palnet.togten.com"')
+    ).toBe('Unable to resolve host "self"');
   });
 
   it('reduces a quoted local host', () => {
@@ -167,6 +173,14 @@ describe('reduceUrls bare hostnames', () => {
     );
     expect(output).toContain('https://tlon/foo');
     expect(output).not.toContain('sampel-palnet');
+  });
+
+  it('reduces a togten url to the self-hosted placeholder', () => {
+    const output = reduceUrls(
+      'GET https://sampel-palnet.togten.com/apps/groups/foo failed'
+    );
+    expect(output).toContain('https://self/foo');
+    expect(output).not.toContain('togten');
   });
 });
 
@@ -292,7 +306,7 @@ describe('scrubExtra', () => {
         list: ['https://c.tlon.network/apps/groups/dm/~x', 3],
       })
     ).toEqual({
-      note: 'go https://togten/group',
+      note: 'go https://self/group',
       list: ['https://tlon/dm', 3],
     });
   });
@@ -471,7 +485,7 @@ describe('scrubBreadcrumb', () => {
     expect(scrubbed).not.toBeNull();
     expect(scrubbed?.data).toEqual({
       from: 'https://tlon/dm',
-      to: 'https://togten/group',
+      to: 'https://self/group',
     });
     expect(crumb.data.from).toBe('https://a.tlon.network/apps/groups/dm/~x');
   });
@@ -547,7 +561,7 @@ describe('scrubSentryEvent', () => {
     expect(output.breadcrumbs).toHaveLength(1);
     expect(output.breadcrumbs?.[0]).toMatchObject({ category: 'navigation' });
     expect(output.breadcrumbs?.[0]?.data).toEqual({
-      to: 'https://togten/group',
+      to: 'https://self/group',
     });
     expect(output.extra).toEqual({ note: 'see https://tlon/dm' });
     expect(output.tags).toEqual({ logger: 'sync' });
@@ -630,8 +644,8 @@ describe('scrubSentryEvent', () => {
     const outFrames = output.exception?.values?.[0]?.stacktrace?.frames;
     expect(outFrames).toHaveLength(2);
     expect(outFrames?.[0]).toEqual({
-      filename: 'https://togten/apps/groups/assets/index-abc.js',
-      abs_path: 'https://togten/apps/groups/assets/index-abc.js',
+      filename: 'https://self/apps/groups/assets/index-abc.js',
+      abs_path: 'https://self/apps/groups/assets/index-abc.js',
       lineno: 42,
       colno: 7,
       function: 'doWork',
@@ -641,7 +655,7 @@ describe('scrubSentryEvent', () => {
     expect(outFrames?.[0]).not.toBe(frames[0]);
     expect(outFrames?.[1]).toEqual({ filename: 'app:///main.jsbundle' });
     expect(output.debug_meta?.images?.[0]).toEqual({
-      code_file: 'https://togten/apps/groups/assets/index-abc.js',
+      code_file: 'https://self/apps/groups/assets/index-abc.js',
       debug_id: 'abc',
     });
     expect(output.debug_meta?.images?.[0]).not.toBe(images[0]);

--- a/packages/shared/src/errorReporting.ts
+++ b/packages/shared/src/errorReporting.ts
@@ -1,4 +1,4 @@
-export type Hosting = 'tlon' | 'togten' | 'local' | 'self';
+export type Hosting = 'tlon' | 'local' | 'self';
 
 export type SentryLevel = 'error' | 'warning' | 'info';
 
@@ -110,9 +110,6 @@ export function hostingFromHostname(hostname: string): Hosting {
   if (host === 'tlon.network' || host.endsWith('.tlon.network')) {
     return 'tlon';
   }
-  if (host === 'togten.com' || host.endsWith('.togten.com')) {
-    return 'togten';
-  }
   if (
     host === '' ||
     host === 'localhost' ||
@@ -135,7 +132,6 @@ const URL_PATTERN = /https?:\/\/[^\s"'<>()]+/gi;
 // Hosts that `reduceUrls` itself emits. A second pass must leave them alone.
 const PLACEHOLDER_HOSTS: ReadonlySet<string> = new Set([
   'tlon',
-  'togten',
   'local',
   'self',
 ]);
@@ -143,8 +139,7 @@ const PLACEHOLDER_HOSTS: ReadonlySet<string> = new Set([
 // Hostnames that appear without a scheme: any host under a known hosting
 // suffix, and any quoted fully-qualified hostname (iOS/Android network errors
 // quote the host they failed against).
-const HOSTING_SUFFIX_HOST_PATTERN =
-  /\b(?:[a-z0-9-]+\.)+(?:tlon\.network|togten\.com)\b/gi;
+const HOSTING_SUFFIX_HOST_PATTERN = /\b(?:[a-z0-9-]+\.)+tlon\.network\b/gi;
 const QUOTED_HOST_PATTERN = /([“"'])((?:[a-z0-9-]+\.)+[a-z]{2,63})([”"'])/gi;
 // Quoted file names look like hostnames; leave them alone.
 const NOT_A_TLD = new Set([


### PR DESCRIPTION
## Summary

Removes the `togten` Sentry hosting class added in #6461. `togten.com` isn't a hosting provider, it's a private domain for a couple of self-hosted ships, so those hosts should scrub like any other self-hosted ship instead of getting their own class.

## Changes

- `packages/shared/src/errorReporting.ts`: removed `togten` from the `Hosting` type, deleted the `togten.com` branch in `hostingFromHostname` (falls through to `self`), dropped `togten` from the placeholder-host set, and narrowed `HOSTING_SUFFIX_HOST_PATTERN` to `tlon.network` only.
- `packages/shared/src/errorReporting.test.ts`: retargeted togten expectations from `togten` to `self`, added explicit cases for the bare-hostname, URL, and quoted-hostname forms.

## How did I test?

- `pnpm --filter ./packages/shared tsc` and `pnpm --filter ./packages/app tsc` pass.
- `vitest run src/errorReporting.test.ts`: 128 pass.
- `pnpm format:check` passes.

## Risks and impact

- Safe to rollback without consulting PR author? Yes
- Affects important code area:
  - [ ] Onboarding
  - [ ] State / providers
  - [ ] Message sync
  - [ ] Channel display
  - [ ] Notifications
  - [ ] Other:

URL and quoted-hostname forms of togten hosts still get scrubbed (now to `self` instead of `togten`). A bare unquoted `foo.togten.com` in free text is no longer rewritten, matching how every other self-hosted domain is handled today. From the next build, events from those ships carry `hosting=self` instead of `hosting=togten`. The only other consumer of the `Hosting` type, `apps/tlon-web/src/sentry-bootstrap.ts`, just passes the value through as a tag and needs no change.

## Rollback plan

Revert the commit. No data or schema changes involved.

## Screenshots / videos

N/A
