### PR TITLE
logs: fingerprint every %fail and send crashes to PostHog error tracking

### DIFF
--- a/desk/app/channels.hoon
+++ b/desk/app/channels.hoon
@@ -214,6 +214,7 @@
   ++  on-poke
     %-  on-poke:guard
     |=  =rail
+    ~|  [%on-poke -.rail]
     %-  step:un:guard
     ^-  (quip card _this)
     =^  cards  state
@@ -222,6 +223,7 @@
   ::
   ++  on-watch
     |=  =path
+    ~|  [%on-watch ?~(path %$ i.path)]
     %-  step:un:guard
     ^-  (quip card _this)
     =^  cards  state
@@ -240,6 +242,7 @@
   ++  on-agent
     %-  on-agent:guard
     |=  [=wire =sign:guard]
+    ~|  [%on-agent ?~(wire %$ i.wire) -.sign]
     %-  step:un:guard
     ^-  (quip card _this)
     =^  cards  state
@@ -248,6 +251,7 @@
   ::
   ++  on-arvo
     |=  [=wire sign=sign-arvo]
+    ~|  [%on-arvo ?~(wire %$ i.wire)]
     %-  step:un:guard
     ^-  (quip card _this)
     =^  cards  state

--- a/desk/app/channels.hoon
+++ b/desk/app/channels.hoon
@@ -242,7 +242,7 @@
   ++  on-agent
     %-  on-agent:guard
     |=  [=wire =sign:guard]
-    ~|  [%on-agent ?~(wire %$ i.wire) -.sign]
+    ~|  [%on-agent ?~(wire %$ i.wire) -.sign src.bowl]
     %-  step:un:guard
     ^-  (quip card _this)
     =^  cards  state

--- a/desk/app/groups.hoon
+++ b/desk/app/groups.hoon
@@ -216,7 +216,7 @@
   ::
   ++  on-agent
     |=  [=wire =sign:agent:gall]
-    ~|  [%on-agent ?~(wire %$ i.wire) -.sign]
+    ~|  [%on-agent ?~(wire %$ i.wire) -.sign src.bowl]
     %-  step:un:guard
     ^-  (quip card _this)
     =^  cards  state

--- a/desk/app/groups.hoon
+++ b/desk/app/groups.hoon
@@ -189,6 +189,7 @@
   ::
   ++  on-poke
     |=  [=mark =vase]
+    ~|  [%on-poke mark]
     %-  step:un:guard
     ^-  (quip card _this)
     =^  cards  state
@@ -196,6 +197,7 @@
     [cards this]
   ++  on-watch
     |=  =path
+    ~|  [%on-watch ?~(path %$ i.path)]
     %-  step:un:guard
     ^-  (quip card _this)
     =^  cards  state
@@ -214,6 +216,7 @@
   ::
   ++  on-agent
     |=  [=wire =sign:agent:gall]
+    ~|  [%on-agent ?~(wire %$ i.wire) -.sign]
     %-  step:un:guard
     ^-  (quip card _this)
     =^  cards  state
@@ -221,6 +224,7 @@
     [cards this]
   ++  on-arvo
     |=  [=wire sign=sign-arvo]
+    ~|  [%on-arvo ?~(wire %$ i.wire)]
     %-  step:un:guard
     ^-  (quip card _this)
     =^  cards  state

--- a/desk/app/logs.hoon
+++ b/desk/app/logs.hoon
@@ -136,6 +136,16 @@
       ?.  (gte level (volume-val:l u.vol))
         cor
       =.  data.a-log  ['commit'^s+commit data.a-log]
+      ::  every crash gets a stable identity so dashboards and alerts can
+      ::  group by cause instead of matching on stack-trace substrings
+      ::
+      =?  data.a-log  ?=(%fail -.event.a-log)
+        =/  fpr  (fingerprint:l sap.bowl event.a-log)
+        ?~  fpr  data.a-log
+        :*  'fingerprint'^s+fp.u.fpr
+            'signature'^s+sig.u.fpr
+            data.a-log
+        ==
       =.  cor  (send-posthog-event sap.bowl now.bowl +.a-log)
       =?  cor  ?=(^ otel)
         (send-otel-event u.otel sap.bowl now.bowl +.a-log)

--- a/desk/app/logs.hoon
+++ b/desk/app/logs.hoon
@@ -143,6 +143,7 @@
         =/  fpr  (fingerprint:l sap.bowl event.a-log)
         ?~  fpr  data.a-log
         :*  'fingerprint'^s+fp.u.fpr
+            'fingerprint_exact'^s+exact.u.fpr
             'signature'^s+sig.u.fpr
             data.a-log
         ==

--- a/desk/app/notify.hoon
+++ b/desk/app/notify.hoon
@@ -543,7 +543,7 @@
   ::
   ++  on-agent
     |=  [=wire =sign:agent:gall]
-    ~|  [%on-agent ?~(wire %$ i.wire) -.sign]
+    ~|  [%on-agent ?~(wire %$ i.wire) -.sign src.bowl]
     ^-  (quip card _this)
     ?+  wire  (on-agent:def wire sign)
     ::

--- a/desk/app/notify.hoon
+++ b/desk/app/notify.hoon
@@ -263,6 +263,7 @@
   ::
   ++  on-poke
     |=  [=mark =vase]
+    ~|  [%on-poke mark]
     ^-  (quip card _this)
     |^
     =^  cards  state
@@ -498,6 +499,7 @@
   ::
   ++  on-watch
     |=  =path
+    ~|  [%on-watch ?~(path %$ i.path)]
     ^-  (quip card _this)
     ?+  path  (on-watch:def path)
       [%http-response *]  [~ this]
@@ -541,6 +543,7 @@
   ::
   ++  on-agent
     |=  [=wire =sign:agent:gall]
+    ~|  [%on-agent ?~(wire %$ i.wire) -.sign]
     ^-  (quip card _this)
     ?+  wire  (on-agent:def wire sign)
     ::
