### PR TITLE
openclaw: state the owner-only policy in the blocked-tool reason

### DIFF
--- a/packages/openclaw/SECURITY.md
+++ b/packages/openclaw/SECURITY.md
@@ -378,21 +378,21 @@ try {
 | Scenario | Behavior |
 | -------- | -------- |
 | Owner uses restricted tool | ✅ Allowed |
-| Non-owner uses restricted tool | ❌ Blocked with error message |
+| Non-owner uses restricted tool (DM or group) | ❌ Blocked; the tool result tells the model the tool is owner-only and what to say |
 | Non-owner tricks LLM into using tool | ❌ Still blocked (hook-level enforcement) |
-| Internal session (heartbeat, cron) | ✅ Allowed (no role = not a user DM) |
+| Internal session (heartbeat, cron) | ✅ Allowed (no stored role = not a user-initiated turn) |
 
 **Implementation:**
-- `before_tool_call` hook intercepts calls to restricted tools
-- Checks SenderRole from session tracker
-- Only blocks when role is explicitly `"user"` (non-owner DM)
+- `before_tool_call` hook intercepts calls to restricted tools (policy in `src/owner-only-tools.ts`: `OWNER_ONLY_TOOLS`, `resolveOwnerOnlyToolBlock`)
+- Checks SenderRole from session tracker (stored the same way for DM and group senders)
+- Only blocks when role is explicitly `"user"` (a non-owner sender, DM or group)
 - Owner sessions (`"owner"`) and internal sessions (`undefined` role) are allowed
-- Returns `{ block: true }` for non-owner DM sessions
+- Returns `{ block: true, blockReason }`. OpenClaw core (verified on 2026.5.28 through 2026.8.2) hands `blockReason` to the model verbatim as the tool result, so the reason states the owner-only policy and tells the model what to say; the earlier `The X tool is not available.` led bots to invent reloads and outages (TLON-6363)
 
 **Critical Invariant:**
 
 ```
-Non-owner DM senders MUST NOT be able to use any restricted tools.
+Non-owner senders (DM or group) MUST NOT be able to use any restricted tools.
 This check is enforced at the plugin hook level and cannot be bypassed via prompt injection.
 ```
 
@@ -449,3 +449,4 @@ If you discover a security vulnerability:
 | 2026-02-11 | Added agent-initiated blocking via response directive |
 | 2026-02-12 | Added tool access control - tlon skill owner-only |
 | 2026-08-17 | Owner registered slash commands engage bare in any watched chat channel (§4) |
+| 2026-09-04 | Owner-only block reason states the policy so bots explain it correctly (TLON-6363) |

--- a/packages/openclaw/index.ts
+++ b/packages/openclaw/index.ts
@@ -61,6 +61,7 @@ import {
 } from './src/monitor/agent-onboarding.js';
 import { isRouteDebugEnabled } from './src/monitor/session-routing.js';
 import { setTlonRuntime } from './src/runtime.js';
+import { resolveOwnerOnlyToolBlock } from './src/owner-only-tools.js';
 import { getSessionRole } from './src/session-roles.js';
 import { parseTlonTarget } from './src/targets.js';
 import {
@@ -1007,14 +1008,14 @@ export default defineBundledChannelEntry({
     });
 
     // Tool access control: block sensitive tools for non-owners
-    const ownerOnlyTools = new Set(['tlon', 'cron', 'read']);
     const logToolTraceContents = liveToolTraceContentsEnabled();
 
     api.on('before_tool_call', async (event, ctx) => {
       const toolCallId = readToolCallId(event);
       const role = getSessionRole(ctx.sessionKey ?? '');
-      const isOwnerOnlyTool = ownerOnlyTools.has(event.toolName);
-      const blocksNonOwner = isOwnerOnlyTool && role === 'user';
+      const ownerOnlyDecision = resolveOwnerOnlyToolBlock(event.toolName, role);
+      const isOwnerOnlyTool = ownerOnlyDecision.ownerOnly;
+      const blocksNonOwner = ownerOnlyDecision.blocked;
       const isMcpDescribe = isMcpDescribeToolName(event.toolName);
       const isMcpCall = isMcpCallToolName(event.toolName);
       const isMcpTool = isMcpDescribe || isMcpCall;
@@ -1046,9 +1047,7 @@ export default defineBundledChannelEntry({
       const isBlocked = blocksNonOwner || blocksOnboardingMcp;
       const blockReason = blocksOnboardingMcp
         ? 'This scheduled onboarding update may inspect and call only selected-provider MCP tools explicitly described as read-only.'
-        : blocksNonOwner
-          ? `The ${event.toolName} tool is not available.`
-          : undefined;
+        : ownerOnlyDecision.reason;
       if (contextLensEnabled) {
         // Capture tool activity even when no conversation run owns this
         // session (cron wakes — including jobs that reuse the main session

--- a/packages/openclaw/src/monitor/index.ts
+++ b/packages/openclaw/src/monitor/index.ts
@@ -58,6 +58,7 @@ import {
 } from '../pending-nudge.js';
 import { emitTlonPluginErrorTelemetry } from '../plugin-error-observability.js';
 import { getTlonRuntime } from '../runtime.js';
+import { OWNER_ONLY_TOOLS } from '../owner-only-tools.js';
 import { setSessionRole } from '../session-roles.js';
 import {
   DM_INVITE_PREVIEW,
@@ -3082,7 +3083,7 @@ async function monitorTlonProviderScoped(opts: MonitorTlonOpts): Promise<void> {
         const currentLens = contextLenses.get(lens.lensId);
         contextLenses.update(lens.lensId, {
           tools: {
-            ownerOnlyAvailable: ['tlon', 'cron', 'read'],
+            ownerOnlyAvailable: [...OWNER_ONLY_TOOLS],
             called: currentLens?.tools.called ?? [],
             callCount: currentLens?.tools.callCount ?? 0,
             lastStartedAt: currentLens?.tools.lastStartedAt ?? null,

--- a/packages/openclaw/src/owner-only-tools.test.ts
+++ b/packages/openclaw/src/owner-only-tools.test.ts
@@ -1,0 +1,100 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  OWNER_ONLY_BLOCK_REASON_MAX_CHARS,
+  OWNER_ONLY_TOOLS,
+  formatOwnerOnlyToolBlockReason,
+  resolveOwnerOnlyToolBlock,
+} from './owner-only-tools.js';
+import type { SenderRole } from './session-roles.js';
+
+const EXPECTED_OWNER_ONLY_TOOLS = ['tlon', 'cron', 'read'] as const;
+
+describe('OWNER_ONLY_TOOLS', () => {
+  it('contains exactly the expected tools in advertised order', () => {
+    expect([...OWNER_ONLY_TOOLS]).toEqual([...EXPECTED_OWNER_ONLY_TOOLS]);
+  });
+});
+
+describe('resolveOwnerOnlyToolBlock', () => {
+  it.each(EXPECTED_OWNER_ONLY_TOOLS)(
+    'blocks %s for a non-owner user session with the policy reason',
+    (tool) => {
+      expect(resolveOwnerOnlyToolBlock(tool, 'user')).toEqual({
+        ownerOnly: true,
+        blocked: true,
+        reason: formatOwnerOnlyToolBlockReason(tool),
+      });
+    }
+  );
+
+  it.each(EXPECTED_OWNER_ONLY_TOOLS)(
+    'allows %s for the owner session',
+    (tool) => {
+      expect(resolveOwnerOnlyToolBlock(tool, 'owner')).toEqual({
+        ownerOnly: true,
+        blocked: false,
+      });
+    }
+  );
+
+  it.each(EXPECTED_OWNER_ONLY_TOOLS)(
+    'allows %s for internal sessions without a stored role',
+    (tool) => {
+      expect(resolveOwnerOnlyToolBlock(tool, undefined)).toEqual({
+        ownerOnly: true,
+        blocked: false,
+      });
+    }
+  );
+
+  it.each([['user'], ['owner'], [undefined]] as [SenderRole | undefined][])(
+    'does not treat web_search as owner-only for role %s',
+    (role) => {
+      expect(resolveOwnerOnlyToolBlock('web_search', role)).toEqual({
+        ownerOnly: false,
+        blocked: false,
+      });
+    }
+  );
+});
+
+describe('formatOwnerOnlyToolBlockReason', () => {
+  it.each(EXPECTED_OWNER_ONLY_TOOLS)(
+    'states the owner-only policy for %s',
+    (tool) => {
+      const reason = formatOwnerOnlyToolBlockReason(tool);
+      expect(reason.startsWith('Blocked by policy:')).toBe(true);
+      expect(reason).toContain(`the ${tool} tool is owner-only`);
+      expect(reason).toContain('not the owner');
+      expect(reason).toContain('Tell them you cannot do this for them');
+      expect(reason).toContain('do not retry for them');
+      expect(reason).toContain(
+        'do not blame a reload, outage, or missing tool'
+      );
+    }
+  );
+
+  it.each(EXPECTED_OWNER_ONLY_TOOLS)(
+    'never claims %s is "not available" (TLON-6363 regression guard)',
+    (tool) => {
+      expect(formatOwnerOnlyToolBlockReason(tool).toLowerCase()).not.toContain(
+        'not available'
+      );
+    }
+  );
+
+  it.each(EXPECTED_OWNER_ONLY_TOOLS)(
+    'keeps the %s reason on one line within the owner-notice cap',
+    (tool) => {
+      const reason = formatOwnerOnlyToolBlockReason(tool);
+      expect(reason).not.toMatch(/\r/);
+      expect(reason).not.toMatch(/\n/);
+      // Literal oracle: silent-failure-notice.ts MAX_ERROR_TEXT_LENGTH (the
+      // owner notice truncates the reason beyond this), kept independent of
+      // the module's own constant so both cannot drift together.
+      expect(OWNER_ONLY_BLOCK_REASON_MAX_CHARS).toBe(200);
+      expect(reason.length).toBeLessThanOrEqual(200);
+    }
+  );
+});

--- a/packages/openclaw/src/owner-only-tools.ts
+++ b/packages/openclaw/src/owner-only-tools.ts
@@ -1,0 +1,49 @@
+/**
+ * Owner-only tool policy shared by the before_tool_call gate (index.ts) and
+ * the ContextLens owner-tool advertisement (monitor/index.ts).
+ *
+ * The block reason is the ONLY text the model receives for a vetoed call:
+ * OpenClaw core (2026.5.28 through 2026.8.2) returns `blockReason` verbatim as
+ * a normal, non-error tool result with no framing. Observers (after_tool_call
+ * `event.error`, the owner "silent failure" notice) keep only its first line,
+ * capped at 400 / 200 chars — keep it one line and within the cap below.
+ */
+import type { SenderRole } from './session-roles.js';
+
+export const OWNER_ONLY_TOOLS: ReadonlySet<string> = new Set([
+  'tlon',
+  'cron',
+  'read',
+]);
+
+/** Longest first line the TLON-6361 owner notice shows untruncated. */
+export const OWNER_ONLY_BLOCK_REASON_MAX_CHARS = 200;
+
+export function formatOwnerOnlyToolBlockReason(toolName: string): string {
+  return (
+    `Blocked by policy: the ${toolName} tool is owner-only and this requester is not the owner. ` +
+    'Tell them you cannot do this for them; do not retry for them, and do not blame a reload, outage, or missing tool.'
+  );
+}
+
+export type OwnerOnlyToolDecision = {
+  /** The tool is in the owner-only set. */
+  ownerOnly: boolean;
+  /** Veto the call: owner-only tool and the session role is a non-owner user. */
+  blocked: boolean;
+  /** Model-facing reason; present iff `blocked`. */
+  reason?: string;
+};
+
+export function resolveOwnerOnlyToolBlock(
+  toolName: string,
+  role: SenderRole | undefined
+): OwnerOnlyToolDecision {
+  const ownerOnly = OWNER_ONLY_TOOLS.has(toolName);
+  // Only an explicit non-owner ('user') role blocks. Owner sessions and
+  // internal sessions (heartbeat, cron, subagents — no stored role) pass.
+  const blocked = ownerOnly && role === 'user';
+  return blocked
+    ? { ownerOnly, blocked, reason: formatOwnerOnlyToolBlockReason(toolName) }
+    : { ownerOnly, blocked };
+}

--- a/packages/openclaw/test/cases/04-security.test.ts
+++ b/packages/openclaw/test/cases/04-security.test.ts
@@ -22,6 +22,7 @@ import {
 } from '../lib/index.js';
 import { getLatestSequenceForAuthor } from '../lib/post-baseline.js';
 import { fakeModel } from '../support/fake-model/client.js';
+import { formatOwnerOnlyToolBlockReason } from '../../src/owner-only-tools.js';
 
 function sleep(ms: number): Promise<void> {
   return new Promise((resolve) => setTimeout(resolve, ms));
@@ -164,7 +165,8 @@ describe('security', () => {
 
       // Script the model to try the same tool call as the owner test, only
       // this time from ~mug. The plugin's before_tool_call gate should
-      // reject. Agent will likely emit a text refusal on the next turn.
+      // reject; the gate's block reason is asserted on the follow-up model
+      // call below. Agent will likely emit a text refusal on the next turn.
       const token = `mug-${Date.now().toString(36)}`;
       const key = 'sec-nonowner-tool';
       await fakeModel.script(key, [
@@ -189,6 +191,25 @@ describe('security', () => {
       const afterNickname = extractNickname(afterProfile);
       console.log(`[TEST] Bot nickname after: "${afterNickname}"`);
       expect(afterNickname).not.toBe(token);
+
+      // The block reason is the only thing the model learns about the veto:
+      // core returns it verbatim as the tool result. Find this test's tool
+      // call by its token, then the tool result the follow-up model call
+      // carried for it (the ~mug DM session is long-lived, so scope by id
+      // rather than scanning every tool message in history).
+      const calls = await fakeModel.received(key);
+      const messages = calls.flatMap((call) => call.messages ?? []);
+      const blockedCall = messages
+        .flatMap((message) => message.tool_calls ?? [])
+        .find((toolCall) => toolCall.function?.arguments?.includes(token));
+      expect(blockedCall?.id).toBeDefined();
+      const blockedResult = messages.find(
+        (message) =>
+          message.role === 'tool' && message.tool_call_id === blockedCall?.id
+      );
+      expect(blockedResult?.content?.text).toBe(
+        formatOwnerOnlyToolBlockReason('tlon')
+      );
     });
   });
 


### PR DESCRIPTION
## Summary

Non-owner requests blocked from the owner-only `tlon`, `cron`, or `read` tools now receive an explicit policy reason, with instructions to explain the denial without inventing outages or reload problems. OpenClaw core hands the hook's `blockReason` to the model verbatim as a plain, non-error tool result (verified on 2026.5.28 through 2026.8.2), and the old `The <tool> tool is not available.` led bots to confabulate: one told a group the upload tool "isn't exposed after the reload", another told a DM sender the Tlon CLI was unreachable. The restricted tools and the authorization rule are unchanged. Linear: https://linear.app/tlon/issue/TLON-6363

## Changes

- `packages/openclaw/src/owner-only-tools.ts` (new): the owner-only tool set, the role rule (only an explicit `user` role blocks; owner and role-less internal sessions pass), and the reason text, one line of 197 characters so it survives the first-line caps observers apply (core's `after_tool_call` error at 400, the owner "silent failure" notice at 200).
- `packages/openclaw/index.ts`: the `before_tool_call` gate takes its decision and reason from that module.
- `packages/openclaw/src/monitor/index.ts`: the ContextLens `ownerOnlyAvailable` advertisement reads the shared set.
- `packages/openclaw/test/cases/04-security.test.ts`: the non-owner case also asserts, scoped by `tool_call_id`, that the follow-up model call carried exactly the new reason.
- `packages/openclaw/SECURITY.md` §13: documents the reason and says "DM or group" where it said "DM", since group senders are gated identically.

Not included: no change to the gating rule or tool set, no prompt or tool-description changes, no Hermes change (its adapter already states its policy).

## How did I test?

- In `packages/openclaw`: `pnpm tsc`, `pnpm test` (1733 tests, including a new unit file pinning the tool set, role rule, and reason text) and `oxfmt --check` clean; no new `oxlint` warnings. Six mutations (old wording, flipped role rule, inserted newline, dropped `read`, reordered set, dropped instruction sentences) each fail the new unit file.
- Shared Docker e2e `04-security` (fake model, ephemeral fakezods): 11 passed, 1 skipped on OpenClaw 2026.5.28 (the image default) and again on 2026.7.1 (production). The shared compose passes no build args, so the 2026.7.1 run was made by temporarily setting the `OPENCLAW_CORE_VERSION` default in `packages/openclaw/dev/Dockerfile.test`; the image build logged `openclaw-core-version=2026.7.1`. That file is not part of this PR.
- The e2e checks the reason delivered to the model; the model's reply is scripted (`Tool rejected by policy.`), so real-model wording is not exercised. The case scripts a reply and therefore does not exercise the owner "silent failure" notice.

## Risks and impact

- Safe to rollback without consulting PR author? Yes
- Affects important code area:
  - [ ] Onboarding
  - [ ] State / providers
  - [ ] Message sync
  - [ ] Channel display
  - [ ] Notifications
  - [x] Other: OpenClaw bot plugin tool gate (model-facing text only)

Owner-visible surfaces (the Lens tool-run error and, on 2026.7.1 which counts a block as a tool error, the owner "silent failure" notice) now carry the longer reason.

## Rollback plan

Revert the merge commit. No config, data, or ship-side migration; the plugin reaches bots through the usual develop → master → fleet plugin refresh.

## Screenshots / videos

None.
