### PR TITLE
Sentry triage batch 2: scry error bodies, hosting status messages, notification payload shape

### DIFF
--- a/apps/tlon-mobile/src/hooks/useNotificationListener.ts
+++ b/apps/tlon-mobile/src/hooks/useNotificationListener.ts
@@ -92,6 +92,24 @@ function getNotificationType(data: ProcessableNotificationData) {
   return data.type ?? 'channelNotification';
 }
 
+// Shape-only description of a notification we failed to parse: which delivery
+// path it came in on, and which keys the payload carried. Key names only --
+// the values hold message content.
+function describeNotificationShape(notification: Notification) {
+  const { trigger } = notification.request;
+  const triggerType =
+    trigger != null &&
+    typeof trigger === 'object' &&
+    'type' in trigger &&
+    typeof trigger.type === 'string'
+      ? trigger.type
+      : 'none';
+  return {
+    notificationTrigger: triggerType,
+    payloadKeys: Object.keys(readRawPayload(notification)).sort().join(','),
+  };
+}
+
 export function getNotificationRouteCategory(
   data: ProcessableNotificationData
 ) {
@@ -200,6 +218,7 @@ export default function useNotificationListener() {
             context: 'Failed to get notification payload',
             properties: {
               notificationType: data?.type ?? 'null',
+              ...describeNotificationShape(notificationResponse.notification),
             },
           });
         } else {

--- a/packages/api/src/__tests__/scryErrorBody.test.ts
+++ b/packages/api/src/__tests__/scryErrorBody.test.ts
@@ -1,0 +1,90 @@
+import { afterEach, describe, expect, test, vi } from 'vitest';
+
+import {
+  BadResponseError,
+  internalConfigureClient,
+  internalRemoveClient,
+  scry,
+  scryNoun,
+} from '../client/urbit';
+
+// The airlock rejects a failed scry with the `Response` itself, whose
+// `toString()` is the literal `[object Response]`. These cover the message the
+// wrapper builds from it (JAVASCRIPT-REACT-1M and friends).
+function fakeClient(overrides: Record<string, unknown> = {}) {
+  return {
+    delete: vi.fn(),
+    on: vi.fn(),
+    ...overrides,
+  };
+}
+
+function configure(client: Record<string, unknown>) {
+  internalConfigureClient({
+    shipName: '~zod',
+    shipUrl: 'http://example.test',
+    client: client as any,
+  });
+}
+
+afterEach(() => {
+  internalRemoveClient();
+});
+
+describe('scry error bodies', () => {
+  test('a failed scry reports the status and the response body', async () => {
+    configure(
+      fakeClient({
+        scryWithInfo: vi
+          .fn()
+          .mockRejectedValue(
+            new Response('gall: agent not running', { status: 503 })
+          ),
+      })
+    );
+
+    const rejection = (await scry({
+      app: 'groups',
+      path: '/v1/groups',
+    }).catch((e) => e)) as BadResponseError;
+
+    expect(rejection).toBeInstanceOf(BadResponseError);
+    expect(rejection.message).toBe('HTTP 503: gall: agent not running');
+    expect(rejection.message).not.toContain('[object Response]');
+    expect(rejection.status).toBe(503);
+  });
+
+  test('a failed scryNoun reports the status and the response body', async () => {
+    configure(
+      fakeClient({
+        scryNounWithInfo: vi
+          .fn()
+          .mockRejectedValue(new Response('no such path', { status: 404 })),
+      })
+    );
+
+    const rejection = (await scryNoun({
+      app: 'lanyard',
+      path: '/v1/records',
+    }).catch((e) => e)) as BadResponseError;
+
+    expect(rejection).toBeInstanceOf(BadResponseError);
+    expect(rejection.message).toBe('HTTP 404: no such path');
+    expect(rejection.message).not.toContain('[object Response]');
+    expect(rejection.status).toBe(404);
+  });
+
+  test('an empty error body leaves the status as the whole message', async () => {
+    configure(
+      fakeClient({
+        scryWithInfo: vi
+          .fn()
+          .mockRejectedValue(new Response('', { status: 502 })),
+      })
+    );
+
+    await expect(
+      scry({ app: 'groups', path: '/v1/groups' })
+    ).rejects.toMatchObject({ status: 502, message: 'HTTP 502' });
+  });
+});

--- a/packages/api/src/__tests__/urbitRequestTimeout.test.ts
+++ b/packages/api/src/__tests__/urbitRequestTimeout.test.ts
@@ -1,5 +1,11 @@
-import { describe, expect, it } from 'vitest';
+import { afterEach, describe, expect, it, vi } from 'vitest';
 
+import {
+  internalConfigureClient,
+  internalRemoveClient,
+  scry,
+  scryNoun,
+} from '../client/urbit';
 import { ThreadResponseBodyError, Urbit } from '../http-api/Urbit';
 
 // Mimics real fetch behavior for a response whose headers arrive but whose
@@ -22,6 +28,16 @@ function stalledBodyFetch(status = 200): typeof fetch {
       headers: { 'content-type': 'application/json' },
     });
   };
