### PR TITLE
Identify PostHog client on session ready, not just on init

### DIFF
--- a/apps/tlon-mobile/src/__uitests__/useTelemetry.identify.test.tsx
+++ b/apps/tlon-mobile/src/__uitests__/useTelemetry.identify.test.tsx
@@ -1,0 +1,221 @@
+import {
+  afterEach,
+  beforeEach,
+  describe,
+  expect,
+  it,
+  jest,
+} from '@jest/globals';
+import { act, renderHook } from '@testing-library/react-native';
+
+const mockState = {
+  distinctId: '0192-anon' as string | undefined,
+  sdkOptedOut: false,
+  readyPromise: Promise.resolve(),
+  session: { phase: 'ready', startTime: 1 } as {
+    phase: string;
+    startTime: number;
+  } | null,
+  settings: {
+    data: { enableTelemetry: true as boolean | null, logActivity: null },
+    isLoading: false,
+  },
+};
+
+// The real web variant of this module calls `posthog.init` at import time.
+jest.mock('@tloncorp/app/hooks/usePosthog', () => {
+  const fake = {
+    getIsOptedOut: () => mockState.sdkOptedOut,
+    optIn: jest.fn(),
+    optOut: jest.fn(),
+    capture: jest.fn(),
+    reset: jest.fn(),
+    flush: jest.fn(async () => {}),
+    identify: jest.fn((userId: string) => {
+      mockState.distinctId = userId;
+    }),
+    distinctId: () => mockState.distinctId,
+    ready: jest.fn(() => mockState.readyPromise),
+  };
+  return { usePosthog: () => fake };
+});
+
+jest.mock('@tloncorp/shared', () => ({
+  AnalyticsEvent: { AppActive: 'App Active', WebAppOpened: 'Web App Opened' },
+  clearBreadcrumbs: jest.fn(),
+  createDevLogger: () => ({
+    log: jest.fn(),
+    crumb: jest.fn(),
+    trackError: jest.fn(),
+    trackEvent: jest.fn(),
+  }),
+  useCurrentSession: () => mockState.session,
+}));
+
+jest.mock('@tloncorp/shared/db', () => {
+  const storageItem = {
+    value: true,
+    isLoading: false,
+    setValue: jest.fn(),
+    resetValue: jest.fn(),
+  };
+  return {
+    didInitializeTelemetry: {
+      useStorageItem: () => storageItem,
+      getValue: async () => true,
+      resetValue: jest.fn(),
+    },
+    hasClearedLegacyWebTelemetry: {
+      getValue: async () => true,
+      setValue: jest.fn(),
+    },
+    lastAnonymousAppOpenAt: {
+      getValue: async () => null,
+      setValue: jest.fn(),
+      resetValue: jest.fn(),
+    },
+  };
+});
+
+jest.mock('@tloncorp/shared/store', () => ({
+  useTelemetrySettings: () => mockState.settings,
+  updateEnableTelemetry: jest.fn(),
+}));
+
+// `@tloncorp/api`'s exports map has no `require` condition, so jest cannot
+// resolve it; a bare-specifier virtual mock keys globally and covers the
+// hook's own import.
+jest.mock('@tloncorp/api', () => ({ getCurrentUserIsHosted: () => true }), {
+  virtual: true,
+});
+
+jest.mock('@tloncorp/app/hooks/useCurrentUser', () => ({
+  useCurrentUserId: () => '~sampel-palnet',
+}));
+
+jest.mock('tamagui', () => ({ isWeb: false }));
+
+// Aliased: the mock returns one shared object, so this reads the fake rather
+// than acting as a hook call.
+import { usePosthog as readFakePosthog } from '@tloncorp/app/hooks/usePosthog';
+import { useTelemetry } from '@tloncorp/app/hooks/useTelemetry';
+
+const posthog = readFakePosthog();
+
+let resolveReady!: () => void;
+
+beforeEach(() => {
+  mockState.distinctId = '0192-anon';
+  mockState.sdkOptedOut = false;
+  mockState.session = { phase: 'ready', startTime: 1 };
+  mockState.settings = {
+    data: { enableTelemetry: true, logActivity: null },
+    isLoading: false,
+  };
+  mockState.readyPromise = new Promise<void>((resolve) => {
+    resolveReady = resolve;
+  });
+  jest.clearAllMocks();
+});
+
+afterEach(() => {
+  resolveReady();
+});
+
+async function settleReady() {
+  await act(async () => {
+    resolveReady();
+  });
+}
+
+describe('useTelemetry identify-on-session', () => {
+  it('identifies the ship once the sdk reports ready', async () => {
+    renderHook(() => useTelemetry());
+
+    expect(posthog.identify).not.toHaveBeenCalled();
+
+    await settleReady();
+
+    expect(posthog.identify).toHaveBeenCalledTimes(1);
+    expect(posthog.identify).toHaveBeenCalledWith('~sampel-palnet', {
+      isHostedUser: true,
+      userId: '~sampel-palnet',
+    });
+  });
+
+  it('does not re-identify when the sdk already reports the ship', async () => {
+    mockState.distinctId = '~sampel-palnet';
+
+    renderHook(() => useTelemetry());
+    await settleReady();
+
+    expect(posthog.identify).not.toHaveBeenCalled();
+  });
+
+  it('does not identify when telemetry is disabled', async () => {
+    mockState.settings = {
+      data: { enableTelemetry: false, logActivity: null },
+      isLoading: false,
+    };
+    mockState.sdkOptedOut = true;
+
+    renderHook(() => useTelemetry());
+    await settleReady();
+
+    expect(posthog.identify).not.toHaveBeenCalled();
+  });
+
+  it('honours an opt-out that only becomes readable once the sdk is ready', async () => {
+    mockState.settings = {
+      data: { enableTelemetry: null, logActivity: null },
+      isLoading: false,
+    };
+    mockState.sdkOptedOut = false;
+
+    renderHook(() => useTelemetry());
+
+    await act(async () => {
+      mockState.sdkOptedOut = true;
+      resolveReady();
+    });
+
+    expect(posthog.identify).not.toHaveBeenCalled();
+  });
+
+  it('waits for settings to load before identifying', async () => {
+    mockState.settings = {
+      data: { enableTelemetry: true, logActivity: null },
+      isLoading: true,
+    };
+
+    const { rerender } = renderHook(() => useTelemetry());
+    await settleReady();
+
+    expect(posthog.ready).not.toHaveBeenCalled();
+    expect(posthog.identify).not.toHaveBeenCalled();
+
+    mockState.settings = {
+      data: { enableTelemetry: true, logActivity: null },
+      isLoading: false,
+    };
+    mockState.readyPromise = new Promise<void>((resolve) => {
+      resolveReady = resolve;
+    });
+
+    await act(async () => {
+      rerender(undefined);
+    });
+    await settleReady();
+
+    expect(posthog.identify).toHaveBeenCalledTimes(1);
+  });
+
+  it('identifies once across multiple mounted consumers', async () => {
+    renderHook(() => useTelemetry());
+    renderHook(() => useTelemetry());
+
+    await settleReady();
+
+    expect(posthog.identify).toHaveBeenCalledTimes(1);
+  });
+});