@@ -687,6 +690,7 @@
   ::
   ++  on-arvo
     |=  [=wire =sign-arvo]
+    ~|  [%on-arvo ?~(wire %$ i.wire)]
     ^-  (quip card _this)
     ?+  wire  (on-arvo:def wire sign-arvo)
       [%eyre ~]  [~ this]

--- a/desk/app/presence.hoon
+++ b/desk/app/presence.hoon
@@ -324,6 +324,7 @@
 ::
 ++  on-poke
   |=  [=mark =vase]
+  ~|  [%on-poke mark]
   ^-  (quip card _this)
   ~|  mark=mark
   ?+  mark  !!
@@ -405,6 +406,7 @@
 ::
 ++  on-watch
   |=  =path
+  ~|  [%on-watch ?~(path %$ i.path)]
   ^-  (quip card _this)
   ?+  path  !!
       [%v1 ~]
@@ -437,6 +439,7 @@
 ::
 ++  on-agent
   |=  [=wire =sign:agent:gall]
+  ~|  [%on-agent ?~(wire %$ i.wire) -.sign]
   ^-  (quip card _this)
   ~|  wire=wire
   ?+  wire  ~|(%strange-wire !!)
@@ -609,6 +612,7 @@
 ::
 ++  on-arvo
   |=  [=wire sign=sign-arvo]
+  ~|  [%on-arvo ?~(wire %$ i.wire)]
   ^-  (quip card _this)
   ~|  wire=wire
   ?+  wire  ~|(%strange-wire !!)

--- a/desk/app/presence.hoon
+++ b/desk/app/presence.hoon
@@ -439,7 +439,7 @@
 ::
 ++  on-agent
   |=  [=wire =sign:agent:gall]
-  ~|  [%on-agent ?~(wire %$ i.wire) -.sign]
+  ~|  [%on-agent ?~(wire %$ i.wire) -.sign src.bowl]
   ^-  (quip card _this)
   ~|  wire=wire
   ?+  wire  ~|(%strange-wire !!)

--- a/desk/lib/logs.hoon
+++ b/desk/lib/logs.hoon
@@ -54,6 +54,148 @@
     %error  3
     %fatal  3
   ==
+::  +fingerprint: stable identity for a %fail, independent of line numbers
+::
+::    signature is human-readable, built from parts that survive a recompile:
+::      "/gall/groups | group join failed | se-c-join-access-denied | app/groups>sys/vane/gall"
+::    origin, the developer's message (first line of the echo), the first
+::    error tag in the tang, and the chain of source files in the stack
+::    trace with line numbers stripped. fingerprint is eight hex digits of
+::    its +mug. %tell events have no fingerprint.
+::
+++  fingerprint
+  |=  [origin=path event=log-event]
+  ^-  (unit [fp=@t sig=@t])
+  ?.  ?=(%fail -.event)  ~
+  =/  message=tape  (head-line echo.event)
+  =/  lines=(list tape)  (tang-lines tang.event)
+  =/  reason=(unit tape)  (find-reason lines)
+  =/  chain=tape  (file-chain lines)
+  =/  sig=tape
+    ;:  welp
+      (spud origin)
+      " | "  message
+      ?~(reason "" (welp " | " u.reason))
+      ?:(=("" chain) "" (welp " | " chain))
+    ==
+  :-  ~
+  :-  (crip ((x-co:co 8) (mug sig)))
+  (crip (scag 240 sig))
+::  +tang-lines: wash a tang into lines, wide enough that spans don't wrap
+::
+++  tang-lines
+  |=  t=tang
+  ^-  (list tape)
+  (zing (turn t (cury wash [0 200])))
+::  +head-line: first line of a tang, trimmed
+::
+++  head-line
+  |=  t=tang
+  ^-  tape
+  =/  lines  (tang-lines t)
+  ?~  lines  ""
+  (trim-line i.lines)
+::  +trim-line: drop leading spaces and the "! " that gall prefixes
+::
+++  trim-line
+  |=  l=tape
+  ^-  tape
+  =.  l  |-(?:(&(?=(^ l) =(32 i.l)) $(l t.l) l))
+  ?:(&(?=([@ @ *] l) =(33 i.l) =(32 i.t.l)) t.t.l l)
+::  +span-line: "/app/groups/hoon:<[2.150 5].[2.152 41]>"
+::
+++  span-line
+  |=  l=tape
+  ^-  ?
+  ?&  ?=(^ l)
+      =(47 i.l)
+      ?=(^ (find ":<[" l))
+  ==
+::  +find-reason: the first error tag in a tang
+::
+::    a tag is a single token like "se-c-join-access-denied", or a
+::    %-prefixed one anywhere in the line like "[%bad-agent-take ~.contact ~]".
+::    spans, commit markers, key=value dumps and gall's own wire names
+::    ("watch-ack", "poke-fail") are skipped so they don't stand in for
+::    the actual cause.
+::
+++  find-reason
+  |=  lines=(list tape)
+  ^-  (unit tape)
+  |-
+  ?~  lines  ~
+  =/  l=tape  (trim-line i.lines)
+  ?:  ?|  =(~ l)
+          (span-line l)
+          ?=(^ (find "commit " l))
+      ==
+    $(lines t.lines)
+  =?  l  &(?=(^ l) =(91 i.l))  t.l
+  =/  tok=tape  (scag (fall (find " " l) (lent l)) l)
+  =/  single=?  =((lent tok) (lent l))
+  ?:  ?=(^ (find "=" tok))  $(lines t.lines)
+  =.  tok  (skip tok |=(c=@tD |(=(c 93) =(c 39))))  ::  drop ']' and quotes
+  =?  tok  &(?=(^ tok) =(37 i.tok))  t.tok
+  ?:  (gall-wire tok)  $(lines t.lines)
+  ?:  ?&  ?=(^ tok)
+          (gte i.tok 'a')
+          (lte i.tok 'z')
+          |(single (tagged (trim-line i.lines)))
+      ==
+    `tok
+  $(lines t.lines)
+::  +tagged: line starts with a %tag, bare or in brackets
+::
+++  tagged
+  |=  l=tape
+  ^-  ?
+  ?|  &(?=(^ l) =(37 i.l))
+      &(?=([@ @ *] l) =(91 i.l) =(37 i.t.l))
+  ==
+::  +gall-wire: gall's own labels for where a crash happened, not why
+::
+++  gall-wire
+  |=  tok=tape
+  ^-  ?
+  %-  ~(has in gall-wires)
+  (crip tok)
+::
+++  gall-wires
+  ^-  (set @t)
+  %-  sy
+  :~  'poke-ack'  'watch-ack'  'poke-fail'  'watch-fail'  'fact'  'kick'
+      'agent'  'arvo'  'on-poke'  'on-watch'  'on-agent'  'on-arvo'
+      'on-init'  'on-load'  'on-leave'  'on-save'  'on-peek'  'on-fail'
+  ==
+::  +file-chain: source files in the stack, deduplicated, no line numbers
+::
+::    "/app/groups/hoon:<..>" lines become "app/groups"; consecutive repeats
+::    collapse; capped at six entries: "app/groups>lib/negotiate>sys/vane/gall"
+::
+++  file-chain
+  |=  lines=(list tape)
+  ^-  tape
+  =/  files=(list tape)
+    %+  murn  lines
+    |=  l=tape
+    ^-  (unit tape)
+    =.  l  (trim-line l)
+    ?.  (span-line l)  ~
+    =/  file=tape  (scag (need (find ":<[" l)) l)
+    =?  file  &(?=(^ file) =(47 i.file))  t.file
+    =/  suf=tape  "/hoon"
+    =?  file  ?&  (gte (lent file) (lent suf))
+                  =(suf (slag (sub (lent file) (lent suf)) file))
+              ==
+      (scag (sub (lent file) (lent suf)) file)
+    `file
+  =/  chain=(list tape)
+    %-  flop
+    %+  roll  files
+    |=  [f=tape acc=(list tape)]
+    ?:  &(?=(^ acc) =(f i.acc))  acc
+    [f acc]
+  (zing (join ">" (scag 6 chain)))
 ::
 ++  enjs
   =,  format

