### PR TITLE
Notes: stop a short editable note scrolling out of view above the keyboard (TLON-6540)

### DIFF
--- a/packages/app/ui/components/NotesChannel/NotesNoteDetail.test.tsx
+++ b/packages/app/ui/components/NotesChannel/NotesNoteDetail.test.tsx
@@ -19,6 +19,7 @@ import {
 const mocks = vi.hoisted(() => ({
   draftStashes: {} as Record<string, Record<string, unknown>>,
   getDraftStashes: vi.fn(),
+  isWeb: true,
   notes: [] as Array<Record<string, unknown>>,
   saveNotebookNote: vi.fn(),
   setDraftStashes: vi.fn(),
@@ -64,7 +65,10 @@ vi.mock('tamagui', () => ({
   XStack: 'XStack',
   YStack: 'YStack',
   getTokenValue: () => 16,
-  isWeb: true,
+  // Read at render time, so a test can switch platform without re-importing.
+  get isWeb() {
+    return mocks.isWeb;
+  },
 }));
 
 vi.mock('../Channel/ChannelHeader', () => ({
@@ -159,46 +163,47 @@ describe('deriveNotesNoteSaveFieldIntent', () => {
   });
 });
 
+beforeAll(() => {
+  Object.assign(globalThis, {
+    IS_REACT_ACT_ENVIRONMENT: true,
+    requestAnimationFrame: (callback: FrameRequestCallback) => {
+      callback(0);
+      return 0;
+    },
+  });
+});
+
+afterAll(() => {
+  delete (globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean })
+    .IS_REACT_ACT_ENVIRONMENT;
+  delete (
+    globalThis as unknown as {
+      requestAnimationFrame?: typeof requestAnimationFrame;
+    }
+  ).requestAnimationFrame;
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mocks.draftStashes = {};
+  mocks.getDraftStashes.mockResolvedValue({});
+  mocks.setDraftStashes.mockResolvedValue(undefined);
+  mocks.isWeb = true;
+  mocks.notes = [note(1, 'Original A'), note(2, 'Original B')];
+  mocks.useNotebookData.mockImplementation(() => ({
+    folders: [],
+    notes: mocks.notes,
+    canEdit: true,
+    rootFolderId: 0,
+    gate: null,
+  }));
+});
+
 describe('NotesNoteDetail note switching', () => {
-  beforeAll(() => {
-    Object.assign(globalThis, {
-      IS_REACT_ACT_ENVIRONMENT: true,
-      requestAnimationFrame: (callback: FrameRequestCallback) => {
-        callback(0);
-        return 0;
-      },
-    });
-  });
-
-  afterAll(() => {
-    delete (globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean })
-      .IS_REACT_ACT_ENVIRONMENT;
-    delete (
-      globalThis as unknown as {
-        requestAnimationFrame?: typeof requestAnimationFrame;
-      }
-    ).requestAnimationFrame;
-  });
-
-  afterEach(() => {
-    vi.restoreAllMocks();
-  });
-
-  beforeEach(() => {
-    vi.clearAllMocks();
-    mocks.draftStashes = {};
-    mocks.getDraftStashes.mockResolvedValue({});
-    mocks.setDraftStashes.mockResolvedValue(undefined);
-    mocks.notes = [note(1, 'Original A'), note(2, 'Original B')];
-    mocks.useNotebookData.mockImplementation(() => ({
-      folders: [],
-      notes: mocks.notes,
-      canEdit: true,
-      rootFolderId: 0,
-      gate: null,
-    }));
-  });
-
   it('keeps same-note saves FIFO across A → B → A visits', async () => {
     const firstSave = deferred<Record<string, unknown>>();
     mocks.saveNotebookNote
@@ -1680,5 +1685,51 @@ describe('NotesNoteDetail note switching', () => {
     ).toBe('Remote A');
 
     act(() => renderer!.unmount());
+  });
+});
+
+describe('NotesNoteDetail scroll container', () => {
+  async function renderScrollView() {
+    let renderer!: ReactTestRenderer;
+    await act(async () => {
+      renderer = create(
+        <NotesNoteDetail
+          headerActionsPlacement="none"
+          noteId={1}
+          notebookFlag="~zod/notebook"
+          startInEdit
+        />
+      );
+    });
+    const scrollView = renderer.root.findByProps({
+      testID: 'NotesDetailScrollView',
+    });
+    return { renderer, scrollView };
+  }
+
+  it('sizes the native content container to the note, not the viewport', async () => {
+    // A container grown to the viewport gave automaticallyAdjustKeyboardInsets
+    // a full keyboard's worth of scroll range on a three-line note, which let
+    // the whole note scroll off the top (TLON-6540).
+    mocks.isWeb = false;
+    const { renderer, scrollView } = await renderScrollView();
+
+    expect(scrollView.props.contentContainerStyle ?? {}).not.toHaveProperty(
+      'flexGrow'
+    );
+
+    act(() => renderer.unmount());
+  });
+
+  it('keeps the web editor pane pinned to the viewport', async () => {
+    mocks.isWeb = true;
+    const { renderer, scrollView } = await renderScrollView();
+
+    expect(scrollView.props.contentContainerStyle).toEqual({
+      flexGrow: 1,
+      height: '100%',
+    });
+
+    act(() => renderer.unmount());
   });
 });

--- a/packages/app/ui/components/NotesChannel/NotesNoteDetail.tsx
+++ b/packages/app/ui/components/NotesChannel/NotesNoteDetail.tsx
@@ -1627,8 +1627,13 @@ export function NotesNoteDetail({
         keyboardDismissMode="interactive"
         keyboardShouldPersistTaps="handled"
         scrollEnabled={!useWebEditorPane}
+        // On native the content sizes to the note. Growing it to the viewport
+        // let automaticallyAdjustKeyboardInsets grant a keyboard's worth of
+        // scroll range to a three-line note, so it could scroll entirely off
+        // the top (TLON-6540). The web editor pane is pinned to the viewport
+        // and the textarea scrolls internally instead.
         contentContainerStyle={
-          useWebEditorPane ? { flexGrow: 1, height: '100%' } : { flexGrow: 1 }
+          useWebEditorPane ? { flexGrow: 1, height: '100%' } : undefined
         }
         onScroll={handleScroll}
         onScrollBeginDrag={handleScrollBeginDrag}


### PR DESCRIPTION
## Summary

On native, the note detail scroll view grew its content container to fill the viewport (`contentContainerStyle={{ flexGrow: 1 }}`), so `automaticallyAdjustKeyboardInsets` granted a full keyboard's worth of scroll range even to a three-line note, which could then be swiped entirely above the top edge and stay there. The content now sizes to the note on native, so the keyboard inset only exposes range when there is content hidden behind the keyboard. The web editor pane is unchanged.

Fixes [TLON-6540](https://linear.app/tlon/issue/TLON-6540/notes-short-editable-note-can-be-scrolled-entirely-out-of-view-above). The bug predates #6460 and is independent of its scroll-restore logic; this applies cleanly on top of that branch too (same conditional, same place).

## Changes

- `NotesNoteDetail.tsx`: `contentContainerStyle` is `undefined` on native instead of `{ flexGrow: 1 }`; the web editor pane keeps `{ flexGrow: 1, height: '100%' }`. Comment explains why.
- `NotesNoteDetail.test.tsx`: two tests, one asserting the native content container carries no `flexGrow`, one asserting the web editor pane keeps its pinned style. The tamagui `isWeb` mock is read through a getter so a test can pick the platform; the act-environment and mock-reset hooks moved to file scope so both `describe` blocks share them.

`flexGrow: 1` was not load-bearing for tap-to-focus: the body input is laid out at its 360pt `MIN_BODY_INPUT_HEIGHT` regardless, and a tap in the grown blank area was an *unhandled* tap (`keyboardShouldPersistTaps="handled"`) that dismissed the keyboard. Confirmed with real taps before the change (see Linear).

## How did I test?

Fresh stim-owned iPhone 17 / iOS 26.5 simulator plus an iPhone SE (3rd gen), software keyboard on, using the `NotesChannel` cosmos fixture ("Editor Header", five-line note). A temporary effect focused the body and called `scrollTo({ y: 100000 })`, which RCTScrollView clamps to `contentSize − layout + contentInset.bottom`, i.e. exactly the range a swipe can settle in.

| iPhone 17, inset 335pt | contentH | layoutH | max offset | screen at max |
|---|---|---|---|---|
| before | 763 | 763 | **335** | header, blank, keyboard |
| after | 486 | 763 | **58** | title text + full body visible |
| after, 45-line note | 1116 | 763 | 688 | last line right above the keyboard |

iPhone SE 3 after: `contentH=486 layoutH=598 inset=260` → 148pt reachable (title tucks under the header, body's last lines visible). That residual is entirely the blank tail of `MIN_BODY_INPUT_HEIGHT = 360` and is discussed on the Linear issue with two options (lower the constant to ≤ ~210pt, or make the minimum fill the visible area dynamically); left as a design decision.

- Real gesture as a cross-check (CGEvent mouse drag into the Simulator window, keyboard open, after the fix): the swipe overshoots to 135pt during the drag and settles at 58pt, the same clamp as the `scrollTo` measurement.
- `vitest` NotesNoteDetail: 22/22
- `pnpm tsc` in `packages/app` and `apps/tlon-mobile`: clean
- `oxfmt --check`: clean; `oxlint` shows only pre-existing warnings elsewhere in the file
- `stim logs --errors`: clean on both simulators across all runs
- Web not exercised in a browser: preview mode on web also loses the grow, but there is no keyboard inset there and the background is painted by the parent, so no visible change is expected.

## Risks and impact

- Safe to rollback without consulting PR author? Yes
- Affects important code area:
  - [ ] Onboarding
  - [ ] State / providers
  - [ ] Message sync
  - [x] Channel display
  - [ ] Notifications
  - [ ] Other:

## Rollback plan

Revert the commit. It restores the previous content container style and the previous test layout; there are no data or API changes.

## Screenshots / videos

Before / after / long note / iPhone SE at maximum scroll with the keyboard open are attached to [TLON-6540](https://linear.app/tlon/issue/TLON-6540/notes-short-editable-note-can-be-scrolled-entirely-out-of-view-above) (verification comment).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