--- a/packages/app/hooks/sessionIdentity.ts
+++ b/packages/app/hooks/sessionIdentity.ts
@@ -1,0 +1,23 @@
+import { PosthogClient } from './usePosthog.base';
+
+/**
+ * Links the PostHog client to the current ship. Idempotent: the SDK's persisted
+ * id is the ship id in steady state, so this only fires when the two have
+ * diverged (fresh install, reset SDK storage, new login).
+ */
+export function ensureIdentified({
+  posthog,
+  userId,
+  isHosted,
+}: {
+  posthog: Pick<PosthogClient, 'identify' | 'distinctId'>;
+  userId: string;
+  isHosted: boolean;
+}): boolean {
+  if (!userId || posthog.distinctId() === userId) {
+    return false;
+  }
+
+  posthog.identify(userId, { isHostedUser: isHosted, userId });
+  return true;
+}

--- a/packages/app/hooks/usePosthog.base.tsx
+++ b/packages/app/hooks/usePosthog.base.tsx
@@ -7,4 +7,5 @@ export interface PosthogClient {
   flush: () => Promise<void>;
   reset: () => void;
   distinctId: () => string | undefined;
+  ready: () => Promise<void>;
 }

--- a/packages/app/hooks/usePosthog.native.ts
+++ b/packages/app/hooks/usePosthog.native.ts
@@ -21,6 +21,9 @@ export function usePosthog() {
       distinctId: () => {
         return posthog?.getDistinctId();
       },
+      ready: async () => {
+        await posthog?.ready();
+      },
     };
   }, [posthog]);
 }

