### PR TITLE
Fix navigation-context crash in Pressable by removing link props (staging)

### DIFF
--- a/apps/tlon-mobile/jest.config.js
+++ b/apps/tlon-mobile/jest.config.js
@@ -3,8 +3,16 @@ module.exports = {
     // mock react-native-svg-transformer
     // https://github.com/kristerkari/react-native-svg-transformer?tab=readme-ov-file#usage-with-jest
     '\\.svg': '<rootDir>/src/test/reactNativeSvgTransformerMock.ts',
+    // @tloncorp/api's "." export map has no require/default condition, so
+    // jest's CJS resolution can't find it. Point it at the same source Metro
+    // resolves through the package's tlon-source condition.
+    '^@tloncorp/api$': '<rootDir>/../../packages/api/src/index.ts',
   },
   preset: 'jest-expo',
+  // react-native-worklets (pulled in by reanimated) only loads under jest with
+  // its `.native` variants filtered out; without this its module registry
+  // blows up as soon as anything imports @tloncorp/ui.
+  resolver: 'react-native-worklets/jest/resolver',
   setupFiles: ['./src/test/jestSetup.tsx'],
   transform: {
     // from babel-jest-preset

--- a/apps/tlon-mobile/src/__uitests__/Pressable.test.tsx
+++ b/apps/tlon-mobile/src/__uitests__/Pressable.test.tsx
@@ -1,0 +1,58 @@
+import { describe, expect, it, jest } from '@jest/globals';
+import { fireEvent, render, screen } from '@testing-library/react-native';
+import { Button, Pressable } from '@tloncorp/ui';
+import { config } from '@tloncorp/ui/config';
+import React from 'react';
+import { GestureResponderEvent, Text } from 'react-native';
+import { TamaguiProvider } from 'tamagui';
+
+// Importing anything from the `@tloncorp/ui` barrel drags in `@tloncorp/shared`'s
+// store (via `Carousel` -> `Image`), which reaches expo native modules that have
+// no JSI backing under jest.
+jest.mock('expo-contacts', () => ({}));
+jest.mock('expo-speech-recognition', () => ({}));
+
+// Regression test for TLON-6529 (Sentry REACT-NATIVE-13R). `Pressable` used to
+// call `useLinkProps` on every render, which throws "Couldn't find a navigation
+// object" wherever it renders outside a `NavigationContainer` — as it does when
+// `@gorhom/portal` hoists a sheet out of the navigation tree during onboarding.
+// These tests render with no navigation context at all.
+function renderWithoutNavigation(ui: React.ReactElement) {
+  return render(
+    <TamaguiProvider config={config} defaultTheme="light">
+      {ui}
+    </TamaguiProvider>
+  );
+}
+
+describe('Pressable outside a NavigationContainer', () => {
+  it('renders and handles presses', () => {
+    const onPress = jest.fn<(event: GestureResponderEvent) => void>();
+
+    expect(() =>
+      renderWithoutNavigation(
+        <Pressable testID="pressable" onPress={onPress}>
+          <Text>tap</Text>
+        </Pressable>
+      )
+    ).not.toThrow();
+
+    fireEvent.press(screen.getByTestId('pressable'));
+    expect(onPress).toHaveBeenCalledTimes(1);
+  });
+
+  // The reported crash arrived through `styled(Pressable)`, so cover a wrapper
+  // as well as the bare component.
+  it('renders and handles presses through Button', () => {
+    const onPress = jest.fn<(event: GestureResponderEvent) => void>();
+
+    expect(() =>
+      renderWithoutNavigation(
+        <Button testID="button" label="x" onPress={onPress} />
+      )
+    ).not.toThrow();
+
+    fireEvent.press(screen.getByTestId('button'));
+    expect(onPress).toHaveBeenCalledTimes(1);
+  });
+});

--- a/packages/ui/src/components/Pressable.tsx
+++ b/packages/ui/src/components/Pressable.tsx
@@ -1,4 +1,3 @@
-import { NavigationAction, useLinkProps } from '@react-navigation/native';
 import { forwardRef, useMemo } from 'react';
 import { GestureResponderEvent, LayoutChangeEvent } from 'react-native';
 import { View, ViewProps, isWeb } from 'tamagui';
@@ -14,8 +13,6 @@ type PressableProps = Omit<
   onPressIn?: PressHandler;
   onPressOut?: PressHandler;
   onLayout?: (event: LayoutChangeEvent) => void;
-  to?: string;
-  action?: NavigationAction;
   children?: React.ReactNode;
 };
 
