### PR TITLE
fix(chat): show one tombstone when a message is deleted

### DIFF
--- a/packages/api/src/client/channelsApi.test.ts
+++ b/packages/api/src/client/channelsApi.test.ts
@@ -1,0 +1,72 @@
+import { expect, test } from 'vitest';
+
+import type * as ub from '../urbit';
+import { toChannelsUpdate } from './channelsApi';
+
+const nest = 'chat/~zod/test';
+const postId = '170.141.184.508.156.853.761.867.717.508.987.879.424';
+const replyId = '170.141.184.508.156.856.230.907.384.944.729.784.320';
+
+const tombstone: ub.PostTombstone = {
+  id: postId,
+  author: '~zod',
+  seq: 5,
+  'deleted-at': 1789187650000,
+  type: 'tombstone',
+};
+
+const post: ub.Post = {
+  seal: {
+    id: postId,
+    reacts: {},
+    replies: null,
+    meta: { replyCount: 0, lastRepliers: [], lastReply: null },
+    seq: 5,
+  },
+  essay: {
+    content: [{ inline: ['hi'] }],
+    author: '~zod',
+    sent: 1789187602325,
+    kind: '/chat',
+    blob: null,
+    meta: null,
+  },
+  type: 'post',
+};
+
+function postEvent(rPost: ub.PostResponse): ub.ChannelsSubscribeResponse {
+  return {
+    nest,
+    response: { post: { id: postId, 'r-post': rPost } },
+  } as ub.ChannelsSubscribeResponse;
+}
+
+test('a live post set decodes to addPost', () => {
+  const update = toChannelsUpdate(postEvent({ set: post }));
+  expect(update.type).toBe('addPost');
+});
+
+test('a tombstone post set decodes to deletePost', () => {
+  expect(toChannelsUpdate(postEvent({ set: tombstone }))).toEqual({
+    type: 'deletePost',
+    postId,
+    channelId: nest,
+  });
+});
+
+test('a tombstone reply set decodes to deletePost', () => {
+  const update = toChannelsUpdate(
+    postEvent({
+      reply: {
+        id: replyId,
+        'r-reply': { set: { ...tombstone, id: replyId } },
+        meta: { replyCount: 0, lastRepliers: [], lastReply: null },
+      },
+    })
+  );
+  expect(update).toEqual({
+    type: 'deletePost',
+    postId: replyId,
+    channelId: nest,
+  });
+});

--- a/packages/api/src/client/channelsApi.ts
+++ b/packages/api/src/client/channelsApi.ts
@@ -12,7 +12,12 @@ import {
   getChannelIdType,
   isGroupChannelId,
 } from './apiUtils';
