### PR TITLE
Keep Markdown code blocks when editing a message

### DIFF
--- a/apps/tlon-web/e2e/chat-core-functionality.spec.ts
+++ b/apps/tlon-web/e2e/chat-core-functionality.spec.ts
@@ -93,6 +93,12 @@ test('should test comprehensive chat functionality', async ({
   await helpers.sendMessage(zodPage, 'Edit this message');
   await helpers.editMessage(zodPage, 'Edit this message', 'Edited message');
 
+  // A fenced code block must survive a round-trip through the edit input
+  await helpers.editMessageWithCodeBlock(zodPage, {
+    lead: 'Code sample below',
+    code: 'const answer = 42;',
+  });
+
   // Mention a user in a message
   await helpers.sendMentionMessage(zodPage, {
     inputText: 'mentioning @ten',

--- a/apps/tlon-web/e2e/helpers.ts
+++ b/apps/tlon-web/e2e/helpers.ts
@@ -2166,6 +2166,42 @@ export async function editMessage(
 }
 
 /**
+ * Sends a message whose body is a line of prose followed by a fenced code
+ * block, opens it for editing, and re-sends it unchanged. Both the edit input
+ * and the re-sent post must still carry the code block.
+ */
+export async function editMessageWithCodeBlock(
+  page: Page,
+  { lead, code }: { lead: string; code: string }
+) {
+  const fencedCode = ['```', code, '```'].join('\n');
+
+  await waitForSessionStability(page);
+  await page.getByTestId('MessageInput').click();
+  await page.fill(
+    '[data-testid="MessageInput"]',
+    [lead, fencedCode].join('\n')
+  );
+  await page.getByTestId('MessageInputSendButton').click({ force: true });
+
+  const renderedCode = page.getByTestId('Post').getByText(code).first();
+  await expect(renderedCode).toBeVisible({ timeout: 10000 });
+
+  await longPressMessage(page, lead);
+  await page.getByText('Edit message').click();
+
+  await expect
+    .poll(() => page.getByTestId('MessageInput').inputValue(), {
+      timeout: 10000,
+    })
+    .toContain(fencedCode);
+
+  // Re-send untouched: the code block should come back out the way it went in.
+  await page.getByTestId('MessageInputSendButton').click();
+  await expect(renderedCode).toBeVisible({ timeout: 15000 });
+}
+
+/**
  * Verifies message preview on Home screen
  */
 export async function verifyMessagePreview(

--- a/packages/api/src/__tests__/content-helpers.test.ts
+++ b/packages/api/src/__tests__/content-helpers.test.ts
@@ -78,6 +78,63 @@ describe('contentToTextAndMentions / textAndMentionsToContent round-trip', () =>
   });
 });
 
+describe('contentToTextAndMentions block separators', () => {
+  const paragraph = (text: string) => ({
+    type: 'paragraph',
+    content: [{ type: 'text', text }],
+  });
+
+  test('separates a code block from the paragraphs around it', () => {
+    const result = contentToTextAndMentions({
+      type: 'doc',
+      content: [
+        paragraph('before'),
+        {
+          type: 'codeBlock',
+          content: [{ type: 'text', text: 'const x = 42;' }],
+        },
+        paragraph('after'),
+      ],
+    });
+
+    expect(result.text).toBe('before\n```\nconst x = 42;\n```\nafter');
+  });
+
+  test('separates a blockquote from the paragraph before it', () => {
+    const result = contentToTextAndMentions({
+      type: 'doc',
+      content: [
+        paragraph('before'),
+        { type: 'blockquote', content: [paragraph('quoted')] },
+        paragraph('after'),
+      ],
+    });
+
+    expect(result.text).toBe('before\n> quoted\nafter');
+  });
+
+  test('keeps mention offsets aligned across blocks', () => {
+    const result = contentToTextAndMentions({
+      type: 'doc',
+      content: [
+        {
+          type: 'codeBlock',
+          content: [{ type: 'text', text: 'const x = 42;' }],
+        },
+        {
+          type: 'paragraph',
+          content: [{ type: 'mention', attrs: { id: '~zod' } }],
+        },
+      ],
+    });
+
+    expect(result.mentions).toHaveLength(1);
+    expect(
+      result.text.slice(result.mentions[0].start, result.mentions[0].end)
+    ).toBe('~zod');
+  });
+});
+
 describe('post blob helpers', () => {
   test('parses the complete agent onboarding protocol', () => {
     const entries = [

--- a/packages/api/src/__tests__/content-helpers.test.ts
+++ b/packages/api/src/__tests__/content-helpers.test.ts
@@ -95,8 +95,12 @@ describe('textAndMentionsToContent closing fences', () => {
     });
   });
 
-  test('keeps a mention that follows the closing fence', () => {
-    const text = '```\nconst x = 42;\n```~zod';
+  test.each([
+    ['flush against the fence', '```~zod'],
+    ['separated by a space', '``` ~zod'],
+    ['separated by several spaces', '```   ~zod'],
+  ])('keeps a mention %s', (_label, closingLine) => {
+    const text = `\`\`\`\nconst x = 42;\n${closingLine}`;
     const result = textAndMentionsToContent(text, [
       {
         id: '~zod',
@@ -106,9 +110,20 @@ describe('textAndMentionsToContent closing fences', () => {
       },
     ]);
 
+    // No stray text node before the mention: the gap between the fence and
+    // the mention must not shift the mention's offsets.
     expect(result.content?.[1]).toEqual({
       type: 'paragraph',
       content: [{ type: 'mention', attrs: { id: '~zod' } }],
+    });
+  });
+
+  test('keeps prose separated from the closing fence by a space', () => {
+    expect(
+      textAndMentionsToContent('```\nconst x = 42;\n``` after', []).content?.[1]
+    ).toEqual({
+      type: 'paragraph',
+      content: [{ type: 'text', text: 'after ' }],
     });
   });
 

--- a/packages/api/src/__tests__/content-helpers.test.ts
+++ b/packages/api/src/__tests__/content-helpers.test.ts
@@ -78,6 +78,54 @@ describe('contentToTextAndMentions / textAndMentionsToContent round-trip', () =>
   });
 });
 
+describe('textAndMentionsToContent closing fences', () => {
+  test('keeps prose typed directly onto the closing fence', () => {
+    expect(
+      textAndMentionsToContent('```\nconst x = 42;\n```after', [])
+    ).toEqual({
+      type: 'doc',
+      content: [
+        {
+          type: 'codeBlock',
+          content: [{ type: 'text', text: 'const x = 42;' }],
+          attrs: { language: 'plaintext' },
+        },
+        { type: 'paragraph', content: [{ type: 'text', text: 'after ' }] },
+      ],
+    });
+  });
+
+  test('keeps a mention that follows the closing fence', () => {
+    const text = '```\nconst x = 42;\n```~zod';
+    const result = textAndMentionsToContent(text, [
+      {
+        id: '~zod',
+        display: '~zod',
+        start: text.indexOf('~zod'),
+        end: text.length,
+      },
+    ]);
+
+    expect(result.content?.[1]).toEqual({
+      type: 'paragraph',
+      content: [{ type: 'mention', attrs: { id: '~zod' } }],
+    });
+  });
+
+  test('drops a bare closing fence with only trailing whitespace', () => {
+    expect(textAndMentionsToContent('```\nconst x = 42;\n```   ', [])).toEqual({
+      type: 'doc',
+      content: [
+        {
+          type: 'codeBlock',
+          content: [{ type: 'text', text: 'const x = 42;' }],
+          attrs: { language: 'plaintext' },
+        },
+      ],
+    });
+  });
+});
+
 describe('contentToTextAndMentions block separators', () => {
   const paragraph = (text: string) => ({
     type: 'paragraph',

--- a/packages/api/src/client/content-helpers.ts
+++ b/packages/api/src/client/content-helpers.ts
@@ -433,18 +433,20 @@ export function textAndMentionsToContent(
 
         // Only the opening fence carries an info string. Anything typed after
         // a closing fence is prose, so carry it over to the next text line
-        // rather than dropping the rest of the line on the floor.
-        const fenceLength = text.match(/^`+/)![0].length;
-        const trailing = text.slice(fenceLength);
-        if (trailing.trim() !== '') {
+        // rather than dropping the rest of the line on the floor. `processLine`
+        // trims what it is given, so drop the gap between the fence and the
+        // prose here too, or the mention offsets land a character early.
+        const fence = text.match(/^`+\s*/)![0];
+        const trailing = text.slice(fence.length);
+        if (trailing !== '') {
           currentLines.push({
             text: trailing,
             mentions: line.mentions
-              .filter((mention) => mention.start >= fenceLength)
+              .filter((mention) => mention.start >= fence.length)
               .map((mention) => ({
                 ...mention,
-                start: mention.start - fenceLength,
-                end: mention.end - fenceLength,
+                start: mention.start - fence.length,
+                end: mention.end - fence.length,
               })),
           });
         }

--- a/packages/api/src/client/content-helpers.ts
+++ b/packages/api/src/client/content-helpers.ts
@@ -478,13 +478,19 @@ export function contentToTextAndMentions(jsonContent: JSONContent): {
     };
   }
 
-  let paragrahCount = 0;
+  // Every top-level node starts on its own line, so each one but the first is
+  // preceded by a newline.
+  let hasEmittedNode = false;
+  const startNode = () => {
+    if (hasEmittedNode) {
+      text.push('\n');
+    }
+    hasEmittedNode = true;
+  };
+
   content.forEach((node) => {
     if (node.type === 'paragraph') {
-      if (paragrahCount > 0) {
-        text.push('\n');
-      }
-      paragrahCount++;
+      startNode();
       if (!node.content) {
         return;
       }
@@ -562,13 +568,15 @@ export function contentToTextAndMentions(jsonContent: JSONContent): {
       if (!node.content || !node.content[0].text) {
         return;
       }
+      startNode();
       text.push('```\n');
       text.push(node.content[0].text);
-      text.push('\n```\n');
+      text.push('\n```');
     } else if (node.type === 'blockquote') {
       if (!node.content) {
         return;
       }
+      startNode();
       text.push('> ');
       node.content.forEach((child, index) => {
         if (child.type === 'paragraph' && child.content) {
@@ -582,7 +590,6 @@ export function contentToTextAndMentions(jsonContent: JSONContent): {
           }
         }
       });
-      text.push('\n');
     }
   });
 

--- a/packages/api/src/client/content-helpers.ts
+++ b/packages/api/src/client/content-helpers.ts
@@ -430,6 +430,24 @@ export function textAndMentionsToContent(
           },
         });
         currentCodeBlock = [];
+
+        // Only the opening fence carries an info string. Anything typed after
+        // a closing fence is prose, so carry it over to the next text line
+        // rather than dropping the rest of the line on the floor.
+        const fenceLength = text.match(/^`+/)![0].length;
+        const trailing = text.slice(fenceLength);
+        if (trailing.trim() !== '') {
+          currentLines.push({
+            text: trailing,
+            mentions: line.mentions
+              .filter((mention) => mention.start >= fenceLength)
+              .map((mention) => ({
+                ...mention,
+                start: mention.start - fenceLength,
+                end: mention.end - fenceLength,
+              })),
+          });
+        }
       }
     } else if (inCodeBlock) {
       currentCodeBlock.push(line);

--- a/packages/shared/src/logic/content-helpers.test.ts
+++ b/packages/shared/src/logic/content-helpers.test.ts
@@ -1,8 +1,12 @@
 import {
   Mention,
+  contentToTextAndMentions,
   textAndMentionsToContent,
 } from '@tloncorp/api/client/content-helpers';
-import { expect, test } from 'vitest';
+import { Story, constructStory } from '@tloncorp/api/urbit/channel';
+import { describe, expect, test } from 'vitest';
+
+import { JSONToInlines, diaryMixedToJSON } from './tiptap';
 
 test('textAndMentionsToContent: multiline mentions', () => {
   const text = "User One Hello, world! here's more to the message.\nUser Two";
@@ -360,5 +364,49 @@ test('textAndMentionsToContent: text immediately before mention (no space)', () 
         ],
       },
     ],
+  });
+});
+
+/**
+ * The bare chat input round-trips a message through the wire format when you
+ * edit it: text -> editor JSON -> story (what the backend stores) -> editor
+ * JSON -> text. Fenced code blocks used to be dropped on the way back.
+ */
+describe('chat edit round-trip', () => {
+  const editText = (sent: string) => {
+    const story = constructStory(
+      JSONToInlines(textAndMentionsToContent(sent, []))
+    ) as Story;
+    return contentToTextAndMentions(diaryMixedToJSON(story)).text;
+  };
+
+  test('preserves a lone code block', () => {
+    expect(editText('```\nconst x = 42;\n```')).toBe('```\nconst x = 42;\n```');
+  });
+
+  test('preserves a multiline code block', () => {
+    expect(editText('```\nconst x = 42;\nconst y = x + 1;\n```')).toBe(
+      '```\nconst x = 42;\nconst y = x + 1;\n```'
+    );
+  });
+
+  test('preserves a code block between paragraphs', () => {
+    // `processLine` pads each line with a trailing space on the way in, so the
+    // surrounding prose comes back padded — only the fenced block matters here.
+    expect(editText('before\n```\nconst x = 42;\n```\nafter')).toBe(
+      'before \n```\nconst x = 42;\n```\nafter '
+    );
+  });
+
+  test('preserves two code blocks', () => {
+    expect(editText('```\nfirst\n```\n```\nsecond\n```')).toBe(
+      '```\nfirst\n```\n```\nsecond\n```'
+    );
+  });
+
+  test('leaves inline code alone', () => {
+    expect(editText('use `const x = 42;` here')).toBe(
+      'use `const x = 42;` here '
+    );
   });
 });

--- a/packages/shared/src/logic/content-helpers.test.ts
+++ b/packages/shared/src/logic/content-helpers.test.ts
@@ -409,4 +409,25 @@ describe('chat edit round-trip', () => {
       'use `const x = 42;` here '
     );
   });
+
+  // Editing a code block puts the caret right after the closing fence, so
+  // typing there is an easy way to lose text if the fence line's remainder is
+  // discarded.
+  test('keeps prose typed directly onto the closing fence', () => {
+    expect(editText('```\nconst x = 42;\n```after')).toBe(
+      '```\nconst x = 42;\n```\nafter '
+    );
+  });
+
+  test('keeps prose typed onto a longer closing fence', () => {
+    expect(editText('````\nconst x = 42;\n````after')).toBe(
+      '```\nconst x = 42;\n```\nafter '
+    );
+  });
+
+  test('ignores whitespace after a closing fence', () => {
+    expect(editText('```\nconst x = 42;\n```   ')).toBe(
+      '```\nconst x = 42;\n```'
+    );
+  });
 });

--- a/packages/shared/src/logic/tiptap.test.ts
+++ b/packages/shared/src/logic/tiptap.test.ts
@@ -1,7 +1,8 @@
 import { Block, Inline, JSONContent } from '@tloncorp/api/urbit';
+import { Story } from '@tloncorp/api/urbit/channel';
 import { describe, expect, test } from 'vitest';
 
-import { JSONToInlines } from './tiptap';
+import { JSONToInlines, diaryMixedToJSON } from './tiptap';
 
 test('tiptap: test mixed text, inline code and code block with langs', () => {
   const json: JSONContent = {
@@ -222,5 +223,56 @@ describe('JSONToInlines - links with marks', () => {
       },
       { break: null },
     ]);
+  });
+});
+
+describe('diaryMixedToJSON - code blocks', () => {
+  test('emits a code block as a sibling of paragraphs, not nested in one', () => {
+    const story: Story = [{ inline: [{ code: 'const x = 42;' }] }];
+
+    expect(diaryMixedToJSON(story)).toEqual({
+      type: 'doc',
+      content: [
+        {
+          type: 'codeBlock',
+          content: [{ type: 'text', text: 'const x = 42;' }],
+        },
+      ],
+    });
+  });
+
+  test('keeps surrounding inline text in order around a code block', () => {
+    const story: Story = [
+      { inline: ['before', { code: 'const x = 42;' }, 'after'] },
+    ];
+
+    expect(diaryMixedToJSON(story)).toEqual({
+      type: 'doc',
+      content: [
+        { type: 'paragraph', content: [{ type: 'text', text: 'before' }] },
+        {
+          type: 'codeBlock',
+          content: [{ type: 'text', text: 'const x = 42;' }],
+        },
+        { type: 'paragraph', content: [{ type: 'text', text: 'after' }] },
+      ],
+    });
+  });
+
+  test('keeps inline text ahead of a blockquote in order', () => {
+    const story: Story = [{ inline: ['before', { blockquote: ['quoted'] }] }];
+
+    expect(diaryMixedToJSON(story)).toEqual({
+      type: 'doc',
+      content: [
+        { type: 'paragraph', content: [{ type: 'text', text: 'before' }] },
+        {
+          type: 'blockquote',
+          content: [
+            { type: 'paragraph', content: [{ type: 'text', text: 'quoted' }] },
+          ],
+        },
+      ],
+    });
   });
 });

--- a/packages/shared/src/logic/tiptap.ts
+++ b/packages/shared/src/logic/tiptap.ts
@@ -536,14 +536,15 @@ export function wrapParagraphs(content: JSONContent[]) {
 
   const wrappedContent = content.reduce((memo, c) => {
     switch (c.type) {
+      // Block-level nodes can't legally sit inside a paragraph, so emit them
+      // as siblings, flushing any inline content queued ahead of them first.
       case 'paragraph':
+      case 'blockquote':
+      case 'codeBlock':
         if (wrapQueue.length > 0) {
           memo.push(makeParagraph(wrapQueue));
+          wrapQueue = [];
         }
-        memo.push(c);
-        wrapQueue = [];
-        break;
-      case 'blockquote':
         memo.push(c);
         break;
       default:


### PR DESCRIPTION
## Summary

Editing a chat message that contains a Markdown code block loaded an edit input with the code block missing, so re-sending silently destroyed it. Reported by ~sovbus-sovbus in the developers channel.

Fixes TLON-6515

## Changes

Chat stores a fenced block as an **inline** `{ code: "..." }` inside an inline verse rather than a `{ block: { code: ... } }` verse — `isBlockCode` classifies string-valued `code` as inline — so it comes back through the inline path on edit. Two things went wrong there:

- **`wrapParagraphs`** (`packages/shared/src/logic/tiptap.ts`) only recognized `paragraph` and `blockquote` as block-level. The `codeBlock` node produced by `inlineToContent` fell into the inline wrap queue, so `diaryMixedToJSON` emitted `paragraph > codeBlock` — not a legal ProseMirror shape.
- **`contentToTextAndMentions`** (`packages/api/src/client/content-helpers.ts`) only handles `text` and `mention` children of a paragraph. The nested `codeBlock` matched neither and was silently dropped.

Traced end to end before the fix:

| stage | value |
| --- | --- |
| typed | <code>```\nconst a = 1\n```</code> |
| stored story | `[{"inline":[{"code":"const a = 1"}]}]` |
| back to editor JSON | `paragraph > codeBlock` |
| back to text | `""` |

The fix:

- `wrapParagraphs` treats `codeBlock` as block-level alongside `paragraph` and `blockquote`, flushing any queued inline content first so ordering is preserved. That flush also fixes a latent bug where a blockquote preceded by inline text in the same verse came out **ahead of** that text.
- `contentToTextAndMentions` uses one uniform "newline before every node but the first" separator instead of counting only paragraphs. This additionally fixes a paragraph and a following fence or blockquote running together with no break — previously `hello` followed by a fence serialized as <code>hello```</code>.

`ChatInput` uses `BareChatInput` on every platform, so this fixes mobile chat too, and it corrects the node shape handed to the TipTap-based inputs as well.

### Second commit: prose typed onto a closing fence

Found by the iOS agent QA run on this PR. `textAndMentionsToContent` treated any line starting with a fence as a pure delimiter and discarded the rest of the line, so <code>```aftercode</code> closed the block and dropped `aftercode`. Only an opening fence carries an info string; on a closing fence the remainder is prose, so it now carries over to the following text line, with mention offsets shifted past the fence and trailing whitespace ignored.

This is a **send-path bug that predates this PR** — it drops the text for a freshly composed message on `develop` too — but it was unreachable while editing, because the edit input never contained a fence to type after. Showing the fence puts a caret right there, so it belongs with this change.

A follow-up commit fixes an offset bug in that carry-over, caught by Codex: `processLine` trims the line it is handed, so a suffix that kept its leading whitespace while its mention offsets were shifted by the fence length alone landed one character high — <code>``` ~zod</code> round-tripped into `~ ~zod`. The gap is now folded into the matched fence so slice and offsets are normalized together.

## How did I test?

- `packages/shared/src/logic/tiptap.test.ts` — `diaryMixedToJSON` emits code blocks as siblings; ordering holds around code blocks and blockquotes
- `packages/shared/src/logic/content-helpers.test.ts` — full send → store → edit round-trip: lone block, multiline block, block between paragraphs, two adjacent blocks, inline code untouched
- `packages/api/src/__tests__/content-helpers.test.ts` — separator and mention-offset unit tests
- `apps/tlon-web/e2e/chat-core-functionality.spec.ts` — sends prose plus a fenced block, opens the edit input, asserts the fence is present, re-sends unchanged, asserts the code still renders

13 of the new assertions fail on `develop` and pass with the fix (verified by reverting the source files and re-running). Full suites green: `packages/api` 930, `packages/shared` 789. `tsc --noEmit` clean for `packages/api`, `packages/shared`, `apps/tlon-web`; oxlint and oxfmt clean. E2E: `pnpm e2e:test chat-core-functionality.spec.ts` — 5 passed against live ~zod/~ten.

### Known limitations, unchanged here

- `processLine` pads each word with a trailing space, so prose comes back from an edit with trailing whitespace. Pre-existing and independent of code blocks — the padding is already in the stored story at send time.
- The fence's language is dropped on the chat path, including an opening fence's info string (<code>```js</code> loses `js`). Chat's `JSONToInlines(json)` (`codeWithLang = false`) stores `{ code: string }` with no lang field, so the language never survives a *send* either. Preserving it needs changes on both ends of the wire format; not a regression from this bug.

## Risks and impact

- Safe to rollback without consulting PR author? Yes
- Affects important code area:
  - [ ] Onboarding
  - [ ] State / providers
  - [ ] Message sync
  - [ ] Channel display
  - [ ] Notifications
  - [x] Other: message content serialization (chat edit + draft round-trip, all platforms)

Both functions sit on the story ↔ text boundary used by chat editing, draft save/reload, and DM quote-reply. Draft round-trips are unaffected: drafts are written by `textAndMentionsToContent`, which already emits top-level code blocks, and the quote-reply prefix carries its own newline that becomes a paragraph node supplying the same separator. Verified both by hand and by the suites above.

## Rollback plan

`git revert` the commit. No migrations, no persisted-format change — both functions are pure in-memory transforms, and nothing about what gets stored on the backend changes.

## Screenshots / videos

None — covered by the e2e assertion on the edit input's contents.
