### PR TITLE
Keep the chat delivery indicator off grouped block content

### DIFF
--- a/packages/app/fixtures/ChatMessage.fixture.tsx
+++ b/packages/app/fixtures/ChatMessage.fixture.tsx
@@ -286,6 +286,11 @@ const PostVariantsFixture = ({ post }: { post: db.Post }) => {
             post={{ ...post, deliveryStatus: 'pending' }}
           />
           <PostSpecimen
+            label="Pending (showAuthor=false)"
+            post={{ ...post, deliveryStatus: 'pending' }}
+            showAuthor={false}
+          />
+          <PostSpecimen
             label="Failed (showAuthor=true)"
             post={{ ...post, deliveryStatus: 'failed' }}
             onPressRetry={async (p) => {

--- a/packages/app/ui/components/ChatMessage/StaticChatMessage.tsx
+++ b/packages/app/ui/components/ChatMessage/StaticChatMessage.tsx
@@ -160,6 +160,8 @@ export function StaticChatMessage({
     post.deliveryStatus === 'failed' ||
     post.editStatus === 'failed' ||
     post.deleteStatus === 'failed';
+  const activeDeliveryStatus =
+    post.deliveryStatus !== 'failed' ? post.deliveryStatus : null;
 
   const handleRepliesPressed = useCallback(() => {
     onPressReplies?.(post);
@@ -601,7 +603,7 @@ export function StaticChatMessage({
         />
       ) : null}
 
-      {!hideSentAtTimestamp && !showAuthor && (
+      {!hideSentAtTimestamp && !showAuthor && !activeDeliveryStatus && (
         <SentTimeText
           sentAt={post.sentAt}
           color="$tertiaryText"
@@ -611,15 +613,17 @@ export function StaticChatMessage({
         />
       )}
 
-      {!!post.deliveryStatus && post.deliveryStatus !== 'failed' ? (
+      {activeDeliveryStatus ? (
+        // Without an author row the top-right corner is the content itself
+        // (full-width images, videos, refs), so use the empty avatar gutter.
         <View
           pointerEvents="none"
           position="absolute"
-          right={12}
+          {...(showAuthor ? { right: 12 } : { left: 12 })}
           top={8}
           zIndex={199}
         >
-          <ChatMessageDeliveryStatus status={post.deliveryStatus} />
+          <ChatMessageDeliveryStatus status={activeDeliveryStatus} />
         </View>
       ) : null}
 


### PR DESCRIPTION
## Summary

A chat post that is grouped under a previous message from the same author has no author row, so the send-status chevrons (`>>`) that `StaticChatMessage` positions at the post's top-right corner land on the content itself. For text that corner is usually empty; for block-shaped content (images, videos, link previews, references) it is the media, which is what the ticket's screenshot shows. This moves the indicator into the empty avatar gutter for grouped posts and leaves it where it was for posts that have an author row.

Linear: https://linear.app/tlon/issue/TLON-5430/arrows-show-up-on-top-of-video-when-above-a-text-chat-message-from

## Changes

- `packages/app/ui/components/ChatMessage/StaticChatMessage.tsx`: the absolutely positioned `ChatMessageDeliveryStatus` wrapper now uses `left: 12` when `showAuthor` is false and keeps `right: 12` when it is true. The 48px (44px desktop) `$4xl` left padding on the content column is the avatar gutter, which is empty for grouped posts, so the 24px indicator sits beside the first line of content instead of on top of it. The gutter was the site of the web-only hover timestamp (`SentTimeText` at `left: 5, top: 12`), so that timestamp stays hidden while the indicator is showing rather than overlapping it.
- `packages/app/fixtures/ChatMessage.fixture.tsx`: adds a `Pending (showAuthor=false)` specimen to the `MessageStates` fixture next to the existing `Failed (showAuthor=false)` one, so the grouped case is visible in Cosmos.

The top-right placement for grouped posts dates from `7bb17497d1` (Feb 2025), when the author-row case still rendered the indicator inline in `AuthorRow`; `0cd43c90a5` (Mar 2026) then made the absolute view the only rendering for all posts. Both `StaticChatMessage` and the thread view share this component through `Scroller`, so the fix covers the main scroll and threads.

## How did I test?

Self-hosted dev ship, throwaway group "TLON-5430 repro", chat channel. Steps: send a text message, then attach an image from the media library and send it as the same author, so the image post is grouped (no author row).

- iOS Simulator (iPhone 17, iOS 26.5), debug build. Before: while the image post is in flight the `>>` renders over the image's top-right corner (`before-ios.mp4`, still below). After: the chevrons render in the gutter to the left of the image, and the image is untouched; a following grouped text post shows the indicator in the gutter next to the text (`after-ios.mp4`).
- Android emulator (API 35), `productionDebug`. Before: same overlay on the image's top-right corner (`before-android.mp4`, still below). After: indicator in the gutter, nothing on the image (`after-android.mp4`).

On a local ship the in-flight window is short (roughly half a second on iOS, a little longer on Android), so the stills below are frames from the recordings. Web was not exercised; the hover-timestamp change is web-only and was reviewed by reading `StaticChatMessage`.

## Risks and impact

- Safe to rollback without consulting PR author? Yes
- Affects important code area:
  - [ ] Onboarding
  - [ ] State / providers
  - [ ] Message sync
  - [x] Channel display
  - [ ] Notifications
  - [ ] Other:

Scope is the send-status indicator on chat and thread posts on all platforms. Worst case if the placement is wrong is a misplaced 24px glyph for the seconds a post is in flight; nothing about delivery itself changes. On web, the hover timestamp of a grouped post is suppressed while its `deliveryStatus` is `sent` or `needs_verification`, which can persist longer than the in-flight window (until the sequenced post replaces the local row, or while offline). The message-actions preview (`MessageContainer`) renders `StaticChatMessage` without `showAuthor`, so an in-flight post previewed there now shows the indicator in the gutter under the preview's own author row instead of over the content.

## Rollback plan

Revert the PR. No data, schema, or settings changes.

## Screenshots / videos

Before, iOS (grouped image post in flight):

![before-ios-inflight](https://github.com/user-attachments/assets/ac57e25c-ed2b-406d-807a-1893071604f3)

After, iOS:

![after-ios-inflight](https://github.com/user-attachments/assets/e4aad854-13e4-4020-a5a2-b47d63524523)

Before, Android:

![before-android-inflight](https://github.com/user-attachments/assets/8f4b4832-10ef-4db5-9c70-e65366cb6f4c)

After, Android:

![after-android-inflight](https://github.com/user-attachments/assets/8e4ec4cf-22b0-48f4-bff9-100aaac92cc4)

Recording, before, iOS:

https://github.com/user-attachments/assets/dca046ec-21c1-4d83-8fc3-42acfde72925

Recording, after, iOS:

https://github.com/user-attachments/assets/d9d63362-a918-4828-b1f8-37dc26479174

Recording, before, Android:

https://github.com/user-attachments/assets/13f35bf5-cabf-4baf-bedc-573dda33b6fd

Recording, after, Android:

https://github.com/user-attachments/assets/865c2c2a-5581-4bf8-b9bd-1a847b2263dd
