### PR TITLE
Add a static desk N-1 compatibility checker and CI gate

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -97,8 +97,29 @@ jobs:
       - name: Check Types
         run: pnpm -r tsc
 
+      # Desk N-1 compatibility (docs/tlon-apps/desk-compatibility.md). A
+      # depth-1 checkout has no tags and no history, so the checker's refs are
+      # fetched narrowly rather than by deepening the whole clone: the N-1 tag
+      # named by MIN_GROUPS_VERSION, plus the two refs the incident fixtures
+      # replay (kept in sync with fixtures.test.ts; the fixtures also fetch
+      # them on demand, so a drift here costs a slower failure, not a wrong
+      # one).
+      - name: Fetch desk refs for the compatibility check
+        run: |
+          set -euo pipefail
+          MIN=$(node -p "require('fs').readFileSync('packages/shared/src/logic/deskCompatibility.ts','utf8').match(/MIN_GROUPS_VERSION = '([^']+)'/)[1]")
+          echo "MIN_GROUPS_VERSION=$MIN" >> "$GITHUB_ENV"
+          git fetch --no-tags --depth=1 origin "refs/tags/v${MIN}:refs/tags/v${MIN}"
+          git fetch --no-tags --depth=1 origin "refs/tags/v12.1.0:refs/tags/v12.1.0"
+          git fetch --no-tags --depth=1 origin 854b46c3ddd7ccf122485dd447a1225da7a66638
+
       - name: Run Tests
         run: pnpm test:ci
+
+      # Rule (b): this branch may not depend on anything the previous desk
+      # release lacks. Blocking, and inside ci-ok by way of test-build.
+      - name: Check desk N-1 compatibility
+        run: pnpm check:desk-compat --desk-ref "v${MIN_GROUPS_VERSION}"
 
       - name: tlon-skill build smoke
         run: pnpm --filter '@tloncorp/tlon-skill' build:smoke

--- a/.github/workflows/desk-compat.yml
+++ b/.github/workflows/desk-compat.yml
@@ -1,0 +1,56 @@
+# Desk N-1 compatibility on the release branch.
+#
+# ci.yml is `pull_request`-only, so nothing there runs on a staging push — and
+# its `changes` job has no checkout (PR filtering goes through the API), which
+# is why a paths-filter is not an option here: dorny/paths-filter needs a
+# working tree on push. So this runs unconditionally.
+#
+# Policy: docs/tlon-apps/desk-compatibility.md
+name: Desk N-1 Compatibility
+on:
+  push:
+    branches:
+      - "staging"
+  workflow_dispatch:
+jobs:
+  check:
+    runs-on: blacksmith-2vcpu-ubuntu-2404
+    name: Check the release candidate against desk N-1
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version-file: .nvmrc
+      - uses: pnpm/action-setup@v3
+        with:
+          run_install: |
+            - recursive: true
+              args: [--frozen-lockfile]
+
+      # A default checkout is depth 1 with no tags, so neither the N-1 desk tag
+      # nor origin/master is present. Fetch them narrowly.
+      - name: Fetch the refs the check compares
+        run: |
+          set -euo pipefail
+          MIN=$(node -p "require('fs').readFileSync('packages/shared/src/logic/deskCompatibility.ts','utf8').match(/MIN_GROUPS_VERSION = '([^']+)'/)[1]")
+          echo "MIN_GROUPS_VERSION=$MIN" >> "$GITHUB_ENV"
+          git fetch --no-tags --depth=1 origin "refs/tags/v${MIN}:refs/tags/v${MIN}"
+          git fetch --no-tags --depth=1 origin refs/heads/master:refs/remotes/origin/master
+
+      # Rule (b): the candidate must not need anything N-1 lacks.
+      - run: pnpm check:desk-compat --desk-ref "v$MIN_GROUPS_VERSION"
+        name: Candidate client vs desk N-1
+
+      # Candidate self-consistency: a client change needing a desk change
+      # nobody made.
+      - run: pnpm check:desk-compat --desk-ref "$GITHUB_SHA"
+        name: Candidate client vs candidate desk
+
+      # Rule (c): a desk change that removed something the released client
+      # still uses. origin/master is the last sync of `staging` after a
+      # deployment workflow *ran* — sync.yml triggers on `types: [completed]`,
+      # which fires whatever the conclusion, and merges the staging tip as it
+      # stands at that moment. So it is the best standing proxy for the
+      # released client, not proof of a deployed SHA.
+      - run: pnpm check:desk-compat --client-ref origin/master --desk-ref "$GITHUB_SHA"
+        name: Released client vs candidate desk

--- a/docs/release-checklist.md
+++ b/docs/release-checklist.md
@@ -50,7 +50,12 @@ receive updates, and post against desk release N-1.
 - [ ] If the checker warns that a `protocolBumps` entry matches no observed
       difference, the bump it describes has become N-1. **Delete the entry** as
       part of this release; a stale entry is standing permission for a mismatch
-      nobody is tracking.
+      nobody is tracking. The same applies to a `gaps` entry the checker says
+      excused nothing: the request it covers is served again, so remove it.
+- [ ] With a bump in flight the summary reads `no blocking protocol difference`
+      rather than `no version difference`. Those are not the same statement —
+      the second means the desks agree; the first means the only disagreement is
+      the one this release is deliberately shipping.
 - [ ] Read the `UNVERIFIED` list rather than skipping it: it never changes the
       exit code, and each entry is a call the checker could not decide.
 

--- a/docs/release-checklist.md
+++ b/docs/release-checklist.md
@@ -1,0 +1,65 @@
+# Release checklist
+
+Reconstructed from what the workflows actually do. Where a step names a
+workflow, that workflow's trigger is the authority for when it runs.
+
+| stage        | what happens                                                        | workflow                        |
+| ------------ | ------------------------------------------------------------------- | ------------------------------- |
+| feature      | PRs merge into `develop`; the app suite runs on each                | `ci.yml` (`pull_request`)       |
+| version bump | `desk.docket-0`'s `version+[X Y Z]` is rewritten and pushed         | `bump.yml` (the only writer)    |
+| glob         | the web bundle is built and globbed, docket updated                 | `build-and-glob.yml`            |
+| staging      | `develop` merges to `staging`; pushing it back-merges to `develop`  | `sync-dev.yml`                  |
+| release tag  | a `vX.Y.Z` tag is created **by hand** — no workflow creates one     | —                               |
+| livenet      | the tag is deployed to `~sogryp-dister-dozzod-dozzod`               | `deploy-livenet.yml`            |
+| master sync  | on a completed livenet deploy, `staging` merges into `master`       | `sync.yml` (`workflow_run`)     |
+| mobile       | EAS builds are cut separately                                       | `mobile-build.yml`              |
+
+`vX.Y.Z` tags are **desk** version tags: the tag matches `desk.docket-0`'s
+`version+[X Y Z]` at that commit. `origin/master`'s tip is the last sync of
+`staging` after a deployment workflow ran — `sync.yml` triggers on
+`types: [completed]`, whatever the conclusion, and merges the staging tip as it
+stands then. Treat it as the standing proxy for the released client, not as a
+verified deployed SHA.
+
+## Before tagging
+
+- [ ] `develop` is green, and `staging` carries exactly the commits you intend.
+- [ ] `desk.docket-0`'s `version+[X Y Z]` matches the tag, and its glob hash and
+      URL point at the bundle built from this commit.
+
+### Desk N-1 compatibility
+
+Policy: `docs/tlon-apps/desk-compatibility.md`. Release N must start, sync,
+receive updates, and post against desk release N-1.
+
+- [ ] `MIN_GROUPS_VERSION` equals the **previous** desk release, not the one you
+      are cutting.
+- [ ] `pnpm check:desk-compat` exits 0 for all three ref pairs — rule (b), then
+      self-consistency, then rule (c):
+
+      pnpm check:desk-compat --client-ref <candidate> --desk-ref v<N-1>
+      pnpm check:desk-compat --client-ref <candidate> --desk-ref <candidate>
+      pnpm check:desk-compat --client-ref origin/master --desk-ref <candidate>
+
+- [ ] Run 1 reports **no** negotiation-protocol difference. A bump blocks the
+      pair outright, whatever the paths say, so it must ship a release ahead of
+      the client that needs it.
+- [ ] Read the `UNVERIFIED` list rather than skipping it: it never changes the
+      exit code, and each entry is a call the checker could not decide.
+
+## Tagging and deploying
+
+- [ ] Create and push the `vX.Y.Z` tag on the release commit.
+- [ ] Dispatch `deploy-livenet.yml` with that tag. It refuses one that does not
+      exist.
+- [ ] Confirm the deploy succeeded, then that `sync.yml` ran and
+      `origin/master` advanced to the commit you tagged. `sync.yml` fires on a
+      completed run of either polarity, so a failed deploy can still move
+      `master`: check the deploy's conclusion, not just that master moved.
+
+## After deploying
+
+- [ ] Raise `MIN_GROUPS_VERSION` to the release you just shipped, **only once it
+      has shipped**, and re-pin the `~bus` E2E pier
+      (`apps/tlon-web/e2e/shipManifest.json`) in the same change.
+- [ ] Cut mobile builds from the release tag if it includes native changes.

--- a/docs/release-checklist.md
+++ b/docs/release-checklist.md
@@ -44,8 +44,26 @@ receive updates, and post against desk release N-1.
 - [ ] Run 1 reports **no** negotiation-protocol difference. A bump blocks the
       pair outright, whatever the paths say, so it must ship a release ahead of
       the client that needs it.
+- [ ] If run 1 reports an `ALLOWED PROTOCOL BUMP`, that bump is shipping in this
+      release: N-1 support for the protocol is suspended, which is a deliberate
+      break for anyone still on N-1. Confirm the issue it names says so.
+- [ ] If the checker warns that a `protocolBumps` entry matches no observed
+      difference, the bump it describes has become N-1. **Delete the entry** as
+      part of this release; a stale entry is standing permission for a mismatch
+      nobody is tracking.
 - [ ] Read the `UNVERIFIED` list rather than skipping it: it never changes the
       exit code, and each entry is a call the checker could not decide.
+
+### Shipping an `agent:neg` protocol bump
+
+A bump is the change that creates the difference rule (d) forbids, so the bump
+PR cannot pass its own gate unless it says so:
+
+- [ ] The bump PR adds a `protocolBumps` entry to
+      `packages/scripts/src/check-desk-compat/known-gaps.json` — agent,
+      protocol, `from`, `to`, and the issue tracking it.
+- [ ] The release *after* the one carrying the bump removes that entry, once the
+      bump has become N-1. The checker warns while an entry matches nothing.
 
 ## Tagging and deploying
 

--- a/docs/tlon-apps/desk-compatibility.md
+++ b/docs/tlon-apps/desk-compatibility.md
@@ -166,6 +166,17 @@ already broken. An entry must name the commit that broke it. Adding one to turn
 a red gate green is the one thing the file is not for — a *new* `MISSING` means
 the change under review needs its desk change to ship first.
 
+Two rules keep an entry from outliving its breakage:
+
+- An entry excuses a request only where it was **already** broken. In the
+  removal run (`--client-ref origin/master`) the released client shipped with
+  its own desk; if that desk serves the request, this change is what is breaking
+  it, and the entry — written about some older breakage — does not apply.
+- The checker **warns when an entry excuses nothing** in a full scan, exactly as
+  it does for a stale `protocolBumps` entry. Delete it: the gap it names has
+  been fixed, and leaving it is standing permission for a regression nobody is
+  tracking.
+
 ## What the static check cannot see
 
 Response shapes; `.^` fan-out beyond one level or inside helper arms; whether an

--- a/docs/tlon-apps/desk-compatibility.md
+++ b/docs/tlon-apps/desk-compatibility.md
@@ -104,9 +104,29 @@ both drop real coverage and let a genuinely absent arm hide behind them. `?<`
 asserts the negation, so a self-check there *rejects* the frontend and stays
 conservative.
 
-**Deleted agents**: an agent the client's own desk has and the desk under test
-does not is `MISSING`, not "out of desk" — otherwise deleting an agent would
-walk straight through the removal gate. An app in neither tree is out of desk.
+**Removals** are read against the client's own desk, because a removal has many
+spellings and only the comparison tells them apart. Each of these is `MISSING`,
+not "out of desk" or "unverifiable", whenever the client's desk had the thing
+and the desk under test does not:
+
+- the agent file is gone;
+- the name is gone from `desk.bill`, so the agent is not started — its source
+  and its mar files survive, and would otherwise answer for an agent that is not
+  running (failure mode: *not started, so nothing answers*);
+- the surface is handed to `on-peek:def` / `on-watch:def`, which the pinned
+  default-agent nacks;
+- the surface is replaced by something that provably answers the same for every
+  path (`|=(* ~)`), or its arm is gone entirely.
+
+The last one is deliberately narrow: an arm holding any conditional rune or
+equality test is one this reader *failed to parse*, not one the desk removed,
+and it stays `UNVERIFIED`. Where both trees agree — both unbilled, both
+defaulted, both unparseable — nothing is decided, because there is no change to
+attribute.
+
+`::` comments are stripped before anything structural is read, so a rune written
+in prose cannot move the depth counter and swallow the arms below it. A `::`
+inside a cord or tape is text and survives.
 
 **Marks**: ownership is decided by exclusion against `peru.yaml`'s pick lists —
 read from the **desk under test**, since a mark dropped from its pick list

--- a/docs/tlon-apps/desk-compatibility.md
+++ b/docs/tlon-apps/desk-compatibility.md
@@ -40,6 +40,17 @@ compatibility rescues it. A protocol bump must ship one release ahead of the
 client that needs it, exactly like a new path. This is also why v12.1.0 is
 unusable as a pinned N-1 pier and v12.2.0 is.
 
+The bump PR is itself the change that creates the difference, so it would
+otherwise never be able to merge. It adds an entry to `protocolBumps` in
+`packages/scripts/src/check-desk-compat/known-gaps.json` naming the agent,
+protocol, `from`/`to` versions and an issue. The checker still prints the
+difference loudly — in its own `ALLOWED PROTOCOL BUMP` section — but stops
+failing on that exact transition; any other mismatch still blocks. N-1 support
+for the protocol is suspended until the bump becomes N-1, and the next release
+removes the entry. While an entry matches no observed difference the checker
+warns rather than failing, because the candidate-vs-candidate run legitimately
+shows no differences at all.
+
 ## Running the checker
 
 ```
@@ -81,8 +92,7 @@ Rules are applied in this order; the first that fires decides.
 - **P4 — open value sets ⇒ `UNVERIFIED`.** `` `/${feedVersion()}/…` `` leaves no
   prefix to match against.
 
-A guard is otherwise conservative — it may reject a request the arms would have
-served — but a **self-guard is treated as satisfied and ignored entirely**,
+A **self-guard is treated as satisfied and ignored entirely**,
 affecting neither `FOUND` nor `MISSING`. `?> from-self`, `?> =(src our)` and
 `(team:title our.bowl src.bowl)` all assert that the caller is this ship, which
 every frontend request is by construction: the client only ever scries and
@@ -91,7 +101,13 @@ both drop real coverage and let a genuinely absent arm hide behind them. `?<`
 asserts the negation, so a self-check there *rejects* the frontend and stays
 conservative.
 
+**Deleted agents**: an agent the client's own desk has and the desk under test
+does not is `MISSING`, not "out of desk" — otherwise deleting an agent would
+walk straight through the removal gate. An app in neither tree is out of desk.
+
 **Marks**: ownership is decided by exclusion against `peru.yaml`'s pick lists —
+read from the **desk under test**, since a mark dropped from its pick list
+without a local mar file is a removal —
 anything under `desk/mar` that is not vendored and not an out-of-desk app is
 repo-owned, and its absence is a removal. The alternative ("ours if it resolves
 at either ref") is self-defeating for exactly the removal case, because deleting
@@ -99,7 +115,16 @@ the mar file also erases the proof we owned the mark. `FOUND` for a mark claims
 only that the file exists.
 
 Conditional branches are reported **per branch, never unioned**, each carrying
-its guard text.
+its guard text — including the condition an early `return` inside an `if`
+implicitly negates for the returns after it. A `MISSING` branch whose sibling at
+the same call site is `FOUND` is the policy's fallback exception: it is reported
+in its own *covered fallback* section with the guard, and does not fail the run.
+A `MISSING` with no served sibling still blocks.
+
+A guard is otherwise conservative in **both** directions — it may reject a
+request the arms would have served, so a match proves no more than an absence
+does — whether it sits before the dispatcher or inside the matched arm. The one
+exception is the self-guard below.
 
 ## Reading `UNVERIFIED`
 

--- a/docs/tlon-apps/desk-compatibility.md
+++ b/docs/tlon-apps/desk-compatibility.md
@@ -43,7 +43,10 @@ unusable as a pinned N-1 pier and v12.2.0 is.
 The bump PR is itself the change that creates the difference, so it would
 otherwise never be able to merge. It adds an entry to `protocolBumps` in
 `packages/scripts/src/check-desk-compat/known-gaps.json` naming the agent,
-protocol, `from`/`to` versions and an issue. The checker still prints the
+protocol, `from`/`to` versions and an issue. `from`/`to` name the transition,
+and an entry matches it in either orientation: the gate run reads the candidate
+against N-1 and sees new/old, while a released-client run reads the other way.
+Only that one pair of versions is excused. The checker still prints the
 difference loudly — in its own `ALLOWED PROTOCOL BUMP` section — but stops
 failing on that exact transition; any other mismatch still blocks. N-1 support
 for the protocol is suspended until the bump becomes N-1, and the next release
@@ -116,10 +119,30 @@ only that the file exists.
 
 Conditional branches are reported **per branch, never unioned**, each carrying
 its guard text — including the condition an early `return` inside an `if`
-implicitly negates for the returns after it. A `MISSING` branch whose sibling at
-the same call site is `FOUND` is the policy's fallback exception: it is reported
-in its own *covered fallback* section with the guard, and does not fail the run.
-A `MISSING` with no served sibling still blocks.
+implicitly negates for the returns after it.
+
+### Writing a fallback the checker recognises
+
+A `MISSING` branch is excused only as a *covered fallback*, and the bar is
+deliberately narrow, because the exception suppresses the one signal the gate
+exists to give:
+
+- **Guard on a capability, not on a situation.** The guard must name what the
+  desk supports — `getActivitySupportsNotes()`, `groupsVersionSupportsNotesSearch`,
+  `REACTIONS_MIN_GROUPS_VERSION` — so its two branches are the same request
+  written for two desk versions. A branch on `whomIsDm(whom)` or
+  `type === 'channel'` picks between two requests the client makes in different
+  *situations*; its sibling being served says nothing about N-1, and the
+  `MISSING` one still blocks.
+- **Serve the complementary branch at the same call site.** Coverage requires a
+  `FOUND` request under the negation of that same guard, at that same line. Any
+  other served request nearby does not count.
+- **Guard every site.** Coverage is decided per call site. If the same request
+  is also made unconditionally somewhere else, the request still blocks, and the
+  report lists which sites are covered and which are blocking.
+
+A covered fallback is reported in its own section with the guard and does not
+fail the run. Everything else that is `MISSING` blocks.
 
 A guard is otherwise conservative in **both** directions — it may reject a
 request the arms would have served, so a match proves no more than an absence

--- a/docs/tlon-apps/desk-compatibility.md
+++ b/docs/tlon-apps/desk-compatibility.md
@@ -1,0 +1,128 @@
+# Desk compatibility: the N-1 policy
+
+Every app release N must **start, sync, receive updates, and post** against the
+previous %groups desk release, N-1. Feature parity is not required.
+
+We satisfy that by **release ordering**, not runtime fallbacks: a desk change
+the client will depend on ships one desk release *before* any client release
+depends on it. A fallback is the exception, and an untested fallback is worse
+than none.
+
+## Rules
+
+**(a) `MIN_GROUPS_VERSION` records the floor; it does not set it.**
+`packages/shared/src/logic/deskCompatibility.ts` holds the oldest %groups desk
+this client supports; by policy it equals the previous desk release. Raising it
+is a *release* action taken once that desk has shipped.
+
+**(b) A client PR that adds a dependency N-1 lacks is blocked** until the desk
+change has shipped and become N-1, or the PR carries a fallback tested against
+N-1. "Dependency" means a scry path, a subscription path, a poke mark, a
+thread, or a response shape.
+
+**(c) Desk removal is bounded by the support window** — the currently released
+client plus the candidate client. The released client is taken to be
+`origin/master`'s tip. Read that precisely: `sync.yml` merges `staging` into
+`master` when a deployment workflow *completes*, and its trigger is
+`types: [completed]`, which fires whatever the conclusion; it merges the staging
+tip as it stands at that moment. So `master` is the last sync of staging after a
+deployment run, not a verified deployed SHA. It is the best standing proxy we
+have, and it is never force-pushed, but a failed deploy or a staging push landing
+between deploy and sync can move it ahead of what users run. Recording the
+deployed SHA is a follow-up.
+
+**(d) Negotiation protocols are a hard floor beneath `MIN_GROUPS_VERSION`.**
+Each agent declares a protocol version through `agent:neg`; %groups went
+`~.groups^%2` at v12.1.0 to `~.groups^%3` at v12.2.0. When N and N-1 disagree,
+`negotiate` blocks the pair outright — the invite picker greys the peer out and
+channels render the mismatch notice — so no amount of path-and-mark
+compatibility rescues it. A protocol bump must ship one release ahead of the
+client that needs it, exactly like a new path. This is also why v12.1.0 is
+unusable as a pinned N-1 pier and v12.2.0 is.
+
+## Running the checker
+
+```
+pnpm check:desk-compat --client-ref <ref> --desk-ref <ref> [--json]
+```
+
+Exit `0` = no `MISSING`; `1` = at least one (or a protocol difference); `2` =
+internal error. `UNVERIFIED` never changes the exit code but is always printed:
+it is the checker saying it could not decide, and it is layer 2's inbox.
+
+At release time it runs over **three** ref pairs sharing one ownership set:
+
+| run | client ref       | desk ref       | what it catches                                     |
+| --- | ---------------- | -------------- | --------------------------------------------------- |
+| 1   | candidate client | N-1 desk tag   | rule (b): the candidate needs something N-1 lacks   |
+| 2   | candidate client | candidate desk | candidate self-consistency                          |
+| 3   | released client  | candidate desk | rule (c): the candidate desk removed something live |
+
+## How a verdict is reached
+
+Rules are applied in this order; the first that fires decides.
+
+- **P0 — pre-dispatch obstruction.** The agent guards or rewrites the pole
+  before its `?+` (`channels.hoon` injects `%v0`; `steward.hoon` rejects remote
+  scries), so the pole the dispatcher sees is not the one sent. No `MISSING`
+  verdict is available for that surface. The only agent-wide taint.
+- **P1 — known-prefix absence ⇒ `MISSING`.** Take the request's leading literal
+  segments (the care first, for peeks). If no arm can match that prefix under
+  any completion, the request is missing. Unknown segment counts do not rescue
+  it, and `?(...)` unions are expanded rather than failed open.
+- **P2 — prefix matches, suffix unknown ⇒ `UNVERIFIED`,** unless the matched
+  arm's tail accepts any completion. A TypeScript interpolation does not stop at
+  a slash: a `groupId` is `~ship/name` and spans two segments.
+- **P3 — delegation.** A wildcard-tail arm does not terminate the walk. When the
+  matched arm re-dispatches, the delegated path is rebuilt and P1-P3 re-applied
+  against the sub-dispatcher. Only an arm that *serves* terminates. Where the
+  sub-dispatcher or the rebuilt path cannot be resolved, the answer is
+  `UNVERIFIED` — never an approved arbitrary suffix.
+- **P4 — open value sets ⇒ `UNVERIFIED`.** `` `/${feedVersion()}/…` `` leaves no
+  prefix to match against.
+
+A guard is otherwise conservative — it may reject a request the arms would have
+served — but a **self-guard is treated as satisfied and ignored entirely**,
+affecting neither `FOUND` nor `MISSING`. `?> from-self`, `?> =(src our)` and
+`(team:title our.bowl src.bowl)` all assert that the caller is this ship, which
+every frontend request is by construction: the client only ever scries and
+subscribes to the ship it is logged into. Treating them as obstructions would
+both drop real coverage and let a genuinely absent arm hide behind them. `?<`
+asserts the negation, so a self-check there *rejects* the frontend and stays
+conservative.
+
+**Marks**: ownership is decided by exclusion against `peru.yaml`'s pick lists —
+anything under `desk/mar` that is not vendored and not an out-of-desk app is
+repo-owned, and its absence is a removal. The alternative ("ours if it resolves
+at either ref") is self-defeating for exactly the removal case, because deleting
+the mar file also erases the proof we owned the mark. `FOUND` for a mark claims
+only that the file exists.
+
+Conditional branches are reported **per branch, never unioned**, each carrying
+its guard text.
+
+## Reading `UNVERIFIED`
+
+Each entry names the rule that could not decide it, the call site, and the
+argument text. Entries under `coverage` are out of layer 1's reach by
+construction: out-of-desk apps, agents absent from `desk.bill`, threads, and the
+notes HTTP endpoints, which talk to eyre URLs directly. They are real desk
+dependencies, recorded rather than dropped, and layer 2 reviews them.
+
+## Adding a known gap
+
+`packages/scripts/src/check-desk-compat/known-gaps.json` lists requests that are
+`MISSING` today and knowingly do not fail the gate. Every entry is debt: it
+records a client call the desk does not serve, so the feature behind it is
+already broken. An entry must name the commit that broke it. Adding one to turn
+a red gate green is the one thing the file is not for — a *new* `MISSING` means
+the change under review needs its desk change to ship first.
+
+## What the static check cannot see
+
+Response shapes; `.^` fan-out beyond one level or inside helper arms; whether an
+agent actually accepts a mark's JSON. Layers 2 (agent review at release time)
+and 3 (a pinned N-1 `~bus` in the E2E suite) cover those.
+
+**Out of scope:** desks older than N-1; web-glob versus desk skew; native store
+versions; agents outside `desk/app/`; `tlon-skill` / `openclaw` / `tlon-bot-e2e`.

--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
     "test": "npm rebuild better-sqlite3 && pnpm run -r test run -u",
     "test:ci": "npm rebuild better-sqlite3 && pnpm build:api && pnpm run -r test run",
     "lint:all": "pnpm -r lint",
+    "check:desk-compat": "pnpm --filter 'scripts' check:desk-compat",
     "sync:native-navigation-icons": "node scripts/sync-native-navigation-icons.mjs",
     "check:native-navigation-icons": "node scripts/sync-native-navigation-icons.mjs --check",
     "format": "oxfmt .",

--- a/packages/scripts/package.json
+++ b/packages/scripts/package.json
@@ -5,6 +5,8 @@
   "main": "index.js",
   "scripts": {
     "build": "esbuild src/index.ts --bundle --format=iife --global-name=tlon --conditions=react-native --outfile=build/bundle.js",
+    "check:desk-compat": "tsx src/check-desk-compat/index.ts",
+    "tsc": "tsc --noEmit -p src/check-desk-compat/tsconfig.json",
     "test": "vitest --passWithNoTests"
   },
   "keywords": [],
@@ -16,6 +18,8 @@
   },
   "devDependencies": {
     "@types/node": "^20.10.8",
-    "esbuild": "^0.25.2"
+    "esbuild": "^0.25.2",
+    "tsx": "^4.20.6",
+    "typescript": "~5.9.2"
   }
 }

--- a/packages/scripts/src/check-desk-compat/check.test.ts
+++ b/packages/scripts/src/check-desk-compat/check.test.ts
@@ -2,12 +2,20 @@ import { describe, expect, it } from 'vitest';
 
 import {
   Finding,
+  KnownGap,
   ProtocolBump,
+  Report,
   complementsGuard,
+  formatReport,
+  gapApplies,
+  isBlocking,
   markCoveredFallbacks,
   matchBump,
+  staleGapsIn,
 } from './check';
 import { Dependency } from './extract';
+import { memoryTree } from './git';
+import { loadDesk } from './match';
 import { ProtocolDifference } from './negotiate';
 
 const difference = (
@@ -194,5 +202,135 @@ describe('markCoveredFallbacks', () => {
       },
     ]);
     expect(missing.fallback).toBeUndefined();
+  });
+});
+
+const finding = (over: Partial<Finding> = {}): Finding => ({
+  verdict: 'MISSING',
+  rule: 'P1',
+  reason: '',
+  dependency: record('k', 1),
+  sites: [{ file: SITE, line: 1 }],
+  ...over,
+});
+
+describe('isBlocking', () => {
+  it('is the one answer to "does this MISSING fail the run?"', () => {
+    const gap: KnownGap = { key: 'k', reason: 'debt' };
+    expect(isBlocking(finding())).toBe(true);
+    expect(isBlocking(finding({ allowed: gap }))).toBe(false);
+    expect(isBlocking(finding({ fallback: { coveredBy: 'other' } }))).toBe(
+      false
+    );
+    expect(isBlocking(finding({ verdict: 'FOUND' }))).toBe(false);
+    expect(isBlocking(finding({ verdict: 'UNVERIFIED' }))).toBe(false);
+  });
+});
+
+describe('gapApplies', () => {
+  // %ledger serves /x/v1/init and nothing else.
+  const SERVES = `
+++  on-peek
+  |=  =path
+  ?+  path  [~ ~]
+    [%x %v1 %init ~]  \`\`noun+!>(~)
+  ==
+--
+`.trim();
+  const clientDesk = (app: string) =>
+    loadDesk(
+      memoryTree({
+        'desk/desk.bill': ':~  %ledger\n==\n',
+        'desk/app/ledger.hoon': app,
+      }),
+      'client'
+    );
+  const dep = (path: string): Dependency => ({
+    key: `scry ledger ${path}`,
+    surface: 'scry',
+    app: 'ledger',
+    path: {
+      known: path.split('/').filter(Boolean),
+      unknownTail: false,
+      text: path,
+    },
+    mark: null,
+    thread: null,
+    site: { file: SITE, line: 1 },
+    text: '',
+  });
+
+  it('stands when nothing disproves it', () => {
+    // A self-consistency run has no client-side desk to compare against.
+    expect(gapApplies(dep('/v1/init'), null, null)).toBe(true);
+    expect(gapApplies(dep('/v2/init'), clientDesk(SERVES), new Set())).toBe(
+      true
+    );
+  });
+
+  it('does not excuse a request the client shipped a desk for', () => {
+    // /v1/init worked at the client's own baseline, so a gap entry about some
+    // older breakage is not about this one — the change under review broke it.
+    expect(gapApplies(dep('/v1/init'), clientDesk(SERVES), new Set())).toBe(
+      false
+    );
+  });
+});
+
+describe('staleGapsIn', () => {
+  const gap = (key: string): KnownGap => ({ key, reason: 'debt' });
+
+  it('names an entry that excused nothing', () => {
+    const live = gap('live');
+    const dead = gap('dead');
+    expect(
+      staleGapsIn([live, dead], [finding({ allowed: live })]).map((g) => g.key)
+    ).toEqual(['dead']);
+  });
+
+  it('keeps quiet when every entry did its job', () => {
+    const live = gap('live');
+    expect(staleGapsIn([live], [finding({ allowed: live })])).toEqual([]);
+  });
+});
+
+const report = (over: Partial<Report> = {}): Report => ({
+  clientRef: 'worktree',
+  deskRef: 'v12.2.0',
+  protocolDifferences: [],
+  allowedBumps: [],
+  staleBumps: [],
+  staleGaps: [],
+  findings: [],
+  counts: { found: 0, missing: 0, unverified: 0, allowed: 0, fallback: 0 },
+  ...over,
+});
+
+describe('formatReport', () => {
+  it('does not claim the desks agree when a bump is being allowed through', () => {
+    const plain = formatReport(report());
+    expect(plain).toContain('negotiation protocols: no version difference');
+
+    const bumped = formatReport(
+      report({ allowedBumps: [{ difference: difference(), bump: bump() }] })
+    );
+    expect(bumped).toContain(
+      'negotiation protocols: no blocking protocol difference'
+    );
+    expect(bumped).not.toContain('no version difference');
+    expect(bumped).toContain('ALLOWED PROTOCOL BUMP');
+  });
+
+  it('warns about a gap entry that excused nothing', () => {
+    const text = formatReport(
+      report({
+        staleGaps: [
+          { key: 'subscribe groups /chan/{}', reason: 'debt', issue: 'TLON-1' },
+        ],
+      })
+    );
+    expect(text).toContain(
+      'warning: known-gaps.json still excuses subscribe groups /chan/{} (TLON-1)'
+    );
   });
 });

--- a/packages/scripts/src/check-desk-compat/check.test.ts
+++ b/packages/scripts/src/check-desk-compat/check.test.ts
@@ -1,0 +1,124 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  Finding,
+  ProtocolBump,
+  markCoveredFallbacks,
+  matchBump,
+} from './check';
+import { Dependency } from './extract';
+import { ProtocolDifference } from './negotiate';
+
+const difference = (
+  over: Partial<ProtocolDifference> = {}
+): ProtocolDifference => ({
+  agent: 'groups',
+  protocol: 'groups',
+  clientDeskVersions: ['3'],
+  n1Versions: ['2'],
+  ...over,
+});
+
+const bump = (over: Partial<ProtocolBump> = {}): ProtocolBump => ({
+  agent: 'groups',
+  protocol: 'groups',
+  from: '2',
+  to: '3',
+  issue: 'TLON-0000',
+  ...over,
+});
+
+describe('matchBump', () => {
+  it('allows exactly the bump an entry describes', () => {
+    expect(matchBump(difference(), [bump()])).toBeDefined();
+  });
+
+  it('allows nothing else', () => {
+    // A bump entry is permission for one transition, not for the protocol.
+    expect(
+      matchBump(difference({ clientDeskVersions: ['4'] }), [bump()])
+    ).toBeUndefined();
+    expect(
+      matchBump(difference({ n1Versions: ['1'] }), [bump()])
+    ).toBeUndefined();
+    expect(matchBump(difference({ agent: 'chat' }), [bump()])).toBeUndefined();
+    expect(
+      matchBump(difference({ protocol: 'chat-dms' }), [bump()])
+    ).toBeUndefined();
+    expect(matchBump(difference(), [])).toBeUndefined();
+  });
+});
+
+function finding(
+  over: Partial<Dependency>,
+  verdict: Finding['verdict'],
+  line = 28
+): Finding {
+  return {
+    verdict,
+    rule: 'P1',
+    reason: verdict === 'FOUND' ? 'served' : 'absent',
+    sites: [{ file: 'packages/api/src/client/activityApi.ts', line }],
+    dependency: {
+      key: 'k',
+      surface: 'poke',
+      app: 'activity',
+      path: null,
+      mark: null,
+      thread: null,
+      site: { file: 'packages/api/src/client/activityApi.ts', line },
+      text: '',
+      ...over,
+    },
+  };
+}
+
+describe('markCoveredFallbacks', () => {
+  it('excuses a guarded branch whose sibling at the same site is served', () => {
+    const list = [
+      finding(
+        { key: 'poke activity activity-action-2', guard: 'supportsNotes()' },
+        'MISSING'
+      ),
+      finding(
+        {
+          key: 'poke activity activity-action-1',
+          guard: '! (supportsNotes())',
+        },
+        'FOUND'
+      ),
+    ];
+    markCoveredFallbacks(list);
+    expect(list[0].fallback).toEqual({
+      coveredBy: 'poke activity activity-action-1',
+      guard: 'supportsNotes()',
+    });
+  });
+
+  it('does not excuse it when no branch at that site is served', () => {
+    const list = [
+      finding({ key: 'a', guard: 'supportsNotes()' }, 'MISSING'),
+      finding({ key: 'b', guard: '! (supportsNotes())' }, 'MISSING'),
+    ];
+    markCoveredFallbacks(list);
+    expect(list[0].fallback).toBeUndefined();
+  });
+
+  it('does not excuse an unguarded request that merely shares a file', () => {
+    const list = [
+      finding({ key: 'a' }, 'MISSING'),
+      finding({ key: 'b' }, 'FOUND'),
+    ];
+    markCoveredFallbacks(list);
+    expect(list[0].fallback).toBeUndefined();
+  });
+
+  it('does not excuse a branch served only at some other call site', () => {
+    const list = [
+      finding({ key: 'a', guard: 'g' }, 'MISSING', 28),
+      finding({ key: 'b', guard: '! (g)' }, 'FOUND', 99),
+    ];
+    markCoveredFallbacks(list);
+    expect(list[0].fallback).toBeUndefined();
+  });
+});

--- a/packages/scripts/src/check-desk-compat/check.test.ts
+++ b/packages/scripts/src/check-desk-compat/check.test.ts
@@ -86,6 +86,22 @@ describe('complementsGuard', () => {
     ).toBe(true);
   });
 
+  it('pairs a nested branch at the level that actually differs', () => {
+    const a = 'supportsNotes ? …';
+    const b = 'supportsReactions ? …';
+    // The inner pair: A && B against A && !B.
+    expect(
+      complementsGuard(`${a} && ${b}`, `${a} && ! (supportsReactions)`)
+    ).toBe(true);
+    // The outer pair: A && B against !A.
+    expect(complementsGuard(`${a} && ${b}`, '! (supportsNotes)')).toBe(true);
+    // A sibling under the same conditions is no fallback at all.
+    expect(complementsGuard(`${a} && ${b}`, `${a} && ${b}`)).toBe(false);
+    expect(
+      complementsGuard(`${a} && ${b}`, '! (somethingElse) && ! (andAnother)')
+    ).toBe(false);
+  });
+
   it('rejects a branch that is not about what the desk supports', () => {
     // chatAction picks a mark by conversation kind. Its club branch being
     // served says nothing about whether a DM request works on N-1.

--- a/packages/scripts/src/check-desk-compat/check.test.ts
+++ b/packages/scripts/src/check-desk-compat/check.test.ts
@@ -3,6 +3,7 @@ import { describe, expect, it } from 'vitest';
 import {
   Finding,
   ProtocolBump,
+  complementsGuard,
   markCoveredFallbacks,
   matchBump,
 } from './check';
@@ -29,96 +30,169 @@ const bump = (over: Partial<ProtocolBump> = {}): ProtocolBump => ({
 });
 
 describe('matchBump', () => {
-  it('allows exactly the bump an entry describes', () => {
+  it('matches the transition in either direction', () => {
+    // candidate vs N-1 sees new/old; released-client vs candidate sees old/new.
     expect(matchBump(difference(), [bump()])).toBeDefined();
+    expect(
+      matchBump(difference({ clientDeskVersions: ['2'], n1Versions: ['3'] }), [
+        bump(),
+      ])
+    ).toBeDefined();
   });
 
-  it('allows nothing else', () => {
-    // A bump entry is permission for one transition, not for the protocol.
+  it('matches nothing else', () => {
+    // A bump entry is permission for one pair of versions, not for a protocol.
+    for (const other of [
+      difference({ clientDeskVersions: ['4'] }),
+      difference({ n1Versions: ['1'] }),
+      difference({ clientDeskVersions: ['3'], n1Versions: ['3'] }),
+      difference({ agent: 'chat' }),
+      difference({ protocol: 'chat-dms' }),
+    ]) {
+      expect(matchBump(other, [bump()])).toBeUndefined();
+    }
+    // A swapped entry describes a different transition, in either orientation.
     expect(
-      matchBump(difference({ clientDeskVersions: ['4'] }), [bump()])
-    ).toBeUndefined();
-    expect(
-      matchBump(difference({ n1Versions: ['1'] }), [bump()])
-    ).toBeUndefined();
-    expect(matchBump(difference({ agent: 'chat' }), [bump()])).toBeUndefined();
-    expect(
-      matchBump(difference({ protocol: 'chat-dms' }), [bump()])
+      matchBump(difference({ n1Versions: ['1'] }), [
+        bump({ from: '1', to: '4' }),
+      ])
     ).toBeUndefined();
     expect(matchBump(difference(), [])).toBeUndefined();
   });
 });
 
-function finding(
-  over: Partial<Dependency>,
-  verdict: Finding['verdict'],
-  line = 28
-): Finding {
+describe('complementsGuard', () => {
+  it('accepts the complementary branch of a capability guard', () => {
+    const notes = 'getActivitySupportsNotes()';
+    expect(complementsGuard(notes, `! (${notes})`)).toBe(true);
+    expect(complementsGuard(`${notes} ? …`, `! (${notes})`)).toBe(true);
+    // activityAction's third mark: `!A && !R` still complements `A`.
+    expect(
+      complementsGuard(notes, `! (${notes}) && ! (supportsReactions)`)
+    ).toBe(true);
+    expect(
+      complementsGuard(
+        'REACTIONS_MIN_GROUPS_VERSION',
+        '! (REACTIONS_MIN_GROUPS_VERSION)'
+      )
+    ).toBe(true);
+  });
+
+  it('rejects a branch that is not about what the desk supports', () => {
+    // chatAction picks a mark by conversation kind. Its club branch being
+    // served says nothing about whether a DM request works on N-1.
+    expect(complementsGuard('whomIsDm(whom)', '! (whomIsDm(whom))')).toBe(
+      false
+    );
+    expect(
+      complementsGuard("type === 'channel' ? …", "! (type === 'channel')")
+    ).toBe(false);
+    expect(
+      complementsGuard('count && count > 0 ? …', '! (count && count > 0)')
+    ).toBe(false);
+  });
+
+  it('rejects a sibling that is not the complementary branch', () => {
+    const notes = 'getActivitySupportsNotes()';
+    expect(complementsGuard(notes, notes)).toBe(false);
+    expect(complementsGuard(notes, '! (somethingElse())')).toBe(false);
+    expect(complementsGuard(notes, undefined)).toBe(false);
+    expect(complementsGuard(undefined, `! (${notes})`)).toBe(false);
+  });
+});
+
+const SITE = 'packages/api/src/client/activityApi.ts';
+const NOTES = 'getActivitySupportsNotes()';
+
+function record(key: string, line: number, guard?: string): Dependency {
   return {
-    verdict,
-    rule: 'P1',
-    reason: verdict === 'FOUND' ? 'served' : 'absent',
-    sites: [{ file: 'packages/api/src/client/activityApi.ts', line }],
-    dependency: {
-      key: 'k',
-      surface: 'poke',
-      app: 'activity',
-      path: null,
-      mark: null,
-      thread: null,
-      site: { file: 'packages/api/src/client/activityApi.ts', line },
-      text: '',
-      ...over,
-    },
+    key,
+    surface: 'poke',
+    app: 'activity',
+    path: null,
+    mark: null,
+    thread: null,
+    site: { file: SITE, line },
+    text: '',
+    guard,
   };
 }
 
+function build(
+  rows: { key: string; verdict: Finding['verdict']; records: Dependency[] }[]
+) {
+  const grouped = new Map(rows.map((r) => [r.key, r.records]));
+  const findings: Finding[] = rows.map((r) => ({
+    verdict: r.verdict,
+    rule: 'P1',
+    reason: '',
+    sites: r.records.map((d) => d.site),
+    dependency: r.records[0],
+  }));
+  markCoveredFallbacks(findings, grouped);
+  return findings;
+}
+
 describe('markCoveredFallbacks', () => {
-  it('excuses a guarded branch whose sibling at the same site is served', () => {
-    const list = [
-      finding(
-        { key: 'poke activity activity-action-2', guard: 'supportsNotes()' },
-        'MISSING'
-      ),
-      finding(
-        {
-          key: 'poke activity activity-action-1',
-          guard: '! (supportsNotes())',
-        },
-        'FOUND'
-      ),
-    ];
-    markCoveredFallbacks(list);
-    expect(list[0].fallback).toEqual({
-      coveredBy: 'poke activity activity-action-1',
-      guard: 'supportsNotes()',
+  it('covers a capability branch whose complement is served at that site', () => {
+    const [missing] = build([
+      { key: 'new', verdict: 'MISSING', records: [record('new', 28, NOTES)] },
+      {
+        key: 'old',
+        verdict: 'FOUND',
+        records: [record('old', 28, `! (${NOTES})`)],
+      },
+    ]);
+    expect(missing.fallback).toEqual({ coveredBy: 'old', guard: NOTES });
+  });
+
+  it('does not cover a branch on anything but a capability', () => {
+    const [missing] = build([
+      {
+        key: 'dm',
+        verdict: 'MISSING',
+        records: [record('dm', 28, 'whomIsDm(whom)')],
+      },
+      {
+        key: 'club',
+        verdict: 'FOUND',
+        records: [record('club', 28, '! (whomIsDm(whom))')],
+      },
+    ]);
+    expect(missing.fallback).toBeUndefined();
+    expect(missing.coverage).toBeUndefined();
+  });
+
+  it('covers a request only when every site that would miss is covered', () => {
+    // The same request, guarded at one call site and unconditional at another.
+    const [missing] = build([
+      {
+        key: 'new',
+        verdict: 'MISSING',
+        records: [record('new', 28, NOTES), record('new', 99)],
+      },
+      {
+        key: 'old',
+        verdict: 'FOUND',
+        records: [record('old', 28, `! (${NOTES})`)],
+      },
+    ]);
+    expect(missing.fallback).toBeUndefined();
+    expect(missing.coverage).toEqual({
+      covered: [{ file: SITE, line: 28 }],
+      blocking: [{ file: SITE, line: 99 }],
     });
   });
 
-  it('does not excuse it when no branch at that site is served', () => {
-    const list = [
-      finding({ key: 'a', guard: 'supportsNotes()' }, 'MISSING'),
-      finding({ key: 'b', guard: '! (supportsNotes())' }, 'MISSING'),
-    ];
-    markCoveredFallbacks(list);
-    expect(list[0].fallback).toBeUndefined();
-  });
-
-  it('does not excuse an unguarded request that merely shares a file', () => {
-    const list = [
-      finding({ key: 'a' }, 'MISSING'),
-      finding({ key: 'b' }, 'FOUND'),
-    ];
-    markCoveredFallbacks(list);
-    expect(list[0].fallback).toBeUndefined();
-  });
-
-  it('does not excuse a branch served only at some other call site', () => {
-    const list = [
-      finding({ key: 'a', guard: 'g' }, 'MISSING', 28),
-      finding({ key: 'b', guard: '! (g)' }, 'FOUND', 99),
-    ];
-    markCoveredFallbacks(list);
-    expect(list[0].fallback).toBeUndefined();
+  it('does not cover a branch served only at some other call site', () => {
+    const [missing] = build([
+      { key: 'new', verdict: 'MISSING', records: [record('new', 28, NOTES)] },
+      {
+        key: 'old',
+        verdict: 'FOUND',
+        records: [record('old', 99, `! (${NOTES})`)],
+      },
+    ]);
+    expect(missing.fallback).toBeUndefined();
   });
 });

--- a/packages/scripts/src/check-desk-compat/check.ts
+++ b/packages/scripts/src/check-desk-compat/check.ts
@@ -158,9 +158,10 @@ const CAPABILITY_GUARD =
 
 const conjuncts = (guard?: string) =>
   (guard ?? '')
-    .replace(/\s*\?\s*…\s*$/, '')
     .split(' && ')
-    .map((c) => c.trim())
+    // The `? …` marker says "this is the true branch of that condition"; it is
+    // written on every conjunct, so it is stripped from every conjunct.
+    .map((c) => c.trim().replace(/\s*\?\s*…$/, ''))
     .filter(Boolean);
 
 const negate = (c: string) =>
@@ -402,6 +403,7 @@ export function runCheck(options: CheckOptions): Report {
 const FAILURE_TEXT = {
   crash: 'the agent crashes (watch nack / peek 500)',
   empty: 'the agent returns an empty result',
+  'not-running': 'the agent is not started, so nothing answers',
   unknown: 'failure mode not determined',
 };
 

--- a/packages/scripts/src/check-desk-compat/check.ts
+++ b/packages/scripts/src/check-desk-compat/check.ts
@@ -29,6 +29,11 @@ export interface Finding extends MatchResult {
    * fail the run. Pre-existing debt only — see that file's header.
    */
   allowed?: KnownGap;
+  /**
+   * A sibling branch at the same call site is served at this ref, so the guard
+   * has somewhere to land. Reported, and does not fail the run.
+   */
+  fallback?: { coveredBy: string; guard?: string };
 }
 
 export interface KnownGap {
@@ -38,10 +43,30 @@ export interface KnownGap {
   issue?: string;
 }
 
+/**
+ * One in-flight `agent:neg` bump. Rule (d) makes any protocol difference a hard
+ * floor, which would otherwise mean the bump PR can never merge: it is the
+ * change that creates the difference. An entry says the difference is the
+ * intended one, so it is printed loudly and excluded from the exit code, and
+ * the following release removes it once the bump is N-1.
+ */
+export interface ProtocolBump {
+  agent: string;
+  protocol: string;
+  from: string;
+  to: string;
+  issue: string;
+  note?: string;
+}
+
 export interface Report {
   clientRef: string;
   deskRef: string;
   protocolDifferences: ProtocolDifference[];
+  /** Differences matching an allowed bump; reported, not counted. */
+  allowedBumps: { difference: ProtocolDifference; bump: ProtocolBump }[];
+  /** Entries that match nothing observed, so they may have gone stale. */
+  staleBumps: ProtocolBump[];
   findings: Finding[];
   counts: {
     found: number;
@@ -49,6 +74,8 @@ export interface Report {
     unverified: number;
     /** MISSING entries covered by known-gaps.json; excluded from `missing`. */
     allowed: number;
+    /** MISSING branches whose sibling is served; excluded from `missing`. */
+    fallback: number;
   };
 }
 
@@ -66,14 +93,55 @@ const DESK_PATHS = ['desk', 'peru.yaml'];
  * checkout the checker runs in, not from either ref under test: it is a policy
  * file about *this* repo's debt.
  */
-export function loadKnownGaps(): Map<string, KnownGap> {
+function loadPolicy(): { gaps?: KnownGap[]; protocolBumps?: ProtocolBump[] } {
   const here = dirname(fileURLToPath(import.meta.url));
-  const parsed = JSON.parse(
-    readFileSync(join(here, 'known-gaps.json'), 'utf8')
-  ) as {
-    gaps?: KnownGap[];
-  };
-  return new Map((parsed.gaps ?? []).map((g) => [g.key, g]));
+  return JSON.parse(readFileSync(join(here, 'known-gaps.json'), 'utf8'));
+}
+
+export function loadKnownGaps(): Map<string, KnownGap> {
+  return new Map((loadPolicy().gaps ?? []).map((g) => [g.key, g]));
+}
+
+export const loadProtocolBumps = (): ProtocolBump[] =>
+  loadPolicy().protocolBumps ?? [];
+
+/** An observed difference is allowed only if a bump entry describes it exactly. */
+export function matchBump(
+  difference: ProtocolDifference,
+  bumps: ProtocolBump[]
+): ProtocolBump | undefined {
+  return bumps.find(
+    (b) =>
+      b.agent === difference.agent &&
+      b.protocol === difference.protocol &&
+      difference.n1Versions.join() === b.from &&
+      difference.clientDeskVersions.join() === b.to
+  );
+}
+
+/**
+ * A guarded branch whose sibling is served is the policy's fallback exception,
+ * not a failure. Conditional branches are never unioned — each is its own
+ * record — so a fallback shows up as two records sharing one call site.
+ */
+export function markCoveredFallbacks(findings: Finding[]): void {
+  const foundBySite = new Map<string, string>();
+  for (const finding of findings) {
+    if (finding.verdict !== 'FOUND') continue;
+    for (const site of finding.sites) {
+      foundBySite.set(`${site.file}:${site.line}`, finding.dependency.key);
+    }
+  }
+  for (const finding of findings) {
+    if (finding.verdict !== 'MISSING' || !finding.dependency.guard) continue;
+    for (const site of finding.sites) {
+      const coveredBy = foundBySite.get(`${site.file}:${site.line}`);
+      if (coveredBy) {
+        finding.fallback = { coveredBy, guard: finding.dependency.guard };
+        break;
+      }
+    }
+  }
 }
 
 export function toRequest(dep: Dependency): PathRequest | null {
@@ -132,8 +200,11 @@ export function runCheck(options: CheckOptions): Report {
       : openTree(options.clientRef, DESK_PATHS);
 
   try {
-    const desk = loadDesk(deskTree, options.deskRef);
-    const vendored = loadOwnership(clientDeskTree);
+    const desk = loadDesk(deskTree, options.deskRef, clientDeskTree);
+    // Vendored availability is a property of the desk under test: a mark
+    // dropped from *its* pick list without a local mar file is a removal, and
+    // reading the client ref's older list would report it as unverifiable.
+    const vendored = loadOwnership(deskTree);
     const allowlist = loadKnownGaps();
 
     let deps = extractClient(clientTree);
@@ -161,19 +232,36 @@ export function runCheck(options: CheckOptions): Report {
           : {}),
       });
     }
+    markCoveredFallbacks(findings);
     findings.sort((a, b) => a.dependency.key.localeCompare(b.dependency.key));
 
+    const bumps = loadProtocolBumps();
+    const observed = compareProtocols(clientDeskTree, deskTree);
+    const allowedBumps: Report['allowedBumps'] = [];
+    const protocolDifferences: ProtocolDifference[] = [];
+    for (const difference of observed) {
+      const bump = matchBump(difference, bumps);
+      if (bump) allowedBumps.push({ difference, bump });
+      else protocolDifferences.push(difference);
+    }
+
     const count = (p: (f: Finding) => boolean) => findings.filter(p).length;
+    const excused = (f: Finding) => Boolean(f.allowed || f.fallback);
     return {
       clientRef: options.clientRef,
       deskRef: options.deskRef,
-      protocolDifferences: compareProtocols(clientDeskTree, deskTree),
+      protocolDifferences,
+      allowedBumps,
+      staleBumps: bumps.filter((b) => !allowedBumps.some((a) => a.bump === b)),
       findings,
       counts: {
         found: count((f) => f.verdict === 'FOUND'),
-        missing: count((f) => f.verdict === 'MISSING' && !f.allowed),
+        missing: count((f) => f.verdict === 'MISSING' && !excused(f)),
         unverified: count((f) => f.verdict === 'UNVERIFIED'),
         allowed: count((f) => f.verdict === 'MISSING' && Boolean(f.allowed)),
+        fallback: count(
+          (f) => f.verdict === 'MISSING' && !f.allowed && Boolean(f.fallback)
+        ),
       },
     };
   } finally {
@@ -205,6 +293,9 @@ function describe(finding: Finding): string[] {
     `    sites: ${shown.join(', ')}${more > 0 ? ` (+${more} more)` : ''}`
   );
   if (finding.verdict === 'UNVERIFIED') lines.push(`    text:  ${dep.text}`);
+  if (finding.fallback) {
+    lines.push(`    covers N-1: ${finding.fallback.coveredBy}`);
+  }
   if (finding.allowed) {
     const { reason, broke_at, issue } = finding.allowed;
     lines.push(`    known: ${reason}`);
@@ -235,6 +326,23 @@ export function formatReport(report: Report): string {
     );
   } else out.push('negotiation protocols: no version difference', '');
 
+  for (const { difference: d, bump } of report.allowedBumps) {
+    out.push(
+      `ALLOWED PROTOCOL BUMP: %${d.agent} ~.${d.protocol} ${bump.from} -> ${bump.to}, tracked by ${bump.issue}`,
+      ...(bump.note ? [`  ${bump.note}`] : []),
+      '  N-1 support is suspended for this protocol until the bump becomes N-1.',
+      ''
+    );
+  }
+  for (const bump of report.staleBumps) {
+    out.push(
+      `warning: known-gaps.json still allows the %${bump.agent} ~.${bump.protocol} ` +
+        `${bump.from} -> ${bump.to} bump (${bump.issue}), but this pair shows no such ` +
+        'difference. Remove the entry once the bump is N-1.',
+      ''
+    );
+  }
+
   const section = (title: string, keep: (f: Finding) => boolean) => {
     const findings = report.findings.filter(keep);
     if (findings.length === 0) return;
@@ -244,15 +352,23 @@ export function formatReport(report: Report): string {
       ''
     );
   };
-  section('MISSING', (f) => f.verdict === 'MISSING' && !f.allowed);
+  section(
+    'MISSING',
+    (f) => f.verdict === 'MISSING' && !f.allowed && !f.fallback
+  );
+  section(
+    'MISSING on this branch, but a sibling branch is served',
+    (f) => Boolean(f.fallback) && !f.allowed
+  );
   section('MISSING but allowed by known-gaps.json', (f) => Boolean(f.allowed));
   section('UNVERIFIED', (f) => f.verdict === 'UNVERIFIED');
 
-  const { found, missing, unverified, allowed } = report.counts;
+  const { found, missing, unverified, allowed, fallback } = report.counts;
   const sites = report.findings.reduce((n, f) => n + f.sites.length, 0);
   out.push(
-    `summary: ${found} FOUND, ${missing} MISSING, ${unverified} UNVERIFIED, ${allowed} known gap(s) ` +
-      `over ${report.findings.length} distinct requests from ${sites} call sites`
+    `summary: ${found} FOUND, ${missing} MISSING, ${unverified} UNVERIFIED, ` +
+      `${fallback} covered fallback(s), ${allowed} known gap(s) over ` +
+      `${report.findings.length} distinct requests from ${sites} call sites`
   );
   out.push(
     report.protocolDifferences.length > 0

--- a/packages/scripts/src/check-desk-compat/check.ts
+++ b/packages/scripts/src/check-desk-compat/check.ts
@@ -70,6 +70,8 @@ export interface Report {
   allowedBumps: { difference: ProtocolDifference; bump: ProtocolBump }[];
   /** Entries that match nothing observed, so they may have gone stale. */
   staleBumps: ProtocolBump[];
+  /** Gap entries that excused nothing in this run, for the same reason. */
+  staleGaps: KnownGap[];
   findings: Finding[];
   counts: {
     found: number;
@@ -107,6 +109,14 @@ export function loadKnownGaps(): Map<string, KnownGap> {
 
 export const loadProtocolBumps = (): ProtocolBump[] =>
   loadPolicy().protocolBumps ?? [];
+
+/**
+ * The one definition of "this MISSING fails the run". The exit code, the
+ * counts, the report section and the fixtures all read it, so they cannot
+ * drift into disagreeing about whether a covered fallback is a failure.
+ */
+export const isBlocking = (f: Finding) =>
+  f.verdict === 'MISSING' && !f.allowed && !f.fallback;
 
 /**
  * An observed difference is allowed only if a bump entry describes it exactly.
@@ -266,6 +276,34 @@ export function classify(
   return matchPath(desk, request);
 }
 
+/**
+ * Whether a known-gap entry is about *this* request.
+ *
+ * An entry documents a request that was already broken at the baseline it
+ * names. In the removal run the client ref shipped with its own desk, so a
+ * request that desk serves is one the change under review is breaking now — and
+ * an entry written about some older breakage must not excuse it. With no client
+ * desk to compare against there is nothing to disprove, so the entry stands.
+ */
+export function gapApplies(
+  dep: Dependency,
+  clientDesk: Desk | null,
+  vendored: Set<string> | null
+): boolean {
+  return (
+    clientDesk === null ||
+    classify(dep, clientDesk, vendored ?? new Set()).verdict !== 'FOUND'
+  );
+}
+
+/**
+ * Gap entries that excused nothing. Every one is debt someone is meant to pay
+ * off, so an entry outliving the breakage it documents has to be noticed the
+ * same way a stale protocol bump is.
+ */
+export const staleGapsIn = (gaps: KnownGap[], findings: Finding[]) =>
+  gaps.filter((g) => !findings.some((f) => f.allowed === g));
+
 export function runCheck(options: CheckOptions): Report {
   const clientTree = openTree(options.clientRef, CLIENT_ROOTS);
   const deskTree = openTree(options.deskRef, DESK_PATHS);
@@ -297,6 +335,12 @@ export function runCheck(options: CheckOptions): Report {
     for (const dep of deps)
       grouped.set(dep.key, [...(grouped.get(dep.key) ?? []), dep]);
 
+    const clientDesk =
+      clientDeskTree === deskTree
+        ? null
+        : loadDesk(clientDeskTree, options.clientRef);
+    const vendoredThere = clientDesk ? loadOwnership(clientDeskTree) : null;
+
     const findings: Finding[] = [];
     for (const group of grouped.values()) {
       const result = classify(group[0], desk, vendored);
@@ -304,7 +348,9 @@ export function runCheck(options: CheckOptions): Report {
         ...result,
         dependency: group[0],
         sites: group.map((d) => d.site),
-        ...(result.verdict === 'MISSING' && allowlist.has(group[0].key)
+        ...(result.verdict === 'MISSING' &&
+        allowlist.has(group[0].key) &&
+        gapApplies(group[0], clientDesk, vendoredThere)
           ? { allowed: allowlist.get(group[0].key) }
           : {}),
       });
@@ -323,17 +369,20 @@ export function runCheck(options: CheckOptions): Report {
     }
 
     const count = (p: (f: Finding) => boolean) => findings.filter(p).length;
-    const excused = (f: Finding) => Boolean(f.allowed || f.fallback);
     return {
       clientRef: options.clientRef,
       deskRef: options.deskRef,
       protocolDifferences,
       allowedBumps,
       staleBumps: bumps.filter((b) => !allowedBumps.some((a) => a.bump === b)),
+      // A partial scan cannot tell a stale entry from an unvisited one.
+      staleGaps: options.onlySites
+        ? []
+        : staleGapsIn([...allowlist.values()], findings),
       findings,
       counts: {
         found: count((f) => f.verdict === 'FOUND'),
-        missing: count((f) => f.verdict === 'MISSING' && !excused(f)),
+        missing: count(isBlocking),
         unverified: count((f) => f.verdict === 'UNVERIFIED'),
         allowed: count((f) => f.verdict === 'MISSING' && Boolean(f.allowed)),
         fallback: count(
@@ -408,6 +457,8 @@ export function formatReport(report: Report): string {
       '  negotiate refuses a pair that disagrees on a protocol, whatever the paths say.',
       ''
     );
+  } else if (report.allowedBumps.length > 0) {
+    out.push('negotiation protocols: no blocking protocol difference', '');
   } else out.push('negotiation protocols: no version difference', '');
 
   for (const { difference: d, bump } of report.allowedBumps) {
@@ -426,6 +477,13 @@ export function formatReport(report: Report): string {
       ''
     );
   }
+  for (const gap of report.staleGaps) {
+    out.push(
+      `warning: known-gaps.json still excuses ${gap.key} (${gap.issue ?? 'no issue'}), ` +
+        'but this run reports no such MISSING. Remove the entry.',
+      ''
+    );
+  }
 
   const section = (title: string, keep: (f: Finding) => boolean) => {
     const findings = report.findings.filter(keep);
@@ -436,10 +494,7 @@ export function formatReport(report: Report): string {
       ''
     );
   };
-  section(
-    'MISSING',
-    (f) => f.verdict === 'MISSING' && !f.allowed && !f.fallback
-  );
+  section('MISSING', isBlocking);
   section(
     'MISSING on this branch, but a sibling branch is served',
     (f) => Boolean(f.fallback) && !f.allowed

--- a/packages/scripts/src/check-desk-compat/check.ts
+++ b/packages/scripts/src/check-desk-compat/check.ts
@@ -30,10 +30,13 @@ export interface Finding extends MatchResult {
    */
   allowed?: KnownGap;
   /**
-   * A sibling branch at the same call site is served at this ref, so the guard
-   * has somewhere to land. Reported, and does not fail the run.
+   * Every site making this request guards it on a capability, and the
+   * complementary branch of that guard is served at this ref, so the guard has
+   * somewhere to land. Reported, and does not fail the run.
    */
   fallback?: { coveredBy: string; guard?: string };
+  /** Which of this request's sites are covered, and which still block. */
+  coverage?: { covered: SourceLocation[]; blocking: SourceLocation[] };
 }
 
 export interface KnownGap {
@@ -105,41 +108,115 @@ export function loadKnownGaps(): Map<string, KnownGap> {
 export const loadProtocolBumps = (): ProtocolBump[] =>
   loadPolicy().protocolBumps ?? [];
 
-/** An observed difference is allowed only if a bump entry describes it exactly. */
+/**
+ * An observed difference is allowed only if a bump entry describes it exactly.
+ *
+ * Direction is not fixed: candidate-vs-N-1 sees the new version on the client
+ * side and the old on the desk under test, while released-client-vs-candidate
+ * sees exactly the reverse. Both are the same permitted transition, so the
+ * entry matches either orientation — but only that pair of versions.
+ */
 export function matchBump(
   difference: ProtocolDifference,
   bumps: ProtocolBump[]
 ): ProtocolBump | undefined {
+  const left = difference.clientDeskVersions.join();
+  const right = difference.n1Versions.join();
   return bumps.find(
     (b) =>
       b.agent === difference.agent &&
       b.protocol === difference.protocol &&
-      difference.n1Versions.join() === b.from &&
-      difference.clientDeskVersions.join() === b.to
+      ((left === b.to && right === b.from) ||
+        (left === b.from && right === b.to))
   );
 }
 
 /**
- * A guarded branch whose sibling is served is the policy's fallback exception,
- * not a failure. Conditional branches are never unioned — each is its own
- * record — so a fallback shows up as two records sharing one call site.
+ * Identifiers that make a guard a *capability* guard — one that asks what the
+ * desk supports, so its two branches are the same request written for two desk
+ * versions. Taken from what the client actually spells:
+ * `getActivitySupportsNotes`, `activityVersionSupportsNotes`,
+ * `groupsVersionSupportsNotesSearch`, `REACTIONS_MIN_GROUPS_VERSION`,
+ * `NOTES_ACTIVITY_MIN_GROUPS_VERSION`, `groupsVersion`.
+ *
+ * A branch on anything else — `whomIsDm(whom)`, `type === 'channel'` — chooses
+ * between two requests the client makes in different situations, not between
+ * two desks. Its sibling being served says nothing about the missing one.
  */
-export function markCoveredFallbacks(findings: Finding[]): void {
-  const foundBySite = new Map<string, string>();
+const CAPABILITY_GUARD =
+  /\b(\w*MIN_GROUPS_VERSION|\w*[Ss]upports\w*|\w*[Cc]apab\w*|\w*[Dd]esk[Vv]ersion\w*|\w*[Gg]roups[Vv]ersion\w*|isDeskAtLeast\w*|hasFeature\w*)\b/;
+
+const conjuncts = (guard?: string) =>
+  (guard ?? '')
+    .replace(/\s*\?\s*…\s*$/, '')
+    .split(' && ')
+    .map((c) => c.trim())
+    .filter(Boolean);
+
+const negate = (c: string) =>
+  /^!\s*\(.*\)$/.test(c)
+    ? c
+        .replace(/^!\s*\(/, '')
+        .replace(/\)$/, '')
+        .trim()
+    : `! (${c})`;
+
+/**
+ * Whether `found` runs exactly when `missing` does not, on a capability this
+ * reader recognises. Requiring the complementary branch of the *same* guard is
+ * what stops an unrelated served sibling on the same line from excusing a gap.
+ */
+export function complementsGuard(missing?: string, found?: string): boolean {
+  const theirs = conjuncts(found);
+  return conjuncts(missing).some(
+    (c) => CAPABILITY_GUARD.test(c) && theirs.includes(negate(c))
+  );
+}
+
+/**
+ * A guarded branch whose complementary branch is served is the policy's
+ * fallback exception, not a failure.
+ *
+ * Coverage is decided per *record*, not per request: one call site may guard
+ * the request while another makes it unconditionally, and only the guarded one
+ * is excused. A request is covered only when every site that would miss is.
+ */
+export function markCoveredFallbacks(
+  findings: Finding[],
+  grouped: Map<string, Dependency[]>
+): void {
+  const at = (s: SourceLocation) => `${s.file}:${s.line}`;
+  const servedAt = new Map<string, { key: string; guard?: string }[]>();
   for (const finding of findings) {
     if (finding.verdict !== 'FOUND') continue;
-    for (const site of finding.sites) {
-      foundBySite.set(`${site.file}:${site.line}`, finding.dependency.key);
+    for (const dep of grouped.get(finding.dependency.key) ?? []) {
+      const list = servedAt.get(at(dep.site)) ?? [];
+      list.push({ key: finding.dependency.key, guard: dep.guard });
+      servedAt.set(at(dep.site), list);
     }
   }
   for (const finding of findings) {
-    if (finding.verdict !== 'MISSING' || !finding.dependency.guard) continue;
-    for (const site of finding.sites) {
-      const coveredBy = foundBySite.get(`${site.file}:${site.line}`);
-      if (coveredBy) {
-        finding.fallback = { coveredBy, guard: finding.dependency.guard };
-        break;
+    if (finding.verdict !== 'MISSING') continue;
+    const covered: SourceLocation[] = [];
+    const blocking: SourceLocation[] = [];
+    let coveredBy: string | undefined;
+    let guard: string | undefined;
+    for (const dep of grouped.get(finding.dependency.key) ?? []) {
+      const sibling = (servedAt.get(at(dep.site)) ?? []).find((s) =>
+        complementsGuard(dep.guard, s.guard)
+      );
+      if (!sibling) {
+        blocking.push(dep.site);
+        continue;
       }
+      covered.push(dep.site);
+      coveredBy ??= sibling.key;
+      guard ??= dep.guard;
+    }
+    if (covered.length === 0) continue;
+    finding.coverage = { covered, blocking };
+    if (blocking.length === 0) {
+      finding.fallback = { coveredBy: coveredBy!, guard };
     }
   }
 }
@@ -232,7 +309,7 @@ export function runCheck(options: CheckOptions): Report {
           : {}),
       });
     }
-    markCoveredFallbacks(findings);
+    markCoveredFallbacks(findings, grouped);
     findings.sort((a, b) => a.dependency.key.localeCompare(b.dependency.key));
 
     const bumps = loadProtocolBumps();
@@ -295,6 +372,13 @@ function describe(finding: Finding): string[] {
   if (finding.verdict === 'UNVERIFIED') lines.push(`    text:  ${dep.text}`);
   if (finding.fallback) {
     lines.push(`    covers N-1: ${finding.fallback.coveredBy}`);
+  } else if (finding.coverage) {
+    // Guarded at some sites and not at others: say which sites still block, so
+    // the fix is "guard these too", not "why is my fallback ignored?".
+    const at = (l: SourceLocation[]) =>
+      l.map((s) => `${s.file}:${s.line}`).join(', ');
+    lines.push(`    covered at: ${at(finding.coverage.covered)}`);
+    lines.push(`    blocks at:  ${at(finding.coverage.blocking)}`);
   }
   if (finding.allowed) {
     const { reason, broke_at, issue } = finding.allowed;

--- a/packages/scripts/src/check-desk-compat/check.ts
+++ b/packages/scripts/src/check-desk-compat/check.ts
@@ -1,0 +1,269 @@
+import { readFileSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+import {
+  CLIENT_ROOTS,
+  Dependency,
+  SourceLocation,
+  extractClient,
+} from './extract';
+import { openTree } from './git';
+import { loadOwnership, matchMark } from './marks';
+import {
+  Desk,
+  MatchResult,
+  PathRequest,
+  SCRY_CARE,
+  loadDesk,
+  matchPath,
+} from './match';
+import { ProtocolDifference, compareProtocols } from './negotiate';
+
+export interface Finding extends MatchResult {
+  dependency: Dependency;
+  /** Every call site that produces this request. */
+  sites: SourceLocation[];
+  /**
+   * Listed in known-gaps.json: still reported, still MISSING, but does not
+   * fail the run. Pre-existing debt only — see that file's header.
+   */
+  allowed?: KnownGap;
+}
+
+export interface KnownGap {
+  key: string;
+  reason: string;
+  broke_at?: string;
+  issue?: string;
+}
+
+export interface Report {
+  clientRef: string;
+  deskRef: string;
+  protocolDifferences: ProtocolDifference[];
+  findings: Finding[];
+  counts: {
+    found: number;
+    missing: number;
+    unverified: number;
+    /** MISSING entries covered by known-gaps.json; excluded from `missing`. */
+    allowed: number;
+  };
+}
+
+export interface CheckOptions {
+  clientRef: string;
+  deskRef: string;
+  /** Restrict extraction to these `file:line` call sites. */
+  onlySites?: SourceLocation[];
+}
+
+const DESK_PATHS = ['desk', 'peru.yaml'];
+
+/**
+ * Pre-existing MISSING requests that do not fail the run. Read from the
+ * checkout the checker runs in, not from either ref under test: it is a policy
+ * file about *this* repo's debt.
+ */
+export function loadKnownGaps(): Map<string, KnownGap> {
+  const here = dirname(fileURLToPath(import.meta.url));
+  const parsed = JSON.parse(
+    readFileSync(join(here, 'known-gaps.json'), 'utf8')
+  ) as {
+    gaps?: KnownGap[];
+  };
+  return new Map((parsed.gaps ?? []).map((g) => [g.key, g]));
+}
+
+export function toRequest(dep: Dependency): PathRequest | null {
+  if (dep.app === null || dep.path === null) return null;
+  return {
+    app: dep.app,
+    surface: dep.surface === 'scry' ? 'scry' : 'subscribe',
+    known:
+      dep.surface === 'scry'
+        ? [SCRY_CARE, ...dep.path.known]
+        : [...dep.path.known],
+    unknownTail: dep.path.unknownTail,
+  };
+}
+
+export function classify(
+  dep: Dependency,
+  desk: Desk,
+  vendored: Set<string>
+): MatchResult {
+  // Raw eyre URLs and threads are not matcher targets — the N-1 policy defines
+  // no ownership rule for either — so they are recorded as unresolved coverage
+  // for layer 2 rather than dropped.
+  if (dep.surface === 'http' || dep.surface === 'thread') {
+    return {
+      verdict: 'UNVERIFIED',
+      rule: 'coverage',
+      reason: `${dep.surface === 'http' ? 'raw eyre HTTP endpoint' : 'thread'} is outside layer 1`,
+    };
+  }
+  if (dep.surface === 'poke')
+    return matchMark(desk, vendored, dep.app, dep.mark);
+  const request = toRequest(dep);
+  if (request === null || dep.unresolved) {
+    // P4 — an open value set (`/${feedVersion()}/…`) leaves no prefix to match
+    // an arm against, so no arm can settle it.
+    const openValueSet =
+      dep.path !== null && dep.path.known.length === 0 && dep.path.unknownTail;
+    return {
+      verdict: 'UNVERIFIED',
+      rule: openValueSet ? 'P4' : 'extraction',
+      reason: dep.unresolved ?? 'extraction could not resolve app or path',
+    };
+  }
+  return matchPath(desk, request);
+}
+
+export function runCheck(options: CheckOptions): Report {
+  const clientTree = openTree(options.clientRef, CLIENT_ROOTS);
+  const deskTree = openTree(options.deskRef, DESK_PATHS);
+  // The desk that ships alongside the client ref: it supplies the protocol
+  // comparison, and the one ownership set all three release runs share.
+  const clientDeskTree =
+    options.clientRef === options.deskRef
+      ? deskTree
+      : openTree(options.clientRef, DESK_PATHS);
+
+  try {
+    const desk = loadDesk(deskTree, options.deskRef);
+    const vendored = loadOwnership(clientDeskTree);
+    const allowlist = loadKnownGaps();
+
+    let deps = extractClient(clientTree);
+    if (options.onlySites) {
+      const wanted = new Set(
+        options.onlySites.map((s) => `${s.file}:${s.line}`)
+      );
+      deps = deps.filter((d) => wanted.has(`${d.site.file}:${d.site.line}`));
+    }
+
+    // Collapse identical requests, keeping every call site that produced one.
+    const grouped = new Map<string, Dependency[]>();
+    for (const dep of deps)
+      grouped.set(dep.key, [...(grouped.get(dep.key) ?? []), dep]);
+
+    const findings: Finding[] = [];
+    for (const group of grouped.values()) {
+      const result = classify(group[0], desk, vendored);
+      findings.push({
+        ...result,
+        dependency: group[0],
+        sites: group.map((d) => d.site),
+        ...(result.verdict === 'MISSING' && allowlist.has(group[0].key)
+          ? { allowed: allowlist.get(group[0].key) }
+          : {}),
+      });
+    }
+    findings.sort((a, b) => a.dependency.key.localeCompare(b.dependency.key));
+
+    const count = (p: (f: Finding) => boolean) => findings.filter(p).length;
+    return {
+      clientRef: options.clientRef,
+      deskRef: options.deskRef,
+      protocolDifferences: compareProtocols(clientDeskTree, deskTree),
+      findings,
+      counts: {
+        found: count((f) => f.verdict === 'FOUND'),
+        missing: count((f) => f.verdict === 'MISSING' && !f.allowed),
+        unverified: count((f) => f.verdict === 'UNVERIFIED'),
+        allowed: count((f) => f.verdict === 'MISSING' && Boolean(f.allowed)),
+      },
+    };
+  } finally {
+    clientTree.dispose();
+    if (clientDeskTree !== deskTree) clientDeskTree.dispose();
+    deskTree.dispose();
+  }
+}
+
+// --- reporting --------------------------------------------------------------
+
+const FAILURE_TEXT = {
+  crash: 'the agent crashes (watch nack / peek 500)',
+  empty: 'the agent returns an empty result',
+  unknown: 'failure mode not determined',
+};
+
+function describe(finding: Finding): string[] {
+  const dep = finding.dependency;
+  const lines = [`  ${dep.key}`, `    why:   ${finding.reason}`];
+  if (finding.evidence) lines.push(`    desk:  ${finding.evidence}`);
+  if (finding.failureMode && finding.verdict === 'MISSING') {
+    lines.push(`    fails: ${FAILURE_TEXT[finding.failureMode]}`);
+  }
+  if (dep.guard) lines.push(`    guard: ${dep.guard}`);
+  const shown = finding.sites.slice(0, 6).map((s) => `${s.file}:${s.line}`);
+  const more = finding.sites.length - shown.length;
+  lines.push(
+    `    sites: ${shown.join(', ')}${more > 0 ? ` (+${more} more)` : ''}`
+  );
+  if (finding.verdict === 'UNVERIFIED') lines.push(`    text:  ${dep.text}`);
+  if (finding.allowed) {
+    const { reason, broke_at, issue } = finding.allowed;
+    lines.push(`    known: ${reason}`);
+    if (broke_at || issue) {
+      lines.push(
+        `    debt:  broke at ${broke_at ?? '?'}, tracked by ${issue ?? '?'}`
+      );
+    }
+  }
+  return lines;
+}
+
+export function formatReport(report: Report): string {
+  const out = [
+    `desk-compat: client ${report.clientRef} vs desk ${report.deskRef}`,
+    '',
+  ];
+  if (report.protocolDifferences.length > 0) {
+    out.push('NEGOTIATION PROTOCOL MISMATCH (blocks the pair outright)');
+    for (const d of report.protocolDifferences) {
+      out.push(
+        `  %${d.agent} ~.${d.protocol}: client desk [${d.clientDeskVersions.join(', ') || '-'}] vs desk under test [${d.n1Versions.join(', ') || '-'}]`
+      );
+    }
+    out.push(
+      '  negotiate refuses a pair that disagrees on a protocol, whatever the paths say.',
+      ''
+    );
+  } else out.push('negotiation protocols: no version difference', '');
+
+  const section = (title: string, keep: (f: Finding) => boolean) => {
+    const findings = report.findings.filter(keep);
+    if (findings.length === 0) return;
+    out.push(
+      `${title} (${findings.length})`,
+      ...findings.flatMap(describe),
+      ''
+    );
+  };
+  section('MISSING', (f) => f.verdict === 'MISSING' && !f.allowed);
+  section('MISSING but allowed by known-gaps.json', (f) => Boolean(f.allowed));
+  section('UNVERIFIED', (f) => f.verdict === 'UNVERIFIED');
+
+  const { found, missing, unverified, allowed } = report.counts;
+  const sites = report.findings.reduce((n, f) => n + f.sites.length, 0);
+  out.push(
+    `summary: ${found} FOUND, ${missing} MISSING, ${unverified} UNVERIFIED, ${allowed} known gap(s) ` +
+      `over ${report.findings.length} distinct requests from ${sites} call sites`
+  );
+  out.push(
+    report.protocolDifferences.length > 0
+      ? 'result: FAIL (negotiation protocol difference)'
+      : missing > 0
+        ? 'result: FAIL'
+        : 'result: PASS (UNVERIFIED entries do not fail the run)'
+  );
+  return out.join('\n');
+}
+
+/** 0 = no MISSING; 1 = one or more; 2 = internal error (set by the CLI). */
+export const exitCodeFor = (report: Report) =>
+  report.counts.missing > 0 || report.protocolDifferences.length > 0 ? 1 : 0;

--- a/packages/scripts/src/check-desk-compat/extract.test.ts
+++ b/packages/scripts/src/check-desk-compat/extract.test.ts
@@ -218,6 +218,35 @@ describe('argument forms', () => {
     expect(placeholder?.unresolved).toContain('placeholder');
   });
 
+  it('resolves only the bindings that can reach the call', () => {
+    // An assignment after the call, or inside a closure that may never run,
+    // cannot be the value the call sent.
+    expect(
+      keys(`import { scry } from './urbit';
+        export const f = () => {
+          let path = '/v1/live';
+          const later = () => { path = '/v1/never-sent'; };
+          const out = scry({ app: 'groups', path });
+          path = '/v1/after-the-call';
+          return [out, later];
+        };`)
+    ).toEqual(['scry groups /v1/live']);
+  });
+
+  it('resolves nothing when a loop makes the ordering meaningless', () => {
+    // In a loop the call sees the previous iteration's value, so position no
+    // longer says which assignment reaches it.
+    const [dep] = extract(`import { scry } from './urbit';
+      export const f = (ids: string[]) => {
+        let path = '/v1/first';
+        for (const id of ids) {
+          scry({ app: 'groups', path });
+          path = \`/v1/\${id}\`;
+        }
+      };`);
+    expect(dep.unresolved).toBeDefined();
+  });
+
   it('records what it cannot resolve rather than dropping it', () => {
     // An open value set: feedVersion() returns 'v7' | 'v6' | 'v5' at runtime.
     expect(
@@ -277,6 +306,28 @@ describe('helper expansion', () => {
     expect(withHelpers("poke(channelPostAction('chat/~zod/x', {}))")).toContain(
       'poke channels channel-action-2'
     );
+  });
+
+  it('keeps the condition a conditional return sits under', () => {
+    // Without it, every call site of a version-gated helper looks like it needs
+    // all three marks, and the documented fallback can never pass the gate.
+    const deps = extract(
+      `import { poke } from './urbit';\n${HELPERS}\nexport const f = () => poke(activityAction({}));`
+    );
+    const guardOf = (mark: string) =>
+      deps.find((d) => d.mark === mark)?.guard ?? '';
+    expect(guardOf('activity-action-2')).toContain(
+      'getActivitySupportsNotes()'
+    );
+    expect(guardOf('activity-action-1')).toContain(
+      '! (getActivitySupportsNotes())'
+    );
+    expect(guardOf('activity-action')).toContain(
+      '! (getActivitySupportsNotes())'
+    );
+    // Every branch still comes from the one call site, which is what lets a
+    // served sibling cover a missing one.
+    expect(new Set(deps.map((d) => d.site.line)).size).toBe(1);
   });
 
   it('keeps every branch of a helper as its own record', () => {

--- a/packages/scripts/src/check-desk-compat/extract.test.ts
+++ b/packages/scripts/src/check-desk-compat/extract.test.ts
@@ -199,6 +199,74 @@ describe('argument forms', () => {
     );
   });
 
+  it('guards each arm of a ternary written as the poke argument itself', () => {
+    // `poke(a ? new : old)` is the same fallback as `poke({ mark: a ? … : … })`
+    // and has to read as one, or the new mark looks unconditional.
+    const deps = extract(`import { poke } from './urbit';
+      export const f = (json: unknown) => {
+        const modern = { app: 'activity', mark: 'activity-action-2', json };
+        const legacy = { app: 'activity', mark: 'activity-action-1', json };
+        return poke(getActivitySupportsNotes() ? modern : legacy);
+      };`);
+    expect(deps.map((d) => `${d.mark} ${d.guard}`).sort()).toEqual([
+      'activity-action-1 ! (getActivitySupportsNotes())',
+      'activity-action-2 getActivitySupportsNotes() ? …',
+    ]);
+  });
+
+  it('conjoins a nested ternary with the branch it sits under', () => {
+    const deps = extract(`import { poke } from './urbit';
+      export const f = (json: unknown) => {
+        return poke(
+          supportsNotes
+            ? supportsReactions
+              ? { app: 'activity', mark: 'activity-action-3', json }
+              : { app: 'activity', mark: 'activity-action-2', json }
+            : { app: 'activity', mark: 'activity-action-1', json }
+        );
+      };`);
+    expect(deps.map((d) => `${d.mark} ${d.guard}`).sort()).toEqual([
+      'activity-action-1 ! (supportsNotes)',
+      'activity-action-2 supportsNotes ? … && ! (supportsReactions)',
+      'activity-action-3 supportsNotes ? … && supportsReactions ? …',
+    ]);
+  });
+
+  it('keeps only the last write on a straight line', () => {
+    // Nothing between the two assignments can skip either, so the first is
+    // dead and the request it describes was never sent.
+    expect(
+      keys(`import { scry } from './urbit';
+        export const f = () => {
+          let path = '/v1/removed';
+          path = '/v1/served';
+          return scry({ app: 'groups', path });
+        };`)
+    ).toEqual(['scry groups /v1/served']);
+  });
+
+  it('keeps every write once control flow can skip one', () => {
+    // Each of these leaves it open which assignment the call actually read, so
+    // both requests stay on the record.
+    const ambiguous = [
+      "let path = '/v1/a'; if (x) { path = '/v1/b'; }",
+      "let path = '/v1/a'; if (x) path = '/v1/b';",
+      "let path = '/v1/a'; x && (path = '/v1/b');",
+      "let path = '/v1/a'; path = x ? '/v1/b' : '/v1/a';",
+      "let path = '/v1/a'; for (const y of ys) { path = '/v1/b'; }",
+      "let path = '/v1/a'; try { path = '/v1/b'; } catch {}",
+    ];
+    for (const setup of ambiguous) {
+      expect(
+        keys(`import { scry } from './urbit';
+          export const f = (x: boolean, ys: string[]) => {
+            ${setup}
+            return scry({ app: 'groups', path });
+          };`)
+      ).toContain('scry groups /v1/a');
+    }
+  });
+
   it('drops an empty initialiser that a later assignment overwrites', () => {
     // activityApi.ts:57 — `let scryPath = ''` is only a placeholder because
     // both branches below it assign the path the call actually sends.

--- a/packages/scripts/src/check-desk-compat/extract.test.ts
+++ b/packages/scripts/src/check-desk-compat/extract.test.ts
@@ -1,0 +1,334 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  Dependency,
+  extractClient,
+  extractFile,
+  segmentsFromLiteral,
+} from './extract';
+import { memoryTree } from './git';
+
+function extract(
+  source: string,
+  file = 'packages/api/src/client/thing.ts'
+): Dependency[] {
+  const out: Dependency[] = [];
+  extractFile(file, source, out);
+  return out;
+}
+const keys = (source: string, file?: string) =>
+  extract(source, file)
+    .map((d) => d.key)
+    .sort();
+
+/** Helper definitions the poke sites below build on. */
+const HELPERS = `
+  export function groupAction(json: unknown) {
+    return { app: 'groups', mark: 'group-action-5', json };
+  }
+  export function channelAction(nest: string, action: unknown) {
+    return { app: 'channels', mark: 'channel-action-2', json: { nest, action } };
+  }
+  export function channelPostAction(nest: string, action: unknown) {
+    return channelAction(nest, { post: action });
+  }
+  export function chatAction(whom: string, delta: unknown) {
+    if (whomIsDm(whom)) {
+      const action = { app: 'chat', mark: 'chat-dm-action-2', json: delta };
+      return action;
+    }
+    const action = { app: 'chat', mark: 'chat-club-action-2', json: delta };
+    return action;
+  }
+  export function activityAction(action: unknown) {
+    if (getActivitySupportsNotes()) {
+      return { app: 'activity', mark: 'activity-action-2', json: action };
+    }
+    return {
+      app: 'activity',
+      mark: getActivitySupportsReactions() ? 'activity-action-1' : 'activity-action',
+      json: action,
+    };
+  }
+`;
+const withHelpers = (body: string) =>
+  keys(
+    `import { poke } from './urbit';\n${HELPERS}\nexport const f = (whom: string) => ${body};`
+  );
+
+it('splits a literal path, dropping a segment glued to an interpolation', () => {
+  expect(segmentsFromLiteral('/v10/init', false)).toEqual(['v10', 'init']);
+  // `/v1/foo${x}` — `foo` is not a complete segment.
+  expect(segmentsFromLiteral('/v1/foo', true)).toEqual(['v1']);
+  expect(segmentsFromLiteral('/v1/foo/', true)).toEqual(['v1', 'foo']);
+});
+
+describe('binding is by import source, not by name', () => {
+  it('binds every form a wrapper arrives in', () => {
+    expect(
+      keys(
+        "import { scry } from './urbit';\nexport const f = () => scry({ app: 'groups', path: '/v3/groups' });"
+      )
+    ).toEqual(['scry groups /v3/groups']);
+    expect(
+      keys(
+        "import { scry as fetchIt } from '@tloncorp/api';\nexport const f = () => fetchIt({ app: 'groups', path: '/v3/groups' });"
+      )
+    ).toEqual(['scry groups /v3/groups']);
+    expect(
+      keys(
+        "import * as api from '@tloncorp/api';\nexport const f = () => api.subscribe({ app: 'chat', path: '/v1' }, () => {});"
+      )
+    ).toEqual(['subscribe chat /v1']);
+  });
+
+  it('ignores same-named functions and `.subscribe` on unrelated objects', () => {
+    expect(
+      keys(
+        "import { poke } from './local-helpers';\nexport const f = () => poke({ app: 'groups', mark: 'group-action-5' });"
+      )
+    ).toEqual([]);
+    expect(
+      keys(
+        "import { useStore } from 'zustand';\nexport const f = () => useStore.subscribe(() => {});"
+      )
+    ).toEqual([]);
+  });
+});
+
+describe('argument forms', () => {
+  it('reads a template path down to its literal prefix, directly or through a local', () => {
+    const inline = extract(
+      "import { scry } from './urbit';\nexport const f = (g: string) => scry({ app: 'groups', path: `/v3/ui/groups/${g}` });"
+    );
+    expect(inline[0].path).toMatchObject({
+      known: ['v3', 'ui', 'groups'],
+      unknownTail: true,
+    });
+    const shorthand = extract(
+      "import { scry } from './urbit';\nexport const f = (g: string) => { const path = `/v3/ui/groups/${g}`; return scry({ app: 'groups', path }); };"
+    );
+    expect(shorthand[0].path).toMatchObject({ known: ['v3', 'ui', 'groups'] });
+  });
+
+  it('reports a conditional path per branch, never unioned, with its guard', () => {
+    const deps = extract(
+      "import { scry } from './urbit';\nexport const f = () => scry({ app: 'activity', path: getActivitySupportsNotes() ? '/v6/activity' : '/v4/activity' });"
+    );
+    expect(deps.map((d) => d.key).sort()).toEqual([
+      'scry activity /v4/activity',
+      'scry activity /v6/activity',
+    ]);
+    expect(deps.every((d) => d.guard)).toBe(true);
+  });
+
+  it('pairs multi-branch app and path by branch, not by cross product', () => {
+    expect(
+      keys(`
+        import { scry } from './urbit';
+        export const f = (channelId: string, postId: string) => {
+          let app: 'chat' | 'channels';
+          let path: string;
+          if (isDmChannelId(channelId)) {
+            app = 'chat';
+            path = \`/v4/dm/\${channelId}/writs/writ/id/\${postId}\`;
+          } else {
+            app = 'channels';
+            path = \`/v5/\${channelId}/posts/post/\${postId}\`;
+          }
+          return scry({ app, path });
+        };
+      `)
+      // Identity keeps the literal text after each interpolation, so two calls
+      // that share a prefix are not silently the same request.
+    ).toEqual([
+      'scry channels /v5/{}/posts/post/{}',
+      'scry chat /v4/dm/{}/writs/writ/id/{}',
+    ]);
+  });
+
+  it('keeps a template shape distinct from one that merely shares its prefix', () => {
+    const two = `import { subscribe } from './urbit';
+      export const a = (id: string) => subscribe({ app: 'groups', path: \`/chan/\${id}\` }, () => {});
+      export const b = (id: string) => subscribe({ app: 'groups', path: \`/chan/\${id}/new-feature\` }, () => {});`;
+    expect(keys(two)).toEqual([
+      'subscribe groups /chan/{}',
+      'subscribe groups /chan/{}/new-feature',
+    ]);
+  });
+
+  it('only anonymises a plain identifier chain, and hashes the rest whole', () => {
+    const sub = (path: string) =>
+      keys(
+        `import { subscribe } from './urbit';
+         export const f = (id: string, o: { id: string }) =>
+           subscribe({ app: 'groups', path: ${path} }, () => {});`
+      )[0];
+    expect(sub('`/chan/${id}`')).toBe('subscribe groups /chan/{}');
+    expect(sub('`/chan/${o.id}`')).toBe('subscribe groups /chan/{}');
+    // An expression receiver is not a plain chain, and a suffix folded into
+    // the expression must not collapse onto the shorter shape.
+    expect(sub("`/chan/${({ path: id + '/new-feature' }).path}`")).not.toBe(
+      'subscribe groups /chan/{}'
+    );
+    expect(sub("`/chan/${id + '/new-feature'}`")).not.toBe(
+      'subscribe groups /chan/{}'
+    );
+    // Two long expressions that differ only past 200 characters stay distinct.
+    const pad = "'".concat('x'.repeat(210), "'");
+    expect(sub(`\`/chan/\${id + ${pad} + 'a'}\``)).not.toBe(
+      sub(`\`/chan/\${id + ${pad} + 'b'}\``)
+    );
+    // A literal brace cannot spell a hole.
+    expect(sub("'/chan/{}'")).not.toBe(sub('`/chan/${id}`'));
+  });
+
+  it('records an endpoint assigned from a call, instead of dropping the branch', () => {
+    const deps = extract(`import { scry } from './urbit';
+      export const f = (n: number) => {
+        let endpoint = { app: 'groups', path: '/v3/groups' };
+        if (n > 0) endpoint = buildEndpoint(n);
+        return scry(endpoint);
+      };`);
+    expect(deps.map((d) => d.key).sort()).toEqual([
+      'scry ? ?',
+      'scry groups /v3/groups',
+    ]);
+    expect(deps.find((d) => d.key === 'scry ? ?')?.unresolved).toContain(
+      'buildEndpoint'
+    );
+  });
+
+  it('keeps the real assignments when a placeholder precedes them', () => {
+    // activityApi.ts:57 — `let scryPath = ''` is not a request, but the two
+    // paths assigned after it are, and both must survive as their own records.
+    const deps = extract(`import { scry } from './urbit';
+      export const f = (id: string, dm: boolean) => {
+        let scryPath = '';
+        if (dm) { scryPath = \`/v4/activity/dm-threads/\${id}\`; }
+        else { scryPath = \`/v4/activity/threads/\${id}\`; }
+        return scry({ app: 'activity', path: scryPath });
+      };`);
+    expect(deps.map((d) => d.key).sort()).toEqual([
+      'scry activity /',
+      'scry activity /v4/activity/dm-threads/{}',
+      'scry activity /v4/activity/threads/{}',
+    ]);
+    const placeholder = deps.find((d) => d.key === 'scry activity /');
+    expect(placeholder?.unresolved).toContain('placeholder');
+  });
+
+  it('records what it cannot resolve rather than dropping it', () => {
+    // An open value set: feedVersion() returns 'v7' | 'v6' | 'v5' at runtime.
+    expect(
+      extract(
+        "import { scry } from './urbit';\nexport const f = () => scry({ app: 'activity', path: `/${feedVersion()}/feed/init/30` });"
+      )[0].unresolved
+    ).toContain('could not be resolved');
+    expect(
+      extract(
+        "import { poke } from './urbit';\nexport const f = (a: unknown) => poke(buildSomething(a));"
+      )[0].unresolved
+    ).toContain('buildSomething');
+    expect(
+      extract(
+        'export const init = async (airlock: Urbit) => airlock.subscribe(sub(set, get));'
+      )[0].unresolved
+    ).toContain('airlock.subscribe');
+  });
+
+  it('reads both dependencies of a tracked poke: the mark and the watch endpoint', () => {
+    expect(
+      keys(`
+        import { trackedPoke } from './urbit';
+        export const f = () =>
+          trackedPoke(
+            { app: 'groups', mark: 'group-action-5', json: {} },
+            { app: 'groups', path: '/v3/groups' },
+            () => true
+          );
+      `)
+    ).toEqual(['poke groups group-action-5', 'subscribe groups /v3/groups']);
+  });
+
+  it('reads the web client, whose subscribeOnce is positional (app, path, timeout)', () => {
+    const web = 'apps/tlon-web/src/logic/useThing.tsx';
+    expect(
+      keys(
+        "import api from '@/api';\nexport const f = (t: number) => api.subscribeOnce<string>('groups', '/v3/groups', t);",
+        web
+      )
+    ).toEqual(['subscribe groups /v3/groups']);
+    expect(
+      keys(
+        "import api from '@/api';\nexport const f = () => api.poke({ app: 'groups-ui', mark: 'ui-vita-toggle', json: true });",
+        web
+      )
+    ).toEqual(['poke groups-ui ui-vita-toggle']);
+  });
+});
+
+describe('helper expansion', () => {
+  it('resolves an object-literal return, and one hop of forwarding', () => {
+    expect(withHelpers('poke(groupAction({}))')).toContain(
+      'poke groups group-action-5'
+    );
+    // channelPostAction returns channelAction(...), not an object literal.
+    expect(withHelpers("poke(channelPostAction('chat/~zod/x', {}))")).toContain(
+      'poke channels channel-action-2'
+    );
+  });
+
+  it('keeps every branch of a helper as its own record', () => {
+    expect(withHelpers('poke(chatAction(whom, {}))')).toEqual(
+      expect.arrayContaining([
+        'poke chat chat-dm-action-2',
+        'poke chat chat-club-action-2',
+      ])
+    );
+    // A capability-dependent mark: one record per value it can take.
+    expect(withHelpers('poke(activityAction({}))')).toEqual(
+      expect.arrayContaining([
+        'poke activity activity-action',
+        'poke activity activity-action-1',
+        'poke activity activity-action-2',
+      ])
+    );
+  });
+
+  it('resolves a helper through a local variable', () => {
+    expect(
+      keys(
+        `import { poke } from './urbit';\n${HELPERS}\nexport const f = () => { const action = groupAction({}); return poke(action); };`
+      )
+    ).toContain('poke groups group-action-5');
+  });
+
+  it('finds a helper defined in another module of the scanned tree', () => {
+    const deps = extractClient(
+      memoryTree({
+        'packages/api/src/urbit/channel.ts':
+          "export function channelAction(nest: string, action: unknown) { return { app: 'channels', mark: 'channel-action-2', json: { nest, action } }; }",
+        'packages/api/src/client/postsApi.ts':
+          "import { poke } from './urbit';\nimport * as ub from '@tloncorp/api/urbit';\nexport const f = () => poke(ub.channelAction('chat/~zod/x', {}));",
+      }),
+      ['packages/api/src']
+    );
+    expect(deps.map((d) => d.key)).toContain('poke channels channel-action-2');
+  });
+});
+
+it('skips the wrapper definitions and test files', () => {
+  const deps = extractClient(
+    memoryTree({
+      'packages/api/src/client/urbit.ts':
+        "import { poke } from './urbit';\nexport const f = () => poke({ app: 'groups', mark: 'x' });",
+      'packages/api/src/__tests__/t.test.ts':
+        "import { scry } from '../client/urbit';\nexport const f = () => scry({ app: 'groups', path: '/v3/groups' });",
+      'packages/api/src/client/real.ts':
+        "import { scry } from './urbit';\nexport const f = () => scry({ app: 'groups', path: '/v1/init' });",
+    }),
+    ['packages/api/src']
+  );
+  expect(deps.map((d) => d.key)).toEqual(['scry groups /v1/init']);
+});

--- a/packages/scripts/src/check-desk-compat/extract.test.ts
+++ b/packages/scripts/src/check-desk-compat/extract.test.ts
@@ -199,9 +199,9 @@ describe('argument forms', () => {
     );
   });
 
-  it('keeps the real assignments when a placeholder precedes them', () => {
-    // activityApi.ts:57 — `let scryPath = ''` is not a request, but the two
-    // paths assigned after it are, and both must survive as their own records.
+  it('drops an empty initialiser that a later assignment overwrites', () => {
+    // activityApi.ts:57 — `let scryPath = ''` is only a placeholder because
+    // both branches below it assign the path the call actually sends.
     const deps = extract(`import { scry } from './urbit';
       export const f = (id: string, dm: boolean) => {
         let scryPath = '';
@@ -210,12 +210,21 @@ describe('argument forms', () => {
         return scry({ app: 'activity', path: scryPath });
       };`);
     expect(deps.map((d) => d.key).sort()).toEqual([
-      'scry activity /',
       'scry activity /v4/activity/dm-threads/{}',
       'scry activity /v4/activity/threads/{}',
     ]);
-    const placeholder = deps.find((d) => d.key === 'scry activity /');
-    expect(placeholder?.unresolved).toContain('placeholder');
+  });
+
+  it('keeps an empty path that nothing overwrites', () => {
+    // chatApi.ts subscribes to `/` for real. Only a competing assignment makes
+    // an empty string a placeholder; on its own it is the request.
+    const deps = extract(`import { subscribe } from './urbit';
+      export const f = () => {
+        const path = '';
+        return subscribe({ app: 'chat', path }, () => {});
+      };`);
+    expect(deps.map((d) => d.key)).toEqual(['subscribe chat /']);
+    expect(deps[0].unresolved).toBeUndefined();
   });
 
   it('resolves only the bindings that can reach the call', () => {

--- a/packages/scripts/src/check-desk-compat/extract.test.ts
+++ b/packages/scripts/src/check-desk-compat/extract.test.ts
@@ -199,6 +199,27 @@ describe('argument forms', () => {
     );
   });
 
+  it('conjoins nested conditionals inside a property', () => {
+    // `mark: A ? B ? x : y : z` sends x under A && B. A guard reading only `A`
+    // would pair x with y's sibling as if either could serve it.
+    const deps = extract(`import { poke } from './urbit';
+      export const f = (json: unknown) =>
+        poke({
+          app: 'activity',
+          mark: supportsNotes
+            ? supportsReactions
+              ? 'activity-action-3'
+              : 'activity-action-2'
+            : 'activity-action-1',
+          json,
+        });`);
+    expect(deps.map((d) => `${d.mark} ${d.guard}`).sort()).toEqual([
+      'activity-action-1 ! (supportsNotes)',
+      'activity-action-2 supportsNotes ? … && ! (supportsReactions)',
+      'activity-action-3 supportsNotes ? … && supportsReactions ? …',
+    ]);
+  });
+
   it('guards each arm of a ternary written as the poke argument itself', () => {
     // `poke(a ? new : old)` is the same fallback as `poke({ mark: a ? … : … })`
     // and has to read as one, or the new mark looks unconditional.

--- a/packages/scripts/src/check-desk-compat/extract.ts
+++ b/packages/scripts/src/check-desk-compat/extract.ts
@@ -279,29 +279,62 @@ function enclosingFunction(node: ts.Node): ts.Node | undefined {
  * function body. Multi-branch assignment is *not* collapsed — each branch
  * becomes its own record, carrying the block it came from.
  */
-function localAssignments(scope: ts.Node, name: string): Val<ts.Expression>[] {
+function localAssignments(
+  scope: ts.Node,
+  name: string,
+  /** Position of the call. Only assignments before it can reach it. */
+  before?: number
+): Val<ts.Expression>[] {
+  // A call inside a loop sees the previous iteration's value, so ordering says
+  // nothing about which assignment reaches it.
+  if (before !== undefined && inLoop(scope, before)) return [];
   const out: Val<ts.Expression>[] = [];
   const visit = (node: ts.Node) => {
-    if (
+    // A nested closure's assignments run on its own schedule, not this one's.
+    if (node !== scope && ts.isFunctionLike(node)) return;
+    const value =
       ts.isVariableDeclaration(node) &&
       ts.isIdentifier(node.name) &&
       node.name.text === name &&
       node.initializer &&
       node.initializer.kind !== ts.SyntaxKind.NullKeyword
-    ) {
-      out.push({ value: node.initializer, block: enclosingBlock(node) });
-    } else if (
-      ts.isBinaryExpression(node) &&
-      node.operatorToken.kind === ts.SyntaxKind.EqualsToken &&
-      ts.isIdentifier(node.left) &&
-      node.left.text === name
-    ) {
-      out.push({ value: node.right, block: enclosingBlock(node) });
+        ? node.initializer
+        : ts.isBinaryExpression(node) &&
+            node.operatorToken.kind === ts.SyntaxKind.EqualsToken &&
+            ts.isIdentifier(node.left) &&
+            node.left.text === name
+          ? node.right
+          : null;
+    if (value && (before === undefined || node.getStart() < before)) {
+      out.push({ value, block: enclosingBlock(node) });
     }
     ts.forEachChild(node, visit);
   };
   ts.forEachChild(scope, visit);
   return out;
+}
+
+/** Is the position inside a loop that the scope encloses? */
+function inLoop(scope: ts.Node, pos: number): boolean {
+  let found = false;
+  const visit = (node: ts.Node) => {
+    if (found) return;
+    if (
+      (ts.isForStatement(node) ||
+        ts.isForInStatement(node) ||
+        ts.isForOfStatement(node) ||
+        ts.isWhileStatement(node) ||
+        ts.isDoStatement(node)) &&
+      node.getStart() <= pos &&
+      pos < node.getEnd()
+    ) {
+      found = true;
+      return;
+    }
+    ts.forEachChild(node, visit);
+  };
+  ts.forEachChild(scope, visit);
+  return found;
 }
 
 /** The initialiser of an object property, or 'shorthand' for `{ path }`. */
@@ -345,7 +378,8 @@ function literalValues(
   ctx: Ctx,
   obj: ts.ObjectLiteralExpression,
   name: string,
-  scope: ts.Node | undefined
+  scope: ts.Node | undefined,
+  callPos?: number
 ): Val<string | null>[] {
   const resolve = (expr: ts.Expression): Val<string | null>[] => {
     if (ts.isConditionalExpression(expr)) return branches(ctx, expr, resolve);
@@ -354,7 +388,7 @@ function literalValues(
   const prop = property(obj, name);
   if (prop === null) return [{ value: null }];
   const local = (identifier: string) =>
-    scope ? localAssignments(scope, identifier) : [];
+    scope ? localAssignments(scope, identifier, callPos) : [];
   const assignments =
     prop === 'shorthand'
       ? local(name)
@@ -374,6 +408,7 @@ function pathValues(
   ctx: Ctx,
   expr: ts.Expression,
   scope: ts.Node | undefined,
+  callPos?: number,
   depth = 0
 ): Val<PathPattern>[] {
   const text = textOf(ctx, expr);
@@ -411,13 +446,15 @@ function pathValues(
     ];
   }
   if (ts.isConditionalExpression(expr)) {
-    return branches(ctx, expr, (e) => pathValues(ctx, e, scope, depth));
+    return branches(ctx, expr, (e) =>
+      pathValues(ctx, e, scope, callPos, depth)
+    );
   }
   if (ts.isIdentifier(expr) && depth === 0 && scope) {
-    const assignments = localAssignments(scope, expr.text);
+    const assignments = localAssignments(scope, expr.text, callPos);
     if (assignments.length > 0) {
       return assignments.flatMap((a) =>
-        pathValues(ctx, a.value, scope, depth + 1).map((v) => ({
+        pathValues(ctx, a.value, scope, callPos, depth + 1).map((v) => ({
           ...v,
           block: a.block,
         }))
@@ -504,40 +541,94 @@ function expandHelper(ctx: Ctx, name: string, depth = 0): PokeParams[] {
   if (!body)
     return [{ app: null, mark: null, unresolved: `helper ${name} not found` }];
 
-  const returns: ts.Expression[] = [];
-  const collect = (node: ts.Node) => {
-    if (ts.isReturnStatement(node) && node.expression)
-      returns.push(node.expression);
-    ts.forEachChild(node, collect);
+  /**
+   * Each return with the condition it sits under. An early `return` inside an
+   * `if` implicitly negates that condition for everything after it, which is
+   * exactly how `activityAction` gates `activity-action-2`; without the
+   * condition every call site would look like it needs all three marks, and
+   * the documented fallback could never pass the gate.
+   */
+  const returns: [ts.Expression, string | undefined][] = [];
+  const both = (a?: string, b?: string) =>
+    [a, b].filter(Boolean).join(' && ') || undefined;
+  const statementsOf = (s: ts.Statement): readonly ts.Statement[] =>
+    ts.isBlock(s) ? s.statements : [s];
+  const alwaysReturns = (s: ts.Statement): boolean => {
+    const list = statementsOf(s);
+    const last = list[list.length - 1];
+    return Boolean(
+      last && (ts.isReturnStatement(last) || ts.isThrowStatement(last))
+    );
   };
-  ts.forEachChild(body, collect);
+  const nested = (node: ts.Node, guard?: string) => {
+    if (ts.isFunctionLike(node)) return;
+    if (ts.isReturnStatement(node) && node.expression) {
+      returns.push([node.expression, guard]);
+    }
+    ts.forEachChild(node, (n) => nested(n, guard));
+  };
+  const walkStatements = (list: readonly ts.Statement[], guard?: string) => {
+    let acc = guard;
+    for (const stmt of list) {
+      if (ts.isReturnStatement(stmt)) {
+        if (stmt.expression) returns.push([stmt.expression, acc]);
+        continue;
+      }
+      if (ts.isIfStatement(stmt)) {
+        const cond = textOf(ctx, stmt.expression);
+        walkStatements(statementsOf(stmt.thenStatement), both(acc, cond));
+        if (stmt.elseStatement) {
+          walkStatements(
+            statementsOf(stmt.elseStatement),
+            both(acc, `! (${cond})`)
+          );
+        } else if (alwaysReturns(stmt.thenStatement)) {
+          acc = both(acc, `! (${cond})`);
+        }
+        continue;
+      }
+      nested(stmt, acc);
+    }
+  };
+  if (ts.isBlock(body)) walkStatements(body.statements);
+  else returns.push([body as ts.Expression, undefined]);
 
   const results: PokeParams[] = [];
   const unresolved = (why: string) =>
     results.push({ app: null, mark: null, unresolved: why });
-  const fromObject = (obj: ts.ObjectLiteralExpression) => {
+  const fromObject = (obj: ts.ObjectLiteralExpression, guard?: string) => {
     for (const { a, b } of pairByBlock(
       literalValues(ctx, obj, 'app', undefined),
       literalValues(ctx, obj, 'mark', undefined)
     )) {
-      results.push({ app: a.value, mark: b.value, guard: b.guard ?? a.guard });
+      results.push({
+        app: a.value,
+        mark: b.value,
+        guard: both(guard, b.guard ?? a.guard),
+      });
     }
   };
 
-  const read = (expr: ts.Expression, hop: number) => {
-    if (ts.isObjectLiteralExpression(expr)) return fromObject(expr);
+  const read = (expr: ts.Expression, hop: number, guard?: string) => {
+    if (ts.isObjectLiteralExpression(expr)) return fromObject(expr, guard);
     const forwarded = ts.isCallExpression(expr) ? calleeName(expr) : null;
     if (forwarded && hop < 2 && HELPER_WHITELIST.has(forwarded)) {
-      return results.push(...expandHelper(ctx, forwarded, hop + 1));
+      return results.push(
+        ...expandHelper(ctx, forwarded, hop + 1).map((r) => ({
+          ...r,
+          guard: both(guard, r.guard),
+        }))
+      );
     }
     // `const action: Poke<...> = {...}; return action;`
     const local = ts.isIdentifier(expr)
-      ? localAssignments(body, expr.text)
+      ? localAssignments(body, expr.text, expr.getStart(ctx.sf))
       : [];
-    if (local.length > 0) return local.forEach((a) => read(a.value, hop));
+    if (local.length > 0)
+      return local.forEach((a) => read(a.value, hop, guard));
     unresolved(`helper ${name} returns ${textOf(ctx, expr)}`);
   };
-  returns.forEach((expr) => read(expr, depth));
+  returns.forEach(([expr, guard]) => read(expr, depth, guard));
 
   if (results.length === 0)
     unresolved(`helper ${name} has no resolvable return`);
@@ -553,12 +644,15 @@ function readEndpoint(
   surface: 'scry' | 'subscribe'
 ) {
   const scope = enclosingFunction(node);
+  const pos = node.getStart(ctx.sf);
   if (!arg) return push(ctx, node, { surface, unresolved: 'missing argument' });
   if (ts.isObjectLiteralExpression(arg)) {
-    return readEndpointObject(ctx, node, arg, surface, scope);
+    return readEndpointObject(ctx, node, arg, surface, scope, pos);
   }
   const assignments =
-    ts.isIdentifier(arg) && scope ? localAssignments(scope, arg.text) : [];
+    ts.isIdentifier(arg) && scope
+      ? localAssignments(scope, arg.text, node.getStart(ctx.sf))
+      : [];
   if (assignments.length === 0) {
     return push(ctx, node, {
       surface,
@@ -569,7 +663,7 @@ function readEndpoint(
   // ship, so it is recorded as coverage rather than silently dropped.
   for (const a of assignments) {
     if (ts.isObjectLiteralExpression(a.value)) {
-      readEndpointObject(ctx, node, a.value, surface, scope);
+      readEndpointObject(ctx, node, a.value, surface, scope, pos);
     } else {
       push(ctx, node, {
         surface,
@@ -585,7 +679,8 @@ function readEndpointObject(
   node: ts.Node,
   obj: ts.ObjectLiteralExpression,
   surface: 'scry' | 'subscribe',
-  scope: ts.Node | undefined
+  scope: ts.Node | undefined,
+  callPos: number
 ) {
   const prop = property(obj, 'path');
   const unknown = (text: string): Val<PathPattern>[] => [
@@ -594,19 +689,19 @@ function readEndpointObject(
   let paths: Val<PathPattern>[];
   if (prop === null) paths = unknown('<no path>');
   else if (prop === 'shorthand') {
-    const assignments = scope ? localAssignments(scope, 'path') : [];
+    const assignments = scope ? localAssignments(scope, 'path', callPos) : [];
     paths = assignments.length
       ? assignments.flatMap((a) =>
-          pathValues(ctx, a.value, scope, 1).map((v) => ({
+          pathValues(ctx, a.value, scope, callPos, 1).map((v) => ({
             ...v,
             block: a.block,
           }))
         )
       : unknown('path (shorthand, unresolved)');
-  } else paths = pathValues(ctx, prop, scope);
+  } else paths = pathValues(ctx, prop, scope, callPos);
 
   for (const { a: app, b: path } of pairByBlock(
-    literalValues(ctx, obj, 'app', scope),
+    literalValues(ctx, obj, 'app', scope, callPos),
     paths
   )) {
     push(ctx, node, {
@@ -637,6 +732,7 @@ function readPokeParams(
   depth = 0
 ) {
   const scope = enclosingFunction(node);
+  const pos = node.getStart(ctx.sf);
   const emit = (r: PokeParams) =>
     push(ctx, node, {
       surface: 'poke',
@@ -652,8 +748,8 @@ function readPokeParams(
 
   if (ts.isObjectLiteralExpression(arg)) {
     for (const { a, b } of pairByBlock(
-      literalValues(ctx, arg, 'app', scope),
-      literalValues(ctx, arg, 'mark', scope)
+      literalValues(ctx, arg, 'app', scope, pos),
+      literalValues(ctx, arg, 'mark', scope, pos)
     )) {
       emit({ app: a.value, mark: b.value, guard: b.guard ?? a.guard });
     }
@@ -675,7 +771,11 @@ function readPokeParams(
   }
   // Bounded local-variable resolution: one hop.
   if (ts.isIdentifier(arg) && scope && depth === 0) {
-    const assignments = localAssignments(scope, arg.text);
+    const assignments = localAssignments(
+      scope,
+      arg.text,
+      node.getStart(ctx.sf)
+    );
     if (assignments.length) {
       return assignments.forEach((a) =>
         readPokeParams(ctx, node, a.value, depth + 1)
@@ -705,7 +805,12 @@ function readCall(
         return readEndpoint(ctx, node, args[0], 'subscribe');
       // apps/tlon-web/src/api.ts: subscribeOnce(app, path, timeout)
       for (const path of args[1]
-        ? pathValues(ctx, args[1], enclosingFunction(node))
+        ? pathValues(
+            ctx,
+            args[1],
+            enclosingFunction(node),
+            node.getStart(ctx.sf)
+          )
         : [{ value: { known: [], unknownTail: true, text: '<missing>' } }]) {
         const app = args[0] ? stringLiteralOf(args[0]) : null;
         push(ctx, node, {

--- a/packages/scripts/src/check-desk-compat/extract.ts
+++ b/packages/scripts/src/check-desk-compat/extract.ts
@@ -412,9 +412,18 @@ function branches<T>(
   resolve: (e: ts.Expression) => Val<T>[]
 ): Val<T>[] {
   const guard = textOf(ctx, expr.condition);
+  // Conjoined, never overwritten: in `a ? b ? x : y : z` the value `x` is sent
+  // under `a && b`, and a guard that said only `a` would pair `x` with the
+  // wrong sibling.
   return [
-    ...resolve(expr.whenTrue).map((v) => ({ ...v, guard: `${guard} ? …` })),
-    ...resolve(expr.whenFalse).map((v) => ({ ...v, guard: `! (${guard})` })),
+    ...resolve(expr.whenTrue).map((v) => ({
+      ...v,
+      guard: bothGuards(`${guard} ? …`, v.guard),
+    })),
+    ...resolve(expr.whenFalse).map((v) => ({
+      ...v,
+      guard: bothGuards(`! (${guard})`, v.guard),
+    })),
   ];
 }
 

--- a/packages/scripts/src/check-desk-compat/extract.ts
+++ b/packages/scripts/src/check-desk-compat/extract.ts
@@ -1,0 +1,821 @@
+import { createHash } from 'node:crypto';
+
+import ts from 'typescript';
+
+import { Tree } from './git';
+
+export type Surface = 'scry' | 'subscribe' | 'poke' | 'thread' | 'http';
+
+export interface SourceLocation {
+  file: string;
+  line: number;
+}
+
+/**
+ * A request path as far as extraction could resolve it. `known` is the leading
+ * run of fixed segments; `unknownTail` is unbounded in value *and segment
+ * count*, because an interpolation does not stop at a slash — a `groupId` is
+ * `~ship/name` and occupies two segments.
+ */
+export interface PathPattern {
+  known: string[];
+  unknownTail: boolean;
+  text: string;
+  /**
+   * The whole path with each interpolation written as a `{…}` hole. Identity
+   * turns on this, not on `known`, so `/chan/${id}` and
+   * `/chan/${id}/new-feature` stay separate requests — otherwise a new call
+   * would inherit an older one's known-gaps.json exemption.
+   *
+   * The hole is `{}` only for a plain identifier chain. Anything else is
+   * hashed over its whole text, because a suffix can be moved inside the
+   * expression (`` `/chan/${id + '/new'}` ``) and must not collapse onto the
+   * shorter shape. Literal braces are percent-escaped, so a literal can never
+   * spell a hole.
+   */
+  shape?: string;
+}
+
+/** One thing the client asks of the desk, at one call site. */
+export interface Dependency {
+  /** Stable identity: surface + app + path/mark. The report key. */
+  key: string;
+  surface: Surface;
+  app: string | null;
+  path: PathPattern | null;
+  mark: string | null;
+  thread: string | null;
+  site: SourceLocation;
+  /** Verbatim source text of the argument this record came from. */
+  text: string;
+  /** Guard text when this record is one branch of a conditional. */
+  guard?: string;
+  /** Set when extraction could not resolve it; forces UNVERIFIED. */
+  unresolved?: string;
+}
+
+const set = (names: string) => new Set(names.split(' '));
+
+/**
+ * Directories scanned for ship call sites. `tlon-skill`, `openclaw` and
+ * `tlon-bot-e2e` are separately packaged tooling that `ci.yml` already treats
+ * as unconsumed by the app, so they are out of scope.
+ */
+export const CLIENT_ROOTS = [
+  'packages/api/src',
+  'packages/shared/src',
+  'packages/app',
+  'apps/tlon-web/src',
+];
+
+/**
+ * Module specifiers that deliver a wrapper by name. Binding is by *source*,
+ * not by name: a local called `poke` that came from somewhere else is not a
+ * ship call, and a wrapper renamed on import still is.
+ */
+const WRAPPER_SPECIFIERS = set(
+  './urbit ../urbit ../client/urbit ./client/urbit @tloncorp/api ' +
+    '@tloncorp/api/client @tloncorp/api/client/urbit @tloncorp/api/api/urbit'
+);
+/** The web app's own legacy client (`apps/tlon-web/src/api.ts`). */
+const WEB_CLIENT_SPECIFIERS = set('@/api ../api ../../api');
+
+const WRAPPERS = set(
+  'subscribe subscribeOnce poke pokeNoun trackedPoke trackedPokeNoun ' +
+    'scry scryNoun thread requestJson request'
+);
+
+/**
+ * Poke-params builders expanded one hop, following transitive forwarding
+ * (`channelPostAction` returns `channelAction(...)`, not an object literal).
+ */
+export const HELPER_WHITELIST = set(
+  'groupAction groupNavigationBatchUpdate chatAction channelAction ' +
+    'channelPostAction activityAction stewardGatewayAction multiDmAction'
+);
+
+/** Files that *define* the wrappers, rather than calling them. */
+const DEFINITION_FILES = [
+  'packages/api/src/client/urbit.ts',
+  'packages/api/src/http-api/',
+  'apps/tlon-web/src/api.ts',
+];
+
+const isSkipped = (file: string) =>
+  DEFINITION_FILES.some((d) => file === d || file.startsWith(d)) ||
+  /(^|\/)(__tests__|__mocks__)\//.test(file) ||
+  /\.(test|spec)\.tsx?$/.test(file);
+
+type Helpers = Map<string, ts.FunctionLikeDeclaration>;
+
+interface Bindings {
+  /** local name -> wrapper name */
+  wrappers: Map<string, string>;
+  /** namespace aliases of a wrapper module */
+  namespaces: Set<string>;
+  /** default-import aliases of apps/tlon-web/src/api.ts */
+  webClients: Set<string>;
+}
+
+interface Ctx {
+  file: string;
+  sf: ts.SourceFile;
+  helpers: Helpers;
+  out: Dependency[];
+}
+
+/** A resolved value plus the branch it came from. */
+interface Val<T> {
+  value: T;
+  guard?: string;
+  block?: ts.Node | null;
+}
+
+function collectBindings(sf: ts.SourceFile): Bindings {
+  const wrappers = new Map<string, string>();
+  const namespaces = new Set<string>();
+  const webClients = new Set<string>();
+  for (const stmt of sf.statements) {
+    if (!ts.isImportDeclaration(stmt) || !stmt.importClause) continue;
+    if (!ts.isStringLiteral(stmt.moduleSpecifier)) continue;
+    const spec = stmt.moduleSpecifier.text;
+    const { name, namedBindings } = stmt.importClause;
+    if (WRAPPER_SPECIFIERS.has(spec) && namedBindings) {
+      if (ts.isNamedImports(namedBindings)) {
+        for (const el of namedBindings.elements) {
+          const imported = (el.propertyName ?? el.name).text;
+          if (WRAPPERS.has(imported)) wrappers.set(el.name.text, imported);
+        }
+      } else namespaces.add(namedBindings.name.text);
+    }
+    if (WEB_CLIENT_SPECIFIERS.has(spec) && name) webClients.add(name.text);
+  }
+  return { wrappers, namespaces, webClients };
+}
+
+type Callee = { wrapper: string; positional: boolean } | 'airlock' | null;
+
+function resolveCallee(node: ts.CallExpression, b: Bindings): Callee {
+  const callee = node.expression;
+  if (ts.isIdentifier(callee)) {
+    const wrapper = b.wrappers.get(callee.text);
+    return wrapper ? { wrapper, positional: false } : null;
+  }
+  if (
+    !ts.isPropertyAccessExpression(callee) ||
+    !ts.isIdentifier(callee.expression)
+  ) {
+    return null;
+  }
+  const obj = callee.expression.text;
+  const prop = callee.name.text;
+  if (obj === 'airlock' && prop === 'subscribe') return 'airlock';
+  if (!WRAPPERS.has(prop)) return null;
+  if (b.namespaces.has(obj)) return { wrapper: prop, positional: false };
+  // The web client's `subscribeOnce(app, path, timeout)` is positional — a
+  // distinct arity rule from the @tloncorp/api wrapper of the same name.
+  if (b.webClients.has(obj))
+    return { wrapper: prop, positional: prop === 'subscribeOnce' };
+  return null;
+}
+
+const lineOf = (ctx: Ctx, node: ts.Node) =>
+  ctx.sf.getLineAndCharacterOfPosition(node.getStart(ctx.sf)).line + 1;
+const textOf = (ctx: Ctx, node: ts.Node) =>
+  node.getText(ctx.sf).replace(/\s+/g, ' ').slice(0, 200);
+
+function makeKey(d: Omit<Dependency, 'key' | 'site' | 'text'>): string {
+  if (d.surface === 'poke') return `poke ${d.app ?? '?'} ${d.mark ?? '?'}`;
+  if (d.surface === 'thread') return `thread ${d.thread ?? '?'}`;
+  if (d.surface === 'http') return `http ${d.path?.text ?? '?'}`;
+  if (d.path === null) return `${d.surface} ${d.app ?? '?'} ?`;
+  if (d.path.shape) return `${d.surface} ${d.app ?? '?'} ${d.path.shape}`;
+  const segments = [...d.path.known];
+  if (d.path.unknownTail) segments.push('*');
+  return `${d.surface} ${d.app ?? '?'} /${segments.join('/')}`;
+}
+
+function push(
+  ctx: Ctx,
+  node: ts.Node,
+  fields: Partial<Omit<Dependency, 'key' | 'site' | 'text'>> & {
+    surface: Surface;
+  }
+) {
+  const base = {
+    app: null,
+    path: null,
+    mark: null,
+    thread: null,
+    ...fields,
+  } as Omit<Dependency, 'key' | 'site' | 'text'>;
+  ctx.out.push({
+    ...base,
+    key: makeKey(base),
+    site: { file: ctx.file, line: lineOf(ctx, node) },
+    text: textOf(ctx, node),
+  });
+}
+
+// --- value resolution -------------------------------------------------------
+
+/**
+ * Literal path text. Braces are percent-escaped rather than doubled: a hole is
+ * spelled `{}` or `{#hash}`, so `%7B` can never be produced by one, and the
+ * literal `'/chan/{}'` cannot collide with `` `/chan/${x}` ``.
+ */
+const literalShape = (text: string) =>
+  text.replace(/\{/g, '%7B').replace(/\}/g, '%7D');
+
+/** `a`, `a.b.c` — no calls, no computed access, no parenthesised receiver. */
+function isPlainChain(expr: ts.Expression): boolean {
+  if (ts.isIdentifier(expr)) return true;
+  return (
+    ts.isPropertyAccessExpression(expr) &&
+    !expr.questionDotToken &&
+    isPlainChain(expr.expression)
+  );
+}
+
+/**
+ * The hole an interpolation leaves in a shape. A plain identifier chain is
+ * anonymous; anything else is hashed over its *whole* text, so a suffix folded
+ * into the expression cannot collapse onto the shorter shape and two long
+ * expressions that differ late stay distinct.
+ */
+function hole(ctx: Ctx, expr: ts.Expression): string {
+  if (isPlainChain(expr)) return '{}';
+  const normalized = expr.getText(ctx.sf).replace(/\s+/g, ' ');
+  return `{#${createHash('sha1').update(normalized).digest('hex').slice(0, 8)}}`;
+}
+
+/** Turn a resolved template head into path segments. */
+export function segmentsFromLiteral(
+  head: string,
+  unknownTail: boolean
+): string[] {
+  const parts = head.split('/').filter(Boolean);
+  // A final literal chunk glued to an interpolation is not a complete segment.
+  if (unknownTail && !head.endsWith('/')) parts.pop();
+  return parts;
+}
+
+function enclosingBlock(node: ts.Node): ts.Node | null {
+  for (let cur = node.parent; cur; cur = cur.parent) {
+    if (ts.isBlock(cur) || ts.isCaseClause(cur)) return cur;
+  }
+  return null;
+}
+
+function enclosingFunction(node: ts.Node): ts.Node | undefined {
+  for (let cur = node.parent; cur; cur = cur.parent) {
+    if (ts.isFunctionLike(cur)) return cur;
+  }
+  return undefined;
+}
+
+/**
+ * Bounded local-variable resolution: one assignment chain, one hop, inside one
+ * function body. Multi-branch assignment is *not* collapsed — each branch
+ * becomes its own record, carrying the block it came from.
+ */
+function localAssignments(scope: ts.Node, name: string): Val<ts.Expression>[] {
+  const out: Val<ts.Expression>[] = [];
+  const visit = (node: ts.Node) => {
+    if (
+      ts.isVariableDeclaration(node) &&
+      ts.isIdentifier(node.name) &&
+      node.name.text === name &&
+      node.initializer &&
+      node.initializer.kind !== ts.SyntaxKind.NullKeyword
+    ) {
+      out.push({ value: node.initializer, block: enclosingBlock(node) });
+    } else if (
+      ts.isBinaryExpression(node) &&
+      node.operatorToken.kind === ts.SyntaxKind.EqualsToken &&
+      ts.isIdentifier(node.left) &&
+      node.left.text === name
+    ) {
+      out.push({ value: node.right, block: enclosingBlock(node) });
+    }
+    ts.forEachChild(node, visit);
+  };
+  ts.forEachChild(scope, visit);
+  return out;
+}
+
+/** The initialiser of an object property, or 'shorthand' for `{ path }`. */
+function property(
+  obj: ts.ObjectLiteralExpression,
+  name: string
+): ts.Expression | 'shorthand' | null {
+  for (const prop of obj.properties) {
+    const key =
+      ts.isIdentifier(prop.name ?? prop) ||
+      ts.isStringLiteral(prop.name ?? prop)
+        ? (prop.name as ts.Identifier | ts.StringLiteral).text
+        : null;
+    if (key !== name) continue;
+    if (ts.isPropertyAssignment(prop)) return prop.initializer;
+    if (ts.isShorthandPropertyAssignment(prop)) return 'shorthand';
+  }
+  return null;
+}
+
+const stringLiteralOf = (expr: ts.Expression) =>
+  ts.isStringLiteral(expr) || ts.isNoSubstitutionTemplateLiteral(expr)
+    ? expr.text
+    : null;
+
+/** Branch a conditional into its two arms, each carrying the guard text. */
+function branches<T>(
+  ctx: Ctx,
+  expr: ts.ConditionalExpression,
+  resolve: (e: ts.Expression) => Val<T>[]
+): Val<T>[] {
+  const guard = textOf(ctx, expr.condition);
+  return [
+    ...resolve(expr.whenTrue).map((v) => ({ ...v, guard: `${guard} ? …` })),
+    ...resolve(expr.whenFalse).map((v) => ({ ...v, guard: `! (${guard})` })),
+  ];
+}
+
+/** Every string-literal value a property can take (`app`, `mark`). */
+function literalValues(
+  ctx: Ctx,
+  obj: ts.ObjectLiteralExpression,
+  name: string,
+  scope: ts.Node | undefined
+): Val<string | null>[] {
+  const resolve = (expr: ts.Expression): Val<string | null>[] => {
+    if (ts.isConditionalExpression(expr)) return branches(ctx, expr, resolve);
+    return [{ value: stringLiteralOf(expr) }];
+  };
+  const prop = property(obj, name);
+  if (prop === null) return [{ value: null }];
+  const local = (identifier: string) =>
+    scope ? localAssignments(scope, identifier) : [];
+  const assignments =
+    prop === 'shorthand'
+      ? local(name)
+      : ts.isIdentifier(prop)
+        ? local(prop.text)
+        : [];
+  if (assignments.length > 0) {
+    return assignments.flatMap((a) =>
+      resolve(a.value).map((v) => ({ ...v, block: a.block }))
+    );
+  }
+  return prop === 'shorthand' ? [{ value: null }] : resolve(prop);
+}
+
+/** Every path a property can take, resolved down to its literal prefix. */
+function pathValues(
+  ctx: Ctx,
+  expr: ts.Expression,
+  scope: ts.Node | undefined,
+  depth = 0
+): Val<PathPattern>[] {
+  const text = textOf(ctx, expr);
+  if (ts.isStringLiteral(expr) || ts.isNoSubstitutionTemplateLiteral(expr)) {
+    return [
+      {
+        value: {
+          known: segmentsFromLiteral(expr.text, false),
+          unknownTail: false,
+          text,
+          shape: literalShape(expr.text),
+        },
+      },
+    ];
+  }
+  if (ts.isTemplateExpression(expr)) {
+    const unknownTail = expr.templateSpans.length > 0;
+    return [
+      {
+        value: {
+          known: segmentsFromLiteral(expr.head.text, unknownTail),
+          unknownTail,
+          text,
+          // Literal text after each interpolation is still identity, even
+          // though matching stops at the first unknown.
+          shape:
+            literalShape(expr.head.text) +
+            expr.templateSpans
+              .map(
+                (s) => hole(ctx, s.expression) + literalShape(s.literal.text)
+              )
+              .join(''),
+        },
+      },
+    ];
+  }
+  if (ts.isConditionalExpression(expr)) {
+    return branches(ctx, expr, (e) => pathValues(ctx, e, scope, depth));
+  }
+  if (ts.isIdentifier(expr) && depth === 0 && scope) {
+    const assignments = localAssignments(scope, expr.text);
+    if (assignments.length > 0) {
+      return assignments.flatMap((a) =>
+        pathValues(ctx, a.value, scope, depth + 1).map((v) => ({
+          ...v,
+          block: a.block,
+        }))
+      );
+    }
+  }
+  return [{ value: { known: [], unknownTail: true, text } }];
+}
+
+/**
+ * Pair values assigned in the same branch.
+ *
+ * `getPostWithReplies` assigns `app` and `path` in three `if/else` arms; the
+ * cross product would invent `chat` + `/v5/...`, a request no code path makes.
+ */
+function pairByBlock<A, B>(
+  as: Val<A>[],
+  bs: Val<B>[]
+): { a: Val<A>; b: Val<B> }[] {
+  if (
+    as.length > 1 &&
+    bs.length > 1 &&
+    as.every((v) => v.block) &&
+    bs.every((v) => v.block)
+  ) {
+    const paired = bs.map((b) => ({
+      a: as.find((a) => a.block === b.block),
+      b,
+    }));
+    if (paired.every((p) => p.a)) return paired as { a: Val<A>; b: Val<B> }[];
+  }
+  return as.flatMap((a) => bs.map((b) => ({ a, b })));
+}
+
+// --- helper expansion -------------------------------------------------------
+
+const HELPER_HINT = new RegExp(
+  [...HELPER_WHITELIST].map((h) => `\\b${h}\\b`).join('|')
+);
+
+function indexHelpers(sf: ts.SourceFile, into: Helpers) {
+  const visit = (node: ts.Node) => {
+    if (
+      ts.isFunctionDeclaration(node) &&
+      node.name &&
+      HELPER_WHITELIST.has(node.name.text)
+    ) {
+      into.set(node.name.text, node);
+    } else if (
+      ts.isVariableDeclaration(node) &&
+      ts.isIdentifier(node.name) &&
+      HELPER_WHITELIST.has(node.name.text) &&
+      node.initializer &&
+      ts.isFunctionLike(node.initializer)
+    ) {
+      into.set(node.name.text, node.initializer);
+    }
+    ts.forEachChild(node, visit);
+  };
+  ts.forEachChild(sf, visit);
+}
+
+const calleeName = (expr: ts.CallExpression) =>
+  ts.isIdentifier(expr.expression)
+    ? expr.expression.text
+    : ts.isPropertyAccessExpression(expr.expression)
+      ? expr.expression.name.text
+      : null;
+
+interface PokeParams {
+  app: string | null;
+  mark: string | null;
+  guard?: string;
+  unresolved?: string;
+}
+
+/**
+ * Every `{app, mark}` pair a whitelisted helper can return, one per return
+ * statement so guarded branches stay separate. One hop of forwarding is
+ * followed, which recovers `channelPostAction` → `channelAction`.
+ */
+function expandHelper(ctx: Ctx, name: string, depth = 0): PokeParams[] {
+  const body = ctx.helpers.get(name)?.body;
+  if (!body)
+    return [{ app: null, mark: null, unresolved: `helper ${name} not found` }];
+
+  const returns: ts.Expression[] = [];
+  const collect = (node: ts.Node) => {
+    if (ts.isReturnStatement(node) && node.expression)
+      returns.push(node.expression);
+    ts.forEachChild(node, collect);
+  };
+  ts.forEachChild(body, collect);
+
+  const results: PokeParams[] = [];
+  const unresolved = (why: string) =>
+    results.push({ app: null, mark: null, unresolved: why });
+  const fromObject = (obj: ts.ObjectLiteralExpression) => {
+    for (const { a, b } of pairByBlock(
+      literalValues(ctx, obj, 'app', undefined),
+      literalValues(ctx, obj, 'mark', undefined)
+    )) {
+      results.push({ app: a.value, mark: b.value, guard: b.guard ?? a.guard });
+    }
+  };
+
+  const read = (expr: ts.Expression, hop: number) => {
+    if (ts.isObjectLiteralExpression(expr)) return fromObject(expr);
+    const forwarded = ts.isCallExpression(expr) ? calleeName(expr) : null;
+    if (forwarded && hop < 2 && HELPER_WHITELIST.has(forwarded)) {
+      return results.push(...expandHelper(ctx, forwarded, hop + 1));
+    }
+    // `const action: Poke<...> = {...}; return action;`
+    const local = ts.isIdentifier(expr)
+      ? localAssignments(body, expr.text)
+      : [];
+    if (local.length > 0) return local.forEach((a) => read(a.value, hop));
+    unresolved(`helper ${name} returns ${textOf(ctx, expr)}`);
+  };
+  returns.forEach((expr) => read(expr, depth));
+
+  if (results.length === 0)
+    unresolved(`helper ${name} has no resolvable return`);
+  return results;
+}
+
+// --- argument readers -------------------------------------------------------
+
+function readEndpoint(
+  ctx: Ctx,
+  node: ts.Node,
+  arg: ts.Expression | undefined,
+  surface: 'scry' | 'subscribe'
+) {
+  const scope = enclosingFunction(node);
+  if (!arg) return push(ctx, node, { surface, unresolved: 'missing argument' });
+  if (ts.isObjectLiteralExpression(arg)) {
+    return readEndpointObject(ctx, node, arg, surface, scope);
+  }
+  const assignments =
+    ts.isIdentifier(arg) && scope ? localAssignments(scope, arg.text) : [];
+  if (assignments.length === 0) {
+    return push(ctx, node, {
+      surface,
+      unresolved: `endpoint argument is ${textOf(ctx, arg)}`,
+    });
+  }
+  // An assignment this reader cannot read is still a branch that reaches the
+  // ship, so it is recorded as coverage rather than silently dropped.
+  for (const a of assignments) {
+    if (ts.isObjectLiteralExpression(a.value)) {
+      readEndpointObject(ctx, node, a.value, surface, scope);
+    } else {
+      push(ctx, node, {
+        surface,
+        guard: a.guard,
+        unresolved: `endpoint comes from ${textOf(ctx, a.value)}`,
+      });
+    }
+  }
+}
+
+function readEndpointObject(
+  ctx: Ctx,
+  node: ts.Node,
+  obj: ts.ObjectLiteralExpression,
+  surface: 'scry' | 'subscribe',
+  scope: ts.Node | undefined
+) {
+  const prop = property(obj, 'path');
+  const unknown = (text: string): Val<PathPattern>[] => [
+    { value: { known: [], unknownTail: true, text } },
+  ];
+  let paths: Val<PathPattern>[];
+  if (prop === null) paths = unknown('<no path>');
+  else if (prop === 'shorthand') {
+    const assignments = scope ? localAssignments(scope, 'path') : [];
+    paths = assignments.length
+      ? assignments.flatMap((a) =>
+          pathValues(ctx, a.value, scope, 1).map((v) => ({
+            ...v,
+            block: a.block,
+          }))
+        )
+      : unknown('path (shorthand, unresolved)');
+  } else paths = pathValues(ctx, prop, scope);
+
+  for (const { a: app, b: path } of pairByBlock(
+    literalValues(ctx, obj, 'app', scope),
+    paths
+  )) {
+    push(ctx, node, {
+      surface,
+      app: app.value,
+      path: path.value,
+      guard: path.guard ?? app.guard,
+      unresolved:
+        app.value === null
+          ? 'app is not a string literal'
+          : path.value.known.length === 0
+            ? path.value.unknownTail
+              ? `path could not be resolved: ${path.value.text}`
+              : // `let scryPath = ''` before an if/else assigns the real one.
+                // An empty path *can* be a real request — chat watches the
+                // root — so this only says the literal is a placeholder, and
+                // reports it as coverage rather than as a request.
+                'empty literal placeholder, assigned before use'
+            : undefined,
+    });
+  }
+}
+
+function readPokeParams(
+  ctx: Ctx,
+  node: ts.Node,
+  arg: ts.Expression | undefined,
+  depth = 0
+) {
+  const scope = enclosingFunction(node);
+  const emit = (r: PokeParams) =>
+    push(ctx, node, {
+      surface: 'poke',
+      app: r.app,
+      mark: r.mark,
+      guard: r.guard,
+      unresolved:
+        r.unresolved ??
+        (r.mark === null ? 'mark is not a string literal' : undefined),
+    });
+  if (!arg)
+    return push(ctx, node, { surface: 'poke', unresolved: 'missing argument' });
+
+  if (ts.isObjectLiteralExpression(arg)) {
+    for (const { a, b } of pairByBlock(
+      literalValues(ctx, arg, 'app', scope),
+      literalValues(ctx, arg, 'mark', scope)
+    )) {
+      emit({ app: a.value, mark: b.value, guard: b.guard ?? a.guard });
+    }
+    return;
+  }
+  if (ts.isCallExpression(arg)) {
+    const name = calleeName(arg);
+    if (name && HELPER_WHITELIST.has(name))
+      return expandHelper(ctx, name).forEach(emit);
+    return push(ctx, node, {
+      surface: 'poke',
+      unresolved: `poke params come from ${name ?? 'a call'}(…)`,
+    });
+  }
+  // Each branch is its own record; never unioned.
+  if (ts.isConditionalExpression(arg)) {
+    readPokeParams(ctx, node, arg.whenTrue, depth);
+    return readPokeParams(ctx, node, arg.whenFalse, depth);
+  }
+  // Bounded local-variable resolution: one hop.
+  if (ts.isIdentifier(arg) && scope && depth === 0) {
+    const assignments = localAssignments(scope, arg.text);
+    if (assignments.length) {
+      return assignments.forEach((a) =>
+        readPokeParams(ctx, node, a.value, depth + 1)
+      );
+    }
+  }
+  push(ctx, node, {
+    surface: 'poke',
+    unresolved: `poke params are ${textOf(ctx, arg)}`,
+  });
+}
+
+function readCall(
+  ctx: Ctx,
+  node: ts.CallExpression,
+  kind: { wrapper: string; positional: boolean }
+) {
+  const args = node.arguments;
+  switch (kind.wrapper) {
+    case 'scry':
+    case 'scryNoun':
+      return readEndpoint(ctx, node, args[0], 'scry');
+    case 'subscribe':
+      return readEndpoint(ctx, node, args[0], 'subscribe');
+    case 'subscribeOnce':
+      if (!kind.positional)
+        return readEndpoint(ctx, node, args[0], 'subscribe');
+      // apps/tlon-web/src/api.ts: subscribeOnce(app, path, timeout)
+      for (const path of args[1]
+        ? pathValues(ctx, args[1], enclosingFunction(node))
+        : [{ value: { known: [], unknownTail: true, text: '<missing>' } }]) {
+        const app = args[0] ? stringLiteralOf(args[0]) : null;
+        push(ctx, node, {
+          surface: 'subscribe',
+          app,
+          path: path.value,
+          unresolved: app === null ? 'app is not a string literal' : undefined,
+        });
+      }
+      return;
+    case 'poke':
+    case 'pokeNoun':
+      return readPokeParams(ctx, node, args[0]);
+    case 'trackedPoke':
+    case 'trackedPokeNoun':
+      // Both arguments are dependencies: a mark in arg 0 and a watch endpoint
+      // in arg 1.
+      readPokeParams(ctx, node, args[0]);
+      return readEndpoint(ctx, node, args[1], 'subscribe');
+    case 'thread': {
+      const prop =
+        args[0] && ts.isObjectLiteralExpression(args[0])
+          ? property(args[0], 'threadName')
+          : null;
+      const name = prop && prop !== 'shorthand' ? stringLiteralOf(prop) : null;
+      return push(ctx, node, {
+        surface: 'thread',
+        thread: name,
+        unresolved:
+          name === null ? 'threadName is not a string literal' : undefined,
+      });
+    }
+    case 'requestJson':
+    case 'request':
+      // Raw eyre URLs are not a matcher target; recorded so layer 2 reviews
+      // them rather than the report silently dropping them.
+      return push(ctx, node, {
+        surface: 'http',
+        path: {
+          known: [],
+          unknownTail: true,
+          text: args[0] ? textOf(ctx, args[0]) : '<missing>',
+        },
+        unresolved: 'raw eyre URL — outside layer 1, reviewed by layer 2',
+      });
+  }
+}
+
+const parse = (file: string, source: string) =>
+  ts.createSourceFile(
+    file,
+    source,
+    ts.ScriptTarget.Latest,
+    /* setParentNodes */ true,
+    file.endsWith('.tsx') ? ts.ScriptKind.TSX : ts.ScriptKind.TS
+  );
+
+export function extractFile(
+  file: string,
+  source: string,
+  out: Dependency[],
+  sharedHelpers?: Helpers
+): void {
+  const sf = parse(file, source);
+  const bindings = collectBindings(sf);
+  const helpers: Helpers = new Map(sharedHelpers);
+  indexHelpers(sf, helpers);
+  const ctx: Ctx = { file, sf, helpers, out };
+  const visit = (node: ts.Node) => {
+    if (ts.isCallExpression(node)) {
+      const kind = resolveCallee(node, bindings);
+      if (kind === 'airlock') {
+        push(ctx, node, {
+          surface: 'subscribe',
+          unresolved:
+            'airlock.subscribe on a supplied client; app and path come from a factory callback',
+        });
+      } else if (kind) readCall(ctx, node, kind);
+    }
+    ts.forEachChild(node, visit);
+  };
+  ts.forEachChild(sf, visit);
+}
+
+/**
+ * Whole-tree extraction. Syntax-only: no `createProgram`, no type checker, no
+ * module resolution, so it runs over a bare `git archive` tree with no
+ * `node_modules`.
+ */
+export function extractClient(
+  tree: Tree,
+  roots: string[] = CLIENT_ROOTS
+): Dependency[] {
+  const files: { file: string; source: string }[] = [];
+  for (const root of roots) {
+    for (const file of tree.list(
+      root,
+      (p) => /\.tsx?$/.test(p) && !p.endsWith('.d.ts')
+    )) {
+      const source = isSkipped(file) ? null : tree.readFile(file);
+      if (source !== null) files.push({ file, source });
+    }
+  }
+  // Helpers are defined in a handful of modules but called from many, so index
+  // them across the tree before extracting.
+  const shared: Helpers = new Map();
+  for (const { file, source } of files) {
+    if (HELPER_HINT.test(source)) indexHelpers(parse(file, source), shared);
+  }
+  const out: Dependency[] = [];
+  for (const { file, source } of files) extractFile(file, source, out, shared);
+  return out;
+}

--- a/packages/scripts/src/check-desk-compat/extract.ts
+++ b/packages/scripts/src/check-desk-compat/extract.ts
@@ -311,7 +311,13 @@ function localAssignments(
     ts.forEachChild(node, visit);
   };
   ts.forEachChild(scope, visit);
-  return out;
+  // `let scryPath = ''` is a placeholder only because something later
+  // overwrites it. On its own it is the value the call sends.
+  const isEmptyLiteral = (v: Val<ts.Expression>) =>
+    (ts.isStringLiteral(v.value) ||
+      ts.isNoSubstitutionTemplateLiteral(v.value)) &&
+    v.value.text === '';
+  return out.length > 1 ? out.filter((v) => !isEmptyLiteral(v)) : out;
 }
 
 /** Is the position inside a loop that the scope encloses? */
@@ -712,14 +718,8 @@ function readEndpointObject(
       unresolved:
         app.value === null
           ? 'app is not a string literal'
-          : path.value.known.length === 0
-            ? path.value.unknownTail
-              ? `path could not be resolved: ${path.value.text}`
-              : // `let scryPath = ''` before an if/else assigns the real one.
-                // An empty path *can* be a real request — chat watches the
-                // root — so this only says the literal is a placeholder, and
-                // reports it as coverage rather than as a request.
-                'empty literal placeholder, assigned before use'
+          : path.value.known.length === 0 && path.value.unknownTail
+            ? `path could not be resolved: ${path.value.text}`
             : undefined,
     });
   }

--- a/packages/scripts/src/check-desk-compat/extract.ts
+++ b/packages/scripts/src/check-desk-compat/extract.ts
@@ -317,7 +317,42 @@ function localAssignments(
     (ts.isStringLiteral(v.value) ||
       ts.isNoSubstitutionTemplateLiteral(v.value)) &&
     v.value.text === '';
-  return out.length > 1 ? out.filter((v) => !isEmptyLiteral(v)) : out;
+  const kept = out.length > 1 ? out.filter((v) => !isEmptyLiteral(v)) : out;
+  // On a straight line the last write is the only one the call can read.
+  // Anything that makes reachability a question — a branch, a loop, a
+  // short-circuit, a `case` — keeps every candidate, since the reader cannot
+  // tell which one ran.
+  const block = kept[0]?.block ?? null;
+  if (
+    kept.length > 1 &&
+    block !== null &&
+    kept.every((v) => v.block === block && runsUnconditionally(v.value, block))
+  ) {
+    return [kept[kept.length - 1]];
+  }
+  return kept;
+}
+
+/** Does this assignment run every time control reaches its block? */
+function runsUnconditionally(node: ts.Node, block: ts.Node): boolean {
+  const SHORT_CIRCUIT = new Set([
+    ts.SyntaxKind.AmpersandAmpersandToken,
+    ts.SyntaxKind.BarBarToken,
+    ts.SyntaxKind.QuestionQuestionToken,
+  ]);
+  for (let cur = node.parent; cur && cur !== block; cur = cur.parent) {
+    if (
+      ts.isConditionalExpression(cur) ||
+      ts.isIfStatement(cur) ||
+      ts.isSwitchStatement(cur) ||
+      ts.isTryStatement(cur) ||
+      ts.isIterationStatement(cur, false) ||
+      (ts.isBinaryExpression(cur) && SHORT_CIRCUIT.has(cur.operatorToken.kind))
+    ) {
+      return false;
+    }
+  }
+  return true;
 }
 
 /** Is the position inside a loop that the scope encloses? */
@@ -365,6 +400,10 @@ const stringLiteralOf = (expr: ts.Expression) =>
   ts.isStringLiteral(expr) || ts.isNoSubstitutionTemplateLiteral(expr)
     ? expr.text
     : null;
+
+/** Both guards had to hold for the record to be sent. */
+const bothGuards = (a?: string, b?: string) =>
+  [a, b].filter(Boolean).join(' && ') || undefined;
 
 /** Branch a conditional into its two arms, each carrying the guard text. */
 function branches<T>(
@@ -555,8 +594,6 @@ function expandHelper(ctx: Ctx, name: string, depth = 0): PokeParams[] {
    * the documented fallback could never pass the gate.
    */
   const returns: [ts.Expression, string | undefined][] = [];
-  const both = (a?: string, b?: string) =>
-    [a, b].filter(Boolean).join(' && ') || undefined;
   const statementsOf = (s: ts.Statement): readonly ts.Statement[] =>
     ts.isBlock(s) ? s.statements : [s];
   const alwaysReturns = (s: ts.Statement): boolean => {
@@ -582,14 +619,14 @@ function expandHelper(ctx: Ctx, name: string, depth = 0): PokeParams[] {
       }
       if (ts.isIfStatement(stmt)) {
         const cond = textOf(ctx, stmt.expression);
-        walkStatements(statementsOf(stmt.thenStatement), both(acc, cond));
+        walkStatements(statementsOf(stmt.thenStatement), bothGuards(acc, cond));
         if (stmt.elseStatement) {
           walkStatements(
             statementsOf(stmt.elseStatement),
-            both(acc, `! (${cond})`)
+            bothGuards(acc, `! (${cond})`)
           );
         } else if (alwaysReturns(stmt.thenStatement)) {
-          acc = both(acc, `! (${cond})`);
+          acc = bothGuards(acc, `! (${cond})`);
         }
         continue;
       }
@@ -610,7 +647,7 @@ function expandHelper(ctx: Ctx, name: string, depth = 0): PokeParams[] {
       results.push({
         app: a.value,
         mark: b.value,
-        guard: both(guard, b.guard ?? a.guard),
+        guard: bothGuards(guard, b.guard ?? a.guard),
       });
     }
   };
@@ -622,7 +659,7 @@ function expandHelper(ctx: Ctx, name: string, depth = 0): PokeParams[] {
       return results.push(
         ...expandHelper(ctx, forwarded, hop + 1).map((r) => ({
           ...r,
-          guard: both(guard, r.guard),
+          guard: bothGuards(guard, r.guard),
         }))
       );
     }
@@ -729,7 +766,9 @@ function readPokeParams(
   ctx: Ctx,
   node: ts.Node,
   arg: ts.Expression | undefined,
-  depth = 0
+  depth = 0,
+  /** The branch condition that had to hold for this argument to be sent. */
+  guard?: string
 ) {
   const scope = enclosingFunction(node);
   const pos = node.getStart(ctx.sf);
@@ -738,13 +777,14 @@ function readPokeParams(
       surface: 'poke',
       app: r.app,
       mark: r.mark,
-      guard: r.guard,
+      guard: bothGuards(guard, r.guard),
       unresolved:
         r.unresolved ??
         (r.mark === null ? 'mark is not a string literal' : undefined),
     });
-  if (!arg)
-    return push(ctx, node, { surface: 'poke', unresolved: 'missing argument' });
+  const unresolved = (why: string) =>
+    push(ctx, node, { surface: 'poke', guard, unresolved: why });
+  if (!arg) return unresolved('missing argument');
 
   if (ts.isObjectLiteralExpression(arg)) {
     for (const { a, b } of pairByBlock(
@@ -759,15 +799,22 @@ function readPokeParams(
     const name = calleeName(arg);
     if (name && HELPER_WHITELIST.has(name))
       return expandHelper(ctx, name).forEach(emit);
-    return push(ctx, node, {
-      surface: 'poke',
-      unresolved: `poke params come from ${name ?? 'a call'}(…)`,
-    });
+    return unresolved(`poke params come from ${name ?? 'a call'}(…)`);
   }
-  // Each branch is its own record; never unioned.
+  // Each branch is its own record, carrying its own guard; never unioned. The
+  // guard is what lets a capability fallback written as `a ? new : old` be
+  // recognised as one, exactly as the `{ mark: a ? … : … }` spelling is.
   if (ts.isConditionalExpression(arg)) {
-    readPokeParams(ctx, node, arg.whenTrue, depth);
-    return readPokeParams(ctx, node, arg.whenFalse, depth);
+    const condition = textOf(ctx, arg.condition);
+    const under = (text: string) => bothGuards(guard, text);
+    readPokeParams(ctx, node, arg.whenTrue, depth, under(`${condition} ? …`));
+    return readPokeParams(
+      ctx,
+      node,
+      arg.whenFalse,
+      depth,
+      under(`! (${condition})`)
+    );
   }
   // Bounded local-variable resolution: one hop.
   if (ts.isIdentifier(arg) && scope && depth === 0) {
@@ -778,14 +825,11 @@ function readPokeParams(
     );
     if (assignments.length) {
       return assignments.forEach((a) =>
-        readPokeParams(ctx, node, a.value, depth + 1)
+        readPokeParams(ctx, node, a.value, depth + 1, guard)
       );
     }
   }
-  push(ctx, node, {
-    surface: 'poke',
-    unresolved: `poke params are ${textOf(ctx, arg)}`,
-  });
+  unresolved(`poke params are ${textOf(ctx, arg)}`);
 }
 
 function readCall(

--- a/packages/scripts/src/check-desk-compat/fixtures.test.ts
+++ b/packages/scripts/src/check-desk-compat/fixtures.test.ts
@@ -4,7 +4,7 @@ import { fileURLToPath } from 'node:url';
 
 import { describe, expect, it } from 'vitest';
 
-import { Finding, runCheck } from './check';
+import { Finding, isBlocking, runCheck } from './check';
 import { WORKTREE_REF, ensureRef } from './git';
 
 /**
@@ -23,6 +23,8 @@ import { WORKTREE_REF, ensureRef } from './git';
 const CLIENT = '854b46c';
 const N1 = 'v12.1.0';
 const SHIPPED_WITH = 'v12.2.0';
+/** Two releases back: old enough that the activity fallbacks are exercised. */
+const WITH_FALLBACKS = 'v12.0.0';
 
 /**
  * The desk this working tree must support, read from the constant that defines
@@ -40,7 +42,8 @@ const MIN_GROUPS_VERSION = /MIN_GROUPS_VERSION = '([^']+)'/.exec(
 )?.[1];
 const N1_TAG = `v${MIN_GROUPS_VERSION}`;
 
-for (const ref of [CLIENT, N1, SHIPPED_WITH, N1_TAG]) ensureRef(ref);
+for (const ref of [CLIENT, N1, SHIPPED_WITH, WITH_FALLBACKS, N1_TAG])
+  ensureRef(ref);
 
 const missingKeys = (findings: Finding[]) =>
   findings
@@ -76,6 +79,10 @@ describe('incident fixture — the two call sites that broke build 440', () => {
     );
     expect(byKey.get('scry groups-ui /v10/init')).toBe('empty');
     expect(byKey.get('subscribe groups /v3/groups')).toBe('crash');
+  });
+
+  it('calls no gap stale on a scan that visited two call sites', () => {
+    expect(report.staleGaps).toEqual([]);
   });
 
   it('would have flagged the boundary on the protocol check alone', () => {
@@ -121,6 +128,40 @@ describe('full-scan fixture — everything build 440 required', () => {
     expect(report.counts.missing).toBeGreaterThan(0);
     expect(report.counts.found).toBeGreaterThan(40);
   });
+
+  it('finds every gap entry still doing its job', () => {
+    expect(report.staleGaps).toEqual([]);
+  });
+});
+
+describe('a desk old enough to need the activity fallbacks', () => {
+  const report = runCheck({
+    clientRef: WORKTREE_REF,
+    deskRef: WITH_FALLBACKS,
+  });
+
+  // The bug this guards: the gate excludes covered fallbacks from `missing`,
+  // so anything that recomputes "blocking" by hand can fail on a run the
+  // checker passes.
+  it('agrees with the gate about what blocks', () => {
+    expect(report.counts.fallback).toBeGreaterThan(0);
+    expect(report.findings.filter(isBlocking).length).toBe(
+      report.counts.missing
+    );
+    for (const covered of report.findings.filter((f) => f.fallback)) {
+      expect(isBlocking(covered)).toBe(false);
+    }
+  });
+
+  it('covers exactly the capability-guarded activity branches', () => {
+    expect(
+      report.findings.filter((f) => f.fallback).map((f) => f.dependency.key)
+    ).toEqual([
+      'poke activity activity-action-2',
+      'scry activity /v6/volume-settings',
+      'subscribe activity /v6',
+    ]);
+  });
 });
 
 describe('this working tree against the desk release it must support', () => {
@@ -129,9 +170,9 @@ describe('this working tree against the desk release it must support', () => {
   const report = runCheck({ clientRef: WORKTREE_REF, deskRef: N1_TAG });
 
   it('has no blocking MISSING, and no protocol difference', () => {
-    const blocking = report.findings.filter(
-      (f) => f.verdict === 'MISSING' && !f.allowed
-    );
+    // `isBlocking` is the checker's own predicate, so a covered fallback cannot
+    // pass the gate and fail this test.
+    const blocking = report.findings.filter(isBlocking);
     expect(blocking.map((f) => f.dependency.key)).toEqual([]);
     expect(report.counts.missing).toBe(0);
     expect(report.protocolDifferences).toEqual([]);

--- a/packages/scripts/src/check-desk-compat/fixtures.test.ts
+++ b/packages/scripts/src/check-desk-compat/fixtures.test.ts
@@ -1,3 +1,7 @@
+import { readFileSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
 import { describe, expect, it } from 'vitest';
 
 import { Finding, runCheck } from './check';
@@ -20,7 +24,23 @@ const CLIENT = '854b46c';
 const N1 = 'v12.1.0';
 const SHIPPED_WITH = 'v12.2.0';
 
-for (const ref of [CLIENT, N1, SHIPPED_WITH]) ensureRef(ref);
+/**
+ * The desk this working tree must support, read from the constant that defines
+ * it rather than pinned: once MIN_GROUPS_VERSION moves, this fixture must move
+ * with it, or `test:ci` would fail on a perfectly valid client.
+ */
+const MIN_GROUPS_VERSION = /MIN_GROUPS_VERSION = '([^']+)'/.exec(
+  readFileSync(
+    join(
+      dirname(fileURLToPath(import.meta.url)),
+      '../../../shared/src/logic/deskCompatibility.ts'
+    ),
+    'utf8'
+  )
+)?.[1];
+const N1_TAG = `v${MIN_GROUPS_VERSION}`;
+
+for (const ref of [CLIENT, N1, SHIPPED_WITH, N1_TAG]) ensureRef(ref);
 
 const missingKeys = (findings: Finding[]) =>
   findings
@@ -104,9 +124,9 @@ describe('full-scan fixture — everything build 440 required', () => {
 });
 
 describe('this working tree against the desk release it must support', () => {
-  // The gate the `test-build` step runs. If this branch needs something
-  // v12.2.0 does not serve, that is the whole point of the check.
-  const report = runCheck({ clientRef: WORKTREE_REF, deskRef: SHIPPED_WITH });
+  // The gate the `test-build` step runs, against whichever release
+  // MIN_GROUPS_VERSION currently names.
+  const report = runCheck({ clientRef: WORKTREE_REF, deskRef: N1_TAG });
 
   it('has no blocking MISSING, and no protocol difference', () => {
     const blocking = report.findings.filter(

--- a/packages/scripts/src/check-desk-compat/fixtures.test.ts
+++ b/packages/scripts/src/check-desk-compat/fixtures.test.ts
@@ -1,0 +1,144 @@
+import { describe, expect, it } from 'vitest';
+
+import { Finding, runCheck } from './check';
+import { WORKTREE_REF, ensureRef } from './git';
+
+/**
+ * The v10/v3 incident, replayed.
+ *
+ * `854b46c` is the client commit that shipped `/v10/init` and the `/v3/groups`
+ * subscription; `v12.1.0` is the desk release before the one that added them.
+ * The desk change and the client cutover landed nine seconds apart, so no
+ * released desk could serve that client.
+ *
+ * These **hard-fail rather than skip** when the refs are absent: a
+ * compatibility gate that quietly skips its only regression evidence is worse
+ * than no gate. Refs are fetched on demand (`--no-tags --depth=1`), which is
+ * what a fresh CI checkout needs.
+ */
+const CLIENT = '854b46c';
+const N1 = 'v12.1.0';
+const SHIPPED_WITH = 'v12.2.0';
+
+for (const ref of [CLIENT, N1, SHIPPED_WITH]) ensureRef(ref);
+
+const missingKeys = (findings: Finding[]) =>
+  findings
+    .filter((f) => f.verdict === 'MISSING')
+    .map((f) => f.dependency.key)
+    .sort();
+
+describe('incident fixture — the two call sites that broke build 440', () => {
+  const report = runCheck({
+    clientRef: CLIENT,
+    deskRef: N1,
+    onlySites: [
+      { file: 'packages/api/src/client/initApi.ts', line: 38 },
+      { file: 'packages/api/src/client/groupsApi.ts', line: 1327 },
+    ],
+  });
+
+  it('produces exactly two records, keyed by surface, both MISSING by P1', () => {
+    expect(report.findings.map((f) => f.dependency.key).sort()).toEqual([
+      'scry groups-ui /v10/init',
+      'subscribe groups /v3/groups',
+    ]);
+    expect(report.findings.map((f) => [f.verdict, f.rule])).toEqual([
+      ['MISSING', 'P1'],
+      ['MISSING', 'P1'],
+    ]);
+    expect([report.counts.found, report.counts.unverified]).toEqual([0, 0]);
+  });
+
+  it('records the different failure modes of a peek and a watch', () => {
+    const byKey = new Map(
+      report.findings.map((f) => [f.dependency.key, f.failureMode])
+    );
+    expect(byKey.get('scry groups-ui /v10/init')).toBe('empty');
+    expect(byKey.get('subscribe groups /v3/groups')).toBe('crash');
+  });
+
+  it('would have flagged the boundary on the protocol check alone', () => {
+    // %groups moved 2 → 3, and the two agents that expect it moved with it.
+    expect(
+      report.protocolDifferences.map(
+        (d) =>
+          `${d.agent} ~.${d.protocol} ${d.clientDeskVersions}/${d.n1Versions}`
+      )
+    ).toEqual([
+      'channels ~.groups 3/2',
+      'channels-server ~.groups 3/2',
+      'groups ~.groups 3/2',
+    ]);
+  });
+});
+
+describe('full-scan fixture — everything build 440 required', () => {
+  const report = runCheck({ clientRef: CLIENT, deskRef: N1 });
+
+  // A superset check with an explicit list, so it documents what the release
+  // required without breaking when extraction improves.
+  it('reports every hand-verified gap as MISSING', () => {
+    expect(missingKeys(report.findings)).toEqual(
+      expect.arrayContaining([
+        // v12.1.0's groups-ui tops out at [%x %v9 %init ~]
+        'scry groups-ui /v10/init',
+        // absent at v12.1.0; the watch arms stop at [%v2 %groups ~]
+        'subscribe groups /v3/groups',
+        // v12.1.0's changes arms stop at [%x %v10 %changes since=@ ~]
+        'scry groups-ui /v11/changes/{}',
+        // v12.1.0 has [%x ver=?(%v0 %v1 %v2) %ui %groups …]; %v3 arrives at 12.2.0
+        'scry groups /v3/ui/groups/{}',
+        // desk/mar/group/ at v12.1.0 has action-0…action-4 only
+        'poke groups group-action-5',
+        // the scry form of /v3/groups is distinct from the subscription
+        'scry groups /v3/groups',
+      ])
+    );
+  });
+
+  it('fails the run, but still resolves most of the tree', () => {
+    expect(report.counts.missing).toBeGreaterThan(0);
+    expect(report.counts.found).toBeGreaterThan(40);
+  });
+});
+
+describe('this working tree against the desk release it must support', () => {
+  // The gate the `test-build` step runs. If this branch needs something
+  // v12.2.0 does not serve, that is the whole point of the check.
+  const report = runCheck({ clientRef: WORKTREE_REF, deskRef: SHIPPED_WITH });
+
+  it('has no blocking MISSING, and no protocol difference', () => {
+    const blocking = report.findings.filter(
+      (f) => f.verdict === 'MISSING' && !f.allowed
+    );
+    expect(blocking.map((f) => f.dependency.key)).toEqual([]);
+    expect(report.counts.missing).toBe(0);
+    expect(report.protocolDifferences).toEqual([]);
+  });
+
+  it('exempts only what known-gaps.json names, by exact request shape', () => {
+    const allowed = report.findings.filter((f) => f.allowed);
+    expect(allowed.map((f) => f.dependency.key)).toEqual([
+      'subscribe groups /chan/{}',
+    ]);
+    expect(allowed[0].allowed?.issue).toBe('TLON-6538');
+  });
+});
+
+describe('the same client against the desk that actually shipped it', () => {
+  const report = runCheck({ clientRef: CLIENT, deskRef: SHIPPED_WITH });
+
+  it('serves every path the previous release could not, and agrees on protocols', () => {
+    const keys = missingKeys(report.findings);
+    for (const key of [
+      'scry groups-ui /v10/init',
+      'subscribe groups /v3/groups',
+      'scry groups-ui /v11/changes/{}',
+      'poke groups group-action-5',
+    ]) {
+      expect(keys).not.toContain(key);
+    }
+    expect(report.protocolDifferences).toEqual([]);
+  });
+});

--- a/packages/scripts/src/check-desk-compat/git.ts
+++ b/packages/scripts/src/check-desk-compat/git.ts
@@ -1,0 +1,181 @@
+import { execFileSync, spawnSync } from 'node:child_process';
+import {
+  existsSync,
+  mkdtempSync,
+  readFileSync,
+  readdirSync,
+  rmSync,
+  statSync,
+} from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join, posix } from 'node:path';
+
+/** Ref meaning "read the working tree", so uncommitted work can be checked. */
+export const WORKTREE_REF = 'worktree';
+
+let cachedRoot: string | null = null;
+
+function repoRoot(): string {
+  cachedRoot ??= execFileSync('git', ['rev-parse', '--show-toplevel'], {
+    encoding: 'utf8',
+  }).trim();
+  return cachedRoot;
+}
+
+function git(args: string[]) {
+  return spawnSync('git', args, {
+    cwd: repoRoot(),
+    encoding: 'utf8',
+    maxBuffer: 256 * 1024 * 1024,
+  });
+}
+
+function refExists(ref: string): boolean {
+  return (
+    ref === WORKTREE_REF ||
+    git(['cat-file', '-e', `${ref}^{commit}`]).status === 0
+  );
+}
+
+/**
+ * Make `ref` readable, fetching it if the checkout lacks it.
+ *
+ * CI checks out at depth 1 with no tags, so neither the N-1 desk tag nor a
+ * historical client SHA is present. A targeted `--no-tags --depth=1` fetch
+ * covers both; deepening the whole clone is not an acceptable substitute.
+ */
+export function ensureRef(ref: string): void {
+  if (refExists(ref)) return;
+  const attempts: string[][] = [];
+  const fetch = (spec: string) => [
+    'fetch',
+    '--no-tags',
+    '--depth=1',
+    'origin',
+    spec,
+  ];
+  if (/^v\d+\.\d+\.\d+$/.test(ref))
+    attempts.push(fetch(`refs/tags/${ref}:refs/tags/${ref}`));
+  else if (ref.startsWith('origin/')) {
+    const branch = ref.slice('origin/'.length);
+    attempts.push(fetch(`refs/heads/${branch}:refs/remotes/origin/${branch}`));
+  }
+  // A bare SHA cannot be written to a named local ref, but fetching it leaves
+  // it reachable, which is all `git archive` needs.
+  attempts.push(fetch(ref));
+  for (const args of attempts) {
+    if (git(args).status === 0 && refExists(ref)) return;
+  }
+  throw new Error(
+    `ref '${ref}' is not present and could not be fetched. Tried: ` +
+      attempts.map((a) => `git ${a.join(' ')}`).join('; ')
+  );
+}
+
+export interface Tree {
+  readonly ref: string;
+  readFile(relPath: string): string | null;
+  exists(relPath: string): boolean;
+  /** Repo-relative paths of every file under `relDir`, recursively, sorted. */
+  list(relDir: string, filter?: (p: string) => boolean): string[];
+  dispose(): void;
+}
+
+class DirTree implements Tree {
+  constructor(
+    readonly ref: string,
+    private readonly root: string,
+    private readonly temporary: boolean
+  ) {}
+
+  readFile(relPath: string): string | null {
+    const p = join(this.root, relPath);
+    try {
+      return statSync(p).isDirectory() ? null : readFileSync(p, 'utf8');
+    } catch {
+      return null;
+    }
+  }
+
+  exists(relPath: string): boolean {
+    return existsSync(join(this.root, relPath));
+  }
+
+  list(relDir: string, filter?: (p: string) => boolean): string[] {
+    const out: string[] = [];
+    const walk = (rel: string) => {
+      let entries;
+      try {
+        entries = readdirSync(join(this.root, rel), { withFileTypes: true });
+      } catch {
+        return;
+      }
+      for (const e of entries) {
+        if (e.name === 'node_modules' || e.name === '.git') continue;
+        const child = posix.join(rel, e.name);
+        if (e.isDirectory()) walk(child);
+        else if (!filter || filter(child)) out.push(child);
+      }
+    };
+    walk(relDir);
+    return out.sort();
+  }
+
+  dispose() {
+    if (this.temporary) rmSync(this.root, { recursive: true, force: true });
+  }
+}
+
+/**
+ * Materialise `paths` at `ref` into a temp directory, or hand back the working
+ * tree. `git archive` rather than a checkout, so a run never touches the
+ * caller's index or working tree.
+ */
+export function openTree(ref: string, paths: string[]): Tree {
+  if (ref === WORKTREE_REF) return new DirTree(ref, repoRoot(), false);
+  ensureRef(ref);
+  // Paths absent at this ref make `git archive` fail outright, so probe first.
+  const present = paths.filter(
+    (p) => git(['cat-file', '-e', `${ref}:${p}`]).status === 0
+  );
+  if (present.length === 0) {
+    throw new Error(`none of [${paths.join(', ')}] exist at ref '${ref}'`);
+  }
+  const dir = mkdtempSync(join(tmpdir(), 'desk-compat-'));
+  const fail = (what: string, err?: Buffer) => {
+    rmSync(dir, { recursive: true, force: true });
+    return new Error(
+      `${what} at ${ref} failed: ${err?.toString() ?? 'unknown error'}`
+    );
+  };
+  const archive = spawnSync(
+    'git',
+    ['archive', '--format=tar', ref, '--', ...present],
+    {
+      cwd: repoRoot(),
+      maxBuffer: 512 * 1024 * 1024,
+    }
+  );
+  if (archive.status !== 0) throw fail('git archive', archive.stderr);
+  const extract = spawnSync('tar', ['-x', '-C', dir], {
+    input: archive.stdout,
+    maxBuffer: 512 * 1024 * 1024,
+  });
+  if (extract.status !== 0) throw fail('tar extract', extract.stderr);
+  return new DirTree(ref, dir, true);
+}
+
+/** In-memory tree, so tests can exercise rules against hand-written agents. */
+export function memoryTree(files: Record<string, string>): Tree {
+  const has = (p: string) => Object.prototype.hasOwnProperty.call(files, p);
+  return {
+    ref: 'memory',
+    readFile: (p) => (has(p) ? files[p] : null),
+    exists: has,
+    list: (dir, filter) =>
+      Object.keys(files)
+        .filter((f) => f.startsWith(`${dir}/`) && (!filter || filter(f)))
+        .sort(),
+    dispose: () => {},
+  };
+}

--- a/packages/scripts/src/check-desk-compat/hoon.test.ts
+++ b/packages/scripts/src/check-desk-compat/hoon.test.ts
@@ -1,0 +1,277 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  expandPattern,
+  indexArms,
+  parseDispatcher,
+  preDispatchObstructions,
+  splitTokens,
+} from './hoon';
+
+/** Flattened alternatives as `seg/seg/…` strings, or null when unparseable. */
+const shapes = (pattern: string) =>
+  expandPattern(pattern)?.map((alt) =>
+    alt.map((e) => (e.k === 'lit' ? e.v : e.k)).join('/')
+  ) ?? null;
+
+describe('pattern grammar', () => {
+  it('reads every atomic form the desk uses', () => {
+    expect(shapes('[%x %v10 %init ~]')).toEqual(['x/v10/init/nil']);
+    expect(shapes('[%x %v5 %changes since=@ ~]')).toEqual([
+      'x/v5/changes/any/nil',
+    ]);
+    expect(shapes('[%server %groups ship=@ name=@ rest=*]')).toEqual([
+      'server/groups/any/any/rest',
+    ]);
+    expect(shapes('[%u %v1 %book her=@p ~]')).toEqual(['u/v1/book/any/nil']);
+    expect(shapes('~')).toEqual(['nil']);
+  });
+
+  it('does not mistake a named mold for "any knot"', () => {
+    // `=kind:c` is ?(%diary %heap %chat) (sur/channels.hoon:147) and `=cid` is
+    // @uvF — neither accepts every segment, so both stay opaque.
+    expect(shapes('[%x v=%v0 =kind:c ship=@ ~]')).toEqual([
+      'x/v0/opaque/any/nil',
+    ]);
+    expect(shapes('[%u %v1 %book %id =cid ~]')).toEqual([
+      'u/v1/book/id/opaque/nil',
+    ]);
+  });
+
+  it('expands unions, which is what lets a version be rejected rather than failed open', () => {
+    expect(shapes('[%x ver=?(%v0 %v1 %v2) %ui %groups ~]')).toEqual([
+      'x/v0/ui/groups/nil',
+      'x/v1/ui/groups/nil',
+      'x/v2/ui/groups/nil',
+    ]);
+    expect(shapes('[%x %v1 %heads since=?(~ [u=@ ~])]')).toEqual([
+      'x/v1/heads/nil',
+      'x/v1/heads/any/nil',
+    ]);
+    expect(shapes('[%record ?([@ @ ~] [@ @ @ ~])]')).toEqual([
+      'record/any/any/nil',
+      'record/any/any/any/nil',
+    ]);
+    expect(shapes('[?(%x %u) %show *]')).toEqual([
+      'x/show/rest',
+      'u/show/rest',
+    ]);
+  });
+
+  it('refuses syntax it does not model, rather than guessing', () => {
+    expect(shapes('[%~.~ %foo ~]')).toBeNull();
+    expect(shapes('[!>(`action`vase) ~]')).toBeNull();
+  });
+
+  it('keeps bracketed and parenthesised groups whole when tokenising', () => {
+    expect(splitTokens('%x ver=?(%v0 %v1) [u=@ ~] *')).toEqual([
+      '%x',
+      'ver=?(%v0 %v1)',
+      '[u=@ ~]',
+      '*',
+    ]);
+  });
+});
+
+// Arm pattern alone at headerIndent+4 with the body underneath, and a nested
+// `:*` whose `==` must not end the dispatcher early.
+const STANDALONE = `
+?+    pole  [~ ~]
+    [%x %pins ~]  \`\`ui-pins+!>(pins)
+::
+    [%x %v9 %init ~]
+  =+  .^(a (scry %gx %groups /v3/init/noun))
+  =/  init=init-9:u
+    :*  a
+        b
+    ==
+  \`\`ui-init-9+!>(init)
+::
+    [%x %v11 %changes since=@ ~]
+  \`\`json+!>(changes)
+==
+`.trim();
+
+// Pattern and body sharing a line at headerIndent+2, mixed with the other
+// layout, plus a bare bracketed body line that must not read as an arm.
+const MIXED = `
+?+  pole  ~|(bad-watch-path+pole !!)
+    [%server %groups ship=@ name=@ rest=*]
+  =/  se-core  (se-abed:se-core [our.bowl name.pole])
+  [[bot %steward] %poke %some-mark !>(payload)]
+::
+  [%v1 %groups ~]  ?>(from-self cor)
+::
+  [%v2 %groups ~]  ?>(from-self cor)
+==
+`.trim();
+
+// The three real shapes whose body lines sit at an arm column: a `:^` child
+// (groups.hoon:1336), a `?~` branch result (contacts.hoon:809), and a `=/`
+// initialiser (activity.hoon:631). Each must stay body — stealing one
+// truncates its arm, hiding whatever the rest of the body depends on.
+const OUTDENTED_BODIES = `
+?+    pole  [~ ~]
+      [%x %v3 %changes since=@ rest=*]
+    =+  since=(slav %da since.pole)
+    :^  ~  ~
+      %group-changed-groups-3
+    (~(run by (changes since)) group-ui:group:v11:gc)
+::
+        [%x %v1 %book her=@p ~]
+      ?~  who=(slaw %p her.pat)
+        [~ ~]
+      \`\`contact-page-0+page
+::
+      [%x ver=?(%v4 %v5) %event id=@ ~]
+    =/  =time-event:a
+      [id.pole (got:on-event:a stream:base (slav %da id.pole))]
+    \`\`json+!>(event)
+::
+      [%x ver=?(%v4 %v5 %v6) ~]
+    =/  =full-info:a
+      [indices activity volume-settings]
+    ?-    ver.pole
+        %v4  \`\`activity-full-4+!>(legacy)
+    ==
+::
+      [%x %v7 %pair ~]
+    :-  %noun
+      [indices activity]
+    \`\`noun+!>(out)
+::
+      [%x %v8 %fallback ~]
+    =/  default
+      [%x %v1 ~]
+    \`\`noun+!>(default)
+==
+`.trim();
+
+describe('parseDispatcher', () => {
+  const parse = (source: string) => {
+    const lines = source.split('\n');
+    return parseDispatcher(lines, 0, lines.length)!;
+  };
+
+  it('reads both arm layouts and neither nested runes nor bracketed body lines', () => {
+    const standalone = parse(STANDALONE);
+    expect(standalone.subject).toBe('pole');
+    expect(standalone.defaultKind).toBe('empty');
+    expect(standalone.arms.map((a) => a.patternText)).toEqual([
+      '[%x %pins ~]',
+      '[%x %v9 %init ~]',
+      '[%x %v11 %changes since=@ ~]',
+    ]);
+    const mixed = parse(MIXED);
+    expect(mixed.defaultKind).toBe('crash');
+    expect(mixed.arms.map((a) => a.patternText)).toEqual([
+      '[%server %groups ship=@ name=@ rest=*]',
+      '[%v1 %groups ~]',
+      '[%v2 %groups ~]',
+    ]);
+    expect([standalone.unparsedArms, mixed.unparsedArms]).toEqual([0, 0]);
+  });
+
+  it('keeps an arm body, so delegation and fan-out can be read from it', () => {
+    expect(parse(STANDALONE).arms[1].bodyText).toContain('/v3/init/noun');
+  });
+
+  it('does not mistake an outdented body line for an arm', () => {
+    const d = parse(OUTDENTED_BODIES);
+    expect(d.arms.map((a) => a.patternText)).toEqual([
+      '[%x %v3 %changes since=@ rest=*]',
+      '[%x %v1 %book her=@p ~]',
+      '[%x ver=?(%v4 %v5) %event id=@ ~]',
+      '[%x ver=?(%v4 %v5 %v6) ~]',
+      '[%x %v7 %pair ~]',
+      '[%x %v8 %fallback ~]',
+    ]);
+    // Nothing was left unparseable, which is what would suppress MISSING.
+    expect(d.unparsedArms).toBe(0);
+    // Each arm keeps its whole body, so what the body depends on stays visible.
+    expect(d.arms[0].bodyText).toContain('group-changed-groups-3');
+    expect(d.arms[2].bodyText).toContain('got:on-event:a');
+    // activity.hoon:452 — a tuple of bare names is a value, and the `?-` it
+    // precedes must stay inside the arm.
+    expect(d.arms[3].bodyText).toContain('[indices activity volume-settings]');
+    expect(d.arms[3].bodyText).toContain('?-    ver.pole');
+    // The same tuple-of-names under a `:-` rather than a `=/`: a bracket that
+    // pins no `%tag`, face, aura, `*` or `~` is a value, whatever precedes it.
+    expect(d.arms[4].bodyText).toContain('[indices activity]');
+    // And a `=/` that binds a genuinely path-shaped tuple: the value of a
+    // binding is never the next arm, however much it looks like a pattern.
+    expect(d.arms[5].bodyText).toContain('[%x %v1 ~]');
+  });
+
+  it('reports source line numbers when parsing a slice of a file', () => {
+    const lines = OUTDENTED_BODIES.split('\n');
+    const d = parseDispatcher(lines, 0, lines.length, 1456)!;
+    expect(d.headerLine).toBe(1457);
+    expect(d.arms[0].line).toBe(1458);
+    expect(d.arms[0].bodyStartLine).toBe(1459);
+  });
+
+  it('treats a `:def` default as a nack, since the pinned default-agent crashes', () => {
+    expect(
+      parse('?+  path  (on-peek:def path)\n  [%x %a ~]  ``json+!>(a)\n==')
+        .defaultKind
+    ).toBe('default-agent');
+  });
+});
+
+it('indexes each `++` arm with the range its body occupies', () => {
+  const arms = indexArms([
+    '|_  =bowl:gall',
+    '++  peek',
+    '  |=  =path',
+    '  [~ ~]',
+    '++  watch',
+    '  cor',
+    '--',
+  ]);
+  expect([...arms.keys()]).toEqual(['peek', 'watch']);
+  expect([arms.get('peek')!.start, arms.get('peek')!.end]).toEqual([1, 4]);
+});
+
+describe('preDispatchObstructions', () => {
+  const find = (lines: string[], subject: string) =>
+    preDispatchObstructions(lines, 0, lines.length, subject);
+
+  it('tells a guard apart from a rewrite of the subject', () => {
+    const found = find(
+      [
+        '?>  ?=(^ pole)',
+        '=?  +.pole  !?=([?(%v0 %v1) *] +.pole)',
+        '  [%v0 +.pole]',
+      ],
+      'pole'
+    );
+    expect(found.map((o) => o.kind)).toEqual(['guard', 'rewrite']);
+    // `+.pole` skips the care, and the injection cannot fire for %v0 or %v1.
+    expect(found[1].inertWhen).toEqual({ index: 1, members: ['v0', 'v1'] });
+  });
+
+  it('resolves a locally bound union, as reel spells the same injection', () => {
+    const found = find(
+      ['=/  any  ?(%v0 %v1)', '=?  pole  !?=([any *] pole)', '  [%v0 pole]'],
+      'pole'
+    );
+    expect(found[0].inertWhen).toEqual({ index: 0, members: ['v0', 'v1'] });
+  });
+
+  it('leaves a rewrite it cannot read with no inert case', () => {
+    // lanyard strips the care and gates on %v1; nothing about that is a union.
+    expect(find(['=.  path  t.path'], 'path')[0]).toMatchObject({
+      kind: 'rewrite',
+      inertWhen: undefined,
+    });
+  });
+
+  it('ignores bindings that leave the subject alone', () => {
+    // `=^ cards state` in a delegating on-watch is an ordinary binding.
+    expect(
+      find(['=^  cards  state', '  abet:(watch:cor path)'], 'path')
+    ).toEqual([]);
+    expect(find(['=/  =(pole knot)  path'], 'pole')).toEqual([]);
+  });
+});

--- a/packages/scripts/src/check-desk-compat/hoon.test.ts
+++ b/packages/scripts/src/check-desk-compat/hoon.test.ts
@@ -6,6 +6,8 @@ import {
   parseDispatcher,
   preDispatchObstructions,
   splitTokens,
+  stripComment,
+  stripComments,
 } from './hoon';
 
 /** Flattened alternatives as `seg/seg/…` strings, or null when unparseable. */
@@ -146,6 +148,52 @@ const OUTDENTED_BODIES = `
     \`\`noun+!>(default)
 ==
 `.trim();
+
+describe('stripComment', () => {
+  it('removes a trailing comment, runes and all', () => {
+    expect(
+      stripComment('    [%x %v1 ~]  cor  :: handled like ?+  :~  ==')
+    ).toBe('    [%x %v1 ~]  cor');
+    expect(stripComment(':: whole line')).toBe('');
+    expect(stripComment('  ?+  pole  [~ ~]')).toBe('  ?+  pole  [~ ~]');
+  });
+
+  it('keeps a `::` that is text, not a comment', () => {
+    expect(stripComment("  =/  sep  '::'  :: the separator")).toBe(
+      "  =/  sep  '::'"
+    );
+    expect(stripComment('  =/  t  "a::b"')).toBe('  =/  t  "a::b"');
+    expect(stripComment("  =/  q  '\\''  :: escaped quote")).toBe(
+      "  =/  q  '\\''"
+    );
+  });
+});
+
+describe('a rune inside a comment', () => {
+  const COMMENTED = `
+?+    pole  [~ ~]
+    [%x %v1 %init ~]
+  cor  :: the ?+ below is handled elsewhere  :~
+::
+    [%x %v2 %init ~]
+  cor
+==
+`.trim();
+
+  it('does not swallow the arms below it', () => {
+    const raw = COMMENTED.split('\n');
+    // Unstripped, the commented `?+` and `:~` push the depth up and the second
+    // arm is read as body.
+    expect(
+      parseDispatcher(raw, 0, raw.length)!.arms.map((a) => a.patternText)
+    ).toEqual(['[%x %v1 %init ~]']);
+
+    const clean = stripComments(raw);
+    expect(
+      parseDispatcher(clean, 0, clean.length)!.arms.map((a) => a.patternText)
+    ).toEqual(['[%x %v1 %init ~]', '[%x %v2 %init ~]']);
+  });
+});
 
 describe('parseDispatcher', () => {
   const parse = (source: string) => {

--- a/packages/scripts/src/check-desk-compat/hoon.ts
+++ b/packages/scripts/src/check-desk-compat/hoon.ts
@@ -69,6 +69,35 @@ const indentOf = (line: string) => line.length - line.trimStart().length;
 const isCode = (line: string) =>
   line.trim().length > 0 && !line.trim().startsWith('::');
 
+/**
+ * Blank out a `::` comment, keeping the line (and so every line number) in
+ * place. A `::` inside a cord or tape is text, not a comment, so the scan
+ * tracks quoting.
+ *
+ * Every structural read — rune counting, arm layout, body branching, nested
+ * dispatch — runs on the result. A rune written in a trailing comment would
+ * otherwise move the depth counter and swallow the arms below it, turning
+ * served requests into blocking MISSING.
+ */
+export function stripComment(line: string): string {
+  let quote: string | null = null;
+  for (let i = 0; i < line.length; i++) {
+    const c = line[i];
+    if (quote !== null) {
+      if (c === '\\') i++;
+      else if (c === quote) quote = null;
+    } else if (c === "'" || c === '"') {
+      quote = c;
+    } else if (c === ':' && line[i + 1] === ':') {
+      return line.slice(0, i).trimEnd();
+    }
+  }
+  return line;
+}
+
+export const stripComments = (lines: string[]): string[] =>
+  lines.map(stripComment);
+
 function count(line: string, re: RegExp): number {
   re.lastIndex = 0;
   let n = 0;

--- a/packages/scripts/src/check-desk-compat/hoon.ts
+++ b/packages/scripts/src/check-desk-compat/hoon.ts
@@ -1,0 +1,558 @@
+/**
+ * A deliberately small Hoon reader: just enough to answer "does this agent
+ * serve this pole?".
+ *
+ * It is a *line* grammar, which the source permits because every `?+` arm
+ * pattern in `desk/app` sits on one physical line. That is necessary but not
+ * sufficient — arm bodies and nested running runes span lines — so arm
+ * boundaries come from the arm indentation plus a `==`-depth counter, and
+ * anything that does not parse is recorded rather than guessed at.
+ */
+
+/**
+ * An atom of a flattened arm pattern. `opaque` is a named mold this reader
+ * cannot resolve — `=kind:c` is `?(%diary %heap %chat)`, not "any knot" — so it
+ * consumes a segment without establishing that the segment is accepted.
+ */
+export type Elem =
+  | { k: 'lit'; v: string }
+  | { k: 'any' }
+  | { k: 'opaque'; name: string }
+  | { k: 'rest' }
+  | { k: 'nil' };
+
+type Node =
+  | { t: 'lit'; v: string }
+  | { t: 'any' }
+  | { t: 'opaque'; name: string }
+  | { t: 'rest' }
+  | { t: 'nil' }
+  | { t: 'union'; members: Node[] }
+  | { t: 'tuple'; items: Node[] };
+
+export interface Arm {
+  patternText: string;
+  /** 1-based line of the arm pattern. */
+  line: number;
+  /** 1-based line the body's first line occupies, for nested diagnostics. */
+  bodyStartLine: number;
+  /** Every concrete element list this pattern can take, unions expanded. */
+  alternatives: Elem[][];
+  bodyText: string;
+  /** Faces bound by the pattern, mapped to their token index. */
+  faces: Record<string, number>;
+  parsed: boolean;
+}
+
+export type DefaultKind = 'crash' | 'empty' | 'default-agent' | 'unknown';
+
+export interface Dispatcher {
+  subject: string;
+  /** 1-based line of the `?+`. */
+  headerLine: number;
+  defaultKind: DefaultKind;
+  arms: Arm[];
+  /** Arms whose pattern would not parse; forbids a MISSING verdict. */
+  unparsedArms: number;
+  /** Name of the `++` arm the dispatcher sits in, when known. */
+  armName?: string;
+}
+
+// Runes whose tall form is terminated by `==`. Counted so a nested one cannot
+// end the dispatcher early or hide an arm.
+const OPENER_RE =
+  /(?:^|\s)(?:\?\+|\?-|:~|:\*|;:|;~|=~|%\*|\$%|\$\?|\$:)(?=\s|$)/g;
+const CLOSER_RE = /(?:^|\s)==(?=\s|$)/g;
+const MAX_ALTERNATIVES = 256;
+
+const indentOf = (line: string) => line.length - line.trimStart().length;
+const isCode = (line: string) =>
+  line.trim().length > 0 && !line.trim().startsWith('::');
+
+function count(line: string, re: RegExp): number {
+  re.lastIndex = 0;
+  let n = 0;
+  while (re.exec(line) !== null) n++;
+  return n;
+}
+
+/** Whitespace split that keeps bracketed and parenthesised groups whole. */
+export function splitTokens(text: string): string[] {
+  const out: string[] = [];
+  let depth = 0;
+  let current = '';
+  for (const c of text) {
+    if (c === '[' || c === '(') depth++;
+    if (c === ']' || c === ')') depth--;
+    if (/\s/.test(c) && depth === 0) {
+      if (current) out.push(current);
+      current = '';
+    } else current += c;
+  }
+  if (current) out.push(current);
+  return out;
+}
+
+const stripFace = (token: string) =>
+  /^([a-z][a-z0-9-]*)=(.+)$/s.exec(token)?.[2] ?? token;
+
+function parseNode(token: string): Node | null {
+  const rest = stripFace(token);
+  if (rest === '~') return { t: 'nil' };
+  if (rest === '*') return { t: 'rest' };
+  if (rest === '^') return { t: 'any' };
+  if (/^%[a-z0-9][a-z0-9-]*$/.test(rest)) return { t: 'lit', v: rest.slice(1) };
+  // `@`, `@p`, `@ud` accept any knot. A named mold (`=kind:c`, `=cid`, or a
+  // locally bound `any`) does not: it is whatever `sur/` says it is.
+  if (/^@[a-z]*$/.test(rest)) return { t: 'any' };
+  const mold = /^=?([a-z][a-z0-9-]*(?::[a-z0-9-]+)*)$/.exec(rest);
+  if (mold) return { t: 'opaque', name: mold[1] };
+  const group = (open: string, t: 'union' | 'tuple') => {
+    if (!rest.startsWith(open) || !rest.endsWith(open === '?(' ? ')' : ']'))
+      return null;
+    const inner = splitTokens(rest.slice(open.length, -1)).map(parseNode);
+    if (inner.some((n) => n === null)) return null;
+    return t === 'union'
+      ? ({ t, members: inner as Node[] } as Node)
+      : ({ t, items: inner as Node[] } as Node);
+  };
+  return group('?(', 'union') ?? group('[', 'tuple');
+}
+
+function parsePattern(text: string): Node[] | null {
+  const trimmed = text.trim();
+  if (trimmed.startsWith('[') && trimmed.endsWith(']')) {
+    const items = splitTokens(trimmed.slice(1, -1)).map(parseNode);
+    return items.some((i) => i === null) ? null : (items as Node[]);
+  }
+  const single = parseNode(trimmed);
+  return single === null ? null : [single];
+}
+
+/**
+ * Flatten a pattern into every concrete element list it can match.
+ *
+ * Nested tuples always flatten: a path pattern is right-nested, so
+ * `[%a %b [u=@ ~]]` and `[%a %b u=@ ~]` are the same cell. Unions expand into
+ * alternatives, which is what lets `ver=?(%v0 %v1 %v2)` *reject* `%v3` rather
+ * than fail open.
+ */
+function expand(nodes: Node[]): Elem[][] | null {
+  let acc: Elem[][] = [[]];
+  for (const node of nodes) {
+    const options = expandNode(node);
+    if (options === null) return null;
+    const next: Elem[][] = [];
+    for (const prefix of acc) {
+      for (const option of options) {
+        next.push([...prefix, ...option]);
+        if (next.length > MAX_ALTERNATIVES) return null;
+      }
+    }
+    acc = next;
+  }
+  return acc;
+}
+
+function expandNode(node: Node): Elem[][] | null {
+  if (node.t === 'tuple') return expand(node.items);
+  if (node.t === 'union') {
+    const out: Elem[][] = [];
+    for (const member of node.members) {
+      const expanded = expandNode(member);
+      if (expanded === null || out.length > MAX_ALTERNATIVES) return null;
+      out.push(...expanded);
+    }
+    return out;
+  }
+  if (node.t === 'lit') return [[{ k: 'lit', v: node.v }]];
+  if (node.t === 'opaque') return [[{ k: 'opaque', name: node.name }]];
+  return [[{ k: node.t }]];
+}
+
+/** Parse a pattern and flatten it; exported for the grammar tests. */
+export function expandPattern(text: string): Elem[][] | null {
+  const nodes = parsePattern(text);
+  return nodes === null ? null : expand(nodes);
+}
+
+function looksLikePattern(t: string): boolean {
+  return (
+    t.startsWith('[') ||
+    t.startsWith('?(') ||
+    (t.startsWith('%') && !/^%[-+*^~]/.test(t)) ||
+    /^(~|\*|@[a-z]*)($|\s)/.test(t) ||
+    /^[a-z][a-z0-9-]*=/.test(t)
+  );
+}
+
+/**
+ * Tell an arm pattern from a body expression that happens to sit at the same
+ * column. Lexical only — no evaluation — but enough for the three shapes that
+ * otherwise steal a body line and silently truncate the arm:
+ *
+ *   groups.hoon:1336   `%group-changed-groups-3`   a `:^` child, not an arm
+ *   contacts.hoon:809  `[~ ~]`                     a `?~` branch result
+ *   activity.hoon:631  `[id.pole (got:… …)]`       a `=/` initialiser
+ *   activity.hoon:452  `[indices activity volume-settings]`  likewise
+ */
+function couldBeArmPattern(text: string, hasInlineBody: boolean): boolean {
+  const bracketed = text.startsWith('[') && text.endsWith(']');
+  // A bare `%tag` is only an arm when it carries its body on the same line;
+  // standing alone it is a child of the rune above it.
+  if (
+    !bracketed &&
+    text !== '~' &&
+    !(hasInlineBody && /^%[a-z0-9]/.test(text))
+  ) {
+    return false;
+  }
+  const inner = bracketed ? text.slice(1, -1) : text;
+  // A path pattern always pins something: a `%tag`, a `face=`, an `@` aura, a
+  // `*` or a `~`. A bracket of bare names is a tuple of values.
+  if (!/[%=@*~]/.test(inner)) return false;
+  for (const token of bracketed ? splitTokens(inner) : [text]) {
+    // A wing dereference (`id.pole`) or a call (`(got:… …)`) is an expression.
+    // `?(` is a union, not a call.
+    if (token.includes('.') || /(^|[^?])\(/.test(token)) return false;
+  }
+  return true;
+}
+
+/** Runes whose next line is the value they bind, never the next arm. */
+const CONTINUES_RE = /^(=\/|=\||=\*|=\+|=\.)(\s|$)/;
+
+/** In a path, `~` only terminates. `[~ ~]` is a result, not a pattern. */
+const nilOnlyTerminates = (alts: Elem[][]) =>
+  alts.every((alt) =>
+    alt.every((e, i) => e.k !== 'nil' || i === alt.length - 1)
+  );
+
+function classifyDefault(text: string): DefaultKind {
+  // The pinned 408k-rc2 default-agent crashes on an unsupported peek or watch
+  // rather than returning [~ ~], so `:def` is a nack, not a silent empty.
+  if (/:def\b/.test(text)) return 'default-agent';
+  if (text.includes('!!')) return 'crash';
+  if (/^(\[\s*~\s+~\s*\]|~)$/.test(text.trim())) return 'empty';
+  return 'unknown';
+}
+
+const bracketBalance = (token: string) =>
+  [...token].reduce((n, c) => n + (c === '[' ? 1 : c === ']' ? -1 : 0), 0);
+
+/**
+ * Parse the first `?+` dispatcher in `lines[from..to)`, or null when there is
+ * none — a stub arm, or one that delegates somewhere the caller must follow.
+ */
+export function parseDispatcher(
+  lines: string[],
+  from: number,
+  to: number,
+  /** Added to reported line numbers, so a nested parse keeps source offsets. */
+  lineOffset = 0
+): Dispatcher | null {
+  let headerIdx = -1;
+  for (let i = from; i < to && headerIdx === -1; i++) {
+    if (/^\s*\?\+/.test(lines[i])) headerIdx = i;
+  }
+  if (headerIdx === -1) return null;
+  const header = lines[headerIdx];
+  const m = /^(\s*)\?\+\s+(\S+)\s*(.*)$/.exec(header);
+  if (!m) return null;
+  const subject = m[2];
+  let defaultText = m[3].trim();
+
+  let cursor = headerIdx + 1;
+  const skipBlank = () => {
+    while (cursor < to && !isCode(lines[cursor])) cursor++;
+  };
+  skipBlank();
+  if (defaultText === '') {
+    if (cursor >= to) return null;
+    defaultText = lines[cursor++].trim();
+    skipBlank();
+  }
+  if (cursor >= to) return null;
+
+  // Hoon lays a wutlus arm out one of two ways: pattern and body share a line,
+  // or the pattern sits alone with the body *outdented* under it. Both are
+  // indented past the `?+`, but not by a fixed amount — groups.hoon:1295 sits
+  // at +5 where its neighbours sit at +4 — so the discriminator is the layout,
+  // not the column: an arm either carries its body inline, or is followed by a
+  // less-indented line. That is what keeps a bare `[...]` body line from
+  // reading as an arm.
+  const headerIndent = indentOf(header);
+  const nextCodeIndent = (from: number) => {
+    for (let i = from; i < to; i++) {
+      if (isCode(lines[i])) return indentOf(lines[i]);
+    }
+    return -1;
+  };
+
+  const arms: Arm[] = [];
+  let unparsedArms = 0;
+  let depth = 0;
+  let pending: {
+    tokens: string[];
+    line: number;
+    bodyStart: number;
+    body: string[];
+  } | null = null;
+
+  const flush = () => {
+    if (!pending) return;
+    const patternText = pending.tokens.join(' ');
+    const alternatives = expandPattern(patternText);
+    if (alternatives === null) unparsedArms++;
+    const faces: Record<string, number> = {};
+    const tokens = patternText.startsWith('[')
+      ? splitTokens(patternText.slice(1, -1))
+      : [patternText];
+    tokens.forEach((token, i) => {
+      const face = /^([a-z][a-z0-9-]*)=/.exec(token)?.[1];
+      if (face) faces[face] = i;
+    });
+    arms.push({
+      patternText,
+      line: pending.line + lineOffset,
+      bodyStartLine: pending.bodyStart + lineOffset,
+      alternatives: alternatives ?? [],
+      bodyText: pending.body.join('\n'),
+      faces,
+      parsed: alternatives !== null,
+    });
+    pending = null;
+  };
+
+  let previousCode = '';
+  for (let i = cursor; i < to; i++) {
+    const line = lines[i];
+    const trimmed = line.trim();
+    const indent = indentOf(line);
+    if (trimmed === '==' && depth === 0 && indent <= headerIndent) break;
+    // A line right under `=/ x` is the value bound to `x`, never the next arm.
+    const continuesBinding = CONTINUES_RE.test(previousCode);
+    if (isCode(line)) previousCode = trimmed;
+    if (
+      isCode(line) &&
+      depth === 0 &&
+      indent > headerIndent &&
+      !continuesBinding &&
+      looksLikePattern(trimmed)
+    ) {
+      // The pattern is the leading bracket-balanced token run; the rest of the
+      // line is body.
+      const tokens = splitTokens(trimmed);
+      let take = 1;
+      let balance = bracketBalance(tokens[0] ?? '');
+      while (balance !== 0 && take < tokens.length)
+        balance += bracketBalance(tokens[take++]);
+      const body = tokens.slice(take).join(' ');
+      const patternText = tokens.slice(0, take).join(' ');
+      const laidOutAsArm = body !== '' || nextCodeIndent(i + 1) < indent;
+      const expanded =
+        balance === 0 &&
+        laidOutAsArm &&
+        couldBeArmPattern(patternText, body !== '')
+          ? expandPattern(patternText)
+          : undefined;
+      // `expanded === null` is a pattern this reader cannot read, which is
+      // still an arm (and suppresses MISSING). A pattern whose `~` does not
+      // terminate is a result expression, so it is body.
+      if (
+        expanded !== undefined &&
+        (expanded === null || nilOnlyTerminates(expanded))
+      ) {
+        flush();
+        pending = {
+          tokens: tokens.slice(0, take),
+          line: i + 1,
+          bodyStart: body !== '' ? i + 1 : i + 2,
+          body: body ? [body] : [],
+        };
+        depth += count(line, OPENER_RE) - count(line, CLOSER_RE);
+        continue;
+      }
+    }
+    if (pending) pending.body.push(line);
+    depth = Math.max(
+      0,
+      depth + count(line, OPENER_RE) - count(line, CLOSER_RE)
+    );
+  }
+  flush();
+
+  return {
+    subject,
+    headerLine: headerIdx + 1 + lineOffset,
+    defaultKind: classifyDefault(defaultText),
+    arms,
+    unparsedArms,
+  };
+}
+
+export interface HoonArmRange {
+  name: string;
+  /** 0-based, inclusive. */
+  start: number;
+  /** 0-based, exclusive. */
+  end: number;
+  indent: number;
+}
+
+/** Index every `++ name` arm in a file by name. */
+export function indexArms(lines: string[]): Map<string, HoonArmRange> {
+  const out = new Map<string, HoonArmRange>();
+  const open: HoonArmRange[] = [];
+  const close = (upTo: number, indent: number) => {
+    while (open.length && open[open.length - 1].indent >= indent) {
+      const arm = open.pop()!;
+      arm.end = upTo;
+      if (!out.has(arm.name)) out.set(arm.name, arm);
+    }
+  };
+  lines.forEach((line, i) => {
+    if (!isCode(line)) return;
+    const arm = /^(\s*)\+\+\s+([a-z][a-z0-9-]*)\s*(.*)$/.exec(line);
+    const end = /^(\s*)(--|\+\$|\+\*)/.exec(line);
+    if (arm) {
+      close(i, arm[1].length);
+      open.push({
+        name: arm[2],
+        start: i,
+        end: lines.length,
+        indent: arm[1].length,
+      });
+    } else if (end) close(i, end[1].length);
+  });
+  close(lines.length, 0);
+  return out;
+}
+
+/**
+ * Lines between an arm's header and its dispatcher that guard or rewrite the
+ * subject. Their presence is P0: the pole the `?+` sees is not the pole the
+ * client sent, so no MISSING verdict is available.
+ */
+export interface Obstruction {
+  text: string;
+  /**
+   * A `guard` can reject the request before the dispatcher sees it, so no
+   * MISSING verdict is available. A `rewrite` changes the pole itself, so
+   * neither MISSING nor FOUND is — the arms are matching a different path.
+   */
+  kind: 'guard' | 'rewrite';
+  /**
+   * The version-injection form, `=? +.pole !?=([?(%v0 %v1) *] +.pole)`, is
+   * provably inert when the segment at `index` is already one of `members`.
+   */
+  inertWhen?: { index: number; members: string[] };
+}
+
+/**
+ * Guards that are satisfied by construction for a frontend request: the client
+ * only ever scries and subscribes to its own ship, so `?> from-self` and its
+ * spellings can neither reject it nor hide an absent arm. They are ignored
+ * outright; any other guard expression stays conservative.
+ */
+const SELF_GUARDS = new Set([
+  'from-self',
+  '=(src.bowl our.bowl)',
+  '=(our.bowl src.bowl)',
+  '=(our src)',
+  '=(src our)',
+  '(team:title our.bowl src.bowl)',
+]);
+
+export const isSelfGuard = (expr: string) =>
+  SELF_GUARDS.has(
+    expr
+      .trim()
+      .replace(/\s+/g, ' ')
+      .replace(/:bowl$/, '')
+  );
+
+/**
+ * A `?>` whose assertion is a self-check, with the value it produces. `?<`
+ * asserts the negation, so a self-check there *rejects* the frontend and is
+ * deliberately not recognised.
+ */
+export function stripSelfGuard(line: string): string {
+  const tall = /^(\s*)\?>\s+(\S.*)$/.exec(line);
+  if (tall) return isSelfGuard(tall[2]) ? tall[1] : line;
+  // Wide form can sit anywhere, including inside another rune:
+  // contacts.hoon:923 is `~|(local-news+src.bowl ?>(=(our src):bowl cor))`.
+  let out = line;
+  for (let i = out.indexOf('?>('); i !== -1; i = out.indexOf('?>(', i + 3)) {
+    const end = closingParen(out, i + 2);
+    if (end === -1) break;
+    const [assertion, ...produces] = splitTokens(out.slice(i + 3, end));
+    if (!isSelfGuard(assertion ?? '')) continue;
+    out = out.slice(0, i) + produces.join(' ') + out.slice(end + 1);
+    i = -3;
+  }
+  return out;
+}
+
+function closingParen(text: string, open: number): number {
+  let depth = 0;
+  for (let i = open; i < text.length; i++) {
+    if (text[i] === '(') depth++;
+    else if (text[i] === ')' && --depth === 0) return i;
+  }
+  return -1;
+}
+
+export function preDispatchObstructions(
+  lines: string[],
+  from: number,
+  to: number,
+  subject = 'pole|path|pat'
+): Obstruction[] {
+  const subjectRe = new RegExp(`\\b(?:${subject})\\b`);
+  const region: string[] = [];
+  for (let i = from; i < to; i++) {
+    if (isCode(lines[i])) region.push(lines[i].trim());
+  }
+  const out: Obstruction[] = [];
+  for (const raw of region) {
+    // A self-guard is satisfied for every frontend request, so it is not an
+    // obstruction at all — it blocks neither FOUND nor MISSING.
+    const text = stripSelfGuard(raw);
+    if (text.trim() === '') continue;
+    if (/^(\?>|\?<)[\s(]/.test(text) || /^(\?>|\?<)$/.test(text)) {
+      out.push({ text, kind: 'guard' });
+      continue;
+    }
+    // A change rune only matters when it targets the subject: `=^ cards state`
+    // in a delegating `on-watch` is an ordinary binding.
+    if (!/^(=\?|=\.)(\s|$)/.test(text) || !subjectRe.test(text)) continue;
+    out.push({
+      text,
+      kind: 'rewrite',
+      inertWhen: versionInjection(text, region),
+    });
+  }
+  return out;
+}
+
+/** Read `=? [+.]<subject> !?=([?(%a %b) *] …)` and the union it tests against. */
+function versionInjection(
+  text: string,
+  region: string[]
+): Obstruction['inertWhen'] {
+  // The union may contain spaces (`?(%v0 %v1)`), so stop at the ` *]` tail.
+  const m = /^=\?\s+(\+\.)?[a-z][a-z0-9-]*\s+!\?=\(\[(.+?)\s+\*\]/.exec(text);
+  if (!m) return undefined;
+  // `+.pole` skips the head (the care, for a peek); a bare subject does not.
+  const index = m[1] ? 1 : 0;
+  const union = m[2].startsWith('?(')
+    ? m[2]
+    : // `=/  any  ?(%v0 %v1)` a line or two up — reel does this.
+      region.find((l) => new RegExp(`^=/\\s+${m[2]}\\s+\\?\\(`).test(l));
+  if (!union) return undefined;
+  const members = Array.from(union.matchAll(/%([a-z0-9][a-z0-9-]*)/g)).map(
+    (x) => x[1]
+  );
+  return members.length > 0 ? { index, members } : undefined;
+}

--- a/packages/scripts/src/check-desk-compat/index.ts
+++ b/packages/scripts/src/check-desk-compat/index.ts
@@ -1,0 +1,55 @@
+#!/usr/bin/env node
+import { exitCodeFor, formatReport, runCheck } from './check';
+import { WORKTREE_REF } from './git';
+
+const USAGE = `
+Usage: pnpm check:desk-compat [options]
+
+  --client-ref <ref>     client tree to extract from (default: ${WORKTREE_REF})
+  --desk-ref <ref>       desk tree to check against (required)
+  --json                 emit the report as JSON instead of text
+
+Exit codes: 0 = no MISSING, 1 = one or more MISSING (or a negotiation protocol
+difference), 2 = internal error.
+
+The three release-time runs (docs/tlon-apps/desk-compatibility.md):
+  --client-ref <candidate>     --desk-ref v<N-1>        rule (b)
+  --client-ref <candidate>     --desk-ref <candidate>   self-consistency
+  --client-ref origin/master   --desk-ref <candidate>   rule (c), removal
+`.trim();
+
+function main(): number {
+  const args: Record<string, string | boolean> = {};
+  const argv = process.argv.slice(2);
+  argv.forEach((arg, i) => {
+    if (!arg.startsWith('--')) return;
+    const name = arg.slice(2);
+    args[name] = name === 'json' || name === 'help' ? true : argv[i + 1];
+  });
+
+  if (args.help) {
+    console.log(USAGE);
+    return 0;
+  }
+  const deskRef = args['desk-ref'];
+  if (typeof deskRef !== 'string' || deskRef.length === 0) {
+    console.error(`error: --desk-ref is required\n\n${USAGE}`);
+    return 2;
+  }
+  const clientRef = args['client-ref'];
+  const report = runCheck({
+    clientRef: typeof clientRef === 'string' ? clientRef : WORKTREE_REF,
+    deskRef,
+  });
+  console.log(
+    args.json ? JSON.stringify(report, null, 2) : formatReport(report)
+  );
+  return exitCodeFor(report);
+}
+
+try {
+  process.exitCode = main();
+} catch (error) {
+  console.error(`desk-compat: ${(error as Error).message}`);
+  process.exitCode = 2;
+}

--- a/packages/scripts/src/check-desk-compat/known-gaps.json
+++ b/packages/scripts/src/check-desk-compat/known-gaps.json
@@ -1,0 +1,24 @@
+{
+  "$comment": [
+    "Requests that are MISSING today and are knowingly not blocking the gate.",
+    "",
+    "Every entry is debt, not an exemption: it records a client call the desk",
+    "does not serve, so the feature behind it is already broken. An entry must",
+    "name the commit that broke it and the issue that will remove it. Adding an",
+    "entry to get a red gate green is the one thing this file is not for — a new",
+    "MISSING means the change under review needs the desk to ship first.",
+    "",
+    "A key is the exact request shape. An interpolation is written `{}` when it",
+    "is a plain identifier chain and `{#<hash>}` otherwise, and literal braces",
+    "are percent-escaped — so a longer path that merely shares a prefix, or one",
+    "whose suffix moved inside the expression, cannot inherit an exemption."
+  ],
+  "gaps": [
+    {
+      "key": "subscribe groups /chan/{}",
+      "reason": "getChannelPreview (groupsApi.ts) still subscribes to /chan/<nest>, which %groups deprecated in 50f96a667f (2026-03-25) and no longer serves at any v12 tag. The watch dispatcher nacks, so channel previews have been silently broken since before v12.0.0. The replacement is /v1/channels/<app>/<ship>/<name>/preview with the %channel-preview-1 mark, which is a behaviour change this PR does not make.",
+      "broke_at": "50f96a667f",
+      "issue": "TLON-6538"
+    }
+  ]
+}

--- a/packages/scripts/src/check-desk-compat/known-gaps.json
+++ b/packages/scripts/src/check-desk-compat/known-gaps.json
@@ -13,6 +13,15 @@
     "are percent-escaped — so a longer path that merely shares a prefix, or one",
     "whose suffix moved inside the expression, cannot inherit an exemption."
   ],
+  "$protocolBumps": [
+    "One in-flight `agent:neg` bump, while it is landing. Rule (d) makes any",
+    "protocol difference a hard floor, so without an entry the bump PR itself",
+    "could never merge. An entry is printed loudly and excluded from the exit",
+    "code; the next release removes it once the bump has become N-1, and the",
+    "checker warns while an entry matches no observed difference.",
+    "Shape: { agent, protocol, from, to, issue, note }."
+  ],
+  "protocolBumps": [],
   "gaps": [
     {
       "key": "subscribe groups /chan/{}",

--- a/packages/scripts/src/check-desk-compat/marks.test.ts
+++ b/packages/scripts/src/check-desk-compat/marks.test.ts
@@ -15,7 +15,7 @@ git module landscape:
 `;
 const VENDORED = vendoredMarks(PERU);
 
-function desk(files: string[]) {
+function desk(files: string[], clientApps?: string[]) {
   const tree: Record<string, string> = {
     'desk/desk.bill': ':~  %groups\n    %chat\n==\n',
     'desk/app/groups.hoon': '|_  =bowl:gall\n--\n',
@@ -23,7 +23,17 @@ function desk(files: string[]) {
     'desk/app/notes.hoon': '|_  =bowl:gall\n--\n',
   };
   for (const f of files) tree[f] = ':: mark\n';
-  return loadDesk(memoryTree(tree), 'test');
+  const client = Object.fromEntries(
+    (clientApps ?? []).map((a) => [
+      `desk/app/${a}.hoon`,
+      '|_  =bowl:gall\n--\n',
+    ])
+  );
+  return loadDesk(
+    memoryTree(tree),
+    'test',
+    clientApps ? memoryTree(client) : undefined
+  );
 }
 
 describe('vendoredMarks', () => {
@@ -88,6 +98,29 @@ describe('matchMark — ownership by exclusion from peru, never by the refs unde
     ],
   ])('%s', (_name, files, app, mark, verdict) => {
     expect(matchMark(desk(files), VENDORED, app, mark).verdict).toBe(verdict);
+  });
+
+  // The client's desk has %ping; N-1 does not. Nothing the client pokes at it
+  // can be delivered, so a surviving mar file must not answer for the agent.
+  it('reports a poke at a deleted agent, mar file or not', () => {
+    for (const files of [[], ['desk/mar/ping/action.hoon']]) {
+      const result = matchMark(
+        desk(files, ['ping']),
+        VENDORED,
+        'ping',
+        'ping-action'
+      );
+      expect(result.verdict).toBe('MISSING');
+      expect(result.reason).toContain('no longer an agent');
+      expect(result.failureMode).toBe('crash');
+    }
+  });
+
+  it('calls no removal on an app the client never had', () => {
+    // %settings lives in another desk; it was never ours to remove.
+    expect(
+      matchMark(desk([]), VENDORED, 'settings', 'settings-event').verdict
+    ).toBe('UNVERIFIED');
   });
 
   it('claims only that the file exists, never that the agent accepts it', () => {

--- a/packages/scripts/src/check-desk-compat/marks.test.ts
+++ b/packages/scripts/src/check-desk-compat/marks.test.ts
@@ -15,20 +15,23 @@ git module landscape:
 `;
 const VENDORED = vendoredMarks(PERU);
 
-function desk(files: string[], clientApps?: string[]) {
+function desk(files: string[], clientApps?: string[], bill = '%groups %chat') {
   const tree: Record<string, string> = {
-    'desk/desk.bill': ':~  %groups\n    %chat\n==\n',
+    'desk/desk.bill': `:~  ${bill}\n==\n`,
     'desk/app/groups.hoon': '|_  =bowl:gall\n--\n',
     'desk/app/chat.hoon': '|_  =bowl:gall\n--\n',
     'desk/app/notes.hoon': '|_  =bowl:gall\n--\n',
   };
   for (const f of files) tree[f] = ':: mark\n';
-  const client = Object.fromEntries(
+  const client: Record<string, string> = Object.fromEntries(
     (clientApps ?? []).map((a) => [
       `desk/app/${a}.hoon`,
       '|_  =bowl:gall\n--\n',
     ])
   );
+  // The client's desk bills everything it ships.
+  client['desk/desk.bill'] =
+    `:~  %groups %chat ${(clientApps ?? []).map((a) => `%${a}`).join(' ')}\n==\n`;
   return loadDesk(
     memoryTree(tree),
     'test',
@@ -114,6 +117,34 @@ describe('matchMark — ownership by exclusion from peru, never by the refs unde
       expect(result.reason).toContain('no longer an agent');
       expect(result.failureMode).toBe('crash');
     }
+  });
+
+  // Dropping the name from desk.bill stops the agent; its mar files survive
+  // untouched, so the file lookup would happily answer for an agent that is
+  // not running.
+  it('reports a poke at an unbilled agent, mar file or not', () => {
+    for (const files of [[], ['desk/mar/chat/action.hoon']]) {
+      const result = matchMark(
+        desk(files, [], '%groups'),
+        VENDORED,
+        'chat',
+        'chat-action'
+      );
+      expect(result.verdict).toBe('MISSING');
+      expect(result.reason).toContain('desk.bill');
+      expect(result.failureMode).toBe('not-running');
+    }
+  });
+
+  it('still answers normally for an agent both desks bill', () => {
+    expect(
+      matchMark(
+        desk(['desk/mar/chat/action.hoon'], []),
+        VENDORED,
+        'chat',
+        'chat-action'
+      ).verdict
+    ).toBe('FOUND');
   });
 
   it('calls no removal on an app the client never had', () => {

--- a/packages/scripts/src/check-desk-compat/marks.test.ts
+++ b/packages/scripts/src/check-desk-compat/marks.test.ts
@@ -1,0 +1,103 @@
+import { describe, expect, it } from 'vitest';
+
+import { memoryTree } from './git';
+import { markCandidates, matchMark, vendoredMarks } from './marks';
+import { Verdict, loadDesk } from './match';
+
+const PERU = `
+git module base:
+  pick:
+    - pkg/base-dev/mar/noun.hoon
+    - pkg/base-dev/lib/dbug.hoon
+git module landscape:
+  pick:
+    - desk/mar/docket-0.hoon
+`;
+const VENDORED = vendoredMarks(PERU);
+
+function desk(files: string[]) {
+  const tree: Record<string, string> = {
+    'desk/desk.bill': ':~  %groups\n    %chat\n==\n',
+    'desk/app/groups.hoon': '|_  =bowl:gall\n--\n',
+    'desk/app/chat.hoon': '|_  =bowl:gall\n--\n',
+    'desk/app/notes.hoon': '|_  =bowl:gall\n--\n',
+  };
+  for (const f of files) tree[f] = ':: mark\n';
+  return loadDesk(memoryTree(tree), 'test');
+}
+
+describe('vendoredMarks', () => {
+  it('reads the mark picks and nothing else', () => {
+    expect([...VENDORED].sort()).toEqual(['docket-0', 'noun']);
+  });
+});
+
+describe('markCandidates', () => {
+  it('enumerates every hyphen grouping', () => {
+    expect(markCandidates('group-action-5')).toEqual([
+      'desk/mar/group-action-5.hoon',
+      'desk/mar/group/action-5.hoon',
+      'desk/mar/group-action/5.hoon',
+      'desk/mar/group/action/5.hoon',
+    ]);
+  });
+
+  it('handles a flat mark', () => {
+    expect(markCandidates('noun')).toEqual(['desk/mar/noun.hoon']);
+  });
+});
+
+describe('matchMark — ownership by exclusion from peru, never by the refs under test', () => {
+  it('does not treat an unresolved mark as a removal', () => {
+    expect(matchMark(desk([]), VENDORED, 'groups', null).verdict).toBe(
+      'UNVERIFIED'
+    );
+  });
+
+  it.each<[string, string[], string, string, Verdict]>([
+    [
+      'nested at any hyphen grouping',
+      ['desk/mar/chat/club/action-2.hoon'],
+      'chat',
+      'chat-club-action-2',
+      'FOUND',
+    ],
+    // group-action-5 is on no pick list, so its absence is a removal.
+    [
+      'repo-owned and absent is a removal',
+      ['desk/mar/group/action-4.hoon'],
+      'groups',
+      'group-action-5',
+      'MISSING',
+    ],
+    // noun is on a pick list, so its absence from desk/mar proves nothing.
+    ['vendored and absent proves nothing', [], 'groups', 'noun', 'UNVERIFIED'],
+    [
+      'a mark aimed at an out-of-desk app is not ours to judge',
+      [],
+      'settings',
+      'settings-event',
+      'UNVERIFIED',
+    ],
+    [
+      'nor is one aimed at an agent missing from desk.bill',
+      [],
+      'notes',
+      'notes-action',
+      'UNVERIFIED',
+    ],
+  ])('%s', (_name, files, app, mark, verdict) => {
+    expect(matchMark(desk(files), VENDORED, app, mark).verdict).toBe(verdict);
+  });
+
+  it('claims only that the file exists, never that the agent accepts it', () => {
+    const result = matchMark(
+      desk(['desk/mar/group/action-5.hoon']),
+      VENDORED,
+      'groups',
+      'group-action-5'
+    );
+    expect(result.reason).toBe('mark file present');
+    expect(result.evidence).toBe('desk/mar/group/action-5.hoon');
+  });
+});

--- a/packages/scripts/src/check-desk-compat/marks.ts
+++ b/packages/scripts/src/check-desk-compat/marks.ts
@@ -58,6 +58,18 @@ export function matchMark(
   });
   if (mark === null)
     return unverified('mark could not be resolved to a string literal');
+  // A deleted agent cannot accept any mark, however many mar files survive it.
+  // Checking before the file lookup is the point: a leftover mar would
+  // otherwise report FOUND for a poke that now crashes.
+  if (app !== null && !desk.hasApp(app) && desk.clientHadApp(app)) {
+    return {
+      verdict: 'MISSING',
+      rule: 'marks',
+      reason: `%${app} is no longer an agent in this desk, but the client still pokes it`,
+      evidence: `desk/app/${app}.hoon (removed)`,
+      failureMode: 'crash',
+    };
+  }
   const candidates = markCandidates(mark);
   const hit = candidates.find((c) => desk.marFiles.has(c));
   // FOUND for a mark claims only that the file exists — not that the agent

--- a/packages/scripts/src/check-desk-compat/marks.ts
+++ b/packages/scripts/src/check-desk-compat/marks.ts
@@ -1,0 +1,95 @@
+import { Tree } from './git';
+import { Desk, MatchResult } from './match';
+
+/**
+ * Marks vendored from upstream, read off `peru.yaml`'s pick lists.
+ *
+ * Ownership is decided by **exclusion**: everything under `desk/mar` that is
+ * not on a pick list and is not an out-of-desk app is repo-owned by
+ * construction. The obvious alternative — "a mark is ours if it resolves at
+ * either ref of the pair" — is self-defeating for the removal case, because
+ * deleting the mar file also erases the proof we ever owned the mark, and a
+ * real removal PR must delete the backend references too or the desk will not
+ * build.
+ */
+export function vendoredMarks(peruYaml: string): Set<string> {
+  return new Set(
+    Array.from(
+      peruYaml.matchAll(/^\s*-\s+\S*mar\/([A-Za-z0-9_/-]+)\.hoon\s*$/gm)
+    ).map((m) => m[1].split('/').join('-'))
+  );
+}
+
+export function loadOwnership(tree: Tree): Set<string> {
+  const peru = tree.readFile('peru.yaml');
+  return peru === null ? new Set() : vendoredMarks(peru);
+}
+
+/**
+ * Every file path Clay would consider for a name. `%a-b-c` may live at any
+ * hyphen grouping — `mar/group/action-5.hoon`, `mar/chat/club/action-2.hoon`,
+ * `mar/invite-decline.hoon` — so every subset of the hyphens is a candidate
+ * directory split.
+ */
+export function markCandidates(mark: string): string[] {
+  const parts = mark.split('-');
+  const out: string[] = [];
+  for (let mask = 0; mask < 1 << Math.min(parts.length - 1, 12); mask++) {
+    const segments = [parts[0]];
+    for (let i = 1; i < parts.length; i++) {
+      if (mask & (1 << (i - 1))) segments.push(parts[i]);
+      else segments[segments.length - 1] += `-${parts[i]}`;
+    }
+    out.push(`desk/mar/${segments.join('/')}.hoon`);
+  }
+  return [...new Set(out)];
+}
+
+export function matchMark(
+  desk: Desk,
+  vendored: Set<string>,
+  app: string | null,
+  mark: string | null
+): MatchResult {
+  const unverified = (reason: string): MatchResult => ({
+    verdict: 'UNVERIFIED',
+    rule: 'marks',
+    reason,
+  });
+  if (mark === null)
+    return unverified('mark could not be resolved to a string literal');
+  const candidates = markCandidates(mark);
+  const hit = candidates.find((c) => desk.marFiles.has(c));
+  // FOUND for a mark claims only that the file exists — not that the agent
+  // accepts it, and nothing about the JSON shape.
+  if (hit) {
+    return {
+      verdict: 'FOUND',
+      rule: 'marks',
+      reason: 'mark file present',
+      evidence: hit,
+    };
+  }
+  if (vendored.has(mark)) {
+    return unverified(
+      `%${mark} is vendored by peru into desk-deps/, which is not in the repo tree`
+    );
+  }
+  if (app !== null && !desk.hasApp(app)) {
+    return unverified(
+      `%${mark} targets %${app}, which is not an agent in this desk`
+    );
+  }
+  if (app !== null && !desk.bill.has(app)) {
+    return unverified(
+      `%${mark} targets %${app}, which is not listed in desk/desk.bill`
+    );
+  }
+  return {
+    verdict: 'MISSING',
+    rule: 'marks',
+    reason: `no mar file for %${mark} (repo-owned by exclusion from peru.yaml)`,
+    evidence: candidates.slice(0, 4).join(', '),
+    failureMode: 'crash',
+  };
+}

--- a/packages/scripts/src/check-desk-compat/marks.ts
+++ b/packages/scripts/src/check-desk-compat/marks.ts
@@ -70,6 +70,17 @@ export function matchMark(
       failureMode: 'crash',
     };
   }
+  // Dropping the name from desk.bill stops the agent while leaving its source
+  // — and its marks — in place, so this too must beat the mar file lookup.
+  if (app !== null && !desk.bill.has(app) && desk.clientBilled(app)) {
+    return {
+      verdict: 'MISSING',
+      rule: 'marks',
+      reason: `%${app} is no longer listed in desk/desk.bill, so it does not run`,
+      evidence: 'desk/desk.bill (removed)',
+      failureMode: 'not-running',
+    };
+  }
   const candidates = markCandidates(mark);
   const hit = candidates.find((c) => desk.marFiles.has(c));
   // FOUND for a mark claims only that the file exists — not that the agent

--- a/packages/scripts/src/check-desk-compat/match.test.ts
+++ b/packages/scripts/src/check-desk-compat/match.test.ts
@@ -37,6 +37,68 @@ function check(files: Record<string, string>, request: PathRequest): string {
   return `${r.verdict} ${r.rule}`;
 }
 
+const DISPATCHES = `
+++  on-peek
+  |=  =path
+  ?+  path  [~ ~]
+    [%x %v1 %init ~]  \`\`noun+!>(~)
+  ==
+++  on-watch  on-watch:def
+--
+`.trim();
+
+const DELEGATES_BOTH = `
+++  on-peek  on-peek:def
+++  on-watch  on-watch:def
+--
+`.trim();
+
+describe('handing a surface to default-agent', () => {
+  const BILL_LEDGER = ':~  %ledger\n==\n';
+  const desk = (app: string) => ({
+    'desk/desk.bill': BILL_LEDGER,
+    'desk/app/ledger.hoon': app,
+  });
+  const run = (deskApp: string, clientApp: string | null, r: PathRequest) => {
+    const loaded = loadDesk(
+      memoryTree(desk(deskApp)),
+      'test',
+      clientApp === null ? undefined : memoryTree(desk(clientApp))
+    );
+    const result = matchPath(loaded, r);
+    return `${result.verdict} ${result.rule}`;
+  };
+
+  it('is a removal when the client desk dispatched that surface itself', () => {
+    // The pinned default-agent nacks, so `on-peek:def` deletes the surface as
+    // surely as deleting the arms would.
+    expect(
+      run(DELEGATES_BOTH, DISPATCHES, scry('ledger', ['x', 'v1', 'init']))
+    ).toBe('MISSING P1');
+  });
+
+  it('stays unverifiable when it was the default in both trees', () => {
+    expect(
+      run(DELEGATES_BOTH, DELEGATES_BOTH, scry('ledger', ['x', 'v1', 'init']))
+    ).toBe('UNVERIFIED coverage');
+    // No client desk at all (a self-consistency run) decides nothing either.
+    expect(run(DELEGATES_BOTH, null, scry('ledger', ['x', 'v1', 'init']))).toBe(
+      'UNVERIFIED coverage'
+    );
+  });
+
+  it('judges each surface on its own', () => {
+    // %ledger dispatches on-peek and delegates on-watch in *both* trees, so the
+    // watch is unverifiable while the peek is read normally.
+    expect(run(DISPATCHES, DISPATCHES, watch('ledger', ['v1']))).toBe(
+      'UNVERIFIED coverage'
+    );
+    expect(run(DISPATCHES, DISPATCHES, scry('ledger', ['x', 'v2']))).toBe(
+      'MISSING P1'
+    );
+  });
+});
+
 // %chat's real root subscription: `~` is an arm like any other, so a request
 // with no segments is a request, not a missing one.
 const ROOT_WATCH = `

--- a/packages/scripts/src/check-desk-compat/match.test.ts
+++ b/packages/scripts/src/check-desk-compat/match.test.ts
@@ -37,6 +37,42 @@ function check(files: Record<string, string>, request: PathRequest): string {
   return `${r.verdict} ${r.rule}`;
 }
 
+// %chat's real root subscription: `~` is an arm like any other, so a request
+// with no segments is a request, not a missing one.
+const ROOT_WATCH = `
+++  on-watch
+  |=  =path
+  ?+  path  ~|(bad-path+path !!)
+    ~          cor
+    [%ui ~]    cor
+  ==
+--
+`.trim();
+
+const NO_ROOT_WATCH = `
+++  on-watch
+  |=  =path
+  ?+  path  ~|(bad-path+path !!)
+    [%ui ~]    cor
+  ==
+--
+`.trim();
+
+describe('the root path', () => {
+  const chat = (app: string) => ({
+    'desk/desk.bill': ':~  %chat\n==\n',
+    'desk/app/chat.hoon': app,
+  });
+
+  it('is served when an arm terminates immediately', () => {
+    expect(check(chat(ROOT_WATCH), watch('chat', []))).toBe('FOUND P1');
+  });
+
+  it('is missing when every arm demands a segment', () => {
+    expect(check(chat(NO_ROOT_WATCH), watch('chat', []))).toBe('MISSING P1');
+  });
+});
+
 describe('matchAlternative', () => {
   const m = (alt: string, known: string[], unknownTail: boolean) =>
     matchAlternative(elems(alt), known, unknownTail);

--- a/packages/scripts/src/check-desk-compat/match.test.ts
+++ b/packages/scripts/src/check-desk-compat/match.test.ts
@@ -1,0 +1,622 @@
+import { describe, expect, it } from 'vitest';
+
+import { memoryTree } from './git';
+import { Elem } from './hoon';
+import { PathRequest, loadDesk, matchAlternative, matchPath } from './match';
+
+const BILL =
+  ':~  %groups\n    %groups-ui\n    %steward\n    %channels\n    %contacts\n==\n';
+const elems = (spec: string): Elem[] =>
+  spec
+    .split('/')
+    .map(
+      (s) =>
+        (s === 'nil' || s === 'rest' || s === 'any'
+          ? { k: s }
+          : { k: 'lit', v: s }) as Elem
+    );
+
+const scry = (
+  app: string,
+  known: string[],
+  unknownTail = false
+): PathRequest => ({ app, surface: 'scry', known, unknownTail });
+const watch = (
+  app: string,
+  known: string[],
+  unknownTail = false
+): PathRequest => ({ app, surface: 'subscribe', known, unknownTail });
+
+/** `<verdict> <rule>`, so a case reads as one line. */
+function check(files: Record<string, string>, request: PathRequest): string {
+  const desk = loadDesk(
+    memoryTree({ 'desk/desk.bill': BILL, ...files }),
+    'test'
+  );
+  const r = matchPath(desk, request);
+  return `${r.verdict} ${r.rule}`;
+}
+
+describe('matchAlternative', () => {
+  const m = (alt: string, known: string[], unknownTail: boolean) =>
+    matchAlternative(elems(alt), known, unknownTail);
+
+  it('serves a literal request only when an arm terminates exactly there', () => {
+    expect(m('x/v10/init/nil', ['x', 'v10', 'init'], false)).toBe('exact');
+    expect(m('x/v9/init/nil', ['x', 'v10', 'init'], false)).toBe('no');
+    // The bare /v1/lens against [%v1 %recent ~]: an arm needing more segments
+    // than a literal request has does not serve it.
+    expect(m('v1/recent/nil', ['v1'], false)).toBe('no');
+    expect(m('x/v1/nil', ['x', 'v1', 'more'], false)).toBe('no');
+  });
+
+  it('treats an unknown tail as unbounded in value and in segment count', () => {
+    expect(m('x/v1/lens/rest', ['x', 'v1', 'lens'], true)).toBe('open');
+    expect(m('x/v11/changes/any/nil', ['x', 'v11', 'changes'], true)).toBe(
+      'prefix'
+    );
+    expect(m('x/v11/changes/any/nil', ['x', 'v11', 'changes'], false)).toBe(
+      'no'
+    );
+    // An arm that ends at the prefix cannot serve a request with more to come.
+    expect(m('x/v3/groups/nil', ['x', 'v3', 'groups'], true)).toBe('no');
+  });
+});
+
+const PEEK = `
+++  on-peek   peek:cor
+--
+++  peek
+  |=  =(pole knot)
+  ?+    pole  [~ ~]
+      [%x %v9 %init ~]  \`\`ui-init-9+!>(init)
+  ::
+      [%x ver=?(%v0 %v1 %v2) %ui %groups ship=@ name=@ ~]
+    \`\`group-ui+!>(group)
+  ==
+--
+`.trim();
+
+// A `$(pole …)` rewrite sitting behind a head a %v3 prefix cannot reach.
+const WATCH = `
+++  on-watch   watch:cor
+--
+++  watch
+  |=  =(pole knot)
+  ?+  pole  ~|(bad-watch-path+pole !!)
+    [%v1 %groups ~]  ?>(from-self cor)
+  ::
+      [%gangs ship=@ name=@ %preview ~]
+    $(pole /v1/foreigns/[ship.pole]/[name.pole]/preview)
+  ==
+--
+`.trim();
+
+// channels' shape: a version injection, plus an arm for a version the
+// injection does not list — which is the way a real one goes wrong.
+const OBSTRUCTED = `
+++  on-peek   peek:cor
+--
+++  peek
+  |=  =(pole knot)
+  =?  +.pole  !?=([?(%v0 %v1) *] +.pole)
+    [%v0 +.pole]
+  ?+    pole  [~ ~]
+      [%x %v0 %init ~]  \`\`init+!>(init)
+  ::
+      [%x %v7 %init ~]  \`\`init+!>(init)
+  ==
+--
+`.trim();
+
+// A pre-dispatch guard this reader cannot discharge: it may reject before the
+// dispatcher is reached, so absence proves nothing.
+const GUARDED = `
+++  on-peek
+  |=  =path
+  ?>  (can-read:perms src.bowl)
+  (peek:cor path)
+--
+++  peek
+  |=  =path
+  ?+  path  [~ ~]
+    [%x %v1 %status ~]  \`\`json+!>(status)
+  ==
+--
+`.trim();
+
+// steward's actual shape: the guard is a self-check, satisfied by every
+// frontend request, so it changes nothing either way.
+const SELF_GUARDED = GUARDED.replace(
+  '?>  (can-read:perms src.bowl)',
+  '?>  =(src our):bowl'
+);
+
+// groups' /vN/changes shape: `since` is required before the `rest` capture.
+const REQUIRED_SUFFIX = `
+++  on-peek  peek:cor
+--
+++  peek
+  |=  =(pole knot)
+  ?+    pole  [~ ~]
+      [%x %v3 %changes since=@ rest=*]
+    \`\`group-changed-groups-3+!>(changes)
+  ==
+--
+`.trim();
+
+// channels' /vN/changes shape: a nested `?+` decides the tail.
+const NESTED = `
+++  on-peek  peek:cor
+--
+++  peek
+  |=  =(pole knot)
+  ?+    pole  [~ ~]
+      [%x %v6 %changes since=@ rest=*]
+    ?+  rest.pole  [~ ~]
+        ~
+      \`\`channel-changed-posts-1+!>(changes)
+    ::
+        [%count ~]
+      \`\`json+!>(count)
+    ==
+  ==
+--
+`.trim();
+
+// contacts.hoon's shape: the pattern matches, then the body rejects.
+const BRANCHING_BODY = `
+++  on-peek  peek:cor
+--
+++  peek
+  |=  =(pole knot)
+  ?+    pole  [~ ~]
+      [%x %v1 %book her=@p ~]
+    ?~  who=(slaw %p her.pole)
+      [~ ~]
+    \`\`contact-page-0+!>(page)
+  ==
+--
+`.trim();
+
+// The same empty-or-/count decision as NESTED, spelled with `?:`.
+const CONDITIONAL_TAIL = `
+++  on-peek  peek:cor
+--
+++  peek
+  |=  =(pole knot)
+  ?+    pole  [~ ~]
+      [%x %v6 %changes since=@ rest=*]
+    ?:  =(~ rest.pole)
+      \`\`changed-posts+!>(changes)
+    \`\`json+!>(count)
+  ==
+--
+`.trim();
+
+// A `?~` between the arm and the nested `?+` may already have returned.
+const GUARDED_NESTED = NESTED.replace(
+  '    ?+  rest.pole  [~ ~]',
+  '    ?~  since.pole  [~ ~]\n    ?+  rest.pole  [~ ~]'
+);
+
+// A `.^` that only runs on one side of a `?:` cannot prove absence.
+const CONDITIONAL_FANOUT = `
+++  on-peek  peek:cor
+--
+++  peek
+  |=  =(pole knot)
+  ?+    pole  [~ ~]
+      [%x %v10 %init ~]
+    ?:  cached
+      \`\`ui-init-10+!>(cache)
+    =+  .^(a (scry %gx %groups /v4/init/noun))
+    \`\`ui-init-10+!>(init)
+  ==
+--
+`.trim();
+
+// One readable `.^` to a missing path, beside one this reader cannot read.
+const MIXED_FANOUT = `
+++  on-peek  peek:cor
+--
+++  peek
+  |=  =(pole knot)
+  ?+    pole  [~ ~]
+      [%x %v10 %init ~]
+    =+  .^(a (scry %gx %groups (snoc rest %init)))
+    =+  .^(b (scry %gx %groups /v4/init/noun))
+    \`\`ui-init-10+!>(init)
+  ==
+--
+`.trim();
+
+// steward's shape: a `*`-tailed arm forwarding into a sub-core that serves
+// only some completions, and a watch surface that inverts it exactly.
+const DELEGATING = `
+++  on-peek
+  |=  =path
+  (peek:cor path)
+++  on-watch  watch:cor
+--
+++  watch
+  |=  =path
+  ?+  path  ~|(bad-watch-path+path !!)
+    [%v1 %lens *]  (le-watch:le-core [%v1 t.t.path])
+  ==
+++  peek
+  |=  =path
+  ?+  path  [~ ~]
+    [%x %v1 %lens *]  (le-peek:le-core [%v1 t.t.t.path])
+  ==
+++  le-core
+  |%
+  ++  le-watch
+    |=  =path
+    ?+  path  ~|(bad-lens-watch-path+path !!)
+      [%v1 ~]  cor
+    ==
+  ++  le-peek
+    |=  =path
+    ?+  path  [~ ~]
+      [%v1 %recent ~]  \`\`lens-update-1+!>(recent)
+    ==
+  --
+--
+`.trim();
+
+// An arm that serves when `rest` is empty and re-dispatches otherwise.
+const PARTIAL = `
+++  on-peek  peek:cor
+--
+++  peek
+  |=  =(pole knot)
+  ?+    pole  [~ ~]
+      [%x %v3 %ui %groups ship=@ name=@ rest=*]
+    ?.  ?=(~ rest.pole)
+      $(pole [%x %v3 %groups ship name rest]:pole)
+    \`\`group-ui+!>(group)
+  ==
+--
+`.trim();
+
+const FANOUT = `
+++  on-peek  peek:cor
+--
+++  peek
+  |=  =(pole knot)
+  ?+    pole  [~ ~]
+      [%x %v10 %init ~]
+    =+  .^(a (scry %gx %groups /v4/init/noun))
+    \`\`ui-init-10+!>(init)
+  ==
+--
+`.trim();
+
+const GROUPS_V4 = `
+++  on-peek  peek:cor
+--
+++  peek
+  |=  =(pole knot)
+  ?+    pole  [~ ~]
+      [%x %v4 %init ~]  \`\`init+!>(init)
+  ==
+--
+`.trim();
+
+const ui = { 'desk/app/groups-ui.hoon': PEEK };
+const steward = { 'desk/app/steward.hoon': DELEGATING };
+
+describe('classification precedence', () => {
+  it('P1 — no arm can match the known prefix, whatever the suffix', () => {
+    expect(check(ui, scry('groups-ui', ['x', 'v10', 'init']))).toBe(
+      'MISSING P1'
+    );
+    expect(check(ui, scry('groups-ui', ['x', 'v9', 'init']))).toBe('FOUND P1');
+    // The `?(...)` union-expander regression: right shape, right arity,
+    // excluded solely because %v3 sits outside ?(%v0 %v1 %v2).
+    expect(
+      check(ui, scry('groups-ui', ['x', 'v3', 'ui', 'groups'], true))
+    ).toBe('MISSING P1');
+    // A rewrite behind a head the prefix cannot reach is no back door.
+    expect(
+      check(
+        { 'desk/app/groups.hoon': WATCH },
+        watch('groups', ['v3', 'groups'])
+      )
+    ).toBe('MISSING P1');
+  });
+
+  it('P2 — the prefix matches but the arm rejects some completions', () => {
+    expect(
+      check(ui, scry('groups-ui', ['x', 'v1', 'ui', 'groups'], true))
+    ).toBe('UNVERIFIED P2');
+  });
+
+  it('P0 — a rewrite of the pole forbids FOUND as well as MISSING', () => {
+    const files = { 'desk/app/groups.hoon': OBSTRUCTED };
+    // A `%v7 %init` arm added without extending the injection list matches
+    // here, while the live pole becomes /v0/v7/init. Claiming FOUND would be
+    // the false positive that matters.
+    expect(check(files, scry('groups', ['x', 'v7', 'init']))).toBe(
+      'UNVERIFIED P0'
+    );
+    expect(check(files, scry('groups', ['x', 'v9', 'init']))).toBe(
+      'UNVERIFIED P0'
+    );
+    // %v0 is in the union the injection tests for, so it provably does not
+    // fire and the arm really is what the request reaches.
+    expect(check(files, scry('groups', ['x', 'v0', 'init']))).toBe('FOUND P1');
+  });
+
+  it('P0 — a guard forbids only MISSING, since it leaves the pole alone', () => {
+    const files = { 'desk/app/steward.hoon': GUARDED };
+    expect(check(files, scry('steward', ['x', 'v1', 'status']))).toBe(
+      'FOUND P1'
+    );
+    expect(check(files, scry('steward', ['x', 'v1', 'gone']))).toBe(
+      'UNVERIFIED P0'
+    );
+  });
+
+  it('a self-guard is satisfied by construction and changes no verdict', () => {
+    // The client only ever asks its own ship, so `?> =(src our)` cannot reject
+    // it — and must not hide an absent arm either.
+    const files = { 'desk/app/steward.hoon': SELF_GUARDED };
+    expect(check(files, scry('steward', ['x', 'v1', 'status']))).toBe(
+      'FOUND P1'
+    );
+    expect(check(files, scry('steward', ['x', 'v1', 'gone']))).toBe(
+      'MISSING P1'
+    );
+    for (const guard of [
+      '?>  from-self',
+      '?>  =(our.bowl src.bowl)',
+      '?>  =(src.bowl our.bowl)',
+      '?>  =(our src)',
+      '?>  (team:title our.bowl src.bowl)',
+      '?>(from-self (peek:cor path))',
+    ]) {
+      const spelling = {
+        'desk/app/steward.hoon': GUARDED.replace(
+          '?>  (can-read:perms src.bowl)',
+          guard
+        ).replace(guard.startsWith('?>(') ? '  (peek:cor path)\n' : '', ''),
+      };
+      expect(check(spelling, scry('steward', ['x', 'v1', 'gone']))).toBe(
+        'MISSING P1'
+      );
+    }
+    // `?<` asserts the negation, so a self-check there rejects the frontend.
+    const inverted = {
+      'desk/app/steward.hoon': GUARDED.replace(
+        '?>  (can-read:perms src.bowl)',
+        '?<  from-self'
+      ),
+    };
+    expect(check(inverted, scry('steward', ['x', 'v1', 'gone']))).toBe(
+      'UNVERIFIED P0'
+    );
+  });
+
+  it('P3 — matching a `*` tail is not service; only an arm that serves terminates', () => {
+    expect(check(steward, scry('steward', ['x', 'v1', 'lens', 'recent']))).toBe(
+      'FOUND P1'
+    );
+    expect(check(steward, scry('steward', ['x', 'v1', 'lens']))).toBe(
+      'MISSING P1'
+    );
+    // The watch surface inverts exactly: only the bare prefix is accepted.
+    expect(check(steward, watch('steward', ['v1', 'lens']))).toBe('FOUND P1');
+    expect(check(steward, watch('steward', ['v1', 'lens', 'recent']))).toBe(
+      'MISSING P1'
+    );
+    // An arm that both serves and re-dispatches claims neither verdict.
+    expect(
+      check(
+        { 'desk/app/groups.hoon': PARTIAL },
+        scry('groups', ['x', 'v3', 'ui', 'groups', '~zod', 'x'])
+      )
+    ).toBe('UNVERIFIED P3');
+  });
+
+  it('reaches a `rest` capture only once every element before it matched', () => {
+    const files = { 'desk/app/groups.hoon': REQUIRED_SUFFIX };
+    // /v3/changes omits the required `since`, so the arm does not match and
+    // the dispatcher falls through to its empty default.
+    expect(check(files, scry('groups', ['x', 'v3', 'changes']))).toBe(
+      'MISSING P1'
+    );
+    expect(
+      check(files, scry('groups', ['x', 'v3', 'changes', '~2026.1.1']))
+    ).toBe('FOUND P3');
+  });
+
+  it('follows a nested `?+` inside the matched arm', () => {
+    const files = { 'desk/app/channels.hoon': NESTED };
+    const at = (...tail: string[]) =>
+      check(
+        files,
+        scry('channels', ['x', 'v6', 'changes', '~2026.1.1', ...tail])
+      );
+    expect(at()).toBe('FOUND P1');
+    expect(at('count')).toBe('FOUND P1');
+    // The nested dispatcher serves only those two; the outer `rest=*` does not
+    // make the arm accept everything after it.
+    expect(at('bogus')).toBe('MISSING P1');
+  });
+
+  it('follows `.^` fan-out one level, and MISSING wins over unreadable', () => {
+    const req = scry('groups-ui', ['x', 'v10', 'init']);
+    const withGroups = (source: string) => ({
+      'desk/app/groups-ui.hoon': FANOUT,
+      'desk/app/groups.hoon': source,
+    });
+    expect(check(withGroups(GROUPS_V4), req)).toBe('FOUND P1');
+    expect(check(withGroups(GROUPS_V4.replace('%v4', '%v3')), req)).toBe(
+      'MISSING P3'
+    );
+    // One scry this reader cannot resolve must not mask the literal one beside
+    // it that is genuinely gone.
+    const mixed = {
+      'desk/app/groups-ui.hoon': MIXED_FANOUT,
+      'desk/app/groups.hoon': GROUPS_V4.replace('%v4', '%v3'),
+    };
+    expect(check(mixed, req)).toBe('MISSING P3');
+  });
+
+  it('does not claim service when the body still decides', () => {
+    // contacts.hoon:808 matches `her=@p` and then rejects with `?~ (slaw %p …)`.
+    const files = { 'desk/app/contacts.hoon': BRANCHING_BODY };
+    expect(check(files, scry('contacts', ['x', 'v1', 'book', '~zod']))).toBe(
+      'UNVERIFIED P3'
+    );
+    // The same empty-or-/count decision written with `?:` instead of a `?+`
+    // must not read as "the arm serves everything after `rest`".
+    const tail = { 'desk/app/channels.hoon': CONDITIONAL_TAIL };
+    expect(
+      check(
+        tail,
+        scry('channels', ['x', 'v6', 'changes', '~2026.1.1', 'bogus'])
+      )
+    ).toBe('UNVERIFIED P3');
+    // A branch before a nested `?+` may already have returned, so the nested
+    // dispatcher is not the whole decision either way.
+    const guarded = { 'desk/app/channels.hoon': GUARDED_NESTED };
+    const at = (...tail: string[]) =>
+      check(
+        guarded,
+        scry('channels', ['x', 'v6', 'changes', '~2026.1.1', ...tail])
+      );
+    expect(at()).toBe('UNVERIFIED P3');
+    expect(at('bogus')).toBe('UNVERIFIED P3');
+  });
+
+  it('bounds `.^` fan-out at one level across agents', () => {
+    // groups-ui → groups → channels. The second hop must not be followed, or
+    // the "one level" limit would be per-agent rather than per-request.
+    const chain = {
+      'desk/app/groups-ui.hoon': FANOUT,
+      'desk/app/groups.hoon': FANOUT.replace('%v10', '%v4').replace(
+        '%groups /v4/init',
+        '%channels /v6/init'
+      ),
+      'desk/app/channels.hoon': GROUPS_V4.replace('%v4', '%v9'),
+    };
+    expect(check(chain, scry('groups-ui', ['x', 'v10', 'init']))).toBe(
+      'UNVERIFIED P3'
+    );
+  });
+
+  it('sees a branch in wide form, and every rune that can reject', () => {
+    // Wide form puts the rune against its `(`: contacts.hoon:873 is
+    // `?:(?=([~ ^ *] per) …)`, groups.hoon:1142 is `?>(from-self cor)`.
+    const arm = (body: string) =>
+      check(
+        {
+          'desk/app/groups.hoon':
+            '++  on-peek  peek:cor\n--\n++  peek\n  |=  =(pole knot)\n' +
+            `  ?+    pole  [~ ~]\n      [%x %v1 %thing ~]  ${body}\n  ==\n--\n`,
+        },
+        scry('groups', ['x', 'v1', 'thing'])
+      );
+    expect(arm('``json+!>(0)')).toBe('FOUND P1');
+    // A self-guard is satisfied, so it leaves the arm serving.
+    expect(arm('?>(from-self ``json+!>(0))')).toBe('FOUND P1');
+    expect(arm('?>(=(our.bowl src.bowl) ``json+!>(0))')).toBe('FOUND P1');
+    // contacts.hoon:923 nests the guard inside a `~|` trace.
+    expect(
+      arm('~|(local-news+src.bowl ?>(=(our src):bowl ``json+!>(0)))')
+    ).toBe('FOUND P1');
+    for (const body of [
+      '?:(cached [~ ~] ``json+!>(0))',
+      '?>((can-read:perms src.bowl) ``json+!>(0))',
+      '?<(from-self ``json+!>(0))',
+      '?&(a b)',
+      '?|(a b)',
+      '=?(a b ``json+!>(0))',
+      '``json+!>((need (get id)))',
+      '%-  need  (get id)',
+    ]) {
+      expect(arm(body)).toBe('UNVERIFIED P3');
+    }
+  });
+
+  it('does not blame a `.^` that only runs on one branch', () => {
+    const files = {
+      'desk/app/groups-ui.hoon': CONDITIONAL_FANOUT,
+      'desk/app/groups.hoon': GROUPS_V4.replace('%v4', '%v3'),
+    };
+    expect(check(files, scry('groups-ui', ['x', 'v10', 'init']))).toBe(
+      'UNVERIFIED P3'
+    );
+  });
+
+  it('does not resolve a request through a mold it cannot read', () => {
+    const channels = {
+      'desk/app/channels.hoon':
+        '++  on-watch  watch:cor\n--\n++  watch\n  |=  =(pole knot)\n' +
+        '  ?+  pole  ~|(bad !!)\n    [%v4 =kind:c ship=@ name=@ ~]  cor\n  ==\n--\n',
+    };
+    // %notes is not in ?(%diary %heap %chat), so the live dispatcher crashes.
+    expect(
+      check(channels, watch('channels', ['v4', 'notes', '~zod', 'example']))
+    ).toBe('UNVERIFIED extraction');
+  });
+
+  it('claims nothing about what it cannot read', () => {
+    expect(check({}, watch('settings', ['desk', 'groups']))).toBe(
+      'UNVERIFIED coverage'
+    );
+    expect(
+      check({ 'desk/app/notes.hoon': PEEK }, scry('notes', ['x', 'v0'], true))
+    ).toBe('UNVERIFIED coverage');
+    const stub = { 'desk/app/groups.hoon': '++  on-peek  on-peek:def\n--\n' };
+    expect(check(stub, scry('groups', ['x', 'anything']))).toBe(
+      'UNVERIFIED coverage'
+    );
+  });
+});
+
+describe('what a verdict reports', () => {
+  const desk = (files: Record<string, string>) =>
+    loadDesk(memoryTree({ 'desk/desk.bill': BILL, ...files }), 'test');
+
+  it('records the failure mode, which differs between a peek and a watch', () => {
+    expect(
+      matchPath(desk(ui), scry('groups-ui', ['x', 'v10', 'init'])).failureMode
+    ).toBe('empty');
+    expect(
+      matchPath(
+        desk({ 'desk/app/groups.hoon': WATCH }),
+        watch('groups', ['v3', 'groups'])
+      ).failureMode
+    ).toBe('crash');
+  });
+
+  it('reports a nested verdict against its real file line', () => {
+    // The nested `?+` is parsed from the arm body, so its evidence must carry
+    // the file offset, not a line number relative to that slice.
+    const result = matchPath(
+      desk({ 'desk/app/channels.hoon': NESTED }),
+      scry('channels', ['x', 'v6', 'changes', '~2026.1.1', 'count'])
+    );
+    const line = Number(
+      /channels\.hoon:(\d+)/.exec(result.evidence ?? '')?.[1]
+    );
+    expect(NESTED.split('\n')[line - 1]).toContain('[%count ~]');
+  });
+
+  it('names the sub-dispatcher and the onward scry a verdict turned on', () => {
+    expect(
+      matchPath(desk(steward), scry('steward', ['x', 'v1', 'lens'])).reason
+    ).toContain('le-peek');
+    const gone = {
+      'desk/app/groups-ui.hoon': FANOUT,
+      'desk/app/groups.hoon': GROUPS_V4.replace('%v4', '%v3'),
+    };
+    expect(
+      matchPath(desk(gone), scry('groups-ui', ['x', 'v10', 'init'])).reason
+    ).toContain('%groups /v4/init');
+  });
+});

--- a/packages/scripts/src/check-desk-compat/match.test.ts
+++ b/packages/scripts/src/check-desk-compat/match.test.ts
@@ -349,13 +349,33 @@ describe('classification precedence', () => {
     expect(check(files, scry('groups', ['x', 'v0', 'init']))).toBe('FOUND P1');
   });
 
-  it('P0 — a guard forbids only MISSING, since it leaves the pole alone', () => {
+  it('P0 — a guard this reader cannot discharge forbids both verdicts', () => {
+    // It may reject a request the arms would have served, so a match proves no
+    // more than an absence does. Same treatment as the in-body rule.
     const files = { 'desk/app/steward.hoon': GUARDED };
     expect(check(files, scry('steward', ['x', 'v1', 'status']))).toBe(
-      'FOUND P1'
+      'UNVERIFIED P0'
     );
     expect(check(files, scry('steward', ['x', 'v1', 'gone']))).toBe(
       'UNVERIFIED P0'
+    );
+  });
+
+  it('reports an agent the client uses and the desk deleted', () => {
+    // Without the client-side desk, a removed agent is indistinguishable from
+    // one that was never in this desk, and the removal gate passes.
+    const desk = loadDesk(
+      memoryTree({ 'desk/desk.bill': BILL }),
+      'test',
+      memoryTree({ 'desk/app/steward.hoon': DELEGATING })
+    );
+    const result = matchPath(desk, scry('steward', ['x', 'v1', 'lens']));
+    expect([result.verdict, result.rule]).toEqual(['MISSING', 'P1']);
+    expect(result.reason).toContain('no longer an agent');
+    // An app in neither tree is simply out of desk.
+    const absent = loadDesk(memoryTree({ 'desk/desk.bill': BILL }), 'test');
+    expect(matchPath(absent, scry('settings', ['x', 'all'])).verdict).toBe(
+      'UNVERIFIED'
     );
   });
 

--- a/packages/scripts/src/check-desk-compat/match.test.ts
+++ b/packages/scripts/src/check-desk-compat/match.test.ts
@@ -53,6 +53,83 @@ const DELEGATES_BOTH = `
 --
 `.trim();
 
+const WATCHES = `
+++  on-peek  on-peek:def
+++  on-watch
+  |=  =path
+  ?+  path  ~|(bad+path !!)
+    [%v1 ~]  cor
+  ==
+--
+`.trim();
+
+describe('a comment in an agent file', () => {
+  const COMMENTED = [
+    '++  on-peek',
+    '  |=  =pole',
+    '  ?+    pole  [~ ~]',
+    '      [%x %v1 %init ~]',
+    '    cor  :: the ?+ in :~ this comment is prose',
+    '  ::',
+    '      [%x %v2 %init ~]',
+    '    cor',
+    '  ==',
+    '--',
+  ].join('\n');
+
+  it('cannot swallow the arms written after it', () => {
+    const files = {
+      'desk/desk.bill': ':~  %ledger\n==\n',
+      'desk/app/ledger.hoon': COMMENTED,
+    };
+    const loaded = loadDesk(memoryTree(files), 'test');
+    for (const version of ['v1', 'v2']) {
+      expect(
+        matchPath(loaded, scry('ledger', ['x', version, 'init'])).verdict
+      ).toBe('FOUND');
+    }
+    expect(matchPath(loaded, scry('ledger', ['x', 'v3', 'init'])).verdict).toBe(
+      'MISSING'
+    );
+  });
+});
+
+describe('dropping an agent from desk.bill', () => {
+  const app = '|_  =bowl:gall\n--\n';
+  const run = (deskBill: string, clientBill: string | null, r: PathRequest) => {
+    const files = (bill: string) => ({
+      'desk/desk.bill': bill,
+      'desk/app/ledger.hoon': app,
+    });
+    const result = matchPath(
+      loadDesk(
+        memoryTree(files(deskBill)),
+        'test',
+        clientBill === null ? undefined : memoryTree(files(clientBill))
+      ),
+      r
+    );
+    return `${result.verdict} ${result.rule} ${result.failureMode ?? '-'}`;
+  };
+  const request = scry('ledger', ['x', 'v1']);
+
+  it('is a removal even though every line of the agent survives', () => {
+    expect(run(':~  %other\n==\n', ':~  %ledger\n==\n', request)).toBe(
+      'MISSING P1 not-running'
+    );
+  });
+
+  it('decides nothing about an agent neither desk bills', () => {
+    // %ledger may simply live in another desk.
+    expect(run(':~  %other\n==\n', ':~  %other\n==\n', request)).toBe(
+      'UNVERIFIED coverage -'
+    );
+    expect(run(':~  %other\n==\n', null, request)).toBe(
+      'UNVERIFIED coverage -'
+    );
+  });
+});
+
 describe('handing a surface to default-agent', () => {
   const BILL_LEDGER = ':~  %ledger\n==\n';
   const desk = (app: string) => ({
@@ -68,6 +145,20 @@ describe('handing a surface to default-agent', () => {
     const result = matchPath(loaded, r);
     return `${result.verdict} ${result.rule}`;
   };
+  const failureOf = (
+    deskApp: string,
+    clientApp: string,
+    r: PathRequest,
+    deskFiles: Record<string, string> = {}
+  ) =>
+    matchPath(
+      loadDesk(
+        memoryTree({ ...desk(deskApp), ...deskFiles }),
+        'test',
+        memoryTree(desk(clientApp))
+      ),
+      r
+    ).failureMode;
 
   it('is a removal when the client desk dispatched that surface itself', () => {
     // The pinned default-agent nacks, so `on-peek:def` deletes the surface as
@@ -85,6 +176,44 @@ describe('handing a surface to default-agent', () => {
     expect(run(DELEGATES_BOTH, null, scry('ledger', ['x', 'v1', 'init']))).toBe(
       'UNVERIFIED coverage'
     );
+  });
+
+  it('reads a stub or a vanished arm the same way', () => {
+    const stub = [
+      '++  on-peek  |=(* ~)',
+      '++  on-watch  on-watch:def',
+      '--',
+    ].join('\n');
+    const gone = ['++  on-watch  on-watch:def', '--'].join('\n');
+    for (const removed of [stub, gone]) {
+      expect(
+        run(removed, DISPATCHES, scry('ledger', ['x', 'v1', 'init']))
+      ).toBe('MISSING P1');
+      // Unchanged between the trees, it is still merely unreadable.
+      expect(run(removed, removed, scry('ledger', ['x', 'v1', 'init']))).toBe(
+        'UNVERIFIED coverage'
+      );
+    }
+    // A peek that answers nothing is empty; a watch that answers nothing nacks.
+    expect(failureOf(stub, DISPATCHES, scry('ledger', ['x', 'v1']))).toBe(
+      'empty'
+    );
+    expect(failureOf(gone, WATCHES, watch('ledger', ['v1']))).toBe('crash');
+  });
+
+  it('does not call an arm it failed to index a removal', () => {
+    // The arm is plainly in the file; not finding it is this reader's problem,
+    // and a reader failure must never read as a removal.
+    const unreadable = [
+      '++  on-peek',
+      '  |=  =path',
+      '  ?:  =(path /x/v1/init)  [~ ~]',
+      '  [~ ~]',
+      '--',
+    ].join('\n');
+    expect(
+      run(unreadable, DISPATCHES, scry('ledger', ['x', 'v1', 'init']))
+    ).toBe('UNVERIFIED coverage');
   });
 
   it('judges each surface on its own', () => {

--- a/packages/scripts/src/check-desk-compat/match.ts
+++ b/packages/scripts/src/check-desk-compat/match.ts
@@ -84,10 +84,16 @@ export interface Desk {
   bill: Set<string>;
   marFiles: Set<string>;
   hasApp(app: string): boolean;
+  /**
+   * Whether the desk shipping with the *client* ref had this agent. An app in
+   * that tree and not in this one was deleted, which is a removal the gate must
+   * catch; an app in neither is simply out of desk.
+   */
+  clientHadApp(app: string): boolean;
   agent(app: string): Agent | null;
 }
 
-export function loadDesk(tree: Tree, ref: string): Desk {
+export function loadDesk(tree: Tree, ref: string, clientDesk?: Tree): Desk {
   const bill = new Set(
     Array.from(
       (tree.readFile('desk/desk.bill') ?? '').matchAll(/%([a-z][a-z0-9-]*)/g)
@@ -101,6 +107,7 @@ export function loadDesk(tree: Tree, ref: string): Desk {
     bill,
     marFiles: new Set(tree.list('desk/mar', (p) => p.endsWith('.hoon'))),
     hasApp: (app) => tree.exists(`desk/app/${app}.hoon`),
+    clientHadApp: (app) => clientDesk?.exists(`desk/app/${app}.hoon`) ?? false,
     agent(app) {
       if (!cache.has(app)) {
         const file = `desk/app/${app}.hoon`;
@@ -261,6 +268,18 @@ export function matchPath(
     evidence,
   });
   if (!desk.hasApp(request.app)) {
+    // An agent the client's own desk has and this one does not was deleted.
+    // Reporting that as "out of desk" would let a removal walk through the
+    // gate it exists to catch.
+    if (desk.clientHadApp(request.app)) {
+      return {
+        verdict: 'MISSING',
+        rule: 'P1',
+        reason: `%${request.app} is no longer an agent in this desk, but the client still uses it`,
+        evidence: `desk/app/${request.app}.hoon (removed)`,
+        failureMode: 'crash',
+      };
+    }
     return unverified(
       `%${request.app} is not an agent in this desk (out-of-desk app)`
     );
@@ -297,24 +316,24 @@ export function matchPath(
     failureMode: failureModeOf(dispatcher),
   });
 
-  // P0 runs before the walk, not after it. A rewrite changes the pole the arms
-  // see, so it invalidates FOUND as much as MISSING: an arm added for `%v7`
-  // without extending the injection list matches here while the live pole
-  // becomes `/v0/v7/…`. Only a rewrite this reader can prove inert for *this*
-  // request — the segment is already a version the injection tests for — is
-  // safe to ignore.
-  const rewrites = surface.obstructions.filter(
-    (o) => o.kind === 'rewrite' && !isInert(o, request)
-  );
-  if (rewrites.length > 0) return p0('rewrites the pole', rewrites);
+  // P0 runs before the walk, not after it, and applies to both verdicts. A
+  // rewrite changes the pole the arms see, so an arm added for `%v7` without
+  // extending the injection list matches here while the live pole becomes
+  // `/v0/v7/…`; a guard this reader cannot discharge can reject a request the
+  // arms would have served. Self-guards never reach here — they are dropped
+  // when obstructions are collected — and a rewrite provably inert for *this*
+  // request is ignored.
+  const active = surface.obstructions.filter((o) => !isInert(o, request));
+  if (active.length > 0) {
+    const kind = active.every((o) => o.kind === 'guard')
+      ? 'guards the pole'
+      : 'rewrites the pole';
+    return p0(kind, active);
+  }
 
   const walked = walk(desk, agent, dispatcher, request, new Set(), depth);
   if (walked.verdict !== 'MISSING') return walked;
-  // A guard can reject before the dispatcher is reached, and an arm this
-  // reader could not parse might have served; neither allows MISSING.
-  if (surface.obstructions.length > 0) {
-    return p0('guards the pole', surface.obstructions);
-  }
+  // An arm this reader could not parse might have served the request.
   if (dispatcher.unparsedArms > 0) {
     return {
       verdict: 'UNVERIFIED',

--- a/packages/scripts/src/check-desk-compat/match.ts
+++ b/packages/scripts/src/check-desk-compat/match.ts
@@ -1,0 +1,834 @@
+import { Tree } from './git';
+import {
+  Arm,
+  Dispatcher,
+  Elem,
+  HoonArmRange,
+  Obstruction,
+  indexArms,
+  parseDispatcher,
+  preDispatchObstructions,
+  splitTokens,
+  stripSelfGuard,
+} from './hoon';
+
+export type Verdict = 'FOUND' | 'MISSING' | 'UNVERIFIED';
+
+/**
+ * Which rule decided a verdict. P0-P4 are the ordered classification
+ * precedence; the first that fires wins.
+ *
+ *   P0  pre-dispatch obstruction — the only agent-wide taint
+ *   P1  known-prefix absence ⇒ MISSING
+ *   P2  prefix matches, suffix unknown ⇒ UNVERIFIED
+ *   P3  delegation: a wildcard-tail arm does not terminate the walk
+ *   P4  open value sets ⇒ UNVERIFIED
+ */
+export type Rule =
+  | 'P0'
+  | 'P1'
+  | 'P2'
+  | 'P3'
+  | 'P4'
+  | 'marks'
+  | 'threads'
+  | 'negotiation'
+  | 'extraction'
+  | 'coverage';
+
+/**
+ * How the desk fails when a request is not served. Watch dispatchers default
+ * to a crash and peek dispatchers to a silent empty, and the user-visible
+ * symptom differs, so the verdict carries which.
+ */
+export type FailureMode = 'crash' | 'empty' | 'unknown';
+
+export interface MatchResult {
+  verdict: Verdict;
+  rule: Rule;
+  reason: string;
+  /** Desk-side evidence: the arm or file the verdict turned on. */
+  evidence?: string;
+  failureMode?: FailureMode;
+}
+
+export interface PathRequest {
+  app: string;
+  surface: 'scry' | 'subscribe';
+  /** Leading segments known exactly. Scries carry the care (`x`) first. */
+  known: string[];
+  unknownTail: boolean;
+}
+
+/** Eyre's `/~/scry/<app><path>` always asks for the `x` care. */
+export const SCRY_CARE = 'x';
+
+interface AgentSurface {
+  kind: 'inline' | 'delegated' | 'default-agent' | 'stub' | 'absent';
+  dispatcher: Dispatcher | null;
+  obstructions: Obstruction[];
+}
+
+interface Agent {
+  name: string;
+  file: string;
+  lines: string[];
+  arms: Map<string, HoonArmRange>;
+  peek: AgentSurface;
+  watch: AgentSurface;
+}
+
+export interface Desk {
+  ref: string;
+  tree: Tree;
+  bill: Set<string>;
+  marFiles: Set<string>;
+  hasApp(app: string): boolean;
+  agent(app: string): Agent | null;
+}
+
+export function loadDesk(tree: Tree, ref: string): Desk {
+  const bill = new Set(
+    Array.from(
+      (tree.readFile('desk/desk.bill') ?? '').matchAll(/%([a-z][a-z0-9-]*)/g)
+    ).map((m) => m[1])
+  );
+  // Agents are parsed lazily; a run touches a handful of the 27.
+  const cache = new Map<string, Agent | null>();
+  return {
+    ref,
+    tree,
+    bill,
+    marFiles: new Set(tree.list('desk/mar', (p) => p.endsWith('.hoon'))),
+    hasApp: (app) => tree.exists(`desk/app/${app}.hoon`),
+    agent(app) {
+      if (!cache.has(app)) {
+        const file = `desk/app/${app}.hoon`;
+        const source = tree.readFile(file);
+        const lines = source?.split('\n');
+        const arms = lines ? indexArms(lines) : null;
+        cache.set(
+          app,
+          lines && arms
+            ? {
+                name: app,
+                file,
+                lines,
+                arms,
+                peek: resolveSurface(lines, arms, 'on-peek'),
+                watch: resolveSurface(lines, arms, 'on-watch'),
+              }
+            : null
+        );
+      }
+      return cache.get(app)!;
+    },
+  };
+}
+
+/**
+ * Find the `?+` an agent's peek or watch actually dispatches on, following one
+ * level of delegation (`++ on-peek peek:cor`, `(peek:cor path)`), and collect
+ * anything that guards or rewrites the subject before that `?+` runs.
+ */
+function resolveSurface(
+  lines: string[],
+  arms: Map<string, HoonArmRange>,
+  entry: 'on-peek' | 'on-watch'
+): AgentSurface {
+  const range = arms.get(entry);
+  if (!range) return { kind: 'absent', dispatcher: null, obstructions: [] };
+
+  const inline = parseDispatcher(lines, range.start, range.end);
+  if (inline?.arms.length) {
+    return {
+      kind: 'inline',
+      dispatcher: { ...inline, armName: entry },
+      obstructions: preDispatchObstructions(
+        lines,
+        range.start + 1,
+        inline.headerLine - 1,
+        inline.subject
+      ),
+    };
+  }
+
+  const entryText = lines.slice(range.start, range.end).join('\n');
+  const obstructions = preDispatchObstructions(
+    lines,
+    range.start + 1,
+    range.end
+  );
+  for (const m of entryText.matchAll(
+    /\b([a-z][a-z0-9-]*)(?::[a-z][a-z0-9-]*)*\b/g
+  )) {
+    const target = m[1] === entry ? undefined : arms.get(m[1]);
+    if (!target) continue;
+    const dispatcher = parseDispatcher(lines, target.start, target.end);
+    if (dispatcher?.arms.length) {
+      return {
+        kind: 'delegated',
+        dispatcher: { ...dispatcher, armName: m[1] },
+        obstructions: [
+          ...obstructions,
+          ...preDispatchObstructions(
+            lines,
+            target.start + 1,
+            dispatcher.headerLine - 1,
+            dispatcher.subject
+          ),
+        ],
+      };
+    }
+  }
+  return {
+    kind: new RegExp(`${entry}:def`).test(entryText) ? 'default-agent' : 'stub',
+    dispatcher: null,
+    obstructions,
+  };
+}
+
+type MatchKind = 'exact' | 'open' | 'prefix' | 'opaque' | 'no';
+
+/**
+ * Walk one flattened arm alternative against a request.
+ *
+ * `prefix` means the arm could still match if the unknown tail supplies the
+ * right segments — only possible when there *is* an unknown tail. `opaque`
+ * means it matched, but only by consuming a named mold whose members this
+ * reader cannot enumerate, so service is not established.
+ */
+export function matchAlternative(
+  alt: Elem[],
+  known: string[],
+  unknownTail: boolean
+): MatchKind {
+  let i = 0;
+  let j = 0;
+  let opaque = false;
+  const settle = (kind: MatchKind) =>
+    opaque && (kind === 'exact' || kind === 'open') ? 'opaque' : kind;
+  while (i < alt.length) {
+    const el = alt[i];
+    // A `rest` accepts everything from here — but only once every element
+    // before it has been matched, which is why this is not a `.some()`.
+    if (el.k === 'rest') return settle('open');
+    if (j >= known.length) {
+      const remaining = alt.slice(i);
+      if (remaining.length === 1 && remaining[0].k === 'nil') {
+        return unknownTail ? 'no' : settle('exact');
+      }
+      // The arm still requires segments the request does not supply.
+      return unknownTail ? 'prefix' : 'no';
+    }
+    if (el.k === 'nil') return 'no';
+    if (el.k === 'lit' && el.v !== known[j]) return 'no';
+    if (el.k === 'opaque') opaque = true;
+    i++;
+    j++;
+  }
+  if (j < known.length) return 'no';
+  return unknownTail ? 'no' : settle('exact');
+}
+
+interface ArmMatch {
+  arm: Arm;
+  alternative: Elem[];
+  kind: 'exact' | 'open';
+}
+
+function failureModeOf(dispatcher: Dispatcher | null): FailureMode {
+  switch (dispatcher?.defaultKind) {
+    case 'crash':
+    case 'default-agent':
+      return 'crash';
+    case 'empty':
+      return 'empty';
+    default:
+      return 'unknown';
+  }
+}
+
+export function matchPath(
+  desk: Desk,
+  request: PathRequest,
+  depth = 0
+): MatchResult {
+  const unverified = (reason: string, evidence?: string): MatchResult => ({
+    verdict: 'UNVERIFIED',
+    rule: 'coverage',
+    reason,
+    evidence,
+  });
+  if (!desk.hasApp(request.app)) {
+    return unverified(
+      `%${request.app} is not an agent in this desk (out-of-desk app)`
+    );
+  }
+  if (!desk.bill.has(request.app)) {
+    return unverified(
+      `%${request.app} is not listed in desk/desk.bill, so it may not be running`
+    );
+  }
+  const agent = desk.agent(request.app);
+  if (!agent) return unverified(`could not read desk/app/${request.app}.hoon`);
+
+  const entry = request.surface === 'scry' ? 'on-peek' : 'on-watch';
+  const surface = request.surface === 'scry' ? agent.peek : agent.watch;
+  if (surface.kind === 'default-agent') {
+    return unverified(
+      `%${request.app} routes ${entry} to default-agent`,
+      agent.file
+    );
+  }
+  if (surface.kind === 'stub' || surface.kind === 'absent') {
+    return unverified(
+      `%${request.app} has no parseable ${entry} dispatcher (${surface.kind})`,
+      agent.file
+    );
+  }
+
+  const dispatcher = surface.dispatcher!;
+  const p0 = (why: string, obstructions: Obstruction[]): MatchResult => ({
+    verdict: 'UNVERIFIED',
+    rule: 'P0',
+    reason: `%${request.app} ${why} before dispatch`,
+    evidence: obstructions.map((o) => o.text).join(' ; '),
+    failureMode: failureModeOf(dispatcher),
+  });
+
+  // P0 runs before the walk, not after it. A rewrite changes the pole the arms
+  // see, so it invalidates FOUND as much as MISSING: an arm added for `%v7`
+  // without extending the injection list matches here while the live pole
+  // becomes `/v0/v7/…`. Only a rewrite this reader can prove inert for *this*
+  // request — the segment is already a version the injection tests for — is
+  // safe to ignore.
+  const rewrites = surface.obstructions.filter(
+    (o) => o.kind === 'rewrite' && !isInert(o, request)
+  );
+  if (rewrites.length > 0) return p0('rewrites the pole', rewrites);
+
+  const walked = walk(desk, agent, dispatcher, request, new Set(), depth);
+  if (walked.verdict !== 'MISSING') return walked;
+  // A guard can reject before the dispatcher is reached, and an arm this
+  // reader could not parse might have served; neither allows MISSING.
+  if (surface.obstructions.length > 0) {
+    return p0('guards the pole', surface.obstructions);
+  }
+  if (dispatcher.unparsedArms > 0) {
+    return {
+      verdict: 'UNVERIFIED',
+      rule: 'extraction',
+      reason: `%${request.app}'s ${entry} has ${dispatcher.unparsedArms} arm(s) this reader could not parse`,
+      evidence: `${agent.file}:${dispatcher.headerLine}`,
+      failureMode: failureModeOf(dispatcher),
+    };
+  }
+  return walked;
+}
+
+// Wide form puts the rune straight against its `(` — `?:(cached …)`,
+// `?>(from-self cor)` — so a whitespace-only boundary misses half of them.
+const BRANCH_RE =
+  /(^|\s)(\?~|\?:|\?-|\?\.|\?\^|\?<|\?>|\?&|\?\||\?\+|=\?)([\s(]|$)/;
+const DECODE_RE = /\bsla[vw]\b[^\n]*\.(pole|path|pat)\b|\(need\s|%-\s+need\b/;
+
+/**
+ * Whether an arm body decides anything about the path after the pattern
+ * matched. `contacts.hoon:808` matches `[%x %v1 %book her=@p ~]` and then
+ * rejects with `?~ who=(slaw %p her.pat)`; the same decision can be spelled
+ * `?:` instead of a nested `?+`. Neither service nor absence is established
+ * through such a body, so the answer is UNVERIFIED.
+ *
+ * Lexical, and deliberately so: evaluating the branch is the machinery this
+ * reader does not have.
+ */
+function bodyBranches(body: string): string | null {
+  for (const raw of body.split('\n')) {
+    // `?>(from-self cor)` cannot reject a frontend request, so it is dropped
+    // before the line is judged; what it produces is still examined.
+    const line = stripSelfGuard(raw);
+    const branch = BRANCH_RE.exec(line);
+    if (branch) return branch[2];
+    if (DECODE_RE.test(line)) return 'a decode that can fail (slaw/slav/need)';
+  }
+  return null;
+}
+
+/** A version-injection rewrite provably does not fire for this request. */
+function isInert(o: Obstruction, request: PathRequest): boolean {
+  const segment = o.inertWhen && request.known[o.inertWhen.index];
+  return segment !== undefined && o.inertWhen!.members.includes(segment);
+}
+
+const MAX_DELEGATION_DEPTH = 4;
+
+function walk(
+  desk: Desk,
+  agent: Agent,
+  dispatcher: Dispatcher,
+  request: PathRequest,
+  visited: Set<string>,
+  depth: number
+): MatchResult {
+  const where = `${agent.file}:${dispatcher.headerLine}`;
+  const key = `${agent.name}|${dispatcher.headerLine}|${request.known.join('/')}|${request.unknownTail}`;
+  if (visited.has(key) || depth > MAX_DELEGATION_DEPTH) {
+    return {
+      verdict: 'UNVERIFIED',
+      rule: 'P3',
+      reason: 'delegation walk did not terminate within its bound',
+      evidence: where,
+    };
+  }
+  visited.add(key);
+
+  const served: ArmMatch[] = [];
+  const prefixed: Arm[] = [];
+  const opaque: { arm: Arm; mold: string }[] = [];
+  for (const arm of dispatcher.arms) {
+    if (!arm.parsed) continue;
+    for (const alternative of arm.alternatives) {
+      const kind = matchAlternative(
+        alternative,
+        request.known,
+        request.unknownTail
+      );
+      if (kind === 'exact' || kind === 'open')
+        served.push({ arm, alternative, kind });
+      else if (kind === 'prefix') prefixed.push(arm);
+      else if (kind === 'opaque') {
+        const el = alternative.find((e) => e.k === 'opaque');
+        opaque.push({ arm, mold: el?.k === 'opaque' ? el.name : '?' });
+      }
+    }
+  }
+
+  if (served.length === 0) {
+    // The arm matched only by consuming a named mold — `=kind:c` is
+    // `?(%diary %heap %chat)`, not "any knot" — so neither service nor absence
+    // is established without resolving the type.
+    if (opaque.length > 0) {
+      return {
+        verdict: 'UNVERIFIED',
+        rule: 'extraction',
+        reason: `matching /${request.known.join('/')} turns on the mold +$${opaque[0].mold}, which this reader does not resolve`,
+        evidence: `${agent.file}:${opaque[0].arm.line} ${opaque[0].arm.patternText}`,
+        failureMode: failureModeOf(dispatcher),
+      };
+    }
+    // P2 — the prefix matches but the matched arms do not accept every
+    // completion at that position.
+    if (prefixed.length > 0) {
+      return {
+        verdict: 'UNVERIFIED',
+        rule: 'P2',
+        reason: `prefix /${request.known.join('/')} reaches ${prefixed.length} arm(s) but the interpolated tail is unbounded`,
+        evidence: prefixed
+          .slice(0, 3)
+          .map((a) => `${agent.file}:${a.line} ${a.patternText}`)
+          .join(' | '),
+        failureMode: failureModeOf(dispatcher),
+      };
+    }
+    // P1 — no arm can match the known prefix under any completion.
+    return {
+      verdict: 'MISSING',
+      rule: 'P1',
+      reason: `no ${dispatcher.armName ?? 'dispatch'} arm in %${agent.name} can match /${request.known.join('/')}`,
+      evidence: `${where} (${dispatcher.arms.length} arms, default ${dispatcher.defaultKind})`,
+      failureMode: failureModeOf(dispatcher),
+    };
+  }
+
+  // P3 — only an arm that *serves* terminates the walk.
+  const results = served.map((m) =>
+    resolveArm(desk, agent, dispatcher, request, m, visited, depth)
+  );
+  return (
+    results.find((r) => r.verdict === 'MISSING') ??
+    results.find((r) => r.verdict === 'UNVERIFIED') ??
+    results[0]
+  );
+}
+
+function resolveArm(
+  desk: Desk,
+  agent: Agent,
+  dispatcher: Dispatcher,
+  request: PathRequest,
+  match: ArmMatch,
+  visited: Set<string>,
+  depth: number
+): MatchResult {
+  const where = `${agent.file}:${match.arm.line} ${match.arm.patternText}`;
+  const unverified = (reason: string): MatchResult => ({
+    verdict: 'UNVERIFIED',
+    rule: 'P3',
+    reason,
+    evidence: where,
+  });
+  const delegation = findDelegation(agent, dispatcher, match.arm);
+
+  if (delegation) {
+    // An arm that serves some completions and re-dispatches others turns on a
+    // condition this reader cannot evaluate, and matching a wildcard tail is
+    // not service — so neither FOUND nor MISSING is available.
+    if (!delegation.whole) {
+      return unverified(
+        `arm serves some requests directly and re-dispatches others into ${delegation.target}`
+      );
+    }
+    const rebuilt =
+      delegation.expr && rebuildPath(match, request, delegation.expr);
+    if (!rebuilt) {
+      return unverified(
+        `arm delegates to ${delegation.target} with a path this reader could not rebuild (${delegation.expr ?? 'multi-argument call'})`
+      );
+    }
+    const targetRange = agent.arms.get(delegation.target);
+    const sub =
+      delegation.kind === 'self'
+        ? dispatcher
+        : targetRange &&
+          parseDispatcher(agent.lines, targetRange.start, targetRange.end);
+    if (!sub?.arms.length) {
+      return unverified(
+        `arm delegates to ${delegation.target}, whose dispatcher could not be resolved`
+      );
+    }
+    const inner = walk(
+      desk,
+      agent,
+      { ...sub, armName: delegation.target },
+      { ...request, ...rebuilt },
+      visited,
+      depth + 1
+    );
+    return {
+      ...inner,
+      reason: `${inner.reason} (via ${delegation.target}, delegated path /${rebuilt.known.join('/')})`,
+      evidence: inner.evidence ?? where,
+    };
+  }
+
+  // A nested `?+` inside the arm decides the rest of the path, so the outer
+  // arm has not served anything yet — `[%x ver %changes since=@ rest=*]`
+  // accepts only an empty `rest` or `/count`.
+  const bodyLines = match.arm.bodyText.split('\n');
+  const nested = parseDispatcher(
+    bodyLines,
+    0,
+    bodyLines.length,
+    match.arm.bodyStartLine - 1
+  );
+  if (nested?.arms.length) {
+    // Only an unconditional path from the arm to the `?+` makes the nested
+    // dispatcher the decision: a `?~` above it may already have returned.
+    const before = bodyLines
+      .slice(0, nested.headerLine - match.arm.bodyStartLine)
+      .join('\n');
+    const branch = bodyBranches(before);
+    if (branch) {
+      return unverified(
+        `arm branches on \`${branch}\` before re-dispatching, so the nested \`?+\` is not the whole decision`
+      );
+    }
+    const expr = singleExpression(nested.subject);
+    const rebuilt = expr && rebuildPath(match, request, expr);
+    if (!rebuilt) {
+      return unverified(
+        `arm re-dispatches on ${nested.subject}, which this reader could not rebuild`
+      );
+    }
+    const inner = walk(
+      desk,
+      agent,
+      { ...nested, armName: `nested ?+ ${nested.subject}` },
+      { ...request, ...rebuilt },
+      visited,
+      depth + 1
+    );
+    return {
+      ...inner,
+      reason: `${inner.reason} (nested dispatch on ${nested.subject}, /${rebuilt.known.join('/')})`,
+      evidence: inner.evidence ?? where,
+    };
+  }
+
+  // Follow `.^` fan-out one level, literal poles only. The literal calls are
+  // evaluated before the unresolved ones are reported, so one unreadable scry
+  // cannot mask a missing dependency beside it.
+  const fanout = scryFanout(match.arm.bodyText);
+  if (depth > 0 && (fanout.calls.length > 0 || fanout.unresolved)) {
+    return unverified('nested scry fan-out beyond one level is not followed');
+  }
+  // A `.^` the arm reaches unconditionally is a dependency; one under a `?:`
+  // may never run, so it can only soften the verdict, never produce MISSING.
+  const conditional = bodyBranches(match.arm.bodyText);
+  const onward = fanout.calls.map(
+    (inner) => [inner, matchPath(desk, inner, depth + 1)] as const
+  );
+  const worst =
+    (conditional ? null : onward.find(([, r]) => r.verdict === 'MISSING')) ??
+    (fanout.unresolved ? null : onward.find(([, r]) => r.verdict !== 'FOUND'));
+  if (worst) {
+    const [inner, result] = worst;
+    const verdict = conditional ? 'UNVERIFIED' : result.verdict;
+    return {
+      verdict,
+      rule: 'P3',
+      reason:
+        `arm scries %${inner.app} /${inner.known.slice(1).join('/')}, which is ${result.verdict.toLowerCase()}` +
+        (conditional
+          ? `, under a \`${conditional}\` branch`
+          : `: ${result.reason}`),
+      evidence: result.evidence ?? where,
+      failureMode: verdict === 'MISSING' ? result.failureMode : undefined,
+    };
+  }
+  if (fanout.unresolved) {
+    return unverified(
+      `arm scries onward through an expression this reader could not resolve (${fanout.unresolved})`
+    );
+  }
+  // An arm body that calls a same-file helper which itself scries is beyond
+  // one level, so it propagates as UNVERIFIED rather than FOUND.
+  const helper = scryingHelper(agent, match.arm);
+  if (helper) {
+    return unverified(
+      `arm body calls +${helper}, which scries onward (beyond the one-level limit)`
+    );
+  }
+  // The pattern matched, but the body still decides — a `?~` on a decoded
+  // segment rejects paths the pattern accepts.
+  if (conditional) {
+    return unverified(
+      `arm body branches on \`${conditional}\`, so matching the pattern does not establish service`
+    );
+  }
+  return {
+    verdict: 'FOUND',
+    rule: match.kind === 'open' ? 'P3' : 'P1',
+    reason: `served by ${match.arm.patternText}`,
+    evidence: where,
+  };
+}
+
+interface Delegation {
+  kind: 'self' | 'arm';
+  target: string;
+  /** null when the delegated path is not a single rebuildable expression. */
+  expr: string | null;
+  /** Whole body is the delegating call, so the arm never serves directly. */
+  whole: boolean;
+}
+
+/**
+ * A matched arm whose body re-dispatches rather than serving: a `$(pole …)`
+ * rewrite back into the same wutlus, or a call into a sub-core arm with a
+ * reconstructed path such as `(le-peek:le-core [%v1 t.t.t.path])`.
+ *
+ * The path is rebuilt only when the delegated argument is a *single*
+ * expression. A multi-argument call like `(go-peek:… ver.pole rest.pole)`
+ * cannot be told apart from a path spelled as loose tokens without the
+ * callee's signature, so it stays unresolved rather than being guessed at.
+ */
+function findDelegation(
+  agent: Agent,
+  dispatcher: Dispatcher,
+  arm: Arm
+): Delegation | null {
+  const body = arm.bodyText;
+  const normalized = body.trim().replace(/\s+/g, ' ');
+  const self = findCall(body, `$(${dispatcher.subject}`);
+  if (self) {
+    return {
+      kind: 'self',
+      target: dispatcher.armName ?? 'self',
+      expr: singleExpression(self.expr),
+      whole: normalized === self.full.trim().replace(/\s+/g, ' '),
+    };
+  }
+  for (const call of balancedCalls(body)) {
+    const tokens = splitTokens(call);
+    const head = tokens[0]?.split(':')[0];
+    if (tokens.length < 2 || !head || head === agent.name) continue;
+    const target = agent.arms.get(head);
+    if (!target || (target.start >= arm.line - 1 && target.end <= arm.line))
+      continue;
+    if (!parseDispatcher(agent.lines, target.start, target.end)?.arms.length)
+      continue;
+    const rest = tokens.slice(1);
+    return {
+      kind: 'arm',
+      target: head,
+      expr: rest.length === 1 ? singleExpression(rest[0]) : null,
+      whole: normalized === `(${call.trim().replace(/\s+/g, ' ')})`,
+    };
+  }
+  return null;
+}
+
+/** Accept only the delegated-path forms this reader can rebuild faithfully. */
+function singleExpression(text: string): string | null {
+  const trimmed = text.trim().replace(/\n\s*/g, ' ');
+  return /^\[.*\](:[a-z][a-z0-9-]*)?$/.test(trimmed) ||
+    /^\/\S*$/.test(trimmed) ||
+    /^(?:t\.)*(pole|path|pat)$/.test(trimmed) ||
+    /^[a-z][a-z0-9-]*\.(pole|path|pat)$/.test(trimmed)
+    ? trimmed
+    : null;
+}
+
+function matchParen(text: string, open: number): number {
+  let depth = 0;
+  for (let i = open; i < text.length; i++) {
+    if (text[i] === '(') depth++;
+    if (text[i] === ')' && --depth === 0) return i;
+  }
+  return -1;
+}
+
+function findCall(
+  text: string,
+  opener: string
+): { expr: string; full: string } | null {
+  const idx = text.indexOf(opener);
+  if (idx === -1) return null;
+  const open = text.indexOf('(', idx);
+  const end = matchParen(text, open);
+  if (end === -1) return null;
+  const inner = text.slice(open + 1, end);
+  // Drop the subject name that follows `$(`.
+  return {
+    expr: inner.slice(inner.indexOf(' ') + 1).trim(),
+    full: text.slice(idx, end + 1),
+  };
+}
+
+function balancedCalls(text: string): string[] {
+  const out: string[] = [];
+  for (let i = 0; i < text.length; i++) {
+    if (text[i] !== '(') continue;
+    const end = matchParen(text, i);
+    if (end !== -1) out.push(text.slice(i + 1, end));
+  }
+  return out;
+}
+
+/**
+ * Rebuild the path an arm hands to a sub-dispatcher. Handles the forms that
+ * appear in `desk/app`: a literal path, literal knots, `t.t.…path` slices, and
+ * a face bound by the matched arm.
+ */
+export function rebuildPath(
+  match: ArmMatch,
+  request: PathRequest,
+  expr: string
+): { known: string[]; unknownTail: boolean } | null {
+  let trimmed = expr.trim();
+  if (trimmed.startsWith('/')) {
+    return { known: trimmed.split('/').filter(Boolean), unknownTail: false };
+  }
+  // `[…]:pole` binds the faces inside the tuple against the matched pole.
+  trimmed = trimmed.replace(/^(\[.*\]):[a-z][a-z0-9-]*$/, '$1');
+  const tokens = trimmed.startsWith('[')
+    ? splitTokens(trimmed.slice(1, -1))
+    : splitTokens(trimmed);
+  // Face indices line up with element indices only when every pattern token
+  // expanded to exactly one element.
+  const patternTokens = match.arm.patternText.startsWith('[')
+    ? splitTokens(match.arm.patternText.slice(1, -1))
+    : [match.arm.patternText];
+  const facesUsable = patternTokens.length === match.alternative.length;
+
+  const known: string[] = [];
+  let unknownTail = false;
+  const takeFrom = (drop: number) => {
+    if (drop > request.known.length && request.unknownTail) return false;
+    known.push(...request.known.slice(drop));
+    unknownTail = request.unknownTail;
+    return true;
+  };
+  for (const token of tokens) {
+    if (unknownTail) return null;
+    // A `~` terminator in the rebuilt tuple pins the length exactly.
+    if (token === '~') continue;
+    const lit = /^%([a-z0-9][a-z0-9-]*)$/.exec(token);
+    if (lit) {
+      known.push(lit[1]);
+      continue;
+    }
+    const slice = /^((?:t\.)*)(pole|path|pat)$/.exec(token);
+    if (slice) {
+      if (!takeFrom((slice[1].match(/t\./g) ?? []).length)) return null;
+      continue;
+    }
+    const face = /^([a-z][a-z0-9-]*)(?:\.(?:pole|path|pat))?$/.exec(token)?.[1];
+    const idx = face && facesUsable ? match.arm.faces[face] : undefined;
+    if (idx === undefined) return null;
+    if (match.alternative[idx]?.k === 'rest') {
+      if (!takeFrom(idx)) return null;
+    } else if (idx < request.known.length) known.push(request.known[idx]);
+    else return null;
+  }
+  return { known, unknownTail };
+}
+
+/** Literal `.^(… (scry %gx %app /a/b/mark))` calls in an arm body. */
+export function scryFanout(body: string): {
+  calls: PathRequest[];
+  unresolved: string | null;
+} {
+  const calls: PathRequest[] = [];
+  let unresolved: string | null = null;
+  for (
+    let idx = body.indexOf('.^');
+    idx !== -1;
+    idx = body.indexOf('.^', idx + 2)
+  ) {
+    const open = body.indexOf('(', idx);
+    const end = open === -1 ? -1 : matchParen(body, open);
+    const chunk =
+      end === -1 ? body.slice(idx, idx + 120) : body.slice(idx, end + 1);
+    const scryIdx = chunk.indexOf('(scry ');
+    if (scryIdx === -1) {
+      unresolved = chunk.trim().split('\n')[0];
+      continue;
+    }
+    const inner = chunk.slice(scryIdx + 1, matchParen(chunk, scryIdx));
+    const tokens = splitTokens(inner);
+    const care = /^%g([a-z])$/.exec(tokens[1] ?? '')?.[1];
+    const app = /^%([a-z][a-z0-9-]*)$/.exec(tokens[2] ?? '')?.[1];
+    const path = tokens[3] ?? '';
+    if (!care || !app || !path.startsWith('/') || /[()[\]]/.test(path)) {
+      unresolved = inner.trim().split('\n')[0];
+      continue;
+    }
+    const segments = path.split('/').filter(Boolean);
+    // The last segment of a `.^` path is the result mark, not part of the pole.
+    segments.pop();
+    calls.push({
+      app,
+      surface: 'scry',
+      known: [care, ...segments],
+      unknownTail: false,
+    });
+  }
+  return { calls, unresolved };
+}
+
+function scryingHelper(agent: Agent, arm: Arm): string | null {
+  for (const call of balancedCalls(arm.bodyText)) {
+    const head = splitTokens(call)[0]?.split(':')[0];
+    const range = head && agent.arms.get(head);
+    if (
+      range &&
+      agent.lines.slice(range.start, range.end).join('\n').includes('.^')
+    ) {
+      return head!;
+    }
+  }
+  return null;
+}

--- a/packages/scripts/src/check-desk-compat/match.ts
+++ b/packages/scripts/src/check-desk-compat/match.ts
@@ -90,7 +90,39 @@ export interface Desk {
    * catch; an app in neither is simply out of desk.
    */
   clientHadApp(app: string): boolean;
+  /**
+   * Whether the client's own desk dispatched this surface itself. Replacing a
+   * real `on-peek` with `on-peek:def` removes the surface as surely as deleting
+   * the arms, so a removal PR must not read as merely unverifiable.
+   */
+  clientDispatched(app: string, surface: PathRequest['surface']): boolean;
   agent(app: string): Agent | null;
+}
+
+/** Agents are parsed lazily; a run touches a handful of the 27. */
+function agentLoader(tree: Tree): (app: string) => Agent | null {
+  const cache = new Map<string, Agent | null>();
+  return (app) => {
+    if (!cache.has(app)) {
+      const file = `desk/app/${app}.hoon`;
+      const lines = tree.readFile(file)?.split('\n');
+      const arms = lines ? indexArms(lines) : null;
+      cache.set(
+        app,
+        lines && arms
+          ? {
+              name: app,
+              file,
+              lines,
+              arms,
+              peek: resolveSurface(lines, arms, 'on-peek'),
+              watch: resolveSurface(lines, arms, 'on-watch'),
+            }
+          : null
+      );
+    }
+    return cache.get(app)!;
+  };
 }
 
 export function loadDesk(tree: Tree, ref: string, clientDesk?: Tree): Desk {
@@ -99,8 +131,8 @@ export function loadDesk(tree: Tree, ref: string, clientDesk?: Tree): Desk {
       (tree.readFile('desk/desk.bill') ?? '').matchAll(/%([a-z][a-z0-9-]*)/g)
     ).map((m) => m[1])
   );
-  // Agents are parsed lazily; a run touches a handful of the 27.
-  const cache = new Map<string, Agent | null>();
+  const load = agentLoader(tree);
+  const loadClient = clientDesk ? agentLoader(clientDesk) : null;
   return {
     ref,
     tree,
@@ -108,28 +140,13 @@ export function loadDesk(tree: Tree, ref: string, clientDesk?: Tree): Desk {
     marFiles: new Set(tree.list('desk/mar', (p) => p.endsWith('.hoon'))),
     hasApp: (app) => tree.exists(`desk/app/${app}.hoon`),
     clientHadApp: (app) => clientDesk?.exists(`desk/app/${app}.hoon`) ?? false,
-    agent(app) {
-      if (!cache.has(app)) {
-        const file = `desk/app/${app}.hoon`;
-        const source = tree.readFile(file);
-        const lines = source?.split('\n');
-        const arms = lines ? indexArms(lines) : null;
-        cache.set(
-          app,
-          lines && arms
-            ? {
-                name: app,
-                file,
-                lines,
-                arms,
-                peek: resolveSurface(lines, arms, 'on-peek'),
-                watch: resolveSurface(lines, arms, 'on-watch'),
-              }
-            : null
-        );
-      }
-      return cache.get(app)!;
+    clientDispatched(app, surface) {
+      const agent = loadClient?.(app);
+      if (!agent) return false;
+      const kind = (surface === 'scry' ? agent.peek : agent.watch).kind;
+      return kind === 'inline' || kind === 'delegated';
     },
+    agent: load,
   };
 }
 
@@ -295,6 +312,18 @@ export function matchPath(
   const entry = request.surface === 'scry' ? 'on-peek' : 'on-watch';
   const surface = request.surface === 'scry' ? agent.peek : agent.watch;
   if (surface.kind === 'default-agent') {
+    // The pinned default-agent nacks an unsupported peek or watch. Handing the
+    // surface to it is therefore a removal whenever the client's own desk
+    // dispatched it — the same gap as deleting the arms, spelled differently.
+    if (desk.clientDispatched(request.app, request.surface)) {
+      return {
+        verdict: 'MISSING',
+        rule: 'P1',
+        reason: `%${request.app} now routes ${entry} to default-agent, which the client's desk dispatched itself`,
+        evidence: agent.file,
+        failureMode: 'crash',
+      };
+    }
     return unverified(
       `%${request.app} routes ${entry} to default-agent`,
       agent.file

--- a/packages/scripts/src/check-desk-compat/match.ts
+++ b/packages/scripts/src/check-desk-compat/match.ts
@@ -9,6 +9,7 @@ import {
   parseDispatcher,
   preDispatchObstructions,
   splitTokens,
+  stripComments,
   stripSelfGuard,
 } from './hoon';
 
@@ -41,7 +42,7 @@ export type Rule =
  * to a crash and peek dispatchers to a silent empty, and the user-visible
  * symptom differs, so the verdict carries which.
  */
-export type FailureMode = 'crash' | 'empty' | 'unknown';
+export type FailureMode = 'crash' | 'empty' | 'not-running' | 'unknown';
 
 export interface MatchResult {
   verdict: Verdict;
@@ -96,8 +97,21 @@ export interface Desk {
    * the arms, so a removal PR must not read as merely unverifiable.
    */
   clientDispatched(app: string, surface: PathRequest['surface']): boolean;
+  /**
+   * Whether the client's own desk started this agent. Dropping a name from
+   * `desk.bill` stops the agent without touching a line of its source, so the
+   * app file surviving proves nothing.
+   */
+  clientBilled(app: string): boolean;
   agent(app: string): Agent | null;
 }
+
+const billIn = (tree: Tree) =>
+  new Set(
+    Array.from(
+      (tree.readFile('desk/desk.bill') ?? '').matchAll(/%([a-z][a-z0-9-]*)/g)
+    ).map((m) => m[1])
+  );
 
 /** Agents are parsed lazily; a run touches a handful of the 27. */
 function agentLoader(tree: Tree): (app: string) => Agent | null {
@@ -105,7 +119,11 @@ function agentLoader(tree: Tree): (app: string) => Agent | null {
   return (app) => {
     if (!cache.has(app)) {
       const file = `desk/app/${app}.hoon`;
-      const lines = tree.readFile(file)?.split('\n');
+      // Stripped once, here: this is the only place an agent file becomes
+      // lines, so nothing downstream can read a comment as code.
+      const source = tree.readFile(file);
+      const lines =
+        source === null ? undefined : stripComments(source.split('\n'));
       const arms = lines ? indexArms(lines) : null;
       cache.set(
         app,
@@ -126,11 +144,8 @@ function agentLoader(tree: Tree): (app: string) => Agent | null {
 }
 
 export function loadDesk(tree: Tree, ref: string, clientDesk?: Tree): Desk {
-  const bill = new Set(
-    Array.from(
-      (tree.readFile('desk/desk.bill') ?? '').matchAll(/%([a-z][a-z0-9-]*)/g)
-    ).map((m) => m[1])
-  );
+  const bill = billIn(tree);
+  const clientBill = clientDesk ? billIn(clientDesk) : null;
   const load = agentLoader(tree);
   const loadClient = clientDesk ? agentLoader(clientDesk) : null;
   return {
@@ -140,6 +155,7 @@ export function loadDesk(tree: Tree, ref: string, clientDesk?: Tree): Desk {
     marFiles: new Set(tree.list('desk/mar', (p) => p.endsWith('.hoon'))),
     hasApp: (app) => tree.exists(`desk/app/${app}.hoon`),
     clientHadApp: (app) => clientDesk?.exists(`desk/app/${app}.hoon`) ?? false,
+    clientBilled: (app) => clientBill?.has(app) ?? false,
     clientDispatched(app, surface) {
       const agent = loadClient?.(app);
       if (!agent) return false;
@@ -261,6 +277,18 @@ interface ArmMatch {
   kind: 'exact' | 'open';
 }
 
+/**
+ * Anything that looks like it branches on the path: a conditional rune, or an
+ * equality test. An arm holding one of these dispatches somehow, whether or not
+ * this reader can follow it.
+ */
+const DISPATCH_ISH = /(^|\s)(\?[-+:~=.^<>&|]|=\()/;
+
+const armText = (agent: Agent, entry: string) => {
+  const range = agent.arms.get(entry);
+  return range ? agent.lines.slice(range.start + 1, range.end).join('\n') : '';
+};
+
 function failureModeOf(dispatcher: Dispatcher | null): FailureMode {
   switch (dispatcher?.defaultKind) {
     case 'crash':
@@ -302,6 +330,17 @@ export function matchPath(
     );
   }
   if (!desk.bill.has(request.app)) {
+    // Unbilled is unstarted. When the client's desk billed it, the agent the
+    // client talks to is simply gone, however intact its source looks.
+    if (desk.clientBilled(request.app)) {
+      return {
+        verdict: 'MISSING',
+        rule: 'P1',
+        reason: `%${request.app} is no longer listed in desk/desk.bill, so it does not run`,
+        evidence: 'desk/desk.bill (removed)',
+        failureMode: 'not-running',
+      };
+    }
     return unverified(
       `%${request.app} is not listed in desk/desk.bill, so it may not be running`
     );
@@ -330,6 +369,21 @@ export function matchPath(
     );
   }
   if (surface.kind === 'stub' || surface.kind === 'absent') {
+    // `stub` covers two very different things and only one is a removal: an
+    // arm that provably answers the same thing for every path, and an arm that
+    // dispatches in a shape this reader cannot parse. Calling the second a
+    // removal would block every PR over a parser bug. `absent` needs no such
+    // care — its arm text is empty, so it fails the same test.
+    const removed = !DISPATCH_ISH.test(armText(agent, entry));
+    if (removed && desk.clientDispatched(request.app, request.surface)) {
+      return {
+        verdict: 'MISSING',
+        rule: 'P1',
+        reason: `%${request.app} no longer dispatches ${entry} (${surface.kind}), but the client's desk did`,
+        evidence: agent.file,
+        failureMode: request.surface === 'scry' ? 'empty' : 'crash',
+      };
+    }
     return unverified(
       `%${request.app} has no parseable ${entry} dispatcher (${surface.kind})`,
       agent.file

--- a/packages/scripts/src/check-desk-compat/negotiate.test.ts
+++ b/packages/scripts/src/check-desk-compat/negotiate.test.ts
@@ -67,6 +67,18 @@ describe('protocolsInSource', () => {
     expect([...(mixed.get('channels') ?? [])]).toEqual(['5']);
   });
 
+  it('does not read a commented-out charge as a declaration', () => {
+    const commented = protocolsInSource(
+      [
+        '%-  %-  agent:neg',
+        '    :+  notify=&',
+        '      [~.groups^%3 ~ ~]  :: was [~.groups^%2 ~ ~]',
+        '%-  agent:dbug',
+      ].join('\n')
+    );
+    expect([...(commented.get('groups') ?? [])]).toEqual(['3']);
+  });
+
   it('finds nothing in an agent that does not negotiate', () => {
     expect(protocolsInSource('|_  =bowl:gall\n--\n').size).toBe(0);
   });

--- a/packages/scripts/src/check-desk-compat/negotiate.test.ts
+++ b/packages/scripts/src/check-desk-compat/negotiate.test.ts
@@ -1,0 +1,67 @@
+import { describe, expect, it } from 'vitest';
+
+import { memoryTree } from './git';
+import { compareProtocols, protocolsInSource } from './negotiate';
+
+// The `%9` below the agent:dbug line is past the declaration and must not be read.
+const GROUPS = (v: string) =>
+  [
+    '%-  %-  agent:neg',
+    '    :+  notify=&',
+    `      [~.groups^%${v} ~ ~]`,
+    '    %-  my',
+    `    :~  %groups^[~.groups^%${v} ~ ~]`,
+    '        %channels^[~.channels^%4 ~ ~]',
+    '    ==',
+    '%-  agent:dbug',
+    '++  peek  [~.groups^%9 ~ ~]',
+  ].join('\n');
+
+const CHAT = [
+  '%-  %-  agent:neg',
+  '    :+  |',
+  '      [~.chat-dms^%2 ~ ~]',
+  '%-  agent:dbug',
+].join('\n');
+
+const LANYARD = [
+  '%-  %-  agent:negotiate',
+  '    [notify=| expose=[~.lanyard^%1 ~ ~] expect=[%verifier^[~.verifier^%0 ~ ~] ~ ~]]',
+  '%-  agent:dbug',
+].join('\n');
+
+const tree = (v: string) =>
+  memoryTree({ 'desk/app/groups.hoon': GROUPS(v), 'desk/app/chat.hoon': CHAT });
+
+describe('protocolsInSource', () => {
+  it('reads exposed and expected protocols, in both declaration forms', () => {
+    const groups = protocolsInSource(GROUPS('3'));
+    expect([...groups.get('groups')!, ...groups.get('channels')!]).toEqual([
+      '3',
+      '4',
+    ]);
+    const lanyard = protocolsInSource(LANYARD);
+    expect([...lanyard.get('lanyard')!, ...lanyard.get('verifier')!]).toEqual([
+      '1',
+      '0',
+    ]);
+  });
+
+  it('finds nothing in an agent that does not negotiate', () => {
+    expect(protocolsInSource('|_  =bowl:gall\n--\n').size).toBe(0);
+  });
+});
+
+describe('compareProtocols', () => {
+  it('flags the 12.1.0 to 12.2.0 boundary, and only the protocol that moved', () => {
+    expect(compareProtocols(tree('3'), tree('3'))).toEqual([]);
+    expect(compareProtocols(tree('3'), tree('2'))).toEqual([
+      {
+        agent: 'groups',
+        protocol: 'groups',
+        clientDeskVersions: ['3'],
+        n1Versions: ['2'],
+      },
+    ]);
+  });
+});

--- a/packages/scripts/src/check-desk-compat/negotiate.test.ts
+++ b/packages/scripts/src/check-desk-compat/negotiate.test.ts
@@ -47,6 +47,26 @@ describe('protocolsInSource', () => {
     ]);
   });
 
+  it('reads a charge written on the line that opens the wrapper', () => {
+    // Nothing in the desk spells it this way today, but the grammar allows it
+    // and the whole gate rests on seeing every declared protocol.
+    const inline = protocolsInSource(
+      ['%-  %-  agent:neg  [~.groups^%4 ~ ~]', '%-  agent:dbug'].join('\n')
+    );
+    expect([...(inline.get('groups') ?? [])]).toEqual(['4']);
+
+    const mixed = protocolsInSource(
+      [
+        '%-  %-  agent:neg  :+  notify=&  [~.groups^%4 ~ ~]',
+        '    (my %channels^[~.channels^%5 ~ ~] ~)',
+        '%-  agent:dbug',
+        '++  peek  [~.groups^%9 ~ ~]',
+      ].join('\n')
+    );
+    expect([...(mixed.get('groups') ?? [])]).toEqual(['4']);
+    expect([...(mixed.get('channels') ?? [])]).toEqual(['5']);
+  });
+
   it('finds nothing in an agent that does not negotiate', () => {
     expect(protocolsInSource('|_  =bowl:gall\n--\n').size).toBe(0);
   });

--- a/packages/scripts/src/check-desk-compat/negotiate.ts
+++ b/packages/scripts/src/check-desk-compat/negotiate.ts
@@ -1,0 +1,78 @@
+import { Tree } from './git';
+
+export interface ProtocolDifference {
+  agent: string;
+  protocol: string;
+  clientDeskVersions: string[];
+  n1Versions: string[];
+}
+
+/**
+ * Every `agent:neg` protocol version an agent declares, exposed or expected.
+ *
+ * The version-carrying atom is always `~.<term>^%<n>`, and the same atom
+ * appears verbatim in both the expose slot and every dependent's expect map —
+ * so collecting the set per agent and comparing sets catches a bump without
+ * modelling which slot is which.
+ */
+export function protocolsInSource(source: string): Map<string, Set<string>> {
+  const out = new Map<string, Set<string>>();
+  let inBlock = false;
+  for (const line of source.split('\n')) {
+    if (/agent:neg(otiate)?\b/.test(line)) inBlock = true;
+    // The wrapper stack ends at the next agent combinator.
+    else if (
+      inBlock &&
+      /^%-\s+agent:dbug|^\^-\s+agent:gall|^%\^\s+verb/.test(line)
+    ) {
+      inBlock = false;
+    } else if (inBlock) {
+      for (const m of line.matchAll(/~\.([a-z][a-z0-9-]*)\^%(\d+)/g)) {
+        out.set(m[1], (out.get(m[1]) ?? new Set()).add(m[2]));
+      }
+    }
+  }
+  return out;
+}
+
+function protocolsByAgent(tree: Tree): Map<string, Map<string, Set<string>>> {
+  const out = new Map<string, Map<string, Set<string>>>();
+  for (const file of tree.list('desk/app', (p) => p.endsWith('.hoon'))) {
+    const protocols = protocolsInSource(tree.readFile(file) ?? '');
+    if (protocols.size > 0) {
+      out.set(
+        file.replace(/^desk\/app\//, '').replace(/\.hoon$/, ''),
+        protocols
+      );
+    }
+  }
+  return out;
+}
+
+/**
+ * Rule (d): a protocol version difference between two desks blocks the pair
+ * outright. `negotiate` refuses them regardless of what the paths say, so this
+ * is reported ahead of any dispatch analysis.
+ */
+export function compareProtocols(
+  clientDesk: Tree,
+  n1Desk: Tree
+): ProtocolDifference[] {
+  const a = protocolsByAgent(clientDesk);
+  const b = protocolsByAgent(n1Desk);
+  const out: ProtocolDifference[] = [];
+  for (const agent of [...new Set([...a.keys(), ...b.keys()])].sort()) {
+    const left = a.get(agent) ?? new Map<string, Set<string>>();
+    const right = b.get(agent) ?? new Map<string, Set<string>>();
+    for (const protocol of [
+      ...new Set([...left.keys(), ...right.keys()]),
+    ].sort()) {
+      const clientDeskVersions = [...(left.get(protocol) ?? [])].sort();
+      const n1Versions = [...(right.get(protocol) ?? [])].sort();
+      if (clientDeskVersions.join() !== n1Versions.join()) {
+        out.push({ agent, protocol, clientDeskVersions, n1Versions });
+      }
+    }
+  }
+  return out;
+}

--- a/packages/scripts/src/check-desk-compat/negotiate.ts
+++ b/packages/scripts/src/check-desk-compat/negotiate.ts
@@ -26,10 +26,13 @@ export function protocolsInSource(source: string): Map<string, Set<string>> {
       /^%-\s+agent:dbug|^\^-\s+agent:gall|^%\^\s+verb/.test(line)
     ) {
       inBlock = false;
-    } else if (inBlock) {
-      for (const m of line.matchAll(/~\.([a-z][a-z0-9-]*)\^%(\d+)/g)) {
-        out.set(m[1], (out.get(m[1]) ?? new Set()).add(m[2]));
-      }
+      continue;
+    }
+    if (!inBlock) continue;
+    // The triggering line is scanned too: `%-  %-  agent:neg  [~.groups^%4 ~ ~]`
+    // carries its charge inline, and skipping it would hide the protocol.
+    for (const m of line.matchAll(/~\.([a-z][a-z0-9-]*)\^%(\d+)/g)) {
+      out.set(m[1], (out.get(m[1]) ?? new Set()).add(m[2]));
     }
   }
   return out;

--- a/packages/scripts/src/check-desk-compat/negotiate.ts
+++ b/packages/scripts/src/check-desk-compat/negotiate.ts
@@ -1,4 +1,5 @@
 import { Tree } from './git';
+import { stripComment } from './hoon';
 
 export interface ProtocolDifference {
   agent: string;
@@ -18,7 +19,11 @@ export interface ProtocolDifference {
 export function protocolsInSource(source: string): Map<string, Set<string>> {
   const out = new Map<string, Set<string>>();
   let inBlock = false;
-  for (const line of source.split('\n')) {
+  for (const raw of source.split('\n')) {
+    // A commented-out charge (`:: was [~.groups^%2 ~ ~]`) is not a
+    // declaration; reading one would invent a version difference and
+    // block every pair.
+    const line = stripComment(raw);
     if (/agent:neg(otiate)?\b/.test(line)) inBlock = true;
     // The wrapper stack ends at the next agent combinator.
     else if (

--- a/packages/scripts/src/check-desk-compat/tsconfig.json
+++ b/packages/scripts/src/check-desk-compat/tsconfig.json
@@ -1,0 +1,18 @@
+// Scoped to this directory on purpose.
+//
+// `packages/scripts`' own tsconfig pulls in @tloncorp/api's sources, which do
+// not typecheck standalone (they reference the React Native `__DEV__` global).
+// The compatibility checker depends on nothing but `typescript` and node, so it
+// gets its own project and can be typechecked by `pnpm -r tsc`.
+{
+  "extends": "../../../../tsconfig.json",
+  "include": ["."],
+  "compilerOptions": {
+    "composite": false,
+    "noEmit": true,
+    "types": ["node"],
+    "lib": ["es2022"],
+    "module": "esnext",
+    "moduleResolution": "bundler"
+  }
+}

--- a/packages/shared/src/logic/deskCompatibility.ts
+++ b/packages/shared/src/logic/deskCompatibility.ts
@@ -1,11 +1,15 @@
 import { isVersionBelow, parseVersion } from './semver';
 
-// Oldest %groups desk this client supports. Ships reporting a lower docket
-// version get the desk-outdated notice instead of an empty home. Raise it only
-// when dropping backwards-compatibility for older desks; adding a new desk
-// dependency without a fallback also requires raising it (12.2.0 = first desk
-// with /v10/init and the /v3/groups subscription, which the client currently
-// requires with no fallback).
+// The oldest %groups desk this client supports: by policy, the previous desk
+// release (docs/tlon-apps/desk-compatibility.md). Ships below it get the
+// desk-outdated notice instead of an empty home.
+//
+// This constant RECORDS the floor. It is NOT the lever for shipping a new desk
+// dependency: a client change needing something only the current desk serves
+// waits for that desk to become N-1, or carries a fallback tested against N-1.
+// Raise it only as part of a release, once the desk release it names has
+// shipped and `pnpm check:desk-compat` passes — and re-pin the ~bus pier in the
+// same change (apps/tlon-web/e2e/shipManifest.json).
 export const MIN_GROUPS_VERSION = '12.2.0';
 
 export type DeskVersionClassification = 'ok' | 'outdated' | 'unknown';

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1140,6 +1140,12 @@ importers:
       esbuild:
         specifier: 0.27.3
         version: 0.27.3
+      tsx:
+        specifier: ^4.20.6
+        version: 4.22.4
+      typescript:
+        specifier: ~5.9.2
+        version: 5.9.3
 
   packages/shared:
     dependencies:


### PR DESCRIPTION
## Summary

Stacked on #6498 (targets `po/tlon-6522-desk-compat-gate`), and PR 1 of 3 for TLON-6528. Adds layer 1 of the N-1 desk policy: a static checker that extracts every request the client makes of the desk and matches it against a chosen desk ref, wired into CI so a branch cannot merge while depending on something the previous desk release does not serve. No runtime behavior changes; the only edit to shipped code is a comment.

## Changes

**Checker (`packages/scripts/src/check-desk-compat/`)**

- Extracts every scry, subscribe, poke and thread request from `packages/api`, `packages/shared`, `packages/app`, `apps/tlon-web/src` and `apps/tlon-mobile/src` with the TypeScript compiler API, binding client wrappers by import source rather than by name, and keeping conditional branches separate instead of unioning them.
- Matches each request against the desk's peek and watch dispatch arms and its `desk/mar` files, read at a git ref, under an ordered precedence P0 to P4 (pre-dispatch obstruction, known-prefix absence, unknown suffix, delegation to sub-dispatchers, open value sets), following `.^` fan-out one level. Mark ownership is decided by exclusion against `peru.yaml`'s pick lists, so a deleted repo-owned mark still reads as a removal.
- Compares `agent:neg` protocol versions (`~.groups^%N`) between the two desks and reports any difference ahead of path analysis, since a mismatch blocks the pair whatever the paths say.
- Reports FOUND / MISSING / UNVERIFIED per request with the deciding rule, the desk-side evidence, the failure mode (watch nack versus empty peek) and the call sites. Only MISSING or a protocol difference fails the run; UNVERIFIED is always printed and never changes the exit code.
- `known-gaps.json` holds an allowlist whose entries are still printed and still MISSING but are excluded from the exit code. It carries one entry: `getChannelPreview` subscribes to `/chan/*`, which the desk deprecated in v11.2.0, so channel previews are already broken (TLON-6538).
- Conditional branches keep their guard. A MISSING request behind a recognised capability guard (`getActivitySupportsNotes()`, `*MIN_GROUPS_VERSION` and the other spellings in the tree) whose complementary branch at the same call site is served is reported as a covered fallback, printed with its guard, and does not fail the run. Coverage is decided per call site, so a request that is guarded at one site and unconditional at another still blocks. A branch on anything other than a capability check (`whomIsDm`, a message type) never covers.
- A known-gap entry only excuses a request that was already broken at the baseline it documents: in the released-client run it does not apply when the desk that client shipped with served the request, and the checker warns when an entry excuses nothing. Removals the released-client run treats as MISSING rather than unverifiable: an agent deleted or dropped from `desk.bill`, and a used dispatcher replaced by the default agent or by a stub that provably answers nothing; a dispatcher the reader merely cannot parse stays UNVERIFIED. Comments are stripped before any structural read of a Hoon file.
- `known-gaps.json` also carries a `protocolBumps` allowlist. A desk PR that bumps an `agent:neg` protocol adds an issue-referenced entry for that exact transition; the mismatch is still printed as an allowed bump, and the release checklist removes the entry once the bump has become N-1. Any other protocol difference still fails.
- Guards are two-directional: a pre-dispatch or in-body guard the checker cannot prove satisfied moves the request to UNVERIFIED, whether the arm matched or not; the ship's own self-checks (`from-self` and its spellings) are treated as satisfied. A repo-owned agent present in the client's desk but absent from the desk under test is MISSING, not an out-of-desk app.

**CLI and packaging**

- `pnpm check:desk-compat --desk-ref <ref> [--client-ref <ref>] [--json]`. The client ref defaults to the working tree so uncommitted work can be checked, and refs absent from a shallow checkout are fetched narrowly on demand.
- `packages/scripts` gains `tsx` and `typescript`, plus a tsconfig scoped to the checker so `pnpm -r tsc` covers it (the package's own config pulls in `@tloncorp/api` sources that do not typecheck standalone).

**CI**

- `ci.yml`: the `test-build` job fetches the N-1 tag named by `MIN_GROUPS_VERSION` along with the two refs the fixtures replay, then runs the check against that tag. Blocking, and inside `ci-ok` by way of `test-build`.
- `desk-compat.yml`: a new workflow on pushes to `staging` and on `workflow_dispatch`, running the three release pairs (candidate against N-1, candidate against itself, `origin/master` against the candidate) so desk-side removals are caught too. `origin/master` is the last sync of staging after a deployment workflow ran, which is a standing proxy for the released client rather than a verified deployed SHA, and both the workflow and the docs say so.

**Docs and comments**

- `docs/tlon-apps/desk-compatibility.md`: the policy and its four rules, the verdict precedence, how to read UNVERIFIED, why self-guards (`?> from-self` and its spellings) are treated as satisfied, how (and when not) to add a known gap, and what the static check cannot see.
- `docs/release-checklist.md`: the release flow as the workflows actually implement it, plus the layer-1 steps to run at tag time.
- `packages/shared/src/logic/deskCompatibility.ts`: comment only. It restates that `MIN_GROUPS_VERSION` records the floor and is not the lever for shipping a new desk dependency. The value stays at `12.2.0`.

## How did I test?

- Unit tests in `packages/scripts` cover the extractor, the Hoon reader, the matcher rules, mark resolution and the protocol comparison (`extract.test.ts`, `hoon.test.ts`, `match.test.ts`, `marks.test.ts`, `negotiate.test.ts`, `check.test.ts`), and `fixtures.test.ts` pins the build-440 incident end to end.
- The incident fixture asserts that client `854b46c` against desk v12.1.0 reports the three `~.groups` protocol mismatches and the six requests that release needed and v12.1.0 did not serve (`poke groups group-action-5`, `scry groups /v3/groups`, `scry groups /v3/ui/groups/{}`, `scry groups-ui /v10/init`, `scry groups-ui /v11/changes/{}`, `subscribe groups /v3/groups`), and that the same client against v12.2.0, the desk that shipped it, reports none of them. The fixtures hard-fail rather than skip when a ref is absent.
- The same file checks this tree against v12.2.0 and requires zero MISSING: 56 FOUND, 0 MISSING, 79 UNVERIFIED, no covered fallbacks and the single known gap over 136 distinct requests.
- Ran the `packages/scripts` tests, `pnpm -r tsc`, `pnpm format:check` and `pnpm lint:all`.
- Not verifiable locally: that the narrow `git fetch` of the desk tag and the incident SHA succeeds on a fresh GitHub runner, since both refs were already in my object store. The first CI run on this PR exercises that path.

## Risks and impact

- Safe to rollback without consulting PR author? Yes
- The matcher is conservative by design: when it cannot prove that an arm serves or rejects a path (guards, branching bodies, named molds, delegation it cannot rebuild) it reports UNVERIFIED rather than guessing. A refactor of a served arm therefore tends to move a request from FOUND to UNVERIFIED, which is printed but never blocks; only a request that no arm can match, a removed mark, or a protocol-version difference fails the run.
- Affects important code area:
  - [ ] Onboarding
  - [ ] State / providers
  - [ ] Message sync
  - [ ] Channel display
  - [ ] Notifications

## Rollback plan

Revert the PR. It adds developer tooling, a CI step, a workflow and docs, and the only shipped-code edit is a comment, so a revert leaves no runtime or data state behind. If the gate blocks unrelated work before a revert can land, the `Check desk N-1 compatibility` step in `ci.yml` and `desk-compat.yml` can be dropped on their own.

## Screenshots / videos

n/a
