### PR TITLE
channels: stop downgrading said reacts to shortcodes

### DIFF
--- a/desk/lib/channel-utils.hoon
+++ b/desk/lib/channel-utils.hoon
@@ -334,23 +334,25 @@
   ::  remove .seq and .mod-at
   [- |3]:seal
 ::
+::  NOTE  v9 and later carry reacts as unicode glyphs, so .reacts passes
+::        through untouched here. only +s-post-1 and +s-post-2 downgrade to
+::        v7 shortcodes, because their output types really are v7/v8.
+::
 ++  s-post-3
   |=  =post:v9:cv
   ~>  %spin.['libcu-s-post-3']
   ^-  simple-post:v9:cv
   :_  +>.post
   %=  -.post
-    reacts   (v7:reacts:v9:ccv reacts.post)
     replies  (s-replies-3 replies.post)
   ==
 ::
 ++  s-post-4
   |=  =post:v10:cv
-  ~>  %spin.['libcu-s-post-3']
+  ~>  %spin.['libcu-s-post-4']
   ^-  simple-post:v10:cv
   :_  +>.post
   %=  -.post
-    reacts   (v7:reacts:v9:ccv reacts.post)
     replies  (s-replies-4 replies.post)
   ==
 ++  suv-post
@@ -904,7 +906,11 @@
     ?~  reply
       &+[*reply-seal:c ~[%inline 'Unknown comment']~ ~nul *@da]
     ?:  ?=(%| -.u.reply)  u.reply
-    &+(suv-reply-2 p.plan +.u.reply)
+    ::  NOTE  +suv-reply-2 is the v8 builder; its output nests here because
+    ::        v8 and v9 $memo are identical, but it downgrades reacts to v7
+    ::        shortcodes. v9 wants glyphs, so use the v9 builder.
+    ::
+    &+(suv-reply-3 p.plan +.u.reply)
   [%channel-said-2 !>(`said:v9:cv`[nest %reply p.plan reply])]
 ++  said-4
   |=  [=nest:c =plan:c posts=v-posts:c]

