### PR TITLE
[TEST] onboarding: mark the pre-login log in link as (test)

### DIFF
--- a/apps/tlon-mobile/src/screens/Onboarding/WelcomeScreen.tsx
+++ b/apps/tlon-mobile/src/screens/Onboarding/WelcomeScreen.tsx
@@ -125,7 +125,7 @@ export const WelcomeScreen = ({ navigation }: Props) => {
               onPress={() => setOpen(true)}
             >
               <SizableText color="$primaryText">
-                Have an account? Log in
+                Have an account? Log in (test)
               </SizableText>
             </Pressable>
           </XStack>


### PR DESCRIPTION
> **This is a workflow test PR. It exercises the `tlon-workflow` skill end to end and should be closed, not merged.**

## Summary

The pre-login landing screen's log-in link reads `Have an account? Log in`. This changes it to `Have an account? Log in (test)`. It is a deliberate throwaway string used to prove the mobile agent loop — worktree, dual-platform build, before/after capture, PR with evidence — actually works; nothing here is intended for users.

## Changes

- `apps/tlon-mobile/src/screens/Onboarding/WelcomeScreen.tsx`: the `SizableText` inside the `Pressable` that opens the log-in `ActionSheet` now reads `Have an account? Log in (test)`. The `Pressable`'s `onPress` and the sheet it opens are untouched.

## How did I test?

Built and ran both platforms from this branch:

- iOS: `stim-tlon-mobile (iPhone 17 26.5)` simulator, `io.tlon.groups`
- Android: `stim-tlon-mobile` emulator (`emulator-5556`), `productionDebug` variant, `io.tlon.groups`

Same repro on each, before and after the edit: launch to the pre-login landing screen, read the link's label, press it, confirm the log-in action sheet still opens with `Log in with phone number` / `Log in with email` / `Or configure self hosted`, then dismiss it. Before the edit the label read `Have an account? Log in`; after, `Have an account? Log in (test)`, applied by Fast Refresh with no rebuild. Recordings of both passes on both platforms are attached.

Also signed in once through the changed link on iOS to confirm the flow behind it is unaffected: link -> `Or configure self hosted` -> the self-hosted form arrives with the ship URL and access code prefilled -> one press on `Connect` reached the chat list.

`stim logs --errors` reported no matching records on the workspace after the run.

## Risks and impact

- Safe to rollback without consulting PR author? Yes
- Affects important code area:
  - [x] Onboarding
  - [ ] State / providers
  - [ ] Message sync
  - [ ] Channel display
  - [ ] Notifications
  - [ ] Other:

One string on one pre-login screen, on mobile only. The worst case if it shipped is that every signed-out user sees `(test)` next to the log-in link — cosmetic, confusing, and no functional effect: nothing branches on this text. It should not ship, which is why this PR is a draft to be closed.

## Rollback plan

Close this PR, or revert the single commit on this branch. No migration, no persisted state, nothing else depends on the string.

## Screenshots / videos

**Before, iOS** — the link reads `Have an account? Log in`

https://github.com/user-attachments/assets/06a9ac77-2e66-49cd-b67c-b2585b6f0862

**After, iOS** — the link reads `Have an account? Log in (test)`

https://github.com/user-attachments/assets/7a9ce37e-8151-4dff-a814-82c6cd9b6797

**Before, Android** — the link reads `Have an account? Log in`

https://github.com/user-attachments/assets/7ecc8b05-d294-43aa-b555-1db6c571c9c3

**After, Android** — the link reads `Have an account? Log in (test)`

https://github.com/user-attachments/assets/d07e59bb-5776-4077-98c6-68ae7f8144b1