-import { toPostData, toPostReplyData, toReactionsData } from './postsApi';
+import {
+  isPostTombstone,
+  toPostData,
+  toPostReplyData,
+  toReactionsData,
+} from './postsApi';
 import {
   poke,
   scry,
@@ -272,7 +277,7 @@ export const toChannelsUpdate = (
         const postResponse = channelEvent.response.post['r-post'];
 
         if ('set' in postResponse) {
-          if (postResponse.set !== null) {
+          if (postResponse.set !== null && !isPostTombstone(postResponse.set)) {
             const postToAdd = { id: postId, ...postResponse.set };
 
             logger.log(`add post event`);
@@ -317,7 +322,7 @@ export const toChannelsUpdate = (
         const replyResponse =
           channelEvent.response.post['r-post'].reply['r-reply'];
         if ('set' in replyResponse) {
-          if (replyResponse.set !== null) {
+          if (!isPostTombstone(replyResponse.set)) {
             logger.log(`add reply event`);
             return {
               type: 'addPost',

--- a/packages/api/src/client/channelsApi.ts
+++ b/packages/api/src/client/channelsApi.ts
@@ -322,7 +322,10 @@ export const toChannelsUpdate = (
         const replyResponse =
           channelEvent.response.post['r-post'].reply['r-reply'];
         if ('set' in replyResponse) {
-          if (!isPostTombstone(replyResponse.set)) {
+          if (
+            replyResponse.set !== null &&
+            !isPostTombstone(replyResponse.set)
+          ) {
             logger.log(`add reply event`);
             return {
               type: 'addPost',

--- a/packages/api/src/client/postsApi.ts
+++ b/packages/api/src/client/postsApi.ts
@@ -1409,7 +1409,7 @@ function isPostDataResponse(
   return !!(post.seal.replies && !Array.isArray(post.seal.replies));
 }
 
-function isPostTombstone(
+export function isPostTombstone(
   post:
     | ub.Post
     | ub.PostTombstone

--- a/packages/api/src/urbit/channel.ts
+++ b/packages/api/src/urbit/channel.ts
@@ -416,12 +416,14 @@ export type Command =
   | DiffMeta;
 
 export type PostResponse =
-  | { set: Post | null }
+  | { set: Post | PostTombstone | null }
   | { reply: { id: string; 'r-reply': ReplyResponse; meta: ReplyMeta } }
   | { essay: PostEssay }
   | { reacts: Record<string, React> };
 
-export type ReplyResponse = { set: Reply } | { reacts: Record<string, React> };
+export type ReplyResponse =
+  | { set: Reply | PostTombstone }
+  | { reacts: Record<string, React> };
 
 export interface ChannelPostResponse {
   post: {

--- a/packages/shared/src/store/sync/deletePostListeners.test.ts
+++ b/packages/shared/src/store/sync/deletePostListeners.test.ts
@@ -1,0 +1,72 @@
+import { beforeEach, expect, test, vi } from 'vitest';
+
+import * as db from '../../db';
+import { setupDatabaseTestSuite } from '../../test/helpers';
+import {
+  addToChannelPosts,
+  deleteFromChannelPosts,
+} from '../useChannelPosts/subscriptions';
+import { handleChannelsUpdate, syncCachedChanges } from './sync';
+
+vi.mock('../useChannelPosts/subscriptions', () => ({
+  addToChannelPosts: vi.fn(),
+  deleteFromChannelPosts: vi.fn(),
+}));
+
+setupDatabaseTestSuite();
+
+const channelId = 'chat/~zod/test';
+const livePost: db.Post = {
+  id: '170.141.184.508.156.853.761.867.717.508.987.879.424',
+  type: 'chat',
+  channelId,
+  authorId: '~zod',
+  sentAt: 1789187602325,
+  receivedAt: 1789187602325,
+  sequenceNum: 5,
+  content: null,
+  hidden: false,
+};
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+test('a deletePost update reaches the deleted-post listeners', async () => {
+  await db.insertChannels([{ id: channelId, type: 'chat' }]);
+  await db.insertChannelPosts({ posts: [livePost] });
+
+  await handleChannelsUpdate(
+    { type: 'deletePost', postId: livePost.id, channelId },
+    undefined as never
+  );
+
+  expect(deleteFromChannelPosts).toHaveBeenCalledWith({ id: livePost.id });
+  expect(addToChannelPosts).not.toHaveBeenCalled();
+  const row = await db.getPost({ postId: livePost.id });
+  expect(row?.isDeleted).toBe(true);
+});
+
+test('a tombstone in the changes feed reaches the deleted-post listeners', async () => {
+  vi.spyOn(db.changesSyncedAt, 'getValue').mockResolvedValue(10);
+  const tombstone: db.Post = { ...livePost, isDeleted: true, content: null };
+
+  await syncCachedChanges({
+    begin: 5,
+    end: 20,
+    changes: {
+      groups: [],
+      posts: [tombstone, { ...livePost, id: 'other', sequenceNum: 6 }],
+      contacts: [],
+      unreads: { groupUnreads: [], channelUnreads: [], threadActivity: [] },
+      deletedChannelIds: [],
+    },
+  });
+
+  expect(deleteFromChannelPosts).toHaveBeenCalledTimes(1);
+  expect(deleteFromChannelPosts).toHaveBeenCalledWith(tombstone);
+  expect(addToChannelPosts).toHaveBeenCalledTimes(1);
+  expect(addToChannelPosts).toHaveBeenCalledWith(
+    expect.objectContaining({ id: 'other' })
+  );
+});

--- a/packages/shared/src/store/sync/sync.ts
+++ b/packages/shared/src/store/sync/sync.ts
@@ -47,7 +47,10 @@ import { migrateLegacyContextLensFlag } from '../settingsActions';
 import { SyncCtx, SyncPriority, syncQueue } from '../syncQueue';
 import { getSystemContacts } from '../systemContactsApi';
 import { clearChannelPostsQueries } from '../useChannelPosts/queries';
-import { addToChannelPosts } from '../useChannelPosts/subscriptions';
+import {
+  addToChannelPosts,
+  deleteFromChannelPosts,
+} from '../useChannelPosts/subscriptions';
 import { logger } from './logger';
 import { syncContacts } from './syncContacts';
 import { syncGroup } from './syncGroup';
@@ -469,7 +472,11 @@ function notifyChannelPostListenersFromLatestChanges(posts: db.Post[]) {
       continue;
     }
     seenIds.add(post.id);
-    addToChannelPosts(post);
+    if (post.isDeleted) {
+      deleteFromChannelPosts(post);
+    } else {
+      addToChannelPosts(post);
+    }
     notified++;
   }
   return notified;
@@ -1752,6 +1759,7 @@ export const handleChannelsUpdate = async (
       }
       break;
     case 'deletePost':
+      deleteFromChannelPosts({ id: update.postId });
       await db.markPostAsDeleted(update.postId, ctx);
       await db.recomputeChannelLastPost({ channelId: update.channelId }, ctx);
       break;

--- a/packages/shared/src/store/useChannelPosts/subscriptions.ts
+++ b/packages/shared/src/store/useChannelPosts/subscriptions.ts
@@ -63,7 +63,7 @@ export const addToChannelPosts = (post: SubscriptionPost) => {
   newPostListeners.forEach((listener) => listener(post));
 };
 
-export const deleteFromChannelPosts = (post: db.Post) => {
+export const deleteFromChannelPosts = (post: Pick<db.Post, 'id'>) => {
   deletedPostListeners.forEach((listener) => listener(post.id, true));
 };
 


### PR DESCRIPTION
## Summary

Deleting a chat message in a group channel can render two "Message deleted" rows for the one post and raise a duplicate-key error from the message list (`Encountered two children with the same key` on FlatList; `[legend-list] Error: Detected overlapping key` plus a blank gap on LegendList). It only shows when the deleted post is already in the channel's loaded pages, which is why the ticket's steps reproduce intermittently.

The `/v4` `%channels` subscription encodes a deleted post as a `%set` whose value is a tombstone object (`type: 'tombstone'`), not `null` ([`channel-json.hoon#L216`](https://github.com/tloncorp/tlon-apps/blob/ce462c16fd11b384327f5eae835ba7cd42f30365/desk/lib/channel-json.hoon#L216)). `toChannelsUpdate` only checked `set !== null`, so every delete decoded as `addPost`. The tombstone then lands in the channel's in-memory `newPosts` with a `sentAt` derived from the post id rather than `essay.sent` ([`postsApi.ts#L1288`](https://github.com/tloncorp/tlon-apps/blob/ce462c16fd11b384327f5eae835ba7cd42f30365/packages/api/src/client/postsApi.ts#L1288)), and `mergePendingPosts` dedupes `newPosts` against the loaded pages by `sentAt`, so both copies survive.

Linear: https://linear.app/tlon/issue/TLON-6178/deleting-a-chat-message-renders-duplicate-message-deleted-tombstones

## Changes

- `channelsApi.ts`: a `%set` whose value is a tombstone decodes to the existing `deletePost` update, for posts and replies, so it takes the `markPostAsDeleted` path instead of `handleAddPost`. This is the path the `null` encoding took before tombstones existed.
- `sync.ts`: the `deletePost` case also calls `deleteFromChannelPosts`, the overlay a local delete uses, so a post that is only in `newPosts` (sent this visit, deleted elsewhere) is tombstoned or hidden at once instead of staying live until remount.
- `sync.ts`: tombstones in the changes feed (used on resume) go to `deleteFromChannelPosts` instead of `addToChannelPosts`; `insertChanges` still upserts the row.
- Tests: `channelsApi.test.ts` and `deletePostListeners.test.ts` cover the decoding and the listener routing; each fails without its change.

Not changed: a reply tombstone carries recomputed reply `meta` that the `deletePost` update drops, so the parent's reply count refreshes on the next thread fetch. The old path did not apply it either.

## How did I test?

iOS simulator (iPhone 17, iOS 26.5) and Android emulator, debug builds against a dev ship, "Show deleted messages" on in Settings > Appearance, in a throwaway solo group's chat channel.

Before, both platforms: send a message, leave the channel, re-enter it, long-press the message, Delete message, confirm. Observed: a blank gap where the tombstone should be, the red error toast, and `[legend-list] Error: Detected overlapping key (<post id>)` in the logs. The Android client sitting in the same channel also hit the error when the post was deleted from iOS.

After, same steps on both platforms: one "Message deleted" row, no gap, no toast, `stim logs --errors` clean.

## Risks and impact

- Safe to rollback without consulting PR author? Yes
- Affects important code area:
  - [ ] Onboarding
  - [ ] State / providers
  - [x] Message sync
  - [x] Channel display
  - [ ] Notifications
  - [ ] Other:

**Worst case if wrong: a remote delete is not reflected until the channel is reopened.** Scope is decoding of group-channel post and reply delete events on the `/v4` subscription and the changes feed, all platforms; DMs use `%chat` and are not touched. `markPostAsDeleted` is an update, so a tombstone for a post the client never received writes nothing; the changes feed and page backfill still insert it. No query keys, table dependencies, or schema changed.

## Rollback plan

Revert the PR.

## Screenshots / videos

iOS before:

https://github.com/user-attachments/assets/ae0b1ae5-da36-4c1a-94aa-73955e2a191d

iOS after:

https://github.com/user-attachments/assets/7d7ac80a-66f9-41bb-8cb0-398dd375a451

Android before:

https://github.com/user-attachments/assets/dece12bb-8de8-4f64-9e71-6c19e96d7950

Android after:

https://github.com/user-attachments/assets/fa460611-3ef2-45c3-9917-677bdb66e6b9