--- a/desk/tests/lib/channel-utils.hoon
+++ b/desk/tests/lib/channel-utils.hoon
@@ -1,0 +1,103 @@
+::  channel-utils unit tests
+::
+::    covers the $said builders behind the /vN/said post-reference endpoints
+::    (TLON-6536). hosts store reacts as unicode glyphs, and the v9/v10 output
+::    types carry them as-is. the builders used to run post reacts through the
+::    v7 shortcode conversion anyway; a `:laughing:` shortcode is a valid @t so
+::    the output cast never caught it. these lock in glyph passthrough for both
+::    the v4 (said-3) and v5 (said-4) builders, for posts and replies.
+::
+/-  c=channels, cv=channels-ver
+/+  *test, utils=channel-utils
+|%
+++  the-nest  `nest:c`[%chat ~zod %test]
+++  post-id   `id-post:c`~2026.1.1
+++  reply-id  `id-reply:c`~2026.1.2
+++  glyph     '😆'
+::  +the-reacts: the one react as every v9+ consumer should see it
+::
+++  the-reacts    `reacts:c`(my ~[[~bus glyph]])
+++  the-v-reacts  `v-reacts:c`(my ~[[~bus [0 `glyph]]])
+++  the-memo      `memo:c`[~[[%inline ~['hi']]] ~zod post-id]
+++  the-v-reply
+  ^-  v-reply:c
+  :-  [reply-id the-v-reacts]
+  [0 the-memo ~]
+++  the-v-post
+  ^-  v-post:c
+  :-  :*  post-id
+          1
+          post-id
+          (gas:on-v-replies:c *v-replies:c ~[[reply-id &+the-v-reply]])
+          the-v-reacts
+      ==
+  [0 the-memo /chat ~ ~]
+++  the-posts
+  ^-  v-posts:c
+  (gas:on-v-posts:c *v-posts:c ~[[post-id &+the-v-post]])
+::  +post-reacts-4 / +reply-reacts-4: pull reacts off a v10 $said
+::
+++  post-reacts-4
+  |=  =said:c
+  ^-  reacts:c
+  ?>  ?=(%post -.q.said)
+  ?>  ?=(%& -.post.q.said)
+  reacts.+.post.q.said
+++  reply-reacts-4
+  |=  =said:c
+  ^-  reacts:c
+  ?>  ?=(%reply -.q.said)
+  ?>  ?=(%& -.reply.q.said)
+  reacts.+.reply.q.said
+::  +post-reacts-3 / +reply-reacts-3: pull reacts off a v9 $said
+::
+++  post-reacts-3
+  |=  =said:v9:cv
+  ^-  reacts:c
+  ?>  ?=(%post -.q.said)
+  ?>  ?=(%& -.post.q.said)
+  reacts.+.post.q.said
+++  reply-reacts-3
+  |=  =said:v9:cv
+  ^-  reacts:c
+  ?>  ?=(%reply -.q.said)
+  ?>  ?=(%& -.reply.q.said)
+  reacts.+.reply.q.said
+::  /v5/said: post reacts stay unicode
+::
+++  test-said-4-post-reacts-stay-unicode
+  =/  =cage  (said-4:utils the-nest [post-id ~] the-posts)
+  =/  =said:c  !<(said:c q.cage)
+  ;:  weld
+    (expect-eq !>(%channel-said-3) !>(p.cage))
+    (expect-eq !>(the-nest) !>(p.said))
+    (expect-eq !>(the-reacts) !>((post-reacts-4 said)))
+  ==
+::  /v5/said: reply reacts stay unicode
+::
+++  test-said-4-reply-reacts-stay-unicode
+  =/  =cage  (said-4:utils the-nest [post-id `reply-id] the-posts)
+  =/  =said:c  !<(said:c q.cage)
+  ;:  weld
+    (expect-eq !>(%channel-said-3) !>(p.cage))
+    (expect-eq !>(the-reacts) !>((reply-reacts-4 said)))
+  ==
+::  /v4/said: post reacts stay unicode
+::
+++  test-said-3-post-reacts-stay-unicode
+  =/  =cage  (said-3:utils the-nest [post-id ~] the-posts)
+  =/  =said:v9:cv  !<(said:v9:cv q.cage)
+  ;:  weld
+    (expect-eq !>(%channel-said-2) !>(p.cage))
+    (expect-eq !>(the-reacts) !>((post-reacts-3 said)))
+  ==
+::  /v4/said: reply reacts stay unicode
+::
+++  test-said-3-reply-reacts-stay-unicode
+  =/  =cage  (said-3:utils the-nest [post-id `reply-id] the-posts)
+  =/  =said:v9:cv  !<(said:v9:cv q.cage)
+  ;:  weld
+    (expect-eq !>(%channel-said-2) !>(p.cage))
+    (expect-eq !>(the-reacts) !>((reply-reacts-3 said)))
+  ==
+--


### PR DESCRIPTION
## Summary

Post references fetched through `/v4/said` and `/v5/said` returned emoji reactions as shortcodes (`:laughing:`) even though hosts store them as unicode glyphs. The desk was manufacturing the shortcodes on the way out; no client was ever sending them. This is the source of the read-side "shortcode reaction detected" probes that have been firing since v11.0.0.

Fixes TLON-6536.

## Changes

`desk/lib/channel-utils.hoon`:

- `+s-post-3` and `+s-post-4` rebuilt the seal with `(v7:reacts:v9:ccv reacts.post)`, running every glyph through emojimart's unicode-to-shortcode map. The v9/v10 output types carry reacts as glyphs, so the conversion was simply wrong here. A shortcode is a valid `@t` and nests under the current react type, so the `^- simple-post:v9/v10:cv` cast never caught it. Both now pass `.reacts` through untouched. `+s-post-1` and `+s-post-2` keep the conversion, since their output types really are v7/v8.
- `+said-3` built its reply half with `+suv-reply-2`, the **v8** builder. Its output nests here because v8 and v9 `$memo` are identical (the v9-to-v8 memo conversion is the identity), but it applied the same shortcode downgrade. It now uses `+suv-reply-3`. `+said-4` already used the right builder, so v5 reply reacts were never affected.
- Fixed a copy-paste `%spin` label on `+s-post-4`.

`desk/tests/lib/channel-utils.hoon` (new): covers glyph passthrough for posts and replies across both builders. Nothing under `desk/tests/` exercised `said-N` before this.

Note that `+s-post-3` / `+s-post-4` also feed the v4/v5 heads, changes and init-posts endpoints, which were emitting shortcodes for the same reason. Those are corrected by the same change.

## How did I test?

Built and ran on `~ticpen-todtyn-nocsyx-lassul`, using a throwaway empty-bill desk so the moon's `%groups` was untouched.

Before the change, three of the four new tests fail with exactly the reported symptom:

```
FAILED  test-said-4-post-reacts-stay-unicode   expected '😆', actual ':laughing:'
FAILED  test-said-3-post-reacts-stay-unicode   expected '😆', actual ':laughing:'
FAILED  test-said-3-reply-reacts-stay-unicode  expected '😆', actual ':laughing:'
OK      test-said-4-reply-reacts-stay-unicode
```

After the change all four pass. The full desk suite is 276 passing. One unrelated test, `/tests/app/logs/test-log-fail`, fails both before and after; it compares a build commit string (`60a6b8429` vs `development`) and is independent of this change.

## Risks and impact

- Safe to rollback without consulting PR author? Yes
- Affects important code area:
  - [ ] Onboarding
  - [ ] State / providers
  - [ ] Message sync
  - [x] Channel display
  - [ ] Notifications
  - [x] Other: post references / quotes, and the v4/v5 heads, changes and init-posts endpoints

Reactions already stored client-side as shortcodes are unaffected by this and will keep rendering; the UI maps shortcodes back to emoji. This only stops new responses from carrying them. Client-side cleanup of already-stored values is a separate follow-up on the ticket.

## Rollback plan

Revert the commit. No state migration is involved, and the wire types are unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)