+}
+
+// Stalls only the scry itself, so tearing the client down (which POSTs a
+// channel delete) doesn't hit the stalled response too.
+function stalledScryFetch(status: number): typeof fetch {
+  const stalled = stalledBodyFetch(status);
+  return async (input: any, init?: any) =>
+    String(input).includes('/~/scry/')
+      ? stalled(input, init)
+      : new Response('', { status: 200 });
 }
 
 function completingFetch(body: string): typeof fetch {
@@ -111,5 +127,57 @@ describe('Urbit request timeouts cover the response body read', () => {
   it('request rejects when the response body stalls after headers', async () => {
     const client = new Urbit('', undefined, 'groups', stalledBodyFetch());
     await expect(client.request('/some/path', {}, 50)).rejects.toThrow();
+  });
+});
+
+describe('the client wrapper bounds its diagnostic error-body read', () => {
+  afterEach(() => {
+    internalRemoveClient();
+    vi.useRealTimers();
+  });
+
+  // The status arrives with the headers, but `scryWithInfo` disarms the
+  // request's timeout in its `finally` before the rejection reaches the
+  // wrapper -- so reading the body for the error message has to carry its own
+  // deadline, or a stalled error body hangs a scry that has already failed.
+  function configureStalledClient(status: number) {
+    vi.useFakeTimers();
+    internalConfigureClient({
+      shipName: '~zod',
+      shipUrl: '',
+      client: new Urbit('', undefined, 'groups', stalledScryFetch(status)),
+    });
+  }
+
+  it('scry rejects with the status when the error body stalls', async () => {
+    configureStalledClient(503);
+
+    const rejection = scry({
+      app: 'groups',
+      path: '/v3/groups',
+      timeout: 10,
+    }).catch((e) => e);
+    await vi.advanceTimersByTimeAsync(30_000);
+
+    await expect(rejection).resolves.toMatchObject({
+      status: 503,
+      message: 'HTTP 503',
+    });
+  });
+
+  it('scryNoun rejects with the status when the error body stalls', async () => {
+    configureStalledClient(504);
+
+    const rejection = scryNoun({
+      app: 'lanyard',
+      path: '/v1/records',
+      timeout: 10,
+    }).catch((e) => e);
+    await vi.advanceTimersByTimeAsync(30_000);
+
+    await expect(rejection).resolves.toMatchObject({
+      status: 504,
+      message: 'HTTP 504',
+    });
   });
 });

--- a/packages/api/src/client/hostingApi.test.ts
+++ b/packages/api/src/client/hostingApi.test.ts
@@ -1,12 +1,15 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 import {
+  HostingError,
   completeTlawnLLMAuth,
   configureHostingSessionStore,
   deleteTlawnProviderKey,
   disconnectTlawnLLMAuth,
+  getTlawnBotInfo,
   getTlawnLLMAuthFlow,
   getTlawnLLMAuthStatus,
+  getTlawnNickname,
   getTlawnOpenRouterRecommendedModels,
   getTlawnOpenRouterZdrEndpoints,
   startTlawnLLMAuth,
@@ -229,5 +232,91 @@ describe('Tlawn provider auth', () => {
       'https://hosting.test/v1/tlawn/users/user-1/openrouter/recommended-models',
       'https://hosting.test/v1/tlawn/users/user-1/openrouter/zdr-endpoints',
     ]);
+  });
+});
+
+describe('hosting error reporting', () => {
+  beforeEach(() => {
+    vi.restoreAllMocks();
+    vi.stubGlobal('window', undefined);
+    vi.stubGlobal('tlonEnv', {
+      API_URL: 'https://hosting.test',
+      API_AUTH_USERNAME: undefined,
+      API_AUTH_PASSWORD: undefined,
+    });
+    configureHostingSessionStore({
+      authToken: {
+        getValue: async () => 'session=abc; HttpOnly;',
+        setValue: async () => undefined,
+      },
+    });
+  });
+
+  it('reports a rejected request by its status, not as a parse failure', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi
+        .fn()
+        .mockResolvedValue(
+          new Response('', { status: 401, statusText: 'Unauthorized' })
+        )
+    );
+
+    const rejection = await getTlawnBotInfo('~zod').catch((e) => e);
+
+    expect(rejection).toBeInstanceOf(HostingError);
+    expect(rejection.message).toBe('Hosting request failed (401 Unauthorized)');
+    expect(rejection.details).toMatchObject({ status: 401 });
+  });
+
+  it("keeps hosting's own error message when the body carries one", async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockResolvedValue(
+        new Response(JSON.stringify({ message: 'node is booting' }), {
+          status: 409,
+          headers: { 'Content-Type': 'application/json' },
+        })
+      )
+    );
+
+    const rejection = await getTlawnBotInfo('~zod').catch((e) => e);
+
+    expect(rejection.message).toBe('node is booting');
+    expect(rejection.details).toMatchObject({ status: 409 });
+  });
+
+  it('still reports an unparseable success body as a parse failure', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockResolvedValue(new Response('<html>', { status: 200 }))
+    );
+
+    const rejection = await getTlawnBotInfo('~zod').catch((e) => e);
+
+    expect(rejection.message).toBe('Failed to parse response');
+    expect(rejection.details).toMatchObject({
+      status: 200,
+      responseText: '<html>',
+    });
+  });
+
+  it('carries the status in the nullable-string fallback message', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi
+        .fn()
+        .mockResolvedValue(
+          new Response('', { status: 404, statusText: 'Not Found' })
+        )
+    );
+
+    const rejection = await getTlawnNickname('~zod').catch((e) => e);
+
+    expect(rejection).toBeInstanceOf(HostingError);
+    expect(rejection.message).toBe(
+      'An unknown error has occurred. (404 Not Found)'
+    );
+    expect(rejection.details).toMatchObject({ status: 404 });
   });
 });

