### PR TITLE
Gate app startup on groups desk version compatibility

### DIFF
--- a/apps/tlon-mobile/cosmos.imports.ts
+++ b/apps/tlon-mobile/cosmos.imports.ts
@@ -81,6 +81,7 @@ import * as fixture76 from './src/fixtures/InputToolbar.fixture';
 import * as fixture77 from './src/fixtures/Onboarding.fixture';
 import * as fixture78 from './src/fixtures/SetNicknameScreen.fixture';
 import * as fixture79 from './src/fixtures/HostingAuthReconnectScreen.fixture';
+import * as fixture80 from './src/fixtures/DeskOutdatedScreen.fixture';
 import * as decorator1 from './src/fixtures/cosmos.decorator';
 
 export const rendererConfig: RendererConfig = {
@@ -253,6 +254,7 @@ const fixtures = {
     module: fixture74,
   },
   'src/App.fixture.tsx': { module: fixture75 },
+  'src/fixtures/DeskOutdatedScreen.fixture.tsx': { module: fixture80 },
   'src/fixtures/HostingAuthReconnectScreen.fixture.tsx': { module: fixture79 },
   'src/fixtures/InputToolbar.fixture.tsx': { module: fixture76 },
   'src/fixtures/Onboarding.fixture.tsx': { module: fixture77 },

--- a/apps/tlon-mobile/jest.config.js
+++ b/apps/tlon-mobile/jest.config.js
@@ -3,8 +3,16 @@ module.exports = {
     // mock react-native-svg-transformer
     // https://github.com/kristerkari/react-native-svg-transformer?tab=readme-ov-file#usage-with-jest
     '\\.svg': '<rootDir>/src/test/reactNativeSvgTransformerMock.ts',
+    // @tloncorp/api's "." export map has no require/default condition, so
+    // jest's CJS resolution can't find it. Point it at the same source Metro
+    // resolves through the package's tlon-source condition.
+    '^@tloncorp/api$': '<rootDir>/../../packages/api/src/index.ts',
   },
   preset: 'jest-expo',
+  // react-native-worklets (pulled in by reanimated) only loads under jest with
+  // its `.native` variants filtered out; without this its module registry
+  // blows up as soon as anything imports @tloncorp/ui.
+  resolver: 'react-native-worklets/jest/resolver',
   setupFiles: ['./src/test/jestSetup.tsx'],
   transform: {
     // from babel-jest-preset

--- a/apps/tlon-mobile/src/App.main.tsx
+++ b/apps/tlon-mobile/src/App.main.tsx
@@ -177,14 +177,15 @@ const MainApp = () => {
   const splashReplacesAuthenticatedApp =
     showSplashSequence &&
     (forcedSplash || activeSplashSequenceMode === 'tlonbotRevival');
-  // The revival splash onboards against the ship's desk, so it can't stand in
-  // for the app while the desk is gated — including while a cold probe is
-  // still deciding, which isDeskGated covers. Falling through renders the
-  // notice (or its spinner), which AuthenticatedApp already handles.
+  // The revival splash onboards against the ship's desk, so it may only stand
+  // in for the app once a clean verdict exists. No verdict means "not probed
+  // yet", and the normal path below is what probes — it runs sync start — so a
+  // cold start renders that path (its spinner while probing) and hands over to
+  // the splash only when the desk is recorded as usable.
   const deskCompat = store.useDeskCompatibility();
   const authenticatedContent = !connected ? (
     offline
-  ) : splashReplacesAuthenticatedApp && !store.isDeskGated(deskCompat) ? (
+  ) : splashReplacesAuthenticatedApp && deskCompat?.status === 'ok' ? (
     <AppDataProvider inviteSystemContacts={inviteSystemContacts}>
       {splash}
     </AppDataProvider>

--- a/apps/tlon-mobile/src/App.main.tsx
+++ b/apps/tlon-mobile/src/App.main.tsx
@@ -36,6 +36,7 @@ import { posthog } from '@tloncorp/app/utils/posthog';
 import { createDevLogger } from '@tloncorp/shared';
 import * as db from '@tloncorp/shared/db';
 import { withRetry } from '@tloncorp/shared/logic';
+import * as store from '@tloncorp/shared/store';
 import * as SplashScreen from 'expo-splash-screen';
 import { useCallback, useEffect, useRef, useState } from 'react';
 import { Platform, StatusBar } from 'react-native';
@@ -176,9 +177,14 @@ const MainApp = () => {
   const splashReplacesAuthenticatedApp =
     showSplashSequence &&
     (forcedSplash || activeSplashSequenceMode === 'tlonbotRevival');
+  // The revival splash onboards against the ship's desk, so it can't stand in
+  // for the app while the desk is gated — including while a cold probe is
+  // still deciding, which isDeskGated covers. Falling through renders the
+  // notice (or its spinner), which AuthenticatedApp already handles.
+  const deskCompat = store.useDeskCompatibility();
   const authenticatedContent = !connected ? (
     offline
-  ) : splashReplacesAuthenticatedApp ? (
+  ) : splashReplacesAuthenticatedApp && !store.isDeskGated(deskCompat) ? (
     <AppDataProvider inviteSystemContacts={inviteSystemContacts}>
       {splash}
     </AppDataProvider>

--- a/apps/tlon-mobile/src/__uitests__/DeskOutdatedScreen.test.tsx
+++ b/apps/tlon-mobile/src/__uitests__/DeskOutdatedScreen.test.tsx
@@ -1,0 +1,127 @@
+import { afterEach, beforeEach, describe, it, jest } from '@jest/globals';
+import {
+  NavigationContainer,
+  NavigationIndependentTree,
+} from '@react-navigation/native';
+import { render, screen, userEvent } from '@testing-library/react-native';
+import '@testing-library/react-native/extend-expect';
+import { DESK_UPDATE_HELP_URL } from '@tloncorp/app/constants';
+import { DeskOutdatedScreen } from '@tloncorp/app/features/DeskOutdatedScreen';
+import { Provider as TamaguiProvider } from '@tloncorp/app/provider';
+import { QueryClientProvider, queryClient } from '@tloncorp/shared';
+import type { ComponentProps, PropsWithChildren } from 'react';
+import { Linking } from 'react-native';
+import {
+  SafeAreaProvider,
+  initialWindowMetrics,
+} from 'react-native-safe-area-context';
+
+// Reached transitively through the UI packages; their native modules can't load
+// under jest and nothing on this screen touches them.
+jest.mock('expo-contacts', () => ({}));
+jest.mock('expo-speech-recognition', () => ({}));
+
+type ScreenProps = ComponentProps<typeof DeskOutdatedScreen>;
+
+function Wrapper({ children }: PropsWithChildren) {
+  return (
+    <QueryClientProvider client={queryClient}>
+      <NavigationIndependentTree>
+        <NavigationContainer>
+          <SafeAreaProvider initialMetrics={initialWindowMetrics}>
+            <TamaguiProvider defaultTheme="light">{children}</TamaguiProvider>
+          </SafeAreaProvider>
+        </NavigationContainer>
+      </NavigationIndependentTree>
+    </QueryClientProvider>
+  );
+}
+
+function screenWith(props: Partial<ScreenProps> = {}) {
+  return (
+    <DeskOutdatedScreen
+      currentVersion="12.1.0"
+      minimumVersion="12.2.0"
+      onRetry={() => {}}
+      {...props}
+    />
+  );
+}
+
+function renderScreen(props: Partial<ScreenProps> = {}) {
+  return render(screenWith(props), { wrapper: Wrapper });
+}
+
+describe('DeskOutdatedScreen', () => {
+  beforeEach(() => {
+    jest.useFakeTimers();
+  });
+
+  afterEach(() => {
+    jest.runOnlyPendingTimers();
+    jest.useRealTimers();
+    jest.restoreAllMocks();
+  });
+
+  it('reports the version the ship has and the one it needs', () => {
+    renderScreen();
+
+    expect(screen.getByTestId('desk-outdated-screen')).toBeOnTheScreen();
+    expect(screen.getByTestId('desk-outdated-current')).toHaveTextContent(
+      '12.1.0'
+    );
+    expect(screen.getByTestId('desk-outdated-minimum')).toHaveTextContent(
+      '12.2.0'
+    );
+  });
+
+  it('falls back to generic copy when no version was reported', () => {
+    renderScreen({ currentVersion: null });
+
+    expect(screen.getByTestId('desk-outdated-current')).toHaveTextContent(
+      'an older version'
+    );
+  });
+
+  it('retries on demand, and not while a probe is already running', async () => {
+    const user = userEvent.setup();
+    const onRetry = jest.fn();
+    const { rerender } = renderScreen({ onRetry });
+
+    await user.press(screen.getByTestId('desk-outdated-retry'));
+    expect(onRetry).toHaveBeenCalledTimes(1);
+
+    rerender(screenWith({ onRetry, isProbing: true }));
+
+    await user.press(screen.getByTestId('desk-outdated-retry'));
+    expect(onRetry).toHaveBeenCalledTimes(1);
+  });
+
+  it('opens the update instructions', async () => {
+    const user = userEvent.setup();
+    const openURL = jest
+      .spyOn(Linking, 'openURL')
+      .mockImplementation(async () => true);
+    renderScreen();
+
+    await user.press(screen.getByTestId('desk-outdated-help'));
+
+    expect(openURL).toHaveBeenCalledWith(DESK_UPDATE_HELP_URL);
+  });
+
+  it('offers a way out when a logout handler is given', async () => {
+    const user = userEvent.setup();
+    const onLogout = jest.fn<() => void>();
+    renderScreen({ onLogout });
+
+    await user.press(screen.getByText('Log out'));
+
+    expect(onLogout).toHaveBeenCalled();
+  });
+
+  it('omits the logout control where there is no logout to offer', () => {
+    renderScreen();
+
+    expect(screen.queryByText('Log out')).toBeNull();
+  });
+});

--- a/apps/tlon-mobile/src/components/AuthenticatedApp.tsx
+++ b/apps/tlon-mobile/src/components/AuthenticatedApp.tsx
@@ -205,7 +205,7 @@ function AuthenticatedApp({
 
       // app returned from background
       if (status === 'active') {
-        if (store.getSession()?.deskCompat) {
+        if (store.isDeskGated(store.getSession()?.deskCompat)) {
           // Gated on desk compatibility: syncSince would fail the same way
           // startup did. Read live rather than from render state so a gate that
           // arrives mid-session is respected.
@@ -480,10 +480,11 @@ export default function ConnectedAuthenticatedApp({
         onLogout={onLogout}
         requireHostingAuth={requireHostingAuth}
       />
-      {/* The overlay is opaque and full-screen, so it would bury the desk
-          notice — and the spinner that precedes it — under an onboarding
-          sequence that can't complete against an incompatible desk anyway. */}
-      {deskCompat ? null : authenticatedOverlay}
+      {/* Only once the desk is known good. The overlay is opaque and
+          full-screen, so it would bury the notice — and the spinner that
+          precedes it — and its onboarding sequence starts furnishing a group
+          straight away, which an incompatible desk can't serve. */}
+      {deskCompat?.status === 'ok' ? authenticatedOverlay : null}
     </ZStack>
   );
 }

--- a/apps/tlon-mobile/src/components/AuthenticatedApp.tsx
+++ b/apps/tlon-mobile/src/components/AuthenticatedApp.tsx
@@ -283,9 +283,15 @@ function AuthenticatedApp({
         <RootStack />
       )}
       {AUTOMATED_TEST && <AutomatedTestSyncScreen />}
+      {/* Shake-triggered, so it can't cover the notice on its own; someone who
+          shakes the phone at a broken-looking screen wants the bug reporter. */}
       {poorUxReportModal}
-      {promptSheet}
-      {webAppSplashSheet}
+      {/* Both open themselves — the revival prompt from the app-status
+          callback, the web-app splash from its own mount effect — so they'd
+          cover the notice, and the prompt leads into an onboarding flow this
+          desk can't serve. Same gate as the onboarding overlay below. */}
+      {deskCompat?.status === 'ok' ? promptSheet : null}
+      {deskCompat?.status === 'ok' ? webAppSplashSheet : null}
     </ZStack>
   );
 }

--- a/apps/tlon-mobile/src/components/AuthenticatedApp.tsx
+++ b/apps/tlon-mobile/src/components/AuthenticatedApp.tsx
@@ -21,6 +21,7 @@ import {
   markPushNotifTapSyncSinceComplete,
 } from '@tloncorp/app/lib/pushNotifTapTelemetry';
 import { recoverTlonbotRevivalDeferredConfig } from '@tloncorp/app/lib/tlonbotRevivalDeferredConfig';
+import { DeskOutdatedScreen } from '@tloncorp/app/features/DeskOutdatedScreen';
 import { RootStack } from '@tloncorp/app/navigation/RootStack';
 import { AppDataProvider } from '@tloncorp/app/provider/AppDataProvider';
 import {
@@ -69,6 +70,26 @@ import { useTlonbotRevivalPrompt } from './TlonbotRevivalPromptSheet';
 
 const ABANDONED_FLUSH_TIMEOUT_MS = 300;
 const hostingAuthLogger = createDevLogger('hosting auth guard', true);
+
+// Prefetch posts for the chat list, once per login. Runs after sync start —
+// including a sync start that only succeeded on a desk-compatibility retry,
+// where the first attempt returned as a gated no-op. The sync size depends on
+// the connection, which is why this lives here rather than in shared sync.
+async function syncInitialPostsIfNeeded() {
+  if (await db.didSyncInitialPosts.getValue()) {
+    return;
+  }
+
+  const net = await NetInfo.fetch();
+  const syncSize =
+    net.isConnected &&
+    (net.type === 'wifi' ||
+      (net.type === 'cellular' &&
+        ['4g', '5g'].includes(net.details.cellularGeneration ?? '')))
+      ? 'heavy'
+      : 'light';
+  sync.syncInitialPosts({ syncSize });
+}
 
 type RequireHostingAuth = (options?: { force?: boolean }) => Promise<boolean>;
 
@@ -124,11 +145,15 @@ function useRequireHostingAuth(
 }
 
 function AuthenticatedApp({
+  onLogout,
   requireHostingAuth,
 }: {
+  onLogout: () => void | Promise<void>;
   requireHostingAuth: RequireHostingAuth;
 }) {
   const telemetry = useTelemetry();
+  const deskCompat = store.useDeskCompatibility();
+  const { contactId } = useShip();
   const checkNodeStopped = useCheckNodeStopped();
   const { maybeShowPrompt, promptSheet } = useTlonbotRevivalPrompt();
   const { splashSheet: webAppSplashSheet } = useWebAppSplash();
@@ -180,6 +205,12 @@ function AuthenticatedApp({
 
       // app returned from background
       if (status === 'active') {
+        if (store.getSession()?.deskCompat) {
+          // Gated on desk compatibility: syncSince would fail the same way
+          // startup did. Read live rather than from render state so a gate that
+          // arrives mid-session is respected.
+          return;
+        }
         updateSession({ isSyncing: true });
         syncSince({ callCtx: { cause: 'app-foregrounded' } })
           .catch(() => {})
@@ -228,9 +259,29 @@ function AuthenticatedApp({
     db.nodeStoppedWhileLoggedIn.setValue(false);
   }, []);
 
+  const handleRetryDeskCompatibility = useCallback(() => {
+    sync
+      .retryDeskCompatibility({ onRecovered: syncInitialPostsIfNeeded })
+      .catch(() => {});
+  }, []);
+
   return (
     <ZStack flex={1}>
-      <RootStack />
+      {store.shouldShowDeskNotice(deskCompat) ? (
+        // In place of the navigator rather than around it, so the node-stopped
+        // and app-status handling above stays mounted: a paused or suspended
+        // hosted node still kicks back to onboarding while this is up.
+        <DeskOutdatedScreen
+          currentVersion={deskCompat.current}
+          minimumVersion={deskCompat.minimum}
+          shipName={contactId ?? undefined}
+          isProbing={deskCompat.status === 'probing'}
+          onRetry={handleRetryDeskCompatibility}
+          onLogout={onLogout}
+        />
+      ) : (
+        <RootStack />
+      )}
       {AUTOMATED_TEST && <AutomatedTestSyncScreen />}
       {poorUxReportModal}
       {promptSheet}
@@ -240,35 +291,29 @@ function AuthenticatedApp({
 }
 
 function AuthenticatedAppContent({
+  onLogout,
   requireHostingAuth,
 }: {
+  onLogout: () => void | Promise<void>;
   requireHostingAuth: RequireHostingAuth;
 }) {
   const [clientReady, setClientReady] = useState(false);
   const configureClient = useConfigureUrbitClient();
+  const deskCompat = store.useDeskCompatibility();
+  // Hold the spinner until the cold-start probe reports, rather than flashing
+  // the app on ahead of the notice. Bounded by the probe's own timeout.
+  const isProbingColdStart = store.isDeskProbePending(deskCompat);
 
   useEffect(() => {
     let canceled = false;
 
     configureClient();
-    // we store a flag to ensure this runs only once per login, not anytime
-    // the app is opened
-    db.didSyncInitialPosts.getValue().then((didSyncInitialPosts) => {
+    // syncInitialPostsIfNeeded checks the once-per-login flag itself; reading
+    // it here holds the spinner until storage is readable.
+    db.didSyncInitialPosts.getValue().then(() => {
       sync
         .syncStart()
-        .then(async () => {
-          if (!didSyncInitialPosts) {
-            const net = await NetInfo.fetch();
-            const syncSize =
-              net.isConnected &&
-              (net.type === 'wifi' ||
-                (net.type === 'cellular' &&
-                  ['4g', '5g'].includes(net.details.cellularGeneration ?? '')))
-                ? 'heavy'
-                : 'light';
-            sync.syncInitialPosts({ syncSize });
-          }
-        })
+        .then(syncInitialPostsIfNeeded)
         .catch(() => {});
 
       if (!canceled) {
@@ -281,7 +326,7 @@ function AuthenticatedAppContent({
     };
   }, [configureClient]);
 
-  if (!clientReady) {
+  if (!clientReady || isProbingColdStart) {
     return (
       <ZStack flex={1} alignItems="center" justifyContent="center">
         <LoadingSpinner />
@@ -300,7 +345,10 @@ function AuthenticatedAppContent({
       <BottomSheetModalProvider>
         <ForwardPostSheetProvider>
           <ShareIntentForwardSheetProvider enabled>
-            <AuthenticatedApp requireHostingAuth={requireHostingAuth} />
+            <AuthenticatedApp
+              onLogout={onLogout}
+              requireHostingAuth={requireHostingAuth}
+            />
           </ShareIntentForwardSheetProvider>
         </ForwardPostSheetProvider>
       </BottomSheetModalProvider>
@@ -323,6 +371,7 @@ export default function ConnectedAuthenticatedApp({
   const [authAttempt, setAuthAttempt] = useState(0);
   const [profile, setProfile] = useState<db.Contact | null>(null);
   const { contactId } = useShip();
+  const deskCompat = store.useDeskCompatibility();
   const { getToken: getRecaptchaToken } = useRecaptcha(
     hostingAuthState === 'expired'
   );
@@ -427,8 +476,14 @@ export default function ConnectedAuthenticatedApp({
 
   return (
     <ZStack flex={1}>
-      <AuthenticatedAppContent requireHostingAuth={requireHostingAuth} />
-      {authenticatedOverlay}
+      <AuthenticatedAppContent
+        onLogout={onLogout}
+        requireHostingAuth={requireHostingAuth}
+      />
+      {/* The overlay is opaque and full-screen, so it would bury the desk
+          notice — and the spinner that precedes it — under an onboarding
+          sequence that can't complete against an incompatible desk anyway. */}
+      {deskCompat ? null : authenticatedOverlay}
     </ZStack>
   );
 }

--- a/apps/tlon-mobile/src/components/AuthenticatedApp.tsx
+++ b/apps/tlon-mobile/src/components/AuthenticatedApp.tsx
@@ -171,6 +171,7 @@ function AuthenticatedApp({
 
   const handleAppStatusChange = useCallback(
     async (status: AppStatus) => {
+      let gated = false;
       if (status === 'inactive' || status === 'background') {
         const didAbandonChatList = markChatListMeasurementAbandoned(status);
         const didAbandonPushNotif =
@@ -194,8 +195,20 @@ function AuthenticatedApp({
         if (!(await requireHostingAuth())) {
           return;
         }
+
+        // Read live rather than from render state, so a gate that arrives
+        // mid-session is respected. Everything that would talk to the desk is
+        // skipped while it's up — including on 'opened', which fires as soon as
+        // the notice mounts. Node status still has to be checked: a paused or
+        // suspended host has to kick back to onboarding from here.
+        gated = store.isDeskGated(store.getSession()?.deskCompat);
+
         startChatListSettleMeasurement(status);
-        recoverTlonbotRevivalDeferredConfig(status).catch(() => {});
+        if (!gated) {
+          // Furnishes a group and pushes profile/bot config to the host.
+          recoverTlonbotRevivalDeferredConfig(status).catch(() => {});
+        }
+        // Local only: reads the native background cache into the db.
         await checkForCachedChanges();
         telemetry.captureAppActive();
         const nodeCheck = await checkNodeStopped();
@@ -205,10 +218,8 @@ function AuthenticatedApp({
 
       // app returned from background
       if (status === 'active') {
-        if (store.isDeskGated(store.getSession()?.deskCompat)) {
-          // Gated on desk compatibility: syncSince would fail the same way
-          // startup did. Read live rather than from render state so a gate that
-          // arrives mid-session is respected.
+        if (gated) {
+          // syncSince would fail the same way startup did.
           return;
         }
         updateSession({ isSyncing: true });

--- a/apps/tlon-mobile/src/components/AuthenticatedApp.tsx
+++ b/apps/tlon-mobile/src/components/AuthenticatedApp.tsx
@@ -270,6 +270,22 @@ function AuthenticatedApp({
     db.nodeStoppedWhileLoggedIn.setValue(false);
   }, []);
 
+  // The desk gate skips the desk-dependent half of the 'opened' callback, and
+  // clearing it — by Try again or by an automatic recovery — raises no
+  // app-status event of its own, so deferred config would sit unapplied until
+  // the next foreground.
+  const wasDeskGated = useRef(false);
+  useEffect(() => {
+    if (store.isDeskGated(deskCompat)) {
+      wasDeskGated.current = true;
+      return;
+    }
+    if (deskCompat?.status === 'ok' && wasDeskGated.current) {
+      wasDeskGated.current = false;
+      recoverTlonbotRevivalDeferredConfig('desk_gate_cleared').catch(() => {});
+    }
+  }, [deskCompat]);
+
   const handleRetryDeskCompatibility = useCallback(() => {
     sync
       .retryDeskCompatibility({ onRecovered: syncInitialPostsIfNeeded })

--- a/apps/tlon-mobile/src/fixtures/DeskOutdatedScreen.fixture.tsx
+++ b/apps/tlon-mobile/src/fixtures/DeskOutdatedScreen.fixture.tsx
@@ -1,0 +1,36 @@
+import { FixtureWrapper } from '@tloncorp/app/fixtures/FixtureWrapper';
+import { DeskOutdatedScreen } from '@tloncorp/app/features/DeskOutdatedScreen';
+
+export default {
+  'Desk outdated — version reported': (
+    <FixtureWrapper safeArea={false}>
+      <DeskOutdatedScreen
+        currentVersion="12.1.0"
+        minimumVersion="12.2.0"
+        shipName="~palfun-foslup"
+        onRetry={() => {}}
+        onLogout={async () => undefined}
+      />
+    </FixtureWrapper>
+  ),
+  'Desk outdated — retrying': (
+    <FixtureWrapper safeArea={false}>
+      <DeskOutdatedScreen
+        currentVersion="12.1.0"
+        minimumVersion="12.2.0"
+        isProbing
+        onRetry={() => {}}
+        onLogout={async () => undefined}
+      />
+    </FixtureWrapper>
+  ),
+  'Desk outdated — no version reported': (
+    <FixtureWrapper safeArea={false}>
+      <DeskOutdatedScreen
+        currentVersion={null}
+        minimumVersion="12.2.0"
+        onRetry={() => {}}
+      />
+    </FixtureWrapper>
+  ),
+};

--- a/apps/tlon-web/e2e/desk-compat.spec.ts
+++ b/apps/tlon-web/e2e/desk-compat.spec.ts
@@ -1,0 +1,72 @@
+import { expect, test } from '@playwright/test';
+
+import shipManifest from './shipManifest.json';
+
+const zodUrl = `${shipManifest['~zod'].webUrl}/apps/groups/`;
+
+// The startup probe reads the %groups version out of the docket charge, so
+// rewriting that one response is enough to make a healthy ship look outdated.
+const CHARGES_SCRY = /\/~\/scry\/docket\/charges\.json/;
+const INIT_SCRY = /\/~\/scry\/groups-ui\/v10\/init\.json/;
+const OUTDATED_VERSION = '0.0.1';
+
+test('blocks startup when the ship reports an outdated %groups desk', async ({
+  browser,
+}) => {
+  const context = await browser.newContext({
+    storageState: shipManifest['~zod'].authFile,
+  });
+  await context.addInitScript(() => {
+    (globalThis as any).TLON_IS_E2E = true;
+  });
+  const page = await context.newPage();
+
+  const initRequests: string[] = [];
+  page.on('request', (request) => {
+    if (INIT_SCRY.test(request.url())) {
+      initRequests.push(request.url());
+    }
+  });
+
+  // Installed before the first navigation: the probe runs at the very start of
+  // sync, so a route added afterwards would be too late.
+  await page.route(CHARGES_SCRY, (route) =>
+    route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify({
+        initial: { groups: { version: OUTDATED_VERSION } },
+      }),
+    })
+  );
+
+  try {
+    await page.goto(zodUrl);
+
+    await expect(page.getByTestId('desk-outdated-screen')).toBeVisible({
+      timeout: 30000,
+    });
+    await expect(page.getByTestId('desk-outdated-current')).toHaveText(
+      OUTDATED_VERSION
+    );
+    // Asserted as a shape rather than a literal so bumping the minimum doesn't
+    // drag this test along with it.
+    await expect(page.getByTestId('desk-outdated-minimum')).toHaveText(
+      /^\d+\.\d+\.\d+$/
+    );
+
+    // The whole point of the gate: nothing that an old desk would reject.
+    expect(initRequests).toHaveLength(0);
+
+    // Now let the ship report its real version, as an update would.
+    await page.unroute(CHARGES_SCRY);
+    await page.getByTestId('desk-outdated-retry').click();
+
+    // Recovers in place, with no reload.
+    await expect(page.getByText('Home')).toBeVisible({ timeout: 30000 });
+    await expect(page.getByTestId('desk-outdated-screen')).toHaveCount(0);
+    expect(initRequests.length).toBeGreaterThan(0);
+  } finally {
+    await context.close();
+  }
+});

--- a/apps/tlon-web/src/app.tsx
+++ b/apps/tlon-web/src/app.tsx
@@ -402,7 +402,7 @@ function DeskOutdatedNotice({
   shipName,
   onLogout,
 }: {
-  deskCompat: store.DeskCompatibility;
+  deskCompat: store.DeskGate;
   shipName?: string;
   onLogout?: () => void | Promise<void>;
 }) {

--- a/apps/tlon-web/src/app.tsx
+++ b/apps/tlon-web/src/app.tsx
@@ -8,13 +8,16 @@ import {
   useNavigationContainerRef,
 } from '@react-navigation/native';
 import { ENABLED_LOGGERS } from '@tloncorp/app/constants';
+import { DeskOutdatedScreen } from '@tloncorp/app/features/DeskOutdatedScreen';
 import useBrowserNotifications from '@tloncorp/app/hooks/useBrowserNotifications';
 import { useConfigureUrbitClient } from '@tloncorp/app/hooks/useConfigureUrbitClient';
 import { useCurrentUserId } from '@tloncorp/app/hooks/useCurrentUser';
 import useDesktopNotifications from '@tloncorp/app/hooks/useDesktopNotifications';
 import { useFindSuggestedContacts } from '@tloncorp/app/hooks/useFindSuggestedContacts';
+import { useHandleLogout } from '@tloncorp/app/hooks/useHandleLogout';
 import { useNavigationLogging } from '@tloncorp/app/hooks/useNavigationLogger';
 import { useRenderCount } from '@tloncorp/app/hooks/useRenderCount';
+import { useResetDb } from '@tloncorp/app/hooks/useResetDb';
 import { useTelemetry } from '@tloncorp/app/hooks/useTelemetry';
 import {
   SplashScreenTask,
@@ -390,6 +393,41 @@ function AppRoutes() {
   );
 }
 
+// This client can be pointed at any ship — a dev server, Electron, or a cached
+// build that outlived the ship's desk — so the notice belongs on web too. It
+// takes precedence over the loading states below: a gated start never sets
+// session.startTime, so the splash screen would otherwise wait forever.
+function DeskOutdatedNotice({
+  deskCompat,
+  shipName,
+  onLogout,
+}: {
+  deskCompat: store.DeskCompatibility;
+  shipName?: string;
+  onLogout?: () => void | Promise<void>;
+}) {
+  const handleRetry = useCallback(() => {
+    sync
+      .retryDeskCompatibility({
+        // The single syncStart below already resolved as a gated no-op, so its
+        // post-start work has to be run again on a successful retry.
+        onRecovered: () => sync.syncInitialPosts({ syncSize: 'light' }),
+      })
+      .catch(() => {});
+  }, []);
+
+  return (
+    <DeskOutdatedScreen
+      currentVersion={deskCompat.current}
+      minimumVersion={deskCompat.minimum}
+      shipName={shipName}
+      isProbing={deskCompat.status === 'probing'}
+      onRetry={handleRetry}
+      onLogout={onLogout}
+    />
+  );
+}
+
 function ConnectedDesktopApp({
   ship,
   shipUrl,
@@ -401,7 +439,13 @@ function ConnectedDesktopApp({
 }) {
   const [clientReady, setClientReady] = useState(false);
   const configureClient = useConfigureUrbitClient();
+  const deskCompat = store.useDeskCompatibility();
   const hasSyncedRef = React.useRef(false);
+  // Same handler the desktop settings navigator uses: it clears the stored
+  // Electron credentials and reloads back to the login screen, which is the
+  // only way off a ship whose desk this build can't talk to.
+  const resetDb = useResetDb();
+  const handleLogout = useHandleLogout({ resetDb });
   useDesktopNotifications(clientReady);
 
   useEffect(() => {
@@ -435,6 +479,19 @@ function ConnectedDesktopApp({
 
     initializeClient();
   }, [configureClient, ship, shipUrl, authCookie]);
+
+  // Rendered outside AppRoutes, so there is no NavigationContainer above it.
+  // Depends on TLON-6529 (dropping link support from ui/Pressable, which calls
+  // useLinkProps unconditionally) landing first; this branch rebases onto it.
+  if (store.shouldShowDeskNotice(deskCompat)) {
+    return (
+      <DeskOutdatedNotice
+        deskCompat={deskCompat}
+        shipName={ship}
+        onLogout={handleLogout}
+      />
+    );
+  }
 
   if (!clientReady) {
     return (
@@ -476,6 +533,7 @@ function ConnectedWebApp() {
   const [dbIsLoaded, setDbIsLoaded] = useState(false);
   const configureClient = useConfigureUrbitClient();
   const session = store.useCurrentSession();
+  const deskCompat = store.useDeskCompatibility();
   const hasSyncedRef = React.useRef(false);
   const dbLoadFailureReportedRef = React.useRef(false);
   const telemetry = useTelemetry();
@@ -497,7 +555,8 @@ function ConnectedWebApp() {
       if (!hasSyncedRef.current) {
         sync
           .syncStart(false)
-          .then(() => sync.syncInitialPosts({ syncSize: 'light' }));
+          .then(() => sync.syncInitialPosts({ syncSize: 'light' }))
+          .catch(() => {});
         hasSyncedRef.current = true;
         telemetry.captureAppActive('web');
       }
@@ -560,6 +619,18 @@ function ConnectedWebApp() {
     useCallback(() => true, []),
     splashScreenProgress.finished
   );
+
+  // Rendered outside AppRoutes, so there is no NavigationContainer above it.
+  // Depends on TLON-6529 (dropping link support from ui/Pressable, which calls
+  // useLinkProps unconditionally) landing first; this branch rebases onto it.
+  // No onLogout: the app offers no logout on plain web either (Log out is
+  // hidden when isWeb, ui/components/SettingsScreenView.tsx), and there the
+  // handler would only clear local state and reload into the same cookie.
+  if (store.shouldShowDeskNotice(deskCompat)) {
+    return (
+      <DeskOutdatedNotice deskCompat={deskCompat} shipName={currentUserId} />
+    );
+  }
 
   if (!hideSplashScreen) {
     return (

--- a/packages/api/src/__tests__/reauthChannel.test.ts
+++ b/packages/api/src/__tests__/reauthChannel.test.ts
@@ -1,6 +1,9 @@
 import { afterEach, describe, expect, test, vi } from 'vitest';
 
-import { AuthFailureError } from '../client/landscapeApi';
+import {
+  AuthFailureError,
+  getLandscapeAuthCookie,
+} from '../client/landscapeApi';
 import {
   internalConfigureClient,
   internalRemoveClient,
@@ -585,5 +588,66 @@ describe('scry reauth retry', () => {
 
     await vi.advanceTimersByTimeAsync(50);
     await expect(attempt).rejects.toThrow('scry timed out');
+  });
+});
+
+describe('login timeout', () => {
+  const LOGIN_TIMEOUT = 30 * 1000;
+
+  // A login the ship never answers. Only the abort signal ends it, which is
+  // what a real fetch does.
+  function hangingLoginFetch() {
+    return vi.fn(
+      (_url: string, init?: RequestInit) =>
+        new Promise<Response>((_resolve, reject) => {
+          init?.signal?.addEventListener('abort', () =>
+            reject(new DOMException('The operation was aborted.', 'AbortError'))
+          );
+        })
+    );
+  }
+
+  test('bounds a login the ship never answers', async () => {
+    vi.useFakeTimers();
+    vi.stubGlobal('fetch', hangingLoginFetch());
+
+    const attempt = getLandscapeAuthCookie('http://example.test', 'code');
+    // Observed rather than awaited, so an unbounded login fails the assertion
+    // below instead of timing the test out.
+    const settled = vi.fn();
+    void attempt.then(settled, settled);
+
+    await vi.advanceTimersByTimeAsync(LOGIN_TIMEOUT + 1);
+
+    expect(settled).toHaveBeenCalled();
+    await expect(attempt).rejects.toThrow(/Login timed out/);
+  });
+
+  test('a 403 whose reauth hangs rejects the scry instead of holding it', async () => {
+    vi.useFakeTimers();
+    const scryWithInfo = vi
+      .fn()
+      .mockRejectedValue(
+        Object.assign(new Error('forbidden'), { status: 403 })
+      );
+    const client = fakeClient({ scryWithInfo });
+    vi.stubGlobal('fetch', hangingLoginFetch());
+    internalConfigureClient({
+      shipName: '~zod',
+      shipUrl: 'http://example.test',
+      getCode: vi.fn(async () => 'code'),
+      client: client as any,
+    });
+
+    const attempt = scry({ app: 'hood', path: '/kiln/pikes', timeout: 50 });
+    const settled = vi.fn();
+    void attempt.then(settled, settled);
+
+    await vi.advanceTimersByTimeAsync(LOGIN_TIMEOUT + 1);
+
+    // The queued caller settles rather than waiting on a silent ship forever.
+    expect(settled).toHaveBeenCalled();
+    await expect(attempt).rejects.toThrow(/Error during reauth/);
+    expect(scryWithInfo).toHaveBeenCalledTimes(1);
   });
 });

--- a/packages/api/src/__tests__/reauthChannel.test.ts
+++ b/packages/api/src/__tests__/reauthChannel.test.ts
@@ -5,6 +5,8 @@ import {
   internalConfigureClient,
   internalRemoveClient,
   poke,
+  scry,
+  scryNoun,
   subscribe,
 } from '../client/urbit';
 import { Atom } from '@urbit/nockjs';
@@ -509,5 +511,79 @@ describe('storms', () => {
     // the late failure saw the epoch move and just retried
     expect(loginFetch).toHaveBeenCalledTimes(1);
     expect(client.seamlessReset).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe('scry reauth retry', () => {
+  test('bounds the retry that follows a 403 instead of hanging on it', async () => {
+    vi.useFakeTimers();
+    // Stands in for Urbit.scry, where the timeout is what aborts the request:
+    // a call issued without one has nothing to stop it.
+    const scryWithInfo = vi.fn(
+      async ({ timeout }: { app: string; path: string; timeout?: number }) => {
+        if (scryWithInfo.mock.calls.length === 1) {
+          throw Object.assign(new Error('forbidden'), { status: 403 });
+        }
+        return new Promise<never>((_resolve, reject) => {
+          if (timeout != null) {
+            setTimeout(() => reject(new Error('scry timed out')), timeout);
+          }
+        });
+      }
+    );
+    const client = fakeClient({ scryWithInfo });
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue(loginResponse()));
+    internalConfigureClient({
+      shipName: '~zod',
+      shipUrl: 'http://example.test',
+      getCode: vi.fn(async () => 'code'),
+      client: client as any,
+    });
+
+    const attempt = scry({ app: 'hood', path: '/kiln/pikes', timeout: 50 });
+    // Observed rather than awaited: an unbounded retry never settles, and the
+    // assertion below should say so rather than time the test out.
+    void attempt.catch(() => {});
+
+    await vi.advanceTimersByTimeAsync(0);
+    expect(scryWithInfo).toHaveBeenCalledTimes(2);
+    expect(scryWithInfo.mock.calls[1][0]).toMatchObject({ timeout: 50 });
+
+    await vi.advanceTimersByTimeAsync(50);
+    await expect(attempt).rejects.toThrow('scry timed out');
+  });
+
+  test('bounds the noun retry that follows a 403 in the same way', async () => {
+    vi.useFakeTimers();
+    const scryNounWithInfo = vi.fn(
+      async ({ timeout }: { app: string; path: string; timeout?: number }) => {
+        if (scryNounWithInfo.mock.calls.length === 1) {
+          throw Object.assign(new Error('forbidden'), { status: 403 });
+        }
+        return new Promise<never>((_resolve, reject) => {
+          if (timeout != null) {
+            setTimeout(() => reject(new Error('scry timed out')), timeout);
+          }
+        });
+      }
+    );
+    const client = fakeClient({ scryNounWithInfo });
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue(loginResponse()));
+    internalConfigureClient({
+      shipName: '~zod',
+      shipUrl: 'http://example.test',
+      getCode: vi.fn(async () => 'code'),
+      client: client as any,
+    });
+
+    const attempt = scryNoun({ app: 'hood', path: '/kiln/pikes', timeout: 50 });
+    void attempt.catch(() => {});
+
+    await vi.advanceTimersByTimeAsync(0);
+    expect(scryNounWithInfo).toHaveBeenCalledTimes(2);
+    expect(scryNounWithInfo.mock.calls[1][0]).toMatchObject({ timeout: 50 });
+
+    await vi.advanceTimersByTimeAsync(50);
+    await expect(attempt).rejects.toThrow('scry timed out');
   });
 });

--- a/packages/api/src/client/landscapeApi.ts
+++ b/packages/api/src/client/landscapeApi.ts
@@ -1,15 +1,35 @@
+// A hung login would otherwise be unbounded, and callers wait on it before
+// retrying the request that triggered the reauth — holding a sync queue worker
+// for as long as the ship stays silent.
+const LOGIN_TIMEOUT = 30 * 1000;
+
 export const getLandscapeAuthCookie = async (
   shipUrl: string,
   accessCode: string
 ) => {
-  const response = await fetch(`${shipUrl}/~/login`, {
-    method: 'POST',
-    headers: {
-      'Content-Type': 'application/x-www-form-urlencoded;charset=UTF-8',
-    },
-    body: `password=${accessCode}`,
-    credentials: 'include',
-  });
+  // AbortSignal.timeout isn't available on every runtime we ship to.
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), LOGIN_TIMEOUT);
+
+  let response: Response;
+  try {
+    response = await fetch(`${shipUrl}/~/login`, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/x-www-form-urlencoded;charset=UTF-8',
+      },
+      body: `password=${accessCode}`,
+      credentials: 'include',
+      signal: controller.signal,
+    });
+  } catch (err) {
+    if (controller.signal.aborted) {
+      throw new Error(`Login timed out after ${LOGIN_TIMEOUT}ms`);
+    }
+    throw err;
+  } finally {
+    clearTimeout(timer);
+  }
 
   if (response.status < 200 || response.status > 299) {
     throw new AuthFailureError(response.status);

--- a/packages/api/src/client/settingsApi.ts
+++ b/packages/api/src/client/settingsApi.ts
@@ -382,17 +382,23 @@ export interface Pikes {
   [desk: string]: Pike;
 }
 
-export async function getAppInfo(): Promise<db.AppInfo> {
-  const pikes = await scry<Pikes>({
-    app: 'hood',
-    path: '/kiln/pikes',
-  });
-  const charges = (
-    await scry<ChargeUpdateInitial>({
+export async function getAppInfo({
+  timeout,
+}: { timeout?: number } = {}): Promise<db.AppInfo> {
+  // Parallel rather than sequential: startup gates on this, so the two scries
+  // should cost one round trip, not two.
+  const [pikes, charges] = await Promise.all([
+    scry<Pikes>({
+      app: 'hood',
+      path: '/kiln/pikes',
+      timeout,
+    }),
+    scry<ChargeUpdateInitial>({
       app: 'docket',
       path: '/charges',
-    })
-  ).initial;
+      timeout,
+    }).then((update) => update?.initial),
+  ]);
 
   const groupsPike = pikes?.['groups'] ?? {};
   const groupsCharge = charges?.['groups'] ?? {};

--- a/packages/api/src/client/settingsApi.ts
+++ b/packages/api/src/client/settingsApi.ts
@@ -382,6 +382,11 @@ export interface Pikes {
   [desk: string]: Pike;
 }
 
+// Ceiling for the pike scry. Short on purpose: it only carries the hash and
+// sync node shown on the App Info screen, and startup can't afford to wait on
+// it for the version it does need.
+const DIAGNOSTICS_TIMEOUT = 3 * 1000;
+
 export async function getAppInfo({
   timeout,
 }: { timeout?: number } = {}): Promise<db.AppInfo> {
@@ -389,11 +394,13 @@ export async function getAppInfo({
   // should cost one round trip, not two.
   const [pikes, charges] = await Promise.all([
     // The pike is diagnostics only. Losing it must not throw away the version
-    // from the charge, which is the answer the startup gate is waiting for.
+    // from the charge, which is the answer the startup gate is waiting for —
+    // and it has to give up well inside the gate's own deadline, or a hung
+    // pike would hold this Promise.all past it and lose the version anyway.
     scry<Pikes>({
       app: 'hood',
       path: '/kiln/pikes',
-      timeout,
+      timeout: Math.min(timeout ?? DIAGNOSTICS_TIMEOUT, DIAGNOSTICS_TIMEOUT),
     }).catch(() => null),
     scry<ChargeUpdateInitial>({
       app: 'docket',

--- a/packages/api/src/client/settingsApi.ts
+++ b/packages/api/src/client/settingsApi.ts
@@ -388,11 +388,13 @@ export async function getAppInfo({
   // Parallel rather than sequential: startup gates on this, so the two scries
   // should cost one round trip, not two.
   const [pikes, charges] = await Promise.all([
+    // The pike is diagnostics only. Losing it must not throw away the version
+    // from the charge, which is the answer the startup gate is waiting for.
     scry<Pikes>({
       app: 'hood',
       path: '/kiln/pikes',
       timeout,
-    }),
+    }).catch(() => null),
     scry<ChargeUpdateInitial>({
       app: 'docket',
       path: '/charges',
@@ -400,13 +402,13 @@ export async function getAppInfo({
     }).then((update) => update?.initial),
   ]);
 
-  const groupsPike = pikes?.['groups'] ?? {};
+  const groupsPike = pikes?.['groups'];
   const groupsCharge = charges?.['groups'] ?? {};
 
   return {
     groupsVersion: groupsCharge.version ?? 'n/a',
-    groupsHash: groupsPike.hash ?? 'n/a',
-    groupsSyncNode: groupsPike.sync?.ship ?? 'n/a',
+    groupsHash: groupsPike?.hash ?? 'n/a',
+    groupsSyncNode: groupsPike?.sync?.ship ?? 'n/a',
   };
 }
 

--- a/packages/api/src/client/urbit.ts
+++ b/packages/api/src/client/urbit.ts
@@ -845,7 +845,14 @@ export async function scry<T>({
       logger.log('scry failed with 403, authing to try again');
       await reauthOnce(sent);
       const { result, responseSizeInBytes, responseStatus } =
-        await activeClient.scryWithInfo<T>({ app, path });
+        await activeClient.scryWithInfo<T>({
+          app,
+          path,
+          // Same bound as the first attempt: an un-timed retry has nothing to
+          // abort it, so a hung one never settles and holds its caller — and,
+          // for queued work, its sync queue thread — forever.
+          timeout: timeout ?? DEFAULT_SCRY_TIMEOUT,
+        });
       trackDuration('success', { responseSizeInBytes, responseStatus });
       return result;
     }
@@ -954,7 +961,12 @@ export async function scryNoun({
       logger.log('scry failed with 403, authing to try again');
       await reauth();
       const { result, responseSizeInBytes, responseStatus } =
-        await config.client.scryNounWithInfo({ app, path });
+        // Bounded like the first attempt, for the reason given on scry above.
+        await config.client.scryNounWithInfo({
+          app,
+          path,
+          timeout: timeout ?? DEFAULT_SCRY_TIMEOUT,
+        });
       trackDuration('success', { responseSizeInBytes, responseStatus });
       return result;
     }

--- a/packages/api/src/types/analytics.ts
+++ b/packages/api/src/types/analytics.ts
@@ -48,6 +48,7 @@ export enum AnalyticsEvent {
   LatestPostsFetched = 'Latest Posts Fetched',
   LatestPostsWritten = 'Latest Posts Written',
   SubscriptionsEstablished = 'Subscriptions Established',
+  DeskIncompatible = 'Desk Incompatible',
   AuthFailedToGetCode = 'Failed to get access code',
   AuthForcedLogout = 'Auth Forced Logout',
   NodeConnectionDebug = 'Node Connection Debug',

--- a/packages/app/constants.ts
+++ b/packages/app/constants.ts
@@ -10,10 +10,11 @@ export const TLON_APP_STORE_URL =
 export const TLON_PLAY_STORE_URL =
   'https://play.google.com/store/apps/details?id=io.tlon.groups&utm_source=webapp';
 export const SUPPORT_EMAIL = 'support@tlon.io';
-// Where we send someone whose ship's %groups desk is too old to talk to.
-// Placeholder: the exact page is pending — point this at the update
-// instructions rather than the docs root once the team names one.
-export const DESK_UPDATE_HELP_URL = 'https://docs.tlon.io/';
+// Where we send someone whose ship's %groups desk is too old to talk to: the
+// user manual's update order (runtime, kernel, apps), including blocked app
+// updates, `|bump` and `+vats`.
+export const DESK_UPDATE_HELP_URL =
+  'https://docs.urbit.org/user-manual/os/updates';
 export const CHAT_REF_LIKE_MAX_WIDTH = 600;
 export const MCP_OAUTH_COMPLETION_PATH = 'mcp-oauth/complete';
 

--- a/packages/app/constants.ts
+++ b/packages/app/constants.ts
@@ -10,6 +10,10 @@ export const TLON_APP_STORE_URL =
 export const TLON_PLAY_STORE_URL =
   'https://play.google.com/store/apps/details?id=io.tlon.groups&utm_source=webapp';
 export const SUPPORT_EMAIL = 'support@tlon.io';
+// Where we send someone whose ship's %groups desk is too old to talk to.
+// Placeholder: the exact page is pending — point this at the update
+// instructions rather than the docs root once the team names one.
+export const DESK_UPDATE_HELP_URL = 'https://docs.tlon.io/';
 export const CHAT_REF_LIKE_MAX_WIDTH = 600;
 export const MCP_OAUTH_COMPLETION_PATH = 'mcp-oauth/complete';
 

--- a/packages/app/features/DeskOutdatedScreen.tsx
+++ b/packages/app/features/DeskOutdatedScreen.tsx
@@ -1,0 +1,110 @@
+import { Button, TlonText } from '@tloncorp/ui';
+import { useCallback } from 'react';
+import { Linking } from 'react-native';
+import { View, YStack } from 'tamagui';
+
+import { DESK_UPDATE_HELP_URL } from '../constants';
+// Imported directly rather than through the `../ui` barrel: this screen is
+// mounted by the app shell before anything else, so it shouldn't drag the whole
+// component library in behind it.
+import { EmailSupportLink } from '../ui/components/EmailSupportLink';
+import { ScreenHeader } from '../ui/components/ScreenHeader';
+
+export type DeskOutdatedScreenProps = {
+  /** Version the ship reports, or null when we couldn't read one. */
+  currentVersion: string | null;
+  minimumVersion: string;
+  /** How to name the ship in the copy; defaults to a generic phrase. */
+  shipName?: string;
+  /** A re-probe is in flight, so the retry action is unavailable. */
+  isProbing?: boolean;
+  onRetry: () => void;
+  /** Omitted where there's no logout to offer, e.g. web. */
+  onLogout?: () => void | Promise<void>;
+};
+
+export function DeskOutdatedScreen({
+  currentVersion,
+  minimumVersion,
+  shipName,
+  isProbing = false,
+  onRetry,
+  onLogout,
+}: DeskOutdatedScreenProps) {
+  const handleHelpPress = useCallback(() => {
+    Linking.openURL(DESK_UPDATE_HELP_URL);
+  }, []);
+
+  return (
+    <View flex={1} backgroundColor="$background" testID="desk-outdated-screen">
+      <ScreenHeader
+        title="Update your ship"
+        backgroundColor="$background"
+        leftControls={
+          onLogout ? (
+            <ScreenHeader.TextButton color="$secondaryText" onPress={onLogout}>
+              Log out
+            </ScreenHeader.TextButton>
+          ) : undefined
+        }
+      />
+      <YStack flex={1} paddingHorizontal="$2xl" paddingBottom="$2xl">
+        <YStack gap="$m" marginTop="$3.5xl">
+          <TlonText.Text size="$title/l" color="$primaryText" trimmed={false}>
+            Your ship needs an update
+          </TlonText.Text>
+          <TlonText.Text
+            size="$label/xl"
+            color="$secondaryText"
+            trimmed={false}
+            maxWidth={340}
+          >
+            {'Tlon needs the Groups desk '}
+            <TlonText.RawText
+              testID="desk-outdated-minimum"
+              color="$primaryText"
+              fontWeight="500"
+            >
+              {minimumVersion}
+            </TlonText.RawText>
+            {' or newer. '}
+            {shipName ?? 'Your ship'}
+            {' reports '}
+            <TlonText.RawText
+              testID="desk-outdated-current"
+              color="$primaryText"
+              fontWeight="500"
+            >
+              {currentVersion ?? 'an older version'}
+            </TlonText.RawText>
+            .
+          </TlonText.Text>
+        </YStack>
+
+        <YStack marginTop="auto" gap="$xl">
+          <Button
+            preset="hero"
+            label="Try again"
+            loading={isProbing}
+            disabled={isProbing}
+            onPress={onRetry}
+            testID="desk-outdated-retry"
+          />
+          <Button
+            preset="minimal"
+            size="medium"
+            label="How to update"
+            onPress={handleHelpPress}
+            centered
+            testID="desk-outdated-help"
+          />
+          <EmailSupportLink
+            size="$label/l"
+            prompt="Still stuck? Email"
+            subject="Help! My ship needs an update."
+          />
+        </YStack>
+      </YStack>
+    </View>
+  );
+}

--- a/packages/shared/src/logic/deskCompatibility.test.ts
+++ b/packages/shared/src/logic/deskCompatibility.test.ts
@@ -1,0 +1,37 @@
+import { describe, expect, test } from 'vitest';
+
+import { MIN_GROUPS_VERSION, classifyDeskVersion } from './deskCompatibility';
+import { parseVersion } from './semver';
+
+describe('classifyDeskVersion', () => {
+  test('accepts the minimum release and anything above it', () => {
+    expect(classifyDeskVersion(MIN_GROUPS_VERSION)).toBe('ok');
+    expect(classifyDeskVersion('12.2.0')).toBe('ok');
+    expect(classifyDeskVersion('12.2.1')).toBe('ok');
+    expect(classifyDeskVersion('13.0.0')).toBe('ok');
+  });
+
+  test('gates releases below the minimum', () => {
+    expect(classifyDeskVersion('12.1.0')).toBe('outdated');
+    expect(classifyDeskVersion('12.0.1')).toBe('outdated');
+    expect(classifyDeskVersion('11.4.0')).toBe('outdated');
+    expect(classifyDeskVersion('0.0.1')).toBe('outdated');
+  });
+
+  test('fails open on anything it cannot fully parse', () => {
+    // These must never gate: '12.2.0 dirty' would pass a prefix check and then
+    // compare as equal to the minimum inside isVersionBelow, and 'n/a' is what
+    // the version scry reports when the docket charge is missing entirely.
+    expect(classifyDeskVersion(undefined)).toBe('unknown');
+    expect(classifyDeskVersion(null)).toBe('unknown');
+    expect(classifyDeskVersion('')).toBe('unknown');
+    expect(classifyDeskVersion('n/a')).toBe('unknown');
+    expect(classifyDeskVersion('12.2')).toBe('unknown');
+    expect(classifyDeskVersion('v12.2.0')).toBe('unknown');
+    expect(classifyDeskVersion('12.1.0 dirty')).toBe('unknown');
+  });
+
+  test('the minimum itself is a parseable version', () => {
+    expect(parseVersion(MIN_GROUPS_VERSION)).not.toBeNull();
+  });
+});

--- a/packages/shared/src/logic/deskCompatibility.ts
+++ b/packages/shared/src/logic/deskCompatibility.ts
@@ -1,0 +1,30 @@
+import { isVersionBelow, parseVersion } from './semver';
+
+// Oldest %groups desk this client supports. Ships reporting a lower docket
+// version get the desk-outdated notice instead of an empty home. Raise it only
+// when dropping backwards-compatibility for older desks; adding a new desk
+// dependency without a fallback also requires raising it (12.2.0 = first desk
+// with /v10/init and the /v3/groups subscription, which the client currently
+// requires with no fallback).
+export const MIN_GROUPS_VERSION = '12.2.0';
+
+export type DeskVersionClassification = 'ok' | 'outdated' | 'unknown';
+
+/**
+ * Classify the %groups desk version reported by the ship's docket metadata.
+ *
+ * Fails open by design. The label is a proxy for path availability, not proof
+ * of it — a dev checkout can carry stale metadata alongside new code — so
+ * anything we can't read as a full semver ('n/a' when the charge is missing,
+ * a partially parseable '12.2.0 dirty', a bare '12.2') is 'unknown' and the
+ * app starts normally. Only a version we can parse *and* that sits strictly
+ * below the minimum gates startup.
+ */
+export function classifyDeskVersion(
+  groupsVersion?: string | null
+): DeskVersionClassification {
+  if (!groupsVersion || parseVersion(groupsVersion) === null) {
+    return 'unknown';
+  }
+  return isVersionBelow(groupsVersion, MIN_GROUPS_VERSION) ? 'outdated' : 'ok';
+}

--- a/packages/shared/src/logic/index.ts
+++ b/packages/shared/src/logic/index.ts
@@ -2,6 +2,7 @@ export * from './utilHooks';
 export * from './contextLens';
 export * from './embed';
 export * from './semver';
+export * from './deskCompatibility';
 export * from './reactionSupport';
 export * from './threadUnreads';
 export * from './notesActivitySupport';

--- a/packages/shared/src/store/session.ts
+++ b/packages/shared/src/store/session.ts
@@ -3,11 +3,23 @@ import { useSyncExternalStore } from 'react';
 
 export type SyncPhase = 'init' | 'high' | 'low' | 'ready';
 
+// Set while the startup desk-version probe is in flight or has found the ship's
+// %groups desk too old to talk to. Absent means the app is free to sync.
+export type DeskCompatibility = {
+  status: 'probing' | 'incompatible';
+  current: string | null;
+  minimum: string;
+  // Whether the gated sync was a recovery run (subscriptions already live), so
+  // a retry can resume with the same alreadySubscribed semantics.
+  subscribed: boolean;
+};
+
 export type Session = {
   startTime?: number;
   channelStatus?: ChannelStatus;
   phase?: SyncPhase;
   isSyncing?: boolean;
+  deskCompat?: DeskCompatibility;
 };
 
 // Session — time when subscriptions were first initialized after which we can assume
@@ -54,7 +66,21 @@ export function getInitializedClient() {
   return initializedClient;
 }
 
+// A token for the current client's lifetime. Long-running work captures it and
+// checks it again before writing anything back, so an answer that arrives after
+// a logout — or after a re-login to the same ship, which `internalConfigureClient`
+// serves with the same Urbit object and the same ship name — can be told apart
+// from one that still belongs to the live login.
+let clientGeneration = 0;
+
+export function getClientGeneration() {
+  return clientGeneration;
+}
+
 export function updateInitializedClient(newValue: boolean) {
+  // configureClient and removeClient are the only callers, so this is the one
+  // place the client's lifetime changes.
+  clientGeneration += 1;
   initializedClient = newValue;
   initializedClientListeners.forEach((listener) => listener(newValue));
 }
@@ -74,6 +100,32 @@ export function useInitializedClient() {
     subscribeToInitializedClient,
     getInitializedClient
   );
+}
+
+export function useDeskCompatibility() {
+  const currentSession = useCurrentSession();
+  return currentSession?.deskCompat;
+}
+
+/**
+ * Whether the startup probe is still running with no verdict yet. `current` is
+ * null only in that state — an incompatible verdict always carries the version
+ * it read — so the shell can hold a loading state here instead of flashing a
+ * notice that has no version to report.
+ */
+export function isDeskProbePending(deskCompat?: DeskCompatibility) {
+  return deskCompat?.status === 'probing' && deskCompat.current === null;
+}
+
+/**
+ * Whether the desk-outdated notice belongs on screen. A retry from the notice
+ * goes back to 'probing' but keeps the version it found, so the notice stays up
+ * with its retry action busy rather than blinking out.
+ */
+export function shouldShowDeskNotice(
+  deskCompat?: DeskCompatibility
+): deskCompat is DeskCompatibility {
+  return deskCompat != null && !isDeskProbePending(deskCompat);
 }
 
 export function useIsSyncing() {

--- a/packages/shared/src/store/session.ts
+++ b/packages/shared/src/store/session.ts
@@ -3,9 +3,9 @@ import { useSyncExternalStore } from 'react';
 
 export type SyncPhase = 'init' | 'high' | 'low' | 'ready';
 
-// Set while the startup desk-version probe is in flight or has found the ship's
-// %groups desk too old to talk to. Absent means the app is free to sync.
-export type DeskCompatibility = {
+// The startup desk-version probe is in flight, or has found the ship's %groups
+// desk too old to talk to. Startup is blocked in both states.
+export type DeskGate = {
   status: 'probing' | 'incompatible';
   current: string | null;
   minimum: string;
@@ -13,6 +13,11 @@ export type DeskCompatibility = {
   // a retry can resume with the same alreadySubscribed semantics.
   subscribed: boolean;
 };
+
+// `undefined` means the probe hasn't reported in this session yet — which is
+// not the same as compatible, so nothing may assume a usable desk until this
+// says 'ok'.
+export type DeskCompatibility = { status: 'ok' } | DeskGate;
 
 export type Session = {
   startTime?: number;
@@ -108,13 +113,28 @@ export function useDeskCompatibility() {
 }
 
 /**
+ * Whether startup is blocked on the desk — either still probing, or already
+ * refused. Anything that would talk to the desk has to wait for this to be
+ * false *and* for a verdict to exist.
+ */
+export function isDeskGated(
+  deskCompat?: DeskCompatibility
+): deskCompat is DeskGate {
+  return deskCompat != null && deskCompat.status !== 'ok';
+}
+
+/**
  * Whether the startup probe is still running with no verdict yet. `current` is
  * null only in that state — an incompatible verdict always carries the version
  * it read — so the shell can hold a loading state here instead of flashing a
  * notice that has no version to report.
  */
 export function isDeskProbePending(deskCompat?: DeskCompatibility) {
-  return deskCompat?.status === 'probing' && deskCompat.current === null;
+  return (
+    isDeskGated(deskCompat) &&
+    deskCompat.status === 'probing' &&
+    deskCompat.current === null
+  );
 }
 
 /**
@@ -124,8 +144,8 @@ export function isDeskProbePending(deskCompat?: DeskCompatibility) {
  */
 export function shouldShowDeskNotice(
   deskCompat?: DeskCompatibility
-): deskCompat is DeskCompatibility {
-  return deskCompat != null && !isDeskProbePending(deskCompat);
+): deskCompat is DeskGate {
+  return isDeskGated(deskCompat) && !isDeskProbePending(deskCompat);
 }
 
 export function useIsSyncing() {

--- a/packages/shared/src/store/sync/sync.test.ts
+++ b/packages/shared/src/store/sync/sync.test.ts
@@ -786,6 +786,7 @@ describe('desk compatibility gate', () => {
 
   let reportedDeskVersion: string | null = MIN_GROUPS_VERSION;
   let probeError: Error | null = null;
+  let pikesError: Error | null = null;
   let heldProbe: { wait: Promise<void>; release: () => void } | null = null;
   let scryCalls: { app: string; path: string; timeout?: number }[] = [];
   type SetValueSpy<
@@ -854,6 +855,9 @@ describe('desk compatibility gate', () => {
         if (probeError) {
           throw probeError;
         }
+        if (app === 'hood' && pikesError) {
+          throw pikesError;
+        }
         if (app === 'hood') {
           return pikesData;
         }
@@ -900,6 +904,7 @@ describe('desk compatibility gate', () => {
   beforeEach(() => {
     reportedDeskVersion = MIN_GROUPS_VERSION;
     probeError = null;
+    pikesError = null;
     heldProbe = null;
     scryCalls = [];
     updateSession(null);
@@ -941,6 +946,106 @@ describe('desk compatibility gate', () => {
       expect(vi.mocked(subscribe)).not.toHaveBeenCalled();
       expect(setDidSyncInitialPosts).not.toHaveBeenCalled();
       expect(setUserHasCompletedFirstSync).not.toHaveBeenCalled();
+    },
+    FULL_SYNC_TIMEOUT
+  );
+
+  test(
+    'a failing pikes scry does not fail the gate open',
+    async () => {
+      // The pike is only diagnostics; the charge carries the version the gate
+      // reads, so losing the pike must not discard a definitive verdict.
+      reportedDeskVersion = '12.1.0';
+      pikesError = new Error('pikes unavailable');
+
+      await syncStart();
+
+      expect(getSession()?.deskCompat).toMatchObject({
+        status: 'incompatible',
+        current: '12.1.0',
+      });
+      expect(didScry('/v10/init')).toBe(false);
+    },
+    FULL_SYNC_TIMEOUT
+  );
+
+  test(
+    'has no verdict before the probe reports, and a clean one after',
+    async () => {
+      // 'undefined' is "not probed yet", which the shells must not read as
+      // compatible: the overlay they mount talks to the desk immediately.
+      expect(getSession()?.deskCompat).toBeUndefined();
+
+      const release = holdProbe();
+      const started = syncStart();
+      await vi.waitFor(() => expect(probeCount()).toBe(1));
+      expect(getSession()?.deskCompat).toEqual({
+        status: 'probing',
+        current: null,
+        minimum: MIN_GROUPS_VERSION,
+        subscribed: false,
+      });
+
+      release();
+      await started;
+
+      expect(getSession()?.deskCompat).toEqual({ status: 'ok' });
+    },
+    FULL_SYNC_TIMEOUT
+  );
+
+  test(
+    'a retry whose probe fails keeps the notice',
+    async () => {
+      reportedDeskVersion = '12.1.0';
+      await syncStart();
+      const gated = getSession()?.deskCompat;
+
+      probeError = new Error('network down');
+      const onRecovered = vi.fn();
+      await retryDeskCompatibility({ onRecovered });
+
+      // Nothing was learned, so the version we did observe still stands —
+      // failing open here would swap a useful notice for a broken app.
+      expect(getSession()?.deskCompat).toEqual(gated);
+      expect(didScry('/v10/init')).toBe(false);
+      expect(onRecovered).not.toHaveBeenCalled();
+    },
+    FULL_SYNC_TIMEOUT
+  );
+
+  test(
+    'a retry whose probe times out keeps the notice',
+    async () => {
+      reportedDeskVersion = '12.1.0';
+      await syncStart();
+      const gated = getSession()?.deskCompat;
+
+      const release = holdProbe();
+      vi.useFakeTimers();
+      try {
+        const onRecovered = vi.fn();
+        const retrying = retryDeskCompatibility({ onRecovered });
+        let finished = false;
+        void retrying.then(() => {
+          finished = true;
+        });
+
+        await vi.advanceTimersByTimeAsync(PROBE_TIMEOUT + 1);
+        for (let i = 0; i < 30 && !finished; i++) {
+          await vi.advanceTimersByTimeAsync(1000);
+        }
+        expect(finished).toBe(true);
+
+        expect(getSession()?.deskCompat).toEqual(gated);
+        expect(didScry('/v10/init')).toBe(false);
+        expect(onRecovered).not.toHaveBeenCalled();
+
+        release();
+        await vi.advanceTimersByTimeAsync(1000);
+      } finally {
+        vi.useRealTimers();
+      }
     },
     FULL_SYNC_TIMEOUT
   );
@@ -1000,7 +1105,7 @@ describe('desk compatibility gate', () => {
       const onRecovered = vi.fn();
       await retryDeskCompatibility({ onRecovered });
 
-      expect(getSession()?.deskCompat).toBeUndefined();
+      expect(getSession()?.deskCompat).toEqual({ status: 'ok' });
       expect(didScry('/v10/init')).toBe(true);
       expect(vi.mocked(subscribe)).toHaveBeenCalled();
       expect(getSession()?.phase).toBe('ready');
@@ -1069,7 +1174,7 @@ describe('desk compatibility gate', () => {
       reportedDeskVersion = MIN_GROUPS_VERSION;
       await retryDeskCompatibility();
 
-      expect(getSession()?.deskCompat).toBeUndefined();
+      expect(getSession()?.deskCompat).toEqual({ status: 'ok' });
       expect(didScry('/v10/init')).toBe(true);
       // alreadySubscribed was preserved, so the live subscriptions weren't
       // established on top of themselves.
@@ -1111,7 +1216,7 @@ describe('desk compatibility gate', () => {
 
       await syncStart();
 
-      expect(getSession()?.deskCompat).toBeUndefined();
+      expect(getSession()?.deskCompat).toEqual({ status: 'ok' });
       expect(didScry('/v10/init')).toBe(true);
     },
     FULL_SYNC_TIMEOUT
@@ -1125,7 +1230,7 @@ describe('desk compatibility gate', () => {
 
       await syncStart();
 
-      expect(getSession()?.deskCompat).toBeUndefined();
+      expect(getSession()?.deskCompat).toEqual({ status: 'ok' });
       expect(didScry('/v10/init')).toBe(true);
     },
     FULL_SYNC_TIMEOUT
@@ -1146,7 +1251,7 @@ describe('desk compatibility gate', () => {
         // The per-scry timeout lives inside the client; this is the ceiling on
         // the whole probe, reauth round trips included.
         await vi.advanceTimersByTimeAsync(PROBE_TIMEOUT + 1);
-        expect(getSession()?.deskCompat).toBeUndefined();
+        expect(getSession()?.deskCompat).toEqual({ status: 'ok' });
 
         // Let the rest of a failed-open startup run to completion.
         for (let i = 0; i < 30 && !finished; i++) {
@@ -1162,7 +1267,7 @@ describe('desk compatibility gate', () => {
         release();
         await vi.advanceTimersByTimeAsync(1000);
 
-        expect(getSession()?.deskCompat).toBeUndefined();
+        expect(getSession()?.deskCompat).toEqual({ status: 'ok' });
         expect(setAppInfo).not.toHaveBeenCalled();
       } finally {
         vi.useRealTimers();
@@ -1264,7 +1369,7 @@ describe('desk compatibility gate', () => {
       releaseSecond();
       await second;
 
-      expect(getSession()?.deskCompat).toBeUndefined();
+      expect(getSession()?.deskCompat).toEqual({ status: 'ok' });
     },
     FULL_SYNC_TIMEOUT
   );
@@ -1287,13 +1392,18 @@ describe('desk compatibility gate', () => {
       await first;
 
       expect(setAppInfo).not.toHaveBeenCalled();
-      expect(getSession()?.deskCompat?.current).toBeNull();
+      expect(getSession()?.deskCompat).toEqual({
+        status: 'probing',
+        current: null,
+        minimum: MIN_GROUPS_VERSION,
+        subscribed: false,
+      });
 
       reportedDeskVersion = MIN_GROUPS_VERSION;
       releaseSecond();
       await second;
 
-      expect(getSession()?.deskCompat).toBeUndefined();
+      expect(getSession()?.deskCompat).toEqual({ status: 'ok' });
     },
     FULL_SYNC_TIMEOUT
   );
@@ -1368,13 +1478,13 @@ describe('desk compatibility gate', () => {
       releaseNew();
       await newStart;
 
-      expect(getSession()?.deskCompat).toBeUndefined();
+      expect(getSession()?.deskCompat).toEqual({ status: 'ok' });
     },
     FULL_SYNC_TIMEOUT
   );
 
   test(
-    'a retry that fails after a clean verdict leaves the gate cleared',
+    'a retry that fails after a clean verdict leaves the desk marked ok',
     async () => {
       reportedDeskVersion = '12.1.0';
       await syncStart();
@@ -1390,8 +1500,8 @@ describe('desk compatibility gate', () => {
       );
 
       // The desk turned out to be fine; the failure was somewhere else, so the
-      // notice must not come back and claim otherwise.
-      expect(getSession()?.deskCompat).toBeUndefined();
+      // verdict stands and the notice must not come back and claim otherwise.
+      expect(getSession()?.deskCompat).toEqual({ status: 'ok' });
       expect(onRecovered).not.toHaveBeenCalled();
     },
     FULL_SYNC_TIMEOUT
@@ -1423,13 +1533,16 @@ describe('desk compatibility gate', () => {
     async () => {
       reportedDeskVersion = '12.1.0';
       await syncStart();
-      expect(getSession()?.deskCompat?.subscribed).toBe(false);
+      expect(getSession()?.deskCompat).toMatchObject({
+        status: 'incompatible',
+        subscribed: false,
+      });
       expect(vi.mocked(subscribe)).not.toHaveBeenCalled();
 
       reportedDeskVersion = MIN_GROUPS_VERSION;
       await handleDiscontinuity({ context: 'test' });
 
-      expect(getSession()?.deskCompat).toBeUndefined();
+      expect(getSession()?.deskCompat).toEqual({ status: 'ok' });
       // It never subscribed while gated, so recovery has to do it now.
       expect(vi.mocked(subscribe)).toHaveBeenCalled();
     },

--- a/packages/shared/src/store/sync/sync.test.ts
+++ b/packages/shared/src/store/sync/sync.test.ts
@@ -1018,6 +1018,25 @@ describe('desk compatibility gate', () => {
   );
 
   test(
+    'gates on a version it could not persist',
+    async () => {
+      reportedDeskVersion = '12.1.0';
+      setAppInfo.mockRejectedValue(new Error('storage unavailable'));
+
+      await syncStart();
+
+      // The write is best effort; the version it carried still decides.
+      expect(setAppInfo).toHaveBeenCalled();
+      expect(getSession()?.deskCompat).toMatchObject({
+        status: 'incompatible',
+        current: '12.1.0',
+      });
+      expect(didScry('/v10/init')).toBe(false);
+    },
+    FULL_SYNC_TIMEOUT
+  );
+
+  test(
     'has no verdict before the probe reports, and a clean one after',
     async () => {
       // 'undefined' is "not probed yet", which the shells must not read as

--- a/packages/shared/src/store/sync/sync.test.ts
+++ b/packages/shared/src/store/sync/sync.test.ts
@@ -1172,6 +1172,42 @@ describe('desk compatibility gate', () => {
   );
 
   test(
+    'releases the queue thread a hanging probe held, once it settles',
+    async () => {
+      const release = holdProbe();
+      vi.useFakeTimers();
+      try {
+        const started = syncStart();
+        let finished = false;
+        void started.then(() => {
+          finished = true;
+        });
+
+        await vi.advanceTimersByTimeAsync(PROBE_TIMEOUT + 1);
+        for (let i = 0; i < 30 && !finished; i++) {
+          await vi.advanceTimersByTimeAsync(1000);
+        }
+        expect(finished).toBe(true);
+
+        // Startup gave up on it, but the probe is still running inside the
+        // queue: Promise.race doesn't cancel the loser, so it keeps its worker
+        // thread until the request itself settles.
+        expect(syncQueue.activeThreads).toBeGreaterThan(0);
+
+        release();
+        await vi.advanceTimersByTimeAsync(1000);
+
+        // Settling is what hands the thread back — which is why every scry,
+        // including the one a 403 retries, has to be bounded.
+        expect(syncQueue.activeThreads).toBe(0);
+      } finally {
+        vi.useRealTimers();
+      }
+    },
+    FULL_SYNC_TIMEOUT
+  );
+
+  test(
     'drops a probe answer that arrives after logout',
     async () => {
       reportedDeskVersion = '12.1.0';

--- a/packages/shared/src/store/sync/sync.test.ts
+++ b/packages/shared/src/store/sync/sync.test.ts
@@ -1,6 +1,7 @@
 import {
   StructuredChannelDescriptionPayload,
   scry,
+  subscribe,
   toClientGroup,
 } from '@tloncorp/api';
 import '@tloncorp/api';
@@ -22,11 +23,22 @@ import {
 import { GroupV11 as UrbitGroup } from '@tloncorp/api/urbit/groups';
 import * as $ from 'drizzle-orm';
 import { pick } from 'lodash';
-import { expect, test, vi } from 'vitest';
+import {
+  afterAll,
+  afterEach,
+  beforeAll,
+  beforeEach,
+  describe,
+  expect,
+  test,
+  vi,
+} from 'vitest';
+import type { MockInstance } from 'vitest';
 
 import rawChannelPostWithRepliesData from '../../../../api/src/__tests__/fixtures/channelPostWithReplies.json';
 import rawChannelPostsData from '../../../../api/src/__tests__/fixtures/channelPosts.json';
 import * as db from '../../db';
+import { MIN_GROUPS_VERSION } from '../../logic';
 import rawNewestPostData from '../../test/channelNewestPost.json';
 import rawAfterNewestPostData from '../../test/channelPostsAfterNewest.json';
 import rawContactsData from '../../test/contactsDirectory.json';
@@ -40,16 +52,28 @@ import {
   setupDatabaseTestSuite,
 } from '../../test/helpers';
 import rawGroupsInit2 from '../../test/init.json';
+import {
+  DeskCompatibility,
+  getSession,
+  subscribeToSession,
+  updateInitializedClient,
+  updateSession,
+} from '../session';
 import { syncQueue } from '../syncQueue';
 import {
+  clearSyncStartLock,
   ensureDmInviteChannel,
+  handleDiscontinuity,
+  retryDeskCompatibility,
   syncChannelWithBackoff,
   syncDms,
   syncGroups,
   syncInitData,
+  syncInitialPosts,
   syncLatestPosts,
   syncPinnedItems,
   syncPosts,
+  syncStart,
   syncThreadPosts,
   syncUpdatedPosts,
 } from './sync';
@@ -83,6 +107,27 @@ vi.mock('../lure', () => ({
     }),
   },
 }));
+
+const DEFAULT_USER_ID = '~solfer-magfed';
+// Mutable so a test can switch ships mid-flight; hoisted because vi.mock's
+// factory runs before the module body.
+const urbitMockState = vi.hoisted(() => ({ currentUserId: '~solfer-magfed' }));
+
+// Extends the shared mock in test/setup.ts: the sync start lifecycle tests
+// below need to see whether subscriptions were established.
+vi.mock('../../../../api/src/client/urbit', async (importOriginal) => {
+  const mod = (await importOriginal()) as Record<string, unknown>;
+
+  return {
+    ...mod,
+    scry: vi.fn(),
+    poke: vi.fn(),
+    trackedPoke: vi.fn(),
+    subscribe: vi.fn(),
+    subscribeOnce: vi.fn(),
+    getCurrentUserId: () => urbitMockState.currentUserId,
+  };
+});
 
 const outputData = [
   {
@@ -725,5 +770,648 @@ test('syncs groups, decoding structured description payloads', async () => {
   expect(channelFromDb!.description).toEqual(descriptionText);
   expect(channelFromDb!.contentConfiguration).toMatchObject(
     channelContentConfiguration
+  );
+});
+
+// Desk compatibility gate: startup probes the ship's %groups version before it
+// touches any path an old desk can't serve.
+describe('desk compatibility gate', () => {
+  // Anything that gets past the gate runs the whole of sync start, including
+  // the init-data writes, which take longer than the default per-test budget.
+  // The gated cases are fast, but they get the same budget so a regression
+  // that lets sync through fails on an assertion rather than on the clock.
+  const FULL_SYNC_TIMEOUT = 30_000;
+  const PROBE_TIMEOUT = 10 * 1000;
+  const pikesData = { groups: { hash: '0v1.abc', sync: { ship: '~zod' } } };
+
+  let reportedDeskVersion: string | null = MIN_GROUPS_VERSION;
+  let probeError: Error | null = null;
+  let heldProbe: { wait: Promise<void>; release: () => void } | null = null;
+  let scryCalls: { app: string; path: string; timeout?: number }[] = [];
+  type SetValueSpy<
+    T extends { setValue: (...args: never[]) => Promise<void> },
+  > = MockInstance<Parameters<T['setValue']>, Promise<void>>;
+  let setAppInfo: SetValueSpy<typeof db.appInfo>;
+  let setDidSyncInitialPosts: SetValueSpy<typeof db.didSyncInitialPosts>;
+  let setUserHasCompletedFirstSync: SetValueSpy<
+    typeof db.userHasCompletedFirstSync
+  >;
+
+  const scryPaths = () => scryCalls.map(({ app, path }) => `${app}${path}`);
+  const didScry = (fragment: string) =>
+    scryPaths().some((path) => path.includes(fragment));
+  const probeCount = () =>
+    scryCalls.filter(({ path }) => path === '/kiln/pikes').length;
+
+  // Lets a test keep the probe in flight while it does something else (log out,
+  // let the timeout fire) and then decide what a late answer does.
+  const holdProbe = () => {
+    let release = () => {};
+    const wait = new Promise<void>((resolve) => {
+      release = resolve;
+    });
+    const gate = { wait, release };
+    heldProbe = gate;
+    return () => {
+      if (heldProbe === gate) {
+        heldProbe = null;
+      }
+      release();
+    };
+  };
+
+  // What useHandleLogout does: drops the client, clears the session, releases
+  // the sync lock. updateInitializedClient is the lifecycle call underneath
+  // clientActions' configureClient/removeClient.
+  const logOut = () => {
+    updateInitializedClient(false);
+    updateSession(null);
+    clearSyncStartLock();
+  };
+  const logIn = (userId = DEFAULT_USER_ID) => {
+    urbitMockState.currentUserId = userId;
+    updateInitializedClient(true);
+  };
+
+  const installScryMock = () => {
+    vi.mocked(scry).mockImplementation((async (args: {
+      app: string;
+      path: string;
+      timeout?: number;
+    }) => {
+      scryCalls.push(args);
+      const { app, path } = args;
+      const isProbePath =
+        (app === 'hood' && path === '/kiln/pikes') ||
+        (app === 'docket' && path === '/charges');
+      if (isProbePath) {
+        // Captured synchronously: a second probe gets its own gate, and this
+        // one keeps waiting on the gate it was issued under.
+        const gate = heldProbe;
+        if (gate) {
+          await gate.wait;
+        }
+        if (probeError) {
+          throw probeError;
+        }
+        if (app === 'hood') {
+          return pikesData;
+        }
+        return {
+          initial:
+            reportedDeskVersion === null
+              ? {}
+              : { groups: { version: reportedDeskVersion } },
+        };
+      }
+      if (app === 'groups-ui' && path === '/v10/init') {
+        return groupsInitData;
+      }
+      if (app === 'groups-ui' && path.startsWith('/v4/heads')) {
+        return headsData;
+      }
+      // The remaining paths are incidental to the gate, but the ones whose
+      // sync contexts set retry: true cost seconds of backoff if they throw,
+      // so hand them an empty-but-valid response.
+      if (app === 'contacts') {
+        return {};
+      }
+      if (app === 'groups-ui' && path === '/suggested-contacts') {
+        return [];
+      }
+      if (app === 'activity' && path.includes('/feed/init/')) {
+        return { all: [], mentions: [], replies: [], summaries: {} };
+      }
+      return undefined;
+    }) as unknown as typeof scry);
+  };
+
+  beforeAll(() => {
+    // Skips the 1s spacer syncStart leaves for syncSince to queue.
+    (globalThis as any).TLON_IS_E2E = true;
+  });
+
+  afterAll(() => {
+    delete (globalThis as any).TLON_IS_E2E;
+    updateSession(null);
+    clearSyncStartLock();
+  });
+
+  beforeEach(() => {
+    reportedDeskVersion = MIN_GROUPS_VERSION;
+    probeError = null;
+    heldProbe = null;
+    scryCalls = [];
+    updateSession(null);
+    clearSyncStartLock();
+    // Without a live client the lifetime token never changes, and the guards
+    // that depend on it would go untested.
+    logIn();
+    vi.mocked(subscribe).mockClear();
+    // The shared storage mock discards writes, so reads always come back as
+    // the default: assert on the writes instead.
+    setAppInfo = vi.spyOn(db.appInfo, 'setValue');
+    setDidSyncInitialPosts = vi.spyOn(db.didSyncInitialPosts, 'setValue');
+    setUserHasCompletedFirstSync = vi.spyOn(
+      db.userHasCompletedFirstSync,
+      'setValue'
+    );
+    installScryMock();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  test(
+    'gates startup when the ship reports an outdated desk',
+    async () => {
+      reportedDeskVersion = '12.1.0';
+
+      await syncStart();
+
+      expect(getSession()?.deskCompat).toEqual({
+        status: 'incompatible',
+        current: '12.1.0',
+        minimum: MIN_GROUPS_VERSION,
+        subscribed: false,
+      });
+      // Nothing an old desk would reject was attempted.
+      expect(didScry('/v10/init')).toBe(false);
+      expect(vi.mocked(subscribe)).not.toHaveBeenCalled();
+      expect(setDidSyncInitialPosts).not.toHaveBeenCalled();
+      expect(setUserHasCompletedFirstSync).not.toHaveBeenCalled();
+    },
+    FULL_SYNC_TIMEOUT
+  );
+
+  test(
+    'probes with a bounded timeout and no retries',
+    async () => {
+      reportedDeskVersion = '12.1.0';
+
+      await syncStart();
+
+      const probeCalls = scryCalls.filter(
+        ({ app }) => app === 'hood' || app === 'docket'
+      );
+      expect(probeCalls).toHaveLength(2);
+      expect(probeCalls.every(({ timeout }) => timeout === PROBE_TIMEOUT)).toBe(
+        true
+      );
+    },
+    FULL_SYNC_TIMEOUT
+  );
+
+  test(
+    'releases the sync lock, so a later start probes again',
+    async () => {
+      reportedDeskVersion = '12.1.0';
+
+      await syncStart();
+      expect(probeCount()).toBe(1);
+
+      await syncStart();
+      expect(probeCount()).toBe(2);
+    },
+    FULL_SYNC_TIMEOUT
+  );
+
+  test(
+    'concurrent cold starts share one probe',
+    async () => {
+      reportedDeskVersion = '12.1.0';
+
+      await Promise.all([syncStart(), syncStart()]);
+
+      expect(probeCount()).toBe(1);
+    },
+    FULL_SYNC_TIMEOUT
+  );
+
+  test(
+    'recovers in place once the ship is updated, without a reload',
+    async () => {
+      reportedDeskVersion = '12.1.0';
+      await syncStart();
+      expect(getSession()?.deskCompat?.status).toBe('incompatible');
+
+      reportedDeskVersion = MIN_GROUPS_VERSION;
+      const onRecovered = vi.fn();
+      await retryDeskCompatibility({ onRecovered });
+
+      expect(getSession()?.deskCompat).toBeUndefined();
+      expect(didScry('/v10/init')).toBe(true);
+      expect(vi.mocked(subscribe)).toHaveBeenCalled();
+      expect(getSession()?.phase).toBe('ready');
+      // The shells' post-start work ran as a no-op while gated, so the retry has
+      // to run it again.
+      expect(onRecovered).toHaveBeenCalledTimes(1);
+    },
+    FULL_SYNC_TIMEOUT
+  );
+
+  test(
+    'a retry that stays outdated keeps the notice and skips the follow-up',
+    async () => {
+      reportedDeskVersion = '12.1.0';
+      await syncStart();
+
+      const onRecovered = vi.fn();
+      await retryDeskCompatibility({ onRecovered });
+
+      expect(getSession()?.deskCompat).toMatchObject({
+        status: 'incompatible',
+        current: '12.1.0',
+      });
+      expect(onRecovered).not.toHaveBeenCalled();
+    },
+    FULL_SYNC_TIMEOUT
+  );
+
+  test(
+    'a retry blocked by a sync already in flight restores the notice',
+    async () => {
+      reportedDeskVersion = '12.1.0';
+      await syncStart();
+
+      // Another sync start holds the lock, so the retry's own start bails before
+      // it can re-probe. The notice has to come back rather than stay disabled.
+      const release = holdProbe();
+      const inFlight = syncStart();
+      const onRecovered = vi.fn();
+      await retryDeskCompatibility({ onRecovered });
+
+      expect(getSession()?.deskCompat).toMatchObject({
+        status: 'incompatible',
+        current: '12.1.0',
+      });
+      expect(onRecovered).not.toHaveBeenCalled();
+
+      release();
+      await inFlight;
+    },
+    FULL_SYNC_TIMEOUT
+  );
+
+  test(
+    'a gate during recovery retries as a recovery',
+    async () => {
+      reportedDeskVersion = '12.1.0';
+
+      await syncStart(true);
+
+      expect(getSession()?.deskCompat).toMatchObject({
+        status: 'incompatible',
+        subscribed: true,
+      });
+
+      reportedDeskVersion = MIN_GROUPS_VERSION;
+      await retryDeskCompatibility();
+
+      expect(getSession()?.deskCompat).toBeUndefined();
+      expect(didScry('/v10/init')).toBe(true);
+      // alreadySubscribed was preserved, so the live subscriptions weren't
+      // established on top of themselves.
+      expect(vi.mocked(subscribe)).not.toHaveBeenCalled();
+    },
+    FULL_SYNC_TIMEOUT
+  );
+
+  test(
+    'a retry keeps the version it is showing while it re-probes',
+    async () => {
+      reportedDeskVersion = '12.1.0';
+      await syncStart();
+
+      const release = holdProbe();
+      const retrying = retryDeskCompatibility();
+      await vi.waitFor(() =>
+        expect(getSession()?.deskCompat?.status).toBe('probing')
+      );
+
+      // Not reset to a bare cold-start probe: the shell keeps the notice up
+      // (its `current` is what tells it apart from a first-run probe).
+      expect(getSession()?.deskCompat).toMatchObject({
+        status: 'probing',
+        current: '12.1.0',
+        subscribed: false,
+      });
+
+      release();
+      await retrying;
+    },
+    FULL_SYNC_TIMEOUT
+  );
+
+  test(
+    'fails open when the probe itself fails',
+    async () => {
+      probeError = new Error('network down');
+
+      await syncStart();
+
+      expect(getSession()?.deskCompat).toBeUndefined();
+      expect(didScry('/v10/init')).toBe(true);
+    },
+    FULL_SYNC_TIMEOUT
+  );
+
+  test(
+    'fails open when the ship reports no version at all',
+    async () => {
+      // A missing docket charge is reported as 'n/a' by getAppInfo.
+      reportedDeskVersion = null;
+
+      await syncStart();
+
+      expect(getSession()?.deskCompat).toBeUndefined();
+      expect(didScry('/v10/init')).toBe(true);
+    },
+    FULL_SYNC_TIMEOUT
+  );
+
+  test(
+    'gives up on a hanging probe and lets a late answer change nothing',
+    async () => {
+      const release = holdProbe();
+      vi.useFakeTimers();
+      try {
+        const started = syncStart();
+        let finished = false;
+        void started.then(() => {
+          finished = true;
+        });
+
+        // The per-scry timeout lives inside the client; this is the ceiling on
+        // the whole probe, reauth round trips included.
+        await vi.advanceTimersByTimeAsync(PROBE_TIMEOUT + 1);
+        expect(getSession()?.deskCompat).toBeUndefined();
+
+        // Let the rest of a failed-open startup run to completion.
+        for (let i = 0; i < 30 && !finished; i++) {
+          await vi.advanceTimersByTimeAsync(1000);
+        }
+        expect(finished).toBe(true);
+        expect(didScry('/v10/init')).toBe(true);
+        expect(setAppInfo).not.toHaveBeenCalled();
+
+        // The ship finally answers, with a version that would have gated. Too
+        // late: startup already went ahead without it.
+        reportedDeskVersion = '12.1.0';
+        release();
+        await vi.advanceTimersByTimeAsync(1000);
+
+        expect(getSession()?.deskCompat).toBeUndefined();
+        expect(setAppInfo).not.toHaveBeenCalled();
+      } finally {
+        vi.useRealTimers();
+      }
+    },
+    FULL_SYNC_TIMEOUT
+  );
+
+  test(
+    'drops a probe answer that arrives after logout',
+    async () => {
+      reportedDeskVersion = '12.1.0';
+      const release = holdProbe();
+      const started = syncStart();
+      await vi.waitFor(() => expect(probeCount()).toBe(1));
+
+      logOut();
+      release();
+      await started;
+
+      // Not just "no gate": startup must not resurrect the session it was
+      // running for, either.
+      expect(getSession()).toBeNull();
+      // Suppressed at the same point as the capability flags, inside
+      // syncAppInfo.
+      expect(setAppInfo).not.toHaveBeenCalled();
+      // Startup stopped rather than syncing on behalf of a logged-out session.
+      expect(didScry('/v10/init')).toBe(false);
+    },
+    FULL_SYNC_TIMEOUT
+  );
+
+  test(
+    'a probe answering after a re-login to the same ship changes nothing',
+    async () => {
+      reportedDeskVersion = '12.1.0';
+      const releaseFirst = holdProbe();
+      const first = syncStart();
+      await vi.waitFor(() => expect(probeCount()).toBe(1));
+
+      // Same ship, same session shape — only the client's lifetime differs.
+      logOut();
+      logIn();
+      const releaseSecond = holdProbe();
+      const second = syncStart();
+      await vi.waitFor(() => expect(probeCount()).toBe(2));
+
+      // The previous login's answer lands last, carrying a version that would
+      // have gated this one.
+      releaseFirst();
+      await first;
+
+      expect(setAppInfo).not.toHaveBeenCalled();
+      expect(getSession()?.deskCompat).toEqual({
+        status: 'probing',
+        current: null,
+        minimum: MIN_GROUPS_VERSION,
+        subscribed: false,
+      });
+
+      // The live login's own probe is still the one that decides.
+      reportedDeskVersion = MIN_GROUPS_VERSION;
+      releaseSecond();
+      await second;
+
+      expect(getSession()?.deskCompat).toBeUndefined();
+    },
+    FULL_SYNC_TIMEOUT
+  );
+
+  test(
+    'a probe answering after a switch to another ship changes nothing',
+    async () => {
+      reportedDeskVersion = '12.1.0';
+      const releaseFirst = holdProbe();
+      const first = syncStart();
+      await vi.waitFor(() => expect(probeCount()).toBe(1));
+
+      logOut();
+      logIn('~nibset-napwyn');
+      const releaseSecond = holdProbe();
+      const second = syncStart();
+      await vi.waitFor(() => expect(probeCount()).toBe(2));
+
+      releaseFirst();
+      await first;
+
+      expect(setAppInfo).not.toHaveBeenCalled();
+      expect(getSession()?.deskCompat?.current).toBeNull();
+
+      reportedDeskVersion = MIN_GROUPS_VERSION;
+      releaseSecond();
+      await second;
+
+      expect(getSession()?.deskCompat).toBeUndefined();
+    },
+    FULL_SYNC_TIMEOUT
+  );
+
+  test(
+    'a retry interrupted by logout neither restores the notice nor prefetches',
+    async () => {
+      reportedDeskVersion = '12.1.0';
+      await syncStart();
+
+      // The gated start above already persisted the version it read; only the
+      // retry's own answer is under test here.
+      setAppInfo.mockClear();
+      const release = holdProbe();
+      const onRecovered = vi.fn();
+      const retrying = retryDeskCompatibility({ onRecovered });
+      await vi.waitFor(() => expect(probeCount()).toBe(2));
+
+      logOut();
+      release();
+      await retrying;
+
+      // There is no notice to restore and no one to prefetch for.
+      expect(getSession()).toBeNull();
+      expect(onRecovered).not.toHaveBeenCalled();
+      expect(setAppInfo).not.toHaveBeenCalled();
+    },
+    FULL_SYNC_TIMEOUT
+  );
+
+  test(
+    'a retry finishing after a new login leaves that login alone',
+    async () => {
+      reportedDeskVersion = '12.1.0';
+      await syncStart();
+
+      setAppInfo.mockClear();
+      const releaseRetry = holdProbe();
+      const onRecovered = vi.fn();
+      const retrying = retryDeskCompatibility({ onRecovered });
+      await vi.waitFor(() => expect(probeCount()).toBe(2));
+
+      // Logged out and back in while Retry was still waiting; the new login is
+      // part-way through its own cold probe.
+      logOut();
+      logIn();
+      const releaseNew = holdProbe();
+      const newStart = syncStart();
+      await vi.waitFor(() => expect(probeCount()).toBe(3));
+
+      releaseRetry();
+      await retrying;
+
+      // The new login is still deciding for itself: the old retry must not
+      // stamp its verdict, or its version, onto it.
+      expect(getSession()?.deskCompat).toEqual({
+        status: 'probing',
+        current: null,
+        minimum: MIN_GROUPS_VERSION,
+        subscribed: false,
+      });
+      expect(onRecovered).not.toHaveBeenCalled();
+      expect(setAppInfo).not.toHaveBeenCalled();
+
+      // Nor may it hand the sync lock to a third start while the new login is
+      // still using it.
+      const probesBefore = probeCount();
+      await syncStart();
+      expect(probeCount()).toBe(probesBefore);
+
+      reportedDeskVersion = MIN_GROUPS_VERSION;
+      releaseNew();
+      await newStart;
+
+      expect(getSession()?.deskCompat).toBeUndefined();
+    },
+    FULL_SYNC_TIMEOUT
+  );
+
+  test(
+    'a retry that fails after a clean verdict leaves the gate cleared',
+    async () => {
+      reportedDeskVersion = '12.1.0';
+      await syncStart();
+
+      reportedDeskVersion = MIN_GROUPS_VERSION;
+      vi.spyOn(db, 'getEnqueuedPosts').mockRejectedValueOnce(
+        new Error('db gone')
+      );
+      const onRecovered = vi.fn();
+
+      await expect(retryDeskCompatibility({ onRecovered })).rejects.toThrow(
+        'db gone'
+      );
+
+      // The desk turned out to be fine; the failure was somewhere else, so the
+      // notice must not come back and claim otherwise.
+      expect(getSession()?.deskCompat).toBeUndefined();
+      expect(onRecovered).not.toHaveBeenCalled();
+    },
+    FULL_SYNC_TIMEOUT
+  );
+
+  test(
+    'keeps the gate across a discontinuity',
+    async () => {
+      reportedDeskVersion = '12.1.0';
+      await syncStart(true);
+
+      const seen: (DeskCompatibility | undefined)[] = [];
+      const unsubscribe = subscribeToSession((session) =>
+        seen.push(session?.deskCompat)
+      );
+      await handleDiscontinuity({ context: 'test' });
+      unsubscribe();
+
+      // The notice must not blink off while the session is reset and re-probed.
+      expect(seen.length).toBeGreaterThan(0);
+      expect(seen.every((deskCompat) => deskCompat != null)).toBe(true);
+      expect(getSession()?.deskCompat?.status).toBe('incompatible');
+    },
+    FULL_SYNC_TIMEOUT
+  );
+
+  test(
+    'a cold-gated session recovers through a discontinuity as a cold start',
+    async () => {
+      reportedDeskVersion = '12.1.0';
+      await syncStart();
+      expect(getSession()?.deskCompat?.subscribed).toBe(false);
+      expect(vi.mocked(subscribe)).not.toHaveBeenCalled();
+
+      reportedDeskVersion = MIN_GROUPS_VERSION;
+      await handleDiscontinuity({ context: 'test' });
+
+      expect(getSession()?.deskCompat).toBeUndefined();
+      // It never subscribed while gated, so recovery has to do it now.
+      expect(vi.mocked(subscribe)).toHaveBeenCalled();
+    },
+    FULL_SYNC_TIMEOUT
+  );
+
+  test(
+    'syncInitialPosts is a no-op while gated',
+    async () => {
+      reportedDeskVersion = '12.1.0';
+      await syncStart();
+      const callsBefore = scryCalls.length;
+
+      await syncInitialPosts({ syncSize: 'light' });
+
+      expect(scryCalls.length).toBe(callsBefore);
+      expect(setDidSyncInitialPosts).not.toHaveBeenCalled();
+    },
+    FULL_SYNC_TIMEOUT
   );
 });

--- a/packages/shared/src/store/sync/sync.test.ts
+++ b/packages/shared/src/store/sync/sync.test.ts
@@ -1194,6 +1194,60 @@ describe('desk compatibility gate', () => {
   );
 
   test(
+    'a second cold start in the same login does not re-subscribe',
+    async () => {
+      // What a remount looks like: the previous mount's subscriptions are
+      // still live, and a second set on top of them doubles every event.
+      await syncStart();
+      const afterFirst = vi.mocked(subscribe).mock.calls.length;
+      expect(afterFirst).toBeGreaterThan(0);
+
+      await syncStart();
+
+      expect(vi.mocked(subscribe).mock.calls.length).toBe(afterFirst);
+    },
+    FULL_SYNC_TIMEOUT
+  );
+
+  test(
+    'a new login subscribes again',
+    async () => {
+      await syncStart();
+      const afterFirst = vi.mocked(subscribe).mock.calls.length;
+
+      logOut();
+      logIn();
+      await syncStart();
+
+      expect(vi.mocked(subscribe).mock.calls.length).toBeGreaterThan(
+        afterFirst
+      );
+    },
+    FULL_SYNC_TIMEOUT
+  );
+
+  test(
+    'a gated start subscribes once it recovers, and not again',
+    async () => {
+      reportedDeskVersion = '12.1.0';
+      await syncStart();
+      // Nothing was registered while the gate was up, so the marker must not
+      // claim otherwise.
+      expect(vi.mocked(subscribe)).not.toHaveBeenCalled();
+
+      reportedDeskVersion = MIN_GROUPS_VERSION;
+      await retryDeskCompatibility();
+      const afterRetry = vi.mocked(subscribe).mock.calls.length;
+      expect(afterRetry).toBeGreaterThan(0);
+
+      await syncStart();
+
+      expect(vi.mocked(subscribe).mock.calls.length).toBe(afterRetry);
+    },
+    FULL_SYNC_TIMEOUT
+  );
+
+  test(
     'recovers in place once the ship is updated, without a reload',
     async () => {
       reportedDeskVersion = '12.1.0';

--- a/packages/shared/src/store/sync/sync.test.ts
+++ b/packages/shared/src/store/sync/sync.test.ts
@@ -1198,6 +1198,8 @@ describe('desk compatibility gate', () => {
     async () => {
       // What a remount looks like: the previous mount's subscriptions are
       // still live, and a second set on top of them doubles every event.
+      // Note the lens backfill fails under this mock (no %steward fixture),
+      // which must not count as a failed subscribe.
       await syncStart();
       const afterFirst = vi.mocked(subscribe).mock.calls.length;
       expect(afterFirst).toBeGreaterThan(0);
@@ -1205,6 +1207,58 @@ describe('desk compatibility gate', () => {
       await syncStart();
 
       expect(vi.mocked(subscribe).mock.calls.length).toBe(afterFirst);
+    },
+    FULL_SYNC_TIMEOUT
+  );
+
+  test(
+    'a failed high-priority subscribe leaves the next start to retry',
+    async () => {
+      vi.mocked(subscribe).mockImplementation((async (endpoint: {
+        app: string;
+      }) => {
+        // Presence is the high-priority subscribe whose rejection actually
+        // propagates; the others are fire-and-forget by design.
+        if (endpoint.app === 'presence') {
+          throw new Error('subscribe failed');
+        }
+        return 1;
+      }) as unknown as typeof subscribe);
+
+      await syncStart();
+      const afterFirst = vi.mocked(subscribe).mock.calls.length;
+
+      // The set that failed has to be registered again rather than being
+      // treated as live for the rest of the session.
+      await syncStart();
+
+      expect(vi.mocked(subscribe).mock.calls.length).toBeGreaterThan(
+        afterFirst
+      );
+    },
+    FULL_SYNC_TIMEOUT
+  );
+
+  test(
+    'a failed low-priority subscribe leaves the next start to retry',
+    async () => {
+      vi.mocked(subscribe).mockImplementation((async (endpoint: {
+        app: string;
+      }) => {
+        if (endpoint.app === 'activity') {
+          throw new Error('subscribe failed');
+        }
+        return 1;
+      }) as unknown as typeof subscribe);
+
+      await syncStart();
+      const afterFirst = vi.mocked(subscribe).mock.calls.length;
+
+      await syncStart();
+
+      expect(vi.mocked(subscribe).mock.calls.length).toBeGreaterThan(
+        afterFirst
+      );
     },
     FULL_SYNC_TIMEOUT
   );

--- a/packages/shared/src/store/sync/sync.test.ts
+++ b/packages/shared/src/store/sync/sync.test.ts
@@ -1046,6 +1046,26 @@ describe('desk compatibility gate', () => {
   );
 
   test(
+    'an unwritable version still drives the activity endpoints',
+    async () => {
+      // Storage is broken and what's already there is older than the ship, so
+      // re-deriving the flags from it would drop us to legacy endpoints.
+      setAppInfo.mockRejectedValue(new Error('storage unavailable'));
+      vi.spyOn(db.appInfo, 'getValue').mockImplementation(async () => ({
+        groupsVersion: '11.0.0',
+        groupsHash: 'n/a',
+        groupsSyncNode: 'n/a',
+      }));
+
+      await syncStart();
+
+      expect(didScry('/v5/feed/init/')).toBe(false);
+      expect(didScry('/v7/feed/init/')).toBe(true);
+    },
+    FULL_SYNC_TIMEOUT
+  );
+
+  test(
     'gates on a version it could not persist',
     async () => {
       reportedDeskVersion = '12.1.0';
@@ -1732,6 +1752,47 @@ describe('desk compatibility gate', () => {
       expect(seen.every((deskCompat) => deskCompat != null)).toBe(true);
       expect(getSession()?.deskCompat?.status).toBe('incompatible');
       expect(setDidSyncInitialPosts).not.toHaveBeenCalled();
+    },
+    FULL_SYNC_TIMEOUT
+  );
+
+  test(
+    'a discontinuity in a clean session keeps the ok verdict throughout',
+    async () => {
+      await syncStart();
+      expect(getSession()?.deskCompat).toEqual({ status: 'ok' });
+
+      const seen: (DeskCompatibility | undefined)[] = [];
+      const unsubscribe = subscribeToSession((session) =>
+        seen.push(session?.deskCompat)
+      );
+      await handleDiscontinuity({ context: 'test' });
+      unsubscribe();
+
+      // Never absent and never back to probing: the shells read either as
+      // "not usable yet" and tear down what they only show on a good desk.
+      expect(seen.length).toBeGreaterThan(0);
+      expect(seen.every((deskCompat) => deskCompat?.status === 'ok')).toBe(
+        true
+      );
+      expect(getSession()?.deskCompat).toEqual({ status: 'ok' });
+    },
+    FULL_SYNC_TIMEOUT
+  );
+
+  test(
+    'a discontinuity whose reprobe finds an outdated desk still gates',
+    async () => {
+      await syncStart();
+      expect(getSession()?.deskCompat).toEqual({ status: 'ok' });
+
+      reportedDeskVersion = '12.1.0';
+      await handleDiscontinuity({ context: 'test' });
+
+      expect(getSession()?.deskCompat).toMatchObject({
+        status: 'incompatible',
+        current: '12.1.0',
+      });
     },
     FULL_SYNC_TIMEOUT
   );

--- a/packages/shared/src/store/sync/sync.test.ts
+++ b/packages/shared/src/store/sync/sync.test.ts
@@ -1018,6 +1018,34 @@ describe('desk compatibility gate', () => {
   );
 
   test(
+    'leaves the fetched version driving the activity endpoints',
+    async () => {
+      // The shared storage mock discards writes, so give this case working
+      // storage: what's under test is that the write lands before
+      // syncReactionSupport re-derives the same flags from it.
+      let persisted: Awaited<ReturnType<typeof db.appInfo.getValue>> = null;
+      setAppInfo.mockImplementation(async (value) => {
+        // Real storage settles on a later tick; an instant stub would hide
+        // whether the write is actually awaited.
+        await new Promise((resolve) => setTimeout(resolve, 0));
+        persisted = value as typeof persisted;
+      });
+      vi.spyOn(db.appInfo, 'getValue').mockImplementation(
+        async () => persisted
+      );
+
+      await syncStart();
+
+      expect(persisted).toMatchObject({ groupsVersion: MIN_GROUPS_VERSION });
+      // v5 is the pre-reaction feed: asking for it would mean the capability
+      // flags had been re-derived from a value that wasn't written yet.
+      expect(didScry('/v5/feed/init/')).toBe(false);
+      expect(didScry('/v7/feed/init/')).toBe(true);
+    },
+    FULL_SYNC_TIMEOUT
+  );
+
+  test(
     'gates on a version it could not persist',
     async () => {
       reportedDeskVersion = '12.1.0';

--- a/packages/shared/src/store/sync/sync.test.ts
+++ b/packages/shared/src/store/sync/sync.test.ts
@@ -787,6 +787,7 @@ describe('desk compatibility gate', () => {
   let reportedDeskVersion: string | null = MIN_GROUPS_VERSION;
   let probeError: Error | null = null;
   let pikesError: Error | null = null;
+  let pikesHangs = false;
   let heldProbe: { wait: Promise<void>; release: () => void } | null = null;
   let scryCalls: { app: string; path: string; timeout?: number }[] = [];
   type SetValueSpy<
@@ -858,6 +859,18 @@ describe('desk compatibility gate', () => {
         if (app === 'hood' && pikesError) {
           throw pikesError;
         }
+        if (app === 'hood' && pikesHangs) {
+          // Mirrors the client: the timeout it was given is the only thing
+          // that ends a hung scry.
+          return new Promise((_resolve, reject) => {
+            if (args.timeout != null) {
+              setTimeout(
+                () => reject(new Error('pikes timed out')),
+                args.timeout
+              );
+            }
+          });
+        }
         if (app === 'hood') {
           return pikesData;
         }
@@ -905,6 +918,7 @@ describe('desk compatibility gate', () => {
     reportedDeskVersion = MIN_GROUPS_VERSION;
     probeError = null;
     pikesError = null;
+    pikesHangs = false;
     heldProbe = null;
     scryCalls = [];
     updateSession(null);
@@ -965,6 +979,37 @@ describe('desk compatibility gate', () => {
         current: '12.1.0',
       });
       expect(didScry('/v10/init')).toBe(false);
+    },
+    FULL_SYNC_TIMEOUT
+  );
+
+  test(
+    'gates on the charge even when the pike scry hangs',
+    async () => {
+      // The pike is bounded well inside the probe's own deadline, so a hung
+      // one can't hold the version past the point where startup gives up and
+      // fails open.
+      reportedDeskVersion = '12.1.0';
+      pikesHangs = true;
+      vi.useFakeTimers();
+      try {
+        const started = syncStart();
+        let finished = false;
+        void started.then(() => {
+          finished = true;
+        });
+
+        await vi.advanceTimersByTimeAsync(PROBE_TIMEOUT / 2);
+
+        expect(getSession()?.deskCompat).toMatchObject({
+          status: 'incompatible',
+          current: '12.1.0',
+        });
+        expect(finished).toBe(true);
+        expect(didScry('/v10/init')).toBe(false);
+      } finally {
+        vi.useRealTimers();
+      }
     },
     FULL_SYNC_TIMEOUT
   );
@@ -1061,9 +1106,13 @@ describe('desk compatibility gate', () => {
         ({ app }) => app === 'hood' || app === 'docket'
       );
       expect(probeCalls).toHaveLength(2);
-      expect(probeCalls.every(({ timeout }) => timeout === PROBE_TIMEOUT)).toBe(
-        true
-      );
+      // The charge carries the version the gate reads, so it gets the whole
+      // budget; the pike is diagnostics and gets a much shorter one, so it
+      // can't hold the pair past the gate's own deadline.
+      const charges = probeCalls.find(({ app }) => app === 'docket');
+      const pikes = probeCalls.find(({ app }) => app === 'hood');
+      expect(charges?.timeout).toBe(PROBE_TIMEOUT);
+      expect(pikes?.timeout).toBeLessThan(PROBE_TIMEOUT);
     },
     FULL_SYNC_TIMEOUT
   );

--- a/packages/shared/src/store/sync/sync.test.ts
+++ b/packages/shared/src/store/sync/sync.test.ts
@@ -887,6 +887,9 @@ describe('desk compatibility gate', () => {
       if (app === 'groups-ui' && path.startsWith('/v4/heads')) {
         return headsData;
       }
+      if (app === 'groups-ui' && path.startsWith('/v6/init-posts/')) {
+        return { channels: {}, chat: {} };
+      }
       // The remaining paths are incidental to the gate, but the ones whose
       // sync contexts set retry: true cost seconds of backoff if they throw,
       // so hand them an empty-but-valid response.
@@ -1573,6 +1576,7 @@ describe('desk compatibility gate', () => {
       expect(seen.length).toBeGreaterThan(0);
       expect(seen.every((deskCompat) => deskCompat != null)).toBe(true);
       expect(getSession()?.deskCompat?.status).toBe('incompatible');
+      expect(setDidSyncInitialPosts).not.toHaveBeenCalled();
     },
     FULL_SYNC_TIMEOUT
   );
@@ -1594,6 +1598,27 @@ describe('desk compatibility gate', () => {
       expect(getSession()?.deskCompat).toEqual({ status: 'ok' });
       // It never subscribed while gated, so recovery has to do it now.
       expect(vi.mocked(subscribe)).toHaveBeenCalled();
+    },
+    FULL_SYNC_TIMEOUT
+  );
+
+  test(
+    'recovers the initial-post prefetch a gate skipped',
+    async () => {
+      reportedDeskVersion = '12.1.0';
+      await syncStart();
+      // The shells' post-start call already ran, as a no-op.
+      expect(setDidSyncInitialPosts).not.toHaveBeenCalled();
+
+      reportedDeskVersion = MIN_GROUPS_VERSION;
+      await handleDiscontinuity({ context: 'test' });
+
+      // Nothing re-invokes the shells here, so the recovery owes them the
+      // prefetch they lost.
+      expect(getSession()?.deskCompat).toEqual({ status: 'ok' });
+      await vi.waitFor(() =>
+        expect(setDidSyncInitialPosts).toHaveBeenCalledWith(true)
+      );
     },
     FULL_SYNC_TIMEOUT
   );

--- a/packages/shared/src/store/sync/sync.ts
+++ b/packages/shared/src/store/sync/sync.ts
@@ -564,13 +564,17 @@ export const syncAppInfo = async (
   api.setActivitySupportsNotes(
     activityVersionSupportsNotes(appInfo?.groupsVersion)
   );
-  // Best effort: the version is what the compatibility check is waiting for, so
-  // a local storage failure must not turn a definitive answer into a lost one.
-  db.appInfo.setValue(appInfo).catch((err) => {
+  // Awaited, because syncReactionSupport re-derives these same flags from the
+  // persisted value moments later and would otherwise read a stale one. A
+  // failed write is survivable, though — it must not cost the caller the
+  // version it just fetched.
+  try {
+    await db.appInfo.setValue(appInfo);
+  } catch (err) {
     logger.trackError('Failed to persist app info', {
       error: err instanceof Error ? err.message : String(err),
     });
-  });
+  }
   return appInfo;
 };
 

--- a/packages/shared/src/store/sync/sync.ts
+++ b/packages/shared/src/store/sync/sync.ts
@@ -14,8 +14,10 @@ import { SETTINGS_SINGLETON_KEY } from '../../db/schema';
 import { runIfDev } from '../../debug';
 import { AnalyticsEvent, AnalyticsSeverity } from '../../domain';
 import {
+  MIN_GROUPS_VERSION,
   activityVersionSupportsNotes,
   activityVersionSupportsReactions,
+  classifyDeskVersion,
 } from '../../logic';
 import { perfMark, perfTime } from '../../perfLog';
 import {
@@ -42,7 +44,12 @@ import { useLureState } from '../lure';
 import { markNotesNotebookStaleForNoteEvent } from '../notesActions';
 import { verifyPostDelivery } from '../postActions/verifyPostDelivery';
 import { clearPresenceState, handlePresenceEvent } from '../presence';
-import { getSession, setSession, updateSession } from '../session';
+import {
+  getClientGeneration,
+  getSession,
+  setSession,
+  updateSession,
+} from '../session';
 import { migrateLegacyContextLensFlag } from '../settingsActions';
 import { SyncCtx, SyncPriority, syncQueue } from '../syncQueue';
 import { getSystemContacts } from '../systemContactsApi';
@@ -63,8 +70,9 @@ export const syncInitData = async (
   queryCtx?: QueryCtx,
   yieldWriter?: boolean
 ): Promise<() => Promise<void>> => {
-  // the init endpoint version is capability-picked and this can run before
-  // syncAppInfo on a fresh boot — apply the persisted capabilities first
+  // the init endpoint version is capability-picked, and while sync start now
+  // resolves a fresh version before it gets here, that probe is allowed to fail
+  // — apply the persisted capabilities first so this never runs on the defaults
   await syncReactionSupport();
   const initData = await syncQueue.add('init', syncCtx, () =>
     api.getInitData()
@@ -333,10 +341,11 @@ export const syncLatestChanges = async ({
     };
   }
 
-  // this runs before syncStart's syncAppInfo on a fresh boot, and the
-  // changes endpoint version is capability-picked — apply the persisted
-  // capabilities first so a notes-capable ship's first window doesn't
-  // fetch v8 (which drops note sources) and advance the cursor past them
+  // the changes endpoint version is capability-picked, and this also runs
+  // outside sync start (background sync, foregrounding) where nothing has
+  // resolved a fresh version — apply the persisted capabilities first so a
+  // notes-capable ship's first window doesn't fetch v8 (which drops note
+  // sources) and advance the cursor past them
   await syncReactionSupport();
 
   const perfStop = perfMark('syncLatestChanges.total');
@@ -529,15 +538,33 @@ export const syncSettings = async (ctx?: SyncCtx) => {
   }
 };
 
-export const syncAppInfo = async (ctx?: SyncCtx) => {
-  const appInfo = await syncQueue.add('appInfo', ctx, () => api.getAppInfo());
+export const syncAppInfo = async (
+  ctx?: SyncCtx,
+  options?: {
+    timeout?: number;
+    /**
+     * Checked once the fetch lands. When it says the caller has moved on —
+     * logged out, replaced the client, given up waiting — nothing is applied or
+     * persisted and this resolves to null, so a late answer can't leak into the
+     * next session.
+     */
+    isStale?: () => boolean;
+  }
+) => {
+  const appInfo = await syncQueue.add('appInfo', ctx, () =>
+    api.getAppInfo({ timeout: options?.timeout })
+  );
+  if (options?.isStale?.()) {
+    return null;
+  }
   api.setActivitySupportsReactions(
     activityVersionSupportsReactions(appInfo?.groupsVersion)
   );
   api.setActivitySupportsNotes(
     activityVersionSupportsNotes(appInfo?.groupsVersion)
   );
-  return db.appInfo.setValue(appInfo);
+  await db.appInfo.setValue(appInfo);
+  return appInfo;
 };
 
 // Resolves the backend's reaction/notes capabilities from the last-known
@@ -2009,6 +2036,12 @@ export async function syncSequencedPosts(
 export async function syncInitialPosts(config: {
   syncSize: 'heavy' | 'light';
 }) {
+  if (getSession()?.deskCompat) {
+    // Startup is gated on desk compatibility. Return without marking the first
+    // sync done, so it still runs once the ship is updated.
+    return;
+  }
+
   try {
     const params = {
       // TODO: set defaults once we have perf data that's not
@@ -2204,8 +2237,14 @@ export const handleDiscontinuity = async (config: {
   }
 
   const session = getSession();
+  // The desk gate has to survive the reset: the notice is still the right UI
+  // until the re-probe inside syncStart says otherwise, and dropping it here
+  // flashes the app back on mid-recovery.
+  const deskCompat = session?.deskCompat;
   if (session?.channelStatus && config.retainChannelStatus) {
-    setSession({ channelStatus: session?.channelStatus });
+    setSession({ channelStatus: session.channelStatus, deskCompat });
+  } else if (deskCompat) {
+    setSession({ deskCompat });
   } else {
     updateSession(null);
   }
@@ -2213,8 +2252,10 @@ export const handleDiscontinuity = async (config: {
   // clear any existing channel queries
   clearChannelPostsQueries();
 
-  // finally, refetch start data
-  await syncStart(true);
+  // finally, refetch start data. A session gated before it ever subscribed has
+  // to recover as a cold start, or a newly compatible desk would never get its
+  // subscriptions set up.
+  await syncStart(deskCompat ? deskCompat.subscribed : true);
 };
 
 export const handleChannelStatusChange = async (status: ChannelStatus) => {
@@ -2261,9 +2302,171 @@ export const handleChannelStatusChange = async (status: ChannelStatus) => {
 };
 
 let isSyncing = false;
+// Which client lifetime took the lock, so a start that outlives its own login
+// can't release a lock a newer one now holds.
+let syncLockGeneration: number | null = null;
 export function clearSyncStartLock() {
   isSyncing = false;
+  syncLockGeneration = null;
 }
+
+// Long enough to survive a slow ship, short enough that a hanging one doesn't
+// hold the cold-start spinner indefinitely.
+const DESK_PROBE_TIMEOUT = 10 * 1000;
+
+/**
+ * Startup probe: is the ship's %groups desk new enough to serve the paths the
+ * rest of sync start depends on? Returns false when startup should stop.
+ *
+ * Version only, and it fails open: a network error, a timeout, a missing docket
+ * charge or anything else unparseable proceeds exactly as before. The docket
+ * label is a proxy for path availability, not proof of it, so this errs towards
+ * the pre-existing behaviour rather than towards blocking.
+ *
+ * It doubles as the app-info sync that used to run at low priority, so this
+ * costs no extra requests: it still resolves the backend's reaction/notes
+ * capabilities before the activity feed and subscriptions pick their endpoint
+ * versions, falling back to the last-known persisted version if the fetch
+ * fails.
+ */
+const checkDeskCompatibility = async (
+  alreadySubscribed: boolean | undefined,
+  syncStartPriority: { high: number; low: number }
+) => {
+  const existingDeskCompat = getSession()?.deskCompat;
+  if (existingDeskCompat) {
+    // A retry from the notice. Keep the verdict it's displaying — the version,
+    // and whether the gated run was a recovery — so the shell keeps the notice
+    // on screen instead of dropping back to the cold-start spinner.
+    if (existingDeskCompat.status !== 'probing') {
+      updateSession({
+        deskCompat: { ...existingDeskCompat, status: 'probing' },
+      });
+    }
+  } else if (!alreadySubscribed) {
+    // Cold start: the shell holds a spinner while probing so the app never
+    // flashes on before the notice. A recovery sync already has a rendered app.
+    updateSession({
+      deskCompat: {
+        status: 'probing',
+        current: null,
+        minimum: MIN_GROUPS_VERSION,
+        subscribed: false,
+      },
+    });
+  }
+
+  // Whatever comes back has to belong to the login that asked for it: logout
+  // tears the client down mid-probe, and the next login — even to the same ship,
+  // which internalConfigureClient serves with the same Urbit object and ship
+  // name — must not inherit this one's verdict or persisted app info.
+  const probeGeneration = getClientGeneration();
+  const loginEnded = () =>
+    getSession() === null || getClientGeneration() !== probeGeneration;
+  let abandoned = false;
+  const isAbandoned = () => abandoned || loginEnded();
+
+  // The per-scry timeout isn't enough on its own: a 403 sends `scry` through
+  // `reauthOnce` and re-issues the request without one (urbit.ts), so bound the
+  // whole probe here as well.
+  let probeTimer: ReturnType<typeof setTimeout> | undefined;
+  const probeTimedOut = new Promise<null>((resolve) => {
+    probeTimer = setTimeout(() => {
+      abandoned = true;
+      resolve(null);
+    }, DESK_PROBE_TIMEOUT);
+  });
+
+  const appInfo = await Promise.race([
+    syncAppInfo(
+      { priority: syncStartPriority.high, retry: false },
+      { timeout: DESK_PROBE_TIMEOUT, isStale: isAbandoned }
+    ).catch((err) => {
+      logger.trackError('Desk compatibility probe failed', {
+        error: err instanceof Error ? err.message : String(err),
+      });
+      return null;
+    }),
+    probeTimedOut,
+  ]).finally(() => clearTimeout(probeTimer));
+
+  if (loginEnded()) {
+    // Logged out, or re-clientted, while we waited. Leave the session alone and
+    // stop: whoever comes next runs their own sync start.
+    return false;
+  }
+
+  if (!appInfo) {
+    // Failed, or timed out and gave up. Fall back to the last-known persisted
+    // version for the capability flags, and let startup through as before.
+    syncReactionSupport().catch(() => {});
+  }
+
+  if (classifyDeskVersion(appInfo?.groupsVersion) === 'outdated') {
+    const current = appInfo?.groupsVersion ?? null;
+    updateSession({
+      deskCompat: {
+        status: 'incompatible',
+        current,
+        minimum: MIN_GROUPS_VERSION,
+        subscribed: !!alreadySubscribed,
+      },
+    });
+    logger.trackEvent(AnalyticsEvent.DeskIncompatible, {
+      current,
+      minimum: MIN_GROUPS_VERSION,
+      recovery: !!alreadySubscribed,
+    });
+    return false;
+  }
+
+  // Explicit clear, not a no-op: a previously gated session has to be able to
+  // recover in place once the ship updates.
+  updateSession({ deskCompat: undefined });
+  logger.crumb(`finished syncing app info`);
+  return true;
+};
+
+/**
+ * Re-run startup after the ship has (hopefully) been updated. Keeps the current
+ * client — dropping it would abort the SSE channel and any live subscriptions
+ * for no gain — and resumes with the same alreadySubscribed semantics the gated
+ * run had, so a recovery-time gate never double-subscribes.
+ *
+ * `onRecovered` is the caller's own post-start work. The shells chain it off
+ * their one `syncStart` call, which already resolved as a gated no-op, so a
+ * successful retry has to run it again — and they don't agree on what it is
+ * (mobile picks a sync size from the network, web always asks for a light one).
+ */
+export const retryDeskCompatibility = async (options?: {
+  onRecovered?: () => void | Promise<void>;
+}) => {
+  const deskCompat = getSession()?.deskCompat;
+  if (!deskCompat) {
+    return;
+  }
+
+  // Both the restore and the continuation below belong to the login that
+  // pressed the button: after a logout there is nothing to restore the notice
+  // for, and after a re-login the gate on screen is the new login's.
+  const retryGeneration = getClientGeneration();
+  const isSameLogin = () => getClientGeneration() === retryGeneration;
+
+  updateSession({ deskCompat: { ...deskCompat, status: 'probing' } });
+  try {
+    await syncStart(deskCompat.subscribed);
+  } finally {
+    if (isSameLogin() && getSession()?.deskCompat?.status === 'probing') {
+      // Either syncStart bailed on the sync lock or it threw, so nothing
+      // re-probed. Put the notice back rather than leaving Try again spinning.
+      updateSession({ deskCompat: { ...deskCompat, status: 'incompatible' } });
+    }
+  }
+
+  if (isSameLogin() && !getSession()?.deskCompat) {
+    await options?.onRecovered?.();
+  }
+};
 
 export const syncStart = async (alreadySubscribed?: boolean) => {
   if (isSyncing) {
@@ -2271,6 +2474,8 @@ export const syncStart = async (alreadySubscribed?: boolean) => {
     return;
   }
   isSyncing = true;
+  const startGeneration = getClientGeneration();
+  syncLockGeneration = startGeneration;
   updateSession({ phase: 'high' });
 
   if (!alreadySubscribed) {
@@ -2284,6 +2489,20 @@ export const syncStart = async (alreadySubscribed?: boolean) => {
 
   try {
     let didLoadCachedContacts = false;
+
+    // if running while already subscribed, execute the sync with lower priority. It's
+    // needed for correctness, but expensive and usually inconsequential
+    const syncStartPriority = {
+      high: alreadySubscribed ? SyncPriority.Medium : SyncPriority.High,
+      low: alreadySubscribed ? SyncPriority.Low : SyncPriority.Medium,
+    };
+
+    if (!(await checkDeskCompatibility(alreadySubscribed, syncStartPriority))) {
+      // The ship's desk is too old to serve the paths the rest of this function
+      // needs. Stop before init, subscriptions and first-sync bookkeeping, and
+      // resolve rather than throw so every caller's success path is a no-op.
+      return;
+    }
 
     // it's important that this isn't within the main batchEffects block. If we're
     // returning from a cold open, we don't want to wait for all of High Priority sync
@@ -2301,13 +2520,6 @@ export const syncStart = async (alreadySubscribed?: boolean) => {
     if (!isE2eRun) {
       await new Promise((resolve) => setTimeout(resolve, 1000));
     }
-
-    // if running while already subscribed, execute the sync with lower priority. It's
-    // needed for correctness, but expensive and usually inconsequential
-    const syncStartPriority = {
-      high: alreadySubscribed ? SyncPriority.Medium : SyncPriority.High,
-      low: alreadySubscribed ? SyncPriority.Low : SyncPriority.Medium,
-    };
 
     try {
       await batchEffects('sync start (high)', async (queryCtx) => {
@@ -2398,20 +2610,6 @@ export const syncStart = async (alreadySubscribed?: boolean) => {
     }
 
     updateSession({ phase: 'low' });
-    // Resolve the backend's reaction capability from the *current* version
-    // before the activity feed and subscription below pick their endpoint
-    // versions, so reactions work on first launch and right after a ship
-    // upgrade rather than only after a restart. Fall back to the last-known
-    // (persisted) version if the fresh fetch fails.
-    await syncAppInfo({ priority: syncStartPriority.low + 1 })
-      .then(() => logger.crumb(`finished syncing app info`))
-      .catch((err) => {
-        logger.trackError(
-          'Failed to sync app info; falling back to persisted version for reaction capability',
-          { error: err instanceof Error ? err.message : String(err) }
-        );
-        return syncReactionSupport().catch(() => {});
-      });
     const lowPriorityPromises = [
       alreadySubscribed
         ? Promise.resolve()
@@ -2476,8 +2674,17 @@ export const syncStart = async (alreadySubscribed?: boolean) => {
     await verifyUserInviteLink();
     db.userHasCompletedFirstSync.setValue(true);
   } finally {
-    updateSession({ phase: 'ready' });
-    isSyncing = false;
+    if (getClientGeneration() === startGeneration) {
+      // Only the login that started this run gets to mark it done; otherwise
+      // this resurrects a session the user has logged out of.
+      updateSession({ phase: 'ready' });
+    }
+    if (syncLockGeneration === startGeneration) {
+      // A newer login's start may already hold the lock (logout clears it, and
+      // the next start takes it) — that one releases it itself.
+      isSyncing = false;
+      syncLockGeneration = null;
+    }
   }
 };
 

--- a/packages/shared/src/store/sync/sync.ts
+++ b/packages/shared/src/store/sync/sync.ts
@@ -2366,9 +2366,9 @@ const checkDeskCompatibility = async (
   let abandoned = false;
   const isAbandoned = () => abandoned || loginEnded();
 
-  // The per-scry timeout isn't enough on its own: a 403 sends `scry` through
-  // `reauthOnce` and re-issues the request without one (urbit.ts), so bound the
-  // whole probe here as well.
+  // Each scry is bounded on its own, but a 403 costs a reauth and a second
+  // request, so bound the wait for the pair here too — startup shouldn't sit
+  // behind the worst case of both.
   let probeTimer: ReturnType<typeof setTimeout> | undefined;
   const probeTimedOut = new Promise<null>((resolve) => {
     probeTimer = setTimeout(() => {

--- a/packages/shared/src/store/sync/sync.ts
+++ b/packages/shared/src/store/sync/sync.ts
@@ -47,6 +47,7 @@ import { clearPresenceState, handlePresenceEvent } from '../presence';
 import {
   getClientGeneration,
   getSession,
+  isDeskGated,
   setSession,
   updateSession,
 } from '../session';
@@ -2036,7 +2037,7 @@ export async function syncSequencedPosts(
 export async function syncInitialPosts(config: {
   syncSize: 'heavy' | 'light';
 }) {
-  if (getSession()?.deskCompat) {
+  if (isDeskGated(getSession()?.deskCompat)) {
     // Startup is gated on desk compatibility. Return without marking the first
     // sync done, so it still runs once the ship is updated.
     return;
@@ -2237,14 +2238,17 @@ export const handleDiscontinuity = async (config: {
   }
 
   const session = getSession();
-  // The desk gate has to survive the reset: the notice is still the right UI
-  // until the re-probe inside syncStart says otherwise, and dropping it here
-  // flashes the app back on mid-recovery.
-  const deskCompat = session?.deskCompat;
+  // A gate has to survive the reset: the notice is still the right UI until the
+  // re-probe inside syncStart says otherwise, and dropping it here flashes the
+  // app back on mid-recovery. A clean verdict isn't carried over — the re-probe
+  // reaches its own.
+  const deskGate = isDeskGated(session?.deskCompat)
+    ? session?.deskCompat
+    : undefined;
   if (session?.channelStatus && config.retainChannelStatus) {
-    setSession({ channelStatus: session.channelStatus, deskCompat });
-  } else if (deskCompat) {
-    setSession({ deskCompat });
+    setSession({ channelStatus: session.channelStatus, deskCompat: deskGate });
+  } else if (deskGate) {
+    setSession({ deskCompat: deskGate });
   } else {
     updateSession(null);
   }
@@ -2255,7 +2259,7 @@ export const handleDiscontinuity = async (config: {
   // finally, refetch start data. A session gated before it ever subscribed has
   // to recover as a cold start, or a newly compatible desk would never get its
   // subscriptions set up.
-  await syncStart(deskCompat ? deskCompat.subscribed : true);
+  await syncStart(deskGate ? deskGate.subscribed : true);
 };
 
 export const handleChannelStatusChange = async (status: ChannelStatus) => {
@@ -2334,13 +2338,16 @@ const checkDeskCompatibility = async (
   syncStartPriority: { high: number; low: number }
 ) => {
   const existingDeskCompat = getSession()?.deskCompat;
-  if (existingDeskCompat) {
+  const priorGate = isDeskGated(existingDeskCompat)
+    ? existingDeskCompat
+    : undefined;
+  if (priorGate) {
     // A retry from the notice. Keep the verdict it's displaying — the version,
     // and whether the gated run was a recovery — so the shell keeps the notice
     // on screen instead of dropping back to the cold-start spinner.
-    if (existingDeskCompat.status !== 'probing') {
+    if (priorGate.status !== 'probing') {
       updateSession({
-        deskCompat: { ...existingDeskCompat, status: 'probing' },
+        deskCompat: { ...priorGate, status: 'probing' },
       });
     }
   } else if (!alreadySubscribed) {
@@ -2398,11 +2405,26 @@ const checkDeskCompatibility = async (
 
   if (!appInfo) {
     // Failed, or timed out and gave up. Fall back to the last-known persisted
-    // version for the capability flags, and let startup through as before.
+    // version for the capability flags; what that means for startup is decided
+    // by the classification below.
     syncReactionSupport().catch(() => {});
   }
 
-  if (classifyDeskVersion(appInfo?.groupsVersion) === 'outdated') {
+  const classification = classifyDeskVersion(appInfo?.groupsVersion);
+
+  if (classification === 'unknown' && priorGate?.current) {
+    // A retry that learned nothing — the probe failed, timed out, or came back
+    // unreadable. Keep the verdict we already have: failing open is for a first
+    // probe with nothing to fall back on, not for discarding a version we did
+    // observe. Only seeing a good version clears this.
+    updateSession({
+      deskCompat: { ...priorGate, status: 'incompatible' },
+    });
+    logger.crumb('desk compatibility retry was inconclusive; keeping the gate');
+    return false;
+  }
+
+  if (classification === 'outdated') {
     const current = appInfo?.groupsVersion ?? null;
     updateSession({
       deskCompat: {
@@ -2420,9 +2442,10 @@ const checkDeskCompatibility = async (
     return false;
   }
 
-  // Explicit clear, not a no-op: a previously gated session has to be able to
-  // recover in place once the ship updates.
-  updateSession({ deskCompat: undefined });
+  // A recorded verdict, not a clear: until this lands, nothing else in the app
+  // may assume the desk is usable — and a previously gated session has to be
+  // able to recover in place once the ship updates.
+  updateSession({ deskCompat: { status: 'ok' } });
   logger.crumb(`finished syncing app info`);
   return true;
 };
@@ -2442,7 +2465,7 @@ export const retryDeskCompatibility = async (options?: {
   onRecovered?: () => void | Promise<void>;
 }) => {
   const deskCompat = getSession()?.deskCompat;
-  if (!deskCompat) {
+  if (!isDeskGated(deskCompat)) {
     return;
   }
 
@@ -2463,7 +2486,7 @@ export const retryDeskCompatibility = async (options?: {
     }
   }
 
-  if (isSameLogin() && !getSession()?.deskCompat) {
+  if (isSameLogin() && getSession()?.deskCompat?.status === 'ok') {
     await options?.onRecovered?.();
   }
 };

--- a/packages/shared/src/store/sync/sync.ts
+++ b/packages/shared/src/store/sync/sync.ts
@@ -2325,6 +2325,11 @@ let isSyncing = false;
 // Which client lifetime took the lock, so a start that outlives its own login
 // can't release a lock a newer one now holds.
 let syncLockGeneration: number | null = null;
+// Which client lifetime already has live subscriptions. A remount starts a
+// fresh sync while the previous mount's subscriptions are still up, and
+// registering a second set on top of them doubles every event. Logout bumps the
+// generation (session.ts), so a genuinely new login subscribes again.
+let subscribedGeneration: number | null = null;
 export function clearSyncStartLock() {
   isSyncing = false;
   syncLockGeneration = null;
@@ -2515,16 +2520,20 @@ export const syncStart = async (alreadySubscribed?: boolean) => {
   isSyncing = true;
   const startGeneration = getClientGeneration();
   syncLockGeneration = startGeneration;
+  // A caller that thinks it's starting cold may be a remount over subscriptions
+  // this client lifetime already established; treat that as a warm start.
+  const isSubscribed =
+    alreadySubscribed || subscribedGeneration === startGeneration;
   updateSession({ phase: 'high' });
 
-  if (!alreadySubscribed) {
+  if (!isSubscribed) {
     // Only clear cached presence on a fresh startup. During recovery syncs we keep
     // the current snapshot until new presence events arrive to avoid UI flicker
     clearPresenceState();
   }
 
   const startTime = Date.now();
-  logger.crumb(`sync start running${alreadySubscribed ? ' (recovery)' : ''}`);
+  logger.crumb(`sync start running${isSubscribed ? ' (recovery)' : ''}`);
 
   try {
     let didLoadCachedContacts = false;
@@ -2532,11 +2541,11 @@ export const syncStart = async (alreadySubscribed?: boolean) => {
     // if running while already subscribed, execute the sync with lower priority. It's
     // needed for correctness, but expensive and usually inconsequential
     const syncStartPriority = {
-      high: alreadySubscribed ? SyncPriority.Medium : SyncPriority.High,
-      low: alreadySubscribed ? SyncPriority.Low : SyncPriority.Medium,
+      high: isSubscribed ? SyncPriority.Medium : SyncPriority.High,
+      low: isSubscribed ? SyncPriority.Low : SyncPriority.Medium,
     };
 
-    if (!(await checkDeskCompatibility(alreadySubscribed, syncStartPriority))) {
+    if (!(await checkDeskCompatibility(isSubscribed, syncStartPriority))) {
       // The ship's desk is too old to serve the paths the rest of this function
       // needs. Stop before init, subscriptions and first-sync bookkeeping, and
       // resolve rather than throw so every caller's success path is a no-op.
@@ -2581,7 +2590,7 @@ export const syncStart = async (alreadySubscribed?: boolean) => {
           queryCtx,
           yieldWriter
         );
-        const subsPromise = alreadySubscribed
+        const subsPromise = isSubscribed
           ? Promise.resolve()
           : setupHighPrioritySubscriptions({
               priority: syncStartPriority.high - 1,
@@ -2650,17 +2659,27 @@ export const syncStart = async (alreadySubscribed?: boolean) => {
 
     updateSession({ phase: 'low' });
     const lowPriorityPromises = [
-      alreadySubscribed
+      isSubscribed
         ? Promise.resolve()
         : setupLowPrioritySubscriptions({
             priority: syncStartPriority.low,
-          }).then(() => logger.crumb('subscribed low priority')),
+          })
+            .finally(() => {
+              // Both sets have now been established for this client lifetime
+              // (the high-priority ones went up in the block above), so a later
+              // start in the same lifetime skips them. Marked even on a
+              // rejection: what usually fails here is the lens backfill chained
+              // onto the subscribe, and re-registering every subscription on
+              // the next mount is worse than not retrying that.
+              subscribedGeneration = startGeneration;
+            })
+            .then(() => logger.crumb('subscribed low priority')),
       // On recovery the live subscription persists across the discontinuity,
       // so setupLowPrioritySubscriptions (and its post-subscribe lens
       // backfill) is skipped. Rescry /v1/lens directly to recover any events
       // missed while the SSE connection was down. No-ops on ships without
       // %steward (syncLensRuns swallows the 404).
-      alreadySubscribed
+      isSubscribed
         ? syncLensRuns({ priority: syncStartPriority.low + 1 }).then(() =>
             logger.crumb('finished recovery lens backfill')
           )

--- a/packages/shared/src/store/sync/sync.ts
+++ b/packages/shared/src/store/sync/sync.ts
@@ -564,7 +564,13 @@ export const syncAppInfo = async (
   api.setActivitySupportsNotes(
     activityVersionSupportsNotes(appInfo?.groupsVersion)
   );
-  await db.appInfo.setValue(appInfo);
+  // Best effort: the version is what the compatibility check is waiting for, so
+  // a local storage failure must not turn a definitive answer into a lost one.
+  db.appInfo.setValue(appInfo).catch((err) => {
+    logger.trackError('Failed to persist app info', {
+      error: err instanceof Error ? err.message : String(err),
+    });
+  });
   return appInfo;
 };
 

--- a/packages/shared/src/store/sync/sync.ts
+++ b/packages/shared/src/store/sync/sync.ts
@@ -2537,6 +2537,9 @@ export const syncStart = async (alreadySubscribed?: boolean) => {
 
   try {
     let didLoadCachedContacts = false;
+    // Only meaningful on the subscribing path: the marker below needs to know
+    // that this set went up, and its failure is caught out of reach of it.
+    let didSubscribeHighPriority = false;
 
     // if running while already subscribed, execute the sync with lower priority. It's
     // needed for correctness, but expensive and usually inconsequential
@@ -2644,6 +2647,7 @@ export const syncStart = async (alreadySubscribed?: boolean) => {
         await contactsWriter();
 
         await subsPromise;
+        didSubscribeHighPriority = true;
         trackStep(AnalyticsEvent.SubscriptionsEstablished);
         logger.crumb('finished initializing high priority subs');
 
@@ -2663,17 +2667,17 @@ export const syncStart = async (alreadySubscribed?: boolean) => {
         ? Promise.resolve()
         : setupLowPrioritySubscriptions({
             priority: syncStartPriority.low,
-          })
-            .finally(() => {
-              // Both sets have now been established for this client lifetime
-              // (the high-priority ones went up in the block above), so a later
-              // start in the same lifetime skips them. Marked even on a
-              // rejection: what usually fails here is the lens backfill chained
-              // onto the subscribe, and re-registering every subscription on
-              // the next mount is worse than not retrying that.
+          }).then(() => {
+            if (didSubscribeHighPriority) {
+              // Both sets are confirmed up for this client lifetime, so a later
+              // start in the same lifetime skips them. If either failed the
+              // marker stays unset and the next start registers again — it may
+              // duplicate the set that did work, which is what happens today,
+              // but it never leaves an event stream missing for the session.
               subscribedGeneration = startGeneration;
-            })
-            .then(() => logger.crumb('subscribed low priority')),
+            }
+            logger.crumb('subscribed low priority');
+          }),
       // On recovery the live subscription persists across the discontinuity,
       // so setupLowPrioritySubscriptions (and its post-subscribe lens
       // backfill) is skipped. Rescry /v1/lens directly to recover any events
@@ -2758,21 +2762,25 @@ export const setupHighPrioritySubscriptions = async (ctx?: SyncCtx) => {
 };
 
 export const setupLowPrioritySubscriptions = async (ctx?: SyncCtx) => {
-  return syncQueue.add('setupLowPrioritySubscription', ctx, () => {
-    return Promise.all([
+  return syncQueue.add('setupLowPrioritySubscription', ctx, async () => {
+    // returns null (and skips backfill) when the ship lacks the %steward agent
+    const lensSubscription = api.subscribeToLensUpdates(handleLensUpdate);
+    await Promise.all([
       api.subscribeToActivity(createBatchHandler(handleActivityUpdate)),
       api.subscribeToContactUpdates(createHandler(handleContactUpdate)),
       api.subscribeToStorageUpdates(createHandler(handleStorageUpdate)),
       api.subscribeToLanyardUpdates(handleLanyardUpdate),
       api.subscribeToSettings(createHandler(handleSettingsUpdate)),
-      // returns null (and skips backfill) when the ship lacks the %steward agent
-      api.subscribeToLensUpdates(handleLensUpdate).then((subscribed) => {
-        if (subscribed === null) {
-          return;
-        }
-        return syncLensRuns();
-      }),
+      lensSubscription,
     ]);
+
+    // Backfill, not subscription. Callers read this function's result as
+    // "are the subscriptions up?", so a failed backfill must not answer no.
+    if ((await lensSubscription) !== null) {
+      syncLensRuns().catch((e) =>
+        logger.trackError('post-subscribe lens backfill failed', { error: e })
+      );
+    }
   });
 };
 

--- a/packages/shared/src/store/sync/sync.ts
+++ b/packages/shared/src/store/sync/sync.ts
@@ -558,16 +558,19 @@ export const syncAppInfo = async (
   if (options?.isStale?.()) {
     return null;
   }
+  fetchedGroupsVersion = {
+    generation: getClientGeneration(),
+    groupsVersion: appInfo?.groupsVersion,
+  };
   api.setActivitySupportsReactions(
     activityVersionSupportsReactions(appInfo?.groupsVersion)
   );
   api.setActivitySupportsNotes(
     activityVersionSupportsNotes(appInfo?.groupsVersion)
   );
-  // Awaited, because syncReactionSupport re-derives these same flags from the
-  // persisted value moments later and would otherwise read a stale one. A
-  // failed write is survivable, though — it must not cost the caller the
-  // version it just fetched.
+  // Awaited so the App Info screen and the notes-search gate see it promptly.
+  // The capability flags don't depend on it landing: what protects those is
+  // the in-memory version recorded above.
   try {
     await db.appInfo.setValue(appInfo);
   } catch (err) {
@@ -578,18 +581,28 @@ export const syncAppInfo = async (
   return appInfo;
 };
 
-// Resolves the backend's reaction/notes capabilities from the last-known
-// (persisted) groups version and applies them to the activity client before
-// it picks endpoint versions. A fresh version is fetched by syncAppInfo,
-// which also updates this.
+// The version this client lifetime actually fetched, which outranks whatever
+// is persisted: the write can fail or lag, and re-deriving the flags from a
+// stale value would drop the ship back to legacy activity endpoints for the
+// rest of the session.
+let fetchedGroupsVersion: {
+  generation: number;
+  groupsVersion?: string;
+} | null = null;
+
+// Resolves the backend's reaction/notes capabilities and applies them to the
+// activity client before it picks endpoint versions. Prefers the version this
+// client lifetime fetched, falling back to the last-known persisted one on a
+// fresh launch, before any fetch has happened.
 export const syncReactionSupport = async () => {
-  const appInfo = await db.appInfo.getValue();
+  const groupsVersion =
+    fetchedGroupsVersion?.generation === getClientGeneration()
+      ? fetchedGroupsVersion.groupsVersion
+      : (await db.appInfo.getValue())?.groupsVersion;
   api.setActivitySupportsReactions(
-    activityVersionSupportsReactions(appInfo?.groupsVersion)
+    activityVersionSupportsReactions(groupsVersion)
   );
-  api.setActivitySupportsNotes(
-    activityVersionSupportsNotes(appInfo?.groupsVersion)
-  );
+  api.setActivitySupportsNotes(activityVersionSupportsNotes(groupsVersion));
 };
 
 export const syncVolumeSettings = async (ctx?: SyncCtx) => {
@@ -2248,17 +2261,15 @@ export const handleDiscontinuity = async (config: {
   }
 
   const session = getSession();
-  // A gate has to survive the reset: the notice is still the right UI until the
-  // re-probe inside syncStart says otherwise, and dropping it here flashes the
-  // app back on mid-recovery. A clean verdict isn't carried over — the re-probe
-  // reaches its own.
-  const deskGate = isDeskGated(session?.deskCompat)
-    ? session?.deskCompat
-    : undefined;
+  // The verdict has to survive the reset in either direction: a gate because
+  // the notice is still the right UI until the re-probe says otherwise, and a
+  // clean verdict because dropping it reads as "not probed yet" and tears down
+  // whatever the shells only show on a known-good desk.
+  const deskCompat = session?.deskCompat;
   if (session?.channelStatus && config.retainChannelStatus) {
-    setSession({ channelStatus: session.channelStatus, deskCompat: deskGate });
-  } else if (deskGate) {
-    setSession({ deskCompat: deskGate });
+    setSession({ channelStatus: session.channelStatus, deskCompat });
+  } else if (deskCompat) {
+    setSession({ deskCompat });
   } else {
     updateSession(null);
   }
@@ -2269,9 +2280,9 @@ export const handleDiscontinuity = async (config: {
   // finally, refetch start data. A session gated before it ever subscribed has
   // to recover as a cold start, or a newly compatible desk would never get its
   // subscriptions set up.
-  await syncStart(deskGate ? deskGate.subscribed : true);
+  await syncStart(isDeskGated(deskCompat) ? deskCompat.subscribed : true);
 
-  if (deskGate && getSession()?.deskCompat?.status === 'ok') {
+  if (isDeskGated(deskCompat) && getSession()?.deskCompat?.status === 'ok') {
     // The gate cleared on this restart, so the shells' post-start prefetch —
     // which returned as a no-op while it was up — has to be redone here.
     syncInitialPosts({ syncSize: 'light' }).catch(() => {});
@@ -2371,9 +2382,11 @@ const checkDeskCompatibility = async (
         deskCompat: { ...priorGate, status: 'probing' },
       });
     }
-  } else if (!alreadySubscribed) {
-    // Cold start: the shell holds a spinner while probing so the app never
-    // flashes on before the notice. A recovery sync already has a rendered app.
+  } else if (!alreadySubscribed && !existingDeskCompat) {
+    // First probe of this session: the shell holds a spinner while it runs, so
+    // the app never flashes on before the notice. A recovery sync already has a
+    // rendered app, and an existing verdict stays put until this one replaces
+    // it — re-probing must not read as "not probed yet".
     updateSession({
       deskCompat: {
         status: 'probing',

--- a/packages/shared/src/store/sync/sync.ts
+++ b/packages/shared/src/store/sync/sync.ts
@@ -2260,6 +2260,12 @@ export const handleDiscontinuity = async (config: {
   // to recover as a cold start, or a newly compatible desk would never get its
   // subscriptions set up.
   await syncStart(deskGate ? deskGate.subscribed : true);
+
+  if (deskGate && getSession()?.deskCompat?.status === 'ok') {
+    // The gate cleared on this restart, so the shells' post-start prefetch —
+    // which returned as a no-op while it was up — has to be redone here.
+    syncInitialPosts({ syncSize: 'light' }).catch(() => {});
+  }
 };
 
 export const handleChannelStatusChange = async (status: ChannelStatus) => {


### PR DESCRIPTION
## Summary

Stacked on #6493: the base is that branch, and GitHub retargets this PR to develop once it merges. Depends on #6497 (TLON-6529, which drops link support from ui `Pressable` so the notice can render outside a `NavigationContainer`); that is in develop but not yet in #6493's branch, so until the base picks it up the desk-compat Playwright spec fails on this PR's merge ref (the web notice throws there).

Adds a startup probe that checks the local ship's groups desk version before syncing, so a client build that depends on newer desk endpoints (e.g. the `groups-ui/v10/init` scry shipped in desk 12.2.0) shows an "update needed" notice instead of silently reaching a ready, empty home screen against an older desk. Fixes TLON-6522.

## Changes

- `packages/shared/src/logic/deskCompatibility.ts` (new, +test, exported from `logic/index.ts`): `MIN_GROUPS_VERSION` (12.2.0, a support floor: the oldest desk this client supports, raised only when dropping backcompat) and `classifyDeskVersion`, which compares the ship's reported docket version against it. Fails open on unknown, unparseable, or missing versions; only a parseable, definitely-old version gates.
- `packages/shared/src/store/sync/sync.ts` (+tests in `sync.test.ts`): `syncStart` now runs `checkDeskCompatibility()` first, inside its outer try and ahead of `syncSince`, init and subscriptions. `getAppInfo` scries `hood /kiln/pikes` and `docket /charges` in parallel at high priority with no retry, the probe as a whole is bounded by a 10 s race that fails open on timeout, and an answer landing after the app gave up, or after a logout or any new login (a re-login to the same ship included), is dropped: no capability flags, no persisted app info, no `deskCompat` write.
- `packages/shared/src/store/sync/sync.ts`, gated state and recovery: an outdated desk records `deskCompat: { status: 'incompatible', current, minimum, subscribed }` on the session, fires a `Desk Incompatible` analytics event, and resolves without syncing (never rejects, so every caller's success path is a no-op). `syncStart` resolves a `SyncStartOutcome` (`ok`, `gated`, `busy` or `abandoned`), and the retry handler, both shells and `handleDiscontinuity` branch on that value rather than re-reading the gate afterwards. `retryDeskCompatibility({ onRecovered })` re-probes without replacing the client and runs the shell's post-start work only once the gate clears, with both that continuation and its notice-restore path scoped to the login that pressed the button; a retry from an incompatible state keeps the version it is showing and only flips `status` to `probing`; `handleDiscontinuity` carries the gate across the reset and restarts with `syncStart(deskCompat ? deskCompat.subscribed : true)`, so a session gated before it ever subscribed recovers as a cold start, and if that recovery clears the gate the initial-post prefetch it skipped is redone; `syncInitialPosts` no-ops while gated. A clean or fail-open verdict is recorded as `deskCompat: { status: 'ok' }` rather than clearing the field, so an absent `deskCompat` means "not probed yet"; a retry from an incompatible verdict whose probe comes back inconclusive (failed, timed out, unparseable) keeps that verdict instead of failing open. `syncStart` also remembers which client generation already holds live subscriptions (recorded only once both subscription sets have succeeded, so a failed subscribe leaves the next start to re-register), so a remount that calls it as a cold start in the same login (the revival splash handover, the hosting reconnect) proceeds as already subscribed instead of registering the subscription sets twice. `syncStart`'s end-of-run bookkeeping is scoped the same way: it writes `phase: 'ready'` only for the login that started it, and releases the sync lock only while that start still owns it. Removes the old low-priority `syncAppInfo` call, folding its reaction-support fallback into the probe; the fetched version is kept authoritative in memory for the current login (the persisted copy is a fallback for a fresh launch), so a failed or stale persistence write cannot discard a verdict or downgrade the activity capabilities. A clean `ok` verdict survives a discontinuity reset, so the onboarding overlay and launch sheets stay mounted through a reprobe.
- `packages/shared/src/store/session.ts`: adds `deskCompat` to session state (`{ status: 'ok' }` or a gate with `current`/`minimum`/`subscribed`) plus `useDeskCompatibility()` and the predicates the shells share (gated, probe still pending, notice belongs on screen). Adds a `clientGeneration` counter, bumped in `updateInitializedClient()` (the single call under `configureClient`/`removeClient`), so long-running work can tell its own login from the next one; the ship name and the client object can't, since `internalConfigureClient` serves a same-ship re-login with the same Urbit object under the same name.
- `packages/api/src/client/settingsApi.ts`: `getAppInfo` takes a `timeout` option and runs its two scries in parallel; the pikes scry is optional and carries its own short 3 s bound (its failure yields the `n/a` diagnostics), while a charges failure still rejects, so the version verdict never depends on pikes.
- `packages/api/src/types/analytics.ts`: adds the `Desk Incompatible` event.
- `packages/app/constants.ts`: adds `DESK_UPDATE_HELP_URL`, pointing at the Urbit user manual's updates page (runtime, kernel and app updates in order, including blocked app updates and `|bump`).
- `packages/api/src/client/urbit.ts` and `landscapeApi.ts`: the post-reauth retry in `scry` and `scryNoun` now carries the same timeout as the first attempt, and the reauth login fetch itself is bounded (30 s, AbortController), so no leg of a 403 recovery can hang a caller or its sync queue thread. Previously a 403 re-issued the request unbounded, so a hung retry never settled and held its caller, and for queued work a sync queue thread, indefinitely; the probe's outer race could abandon such a request while it stayed active in the queue.
- `packages/app/features/DeskOutdatedScreen.tsx` (new): props-only screen showing the reported version vs. the minimum, "Try again" (busy while a re-probe is in flight), "How to update", email support, and a log out control when the shell supplies a handler; with `isHosted` (mobile passes it from the ship's hosted `authType`) the copy says Tlon runs the update and the self-update link is not shown. Modelled on #6493's `HostingAuthReconnectScreen`.
- `apps/tlon-mobile/src/components/AuthenticatedApp.tsx`: renders `DeskOutdatedScreen` in place of `RootStack` while gated so node-stopped handling stays mounted; skips foreground `syncSince` while gated; holds the cold-start spinner while probing to avoid an app-then-notice flash; shows #6493's onboarding overlay and the launch sheets (web-app splash, Tlonbot revival prompt) only once a clean verdict is recorded, so none of them can mount ahead of or over the notice; the app-open handler skips desk-dependent work (deferred Tlonbot config recovery) while gated but keeps the hosting-auth and node-stopped checks running, and that recovery is re-run once the gate clears. Threads the existing `onLogout` down to the screen and lifts `syncInitialPostsIfNeeded` to module scope so the startup effect and the retry share one copy.
- `packages/app/hooks/useBootSequence.ts`: the hosted signup boot fires `syncStart` inside `withRetry`, which only retries on a throw; a gated start resolves, so a node still finishing its `%groups` update ended the retries after one attempt and the boot waited on a connection that never came. The retry wrapper now throws on a `gated` outcome so the node gets its three attempts; `ok`, `busy` and `abandoned` resolve as before. The notice itself is not rendered inside the onboarding shell (TLON-6531).
- `apps/tlon-mobile/src/App.main.tsx`: the Tlonbot revival splash replaces the authenticated app only once the verdict is `ok` (an absent verdict means not probed yet), so a cold start in revival mode runs the normal path, probes behind the spinner, and hands over to the splash afterwards, and a gated revival session falls through to the notice; the offline view keeps precedence.
- `apps/tlon-web/src/app.tsx`: renders `DeskOutdatedScreen` ahead of both loading guards, since a gated start never sets `session.startTime` and the web splash would wait forever. Electron's `ConnectedDesktopApp` wires `onLogout` through `useHandleLogout({ resetDb })`; plain web deliberately omits it, since there is no Log out row on web and the handler would be a no-op there.
- `apps/tlon-mobile/src/fixtures/DeskOutdatedScreen.fixture.tsx` (new) and `cosmos.imports.ts`: registers the screen's four states (version reported, retrying, no version reported, hosted) with cosmos.
- `apps/tlon-mobile/jest.config.js`: adds the `react-native-worklets` jest resolver and a `@tloncorp/api` module mapping so the mobile jest suite can load UI components.

## How did I test?

- `packages/shared/src/logic/deskCompatibility.test.ts`: version classification.
- `packages/api/src/__tests__/reauthChannel.test.ts`: a 403 followed by a hanging retry rejects on the timeout instead of hanging, for `scry` and `scryNoun`, and a login the ship never answers rejects after its timeout so a hung reauth releases the scry; all fail against the unbounded code.
- `packages/shared/src/store/sync/sync.test.ts`: gated startup makes no init, subscribe or first-sync-bookkeeping calls; fail-open paths (probe failure, no version reported, a probe that hangs past the timeout and answers too late); concurrent cold starts sharing one probe; retry recovering in place without a reload and running the shell's follow-up; a retry that stays outdated, or is blocked by the sync lock, restoring the notice; the gate surviving a discontinuity, with a cold-gated session recovering as a cold start; `syncInitialPosts` no-op while gated. The suite logs in and out the way `useHandleLogout` does, and covers a probe answering after a logout, after a re-login to the same ship and after a switch to another ship; a retry interrupted by logout neither restoring the notice nor prefetching; a retry finishing after a new login leaving that login and its sync lock alone; a retry that fails after a clean verdict leaving the gate cleared; a hanging probe's sync queue thread being released once the underlying request settles; no verdict before the probe and `{ status: 'ok' }` after; a failing pikes scry not failing the gate open; a retry whose probe fails or times out keeping the notice; a second cold start in one login not re-subscribing while a new login does, a gated start subscribing exactly once after recovery, and a failed high- or low-priority subscribe leaving the next start to retry; a clean session keeping `{ status: 'ok' }` throughout a discontinuity while a reprobe that finds an outdated desk still gates; and the fetched version driving the activity endpoints even when the persisted copy is older or the write fails. Mutation-checked: retry ignoring the existing state, discontinuity always restarting as `syncStart(true)`, dropping the stale guards, dropping `onRecovered`, dropping the probe's timeout race and dropping the explicit verdict write each failed a named test, as did the mutations of the login-generation guards, the subscription marker, and the in-memory version precedence.
- `apps/tlon-mobile/src/__uitests__/DeskOutdatedScreen.test.tsx`: the screen's copy, retry, help link, hosted and logout states (mobile jest suite; not run in CI).
- `apps/tlon-web/e2e/desk-compat.spec.ts`: intercepts `docket/charges.json` on ~zod to report an old version, asserts the notice and that no init scry fires, then unroutes and retries to reach Home. Typechecks; never run (no ships booted).
- `pnpm -r tsc` across all 14 projects, full vitest suites for shared/api/app/web, mobile jest, `pnpm format:check`, oxlint clean. Nothing run on a real ship or device.

## Risks and impact

- Safe to rollback without consulting PR author? Yes
- Affects important code area:
  - [ ] Onboarding
  - [x] State / providers
  - [x] Message sync
  - [ ] Channel display
  - [ ] Notifications
  - [ ] Other:

Every sync start now waits on the app-info fetch before it reaches `syncSince`, on recovery syncs as well as cold starts. That is the same pair of scries that used to run later at low priority, now issued in parallel and bounded by a 10 s timeout that fails open. The docket version is a label rather than proof of running code (mid-OTA reads, dev checkouts with stale labels), so gating is intentionally conservative. `%docket` is a Landscape agent, so a missing charge fails open rather than gating. `desk/desk.docket-0` is currently exactly `12.2.0`, equal to `MIN_GROUPS_VERSION`, so raising the floor above the repo's own docket version would gate the E2E fleet until a pinned N-1 pier exists (TLON-6528, not part of this PR). The mobile jest config change only affects local runnability, not CI. The `urbit.ts` change bounds every timed scry's post-403 retry, not only the probe's; the bound is the caller's own timeout or the client default.

## Rollback plan

Revert the PR. No data or schema changes.

## Screenshots / videos

N/A