@@ -67,16 +64,16 @@ StackComponent.displayName = 'StackComponent';
 /**
  * Component that wraps content and makes it pressable.
  * It provides the same props as `Stack` component.
- * It also accepts `to` and `action` props to use with `useLinkProps`.
- * If `action` is provided, `to` must be specified.
- * More info at https://reactnavigation.org/docs/use-link-props
+ *
+ * This component deliberately has no link support: it must be able to render
+ * outside a `NavigationContainer` (e.g. inside a `@gorhom/portal` host), where
+ * calling a navigation hook throws. If link-style pressables are ever needed,
+ * they belong in a separate component that calls `useLinkProps`.
  *
  * @param props.onPress Function to call when the press is released.
  * @param props.onPressIn Function to call when the press starts.
  * @param props.onPressOut Function to call when the touch moves outside the element bounds.
  * @param props.onLongPress Function to call when the press is held. Disabled on web.
- * @param props.to Absolute path to screen (e.g. `/feeds/hot`).
- * @param props.action Optional action to use for in-page navigation. By default, the path is parsed to an action based on linking config.
  */
 
 const Pressable = forwardRef<any, PressableProps>(
@@ -86,8 +83,6 @@ const Pressable = forwardRef<any, PressableProps>(
       onPressIn,
       onPressOut,
       onLongPress,
-      to,
-      action,
       children,
       style: propStyle,
       disabled: propDisabled,
@@ -97,19 +92,12 @@ const Pressable = forwardRef<any, PressableProps>(
     ref
   ) => {
     const longPressHandler = isWeb ? undefined : onLongPress;
-    const { onPress: onPressLink, ...linkProps } = useLinkProps({
-      href: to ?? '',
-      action: action!,
-    });
 
     // Check for interaction handlers - only needed on mobile for touch bubbling
     // On web, we skip this check as it interferes with styled() components
     const hasInteractionHandler = isWeb
       ? true // Always consider web components interactive
-      : ((to ?? action) == null ? onPress : onPressLink) ||
-        onPressIn ||
-        onPressOut ||
-        onLongPress;
+      : onPress || onPressIn || onPressOut || onLongPress;
 
     // Pressable always blocks touches from bubbling to ancestors, even if
     // no handlers are attached.
@@ -126,32 +114,6 @@ const Pressable = forwardRef<any, PressableProps>(
       ],
       [propStyle, disabledStyle, disabled]
     );
-
-    if (action && !to) {
-      throw new Error(
-        'The `to` prop is required when `action` is specified in `Pressable`'
-      );
-    }
-
-    if (to || action) {
-      return (
-        <StackComponent
-          ref={ref}
-          {...stackProps}
-          {...linkProps}
-          group
-          onPress={onPressLink ?? onPress}
-          onPressIn={onPressIn}
-          onPressOut={onPressOut}
-          onLongPress={longPressHandler}
-          cursor={stackProps.cursor || 'pointer'}
-          disabled={disabled}
-          style={style}
-        >
-          {children}
-        </StackComponent>
-      );
-    }
 
     return (
       <StackComponent


### PR DESCRIPTION
Cherry-pick of #6497 (merged into develop as b3e52c1df5) onto `staging`, so the fix ships in the next release. Same commit, applied cleanly; `Pressable.tsx` and the test are byte-identical to develop.

## Summary

Fixes TLON-6529 (Sentry REACT-NATIVE-13R): `Pressable` called `useLinkProps` on every render, and that hook throws `Couldn't find a navigation object. Is your component inside NavigationContainer?` wherever it renders outside a `NavigationContainer`. During onboarding, `GettingNodeReadyScreen` mounts `StoppedNodePushSheet`, which `@gorhom/portal` renders at the `BottomSheetModalProvider` above the app's only container, so the sheet's hero `Button` (a `styled(Pressable)`) threw and users saw "Something went wrong" instead. No consumer passes `to` or `action`, and the link path was already broken after the react-navigation v7 upgrade, so this deletes link support rather than guarding it.

Observed impact: three real installs on the current store build (467, iOS 9.5.1), all since Sep 8. One iPhone 16 Pro user hit it seven times across 26 hours; the other two hit it once and twice on Sep 10. The remaining seven installs in the Sentry issue are iOS Simulator dev builds. Sentry's per-install app hash and PostHog's `app_error` event from the root error boundary agree install for install. No Android events and no sibling issue under another grouping.

## Changes

- `packages/ui/src/components/Pressable.tsx`: removes the `@react-navigation/native` import, the `to`/`action` props, the `useLinkProps` call, the `action`-requires-`to` throw, and the link render branch. What ships is the previous plain branch unchanged, with `hasInteractionHandler` reduced to the four supplied handlers and the web short-circuit kept, so web behaviour is unchanged.
- `apps/tlon-mobile/jest.config.js`: points `@tloncorp/api` at its source (its export map has no require condition, so jest could not resolve it) and adds the `react-native-worklets/jest/resolver` resolver. Without both, nothing that imports `@tloncorp/ui` could load under jest.
- `apps/tlon-mobile/src/__uitests__/Pressable.test.tsx`: new regression test that renders `Pressable` and `Button` under a raw `TamaguiProvider` with no navigation context, asserting no throw and that the press handler fires.

## How did I test?

- Ran the new tests against the pre-fix source by restoring the original file: both fail with the exact Sentry message, and both pass with the fix.
- Ran the whole mobile jest suite. Same pass/fail shape as develop: `App.test.tsx` still fails, now on a pre-existing `expo-contacts` native module error rather than module resolution. That suite is not run in CI.
- `tsc` clean for ui, app, web and mobile; `pnpm format:check` clean.
- The real portal path is hidden by the Gorhom jest mock, which renders modals inline, so it stays a manual check.

Verification after release: on a build with the fix, fresh install with a hosted account whose node is stopped, `GettingNodeReadyScreen` should show the push sheet instead of "Something went wrong", covering both permission branches (button reading "Notify me when it's ready" and "View notification settings"). `Pressable.tsx` should also drop out of REACT-NATIVE-13R's stack frames on the next store build, though volume is low enough that a quiet issue supplements the manual pass rather than replacing it.

## Risks and impact

- Safe to rollback without consulting PR author? Yes
- Affects important code area:
  - [x] Onboarding
  - [ ] State / providers
  - [ ] Message sync
  - [ ] Channel display
  - [ ] Notifications
  - [x] Other: shared `Pressable` in `packages/ui`

`to` and `action` leave `PressableProps`, so any consumer still passing them would fail typecheck; there are none. If link-style pressables are wanted later, they belong in a separate component that calls `useLinkProps` properly.

## Rollback plan

Revert the PR and rebuild. No migrations, feature flags or persisted state involved; the onboarding crash returns.

## Screenshots / videos

N/A. No visual change, the fix removes a crash on a screen that otherwise renders as designed.