--- a/packages/app/hooks/usePosthog.ts
+++ b/packages/app/hooks/usePosthog.ts
@@ -28,6 +28,8 @@ export function usePosthog() {
       distinctId: () => {
         return posthog?.get_distinct_id();
       },
+      // posthog-js initializes synchronously at import, so it is always ready.
+      ready: async () => {},
     };
   }, [posthog]);
 }

--- a/packages/app/hooks/useTelemetry.test.ts
+++ b/packages/app/hooks/useTelemetry.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it, vi } from 'vitest';
 
 import { captureMandatoryEventWithClient } from './mandatoryTelemetry';
+import { ensureIdentified } from './sessionIdentity';
 
 function client() {
   return {
@@ -58,5 +59,56 @@ describe('captureMandatoryEventWithClient', () => {
     ]);
     expect(posthog.optIn).toHaveBeenCalledTimes(2);
     expect(posthog.optOut).toHaveBeenCalledTimes(2);
+  });
+});
+
+describe('ensureIdentified', () => {
+  function identityClient(distinctId: string | undefined) {
+    return {
+      identify: vi.fn(),
+      distinctId: vi.fn(() => distinctId),
+    };
+  }
+
+  it('identifies when the sdk id has drifted from the ship', () => {
+    const posthog = identityClient('01924f3a-anon');
+
+    expect(
+      ensureIdentified({
+        posthog,
+        userId: '~sampel-palnet',
+        isHosted: true,
+      })
+    ).toBe(true);
+
+    expect(posthog.identify).toHaveBeenCalledOnce();
+    expect(posthog.identify).toHaveBeenCalledWith('~sampel-palnet', {
+      isHostedUser: true,
+      userId: '~sampel-palnet',
+    });
+  });
+
+  it('is a no-op when the sdk already reports the ship', () => {
+    const posthog = identityClient('~sampel-palnet');
+
+    expect(
+      ensureIdentified({
+        posthog,
+        userId: '~sampel-palnet',
+        isHosted: true,
+      })
+    ).toBe(false);
+
+    expect(posthog.identify).not.toHaveBeenCalled();
+  });
+
+  it('does not identify without a ship', () => {
+    const posthog = identityClient('01924f3a-anon');
+
+    expect(ensureIdentified({ posthog, userId: '', isHosted: false })).toBe(
+      false
+    );
+
+    expect(posthog.identify).not.toHaveBeenCalled();
   });
 });

--- a/packages/app/hooks/useTelemetry.ts
+++ b/packages/app/hooks/useTelemetry.ts
@@ -16,6 +16,7 @@ import { isWeb } from 'tamagui';
 
 import { TelemetryClient } from '../types/telemetry';
 import { captureMandatoryEventWithClient } from './mandatoryTelemetry';
+import { ensureIdentified } from './sessionIdentity';
 import { useCurrentUserId } from './useCurrentUser';
 import { usePosthog } from './usePosthog';
 
@@ -30,10 +31,16 @@ export function useClearTelemetryConfig() {
     // Clear before the first await: the native logout path does not await this
     // callback, and a slow or rejected flush must not leave them behind.
     clearBreadcrumbs();
-    await posthog.flush();
-    posthog?.reset();
-    await didInitializeTelemetry.resetValue();
-    await lastAnonymousAppOpenAt.resetValue();
+    posthog.reset();
+    await Promise.all([
+      didInitializeTelemetry.resetValue(),
+      lastAnonymousAppOpenAt.resetValue(),
+    ]);
+    try {
+      await posthog.flush();
+    } catch {
+      // Queued events keep their distinct_id and stay queued for the next flush.
+    }
   }, [posthog]);
 
   return clearConfig;