--- a/desk/lib/logs.hoon
+++ b/desk/lib/logs.hoon
@@ -24,9 +24,15 @@
       [%tell vol echo]
     (pass event log-data)
   ::
+  ::  every event carries the ship that caused it: the peer that nacked,
+  ::  kicked or sent the fact in +on-agent, the poker or subscriber in
+  ::  +on-poke and +on-watch, ourselves elsewhere. this is what tells one
+  ::  bad host apart from a fleet-wide failure.
+  ::
   ++  pass
     |=  [event=log-event data=log-data]
     ^-  card:agent:gall
+    =.  data  ['src'^s+(scot %p src.bowl) data]
     [%pass wire %agent [our.bowl %logs] %poke log-action-1+!>(`a-log`[%log event data])]
   --
 |%

--- a/desk/lib/logs.hoon
+++ b/desk/lib/logs.hoon
@@ -57,30 +57,46 @@
 ::  +fingerprint: stable identity for a %fail, independent of line numbers
 ::
 ::    signature is human-readable, built from parts that survive a recompile:
-::      "/gall/groups | group join failed | se-c-join-access-denied | app/groups>sys/vane/gall"
-::    origin, the developer's message (first line of the echo), the first
-::    error tag in the tang, and the chain of source files in the stack
-::    trace with line numbers stripped. fingerprint is eight hex digits of
-::    its +mug. %tell events have no fingerprint.
+::      "/gall/groups | groups failed | nest-fail | on-agent/contact | -have.@p -need.%full | app/groups>sys/vane/gall"
+::    origin; the developer's message (first line of the echo); the first
+::    error tag in the tang (why); the last tag, usually a ~| dispatch hint
+::    (where); type detail from -have/-need lines and code= tokens; and the
+::    chain of source files in the stack with line numbers stripped.
+::    fingerprint is eight hex digits of its +mug. exact adds the innermost
+::    span with its line numbers, so it distinguishes crash sites within a
+::    release while fingerprint stays constant across releases.
+::    %tell events have no fingerprint.
 ::
 ++  fingerprint
   |=  [origin=path event=log-event]
-  ^-  (unit [fp=@t sig=@t])
+  ^-  (unit [fp=@t sig=@t exact=@t])
   ?.  ?=(%fail -.event)  ~
   =/  message=tape  (head-line echo.event)
   =/  lines=(list tape)  (tang-lines tang.event)
-  =/  reason=(unit tape)  (find-reason lines)
+  =/  tags=(list tape)  (find-tags lines)
+  =/  reason=(unit tape)  ?~(tags ~ `i.tags)
+  =/  where=(unit tape)
+    ?~  tags  ~
+    =/  last=tape  (rear tags)
+    ?:(=(last i.tags) ~ `last)
+  =/  detail=tape  (find-detail lines)
   =/  chain=tape  (file-chain lines)
   =/  sig=tape
     ;:  welp
       (spud origin)
       " | "  message
       ?~(reason "" (welp " | " u.reason))
+      ?~(where "" (welp " | " u.where))
+      ?:(=("" detail) "" (welp " | " detail))
       ?:(=("" chain) "" (welp " | " chain))
     ==
+  =/  site=tape
+    =/  spans  (skim lines |=(l=tape (span-line (trim-line l))))
+    ?~(spans "" (trim-line i.spans))
   :-  ~
-  :-  (crip ((x-co:co 8) (mug sig)))
-  (crip (scag 240 sig))
+  :+  (crip ((x-co:co 8) (mug sig)))
+    (crip (scag 240 sig))
+  (crip ((x-co:co 8) (mug (welp sig site))))
 ::  +tang-lines: wash a tang into lines, wide enough that spans don't wrap
 ::
 ++  tang-lines