--- a/packages/api/src/client/hostingApi.ts
+++ b/packages/api/src/client/hostingApi.ts
@@ -138,6 +138,19 @@ const EXPECTED_ERRORS = [ALREADY_IN_USE, CANNOT_BOOT, RATE_LIMITED];
 
 const MANUAL_UPDATE_REQUIRED_MESSAGE = 'manual update has been requested';
 
+// `401`, or `401 Unauthorized` when the server sent a reason phrase. Used in
+// error messages so a rejected session reads differently from a hosting
+// outage. This is for diagnosis only -- Sentry groups on the stack first, so
+// it is not a guarantee that different statuses land in different issues.
+function statusLabel(response: {
+  status: number;
+  statusText?: string;
+}): string {
+  return response.statusText
+    ? `${response.status} ${response.statusText}`
+    : String(response.status);
+}
+
 const hostingFetchResponse = async (
   path: string,
   init?: RequestInit
@@ -206,27 +219,28 @@ const hostingFetch = async <T extends object>(
   const stopTime = performance.now();
   const responseText = await response.text();
 
+  // Parse before checking `ok`, but only to recover hosting's own error
+  // `message`: a rejected request is reported as the status it is. Hosting
+  // answers an expired session with a 401 and an empty body, which the old
+  // parse-first order reported as `Failed to parse response`.
   let result: { message: string } | T = { message: 'Empty response' };
+  let parsed = true;
   try {
     result = JSON.parse(responseText) as { message: string } | T;
-  } catch (e) {
-    const hostingErr = new HostingError('Failed to parse response', {
-      method: init?.method ?? 'GET',
-      path,
-      status: response.status,
-      responseText,
-    });
-    logger.trackEvent(AnalyticsEvent.UnexpectedHostingError, {
-      details: hostingErr.details,
-      errorMessage: hostingErr.message,
-      errorStack: hostingErr.stack,
-    });
-    throw hostingErr;
+  } catch {
+    parsed = false;
   }
 
   if (!response.ok) {
+    const bodyMessage =
+      parsed &&
+      typeof result === 'object' &&
+      result !== null &&
+      'message' in result
+        ? String(result.message)
+        : null;
     const err = new HostingError(
-      'message' in result ? result.message : 'An unknown error has occurred.',
+      bodyMessage ?? `Hosting request failed (${statusLabel(response)})`,
       {
         method: init?.method ?? 'GET',
         path,
@@ -242,6 +256,21 @@ const hostingFetch = async <T extends object>(
       errorStack: err.stack,
     });
     throw err;
+  }
+
+  if (!parsed) {
+    const hostingErr = new HostingError('Failed to parse response', {
+      method: init?.method ?? 'GET',
+      path,
+      status: response.status,
+      responseText,
+    });
+    logger.trackEvent(AnalyticsEvent.UnexpectedHostingError, {
+      details: hostingErr.details,
+      errorMessage: hostingErr.message,
+      errorStack: hostingErr.stack,
+    });
+    throw hostingErr;
   }
 
   try {
@@ -604,7 +633,7 @@ async function fetchNullableString(
     const message =
       parsed && typeof parsed === 'object' && 'message' in parsed
         ? String((parsed as { message: unknown }).message)
-        : 'An unknown error has occurred.';
+        : `An unknown error has occurred. (${statusLabel(response)})`;
     const err = new HostingError(message, {
       method: init?.method ?? 'GET',
       path,

--- a/packages/api/src/client/urbit.ts
+++ b/packages/api/src/client/urbit.ts
@@ -1088,7 +1088,7 @@ export async function scry<T>({
       errorMessage: res.message,
       responseStatus: res.status,
     });
-    throw new BadResponseError(res.status, res.toString());
+    throw new BadResponseError(res.status, await responseErrorBody(res));
   }
 }
 
@@ -1139,10 +1139,17 @@ export async function requestJson<T = any>(
   }
 }
 
+// Reading a rejected response's body is purely diagnostic, and the request's
+// own timeout is already disarmed by the time the rejection reaches us
+// (`scryWithInfo` cleans its signal up in a `finally`), so an unbounded read
+// would hang a scry that had already failed. Give the read its own deadline
+// and settle for an empty body when it expires.
+const ERROR_BODY_READ_TIMEOUT = 5000;
+
 async function responseErrorBody(res: any): Promise<string> {
   if (typeof res?.text === 'function') {
     try {
-      return await res.text();
+      return await readWithin(res.text(), ERROR_BODY_READ_TIMEOUT);
     } catch {
       // Fall through to the generic cases below.
     }
@@ -1151,6 +1158,17 @@ async function responseErrorBody(res: any): Promise<string> {
   if (typeof res?.message === 'string') return res.message;
   const text = String(res);
   return text === '[object Response]' ? '' : text;
+}
+
+// Resolves with whatever `read` produces, or with an empty body once `ms`
+// elapses. The abandoned read stays attached to the race, so a late rejection
+// is never unhandled.
+function readWithin(read: Promise<string>, ms: number): Promise<string> {
+  let timer: ReturnType<typeof setTimeout> | undefined;
+  const deadline = new Promise<string>((resolve) => {
+    timer = setTimeout(() => resolve(''), ms);
+  });
+  return Promise.race([read, deadline]).finally(() => clearTimeout(timer));
 }
 
 export async function scryNoun({
@@ -1197,7 +1215,7 @@ export async function scryNoun({
       message: res.message,
       responseStatus: res.status,
     });
-    throw new BadResponseError(res.status, res.toString());
+    throw new BadResponseError(res.status, await responseErrorBody(res));
   }
 }
 

--- a/packages/shared/src/errorReporting.test.ts
+++ b/packages/shared/src/errorReporting.test.ts
@@ -814,6 +814,8 @@ const MUST_MATCH = [
   'BadResponseError: HTTP request failed: Error: fetch failed: java.net.UnknownHostException: Unable to resolve host "www.burtonjernigan.org": No address associated with hostname',
   'Error: fetch failed: UnexpectedException: The request timed out. (at ExpoModulesCore/Promise.swift:56)',
   'Error: fetch failed: The request timed out.',
+  'Error: fetch failed: UnexpectedException: Could not connect to the server. (at ExpoModulesCore/Promise.swift:56)',
+  'Error: fetch failed: Could not connect to the server.',
 ];
 
 const MUST_NOT_MATCH = [
@@ -838,12 +840,15 @@ const MUST_NOT_MATCH = [
   'Error: discarded fetched data, had been running for 1271371ms',
   '[query] Database Query Error',
   'BadResponseError: HTTP 404: [object Response]',
+  'BadResponseError: HTTP 503: gall: agent not running',
+  'HostingError: Hosting request failed (401 Unauthorized)',
+  'HostingError: An unknown error has occurred. (404 Not Found)',
   'Error: Urbit client not set.',
 ];
 
 describe('SENTRY_IGNORE_ERRORS', () => {
   it('builds one regex per body', () => {
-    expect(SENTRY_IGNORE_ERRORS).toHaveLength(15);
+    expect(SENTRY_IGNORE_ERRORS).toHaveLength(16);
   });
 
   it.each(MUST_MATCH)('matches %s', (message) => {

--- a/packages/shared/src/errorReporting.ts
+++ b/packages/shared/src/errorReporting.ts
@@ -520,6 +520,7 @@ const REGEX_IGNORE_BODIES = [
   'fetch failed: (?:UnexpectedException: )?The network connection was lost\\.(?: \\([^)]*\\))?',
   'fetch failed: java\\.net\\.UnknownHostException: Unable to resolve host "[^"]*"(?:: No address associated with hostname)?',
   'fetch failed: (?:UnexpectedException: )?The request timed out\\.(?: \\([^)]*\\))?',
+  'fetch failed: (?:UnexpectedException: )?Could not connect to the server\\.(?: \\([^)]*\\))?',
 ];
 
 const IGNORE_BODIES = [


### PR DESCRIPTION
## Summary

Second batch of independent fixes from a Sentry triage pass, following #6504. Each one takes an error report that carried no usable detail (`[object Response]`, `Failed to parse response`, a bare `Unrecognized notification`) and gives it the status, body, or payload shape needed to tell the cases apart, plus one transient iOS network body added to the ignore list.

## Changes

**`packages/api/src/client/urbit.ts`**

- `scry` and `scryNoun` now build their `BadResponseError` message from the existing `responseErrorBody` helper instead of `res.toString()`, which reported every non-2xx as `HTTP <n>: [object Response]`.
- `responseErrorBody` bounds the body read to 5 seconds. The read is diagnostic only and the request's own timeout is already cleared by the time a rejection reaches the wrapper, so a stalled error body would otherwise hang a scry that had already failed. On expiry the read resolves empty and the status still surfaces.

**`packages/api/src/client/hostingApi.ts`**

- `hostingFetch` checks `response.ok` before deciding what to throw. It still parses first so hosting's own body `message` wins when there is one, and otherwise throws `Hosting request failed (<status> <statusText>)`. `Failed to parse response` is now reserved for a 2xx body that will not parse, which is what it was meant to describe.
- `fetchNullableString`'s unknown-error fallback carries the status label. A shared `statusLabel` helper serves both call sites.

**`packages/shared/src/errorReporting.ts`**

- Adds the transient iOS `Could not connect to the server.` body to `REGEX_IGNORE_BODIES`, matching the three sibling network bodies already there.

**`apps/tlon-mobile/src/hooks/useNotificationListener.ts`**

- The `Unrecognized notification` report records the delivery trigger type and the sorted payload key names. Key names only, since the values hold message content.

## How did I test?

- New `packages/api/src/__tests__/scryErrorBody.test.ts`, new stalled-error-body cases in `urbitRequestTimeout.test.ts`, four new cases in `hostingApi.test.ts`, and corpus updates in `errorReporting.test.ts` covering the new ignore body and the new message shapes.
- Ran `packages/api` vitest (937 passed), shared `errorReporting` (140 passed), mobile jest (24 passed), `pnpm -r tsc`, and `pnpm format:check`.

## Risks and impact

- Safe to rollback without consulting PR author? Yes
- Hosting fallback strings that reach onboarding and settings screens change from `Failed to parse response` and `An unknown error has occurred.` to status-bearing text. Messages hosting supplies itself are unchanged.
- Empty-bodied 409 and 429 hosting responses now route through the expected-error analytics path rather than being counted as parse failures, so the parse-failure volume in analytics should drop.
- Affects important code area:
  - [x] Onboarding
  - [ ] State / providers
  - [x] Message sync
  - [ ] Channel display
  - [x] Notifications

## Rollback plan

Revert the PR and deploy. No migrations, no config or feature flags, and no persisted state involved.

## Screenshots / videos

n/a
