### PR TITLE
Fix duplicate tombstones when a chat message is deleted

### DIFF
--- a/packages/api/src/client/channelsApi.test.ts
+++ b/packages/api/src/client/channelsApi.test.ts
@@ -1,5 +1,6 @@
 import { expect, test, vi } from 'vitest';
 
+import rawChannelPostsData from '../__tests__/fixtures/channelPosts.json';
 import type * as ub from '../urbit';
 import { toChannelsUpdate } from './channelsApi';
 
@@ -33,6 +34,19 @@ const event = (response: ub.ChannelsResponse['response']) =>
     nest: channelId,
     response,
   }) as unknown as ub.ChannelsSubscribeResponse;
+
+test('a post set to a live post is still an add', () => {
+  const [id, post] = Object.entries(
+    (rawChannelPostsData as unknown as ub.PagedPosts).posts
+  )[0];
+  const update = toChannelsUpdate(
+    event({ post: { id, 'r-post': { set: post } } })
+  );
+  expect(update).toMatchObject({ type: 'addPost', post: { id, channelId } });
+  expect((update as { post: { isDeleted?: boolean } }).post.isDeleted).toBe(
+    undefined
+  );
+});
 
 test('a post set to a tombstone is a delete, not an add', () => {
   const update = toChannelsUpdate(

--- a/packages/api/src/client/channelsApi.test.ts
+++ b/packages/api/src/client/channelsApi.test.ts
@@ -1,0 +1,68 @@
+import { expect, test, vi } from 'vitest';
+
+import type * as ub from '../urbit';
+import { toChannelsUpdate } from './channelsApi';
+
+vi.mock('./urbit', async () => {
+  const actual = await vi.importActual<typeof import('./urbit')>('./urbit');
+  return {
+    ...actual,
+    poke: vi.fn(),
+    scry: vi.fn(),
+    subscribe: vi.fn(),
+    subscribeOnce: vi.fn(),
+    thread: vi.fn(),
+    trackedPoke: vi.fn(),
+  };
+});
+
+const channelId = 'chat/~zod/test';
+const postId = '170141184508156063143615883506463277056';
+const replyId = '170141184508156080359755299686700810240';
+
+const tombstone = (id: string): ub.PostTombstone => ({
+  id,
+  author: '~zod',
+  seq: 7,
+  'deleted-at': 1789144000000,
+  type: 'tombstone',
+});
+
+const event = (response: ub.ChannelsResponse['response']) =>
+  ({
+    nest: channelId,
+    response,
+  }) as unknown as ub.ChannelsSubscribeResponse;
+
+test('a post set to a tombstone is a delete, not an add', () => {
+  const update = toChannelsUpdate(
+    event({ post: { id: postId, 'r-post': { set: tombstone(postId) } } })
+  );
+  expect(update).toEqual({
+    type: 'deletePost',
+    postId: '170.141.184.508.156.063.143.615.883.506.463.277.056',
+    channelId,
+  });
+});
+
+test('a reply set to a tombstone is a delete, not an add', () => {
+  const update = toChannelsUpdate(
+    event({
+      post: {
+        id: postId,
+        'r-post': {
+          reply: {
+            id: replyId,
+            'r-reply': { set: tombstone(replyId) },
+            meta: { replyCount: 0, lastReply: null, lastRepliers: [] },
+          },
+        },
+      },
+    })
+  );
+  expect(update).toEqual({
+    type: 'deletePost',
+    postId: '170.141.184.508.156.080.359.755.299.686.700.810.240',
+    channelId,
+  });
+});

--- a/packages/api/src/client/channelsApi.ts
+++ b/packages/api/src/client/channelsApi.ts
@@ -12,7 +12,12 @@ import {
   getChannelIdType,
   isGroupChannelId,
 } from './apiUtils';
-import { toPostData, toPostReplyData, toReactionsData } from './postsApi';
+import {
+  isPostTombstone,
+  toPostData,
+  toPostReplyData,
+  toReactionsData,
+} from './postsApi';
 import {
   poke,
   scry,
@@ -272,7 +277,7 @@ export const toChannelsUpdate = (
         const postResponse = channelEvent.response.post['r-post'];
 
         if ('set' in postResponse) {
-          if (postResponse.set !== null) {
+          if (postResponse.set !== null && !isPostTombstone(postResponse.set)) {
             const postToAdd = { id: postId, ...postResponse.set };
 
             logger.log(`add post event`);
@@ -317,7 +322,10 @@ export const toChannelsUpdate = (
         const replyResponse =
           channelEvent.response.post['r-post'].reply['r-reply'];
         if ('set' in replyResponse) {
-          if (replyResponse.set !== null) {
+          if (
+            replyResponse.set !== null &&
+            !isPostTombstone(replyResponse.set)
+          ) {
             logger.log(`add reply event`);
             return {
               type: 'addPost',

--- a/packages/api/src/client/postsApi.ts
+++ b/packages/api/src/client/postsApi.ts
@@ -1409,7 +1409,7 @@ function isPostDataResponse(
   return !!(post.seal.replies && !Array.isArray(post.seal.replies));
 }
 
-function isPostTombstone(
+export function isPostTombstone(
   post:
     | ub.Post
     | ub.PostTombstone

--- a/packages/api/src/urbit/channel.ts
+++ b/packages/api/src/urbit/channel.ts
@@ -416,12 +416,14 @@ export type Command =
   | DiffMeta;
 
 export type PostResponse =
-  | { set: Post | null }
+  | { set: Post | PostTombstone | null }
   | { reply: { id: string; 'r-reply': ReplyResponse; meta: ReplyMeta } }
   | { essay: PostEssay }
   | { reacts: Record<string, React> };
 
-export type ReplyResponse = { set: Reply } | { reacts: Record<string, React> };
+export type ReplyResponse =
+  | { set: Reply | PostTombstone }
+  | { reacts: Record<string, React> };
 
 export interface ChannelPostResponse {
   post: {

--- a/packages/shared/src/store/sync/changesPostListeners.test.ts
+++ b/packages/shared/src/store/sync/changesPostListeners.test.ts
@@ -1,0 +1,73 @@
+import { afterEach, expect, test, vi } from 'vitest';
+
+const mocks = vi.hoisted(() => ({
+  fetchChangesSince: vi.fn(),
+  addToChannelPosts: vi.fn(),
+}));
+
+vi.mock('@tloncorp/api/client/changesApi', () => ({
+  fetchChangesSince: mocks.fetchChangesSince,
+}));
+
+vi.mock('../useChannelPosts/subscriptions', async () => {
+  const actual = await vi.importActual<
+    typeof import('../useChannelPosts/subscriptions')
+  >('../useChannelPosts/subscriptions');
+  return { ...actual, addToChannelPosts: mocks.addToChannelPosts };
+});
+
+import type * as db from '../../db';
+import { setupDatabaseTestSuite } from '../../test/helpers';
+import { syncLatestChanges } from './sync';
+
+setupDatabaseTestSuite();
+
+afterEach(() => {
+  mocks.fetchChangesSince.mockReset();
+  mocks.addToChannelPosts.mockReset();
+});
+
+const channelId = 'chat/~zod/test';
+
+const livePost: db.Post = {
+  id: '170.141.184.508.156.063.143.615.883.506.463.277.056',
+  channelId,
+  type: 'chat',
+  authorId: '~zod',
+  sentAt: 1789144000000,
+  receivedAt: 1789144000100,
+  sequenceNum: 7,
+  content: '[]',
+};
+
+const tombstone: db.Post = {
+  id: '170.141.184.508.156.080.359.755.299.686.700.810.240',
+  channelId,
+  type: 'chat',
+  authorId: '~zod',
+  sentAt: 1789144001100,
+  receivedAt: 1789144001100,
+  sequenceNum: 8,
+  isDeleted: true,
+};
+
+test('the changes feed does not push tombstones into channel post listeners', async () => {
+  mocks.fetchChangesSince.mockResolvedValue({
+    groups: [],
+    posts: [livePost, tombstone],
+    contacts: [],
+    deletedChannelIds: [],
+    unreads: {
+      channelUnreads: [],
+      groupUnreads: [],
+      threadActivity: [],
+    },
+  });
+
+  await syncLatestChanges({ since: Date.now(), callCtx: { cause: 'test' } });
+
+  expect(mocks.addToChannelPosts).toHaveBeenCalledTimes(1);
+  expect(mocks.addToChannelPosts).toHaveBeenCalledWith(
+    expect.objectContaining({ id: livePost.id })
+  );
+});

--- a/packages/shared/src/store/sync/changesPostListeners.test.ts
+++ b/packages/shared/src/store/sync/changesPostListeners.test.ts
@@ -3,6 +3,7 @@ import { afterEach, expect, test, vi } from 'vitest';
 const mocks = vi.hoisted(() => ({
   fetchChangesSince: vi.fn(),
   addToChannelPosts: vi.fn(),
+  deleteFromChannelPosts: vi.fn(),
 }));
 
 vi.mock('@tloncorp/api/client/changesApi', () => ({
@@ -13,18 +14,24 @@ vi.mock('../useChannelPosts/subscriptions', async () => {
   const actual = await vi.importActual<
     typeof import('../useChannelPosts/subscriptions')
   >('../useChannelPosts/subscriptions');
-  return { ...actual, addToChannelPosts: mocks.addToChannelPosts };
+  return {
+    ...actual,
+    addToChannelPosts: mocks.addToChannelPosts,
+    deleteFromChannelPosts: mocks.deleteFromChannelPosts,
+  };
 });
 
 import type * as db from '../../db';
+import { batchEffects } from '../../db/query';
 import { setupDatabaseTestSuite } from '../../test/helpers';
-import { syncLatestChanges } from './sync';
+import { handleChannelsUpdate, syncLatestChanges } from './sync';
 
 setupDatabaseTestSuite();
 
 afterEach(() => {
   mocks.fetchChangesSince.mockReset();
   mocks.addToChannelPosts.mockReset();
+  mocks.deleteFromChannelPosts.mockReset();
 });
 
 const channelId = 'chat/~zod/test';
@@ -51,7 +58,7 @@ const tombstone: db.Post = {
   isDeleted: true,
 };
 
-test('the changes feed does not push tombstones into channel post listeners', async () => {
+test('the changes feed reports tombstones as deletes, not new posts', async () => {
   mocks.fetchChangesSince.mockResolvedValue({
     groups: [],
     posts: [livePost, tombstone],
@@ -70,4 +77,22 @@ test('the changes feed does not push tombstones into channel post listeners', as
   expect(mocks.addToChannelPosts).toHaveBeenCalledWith(
     expect.objectContaining({ id: livePost.id })
   );
+  expect(mocks.deleteFromChannelPosts).toHaveBeenCalledTimes(1);
+  expect(mocks.deleteFromChannelPosts).toHaveBeenCalledWith(
+    expect.objectContaining({ id: tombstone.id })
+  );
+});
+
+test('a subscription deletePost update reports the delete to channel post listeners', async () => {
+  await batchEffects('test:deletePost', (ctx) =>
+    handleChannelsUpdate(
+      { type: 'deletePost', postId: livePost.id, channelId },
+      ctx
+    )
+  );
+
+  expect(mocks.addToChannelPosts).not.toHaveBeenCalled();
+  expect(mocks.deleteFromChannelPosts).toHaveBeenCalledWith({
+    id: livePost.id,
+  });
 });

--- a/packages/shared/src/store/sync/sync.ts
+++ b/packages/shared/src/store/sync/sync.ts
@@ -47,7 +47,10 @@ import { migrateLegacyContextLensFlag } from '../settingsActions';
 import { SyncCtx, SyncPriority, syncQueue } from '../syncQueue';
 import { getSystemContacts } from '../systemContactsApi';
 import { clearChannelPostsQueries } from '../useChannelPosts/queries';
-import { addToChannelPosts } from '../useChannelPosts/subscriptions';
+import {
+  addToChannelPosts,
+  deleteFromChannelPosts,
+} from '../useChannelPosts/subscriptions';
 import { logger } from './logger';
 import { syncContacts } from './syncContacts';
 import { syncGroup } from './syncGroup';
@@ -463,13 +466,16 @@ function notifyChannelPostListenersFromLatestChanges(posts: db.Post[]) {
     if (
       post.parentId ||
       post.type === 'reply' ||
-      post.isDeleted ||
       post.sequenceNum == null ||
       seenIds.has(post.id)
     ) {
       continue;
     }
     seenIds.add(post.id);
+    if (post.isDeleted) {
+      deleteFromChannelPosts(post);
+      continue;
+    }
     addToChannelPosts(post);
     notified++;
   }
@@ -1753,6 +1759,7 @@ export const handleChannelsUpdate = async (
       }
       break;
     case 'deletePost':
+      deleteFromChannelPosts({ id: update.postId });
       await db.markPostAsDeleted(update.postId, ctx);
       await db.recomputeChannelLastPost({ channelId: update.channelId }, ctx);
       break;

--- a/packages/shared/src/store/sync/sync.ts
+++ b/packages/shared/src/store/sync/sync.ts
@@ -463,6 +463,7 @@ function notifyChannelPostListenersFromLatestChanges(posts: db.Post[]) {
     if (
       post.parentId ||
       post.type === 'reply' ||
+      post.isDeleted ||
       post.sequenceNum == null ||
       seenIds.has(post.id)
     ) {

--- a/packages/shared/src/store/useChannelPosts/subscriptions.ts
+++ b/packages/shared/src/store/useChannelPosts/subscriptions.ts
@@ -63,7 +63,7 @@ export const addToChannelPosts = (post: SubscriptionPost) => {
   newPostListeners.forEach((listener) => listener(post));
 };
 
-export const deleteFromChannelPosts = (post: db.Post) => {
+export const deleteFromChannelPosts = (post: Pick<db.Post, 'id'>) => {
   deletedPostListeners.forEach((listener) => listener(post.id, true));
 };
 


### PR DESCRIPTION
## Summary

Deleting a chat message in a group channel could render two "Message deleted" tombstones for the one post and log a duplicate-key error from the message list (`Encountered two children with the same key` on FlatList, `[legend-list] Error: Detected overlapping key` on LegendList, which also leaves a blank gap in the list). It happens whenever the deleted post is already in the channel's loaded pages: deleting a message you sent before the last time you opened the channel, or any message someone else deletes while you are in the channel. Deleting a message you just sent in the same visit does not show it, which is why it looked intermittent.

The cause is on the client's subscription decoding. The `/v4` `%channels` subscription encodes a deleted post as `%set` with a **tombstone object** (`type: 'tombstone'`), not `null` ([`channel-json.hoon#L216`](https://github.com/tloncorp/tlon-apps/blob/bba24ba12bb0a9473299d31d1655f679b14ef9f1/desk/lib/channel-json.hoon#L216), via `channel-response-5` / `r-channels-10` in [`channels.hoon#L81`](https://github.com/tloncorp/tlon-apps/blob/bba24ba12bb0a9473299d31d1655f679b14ef9f1/desk/app/channels.hoon#L81)). `toChannelsUpdate` only checked `set !== null`, so every delete was classified as `addPost`. `toPostData` builds a tombstone with `sentAt` derived from the post id (the host's receipt time) rather than `essay.sent` ([`postsApi.ts#L1288`](https://github.com/tloncorp/tlon-apps/blob/bba24ba12bb0a9473299d31d1655f679b14ef9f1/packages/api/src/client/postsApi.ts#L1288)), `handleAddPost` pushes it into the channel's in-memory `newPosts`, and `mergePendingPosts` dedupes `newPosts` against the loaded pages by `sentAt` ([`useMergePendingPosts.ts#L107`](https://github.com/tloncorp/tlon-apps/blob/bba24ba12bb0a9473299d31d1655f679b14ef9f1/packages/shared/src/store/useMergePendingPosts.ts#L107)). The two copies of the post have the same id and different `sentAt`, so both survive.

The ticket's "sentinel id ~2^127" is an ordinary post id: chat post ids are `@da` timestamps, which sit just above 2^127.

Linear: https://linear.app/tlon/issue/TLON-6178/deleting-a-chat-message-renders-duplicate-message-deleted-tombstones

## Changes

- `channelsApi.ts`: a `%set` whose value is a tombstone is now returned as the existing `deletePost` update for both top-level posts and replies, so it takes the `markPostAsDeleted` / `recomputeChannelLastPost` path in `handleChannelsUpdate` instead of `handleAddPost`. This is the same path the `null` encoding took before tombstones existed. For replies it also stops `handleAddPost` from bumping the parent's reply count for a tombstone it cannot match by cache id.
- `sync.ts`: the `deletePost` case in `handleChannelsUpdate` also calls `deleteFromChannelPosts`, the same overlay a local delete uses, so a channel whose loaded pages still hold the live copy filters the row when "Show deleted messages" is off instead of leaving a marker. Neither the old tombstone-as-`addPost` path nor a bare `markPostAsDeleted` reached that overlay.
- `sync.ts`: `notifyChannelPostListenersFromLatestChanges` sends tombstones to `deleteFromChannelPosts` instead of `addToChannelPosts`. The changes-since feed (`/changes`, used after a discontinuity or on resume) also carries tombstones, and that function forwarded them as new posts, which is the same path with the same `sentAt` mismatch. The tombstone row is still upserted by `insertChanges`.
- `subscriptions.ts`: `deleteFromChannelPosts` takes `Pick<db.Post, 'id'>`; it only ever read the id.
- `postsApi.ts`: export `isPostTombstone`.
- `urbit/channel.ts`: `PostResponse.set` and `ReplyResponse.set` include `PostTombstone`, matching what the backend sends.
- `channelsApi.test.ts`: tombstone `set` events for a post and for a reply decode to `deletePost` (both fail without the change), and a live post `set` still decodes to `addPost`. `changesPostListeners.test.ts`: a tombstone in the changes feed and a subscription `deletePost` update reach `deleteFromChannelPosts` and not `addToChannelPosts` (fail without the `sync.ts` changes).

## How did I test?

iOS simulator (iPhone 17, 26.5) and Android emulator, debug builds against a dev ship, "Show deleted messages" enabled in Settings > Appearance, in a throwaway solo group's chat channel.

Before, on both platforms: send a message, leave the channel, re-enter it, long-press the message, Delete message, confirm. Observed: the tombstone slot renders with a blank gap, the red error toast appears, and `stim logs --errors` shows `[legend-list] Error: Detected overlapping key (<post id>)`. The Android app, sitting in the same channel, also hit the error when the iOS side deleted a post.

After, same steps on both platforms: one "Message deleted" tombstone, no gap, no toast, nothing in `stim logs --errors`. Also checked that the other client in the same channel receives the delete cleanly, that deleting a reply from inside a thread renders a single tombstone (iOS only), that an Android client backgrounded with the channel mounted shows a single tombstone after the post is deleted from iOS and the app is foregrounded (the resume sync path), and that with "Show deleted messages" off an Android client sitting in the channel drops the row when iOS deletes it, with no marker left behind.

## Risks and impact

- Safe to rollback without consulting PR author? Yes
- Affects important code area:
  - [ ] Onboarding
  - [ ] State / providers
  - [x] Message sync
  - [x] Channel display
  - [ ] Notifications
  - [ ] Other:

Scope: decoding of group-channel post and reply delete events on the `/v4` channels subscription, and how those deletes and changes-feed tombstones reach the channel list's post listeners, all platforms (`packages/api` is shared). DMs and group DMs use `%chat` and are not touched.

What the old path did that the new one does not: `handleAddPost` upserted the tombstone as a row, which also rewrote the existing row's `sentAt` to the receipt time and nulled `syncedAt`, and pushed it into `newPosts`. `deletePost` only flips `isDeleted` on the local row, so a delete for a post the client never synced is a no-op until the next post sync, which returns tombstones with their sequence numbers. That matches the pre-tombstone behavior. `deletedAt` is no longer stored from the live event; nothing reads it.

Worst case if wrong: a delete arriving over the subscription is not reflected until the next sync of that channel's posts.

## Rollback plan

Revert the PR. No schema, migration, or settings change.

## Screenshots / videos

Before (iOS; opens on the chat list, enters the channel, deletes a message that was already loaded): 

https://github.com/user-attachments/assets/1b27cd39-c822-47cd-8913-94413b67703d

Before (Android; opens on the LogBox from the cross-client delete, then the send / leave / re-enter / delete flow): 

https://github.com/user-attachments/assets/e125f653-13da-42d5-8b30-ba81fb4c929a

After (iOS; re-enters the channel and deletes a message that was already loaded): 

https://github.com/user-attachments/assets/83f2d006-c0cf-4baf-860f-da169adc7f29

After (Android): 

https://github.com/user-attachments/assets/367ac1b6-80f0-4690-a462-53efc97d859f

