### PR TITLE
fix(chat): keep the delivery status off block content in grouped messages

### DIFF
--- a/packages/app/fixtures/ChatMessage.fixture.tsx
+++ b/packages/app/fixtures/ChatMessage.fixture.tsx
@@ -304,6 +304,16 @@ const PostVariantsFixture = ({ post }: { post: db.Post }) => {
             label="Sent"
             post={{ ...post, deliveryStatus: 'sent' }}
           />
+          <PostSpecimen
+            label="Sent (showAuthor=false)"
+            post={{ ...post, deliveryStatus: 'sent' }}
+            showAuthor={false}
+          />
+          <PostSpecimen
+            label="Sent (showAuthor=false, image)"
+            post={{ ...postWithImage, deliveryStatus: 'sent' }}
+            showAuthor={false}
+          />
           <PostSpecimen label="Edited" post={{ ...post, isEdited: true }} />
           <PostSpecimen label="Hidden" post={{ ...post, hidden: true }} />
           <PostSpecimen label="Deleted" post={{ ...post, isDeleted: true }} />

--- a/packages/app/ui/components/ChatMessage/StaticChatMessage.tsx
+++ b/packages/app/ui/components/ChatMessage/StaticChatMessage.tsx
@@ -160,6 +160,8 @@ export function StaticChatMessage({
     post.deliveryStatus === 'failed' ||
     post.editStatus === 'failed' ||
     post.deleteStatus === 'failed';
+  const showDeliveryStatus =
+    !!post.deliveryStatus && post.deliveryStatus !== 'failed';
 
   const handleRepliesPressed = useCallback(() => {
     onPressReplies?.(post);
@@ -601,7 +603,7 @@ export function StaticChatMessage({
         />
       ) : null}
 
-      {!hideSentAtTimestamp && !showAuthor && (
+      {!hideSentAtTimestamp && !showAuthor && !showDeliveryStatus && (
         <SentTimeText
           sentAt={post.sentAt}
           color="$tertiaryText"
@@ -612,10 +614,13 @@ export function StaticChatMessage({
       )}
 
       {!!post.deliveryStatus && post.deliveryStatus !== 'failed' ? (
+        // Without an author row the top-right corner belongs to the content
+        // (images, video, refs), so the status goes in the empty avatar gutter.
         <View
           pointerEvents="none"
           position="absolute"
-          right={12}
+          left={showAuthor ? undefined : 12}
+          right={showAuthor ? 12 : undefined}
           top={8}
           zIndex={199}
         >


### PR DESCRIPTION
## Summary

Grouped chat posts (no author row, because the previous post is by the same author) draw the pending-send `>>` delivery pill at the top-right of the post, which lands on top of images, video, links and references. This moves the pill into the empty avatar gutter on the left for those posts; posts with an author row keep it at the row's right edge. Applies to the main scroll and threads.

Linear: [TLON-5430](https://linear.app/tlon/issue/TLON-5430/arrows-show-up-on-top-of-video-when-above-a-text-chat-message-from)

## Changes

- `StaticChatMessage`: when `showAuthor` is false, position the `ChatMessageDeliveryStatus` overlay at `left: 12` instead of `right: 12`. The content column starts at `paddingLeft="$4xl"` (48), and the 24px pill at 12..36 lines up with the avatar column of the author row above it.
- While the pill occupies the gutter, skip the hover-only `SentTimeText` that web draws in the same spot.
- Cosmos `ChatMessage` fixture: two `MessageStates` specimens for a sent post without an author row, one text and one image.

The overlay placement dates from [7bb17497d1](https://github.com/tloncorp/tlon-apps/commit/7bb17497d1e4b9d98dd5cbe9667fffcbccf2f7b5). The ticket's guess that TLON-5421 (missing blob fields in replies) is involved does not hold: it reproduces with a plain image post in the main scroll.

**Not done:** reserving right-side padding while the pill shows. The pill is transient, so that would reflow text and resize images a second or two after every send.

## How did I test?

iOS simulator (iPhone 17, iOS 26.5) and Android emulator, debug builds from this branch, signed into a dev ship, group `TLON-5430 repro`. Steps: post a text message, then attach a photo from the media library and send it as the same author.

- Before: while the image post is pending, `>>` sits over the top-right corner of the image (Android; on iOS the image area is still blank during that window and the pill sits where the image's corner renders).
- After: `>>` sits in the left gutter beside the post, the image renders edge to edge under nothing, and the pill disappears once the server echo lands. `stim logs --errors` clean on both platforms.

**Web not run on a device.** The gutter placement and the hover-timestamp guard were checked by reading `SentTimeText` and `ChatMessageActions` positions only.

## Risks and impact

- Safe to rollback without consulting PR author? (Yes)
- Affects important code area:
  - [ ] Onboarding
  - [ ] State / providers
  - [ ] Message sync
  - [x] Channel display
  - [ ] Notifications
  - [ ] Other:

Scope is the transient delivery pill on grouped chat posts, all platforms. Worst case is a design objection to the pill appearing on the left; nothing functional depends on its position (`pointerEvents="none"`).

## Rollback plan

Revert the PR.

## Screenshots / videos

Before iOS:

https://github.com/user-attachments/assets/55344d77-4ab8-4921-8134-7e356b4d2628

After iOS:

https://github.com/user-attachments/assets/d285100d-0d03-432b-b047-e944b983c6c8

Before Android:

https://github.com/user-attachments/assets/9d7f7acd-edf4-4d00-8af8-803c321ad445

After Android:

https://github.com/user-attachments/assets/9793d4ae-5f18-42c1-bcbf-2b049cd18979