@@ -247,6 +254,44 @@ export function useTelemetry(): TelemetryClient {
     telemetryEnabled,
     telemetryInitialized,
     setDisabled,
+    posthog,
+    getIsOptedOut,
+  ]);
+
+  useEffect(() => {
+    if (!ready || !telemetryInitialized) {
+      return;
+    }
+
+    // The SDK's persisted identity and `didInitializeTelemetry` are separate
+    // stores that can diverge, which leaves a session reporting under a stale
+    // anonymous id. Re-link them once the SDK's storage has loaded.
+    let cancelled = false;
+    posthog
+      .ready()
+      .then(() => {
+        if (cancelled || getIsOptedOut()) {
+          return;
+        }
+
+        ensureIdentified({
+          posthog,
+          userId: currentUserId,
+          isHosted: api.getCurrentUserIsHosted(),
+        });
+      })
+      .catch(() => {
+        /* persistence failed to load; leave identity unset */
+      });
+
+    return () => {
+      cancelled = true;
+    };
+  }, [
+    ready,
+    telemetryInitialized,
+    telemetryEnabled,
+    currentUserId,
     posthog,
     getIsOptedOut,
   ]);


### PR DESCRIPTION
## Summary

Fixes TLON-6524. PostHog identified the ship only inside the once-per-install telemetry-init branch, so when the SDK's persisted identity reset (fresh anonymous id) but `didInitializeTelemetry` stayed true, every later JavaScript event including `app_error` landed on an anonymous person. On Android build 440 over three days only 11 of 141 persons carried both native and JavaScript events.

## Changes

- `packages/app/hooks/usePosthog.base.tsx`, `usePosthog.native.ts`, `usePosthog.ts`: add `ready(): Promise<void>` to `PosthogClient`. Native awaits `posthog.ready()`; web resolves immediately since posthog-js initializes at import.
- `packages/app/hooks/sessionIdentity.ts` (new): `ensureIdentified` helper, a no-op when the SDK's `distinctId()` already matches the ship.
- `packages/app/hooks/useTelemetry.ts`: adds an effect that, once the session is ready and telemetry initialized, waits for SDK readiness, re-checks opt-out, and calls `ensureIdentified`; a cancelled flag discards stale resolutions. `useClearTelemetryConfig` now resets identity and storage before a best-effort `flush()` wrapped in try/catch, so a slow or rejected flush can no longer skip the reset on logout.
- `packages/app/hooks/useTelemetry.test.ts`: unit tests for `ensureIdentified`.
- `apps/tlon-mobile/src/__uitests__/useTelemetry.identify.test.tsx` (new): renders the hook with a fake client to cover identify-after-readiness, already-identified, opted-out, settings-loading, and two mounted instances producing one identify call.

## How did I test?

- `packages/app/hooks/useTelemetry.test.ts` and the new `useTelemetry.identify.test.tsx` pass; mutation checks confirm they fail if the effect or the helper's guard is removed.
- tsc for packages/app, tlon-mobile, and tlon-web; full `packages/app` vitest suite; `pnpm format:check`.
- `App.test.tsx` in the mobile suite fails on develop already (unrelated `@tloncorp/api` resolution issue), unaffected by this change.
- After release: in the mobile PostHog project, the share of `$lib = 'posthog-react-native'` events with `$is_identified = true` (excluding mandatory events) should approach 100% for telemetry-enabled users on the fixed build.

## Risks and impact

- Safe to rollback without consulting PR author? Yes
- Affects important code area:
  - [ ] Onboarding
  - [ ] State / providers
  - [ ] Message sync
  - [ ] Channel display
  - [ ] Notifications
  - [x] Other: Telemetry / PostHog identity

Steady state is a no-op on both SDKs (web is always a no-op since ids match). A drifted install sends one `$identify` with the anonymous id as `$anon_distinct_id`, merging that anonymous person's events into the ship person, which is intended. The Android native SDK's separate identity call (it only identifies when the FCM service starts) is out of scope, so native-only persons can still persist until that's addressed separately. On logout, queued events keep their distinct id across `reset()`.

## Rollback plan

Revert the commit. No data or schema changes involved.

## Screenshots / videos

N/A