@@ -111,47 +127,94 @@
       =(47 i.l)
       ?=(^ (find ":<[" l))
   ==
-::  +find-reason: the first error tag in a tang
+::  +tokens: split on spaces, dropping brackets and quotes
 ::
-::    a tag is a single token like "se-c-join-access-denied", or a
-::    %-prefixed one anywhere in the line like "[%bad-agent-take ~.contact ~]".
-::    spans, commit markers, key=value dumps and gall's own wire names
-::    ("watch-ack", "poke-fail") are skipped so they don't stand in for
-::    the actual cause.
+++  tokens
+  |=  l=tape
+  ^-  (list tape)
+  =/  toks=(list tape)
+    %+  murn  (split-spaces l)
+    |=  t=tape
+    =/  clean=tape  (skip t |=(c=@tD |(=(c 91) =(c 93) =(c 39))))
+    ?~(clean ~ `clean)
+  toks
 ::
-++  find-reason
-  |=  lines=(list tape)
-  ^-  (unit tape)
+++  split-spaces
+  |=  l=tape
+  ^-  (list tape)
+  =|  cur=tape
+  =|  out=(list tape)
   |-
-  ?~  lines  ~
-  =/  l=tape  (trim-line i.lines)
+  ?~  l
+    (flop ?~(cur out [(flop cur) out]))
+  ?:  =(32 i.l)
+    $(l t.l, cur ~, out ?~(cur out [(flop cur) out]))
+  $(l t.l, cur [i.l cur])
+::  +find-tags: every error tag in a tang, in order
+::
+::    a tag is a single lowercase token like "se-c-join-access-denied", or
+::    the %terms and ~.knots of a bracketed line like
+::    "[%bad-agent-take ~.contact ~]" joined as "bad-agent-take/contact",
+::    which is also how ~| dispatch hints render. spans, commit markers,
+::    key=value dumps, -have/-need lines and gall's own wire labels
+::    ("watch-ack", "poke-fail") are skipped: they say where, not why.
+::
+++  find-tags
+  |=  lines=(list tape)
+  ^-  (list tape)
+  %+  murn  lines
+  |=  line=tape
+  ^-  (unit tape)
+  =/  l=tape  (trim-line line)
   ?:  ?|  =(~ l)
           (span-line l)
           ?=(^ (find "commit " l))
+          ?=(^ (find "=" l))
+          &(?=(^ l) =(45 i.l))
       ==
-    $(lines t.lines)
-  =?  l  &(?=(^ l) =(91 i.l))  t.l
-  =/  tok=tape  (scag (fall (find " " l) (lent l)) l)
-  =/  single=?  =((lent tok) (lent l))
-  ?:  ?=(^ (find "=" tok))  $(lines t.lines)
-  =.  tok  (skip tok |=(c=@tD |(=(c 93) =(c 39))))  ::  drop ']' and quotes
-  =?  tok  &(?=(^ tok) =(37 i.tok))  t.tok
-  ?:  (gall-wire tok)  $(lines t.lines)
-  ?:  ?&  ?=(^ tok)
-          (gte i.tok 'a')
-          (lte i.tok 'z')
-          |(single (tagged (trim-line i.lines)))
-      ==
-    `tok
-  $(lines t.lines)
-::  +tagged: line starts with a %tag, bare or in brackets
+    ~
+  ?:  &(?=(^ l) =(91 i.l))
+    =/  parts=(list tape)
+      %+  murn  (tokens l)
+      |=  t=tape
+      ^-  (unit tape)
+      ?:  &(?=(^ t) =(37 i.t) ?=(^ t.t) (lower i.t.t))  `t.t
+      ?:  &(?=([@ @ *] t) =(126 i.t) =(46 i.t.t) ?=(^ t.t.t))  `t.t.t
+      ~
+    ?~  parts  ~
+    ?:  (gall-wire i.parts)  ~
+    `(zing (join "/" parts))
+  =/  toks  (tokens l)
+  ?.  ?=([* ~] toks)  ~
+  =/  t=tape  i.toks
+  =?  t  &(?=(^ t) =(37 i.t))  t.t
+  ?.  &(?=(^ t) (lower i.t))  ~
+  ?:  (gall-wire t)  ~
+  `t
 ::
-++  tagged
-  |=  l=tape
-  ^-  ?
-  ?|  &(?=(^ l) =(37 i.l))
-      &(?=([@ @ *] l) =(91 i.l) =(37 i.t.l))
-  ==
+++  lower
+  |=(c=@tD &((gte c 97) (lte c 122)))
+::  +find-detail: type and status detail that narrows a generic tag
+::
+::    "-have.@p -need.%full" for nest-fails, "code=500" for http failures.
+::    at most three items; user data never qualifies.
+::
+++  find-detail
+  |=  lines=(list tape)
+  ^-  tape
+  =/  items=(list tape)
+    %-  scag  :-  3
+    %+  murn  lines
+    |=  line=tape
+    ^-  (unit tape)
+    =/  l=tape  (trim-line line)
+    ?:  |(?=(^ (find "-have." l)) ?=(^ (find "-need." l)))
+      `(zing (join " " (tokens l)))
+    =/  toks  (tokens l)
+    ?.  ?=([* ~] toks)  ~
+    ?:  =("code=" (scag 5 i.toks))  `i.toks
+    ~
+  (zing (join " " items))
 ::  +gall-wire: gall's own labels for where a crash happened, not why
 ::
 ++  gall-wire
@@ -164,8 +227,7 @@
   ^-  (set @t)
   %-  sy
   :~  'poke-ack'  'watch-ack'  'poke-fail'  'watch-fail'  'fact'  'kick'
-      'agent'  'arvo'  'on-poke'  'on-watch'  'on-agent'  'on-arvo'
-      'on-init'  'on-load'  'on-leave'  'on-save'  'on-peek'  'on-fail'
+      'agent'  'arvo'  'on-fail'
   ==
 ::  +file-chain: source files in the stack, deduplicated, no line numbers
 ::

--- a/desk/ted/posthog.hoon
+++ b/desk/ted/posthog.hoon
@@ -4,7 +4,7 @@
 /+  io=strandio, l=logs
 ::
 =+  posthog-key='phc_GyI5iD7kM6RRbb1hIU0fiGmTCh4ha44hthJYJ7a89td'
-=+  posthog-url='https://eu.i.posthog.com/capture/'
+=+  posthog-url='https://eu.i.posthog.com/batch/'
 =+  posthog-retry=3
 =+  posthog-retry-delay=~s5
 ::
@@ -49,28 +49,81 @@
   =+  event=(~(get by p.props) 'event')
   ?~  event  s+'Backend Log'
   ?>(?=(%s -.u.event) u.event)
+=/  timestamp=@t
+  %-  crip
+  =+  (yore time.log-item)
+  =*  d  (d-co:co 2)
+  "{(d y)}-{(d m)}-{(d d.t)}".
+  "T{(d h.t)}:{(d m.t)}:{(d s.t)}".
+  ".{(d ?~(f.t 0 (div (mul 100 i.f.t) 0x1.0000)))}".
+  "Z"
 =/  event=json
   %-  pairs:enjs:format
-  =/  timestamp=@t
-    %-  crip
-    =+  (yore time.log-item)
-    =*  d  (d-co:co 2)
-    "{(d y)}-{(d m)}-{(d d.t)}".
-    "T{(d h.t)}:{(d m.t)}:{(d s.t)}".
-    ".{(d ?~(f.t 0 (div (mul 100 i.f.t) 0x1.0000)))}".
-    "Z"
-  :~  'api_key'^s+posthog-key
-      'distinct_id'^s+id
+  :~  'distinct_id'^s+id
       timestamp+s+timestamp
       event+label
       properties+props
+  ==
+::  crashes also go to posthog error tracking as $exception events, grouped
+::  by the fingerprint %logs attached, so first-seen and regression alerts
+::  come from the product instead of a hand-kept list. the plain event
+::  above is kept so existing dashboards keep working.
+::
+=/  exception=(unit json)
+  ?.  ?=(%fail -.event.log-item)  ~
+  =/  fingerprint=(unit @t)
+    =+  fp=(~(get by p.props) 'fingerprint')
+    ?~  fp  ~
+    ?.  ?=(%s -.u.fp)  ~
+    `p.u.fp
+  ?~  fingerprint  ~
+  =/  message=@t  (crip (head-line:l echo.event.log-item))
+  =/  frames=(list json)
+    %+  turn  (tang-lines:l tang.event.log-item)
+    |=  line=tape
+    =/  t=tape  (trim-line:l line)
+    %-  pairs:enjs:format
+    ?:  (span-line:l t)
+      :~  'filename'^s+(crip (scag (need (find ":<[" t)) t))
+          'function'^s+(crip t)
+          'in_app'^b+&
+      ==
+    :~  'function'^s+(crip t)
+        'in_app'^b+&
+    ==
+  :-  ~
+  %-  pairs:enjs:format
+  :~  'distinct_id'^s+id
+      timestamp+s+timestamp
+      event+s+'$exception'
+      :-  'properties'
+      :-  %o
+      %-  ~(gas by p.props)
+      :~  '$exception_fingerprint'^s+u.fingerprint
+          :-  '$exception_list'
+          :-  %a
+          :_  ~
+          %-  pairs:enjs:format
+          :~  'type'^s+(spat origin)
+              'value'^s+message
+              'mechanism'^(pairs:enjs:format ~['handled'^b+| 'synthetic'^b+|])
+              'stacktrace'^(pairs:enjs:format ~['type'^s+'raw' 'frames'^a+frames])
+          ==
+      ==
+  ==
+=/  body=json
+  %-  pairs:enjs:format
+  :~  'api_key'^s+posthog-key
+      :-  'batch'
+      :-  %a
+      ?~(exception ~[event] ~[event u.exception])
   ==
 ::
 =/  =request:http
   :*  %'POST'
       posthog-url
       ~['content-type'^'application/json']
-      `(as-octs:mimes:html (en:json:html event))
+      `(as-octs:mimes:html (en:json:html body))
   ==
 ::  retry loop
 ::

--- a/desk/ted/posthog.hoon
+++ b/desk/ted/posthog.hoon
@@ -78,19 +78,39 @@
     `p.u.fp
   ?~  fingerprint  ~
   =/  message=@t  (crip (head-line:l echo.event.log-item))
+  ::  "/app/groups/hoon:<[2.150 5].[2.152 41]>" -> line 2150, column 5
+  ::
+  =/  span-pos
+    |=  t=tape
+    ^-  [lineno=@ud colno=@ud]
+    =/  i  (find "<[" t)
+    ?~  i  [0 0]
+    =/  rest=tape  (slag (add 2 u.i) t)
+    =/  ln=tape  (scag (fall (find " " rest) 0) rest)
+    =/  after=tape  (slag +((lent ln)) rest)
+    =/  cn=tape  (scag (fall (find "]" after) 0) after)
+    :-  (fall (rush (crip (skip ln |=(c=@tD =(c 46)))) dem) 0)
+    (fall (rush (crip cn) dem) 0)
   =/  frames=(list json)
     %+  turn  (tang-lines:l tang.event.log-item)
     |=  line=tape
     =/  t=tape  (trim-line:l line)
+    =/  span=?  (span-line:l t)
+    =/  pos=[lineno=@ud colno=@ud]  ?.(span [0 0] (span-pos t))
     %-  pairs:enjs:format
-    ?:  (span-line:l t)
-      :~  'filename'^s+(crip (scag (need (find ":<[" t)) t))
+    %+  weld
+      ^-  (list [@t json])
+      :~  'platform'^s+'custom'
+          'lang'^s+'hoon'
           'function'^s+(crip t)
+          'lineno'^(numb:enjs:format lineno.pos)
+          'colno'^(numb:enjs:format colno.pos)
+          'resolved'^b+&
           'in_app'^b+&
       ==
-    :~  'function'^s+(crip t)
-        'in_app'^b+&
-    ==
+    ^-  (list [@t json])
+    ?.  span  ~
+    ~['filename'^s+(crip (scag (need (find ":<[" t)) t))]
   :-  ~
   %-  pairs:enjs:format
   :~  'distinct_id'^s+id
@@ -100,13 +120,16 @@
       :-  %o
       %-  ~(gas by p.props)
       :~  '$exception_fingerprint'^s+u.fingerprint
+          '$lib'^s+'urbit-logs'
+          '$issue_name'^(fall (~(get by p.props) 'signature') s+message)
+          '$issue_description'^s+message
           :-  '$exception_list'
           :-  %a
           :_  ~
           %-  pairs:enjs:format
           :~  'type'^s+(spat origin)
               'value'^s+message
-              'mechanism'^(pairs:enjs:format ~['handled'^b+| 'synthetic'^b+|])
+              'mechanism'^(pairs:enjs:format ~['handled'^b+| 'synthetic'^b+| 'type'^s+'generic'])
               'stacktrace'^(pairs:enjs:format ~['type'^s+'raw' 'frames'^a+frames])
           ==
       ==

--- a/desk/tests/app/logs.hoon
+++ b/desk/tests/app/logs.hoon
@@ -1,5 +1,5 @@
 /-  l=logs
-/+  *test-agent
+/+  *test-agent, logs
 /=  agent  /app/logs
 |%
 ++  dap  %logs
@@ -15,8 +15,12 @@
     (do-poke log-action-1+!>(`a-log:l`[%log fail ~]))
   =/  =log-item:l
     [now.bowl fail]
+  =/  fpr  (need (fingerprint:logs /gall/test fail))
   =/  =log-data:l
-    ~['commit'^s+'development']
+    :~  'fingerprint'^s+fp.fpr
+        'signature'^s+sig.fpr
+        'commit'^s+'development'
+    ==
   =/  fard=(fyrd:khan cage)
     [q.byk.bowl %posthog noun+!>(`[`path`/gall/test log-item log-data])]
   ::  expect log submission -posthog

--- a/desk/tests/app/logs.hoon
+++ b/desk/tests/app/logs.hoon
@@ -18,6 +18,7 @@
   =/  fpr  (need (fingerprint:logs /gall/test fail))
   =/  =log-data:l
     :~  'fingerprint'^s+fp.fpr
+        'fingerprint_exact'^s+exact.fpr
         'signature'^s+sig.fpr
         'commit'^s+'development'
     ==

--- a/desk/tests/lib/logs.hoon
+++ b/desk/tests/lib/logs.hoon
@@ -118,6 +118,20 @@
     !>  '/gall/notify | notify failed | arvo-response | on-arvo/push | code=500 | app/notify'
     !>  sig:(need (fingerprint:logs /gall/notify event))
 ::
+::  the logging door stamps every event with the ship that caused it
+::
+++  test-src-attached
+  =/  =bowl:gall  *bowl:gall
+  =.  src.bowl  ~sampel-palnet
+  =/  log  ~(. logs [bowl /logs])
+  =/  =card:agent:gall  (tell:log %warn ~[leaf+"hi"] ~)
+  ?>  ?=([%pass * %agent * %poke *] card)
+  =/  act=a-log:l  !<(a-log:l q.cage.task.q.card)
+  ?>  ?=(%log -.act)
+  %+  expect-eq
+    !>  `(unit json)``s+'~sampel-palnet'
+    !>  (~(get by (my data.act)) 'src')
+::
 ++  test-fingerprint-tell-has-none
   %+  expect-eq
     !>  `(unit [fp=@t sig=@t exact=@t])`~

--- a/desk/tests/lib/logs.hoon
+++ b/desk/tests/lib/logs.hoon
@@ -26,8 +26,11 @@
     %+  expect-eq
       !>  8
       !>  (met 3 fp.fpr)
+    %+  expect-eq
+      !>  8
+      !>  (met 3 exact.fpr)
   ==
-::  line numbers change between commits; the fingerprint must not
+::  line numbers change between commits; fingerprint must not, exact should
 ::
 ++  test-fingerprint-ignores-line-numbers
   =/  a=log-event:l
@@ -42,10 +45,14 @@
         leaf+"'commit 0084cc9'"
         leaf+"/sys/vane/gall/hoon:<[1.870 9].[1.870 37]>"
     ==
-  %+  expect-eq
-    !>  fp:(need (fingerprint:logs /gall/groups a))
-    !>  fp:(need (fingerprint:logs /gall/groups b))
-::  %-prefixed tags inside brackets, and gall's "! " prefix
+  =/  fa  (need (fingerprint:logs /gall/groups a))
+  =/  fb  (need (fingerprint:logs /gall/groups b))
+  ;:  weld
+    (expect-eq !>(fp.fa) !>(fp.fb))
+    (expect !>(!=(exact.fa exact.fb)))
+  ==
+::  %-prefixed tags inside brackets keep their knots, and gall's "! " prefix
+::  is dropped
 ::
 ++  test-fingerprint-bracketed-tag
   =/  event=log-event:l
@@ -56,7 +63,27 @@
         leaf+"! /app/groups/hoon:<[2.833 7].[2.834 36]>"
     ==
   %+  expect-eq
-    !>  '/gall/groups | contacts failed | bad-agent-take | app/groups'
+    !>  '/gall/groups | contacts failed | bad-agent-take/contact | app/groups'
+    !>  sig:(need (fingerprint:logs /gall/groups event))
+::  a ~| dispatch hint becomes the "where" component, and -have/-need
+::  narrows a generic nest-fail
+::
+++  test-fingerprint-hint-and-detail
+  =/  event=log-event:l
+    :+  %fail  %error
+    :-  ~[leaf+"groups failed"]
+    :~  leaf+"%fact"
+        leaf+"! take %fact failed, closing subscription"
+        leaf+"! nest-fail"
+        leaf+"! -have.@p"
+        leaf+"! -need.%full"
+        leaf+"! /app/groups/hoon:<[1.160 9].[1.160 38]>"
+        leaf+"! [%on-agent ~.contact %fact]"
+        leaf+"! /app/groups/hoon:<[1.051 5].[1.051 24]>"
+        leaf+"! /sys/vane/gall/hoon:<[1.863 9].[1.863 37]>"
+    ==
+  %+  expect-eq
+    !>  '/gall/groups | groups failed | nest-fail | on-agent/contact/fact | -have.@p -need.%full | app/groups>sys/vane/gall'
     !>  sig:(need (fingerprint:logs /gall/groups event))
 ::  data dumps and multi-word lines are not tags; a tang with no tag still
 ::  yields a signature from message and file chain
@@ -68,14 +95,31 @@
     :~  leaf+"watch-ack"
         leaf+"/app/presence/hoon:<[421 5].[426 84]>"
         leaf+"/app/presence/hoon:<[418 5].[426 84]>"
+        leaf+"[context=/channel/chat/~zod/x src=~zod]"
         leaf+"/sys/vane/gall/hoon:<[1.850 9].[1.850 37]>"
     ==
   %+  expect-eq
     !>  '/gall/presence | context sub nacked, will retry | app/presence>sys/vane/gall'
     !>  sig:(need (fingerprint:logs /gall/presence event))
+::  http failure detail survives, ship names in hints do not
+::
+++  test-fingerprint-code-detail
+  =/  event=log-event:l
+    :+  %fail  %error
+    :-  ~[leaf+"notify failed"]
+    :~  leaf+"%arvo-response"
+        leaf+"! /app/notify/hoon:<[712 7].[727 70]>"
+        leaf+"! mime='text/plain; charset=utf8'"
+        leaf+"! code=500"
+        leaf+"! [%on-arvo ~.push ~sampel-palnet]"
+        leaf+"! /app/notify/hoon:<[708 7].[727 70]>"
+    ==
+  %+  expect-eq
+    !>  '/gall/notify | notify failed | arvo-response | on-arvo/push | code=500 | app/notify'
+    !>  sig:(need (fingerprint:logs /gall/notify event))
 ::
 ++  test-fingerprint-tell-has-none
   %+  expect-eq
-    !>  `(unit [fp=@t sig=@t])`~
+    !>  `(unit [fp=@t sig=@t exact=@t])`~
     !>  (fingerprint:logs /gall/groups [%tell %warn ~[leaf+"hello"]])
 --

--- a/desk/tests/lib/logs.hoon
+++ b/desk/tests/lib/logs.hoon
@@ -1,0 +1,81 @@
+/-  l=logs
+/+  *test, logs
+|%
+::  a groups nack as gall delivers it: wire label, spans, the error tag,
+::  a commit marker, a stdlib span
+::
+++  nack-tang
+  ^-  tang
+  :~  leaf+"watch-ack"
+      leaf+"/app/groups/hoon:<[2.150 5].[2.152 41]>"
+      leaf+"se-c-join-access-denied"
+      leaf+"/app/groups/hoon:<[2.149 5].[2.152 41]>"
+      leaf+"/app/groups/hoon:<[319 17].[319 51]>"
+      leaf+"'commit 938f0c4'"
+      leaf+"/app/groups/hoon:<[277 3].[582 5]>"
+      leaf+"/sys/vane/gall/hoon:<[1.863 9].[1.863 37]>"
+  ==
+++  test-fingerprint-signature
+  =/  event=log-event:l
+    [%fail %error ~[leaf+"group join with token failed"] nack-tang]
+  =/  fpr  (need (fingerprint:logs /gall/groups event))
+  ;:  weld
+    %+  expect-eq
+      !>  '/gall/groups | group join with token failed | se-c-join-access-denied | app/groups>sys/vane/gall'
+      !>  sig.fpr
+    %+  expect-eq
+      !>  8
+      !>  (met 3 fp.fpr)
+  ==
+::  line numbers change between commits; the fingerprint must not
+::
+++  test-fingerprint-ignores-line-numbers
+  =/  a=log-event:l
+    [%fail %error ~[leaf+"groups failed"] nack-tang]
+  =/  b=log-event:l
+    :+  %fail  %error
+    :-  ~[leaf+"groups failed"]
+    :~  leaf+"watch-ack"
+        leaf+"/app/groups/hoon:<[2.191 5].[2.193 41]>"
+        leaf+"se-c-join-access-denied"
+        leaf+"/app/groups/hoon:<[2.190 5].[2.193 41]>"
+        leaf+"'commit 0084cc9'"
+        leaf+"/sys/vane/gall/hoon:<[1.870 9].[1.870 37]>"
+    ==
+  %+  expect-eq
+    !>  fp:(need (fingerprint:logs /gall/groups a))
+    !>  fp:(need (fingerprint:logs /gall/groups b))
+::  %-prefixed tags inside brackets, and gall's "! " prefix
+::
+++  test-fingerprint-bracketed-tag
+  =/  event=log-event:l
+    :+  %fail  %error
+    :-  ~[leaf+"contacts failed"]
+    :~  leaf+"%poke-fail"
+        leaf+"! [%bad-agent-take ~.contact ~]"
+        leaf+"! /app/groups/hoon:<[2.833 7].[2.834 36]>"
+    ==
+  %+  expect-eq
+    !>  '/gall/groups | contacts failed | bad-agent-take | app/groups'
+    !>  sig:(need (fingerprint:logs /gall/groups event))
+::  data dumps and multi-word lines are not tags; a tang with no tag still
+::  yields a signature from message and file chain
+::
+++  test-fingerprint-no-tag
+  =/  event=log-event:l
+    :+  %fail  %warn
+    :-  ~[leaf+"context sub nacked, will retry" leaf+"[src=~zod context=/channel/chat/~zod/x try=4]"]
+    :~  leaf+"watch-ack"
+        leaf+"/app/presence/hoon:<[421 5].[426 84]>"
+        leaf+"/app/presence/hoon:<[418 5].[426 84]>"
+        leaf+"/sys/vane/gall/hoon:<[1.850 9].[1.850 37]>"
+    ==
+  %+  expect-eq
+    !>  '/gall/presence | context sub nacked, will retry | app/presence>sys/vane/gall'
+    !>  sig:(need (fingerprint:logs /gall/presence event))
+::
+++  test-fingerprint-tell-has-none
+  %+  expect-eq
+    !>  `(unit [fp=@t sig=@t])`~
+    !>  (fingerprint:logs /gall/groups [%tell %warn ~[leaf+"hello"]])
+--


### PR DESCRIPTION
## Why

Both PostHog and Grafana classify backend crashes today with hand-maintained substring lists over stack traces (140 entries in the PostHog "Unknown Crashes" series, a regex in the Grafana alert). Those lists key on `file:line:col` spans, so every commit rots them, and nobody can tell a new crash from a known one without editing a dashboard.

## What

**`%logs` names every crash before sending it.** `+fingerprint:logs` builds a signature from parts that survive a recompile:

```
/gall/groups | groups failed | nest-fail | on-agent/contact/fact | -have.@p -need.%full | app/groups>sys/vane/gall
```

origin; the developer's message (first line of the echo); the first error tag in the tang (why); the last tag, normally a `~|` dispatch hint (where); type/status detail from `-have`/`-need` lines and `code=` tokens; and the chain of source files in the stack with line numbers stripped. The `fingerprint` is eight hex digits of its `+mug`. `fingerprint_exact` additionally hashes the innermost span with its line numbers, so it separates crash sites within a release while `fingerprint` stays constant across releases. All three ride along as `log-data`, so they reach PostHog as event properties and Loki as OTLP attributes with no collector changes. Gall's own wire labels (`watch-ack`, `poke-fail`), commit markers, `key=value` data dumps, and bare ship names are never used, so user data can't leak into a signature and cardinality stays bounded.

**Dispatch hints so unexpected crashes have a "where".** Most `%fail` volume outside the known signatures has no message ("groups failed", or nothing) and a generic tag like `nest-fail`, which isn't enough to tell bugs apart. A `~|` hint at the top of `on-poke`, `on-watch`, `on-agent` and `on-arvo` in **groups, channels, notify and presence** puts the mark (or wire head and sign tag) into the tang of every crash beneath it, for free at runtime, so the fingerprint gets `on-poke/group-action-4` or `on-agent/contact/fact` without anyone tagging individual sites. Other agents can adopt the same four lines as needed.

**Crashes also go to PostHog Error Tracking.** `ted/posthog.hoon` now posts to `/batch/` and, for `%fail` events with a fingerprint, adds a `$exception` event carrying `$exception_fingerprint` and an `$exception_list` entry with the message and the stack as raw frames. That gets grouping, first-seen, and regression alerts from the product; the issue is named after the signature. The existing `Backend Log` event is unchanged so current dashboards keep working.

**Every event names the ship that caused it.** The logging door attaches `src` (`src.bowl`) to every event: the peer that nacked, kicked, or sent the fact in `on-agent`, the poker or subscriber in `on-poke`/`on-watch`, ourselves elsewhere. The `on-agent` hints carry `src.bowl` too, so unexpected crashes there show the peer in the trace. That is what separates "one host is nacking everyone" from "everyone is nacking". Ship names stay out of the fingerprint, so grouping is unaffected.

**Convention, no code:** call sites that log an *expected* failure should pass `'code'^s+'<stable-name>'` in `log-data`. Anything without a code is unexpected by definition. Dashboards and alerts can key on `code` presence instead of denylists as call sites adopt it.

## End-to-end check (2026-09-11, ~simtyc on this branch)

Synthetic `%fail` events poked into `%logs` on the dev moon, plus a real `%groups` crash from a bad poke:

- The real crash's nack tang carried the new `[%on-poke %noun]` dispatch hint.
- PostHog received the `Backend Log` event with `fingerprint`, `fingerprint_exact` and `signature`, and the companion `$exception` event. With the documented raw-frame shape (`platform`, `lang`, `lineno`, `colno`, `resolved`, plus `$lib`) PostHog Error Tracking created an issue for it; without those fields the event was stored but never became an issue, which is why the frame shape matters.
- With `%logs` pointed at the primary OTLP ingress, the record landed in primary Loki with the same attributes and with `ship` as a label, confirming #6481 too.

## Tests

- `tests/lib/logs.hoon`: signature shape, fingerprint invariance under line-number changes (and `fingerprint_exact` sensitivity), bracketed `%tags` with knots, dispatch hint + have/need detail, `code=` detail with a ship name dropped, tag-less tangs, `%tell` has none, and the door stamps `src` on every event.
- `tests/app/logs.hoon`: updated for the two new properties on `%fail`.
- Compiled and run on the ~simtyc dev moon: all eight `tests/lib/logs` tests pass; `tests/app/logs/test-log-fail` matches on the two new properties and differs only on the pre-existing `commit` value, which is `development` in the repo but a real hash on any ship with a committed desk.

## Follow-ups

- Dedupe repeated fingerprints per ship inside `%logs` (a bot moon currently logs the same join failure every two minutes).
- Grafana alert on a fingerprint first seen in the last hour on 3+ ships exists but is paused until the hint sweep is live and the top signatures look like distinct bugs.

Part of TLON-6530

🤖 Generated with [Claude Code](https://claude.com/claude-code)



